### PR TITLE
feat(demo): stage branch-specific agent launches

### DIFF
--- a/apps/observer/src/commands/session/startAgent.ts
+++ b/apps/observer/src/commands/session/startAgent.ts
@@ -82,6 +82,7 @@ export function createSessionStartAgentHandler(
     throwIfAborted(context.signal);
     const harnessProviderId =
       payload.harness?.provider ??
+      configuredHarnessProviderForWorktree(project, worktree) ??
       (await rememberedHarnessProviderForWorktree({
         persistence: options.persistence,
         projectId: payload.projectId,
@@ -208,6 +209,14 @@ function validateSnapshotRow(row: WorktreeRow | undefined, projectId: string): v
     projectId,
     worktreeId: row.id,
   };
+}
+
+function configuredHarnessProviderForWorktree(
+  project: ProviderProjectConfig,
+  worktree: WorktreeObservation,
+): string | undefined {
+  return project.worktreeLaunches?.find((candidate) => candidate.branch === worktree.branch)
+    ?.harness;
 }
 
 async function lookupWorktree(input: {

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -335,6 +335,9 @@ export function providerProjectsFromConfig(config: StationConfig): ProviderProje
         providerProject.recoveryBreadcrumbs.path = project.recoveryBreadcrumbs.path;
       }
     }
+    if (project.worktreeLaunches !== undefined) {
+      providerProject.worktreeLaunches = project.worktreeLaunches;
+    }
     return ProviderProjectConfigSchema.parse(providerProject);
   });
 }

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1190,6 +1190,78 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("starts an existing worktree with its configured branch harness when no provider is requested", async () => {
+    const configuredHarness = new CapturingHarnessProvider({ id: "configured-harness", now });
+    const defaultHarness = new CapturingHarnessProvider({ id: "fake-harness", now });
+    const existingWorktree = createFakeWorktree({
+      id: "wt_web_configured",
+      projectId: "web",
+      branch: "configured-branch",
+      now,
+    });
+    const terminal = new FakeTerminalProvider({
+      now,
+      onLaunch: async ({ launchPlan }) => {
+        configuredHarness.addRun(
+          createFakeHarnessRun({
+            id: "run_web_configured",
+            provider: "configured-harness",
+            projectId: "web",
+            worktreeId: "wt_web_configured",
+            sessionId: launchPlan.env?.STATION_SESSION_ID,
+            state: "working",
+            now,
+          }),
+        );
+      },
+    });
+    const project = config.projects[0];
+    if (project === undefined) throw new Error("missing test project");
+    const fixture = createFixture({
+      config: {
+        ...config,
+        projects: [
+          {
+            ...project,
+            worktreeLaunches: [{ branch: "configured-branch", harness: "configured-harness" }],
+          },
+        ],
+      },
+      terminal,
+      harnesses: [defaultHarness, configuredHarness],
+      worktree: new FakeWorktreeProvider({
+        now,
+        worktrees: [existingWorktree],
+      }),
+      sessionIds: ["ses_configured_next"],
+    });
+    await fixture.core.reconcile("pre-start-agent-configured");
+
+    await fixture.queue.dispatch({
+      type: "session.startAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: "wt_web_configured",
+        terminal: { provider: "fake-terminal", focus: false },
+      },
+    });
+    await fixture.queue.drain();
+
+    expect(defaultHarness.lastBuildRequest).toBeUndefined();
+    expect(configuredHarness.lastBuildRequest).toMatchObject({
+      sessionId: "ses_configured_next",
+      worktree: {
+        id: "wt_web_configured",
+      },
+    });
+    expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({
+      harness: "configured-harness",
+      sessionId: "ses_configured_next",
+      state: "working",
+    });
+    fixture.sqlite.close();
+  });
+
   it("remembers the previous harness when the worktree id changes but the normalized path is stable", async () => {
     const rememberedHarness = new CapturingHarnessProvider({ id: "remembered-harness", now });
     const defaultHarness = new CapturingHarnessProvider({ id: "fake-harness", now });
@@ -1507,9 +1579,11 @@ function createFixture(
     terminalIntentRunner?: TerminalIntentRunner;
     sessionIds?: string[];
     featureFlags?: { sessionResumeAgent?: boolean };
+    config?: StationConfig;
   } = {},
 ) {
   const clock = { now: () => new Date(now) };
+  const fixtureConfig = options.config ?? config;
   const sqlite = openObserverSqlite({ clock });
   const ids = observerIds();
   const persistence = createObserverPersistence({ sqlite, clock, idFactory: ids });
@@ -1529,7 +1603,7 @@ function createFixture(
     },
   });
   const core = createObserverCore({
-    config,
+    config: fixtureConfig,
     providers,
     persistence,
     sqlite,
@@ -1541,7 +1615,7 @@ function createFixture(
     queue,
     core,
     providers,
-    projects: config.projects,
+    projects: fixtureConfig.projects,
     persistence,
     featureFlags,
     eventBus,

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -251,6 +251,7 @@ function normalizeProjectConfig(value: unknown): unknown {
       display: normalizeDisplayConfig,
       localConfig: normalizeProjectLocalConfigRef,
       recoveryBreadcrumbs: normalizeProjectRecoveryBreadcrumbsConfig,
+      worktreeLaunches: normalizeProjectWorktreeLaunchConfigs,
     },
   );
 }
@@ -275,6 +276,13 @@ function normalizeProjectLocalConfigRef(value: unknown): unknown {
 
 function normalizeProjectRecoveryBreadcrumbsConfig(value: unknown): unknown {
   return normalizeObject(value);
+}
+
+function normalizeProjectWorktreeLaunchConfigs(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.map((entry) => normalizeObject(entry));
 }
 
 function normalizeObject(

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -68,6 +68,15 @@ export const ProjectRecoveryBreadcrumbsSchema = z
 
 export type ProjectRecoveryBreadcrumbs = z.infer<typeof ProjectRecoveryBreadcrumbsSchema>;
 
+export const ProjectWorktreeLaunchConfigSchema = z
+  .object({
+    branch: nonEmptyStringSchema,
+    harness: providerIdSchema,
+  })
+  .strict();
+
+export type ProjectWorktreeLaunchConfig = z.infer<typeof ProjectWorktreeLaunchConfigSchema>;
+
 export const ProjectConfigSchema = z
   .object({
     id: projectIdSchema,
@@ -83,6 +92,7 @@ export const ProjectConfigSchema = z
     display: ProjectDisplayConfigSchema.optional(),
     localConfig: ProjectLocalConfigRefSchema.optional(),
     recoveryBreadcrumbs: ProjectRecoveryBreadcrumbsSchema.optional(),
+    worktreeLaunches: z.array(ProjectWorktreeLaunchConfigSchema).optional(),
   })
   .strict();
 

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -132,6 +132,36 @@ ${projectToml("station", roots.station)}
     expect(loaded.diagnostics).toEqual([]);
   });
 
+  it("loads per-worktree launch harness defaults", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+    const loaded = await loadConfigFromToml(
+      baseToml(`
+[[projects]]
+id = "web"
+label = "web"
+root = "${root}"
+
+[projects.worktrunk]
+enabled = true
+
+[[projects.worktree_launches]]
+branch = "a11y/playbook-refresh"
+harness = "cursor"
+
+[[projects.worktree_launches]]
+branch = "feat/server-actions"
+harness = "claude"
+`),
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.projects[0]?.worktreeLaunches).toEqual([
+      { branch: "a11y/playbook-refresh", harness: "cursor" },
+      { branch: "feat/server-actions", harness: "claude" },
+    ]);
+  });
+
   it("normalizes managed Worktrunk root policy for a project", async () => {
     const tempDir = await makeTempDir();
     const root = await makeProjectRoot(tempDir, "web");

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -125,6 +125,13 @@ export const ProviderProjectRecoveryBreadcrumbsSchema = z
   })
   .strict();
 
+export const ProviderProjectWorktreeLaunchSchema = z
+  .object({
+    branch: nonEmptyStringSchema,
+    harness: ProviderIdSchema,
+  })
+  .strict();
+
 export const ProviderProjectConfigSchema = z
   .object({
     id: ProjectIdSchema,
@@ -134,6 +141,7 @@ export const ProviderProjectConfigSchema = z
     defaults: ProviderProjectDefaultsSchema,
     worktrunk: ProviderProjectWorktrunkConfigSchema,
     recoveryBreadcrumbs: ProviderProjectRecoveryBreadcrumbsSchema.optional(),
+    worktreeLaunches: z.array(ProviderProjectWorktreeLaunchSchema).optional(),
   })
   .strict();
 

--- a/scripts/demo/RUNBOOK.md
+++ b/scripts/demo/RUNBOOK.md
@@ -7,7 +7,7 @@ overview, and the live interactions staged by `scripts/demo/stage.sh`.
 ## Setup
 
 - **Act 1 (mock):** nothing to stage.
-- **Act 2 (live):** `scripts/demo/stage.sh` → launch `stn --config ~/.station-demo/config.toml` → tear down with `scripts/demo/reset.sh`.
+- **Act 2 (live):** `scripts/demo/stage.sh` clones the showcase repos, seeds one `t3-code` monorepo with ten branch worktrees, installs local provider hooks, and starts the isolated observer → launch `~/.station-demo/run.sh` → tear down with `scripts/demo/reset.sh`.
 
 Everything in Act 2 is isolated under `~/.station-demo`; it never touches your real `~/.config/station` or observer state.
 
@@ -22,10 +22,10 @@ Everything in Act 2 is isolated under `~/.station-demo`; it never touches your r
 | # | Shot | How | README spot |
 |---|------|-----|-------------|
 | 1 | **Hero — overview** | `cd station && STATION_SOURCE=mock STATION_SCENARIO=showcase bun run station` → wait for first frame (throbber shows `⠋`) → capture → `Ctrl-Q` | top, under the tagline |
-| 2 | **New session (any harness)** | `N` → name → project → **pick agent: claude / codex** → agent launches into a pane | "What it does" |
+| 2 | **New session (any harness)** | `N` → name → project → **pick agent: claude / codex / opencode / pi / cursor / crush** → agent launches into a pane | "What it does" |
 | 3 | **Add project** | `A` → folder picker → `~/.station-demo/repos/web` → review → success → `N` to start a session there | "What it does" |
-| 4 | **Split + run a command** | open `is-even` (`[+sh]` or a session) → split (`Ctrl-\`) → run `./check.sh` | optional |
-| 5 | **Split + see diff** | focus the `is-even` worktree → right-click → **See diff (split right)** → `diffnav` renders the planted O(n)→O(1) diff | the automations money shot |
+| 4 | **Split + run a command** | after adding `web`, open it (`[+sh]` or a session) → split (`Ctrl-\`) → run `./check.sh` | optional |
+| 5 | **Split + see diff** | focus the added `web` project → right-click → **See diff (split right)** → `diffnav` renders the planted O(n)→O(1) diff | the automations money shot |
 
 Shot 1 is the reliable hero — zero setup, no real data. The others are live.
 
@@ -44,7 +44,7 @@ Set FontSize 16
 Set Width 1200
 Set Height 720
 Set Shell bash
-Type "stn --config ~/.station-demo/config.toml" Enter
+Type "~/.station-demo/run.sh" Enter
 Sleep 4s
 # …drive the keys for the flow here (Type/Enter/Ctrl+… /Sleep)…
 Sleep 2s
@@ -56,7 +56,7 @@ VHS runs Station in its own PTY; the dual-runtime renderer usually records fine,
 
 - Commit to `docs/images/` and embed: `![Station — live worktree dashboard](docs/images/overview.png)`. Works in private and public; GitHub serves them.
 - Keep GIFs lean (<~5 MB) or upload to a GitHub release/issue to get a CDN URL and avoid repo bloat.
-- **No-real-data guarantee:** Act 1 is mock (famous repos, no real data); Act 2 uses the isolated `is-even`/`web` repos. Never capture against your real observer.
+- **No-real-data guarantee:** Act 1 is mock (famous repos, no real data); Act 2 uses isolated showcase clones plus local `t3-code` and `web` fixtures. Never capture against your real observer.
 - Suggested layout: hero PNG at the top, one "it works" GIF (see-diff or new session) in "What it does".
 
 ## Optional: make the command split a one-tap automation

--- a/scripts/demo/stage.sh
+++ b/scripts/demo/stage.sh
@@ -1,39 +1,125 @@
 #!/usr/bin/env bash
 # Stage a self-contained Station demo for screenshots / recordings.
 #
-# Creates example repos with a planted diff + a runnable task, writes an
-# ISOLATED observer config, and checks demo dependencies. Everything lives under
-# $STATION_DEMO_ROOT (default ~/.station-demo) and never touches your real
-# ~/.config/station or ~/.local/state/station. Launch with:
+# Creates shallow showcase clones with planted diffs, an add-project sample repo,
+# writes an ISOLATED observer config, and checks demo dependencies. Everything
+# lives under $STATION_DEMO_ROOT (default ~/.station-demo) and never touches your
+# real ~/.config/station or ~/.local/state/station. Launch with:
 #
-#   stn --config "$STATION_DEMO_ROOT/config.toml"
+#   "$STATION_DEMO_ROOT/run.sh"
 #
 # Tear it all down with scripts/demo/reset.sh.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DEMO_ROOT="${STATION_DEMO_ROOT:-$HOME/.station-demo}"
 REPOS="$DEMO_ROOT/repos"
 WORKTREES="$DEMO_ROOT/worktrees"
 STATE="$DEMO_ROOT/state"
 CONFIG="$DEMO_ROOT/config.toml"
+RUNNER="$DEMO_ROOT/run.sh"
+HOOKS_REPORT="$DEMO_ROOT/hooks.txt"
+CODEX_DEMO_HOME="$DEMO_ROOT/codex-home"
+CLAUDE_DEMO_HOME="$DEMO_ROOT/claude-home"
+OPENCODE_DEMO_HOME="$DEMO_ROOT/opencode-home"
+CURSOR_HOOKS="$DEMO_ROOT/cursor/hooks.json"
+CRUSH_CONFIG="$DEMO_ROOT/crush/.crush.json"
+WORKTRUNK_CONFIG="$DEMO_ROOT/worktrunk/config.toml"
+STN="${STATION_DEMO_STN:-$ROOT/bin/stn}"
+HOOK_BIN="$ROOT/bin/stn-ingress"
+HOST_ENTRY="$ROOT/station/src/host/hostMain.ts"
+HOST_SOCKET="$STATE/run/station-host.sock"
+
+CLAUDE_CMD="${STATION_CLAUDE_BIN:-claude}"
+CODEX_CMD="${STATION_CODEX_BIN:-codex}"
+CURSOR_CMD="${STATION_CURSOR_AGENT_BIN:-agent}"
+CRUSH_CMD="${STATION_CRUSH_BIN:-crush}"
+OPENCODE_CMD="${STATION_OPENCODE_BIN:-opencode}"
+PI_CMD="${STATION_PI_BIN:-pi}"
 
 step() { printf '\n==> %s\n' "$1"; }
 
+have_tool() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+stn_demo() {
+  PATH="$ROOT/bin:$PATH" \
+    CODEX_HOME="$CODEX_DEMO_HOME" \
+    CLAUDE_CONFIG_DIR="$CLAUDE_DEMO_HOME" \
+    OPENCODE_CONFIG_DIR="$OPENCODE_DEMO_HOME" \
+    STATION_CONFIG_PATH="$CONFIG" \
+    STATION_OBSERVER_SOCKET_PATH="$STATE/observer.sock" \
+    STATION_HOST_ENTRY="$HOST_ENTRY" \
+    STATION_HOST_SOCKET_PATH="$HOST_SOCKET" \
+    "$STN" --config "$CONFIG" "$@"
+}
+
 step "Checking demo dependencies"
 missing=()
-for tool in stn git wt tmux diffnav delta; do
-  command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+for tool in git wt tmux diffnav delta; do
+  have_tool "$tool" || missing+=("$tool")
 done
+[ -x "$STN" ] || missing+=("$STN (run: pnpm build)")
+[ -x "$HOOK_BIN" ] || missing+=("$HOOK_BIN (run: pnpm build)")
 harness_missing=()
-for tool in claude codex; do
-  command -v "$tool" >/dev/null 2>&1 || harness_missing+=("$tool")
+for tool in "$CLAUDE_CMD" "$CODEX_CMD" "$OPENCODE_CMD" "$PI_CMD" "$CURSOR_CMD" "$CRUSH_CMD"; do
+  have_tool "$tool" || harness_missing+=("$tool")
 done
 [ "${#missing[@]}" -eq 0 ] && echo "  core tools: ok" || echo "  MISSING core tools: ${missing[*]}  (run: brew bundle --file Brewfile)"
-[ "${#harness_missing[@]}" -eq 0 ] && echo "  harnesses: claude, codex present" || echo "  harnesses not found: ${harness_missing[*]}  (the new-session flow needs at least one installed + logged in)"
+[ "${#harness_missing[@]}" -eq 0 ] && echo "  harnesses: claude, codex, opencode, pi, cursor, crush present" || echo "  harnesses not found: ${harness_missing[*]}  (the staged assignments need those CLIs installed + logged in)"
 
 step "Resetting demo root: $DEMO_ROOT"
+if [ -f "$CONFIG" ] && [ -x "$STN" ]; then
+  stn_demo observer stop >/dev/null 2>&1 || true
+fi
+tmux kill-session -t stationdemo >/dev/null 2>&1 || true
 rm -rf "$DEMO_ROOT"
 mkdir -p "$REPOS" "$WORKTREES" "$STATE"
+
+clone_showcase_repo() {
+  local name="$1" url="$2" branch="$3"
+  local dir="$REPOS/$name"
+  git clone --quiet --depth 1 --filter=blob:none --sparse --branch "$branch" "$url" "$dir"
+  (
+    cd "$dir"
+    git config user.email "demo@station.local"
+    git config user.name "Station Demo"
+    # Keep the public source visible without letting demo snapshots poll GitHub.
+    git remote add upstream "$url"
+    git remote set-url origin "file://$dir"
+  )
+  echo "  $dir (shallow sparse clone of $url, branch $branch)"
+}
+
+add_worktree_from_repo() {
+  local repo_dir="$1" worktree_group="$2" branch="$3" base="$4" demo_file="$5" note="$6" label="$7"
+  local slug="${branch//\//-}"
+  local path="$WORKTREES/$worktree_group/$slug"
+  mkdir -p "$(dirname "$path")"
+  git -C "$repo_dir" worktree add --quiet -b "$branch" "$path" "$base"
+  (
+    cd "$path"
+    if [ -f "$demo_file" ]; then
+      cat >>"$demo_file" <<DEMO
+
+<!-- STATION demo: $note -->
+DEMO
+    fi
+    cat >STATION_DEMO_NOTES.md <<DEMO
+# STATION demo notes
+
+$note
+DEMO
+  )
+  echo "  $path ($label:$branch)"
+}
+
+add_showcase_worktree() {
+  local repo="$1" branch="$2" base="$3" demo_file="$4" note="$5"
+  add_worktree_from_repo "$REPOS/$repo" "$repo" "$branch" "$base" "$demo_file" "$note" "$repo"
+}
 
 # A git repo with main committed, then a planted uncommitted diff + untracked
 # file so the default "See diff" automation has something to render, plus an
@@ -66,25 +152,132 @@ CHECK
   echo "  $dir (planted diff in $file + untracked $untracked_name)"
 }
 
-step "Creating example repos under $REPOS"
-# is-even: configured below, and on-brand with the mock showcase. The diff is the
-# joke — an O(n) loop collapsing to a one-liner.
-seed_repo "is-even" "is-even.js" \
-  "module.exports = function isEven(n) {
-  // O(n): toggle a flag n times. do not ship this.
-  let even = true;
-  for (let i = 0; i < Math.abs(n); i++) even = !even;
-  return even;
-};" \
-  "module.exports = function isEven(n) {
-  // O(1).
-  return n % 2 === 0;
-};" \
-  "BENCHMARK.md" "# Benchmark
+append_project_config() {
+  local id="$1" label="$2" root="$3" default_branch="$4" harness="$5"
+  cat >>"$CONFIG" <<TOML
 
-Before: O(n) — ~3 evens/sec at n=1e9.
-After:  O(1) — yes."
+[[projects]]
+id = "$id"
+label = "$label"
+root = "$root"
+default_branch = "$default_branch"
 
+[projects.defaults]
+harness = "$harness"
+terminal = "tmux"
+layout = "agent-shell"
+TOML
+}
+
+t3_project_path() {
+  case "$1" in
+    web) printf 'apps/web' ;;
+    api) printf 'apps/api' ;;
+    auth) printf 'packages/auth' ;;
+    db) printf 'packages/db' ;;
+    billing) printf 'packages/billing' ;;
+    ai) printf 'packages/ai' ;;
+    mobile) printf 'apps/mobile' ;;
+    admin) printf 'apps/admin' ;;
+    worker) printf 'packages/worker' ;;
+    docs) printf 'apps/docs' ;;
+    *) return 1 ;;
+  esac
+}
+
+seed_t3_project_files() {
+  local name="$1" harness="$2" title="$3"
+  local dir="$REPOS/t3-code/$(t3_project_path "$name")"
+  mkdir -p "$dir/scripts" "$dir/src"
+  cat >"$dir/package.json" <<JSON
+{"name":"@t3-code/$name","private":true,"type":"module","scripts":{"check":"node scripts/check.mjs"}}
+JSON
+  cat >"$dir/scripts/check.mjs" <<CHECK
+console.log("checking @t3-code/$name");
+console.log("default harness: $harness");
+CHECK
+  cat >"$dir/src/index.ts" <<TS
+export const service = "$name";
+export const defaultHarness = "$harness";
+
+export function describe() {
+  return "$title";
+}
+TS
+  printf '# t3-code/%s\n\n%s\n' "$name" "$title" >"$dir/README.md"
+}
+
+seed_t3_repo() {
+  local dir="$REPOS/t3-code"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email "demo@station.local"
+    git config user.name "Station Demo"
+    cat >package.json <<'JSON'
+{"name":"t3-code","private":true,"type":"module","workspaces":["apps/*","packages/*"]}
+JSON
+    cat >pnpm-workspace.yaml <<'YAML'
+packages:
+  - "apps/*"
+  - "packages/*"
+YAML
+    printf '# t3-code\n\nDemo monorepo with app and package projects.\n' >README.md
+  )
+  seed_t3_project_files "web" "claude" "Next.js app shell for the T3 code workspace."
+  seed_t3_project_files "api" "codex" "Typed RPC API boundary for the T3 code workspace."
+  seed_t3_project_files "auth" "opencode" "OAuth and session handling for the T3 code workspace."
+  seed_t3_project_files "db" "pi" "Drizzle schema and migration package for the T3 code workspace."
+  seed_t3_project_files "billing" "claude" "Stripe usage metering service for the T3 code workspace."
+  seed_t3_project_files "ai" "codex" "AI interaction package for the T3 code workspace."
+  seed_t3_project_files "mobile" "opencode" "Mobile companion app for the T3 code workspace."
+  seed_t3_project_files "admin" "pi" "Admin console for the T3 code workspace."
+  seed_t3_project_files "worker" "cursor" "Background worker package for the T3 code workspace."
+  seed_t3_project_files "docs" "cursor" "Documentation site for the T3 code workspace."
+  (
+    cd "$dir"
+    git add -A
+    git commit -q -m "init t3-code monorepo"
+  )
+}
+
+add_t3_worktree() {
+  local name="$1" harness="$2" branch="$3" note="$4"
+  local subdir
+  subdir="$(t3_project_path "$name")"
+  add_worktree_from_repo "$REPOS/t3-code" "t3-code" "$branch" "main" "$subdir/README.md" "$note" "t3-code"
+}
+
+step "Cloning showcase repos under $REPOS"
+clone_showcase_repo "linux" "https://github.com/torvalds/linux.git" "master"
+clone_showcase_repo "ghostty" "https://github.com/ghostty-org/ghostty.git" "main"
+clone_showcase_repo "svelte" "https://github.com/sveltejs/svelte.git" "main"
+clone_showcase_repo "is-even" "https://github.com/jonschlinkert/is-even.git" "master"
+
+step "Creating showcase worktrees under $WORKTREES"
+add_showcase_worktree "linux" "sched/eevdf-latency" "master" "README" "Experiment with scheduler latency accounting for interactive workloads."
+add_showcase_worktree "linux" "fix/cifs-null-deref" "master" "README" "Tighten CIFS mount teardown around a nullable server response."
+add_showcase_worktree "linux" "mm/folio-reclaim-trace" "master" "README" "Trace folio reclaim pressure around interactive filesystem workloads."
+add_showcase_worktree "ghostty" "feat/kitty-graphics" "main" "README.md" "Prototype broader kitty graphics protocol coverage in the renderer."
+add_showcase_worktree "ghostty" "perf/glyph-atlas-cache" "main" "README.md" "Tune glyph atlas cache reuse for dense terminal redraws."
+add_showcase_worktree "svelte" "compiler/ssr-hydration" "main" "README.md" "Exercise SSR hydration mismatch diagnostics in the compiler."
+add_showcase_worktree "is-even" "perf/constant-time-evenness" "master" "README.md" "Replace iterative evenness checks with a constant-time implementation note."
+
+step "Creating t3-code monorepo under $REPOS/t3-code"
+seed_t3_repo
+add_t3_worktree "web" "claude" "feat-server-actions" "Wire server actions through the dashboard entry flow."
+add_t3_worktree "api" "codex" "perf-router-cache" "Tune router-level caching for repeated list queries."
+add_t3_worktree "auth" "opencode" "fix-oauth-refresh" "Patch token refresh behavior after provider reconnects."
+add_t3_worktree "db" "pi" "chore-drizzle-indexes" "Add indexes around the newest activity queries."
+add_t3_worktree "billing" "claude" "feat-usage-metering" "Prototype usage rollups for metered workspaces."
+add_t3_worktree "ai" "codex" "experiment-streaming-ui" "Exercise streaming response state across route transitions."
+add_t3_worktree "mobile" "opencode" "feat-offline-sync" "Stage offline sync recovery for background edits."
+add_t3_worktree "admin" "pi" "polish-audit-log" "Improve audit-log scanability for support workflows."
+add_t3_worktree "docs" "cursor" "a11y/playbook-refresh" "Refresh onboarding playbooks around environment setup."
+add_t3_worktree "worker" "cursor" "async/queue-retry-backoff" "Harden queue retry backoff for flaky webhook deliveries."
+
+step "Creating add-project repo under $REPOS"
 # web: intentionally NOT added to the config, so you can demo "Add project".
 seed_repo "web" "is-even.js" \
   "module.exports = function isEven(n) { return !(n & 1); };" \
@@ -111,13 +304,17 @@ layout = "agent-shell"
 default_branch = "main"
 harness_permission_mode = "yolo"
 
+[feature_flags]
+station_persistent_agents = true
+
 [worktree.worktrunk]
 command = "wt"
+config_path = "$WORKTRUNK_CONFIG"
 managed_root = "$WORKTREES"
 base = "main"
-include_main = true
+include_main = false
 include_external = false
-use_lifecycle_hooks = false
+use_lifecycle_hooks = true
 
 [terminal.tmux]
 session_prefix = "stationdemo"
@@ -126,22 +323,180 @@ workbench_session = "stationdemo"
 
 [harness.claude]
 enabled = true
-command = "claude"
+command = "$CLAUDE_CMD"
 install_hooks = true
 
 [harness.codex]
 enabled = true
-command = "codex"
+command = "$CODEX_CMD"
 install_hooks = true
+
+[harness.opencode]
+enabled = true
+command = "$OPENCODE_CMD"
+install_hooks = true
+
+[harness.pi]
+enabled = true
+command = "$PI_CMD"
+
+[harness.cursor]
+enabled = true
+command = "$CURSOR_CMD"
+install_hooks = true
+
+[harness.crush]
+enabled = true
+command = "$CRUSH_CMD"
+install_hooks = true
+
+[[projects]]
+id = "linux"
+label = "linux"
+root = "$REPOS/linux"
+default_branch = "master"
+
+[projects.defaults]
+harness = "claude"
+terminal = "tmux"
+layout = "agent-shell"
+
+[[projects]]
+id = "ghostty"
+label = "ghostty"
+root = "$REPOS/ghostty"
+default_branch = "main"
+
+[projects.defaults]
+harness = "codex"
+terminal = "tmux"
+layout = "agent-shell"
+
+[[projects]]
+id = "svelte"
+label = "svelte"
+root = "$REPOS/svelte"
+default_branch = "main"
+
+[projects.defaults]
+harness = "opencode"
+terminal = "tmux"
+layout = "agent-shell"
 
 [[projects]]
 id = "is-even"
 label = "is-even"
 root = "$REPOS/is-even"
+default_branch = "master"
+
+[projects.defaults]
+harness = "pi"
+terminal = "tmux"
+layout = "agent-shell"
 
 [projects.commands]
-test = "./check.sh"
+test = "npm test"
 TOML
+
+append_project_config "t3-code" "t3-code" "$REPOS/t3-code" "main" "codex"
+cat >>"$CONFIG" <<'TOML'
+
+[[projects.worktree_launches]]
+branch = "a11y/playbook-refresh"
+harness = "cursor"
+
+[[projects.worktree_launches]]
+branch = "async/queue-retry-backoff"
+harness = "cursor"
+
+[[projects.worktree_launches]]
+branch = "feat-server-actions"
+harness = "claude"
+
+[[projects.worktree_launches]]
+branch = "perf-router-cache"
+harness = "codex"
+
+[[projects.worktree_launches]]
+branch = "fix-oauth-refresh"
+harness = "opencode"
+
+[[projects.worktree_launches]]
+branch = "chore-drizzle-indexes"
+harness = "pi"
+
+[[projects.worktree_launches]]
+branch = "feat-usage-metering"
+harness = "claude"
+
+[[projects.worktree_launches]]
+branch = "experiment-streaming-ui"
+harness = "codex"
+
+[[projects.worktree_launches]]
+branch = "feat-offline-sync"
+harness = "opencode"
+
+[[projects.worktree_launches]]
+branch = "polish-audit-log"
+harness = "pi"
+TOML
+
+step "Preparing isolated provider homes"
+mkdir -p "$CODEX_DEMO_HOME" "$CLAUDE_DEMO_HOME" "$OPENCODE_DEMO_HOME"
+[ -e "$HOME/.codex/auth.json" ] && ln -sf "$HOME/.codex/auth.json" "$CODEX_DEMO_HOME/auth.json"
+[ -e "$HOME/.codex/config.toml" ] && cp "$HOME/.codex/config.toml" "$CODEX_DEMO_HOME/config.toml"
+
+cat >"$RUNNER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH="$ROOT/bin:\$PATH"
+export CODEX_HOME="$CODEX_DEMO_HOME"
+export CLAUDE_CONFIG_DIR="$CLAUDE_DEMO_HOME"
+export OPENCODE_CONFIG_DIR="$OPENCODE_DEMO_HOME"
+export STATION_CONFIG_PATH="$CONFIG"
+export STATION_OBSERVER_SOCKET_PATH="$STATE/observer.sock"
+export STATION_HOST_ENTRY="$HOST_ENTRY"
+export STATION_HOST_SOCKET_PATH="$HOST_SOCKET"
+exec "$STN" --config "$CONFIG" "\$@"
+EOF
+chmod +x "$RUNNER"
+
+record_hook() {
+  printf '%s\n' "$1" >>"$HOOKS_REPORT"
+}
+
+step "Installing local provider hooks"
+: >"$HOOKS_REPORT"
+if have_tool wt; then
+  stn_demo hooks install worktrunk --yes --worktrunk-config "$WORKTRUNK_CONFIG" >/dev/null
+  record_hook "worktrunk: $WORKTRUNK_CONFIG"
+fi
+if have_tool "$CLAUDE_CMD"; then
+  stn_demo hooks install claude --yes >/dev/null
+  record_hook "claude: $STATE/hooks/station-claude-settings.json, $CLAUDE_DEMO_HOME/settings.json"
+fi
+if have_tool "$CODEX_CMD"; then
+  stn_demo hooks install codex --yes >/dev/null
+  record_hook "codex: $CODEX_DEMO_HOME/station.config.toml"
+fi
+if have_tool "$CURSOR_CMD"; then
+  stn_demo hooks install cursor --yes --cursor-hooks "$CURSOR_HOOKS" >/dev/null
+  record_hook "cursor: $CURSOR_HOOKS"
+fi
+if have_tool "$CRUSH_CMD"; then
+  stn_demo hooks install crush --yes --crush-config "$CRUSH_CONFIG" >/dev/null
+  record_hook "crush: $CRUSH_CONFIG"
+fi
+if have_tool "$OPENCODE_CMD"; then
+  stn_demo hooks install opencode --yes --opencode-config-dir "$OPENCODE_DEMO_HOME" >/dev/null
+  record_hook "opencode: $OPENCODE_DEMO_HOME/plugins/station-agent-state.js"
+fi
+sed 's/^/  /' "$HOOKS_REPORT"
+
+step "Starting isolated observer"
+stn_demo observer start >/dev/null
+stn_demo snapshot --json >/dev/null
 
 cat <<EOF
 
@@ -149,15 +504,17 @@ cat <<EOF
 Demo staged under $DEMO_ROOT
 
 Launch (isolated — does not touch your real config/state):
-  stn --config "$CONFIG"
+  "$RUNNER"
 
 In the dashboard:
-  • is-even shows its main worktree with a planted diff
+  • linux, ghostty, svelte, and is-even are real shallow sparse clones
+  • showcase worktrees are staged under $WORKTREES with plausible branch names and planted diffs
+  • staged harness defaults: linux=claude (3), ghostty=codex (2), svelte=opencode (1), is-even=pi (1)
+  • t3-code is one local monorepo with 10 branch worktrees and mixed branch launch defaults (no crush)
   • 'web' is on disk at $REPOS/web — add it live with the Add-Project flow
 
-Hooks for live agent status (optional, needs logged-in harnesses):
-  stn --config "$CONFIG" hooks install claude
-  stn --config "$CONFIG" hooks install codex
+Local provider hook files:
+  $HOOKS_REPORT
 
 Reset everything:
   scripts/demo/reset.sh


### PR DESCRIPTION
## Summary

Adds branch-specific launch defaults for existing worktree rows and uses them in the demo staging script so `t3-code` can stay one project while still launching a mixed set of agents from its worktree rows.

## Issue

The demo needed `t3-code` to render as one repo with ten worktrees, not ten synthetic project groups. It also needed those worktrees to launch a realistic mix of harnesses: Cursor on the top two rows, then Claude, Codex, OpenCode, and Pi elsewhere, with no Crush assignment.

The previous attempt seeded fake historical `sessions` rows in SQLite to influence the existing remembered-harness fallback. That made the labels look plausible, but it polluted runtime truth: dashboard row activation could treat those fake rows as attachable session history and try to focus a non-existent session instead of starting a real agent.

## Solution

- Adds a parsed project config field, `[[projects.worktree_launches]]`, with `branch` and `harness`.
- Projects that include branch launch defaults pass them into observer provider config.
- `session.startAgent` now resolves harness choice in this order:
  1. explicit command payload harness
  2. configured worktree branch launch harness
  3. most recently seen harness for that worktree/path
  4. project default harness
- Updates `scripts/demo/stage.sh` to stage the full demo:
  - real shallow sparse clones for linux, ghostty, svelte, and is-even
  - one local `t3-code` monorepo with ten branch worktrees
  - top two `t3-code` rows assigned to Cursor
  - mixed branch launch defaults across Claude, Codex, OpenCode, Pi, and Cursor
  - isolated provider homes, local hook installation, and an isolated runner under `~/.station-demo/run.sh`
- Updates the demo runbook to use the isolated runner and the staged `web` Add Project flow.

## Effect in Regular Usage

Normal behavior is unchanged unless a project config opts into `worktree_launches`. Existing no-agent row activation still dispatches `session.startAgent` the same way. For configured branches, Station chooses the configured harness before falling back to remembered history or the project default.

This makes branch-specific launch defaults explicit config instead of hidden SQLite state, so the dashboard can still show a no-agent row and pressing the row key starts a real agent rather than attaching to fake session data.

## UX Implication / Manual Verify

Run:

```sh
scripts/demo/stage.sh
~/.station-demo/run.sh
```

Expected demo shape:

- no `main`/`master` worktree rows
- `t3-code` appears as one project with ten worktrees
- the first two `t3-code` branches are `a11y/playbook-refresh` and `async/queue-retry-backoff`
- pressing a no-agent `t3-code` row starts a real agent using that branch's configured harness; the top two use Cursor

## Validation

- `bash -n scripts/demo/stage.sh`
- `git diff --check`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/config/test/unit/load-config.test.ts apps/observer/test/integration/session-commands.test.ts`
  - note: this unit config only includes the config test
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/session-commands.test.ts`
- `pnpm typecheck`
