### PR TITLE
feat(tui): add project default agent picker

### DIFF
--- a/apps/cli/src/commands/eventHooks.ts
+++ b/apps/cli/src/commands/eventHooks.ts
@@ -4,7 +4,7 @@ import {
   removeObserverEventHookBlocksById,
   type StationConfig,
 } from "@station/config";
-import type { ObserverEventHookConfig } from "@station/contracts";
+import { type ObserverEventHookConfig, STATION_SCHEMA_VERSION } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandRunner } from "@station/runtime";
 import { runExternalCommand, safeErrorFromUnknown } from "@station/runtime";
 import type { CliEnv } from "../env.js";
@@ -197,7 +197,7 @@ async function checkBuiltInNotifyCommand(input: {
     return checkCommandAvailable(input.command, input.args, input.env);
   }
   const invocation = {
-    schemaVersion: "0.6.0",
+    schemaVersion: STATION_SCHEMA_VERSION,
     hookId: `${builtInHookId}-doctor-check`,
     observedAt: "2026-01-01T00:00:00.000Z",
     event: {

--- a/apps/cli/src/commands/eventHooks.ts
+++ b/apps/cli/src/commands/eventHooks.ts
@@ -197,7 +197,7 @@ async function checkBuiltInNotifyCommand(input: {
     return checkCommandAvailable(input.command, input.args, input.env);
   }
   const invocation = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     hookId: `${builtInHookId}-doctor-check`,
     observedAt: "2026-01-01T00:00:00.000Z",
     event: {

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -218,7 +218,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -18,7 +18,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -34,7 +34,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -60,7 +60,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -94,7 +94,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -130,7 +130,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -192,7 +192,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -232,7 +232,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -581,12 +581,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -614,17 +614,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -56,7 +56,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -265,7 +265,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -276,7 +276,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -288,7 +288,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -264,7 +264,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -279,7 +279,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -302,7 +302,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -315,7 +315,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -389,7 +389,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -21,7 +21,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -30,7 +30,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.5.0", stopped: true, at: now };
+            return { schemaVersion: "0.6.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -66,7 +66,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -75,7 +75,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.5.0", stopped: true, at: now };
+            return { schemaVersion: "0.6.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -301,7 +301,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -310,11 +310,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
         reconcile: async (reason: string) => {
           reconciles.push(reason);
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             reason,
             reconciledAt: now,
             snapshot: {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               generatedAt: now,
               observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
               providerHealth: {},
@@ -344,7 +344,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -105,7 +105,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -24,11 +24,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},
@@ -63,7 +63,7 @@ function runningObserverDeps(options: { reconciles?: string[]; hangReconcile?: b
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/unit/observer-process.test.ts
+++ b/apps/cli/test/unit/observer-process.test.ts
@@ -51,7 +51,7 @@ describe("CLI observer process helpers", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -95,7 +95,7 @@ describe("CLI observer process helpers", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -204,7 +204,7 @@ describe("CLI observer process helpers", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },

--- a/apps/observer/src/commands/project.ts
+++ b/apps/observer/src/commands/project.ts
@@ -1,4 +1,8 @@
-import { addProjectToConfig, removeProjectFromConfig } from "@station/config";
+import {
+  addProjectToConfig,
+  removeProjectFromConfig,
+  setProjectDefaultHarnessInConfig,
+} from "@station/config";
 import type { RuntimeClock } from "@station/runtime";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
@@ -57,6 +61,29 @@ export function createProjectRemoveHandler(
       eventBus: options.eventBus,
       clock: options.clock,
       reason: "command:project.remove",
+      trace: context.trace,
+    });
+  };
+}
+
+export function createProjectSetDefaultHarnessHandler(
+  options: CreateProjectCommandHandlerOptions,
+): CommandHandler {
+  return async (context) => {
+    assertCommandType(context, "project.setDefaultHarness");
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: context.command.payload.projectId,
+      harness: context.command.payload.harness,
+      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
+      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+    });
+
+    options.core.updateConfig(result.config);
+    await reconcileAndPublish({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      reason: "command:project.setDefaultHarness",
       trace: context.trace,
     });
   };

--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -358,6 +358,7 @@ function commandScope(command: StationCommand): string {
     case "observer.reconcile":
     case "project.add":
     case "project.remove":
+    case "project.setDefaultHarness":
     case "hooks.install":
       return "global";
   }

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -6,7 +6,11 @@ import type { ObserverPersistence } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
-import { createProjectAddHandler, createProjectRemoveHandler } from "./project.js";
+import {
+  createProjectAddHandler,
+  createProjectRemoveHandler,
+  createProjectSetDefaultHarnessHandler,
+} from "./project.js";
 import type { CommandQueue } from "./queue.js";
 import { createObserverReconcileHandler } from "./reconcile.js";
 import { createSessionAcknowledgeTurnHandler } from "./session/acknowledgeTurn.js";
@@ -182,6 +186,16 @@ export function registerObserverCommandHandlers(
       ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
   );
+  options.queue.registerHandler(
+    "project.setDefaultHarness",
+    createProjectSetDefaultHarnessHandler({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
+      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+    }),
+  );
 
   void options.logger?.info("Observer command handlers registered.", {
     commandTypes: [
@@ -198,6 +212,7 @@ export function registerObserverCommandHandlers(
       "worktree.remove",
       "project.add",
       "project.remove",
+      "project.setDefaultHarness",
     ],
   });
 }

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -37,7 +37,7 @@ describe("observer diagnostics collector", () => {
     };
 
     await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       providerHealth: {
         "fake-worktree": { status: "healthy" },
       },

--- a/apps/observer/test/integration/project-commands.test.ts
+++ b/apps/observer/test/integration/project-commands.test.ts
@@ -67,6 +67,41 @@ describe("observer project commands", () => {
     fixture.sqlite.close();
   });
 
+  it("sets a project default harness through config mutation and reconciles the snapshot", async () => {
+    const fixture = await createFixture();
+    const repo = await makeRepo(fixture.root, "web");
+    await fixture.queue.dispatch({ type: "project.add", payload: { path: repo } });
+    await fixture.queue.drain();
+
+    const receipt = await fixture.queue.dispatch({
+      type: "project.setDefaultHarness",
+      payload: { projectId: "web", harness: "other-harness" },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(
+      loadConfig({ configPath: fixture.configPath, homeDir: fixture.root }),
+    ).resolves.toMatchObject({
+      projects: [
+        expect.objectContaining({
+          defaults: expect.objectContaining({ harness: "other-harness" }),
+        }),
+      ],
+    });
+    expect(fixture.core.getSnapshot()).toMatchObject({
+      projects: [
+        expect.objectContaining({
+          defaults: expect.objectContaining({ harness: "other-harness" }),
+        }),
+      ],
+    });
+
+    fixture.sqlite.close();
+  });
+
   it("records safe command failures for invalid project additions", async () => {
     const fixture = await createFixture();
     const folder = join(fixture.root, "not-git");

--- a/packages/config/src/projects/index.ts
+++ b/packages/config/src/projects/index.ts
@@ -2,6 +2,7 @@ export { addProjectToConfig } from "./add.js";
 export { doctorProject } from "./doctor.js";
 export { findGitRoot, resolveExistingDirectory } from "./git.js";
 export { removeProjectFromConfig } from "./remove.js";
+export { setProjectDefaultHarnessInConfig } from "./setDefaultHarness.js";
 export type {
   AddProjectToConfigOptions,
   AddProjectToConfigResult,
@@ -9,4 +10,6 @@ export type {
   ProjectDoctorResult,
   RemoveProjectFromConfigOptions,
   RemoveProjectFromConfigResult,
+  SetProjectDefaultHarnessOptions,
+  SetProjectDefaultHarnessResult,
 } from "./types.js";

--- a/packages/config/src/projects/setDefaultHarness.ts
+++ b/packages/config/src/projects/setDefaultHarness.ts
@@ -1,0 +1,49 @@
+import { loadConfig, loadConfigFromToml } from "../load/index.js";
+import { projectConfigSafeError } from "./errors.js";
+import { atomicWriteConfig, loadConfigSource } from "./source.js";
+import { setProjectDefaultHarness } from "./tomlBlocks.js";
+import type { SetProjectDefaultHarnessOptions, SetProjectDefaultHarnessResult } from "./types.js";
+
+export async function setProjectDefaultHarnessInConfig(
+  options: SetProjectDefaultHarnessOptions,
+): Promise<SetProjectDefaultHarnessResult> {
+  const loaded = await loadConfigSource(options);
+  const project = loaded.loaded.projects.find((candidate) => candidate.id === options.projectId);
+  if (project === undefined) {
+    throw projectConfigSafeError({
+      code: "PROJECT_NOT_CONFIGURED",
+      message: `Project "${options.projectId}" is not configured.`,
+      projectId: options.projectId,
+    });
+  }
+
+  if (project.defaults.harness === options.harness) {
+    return {
+      status: "unchanged",
+      configPath: loaded.configPath,
+      projectId: options.projectId,
+      harness: options.harness,
+      config: loaded.loaded.config,
+    };
+  }
+
+  const candidateSource = setProjectDefaultHarness(
+    loaded.source,
+    options.projectId,
+    options.harness,
+  );
+  await loadConfigFromToml(candidateSource, {
+    configPath: loaded.configPath,
+    homeDir: loaded.homeDir,
+  });
+  await atomicWriteConfig(loaded.configPath, candidateSource);
+  const after = await loadConfig({ configPath: loaded.configPath, homeDir: loaded.homeDir });
+
+  return {
+    status: "updated",
+    configPath: loaded.configPath,
+    projectId: options.projectId,
+    harness: options.harness,
+    config: after.config,
+  };
+}

--- a/packages/config/src/projects/setDefaultHarness.ts
+++ b/packages/config/src/projects/setDefaultHarness.ts
@@ -32,10 +32,25 @@ export async function setProjectDefaultHarnessInConfig(
     options.projectId,
     options.harness,
   );
-  await loadConfigFromToml(candidateSource, {
+  const candidate = await loadConfigFromToml(candidateSource, {
     configPath: loaded.configPath,
     homeDir: loaded.homeDir,
   });
+  const candidateProject = candidate.projects.find(
+    (nextProject) => nextProject.id === options.projectId,
+  );
+  if (candidateProject?.defaults.harness !== options.harness) {
+    const hint =
+      candidateProject?.localConfig?.enabled === true
+        ? `Edit ${candidateProject.localConfig.path} or remove its [defaults].harness override.`
+        : undefined;
+    throw projectConfigSafeError({
+      code: "PROJECT_DEFAULT_HARNESS_OVERRIDDEN",
+      message: `Project "${options.projectId}" has a default harness override that keeps "${candidateProject?.defaults.harness ?? "unknown"}" effective.`,
+      projectId: options.projectId,
+      ...(hint === undefined ? {} : { hint }),
+    });
+  }
   await atomicWriteConfig(loaded.configPath, candidateSource);
   const after = await loadConfig({ configPath: loaded.configPath, homeDir: loaded.homeDir });
 

--- a/packages/config/src/projects/tomlBlocks.ts
+++ b/packages/config/src/projects/tomlBlocks.ts
@@ -28,6 +28,55 @@ export function removeProjectBlock(source: string, projectId: string): string {
   return `${insertTopLevelEmptyProjectsAssignment(sourceWithoutBlock)}\n`;
 }
 
+export function setProjectDefaultHarness(
+  source: string,
+  projectId: string,
+  harness: string,
+): string {
+  const lines = source.split("\n");
+  const blocks = projectBlocks(lines);
+  const block = blocks.find((candidate) => projectBlockId(candidate.lines) === projectId);
+  if (block === undefined) {
+    throw projectConfigSafeError({
+      code: "PROJECT_BLOCK_NOT_FOUND",
+      message: `Could not find a [[projects]] block for "${projectId}" in config.toml.`,
+      projectId,
+    });
+  }
+
+  const defaultsStart = block.lines.findIndex(isProjectDefaultsTable);
+  if (defaultsStart !== -1) {
+    const start = block.start + defaultsStart;
+    const end = nextProjectSubtableIndex(lines, start + 1, block.end);
+    const harnessIndex = lines
+      .slice(start + 1, end)
+      .findIndex((line) => /^\s*harness\s*=/.test(line));
+    if (harnessIndex !== -1) {
+      const absolute = start + 1 + harnessIndex;
+      const nextLines = [...lines];
+      nextLines[absolute] = `harness = ${quoteTomlString(harness)}`;
+      return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+    }
+    const nextLines = [
+      ...lines.slice(0, start + 1),
+      `harness = ${quoteTomlString(harness)}`,
+      ...lines.slice(start + 1),
+    ];
+    return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+  }
+
+  const insertAt = firstProjectSubtableIndex(block.lines);
+  const absoluteInsertAt = insertAt === -1 ? block.end : block.start + insertAt;
+  const nextLines = [
+    ...lines.slice(0, absoluteInsertAt),
+    "",
+    "[projects.defaults]",
+    `harness = ${quoteTomlString(harness)}`,
+    ...lines.slice(absoluteInsertAt),
+  ];
+  return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+}
+
 function projectBlocks(lines: string[]): Array<{ start: number; end: number; lines: string[] }> {
   const blocks: Array<{ start: number; end: number; lines: string[] }> = [];
   for (let index = 0; index < lines.length; index += 1) {
@@ -61,6 +110,23 @@ function projectBlockId(lines: readonly string[]): string | undefined {
 
 function isProjectArrayTable(line: string): boolean {
   return /^\s*\[\[\s*projects\s*\]\]\s*(?:#.*)?$/.test(line);
+}
+
+function isProjectDefaultsTable(line: string): boolean {
+  return /^\s*\[\s*projects\.defaults\s*\]\s*(?:#.*)?$/.test(line);
+}
+
+function firstProjectSubtableIndex(lines: readonly string[]): number {
+  return lines.findIndex((line) => /^\s*\[\s*projects\.[^\]]+\]\s*(?:#.*)?$/.test(line));
+}
+
+function nextProjectSubtableIndex(lines: readonly string[], start: number, end: number): number {
+  for (let index = start; index < end; index += 1) {
+    if (/^\s*\[\s*projects\.[^\]]+\]\s*(?:#.*)?$/.test(lines[index] ?? "")) {
+      return index;
+    }
+  }
+  return end;
 }
 
 function isNonProjectTable(line: string): boolean {

--- a/packages/config/src/projects/tomlBlocks.ts
+++ b/packages/config/src/projects/tomlBlocks.ts
@@ -54,7 +54,7 @@ export function setProjectDefaultHarness(
     if (harnessIndex !== -1) {
       const absolute = start + 1 + harnessIndex;
       const nextLines = [...lines];
-      nextLines[absolute] = `harness = ${quoteTomlString(harness)}`;
+      nextLines[absolute] = replaceTomlStringValue(nextLines[absolute] ?? "", "harness", harness);
       return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
     }
     const nextLines = [
@@ -199,4 +199,15 @@ function formatMinimalProjectBlock(block: MinimalProjectBlock): string {
 
 function quoteTomlString(value: string): string {
   return JSON.stringify(value);
+}
+
+function replaceTomlStringValue(line: string, key: string, value: string): string {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(
+    `^(\\s*${escapedKey}\\s*=\\s*)(?:"(?:[^"\\\\]|\\\\.)*"|'[^']*')(\\s*(?:#.*)?)$`,
+  ).exec(line);
+  if (match === null) {
+    return `${key} = ${quoteTomlString(value)}`;
+  }
+  return `${match[1]}${quoteTomlString(value)}${match[2]}`;
 }

--- a/packages/config/src/projects/types.ts
+++ b/packages/config/src/projects/types.ts
@@ -40,6 +40,21 @@ export type RemoveProjectFromConfigResult = {
   config: StationConfig;
 };
 
+export type SetProjectDefaultHarnessOptions = {
+  projectId: string;
+  harness: string;
+  configPath?: string;
+  homeDir?: string;
+};
+
+export type SetProjectDefaultHarnessResult = {
+  status: "updated" | "unchanged";
+  configPath: string;
+  projectId: string;
+  harness: string;
+  config: StationConfig;
+};
+
 export type ProjectDoctorResult = {
   project: ProjectConfig;
   rootExists: boolean;

--- a/packages/config/test/unit/project-mutation.test.ts
+++ b/packages/config/test/unit/project-mutation.test.ts
@@ -249,6 +249,139 @@ layout = "agent-shell"
     });
   });
 
+  it("preserves indentation and inline comments when replacing a project default harness", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[projects.defaults]
+  harness = "codex" # team pin
+layout = "agent-shell"
+`,
+    );
+
+    await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    await expect(readFile(configPath, "utf8")).resolves.toContain(
+      '  harness = "opencode" # team pin',
+    );
+  });
+
+  it("inserts a missing harness into an existing project defaults table", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[projects.defaults]
+layout = "agent-shell"
+`,
+    );
+
+    await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    const source = await readFile(configPath, "utf8");
+    expect(source).toContain('[projects.defaults]\nharness = "opencode"\nlayout = "agent-shell"');
+  });
+
+  it("sets the default harness on a non-first project block", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const api = await makeRepo(tempDir, "api");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[[projects]]
+id = "api"
+label = "api"
+root = ${JSON.stringify(api)}
+`,
+    );
+
+    await setProjectDefaultHarnessInConfig({
+      projectId: "api",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    expect(loaded.projects.find((project) => project.id === "web")?.defaults.harness).toBe("codex");
+    expect(loaded.projects.find((project) => project.id === "api")?.defaults.harness).toBe(
+      "opencode",
+    );
+  });
+
+  it("rejects project default harness changes shadowed by project-local defaults", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    await mkdir(join(web, ".station"), { recursive: true });
+    await writeFile(
+      join(web, ".station", "config.toml"),
+      `
+schema_version = 1
+
+[defaults]
+harness = "claude"
+`,
+      "utf8",
+    );
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[projects.local_config]
+enabled = true
+path = ".station/config.toml"
+`,
+    );
+    const before = await readFile(configPath, "utf8");
+
+    await expect(
+      setProjectDefaultHarnessInConfig({
+        projectId: "web",
+        harness: "opencode",
+        configPath,
+        homeDir: tempDir,
+      }),
+    ).rejects.toMatchObject({
+      tag: "ProjectConfigError",
+      code: "PROJECT_DEFAULT_HARNESS_OVERRIDDEN",
+      projectId: "web",
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+  });
+
   it("does not write when the selected project harness is already effective", async () => {
     const tempDir = await makeTempDir();
     const web = await makeRepo(tempDir, "web");
@@ -272,5 +405,32 @@ root = ${JSON.stringify(web)}
 
     expect(result.status).toBe("unchanged");
     await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+  });
+
+  it("rejects default harness changes for an unknown project id", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+`,
+    );
+
+    await expect(
+      setProjectDefaultHarnessInConfig({
+        projectId: "ghost",
+        harness: "opencode",
+        configPath,
+        homeDir: tempDir,
+      }),
+    ).rejects.toMatchObject({
+      tag: "ProjectConfigError",
+      code: "PROJECT_NOT_CONFIGURED",
+      projectId: "ghost",
+    });
   });
 });

--- a/packages/config/test/unit/project-mutation.test.ts
+++ b/packages/config/test/unit/project-mutation.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigError,
   loadConfig,
   removeProjectFromConfig,
+  setProjectDefaultHarnessInConfig,
 } from "@station/config";
 import { describe, expect, it } from "vitest";
 
@@ -185,5 +186,91 @@ root = ${JSON.stringify(web)}
     const loaded = await loadConfig({ configPath, homeDir: tempDir });
     expect(loaded.projects).toEqual([]);
     await expect(readFile(configPath, "utf8")).resolves.toContain("projects = []");
+  });
+
+  it("sets a project default harness on a minimal project block", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+`,
+    );
+
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    expect(result.status).toBe("updated");
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    expect(loaded.projects[0]?.defaults.harness).toBe("opencode");
+    const source = await readFile(configPath, "utf8");
+    expect(source).toContain('[projects.defaults]\nharness = "opencode"');
+  });
+
+  it("replaces an existing project default harness", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[projects.defaults]
+harness = "codex"
+layout = "agent-shell"
+`,
+    );
+
+    await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    const source = await readFile(configPath, "utf8");
+    expect(source).toContain('[projects.defaults]\nharness = "opencode"\nlayout = "agent-shell"');
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    expect(loaded.projects[0]?.defaults).toEqual({
+      harness: "opencode",
+      terminal: "tmux",
+      layout: "agent-shell",
+    });
+  });
+
+  it("does not write when the selected project harness is already effective", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+`,
+    );
+    const before = await readFile(configPath, "utf8");
+
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "codex",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    expect(result.status).toBe("unchanged");
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
   });
 });

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -206,6 +206,15 @@ export const RemoveProjectPayloadSchema = z
 
 export type RemoveProjectPayload = z.infer<typeof RemoveProjectPayloadSchema>;
 
+export const SetProjectDefaultHarnessPayloadSchema = z
+  .object({
+    projectId: ProjectIdSchema,
+    harness: ProviderIdSchema,
+  })
+  .strict();
+
+export type SetProjectDefaultHarnessPayload = z.infer<typeof SetProjectDefaultHarnessPayloadSchema>;
+
 export const InstallHooksPayloadSchema = z
   .object({
     provider: ProviderIdSchema,
@@ -229,6 +238,7 @@ export const StationCommandTypeSchema = z.enum([
   "observer.reconcile",
   "project.add",
   "project.remove",
+  "project.setDefaultHarness",
   "hooks.install",
 ]);
 
@@ -288,6 +298,13 @@ export const RemoveProjectCommandSchema = z
   .object({ type: z.literal("project.remove"), payload: RemoveProjectPayloadSchema })
   .strict();
 
+export const SetProjectDefaultHarnessCommandSchema = z
+  .object({
+    type: z.literal("project.setDefaultHarness"),
+    payload: SetProjectDefaultHarnessPayloadSchema,
+  })
+  .strict();
+
 export const InstallHooksCommandSchema = z
   .object({ type: z.literal("hooks.install"), payload: InstallHooksPayloadSchema })
   .strict();
@@ -307,6 +324,7 @@ export const StationCommandSchema = z.discriminatedUnion("type", [
   ObserverReconcileCommandSchema,
   AddProjectCommandSchema,
   RemoveProjectCommandSchema,
+  SetProjectDefaultHarnessCommandSchema,
   InstallHooksCommandSchema,
 ]);
 

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.5.0" as const;
+export const STATION_SCHEMA_VERSION = "0.6.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -83,7 +83,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.5.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.6.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -662,6 +662,7 @@ describe("contract schemas", () => {
       "observer.reconcile",
       "project.add",
       "project.remove",
+      "project.setDefaultHarness",
       "session.acknowledgeTurn",
       "session.close",
       "session.create",

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -268,6 +268,7 @@ export function isModalOverlayActive(screen: TuiScreen): boolean {
   return (
     screen.name === "help" ||
     screen.name === "newSession" ||
+    screen.name === "projectDefaultAgent" ||
     screen.name === "removeWorktree" ||
     (screen.name === "renameSession" && screen.step === "editName")
   );

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -34,5 +34,6 @@ export * from "./state/operations/renameSession.js";
 export * from "./state/operations/runtimeCommands.js";
 export * from "./state/operations/startAgent.js";
 export * from "./state/operations/types.js";
+export * from "./state/screens/projectDefaultAgent.js";
 export * from "./state/screens/removeWorktree.js";
 export * from "./state/screens/sessionRows.js";

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -31,6 +31,11 @@ export type RenameSessionCommandInput = {
   title: string;
 };
 
+export type SetProjectDefaultHarnessCommandInput = {
+  projectId: ProjectView["id"];
+  harness: ProviderId;
+};
+
 export type BuildFocusCommandOptions = {
   origin?: TerminalFocusOrigin;
 };
@@ -162,6 +167,18 @@ export function buildRenameSessionCommand(input: RenameSessionCommandInput): Sta
     payload: {
       sessionId: input.sessionId,
       title: input.title,
+    },
+  };
+}
+
+export function buildSetProjectDefaultHarnessCommand(
+  input: SetProjectDefaultHarnessCommandInput,
+): Extract<StationCommand, { type: "project.setDefaultHarness" }> {
+  return {
+    type: "project.setDefaultHarness",
+    payload: {
+      projectId: input.projectId,
+      harness: input.harness,
     },
   };
 }

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -15,6 +15,7 @@ export type TuiInputMode =
   | "newSessionEditName"
   | "newSessionPickProject"
   | "newSessionPickAgent"
+  | "projectDefaultAgent"
   | "addProject";
 
 export function deriveTuiInputMode(state: TuiState): TuiInputMode {
@@ -46,6 +47,8 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
       break;
     case "addProject":
       return "addProject";
+    case "projectDefaultAgent":
+      return "projectDefaultAgent";
   }
   return "dashboard";
 }
@@ -516,6 +519,22 @@ export const TUI_KEYMAP: Record<TuiInputMode, readonly TuiBinding[]> = {
       id: "tui.newSessionAgent.choose",
       pattern: { kind: "slot" },
       action: "tui.newSession.chooseAgent",
+      outcome: "handled",
+      help: { keys: "1-9 a-z", label: "choose agent" },
+    },
+  ],
+  projectDefaultAgent: [
+    {
+      id: "tui.projectDefaultAgent.cancel",
+      pattern: { kind: "named", named: "escape" },
+      action: "tui.projectDefaultAgent.cancel",
+      outcome: "handled",
+      help: { keys: "esc", label: "cancel" },
+    },
+    {
+      id: "tui.projectDefaultAgent.choose",
+      pattern: { kind: "slot" },
+      action: "tui.projectDefaultAgent.choose",
       outcome: "handled",
       help: { keys: "1-9 a-z", label: "choose agent" },
     },

--- a/packages/dashboard-core/src/state/operations/localOperationRunner.ts
+++ b/packages/dashboard-core/src/state/operations/localOperationRunner.ts
@@ -1,6 +1,6 @@
 import type { CommandId, SafeError, StationCommand, StationEvent } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
-import { safeErrorToToast } from "../../services/errors/errors.js";
+import { safeErrorToToast, toSafeError } from "../../services/errors/errors.js";
 import type { TuiFolderService } from "../../services/folderService.js";
 import type { TuiObserverService } from "../../services/types.js";
 import {
@@ -215,6 +215,14 @@ export function createTuiLocalOperationRunner(input: {
         if (operation.type === "addProject") {
           void runAddProjectOperation(store(), input.service, operation.command, input.clientLabel);
         }
+        if (operation.type === "setProjectDefaultHarness") {
+          void runSetProjectDefaultHarnessOperation(
+            store(),
+            input.service,
+            operation.command,
+            input.clientLabel,
+          );
+        }
       }
     },
     prepareCommandFailedEvent: (event) => {
@@ -242,6 +250,46 @@ export function createTuiLocalOperationRunner(input: {
       };
     },
   };
+}
+
+async function runSetProjectDefaultHarnessOperation(
+  store: StoreApi<TuiStore>,
+  service: TuiObserverService,
+  command: Extract<StationCommand, { type: "project.setDefaultHarness" }>,
+  clientLabel: string,
+): Promise<void> {
+  try {
+    const receipt = await service.dispatch(command);
+    if (!receipt.accepted) {
+      addSafeCommandToast(
+        store,
+        receipt.error ?? {
+          tag: "CommandExecutionError",
+          code: "COMMAND_REJECTED",
+          message: `${command.type} was rejected.`,
+        },
+      );
+      return;
+    }
+    const completion = await service.waitForCommandCompletion(receipt.commandId);
+    if (completion.status === "failed") {
+      addSafeCommandToast(store, completion.error);
+      return;
+    }
+    const snapshot = await service.loadSnapshot();
+    store.setState(
+      addTuiToast(replaceSnapshot(store.getState(), snapshot), {
+        kind: "success",
+        message: `Default agent set to ${command.payload.harness}.`,
+      }),
+    );
+  } catch (error: unknown) {
+    addSafeCommandToast(store, toSafeError(error, { clientLabel }));
+  }
+}
+
+function addSafeCommandToast(store: StoreApi<TuiStore>, error: SafeError): void {
+  store.setState(addTuiToast(store.getState(), safeErrorToToast(error)));
 }
 
 async function runLoadProjectDirectoryOperation(

--- a/packages/dashboard-core/src/state/operations/types.ts
+++ b/packages/dashboard-core/src/state/operations/types.ts
@@ -63,6 +63,13 @@ export type AddProjectOperation = {
   command: Extract<StationCommand, { type: "project.add" }>;
 };
 
+export type SetProjectDefaultHarnessOperation = {
+  type: "setProjectDefaultHarness";
+  projectId: string;
+  harness: ProviderId;
+  command: Extract<StationCommand, { type: "project.setDefaultHarness" }>;
+};
+
 export type TuiOperation =
   | CreateSessionOperation
   | RemoveWorktreeOperation
@@ -72,4 +79,5 @@ export type TuiOperation =
   | LoadProjectDirectoryOperation
   | ReviewProjectFolderOperation
   | SearchProjectDirectoriesOperation
-  | AddProjectOperation;
+  | AddProjectOperation
+  | SetProjectDefaultHarnessOperation;

--- a/packages/dashboard-core/src/state/operations/types.ts
+++ b/packages/dashboard-core/src/state/operations/types.ts
@@ -65,8 +65,6 @@ export type AddProjectOperation = {
 
 export type SetProjectDefaultHarnessOperation = {
   type: "setProjectDefaultHarness";
-  projectId: string;
-  harness: ProviderId;
   command: Extract<StationCommand, { type: "project.setDefaultHarness" }>;
 };
 

--- a/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
+++ b/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
@@ -1,0 +1,69 @@
+import {
+  choiceValueByKey,
+  isSelectionKey,
+  selectNewSessionHarnessChoices,
+} from "../../selectors/selectors.js";
+import { buildSetProjectDefaultHarnessCommand } from "../commandBuilders.js";
+import type { TuiKey } from "../keys.js";
+import type { TuiTransition } from "../transition.js";
+import type { TuiState } from "../types.js";
+
+export function openProjectDefaultAgentPicker(state: TuiState, projectId: string): TuiState {
+  if (state.snapshot === undefined) {
+    return state;
+  }
+  const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined || project.health.status === "unavailable") {
+    return state;
+  }
+  return {
+    ...state,
+    screen: { name: "projectDefaultAgent", projectId: project.id },
+  };
+}
+
+export function handleProjectDefaultAgentKey(state: TuiState, key: TuiKey): TuiTransition {
+  if (state.screen.name !== "projectDefaultAgent") {
+    return { state };
+  }
+  const projectId = state.screen.projectId;
+  if (key.escape === true) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (state.snapshot === undefined) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (!isSelectionKey(key.input)) {
+    return { state };
+  }
+
+  const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  const option = choiceValueByKey(
+    selectNewSessionHarnessChoices(state.snapshot, project),
+    key.input,
+  );
+  if (option === undefined) {
+    return { state };
+  }
+  if (option.id === project.defaults.harness) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+
+  return {
+    state: { ...state, screen: { name: "dashboard" } },
+    operations: [
+      {
+        type: "setProjectDefaultHarness",
+        projectId: project.id,
+        harness: option.id,
+        command: buildSetProjectDefaultHarnessCommand({
+          projectId: project.id,
+          harness: option.id,
+        }),
+      },
+    ],
+  };
+}

--- a/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
+++ b/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
@@ -57,8 +57,6 @@ export function handleProjectDefaultAgentKey(state: TuiState, key: TuiKey): TuiT
     operations: [
       {
         type: "setProjectDefaultHarness",
-        projectId: project.id,
-        harness: option.id,
         command: buildSetProjectDefaultHarnessCommand({
           projectId: project.id,
           harness: option.id,

--- a/packages/dashboard-core/src/state/transition.ts
+++ b/packages/dashboard-core/src/state/transition.ts
@@ -6,6 +6,7 @@ import { handleDashboardKey } from "./screens/dashboard.js";
 import { handleHelpKey } from "./screens/help.js";
 import { handleNewSessionKey } from "./screens/newSession.js";
 import { handleProjectCollapseKey } from "./screens/projectCollapse.js";
+import { handleProjectDefaultAgentKey } from "./screens/projectDefaultAgent.js";
 import { handleRemoveWorktreeKey } from "./screens/removeWorktree.js";
 import { handleRenameSessionKey } from "./screens/renameSession.js";
 import { handleSearchKey } from "./screens/search.js";
@@ -52,6 +53,8 @@ export function handleTuiKey(
       return handleRenameSessionKey(state, key);
     case "newSession":
       return handleNewSessionKey(state, key);
+    case "projectDefaultAgent":
+      return handleProjectDefaultAgentKey(state, key);
     case "addProject":
       return handleAddProjectKey(state, key);
   }

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ProjectId,
   SafeError,
   SessionId,
   StationSnapshot,
@@ -75,7 +76,8 @@ export type TuiScreen =
       validationError?: string;
     }
   | { name: "addProject"; flow: AddProjectFlowState }
-  | { name: "newSession"; flow: NewSessionFlowState };
+  | { name: "newSession"; flow: NewSessionFlowState }
+  | { name: "projectDefaultAgent"; projectId: ProjectId };
 
 export type CreateInitialTuiStateOptions = {
   initialSnapshot?: StationSnapshot;

--- a/packages/dashboard-core/test/support/fakeObserverService.ts
+++ b/packages/dashboard-core/test/support/fakeObserverService.ts
@@ -14,6 +14,7 @@ export class FakeTuiObserverService implements TuiObserverService {
   cleanupCount = 0;
   loadCount = 0;
   subscribeCount = 0;
+  nextDispatchError: unknown = undefined;
   nextReceipt: CommandReceipt = {
     commandId: "cmd_tui_1",
     accepted: true,
@@ -57,6 +58,11 @@ export class FakeTuiObserverService implements TuiObserverService {
   }
 
   async dispatch(command: StationCommand): Promise<CommandReceipt> {
+    if (this.nextDispatchError !== undefined) {
+      const error = this.nextDispatchError;
+      this.nextDispatchError = undefined;
+      throw error;
+    }
     this.dispatched.push(command);
     return this.nextReceipt;
   }

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -4,6 +4,7 @@ import {
   deriveTuiInputMode,
   handleTuiKey,
   matchingTuiBindings,
+  openProjectDefaultAgentPicker,
   TUI_KEYMAP,
   type TuiInputMode,
   type TuiTransition,
@@ -22,6 +23,7 @@ const ALLOWED_NOOP_BINDINGS = new Set([
   "tui.rename.chooseSlot",
   "tui.newSessionProject.choose",
   "tui.newSessionAgent.choose",
+  "tui.projectDefaultAgent.choose",
   // Add-project metadata is a union over its internal submodes.
   "tui.addProject.cancel",
   "tui.addProject.confirm",
@@ -83,6 +85,7 @@ function representativeStates(): Record<TuiInputMode, TuiState> {
     newSessionEditName: drive(base, [{ input: "N" }, { input: "N" }]),
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
     newSessionPickAgent: drive(base, [{ input: "N" }, { input: "A" }]),
+    projectDefaultAgent: openProjectDefaultAgentPicker(base, "web"),
     addProject: drive(base, [{ input: "A" }]),
   };
 }

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -1,6 +1,16 @@
-import type { SafeError, StationEvent, StationSnapshot, WorktreeRow } from "@station/contracts";
+import type {
+  ProviderId,
+  SafeError,
+  StationEvent,
+  StationSnapshot,
+  WorktreeRow,
+} from "@station/contracts";
 import type { TuiFolderService, TuiObserverService } from "@station/dashboard-core";
-import { createTuiStore, type TuiStore } from "@station/dashboard-core";
+import {
+  createTuiStore,
+  openProjectDefaultAgentPicker,
+  type TuiStore,
+} from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import {
   createCommandSnapshot,
@@ -250,6 +260,107 @@ describe("TUI store", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
   });
 
+  it("sets a project default harness, refreshes the snapshot, and shows success", async () => {
+    const snapshot = createDashboardSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    service.setSnapshot(snapshotWithProjectHarness(snapshot, "web", "opencode"));
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.setState(openProjectDefaultAgentPicker(store.getState(), "web"));
+    store.getState().handleKey({ input: "2" });
+
+    await waitFor(() => service.loadCount === 1);
+    expect(service.dispatched).toEqual([
+      {
+        type: "project.setDefaultHarness",
+        payload: { projectId: "web", harness: "opencode" },
+      },
+    ]);
+    expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
+    expect(store.getState().snapshot?.projects[0]?.defaults.harness).toBe("opencode");
+    expect(store.getState().toasts.map((entry) => entry.toast)).toContainEqual(
+      expect.objectContaining({
+        kind: "success",
+        message: "Default agent set to opencode.",
+      }),
+    );
+  });
+
+  it("shows an error toast when setting a project default harness is rejected", async () => {
+    const snapshot = createDashboardSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    service.nextReceipt = {
+      commandId: "cmd_tui_rejected",
+      accepted: false,
+      status: "rejected",
+      error: {
+        tag: "CommandExecutionError",
+        code: "COMMAND_REJECTED",
+        message: "Default harness was rejected.",
+      },
+    };
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.setState(openProjectDefaultAgentPicker(store.getState(), "web"));
+    store.getState().handleKey({ input: "2" });
+
+    await waitFor(() =>
+      store
+        .getState()
+        .toasts.some((entry) => entry.toast.message === "Default harness was rejected."),
+    );
+    expect(service.waitedForCommandIds).toEqual([]);
+    expect(service.loadCount).toBe(0);
+  });
+
+  it("shows an error toast when setting a project default harness fails completion", async () => {
+    const snapshot = createDashboardSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    service.nextCompletion = {
+      status: "failed",
+      commandId: "cmd_tui_1",
+      error: {
+        tag: "ProjectConfigError",
+        code: "PROJECT_DEFAULT_HARNESS_OVERRIDDEN",
+        message: "Project-local config keeps claude effective.",
+      },
+    };
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.setState(openProjectDefaultAgentPicker(store.getState(), "web"));
+    store.getState().handleKey({ input: "2" });
+
+    await waitFor(() =>
+      store
+        .getState()
+        .toasts.some(
+          (entry) => entry.toast.message === "Project-local config keeps claude effective.",
+        ),
+    );
+    expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
+    expect(service.loadCount).toBe(0);
+  });
+
+  it("shows an error toast when setting a project default harness dispatch throws", async () => {
+    const snapshot = createDashboardSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    service.nextDispatchError = {
+      tag: "ProtocolError",
+      code: "PROTOCOL_SOCKET_CLOSED",
+      message: "Observer socket closed.",
+    };
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.setState(openProjectDefaultAgentPicker(store.getState(), "web"));
+    store.getState().handleKey({ input: "2" });
+
+    await waitFor(() =>
+      store.getState().toasts.some((entry) => entry.toast.message === "Observer socket closed."),
+    );
+    expect(service.waitedForCommandIds).toEqual([]);
+    expect(service.loadCount).toBe(0);
+  });
+
   it("reviews a pasted full path when folder filtering has no matches", async () => {
     const snapshot = createNoProjectsSnapshot();
     const service = new FakeTuiObserverService(snapshot);
@@ -432,6 +543,21 @@ function addProjectSearchResultCount(state: TuiStore) {
   return state.screen.name === "addProject" && state.screen.flow.mode === "choose"
     ? state.screen.flow.searchEntries.length
     : 0;
+}
+
+function snapshotWithProjectHarness(
+  snapshot: StationSnapshot,
+  projectId: string,
+  harness: ProviderId,
+): StationSnapshot {
+  return {
+    ...snapshot,
+    projects: snapshot.projects.map((project) =>
+      project.id === projectId
+        ? { ...project, defaults: { ...project.defaults, harness } }
+        : project,
+    ),
+  };
 }
 
 class SnapshotConnectFailingService extends FakeTuiObserverService {

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -1,4 +1,9 @@
-import { createInitialTuiState, handleTuiKey, openRenameEditForRow } from "@station/dashboard-core";
+import {
+  createInitialTuiState,
+  handleTuiKey,
+  openProjectDefaultAgentPicker,
+  openRenameEditForRow,
+} from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import {
   createCommandSnapshot,
@@ -551,6 +556,53 @@ describe("TUI screen transitions", () => {
         },
       },
     });
+  });
+
+  it("opens and cancels the project default agent picker", () => {
+    const state = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+    const opened = openProjectDefaultAgentPicker(state, "web");
+
+    expect(opened.screen).toEqual({ name: "projectDefaultAgent", projectId: "web" });
+    expect(handleTuiKey(opened, { input: "", escape: true }).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+
+  it("sets a project default agent from the picker", () => {
+    const state = openProjectDefaultAgentPicker(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "web",
+    );
+
+    const transition = handleTuiKey(state, { input: "2" });
+
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.operations).toEqual([
+      {
+        type: "setProjectDefaultHarness",
+        projectId: "web",
+        harness: "opencode",
+        command: {
+          type: "project.setDefaultHarness",
+          payload: {
+            projectId: "web",
+            harness: "opencode",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("closes the project default agent picker without dispatching when selection is unchanged", () => {
+    const state = openProjectDefaultAgentPicker(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "web",
+    );
+
+    const transition = handleTuiKey(state, { input: "1" });
+
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.operations).toBeUndefined();
   });
 
   it("adds a safe error toast when no project exists for a new session", () => {

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -568,6 +568,25 @@ describe("TUI screen transitions", () => {
     });
   });
 
+  it("does not open the project default agent picker without a usable project", () => {
+    const noSnapshot = createInitialTuiState();
+    expect(openProjectDefaultAgentPicker(noSnapshot, "web")).toBe(noSnapshot);
+
+    const snapshot = createDashboardSnapshot();
+    const unavailable = {
+      ...snapshot,
+      projects: snapshot.projects.map((project) =>
+        project.id === "web"
+          ? { ...project, health: { ...project.health, status: "unavailable" as const } }
+          : project,
+      ),
+    };
+    const state = createInitialTuiState({ initialSnapshot: unavailable });
+
+    expect(openProjectDefaultAgentPicker(state, "web").screen).toEqual({ name: "dashboard" });
+    expect(openProjectDefaultAgentPicker(state, "ghost").screen).toEqual({ name: "dashboard" });
+  });
+
   it("sets a project default agent from the picker", () => {
     const state = openProjectDefaultAgentPicker(
       createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
@@ -580,8 +599,6 @@ describe("TUI screen transitions", () => {
     expect(transition.operations).toEqual([
       {
         type: "setProjectDefaultHarness",
-        projectId: "web",
-        harness: "opencode",
         command: {
           type: "project.setDefaultHarness",
           payload: {

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -158,17 +158,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: {
         pid: 1234,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.5.0",
+      "schemaVersion": "0.6.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -309,7 +309,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.5.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.6.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/packages/provider-hooks/test/unit/command.test.ts
+++ b/packages/provider-hooks/test/unit/command.test.ts
@@ -33,7 +33,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -88,7 +88,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -128,7 +128,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               hookId: event.hookId ?? "hook_crush_1",
               provider: event.provider,
               event: event.event,
@@ -197,7 +197,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -262,7 +262,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -382,7 +382,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -449,7 +449,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -498,7 +498,7 @@ describe("provider hook ingress command", () => {
           observedTimeoutMs = options.timeoutMs;
           return {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => ({
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               reportId: report.reportId,
               provider: report.provider,
               eventType: report.eventType,

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.5.0",
+  schemaVersion: "0.6.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -12,9 +12,9 @@ import type { StoreApi } from "zustand/vanilla";
 import type { ProviderId } from "@station/contracts";
 import {
   choiceValueByKey,
-  createNewSessionFlow,
   createNewSessionNameToken,
   generatedSessionBranch,
+  openProjectDefaultAgentPicker,
   selectDashboardViewport,
 } from "@station/dashboard-core";
 import { clampDashboardStateScroll, scrollDashboard } from "@station/dashboard-core";
@@ -271,25 +271,14 @@ export function resolveQuickSessionSubmit(
 }
 
 /**
- * Open the New Session wizard with the given project pre-selected (skips the
- * project-picker step, lands on the review screen). Pure store mutation —
- * no router outcome. Absent or unavailable projects are silently ignored.
+ * Open the project default-agent picker. Pure store mutation — no router
+ * outcome. Absent or unavailable projects are silently ignored.
  */
-export function openNewSessionForProject(store: StoreApi<TuiStore>, projectId: string): void {
-  const state = store.getState();
-  const snapshot = state.snapshot;
-  if (snapshot === undefined) {
-    return;
-  }
-  const project = snapshot.projects.find((candidate) => candidate.id === projectId);
-  if (project === undefined || project.health.status === "unavailable") {
-    return;
-  }
-  const flow = createNewSessionFlow(snapshot, createNewSessionNameToken(), projectId);
-  if (flow === undefined) {
-    return;
-  }
-  store.setState({ ...state, screen: { name: "newSession", flow } });
+export function openDefaultAgentPickerForProject(
+  store: StoreApi<TuiStore>,
+  projectId: string,
+): void {
+  store.setState(openProjectDefaultAgentPicker(store.getState(), projectId));
 }
 
 /**

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -13,7 +13,7 @@
 //    the transition reports dismissPopup/exitCode).
 import { describe, expect, it } from "bun:test";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
-import { createInitialTuiState } from "@station/dashboard-core";
+import { createInitialTuiState, openProjectDefaultAgentPicker } from "@station/dashboard-core";
 import type { TuiKey } from "@station/dashboard-core";
 import { handleTuiKey } from "@station/dashboard-core";
 import type { TuiState } from "@station/dashboard-core";
@@ -103,6 +103,7 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     newSessionEditName: drive(base, [{ input: "N" }, { input: "N" }]),
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
     newSessionPickAgent: drive(base, [{ input: "N" }, { input: "A" }]),
+    projectDefaultAgent: openProjectDefaultAgentPicker(base, "station"),
     addProject: drive(base, [{ input: "A" }]),
   };
 }

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -25,6 +25,7 @@ export type StationInputMode =
   | "newSessionEditName"
   | "newSessionPickProject"
   | "newSessionPickAgent"
+  | "projectDefaultAgent"
   | "addProject";
 
 export function deriveStationMode(state: TuiState): StationInputMode {
@@ -56,6 +57,8 @@ export function deriveStationMode(state: TuiState): StationInputMode {
       break;
     case "addProject":
       return "addProject";
+    case "projectDefaultAgent":
+      return "projectDefaultAgent";
   }
   return "dashboard";
 }
@@ -183,6 +186,10 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   newSessionPickAgent: [
     { id: "station.newSessionAgent.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
     { id: "station.newSessionAgent.choose", pattern: { kind: "slot" }, action: "station.newSession.chooseAgent", outcome: "handled", help: { keys: "1-9 a-z", label: "choose agent" } },
+  ],
+  projectDefaultAgent: [
+    { id: "station.projectDefaultAgent.cancel", pattern: { kind: "named", named: "escape" }, action: "station.projectDefaultAgent.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
+    { id: "station.projectDefaultAgent.choose", pattern: { kind: "slot" }, action: "station.projectDefaultAgent.choose", outcome: "handled", help: { keys: "1-9 a-z", label: "choose agent" } },
   ],
   // The add-project flow has internal modes (start/choose/review/success/
   // failed, with a slash filter and a name editor); this single table covers

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -432,9 +432,8 @@ describe("routeStationMouse", () => {
     );
 
     const outcome = routeStationMouse({ kind: "sheetChoice", choiceKey: "2" }, LEFT_DOWN, store);
-    await Promise.resolve();
-    await Promise.resolve();
 
+    await waitFor(() => fixture.service.loadCount === 1);
     expect(outcome).toEqual({ kind: "handled" });
     expect(
       fixture.service.dispatched.some(
@@ -444,6 +443,11 @@ describe("routeStationMouse", () => {
           command.payload.harness === "opencode",
       ),
     ).toBe(true);
+    expect(fixture.service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
+    const toast = store
+      .getState()
+      .toasts.find((entry) => entry.toast.message === "Default agent set to opencode.");
+    expect(toast?.toast).toMatchObject({ kind: "success" });
   });
 
   it("silently ignores default-agent picker on absent or unavailable project", () => {
@@ -518,4 +522,13 @@ function slotForRow(store: StoreApi<TuiStore>, rowId: string): string {
     throw new Error(`no slot for row ${rowId}`);
   }
   return choice.key;
+}
+
+async function waitFor(assertion: () => boolean): Promise<void> {
+  const deadline = Date.now() + 500;
+  for (;;) {
+    if (assertion()) return;
+    if (Date.now() > deadline) throw new Error("timed out waiting for assertion");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -382,7 +382,7 @@ describe("routeStationMouse", () => {
     }
   });
 
-  it("gates quick-session and harness-picker to dashboard mode", () => {
+  it("gates quick-session and default-agent picker to dashboard mode", () => {
     const store = makeStore();
     store.getState().handleKey({ input: "/" }); // enter search mode
 
@@ -390,7 +390,11 @@ describe("routeStationMouse", () => {
       routeStationMouse({ kind: "quickSessionForProject", projectId: "station" }, LEFT_DOWN, store),
     ).toEqual({ kind: "handled" });
     expect(
-      routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "station" }, LEFT_DOWN, store),
+      routeStationMouse(
+        { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+        LEFT_DOWN,
+        store,
+      ),
     ).toEqual({ kind: "handled" });
   });
 
@@ -401,25 +405,56 @@ describe("routeStationMouse", () => {
     ).toEqual({ kind: "handled" });
   });
 
-  it("opens the new-session wizard pre-configured to a project via [▾] harness picker", () => {
+  it("opens the project default-agent picker via [▾]", () => {
     const store = makeStore();
-    const outcome = routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "station" }, LEFT_DOWN, store);
-    // The outcome is handled (no router effect); the wizard screen is set on the store.
+    const outcome = routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
+    // The outcome is handled (no router effect); the picker screen is set on the store.
     expect(outcome).toEqual({ kind: "handled" });
     const screen = store.getState().screen;
     expect(screen).toBeDefined();
-    expect(screen?.name).toBe("newSession");
-    if (screen?.name === "newSession") {
-      expect(screen.flow.selectedProjectId).toBe("station");
-      expect(screen.flow.selectedHarness).toBe("codex");
+    expect(screen?.name).toBe("projectDefaultAgent");
+    if (screen?.name === "projectDefaultAgent") {
+      expect(screen.projectId).toBe("station");
     }
   });
 
-  it("silently ignores harness-picker on absent or unavailable project", () => {
+  it("selects a project default agent by clicking an agent picker row", async () => {
+    const fixture = makeStationTestStore({ terminalRows: 12 });
+    const store = fixture.store;
+    routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
+
+    const outcome = routeStationMouse({ kind: "sheetChoice", choiceKey: "2" }, LEFT_DOWN, store);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(outcome).toEqual({ kind: "handled" });
+    expect(
+      fixture.service.dispatched.some(
+        (command) =>
+          command.type === "project.setDefaultHarness" &&
+          command.payload.projectId === "station" &&
+          command.payload.harness === "opencode",
+      ),
+    ).toBe(true);
+  });
+
+  it("silently ignores default-agent picker on absent or unavailable project", () => {
     const store = makeStore();
     // Ghost project: no mutation, no router effect.
-    routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "ghost" }, LEFT_DOWN, store);
-    expect(store.getState().screen?.name).not.toBe("newSession");
+    routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "ghost" },
+      LEFT_DOWN,
+      store,
+    );
+    expect(store.getState().screen?.name).not.toBe("projectDefaultAgent");
   });
 });
 

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -14,7 +14,7 @@ import {
   dispatchBindingClick,
   dispatchRowSlot,
   dispatchStationKey,
-  openNewSessionForProject,
+  openDefaultAgentPickerForProject,
   representativeKeyForBinding,
   resolveNewSessionSubmit,
   resolveProjectPaneTarget,
@@ -39,8 +39,8 @@ export type StationMouseTarget =
   | { kind: "openShellForProject"; projectId: string }
   /** The `[+]` quick-session affordance on a project header. */
   | { kind: "quickSessionForProject"; projectId: string }
-  /** The `[▾]` harness-picker affordance on a project header. */
-  | { kind: "showHarnessPickerForProject"; projectId: string }
+  /** The `[▾]` default-agent affordance on a project header. */
+  | { kind: "showDefaultAgentPickerForProject"; projectId: string }
   | { kind: "body" }
   | { kind: "scrollIndicator"; direction: "up" | "down" }
   | { kind: "footerHint"; bindingId: string }
@@ -159,11 +159,11 @@ export function routeStationMouse(
         return { kind: "handled" };
       }
       return fromQuickSessionSubmit(resolveQuickSessionSubmit(store, target.projectId));
-    case "showHarnessPickerForProject":
+    case "showDefaultAgentPickerForProject":
       if (mode !== "dashboard") {
         return { kind: "handled" };
       }
-      openNewSessionForProject(store, target.projectId);
+      openDefaultAgentPickerForProject(store, target.projectId);
       return { kind: "handled" };
     case "scrollIndicator":
       if (!ROW_INTERACTIVE_MODES.has(mode)) {
@@ -230,6 +230,7 @@ export function stationMouseEventKind(event: StationMouseEvent): StationMouseEve
 const SHEET_CHOICE_MODES: ReadonlySet<StationInputMode> = new Set([
   "newSessionPickProject",
   "newSessionPickAgent",
+  "projectDefaultAgent",
 ]);
 
 function routeStationWheel(

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -45,8 +45,7 @@ const SHELL_AFFORDANCE_WIDTH_COMPACT = SHELL_AFFORDANCE_LABEL_COMPACT.length + 1
 
 // The per-project-header quick-session affordance sits after [shell] on project
 // rows: "[quick session]" creates a session (default harness), "[▾]" opens the
-// wizard pre-configured to this project. Compact mode uses "[qs]" when columns
-// are limited.
+// project default-agent picker. Compact mode uses "[qs]" when columns are limited.
 const QUICK_SESSION_AFFORDANCE_LABEL = "[quick session]";
 const QUICK_SESSION_AFFORDANCE_LABEL_COMPACT = "[qs]";
 // Reserved width: leading space + session label + space + [▾]
@@ -298,8 +297,8 @@ function ShellAffordance({
  * The trailing `[quick session] [▾]` (or `[qs] [▾]` in compact mode)
  * quick-session affordance on project headers. Two separate `<text>` elements
  * so each click target fires independently: the session label immediately
- * creates a session (default harness), `[▾]` opens the harness-picker wizard
- * pre-configured to this project.
+ * creates a session (default harness), `[▾]` opens the default-agent picker
+ * for this project.
  */
 function QuickSessionAffordance({
   projectId,
@@ -326,7 +325,7 @@ function QuickSessionAffordance({
       <text
         flexShrink={0}
         fg={pickerHover ? STATION_COLORS.green : STATION_COLORS.gray}
-        {...stationMouseProps(dispatch, { kind: "showHarnessPickerForProject", projectId })}
+        {...stationMouseProps(dispatch, { kind: "showDefaultAgentPickerForProject", projectId })}
         onMouseOver={() => setPickerHover(true)}
         onMouseOut={() => setPickerHover(false)}
       >

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -6,6 +6,7 @@ import type { TuiScreen } from "@station/dashboard-core";
 import { AddProjectSheetView } from "./sheets/AddProjectSheetView.js";
 import { HelpOverlayView } from "./HelpOverlayView.js";
 import { NewSessionSheetView } from "./sheets/NewSessionSheetView.js";
+import { ProjectDefaultAgentSheetView } from "./sheets/ProjectDefaultAgentSheetView.js";
 import { RenameSessionSheetView } from "./sheets/RenameSessionSheetView.js";
 import { RemoveSessionSheetView } from "./sheets/RemoveSessionSheetView.js";
 
@@ -26,6 +27,16 @@ export function OverlayHostView({ snapshot, screen, columns, rows }: OverlayHost
   if (screen.name === "newSession") {
     return (
       <NewSessionSheetView columns={columns} rows={rows} snapshot={snapshot} state={screen.flow} />
+    );
+  }
+  if (screen.name === "projectDefaultAgent") {
+    return (
+      <ProjectDefaultAgentSheetView
+        columns={columns}
+        rows={rows}
+        snapshot={snapshot}
+        screen={screen}
+      />
     );
   }
   if (screen.name === "renameSession" && screen.step === "editName") {

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -308,6 +308,34 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "
 `;
 
+exports[`modal flow golden frames renders the project default agent picker 1`] = `
+"station
+───────────────────────────────────────────────────────────────────────────────
+
+▼ station - 5 worktrees                                           [sh] [qs] [▾]
+ [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell]
+ [2] - docs-cleanup               -         no agent                    [shell]
+ [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell]
+ [4] + session-resume             codex     starting                    [shell]
+ [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell]
+
+▼ observer - 3 worktrees                                          [sh] [qs] [▾]
+ [6] x batch-export               opencode  exited                 #8 ✓ [shell]
+ [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell]
+ [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell]
+
+▼ scripts - 3 worktrees                                           [sh] [qs] [▾]
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Select Station Default Agent                                                 │
+│                                                                              │
+│ 1 codex unknown                                                              │
+│ 2 opencode unknown                                                           │
+│                                                                              │
+│ 1-9/a-z:select   Esc:cancel                                                  │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "station                                                                         
 ─────────────────────────────────────────────────────────────────────────────── 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 
 ▼ scripts - 3 worktrees                                           [sh] [qs] [▾]
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ Select default agent for station                                             │
+│ Select Station Default Agent                                                 │
 │                                                                              │
 │ 1 codex unknown                                                              │
 │ 2 opencode unknown                                                           │

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 
 ▼ scripts - 3 worktrees                                           [sh] [qs] [▾]
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ Select Station Default Agent                                                 │
+│ Select default agent for station                                             │
 │                                                                              │
 │ 1 codex unknown                                                              │
 │ 2 opencode unknown                                                           │

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -86,7 +86,7 @@ const CASES: ModalCase[] = [
       store.setState(openProjectDefaultAgentPicker(store.getState(), "station"));
     },
     trimSnapshotTrailingWhitespace: true,
-    expect: ["Select default agent for station", "1-9/a-z:select   Esc:cancel", "codex"],
+    expect: ["Select Station Default Agent", "1-9/a-z:select   Esc:cancel", "codex"],
   },
   {
     name: "add project sheet",

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -86,7 +86,7 @@ const CASES: ModalCase[] = [
       store.setState(openProjectDefaultAgentPicker(store.getState(), "station"));
     },
     trimSnapshotTrailingWhitespace: true,
-    expect: ["Select Station Default Agent", "1-9/a-z:select   Esc:cancel", "codex"],
+    expect: ["Select default agent for station", "1-9/a-z:select   Esc:cancel", "codex"],
   },
   {
     name: "add project sheet",

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -7,6 +7,7 @@ import type { StoreApi } from "zustand/vanilla";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
+import { openProjectDefaultAgentPicker } from "@station/dashboard-core";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import { DashboardRoot } from "./DashboardRoot.js";
 
@@ -77,6 +78,15 @@ const CASES: ModalCase[] = [
     name: "new session pick agent",
     keys: [{ input: "N" }, { input: "A" }],
     expect: ["Choose Agent", "1-9/a-z:select   Esc:back", "codex"],
+  },
+  {
+    name: "project default agent picker",
+    keys: [],
+    prepare: (store) => {
+      store.setState(openProjectDefaultAgentPicker(store.getState(), "station"));
+    },
+    trimSnapshotTrailingWhitespace: true,
+    expect: ["Select Station Default Agent", "1-9/a-z:select   Esc:cancel", "codex"],
   },
   {
     name: "add project sheet",

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -1,0 +1,72 @@
+import type { KeyedChoice, NewSessionHarnessOption } from "@station/dashboard-core";
+import { useState } from "react";
+import { STATION_COLORS } from "../theme.js";
+import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
+import { spaces } from "./parts.js";
+
+export type AgentChoiceListViewProps = {
+  choices: readonly KeyedChoice<NewSessionHarnessOption>[];
+  width: number;
+};
+
+export function AgentChoiceListView({ choices, width }: AgentChoiceListViewProps) {
+  return (
+    <>
+      {choices.map((choice) => (
+        <AgentChoiceLine
+          key={choice.value.id}
+          choiceKey={choice.key}
+          label={choice.value.label}
+          detail={choice.value.status}
+          color={statusColor(choice.value.status)}
+          width={width}
+        />
+      ))}
+    </>
+  );
+}
+
+function AgentChoiceLine({
+  choiceKey,
+  label,
+  detail,
+  color,
+  width,
+}: {
+  choiceKey: string;
+  label: string;
+  detail: string;
+  color?: string | undefined;
+  width: number;
+}) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  const prefix = ` ${choiceKey} `;
+  const detailPrefix = `${label} `;
+  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
+  const visibleDetail = detail.slice(0, detailWidth);
+  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
+  return (
+    <text
+      fg={hover ? STATION_COLORS.green : STATION_COLORS.foreground}
+      {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {prefix}
+      {detailPrefix}
+      <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
+      {padding}
+    </text>
+  );
+}
+
+function statusColor(status: string | undefined): string | undefined {
+  if (status === "unavailable") {
+    return STATION_COLORS.red;
+  }
+  if (status === "degraded") {
+    return STATION_COLORS.yellow;
+  }
+  return undefined;
+}

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -1,8 +1,6 @@
 import type { KeyedChoice, NewSessionHarnessOption } from "@station/dashboard-core";
-import { useState } from "react";
-import { STATION_COLORS } from "../theme.js";
-import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
-import { spaces } from "./parts.js";
+import { providerHealthStatusColor } from "../theme.js";
+import { SheetChoiceLine } from "./parts.js";
 
 export type AgentChoiceListViewProps = {
   choices: readonly KeyedChoice<NewSessionHarnessOption>[];
@@ -13,60 +11,15 @@ export function AgentChoiceListView({ choices, width }: AgentChoiceListViewProps
   return (
     <>
       {choices.map((choice) => (
-        <AgentChoiceLine
+        <SheetChoiceLine
           key={choice.value.id}
           choiceKey={choice.key}
           label={choice.value.label}
           detail={choice.value.status}
-          color={statusColor(choice.value.status)}
+          color={providerHealthStatusColor(choice.value.status)}
           width={width}
         />
       ))}
     </>
   );
-}
-
-function AgentChoiceLine({
-  choiceKey,
-  label,
-  detail,
-  color,
-  width,
-}: {
-  choiceKey: string;
-  label: string;
-  detail: string;
-  color?: string | undefined;
-  width: number;
-}) {
-  const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
-  const prefix = ` ${choiceKey} `;
-  const detailPrefix = `${label} `;
-  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
-  const visibleDetail = detail.slice(0, detailWidth);
-  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
-  return (
-    <text
-      fg={hover ? STATION_COLORS.green : STATION_COLORS.foreground}
-      {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
-      onMouseOver={() => setHover(true)}
-      onMouseOut={() => setHover(false)}
-    >
-      {prefix}
-      {detailPrefix}
-      <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
-      {padding}
-    </text>
-  );
-}
-
-function statusColor(status: string | undefined): string | undefined {
-  if (status === "unavailable") {
-    return STATION_COLORS.red;
-  }
-  if (status === "degraded") {
-    return STATION_COLORS.yellow;
-  }
-  return undefined;
 }

--- a/station/src/station/view/sheets/NewSessionSheetView.tsx
+++ b/station/src/station/view/sheets/NewSessionSheetView.tsx
@@ -13,11 +13,16 @@ import {
   selectNewSessionProjectChoices,
 } from "@station/dashboard-core";
 import { EditableTextInputView } from "../EditableTextInputView.js";
-import { STATION_COLORS } from "../theme.js";
-import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
+import { providerHealthStatusColor, STATION_COLORS } from "../theme.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import { AgentChoiceListView } from "./AgentChoiceListView.js";
-import { SheetFooter, SheetLabelValue, SheetLine, spaces } from "./parts.js";
+import {
+  SheetChoiceLine,
+  SheetFooter,
+  SheetLabelValue,
+  SheetLine,
+  spaces,
+} from "./parts.js";
 
 export type NewSessionSheetViewProps = {
   snapshot: StationSnapshot;
@@ -103,7 +108,7 @@ function Review({
         label="Agent"
         labelWidth={10}
         value={harness === undefined ? state.selectedHarness : `${harness.label} ${harness.status}`}
-        {...colorProp(statusColor(harness?.status))}
+        {...colorProp(providerHealthStatusColor(harness?.status))}
       />
       <SheetLine width={width}> </SheetLine>
       <SheetFooter width={width}>{"Enter:create N:name P:project A:agent Esc:cancel"}</SheetFooter>
@@ -151,12 +156,12 @@ function ProjectPicker({ snapshot, width }: { snapshot: StationSnapshot; width: 
     <>
       <SheetLine width={width}> </SheetLine>
       {projects.map((choice) => (
-        <ChoiceLine
+        <SheetChoiceLine
           key={choice.value.id}
           choiceKey={choice.key}
           label={choice.value.label}
           detail={choice.value.health.status}
-          color={statusColor(choice.value.health.status)}
+          color={providerHealthStatusColor(choice.value.health.status)}
           width={width}
         />
       ))}
@@ -186,39 +191,6 @@ function AgentPicker({
   );
 }
 
-/** Slot-keyed picker line; a click selects exactly what the key would. */
-function ChoiceLine({
-  choiceKey,
-  label,
-  detail,
-  color,
-  width,
-}: {
-  choiceKey: string;
-  label: string;
-  detail: string;
-  color?: string | undefined;
-  width: number;
-}) {
-  const dispatch = useStationMouse();
-  const prefix = ` ${choiceKey} `;
-  const detailPrefix = `${label} `;
-  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
-  const visibleDetail = detail.slice(0, detailWidth);
-  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
-  return (
-    <text
-      fg={STATION_COLORS.foreground}
-      {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
-    >
-      {prefix}
-      {detailPrefix}
-      <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
-      {padding}
-    </text>
-  );
-}
-
 function selectedHarnessOption(
   snapshot: StationSnapshot,
   project: ProjectView,
@@ -241,16 +213,6 @@ function optionCountForState(
     return selectNewSessionHarnessChoices(snapshot, project).length;
   }
   return 0;
-}
-
-function statusColor(status: string | undefined): string | undefined {
-  if (status === "unavailable") {
-    return STATION_COLORS.red;
-  }
-  if (status === "degraded") {
-    return STATION_COLORS.yellow;
-  }
-  return undefined;
 }
 
 function colorProp(color: string | undefined): { valueColor?: string } {

--- a/station/src/station/view/sheets/NewSessionSheetView.tsx
+++ b/station/src/station/view/sheets/NewSessionSheetView.tsx
@@ -16,6 +16,7 @@ import { EditableTextInputView } from "../EditableTextInputView.js";
 import { STATION_COLORS } from "../theme.js";
 import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import { AgentChoiceListView } from "./AgentChoiceListView.js";
 import { SheetFooter, SheetLabelValue, SheetLine, spaces } from "./parts.js";
 
 export type NewSessionSheetViewProps = {
@@ -178,16 +179,7 @@ function AgentPicker({
   return (
     <>
       <SheetLine width={width}> </SheetLine>
-      {options.map((choice) => (
-        <ChoiceLine
-          key={choice.value.id}
-          choiceKey={choice.key}
-          label={choice.value.label}
-          detail={choice.value.status}
-          color={statusColor(choice.value.status)}
-          width={width}
-        />
-      ))}
+      <AgentChoiceListView choices={options} width={width} />
       <SheetLine width={width}> </SheetLine>
       <SheetFooter width={width}>{"1-9/a-z:select   Esc:back"}</SheetFooter>
     </>

--- a/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
@@ -26,11 +26,13 @@ export function ProjectDefaultAgentSheetView({
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
   const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
   const contentWidth = bottomSheetContentWidth(columns);
+  const title =
+    project === undefined ? "Select Project Default Agent" : `Select default agent for ${project.label}`;
   return (
     <BottomSheetFrameView
       columns={columns}
       rows={rows}
-      title="Select Station Default Agent"
+      title={title}
       contentRows={choices.length + 4}
     >
       <ProjectDefaultAgentPicker choices={choices} width={contentWidth} />

--- a/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
@@ -1,0 +1,56 @@
+import type { StationSnapshot } from "@station/contracts";
+import {
+  bottomSheetContentWidth,
+  selectNewSessionHarnessChoices,
+  type KeyedChoice,
+  type NewSessionHarnessOption,
+  type TuiScreen,
+} from "@station/dashboard-core";
+import { AgentChoiceListView } from "./AgentChoiceListView.js";
+import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import { SheetFooter, SheetLine } from "./parts.js";
+
+export type ProjectDefaultAgentSheetViewProps = {
+  snapshot: StationSnapshot;
+  screen: Extract<TuiScreen, { name: "projectDefaultAgent" }>;
+  columns: number;
+  rows: number;
+};
+
+export function ProjectDefaultAgentSheetView({
+  snapshot,
+  screen,
+  columns,
+  rows,
+}: ProjectDefaultAgentSheetViewProps) {
+  const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
+  const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
+  const contentWidth = bottomSheetContentWidth(columns);
+  return (
+    <BottomSheetFrameView
+      columns={columns}
+      rows={rows}
+      title="Select Station Default Agent"
+      contentRows={choices.length + 4}
+    >
+      <ProjectDefaultAgentPicker choices={choices} width={contentWidth} />
+    </BottomSheetFrameView>
+  );
+}
+
+function ProjectDefaultAgentPicker({
+  choices,
+  width,
+}: {
+  choices: readonly KeyedChoice<NewSessionHarnessOption>[];
+  width: number;
+}) {
+  return (
+    <>
+      <SheetLine width={width}> </SheetLine>
+      <AgentChoiceListView choices={choices} width={width} />
+      <SheetLine width={width}> </SheetLine>
+      <SheetFooter width={width}>{"1-9/a-z:select   Esc:cancel"}</SheetFooter>
+    </>
+  );
+}

--- a/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
@@ -26,13 +26,11 @@ export function ProjectDefaultAgentSheetView({
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
   const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
   const contentWidth = bottomSheetContentWidth(columns);
-  const title =
-    project === undefined ? "Select Project Default Agent" : `Select default agent for ${project.label}`;
   return (
     <BottomSheetFrameView
       columns={columns}
       rows={rows}
-      title={title}
+      title="Select Station Default Agent"
       contentRows={choices.length + 4}
     >
       <ProjectDefaultAgentPicker choices={choices} width={contentWidth} />

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -76,6 +76,41 @@ export function SheetFooter({ width, children }: { width: number; children: stri
   );
 }
 
+export function SheetChoiceLine({
+  choiceKey,
+  label,
+  detail,
+  color,
+  width,
+}: {
+  choiceKey: string;
+  label: string;
+  detail: string;
+  color?: string | undefined;
+  width: number;
+}) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  const prefix = ` ${choiceKey} `;
+  const detailPrefix = `${label} `;
+  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
+  const visibleDetail = detail.slice(0, detailWidth);
+  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
+  return (
+    <text
+      fg={hover ? STATION_COLORS.green : STATION_COLORS.foreground}
+      {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {prefix}
+      {detailPrefix}
+      <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
+      {padding}
+    </text>
+  );
+}
+
 export function SheetProgressFooter({ width, children }: { width: number; children: string }) {
   const throbberWidth = 3;
   const labelText = ` ${children}`.slice(0, Math.max(0, width - throbberWidth));

--- a/station/src/station/view/theme.ts
+++ b/station/src/station/view/theme.ts
@@ -3,6 +3,7 @@
 // takes fg hex strings. Values match the terminal-ish palette the rest of
 // Station already uses.
 import { ROW_COLOR_PURPLE, type RowColor } from "@station/dashboard-core";
+import type { ProviderHealth } from "@station/contracts";
 
 export const STATION_COLORS = {
   gray: "#9ca3af",
@@ -36,4 +37,17 @@ export function rowColorToHex(color: RowColor | undefined): string | undefined {
       // ROW_COLOR_PURPLE is already a hex literal.
       return color;
   }
+}
+
+const PROVIDER_HEALTH_STATUS_COLORS: Record<ProviderHealth["status"], string> = {
+  healthy: STATION_COLORS.green,
+  degraded: STATION_COLORS.yellow,
+  unavailable: STATION_COLORS.red,
+  unknown: STATION_COLORS.gray,
+};
+
+export function providerHealthStatusColor(
+  status: ProviderHealth["status"] | undefined,
+): string | undefined {
+  return status === undefined ? undefined : PROVIDER_HEALTH_STATUS_COLORS[status];
 }

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -140,6 +140,13 @@
       "projectId": "web"
     }
   },
+  "projectSetDefaultHarness": {
+    "type": "project.setDefaultHarness",
+    "payload": {
+      "projectId": "web",
+      "harness": "codex"
+    }
+  },
   "hooksInstall": {
     "type": "hooks.install",
     "payload": {

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -24,7 +24,7 @@
     "alerts": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -109,7 +109,7 @@
     "alerts": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -158,7 +158,7 @@
     "alerts": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -228,7 +228,7 @@
     "alerts": []
   },
   "idleAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -355,7 +355,7 @@
     "alerts": []
   },
   "workingAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -440,7 +440,7 @@
     "alerts": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -524,7 +524,7 @@
     "alerts": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -609,7 +609,7 @@
     "alerts": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -691,7 +691,7 @@
     "alerts": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -775,7 +775,7 @@
     "alerts": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -809,7 +809,7 @@
     ]
   },
   "providerFailure": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -40,7 +40,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -45,10 +45,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -66,7 +66,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,


### PR DESCRIPTION
## Summary

Adds a project-level default agent picker from the project header `[▾]` affordance and wires it through the Station command path.

- adds `project.setDefaultHarness` contracts, observer handling, and config mutation for `[projects.defaults].harness`
- adds a `projectDefaultAgent` dashboard-core screen/operation and Station overlay rendering
- extracts `AgentChoiceListView` so the agent picker list is shared by New Session and the project default-agent dialog
- makes agent rows mouse-selectable through the same keyed choice path used by keyboard selection
- bumps the Station protocol schema to `0.6.0` so stale observers reject this branch with `PROTOCOL_SCHEMA_MISMATCH` instead of accepting the connection and failing later on the new command payload

## UX Implication

Clicking `[quick session]` still creates a session with the current project default. Clicking the adjacent `[▾]` now opens `Select Station Default Agent`; choosing an agent updates that project's default, so future quick sessions use it.

Manual verify: open STATION, click a project header `[▾]`, confirm the `Select Station Default Agent` sheet appears, then click an agent row and verify the picker closes and the project default harness updates.

If the observer was already running from a prior build, this branch now shows a schema mismatch first. Restart the observer from the rebuilt checkout, then rerun the TUI to exercise the new default-agent command.

## Validation

- `pnpm build`
- `pnpm exec vitest run packages/config/test/unit/project-mutation.test.ts packages/contracts/test/schema/contracts-schema.test.ts packages/dashboard-core/test/unit/state/transition.test.ts packages/dashboard-core/test/unit/state/keymap.test.ts packages/protocol/test/unit/messages.test.ts packages/protocol/test/integration/client-server.test.ts packages/client/test/integration/observerService.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/project-commands.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/observer-process.test.ts packages/provider-hooks/test/unit/command.test.ts packages/observability/test/unit/observability.test.ts packages/observability/test/unit/diagnostic-evidence.test.ts`
- `pnpm exec vitest run apps/cli/test/integration/diagnostic-commands.test.ts apps/cli/test/integration/observer-commands.test.ts apps/cli/test/integration/tui-command.test.ts apps/cli/test/integration/project-command.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/diagnostics-collector.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/injected-failures/provider-timeout.test.ts tests/diagnostics/injected-failures/sqlite-write-failure.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.agent-scripted.config.ts`
- `cd station && bun run typecheck`
- `cd station && bun run link:station && bun test src/station/input/stationMouse.test.ts src/station/input/stationKeymap.test.ts src/station/view/modals.golden.test.tsx`
- `pnpm stn snapshot --json` against the old running observer now returns the expected `PROTOCOL_SCHEMA_MISMATCH`

Note: the Station modal golden tests still emit the existing React `act(...)` warnings while passing.