### PR TITLE
fix(test): build before integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format": "biome format --write .",
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",
-    "test:integration": "vitest run --config config/vitest/vitest.integration.config.ts",
+    "test:integration": "pnpm build && vitest run --config config/vitest/vitest.integration.config.ts",
     "test:diagnostics": "vitest run --config config/vitest/vitest.diagnostics.config.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
     "test:e2e": "vitest run --config config/vitest/vitest.e2e.config.ts",


### PR DESCRIPTION
## Summary

Make the focused integration-test script run the build before Vitest.

## Why

`pnpm test:integration` is documented as a standalone focused command, but the release-doctor integration test starts the observer from `apps/cli/dist/observerMain.js`. From an unbuilt checkout, that produced a misleading observer startup timeout instead of running the integration lane reliably.

## Impact

No Station runtime or TUI behavior changes. This only makes the developer test workflow match the observer integration-test prerequisite.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:contracts`
- `pnpm test:integration`