### PR TITLE
refactor(harness): centralize terminal adapter utilities

### DIFF
--- a/integrations/harness/claude/src/compaction.ts
+++ b/integrations/harness/claude/src/compaction.ts
@@ -1,15 +1,6 @@
-export type ClaudePayloadCompactionResult = {
-  payload: unknown;
-  compacted: boolean;
-  originalByteCount: number | null;
-  compactedByteCount: number | null;
-  omittedFieldNames: string[];
-};
+import { compactPayloadByFieldNames, type PayloadCompactionResult } from "@station/harness-shared";
 
-type CompactFieldMetadata = {
-  compacted: true;
-  originalBytes: number | null;
-};
+export type ClaudePayloadCompactionResult = PayloadCompactionResult;
 
 const commonFieldNames = [
   "session_id",
@@ -24,85 +15,6 @@ const commonFieldNames = [
   "station_terminal_provider",
   "station_terminal_target_id",
 ] as const;
-
-const compactedFieldNames = new Set([
-  "tool_input",
-  "tool_response",
-  "permission_suggestions",
-  "prompt",
-  "message",
-  "last_assistant_message",
-]);
-
-function jsonByteCount(value: unknown): number | null {
-  try {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      return null;
-    }
-    return Buffer.byteLength(serialized, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-function compactObjectField(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-  fieldName: "tool_input" | "tool_response" | "permission_suggestions",
-) {
-  if (!hasOwn(input, fieldName)) {
-    return;
-  }
-  output[fieldName] = compactFieldMetadata(input[fieldName]);
-  copiedFields.add(fieldName);
-  omittedFieldNames.add(fieldName);
-}
-
-function compactStringField(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-  fieldName: "prompt" | "message",
-) {
-  if (!hasOwn(input, fieldName)) {
-    return;
-  }
-  output[fieldName] = compactedTextPlaceholder(fieldName, jsonByteCount(input[fieldName]));
-  copiedFields.add(fieldName);
-  omittedFieldNames.add(fieldName);
-}
-
-function compactAssistantMessage(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-) {
-  if (!hasOwn(input, "last_assistant_message")) {
-    return;
-  }
-  output.last_assistant_message = null;
-  copiedFields.add("last_assistant_message");
-  if (input.last_assistant_message !== null) {
-    omittedFieldNames.add("last_assistant_message");
-  }
-}
-
-function compactFieldMetadata(value: unknown): CompactFieldMetadata {
-  return {
-    compacted: true,
-    originalBytes: jsonByteCount(value),
-  };
-}
-
-function compactedTextPlaceholder(fieldName: string, byteCount: number | null): string {
-  const bytes = byteCount === null ? "unknown" : String(byteCount);
-  return `[station compacted ${fieldName}: ${bytes} bytes]`;
-}
 
 function fieldNamesForEvent(eventName: string): string[] {
   const fields: string[] = [...commonFieldNames];
@@ -135,7 +47,6 @@ function fieldNamesForEvent(eventName: string): string[] {
     return fields;
   }
   if (eventName === "Stop") {
-    // background_tasks and session_crons are deliberately not copied.
     fields.push("stop_hook_active", "last_assistant_message");
     return fields;
   }
@@ -147,59 +58,12 @@ function fieldNamesForEvent(eventName: string): string[] {
   return fields;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(value, key);
-}
-
 export function compactClaudeHookPayload(payload: unknown): ClaudePayloadCompactionResult {
-  const originalByteCount = jsonByteCount(payload);
-  if (!isRecord(payload)) {
-    return {
-      payload,
-      compacted: false,
-      originalByteCount,
-      compactedByteCount: originalByteCount,
-      omittedFieldNames: [],
-    };
-  }
-
-  const output: Record<string, unknown> = {};
-  const copiedFields = new Set<string>();
-  const omittedFieldNames = new Set<string>();
-  const eventName = typeof payload.hook_event_name === "string" ? payload.hook_event_name : "";
-
-  for (const fieldName of fieldNamesForEvent(eventName)) {
-    if (!hasOwn(payload, fieldName) || compactedFieldNames.has(fieldName)) {
-      continue;
-    }
-    output[fieldName] = payload[fieldName];
-    copiedFields.add(fieldName);
-  }
-
-  compactObjectField(payload, output, copiedFields, omittedFieldNames, "tool_input");
-  compactObjectField(payload, output, copiedFields, omittedFieldNames, "tool_response");
-  compactObjectField(payload, output, copiedFields, omittedFieldNames, "permission_suggestions");
-  compactStringField(payload, output, copiedFields, omittedFieldNames, "prompt");
-  compactStringField(payload, output, copiedFields, omittedFieldNames, "message");
-  compactAssistantMessage(payload, output, copiedFields, omittedFieldNames);
-
-  for (const fieldName of Object.keys(payload)) {
-    if (copiedFields.has(fieldName)) {
-      continue;
-    }
-    omittedFieldNames.add(fieldName);
-  }
-
-  const compacted = omittedFieldNames.size > 0;
-  return {
-    payload: output,
-    compacted,
-    originalByteCount,
-    compactedByteCount: jsonByteCount(output),
-    omittedFieldNames: [...omittedFieldNames].sort(),
-  };
+  return compactPayloadByFieldNames(payload, {
+    retainedFieldNames: (record) =>
+      fieldNamesForEvent(typeof record.hook_event_name === "string" ? record.hook_event_name : ""),
+    compactObjectFieldNames: ["tool_input", "tool_response", "permission_suggestions"],
+    compactStringFieldNames: ["prompt", "message"],
+    nullWhenPresentFieldNames: ["last_assistant_message"],
+  });
 }

--- a/integrations/harness/claude/src/errors.ts
+++ b/integrations/harness/claude/src/errors.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import { harnessProviderErrorClass } from "@station/harness-shared";
 
 export type ClaudeHarnessErrorCode =
   | "HARNESS_CLAUDE_UNAVAILABLE"
@@ -7,51 +7,11 @@ export type ClaudeHarnessErrorCode =
   | "HARNESS_CLAUDE_EVENT_UNSUPPORTED"
   | "HARNESS_CLAUDE_EVENT_INGEST_FAILED";
 
-export class ClaudeHarnessProviderError extends Error implements SafeError {
-  readonly tag = "HarnessProviderError";
-  readonly code: ClaudeHarnessErrorCode;
-  readonly provider = "claude";
-  readonly hint: string | undefined;
+export const ClaudeHarnessProviderError = harnessProviderErrorClass<ClaudeHarnessErrorCode>({
+  name: "ClaudeHarnessProviderError",
+  provider: "claude",
+});
 
-  constructor(
-    code: ClaudeHarnessErrorCode,
-    message: string,
-    options: { cause?: unknown; hint?: string } = {},
-  ) {
-    super(`${code}: ${message}`, { cause: options.cause });
-    Object.defineProperty(this, "name", {
-      value: "ClaudeHarnessProviderError",
-      configurable: true,
-    });
-    this.code = code;
-    this.hint = options.hint;
-  }
-}
-
-export function claudeHarnessError(
-  code: ClaudeHarnessErrorCode,
-  message: string,
-  cause?: unknown,
-): ClaudeHarnessProviderError {
+export function claudeHarnessError(code: ClaudeHarnessErrorCode, message: string, cause?: unknown) {
   return new ClaudeHarnessProviderError(code, message, { cause });
-}
-
-export function claudeProviderErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: ClaudeHarnessErrorCode;
-    message: string;
-    hint?: string | undefined;
-  },
-): ClaudeHarnessProviderError {
-  if (error instanceof ClaudeHarnessProviderError) {
-    return error;
-  }
-  const options: { cause?: unknown; hint?: string } = {
-    cause: error,
-  };
-  if (fallback.hint !== undefined) {
-    options.hint = fallback.hint;
-  }
-  return new ClaudeHarnessProviderError(fallback.code, fallback.message, options);
 }

--- a/integrations/harness/claude/src/events.ts
+++ b/integrations/harness/claude/src/events.ts
@@ -7,15 +7,14 @@ import type {
   HarnessEventReport,
   ObservedStatus,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
+import { HarnessEventReportSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
-  HarnessEventReportSchema,
-  observedPathIsSameOrInside,
-  STATION_SCHEMA_VERSION,
-  sameObservedPath,
-} from "@station/contracts";
+  applyCorrelation,
+  correlateTerminalBoundHarnessEvent,
+  harnessEventDiagnostics,
+  reportCorrelation,
+} from "@station/harness-shared";
 import { z } from "zod";
 import { claudeHarnessError } from "./errors.js";
 import { isClaudeForwardedEventType } from "./ingressRules.js";
@@ -189,49 +188,18 @@ function providerDataFromClaudeEvent(event: ClaudeHookEvent): Record<string, unk
 function reportCorrelationFromClaudeEvent(
   event: ClaudeHookEvent,
 ): HarnessEventReport["correlation"] {
-  const correlation: NonNullable<HarnessEventReport["correlation"]> = {
+  return reportCorrelation({
     cwd: event.cwd,
     nativeSessionId: event.session_id,
-  };
-  if (event.station_project_id !== undefined) {
-    correlation.projectId = event.station_project_id;
-  }
-  if (event.station_worktree_id !== undefined) {
-    correlation.worktreeId = event.station_worktree_id;
-  }
-  if (event.station_session_id !== undefined) {
-    correlation.sessionId = event.station_session_id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    correlation.terminalTargetId = event.station_terminal_target_id;
-    correlation.harnessRunId = `claude:${event.station_terminal_target_id}`;
-  }
-  return correlation;
-}
-
-function reportDiagnosticsFromClaudeEvent(
-  event: ClaudeHookEvent,
-  input: ClaudeHarnessEventReportInput["diagnostics"],
-): HarnessEventReport["diagnostics"] {
-  const diagnostics: NonNullable<HarnessEventReport["diagnostics"]> = {
-    rawEventType: event.hook_event_name,
-  };
-  if (typeof input?.payloadBytes === "number") {
-    diagnostics.payloadBytes = input.payloadBytes;
-  }
-  if (typeof input?.compactedBytes === "number") {
-    diagnostics.compactedBytes = input.compactedBytes;
-  }
-  if (input?.compacted !== undefined) {
-    diagnostics.compacted = input.compacted;
-  }
-  if (input?.truncated !== undefined) {
-    diagnostics.truncated = input.truncated;
-  }
-  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
-    diagnostics.omittedFieldNames = input.omittedFieldNames;
-  }
-  return diagnostics;
+    projectId: event.station_project_id,
+    worktreeId: event.station_worktree_id,
+    sessionId: event.station_session_id,
+    terminalTargetId: event.station_terminal_target_id,
+    harnessRunId:
+      event.station_terminal_target_id === undefined
+        ? undefined
+        : `claude:${event.station_terminal_target_id}`,
+  });
 }
 
 function reportCoalesceKeyFromClaudeEvent(event: ClaudeHookEvent): string | undefined {
@@ -242,98 +210,6 @@ function reportCoalesceKeyFromClaudeEvent(event: ClaudeHookEvent): string | unde
     return `tool:${event.tool_name}`;
   }
   return undefined;
-}
-
-function correlateClaudeEvent(
-  event: ClaudeHookEvent,
-  context: HarnessEventContext,
-): {
-  sessionId?: string;
-  worktreeId?: string;
-  harnessRunId?: string;
-} {
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(event.cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(event.cwd, context.worktrees);
-  const result: {
-    sessionId?: string;
-    worktreeId?: string;
-    harnessRunId?: string;
-  } = {};
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (terminal?.harnessRunId !== undefined) {
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.harnessRunId = `claude:${terminal.id}`;
-  }
-  return result;
-}
-
-function terminalForId(
-  terminalTargetId: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (terminalTargetId === undefined) {
-    return undefined;
-  }
-  return targets.find((target) => target.id === terminalTargetId);
-}
-
-function terminalForCwd(
-  cwd: string,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  return (
-    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
-    targets.find(
-      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
-    )
-  );
-}
-
-function worktreeForId(
-  worktreeId: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreeId === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === worktreeId);
-}
-
-function worktreeForPath(
-  path: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (path === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => sameObservedPath(worktree.path, path));
-}
-
-function worktreeForCwd(
-  cwd: string,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  return (
-    worktrees.find((worktree) => sameObservedPath(worktree.path, cwd)) ??
-    worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path))
-  );
 }
 
 function turnFromClaudeHookEvent(event: ClaudeHookEvent): HarnessEventReport["turn"] | undefined {
@@ -476,7 +352,12 @@ export function normalizeClaudeRawEvent(
   }
   const event = parseClaudeHookEvent(raw.event);
   const observedAt = raw.observedAt ?? new Date().toISOString();
-  const correlation = correlateClaudeEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "claude",
+    identity: event,
+    context,
+    cwd: event.cwd,
+  });
   const observation: HarnessEventObservation = {
     provider: "claude",
     rawEventType: event.hook_event_name,
@@ -491,15 +372,7 @@ export function normalizeClaudeRawEvent(
   if (turn !== undefined) {
     observation.turn = turn;
   }
-  if (correlation.sessionId !== undefined) {
-    observation.sessionId = correlation.sessionId;
-  }
-  if (correlation.worktreeId !== undefined) {
-    observation.worktreeId = correlation.worktreeId;
-  }
-  if (correlation.harnessRunId !== undefined) {
-    observation.harnessRunId = correlation.harnessRunId;
-  }
+  applyCorrelation(observation, correlation);
   observation.nativeSessionId = event.session_id;
   return [observation];
 }
@@ -525,7 +398,7 @@ export function claudeHookPayloadToHarnessEventReport(
     report.turn = turn;
   }
   report.correlation = reportCorrelationFromClaudeEvent(event);
-  report.diagnostics = reportDiagnosticsFromClaudeEvent(event, input.diagnostics);
+  report.diagnostics = harnessEventDiagnostics(event.hook_event_name, input.diagnostics);
   const coalesceKey = reportCoalesceKeyFromClaudeEvent(event);
   if (coalesceKey !== undefined) {
     report.coalesceKey = coalesceKey;

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -1,6 +1,7 @@
 // Installs/uninstalls the STATION hook into Claude Code's settings.json hooks.
 // Upstream hook contract: https://code.claude.com/docs/en/hooks-guide
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import { ingressHookScriptOptions } from "@station/harness-shared";
 import { CLAUDE_HOOK_EVENT_NAMES, type ClaudeHookEventName } from "./hooks/hookConstants.js";
 import {
   backupIfPresent,
@@ -14,7 +15,7 @@ import {
   resolveClaudeSettingsArtifactPath,
   resolveClaudeUserSettingsPath,
 } from "./hooks/hookPaths.js";
-import { type ClaudeHookScriptOptions, expectedClaudeHookScript } from "./hooks/hookScript.js";
+import { expectedClaudeHookScript } from "./hooks/hookScript.js";
 import {
   type ClaudeSettingsDocument,
   expectedClaudeHookSettings,
@@ -99,40 +100,6 @@ export type ClaudeHookDoctorResult = {
   userSettingsCleanup: ClaudeUserSettingsCleanup;
   message: string;
 };
-
-function scriptOptions(
-  hookScriptPath: string,
-  options: Pick<
-    ClaudeHookPlanOptions,
-    | "stationConfigPath"
-    | "observerSocketPath"
-    | "stateDir"
-    | "hookSpoolDir"
-    | "autoStartFromHooks"
-    | "hookBin"
-  >,
-): ClaudeHookScriptOptions {
-  const input: ClaudeHookScriptOptions = { hookScriptPath };
-  if (options.stationConfigPath !== undefined) {
-    input.stationConfigPath = options.stationConfigPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    input.observerSocketPath = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    input.stateDir = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    input.hookSpoolDir = options.hookSpoolDir;
-  }
-  if (options.autoStartFromHooks !== undefined) {
-    input.autoStartFromHooks = options.autoStartFromHooks;
-  }
-  if (options.hookBin !== undefined) {
-    input.hookBin = options.hookBin;
-  }
-  return input;
-}
 
 function parseArtifactDocument(contents: string): {
   document: ClaudeSettingsDocument;
@@ -220,7 +187,7 @@ export async function planClaudeHooks(
   const before = await readOptionalFile(settingsPath);
   const { document, invalid } = parseArtifactDocument(before);
   const after = stringifyClaudeSettings(expectedClaudeHookSettings({ hookScriptPath }));
-  const script = expectedClaudeHookScript(scriptOptions(hookScriptPath, options));
+  const script = expectedClaudeHookScript(ingressHookScriptOptions(hookScriptPath, options));
   const scriptBefore = await readOptionalFile(hookScriptPath);
   const settingsChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
@@ -261,7 +228,7 @@ export async function installClaudeHooks(
   if (plan.scriptChanged) {
     await writeHookScript(
       plan.hookScriptPath,
-      expectedClaudeHookScript(scriptOptions(plan.hookScriptPath, options)),
+      expectedClaudeHookScript(ingressHookScriptOptions(plan.hookScriptPath, options)),
     );
   }
 

--- a/integrations/harness/claude/src/hooks/hookFiles.ts
+++ b/integrations/harness/claude/src/hooks/hookFiles.ts
@@ -1,80 +1,25 @@
-import { chmod, copyFile, mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
-import { pathExists, readTextFileIfPresent, removeFileIfPresent } from "@station/runtime";
-import { ClaudeHookSetupError } from "./hookErrors.js";
+import { createHookFileOps } from "@station/harness-shared";
+import { ClaudeHookSetupError, type ClaudeHookSetupErrorCode } from "./hookErrors.js";
 
-export async function readOptionalFile(path: string): Promise<string> {
-  try {
-    return (await readTextFileIfPresent(path)) ?? "";
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_CONFIG_UNREADABLE",
-      "Claude hook config could not be read.",
-      { cause },
-    );
-  }
-}
+const hookFiles = createHookFileOps({
+  codes: {
+    unreadable: "CLAUDE_HOOK_CONFIG_UNREADABLE",
+    writeFailed: "CLAUDE_HOOK_WRITE_FAILED",
+  },
+  messages: {
+    configUnreadable: "Claude hook config could not be read.",
+    configMetadataUnreadable: "Claude hook config metadata could not be read.",
+    configWriteFailed: "Claude hook config could not be written.",
+    scriptWriteFailed: "Claude hook script could not be written.",
+    scriptRemoveFailed: "Claude hook file could not be removed.",
+    backupWriteFailed: "Claude hook config backup could not be written.",
+  },
+  error: (code, message, cause) =>
+    new ClaudeHookSetupError(code as ClaudeHookSetupErrorCode, message, { cause }),
+});
 
-export async function writeHookConfig(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o600 });
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_WRITE_FAILED",
-      "Claude hook config could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function writeHookScript(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o700 });
-    await chmod(path, 0o700);
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_WRITE_FAILED",
-      "Claude hook script could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function removeHookFileIfPresent(path: string): Promise<boolean> {
-  try {
-    return await removeFileIfPresent(path);
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_WRITE_FAILED",
-      "Claude hook file could not be removed.",
-      { cause },
-    );
-  }
-}
-
-export async function backupIfPresent(path: string): Promise<string | undefined> {
-  try {
-    if (!(await pathExists(path))) {
-      return undefined;
-    }
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_CONFIG_UNREADABLE",
-      "Claude hook config metadata could not be read.",
-      { cause },
-    );
-  }
-  const backupPath = `${path}.bak.${new Date().toISOString().replaceAll(/[^0-9]/g, "")}`;
-  try {
-    await copyFile(path, backupPath);
-  } catch (cause) {
-    throw new ClaudeHookSetupError(
-      "CLAUDE_HOOK_WRITE_FAILED",
-      "Claude hook config backup could not be written.",
-      { cause },
-    );
-  }
-  return backupPath;
-}
+export const readOptionalFile = hookFiles.readOptionalFile;
+export const writeHookConfig = hookFiles.writeHookConfig;
+export const writeHookScript = hookFiles.writeHookScript;
+export const removeHookFileIfPresent = hookFiles.removeHookScriptIfPresent;
+export const backupIfPresent = hookFiles.backupIfPresent;

--- a/integrations/harness/claude/src/hooks/hookScript.ts
+++ b/integrations/harness/claude/src/hooks/hookScript.ts
@@ -1,46 +1,9 @@
-export type ClaudeHookScriptOptions = {
+import { expectedIngressHookScript, type IngressHookScriptOptions } from "@station/harness-shared";
+
+export type ClaudeHookScriptOptions = IngressHookScriptOptions & {
   hookScriptPath: string;
-  stationConfigPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  hookBin?: string;
 };
 
-function commandLine(args: string[]): string {
-  return args.map(shellQuote).join(" ");
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
-
 export function expectedClaudeHookScript(input: ClaudeHookScriptOptions): string {
-  const hookArgs = [input.hookBin ?? "stn-ingress"];
-  if (input.observerSocketPath !== undefined) {
-    hookArgs.push("--socket", input.observerSocketPath);
-  }
-  if (input.stateDir !== undefined) {
-    hookArgs.push("--state-dir", input.stateDir);
-  }
-  if (input.hookSpoolDir !== undefined) {
-    hookArgs.push("--spool-dir", input.hookSpoolDir);
-  }
-  if (input.stationConfigPath !== undefined) {
-    hookArgs.push("--config", input.stationConfigPath);
-  }
-  if (input.autoStartFromHooks === false) {
-    hookArgs.push("--no-auto-start");
-  }
-  hookArgs.push("claude");
-  return [
-    "#!/usr/bin/env bash",
-    "set -euo pipefail",
-    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    "  exit 0",
-    "fi",
-    `${commandLine(hookArgs)} > /dev/null 2>&1 || true`,
-    "",
-  ].join("\n");
+  return expectedIngressHookScript({ ...input, provider: "claude", swallowErrors: true });
 }

--- a/integrations/harness/claude/src/hooks/hookSettings.ts
+++ b/integrations/harness/claude/src/hooks/hookSettings.ts
@@ -1,4 +1,13 @@
 import {
+  expectedNestedHookSettings,
+  generatedNestedHookEvents,
+  missingNestedHookEvents,
+  type NestedHookDocument,
+  type NestedHookDocumentSpec,
+  nestedDocumentContainsCommand,
+  removeGeneratedNestedHookEntries,
+} from "@station/harness-shared";
+import {
   CLAUDE_HOOK_EVENT_NAMES,
   type ClaudeHookEventName,
   GENERATED_HOOK_SCRIPT_NAME,
@@ -6,7 +15,14 @@ import {
 } from "./hookConstants.js";
 import { ClaudeHookSetupError } from "./hookErrors.js";
 
-export type ClaudeSettingsDocument = Record<string, unknown>;
+export type ClaudeSettingsDocument = NestedHookDocument;
+
+const claudeHookDocumentSpec: NestedHookDocumentSpec<ClaudeHookEventName> = {
+  eventNames: CLAUDE_HOOK_EVENT_NAMES,
+  generatedScriptName: GENERATED_HOOK_SCRIPT_NAME,
+  statusMessage: GENERATED_HOOK_STATUS_MESSAGE,
+  matcherForEvent,
+};
 
 function matcherForEvent(eventName: ClaudeHookEventName): string | undefined {
   if (eventName === "PreToolUse" || eventName === "PostToolUse") {
@@ -15,86 +31,14 @@ function matcherForEvent(eventName: ClaudeHookEventName): string | undefined {
   return undefined;
 }
 
-function generatedHookCommand(hookScriptPath: string): Record<string, unknown> {
-  return {
-    type: "command",
-    command: hookScriptPath,
-    timeout: 30,
-    statusMessage: GENERATED_HOOK_STATUS_MESSAGE,
-  };
-}
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isGeneratedStationHookCommand(value: unknown): boolean {
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (value.type !== "command" || typeof value.command !== "string") {
-    return false;
-  }
-  if (value.command.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`)) {
-    return true;
-  }
-  return (
-    value.statusMessage === GENERATED_HOOK_STATUS_MESSAGE &&
-    value.command.includes(GENERATED_HOOK_SCRIPT_NAME)
-  );
-}
-
-function hookEntriesOf(document: ClaudeSettingsDocument, eventName: string): unknown[] {
-  const hooks = document.hooks;
-  if (!isRecord(hooks)) {
-    return [];
-  }
-  const entries = hooks[eventName];
-  return Array.isArray(entries) ? entries : [];
-}
-
-function entryContainsGeneratedCommand(entry: unknown): boolean {
-  if (!isRecord(entry) || !Array.isArray(entry.hooks)) {
-    return false;
-  }
-  return entry.hooks.some((command) => isGeneratedStationHookCommand(command));
-}
-
-function entryContainsCommandPath(entry: unknown, hookScriptPath: string): boolean {
-  if (!isRecord(entry) || !Array.isArray(entry.hooks)) {
-    return false;
-  }
-  return entry.hooks.some((command) => isRecord(command) && command.command === hookScriptPath);
-}
-
-function cleanEntry(entry: unknown): unknown | undefined {
-  if (!isRecord(entry) || !Array.isArray(entry.hooks)) {
-    return entry;
-  }
-  const remaining = entry.hooks.filter((command) => !isGeneratedStationHookCommand(command));
-  if (remaining.length === 0) {
-    return undefined;
-  }
-  if (remaining.length === entry.hooks.length) {
-    return entry;
-  }
-  return { ...entry, hooks: remaining };
 }
 
 export function expectedClaudeHookSettings(input: {
   hookScriptPath: string;
 }): ClaudeSettingsDocument {
-  const hooks: Record<string, unknown> = {};
-  for (const eventName of CLAUDE_HOOK_EVENT_NAMES) {
-    const entry: Record<string, unknown> = {};
-    const matcher = matcherForEvent(eventName);
-    if (matcher !== undefined) {
-      entry.matcher = matcher;
-    }
-    entry.hooks = [generatedHookCommand(input.hookScriptPath)];
-    hooks[eventName] = [entry];
-  }
-  return { hooks };
+  return expectedNestedHookSettings(claudeHookDocumentSpec, input);
 }
 
 export function stringifyClaudeSettings(document: ClaudeSettingsDocument): string {
@@ -128,66 +72,25 @@ export function missingClaudeHookEvents(
   document: ClaudeSettingsDocument,
   hookScriptPath: string,
 ): ClaudeHookEventName[] {
-  return CLAUDE_HOOK_EVENT_NAMES.filter(
-    (eventName) =>
-      !hookEntriesOf(document, eventName).some((entry) =>
-        entryContainsCommandPath(entry, hookScriptPath),
-      ),
-  );
+  const commands = Object.fromEntries(
+    CLAUDE_HOOK_EVENT_NAMES.map((eventName) => [eventName, hookScriptPath]),
+  ) as Record<ClaudeHookEventName, string>;
+  return missingNestedHookEvents(document, commands, claudeHookDocumentSpec);
 }
 
 export function generatedClaudeHookEvents(document: ClaudeSettingsDocument): string[] {
-  const hooks = document.hooks;
-  if (!isRecord(hooks)) {
-    return [];
-  }
-  return Object.keys(hooks)
-    .filter((eventName) =>
-      hookEntriesOf(document, eventName).some((entry) => entryContainsGeneratedCommand(entry)),
-    )
-    .sort();
+  return generatedNestedHookEvents(document, claudeHookDocumentSpec);
 }
 
 export function removeGeneratedClaudeHookEntries(
   document: ClaudeSettingsDocument,
 ): ClaudeSettingsDocument {
-  const hooks = document.hooks;
-  if (!isRecord(hooks)) {
-    return document;
-  }
-  const cleanedHooks: Record<string, unknown> = {};
-  for (const [eventName, entries] of Object.entries(hooks)) {
-    if (!Array.isArray(entries)) {
-      cleanedHooks[eventName] = entries;
-      continue;
-    }
-    const cleanedEntries = entries
-      .map((entry) => cleanEntry(entry))
-      .filter((entry) => entry !== undefined);
-    if (cleanedEntries.length > 0) {
-      cleanedHooks[eventName] = cleanedEntries;
-    }
-  }
-  const cleaned: ClaudeSettingsDocument = { ...document };
-  if (Object.keys(cleanedHooks).length > 0) {
-    cleaned.hooks = cleanedHooks;
-  } else {
-    delete cleaned.hooks;
-  }
-  return cleaned;
+  return removeGeneratedNestedHookEntries(document, claudeHookDocumentSpec);
 }
 
 export function settingsDocumentContainsCommand(
   document: ClaudeSettingsDocument,
   hookScriptPath: string,
 ): boolean {
-  const hooks = document.hooks;
-  if (!isRecord(hooks)) {
-    return false;
-  }
-  return Object.keys(hooks).some((eventName) =>
-    hookEntriesOf(document, eventName).some((entry) =>
-      entryContainsCommandPath(entry, hookScriptPath),
-    ),
-  );
+  return nestedDocumentContainsCommand(document, hookScriptPath);
 }

--- a/integrations/harness/claude/src/launch.ts
+++ b/integrations/harness/claude/src/launch.ts
@@ -3,6 +3,13 @@ import type {
   HarnessLaunchPlan,
   HarnessPermissionMode,
 } from "@station/contracts";
+import {
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  isYoloPermissionMode,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { ClaudeHarnessProviderError } from "./errors.js";
 
 export type ClaudePermissionMode = HarnessPermissionMode | "auto";
@@ -16,79 +23,8 @@ export type ClaudeLaunchOptions = {
   hookSettingsPath?: string;
 };
 
-type ClaudeProviderDataInput = {
-  mode: "interactive" | "exec";
-  initialPromptProvided: boolean;
-  profile?: string | undefined;
-  permissionMode?: ClaudePermissionMode | undefined;
-  settingsInjected?: boolean | undefined;
-  terminalProvider?: string | undefined;
-  terminalTargetId?: string | undefined;
-  resume?: boolean | undefined;
-  resumeTargetKind?: string | undefined;
-};
-
 const CLAUDE_YOLO_FLAG = "--dangerously-skip-permissions";
 const CLAUDE_PERMISSION_MODE_FLAG = "--permission-mode";
-
-function isYoloPermissionMode(input: {
-  permissionMode?: ClaudePermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-}): boolean {
-  if (input.permissionMode !== undefined) {
-    return input.permissionMode === "yolo";
-  }
-  return input.approvalPolicy === "never" && input.sandboxMode === "danger-full-access";
-}
-
-function claudeLaunchEnv(request: BuildHarnessLaunchRequest): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "claude",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
-  }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  return env;
-}
-
-function claudeProviderData(input: ClaudeProviderDataInput): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: input.mode === "interactive",
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.profile !== undefined) {
-    providerData.profile = input.profile;
-  }
-  if (input.permissionMode !== undefined) {
-    providerData.permissionMode = input.permissionMode;
-  }
-  if (input.settingsInjected === true) {
-    providerData.settingsInjected = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  if (input.resume === true) {
-    providerData.resume = true;
-  }
-  if (input.resumeTargetKind !== undefined) {
-    providerData.resumeTargetKind = input.resumeTargetKind;
-  }
-  return providerData;
-}
 
 function buildClaudeResumeLaunchPlan(
   request: BuildHarnessLaunchRequest,
@@ -121,14 +57,15 @@ function buildClaudeResumeLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const providerDataInput: ClaudeProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
     resume: true,
     resumeTargetKind: request.resume.target.kind,
   };
+  const providerData = commonProviderData(providerDataInput);
   if (options.hookSettingsPath !== undefined) {
-    providerDataInput.settingsInjected = true;
+    providerData.settingsInjected = true;
   }
 
   return {
@@ -136,10 +73,10 @@ function buildClaudeResumeLaunchPlan(
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: claudeLaunchEnv(request),
+    env: harnessLaunchEnv("claude", request),
     mode,
     displayTitle: `${request.project.label} Claude`,
-    providerData: claudeProviderData(providerDataInput),
+    providerData,
   };
 }
 
@@ -178,9 +115,10 @@ export function buildClaudeLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const providerDataInput: ClaudeProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    ...terminalProviderData(request),
   };
   if (profile !== undefined) {
     providerDataInput.profile = profile;
@@ -188,22 +126,17 @@ export function buildClaudeLaunchPlan(
   if (providerPermissionMode !== undefined) {
     providerDataInput.permissionMode = providerPermissionMode;
   }
-  if (options.hookSettingsPath !== undefined) {
-    providerDataInput.settingsInjected = true;
-  }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
+  const providerData = commonProviderData(providerDataInput);
+  if (options.hookSettingsPath !== undefined) providerData.settingsInjected = true;
 
   return {
     provider: "claude",
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: claudeLaunchEnv(request),
+    env: harnessLaunchEnv("claude", request),
     mode,
     displayTitle: `${request.project.label} Claude`,
-    providerData: claudeProviderData(providerDataInput),
+    providerData,
   };
 }

--- a/integrations/harness/claude/src/provider.ts
+++ b/integrations/harness/claude/src/provider.ts
@@ -1,31 +1,13 @@
-import type {
-  BuildHarnessLaunchRequest,
-  HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
-  HarnessHooksStatus,
-  HarnessLaunchPlan,
-  HarnessProvider,
-  HarnessRunObservation,
-  HarnessStatusObservation,
-  ProviderDoctorCheck,
-  ProviderDoctorContext,
-  ProviderHealth,
-  RawHarnessEvent,
-} from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import type { HarnessCapabilities } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  safeErrorFromUnknown,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  hookOptions,
+  type TerminalBoundHarnessProviderSpec,
+  TerminalBoundHarnessProviderWithHooksStatus,
+} from "@station/harness-shared";
+import { runExternalCommand } from "@station/runtime";
 import { classifyClaudeRunStatus } from "./classify.js";
-import { claudeProviderErrorFromUnknown } from "./errors.js";
+import { ClaudeHarnessProviderError } from "./errors.js";
 import { normalizeClaudeRawEvent } from "./events.js";
 import { doctorClaudeHooks, resolveClaudeSettingsArtifactPath } from "./hooks.js";
 import {
@@ -34,24 +16,17 @@ import {
   type ClaudePermissionMode,
 } from "./launch.js";
 
-export type ClaudeHarnessProviderOptions = {
-  command?: string;
+export type ClaudeHarnessProviderOptions = CommonHarnessProviderOptions & {
   profile?: string;
   permissionMode?: ClaudePermissionMode;
   approvalPolicy?: string;
   sandboxMode?: string;
-  installHooks?: boolean;
   claudeSettingsPath?: string;
   claudeConfigDir?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  resume?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
+
+type ClaudeHookOptions = Parameters<typeof doctorClaudeHooks>[0];
+type ClaudeHookResult = Awaited<ReturnType<typeof doctorClaudeHooks>>;
 
 const baseCapabilities: HarnessCapabilities = {
   canLaunch: true,
@@ -66,13 +41,121 @@ const baseCapabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: false,
 };
 
-function command(options: ClaudeHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_CLAUDE_BIN ?? "claude";
-}
+const claudeProviderSpec = {
+  id: "claude",
+  displayName: "Claude Code",
+  command: {
+    envVar: "STATION_CLAUDE_BIN",
+    fallback: "claude",
+  },
+  baseCapabilities,
+  health: {
+    args: ["--version"],
+    unavailable: {
+      code: "HARNESS_CLAUDE_UNAVAILABLE",
+      message: "Claude Code is not available.",
+      hint: "Install Claude Code and ensure `claude --version` succeeds, or configure [harness.claude].command (env override: STATION_CLAUDE_BIN).",
+    },
+    diagnostics: (result) => ({
+      version: result.stdout.trim(),
+    }),
+    okDoctorCheck: {
+      name: "claude.version",
+      okMessage: "Claude Code command is available.",
+      errorMessage: "Claude Code is unavailable.",
+      stopOnFailure: true,
+    },
+  },
+  hooks: {
+    doctor: doctorClaudeHooks,
+    buildOptions: claudeHookOptions,
+    checkName: "claude-hooks",
+    failure: {
+      tag: "ClaudeHookSetupError",
+      code: "CLAUDE_HOOK_DIAGNOSTIC_FAILED",
+      message: "Claude hook diagnostics failed.",
+    },
+    formatCheckMessage: (result) =>
+      `${result.message} Settings artifact: ${result.settingsPath}. User settings: ${result.userSettingsPath}. Script: ${result.hookScriptPath}.`,
+    exposeHooksStatus: true,
+  },
+  extraDoctorChecks: async (options, provider) => {
+    try {
+      const result = await runExternalCommand(
+        {
+          command: provider.command(),
+          args: ["auth", "status"],
+          timeoutMs: options.timeoutMs ?? 5000,
+          maxOutputChars: 4096,
+        },
+        options.runner,
+      );
+      const loggedIn = parseLoggedIn(result.stdout);
+      if (loggedIn === true) {
+        return [
+          {
+            name: "claude.auth",
+            status: "ok",
+            message: "Claude Code authentication is available.",
+          },
+        ];
+      }
+      return [
+        {
+          name: "claude.auth",
+          status: "warn",
+          message:
+            "Claude Code does not report an authenticated login. Sessions will stall at a login screen; run `claude` once to log in.",
+        },
+      ];
+    } catch (cause) {
+      return [
+        {
+          name: "claude.auth",
+          status: "warn",
+          message: "Claude Code authentication status could not be determined.",
+          error: new ClaudeHarnessProviderError(
+            "HARNESS_CLAUDE_UNAVAILABLE",
+            "`claude auth status` failed.",
+            { cause },
+          ),
+        },
+      ];
+    }
+  },
+  buildLaunchOptions: (options, command) => {
+    const launchOptions: ClaudeLaunchOptions = { command };
+    if (options.profile !== undefined) launchOptions.defaultProfile = options.profile;
+    if (options.permissionMode !== undefined) {
+      launchOptions.defaultPermissionMode = options.permissionMode;
+    }
+    if (options.approvalPolicy !== undefined) {
+      launchOptions.defaultApprovalPolicy = options.approvalPolicy;
+    }
+    if (options.sandboxMode !== undefined) launchOptions.defaultSandboxMode = options.sandboxMode;
+    if (options.installHooks === true) {
+      launchOptions.hookSettingsPath = resolveClaudeSettingsArtifactPath(hookPathOptions(options));
+    }
+    return launchOptions;
+  },
+  buildLaunch: buildClaudeLaunchPlan,
+  classifyRun: (run) => classifyClaudeRunStatus(run),
+  normalizeEvent: normalizeClaudeRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<
+  ClaudeHarnessProviderOptions,
+  ClaudeLaunchOptions,
+  ClaudeHookOptions,
+  ClaudeHookResult
+>;
 
-function now(options: ClaudeHarnessProviderOptions): string {
-  const value = options.now?.() ?? systemClock.now();
-  return toIsoTimestamp(value instanceof Date ? value : new Date(value));
+function claudeHookOptions(
+  options: ClaudeHarnessProviderOptions,
+  context?: Parameters<typeof hookOptions>[1],
+): ClaudeHookOptions {
+  return {
+    ...hookPathOptions(options),
+    ...hookOptions(options, context),
+  };
 }
 
 function hookPathOptions(
@@ -85,9 +168,7 @@ function hookPathOptions(
   if (options.claudeConfigDir !== undefined) {
     pathOptions.claudeConfigDir = options.claudeConfigDir;
   }
-  if (options.stateDir !== undefined) {
-    pathOptions.stateDir = options.stateDir;
-  }
+  if (options.stateDir !== undefined) pathOptions.stateDir = options.stateDir;
   return pathOptions;
 }
 
@@ -104,248 +185,13 @@ function parseLoggedIn(stdout: string): boolean | undefined {
   return undefined;
 }
 
-function capabilities(options: ClaudeHarnessProviderOptions): HarnessCapabilities {
-  // Adapter support alone is not enough; resume stays invisible unless this
-  // provider instance is explicitly enabled by [harness.claude].resume.
-  return {
-    ...baseCapabilities,
-    canResume: options.resume === true,
-  };
-}
-
-export class ClaudeHarnessProvider implements HarnessProvider {
-  readonly id = "claude";
-
-  readonly #options: ClaudeHarnessProviderOptions;
-
+export class ClaudeHarnessProvider extends TerminalBoundHarnessProviderWithHooksStatus<
+  ClaudeHarnessProviderOptions,
+  ClaudeLaunchOptions,
+  ClaudeHookOptions,
+  ClaudeHookResult
+> {
   constructor(options: ClaudeHarnessProviderOptions = {}) {
-    this.#options = options;
-  }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities(this.#options);
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = now(this.#options);
-    try {
-      const result = await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["--version"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities: this.capabilities(),
-        diagnostics: {
-          version: result.stdout.trim(),
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: claudeProviderErrorFromUnknown(error, {
-          code: "HARNESS_CLAUDE_UNAVAILABLE",
-          message: "Claude Code is not available.",
-          hint: "Install Claude Code and ensure `claude --version` succeeds, or configure [harness.claude].command (env override: STATION_CLAUDE_BIN).",
-        }),
-        capabilities: this.capabilities(),
-      };
-    }
-  }
-
-  async doctorChecks(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
-    const checks: ProviderDoctorCheck[] = [];
-    const health = await this.health();
-    if (health.status === "healthy") {
-      checks.push({
-        name: "claude.version",
-        status: "ok",
-        message: "Claude Code command is available.",
-      });
-    } else {
-      const check: ProviderDoctorCheck = {
-        name: "claude.version",
-        status: "error",
-        message: "Claude Code is unavailable.",
-      };
-      if (health.lastError !== undefined) {
-        check.error = health.lastError;
-      }
-      checks.push(check);
-      return checks;
-    }
-
-    // `claude --version` succeeds while logged out, so launchability needs a separate auth probe.
-    try {
-      const result = await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["auth", "status"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      const loggedIn = parseLoggedIn(result.stdout);
-      if (loggedIn === true) {
-        checks.push({
-          name: "claude.auth",
-          status: "ok",
-          message: "Claude Code authentication is available.",
-        });
-      } else {
-        checks.push({
-          name: "claude.auth",
-          status: "warn",
-          message:
-            "Claude Code does not report an authenticated login. Sessions will stall at a login screen; run `claude` once to log in.",
-        });
-      }
-    } catch (cause) {
-      checks.push({
-        name: "claude.auth",
-        status: "warn",
-        message: "Claude Code authentication status could not be determined.",
-        error: claudeProviderErrorFromUnknown(cause, {
-          code: "HARNESS_CLAUDE_UNAVAILABLE",
-          message: "`claude auth status` failed.",
-        }),
-      });
-    }
-
-    try {
-      const hookOptions: Parameters<typeof doctorClaudeHooks>[0] = {
-        ...hookPathOptions(this.#options),
-        enabled: this.#options.installHooks === true,
-      };
-      if (this.#options.observerSocketPath !== undefined) {
-        hookOptions.observerSocketPath = this.#options.observerSocketPath;
-      }
-      if (this.#options.hookSpoolDir !== undefined) {
-        hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-      }
-      if (this.#options.autoStartFromHooks !== undefined) {
-        hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-      }
-      if (context?.stationConfigPath !== undefined) {
-        hookOptions.stationConfigPath = context.stationConfigPath;
-      }
-      const hookResult = await doctorClaudeHooks(hookOptions);
-      checks.push({
-        name: "claude-hooks",
-        status: hookResult.status,
-        message: `${hookResult.message} Settings artifact: ${hookResult.settingsPath}. User settings: ${hookResult.userSettingsPath}. Script: ${hookResult.hookScriptPath}.`,
-      });
-    } catch (cause) {
-      checks.push({
-        name: "claude-hooks",
-        status: "error",
-        message: "Claude hook diagnostics failed.",
-        error: safeErrorFromUnknown(cause, {
-          tag: "ClaudeHookSetupError",
-          code: "CLAUDE_HOOK_DIAGNOSTIC_FAILED",
-          message: "Claude hook diagnostics failed.",
-          provider: this.id,
-        }),
-      });
-    }
-    return checks;
-  }
-
-  async hooksStatus(context?: ProviderDoctorContext): Promise<HarnessHooksStatus> {
-    const hookOptions: Parameters<typeof doctorClaudeHooks>[0] = {
-      ...hookPathOptions(this.#options),
-      enabled: this.#options.installHooks === true,
-    };
-    if (this.#options.observerSocketPath !== undefined) {
-      hookOptions.observerSocketPath = this.#options.observerSocketPath;
-    }
-    if (this.#options.hookSpoolDir !== undefined) {
-      hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-    }
-    if (this.#options.autoStartFromHooks !== undefined) {
-      hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-    }
-    if (context?.stationConfigPath !== undefined) {
-      hookOptions.stationConfigPath = context.stationConfigPath;
-    }
-    const hookResult = await doctorClaudeHooks(hookOptions);
-    return {
-      provider: this.id,
-      installed: hookResult.installed,
-      requested: this.#options.installHooks === true,
-      missing: hookResult.missing.map((name) => String(name)),
-      message: hookResult.message,
-    };
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: ClaudeLaunchOptions = {
-      command: command(this.#options),
-    };
-    if (this.#options.profile !== undefined) {
-      options.defaultProfile = this.#options.profile;
-    }
-    if (this.#options.permissionMode !== undefined) {
-      options.defaultPermissionMode = this.#options.permissionMode;
-    }
-    if (this.#options.approvalPolicy !== undefined) {
-      options.defaultApprovalPolicy = this.#options.approvalPolicy;
-    }
-    if (this.#options.sandboxMode !== undefined) {
-      options.defaultSandboxMode = this.#options.sandboxMode;
-    }
-    if (this.#options.installHooks === true) {
-      options.hookSettingsPath = resolveClaudeSettingsArtifactPath(hookPathOptions(this.#options));
-    }
-    return buildClaudeLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "Claude Code",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyClaudeRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.claude.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_CLAUDE_EVENT_INGEST_FAILED",
-          message: "The Claude Code harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizeClaudeRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
+    super(claudeProviderSpec, options);
   }
 }

--- a/integrations/harness/codex/src/compaction.ts
+++ b/integrations/harness/codex/src/compaction.ts
@@ -1,15 +1,6 @@
-export type CodexPayloadCompactionResult = {
-  payload: unknown;
-  compacted: boolean;
-  originalByteCount: number | null;
-  compactedByteCount: number | null;
-  omittedFieldNames: string[];
-};
+import { compactPayloadByFieldNames, type PayloadCompactionResult } from "@station/harness-shared";
 
-type CompactFieldMetadata = {
-  compacted: true;
-  originalBytes: number | null;
-};
+export type CodexPayloadCompactionResult = PayloadCompactionResult;
 
 const commonFieldNames = [
   "session_id",
@@ -28,128 +19,14 @@ const commonFieldNames = [
 
 const turnFieldNames = ["turn_id", "agent_id", "agent_type"] as const;
 
-const compactedFieldNames = new Set([
-  "tool_input",
-  "tool_response",
-  "prompt",
-  "last_assistant_message",
-]);
-
 export function compactCodexHookPayload(payload: unknown): CodexPayloadCompactionResult {
-  const originalByteCount = jsonByteCount(payload);
-  if (!isRecord(payload)) {
-    return {
-      payload,
-      compacted: false,
-      originalByteCount,
-      compactedByteCount: originalByteCount,
-      omittedFieldNames: [],
-    };
-  }
-
-  const output: Record<string, unknown> = {};
-  const copiedFields = new Set<string>();
-  const omittedFieldNames = new Set<string>();
-  const eventName = typeof payload.hook_event_name === "string" ? payload.hook_event_name : "";
-
-  for (const fieldName of fieldNamesForEvent(eventName)) {
-    if (!hasOwn(payload, fieldName) || compactedFieldNames.has(fieldName)) {
-      continue;
-    }
-    output[fieldName] = payload[fieldName];
-    copiedFields.add(fieldName);
-  }
-
-  compactObjectField(payload, output, copiedFields, omittedFieldNames, "tool_input");
-  compactObjectField(payload, output, copiedFields, omittedFieldNames, "tool_response");
-  compactStringField(payload, output, copiedFields, omittedFieldNames, "prompt");
-  compactAssistantMessage(payload, output, copiedFields, omittedFieldNames);
-
-  for (const fieldName of Object.keys(payload)) {
-    if (copiedFields.has(fieldName)) {
-      continue;
-    }
-    omittedFieldNames.add(fieldName);
-  }
-
-  const compacted = omittedFieldNames.size > 0;
-  return {
-    payload: output,
-    compacted,
-    originalByteCount,
-    compactedByteCount: jsonByteCount(output),
-    omittedFieldNames: [...omittedFieldNames].sort(),
-  };
-}
-
-function jsonByteCount(value: unknown): number | null {
-  try {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      return null;
-    }
-    return Buffer.byteLength(serialized, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-function compactObjectField(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-  fieldName: "tool_input" | "tool_response",
-) {
-  if (!hasOwn(input, fieldName)) {
-    return;
-  }
-  output[fieldName] = compactFieldMetadata(input[fieldName]);
-  copiedFields.add(fieldName);
-  omittedFieldNames.add(fieldName);
-}
-
-function compactStringField(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-  fieldName: "prompt",
-) {
-  if (!hasOwn(input, fieldName)) {
-    return;
-  }
-  output[fieldName] = compactedTextPlaceholder(fieldName, jsonByteCount(input[fieldName]));
-  copiedFields.add(fieldName);
-  omittedFieldNames.add(fieldName);
-}
-
-function compactAssistantMessage(
-  input: Record<string, unknown>,
-  output: Record<string, unknown>,
-  copiedFields: Set<string>,
-  omittedFieldNames: Set<string>,
-) {
-  if (!hasOwn(input, "last_assistant_message")) {
-    return;
-  }
-  output.last_assistant_message = null;
-  copiedFields.add("last_assistant_message");
-  if (input.last_assistant_message !== null) {
-    omittedFieldNames.add("last_assistant_message");
-  }
-}
-
-function compactFieldMetadata(value: unknown): CompactFieldMetadata {
-  return {
-    compacted: true,
-    originalBytes: jsonByteCount(value),
-  };
-}
-
-function compactedTextPlaceholder(fieldName: string, byteCount: number | null): string {
-  const bytes = byteCount === null ? "unknown" : String(byteCount);
-  return `[station compacted ${fieldName}: ${bytes} bytes]`;
+  return compactPayloadByFieldNames(payload, {
+    retainedFieldNames: (record) =>
+      fieldNamesForEvent(typeof record.hook_event_name === "string" ? record.hook_event_name : ""),
+    compactObjectFieldNames: ["tool_input", "tool_response"],
+    compactStringFieldNames: ["prompt"],
+    nullWhenPresentFieldNames: ["last_assistant_message"],
+  });
 }
 
 function fieldNamesForEvent(eventName: string): string[] {
@@ -199,12 +76,4 @@ function fieldNamesForEvent(eventName: string): string[] {
   }
   fields.push(...turnFieldNames, "source", "trigger", "tool_name", "tool_use_id");
   return fields;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(value, key);
 }

--- a/integrations/harness/codex/src/errors.ts
+++ b/integrations/harness/codex/src/errors.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import { harnessProviderErrorClass } from "@station/harness-shared";
 
 export type CodexHarnessErrorCode =
   | "HARNESS_CODEX_UNAVAILABLE"
@@ -7,51 +7,11 @@ export type CodexHarnessErrorCode =
   | "HARNESS_CODEX_EVENT_UNSUPPORTED"
   | "HARNESS_CODEX_EVENT_INGEST_FAILED";
 
-export class CodexHarnessProviderError extends Error implements SafeError {
-  readonly tag = "HarnessProviderError";
-  readonly code: CodexHarnessErrorCode;
-  readonly provider = "codex";
-  readonly hint: string | undefined;
+export const CodexHarnessProviderError = harnessProviderErrorClass<CodexHarnessErrorCode>({
+  name: "CodexHarnessProviderError",
+  provider: "codex",
+});
 
-  constructor(
-    code: CodexHarnessErrorCode,
-    message: string,
-    options: { cause?: unknown; hint?: string } = {},
-  ) {
-    super(`${code}: ${message}`, { cause: options.cause });
-    Object.defineProperty(this, "name", {
-      value: "CodexHarnessProviderError",
-      configurable: true,
-    });
-    this.code = code;
-    this.hint = options.hint;
-  }
-}
-
-export function codexHarnessError(
-  code: CodexHarnessErrorCode,
-  message: string,
-  cause?: unknown,
-): CodexHarnessProviderError {
+export function codexHarnessError(code: CodexHarnessErrorCode, message: string, cause?: unknown) {
   return new CodexHarnessProviderError(code, message, { cause });
-}
-
-export function codexProviderErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: CodexHarnessErrorCode;
-    message: string;
-    hint?: string | undefined;
-  },
-): CodexHarnessProviderError {
-  if (error instanceof CodexHarnessProviderError) {
-    return error;
-  }
-  const options: { cause?: unknown; hint?: string } = {
-    cause: error,
-  };
-  if (fallback.hint !== undefined) {
-    options.hint = fallback.hint;
-  }
-  return new CodexHarnessProviderError(fallback.code, fallback.message, options);
 }

--- a/integrations/harness/codex/src/events.ts
+++ b/integrations/harness/codex/src/events.ts
@@ -7,15 +7,14 @@ import type {
   HarnessEventReport,
   ObservedStatus,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
+import { HarnessEventReportSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
-  HarnessEventReportSchema,
-  observedPathIsSameOrInside,
-  STATION_SCHEMA_VERSION,
-  sameObservedPath,
-} from "@station/contracts";
+  applyCorrelation,
+  correlateTerminalBoundHarnessEvent,
+  harnessEventDiagnostics,
+  reportCorrelation,
+} from "@station/harness-shared";
 import { z } from "zod";
 import { codexHarnessError } from "./errors.js";
 
@@ -191,7 +190,12 @@ export function normalizeCodexRawEvent(
 ): HarnessEventObservation[] {
   const event = parseCodexHookEvent(raw.event);
   const observedAt = raw.observedAt ?? new Date().toISOString();
-  const correlation = correlateCodexEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "codex",
+    identity: event,
+    context,
+    cwd: event.cwd,
+  });
   const observation: HarnessEventObservation = {
     provider: "codex",
     rawEventType: event.hook_event_name,
@@ -203,15 +207,7 @@ export function normalizeCodexRawEvent(
   if (turn !== undefined) {
     observation.turn = turn;
   }
-  if (correlation.sessionId !== undefined) {
-    observation.sessionId = correlation.sessionId;
-  }
-  if (correlation.worktreeId !== undefined) {
-    observation.worktreeId = correlation.worktreeId;
-  }
-  if (correlation.harnessRunId !== undefined) {
-    observation.harnessRunId = correlation.harnessRunId;
-  }
+  applyCorrelation(observation, correlation);
   observation.nativeSessionId = event.session_id;
   return [observation];
 }
@@ -237,10 +233,7 @@ export function codexHookPayloadToHarnessEventReport(
   if (correlation !== undefined) {
     report.correlation = correlation;
   }
-  const diagnostics = reportDiagnosticsFromCodexEvent(event, input.diagnostics);
-  if (diagnostics !== undefined) {
-    report.diagnostics = diagnostics;
-  }
+  report.diagnostics = harnessEventDiagnostics(event.hook_event_name, input.diagnostics);
   const coalesceKey = reportCoalesceKeyFromCodexEvent(event);
   if (coalesceKey !== undefined) {
     report.coalesceKey = coalesceKey;
@@ -414,48 +407,14 @@ function providerDataFromCodexEvent(event: CodexHookEvent): Record<string, unkno
 function reportCorrelationFromCodexEvent(
   event: CodexHookEvent,
 ): HarnessEventReport["correlation"] | undefined {
-  const correlation: NonNullable<HarnessEventReport["correlation"]> = {
+  return reportCorrelation({
     cwd: event.cwd,
     nativeSessionId: event.session_id,
-  };
-  if (event.station_project_id !== undefined) {
-    correlation.projectId = event.station_project_id;
-  }
-  if (event.station_worktree_id !== undefined) {
-    correlation.worktreeId = event.station_worktree_id;
-  }
-  if (event.station_session_id !== undefined) {
-    correlation.sessionId = event.station_session_id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    correlation.terminalTargetId = event.station_terminal_target_id;
-  }
-  return correlation;
-}
-
-function reportDiagnosticsFromCodexEvent(
-  event: CodexHookEvent,
-  input: CodexHarnessEventReportInput["diagnostics"],
-): HarnessEventReport["diagnostics"] | undefined {
-  const diagnostics: NonNullable<HarnessEventReport["diagnostics"]> = {
-    rawEventType: event.hook_event_name,
-  };
-  if (typeof input?.payloadBytes === "number") {
-    diagnostics.payloadBytes = input.payloadBytes;
-  }
-  if (typeof input?.compactedBytes === "number") {
-    diagnostics.compactedBytes = input.compactedBytes;
-  }
-  if (input?.compacted !== undefined) {
-    diagnostics.compacted = input.compacted;
-  }
-  if (input?.truncated !== undefined) {
-    diagnostics.truncated = input.truncated;
-  }
-  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
-    diagnostics.omittedFieldNames = input.omittedFieldNames;
-  }
-  return diagnostics;
+    projectId: event.station_project_id,
+    worktreeId: event.station_worktree_id,
+    sessionId: event.station_session_id,
+    terminalTargetId: event.station_terminal_target_id,
+  });
 }
 
 function reportCoalesceKeyFromCodexEvent(event: CodexHookEvent): string | undefined {
@@ -491,96 +450,4 @@ function codexHookEventReportId(event: CodexHookEvent): string {
     parts.push(`source:${event.source}`);
   }
   return parts.map((part) => encodeURIComponent(part)).join(":");
-}
-
-function correlateCodexEvent(
-  event: CodexHookEvent,
-  context: HarnessEventContext,
-): {
-  sessionId?: string;
-  worktreeId?: string;
-  harnessRunId?: string;
-} {
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(event.cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(event.cwd, context.worktrees);
-  const result: {
-    sessionId?: string;
-    worktreeId?: string;
-    harnessRunId?: string;
-  } = {};
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (terminal?.harnessRunId !== undefined) {
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.harnessRunId = `codex:${terminal.id}`;
-  }
-  return result;
-}
-
-function terminalForId(
-  terminalTargetId: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (terminalTargetId === undefined) {
-    return undefined;
-  }
-  return targets.find((target) => target.id === terminalTargetId);
-}
-
-function terminalForCwd(
-  cwd: string,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  return (
-    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
-    targets.find(
-      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
-    )
-  );
-}
-
-function worktreeForId(
-  worktreeId: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreeId === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === worktreeId);
-}
-
-function worktreeForPath(
-  path: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (path === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => sameObservedPath(worktree.path, path));
-}
-
-function worktreeForCwd(
-  cwd: string,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  return (
-    worktrees.find((worktree) => sameObservedPath(worktree.path, cwd)) ??
-    worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path))
-  );
 }

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -1,6 +1,7 @@
 // Installs/uninstalls the STATION hook into Codex's hook config.
 // Upstream hook contract: https://developers.openai.com/codex/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import { ingressHookScriptOptions } from "@station/harness-shared";
 import {
   documentContainsCommand,
   generatedStationHookEvents,
@@ -23,11 +24,7 @@ import {
   resolveCodexConfigPath,
   resolveCodexHookScriptPath,
 } from "./hooks/hookPaths.js";
-import {
-  type CodexHookScriptOptions,
-  expectedCodexHookCommands,
-  expectedCodexHookScript,
-} from "./hooks/hookScript.js";
+import { expectedCodexHookCommands, expectedCodexHookScript } from "./hooks/hookScript.js";
 
 export { CODEX_HOOK_EVENT_NAMES, type CodexHookEventName } from "./hooks/hookConstants.js";
 export { CodexHookSetupError, type CodexHookSetupErrorCode } from "./hooks/hookErrors.js";
@@ -112,7 +109,7 @@ export async function planCodexHooks(options: CodexHookPlanOptions = {}): Promis
   const commands = expectedCodexHookCommands({ hookScriptPath });
   const afterDocument = installCodexHookCommands(document, commands);
   const after = stringifyTomlDocument(afterDocument);
-  const script = expectedCodexHookScript(scriptOptions(hookScriptPath, options));
+  const script = expectedCodexHookScript(ingressHookScriptOptions(hookScriptPath, options));
   const scriptBefore = await readOptionalFile(hookScriptPath);
   const configChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
@@ -159,7 +156,7 @@ export async function installCodexHooks(
   if (plan.scriptChanged) {
     await writeHookScript(
       plan.hookScriptPath,
-      expectedCodexHookScript(scriptOptions(plan.hookScriptPath, options)),
+      expectedCodexHookScript(ingressHookScriptOptions(plan.hookScriptPath, options)),
     );
   }
 
@@ -261,40 +258,6 @@ export async function doctorCodexHooks(
     generatedGlobalCleanup: plan.generatedGlobalCleanup,
     message: doctorMessage({ installed, generatedGlobalInstalled, plan }),
   };
-}
-
-function scriptOptions(
-  hookScriptPath: string,
-  options: Pick<
-    CodexHookPlanOptions,
-    | "stationConfigPath"
-    | "observerSocketPath"
-    | "stateDir"
-    | "hookSpoolDir"
-    | "autoStartFromHooks"
-    | "hookBin"
-  >,
-): CodexHookScriptOptions {
-  const input: CodexHookScriptOptions = { hookScriptPath };
-  if (options.stationConfigPath !== undefined) {
-    input.stationConfigPath = options.stationConfigPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    input.observerSocketPath = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    input.stateDir = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    input.hookSpoolDir = options.hookSpoolDir;
-  }
-  if (options.autoStartFromHooks !== undefined) {
-    input.autoStartFromHooks = options.autoStartFromHooks;
-  }
-  if (options.hookBin !== undefined) {
-    input.hookBin = options.hookBin;
-  }
-  return input;
 }
 
 function installResultFromPlan(plan: CodexHookPlan, installed: boolean): CodexHookInstallResult {

--- a/integrations/harness/codex/src/hooks/hookConfigEditor.ts
+++ b/integrations/harness/codex/src/hooks/hookConfigEditor.ts
@@ -1,5 +1,13 @@
+import {
+  generatedNestedHookEvents,
+  installNestedHookCommands,
+  missingNestedHookEvents,
+  type NestedHookDocument,
+  type NestedHookDocumentSpec,
+  nestedDocumentContainsCommand,
+  removeGeneratedNestedHookCommands,
+} from "@station/harness-shared";
 import { parse, stringify } from "smol-toml";
-import { z } from "zod";
 import {
   CODEX_HOOK_EVENT_NAMES,
   type CodexHookEventName,
@@ -8,150 +16,12 @@ import {
 } from "./hookConstants.js";
 import { CodexHookSetupError } from "./hookErrors.js";
 
-const tomlRecordSchema = z.record(z.string(), z.unknown());
-type TomlRecord = z.infer<typeof tomlRecordSchema>;
-
-export function parseTomlDocument(source: string): Record<string, unknown> {
-  if (source.trim().length === 0) {
-    return {};
-  }
-  try {
-    return parse(source) as Record<string, unknown>;
-  } catch (cause) {
-    throw new CodexHookSetupError("CODEX_HOOK_INVALID_TOML", "Codex config is not valid TOML.", {
-      cause,
-    });
-  }
-}
-
-export function stringifyTomlDocument(document: Record<string, unknown>): string {
-  const result = stringify(document);
-  return result.endsWith("\n") ? result : `${result}\n`;
-}
-
-export function installCodexHookCommands(
-  document: Record<string, unknown>,
-  commands: Record<CodexHookEventName, string>,
-): Record<string, unknown> {
-  const next = cloneRecord(document);
-  const hooksRecord = recordValue(next.hooks);
-  const hooks = hooksRecord === undefined ? {} : cloneRecord(hooksRecord);
-  for (const eventName of CODEX_HOOK_EVENT_NAMES) {
-    hooks[eventName] = withGeneratedHookEntry(hooks[eventName], eventName, commands[eventName]);
-  }
-  next.hooks = hooks;
-  return next;
-}
-
-export function removeGeneratedCodexHookCommands(
-  document: Record<string, unknown>,
-  commands: Record<CodexHookEventName, string>,
-): Record<string, unknown> {
-  const next = cloneRecord(document);
-  const hooksRecord = recordValue(next.hooks);
-  if (hooksRecord === undefined) {
-    return next;
-  }
-  const hooks = cloneRecord(hooksRecord);
-  for (const eventName of CODEX_HOOK_EVENT_NAMES) {
-    const value = withoutGeneratedHookEntry(hooks[eventName], commands[eventName]);
-    if (value === undefined) {
-      delete hooks[eventName];
-    } else {
-      hooks[eventName] = value;
-    }
-  }
-  if (Object.keys(hooks).length === 0) {
-    delete next.hooks;
-  } else {
-    next.hooks = hooks;
-  }
-  return next;
-}
-
-export function missingCodexHookEvents(
-  document: Record<string, unknown>,
-  commands: Record<CodexHookEventName, string>,
-): CodexHookEventName[] {
-  return CODEX_HOOK_EVENT_NAMES.filter(
-    (eventName) => !hookContainsCommand(document, eventName, commands[eventName]),
-  );
-}
-
-export function documentContainsCommand(
-  document: Record<string, unknown>,
-  command: string,
-): boolean {
-  const hooks = recordValue(document.hooks);
-  if (hooks === undefined) {
-    return false;
-  }
-  return Object.values(hooks).some((value) =>
-    hookEntries(value).some((entry) => hookEntryContainsCommand(entry, command)),
-  );
-}
-
-export function generatedStationHookEvents(
-  document: Record<string, unknown>,
-  commands: Record<CodexHookEventName, string>,
-): CodexHookEventName[] {
-  const hooks = recordValue(document.hooks);
-  if (hooks === undefined) {
-    return [];
-  }
-  return CODEX_HOOK_EVENT_NAMES.filter((eventName) =>
-    hookEntries(hooks[eventName]).some((entry) =>
-      hookEntryContainsGeneratedStationHook(entry, commands[eventName]),
-    ),
-  );
-}
-
-function withGeneratedHookEntry(
-  value: unknown,
-  eventName: CodexHookEventName,
-  command: string,
-): unknown {
-  const cleanedValue = withoutGeneratedHookEntry(value, command);
-  const entries = hookEntries(cleanedValue);
-  if (entries.some((entry) => hookEntryContainsCommand(entry, command))) {
-    return entries;
-  }
-  const nextEntries = entries.slice();
-  nextEntries.push(generatedHookEntry(eventName, command));
-  return nextEntries;
-}
-
-function withoutGeneratedHookEntry(value: unknown, command: string): unknown {
-  const entries = hookEntries(value);
-  if (value !== undefined && entries.length === 0) {
-    return value;
-  }
-  const nextEntries = entries
-    .map((entry) => withoutGeneratedHooksFromEntry(entry, command))
-    .filter((entry) => entry !== undefined);
-  return nextEntries.length === 0 ? undefined : nextEntries;
-}
-
-function generatedHookEntry(
-  eventName: CodexHookEventName,
-  command: string,
-): Record<string, unknown> {
-  const entry: Record<string, unknown> = {
-    hooks: [
-      {
-        type: "command",
-        command,
-        timeout: 30,
-        statusMessage: GENERATED_HOOK_STATUS_MESSAGE,
-      },
-    ],
-  };
-  const matcher = matcherForEvent(eventName);
-  if (matcher !== undefined) {
-    entry.matcher = matcher;
-  }
-  return entry;
-}
+const codexHookDocumentSpec: NestedHookDocumentSpec<CodexHookEventName> = {
+  eventNames: CODEX_HOOK_EVENT_NAMES,
+  generatedScriptName: GENERATED_HOOK_SCRIPT_NAME,
+  statusMessage: GENERATED_HOOK_STATUS_MESSAGE,
+  matcherForEvent,
+};
 
 function matcherForEvent(eventName: CodexHookEventName): string | undefined {
   if (eventName === "SessionStart") return "startup|resume|clear|compact";
@@ -165,107 +35,52 @@ function matcherForEvent(eventName: CodexHookEventName): string | undefined {
   return undefined;
 }
 
-function hookContainsCommand(
-  document: Record<string, unknown>,
-  eventName: CodexHookEventName,
-  command: string,
-): boolean {
-  const hooks = recordValue(document.hooks);
-  if (hooks === undefined) {
-    return false;
+export function parseTomlDocument(source: string): NestedHookDocument {
+  if (source.trim().length === 0) {
+    return {};
   }
-  return hookEntries(hooks[eventName]).some((entry) => hookEntryContainsCommand(entry, command));
-}
-
-function hookEntries(value: unknown): Record<string, unknown>[] {
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => {
-      const parsed = recordValue(entry);
-      return parsed === undefined ? [] : [parsed];
+  try {
+    return parse(source) as NestedHookDocument;
+  } catch (cause) {
+    throw new CodexHookSetupError("CODEX_HOOK_INVALID_TOML", "Codex config is not valid TOML.", {
+      cause,
     });
   }
-  const parsed = recordValue(value);
-  if (parsed !== undefined) {
-    return [parsed];
-  }
-  return [];
 }
 
-function hookEntryContainsCommand(entry: Record<string, unknown>, command: string): boolean {
-  const hooks = entry.hooks;
-  if (!Array.isArray(hooks)) {
-    return false;
-  }
-  return hooks.some((hook) => recordValue(hook)?.command === command);
+export function stringifyTomlDocument(document: NestedHookDocument): string {
+  const result = stringify(document);
+  return result.endsWith("\n") ? result : `${result}\n`;
 }
 
-function hookEntryContainsGeneratedStationHook(
-  entry: Record<string, unknown>,
-  command: string,
-): boolean {
-  const hooks = entry.hooks;
-  if (!Array.isArray(hooks)) {
-    return false;
-  }
-  return hooks.some((hook) => isGeneratedStationHook(hook, command));
+export function installCodexHookCommands(
+  document: NestedHookDocument,
+  commands: Record<CodexHookEventName, string>,
+): NestedHookDocument {
+  return installNestedHookCommands(document, commands, codexHookDocumentSpec);
 }
 
-function isGeneratedStationHook(hook: unknown, command: string): boolean {
-  const hookRecord = recordValue(hook);
-  if (hookRecord === undefined || typeof hookRecord.command !== "string") {
-    return false;
-  }
-  if (hookRecord.command === command) {
-    return true;
-  }
-  return (
-    hookRecord.type === "command" &&
-    hookRecord.statusMessage === GENERATED_HOOK_STATUS_MESSAGE &&
-    commandLooksLikeGeneratedHookScript(hookRecord.command)
-  );
+export function removeGeneratedCodexHookCommands(
+  document: NestedHookDocument,
+  commands: Record<CodexHookEventName, string>,
+): NestedHookDocument {
+  return removeGeneratedNestedHookCommands(document, commands, codexHookDocumentSpec);
 }
 
-function commandLooksLikeGeneratedHookScript(command: string): boolean {
-  return (
-    command === GENERATED_HOOK_SCRIPT_NAME || command.endsWith(`/${GENERATED_HOOK_SCRIPT_NAME}`)
-  );
+export function missingCodexHookEvents(
+  document: NestedHookDocument,
+  commands: Record<CodexHookEventName, string>,
+): CodexHookEventName[] {
+  return missingNestedHookEvents(document, commands, codexHookDocumentSpec);
 }
 
-function withoutGeneratedHooksFromEntry(
-  entry: Record<string, unknown>,
-  command: string,
-): Record<string, unknown> | undefined {
-  const hooks = entry.hooks;
-  if (!Array.isArray(hooks)) {
-    return entry;
-  }
-  const nextHooks = hooks.filter((hook) => !isGeneratedStationHook(hook, command));
-  if (nextHooks.length === hooks.length) {
-    return entry;
-  }
-  if (nextHooks.length > 0) {
-    const next = cloneRecord(entry);
-    next.hooks = nextHooks;
-    return next;
-  }
-  const rest = cloneRecord(entry);
-  delete rest.hooks;
-  return Object.keys(rest).length === 0 || onlyGeneratedMatcherKeys(rest) ? undefined : rest;
+export function documentContainsCommand(document: NestedHookDocument, command: string): boolean {
+  return nestedDocumentContainsCommand(document, command);
 }
 
-function onlyGeneratedMatcherKeys(entry: Record<string, unknown>): boolean {
-  return Object.keys(entry).every((key) => key === "matcher");
-}
-
-function recordValue(value: unknown): TomlRecord | undefined {
-  const parsed = tomlRecordSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
-}
-
-function cloneRecord(source: Record<string, unknown>): Record<string, unknown> {
-  const cloned: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(source)) {
-    cloned[key] = value;
-  }
-  return cloned;
+export function generatedStationHookEvents(
+  document: NestedHookDocument,
+  commands: Record<CodexHookEventName, string>,
+): CodexHookEventName[] {
+  return generatedNestedHookEvents(document, codexHookDocumentSpec, commands);
 }

--- a/integrations/harness/codex/src/hooks/hookFiles.ts
+++ b/integrations/harness/codex/src/hooks/hookFiles.ts
@@ -1,80 +1,25 @@
-import { chmod, copyFile, mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
-import { pathExists, readTextFileIfPresent, removeFileIfPresent } from "@station/runtime";
-import { CodexHookSetupError } from "./hookErrors.js";
+import { createHookFileOps } from "@station/harness-shared";
+import { CodexHookSetupError, type CodexHookSetupErrorCode } from "./hookErrors.js";
 
-export async function readOptionalFile(path: string): Promise<string> {
-  try {
-    return (await readTextFileIfPresent(path)) ?? "";
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_CONFIG_UNREADABLE",
-      "Codex hook config could not be read.",
-      { cause },
-    );
-  }
-}
+const hookFiles = createHookFileOps({
+  codes: {
+    unreadable: "CODEX_HOOK_CONFIG_UNREADABLE",
+    writeFailed: "CODEX_HOOK_WRITE_FAILED",
+  },
+  messages: {
+    configUnreadable: "Codex hook config could not be read.",
+    configMetadataUnreadable: "Codex hook config metadata could not be read.",
+    configWriteFailed: "Codex hook config could not be written.",
+    scriptWriteFailed: "Codex hook script could not be written.",
+    scriptRemoveFailed: "Codex hook script could not be removed.",
+    backupWriteFailed: "Codex hook config backup could not be written.",
+  },
+  error: (code, message, cause) =>
+    new CodexHookSetupError(code as CodexHookSetupErrorCode, message, { cause }),
+});
 
-export async function writeHookConfig(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o600 });
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_WRITE_FAILED",
-      "Codex hook config could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function writeHookScript(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o700 });
-    await chmod(path, 0o700);
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_WRITE_FAILED",
-      "Codex hook script could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function removeHookScriptIfPresent(path: string): Promise<boolean> {
-  try {
-    return await removeFileIfPresent(path);
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_WRITE_FAILED",
-      "Codex hook script could not be removed.",
-      { cause },
-    );
-  }
-}
-
-export async function backupIfPresent(path: string): Promise<string | undefined> {
-  try {
-    if (!(await pathExists(path))) {
-      return undefined;
-    }
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_CONFIG_UNREADABLE",
-      "Codex hook config metadata could not be read.",
-      { cause },
-    );
-  }
-  const backupPath = `${path}.bak.${new Date().toISOString().replaceAll(/[^0-9]/g, "")}`;
-  try {
-    await copyFile(path, backupPath);
-  } catch (cause) {
-    throw new CodexHookSetupError(
-      "CODEX_HOOK_WRITE_FAILED",
-      "Codex hook config backup could not be written.",
-      { cause },
-    );
-  }
-  return backupPath;
-}
+export const readOptionalFile = hookFiles.readOptionalFile;
+export const writeHookConfig = hookFiles.writeHookConfig;
+export const writeHookScript = hookFiles.writeHookScript;
+export const removeHookScriptIfPresent = hookFiles.removeHookScriptIfPresent;
+export const backupIfPresent = hookFiles.backupIfPresent;

--- a/integrations/harness/codex/src/hooks/hookScript.ts
+++ b/integrations/harness/codex/src/hooks/hookScript.ts
@@ -1,56 +1,20 @@
+import {
+  expectedHookCommands,
+  expectedIngressHookScript,
+  type IngressHookScriptOptions,
+} from "@station/harness-shared";
 import { CODEX_HOOK_EVENT_NAMES, type CodexHookEventName } from "./hookConstants.js";
 
-export type CodexHookScriptOptions = {
+export type CodexHookScriptOptions = IngressHookScriptOptions & {
   hookScriptPath: string;
-  stationConfigPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  hookBin?: string;
 };
 
 export function expectedCodexHookCommands(input: {
   hookScriptPath: string;
 }): Record<CodexHookEventName, string> {
-  return Object.fromEntries(
-    CODEX_HOOK_EVENT_NAMES.map((eventName) => [eventName, input.hookScriptPath]),
-  ) as Record<CodexHookEventName, string>;
+  return expectedHookCommands(CODEX_HOOK_EVENT_NAMES, input.hookScriptPath);
 }
 
 export function expectedCodexHookScript(input: CodexHookScriptOptions): string {
-  const hookArgs = [input.hookBin ?? "stn-ingress"];
-  if (input.observerSocketPath !== undefined) {
-    hookArgs.push("--socket", input.observerSocketPath);
-  }
-  if (input.stateDir !== undefined) {
-    hookArgs.push("--state-dir", input.stateDir);
-  }
-  if (input.hookSpoolDir !== undefined) {
-    hookArgs.push("--spool-dir", input.hookSpoolDir);
-  }
-  if (input.stationConfigPath !== undefined) {
-    hookArgs.push("--config", input.stationConfigPath);
-  }
-  if (input.autoStartFromHooks === false) {
-    hookArgs.push("--no-auto-start");
-  }
-  hookArgs.push("codex");
-  return [
-    "#!/usr/bin/env bash",
-    "set -euo pipefail",
-    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    "  exit 0",
-    "fi",
-    `${commandLine(hookArgs)} > /dev/null`,
-    "",
-  ].join("\n");
-}
-
-function commandLine(args: string[]): string {
-  return args.map(shellQuote).join(" ");
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+  return expectedIngressHookScript({ ...input, provider: "codex" });
 }

--- a/integrations/harness/codex/src/launch.ts
+++ b/integrations/harness/codex/src/launch.ts
@@ -3,6 +3,13 @@ import type {
   HarnessLaunchPlan,
   HarnessPermissionMode,
 } from "@station/contracts";
+import {
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  isYoloPermissionMode,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { CodexHarnessProviderError } from "./errors.js";
 
 export type CodexLaunchOptions = {
@@ -45,23 +52,13 @@ export function buildCodexLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const env = codexLaunchEnv(request);
-  const providerDataInput: CodexProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    ...terminalProviderData(request),
   };
   if (profile !== undefined) {
     providerDataInput.profile = profile;
-  }
-  if (hookProfile !== undefined) {
-    providerDataInput.hookProfile = hookProfile;
-  }
-  if (
-    hookProfile !== undefined &&
-    configuredProfile !== undefined &&
-    configuredProfile !== hookProfile
-  ) {
-    providerDataInput.configuredProfile = configuredProfile;
   }
   if (providerPermissionMode !== undefined) {
     providerDataInput.permissionMode = providerPermissionMode;
@@ -72,21 +69,18 @@ export function buildCodexLaunchPlan(
   if (!yolo && sandboxMode !== undefined) {
     providerDataInput.sandboxMode = sandboxMode;
   }
-  if (mode === "interactive" && options.noAltScreen !== undefined) {
-    providerDataInput.noAltScreen = options.noAltScreen;
-  }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
-  const providerData = codexProviderData(providerDataInput);
+  const providerData = codexProviderData(providerDataInput, {
+    configuredProfile,
+    hookProfile,
+    noAltScreen: mode === "interactive" ? options.noAltScreen : undefined,
+  });
 
   return {
     provider: "codex",
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env,
+    env: harnessLaunchEnv("codex", request),
     mode,
     displayTitle: `${request.project.label} Codex`,
     providerData,
@@ -123,7 +117,7 @@ function buildCodexResumeLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const providerDataInput: CodexProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
     resume: true,
@@ -132,38 +126,18 @@ function buildCodexResumeLaunchPlan(
   if (profile !== undefined) {
     providerDataInput.profile = profile;
   }
-  if (hookProfile !== undefined) {
-    providerDataInput.hookProfile = hookProfile;
-  }
-  if (
-    hookProfile !== undefined &&
-    configuredProfile !== undefined &&
-    configuredProfile !== hookProfile
-  ) {
-    providerDataInput.configuredProfile = configuredProfile;
-  }
+  const providerData = codexProviderData(providerDataInput, { configuredProfile, hookProfile });
 
   return {
     provider: "codex",
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env: codexLaunchEnv(request),
+    env: harnessLaunchEnv("codex", request),
     mode,
     displayTitle: `${request.project.label} Codex`,
-    providerData: codexProviderData(providerDataInput),
+    providerData,
   };
-}
-
-function isYoloPermissionMode(input: {
-  permissionMode?: HarnessPermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-}): boolean {
-  if (input.permissionMode !== undefined) {
-    return input.permissionMode === "yolo";
-  }
-  return input.approvalPolicy === "never" && input.sandboxMode === "danger-full-access";
 }
 
 function interactiveArgs(request: BuildHarnessLaunchRequest): string[] {
@@ -201,78 +175,23 @@ function appendCodexOptions(
   }
 }
 
-function codexLaunchEnv(request: BuildHarnessLaunchRequest): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "codex",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
+function codexProviderData(
+  input: CommonProviderDataInput,
+  options: {
+    hookProfile?: string | undefined;
+    configuredProfile?: string | undefined;
+    noAltScreen?: boolean | undefined;
+  },
+): Record<string, unknown> {
+  const providerData = commonProviderData(input);
+  if (options.hookProfile !== undefined) providerData.hookProfile = options.hookProfile;
+  if (
+    options.hookProfile !== undefined &&
+    options.configuredProfile !== undefined &&
+    options.configuredProfile !== options.hookProfile
+  ) {
+    providerData.configuredProfile = options.configuredProfile;
   }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  return env;
-}
-
-type CodexProviderDataInput = {
-  mode: "interactive" | "exec";
-  profile?: string | undefined;
-  hookProfile?: string | undefined;
-  configuredProfile?: string | undefined;
-  permissionMode?: HarnessPermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-  noAltScreen?: boolean | undefined;
-  initialPromptProvided: boolean;
-  terminalProvider?: string | undefined;
-  terminalTargetId?: string | undefined;
-  resume?: boolean | undefined;
-  resumeTargetKind?: string | undefined;
-};
-
-function codexProviderData(input: CodexProviderDataInput): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: input.mode === "interactive",
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.profile !== undefined) {
-    providerData.profile = input.profile;
-  }
-  if (input.hookProfile !== undefined) {
-    providerData.hookProfile = input.hookProfile;
-  }
-  if (input.configuredProfile !== undefined) {
-    providerData.configuredProfile = input.configuredProfile;
-  }
-  if (input.permissionMode !== undefined) {
-    providerData.permissionMode = input.permissionMode;
-  }
-  if (input.approvalPolicy !== undefined) {
-    providerData.approvalPolicy = input.approvalPolicy;
-  }
-  if (input.sandboxMode !== undefined) {
-    providerData.sandboxMode = input.sandboxMode;
-  }
-  if (input.noAltScreen === true) {
-    providerData.noAltScreen = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  if (input.resume === true) {
-    providerData.resume = true;
-  }
-  if (input.resumeTargetKind !== undefined) {
-    providerData.resumeTargetKind = input.resumeTargetKind;
-  }
+  if (options.noAltScreen === true) providerData.noAltScreen = true;
   return providerData;
 }

--- a/integrations/harness/codex/src/provider.ts
+++ b/integrations/harness/codex/src/provider.ts
@@ -1,55 +1,27 @@
-import type {
-  BuildHarnessLaunchRequest,
-  HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
-  HarnessHooksStatus,
-  HarnessLaunchPlan,
-  HarnessPermissionMode,
-  HarnessProvider,
-  HarnessRunObservation,
-  HarnessStatusObservation,
-  ProviderDoctorCheck,
-  ProviderDoctorContext,
-  ProviderHealth,
-  RawHarnessEvent,
-} from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import type { HarnessCapabilities, HarnessPermissionMode } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  safeErrorFromUnknown,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  hookOptions,
+  type TerminalBoundHarnessProviderSpec,
+  TerminalBoundHarnessProviderWithHooksStatus,
+} from "@station/harness-shared";
 import { classifyCodexRunStatus } from "./classify.js";
-import { codexProviderErrorFromUnknown } from "./errors.js";
 import { normalizeCodexRawEvent } from "./events.js";
 import { doctorCodexHooks } from "./hooks.js";
 import { buildCodexLaunchPlan, type CodexLaunchOptions } from "./launch.js";
 
 const CODEX_STATION_PROFILE = "station";
 
-export type CodexHarnessProviderOptions = {
-  command?: string;
+export type CodexHarnessProviderOptions = CommonHarnessProviderOptions & {
   profile?: string;
   permissionMode?: HarnessPermissionMode;
   approvalPolicy?: string;
   sandboxMode?: string;
   noAltScreen?: boolean;
-  installHooks?: boolean;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  resume?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
+
+type CodexHookOptions = Parameters<typeof doctorCodexHooks>[0];
+type CodexHookResult = Awaited<ReturnType<typeof doctorCodexHooks>>;
 
 const baseCapabilities: HarnessCapabilities = {
   canLaunch: true,
@@ -64,225 +36,74 @@ const baseCapabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: true,
 };
 
-export class CodexHarnessProvider implements HarnessProvider {
-  readonly id = "codex";
+const codexProviderSpec = {
+  id: "codex",
+  displayName: "Codex",
+  command: {
+    envVar: "STATION_CODEX_BIN",
+    fallback: "codex",
+  },
+  baseCapabilities,
+  health: {
+    args: ["login", "status"],
+    unavailable: {
+      code: "HARNESS_CODEX_UNAVAILABLE",
+      message: "Codex is not available or is not logged in.",
+      hint: "Install Codex and run `codex login status` to verify authentication.",
+    },
+    diagnostics: () => ({
+      auth: "codex login status succeeded",
+    }),
+    okDoctorCheck: {
+      name: "codex.login",
+      okMessage: "Codex authentication is available.",
+      errorMessage: "Codex is unavailable or not authenticated.",
+    },
+  },
+  hooks: {
+    doctor: doctorCodexHooks,
+    buildOptions: (options, context) => hookOptions(options, context),
+    checkName: "codex-hooks",
+    failure: {
+      tag: "CodexHookSetupError",
+      code: "CODEX_HOOK_DIAGNOSTIC_FAILED",
+      message: "Codex hook diagnostics failed.",
+    },
+    formatCheckMessage: (result) =>
+      `${result.message} Profile config: ${result.profileConfigPath}. Base config: ${result.baseConfigPath}. Script: ${result.hookScriptPath}.`,
+    exposeHooksStatus: true,
+  },
+  buildLaunchOptions: (options, command) => {
+    const launchOptions: CodexLaunchOptions = { command };
+    if (options.profile !== undefined) launchOptions.defaultProfile = options.profile;
+    if (options.permissionMode !== undefined) {
+      launchOptions.defaultPermissionMode = options.permissionMode;
+    }
+    if (options.installHooks === true) launchOptions.defaultHookProfile = CODEX_STATION_PROFILE;
+    if (options.approvalPolicy !== undefined) {
+      launchOptions.defaultApprovalPolicy = options.approvalPolicy;
+    }
+    if (options.sandboxMode !== undefined) launchOptions.defaultSandboxMode = options.sandboxMode;
+    if (options.noAltScreen !== undefined) launchOptions.noAltScreen = options.noAltScreen;
+    return launchOptions;
+  },
+  buildLaunch: buildCodexLaunchPlan,
+  classifyRun: (run) => classifyCodexRunStatus(run),
+  normalizeEvent: normalizeCodexRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<
+  CodexHarnessProviderOptions,
+  CodexLaunchOptions,
+  CodexHookOptions,
+  CodexHookResult
+>;
 
-  readonly #options: CodexHarnessProviderOptions;
-
+export class CodexHarnessProvider extends TerminalBoundHarnessProviderWithHooksStatus<
+  CodexHarnessProviderOptions,
+  CodexLaunchOptions,
+  CodexHookOptions,
+  CodexHookResult
+> {
   constructor(options: CodexHarnessProviderOptions = {}) {
-    this.#options = options;
+    super(codexProviderSpec, options);
   }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities(this.#options);
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = now(this.#options);
-    try {
-      await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["login", "status"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities: this.capabilities(),
-        diagnostics: {
-          auth: "codex login status succeeded",
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: codexProviderErrorFromUnknown(error, {
-          code: "HARNESS_CODEX_UNAVAILABLE",
-          message: "Codex is not available or is not logged in.",
-          hint: "Install Codex and run `codex login status` to verify authentication.",
-        }),
-        capabilities: this.capabilities(),
-      };
-    }
-  }
-
-  async doctorChecks(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
-    const health = await this.health();
-    const checks: ProviderDoctorCheck[] = [];
-    if (health.status === "healthy") {
-      checks.push({
-        name: "codex.login",
-        status: "ok",
-        message: "Codex authentication is available.",
-      });
-    } else {
-      const check: ProviderDoctorCheck = {
-        name: "codex.login",
-        status: "error",
-        message: "Codex is unavailable or not authenticated.",
-      };
-      if (health.lastError !== undefined) {
-        check.error = health.lastError;
-      }
-      checks.push(check);
-    }
-
-    try {
-      const hookOptions: Parameters<typeof doctorCodexHooks>[0] = {
-        enabled: this.#options.installHooks === true,
-      };
-      if (this.#options.stateDir !== undefined) {
-        hookOptions.stateDir = this.#options.stateDir;
-      }
-      if (this.#options.observerSocketPath !== undefined) {
-        hookOptions.observerSocketPath = this.#options.observerSocketPath;
-      }
-      if (this.#options.hookSpoolDir !== undefined) {
-        hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-      }
-      if (this.#options.autoStartFromHooks !== undefined) {
-        hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-      }
-      if (context?.stationConfigPath !== undefined) {
-        hookOptions.stationConfigPath = context.stationConfigPath;
-      }
-      const hookResult = await doctorCodexHooks(hookOptions);
-      checks.push({
-        name: "codex-hooks",
-        status: hookResult.status,
-        message: `${hookResult.message} Profile config: ${hookResult.profileConfigPath}. Base config: ${hookResult.baseConfigPath}. Script: ${hookResult.hookScriptPath}.`,
-      });
-    } catch (cause) {
-      checks.push({
-        name: "codex-hooks",
-        status: "error",
-        message: "Codex hook diagnostics failed.",
-        error: safeErrorFromUnknown(cause, {
-          tag: "CodexHookSetupError",
-          code: "CODEX_HOOK_DIAGNOSTIC_FAILED",
-          message: "Codex hook diagnostics failed.",
-          provider: this.id,
-        }),
-      });
-    }
-    return checks;
-  }
-
-  async hooksStatus(context?: ProviderDoctorContext): Promise<HarnessHooksStatus> {
-    const hookOptions: Parameters<typeof doctorCodexHooks>[0] = {
-      enabled: this.#options.installHooks === true,
-    };
-    if (this.#options.stateDir !== undefined) {
-      hookOptions.stateDir = this.#options.stateDir;
-    }
-    if (this.#options.observerSocketPath !== undefined) {
-      hookOptions.observerSocketPath = this.#options.observerSocketPath;
-    }
-    if (this.#options.hookSpoolDir !== undefined) {
-      hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-    }
-    if (this.#options.autoStartFromHooks !== undefined) {
-      hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-    }
-    if (context?.stationConfigPath !== undefined) {
-      hookOptions.stationConfigPath = context.stationConfigPath;
-    }
-    const hookResult = await doctorCodexHooks(hookOptions);
-    return {
-      provider: this.id,
-      installed: hookResult.installed,
-      requested: this.#options.installHooks === true,
-      missing: hookResult.missing.map((name) => String(name)),
-      message: hookResult.message,
-    };
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: CodexLaunchOptions = {
-      command: command(this.#options),
-    };
-    if (this.#options.profile !== undefined) {
-      options.defaultProfile = this.#options.profile;
-    }
-    if (this.#options.permissionMode !== undefined) {
-      options.defaultPermissionMode = this.#options.permissionMode;
-    }
-    if (this.#options.installHooks === true) {
-      options.defaultHookProfile = CODEX_STATION_PROFILE;
-    }
-    if (this.#options.approvalPolicy !== undefined) {
-      options.defaultApprovalPolicy = this.#options.approvalPolicy;
-    }
-    if (this.#options.sandboxMode !== undefined) {
-      options.defaultSandboxMode = this.#options.sandboxMode;
-    }
-    if (this.#options.noAltScreen !== undefined) {
-      options.noAltScreen = this.#options.noAltScreen;
-    }
-    return buildCodexLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "Codex",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyCodexRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.codex.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_CODEX_EVENT_INGEST_FAILED",
-          message: "The Codex harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizeCodexRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
-  }
-}
-
-function command(options: CodexHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_CODEX_BIN ?? "codex";
-}
-
-function now(options: CodexHarnessProviderOptions): string {
-  const value = options.now?.() ?? systemClock.now();
-  return toIsoTimestamp(value instanceof Date ? value : new Date(value));
-}
-
-function capabilities(options: CodexHarnessProviderOptions): HarnessCapabilities {
-  // Adapter support alone is not enough; resume stays invisible unless this
-  // provider instance is explicitly enabled by [harness.codex].resume.
-  return {
-    ...baseCapabilities,
-    canResume: options.resume === true,
-  };
 }

--- a/integrations/harness/crush/package.json
+++ b/integrations/harness/crush/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@station/contracts": "workspace:*",
+    "@station/harness-shared": "workspace:*",
     "@station/runtime": "workspace:*",
     "zod": "^4.1.12"
   }

--- a/integrations/harness/crush/src/events.ts
+++ b/integrations/harness/crush/src/events.ts
@@ -6,10 +6,8 @@ import type {
   HarnessEventContext,
   HarnessEventObservation,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
-import { observedPathIsSameOrInside, sameObservedPath } from "@station/contracts";
+import { applyCorrelation, correlateTerminalBoundHarnessEvent } from "@station/harness-shared";
 import { z } from "zod";
 
 export type CrushHookPayload = z.infer<typeof CrushHookPayloadSchema>;
@@ -50,24 +48,23 @@ export function normalizeCrushRawEvent(
 ): HarnessEventObservation[] {
   const event = parseCrushHookPayload(raw.event);
   const observedAt = raw.observedAt ?? new Date().toISOString();
-  const correlation = correlateCrushEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "crush",
+    identity: event,
+    context,
+    cwd: event.cwd ?? event.station_worktree_path,
+    nativeSessionId: event.session_id,
+    includeProjectId: true,
+    includeTerminalTargetId: true,
+    includeCwd: true,
+  });
   const observation: HarnessEventObservation = {
     provider: "crush",
     rawEventType: event.event,
     observedAt,
     providerData: providerDataFromCrushEvent(event),
   };
-  if (correlation.projectId !== undefined) observation.projectId = correlation.projectId;
-  if (correlation.sessionId !== undefined) observation.sessionId = correlation.sessionId;
-  if (correlation.worktreeId !== undefined) observation.worktreeId = correlation.worktreeId;
-  if (correlation.terminalTargetId !== undefined) {
-    observation.terminalTargetId = correlation.terminalTargetId;
-  }
-  if (correlation.harnessRunId !== undefined) observation.harnessRunId = correlation.harnessRunId;
-  if (correlation.nativeSessionId !== undefined) {
-    observation.nativeSessionId = correlation.nativeSessionId;
-  }
-  if (correlation.cwd !== undefined) observation.cwd = correlation.cwd;
+  applyCorrelation(observation, correlation);
   return [observation];
 }
 
@@ -94,124 +91,6 @@ function providerDataFromCrushEvent(event: CrushHookPayload): Record<string, unk
     providerData.stationTerminalTargetId = event.station_terminal_target_id;
   }
   return providerData;
-}
-
-function correlateCrushEvent(
-  event: CrushHookPayload,
-  context: HarnessEventContext,
-): {
-  projectId?: string;
-  sessionId?: string;
-  worktreeId?: string;
-  terminalTargetId?: string;
-  harnessRunId?: string;
-  nativeSessionId?: string;
-  cwd?: string;
-} {
-  const cwd = event.cwd ?? event.station_worktree_path;
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(cwd, context.worktrees);
-  const result: {
-    projectId?: string;
-    sessionId?: string;
-    worktreeId?: string;
-    terminalTargetId?: string;
-    harnessRunId?: string;
-    nativeSessionId?: string;
-    cwd?: string;
-  } = {};
-  if (event.station_project_id !== undefined) {
-    result.projectId = event.station_project_id;
-  } else if (terminal?.projectId !== undefined) {
-    result.projectId = terminal.projectId;
-  } else if (worktree?.projectId !== undefined) {
-    result.projectId = worktree.projectId;
-  }
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    result.terminalTargetId = event.station_terminal_target_id;
-    result.harnessRunId = `crush:${event.station_terminal_target_id}`;
-  } else if (terminal?.harnessRunId !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = `crush:${terminal.id}`;
-  }
-  if (event.session_id !== undefined) result.nativeSessionId = event.session_id;
-  if (cwd !== undefined) result.cwd = cwd;
-  return result;
-}
-
-function terminalForId(
-  terminalTargetId: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (terminalTargetId === undefined) {
-    return undefined;
-  }
-  return targets.find((target) => target.id === terminalTargetId);
-}
-
-function terminalForCwd(
-  cwd: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (cwd === undefined) {
-    return undefined;
-  }
-  return (
-    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
-    targets.find(
-      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
-    )
-  );
-}
-
-function worktreeForId(
-  worktreeId: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreeId === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === worktreeId);
-}
-
-function worktreeForPath(
-  worktreePath: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreePath === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => sameObservedPath(worktree.path, worktreePath));
-}
-
-function worktreeForCwd(
-  cwd: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (cwd === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path));
 }
 
 function crushHarnessError(code: string, message: string, cause?: unknown): Error {

--- a/integrations/harness/crush/src/hooks.ts
+++ b/integrations/harness/crush/src/hooks.ts
@@ -4,6 +4,11 @@
 // empty stdout so Crush treats it as "no opinion" (never blocks a tool call).
 import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import {
+  expectedIngressHookScript,
+  type IngressHookScriptOptions,
+  ingressHookScriptOptions,
+} from "@station/harness-shared";
 import { z } from "zod";
 
 export const CRUSH_HOOK_EVENT_NAMES = ["PreToolUse"] as const;
@@ -98,7 +103,7 @@ export async function planCrushHooks(options: CrushHookPlanOptions = {}): Promis
   const commands = expectedCrushHookCommands({ hookScriptPath });
   const afterDocument = installCrushHookCommands(document, commands);
   const after = stringifyCrushConfigDocument(afterDocument);
-  const script = expectedCrushHookScript(scriptOptions(hookScriptPath, options));
+  const script = expectedCrushHookScript(ingressHookScriptOptions(hookScriptPath, options));
   const scriptBefore = await readOptionalFile(hookScriptPath);
   const configChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
@@ -128,7 +133,7 @@ export async function installCrushHooks(
   if (plan.scriptChanged) {
     await writeHookScript(
       plan.hookScriptPath,
-      expectedCrushHookScript(scriptOptions(plan.hookScriptPath, options)),
+      expectedCrushHookScript(ingressHookScriptOptions(plan.hookScriptPath, options)),
     );
   }
   const result: CrushHookInstallResult = {
@@ -236,69 +241,12 @@ export function expectedCrushHookCommands(input: {
 }
 
 export function expectedCrushHookScript(input: CrushHookScriptOptions): string {
-  const hookArgs = [input.hookBin ?? "stn-ingress"];
-  if (input.observerSocketPath !== undefined) {
-    hookArgs.push("--socket", input.observerSocketPath);
-  }
-  if (input.stateDir !== undefined) {
-    hookArgs.push("--state-dir", input.stateDir);
-  }
-  if (input.hookSpoolDir !== undefined) {
-    hookArgs.push("--spool-dir", input.hookSpoolDir);
-  }
-  if (input.stationConfigPath !== undefined) {
-    hookArgs.push("--config", input.stationConfigPath);
-  }
-  if (input.autoStartFromHooks === false) {
-    hookArgs.push("--no-auto-start");
-  }
-  hookArgs.push("crush");
-  return [
-    "#!/usr/bin/env bash",
-    "set -euo pipefail",
-    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    "  exit 0",
-    "fi",
-    `${commandLine(hookArgs)} > /dev/null 2>&1 || true`,
-    "",
-  ].join("\n");
+  return expectedIngressHookScript({ ...input, provider: "crush", swallowErrors: true });
 }
 
-type CrushHookScriptOptions = {
+type CrushHookScriptOptions = IngressHookScriptOptions & {
   hookScriptPath: string;
-  stationConfigPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  hookBin?: string;
 };
-
-function scriptOptions(
-  hookScriptPath: string,
-  options: Pick<
-    CrushHookPlanOptions,
-    | "stationConfigPath"
-    | "observerSocketPath"
-    | "stateDir"
-    | "hookSpoolDir"
-    | "autoStartFromHooks"
-    | "hookBin"
-  >,
-): CrushHookScriptOptions {
-  const input: CrushHookScriptOptions = { hookScriptPath };
-  if (options.stationConfigPath !== undefined) input.stationConfigPath = options.stationConfigPath;
-  if (options.observerSocketPath !== undefined) {
-    input.observerSocketPath = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) input.stateDir = options.stateDir;
-  if (options.hookSpoolDir !== undefined) input.hookSpoolDir = options.hookSpoolDir;
-  if (options.autoStartFromHooks !== undefined) {
-    input.autoStartFromHooks = options.autoStartFromHooks;
-  }
-  if (options.hookBin !== undefined) input.hookBin = options.hookBin;
-  return input;
-}
 
 function parseCrushConfigDocument(source: string): CrushConfigDocument {
   if (source.trim().length === 0) {
@@ -489,12 +437,4 @@ function cloneHooks(
     next[eventName] = entries.map((entry) => ({ ...entry }));
   }
   return next;
-}
-
-function commandLine(args: string[]): string {
-  return args.map(shellQuote).join(" ");
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/integrations/harness/crush/src/provider.ts
+++ b/integrations/harness/crush/src/provider.ts
@@ -1,47 +1,31 @@
 import type {
   BuildHarnessLaunchRequest,
   HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
   HarnessLaunchPlan,
   HarnessPermissionMode,
-  HarnessProvider,
   HarnessRunObservation,
   HarnessStatusObservation,
-  ProviderDoctorCheck,
-  ProviderDoctorContext,
-  ProviderHealth,
-  RawHarnessEvent,
   SafeError,
 } from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  safeErrorFromUnknown,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  hookOptions,
+  isYoloPermissionMode,
+  TerminalBoundHarnessProvider,
+  type TerminalBoundHarnessProviderSpec,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { normalizeCrushRawEvent } from "./events.js";
 import { doctorCrushHooks } from "./hooks.js";
 
-export type CrushHarnessProviderOptions = {
-  command?: string;
+export type CrushHarnessProviderOptions = Omit<CommonHarnessProviderOptions, "resume"> & {
   permissionMode?: HarnessPermissionMode;
   approvalPolicy?: string;
   sandboxMode?: string;
-  installHooks?: boolean;
   configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
 
 export type CrushLaunchOptions = {
@@ -68,169 +52,75 @@ const capabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: false,
 };
 
-export class CrushHarnessProvider implements HarnessProvider {
-  readonly id = "crush";
+type CrushHookOptions = Parameters<typeof doctorCrushHooks>[0];
+type CrushHookResult = Awaited<ReturnType<typeof doctorCrushHooks>>;
 
-  readonly #options: CrushHarnessProviderOptions;
+const crushProviderSpec = {
+  id: "crush",
+  displayName: "Crush",
+  command: {
+    envVar: "STATION_CRUSH_BIN",
+    fallback: "crush",
+  },
+  baseCapabilities: capabilities,
+  health: {
+    args: ["--version"],
+    unavailable: {
+      code: "HARNESS_CRUSH_UNAVAILABLE",
+      message: "Crush is not available.",
+      hint: "Install Crush or configure [harness.crush].command.",
+    },
+    diagnostics: () => ({
+      command: "crush --version succeeded",
+    }),
+  },
+  hooks: {
+    doctor: doctorCrushHooks,
+    buildOptions: (options, context) => hookOptions(options, context),
+    checkName: "crush-hooks",
+    failure: {
+      tag: "CrushHookSetupError",
+      code: "CRUSH_HOOK_DIAGNOSTIC_FAILED",
+      message: "Crush hook diagnostics failed.",
+    },
+    formatCheckMessage: (result) =>
+      `${result.message} Hooks: ${result.configPath}. Script: ${result.hookScriptPath}.`,
+  },
+  buildLaunchOptions: (options, command) => {
+    const launchOptions: CrushLaunchOptions = { command };
+    if (options.permissionMode !== undefined) {
+      launchOptions.defaultPermissionMode = options.permissionMode;
+    }
+    if (options.approvalPolicy !== undefined) {
+      launchOptions.defaultApprovalPolicy = options.approvalPolicy;
+    }
+    if (options.sandboxMode !== undefined) launchOptions.defaultSandboxMode = options.sandboxMode;
+    if (options.configPath !== undefined) launchOptions.configPath = options.configPath;
+    if (options.observerSocketPath !== undefined) {
+      launchOptions.observerSocketPath = options.observerSocketPath;
+    }
+    if (options.stateDir !== undefined) launchOptions.stateDir = options.stateDir;
+    if (options.hookSpoolDir !== undefined) launchOptions.hookSpoolDir = options.hookSpoolDir;
+    return launchOptions;
+  },
+  buildLaunch: buildCrushLaunchPlan,
+  classifyRun: (run) => classifyCrushRunStatus(run),
+  normalizeEvent: normalizeCrushRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<
+  CrushHarnessProviderOptions,
+  CrushLaunchOptions,
+  CrushHookOptions,
+  CrushHookResult
+>;
 
+export class CrushHarnessProvider extends TerminalBoundHarnessProvider<
+  CrushHarnessProviderOptions,
+  CrushLaunchOptions,
+  CrushHookOptions,
+  CrushHookResult
+> {
   constructor(options: CrushHarnessProviderOptions = {}) {
-    this.#options = options;
-  }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities;
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = now(this.#options);
-    try {
-      await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["--version"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities,
-        diagnostics: {
-          command: "crush --version succeeded",
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: safeErrorFromUnknown(error, {
-          tag: "HarnessProviderError",
-          code: "HARNESS_CRUSH_UNAVAILABLE",
-          message: "Crush is not available.",
-          hint: "Install Crush or configure [harness.crush].command.",
-          provider: this.id,
-        }),
-        capabilities,
-      };
-    }
-  }
-
-  async doctorChecks(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
-    try {
-      const hookOptions: Parameters<typeof doctorCrushHooks>[0] = {
-        enabled: this.#options.installHooks === true,
-      };
-      if (this.#options.observerSocketPath !== undefined) {
-        hookOptions.observerSocketPath = this.#options.observerSocketPath;
-      }
-      if (this.#options.stateDir !== undefined) {
-        hookOptions.stateDir = this.#options.stateDir;
-      }
-      if (this.#options.hookSpoolDir !== undefined) {
-        hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-      }
-      if (this.#options.autoStartFromHooks !== undefined) {
-        hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-      }
-      if (context?.stationConfigPath !== undefined) {
-        hookOptions.stationConfigPath = context.stationConfigPath;
-      } else if (this.#options.configPath !== undefined) {
-        hookOptions.stationConfigPath = this.#options.configPath;
-      }
-      const hookResult = await doctorCrushHooks(hookOptions);
-      return [
-        {
-          name: "crush-hooks",
-          status: hookResult.status,
-          message: `${hookResult.message} Hooks: ${hookResult.configPath}. Script: ${hookResult.hookScriptPath}.`,
-        },
-      ];
-    } catch (cause) {
-      return [
-        {
-          name: "crush-hooks",
-          status: "error",
-          message: "Crush hook diagnostics failed.",
-          error: safeErrorFromUnknown(cause, {
-            tag: "CrushHookSetupError",
-            code: "CRUSH_HOOK_DIAGNOSTIC_FAILED",
-            message: "Crush hook diagnostics failed.",
-            provider: this.id,
-          }),
-        },
-      ];
-    }
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: CrushLaunchOptions = {
-      command: command(this.#options),
-    };
-    if (this.#options.permissionMode !== undefined) {
-      options.defaultPermissionMode = this.#options.permissionMode;
-    }
-    if (this.#options.approvalPolicy !== undefined) {
-      options.defaultApprovalPolicy = this.#options.approvalPolicy;
-    }
-    if (this.#options.sandboxMode !== undefined) {
-      options.defaultSandboxMode = this.#options.sandboxMode;
-    }
-    if (this.#options.configPath !== undefined) {
-      options.configPath = this.#options.configPath;
-    }
-    if (this.#options.observerSocketPath !== undefined) {
-      options.observerSocketPath = this.#options.observerSocketPath;
-    }
-    if (this.#options.stateDir !== undefined) {
-      options.stateDir = this.#options.stateDir;
-    }
-    if (this.#options.hookSpoolDir !== undefined) {
-      options.hookSpoolDir = this.#options.hookSpoolDir;
-    }
-    return buildCrushLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "Crush",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyCrushRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.crush.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_CRUSH_EVENT_INGEST_FAILED",
-          message: "The Crush harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizeCrushRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
+    super(crushProviderSpec, options);
   }
 }
 
@@ -267,9 +157,10 @@ export function buildCrushLaunchPlan(
     args.unshift("--yolo");
   }
 
-  const providerDataInput: CrushProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    ...terminalProviderData(request),
   };
   if (providerPermissionMode !== undefined) {
     providerDataInput.permissionMode = providerPermissionMode;
@@ -280,20 +171,16 @@ export function buildCrushLaunchPlan(
   if (options.observerSocketPath !== undefined) {
     providerDataInput.observerSocketPathProvided = true;
   }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
 
   return {
     provider: "crush",
     command: options.command ?? "crush",
     args,
     cwd: request.worktree.path,
-    env: crushLaunchEnv(request, options),
+    env: harnessLaunchEnv("crush", request, options),
     mode,
     displayTitle: `${request.project.label} Crush`,
-    providerData: crushProviderData(providerDataInput),
+    providerData: commonProviderData(providerDataInput),
   };
 }
 
@@ -339,93 +226,6 @@ function classifyCrushRunStatus(run: HarnessRunObservation): HarnessStatusObserv
   return output;
 }
 
-function crushLaunchEnv(
-  request: BuildHarnessLaunchRequest,
-  options: CrushLaunchOptions,
-): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "crush",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
-  }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  if (options.configPath !== undefined) {
-    env.STATION_CONFIG_PATH = options.configPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    env.STATION_OBSERVER_SOCKET_PATH = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    env.STATION_OBSERVER_STATE_DIR = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
-  }
-  return env;
-}
-
-function crushProviderData(input: CrushProviderDataInput): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: input.mode === "interactive",
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.permissionMode !== undefined) {
-    providerData.permissionMode = input.permissionMode;
-  }
-  if (input.configPathProvided === true) {
-    providerData.configPathProvided = true;
-  }
-  if (input.observerSocketPathProvided === true) {
-    providerData.observerSocketPathProvided = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  return providerData;
-}
-
-function isYoloPermissionMode(input: {
-  permissionMode?: HarnessPermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-}): boolean {
-  if (input.permissionMode !== undefined) {
-    return input.permissionMode === "yolo";
-  }
-  return input.approvalPolicy === "never" && input.sandboxMode === "danger-full-access";
-}
-
-function command(options: CrushHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_CRUSH_BIN ?? "crush";
-}
-
-function now(options: CrushHarnessProviderOptions): string {
-  const value = options.now?.() ?? systemClock.now();
-  return toIsoTimestamp(value instanceof Date ? value : new Date(value));
-}
-
 function safeError(error: SafeError): SafeError {
   return error;
 }
-
-type CrushProviderDataInput = {
-  mode: "interactive" | "exec";
-  initialPromptProvided: boolean;
-  permissionMode?: HarnessPermissionMode | undefined;
-  configPathProvided?: boolean | undefined;
-  observerSocketPathProvided?: boolean | undefined;
-  terminalProvider?: string | undefined;
-  terminalTargetId?: string | undefined;
-};

--- a/integrations/harness/cursor/src/compaction.ts
+++ b/integrations/harness/cursor/src/compaction.ts
@@ -1,3 +1,5 @@
+import { compactPayloadByFieldNames, type PayloadCompactionResult } from "@station/harness-shared";
+
 export type CursorProviderHookPayloadCompactionResult = {
   payload: unknown;
   compacted: boolean;
@@ -29,56 +31,10 @@ const retainedFieldNames = [
   "station_terminal_target_id",
 ] as const;
 
-function jsonByteCount(value: unknown): number | null {
-  try {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      return null;
-    }
-    return Buffer.byteLength(serialized, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 export function compactCursorProviderHookPayload(
   payload: unknown,
 ): CursorProviderHookPayloadCompactionResult {
-  const originalByteCount = jsonByteCount(payload);
-  if (!isRecord(payload)) {
-    return {
-      payload,
-      compacted: false,
-      originalByteCount,
-      compactedByteCount: originalByteCount,
-      omittedFieldNames: [],
-    };
-  }
-
-  const output: Record<string, unknown> = {};
-  const omittedFieldNames = new Set<string>();
-  for (const fieldName of retainedFieldNames) {
-    if (Object.hasOwn(payload, fieldName)) {
-      output[fieldName] = payload[fieldName];
-    }
-  }
-
-  for (const fieldName of Object.keys(payload)) {
-    if (!Object.hasOwn(output, fieldName)) {
-      omittedFieldNames.add(fieldName);
-    }
-  }
-
-  const compacted = omittedFieldNames.size > 0;
-  return {
-    payload: output,
-    compacted,
-    originalByteCount,
-    compactedByteCount: jsonByteCount(output),
-    omittedFieldNames: [...omittedFieldNames].sort(),
-  };
+  return compactPayloadByFieldNames(payload, {
+    retainedFieldNames,
+  }) satisfies PayloadCompactionResult;
 }

--- a/integrations/harness/cursor/src/errors.ts
+++ b/integrations/harness/cursor/src/errors.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import { harnessProviderErrorClass } from "@station/harness-shared";
 
 export type CursorHarnessErrorCode =
   | "HARNESS_CURSOR_UNAVAILABLE"
@@ -7,49 +7,11 @@ export type CursorHarnessErrorCode =
   | "HARNESS_CURSOR_EVENT_INVALID"
   | "HARNESS_CURSOR_EVENT_INGEST_FAILED";
 
-export class CursorHarnessProviderError extends Error implements SafeError {
-  readonly tag = "HarnessProviderError";
-  readonly code: CursorHarnessErrorCode;
-  readonly provider = "cursor";
-  readonly hint: string | undefined;
+export const CursorHarnessProviderError = harnessProviderErrorClass<CursorHarnessErrorCode>({
+  name: "CursorHarnessProviderError",
+  provider: "cursor",
+});
 
-  constructor(
-    code: CursorHarnessErrorCode,
-    message: string,
-    options: { cause?: unknown; hint?: string } = {},
-  ) {
-    super(`${code}: ${message}`, { cause: options.cause });
-    Object.defineProperty(this, "name", {
-      value: "CursorHarnessProviderError",
-      configurable: true,
-    });
-    this.code = code;
-    this.hint = options.hint;
-  }
-}
-
-export function cursorHarnessError(
-  code: CursorHarnessErrorCode,
-  message: string,
-  cause?: unknown,
-): CursorHarnessProviderError {
+export function cursorHarnessError(code: CursorHarnessErrorCode, message: string, cause?: unknown) {
   return new CursorHarnessProviderError(code, message, { cause });
-}
-
-export function cursorProviderErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: CursorHarnessErrorCode;
-    message: string;
-    hint?: string;
-  },
-): CursorHarnessProviderError {
-  if (error instanceof CursorHarnessProviderError) {
-    return error;
-  }
-  const options: { cause?: unknown; hint?: string } = { cause: error };
-  if (fallback.hint !== undefined) {
-    options.hint = fallback.hint;
-  }
-  return new CursorHarnessProviderError(fallback.code, fallback.message, options);
 }

--- a/integrations/harness/cursor/src/events.ts
+++ b/integrations/harness/cursor/src/events.ts
@@ -7,15 +7,14 @@ import type {
   HarnessEventReport,
   ObservedStatus,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
+import { HarnessEventReportSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
-  HarnessEventReportSchema,
-  observedPathIsSameOrInside,
-  STATION_SCHEMA_VERSION,
-  sameObservedPath,
-} from "@station/contracts";
+  applyCorrelation,
+  correlateTerminalBoundHarnessEvent,
+  harnessEventDiagnostics,
+  reportCorrelation,
+} from "@station/harness-shared";
 import { z } from "zod";
 import { compactCursorProviderHookPayload } from "./compaction.js";
 import { cursorHarnessError } from "./errors.js";
@@ -142,36 +141,20 @@ function providerDataFromCursorEvent(event: CursorProviderHookPayload): Record<s
 function reportCorrelationFromCursorEvent(
   event: CursorProviderHookPayload,
 ): HarnessEventReport["correlation"] | undefined {
-  const correlation: NonNullable<HarnessEventReport["correlation"]> = {};
   const cwd = cursorEventCwd(event);
-  if (cwd !== undefined) correlation.cwd = cwd;
-  if (event.station_project_id !== undefined) correlation.projectId = event.station_project_id;
-  if (event.station_worktree_id !== undefined) correlation.worktreeId = event.station_worktree_id;
-  if (event.station_session_id !== undefined) correlation.sessionId = event.station_session_id;
-  if (event.station_terminal_target_id !== undefined) {
-    correlation.terminalTargetId = event.station_terminal_target_id;
-    correlation.harnessRunId = `cursor:${event.station_terminal_target_id}`;
-  }
   const nativeSessionId = cursorNativeSessionId(event);
-  if (nativeSessionId !== undefined) correlation.nativeSessionId = nativeSessionId;
-  return Object.keys(correlation).length === 0 ? undefined : correlation;
-}
-
-function reportDiagnosticsFromCursorEvent(
-  event: CursorProviderHookPayload,
-  input: CursorProviderHookPayloadReportInput["diagnostics"],
-): HarnessEventReport["diagnostics"] | undefined {
-  const diagnostics: NonNullable<HarnessEventReport["diagnostics"]> = {
-    rawEventType: event.hook_event_name,
-  };
-  if (typeof input?.payloadBytes === "number") diagnostics.payloadBytes = input.payloadBytes;
-  if (typeof input?.compactedBytes === "number") diagnostics.compactedBytes = input.compactedBytes;
-  if (input?.compacted !== undefined) diagnostics.compacted = input.compacted;
-  if (input?.truncated !== undefined) diagnostics.truncated = input.truncated;
-  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
-    diagnostics.omittedFieldNames = input.omittedFieldNames;
-  }
-  return diagnostics;
+  return reportCorrelation({
+    cwd,
+    nativeSessionId,
+    projectId: event.station_project_id,
+    worktreeId: event.station_worktree_id,
+    sessionId: event.station_session_id,
+    terminalTargetId: event.station_terminal_target_id,
+    harnessRunId:
+      event.station_terminal_target_id === undefined
+        ? undefined
+        : `cursor:${event.station_terminal_target_id}`,
+  });
 }
 
 function reportCoalesceKeyFromCursorEvent(event: CursorProviderHookPayload): string | undefined {
@@ -187,131 +170,12 @@ function reportCoalesceKeyFromCursorEvent(event: CursorProviderHookPayload): str
   return parts.length === 0 ? undefined : parts.join(":");
 }
 
-function correlateCursorEvent(
-  event: CursorProviderHookPayload,
-  context: HarnessEventContext,
-): {
-  projectId?: string;
-  sessionId?: string;
-  worktreeId?: string;
-  terminalTargetId?: string;
-  harnessRunId?: string;
-  nativeSessionId?: string;
-  cwd?: string;
-} {
-  const cwd = cursorEventCwd(event);
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(cwd, context.worktrees);
-  const result: {
-    projectId?: string;
-    sessionId?: string;
-    worktreeId?: string;
-    terminalTargetId?: string;
-    harnessRunId?: string;
-    nativeSessionId?: string;
-    cwd?: string;
-  } = {};
-  if (event.station_project_id !== undefined) {
-    result.projectId = event.station_project_id;
-  } else if (terminal?.projectId !== undefined) {
-    result.projectId = terminal.projectId;
-  } else if (worktree?.projectId !== undefined) {
-    result.projectId = worktree.projectId;
-  }
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    result.terminalTargetId = event.station_terminal_target_id;
-    result.harnessRunId = `cursor:${event.station_terminal_target_id}`;
-  } else if (terminal?.harnessRunId !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = `cursor:${terminal.id}`;
-  }
-  const nativeSessionId = cursorNativeSessionId(event);
-  if (nativeSessionId !== undefined) result.nativeSessionId = nativeSessionId;
-  if (cwd !== undefined) result.cwd = cwd;
-  return result;
-}
-
 function cursorEventCwd(event: CursorProviderHookPayload): string | undefined {
   return event.cwd ?? event.station_worktree_path ?? event.workspace_roots?.[0];
 }
 
 function cursorNativeSessionId(event: CursorProviderHookPayload): string | undefined {
   return event.session_id ?? event.conversation_id;
-}
-
-function terminalForId(
-  terminalTargetId: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (terminalTargetId === undefined) {
-    return undefined;
-  }
-  return targets.find((target) => target.id === terminalTargetId);
-}
-
-function terminalForCwd(
-  cwd: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (cwd === undefined) {
-    return undefined;
-  }
-  return (
-    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
-    targets.find(
-      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
-    )
-  );
-}
-
-function worktreeForId(
-  worktreeId: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreeId === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === worktreeId);
-}
-
-function worktreeForPath(
-  worktreePath: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreePath === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => sameObservedPath(worktree.path, worktreePath));
-}
-
-function worktreeForCwd(
-  cwd: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (cwd === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path));
 }
 
 export function parseCursorProviderHookPayload(input: unknown): CursorProviderHookPayload {
@@ -333,7 +197,16 @@ export function normalizeCursorRawEvent(
 ): HarnessEventObservation[] {
   const event = parseCursorProviderHookPayload(raw.event);
   const observedAt = raw.observedAt ?? new Date().toISOString();
-  const correlation = correlateCursorEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "cursor",
+    identity: event,
+    context,
+    cwd: cursorEventCwd(event),
+    nativeSessionId: cursorNativeSessionId(event),
+    includeProjectId: true,
+    includeTerminalTargetId: true,
+    includeCwd: true,
+  });
   const observation: HarnessEventObservation = {
     provider: "cursor",
     rawEventType: event.hook_event_name,
@@ -341,17 +214,7 @@ export function normalizeCursorRawEvent(
     observedAt,
     providerData: providerDataFromCursorEvent(event),
   };
-  if (correlation.projectId !== undefined) observation.projectId = correlation.projectId;
-  if (correlation.sessionId !== undefined) observation.sessionId = correlation.sessionId;
-  if (correlation.worktreeId !== undefined) observation.worktreeId = correlation.worktreeId;
-  if (correlation.terminalTargetId !== undefined) {
-    observation.terminalTargetId = correlation.terminalTargetId;
-  }
-  if (correlation.harnessRunId !== undefined) observation.harnessRunId = correlation.harnessRunId;
-  if (correlation.nativeSessionId !== undefined) {
-    observation.nativeSessionId = correlation.nativeSessionId;
-  }
-  if (correlation.cwd !== undefined) observation.cwd = correlation.cwd;
+  applyCorrelation(observation, correlation);
   return [observation];
 }
 
@@ -373,10 +236,7 @@ export function cursorProviderHookPayloadToHarnessEventReport(
   if (correlation !== undefined) {
     report.correlation = correlation;
   }
-  const diagnostics = reportDiagnosticsFromCursorEvent(event, input.diagnostics);
-  if (diagnostics !== undefined) {
-    report.diagnostics = diagnostics;
-  }
+  report.diagnostics = harnessEventDiagnostics(event.hook_event_name, input.diagnostics);
   const coalesceKey = reportCoalesceKeyFromCursorEvent(event);
   if (coalesceKey !== undefined) {
     report.coalesceKey = coalesceKey;

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -1,6 +1,7 @@
 // Installs/uninstalls the STATION hook into Cursor's .cursor/hooks.json.
 // Upstream hook contract: https://cursor.com/docs/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import { ingressHookScriptOptions } from "@station/harness-shared";
 import {
   documentContainsCommand,
   installCursorHookCommands,
@@ -18,11 +19,7 @@ import {
   writeHookScript,
 } from "./hooks/hookFiles.js";
 import { resolveCursorHookScriptPath, resolveCursorHooksPath } from "./hooks/hookPaths.js";
-import {
-  type CursorHookScriptOptions,
-  expectedCursorHookCommands,
-  expectedCursorHookScript,
-} from "./hooks/hookScript.js";
+import { expectedCursorHookCommands, expectedCursorHookScript } from "./hooks/hookScript.js";
 
 export { CURSOR_HOOK_EVENT_NAMES, type CursorHookEventName } from "./hooks/hookConstants.js";
 export { CursorHookSetupError, type CursorHookSetupErrorCode } from "./hooks/hookErrors.js";
@@ -73,40 +70,6 @@ export type CursorHookDoctorResult = {
   message: string;
 };
 
-function scriptOptions(
-  hookScriptPath: string,
-  options: Pick<
-    CursorHookPlanOptions,
-    | "stationConfigPath"
-    | "observerSocketPath"
-    | "stateDir"
-    | "hookSpoolDir"
-    | "autoStartFromHooks"
-    | "hookBin"
-  >,
-): CursorHookScriptOptions {
-  const input: CursorHookScriptOptions = { hookScriptPath };
-  if (options.stationConfigPath !== undefined) {
-    input.stationConfigPath = options.stationConfigPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    input.observerSocketPath = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    input.stateDir = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    input.hookSpoolDir = options.hookSpoolDir;
-  }
-  if (options.autoStartFromHooks !== undefined) {
-    input.autoStartFromHooks = options.autoStartFromHooks;
-  }
-  if (options.hookBin !== undefined) {
-    input.hookBin = options.hookBin;
-  }
-  return input;
-}
-
 function installResultFromPlan(plan: CursorHookPlan, installed: boolean): CursorHookInstallResult {
   return {
     provider: plan.provider,
@@ -144,7 +107,7 @@ export async function planCursorHooks(
   const commands = expectedCursorHookCommands({ hookScriptPath });
   const afterDocument = installCursorHookCommands(document, commands);
   const after = stringifyJsonDocument(afterDocument);
-  const script = expectedCursorHookScript(scriptOptions(hookScriptPath, options));
+  const script = expectedCursorHookScript(ingressHookScriptOptions(hookScriptPath, options));
   const scriptBefore = await readOptionalFile(hookScriptPath);
   const configChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
@@ -176,7 +139,7 @@ export async function installCursorHooks(
   if (plan.scriptChanged) {
     await writeHookScript(
       plan.hookScriptPath,
-      expectedCursorHookScript(scriptOptions(plan.hookScriptPath, options)),
+      expectedCursorHookScript(ingressHookScriptOptions(plan.hookScriptPath, options)),
     );
   }
 

--- a/integrations/harness/cursor/src/hooks/hookFiles.ts
+++ b/integrations/harness/cursor/src/hooks/hookFiles.ts
@@ -1,80 +1,25 @@
-import { chmod, copyFile, mkdir, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
-import { pathExists, readTextFileIfPresent, removeFileIfPresent } from "@station/runtime";
-import { CursorHookSetupError } from "./hookErrors.js";
+import { createHookFileOps } from "@station/harness-shared";
+import { CursorHookSetupError, type CursorHookSetupErrorCode } from "./hookErrors.js";
 
-export async function readOptionalFile(path: string): Promise<string> {
-  try {
-    return (await readTextFileIfPresent(path)) ?? "";
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_CONFIG_UNREADABLE",
-      "Cursor hook config could not be read.",
-      { cause },
-    );
-  }
-}
+const hookFiles = createHookFileOps({
+  codes: {
+    unreadable: "CURSOR_HOOK_CONFIG_UNREADABLE",
+    writeFailed: "CURSOR_HOOK_WRITE_FAILED",
+  },
+  messages: {
+    configUnreadable: "Cursor hook config could not be read.",
+    configMetadataUnreadable: "Cursor hook config metadata could not be read.",
+    configWriteFailed: "Cursor hook config could not be written.",
+    scriptWriteFailed: "Cursor hook script could not be written.",
+    scriptRemoveFailed: "Cursor hook script could not be removed.",
+    backupWriteFailed: "Cursor hook config backup could not be written.",
+  },
+  error: (code, message, cause) =>
+    new CursorHookSetupError(code as CursorHookSetupErrorCode, message, { cause }),
+});
 
-export async function writeHookConfig(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o600 });
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_WRITE_FAILED",
-      "Cursor hook config could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function writeHookScript(path: string, contents: string): Promise<void> {
-  try {
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
-    await writeFile(path, contents, { mode: 0o700 });
-    await chmod(path, 0o700);
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_WRITE_FAILED",
-      "Cursor hook script could not be written.",
-      { cause },
-    );
-  }
-}
-
-export async function removeHookScriptIfPresent(path: string): Promise<boolean> {
-  try {
-    return await removeFileIfPresent(path);
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_WRITE_FAILED",
-      "Cursor hook script could not be removed.",
-      { cause },
-    );
-  }
-}
-
-export async function backupIfPresent(path: string): Promise<string | undefined> {
-  try {
-    if (!(await pathExists(path))) {
-      return undefined;
-    }
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_CONFIG_UNREADABLE",
-      "Cursor hook config metadata could not be read.",
-      { cause },
-    );
-  }
-  const backupPath = `${path}.bak.${new Date().toISOString().replaceAll(/[^0-9]/g, "")}`;
-  try {
-    await copyFile(path, backupPath);
-  } catch (cause) {
-    throw new CursorHookSetupError(
-      "CURSOR_HOOK_WRITE_FAILED",
-      "Cursor hook config backup could not be written.",
-      { cause },
-    );
-  }
-  return backupPath;
-}
+export const readOptionalFile = hookFiles.readOptionalFile;
+export const writeHookConfig = hookFiles.writeHookConfig;
+export const writeHookScript = hookFiles.writeHookScript;
+export const removeHookScriptIfPresent = hookFiles.removeHookScriptIfPresent;
+export const backupIfPresent = hookFiles.backupIfPresent;

--- a/integrations/harness/cursor/src/hooks/hookScript.ts
+++ b/integrations/harness/cursor/src/hooks/hookScript.ts
@@ -1,56 +1,20 @@
+import {
+  expectedHookCommands,
+  expectedIngressHookScript,
+  type IngressHookScriptOptions,
+} from "@station/harness-shared";
 import { CURSOR_HOOK_EVENT_NAMES, type CursorHookEventName } from "./hookConstants.js";
 
-export type CursorHookScriptOptions = {
+export type CursorHookScriptOptions = IngressHookScriptOptions & {
   hookScriptPath: string;
-  stationConfigPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  hookBin?: string;
 };
-
-function commandLine(args: string[]): string {
-  return args.map(shellQuote).join(" ");
-}
-
-function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
 
 export function expectedCursorHookCommands(input: {
   hookScriptPath: string;
 }): Record<CursorHookEventName, string> {
-  return Object.fromEntries(
-    CURSOR_HOOK_EVENT_NAMES.map((eventName) => [eventName, input.hookScriptPath]),
-  ) as Record<CursorHookEventName, string>;
+  return expectedHookCommands(CURSOR_HOOK_EVENT_NAMES, input.hookScriptPath);
 }
 
 export function expectedCursorHookScript(input: CursorHookScriptOptions): string {
-  const hookArgs = [input.hookBin ?? "stn-ingress"];
-  if (input.observerSocketPath !== undefined) {
-    hookArgs.push("--socket", input.observerSocketPath);
-  }
-  if (input.stateDir !== undefined) {
-    hookArgs.push("--state-dir", input.stateDir);
-  }
-  if (input.hookSpoolDir !== undefined) {
-    hookArgs.push("--spool-dir", input.hookSpoolDir);
-  }
-  if (input.stationConfigPath !== undefined) {
-    hookArgs.push("--config", input.stationConfigPath);
-  }
-  if (input.autoStartFromHooks === false) {
-    hookArgs.push("--no-auto-start");
-  }
-  hookArgs.push("cursor");
-  return [
-    "#!/usr/bin/env bash",
-    "set -euo pipefail",
-    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    "  exit 0",
-    "fi",
-    `${commandLine(hookArgs)} > /dev/null`,
-    "",
-  ].join("\n");
+  return expectedIngressHookScript({ ...input, provider: "cursor" });
 }

--- a/integrations/harness/cursor/src/launch.ts
+++ b/integrations/harness/cursor/src/launch.ts
@@ -1,55 +1,15 @@
 import type { BuildHarnessLaunchRequest, HarnessLaunchPlan } from "@station/contracts";
+import {
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { CursorHarnessProviderError } from "./errors.js";
 
 export type CursorLaunchOptions = {
   command?: string;
 };
-
-function cursorLaunchEnv(request: BuildHarnessLaunchRequest): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "cursor",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
-  }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  return env;
-}
-
-function cursorProviderData(input: {
-  initialPromptProvided: boolean;
-  terminalProvider?: string;
-  terminalTargetId?: string;
-  resume?: boolean;
-  resumeTargetKind?: string;
-}): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: true,
-    observation: "hooks",
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  if (input.resume === true) {
-    providerData.resume = true;
-  }
-  if (input.resumeTargetKind !== undefined) {
-    providerData.resumeTargetKind = input.resumeTargetKind;
-  }
-  return providerData;
-}
 
 export function buildCursorLaunchPlan(
   request: BuildHarnessLaunchRequest,
@@ -86,26 +46,26 @@ export function buildCursorLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const providerDataInput: Parameters<typeof cursorProviderData>[0] = {
+  const providerDataInput: CommonProviderDataInput = {
+    mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    ...terminalProviderData(request),
   };
   if (request.resume !== undefined) {
     providerDataInput.resume = true;
     providerDataInput.resumeTargetKind = request.resume.target.kind;
   }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
+  const providerData = commonProviderData(providerDataInput);
+  providerData.observation = "hooks";
 
   return {
     provider: "cursor",
     command: options.command ?? "agent",
     args,
     cwd: request.worktree.path,
-    env: cursorLaunchEnv(request),
+    env: harnessLaunchEnv("cursor", request),
     mode,
     displayTitle: `${request.project.label} Cursor`,
-    providerData: cursorProviderData(providerDataInput),
+    providerData,
   };
 }

--- a/integrations/harness/cursor/src/provider.ts
+++ b/integrations/harness/cursor/src/provider.ts
@@ -1,47 +1,21 @@
-import type {
-  BuildHarnessLaunchRequest,
-  HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
-  HarnessLaunchPlan,
-  HarnessProvider,
-  HarnessRunObservation,
-  HarnessStatusObservation,
-  ProviderDoctorCheck,
-  ProviderDoctorContext,
-  ProviderHealth,
-  RawHarnessEvent,
-} from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import type { HarnessCapabilities } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  safeErrorFromUnknown,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  hookOptions,
+  TerminalBoundHarnessProvider,
+  type TerminalBoundHarnessProviderSpec,
+} from "@station/harness-shared";
 import { classifyCursorRunStatus } from "./classify.js";
-import { cursorProviderErrorFromUnknown } from "./errors.js";
 import { normalizeCursorRawEvent } from "./events.js";
 import { doctorCursorHooks } from "./hooks.js";
 import { buildCursorLaunchPlan, type CursorLaunchOptions } from "./launch.js";
 
-export type CursorHarnessProviderOptions = {
-  command?: string;
-  installHooks?: boolean;
+export type CursorHarnessProviderOptions = CommonHarnessProviderOptions & {
   configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  resume?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
+
+type CursorHookOptions = Parameters<typeof doctorCursorHooks>[0];
+type CursorHookResult = Awaited<ReturnType<typeof doctorCursorHooks>>;
 
 const baseCapabilities: HarnessCapabilities = {
   canLaunch: true,
@@ -56,159 +30,56 @@ const baseCapabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: false,
 };
 
-function command(options: CursorHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_CURSOR_AGENT_BIN ?? "agent";
-}
+const cursorProviderSpec = {
+  id: "cursor",
+  displayName: "Cursor",
+  command: {
+    envVar: "STATION_CURSOR_AGENT_BIN",
+    fallback: "agent",
+  },
+  baseCapabilities,
+  health: {
+    args: ["--version"],
+    unavailable: {
+      code: "HARNESS_CURSOR_UNAVAILABLE",
+      message: "Cursor Agent is not available.",
+      hint: "Install Cursor Agent or configure [harness.cursor].command.",
+    },
+    diagnostics: () => ({
+      command: "agent --version succeeded",
+      observation: "hooks",
+    }),
+  },
+  hooks: {
+    doctor: doctorCursorHooks,
+    buildOptions: (options, context) => hookOptions(options, context),
+    checkName: "cursor-hooks",
+    failure: {
+      tag: "CursorHookSetupError",
+      code: "CURSOR_HOOK_DIAGNOSTIC_FAILED",
+      message: "Cursor hook diagnostics failed.",
+    },
+    formatCheckMessage: (result) =>
+      `${result.message} Hooks: ${result.hooksPath}. Script: ${result.hookScriptPath}.`,
+  },
+  buildLaunchOptions: (_options, command) => ({ command }),
+  buildLaunch: buildCursorLaunchPlan,
+  classifyRun: (run) => classifyCursorRunStatus(run),
+  normalizeEvent: normalizeCursorRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<
+  CursorHarnessProviderOptions,
+  CursorLaunchOptions,
+  CursorHookOptions,
+  CursorHookResult
+>;
 
-function capabilities(options: CursorHarnessProviderOptions): HarnessCapabilities {
-  // Adapter support alone is not enough; resume stays invisible unless this
-  // provider instance is explicitly enabled by [harness.cursor].resume.
-  return {
-    ...baseCapabilities,
-    canResume: options.resume === true,
-  };
-}
-
-export class CursorHarnessProvider implements HarnessProvider {
-  readonly id = "cursor";
-
-  readonly #options: CursorHarnessProviderOptions;
-
+export class CursorHarnessProvider extends TerminalBoundHarnessProvider<
+  CursorHarnessProviderOptions,
+  CursorLaunchOptions,
+  CursorHookOptions,
+  CursorHookResult
+> {
   constructor(options: CursorHarnessProviderOptions = {}) {
-    this.#options = options;
-  }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities(this.#options);
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = toIsoTimestamp(this.#options.now?.() ?? systemClock.now());
-    try {
-      await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["--version"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities: this.capabilities(),
-        diagnostics: {
-          command: "agent --version succeeded",
-          observation: "hooks",
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: cursorProviderErrorFromUnknown(error, {
-          code: "HARNESS_CURSOR_UNAVAILABLE",
-          message: "Cursor Agent is not available.",
-          hint: "Install Cursor Agent or configure [harness.cursor].command.",
-        }),
-        capabilities: this.capabilities(),
-      };
-    }
-  }
-
-  async doctorChecks(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
-    try {
-      const hookOptions: Parameters<typeof doctorCursorHooks>[0] = {
-        enabled: this.#options.installHooks === true,
-      };
-      if (this.#options.observerSocketPath !== undefined) {
-        hookOptions.observerSocketPath = this.#options.observerSocketPath;
-      }
-      if (this.#options.stateDir !== undefined) {
-        hookOptions.stateDir = this.#options.stateDir;
-      }
-      if (this.#options.hookSpoolDir !== undefined) {
-        hookOptions.hookSpoolDir = this.#options.hookSpoolDir;
-      }
-      if (this.#options.autoStartFromHooks !== undefined) {
-        hookOptions.autoStartFromHooks = this.#options.autoStartFromHooks;
-      }
-      if (context?.stationConfigPath !== undefined) {
-        hookOptions.stationConfigPath = context.stationConfigPath;
-      } else if (this.#options.configPath !== undefined) {
-        hookOptions.stationConfigPath = this.#options.configPath;
-      }
-      const hookResult = await doctorCursorHooks(hookOptions);
-      return [
-        {
-          name: "cursor-hooks",
-          status: hookResult.status,
-          message: `${hookResult.message} Hooks: ${hookResult.hooksPath}. Script: ${hookResult.hookScriptPath}.`,
-        },
-      ];
-    } catch (cause) {
-      return [
-        {
-          name: "cursor-hooks",
-          status: "error",
-          message: "Cursor hook diagnostics failed.",
-          error: safeErrorFromUnknown(cause, {
-            tag: "CursorHookSetupError",
-            code: "CURSOR_HOOK_DIAGNOSTIC_FAILED",
-            message: "Cursor hook diagnostics failed.",
-            provider: this.id,
-          }),
-        },
-      ];
-    }
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: CursorLaunchOptions = {
-      command: command(this.#options),
-    };
-    return buildCursorLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "Cursor",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyCursorRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.cursor.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_CURSOR_EVENT_INGEST_FAILED",
-          message: "The Cursor harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizeCursorRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
+    super(cursorProviderSpec, options);
   }
 }

--- a/integrations/harness/opencode/src/compaction.ts
+++ b/integrations/harness/opencode/src/compaction.ts
@@ -1,3 +1,4 @@
+import { jsonByteCount } from "@station/harness-shared";
 import {
   OpenCodeCompactEventSchema,
   type OpenCodeNativeEvent,
@@ -194,16 +195,4 @@ function omittedNativeFieldNames(
     }
   }
   return [...omitted].sort();
-}
-
-function jsonByteCount(value: unknown): number | null {
-  try {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      return null;
-    }
-    return Buffer.byteLength(serialized, "utf8");
-  } catch {
-    return null;
-  }
 }

--- a/integrations/harness/opencode/src/errors.ts
+++ b/integrations/harness/opencode/src/errors.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import { harnessProviderErrorClass } from "@station/harness-shared";
 
 export type OpenCodeHarnessErrorCode =
   | "HARNESS_OPENCODE_UNAVAILABLE"
@@ -8,49 +8,15 @@ export type OpenCodeHarnessErrorCode =
   | "HARNESS_OPENCODE_EVENT_INGEST_FAILED"
   | "HARNESS_OPENCODE_PLUGIN_INSTALL_FAILED";
 
-export class OpenCodeHarnessProviderError extends Error implements SafeError {
-  readonly tag = "HarnessProviderError";
-  readonly code: OpenCodeHarnessErrorCode;
-  readonly provider = "opencode";
-  readonly hint: string | undefined;
-
-  constructor(
-    code: OpenCodeHarnessErrorCode,
-    message: string,
-    options: { cause?: unknown; hint?: string } = {},
-  ) {
-    super(`${code}: ${message}`, { cause: options.cause });
-    Object.defineProperty(this, "name", {
-      value: "OpenCodeHarnessProviderError",
-      configurable: true,
-    });
-    this.code = code;
-    this.hint = options.hint;
-  }
-}
+export const OpenCodeHarnessProviderError = harnessProviderErrorClass<OpenCodeHarnessErrorCode>({
+  name: "OpenCodeHarnessProviderError",
+  provider: "opencode",
+});
 
 export function openCodeHarnessError(
   code: OpenCodeHarnessErrorCode,
   message: string,
   cause?: unknown,
-): OpenCodeHarnessProviderError {
+) {
   return new OpenCodeHarnessProviderError(code, message, { cause });
-}
-
-export function openCodeProviderErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: OpenCodeHarnessErrorCode;
-    message: string;
-    hint?: string | undefined;
-  },
-): OpenCodeHarnessProviderError {
-  if (error instanceof OpenCodeHarnessProviderError) {
-    return error;
-  }
-  const options: { cause?: unknown; hint?: string } = { cause: error };
-  if (fallback.hint !== undefined) {
-    options.hint = fallback.hint;
-  }
-  return new OpenCodeHarnessProviderError(fallback.code, fallback.message, options);
 }

--- a/integrations/harness/opencode/src/events.ts
+++ b/integrations/harness/opencode/src/events.ts
@@ -7,15 +7,14 @@ import type {
   HarnessEventReport,
   ObservedStatus,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
+import { HarnessEventReportSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
-  HarnessEventReportSchema,
-  observedPathIsSameOrInside,
-  STATION_SCHEMA_VERSION,
-  sameObservedPath,
-} from "@station/contracts";
+  applyCorrelation,
+  correlateTerminalBoundHarnessEvent,
+  harnessEventDiagnostics,
+  reportCorrelation,
+} from "@station/harness-shared";
 import { compactOpenCodeHookPayload } from "./compaction.js";
 import { openCodeHarnessError } from "./errors.js";
 import {
@@ -70,7 +69,17 @@ export function normalizeOpenCodeRawEvent(
   const compaction = compactOpenCodeHookPayload(raw.event);
   const event = parseOpenCodeCompactEvent(compaction.payload);
   const observedAt = event.observed_at ?? raw.observedAt ?? new Date().toISOString();
-  const correlation = correlateOpenCodeEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "opencode",
+    identity: event,
+    context,
+    cwd: event.cwd,
+    nativeSessionId: event.opencode_session_id,
+    pid: event.pid,
+    includeProjectId: true,
+    includeTerminalTargetId: true,
+    includeCwd: true,
+  });
   const observation: HarnessEventObservation = {
     provider: "opencode",
     rawEventType: event.event_type,
@@ -84,43 +93,14 @@ export function normalizeOpenCodeRawEvent(
   if (status !== undefined) {
     observation.status = status;
   }
-  if (correlation.projectId !== undefined) {
-    observation.projectId = correlation.projectId;
-  }
-  if (correlation.sessionId !== undefined) {
-    observation.sessionId = correlation.sessionId;
-  }
-  if (correlation.worktreeId !== undefined) {
-    observation.worktreeId = correlation.worktreeId;
-  }
-  if (correlation.harnessRunId !== undefined) {
-    observation.harnessRunId = correlation.harnessRunId;
-  }
-  if (correlation.terminalTargetId !== undefined) {
-    observation.terminalTargetId = correlation.terminalTargetId;
-  }
-  if (event.opencode_session_id !== undefined) {
-    observation.nativeSessionId = event.opencode_session_id;
-  }
-  if (event.cwd !== undefined) {
-    observation.cwd = event.cwd;
-  }
-  if (event.pid !== undefined) {
-    observation.pid = event.pid;
-  }
+  applyCorrelation(observation, correlation);
   if (compaction.omittedFieldNames.length > 0) {
-    const diagnostics: NonNullable<HarnessEventObservation["diagnostics"]> = {
-      rawEventType: event.event_type,
+    observation.diagnostics = harnessEventDiagnostics(event.event_type, {
       compacted: compaction.compacted,
       omittedFieldNames: compaction.omittedFieldNames,
-    };
-    if (compaction.originalByteCount !== null) {
-      diagnostics.payloadBytes = compaction.originalByteCount;
-    }
-    if (compaction.compactedByteCount !== null) {
-      diagnostics.compactedBytes = compaction.compactedByteCount;
-    }
-    observation.diagnostics = diagnostics;
+      payloadBytes: compaction.originalByteCount,
+      compactedBytes: compaction.compactedByteCount,
+    });
   }
   return [observation];
 }
@@ -156,10 +136,7 @@ export function openCodeHookPayloadToHarnessEventReport(
   if (correlation !== undefined) {
     report.correlation = correlation;
   }
-  const diagnostics = reportDiagnosticsFromOpenCodeEvent(event, input.diagnostics);
-  if (diagnostics !== undefined) {
-    report.diagnostics = diagnostics;
-  }
+  report.diagnostics = harnessEventDiagnostics(event.event_type, input.diagnostics);
   const coalesceKey = reportCoalesceKeyFromOpenCodeEvent(event);
   if (coalesceKey !== undefined) {
     report.coalesceKey = coalesceKey;
@@ -321,54 +298,19 @@ function providerDataFromOpenCodeEvent(event: OpenCodeCompactEvent): Record<stri
 function reportCorrelationFromOpenCodeEvent(
   event: OpenCodeCompactEvent,
 ): HarnessEventReport["correlation"] | undefined {
-  const correlation: NonNullable<HarnessEventReport["correlation"]> = {
+  return reportCorrelation({
     cwd: event.cwd,
-  };
-  if (event.station_project_id !== undefined) {
-    correlation.projectId = event.station_project_id;
-  }
-  if (event.station_worktree_id !== undefined) {
-    correlation.worktreeId = event.station_worktree_id;
-  }
-  if (event.station_session_id !== undefined) {
-    correlation.sessionId = event.station_session_id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    correlation.terminalTargetId = event.station_terminal_target_id;
-    correlation.harnessRunId = `opencode:${event.station_terminal_target_id}`;
-  }
-  if (event.opencode_session_id !== undefined) {
-    correlation.nativeSessionId = event.opencode_session_id;
-  }
-  if (event.pid !== undefined) {
-    correlation.pid = event.pid;
-  }
-  return correlation;
-}
-
-function reportDiagnosticsFromOpenCodeEvent(
-  event: OpenCodeCompactEvent,
-  input: OpenCodeHarnessEventReportInput["diagnostics"],
-): HarnessEventReport["diagnostics"] | undefined {
-  const diagnostics: NonNullable<HarnessEventReport["diagnostics"]> = {
-    rawEventType: event.event_type,
-  };
-  if (typeof input?.payloadBytes === "number") {
-    diagnostics.payloadBytes = input.payloadBytes;
-  }
-  if (typeof input?.compactedBytes === "number") {
-    diagnostics.compactedBytes = input.compactedBytes;
-  }
-  if (input?.compacted !== undefined) {
-    diagnostics.compacted = input.compacted;
-  }
-  if (input?.truncated !== undefined) {
-    diagnostics.truncated = input.truncated;
-  }
-  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
-    diagnostics.omittedFieldNames = input.omittedFieldNames;
-  }
-  return diagnostics;
+    nativeSessionId: event.opencode_session_id,
+    pid: event.pid,
+    projectId: event.station_project_id,
+    worktreeId: event.station_worktree_id,
+    sessionId: event.station_session_id,
+    terminalTargetId: event.station_terminal_target_id,
+    harnessRunId:
+      event.station_terminal_target_id === undefined
+        ? undefined
+        : `opencode:${event.station_terminal_target_id}`,
+  });
 }
 
 function reportCoalesceKeyFromOpenCodeEvent(event: OpenCodeCompactEvent): string | undefined {
@@ -379,112 +321,4 @@ function reportCoalesceKeyFromOpenCodeEvent(event: OpenCodeCompactEvent): string
   if (event.tool_call_id !== undefined) parts.push(`tool:${event.tool_call_id}`);
   if (event.request_id !== undefined) parts.push(`request:${event.request_id}`);
   return parts.length === 0 ? undefined : parts.join(":");
-}
-
-function correlateOpenCodeEvent(
-  event: OpenCodeCompactEvent,
-  context: HarnessEventContext,
-): {
-  projectId?: string;
-  sessionId?: string;
-  worktreeId?: string;
-  harnessRunId?: string;
-  terminalTargetId?: string;
-} {
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(event.cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(event.cwd, context.worktrees);
-  const result: {
-    projectId?: string;
-    sessionId?: string;
-    worktreeId?: string;
-    harnessRunId?: string;
-    terminalTargetId?: string;
-  } = {};
-  if (event.station_project_id !== undefined) {
-    result.projectId = event.station_project_id;
-  } else if (terminal?.projectId !== undefined) {
-    result.projectId = terminal.projectId;
-  } else if (worktree?.projectId !== undefined) {
-    result.projectId = worktree.projectId;
-  }
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    result.terminalTargetId = event.station_terminal_target_id;
-    result.harnessRunId = `opencode:${event.station_terminal_target_id}`;
-  } else if (terminal?.harnessRunId !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.terminalTargetId = terminal.id;
-    result.harnessRunId = `opencode:${terminal.id}`;
-  }
-  return result;
-}
-
-function terminalForId(
-  terminalTargetId: string | undefined,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (terminalTargetId === undefined) {
-    return undefined;
-  }
-  return targets.find((target) => target.id === terminalTargetId);
-}
-
-function terminalForCwd(
-  cwd: string,
-  targets: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  return (
-    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
-    targets.find(
-      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
-    )
-  );
-}
-
-function worktreeForId(
-  worktreeId: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (worktreeId === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === worktreeId);
-}
-
-function worktreeForPath(
-  path: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (path === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => sameObservedPath(worktree.path, path));
-}
-
-function worktreeForCwd(
-  cwd: string,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  return (
-    worktrees.find((worktree) => sameObservedPath(worktree.path, cwd)) ??
-    worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path))
-  );
 }

--- a/integrations/harness/opencode/src/launch.ts
+++ b/integrations/harness/opencode/src/launch.ts
@@ -3,6 +3,13 @@ import type {
   HarnessLaunchPlan,
   HarnessPermissionMode,
 } from "@station/contracts";
+import {
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  isYoloPermissionMode,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { OpenCodeHarnessProviderError } from "./errors.js";
 
 export type OpenCodeLaunchOptions = {
@@ -39,9 +46,12 @@ export function buildOpenCodeLaunchPlan(
     initialPrompt: request.initialPrompt,
   });
 
-  const providerDataInput: OpenCodeProviderDataInput = {
+  const providerDataInput: CommonProviderDataInput = {
     mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    configPathProvided: options.configPath !== undefined,
+    observerSocketPathProvided: options.observerSocketPath !== undefined,
+    ...terminalProviderData(request),
   };
   if (profile !== undefined) {
     providerDataInput.profile = profile;
@@ -55,26 +65,16 @@ export function buildOpenCodeLaunchPlan(
   if (!yolo && sandboxMode !== undefined) {
     providerDataInput.sandboxMode = sandboxMode;
   }
-  if (options.configPath !== undefined) {
-    providerDataInput.configPathProvided = true;
-  }
-  if (options.observerSocketPath !== undefined) {
-    providerDataInput.observerSocketPathProvided = true;
-  }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
 
   return {
     provider: "opencode",
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: openCodeLaunchEnv(request, options),
+    env: harnessLaunchEnv("opencode", request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
-    providerData: openCodeProviderData(providerDataInput),
+    providerData: commonProviderData(providerDataInput),
   };
 }
 
@@ -109,10 +109,10 @@ function buildOpenCodeResumeLaunchPlan(
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: openCodeLaunchEnv(request, options),
+    env: harnessLaunchEnv("opencode", request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
-    providerData: openCodeProviderData({
+    providerData: commonProviderData({
       mode,
       initialPromptProvided: request.initialPrompt !== undefined,
       resume: true,
@@ -151,102 +151,4 @@ function appendOpenCodeOptions(
       args.push(options.initialPrompt);
     }
   }
-}
-
-function openCodeLaunchEnv(
-  request: BuildHarnessLaunchRequest,
-  options: OpenCodeLaunchOptions,
-): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "opencode",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
-  }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  if (options.configPath !== undefined) {
-    env.STATION_CONFIG_PATH = options.configPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    env.STATION_OBSERVER_SOCKET_PATH = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    env.STATION_OBSERVER_STATE_DIR = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
-  }
-  return env;
-}
-
-function isYoloPermissionMode(input: {
-  permissionMode?: HarnessPermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-}): boolean {
-  if (input.permissionMode !== undefined) {
-    return input.permissionMode === "yolo";
-  }
-  return input.approvalPolicy === "never" && input.sandboxMode === "danger-full-access";
-}
-
-type OpenCodeProviderDataInput = {
-  mode: "interactive" | "exec";
-  profile?: string | undefined;
-  permissionMode?: HarnessPermissionMode | undefined;
-  approvalPolicy?: string | undefined;
-  sandboxMode?: string | undefined;
-  initialPromptProvided: boolean;
-  configPathProvided?: boolean | undefined;
-  observerSocketPathProvided?: boolean | undefined;
-  terminalProvider?: string | undefined;
-  terminalTargetId?: string | undefined;
-  resume?: boolean | undefined;
-  resumeTargetKind?: string | undefined;
-};
-
-function openCodeProviderData(input: OpenCodeProviderDataInput): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: input.mode === "interactive",
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.profile !== undefined) {
-    providerData.profile = input.profile;
-  }
-  if (input.permissionMode !== undefined) {
-    providerData.permissionMode = input.permissionMode;
-  }
-  if (input.approvalPolicy !== undefined) {
-    providerData.approvalPolicy = input.approvalPolicy;
-  }
-  if (input.sandboxMode !== undefined) {
-    providerData.sandboxMode = input.sandboxMode;
-  }
-  if (input.configPathProvided === true) {
-    providerData.configPathProvided = true;
-  }
-  if (input.observerSocketPathProvided === true) {
-    providerData.observerSocketPathProvided = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  if (input.resume === true) {
-    providerData.resume = true;
-  }
-  if (input.resumeTargetKind !== undefined) {
-    providerData.resumeTargetKind = input.resumeTargetKind;
-  }
-  return providerData;
 }

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -1,52 +1,26 @@
-import type {
-  BuildHarnessLaunchRequest,
-  HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
-  HarnessLaunchPlan,
-  HarnessPermissionMode,
-  HarnessProvider,
-  HarnessRunObservation,
-  HarnessStatusObservation,
-  ProviderDoctorCheck,
-  ProviderDoctorContext,
-  ProviderHealth,
-  RawHarnessEvent,
-} from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import type { HarnessCapabilities, HarnessPermissionMode } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  safeErrorFromUnknown,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  TerminalBoundHarnessProvider,
+  type TerminalBoundHarnessProviderSpec,
+} from "@station/harness-shared";
 import { classifyOpenCodeRunStatus } from "./classify.js";
-import { openCodeProviderErrorFromUnknown } from "./errors.js";
 import { normalizeOpenCodeRawEvent } from "./events.js";
 import { buildOpenCodeLaunchPlan, type OpenCodeLaunchOptions } from "./launch.js";
 import { doctorOpenCodePlugin } from "./pluginInstall.js";
 
-export type OpenCodeHarnessProviderOptions = {
-  command?: string;
+export type OpenCodeHarnessProviderOptions = CommonHarnessProviderOptions & {
   profile?: string;
   permissionMode?: HarnessPermissionMode;
   approvalPolicy?: string;
   sandboxMode?: string;
   installHooks?: boolean;
   configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
   env?: NodeJS.ProcessEnv;
-  resume?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
+
+type OpenCodePluginOptions = Parameters<typeof doctorOpenCodePlugin>[0];
+type OpenCodePluginResult = Awaited<ReturnType<typeof doctorOpenCodePlugin>>;
 
 const baseCapabilities: HarnessCapabilities = {
   canLaunch: true,
@@ -61,192 +35,89 @@ const baseCapabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: false,
 };
 
-export class OpenCodeHarnessProvider implements HarnessProvider {
-  readonly id = "opencode";
-
-  readonly #options: OpenCodeHarnessProviderOptions;
-
-  constructor(options: OpenCodeHarnessProviderOptions = {}) {
-    this.#options = options;
-  }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities(this.#options);
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = toIsoTimestamp(this.#options.now?.() ?? systemClock.now());
-    try {
-      await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["--version"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities: this.capabilities(),
-        diagnostics: {
-          command: "opencode --version succeeded",
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: openCodeProviderErrorFromUnknown(error, {
-          code: "HARNESS_OPENCODE_UNAVAILABLE",
-          message: "OpenCode is not available.",
-          hint: "Install OpenCode or configure [harness.opencode].command.",
-        }),
-        capabilities: this.capabilities(),
-      };
+const openCodeProviderSpec = {
+  id: "opencode",
+  displayName: "OpenCode",
+  command: {
+    envVar: "STATION_OPENCODE_BIN",
+    fallback: "opencode",
+  },
+  baseCapabilities,
+  health: {
+    args: ["--version"],
+    unavailable: {
+      code: "HARNESS_OPENCODE_UNAVAILABLE",
+      message: "OpenCode is not available.",
+      hint: "Install OpenCode or configure [harness.opencode].command.",
+    },
+    diagnostics: () => ({
+      command: "opencode --version succeeded",
+    }),
+    okDoctorCheck: {
+      name: "opencode.command",
+      okMessage: "OpenCode command is available.",
+      errorMessage: "OpenCode command is unavailable.",
+    },
+  },
+  hooks: {
+    doctor: doctorOpenCodePlugin,
+    buildOptions: openCodePluginOptions,
+    checkName: "opencode-plugin",
+    failure: {
+      tag: "OpenCodePluginSetupError",
+      code: "OPENCODE_PLUGIN_DIAGNOSTIC_FAILED",
+      message: "OpenCode plugin diagnostics failed.",
+    },
+    formatCheckMessage: (result) => `${result.message} Plugin: ${result.pluginPath}.`,
+  },
+  buildLaunchOptions: (options, command) => {
+    const launchOptions: OpenCodeLaunchOptions = { command };
+    if (options.profile !== undefined) launchOptions.defaultProfile = options.profile;
+    if (options.permissionMode !== undefined) {
+      launchOptions.defaultPermissionMode = options.permissionMode;
     }
-  }
+    if (options.approvalPolicy !== undefined) {
+      launchOptions.defaultApprovalPolicy = options.approvalPolicy;
+    }
+    if (options.sandboxMode !== undefined) launchOptions.defaultSandboxMode = options.sandboxMode;
+    if (options.configPath !== undefined) launchOptions.configPath = options.configPath;
+    if (options.observerSocketPath !== undefined) {
+      launchOptions.observerSocketPath = options.observerSocketPath;
+    }
+    if (options.stateDir !== undefined) launchOptions.stateDir = options.stateDir;
+    if (options.hookSpoolDir !== undefined) launchOptions.hookSpoolDir = options.hookSpoolDir;
+    return launchOptions;
+  },
+  buildLaunch: buildOpenCodeLaunchPlan,
+  classifyRun: (run) => classifyOpenCodeRunStatus(run),
+  normalizeEvent: normalizeOpenCodeRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<
+  OpenCodeHarnessProviderOptions,
+  OpenCodeLaunchOptions,
+  OpenCodePluginOptions,
+  OpenCodePluginResult
+>;
 
-  async doctorChecks(_context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
-    const checks: ProviderDoctorCheck[] = [];
-    const health = await this.health();
-    if (health.status === "healthy") {
-      checks.push({
-        name: "opencode.command",
-        status: "ok",
-        message: "OpenCode command is available.",
-      });
-    } else {
-      const check: ProviderDoctorCheck = {
-        name: "opencode.command",
-        status: "error",
-        message: "OpenCode command is unavailable.",
-      };
-      if (health.lastError !== undefined) {
-        check.error = health.lastError;
-      }
-      checks.push(check);
-    }
-
-    try {
-      const pluginOptions: Parameters<typeof doctorOpenCodePlugin>[0] = {
-        enabled: this.#options.installHooks === true,
-        env: this.#options.env ?? process.env,
-      };
-      if (this.#options.observerSocketPath !== undefined) {
-        pluginOptions.observerSocketPath = this.#options.observerSocketPath;
-      }
-      if (this.#options.stateDir !== undefined) {
-        pluginOptions.stateDir = this.#options.stateDir;
-      }
-      if (this.#options.hookSpoolDir !== undefined) {
-        pluginOptions.hookSpoolDir = this.#options.hookSpoolDir;
-      }
-      const pluginResult = await doctorOpenCodePlugin(pluginOptions);
-      checks.push({
-        name: "opencode-plugin",
-        status: pluginResult.status,
-        message: `${pluginResult.message} Plugin: ${pluginResult.pluginPath}.`,
-      });
-    } catch (cause) {
-      checks.push({
-        name: "opencode-plugin",
-        status: "error",
-        message: "OpenCode plugin diagnostics failed.",
-        error: safeErrorFromUnknown(cause, {
-          tag: "OpenCodePluginSetupError",
-          code: "OPENCODE_PLUGIN_DIAGNOSTIC_FAILED",
-          message: "OpenCode plugin diagnostics failed.",
-          provider: this.id,
-        }),
-      });
-    }
-    return checks;
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: OpenCodeLaunchOptions = {
-      command: command(this.#options),
-    };
-    if (this.#options.profile !== undefined) {
-      options.defaultProfile = this.#options.profile;
-    }
-    if (this.#options.permissionMode !== undefined) {
-      options.defaultPermissionMode = this.#options.permissionMode;
-    }
-    if (this.#options.approvalPolicy !== undefined) {
-      options.defaultApprovalPolicy = this.#options.approvalPolicy;
-    }
-    if (this.#options.sandboxMode !== undefined) {
-      options.defaultSandboxMode = this.#options.sandboxMode;
-    }
-    if (this.#options.configPath !== undefined) {
-      options.configPath = this.#options.configPath;
-    }
-    if (this.#options.observerSocketPath !== undefined) {
-      options.observerSocketPath = this.#options.observerSocketPath;
-    }
-    if (this.#options.stateDir !== undefined) {
-      options.stateDir = this.#options.stateDir;
-    }
-    if (this.#options.hookSpoolDir !== undefined) {
-      options.hookSpoolDir = this.#options.hookSpoolDir;
-    }
-    return buildOpenCodeLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "OpenCode",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyOpenCodeRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.opencode.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_OPENCODE_EVENT_INGEST_FAILED",
-          message: "The OpenCode harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizeOpenCodeRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
-  }
-}
-
-function command(options: OpenCodeHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_OPENCODE_BIN ?? "opencode";
-}
-
-function capabilities(options: OpenCodeHarnessProviderOptions): HarnessCapabilities {
-  // Adapter support alone is not enough; resume stays invisible unless this
-  // provider instance is explicitly enabled by [harness.opencode].resume.
-  return {
-    ...baseCapabilities,
-    canResume: options.resume === true,
+function openCodePluginOptions(options: OpenCodeHarnessProviderOptions): OpenCodePluginOptions {
+  const pluginOptions: OpenCodePluginOptions = {
+    enabled: options.installHooks === true,
+    env: options.env ?? process.env,
   };
+  if (options.observerSocketPath !== undefined) {
+    pluginOptions.observerSocketPath = options.observerSocketPath;
+  }
+  if (options.stateDir !== undefined) pluginOptions.stateDir = options.stateDir;
+  if (options.hookSpoolDir !== undefined) pluginOptions.hookSpoolDir = options.hookSpoolDir;
+  return pluginOptions;
+}
+
+export class OpenCodeHarnessProvider extends TerminalBoundHarnessProvider<
+  OpenCodeHarnessProviderOptions,
+  OpenCodeLaunchOptions,
+  OpenCodePluginOptions,
+  OpenCodePluginResult
+> {
+  constructor(options: OpenCodeHarnessProviderOptions = {}) {
+    super(openCodeProviderSpec, options);
+  }
 }

--- a/integrations/harness/pi/src/errors.ts
+++ b/integrations/harness/pi/src/errors.ts
@@ -1,4 +1,4 @@
-import type { SafeError } from "@station/contracts";
+import { harnessProviderErrorClass } from "@station/harness-shared";
 
 export type PiHarnessErrorCode =
   | "HARNESS_PI_UNAVAILABLE"
@@ -7,49 +7,11 @@ export type PiHarnessErrorCode =
   | "HARNESS_PI_EVENT_INVALID"
   | "HARNESS_PI_EVENT_INGEST_FAILED";
 
-export class PiHarnessProviderError extends Error implements SafeError {
-  readonly tag = "HarnessProviderError";
-  readonly code: PiHarnessErrorCode;
-  readonly provider = "pi";
-  readonly hint: string | undefined;
+export const PiHarnessProviderError = harnessProviderErrorClass<PiHarnessErrorCode>({
+  name: "PiHarnessProviderError",
+  provider: "pi",
+});
 
-  constructor(
-    code: PiHarnessErrorCode,
-    message: string,
-    options: { cause?: unknown; hint?: string } = {},
-  ) {
-    super(`${code}: ${message}`, { cause: options.cause });
-    Object.defineProperty(this, "name", {
-      value: "PiHarnessProviderError",
-      configurable: true,
-    });
-    this.code = code;
-    this.hint = options.hint;
-  }
-}
-
-export function piHarnessError(
-  code: PiHarnessErrorCode,
-  message: string,
-  cause?: unknown,
-): PiHarnessProviderError {
+export function piHarnessError(code: PiHarnessErrorCode, message: string, cause?: unknown) {
   return new PiHarnessProviderError(code, message, { cause });
-}
-
-export function piProviderErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: PiHarnessErrorCode;
-    message: string;
-    hint?: string | undefined;
-  },
-): PiHarnessProviderError {
-  if (error instanceof PiHarnessProviderError) {
-    return error;
-  }
-  const options: { cause?: unknown; hint?: string } = { cause: error };
-  if (fallback.hint !== undefined) {
-    options.hint = fallback.hint;
-  }
-  return new PiHarnessProviderError(fallback.code, fallback.message, options);
 }

--- a/integrations/harness/pi/src/event/compaction.ts
+++ b/integrations/harness/pi/src/event/compaction.ts
@@ -1,3 +1,4 @@
+import { compactPayloadByFieldNames, type PayloadCompactionResult } from "@station/harness-shared";
 import { compactFieldNamesForPiEvent } from "./catalog.js";
 import { normalizePiEventType } from "./compactEvent.js";
 
@@ -13,66 +14,17 @@ export function compactPiHookPayload(
   eventType: string,
   payload: unknown,
 ): PiPayloadCompactionResult {
-  const originalByteCount = jsonByteCount(payload);
-  if (!isRecord(payload)) {
-    return {
-      payload,
-      compacted: false,
-      originalByteCount,
-      compactedByteCount: originalByteCount,
-      omittedFieldNames: [],
-    };
-  }
-
-  const output: Record<string, unknown> = {};
-  const copiedFields = new Set<string>();
-  const omittedFieldNames = new Set<string>();
-  const normalizedEventType = normalizePiEventType(
-    typeof payload.event_type === "string" ? payload.event_type : eventType,
-  );
-  output.event_type = normalizedEventType;
-  copiedFields.add("event_type");
-
-  for (const fieldName of compactFieldNamesForPiEvent(normalizedEventType)) {
-    if (fieldName === "event_type" || !hasOwn(payload, fieldName)) {
-      continue;
-    }
-    output[fieldName] = payload[fieldName];
-    copiedFields.add(fieldName);
-  }
-
-  for (const fieldName of Object.keys(payload)) {
-    if (!copiedFields.has(fieldName)) {
-      omittedFieldNames.add(fieldName);
-    }
-  }
-
-  const compacted = omittedFieldNames.size > 0;
-  return {
-    payload: output,
-    compacted,
-    originalByteCount,
-    compactedByteCount: jsonByteCount(output),
-    omittedFieldNames: [...omittedFieldNames].sort(),
-  };
-}
-
-function jsonByteCount(value: unknown): number | null {
-  try {
-    const serialized = JSON.stringify(value);
-    if (serialized === undefined) {
-      return null;
-    }
-    return Buffer.byteLength(serialized, "utf8");
-  } catch {
-    return null;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasOwn(value: Record<string, unknown>, key: string): boolean {
-  return Object.hasOwn(value, key);
+  return compactPayloadByFieldNames(payload, {
+    retainedFieldNames: (record) => {
+      const normalizedEventType = normalizePiEventType(
+        typeof record.event_type === "string" ? record.event_type : eventType,
+      );
+      return compactFieldNamesForPiEvent(normalizedEventType);
+    },
+    overrideOutput: (record, output) => {
+      output.event_type = normalizePiEventType(
+        typeof record.event_type === "string" ? record.event_type : eventType,
+      );
+    },
+  }) satisfies PayloadCompactionResult;
 }

--- a/integrations/harness/pi/src/event/mapping.ts
+++ b/integrations/harness/pi/src/event/mapping.ts
@@ -7,14 +7,15 @@ import type {
   HarnessEventReport,
   ObservedStatus,
   RawHarnessEvent,
-  TerminalTargetObservation,
-  WorktreeObservation,
 } from "@station/contracts";
+import { HarnessEventReportSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
-  HarnessEventReportSchema,
-  observedPathIsSameOrInside,
-  STATION_SCHEMA_VERSION,
-} from "@station/contracts";
+  applyCorrelation,
+  assignDefined,
+  correlateTerminalBoundHarnessEvent,
+  harnessEventDiagnostics,
+  reportCorrelation,
+} from "@station/harness-shared";
 import { piHarnessError } from "../errors.js";
 import { normalizePiEventType, type PiCompactEvent, parsePiCompactEvent } from "./compactEvent.js";
 
@@ -38,7 +39,14 @@ export function normalizePiRawEvent(
 ): HarnessEventObservation[] {
   const event = parsePiCompactEvent(raw.event);
   const observedAt = raw.observedAt ?? new Date().toISOString();
-  const correlation = correlatePiEvent(event, context);
+  const correlation = correlateTerminalBoundHarnessEvent({
+    provider: "pi",
+    identity: event,
+    context,
+    cwd: event.cwd,
+    nativeSessionId: event.pi_session_id,
+    nativeSessionFile: event.pi_session_file,
+  });
   const observation: HarnessEventObservation = {
     provider: "pi",
     rawEventType: event.event_type,
@@ -46,21 +54,7 @@ export function normalizePiRawEvent(
     observedAt,
     providerData: providerDataFromPiEvent(event),
   };
-  if (correlation.sessionId !== undefined) {
-    observation.sessionId = correlation.sessionId;
-  }
-  if (correlation.worktreeId !== undefined) {
-    observation.worktreeId = correlation.worktreeId;
-  }
-  if (correlation.harnessRunId !== undefined) {
-    observation.harnessRunId = correlation.harnessRunId;
-  }
-  if (event.pi_session_id !== undefined) {
-    observation.nativeSessionId = event.pi_session_id;
-  }
-  if (event.pi_session_file !== undefined) {
-    observation.nativeSessionFile = event.pi_session_file;
-  }
+  applyCorrelation(observation, correlation);
   return [observation];
 }
 
@@ -89,10 +83,7 @@ export function piHookPayloadToHarnessEventReport(
   if (correlation !== undefined) {
     report.correlation = correlation;
   }
-  const diagnostics = reportDiagnosticsFromPiEvent(event, input.diagnostics);
-  if (diagnostics !== undefined) {
-    report.diagnostics = diagnostics;
-  }
+  report.diagnostics = harnessEventDiagnostics(event.event_type, input.diagnostics);
   const coalesceKey = reportCoalesceKeyFromPiEvent(event);
   if (coalesceKey !== undefined) {
     report.coalesceKey = coalesceKey;
@@ -254,56 +245,20 @@ function providerDataFromPiEvent(event: PiCompactEvent): Record<string, unknown>
 function reportCorrelationFromPiEvent(
   event: PiCompactEvent,
 ): HarnessEventReport["correlation"] | undefined {
-  const correlation: NonNullable<HarnessEventReport["correlation"]> = {
+  return reportCorrelation({
     cwd: event.cwd,
-  };
-  if (event.station_project_id !== undefined) {
-    correlation.projectId = event.station_project_id;
-  }
-  if (event.station_worktree_id !== undefined) {
-    correlation.worktreeId = event.station_worktree_id;
-  }
-  if (event.station_session_id !== undefined) {
-    correlation.sessionId = event.station_session_id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    correlation.terminalTargetId = event.station_terminal_target_id;
-    correlation.harnessRunId = `pi:${event.station_terminal_target_id}`;
-  }
-  if (event.pi_session_file !== undefined) {
-    correlation.nativeSessionFile = event.pi_session_file;
-  } else if (event.pi_session_id !== undefined) {
-    correlation.nativeSessionId = event.pi_session_id;
-  }
-  if (event.pid !== undefined) {
-    correlation.pid = event.pid;
-  }
-  return correlation;
-}
-
-function reportDiagnosticsFromPiEvent(
-  event: PiCompactEvent,
-  input: PiHarnessEventReportInput["diagnostics"],
-): HarnessEventReport["diagnostics"] | undefined {
-  const diagnostics: NonNullable<HarnessEventReport["diagnostics"]> = {
-    rawEventType: event.event_type,
-  };
-  if (typeof input?.payloadBytes === "number") {
-    diagnostics.payloadBytes = input.payloadBytes;
-  }
-  if (typeof input?.compactedBytes === "number") {
-    diagnostics.compactedBytes = input.compactedBytes;
-  }
-  if (input?.compacted !== undefined) {
-    diagnostics.compacted = input.compacted;
-  }
-  if (input?.truncated !== undefined) {
-    diagnostics.truncated = input.truncated;
-  }
-  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
-    diagnostics.omittedFieldNames = input.omittedFieldNames;
-  }
-  return diagnostics;
+    nativeSessionFile: event.pi_session_file,
+    nativeSessionId: event.pi_session_file === undefined ? event.pi_session_id : undefined,
+    pid: event.pid,
+    projectId: event.station_project_id,
+    worktreeId: event.station_worktree_id,
+    sessionId: event.station_session_id,
+    terminalTargetId: event.station_terminal_target_id,
+    harnessRunId:
+      event.station_terminal_target_id === undefined
+        ? undefined
+        : `pi:${event.station_terminal_target_id}`,
+  });
 }
 
 function reportCoalesceKeyFromPiEvent(event: PiCompactEvent): string | undefined {
@@ -321,101 +276,8 @@ function reportCoalesceKeyFromPiEvent(event: PiCompactEvent): string | undefined
   return parts.length === 0 ? undefined : parts.join(":");
 }
 
-function correlatePiEvent(
-  event: PiCompactEvent,
-  context: HarnessEventContext,
-): {
-  sessionId?: string;
-  worktreeId?: string;
-  harnessRunId?: string;
-} {
-  const terminal =
-    terminalForId(event.station_terminal_target_id, context.terminalTargets) ??
-    terminalForCwd(event.cwd, context.terminalTargets);
-  const worktree =
-    worktreeForId(event.station_worktree_id, context.worktrees) ??
-    worktreeForPath(event.station_worktree_path, context.worktrees) ??
-    worktreeForCwd(event.cwd, context.worktrees);
-  const result: {
-    sessionId?: string;
-    worktreeId?: string;
-    harnessRunId?: string;
-  } = {};
-  if (event.station_session_id !== undefined) {
-    result.sessionId = event.station_session_id;
-  } else if (terminal?.sessionId !== undefined) {
-    result.sessionId = terminal.sessionId;
-  }
-  if (event.station_worktree_id !== undefined) {
-    result.worktreeId = event.station_worktree_id;
-  } else if (terminal?.worktreeId !== undefined) {
-    result.worktreeId = terminal.worktreeId;
-  } else if (worktree !== undefined) {
-    result.worktreeId = worktree.id;
-  }
-  if (event.station_terminal_target_id !== undefined) {
-    result.harnessRunId = `pi:${event.station_terminal_target_id}`;
-  } else if (terminal?.harnessRunId !== undefined) {
-    result.harnessRunId = terminal.harnessRunId;
-  } else if (terminal !== undefined) {
-    result.harnessRunId = `pi:${terminal.id}`;
-  }
-  return result;
-}
-
-function terminalForId(
-  id: string | undefined,
-  terminals: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  if (id === undefined) {
-    return undefined;
-  }
-  return terminals.find((terminal) => terminal.id === id);
-}
-
-function terminalForCwd(
-  cwd: string,
-  terminals: TerminalTargetObservation[],
-): TerminalTargetObservation | undefined {
-  return terminals.find((terminal) => {
-    if (terminal.cwd === undefined) {
-      return false;
-    }
-    return observedPathIsSameOrInside(cwd, terminal.cwd);
-  });
-}
-
-function worktreeForId(
-  id: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (id === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => worktree.id === id);
-}
-
-function worktreeForPath(
-  path: string | undefined,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  if (path === undefined) {
-    return undefined;
-  }
-  return worktrees.find((worktree) => observedPathIsSameOrInside(path, worktree.path));
-}
-
-function worktreeForCwd(
-  cwd: string,
-  worktrees: WorktreeObservation[],
-): WorktreeObservation | undefined {
-  return worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path));
-}
-
 function assignProviderData(target: Record<string, unknown>, key: string, value: unknown): void {
-  if (value !== undefined) {
-    target[key] = value;
-  }
+  assignDefined(target, key, value);
 }
 
 function assertNever(value: never): never {

--- a/integrations/harness/pi/src/launch.ts
+++ b/integrations/harness/pi/src/launch.ts
@@ -1,5 +1,11 @@
 import { fileURLToPath } from "node:url";
 import type { BuildHarnessLaunchRequest, HarnessLaunchPlan } from "@station/contracts";
+import {
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  terminalProviderData,
+} from "@station/harness-shared";
 import { PiHarnessProviderError } from "./errors.js";
 
 export type PiLaunchOptions = {
@@ -41,34 +47,29 @@ export function buildPiLaunchPlan(
     args.push(request.initialPrompt);
   }
 
-  const providerDataInput: PiLaunchProviderDataInput = {
-    extensionPath,
+  const providerDataInput: CommonProviderDataInput = {
+    mode,
     initialPromptProvided: request.initialPrompt !== undefined,
+    configPathProvided: options.configPath !== undefined,
+    observerSocketPathProvided: options.observerSocketPath !== undefined,
+    ...terminalProviderData(request),
   };
   if (request.resume !== undefined) {
     providerDataInput.resume = true;
     providerDataInput.resumeTargetKind = request.resume.target.kind;
   }
-  if (request.terminalTarget !== undefined) {
-    providerDataInput.terminalProvider = request.terminalTarget.provider;
-    providerDataInput.terminalTargetId = request.terminalTarget.id;
-  }
-  if (options.configPath !== undefined) {
-    providerDataInput.configPathProvided = true;
-  }
-  if (options.observerSocketPath !== undefined) {
-    providerDataInput.observerSocketPathProvided = true;
-  }
+  const providerData = commonProviderData(providerDataInput);
+  providerData.extensionPath = extensionPath;
 
   return {
     provider: "pi",
     command: options.command ?? "pi",
     args,
     cwd: request.worktree.path,
-    env: piLaunchEnv(request, options),
+    env: harnessLaunchEnv("pi", request, options),
     mode,
     displayTitle: `${request.project.label} Pi`,
-    providerData: piProviderData(providerDataInput),
+    providerData,
   };
 }
 
@@ -85,76 +86,4 @@ function resumeTargetValue(request: BuildHarnessLaunchRequest): string {
     );
   }
   return resume.target.kind === "session-file" ? resume.target.path : resume.target.id;
-}
-
-function piLaunchEnv(
-  request: BuildHarnessLaunchRequest,
-  options: PiLaunchOptions,
-): Record<string, string> {
-  const env: Record<string, string> = {
-    STATION_PROJECT_ID: request.project.id,
-    STATION_WORKTREE_ID: request.worktree.id,
-    STATION_WORKTREE_PATH: request.worktree.path,
-    STATION_HARNESS_PROVIDER: "pi",
-  };
-  if (request.sessionId !== undefined) {
-    env.STATION_SESSION_ID = request.sessionId;
-  }
-  if (request.terminalTarget !== undefined) {
-    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
-    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
-  }
-  if (options.configPath !== undefined) {
-    env.STATION_CONFIG_PATH = options.configPath;
-  }
-  if (options.observerSocketPath !== undefined) {
-    env.STATION_OBSERVER_SOCKET_PATH = options.observerSocketPath;
-  }
-  if (options.stateDir !== undefined) {
-    env.STATION_OBSERVER_STATE_DIR = options.stateDir;
-  }
-  if (options.hookSpoolDir !== undefined) {
-    env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
-  }
-  return env;
-}
-
-type PiLaunchProviderDataInput = {
-  extensionPath: string;
-  initialPromptProvided: boolean;
-  configPathProvided?: boolean | undefined;
-  observerSocketPathProvided?: boolean | undefined;
-  terminalProvider?: string | undefined;
-  terminalTargetId?: string | undefined;
-  resume?: boolean | undefined;
-  resumeTargetKind?: string | undefined;
-};
-
-function piProviderData(input: PiLaunchProviderDataInput): Record<string, unknown> {
-  const providerData: Record<string, unknown> = {
-    interactive: true,
-    extensionPath: input.extensionPath,
-  };
-  if (input.initialPromptProvided) {
-    providerData.initialPromptProvided = true;
-  }
-  if (input.configPathProvided === true) {
-    providerData.configPathProvided = true;
-  }
-  if (input.observerSocketPathProvided === true) {
-    providerData.observerSocketPathProvided = true;
-  }
-  if (input.terminalProvider !== undefined) {
-    providerData.terminalProvider = input.terminalProvider;
-  }
-  if (input.terminalTargetId !== undefined) {
-    providerData.terminalTargetId = input.terminalTargetId;
-  }
-  if (input.resume === true) {
-    providerData.resume = true;
-  }
-  if (input.resumeTargetKind !== undefined) {
-    providerData.resumeTargetKind = input.resumeTargetKind;
-  }
-  return providerData;
 }

--- a/integrations/harness/pi/src/provider.ts
+++ b/integrations/harness/pi/src/provider.ts
@@ -1,41 +1,16 @@
-import type {
-  BuildHarnessLaunchRequest,
-  HarnessCapabilities,
-  HarnessClassificationContext,
-  HarnessDiscoveryContext,
-  HarnessEventContext,
-  HarnessEventObservation,
-  HarnessLaunchPlan,
-  HarnessProvider,
-  HarnessRunObservation,
-  HarnessStatusObservation,
-  ProviderHealth,
-  RawHarnessEvent,
-} from "@station/contracts";
-import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import type { HarnessCapabilities } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundary,
-  systemClock,
-  toIsoTimestamp,
-} from "@station/runtime";
+  type CommonHarnessProviderOptions,
+  TerminalBoundHarnessProvider,
+  type TerminalBoundHarnessProviderSpec,
+} from "@station/harness-shared";
 import { classifyPiRunStatus } from "./classify.js";
-import { piProviderErrorFromUnknown } from "./errors.js";
 import { normalizePiRawEvent } from "./event/mapping.js";
-import { buildPiLaunchPlan } from "./launch.js";
+import { buildPiLaunchPlan, type PiLaunchOptions } from "./launch.js";
 
-export type PiHarnessProviderOptions = {
-  command?: string;
+export type PiHarnessProviderOptions = CommonHarnessProviderOptions & {
   extensionPath?: string;
   configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  resume?: boolean;
-  now?: () => Date | string;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
 };
 
 const baseCapabilities: HarnessCapabilities = {
@@ -51,131 +26,46 @@ const baseCapabilities: HarnessCapabilities = {
   supportsModifiedEnterSoftNewline: false,
 };
 
-export class PiHarnessProvider implements HarnessProvider {
-  readonly id = "pi";
+const piProviderSpec = {
+  id: "pi",
+  displayName: "Pi",
+  command: {
+    envVar: "STATION_PI_BIN",
+    fallback: "pi",
+  },
+  baseCapabilities,
+  health: {
+    args: ["--version"],
+    unavailable: {
+      code: "HARNESS_PI_UNAVAILABLE",
+      message: "Pi is not available.",
+      hint: "Install Pi or configure [harness.pi].command.",
+    },
+    diagnostics: () => ({
+      command: "pi --version succeeded",
+    }),
+  },
+  buildLaunchOptions: (options, command) => {
+    const launchOptions: PiLaunchOptions = { command };
+    if (options.extensionPath !== undefined) launchOptions.extensionPath = options.extensionPath;
+    if (options.configPath !== undefined) launchOptions.configPath = options.configPath;
+    if (options.observerSocketPath !== undefined) {
+      launchOptions.observerSocketPath = options.observerSocketPath;
+    }
+    if (options.stateDir !== undefined) launchOptions.stateDir = options.stateDir;
+    if (options.hookSpoolDir !== undefined) launchOptions.hookSpoolDir = options.hookSpoolDir;
+    return launchOptions;
+  },
+  buildLaunch: buildPiLaunchPlan,
+  classifyRun: (run) => classifyPiRunStatus(run),
+  normalizeEvent: normalizePiRawEvent,
+} satisfies TerminalBoundHarnessProviderSpec<PiHarnessProviderOptions, PiLaunchOptions>;
 
-  readonly #options: PiHarnessProviderOptions;
-
+export class PiHarnessProvider extends TerminalBoundHarnessProvider<
+  PiHarnessProviderOptions,
+  PiLaunchOptions
+> {
   constructor(options: PiHarnessProviderOptions = {}) {
-    this.#options = options;
+    super(piProviderSpec, options);
   }
-
-  capabilities(): HarnessCapabilities {
-    return capabilities(this.#options);
-  }
-
-  async health(): Promise<ProviderHealth> {
-    const checkedAt = now(this.#options);
-    try {
-      await runExternalCommand(
-        {
-          command: command(this.#options),
-          args: ["--version"],
-          timeoutMs: this.#options.timeoutMs ?? 5000,
-          maxOutputChars: 4096,
-        },
-        this.#options.runner,
-      );
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "healthy",
-        lastCheckedAt: checkedAt,
-        capabilities: this.capabilities(),
-        diagnostics: {
-          command: "pi --version succeeded",
-        },
-      };
-    } catch (error) {
-      return {
-        providerId: this.id,
-        providerType: "harness",
-        status: "unavailable",
-        lastCheckedAt: checkedAt,
-        lastError: piProviderErrorFromUnknown(error, {
-          code: "HARNESS_PI_UNAVAILABLE",
-          message: "Pi is not available.",
-          hint: "Install Pi or configure [harness.pi].command.",
-        }),
-        capabilities: this.capabilities(),
-      };
-    }
-  }
-
-  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
-    const options: Parameters<typeof buildPiLaunchPlan>[1] = {
-      command: command(this.#options),
-    };
-    if (this.#options.extensionPath !== undefined) {
-      options.extensionPath = this.#options.extensionPath;
-    }
-    if (this.#options.configPath !== undefined) {
-      options.configPath = this.#options.configPath;
-    }
-    if (this.#options.observerSocketPath !== undefined) {
-      options.observerSocketPath = this.#options.observerSocketPath;
-    }
-    if (this.#options.stateDir !== undefined) {
-      options.stateDir = this.#options.stateDir;
-    }
-    if (this.#options.hookSpoolDir !== undefined) {
-      options.hookSpoolDir = this.#options.hookSpoolDir;
-    }
-    return buildPiLaunchPlan(request, options);
-  }
-
-  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
-    return discoverTerminalBoundHarnessRuns(context, {
-      harnessProvider: this.id,
-      displayName: "Pi",
-      role: "main-agent",
-    });
-  }
-
-  async classifyRun(
-    run: HarnessRunObservation,
-    _context: HarnessClassificationContext,
-  ): Promise<HarnessStatusObservation> {
-    return classifyPiRunStatus(run);
-  }
-
-  async ingestEvent(
-    event: RawHarnessEvent,
-    context: HarnessEventContext,
-  ): Promise<HarnessEventObservation[]> {
-    const result = await runRuntimeBoundary(
-      {
-        operation: "provider.pi.ingestEvent",
-        error: {
-          tag: "HarnessProviderError",
-          code: "HARNESS_PI_EVENT_INGEST_FAILED",
-          message: "The Pi harness provider failed to ingest an event.",
-          provider: this.id,
-        },
-      },
-      async () => normalizePiRawEvent(event, context),
-    );
-    if (!result.ok) {
-      throw result.error;
-    }
-    return result.value;
-  }
-}
-
-function command(options: PiHarnessProviderOptions): string {
-  return options.command ?? process.env.STATION_PI_BIN ?? "pi";
-}
-
-function now(options: PiHarnessProviderOptions): string {
-  const value = options.now?.() ?? systemClock.now();
-  return toIsoTimestamp(value instanceof Date ? value : new Date(value));
-}
-
-function capabilities(options: PiHarnessProviderOptions): HarnessCapabilities {
-  // Adapter support alone is not enough; resume stays invisible unless this
-  // provider instance is explicitly enabled by [harness.pi].resume.
-  return {
-    ...baseCapabilities,
-    canResume: options.resume === true,
-  };
 }

--- a/packages/harness-shared/package.json
+++ b/packages/harness-shared/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@station/contracts": "workspace:*"
+    "@station/contracts": "workspace:*",
+    "@station/runtime": "workspace:*"
   }
 }

--- a/packages/harness-shared/src/compaction.ts
+++ b/packages/harness-shared/src/compaction.ts
@@ -1,0 +1,105 @@
+export type PayloadCompactionResult = {
+  payload: unknown;
+  compacted: boolean;
+  originalByteCount: number | null;
+  compactedByteCount: number | null;
+  omittedFieldNames: string[];
+};
+
+export type CompactPayloadOptions = {
+  retainedFieldNames: readonly string[] | ((payload: Record<string, unknown>) => readonly string[]);
+  compactObjectFieldNames?: readonly string[];
+  compactStringFieldNames?: readonly string[];
+  nullWhenPresentFieldNames?: readonly string[];
+  overrideOutput?: (payload: Record<string, unknown>, output: Record<string, unknown>) => void;
+};
+
+export function jsonByteCount(value: unknown): number | null {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) return null;
+    return Buffer.byteLength(serialized, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function compactPayloadByFieldNames(
+  payload: unknown,
+  options: CompactPayloadOptions,
+): PayloadCompactionResult {
+  const originalByteCount = jsonByteCount(payload);
+  if (!isRecord(payload)) {
+    return {
+      payload,
+      compacted: false,
+      originalByteCount,
+      compactedByteCount: originalByteCount,
+      omittedFieldNames: [],
+    };
+  }
+
+  const output: Record<string, unknown> = {};
+  const copiedFields = new Set<string>();
+  const omittedFieldNames = new Set<string>();
+  const fieldNames =
+    typeof options.retainedFieldNames === "function"
+      ? options.retainedFieldNames(payload)
+      : options.retainedFieldNames;
+  const compactedFieldNames = new Set([
+    ...(options.compactObjectFieldNames ?? []),
+    ...(options.compactStringFieldNames ?? []),
+    ...(options.nullWhenPresentFieldNames ?? []),
+  ]);
+
+  options.overrideOutput?.(payload, output);
+  for (const fieldName of Object.keys(output)) copiedFields.add(fieldName);
+
+  for (const fieldName of fieldNames) {
+    if (!hasOwn(payload, fieldName) || compactedFieldNames.has(fieldName)) continue;
+    output[fieldName] = payload[fieldName];
+    copiedFields.add(fieldName);
+  }
+  for (const fieldName of options.compactObjectFieldNames ?? []) {
+    if (!hasOwn(payload, fieldName)) continue;
+    output[fieldName] = { compacted: true, originalBytes: jsonByteCount(payload[fieldName]) };
+    copiedFields.add(fieldName);
+    omittedFieldNames.add(fieldName);
+  }
+  for (const fieldName of options.compactStringFieldNames ?? []) {
+    if (!hasOwn(payload, fieldName)) continue;
+    output[fieldName] = compactedTextPlaceholder(fieldName, jsonByteCount(payload[fieldName]));
+    copiedFields.add(fieldName);
+    omittedFieldNames.add(fieldName);
+  }
+  for (const fieldName of options.nullWhenPresentFieldNames ?? []) {
+    if (!hasOwn(payload, fieldName)) continue;
+    output[fieldName] = null;
+    copiedFields.add(fieldName);
+    if (payload[fieldName] !== null) omittedFieldNames.add(fieldName);
+  }
+  for (const fieldName of Object.keys(payload)) {
+    if (!copiedFields.has(fieldName)) omittedFieldNames.add(fieldName);
+  }
+
+  return {
+    payload: output,
+    compacted: omittedFieldNames.size > 0,
+    originalByteCount,
+    compactedByteCount: jsonByteCount(output),
+    omittedFieldNames: [...omittedFieldNames].sort(),
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.hasOwn(value, key);
+}
+
+function compactedTextPlaceholder(fieldName: string, byteCount: number | null): string {
+  const bytes = byteCount === null ? "unknown" : String(byteCount);
+  return `[station compacted ${fieldName}: ${bytes} bytes]`;
+}

--- a/packages/harness-shared/src/errors.ts
+++ b/packages/harness-shared/src/errors.ts
@@ -1,0 +1,55 @@
+import type { SafeError } from "@station/contracts";
+
+export class HarnessProviderError<TCode extends string = string>
+  extends Error
+  implements SafeError
+{
+  readonly tag = "HarnessProviderError";
+  readonly code: TCode;
+  readonly provider: string;
+  readonly hint: string | undefined;
+
+  constructor(input: {
+    name: string;
+    provider: string;
+    code: TCode;
+    message: string;
+    cause?: unknown;
+    hint?: string | undefined;
+  }) {
+    super(`${input.code}: ${input.message}`, { cause: input.cause });
+    Object.defineProperty(this, "name", {
+      value: input.name,
+      configurable: true,
+    });
+    this.provider = input.provider;
+    this.code = input.code;
+    this.hint = input.hint;
+  }
+}
+
+export function harnessProviderErrorClass<TCode extends string>(input: {
+  name: string;
+  provider: string;
+}): new (
+  code: TCode,
+  message: string,
+  options?: { cause?: unknown; hint?: string | undefined },
+) => HarnessProviderError<TCode> {
+  return class extends HarnessProviderError<TCode> {
+    constructor(
+      code: TCode,
+      message: string,
+      options: { cause?: unknown; hint?: string | undefined } = {},
+    ) {
+      super({
+        name: input.name,
+        provider: input.provider,
+        code,
+        message,
+        cause: options.cause,
+        hint: options.hint,
+      });
+    }
+  };
+}

--- a/packages/harness-shared/src/events.ts
+++ b/packages/harness-shared/src/events.ts
@@ -1,0 +1,199 @@
+import type {
+  HarnessEventContext,
+  HarnessEventDiagnostics,
+  HarnessEventObservation,
+  HarnessEventReport,
+  ProviderId,
+  TerminalTargetObservation,
+  WorktreeObservation,
+} from "@station/contracts";
+import { observedPathIsSameOrInside, sameObservedPath } from "@station/contracts";
+
+export type StationHookIdentityLike = {
+  station_project_id?: string | undefined;
+  station_worktree_id?: string | undefined;
+  station_worktree_path?: string | undefined;
+  station_session_id?: string | undefined;
+  station_terminal_target_id?: string | undefined;
+};
+
+export type HarnessEventDiagnosticsInput = {
+  payloadBytes?: number | null;
+  compactedBytes?: number | null;
+  compacted?: boolean;
+  truncated?: boolean;
+  omittedFieldNames?: string[];
+};
+
+export type HarnessEventCorrelation = {
+  projectId?: string | undefined;
+  sessionId?: string | undefined;
+  worktreeId?: string | undefined;
+  terminalTargetId?: string | undefined;
+  harnessRunId?: string | undefined;
+  nativeSessionId?: string | undefined;
+  nativeSessionFile?: string | undefined;
+  cwd?: string | undefined;
+  pid?: number | undefined;
+};
+
+export function harnessEventDiagnostics(
+  rawEventType: string,
+  input: HarnessEventDiagnosticsInput | undefined,
+): HarnessEventDiagnostics {
+  const diagnostics: HarnessEventDiagnostics = { rawEventType };
+  if (typeof input?.payloadBytes === "number") diagnostics.payloadBytes = input.payloadBytes;
+  if (typeof input?.compactedBytes === "number") diagnostics.compactedBytes = input.compactedBytes;
+  if (input?.compacted !== undefined) diagnostics.compacted = input.compacted;
+  if (input?.truncated !== undefined) diagnostics.truncated = input.truncated;
+  if (input?.omittedFieldNames !== undefined && input.omittedFieldNames.length > 0) {
+    diagnostics.omittedFieldNames = input.omittedFieldNames;
+  }
+  return diagnostics;
+}
+
+export function reportCorrelation(
+  input: HarnessEventCorrelation,
+): HarnessEventReport["correlation"] {
+  const correlation: NonNullable<HarnessEventReport["correlation"]> = {};
+  if (input.harnessRunId !== undefined) correlation.harnessRunId = input.harnessRunId;
+  if (input.sessionId !== undefined) correlation.sessionId = input.sessionId;
+  if (input.worktreeId !== undefined) correlation.worktreeId = input.worktreeId;
+  if (input.terminalTargetId !== undefined) correlation.terminalTargetId = input.terminalTargetId;
+  if (input.projectId !== undefined) correlation.projectId = input.projectId;
+  if (input.nativeSessionId !== undefined) correlation.nativeSessionId = input.nativeSessionId;
+  if (input.nativeSessionFile !== undefined)
+    correlation.nativeSessionFile = input.nativeSessionFile;
+  if (input.cwd !== undefined) correlation.cwd = input.cwd;
+  if (input.pid !== undefined) correlation.pid = input.pid;
+  return Object.keys(correlation).length === 0 ? undefined : correlation;
+}
+
+export function applyCorrelation(
+  observation: HarnessEventObservation,
+  correlation: HarnessEventCorrelation,
+): void {
+  if (correlation.projectId !== undefined) observation.projectId = correlation.projectId;
+  if (correlation.sessionId !== undefined) observation.sessionId = correlation.sessionId;
+  if (correlation.worktreeId !== undefined) observation.worktreeId = correlation.worktreeId;
+  if (correlation.terminalTargetId !== undefined) {
+    observation.terminalTargetId = correlation.terminalTargetId;
+  }
+  if (correlation.harnessRunId !== undefined) observation.harnessRunId = correlation.harnessRunId;
+  if (correlation.nativeSessionId !== undefined) {
+    observation.nativeSessionId = correlation.nativeSessionId;
+  }
+  if (correlation.nativeSessionFile !== undefined) {
+    observation.nativeSessionFile = correlation.nativeSessionFile;
+  }
+  if (correlation.cwd !== undefined) observation.cwd = correlation.cwd;
+  if (correlation.pid !== undefined) observation.pid = correlation.pid;
+}
+
+export function correlateTerminalBoundHarnessEvent(input: {
+  provider: ProviderId;
+  identity: StationHookIdentityLike;
+  context: HarnessEventContext;
+  cwd?: string | undefined;
+  nativeSessionId?: string | undefined;
+  nativeSessionFile?: string | undefined;
+  pid?: number | undefined;
+  includeProjectId?: boolean;
+  includeTerminalTargetId?: boolean;
+  includeCwd?: boolean;
+}): HarnessEventCorrelation {
+  const terminal =
+    terminalForId(input.identity.station_terminal_target_id, input.context.terminalTargets) ??
+    terminalForCwd(input.cwd, input.context.terminalTargets);
+  const worktree =
+    worktreeForId(input.identity.station_worktree_id, input.context.worktrees) ??
+    worktreeForPath(input.identity.station_worktree_path, input.context.worktrees) ??
+    worktreeForCwd(input.cwd, input.context.worktrees);
+  const result: HarnessEventCorrelation = {};
+  if (input.includeProjectId === true) {
+    if (input.identity.station_project_id !== undefined) {
+      result.projectId = input.identity.station_project_id;
+    } else if (terminal?.projectId !== undefined) {
+      result.projectId = terminal.projectId;
+    } else if (worktree?.projectId !== undefined) {
+      result.projectId = worktree.projectId;
+    }
+  }
+  if (input.identity.station_session_id !== undefined) {
+    result.sessionId = input.identity.station_session_id;
+  } else if (terminal?.sessionId !== undefined) {
+    result.sessionId = terminal.sessionId;
+  }
+  if (input.identity.station_worktree_id !== undefined) {
+    result.worktreeId = input.identity.station_worktree_id;
+  } else if (terminal?.worktreeId !== undefined) {
+    result.worktreeId = terminal.worktreeId;
+  } else if (worktree !== undefined) {
+    result.worktreeId = worktree.id;
+  }
+  if (input.identity.station_terminal_target_id !== undefined) {
+    if (input.includeTerminalTargetId === true) {
+      result.terminalTargetId = input.identity.station_terminal_target_id;
+    }
+    result.harnessRunId = `${input.provider}:${input.identity.station_terminal_target_id}`;
+  } else if (terminal?.harnessRunId !== undefined) {
+    if (input.includeTerminalTargetId === true) result.terminalTargetId = terminal.id;
+    result.harnessRunId = terminal.harnessRunId;
+  } else if (terminal !== undefined) {
+    if (input.includeTerminalTargetId === true) result.terminalTargetId = terminal.id;
+    result.harnessRunId = `${input.provider}:${terminal.id}`;
+  }
+  if (input.nativeSessionId !== undefined) result.nativeSessionId = input.nativeSessionId;
+  if (input.nativeSessionFile !== undefined) result.nativeSessionFile = input.nativeSessionFile;
+  if (input.includeCwd === true && input.cwd !== undefined) result.cwd = input.cwd;
+  if (input.pid !== undefined) result.pid = input.pid;
+  return result;
+}
+
+export function terminalForId(
+  terminalTargetId: string | undefined,
+  targets: TerminalTargetObservation[],
+): TerminalTargetObservation | undefined {
+  if (terminalTargetId === undefined) return undefined;
+  return targets.find((target) => target.id === terminalTargetId);
+}
+
+export function terminalForCwd(
+  cwd: string | undefined,
+  targets: TerminalTargetObservation[],
+): TerminalTargetObservation | undefined {
+  if (cwd === undefined) return undefined;
+  return (
+    targets.find((target) => target.cwd !== undefined && sameObservedPath(target.cwd, cwd)) ??
+    targets.find(
+      (target) => target.cwd !== undefined && observedPathIsSameOrInside(cwd, target.cwd),
+    )
+  );
+}
+
+export function worktreeForId(
+  worktreeId: string | undefined,
+  worktrees: WorktreeObservation[],
+): WorktreeObservation | undefined {
+  if (worktreeId === undefined) return undefined;
+  return worktrees.find((worktree) => worktree.id === worktreeId);
+}
+
+export function worktreeForPath(
+  worktreePath: string | undefined,
+  worktrees: WorktreeObservation[],
+): WorktreeObservation | undefined {
+  if (worktreePath === undefined) return undefined;
+  return worktrees.find((worktree) => sameObservedPath(worktree.path, worktreePath));
+}
+
+export function worktreeForCwd(
+  cwd: string | undefined,
+  worktrees: WorktreeObservation[],
+): WorktreeObservation | undefined {
+  if (cwd === undefined) return undefined;
+  return (
+    worktrees.find((worktree) => sameObservedPath(worktree.path, cwd)) ??
+    worktrees.find((worktree) => observedPathIsSameOrInside(cwd, worktree.path))
+  );
+}

--- a/packages/harness-shared/src/hooks.ts
+++ b/packages/harness-shared/src/hooks.ts
@@ -1,0 +1,413 @@
+import { chmod, copyFile, mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { pathExists, readTextFileIfPresent, removeFileIfPresent } from "@station/runtime";
+
+export type HookFileErrorFactory = (code: string, message: string, cause?: unknown) => Error;
+
+export type HookFileCodes = {
+  unreadable: string;
+  writeFailed: string;
+};
+
+export type HookFileMessages = {
+  configUnreadable: string;
+  configMetadataUnreadable: string;
+  configWriteFailed: string;
+  scriptWriteFailed: string;
+  scriptRemoveFailed: string;
+  backupWriteFailed: string;
+};
+
+export type HookFileOps = {
+  readOptionalFile(path: string): Promise<string>;
+  writeHookConfig(path: string, contents: string): Promise<void>;
+  writeHookScript(path: string, contents: string): Promise<void>;
+  removeHookScriptIfPresent(path: string): Promise<boolean>;
+  backupIfPresent(path: string): Promise<string | undefined>;
+};
+
+export type IngressHookScriptOptions = {
+  stationConfigPath?: string;
+  observerSocketPath?: string;
+  stateDir?: string;
+  hookSpoolDir?: string;
+  autoStartFromHooks?: boolean;
+  hookBin?: string;
+};
+
+export type NestedHookDocument = Record<string, unknown>;
+
+export type NestedHookDocumentSpec<TName extends string> = {
+  eventNames: readonly TName[];
+  generatedScriptName: string;
+  statusMessage: string;
+  matcherForEvent?: (eventName: TName) => string | undefined;
+  timeout?: number;
+};
+
+function nestedHooksRecord(document: NestedHookDocument): Record<string, unknown> | undefined {
+  return isPlainRecord(document.hooks) ? document.hooks : undefined;
+}
+
+function nestedHookEntries(value: unknown): Record<string, unknown>[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => (isPlainRecord(entry) ? [entry] : []));
+  }
+  return isPlainRecord(value) ? [value] : [];
+}
+
+function cloneRecord(source: Record<string, unknown>): Record<string, unknown> {
+  const cloned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) cloned[key] = value;
+  return cloned;
+}
+
+function generatedNestedHookEntry<TName extends string>(
+  eventName: TName,
+  command: string,
+  spec: NestedHookDocumentSpec<TName>,
+): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    hooks: [
+      {
+        type: "command",
+        command,
+        timeout: spec.timeout ?? 30,
+        statusMessage: spec.statusMessage,
+      },
+    ],
+  };
+  const matcher = spec.matcherForEvent?.(eventName);
+  if (matcher !== undefined) entry.matcher = matcher;
+  return entry;
+}
+
+function withGeneratedNestedHookEntry<TName extends string>(
+  value: unknown,
+  eventName: TName,
+  command: string,
+  spec: NestedHookDocumentSpec<TName>,
+): unknown {
+  const cleanedValue = withoutGeneratedNestedHookEntry(value, command, spec);
+  const entries = nestedHookEntries(cleanedValue);
+  if (entries.some((entry) => nestedHookEntryContainsCommand(entry, command))) return entries;
+  return [...entries, generatedNestedHookEntry(eventName, command, spec)];
+}
+
+function withoutGeneratedNestedHookEntry<TName extends string>(
+  value: unknown,
+  command: string | undefined,
+  spec: NestedHookDocumentSpec<TName>,
+): unknown {
+  const entries = nestedHookEntries(value);
+  if (value !== undefined && entries.length === 0) return value;
+  const nextEntries = entries
+    .map((entry) => withoutGeneratedHooksFromNestedEntry(entry, command, spec))
+    .filter((entry) => entry !== undefined);
+  return nextEntries.length === 0 ? undefined : nextEntries;
+}
+
+function withoutGeneratedHooksFromNestedEntry<TName extends string>(
+  entry: Record<string, unknown>,
+  command: string | undefined,
+  spec: NestedHookDocumentSpec<TName>,
+): Record<string, unknown> | undefined {
+  const hooks = entry.hooks;
+  if (!Array.isArray(hooks)) return entry;
+  const nextHooks = hooks.filter((hook) => !isGeneratedNestedHookCommand(hook, command, spec));
+  if (nextHooks.length === hooks.length) return entry;
+  if (nextHooks.length > 0) {
+    const next = cloneRecord(entry);
+    next.hooks = nextHooks;
+    return next;
+  }
+  const rest = cloneRecord(entry);
+  delete rest.hooks;
+  return Object.keys(rest).length === 0 || onlyGeneratedMatcherKeys(rest) ? undefined : rest;
+}
+
+function nestedHookEntryContainsCommand(entry: Record<string, unknown>, command: string): boolean {
+  const hooks = entry.hooks;
+  return (
+    Array.isArray(hooks) && hooks.some((hook) => isPlainRecord(hook) && hook.command === command)
+  );
+}
+
+function nestedHookEntryContainsGeneratedCommand<TName extends string>(
+  entry: Record<string, unknown>,
+  command: string | undefined,
+  spec: NestedHookDocumentSpec<TName>,
+): boolean {
+  const hooks = entry.hooks;
+  return (
+    Array.isArray(hooks) && hooks.some((hook) => isGeneratedNestedHookCommand(hook, command, spec))
+  );
+}
+
+function isGeneratedNestedHookCommand<TName extends string>(
+  hook: unknown,
+  command: string | undefined,
+  spec: NestedHookDocumentSpec<TName>,
+): boolean {
+  if (!isPlainRecord(hook) || typeof hook.command !== "string") return false;
+  if (command !== undefined && hook.command === command) return true;
+  return (
+    hook.type === "command" &&
+    hook.statusMessage === spec.statusMessage &&
+    commandLooksLikeGeneratedHookScript(hook.command, spec.generatedScriptName)
+  );
+}
+
+function commandLooksLikeGeneratedHookScript(
+  command: string,
+  generatedScriptName: string,
+): boolean {
+  return command === generatedScriptName || command.endsWith(`/${generatedScriptName}`);
+}
+
+function onlyGeneratedMatcherKeys(entry: Record<string, unknown>): boolean {
+  return Object.keys(entry).every((key) => key === "matcher");
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function expectedNestedHookSettings<TName extends string>(
+  spec: NestedHookDocumentSpec<TName>,
+  input: { hookScriptPath: string },
+): NestedHookDocument {
+  const hooks: Record<string, unknown> = {};
+  for (const eventName of spec.eventNames) {
+    hooks[eventName] = [generatedNestedHookEntry(eventName, input.hookScriptPath, spec)];
+  }
+  return { hooks };
+}
+
+export function installNestedHookCommands<TName extends string>(
+  document: NestedHookDocument,
+  commands: Record<TName, string>,
+  spec: NestedHookDocumentSpec<TName>,
+): NestedHookDocument {
+  const next = cloneRecord(document);
+  const hooksRecord = nestedHooksRecord(next);
+  const hooks = hooksRecord === undefined ? {} : cloneRecord(hooksRecord);
+  for (const eventName of spec.eventNames) {
+    hooks[eventName] = withGeneratedNestedHookEntry(
+      hooks[eventName],
+      eventName,
+      commands[eventName],
+      spec,
+    );
+  }
+  next.hooks = hooks;
+  return next;
+}
+
+export function removeGeneratedNestedHookCommands<TName extends string>(
+  document: NestedHookDocument,
+  commands: Record<TName, string>,
+  spec: NestedHookDocumentSpec<TName>,
+): NestedHookDocument {
+  const next = cloneRecord(document);
+  const hooksRecord = nestedHooksRecord(next);
+  if (hooksRecord === undefined) return next;
+  const hooks = cloneRecord(hooksRecord);
+  for (const eventName of spec.eventNames) {
+    const value = withoutGeneratedNestedHookEntry(hooks[eventName], commands[eventName], spec);
+    if (value === undefined) {
+      delete hooks[eventName];
+    } else {
+      hooks[eventName] = value;
+    }
+  }
+  if (Object.keys(hooks).length === 0) {
+    delete next.hooks;
+  } else {
+    next.hooks = hooks;
+  }
+  return next;
+}
+
+export function removeGeneratedNestedHookEntries<TName extends string>(
+  document: NestedHookDocument,
+  spec: NestedHookDocumentSpec<TName>,
+): NestedHookDocument {
+  const hooks = nestedHooksRecord(document);
+  if (hooks === undefined) return document;
+  const cleanedHooks: Record<string, unknown> = {};
+  for (const [eventName, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) {
+      cleanedHooks[eventName] = entries;
+      continue;
+    }
+    const cleanedEntries = entries
+      .map((entry) =>
+        isPlainRecord(entry) ? withoutGeneratedHooksFromNestedEntry(entry, undefined, spec) : entry,
+      )
+      .filter((entry) => entry !== undefined);
+    if (cleanedEntries.length > 0) cleanedHooks[eventName] = cleanedEntries;
+  }
+  const cleaned = cloneRecord(document);
+  if (Object.keys(cleanedHooks).length > 0) {
+    cleaned.hooks = cleanedHooks;
+  } else {
+    delete cleaned.hooks;
+  }
+  return cleaned;
+}
+
+export function missingNestedHookEvents<TName extends string>(
+  document: NestedHookDocument,
+  commands: Record<TName, string>,
+  spec: NestedHookDocumentSpec<TName>,
+): TName[] {
+  const hooks = nestedHooksRecord(document);
+  if (hooks === undefined) return [...spec.eventNames];
+  return spec.eventNames.filter(
+    (eventName) =>
+      !nestedHookEntries(hooks[eventName]).some((entry) =>
+        nestedHookEntryContainsCommand(entry, commands[eventName]),
+      ),
+  );
+}
+
+export function generatedNestedHookEvents<TName extends string>(
+  document: NestedHookDocument,
+  spec: NestedHookDocumentSpec<TName>,
+  commands?: Record<TName, string>,
+): TName[] {
+  const hooks = nestedHooksRecord(document);
+  if (hooks === undefined) return [];
+  return spec.eventNames
+    .filter((eventName) =>
+      nestedHookEntries(hooks[eventName]).some((entry) =>
+        nestedHookEntryContainsGeneratedCommand(entry, commands?.[eventName], spec),
+      ),
+    )
+    .sort();
+}
+
+export function nestedDocumentContainsCommand(
+  document: NestedHookDocument,
+  command: string,
+): boolean {
+  const hooks = nestedHooksRecord(document);
+  if (hooks === undefined) return false;
+  return Object.values(hooks).some((value) =>
+    nestedHookEntries(value).some((entry) => nestedHookEntryContainsCommand(entry, command)),
+  );
+}
+
+export function ingressHookScriptOptions(
+  hookScriptPath: string,
+  options: IngressHookScriptOptions,
+): IngressHookScriptOptions & { hookScriptPath: string } {
+  const input: IngressHookScriptOptions & { hookScriptPath: string } = { hookScriptPath };
+  if (options.stationConfigPath !== undefined) input.stationConfigPath = options.stationConfigPath;
+  if (options.observerSocketPath !== undefined)
+    input.observerSocketPath = options.observerSocketPath;
+  if (options.stateDir !== undefined) input.stateDir = options.stateDir;
+  if (options.hookSpoolDir !== undefined) input.hookSpoolDir = options.hookSpoolDir;
+  if (options.autoStartFromHooks !== undefined)
+    input.autoStartFromHooks = options.autoStartFromHooks;
+  if (options.hookBin !== undefined) input.hookBin = options.hookBin;
+  return input;
+}
+
+export function createHookFileOps(input: {
+  codes: HookFileCodes;
+  messages: HookFileMessages;
+  error: HookFileErrorFactory;
+}): HookFileOps {
+  return {
+    async readOptionalFile(path) {
+      try {
+        return (await readTextFileIfPresent(path)) ?? "";
+      } catch (cause) {
+        throw input.error(input.codes.unreadable, input.messages.configUnreadable, cause);
+      }
+    },
+    async writeHookConfig(path, contents) {
+      try {
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        await writeFile(path, contents, { mode: 0o600 });
+      } catch (cause) {
+        throw input.error(input.codes.writeFailed, input.messages.configWriteFailed, cause);
+      }
+    },
+    async writeHookScript(path, contents) {
+      try {
+        await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+        await writeFile(path, contents, { mode: 0o700 });
+        await chmod(path, 0o700);
+      } catch (cause) {
+        throw input.error(input.codes.writeFailed, input.messages.scriptWriteFailed, cause);
+      }
+    },
+    async removeHookScriptIfPresent(path) {
+      try {
+        return await removeFileIfPresent(path);
+      } catch (cause) {
+        throw input.error(input.codes.writeFailed, input.messages.scriptRemoveFailed, cause);
+      }
+    },
+    async backupIfPresent(path) {
+      try {
+        if (!(await pathExists(path))) return undefined;
+      } catch (cause) {
+        throw input.error(input.codes.unreadable, input.messages.configMetadataUnreadable, cause);
+      }
+      const backupPath = `${path}.bak.${new Date().toISOString().replaceAll(/[^0-9]/g, "")}`;
+      try {
+        await copyFile(path, backupPath);
+      } catch (cause) {
+        throw input.error(input.codes.writeFailed, input.messages.backupWriteFailed, cause);
+      }
+      return backupPath;
+    },
+  };
+}
+
+export function expectedIngressHookScript(
+  input: IngressHookScriptOptions & {
+    provider: string;
+    swallowErrors?: boolean;
+  },
+): string {
+  const hookArgs = [input.hookBin ?? "stn-ingress"];
+  if (input.observerSocketPath !== undefined) hookArgs.push("--socket", input.observerSocketPath);
+  if (input.stateDir !== undefined) hookArgs.push("--state-dir", input.stateDir);
+  if (input.hookSpoolDir !== undefined) hookArgs.push("--spool-dir", input.hookSpoolDir);
+  if (input.stationConfigPath !== undefined) hookArgs.push("--config", input.stationConfigPath);
+  if (input.autoStartFromHooks === false) hookArgs.push("--no-auto-start");
+  hookArgs.push(input.provider);
+  const redirect = input.swallowErrors === true ? "> /dev/null 2>&1 || true" : "> /dev/null";
+  return [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
+    "  exit 0",
+    "fi",
+    `${commandLine(hookArgs)} ${redirect}`,
+    "",
+  ].join("\n");
+}
+
+export function expectedHookCommands<TName extends string>(
+  eventNames: readonly TName[],
+  hookScriptPath: string,
+): Record<TName, string> {
+  return Object.fromEntries(eventNames.map((eventName) => [eventName, hookScriptPath])) as Record<
+    TName,
+    string
+  >;
+}
+
+export function commandLine(args: readonly string[]): string {
+  return args.map(shellQuote).join(" ");
+}
+
+export function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/packages/harness-shared/src/index.ts
+++ b/packages/harness-shared/src/index.ts
@@ -2,3 +2,71 @@ export {
   type ClassifyHarnessRunStatusOptions,
   classifyHarnessRunStatus,
 } from "./classify.js";
+export {
+  type CompactPayloadOptions,
+  compactPayloadByFieldNames,
+  hasOwn,
+  isRecord,
+  jsonByteCount,
+  type PayloadCompactionResult,
+} from "./compaction.js";
+export {
+  HarnessProviderError,
+  harnessProviderErrorClass,
+} from "./errors.js";
+export {
+  applyCorrelation,
+  correlateTerminalBoundHarnessEvent,
+  type HarnessEventCorrelation,
+  type HarnessEventDiagnosticsInput,
+  harnessEventDiagnostics,
+  reportCorrelation,
+  type StationHookIdentityLike,
+  terminalForCwd,
+  terminalForId,
+  worktreeForCwd,
+  worktreeForId,
+  worktreeForPath,
+} from "./events.js";
+export {
+  commandLine,
+  createHookFileOps,
+  expectedHookCommands,
+  expectedIngressHookScript,
+  expectedNestedHookSettings,
+  generatedNestedHookEvents,
+  type HookFileCodes,
+  type HookFileErrorFactory,
+  type HookFileMessages,
+  type HookFileOps,
+  type IngressHookScriptOptions,
+  ingressHookScriptOptions,
+  installNestedHookCommands,
+  missingNestedHookEvents,
+  type NestedHookDocument,
+  type NestedHookDocumentSpec,
+  nestedDocumentContainsCommand,
+  removeGeneratedNestedHookCommands,
+  removeGeneratedNestedHookEntries,
+  shellQuote,
+} from "./hooks.js";
+export {
+  assignDefined,
+  type CommonLaunchEnvOptions,
+  type CommonProviderDataInput,
+  commonProviderData,
+  harnessLaunchEnv,
+  isYoloPermissionMode,
+  terminalProviderData,
+} from "./launch.js";
+export {
+  type CommonHarnessProviderOptions,
+  type HarnessCommandSpec,
+  type HarnessHealthSpec,
+  type HarnessHookDoctorResult,
+  type HarnessHookDoctorSpec,
+  hookOptions,
+  TerminalBoundHarnessProvider,
+  type TerminalBoundHarnessProviderSpec,
+  TerminalBoundHarnessProviderWithHooksStatus,
+} from "./provider.js";

--- a/packages/harness-shared/src/launch.ts
+++ b/packages/harness-shared/src/launch.ts
@@ -1,0 +1,110 @@
+import type {
+  BuildHarnessLaunchRequest,
+  HarnessPermissionMode,
+  ProviderId,
+} from "@station/contracts";
+
+export type CommonLaunchEnvOptions = {
+  configPath?: string;
+  observerSocketPath?: string;
+  stateDir?: string;
+  hookSpoolDir?: string;
+};
+
+export type CommonProviderDataInput = {
+  mode: "interactive" | "exec";
+  initialPromptProvided: boolean;
+  profile?: string | undefined;
+  permissionMode?: string | undefined;
+  approvalPolicy?: string | undefined;
+  sandboxMode?: string | undefined;
+  configPathProvided?: boolean | undefined;
+  observerSocketPathProvided?: boolean | undefined;
+  terminalProvider?: string | undefined;
+  terminalTargetId?: string | undefined;
+  resume?: boolean | undefined;
+  resumeTargetKind?: string | undefined;
+};
+
+export function harnessLaunchEnv(
+  provider: ProviderId,
+  request: BuildHarnessLaunchRequest,
+  options: CommonLaunchEnvOptions = {},
+): Record<string, string> {
+  const env: Record<string, string> = {
+    STATION_PROJECT_ID: request.project.id,
+    STATION_WORKTREE_ID: request.worktree.id,
+    STATION_WORKTREE_PATH: request.worktree.path,
+    STATION_HARNESS_PROVIDER: provider,
+  };
+  if (request.sessionId !== undefined) env.STATION_SESSION_ID = request.sessionId;
+  if (request.terminalTarget !== undefined) {
+    env.STATION_TERMINAL_PROVIDER = request.terminalTarget.provider;
+    env.STATION_TERMINAL_TARGET_ID = request.terminalTarget.id;
+  }
+  if (options.configPath !== undefined) env.STATION_CONFIG_PATH = options.configPath;
+  if (options.observerSocketPath !== undefined) {
+    env.STATION_OBSERVER_SOCKET_PATH = options.observerSocketPath;
+  }
+  if (options.stateDir !== undefined) env.STATION_OBSERVER_STATE_DIR = options.stateDir;
+  if (options.hookSpoolDir !== undefined) env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
+  return env;
+}
+
+export function commonProviderData(input: CommonProviderDataInput): Record<string, unknown> {
+  const providerData: Record<string, unknown> = {
+    interactive: input.mode === "interactive",
+  };
+  assignDefined(
+    providerData,
+    "initialPromptProvided",
+    input.initialPromptProvided ? true : undefined,
+  );
+  assignDefined(providerData, "profile", input.profile);
+  assignDefined(providerData, "permissionMode", input.permissionMode);
+  assignDefined(providerData, "approvalPolicy", input.approvalPolicy);
+  assignDefined(providerData, "sandboxMode", input.sandboxMode);
+  assignDefined(
+    providerData,
+    "configPathProvided",
+    input.configPathProvided === true ? true : undefined,
+  );
+  assignDefined(
+    providerData,
+    "observerSocketPathProvided",
+    input.observerSocketPathProvided === true ? true : undefined,
+  );
+  assignDefined(providerData, "terminalProvider", input.terminalProvider);
+  assignDefined(providerData, "terminalTargetId", input.terminalTargetId);
+  assignDefined(providerData, "resume", input.resume === true ? true : undefined);
+  assignDefined(providerData, "resumeTargetKind", input.resumeTargetKind);
+  return providerData;
+}
+
+export function terminalProviderData(
+  request: BuildHarnessLaunchRequest,
+): Pick<CommonProviderDataInput, "terminalProvider" | "terminalTargetId"> {
+  const output: Pick<CommonProviderDataInput, "terminalProvider" | "terminalTargetId"> = {};
+  if (request.terminalTarget !== undefined) {
+    output.terminalProvider = request.terminalTarget.provider;
+    output.terminalTargetId = request.terminalTarget.id;
+  }
+  return output;
+}
+
+export function isYoloPermissionMode(input: {
+  permissionMode?: HarnessPermissionMode | "auto" | undefined;
+  approvalPolicy?: string | undefined;
+  sandboxMode?: string | undefined;
+}): boolean {
+  if (input.permissionMode !== undefined) {
+    return input.permissionMode === "yolo";
+  }
+  return input.approvalPolicy === "never" && input.sandboxMode === "danger-full-access";
+}
+
+export function assignDefined(target: Record<string, unknown>, key: string, value: unknown): void {
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -1,0 +1,391 @@
+import type {
+  BuildHarnessLaunchRequest,
+  HarnessCapabilities,
+  HarnessClassificationContext,
+  HarnessDiscoveryContext,
+  HarnessEventContext,
+  HarnessEventObservation,
+  HarnessHooksStatus,
+  HarnessLaunchPlan,
+  HarnessProvider,
+  HarnessRunObservation,
+  HarnessStatusObservation,
+  ProviderDoctorCheck,
+  ProviderDoctorContext,
+  ProviderHealth,
+  ProviderId,
+  RawHarnessEvent,
+} from "@station/contracts";
+import { discoverTerminalBoundHarnessRuns } from "@station/contracts";
+import {
+  type ExternalCommandResult,
+  type ExternalCommandRunner,
+  runExternalCommand,
+  runRuntimeBoundary,
+  safeErrorFromUnknown,
+  systemClock,
+  toIsoTimestamp,
+} from "@station/runtime";
+
+export type CommonHarnessProviderOptions = {
+  command?: string;
+  installHooks?: boolean;
+  observerSocketPath?: string;
+  stateDir?: string;
+  hookSpoolDir?: string;
+  autoStartFromHooks?: boolean;
+  resume?: boolean;
+  now?: () => Date | string;
+  timeoutMs?: number;
+  runner?: ExternalCommandRunner;
+};
+
+export type HarnessCommandSpec = {
+  envVar?: string;
+  fallback: string;
+};
+
+export type HarnessHealthSpec = {
+  args: string[];
+  unavailable: {
+    code: string;
+    message: string;
+    hint?: string;
+  };
+  diagnostics?: (result: ExternalCommandResult) => Record<string, string>;
+  okDoctorCheck?: {
+    name: string;
+    okMessage: string;
+    errorMessage: string;
+    stopOnFailure?: boolean;
+  };
+};
+
+export type HarnessHookDoctorResult = {
+  status: "ok" | "warn";
+  installed: boolean;
+  missing?: readonly unknown[];
+  message: string;
+};
+
+export type HarnessHookDoctorSpec<
+  TOptions extends CommonHarnessProviderOptions,
+  THookOptions,
+  THookResult extends HarnessHookDoctorResult,
+> = {
+  doctor: (options: THookOptions) => Promise<THookResult>;
+  buildOptions: (options: TOptions, context?: ProviderDoctorContext) => THookOptions;
+  checkName: string;
+  failure: {
+    tag: string;
+    code: string;
+    message: string;
+  };
+  formatCheckMessage: (result: THookResult) => string;
+  exposeHooksStatus?: boolean;
+};
+
+export type TerminalBoundHarnessProviderSpec<
+  TOptions extends CommonHarnessProviderOptions,
+  TLaunchOptions,
+  THookOptions = never,
+  THookResult extends HarnessHookDoctorResult = HarnessHookDoctorResult,
+> = {
+  id: ProviderId;
+  displayName: string;
+  command: HarnessCommandSpec;
+  baseCapabilities: HarnessCapabilities;
+  health?: HarnessHealthSpec;
+  hooks?: HarnessHookDoctorSpec<TOptions, THookOptions, THookResult>;
+  buildLaunchOptions: (options: TOptions, command: string) => TLaunchOptions;
+  buildLaunch: (
+    request: BuildHarnessLaunchRequest,
+    options: TLaunchOptions,
+  ) => HarnessLaunchPlan | Promise<HarnessLaunchPlan>;
+  classifyRun: (
+    run: HarnessRunObservation,
+    context: HarnessClassificationContext,
+  ) => HarnessStatusObservation | Promise<HarnessStatusObservation>;
+  normalizeEvent?: (
+    event: RawHarnessEvent,
+    context: HarnessEventContext,
+  ) => HarnessEventObservation[] | Promise<HarnessEventObservation[]>;
+  extraDoctorChecks?: (
+    options: TOptions,
+    provider: TerminalBoundHarnessProvider<TOptions, TLaunchOptions, THookOptions, THookResult>,
+  ) => Promise<ProviderDoctorCheck[]>;
+};
+
+export class TerminalBoundHarnessProvider<
+  TOptions extends CommonHarnessProviderOptions,
+  TLaunchOptions,
+  THookOptions = never,
+  THookResult extends HarnessHookDoctorResult = HarnessHookDoctorResult,
+> implements HarnessProvider
+{
+  readonly id: ProviderId;
+
+  protected readonly spec: TerminalBoundHarnessProviderSpec<
+    TOptions,
+    TLaunchOptions,
+    THookOptions,
+    THookResult
+  >;
+  protected readonly providerOptions: TOptions;
+
+  constructor(
+    spec: TerminalBoundHarnessProviderSpec<TOptions, TLaunchOptions, THookOptions, THookResult>,
+    options: TOptions,
+  ) {
+    this.spec = spec;
+    this.providerOptions = options;
+    this.id = spec.id;
+  }
+
+  command(): string {
+    return harnessCommand(this.providerOptions, this.spec.command);
+  }
+
+  capabilities(): HarnessCapabilities {
+    return harnessCapabilities(this.spec.baseCapabilities, this.providerOptions);
+  }
+
+  async health(): Promise<ProviderHealth> {
+    if (this.spec.health === undefined) {
+      return {
+        providerId: this.id,
+        providerType: "harness",
+        status: "healthy",
+        lastCheckedAt: harnessNow(this.providerOptions),
+        capabilities: this.capabilities(),
+      };
+    }
+    const checkedAt = harnessNow(this.providerOptions);
+    try {
+      const result = await runExternalCommand(
+        {
+          command: this.command(),
+          args: this.spec.health.args,
+          timeoutMs: this.providerOptions.timeoutMs ?? 5000,
+          maxOutputChars: 4096,
+        },
+        this.providerOptions.runner,
+      );
+      const health: ProviderHealth = {
+        providerId: this.id,
+        providerType: "harness",
+        status: "healthy",
+        lastCheckedAt: checkedAt,
+        capabilities: this.capabilities(),
+      };
+      const diagnostics = this.spec.health.diagnostics?.(result);
+      if (diagnostics !== undefined) health.diagnostics = diagnostics;
+      return health;
+    } catch (error) {
+      return {
+        providerId: this.id,
+        providerType: "harness",
+        status: "unavailable",
+        lastCheckedAt: checkedAt,
+        lastError: this.unavailableErrorFromUnknown(error),
+        capabilities: this.capabilities(),
+      };
+    }
+  }
+
+  async doctorChecks(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]> {
+    const checks: ProviderDoctorCheck[] = [];
+    if (this.spec.health?.okDoctorCheck !== undefined) {
+      const health = await this.health();
+      if (health.status === "healthy") {
+        checks.push({
+          name: this.spec.health.okDoctorCheck.name,
+          status: "ok",
+          message: this.spec.health.okDoctorCheck.okMessage,
+        });
+      } else {
+        const check: ProviderDoctorCheck = {
+          name: this.spec.health.okDoctorCheck.name,
+          status: "error",
+          message: this.spec.health.okDoctorCheck.errorMessage,
+        };
+        if (health.lastError !== undefined) check.error = health.lastError;
+        checks.push(check);
+        if (this.spec.health.okDoctorCheck.stopOnFailure === true) return checks;
+      }
+    }
+
+    if (this.spec.extraDoctorChecks !== undefined) {
+      checks.push(...(await this.spec.extraDoctorChecks(this.providerOptions, this)));
+    }
+    if (this.spec.hooks !== undefined) {
+      checks.push(await this.hookDoctorCheck(context));
+    }
+    return checks;
+  }
+
+  async buildLaunch(request: BuildHarnessLaunchRequest): Promise<HarnessLaunchPlan> {
+    return this.spec.buildLaunch(
+      request,
+      this.spec.buildLaunchOptions(this.providerOptions, this.command()),
+    );
+  }
+
+  async discoverRuns(context: HarnessDiscoveryContext): Promise<HarnessRunObservation[]> {
+    return discoverTerminalBoundHarnessRuns(context, {
+      harnessProvider: this.id,
+      displayName: this.spec.displayName,
+      role: "main-agent",
+    });
+  }
+
+  async classifyRun(
+    run: HarnessRunObservation,
+    context: HarnessClassificationContext,
+  ): Promise<HarnessStatusObservation> {
+    return this.spec.classifyRun(run, context);
+  }
+
+  async ingestEvent(
+    event: RawHarnessEvent,
+    context: HarnessEventContext,
+  ): Promise<HarnessEventObservation[]> {
+    if (this.spec.normalizeEvent === undefined) return [];
+    const result = await runRuntimeBoundary(
+      {
+        operation: `provider.${this.id}.ingestEvent`,
+        error: {
+          tag: "HarnessProviderError",
+          code: `HARNESS_${this.id.toUpperCase()}_EVENT_INGEST_FAILED`,
+          message: `The ${this.spec.displayName} harness provider failed to ingest an event.`,
+          provider: this.id,
+        },
+      },
+      async () => this.spec.normalizeEvent?.(event, context) ?? [],
+    );
+    if (!result.ok) throw result.error;
+    return result.value;
+  }
+
+  protected async hookStatus(context?: ProviderDoctorContext): Promise<HarnessHooksStatus> {
+    const hooks = this.spec.hooks;
+    if (hooks === undefined || hooks.exposeHooksStatus !== true) {
+      throw new Error(`${this.id} hooks status is not supported.`);
+    }
+    const result = await hooks.doctor(hooks.buildOptions(this.providerOptions, context));
+    return {
+      provider: this.id,
+      installed: result.installed,
+      requested: this.providerOptions.installHooks === true,
+      missing: (result.missing ?? []).map((name) => String(name)),
+      message: result.message,
+    };
+  }
+
+  protected async hookDoctorCheck(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
+    const hooks = this.spec.hooks;
+    if (hooks === undefined) throw new Error("unreachable");
+    try {
+      const hookResult = await hooks.doctor(hooks.buildOptions(this.providerOptions, context));
+      return {
+        name: hooks.checkName,
+        status: hookResult.status,
+        message: hooks.formatCheckMessage(hookResult),
+      };
+    } catch (cause) {
+      return {
+        name: hooks.checkName,
+        status: "error",
+        message: hooks.failure.message,
+        error: safeErrorFromUnknown(cause, {
+          tag: hooks.failure.tag,
+          code: hooks.failure.code,
+          message: hooks.failure.message,
+          provider: this.id,
+        }),
+      };
+    }
+  }
+
+  protected unavailableErrorFromUnknown(error: unknown) {
+    const health = this.spec.health;
+    const safeFallback: {
+      tag: "HarnessProviderError";
+      code: string;
+      message: string;
+      hint?: string;
+      provider: ProviderId;
+    } = {
+      tag: "HarnessProviderError",
+      code: health?.unavailable.code ?? `HARNESS_${this.id.toUpperCase()}_UNAVAILABLE`,
+      message: health?.unavailable.message ?? `${this.spec.displayName} is not available.`,
+      provider: this.id,
+    };
+    if (health?.unavailable.hint !== undefined) safeFallback.hint = health.unavailable.hint;
+    return Object.assign(
+      new Error(`${safeFallback.code}: ${safeFallback.message}`, { cause: error }),
+      safeFallback,
+    );
+  }
+}
+
+export class TerminalBoundHarnessProviderWithHooksStatus<
+  TOptions extends CommonHarnessProviderOptions,
+  TLaunchOptions,
+  THookOptions = never,
+  THookResult extends HarnessHookDoctorResult = HarnessHookDoctorResult,
+> extends TerminalBoundHarnessProvider<TOptions, TLaunchOptions, THookOptions, THookResult> {
+  async hooksStatus(context?: ProviderDoctorContext): Promise<HarnessHooksStatus> {
+    return this.hookStatus(context);
+  }
+}
+
+function harnessCommand(
+  options: Pick<CommonHarnessProviderOptions, "command">,
+  spec: HarnessCommandSpec,
+): string {
+  const envCommand = spec.envVar === undefined ? undefined : process.env[spec.envVar];
+  return options.command ?? envCommand ?? spec.fallback;
+}
+
+function harnessNow(options: Pick<CommonHarnessProviderOptions, "now">): string {
+  const value = options.now?.() ?? systemClock.now();
+  return toIsoTimestamp(value instanceof Date ? value : new Date(value));
+}
+
+function harnessCapabilities(
+  baseCapabilities: HarnessCapabilities,
+  options: Pick<CommonHarnessProviderOptions, "resume">,
+): HarnessCapabilities {
+  return {
+    ...baseCapabilities,
+    canResume: options.resume === true,
+  };
+}
+
+export function hookOptions<
+  TOptions extends Partial<CommonHarnessProviderOptions> & { configPath?: string },
+>(options: TOptions, context?: ProviderDoctorContext) {
+  const output: {
+    enabled: boolean;
+    observerSocketPath?: string;
+    stateDir?: string;
+    hookSpoolDir?: string;
+    autoStartFromHooks?: boolean;
+    stationConfigPath?: string;
+  } = {
+    enabled: options.installHooks === true,
+  };
+  if (options.observerSocketPath !== undefined)
+    output.observerSocketPath = options.observerSocketPath;
+  if (options.stateDir !== undefined) output.stateDir = options.stateDir;
+  if (options.hookSpoolDir !== undefined) output.hookSpoolDir = options.hookSpoolDir;
+  if (options.autoStartFromHooks !== undefined)
+    output.autoStartFromHooks = options.autoStartFromHooks;
+  if (context?.stationConfigPath !== undefined) {
+    output.stationConfigPath = context.stationConfigPath;
+  } else if (options.configPath !== undefined) {
+    output.stationConfigPath = options.configPath;
+  }
+  return output;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,9 @@ importers:
       '@station/contracts':
         specifier: workspace:*
         version: link:../../../packages/contracts
+      '@station/harness-shared':
+        specifier: workspace:*
+        version: link:../../../packages/harness-shared
       '@station/runtime':
         specifier: workspace:*
         version: link:../../../packages/runtime
@@ -357,6 +360,9 @@ importers:
       '@station/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@station/runtime':
+        specifier: workspace:*
+        version: link:../runtime
 
   packages/observability:
     dependencies:


### PR DESCRIPTION
## What changed

- Added shared harness utilities in `packages/harness-shared` for terminal-bound provider plumbing, launch payloads, provider errors, event correlation, compaction mapping, and hook file/script helpers.
- Migrated Claude, Codex, Cursor, Crush, OpenCode, and Pi harness adapters to those shared helpers while preserving provider-specific exports and diagnostics boundaries.
- Updated workspace package dependencies and lockfile entries for the shared harness package.

## Why

The terminal-backed harness adapters had large duplicated implementations for the same lifecycle, hook, launch, and event-correlation behavior. Centralizing that repeated production code reduces maintenance cost while keeping provider-specific behavior at each integration boundary.

Measured production TS/JS delta against `main`: `2320` additions, `4345` deletions, net `-2025 LOC`.

## UX implication

No intended terminal/TUI behavior change. Manual verification should exercise hook doctor/setup and a normal agent launch path for at least one hook-backed provider, for example `stn hooks doctor claude`, `stn hooks doctor codex`, and a normal provider launch.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts integrations/harness/claude/test/unit integrations/harness/codex/test/unit integrations/harness/cursor/test/unit integrations/harness/crush/test/unit integrations/harness/opencode/test/unit integrations/harness/pi/test/unit` (`25` files / `193` tests passed)
- `git diff --check`
- pre-commit `biome check . && node tools/lint/check-source-order.mjs`