### PR TITLE
fix(dashboard): preserve chosen harness across project change in new session flow

### DIFF
--- a/packages/dashboard-core/src/flows/newSession.ts
+++ b/packages/dashboard-core/src/flows/newSession.ts
@@ -336,7 +336,10 @@ function selectProjectByKey(
   if (project === undefined) {
     return state;
   }
-  const harness = firstHarnessOption(snapshot, project);
+  // Harness options are global, so a chosen harness stays valid across projects;
+  // keep the user's selection and only fall back to the default if it disappears.
+  const options = selectNewSessionHarnessOptions(snapshot, project);
+  const harness = options.find((option) => option.id === state.selectedHarness) ?? options[0];
   if (harness === undefined) {
     return state;
   }

--- a/packages/dashboard-core/test/unit/flows/newSession.test.ts
+++ b/packages/dashboard-core/test/unit/flows/newSession.test.ts
@@ -94,12 +94,14 @@ describe("new session flow", () => {
     });
   });
 
-  it("resets agent and regenerates generated names when the project changes", () => {
+  it("keeps the chosen agent and regenerates generated names when the project changes", () => {
     const snapshot = createHarnessSnapshot();
     const opened = createNewSessionFlow(snapshot, "aaaaaa");
     if (opened === undefined) throw new Error("expected a flow");
 
-    const picker = transitionNewSessionFlow(opened, snapshot, { type: "pickProject" });
+    // Pick a non-default harness so the assertion can tell "preserved" from "reset to default".
+    const chosen = { ...opened, selectedHarness: "opencode" as const };
+    const picker = transitionNewSessionFlow(chosen, snapshot, { type: "pickProject" });
     if (picker?.mode !== "pickProject") throw new Error("expected project picker");
     const selected = transitionNewSessionFlow(picker, snapshot, {
       type: "chooseProject",
@@ -110,7 +112,7 @@ describe("new session flow", () => {
     expect(selected).toMatchObject({
       mode: "review",
       selectedProjectId: "api",
-      selectedHarness: "codex",
+      selectedHarness: "opencode",
       branch: "api-bbbbbb",
       nameSource: "generated",
     });


### PR DESCRIPTION
## Problem

In the new-session flow, choosing a non-default harness (**A**) and then changing the project (**P**) silently reverted the harness back to the default. This matches the reported symptom: "I changed the harness, then changed the project … the harness flips back to the default and isn't remembered." The session-name change is innocent — the culprit is the project change.

## Root cause

`selectProjectByKey` (`packages/dashboard-core/src/flows/newSession.ts`) unconditionally overwrote `selectedHarness` with `firstHarnessOption(...)` (the default) whenever the project changed.

This is pure data loss, not defensive behavior: harness options are **global** — `selectNewSessionHarnessOptions(snapshot, _project)` ignores its `project` argument and returns the same list for every project — so the previously chosen harness is always still valid after a project change. (The agent-change and name-change paths already preserved the harness; only this path stomped it.)

## Fix

Keep the user's `selectedHarness` when it's still among the available options, falling back to the first option only if it disappears.

## Test

The existing `"resets agent … when the project changes"` test couldn't catch this: it left the harness at the default (`codex`) throughout, so it couldn't distinguish "reset to default" from "preserved." Rewrote it to pick a non-default harness (`opencode`) before the project change and assert it survives — this now fails against the old code, making it a real regression guard.

## Verify

- `pnpm test:unit newSession` — 16/16 pass; build/typecheck clean.
- Manual: in the new-session sheet, press **A** and pick a non-default harness, then press **P** and pick a different project. The harness keeps your choice (previously reverted to default).
