### PR TITLE
fix(session): honor branch launch defaults

### DIFF
--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -256,9 +256,16 @@ export function buildEnsureAgentWorkspaceIntent(input: {
   return intent;
 }
 
+export function configuredHarnessProviderForWorktree(
+  project: ProviderProjectConfig,
+  worktree: WorktreeObservation,
+): ProviderId | undefined {
+  return project.worktreeLaunches?.find((candidate) => candidate.branch === worktree.branch)
+    ?.harness;
+}
+
 /**
- * Reuse the worktree's last observed harness before project default; shared by
- * session.startAgent and external launch so both choose identically.
+ * Reuse the worktree's last observed harness before project default.
  */
 export async function rememberedHarnessProviderForWorktree(input: {
   persistence: ObserverPersistence;

--- a/apps/observer/src/commands/session/startAgent.ts
+++ b/apps/observer/src/commands/session/startAgent.ts
@@ -12,6 +12,7 @@ import { reconcileAndPublish } from "../reconcile.js";
 import {
   assertNoCurrentAgent,
   buildEnsureAgentWorkspaceIntent,
+  configuredHarnessProviderForWorktree,
   defaultSessionCommandIdFactory,
   deleteSessionTitleSeedBestEffort,
   findProjectOrThrow,
@@ -78,6 +79,7 @@ export function createSessionStartAgentHandler(
     throwIfAborted(context.signal);
     const harnessProviderId =
       payload.harness?.provider ??
+      configuredHarnessProviderForWorktree(project, worktree) ??
       (await rememberedHarnessProviderForWorktree({
         persistence: options.persistence,
         projectId: payload.projectId,

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -335,6 +335,9 @@ export function providerProjectsFromConfig(config: StationConfig): ProviderProje
         providerProject.recoveryBreadcrumbs.path = project.recoveryBreadcrumbs.path;
       }
     }
+    if (project.worktreeLaunches !== undefined) {
+      providerProject.worktreeLaunches = project.worktreeLaunches;
+    }
     return ProviderProjectConfigSchema.parse(providerProject);
   });
 }

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -19,6 +19,7 @@ import {
   resolveHarnessProviderOrThrow,
 } from "../commands/providers.js";
 import {
+  configuredHarnessProviderForWorktree,
   defaultSessionCommandIdFactory,
   findProjectOrThrow,
   rememberedHarnessProviderForWorktree,
@@ -140,6 +141,7 @@ export async function prepareExternalLaunch(
 
   const harnessProviderId =
     params.harness ??
+    configuredHarnessProviderForWorktree(project, worktree) ??
     (await rememberedHarnessProviderForWorktree({
       persistence: deps.persistence,
       projectId: params.projectId,

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1190,6 +1190,78 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("starts an existing worktree with its configured branch harness when no provider is requested", async () => {
+    const configuredHarness = new CapturingHarnessProvider({ id: "configured-harness", now });
+    const defaultHarness = new CapturingHarnessProvider({ id: "fake-harness", now });
+    const existingWorktree = createFakeWorktree({
+      id: "wt_web_configured",
+      projectId: "web",
+      branch: "configured-branch",
+      now,
+    });
+    const terminal = new FakeTerminalProvider({
+      now,
+      onLaunch: async ({ launchPlan }) => {
+        configuredHarness.addRun(
+          createFakeHarnessRun({
+            id: "run_web_configured",
+            provider: "configured-harness",
+            projectId: "web",
+            worktreeId: "wt_web_configured",
+            sessionId: launchPlan.env?.STATION_SESSION_ID,
+            state: "working",
+            now,
+          }),
+        );
+      },
+    });
+    const project = config.projects[0];
+    if (project === undefined) throw new Error("missing test project");
+    const fixture = createFixture({
+      config: {
+        ...config,
+        projects: [
+          {
+            ...project,
+            worktreeLaunches: [{ branch: "configured-branch", harness: "configured-harness" }],
+          },
+        ],
+      },
+      terminal,
+      harnesses: [defaultHarness, configuredHarness],
+      worktree: new FakeWorktreeProvider({
+        now,
+        worktrees: [existingWorktree],
+      }),
+      sessionIds: ["ses_configured_next"],
+    });
+    await fixture.core.reconcile("pre-start-agent-configured");
+
+    await fixture.queue.dispatch({
+      type: "session.startAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: "wt_web_configured",
+        terminal: { provider: "fake-terminal", focus: false },
+      },
+    });
+    await fixture.queue.drain();
+
+    expect(defaultHarness.lastBuildRequest).toBeUndefined();
+    expect(configuredHarness.lastBuildRequest).toMatchObject({
+      sessionId: "ses_configured_next",
+      worktree: {
+        id: "wt_web_configured",
+      },
+    });
+    expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({
+      harness: "configured-harness",
+      sessionId: "ses_configured_next",
+      state: "working",
+    });
+    fixture.sqlite.close();
+  });
+
   it("remembers the previous harness when the worktree id changes but the normalized path is stable", async () => {
     const rememberedHarness = new CapturingHarnessProvider({ id: "remembered-harness", now });
     const defaultHarness = new CapturingHarnessProvider({ id: "fake-harness", now });
@@ -1507,9 +1579,11 @@ function createFixture(
     terminalIntentRunner?: TerminalIntentRunner;
     sessionIds?: string[];
     featureFlags?: { sessionResumeAgent?: boolean };
+    config?: StationConfig;
   } = {},
 ) {
   const clock = { now: () => new Date(now) };
+  const fixtureConfig = options.config ?? config;
   const sqlite = openObserverSqlite({ clock });
   const ids = observerIds();
   const persistence = createObserverPersistence({ sqlite, clock, idFactory: ids });
@@ -1529,7 +1603,7 @@ function createFixture(
     },
   });
   const core = createObserverCore({
-    config,
+    config: fixtureConfig,
     providers,
     persistence,
     sqlite,
@@ -1541,7 +1615,7 @@ function createFixture(
     queue,
     core,
     providers,
-    projects: config.projects,
+    projects: fixtureConfig.projects,
     persistence,
     featureFlags,
     eventBus,

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -66,10 +66,13 @@ function snapshotWith(rows: WorktreeRow[]): StationSnapshot {
   return { rows } as unknown as StationSnapshot;
 }
 
-function fakeCore(rows: WorktreeRow[]): ObserverCore {
+function fakeCore(
+  rows: WorktreeRow[],
+  projects: readonly ProviderProjectConfig[] = [project],
+): ObserverCore {
   const snapshot = snapshotWith(rows);
   return {
-    getProjects: () => [project],
+    getProjects: () => projects,
     getSnapshot: () => snapshot,
     reconcile: async () => snapshot,
     projectHarnessEventStatus: async () => ({}) as never,
@@ -119,9 +122,14 @@ function registryWith(
   });
 }
 
-function deps(rows: WorktreeRow[], station: StationTerminalProvider, harnesses?: Harnesses) {
+function deps(
+  rows: WorktreeRow[],
+  station: StationTerminalProvider,
+  harnesses?: Harnesses,
+  projects: readonly ProviderProjectConfig[] = [project],
+) {
   return {
-    core: fakeCore(rows),
+    core: fakeCore(rows, projects),
     providers: registryWith(station, harnesses),
     persistence: fakePersistence,
     clock: { now: () => new Date(now) },
@@ -169,6 +177,33 @@ describe("prepareExternalLaunch", () => {
       prepareParams,
     );
     expect(result.outcome.kind).toBe("prepared");
+  });
+
+  it("uses the configured branch harness for a new external launch", async () => {
+    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const configuredProject: ProviderProjectConfig = {
+      ...project,
+      worktreeLaunches: [{ branch: "feature/login", harness: "configured-harness" }],
+    };
+    const result = await prepareExternalLaunch(
+      deps(
+        [row()],
+        station,
+        [
+          new FakeHarnessProvider({ id: "fake-harness", now: () => new Date(now) }),
+          new FakeHarnessProvider({ id: "configured-harness", now: () => new Date(now) }),
+        ],
+        [configuredProject],
+      ),
+      prepareParams,
+    );
+
+    expect(result.outcome.kind).toBe("prepared");
+    if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
+    expect(result.outcome.launchPlan.provider).toBe("configured-harness");
+    expect((await station.listTargets())[0]?.harnessBinding?.harnessProvider).toBe(
+      "configured-harness",
+    );
   });
 
   it("guides the user to the config flag when hooks are not requested", async () => {

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -251,6 +251,7 @@ function normalizeProjectConfig(value: unknown): unknown {
       display: normalizeDisplayConfig,
       localConfig: normalizeProjectLocalConfigRef,
       recoveryBreadcrumbs: normalizeProjectRecoveryBreadcrumbsConfig,
+      worktreeLaunches: normalizeProjectWorktreeLaunchConfigs,
     },
   );
 }
@@ -275,6 +276,13 @@ function normalizeProjectLocalConfigRef(value: unknown): unknown {
 
 function normalizeProjectRecoveryBreadcrumbsConfig(value: unknown): unknown {
   return normalizeObject(value);
+}
+
+function normalizeProjectWorktreeLaunchConfigs(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.map((entry) => normalizeObject(entry));
 }
 
 function normalizeObject(

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -68,6 +68,15 @@ export const ProjectRecoveryBreadcrumbsSchema = z
 
 export type ProjectRecoveryBreadcrumbs = z.infer<typeof ProjectRecoveryBreadcrumbsSchema>;
 
+export const ProjectWorktreeLaunchConfigSchema = z
+  .object({
+    branch: nonEmptyStringSchema,
+    harness: providerIdSchema,
+  })
+  .strict();
+
+export type ProjectWorktreeLaunchConfig = z.infer<typeof ProjectWorktreeLaunchConfigSchema>;
+
 export const ProjectConfigSchema = z
   .object({
     id: projectIdSchema,
@@ -83,6 +92,7 @@ export const ProjectConfigSchema = z
     display: ProjectDisplayConfigSchema.optional(),
     localConfig: ProjectLocalConfigRefSchema.optional(),
     recoveryBreadcrumbs: ProjectRecoveryBreadcrumbsSchema.optional(),
+    worktreeLaunches: z.array(ProjectWorktreeLaunchConfigSchema).optional(),
   })
   .strict();
 

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -132,6 +132,36 @@ ${projectToml("station", roots.station)}
     expect(loaded.diagnostics).toEqual([]);
   });
 
+  it("loads per-worktree launch harness defaults", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+    const loaded = await loadConfigFromToml(
+      baseToml(`
+[[projects]]
+id = "web"
+label = "web"
+root = "${root}"
+
+[projects.worktrunk]
+enabled = true
+
+[[projects.worktree_launches]]
+branch = "a11y/playbook-refresh"
+harness = "cursor"
+
+[[projects.worktree_launches]]
+branch = "feat/server-actions"
+harness = "claude"
+`),
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.projects[0]?.worktreeLaunches).toEqual([
+      { branch: "a11y/playbook-refresh", harness: "cursor" },
+      { branch: "feat/server-actions", harness: "claude" },
+    ]);
+  });
+
   it("normalizes managed Worktrunk root policy for a project", async () => {
     const tempDir = await makeTempDir();
     const root = await makeProjectRoot(tempDir, "web");

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -125,6 +125,13 @@ export const ProviderProjectRecoveryBreadcrumbsSchema = z
   })
   .strict();
 
+export const ProviderProjectWorktreeLaunchSchema = z
+  .object({
+    branch: nonEmptyStringSchema,
+    harness: ProviderIdSchema,
+  })
+  .strict();
+
 export const ProviderProjectConfigSchema = z
   .object({
     id: ProjectIdSchema,
@@ -134,6 +141,7 @@ export const ProviderProjectConfigSchema = z
     defaults: ProviderProjectDefaultsSchema,
     worktrunk: ProviderProjectWorktrunkConfigSchema,
     recoveryBreadcrumbs: ProviderProjectRecoveryBreadcrumbsSchema.optional(),
+    worktreeLaunches: z.array(ProviderProjectWorktreeLaunchSchema).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Fixes no-agent worktree launch selection so a project can declare branch-specific harness defaults for existing worktree rows.

This PR intentionally contains only the product fix and tests. It does not include the demo staging script or runbook changes from the earlier demo PR.

## Issue

Station already had a useful fallback: if no harness is explicitly requested, it can reuse the most recently seen harness for the worktree before falling back to the project default.

That was not enough for the demo use case, and it was also a real product gap: there was no explicit config path for saying "this existing branch should launch with this harness" before any real session exists.

The bad workaround was to seed fake historical rows into SQLite `sessions` so the remembered-harness fallback would pick different agents. That was wrong because session rows are runtime truth. The dashboard can use session history to decide whether a row has something attachable, so fake rows can make a no-agent row try to focus a non-existent session instead of starting a real agent.

## Red-First Tests

I added the tests before the fix and verified they failed on `origin/main`:

- `packages/config/test/unit/load-config.test.ts`
  - red failure: `Station config is invalid: projects.0 Unrecognized key: "worktreeLaunches".`
  - proves the config loader did not support branch launch defaults.
- `apps/observer/test/integration/session-commands.test.ts`
  - red failure: `configuredHarness.lastBuildRequest` was `undefined`.
  - proves `session.startAgent` ignored a configured branch harness and fell through to the existing selection path.
- `apps/observer/test/unit/external-launch.test.ts`
  - red failure: expected `fake-harness` to be `configured-harness`.
  - proves the external-launch path had the same missing branch-default lookup.

## Fix

- Adds a strict config shape for project-level branch launch defaults:

```toml
[[projects.worktree_launches]]
branch = "a11y/playbook-refresh"
harness = "cursor"
```

- Carries `worktreeLaunches` through config parsing, provider contracts, and observer project projection.
- Updates both `session.startAgent` and external launch harness resolution order:
  1. explicit command/request harness
  2. configured branch launch harness
  3. remembered harness for the same worktree/path
  4. project default harness

## Effect in Regular Usage

Existing behavior is unchanged unless a project opts into `worktree_launches`.

For normal dashboard usage, pressing a no-agent worktree row still dispatches `session.startAgent`. External launch flows use the same default chain. The difference is that Station can now choose a configured harness for that branch before using remembered history or the project default.

This gives demos and real projects a config-backed way to preassign harnesses for known branches without corrupting runtime session state.

## UX Implication / Manual Verify

Manual check with a config that includes `[[projects.worktree_launches]]`:

1. Start Station with an existing no-agent worktree whose branch matches the configured entry.
2. Press the row's open/start key, or use the external launch path for that worktree.
3. Station should start a new real agent using the configured harness.
4. Rows without a matching entry should continue using remembered harness, then project default.

## Validation

Red-first failures were verified before the fix. After the fix and rebase onto current `origin/main`, these passed:

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/config/test/unit/load-config.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/session-commands.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/observer/test/unit/external-launch.test.ts`
- `pnpm typecheck`
- `git diff --check`
