### PR TITLE
feat(brand): add Station mark asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="./station/assets/station-icon.svg" alt="Station logo" width="64" height="64">
+</p>
+
 # station
 
 **A terminal-native control plane for AI-agent worktree sessions.**

--- a/station/README.md
+++ b/station/README.md
@@ -167,7 +167,7 @@ Run the Station app and verify:
 - the terminal enters a full-screen OpenTUI view
 - on a cold boot the Welcome screen renders; `Enter`/`Space` drops into the pane grid
 - at least one bordered terminal pane renders with a shell process id in the title
-- the Station button (a `⌘` corner indicator) renders
+- the Station button renders the overlapping-square Station mark in the corner
 - typed shell commands echo and render output in the focused pane
 - `Ctrl-O` toggles the read-only dashboard overlay; `Ctrl-C` is delivered to the shell process
 - `Ctrl-Q` exits back to the shell

--- a/station/assets/station-icon.svg
+++ b/station/assets/station-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Station">
+  <rect x="7" y="7" width="12" height="12" fill="none" stroke="#050505" stroke-width="2" />
+  <rect x="13" y="13" width="12" height="12" fill="none" stroke="#050505" stroke-width="2" />
+</svg>

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { DynamicStationButton } from "./DynamicStationButton.js";
-import { ANIM_MS } from "./layout.js";
+import { ANIM_MS, STATION_ICON } from "./layout.js";
 
 // OpenTUI's reconciler commits async layout updates outside React's act(),
 // matching the StationApp integration test's stance for these render checks.
@@ -24,7 +24,7 @@ describe("DynamicStationButton", () => {
     const frame = await captureFrame(
       <DynamicStationButton attention={false} workingCount={2} idleCount={14} />,
     );
-    expect(frame).toContain("⧉");
+    expect(frame).toContain(STATION_ICON);
     expect(frame).not.toContain("session");
   });
 
@@ -32,7 +32,7 @@ describe("DynamicStationButton", () => {
     const frame = await captureFrame(
       <DynamicStationButton attention={true} workingCount={0} idleCount={0} sessionName="hook-scope" />,
     );
-    expect(frame).toContain("⧉");
+    expect(frame).toContain(STATION_ICON);
     // Framed alert: solid "!" rows top and bottom around the centered icon.
     expect(frame).toContain("!!!!");
     expect(frame).not.toContain("needs user");
@@ -42,7 +42,7 @@ describe("DynamicStationButton", () => {
     const frame = await captureFrame(
       <DynamicStationButton attention={false} workingCount={2} idleCount={14} hovered />,
     );
-    expect(frame).toContain("⧉");
+    expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("2 sessions working");
     expect(frame).toContain("14 sessions idle");
   });
@@ -65,7 +65,7 @@ describe("DynamicStationButton", () => {
     const [topBorder, iconRow, titleRow] = lines;
     const buttonLeft = topBorder.indexOf("╭");
     expect(buttonLeft).toBeGreaterThanOrEqual(0);
-    expect(iconRow.slice(buttonLeft)).toContain("⧉");
+    expect(iconRow.slice(buttonLeft)).toContain(STATION_ICON);
     expect(iconRow.slice(buttonLeft)).not.toContain("hook-scope");
     expect(titleRow.slice(buttonLeft)).toContain("hook-scope");
     const bottomBorder = lines.findIndex((line) => line.slice(buttonLeft).startsWith("╰"));

--- a/station/src/stationButton/layout.ts
+++ b/station/src/stationButton/layout.ts
@@ -1,5 +1,6 @@
 // Geometry and sizing math for the station button (no React, no colors).
 
+// Terminal glyph form of the black vector mark in station/assets/station-icon.svg.
 export const STATION_ICON = "⧉";
 export const ATTENTION_MARK = "!";
 


### PR DESCRIPTION
## Summary

- add a black overlapping-square Station SVG mark under `station/assets`
- show the mark at the top of the root README
- align Station button render tests with the shared mark constant and update stale manual-verification wording

## UX

The root README now opens with the Station mark. The live terminal button still uses the same overlapping-square mark while preserving state colors for contrast on the dark terminal background.

## Validation

- `pnpm build`
- `cd station && bun install --frozen-lockfile`
- `cd station && bun run link:station`
- `cd station && bun test src/stationButton/DynamicStationButton.test.tsx src/stationButton/layout.test.ts`
- `cd station && bun run typecheck`
- `xmllint --noout station/assets/station-icon.svg`
- `git diff --check`
- pre-commit `biome check . && node tools/lint/check-source-order.mjs`