### PR TITLE
fix(brand): keep README mark visible in dark mode

### DIFF
--- a/station/assets/station-icon.svg
+++ b/station/assets/station-icon.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Station">
+  <rect x="1" y="1" width="30" height="30" rx="6" fill="#ffffff" stroke="#d4d4d8" />
   <rect x="7" y="7" width="12" height="12" fill="none" stroke="#050505" stroke-width="2" />
   <rect x="13" y="13" width="12" height="12" fill="none" stroke="#050505" stroke-width="2" />
 </svg>


### PR DESCRIPTION
## Summary

- add a light backing tile behind the black Station SVG mark
- preserve the black mark while making the README logo visible on GitHub dark mode

## UX

The root README logo no longer disappears against GitHub's dark background. The mark itself remains black.

## Validation

- `xmllint --noout station/assets/station-icon.svg`
- `git diff --check`
- pre-commit `biome check . && node tools/lint/check-source-order.mjs`