### PR TITLE
feat(dev): isolate Station dev runtime flows (superseded)

### DIFF
--- a/apps/cli/src/commands/eventHooks.ts
+++ b/apps/cli/src/commands/eventHooks.ts
@@ -197,7 +197,7 @@ async function checkBuiltInNotifyCommand(input: {
     return checkCommandAvailable(input.command, input.args, input.env);
   }
   const invocation = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     hookId: `${builtInHookId}-doctor-check`,
     observedAt: "2026-01-01T00:00:00.000Z",
     event: {

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -218,7 +218,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -18,7 +18,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -34,7 +34,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -60,7 +60,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -94,7 +94,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -130,7 +130,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -192,7 +192,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -232,7 +232,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -581,12 +581,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -614,17 +614,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -56,7 +56,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -265,7 +265,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -276,7 +276,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -288,7 +288,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -264,7 +264,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -279,7 +279,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -302,7 +302,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -315,7 +315,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -389,7 +389,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -21,7 +21,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -30,7 +30,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.5.0", stopped: true, at: now };
+            return { schemaVersion: "0.6.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -66,7 +66,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -75,7 +75,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.5.0", stopped: true, at: now };
+            return { schemaVersion: "0.6.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -301,7 +301,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -310,11 +310,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
         reconcile: async (reason: string) => {
           reconciles.push(reason);
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             reason,
             reconciledAt: now,
             snapshot: {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               generatedAt: now,
               observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
               providerHealth: {},
@@ -344,7 +344,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -105,7 +105,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -24,11 +24,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},
@@ -63,7 +63,7 @@ function runningObserverDeps(options: { reconciles?: string[]; hangReconcile?: b
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/unit/observer-process.test.ts
+++ b/apps/cli/test/unit/observer-process.test.ts
@@ -51,7 +51,7 @@ describe("CLI observer process helpers", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -95,7 +95,7 @@ describe("CLI observer process helpers", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -204,7 +204,7 @@ describe("CLI observer process helpers", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.5.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },

--- a/apps/cli/test/unit/tui-dev-script.test.ts
+++ b/apps/cli/test/unit/tui-dev-script.test.ts
@@ -1,0 +1,243 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "@station/config";
+import { afterEach, describe, expect, it } from "vitest";
+
+type TuiDevScript = {
+  installTuiDevHooks: (
+    runtime: { configPath?: string; env: Record<string, string>; generated: boolean },
+    runCommand?: (
+      command: string,
+      args: string[],
+      options: { env: Record<string, string>; cwd: string },
+    ) => { status?: number; stdout?: string; stderr?: string },
+  ) => void;
+  prepareTuiDevRuntime: (input: {
+    argv?: string[];
+    env?: Record<string, string>;
+    root?: string;
+  }) => Promise<{
+    argv: string[];
+    env: Record<string, string>;
+    configPath?: string;
+    generated: boolean;
+  }>;
+};
+
+const tempRoots: string[] = [];
+
+async function loadScript(): Promise<TuiDevScript> {
+  return (await import("../../../../scripts/tui-dev.mjs")) as TuiDevScript;
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  tempRoots.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("tui-dev launcher runtime", () => {
+  it("generates a worktree-local observer config by default", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    const configDir = join(home, ".config", "station");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        'socket_path = "~/.local/state/station/observer.sock"',
+        'state_dir = "~/.local/state/station"',
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { prepareTuiDevRuntime } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    const configPath = join(root, ".dev-state", "tui-dev", "config.toml");
+    const stateDir = join(root, ".dev-state", "tui-dev", "observer");
+    const socketPath = join(stateDir, "run", "observer.sock");
+
+    expect(runtime).toMatchObject({
+      argv: ["--config", configPath, "tui"],
+      configPath,
+      generated: true,
+      env: {
+        STATION_CONFIG_PATH: configPath,
+        STATION_OBSERVER_SOCKET_PATH: socketPath,
+      },
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toContain(
+      `socket_path = ${JSON.stringify(socketPath)}`,
+    );
+    await expect(readFile(configPath, "utf8")).resolves.toContain(
+      `state_dir = ${JSON.stringify(stateDir)}`,
+    );
+    await expect(readFile(configPath, "utf8")).resolves.toContain('terminal = "noop-terminal"');
+    for (const section of ["codex", "claude", "cursor", "opencode"]) {
+      await expect(readFile(configPath, "utf8")).resolves.toContain(`[harness.${section}]`);
+    }
+    expect(runtime.env.CODEX_HOME).toBe(join(root, ".dev-state", "tui-dev", "codex-home"));
+    expect(runtime.env.CLAUDE_CONFIG_DIR).toBe(join(root, ".dev-state", "tui-dev", "claude-home"));
+    expect(runtime.env.STATION_CURSOR_HOME).toBe(
+      join(root, ".dev-state", "tui-dev", "cursor-home"),
+    );
+    expect(runtime.env.OPENCODE_CONFIG_DIR).toBe(
+      join(root, ".dev-state", "tui-dev", "opencode-config"),
+    );
+  });
+
+  it("writes generated config that loads through the real config loader", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    const configDir = join(home, ".config", "station");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        'socket_path = "~/.local/state/station/observer.sock"',
+        'state_dir = "~/.local/state/station"',
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { prepareTuiDevRuntime } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    if (runtime.configPath === undefined) throw new Error("expected generated config path");
+
+    const loaded = await loadConfig({ configPath: runtime.configPath, homeDir: home });
+
+    expect(loaded.config.observer).toMatchObject({
+      socketPath: join(root, ".dev-state", "tui-dev", "observer", "run", "observer.sock"),
+      stateDir: join(root, ".dev-state", "tui-dev", "observer"),
+    });
+    expect(loaded.config.defaults.terminal).toBe("noop-terminal");
+    expect(loaded.config.featureFlags?.stationPersistentAgents).toBe(true);
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+    expect(loaded.config.harness?.claude?.installHooks).toBe(true);
+    expect(loaded.config.harness?.cursor?.installHooks).toBe(true);
+    expect(loaded.config.harness?.opencode?.installHooks).toBe(true);
+  });
+
+  it("respects explicit config choices", async () => {
+    const { prepareTuiDevRuntime } = await loadScript();
+
+    await expect(
+      prepareTuiDevRuntime({
+        argv: ["--config", "/tmp/custom.toml", "tui"],
+        env: {},
+        root: "/tmp/repo",
+      }),
+    ).resolves.toMatchObject({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      configPath: "/tmp/custom.toml",
+      generated: false,
+      env: { STATION_CONFIG_PATH: "/tmp/custom.toml" },
+    });
+
+    await expect(
+      prepareTuiDevRuntime({
+        argv: ["tui"],
+        env: { STATION_CONFIG_PATH: "/tmp/env.toml" },
+        root: "/tmp/repo",
+      }),
+    ).resolves.toMatchObject({
+      argv: ["--config", "/tmp/env.toml", "tui"],
+      configPath: "/tmp/env.toml",
+      generated: false,
+    });
+  });
+
+  it("scrubs generated dev env when an explicit config is selected", async () => {
+    const { prepareTuiDevRuntime } = await loadScript();
+    const root = "/tmp/repo";
+    const generatedRoot = join(root, ".dev-state", "tui-dev");
+
+    const runtime = await prepareTuiDevRuntime({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      env: {
+        STATION_CONFIG_PATH: "/tmp/stale.toml",
+        STATION_OBSERVER_SOCKET_PATH: "/tmp/stale.sock",
+        CODEX_HOME: join(generatedRoot, "codex-home"),
+        CLAUDE_CONFIG_DIR: "/tmp/intentional-claude-home",
+      },
+      root,
+    });
+
+    expect(runtime).toMatchObject({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      configPath: "/tmp/custom.toml",
+      generated: false,
+      env: {
+        STATION_CONFIG_PATH: "/tmp/custom.toml",
+        CLAUDE_CONFIG_DIR: "/tmp/intentional-claude-home",
+      },
+    });
+    expect(runtime.env.STATION_OBSERVER_SOCKET_PATH).toBeUndefined();
+    expect(runtime.env.CODEX_HOME).toBeUndefined();
+  });
+
+  it("installs supported isolated harness hooks", async () => {
+    const { installTuiDevHooks } = await loadScript();
+    const calls: Array<{ command: string; args: string[]; env: Record<string, string> }> = [];
+    const env = {
+      CODEX_HOME: "/tmp/codex-home",
+      CLAUDE_CONFIG_DIR: "/tmp/claude-home",
+      STATION_CURSOR_HOME: "/tmp/cursor-home",
+      OPENCODE_CONFIG_DIR: "/tmp/opencode-config",
+    };
+
+    installTuiDevHooks(
+      { configPath: "/tmp/station.toml", env, generated: true },
+      (command, args, options) => {
+        calls.push({ command, args, env: options.env });
+        return { status: 0 };
+      },
+    );
+
+    expect(calls.map((call) => call.args.slice(-2, -1)[0])).toEqual([
+      "codex",
+      "claude",
+      "cursor",
+      "opencode",
+    ]);
+    for (const call of calls) {
+      expect(call.args).toEqual([
+        expect.any(String),
+        "--config",
+        "/tmp/station.toml",
+        "hooks",
+        "install",
+        expect.any(String),
+        "--yes",
+      ]);
+      expect(call.env).toBe(env);
+    }
+  });
+});

--- a/apps/observer/src/commands/project.ts
+++ b/apps/observer/src/commands/project.ts
@@ -1,4 +1,8 @@
-import { addProjectToConfig, removeProjectFromConfig } from "@station/config";
+import {
+  addProjectToConfig,
+  removeProjectFromConfig,
+  setProjectDefaultHarnessInConfig,
+} from "@station/config";
 import type { RuntimeClock } from "@station/runtime";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
@@ -57,6 +61,29 @@ export function createProjectRemoveHandler(
       eventBus: options.eventBus,
       clock: options.clock,
       reason: "command:project.remove",
+      trace: context.trace,
+    });
+  };
+}
+
+export function createProjectSetDefaultHarnessHandler(
+  options: CreateProjectCommandHandlerOptions,
+): CommandHandler {
+  return async (context) => {
+    assertCommandType(context, "project.setDefaultHarness");
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: context.command.payload.projectId,
+      harness: context.command.payload.harness,
+      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
+      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+    });
+
+    options.core.updateConfig(result.config);
+    await reconcileAndPublish({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      reason: "command:project.setDefaultHarness",
       trace: context.trace,
     });
   };

--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -358,6 +358,7 @@ function commandScope(command: StationCommand): string {
     case "observer.reconcile":
     case "project.add":
     case "project.remove":
+    case "project.setDefaultHarness":
     case "hooks.install":
       return "global";
   }

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -6,7 +6,11 @@ import type { ObserverPersistence } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
-import { createProjectAddHandler, createProjectRemoveHandler } from "./project.js";
+import {
+  createProjectAddHandler,
+  createProjectRemoveHandler,
+  createProjectSetDefaultHarnessHandler,
+} from "./project.js";
 import type { CommandQueue } from "./queue.js";
 import { createObserverReconcileHandler } from "./reconcile.js";
 import { createSessionAcknowledgeTurnHandler } from "./session/acknowledgeTurn.js";
@@ -182,6 +186,16 @@ export function registerObserverCommandHandlers(
       ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
   );
+  options.queue.registerHandler(
+    "project.setDefaultHarness",
+    createProjectSetDefaultHarnessHandler({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
+      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+    }),
+  );
 
   void options.logger?.info("Observer command handlers registered.", {
     commandTypes: [
@@ -198,6 +212,7 @@ export function registerObserverCommandHandlers(
       "worktree.remove",
       "project.add",
       "project.remove",
+      "project.setDefaultHarness",
     ],
   });
 }

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -37,7 +37,7 @@ describe("observer diagnostics collector", () => {
     };
 
     await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       providerHealth: {
         "fake-worktree": { status: "healthy" },
       },

--- a/apps/observer/test/integration/project-commands.test.ts
+++ b/apps/observer/test/integration/project-commands.test.ts
@@ -67,6 +67,41 @@ describe("observer project commands", () => {
     fixture.sqlite.close();
   });
 
+  it("sets a project default harness through config mutation and reconciles the snapshot", async () => {
+    const fixture = await createFixture();
+    const repo = await makeRepo(fixture.root, "web");
+    await fixture.queue.dispatch({ type: "project.add", payload: { path: repo } });
+    await fixture.queue.drain();
+
+    const receipt = await fixture.queue.dispatch({
+      type: "project.setDefaultHarness",
+      payload: { projectId: "web", harness: "other-harness" },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    await expect(
+      loadConfig({ configPath: fixture.configPath, homeDir: fixture.root }),
+    ).resolves.toMatchObject({
+      projects: [
+        expect.objectContaining({
+          defaults: expect.objectContaining({ harness: "other-harness" }),
+        }),
+      ],
+    });
+    expect(fixture.core.getSnapshot()).toMatchObject({
+      projects: [
+        expect.objectContaining({
+          defaults: expect.objectContaining({ harness: "other-harness" }),
+        }),
+      ],
+    });
+
+    fixture.sqlite.close();
+  });
+
   it("records safe command failures for invalid project additions", async () => {
     const fixture = await createFixture();
     const folder = join(fixture.root, "not-git");

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,11 +11,23 @@ Status: current living doc for development, test, and documentation workflow.
 
 ## Local TUI Workflow
 
+| Need | Command | Boundary |
+| --- | --- | --- |
+| Normal run | `pnpm stn` / `pnpm stn tui` | Built CLI, configured observer |
+| UI hot reload against the selected observer | `pnpm station:ui-dev` | Bun renderer only |
+| CLI/package-output watcher | `pnpm dev` / `pnpm station:tui-dev` | Isolated by default, not Bun HMR |
+| Isolated Station sandbox | `pnpm station:devbox` | Isolated observer, host, state, and supported hooks |
+| Isolated Station sandbox with UI HMR | `pnpm station:devbox dev` | Same devbox isolation, Bun renderer hot reload |
+
+Do not use `station:dev` as a catch-all name until it truthfully owns the UI,
+CLI/package, observer, provider, protocol, and host restart boundaries.
+
 - `pnpm stn` opens the normal station popup from the current checkout's built CLI when run inside tmux.
 - `pnpm stn tui` opens the normal station TUI fullscreen from the current checkout's built CLI.
 - Normal tmux popup fast-path registrations are scoped to the checkout root that created them. A popup launcher from another checkout ignores and clears stale normal popup metadata before falling back to that checkout's CLI.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
-- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
+- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, so its observer `state_dir`, socket, and supported harness hook homes cannot collide with another checkout's runtime. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
+- `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.
 - `pnpm station:reset` clears station tmux popup registrations for the current checkout and opens station normally from built code. Inside tmux that means a fresh popup; outside tmux that means the fullscreen TUI.
 - `pnpm station:reset:tmux-tui` is the heavier tmux TUI refresh for this checkout. It requires clean `main`, pulls `origin/main`, clears only station TUI/popup tmux state, rebuilds, restarts the observer, then opens station from the rebuilt checkout. It does not kill worktree sessions or harness agents.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -86,6 +86,7 @@ the same running agent), one command does everything:
 ```bash
 # preferred: one command from any checkout/worktree root (builds first if needed)
 pnpm station:devbox               # start the isolated observer + Station
+pnpm station:devbox dev           # same sandbox, with Bun hot reload for station/src/**
 pnpm station:devbox restart       # rebuild + recycle the observer (agents survive)
 pnpm station:devbox status        # which observer/host am I on? (+ global, read-only)
 pnpm station:devbox logs --follow # tail the isolated observer/host/cli logs
@@ -99,12 +100,14 @@ remain the implementation and still work directly from the package dir:
 ```bash
 cd station
 bun run station:isolated          # isolated observer + persistence flag + Station
+bun run station:isolated dev      # same sandbox, with Bun hot reload
 bun run station:isolated:stop     # tear down the observer + host for this worktree
 ```
 
 `station:isolated` does everything needed for a self-contained sandbox:
 - generates a worktree-local config (`.dev-state/config.toml`: state/socket
-  relocated, `terminal = "noop-terminal"`, persistence flag on);
+  relocated, `terminal = "noop-terminal"`, persistence flag on, supported
+  harness hook flags on);
 - exports `STATION_HOST_ENTRY` (so the host can spawn) and
   `STATION_OBSERVER_SOCKET_PATH` (so Station connects to this observer);
 - sets `CODEX_HOME=.dev-state/codex-home`, seeds it with a symlink to your real
@@ -118,21 +121,29 @@ bun run station:isolated:stop     # tear down the observer + host for this workt
   `CLAUDE_CONFIG_DIR=.dev-state/claude-home` so that install never touches your
   global `~/.claude` and the launched claude reads an isolated config; auth is not
   seeded (see note below);
+- sets `STATION_CURSOR_HOME=.dev-state/cursor-home` and
+  `OPENCODE_CONFIG_DIR=.dev-state/opencode-config`, then installs Cursor and
+  OpenCode hooks there as well;
 - starts the isolated observer and opens Station.
+
+Use `pnpm station:devbox dev` for the same isolated stack with `bun --hot` UI
+reload. It keeps the observer, state, hooks, and host under `.dev-state`, but UI
+edits under `station/src/**` reload in place.
 
 The observer + agents are left running when Station exits, so close/reopen
 reattaches.
 
-> Both **codex** and **claude** get isolated hooks. For claude the script installs
-> the station status hook for the isolated observer — the artifact + script land under
-> `.dev-state/observer`, which is what the launch guard checks, so a claude-default
-> worktree clears the guard. It also exports `CLAUDE_CONFIG_DIR=.dev-state/claude-home`
-> so that install never touches your global `~/.claude/settings.json` and the
-> launched claude reads an isolated config (the observer inherits the env and the
-> host→PTY spawn merges it down). Auth is **not** seeded: on macOS claude keeps
-> credentials in the Keychain (machine-global, not under `CLAUDE_CONFIG_DIR`), so
-> the sandbox stays logged in; on a file-credential platform expect a one-time
-> `claude` login. Your global `~/.claude/settings.json` is never modified.
+> Codex, Claude, Cursor, and OpenCode get isolated hooks/provider homes. For
+> Claude the script installs the station status hook for the isolated observer —
+> the artifact + script land under `.dev-state/observer`, which is what the
+> launch guard checks, so a claude-default worktree clears the guard. It also
+> exports `CLAUDE_CONFIG_DIR=.dev-state/claude-home` so that install never
+> touches your global `~/.claude/settings.json` and the launched claude reads an
+> isolated config (the observer inherits the env and the host→PTY spawn merges it
+> down). Auth is **not** seeded: on macOS claude keeps credentials in the Keychain
+> (machine-global, not under `CLAUDE_CONFIG_DIR`), so the sandbox stays logged in;
+> on a file-credential platform expect a one-time `claude` login. Your global
+> `~/.claude/settings.json` is never modified.
 
 Test the persistence loop:
 1. Open a worktree row → launches a fresh host-backed agent.
@@ -225,19 +236,24 @@ input file and it reloads in place. The split:
 ## 3. Launching via the CLI (`stn tui`)
 
 ```bash
-pnpm dev                                  # rebuild @station/cli on change, then stn tui
-pnpm dev --config /abs/iso-config.toml    # ...against an isolated observer
+pnpm dev                                  # rebuild @station/cli on change, isolated by default
+pnpm dev --config /abs/other-config.toml  # ...against a specific observer/config
 node apps/cli/dist/main.js --config /abs/iso-config.toml tui   # one-shot, no watcher
 ```
 
-`pnpm dev` rebuilds `@station/cli` on change and launches `stn tui`. The CLI
-shells out to the Bun renderer in `station/`: a bare terminal launches the
-**native Station workspace** (its own PTY panes); inside tmux it opens the
-**read-only dashboard** in a tmux popup (tmux owns the panes there). It passes
-`--config` straight through, and `stn tui` auto-starts the observer for the
-configured socket. Because tmux is global, an isolated-state tmux-popup dashboard
-still shows your real tmux agents — that is correct for testing the tmux
-integration (see the tmux gotcha in §1).
+`pnpm dev` rebuilds `@station/cli` on change and launches `stn tui`. With no
+explicit config it generates `.dev-state/tui-dev/config.toml` from your real
+config, relocates the observer `state_dir` and `socket_path` under this checkout,
+and preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that
+observer. The CLI shells out to the Bun renderer in `station/`: a bare terminal
+launches the **native Station workspace** (its own PTY panes); inside tmux it
+opens the **read-only dashboard** in a tmux popup (tmux owns the panes there). It
+passes explicit `--config` choices straight through, and `stn tui` auto-starts
+the observer for the configured socket. The generated default config uses
+`terminal = "noop-terminal"`, so it avoids machine-global tmux pane discovery.
+If you pass an explicit config with `terminal = "tmux"` for tmux-integration
+testing, the popup dashboard can still show your real tmux agents (see the tmux
+gotcha in §1).
 
 > `pnpm dev` rebuilds the **Node CLI**, not the Bun renderer. To hot-reload the
 > Station UI itself as you edit `station/src/**`, use `pnpm station:ui-dev` from §2b.
@@ -299,21 +315,20 @@ snapshots (`*.golden.test.tsx.snap`); `bun test` does not typecheck, so run
 - **"<harness> status hooks are not installed" on launch** → the launch path
   (`externalLaunch.ts` → `assertHooksInstalledOrThrow`) refuses to spawn an agent
   whose status hooks aren't installed *for this observer*, so it never spawns a
-  half-wired agent. codex/claude hooks normally live in your **global** harness
-  home, so you can't install them for the isolated observer without clobbering it.
-  The fix (codex): point `CODEX_HOME` at a wt-local dir and install the hook there
-  — `hooks install` writes `$CODEX_HOME/station.config.toml` + a script under the
-  isolated state dir, never touching `~/.codex`. The agent still needs your login,
-  so seed the isolated home with a symlink to `~/.codex/auth.json` and a copy of
-  `config.toml`. The fix (claude): install the station status hook for the isolated
-  observer — its artifact + script land under the isolated state dir, which is what
-  the guard checks — and set `CLAUDE_CONFIG_DIR` to a wt-local home so the install
-  stays off your global `~/.claude` and the launched claude reads an isolated config;
-  auth isn't seeded because claude stores credentials in the macOS Keychain
-  (machine-global), so the sandbox stays logged in. `station:isolated` does all of
-  this. The generated hooks only fire for STATION-launched sessions (they early-exit
-  unless `STATION_SESSION_ID` and `STATION_WORKTREE_ID` are set), so they never disturb
-  your global agents.
+  half-wired agent. Supported provider hooks normally live in global provider
+  homes (`~/.codex`, `~/.claude`, `~/.cursor`, or `~/.config/opencode`), so the
+  isolated lanes redirect those homes before installing hooks. Codex uses
+  `CODEX_HOME`; Claude uses `CLAUDE_CONFIG_DIR`; Cursor uses `STATION_CURSOR_HOME`;
+  OpenCode uses `OPENCODE_CONFIG_DIR`. Codex auth is a symlink to your real
+  `~/.codex/auth.json`; Claude auth usually comes from the macOS Keychain.
+  The generated hooks only fire for STATION-launched sessions (they early-exit
+  unless `STATION_SESSION_ID` and `STATION_WORKTREE_ID` are set), so they never
+  disturb your global agents.
+  `pnpm dev` / `pnpm station:tui-dev` and `pnpm station:devbox` both do this
+  preflight for Codex, Claude, Cursor, and OpenCode under their own `.dev-state`
+  roots, and launched agents carry the same isolated provider-home env. Crush is
+  cwd-config based (`.crush.json`), so a central dev launcher cannot preconfigure
+  every worktree without writing into those worktrees.
 - **Station connects to the wrong observer** → it reads `STATION_OBSERVER_SOCKET_PATH`;
   point it at the isolated socket. `station:isolated` exports it.
 - **`observer stop` hangs / `OBSERVER_STOP_FAILED`** → an observer mid-reconcile

--- a/integrations/harness/claude/src/launch.ts
+++ b/integrations/harness/claude/src/launch.ts
@@ -21,6 +21,7 @@ export type ClaudeLaunchOptions = {
   defaultApprovalPolicy?: string;
   defaultSandboxMode?: string;
   hookSettingsPath?: string;
+  env?: NodeJS.ProcessEnv;
 };
 
 const CLAUDE_YOLO_FLAG = "--dangerously-skip-permissions";
@@ -73,11 +74,23 @@ function buildClaudeResumeLaunchPlan(
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("claude", request),
+    env: claudeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Claude`,
     providerData,
   };
+}
+
+function claudeLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: ClaudeLaunchOptions,
+): Record<string, string> {
+  const env = harnessLaunchEnv("claude", request);
+  const claudeConfigDir = options.env?.CLAUDE_CONFIG_DIR ?? process.env.CLAUDE_CONFIG_DIR;
+  if (claudeConfigDir !== undefined && claudeConfigDir.length > 0) {
+    env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+  }
+  return env;
 }
 
 export function buildClaudeLaunchPlan(
@@ -134,7 +147,7 @@ export function buildClaudeLaunchPlan(
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("claude", request),
+    env: claudeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Claude`,
     providerData,

--- a/integrations/harness/claude/test/unit/launch.test.ts
+++ b/integrations/harness/claude/test/unit/launch.test.ts
@@ -122,6 +122,17 @@ describe("buildClaudeLaunchPlan", () => {
     });
   });
 
+  it("carries an isolated CLAUDE_CONFIG_DIR into the launch env", () => {
+    const plan = buildClaudeLaunchPlan(request(), {
+      env: { CLAUDE_CONFIG_DIR: "/tmp/station/claude-home" },
+    });
+
+    expect(plan.env).toMatchObject({
+      STATION_HARNESS_PROVIDER: "claude",
+      CLAUDE_CONFIG_DIR: "/tmp/station/claude-home",
+    });
+  });
+
   it("builds non-interactive claude print plans with streamed JSON events", () => {
     const plan = buildClaudeLaunchPlan(
       {

--- a/integrations/harness/codex/src/launch.ts
+++ b/integrations/harness/codex/src/launch.ts
@@ -20,6 +20,7 @@ export type CodexLaunchOptions = {
   defaultApprovalPolicy?: string;
   defaultSandboxMode?: string;
   noAltScreen?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 const CODEX_YOLO_FLAG = "--dangerously-bypass-approvals-and-sandbox";
@@ -80,7 +81,7 @@ export function buildCodexLaunchPlan(
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("codex", request),
+    env: codexLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Codex`,
     providerData,
@@ -133,7 +134,7 @@ function buildCodexResumeLaunchPlan(
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("codex", request),
+    env: codexLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Codex`,
     providerData,
@@ -173,6 +174,18 @@ function appendCodexOptions(
   if (options.noAltScreen === true) {
     args.push("--no-alt-screen");
   }
+}
+
+function codexLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: CodexLaunchOptions,
+): Record<string, string> {
+  const env = harnessLaunchEnv("codex", request);
+  const codexHome = options.env?.CODEX_HOME ?? process.env.CODEX_HOME;
+  if (codexHome !== undefined && codexHome.length > 0) {
+    env.CODEX_HOME = codexHome;
+  }
+  return env;
 }
 
 function codexProviderData(

--- a/integrations/harness/codex/test/unit/launch.test.ts
+++ b/integrations/harness/codex/test/unit/launch.test.ts
@@ -162,6 +162,17 @@ describe("buildCodexLaunchPlan", () => {
     });
   });
 
+  it("carries an isolated CODEX_HOME into the launch env", () => {
+    const plan = buildCodexLaunchPlan(request(), {
+      env: { CODEX_HOME: "/tmp/station/codex-home" },
+    });
+
+    expect(plan.env).toMatchObject({
+      STATION_HARNESS_PROVIDER: "codex",
+      CODEX_HOME: "/tmp/station/codex-home",
+    });
+  });
+
   it("builds non-interactive codex exec plans with JSON events", () => {
     const plan = buildCodexLaunchPlan(
       {

--- a/integrations/harness/cursor/src/hooks/hookPaths.ts
+++ b/integrations/harness/cursor/src/hooks/hookPaths.ts
@@ -14,6 +14,17 @@ export function resolveCursorHooksPath(options: CursorHookPathOptions = {}): str
   if (options.cursorHooksPath !== undefined) {
     return resolveLocalPath(options.cursorHooksPath, options.homeDir);
   }
+  const env = options.env ?? process.env;
+  if (env.STATION_CURSOR_HOOKS_PATH !== undefined && env.STATION_CURSOR_HOOKS_PATH.length > 0) {
+    return resolveLocalPath(env.STATION_CURSOR_HOOKS_PATH, options.homeDir);
+  }
+  if (env.STATION_CURSOR_HOME !== undefined && env.STATION_CURSOR_HOME.length > 0) {
+    return join(
+      resolveLocalPath(env.STATION_CURSOR_HOME, options.homeDir),
+      ".cursor",
+      CURSOR_HOOKS_FILE,
+    );
+  }
   return resolveLocalPath(join("~", ".cursor", CURSOR_HOOKS_FILE), options.homeDir);
 }
 

--- a/integrations/harness/cursor/src/launch.ts
+++ b/integrations/harness/cursor/src/launch.ts
@@ -9,7 +9,20 @@ import { CursorHarnessProviderError } from "./errors.js";
 
 export type CursorLaunchOptions = {
   command?: string;
+  cursorHome?: string;
 };
+
+function cursorLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: CursorLaunchOptions,
+): Record<string, string> {
+  const env = harnessLaunchEnv("cursor", request);
+  const cursorHome = options.cursorHome ?? process.env.STATION_CURSOR_HOME;
+  if (cursorHome !== undefined && cursorHome.length > 0) {
+    env.HOME = cursorHome;
+  }
+  return env;
+}
 
 export function buildCursorLaunchPlan(
   request: BuildHarnessLaunchRequest,
@@ -63,7 +76,7 @@ export function buildCursorLaunchPlan(
     command: options.command ?? "agent",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("cursor", request),
+    env: cursorLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Cursor`,
     providerData,

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -51,6 +51,21 @@ describe("Cursor hook setup", () => {
     await expect(readFile(hookScriptPath, "utf8")).rejects.toThrow();
   });
 
+  it("resolves hook config from STATION_CURSOR_HOME", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
+    const cursorHome = join(root, "cursor-home");
+
+    const plan = await planCursorHooks({
+      env: { STATION_CURSOR_HOME: cursorHome },
+      stationConfigPath: "/tmp/station/config.toml",
+      observerSocketPath: "/tmp/station/run/observer.sock",
+      stateDir: "/tmp/station/state",
+      hookSpoolDir: "/tmp/station/state/spool/hooks",
+    });
+
+    expect(plan.hooksPath).toBe(join(cursorHome, ".cursor", "hooks.json"));
+  });
+
   it("installs, merges hooks.json, writes a 0700 script, and is idempotent", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
     const hooksPath = join(root, "cursor", "hooks.json");

--- a/integrations/harness/cursor/test/unit/provider.test.ts
+++ b/integrations/harness/cursor/test/unit/provider.test.ts
@@ -78,8 +78,8 @@ describe("CursorHarnessProvider", () => {
       homeDir: root,
     });
 
-    const previousHome = process.env.HOME;
-    process.env.HOME = root;
+    const previousCursorHome = process.env.STATION_CURSOR_HOME;
+    process.env.STATION_CURSOR_HOME = root;
     try {
       const provider = createCursorHarnessProvider({
         installHooks: true,
@@ -97,10 +97,10 @@ describe("CursorHarnessProvider", () => {
         }),
       );
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
+      if (previousCursorHome === undefined) {
+        delete process.env.STATION_CURSOR_HOME;
       } else {
-        process.env.HOME = previousHome;
+        process.env.STATION_CURSOR_HOME = previousCursorHome;
       }
     }
   });
@@ -130,6 +130,27 @@ describe("CursorHarnessProvider", () => {
         terminalTargetId: "tmux:station:@1:%2",
       },
     });
+  });
+
+  it("launches Cursor with the isolated dev home when configured", async () => {
+    const previousCursorHome = process.env.STATION_CURSOR_HOME;
+    process.env.STATION_CURSOR_HOME = "/tmp/station/cursor-home";
+    try {
+      const provider = createCursorHarnessProvider({ command: "agent-test" });
+
+      await expect(provider.buildLaunch(request())).resolves.toMatchObject({
+        env: {
+          HOME: "/tmp/station/cursor-home",
+          STATION_HARNESS_PROVIDER: "cursor",
+        },
+      });
+    } finally {
+      if (previousCursorHome === undefined) {
+        delete process.env.STATION_CURSOR_HOME;
+      } else {
+        process.env.STATION_CURSOR_HOME = previousCursorHome;
+      }
+    }
   });
 
   it("launches interactive Cursor resume with the native session id", async () => {

--- a/integrations/harness/opencode/src/launch.ts
+++ b/integrations/harness/opencode/src/launch.ts
@@ -22,6 +22,7 @@ export type OpenCodeLaunchOptions = {
   observerSocketPath?: string;
   stateDir?: string;
   hookSpoolDir?: string;
+  env?: NodeJS.ProcessEnv;
 };
 
 export function buildOpenCodeLaunchPlan(
@@ -71,7 +72,7 @@ export function buildOpenCodeLaunchPlan(
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("opencode", request, options),
+    env: openCodeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
     providerData: commonProviderData(providerDataInput),
@@ -109,7 +110,7 @@ function buildOpenCodeResumeLaunchPlan(
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("opencode", request, options),
+    env: openCodeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
     providerData: commonProviderData({
@@ -119,6 +120,18 @@ function buildOpenCodeResumeLaunchPlan(
       resumeTargetKind: request.resume.target.kind,
     }),
   };
+}
+
+function openCodeLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: OpenCodeLaunchOptions,
+): Record<string, string> {
+  const env = harnessLaunchEnv("opencode", request, options);
+  const opencodeConfigDir = options.env?.OPENCODE_CONFIG_DIR ?? process.env.OPENCODE_CONFIG_DIR;
+  if (opencodeConfigDir !== undefined && opencodeConfigDir.length > 0) {
+    env.OPENCODE_CONFIG_DIR = opencodeConfigDir;
+  }
+  return env;
 }
 
 function interactiveArgs(_request: BuildHarnessLaunchRequest): string[] {

--- a/integrations/harness/opencode/src/pluginInstall.ts
+++ b/integrations/harness/opencode/src/pluginInstall.ts
@@ -145,11 +145,9 @@ export function resolveOpenCodeConfigDir(options: OpenCodePluginPlanOptions = {}
   if (options.opencodeConfigDir !== undefined) {
     return options.opencodeConfigDir;
   }
-  if (
-    options.env?.OPENCODE_CONFIG_DIR !== undefined &&
-    options.env.OPENCODE_CONFIG_DIR.length > 0
-  ) {
-    return options.env.OPENCODE_CONFIG_DIR;
+  const env = options.env ?? process.env;
+  if (env.OPENCODE_CONFIG_DIR !== undefined && env.OPENCODE_CONFIG_DIR.length > 0) {
+    return env.OPENCODE_CONFIG_DIR;
   }
   return join(options.homeDir ?? homedir(), ".config", "opencode");
 }

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -110,6 +110,9 @@ function buildLaunch(
   if (options.hookSpoolDir !== undefined) {
     launchOptions.hookSpoolDir = options.hookSpoolDir;
   }
+  if (options.env !== undefined) {
+    launchOptions.env = options.env;
+  }
   return buildOpenCodeLaunchPlan(request, launchOptions);
 }
 

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -8,6 +8,7 @@ import {
   doctorOpenCodePlugin,
   installOpenCodePlugin,
   planOpenCodePlugin,
+  resolveOpenCodeConfigDir,
   resolveOpenCodePluginPath,
   uninstallOpenCodePlugin,
 } from "../../src/pluginInstall";
@@ -43,6 +44,20 @@ describe("OpenCode plugin setup", () => {
     expect(plan.after).toContain('"session.next.tool.input.delta"');
     expect(plan.after).toContain("/tmp/station/run/observer.sock");
     await expect(readFile(pluginPath, "utf8")).rejects.toThrow();
+  });
+
+  it("resolves config dir from OPENCODE_CONFIG_DIR in process env", async () => {
+    const previous = process.env.OPENCODE_CONFIG_DIR;
+    process.env.OPENCODE_CONFIG_DIR = "/tmp/station/opencode-config";
+    try {
+      expect(resolveOpenCodeConfigDir()).toBe("/tmp/station/opencode-config");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR;
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = previous;
+      }
+    }
   });
 
   it("installs, reports idempotence, and uninstalls only the generated plugin", async () => {

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -161,6 +161,19 @@ describe("OpenCodeHarnessProvider", () => {
     });
   });
 
+  it("carries an isolated OPENCODE_CONFIG_DIR into the launch env", async () => {
+    const provider = createOpenCodeHarnessProvider({
+      env: { OPENCODE_CONFIG_DIR: "/tmp/station/opencode-config" },
+    });
+
+    await expect(provider.buildLaunch(request())).resolves.toMatchObject({
+      env: {
+        STATION_HARNESS_PROVIDER: "opencode",
+        OPENCODE_CONFIG_DIR: "/tmp/station/opencode-config",
+      },
+    });
+  });
+
   it("launches interactive OpenCode resume with the native session id", async () => {
     const provider = createOpenCodeHarnessProvider({
       command: "opencode-test",

--- a/packages/config/src/projects/index.ts
+++ b/packages/config/src/projects/index.ts
@@ -2,6 +2,7 @@ export { addProjectToConfig } from "./add.js";
 export { doctorProject } from "./doctor.js";
 export { findGitRoot, resolveExistingDirectory } from "./git.js";
 export { removeProjectFromConfig } from "./remove.js";
+export { setProjectDefaultHarnessInConfig } from "./setDefaultHarness.js";
 export type {
   AddProjectToConfigOptions,
   AddProjectToConfigResult,
@@ -9,4 +10,6 @@ export type {
   ProjectDoctorResult,
   RemoveProjectFromConfigOptions,
   RemoveProjectFromConfigResult,
+  SetProjectDefaultHarnessOptions,
+  SetProjectDefaultHarnessResult,
 } from "./types.js";

--- a/packages/config/src/projects/setDefaultHarness.ts
+++ b/packages/config/src/projects/setDefaultHarness.ts
@@ -1,0 +1,49 @@
+import { loadConfig, loadConfigFromToml } from "../load/index.js";
+import { projectConfigSafeError } from "./errors.js";
+import { atomicWriteConfig, loadConfigSource } from "./source.js";
+import { setProjectDefaultHarness } from "./tomlBlocks.js";
+import type { SetProjectDefaultHarnessOptions, SetProjectDefaultHarnessResult } from "./types.js";
+
+export async function setProjectDefaultHarnessInConfig(
+  options: SetProjectDefaultHarnessOptions,
+): Promise<SetProjectDefaultHarnessResult> {
+  const loaded = await loadConfigSource(options);
+  const project = loaded.loaded.projects.find((candidate) => candidate.id === options.projectId);
+  if (project === undefined) {
+    throw projectConfigSafeError({
+      code: "PROJECT_NOT_CONFIGURED",
+      message: `Project "${options.projectId}" is not configured.`,
+      projectId: options.projectId,
+    });
+  }
+
+  if (project.defaults.harness === options.harness) {
+    return {
+      status: "unchanged",
+      configPath: loaded.configPath,
+      projectId: options.projectId,
+      harness: options.harness,
+      config: loaded.loaded.config,
+    };
+  }
+
+  const candidateSource = setProjectDefaultHarness(
+    loaded.source,
+    options.projectId,
+    options.harness,
+  );
+  await loadConfigFromToml(candidateSource, {
+    configPath: loaded.configPath,
+    homeDir: loaded.homeDir,
+  });
+  await atomicWriteConfig(loaded.configPath, candidateSource);
+  const after = await loadConfig({ configPath: loaded.configPath, homeDir: loaded.homeDir });
+
+  return {
+    status: "updated",
+    configPath: loaded.configPath,
+    projectId: options.projectId,
+    harness: options.harness,
+    config: after.config,
+  };
+}

--- a/packages/config/src/projects/tomlBlocks.ts
+++ b/packages/config/src/projects/tomlBlocks.ts
@@ -28,6 +28,55 @@ export function removeProjectBlock(source: string, projectId: string): string {
   return `${insertTopLevelEmptyProjectsAssignment(sourceWithoutBlock)}\n`;
 }
 
+export function setProjectDefaultHarness(
+  source: string,
+  projectId: string,
+  harness: string,
+): string {
+  const lines = source.split("\n");
+  const blocks = projectBlocks(lines);
+  const block = blocks.find((candidate) => projectBlockId(candidate.lines) === projectId);
+  if (block === undefined) {
+    throw projectConfigSafeError({
+      code: "PROJECT_BLOCK_NOT_FOUND",
+      message: `Could not find a [[projects]] block for "${projectId}" in config.toml.`,
+      projectId,
+    });
+  }
+
+  const defaultsStart = block.lines.findIndex(isProjectDefaultsTable);
+  if (defaultsStart !== -1) {
+    const start = block.start + defaultsStart;
+    const end = nextProjectSubtableIndex(lines, start + 1, block.end);
+    const harnessIndex = lines
+      .slice(start + 1, end)
+      .findIndex((line) => /^\s*harness\s*=/.test(line));
+    if (harnessIndex !== -1) {
+      const absolute = start + 1 + harnessIndex;
+      const nextLines = [...lines];
+      nextLines[absolute] = `harness = ${quoteTomlString(harness)}`;
+      return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+    }
+    const nextLines = [
+      ...lines.slice(0, start + 1),
+      `harness = ${quoteTomlString(harness)}`,
+      ...lines.slice(start + 1),
+    ];
+    return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+  }
+
+  const insertAt = firstProjectSubtableIndex(block.lines);
+  const absoluteInsertAt = insertAt === -1 ? block.end : block.start + insertAt;
+  const nextLines = [
+    ...lines.slice(0, absoluteInsertAt),
+    "",
+    "[projects.defaults]",
+    `harness = ${quoteTomlString(harness)}`,
+    ...lines.slice(absoluteInsertAt),
+  ];
+  return `${trimRepeatedBlankLines(nextLines).join("\n").trimEnd()}\n`;
+}
+
 function projectBlocks(lines: string[]): Array<{ start: number; end: number; lines: string[] }> {
   const blocks: Array<{ start: number; end: number; lines: string[] }> = [];
   for (let index = 0; index < lines.length; index += 1) {
@@ -61,6 +110,23 @@ function projectBlockId(lines: readonly string[]): string | undefined {
 
 function isProjectArrayTable(line: string): boolean {
   return /^\s*\[\[\s*projects\s*\]\]\s*(?:#.*)?$/.test(line);
+}
+
+function isProjectDefaultsTable(line: string): boolean {
+  return /^\s*\[\s*projects\.defaults\s*\]\s*(?:#.*)?$/.test(line);
+}
+
+function firstProjectSubtableIndex(lines: readonly string[]): number {
+  return lines.findIndex((line) => /^\s*\[\s*projects\.[^\]]+\]\s*(?:#.*)?$/.test(line));
+}
+
+function nextProjectSubtableIndex(lines: readonly string[], start: number, end: number): number {
+  for (let index = start; index < end; index += 1) {
+    if (/^\s*\[\s*projects\.[^\]]+\]\s*(?:#.*)?$/.test(lines[index] ?? "")) {
+      return index;
+    }
+  }
+  return end;
 }
 
 function isNonProjectTable(line: string): boolean {

--- a/packages/config/src/projects/types.ts
+++ b/packages/config/src/projects/types.ts
@@ -40,6 +40,21 @@ export type RemoveProjectFromConfigResult = {
   config: StationConfig;
 };
 
+export type SetProjectDefaultHarnessOptions = {
+  projectId: string;
+  harness: string;
+  configPath?: string;
+  homeDir?: string;
+};
+
+export type SetProjectDefaultHarnessResult = {
+  status: "updated" | "unchanged";
+  configPath: string;
+  projectId: string;
+  harness: string;
+  config: StationConfig;
+};
+
 export type ProjectDoctorResult = {
   project: ProjectConfig;
   rootExists: boolean;

--- a/packages/config/test/unit/project-mutation.test.ts
+++ b/packages/config/test/unit/project-mutation.test.ts
@@ -6,6 +6,7 @@ import {
   ConfigError,
   loadConfig,
   removeProjectFromConfig,
+  setProjectDefaultHarnessInConfig,
 } from "@station/config";
 import { describe, expect, it } from "vitest";
 
@@ -185,5 +186,91 @@ root = ${JSON.stringify(web)}
     const loaded = await loadConfig({ configPath, homeDir: tempDir });
     expect(loaded.projects).toEqual([]);
     await expect(readFile(configPath, "utf8")).resolves.toContain("projects = []");
+  });
+
+  it("sets a project default harness on a minimal project block", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+`,
+    );
+
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    expect(result.status).toBe("updated");
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    expect(loaded.projects[0]?.defaults.harness).toBe("opencode");
+    const source = await readFile(configPath, "utf8");
+    expect(source).toContain('[projects.defaults]\nharness = "opencode"');
+  });
+
+  it("replaces an existing project default harness", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+
+[projects.defaults]
+harness = "codex"
+layout = "agent-shell"
+`,
+    );
+
+    await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "opencode",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    const source = await readFile(configPath, "utf8");
+    expect(source).toContain('[projects.defaults]\nharness = "opencode"\nlayout = "agent-shell"');
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    expect(loaded.projects[0]?.defaults).toEqual({
+      harness: "opencode",
+      terminal: "tmux",
+      layout: "agent-shell",
+    });
+  });
+
+  it("does not write when the selected project harness is already effective", async () => {
+    const tempDir = await makeTempDir();
+    const web = await makeRepo(tempDir, "web");
+    const configPath = await writeBaseConfig(
+      tempDir,
+      `
+[[projects]]
+id = "web"
+label = "web"
+root = ${JSON.stringify(web)}
+`,
+    );
+    const before = await readFile(configPath, "utf8");
+
+    const result = await setProjectDefaultHarnessInConfig({
+      projectId: "web",
+      harness: "codex",
+      configPath,
+      homeDir: tempDir,
+    });
+
+    expect(result.status).toBe("unchanged");
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
   });
 });

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -206,6 +206,15 @@ export const RemoveProjectPayloadSchema = z
 
 export type RemoveProjectPayload = z.infer<typeof RemoveProjectPayloadSchema>;
 
+export const SetProjectDefaultHarnessPayloadSchema = z
+  .object({
+    projectId: ProjectIdSchema,
+    harness: ProviderIdSchema,
+  })
+  .strict();
+
+export type SetProjectDefaultHarnessPayload = z.infer<typeof SetProjectDefaultHarnessPayloadSchema>;
+
 export const InstallHooksPayloadSchema = z
   .object({
     provider: ProviderIdSchema,
@@ -229,6 +238,7 @@ export const StationCommandTypeSchema = z.enum([
   "observer.reconcile",
   "project.add",
   "project.remove",
+  "project.setDefaultHarness",
   "hooks.install",
 ]);
 
@@ -288,6 +298,13 @@ export const RemoveProjectCommandSchema = z
   .object({ type: z.literal("project.remove"), payload: RemoveProjectPayloadSchema })
   .strict();
 
+export const SetProjectDefaultHarnessCommandSchema = z
+  .object({
+    type: z.literal("project.setDefaultHarness"),
+    payload: SetProjectDefaultHarnessPayloadSchema,
+  })
+  .strict();
+
 export const InstallHooksCommandSchema = z
   .object({ type: z.literal("hooks.install"), payload: InstallHooksPayloadSchema })
   .strict();
@@ -307,6 +324,7 @@ export const StationCommandSchema = z.discriminatedUnion("type", [
   ObserverReconcileCommandSchema,
   AddProjectCommandSchema,
   RemoveProjectCommandSchema,
+  SetProjectDefaultHarnessCommandSchema,
   InstallHooksCommandSchema,
 ]);
 

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.5.0" as const;
+export const STATION_SCHEMA_VERSION = "0.6.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -83,7 +83,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.5.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.6.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -662,6 +662,7 @@ describe("contract schemas", () => {
       "observer.reconcile",
       "project.add",
       "project.remove",
+      "project.setDefaultHarness",
       "session.acknowledgeTurn",
       "session.close",
       "session.create",

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -268,6 +268,7 @@ export function isModalOverlayActive(screen: TuiScreen): boolean {
   return (
     screen.name === "help" ||
     screen.name === "newSession" ||
+    screen.name === "projectDefaultAgent" ||
     screen.name === "removeWorktree" ||
     (screen.name === "renameSession" && screen.step === "editName")
   );

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -34,5 +34,6 @@ export * from "./state/operations/renameSession.js";
 export * from "./state/operations/runtimeCommands.js";
 export * from "./state/operations/startAgent.js";
 export * from "./state/operations/types.js";
+export * from "./state/screens/projectDefaultAgent.js";
 export * from "./state/screens/removeWorktree.js";
 export * from "./state/screens/sessionRows.js";

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -31,6 +31,11 @@ export type RenameSessionCommandInput = {
   title: string;
 };
 
+export type SetProjectDefaultHarnessCommandInput = {
+  projectId: ProjectView["id"];
+  harness: ProviderId;
+};
+
 export type BuildFocusCommandOptions = {
   origin?: TerminalFocusOrigin;
 };
@@ -162,6 +167,18 @@ export function buildRenameSessionCommand(input: RenameSessionCommandInput): Sta
     payload: {
       sessionId: input.sessionId,
       title: input.title,
+    },
+  };
+}
+
+export function buildSetProjectDefaultHarnessCommand(
+  input: SetProjectDefaultHarnessCommandInput,
+): Extract<StationCommand, { type: "project.setDefaultHarness" }> {
+  return {
+    type: "project.setDefaultHarness",
+    payload: {
+      projectId: input.projectId,
+      harness: input.harness,
     },
   };
 }

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -15,6 +15,7 @@ export type TuiInputMode =
   | "newSessionEditName"
   | "newSessionPickProject"
   | "newSessionPickAgent"
+  | "projectDefaultAgent"
   | "addProject";
 
 export function deriveTuiInputMode(state: TuiState): TuiInputMode {
@@ -46,6 +47,8 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
       break;
     case "addProject":
       return "addProject";
+    case "projectDefaultAgent":
+      return "projectDefaultAgent";
   }
   return "dashboard";
 }
@@ -516,6 +519,22 @@ export const TUI_KEYMAP: Record<TuiInputMode, readonly TuiBinding[]> = {
       id: "tui.newSessionAgent.choose",
       pattern: { kind: "slot" },
       action: "tui.newSession.chooseAgent",
+      outcome: "handled",
+      help: { keys: "1-9 a-z", label: "choose agent" },
+    },
+  ],
+  projectDefaultAgent: [
+    {
+      id: "tui.projectDefaultAgent.cancel",
+      pattern: { kind: "named", named: "escape" },
+      action: "tui.projectDefaultAgent.cancel",
+      outcome: "handled",
+      help: { keys: "esc", label: "cancel" },
+    },
+    {
+      id: "tui.projectDefaultAgent.choose",
+      pattern: { kind: "slot" },
+      action: "tui.projectDefaultAgent.choose",
       outcome: "handled",
       help: { keys: "1-9 a-z", label: "choose agent" },
     },

--- a/packages/dashboard-core/src/state/operations/localOperationRunner.ts
+++ b/packages/dashboard-core/src/state/operations/localOperationRunner.ts
@@ -1,6 +1,6 @@
 import type { CommandId, SafeError, StationCommand, StationEvent } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
-import { safeErrorToToast } from "../../services/errors/errors.js";
+import { safeErrorToToast, toSafeError } from "../../services/errors/errors.js";
 import type { TuiFolderService } from "../../services/folderService.js";
 import type { TuiObserverService } from "../../services/types.js";
 import {
@@ -215,6 +215,14 @@ export function createTuiLocalOperationRunner(input: {
         if (operation.type === "addProject") {
           void runAddProjectOperation(store(), input.service, operation.command, input.clientLabel);
         }
+        if (operation.type === "setProjectDefaultHarness") {
+          void runSetProjectDefaultHarnessOperation(
+            store(),
+            input.service,
+            operation.command,
+            input.clientLabel,
+          );
+        }
       }
     },
     prepareCommandFailedEvent: (event) => {
@@ -242,6 +250,46 @@ export function createTuiLocalOperationRunner(input: {
       };
     },
   };
+}
+
+async function runSetProjectDefaultHarnessOperation(
+  store: StoreApi<TuiStore>,
+  service: TuiObserverService,
+  command: Extract<StationCommand, { type: "project.setDefaultHarness" }>,
+  clientLabel: string,
+): Promise<void> {
+  try {
+    const receipt = await service.dispatch(command);
+    if (!receipt.accepted) {
+      addSafeCommandToast(
+        store,
+        receipt.error ?? {
+          tag: "CommandExecutionError",
+          code: "COMMAND_REJECTED",
+          message: `${command.type} was rejected.`,
+        },
+      );
+      return;
+    }
+    const completion = await service.waitForCommandCompletion(receipt.commandId);
+    if (completion.status === "failed") {
+      addSafeCommandToast(store, completion.error);
+      return;
+    }
+    const snapshot = await service.loadSnapshot();
+    store.setState(
+      addTuiToast(replaceSnapshot(store.getState(), snapshot), {
+        kind: "success",
+        message: `Default agent set to ${command.payload.harness}.`,
+      }),
+    );
+  } catch (error: unknown) {
+    addSafeCommandToast(store, toSafeError(error, { clientLabel }));
+  }
+}
+
+function addSafeCommandToast(store: StoreApi<TuiStore>, error: SafeError): void {
+  store.setState(addTuiToast(store.getState(), safeErrorToToast(error)));
 }
 
 async function runLoadProjectDirectoryOperation(

--- a/packages/dashboard-core/src/state/operations/types.ts
+++ b/packages/dashboard-core/src/state/operations/types.ts
@@ -63,6 +63,13 @@ export type AddProjectOperation = {
   command: Extract<StationCommand, { type: "project.add" }>;
 };
 
+export type SetProjectDefaultHarnessOperation = {
+  type: "setProjectDefaultHarness";
+  projectId: string;
+  harness: ProviderId;
+  command: Extract<StationCommand, { type: "project.setDefaultHarness" }>;
+};
+
 export type TuiOperation =
   | CreateSessionOperation
   | RemoveWorktreeOperation
@@ -72,4 +79,5 @@ export type TuiOperation =
   | LoadProjectDirectoryOperation
   | ReviewProjectFolderOperation
   | SearchProjectDirectoriesOperation
-  | AddProjectOperation;
+  | AddProjectOperation
+  | SetProjectDefaultHarnessOperation;

--- a/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
+++ b/packages/dashboard-core/src/state/screens/projectDefaultAgent.ts
@@ -1,0 +1,69 @@
+import {
+  choiceValueByKey,
+  isSelectionKey,
+  selectNewSessionHarnessChoices,
+} from "../../selectors/selectors.js";
+import { buildSetProjectDefaultHarnessCommand } from "../commandBuilders.js";
+import type { TuiKey } from "../keys.js";
+import type { TuiTransition } from "../transition.js";
+import type { TuiState } from "../types.js";
+
+export function openProjectDefaultAgentPicker(state: TuiState, projectId: string): TuiState {
+  if (state.snapshot === undefined) {
+    return state;
+  }
+  const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined || project.health.status === "unavailable") {
+    return state;
+  }
+  return {
+    ...state,
+    screen: { name: "projectDefaultAgent", projectId: project.id },
+  };
+}
+
+export function handleProjectDefaultAgentKey(state: TuiState, key: TuiKey): TuiTransition {
+  if (state.screen.name !== "projectDefaultAgent") {
+    return { state };
+  }
+  const projectId = state.screen.projectId;
+  if (key.escape === true) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (state.snapshot === undefined) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (!isSelectionKey(key.input)) {
+    return { state };
+  }
+
+  const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  const option = choiceValueByKey(
+    selectNewSessionHarnessChoices(state.snapshot, project),
+    key.input,
+  );
+  if (option === undefined) {
+    return { state };
+  }
+  if (option.id === project.defaults.harness) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+
+  return {
+    state: { ...state, screen: { name: "dashboard" } },
+    operations: [
+      {
+        type: "setProjectDefaultHarness",
+        projectId: project.id,
+        harness: option.id,
+        command: buildSetProjectDefaultHarnessCommand({
+          projectId: project.id,
+          harness: option.id,
+        }),
+      },
+    ],
+  };
+}

--- a/packages/dashboard-core/src/state/transition.ts
+++ b/packages/dashboard-core/src/state/transition.ts
@@ -6,6 +6,7 @@ import { handleDashboardKey } from "./screens/dashboard.js";
 import { handleHelpKey } from "./screens/help.js";
 import { handleNewSessionKey } from "./screens/newSession.js";
 import { handleProjectCollapseKey } from "./screens/projectCollapse.js";
+import { handleProjectDefaultAgentKey } from "./screens/projectDefaultAgent.js";
 import { handleRemoveWorktreeKey } from "./screens/removeWorktree.js";
 import { handleRenameSessionKey } from "./screens/renameSession.js";
 import { handleSearchKey } from "./screens/search.js";
@@ -52,6 +53,8 @@ export function handleTuiKey(
       return handleRenameSessionKey(state, key);
     case "newSession":
       return handleNewSessionKey(state, key);
+    case "projectDefaultAgent":
+      return handleProjectDefaultAgentKey(state, key);
     case "addProject":
       return handleAddProjectKey(state, key);
   }

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ProjectId,
   SafeError,
   SessionId,
   StationSnapshot,
@@ -75,7 +76,8 @@ export type TuiScreen =
       validationError?: string;
     }
   | { name: "addProject"; flow: AddProjectFlowState }
-  | { name: "newSession"; flow: NewSessionFlowState };
+  | { name: "newSession"; flow: NewSessionFlowState }
+  | { name: "projectDefaultAgent"; projectId: ProjectId };
 
 export type CreateInitialTuiStateOptions = {
   initialSnapshot?: StationSnapshot;

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -4,6 +4,7 @@ import {
   deriveTuiInputMode,
   handleTuiKey,
   matchingTuiBindings,
+  openProjectDefaultAgentPicker,
   TUI_KEYMAP,
   type TuiInputMode,
   type TuiTransition,
@@ -22,6 +23,7 @@ const ALLOWED_NOOP_BINDINGS = new Set([
   "tui.rename.chooseSlot",
   "tui.newSessionProject.choose",
   "tui.newSessionAgent.choose",
+  "tui.projectDefaultAgent.choose",
   // Add-project metadata is a union over its internal submodes.
   "tui.addProject.cancel",
   "tui.addProject.confirm",
@@ -83,6 +85,7 @@ function representativeStates(): Record<TuiInputMode, TuiState> {
     newSessionEditName: drive(base, [{ input: "N" }, { input: "N" }]),
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
     newSessionPickAgent: drive(base, [{ input: "N" }, { input: "A" }]),
+    projectDefaultAgent: openProjectDefaultAgentPicker(base, "web"),
     addProject: drive(base, [{ input: "A" }]),
   };
 }

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -1,4 +1,9 @@
-import { createInitialTuiState, handleTuiKey, openRenameEditForRow } from "@station/dashboard-core";
+import {
+  createInitialTuiState,
+  handleTuiKey,
+  openProjectDefaultAgentPicker,
+  openRenameEditForRow,
+} from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import {
   createCommandSnapshot,
@@ -551,6 +556,53 @@ describe("TUI screen transitions", () => {
         },
       },
     });
+  });
+
+  it("opens and cancels the project default agent picker", () => {
+    const state = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+    const opened = openProjectDefaultAgentPicker(state, "web");
+
+    expect(opened.screen).toEqual({ name: "projectDefaultAgent", projectId: "web" });
+    expect(handleTuiKey(opened, { input: "", escape: true }).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+
+  it("sets a project default agent from the picker", () => {
+    const state = openProjectDefaultAgentPicker(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "web",
+    );
+
+    const transition = handleTuiKey(state, { input: "2" });
+
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.operations).toEqual([
+      {
+        type: "setProjectDefaultHarness",
+        projectId: "web",
+        harness: "opencode",
+        command: {
+          type: "project.setDefaultHarness",
+          payload: {
+            projectId: "web",
+            harness: "opencode",
+          },
+        },
+      },
+    ]);
+  });
+
+  it("closes the project default agent picker without dispatching when selection is unchanged", () => {
+    const state = openProjectDefaultAgentPicker(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "web",
+    );
+
+    const transition = handleTuiKey(state, { input: "1" });
+
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.operations).toBeUndefined();
   });
 
   it("adds a safe error toast when no project exists for a new session", () => {

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -158,17 +158,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       generatedAt: now,
       observer: {
         pid: 1234,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.5.0",
+      "schemaVersion": "0.6.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -309,7 +309,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.5.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.6.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/packages/provider-hooks/test/unit/command.test.ts
+++ b/packages/provider-hooks/test/unit/command.test.ts
@@ -33,7 +33,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -88,7 +88,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.5.0",
+            schemaVersion: "0.6.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -128,7 +128,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               hookId: event.hookId ?? "hook_crush_1",
               provider: event.provider,
               event: event.event,
@@ -197,7 +197,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -262,7 +262,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -382,7 +382,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -449,7 +449,7 @@ describe("provider hook ingress command", () => {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => {
               observedReport = report;
               return {
-                schemaVersion: "0.5.0",
+                schemaVersion: "0.6.0",
                 reportId: report.reportId,
                 provider: report.provider,
                 eventType: report.eventType,
@@ -498,7 +498,7 @@ describe("provider hook ingress command", () => {
           observedTimeoutMs = options.timeoutMs;
           return {
             reportHarnessEvent: async (report): Promise<HarnessEventReportReceipt> => ({
-              schemaVersion: "0.5.0",
+              schemaVersion: "0.6.0",
               reportId: report.reportId,
               provider: report.provider,
               eventType: report.eventType,

--- a/scripts/station-devbox.mjs
+++ b/scripts/station-devbox.mjs
@@ -18,10 +18,11 @@ const LOG_DIR = join(DS, "observer", "logs");
 const STATION_DIR = join(repoRoot, "station");
 const ISOLATED_SCRIPT = join(repoRoot, "station", "scripts", "station-isolated.sh");
 
-const handlers = { start, restart, status, logs, stop, reset, help };
+const handlers = { start, dev, restart, status, logs, stop, reset, help };
 
 const [rawVerb = "start", ...rest] = process.argv.slice(2);
-const verb = rawVerb === "-h" || rawVerb === "--help" ? "help" : rawVerb;
+const verb =
+  rawVerb === "-h" || rawVerb === "--help" ? "help" : rawVerb === "--hot" ? "dev" : rawVerb;
 const handler = handlers[verb];
 if (handler === undefined) {
   process.stderr.write(`Unknown station:devbox command: ${verb}\n\n`);
@@ -40,6 +41,11 @@ function start() {
   // Station UI links are never stale — `station:devbox` needs no separate build.
   run("pnpm", ["build"], { cwd: repoRoot });
   process.exit(run("bun", ["run", "station:isolated"], { cwd: STATION_DIR, check: false }));
+}
+
+function dev() {
+  run("pnpm", ["build"], { cwd: repoRoot });
+  process.exit(run("bun", ["run", "station:isolated", "dev"], { cwd: STATION_DIR, check: false }));
 }
 
 function restart() {
@@ -102,7 +108,7 @@ function stop() {
 
 function reset(args) {
   // Guarded: this deletes the isolated observer DB, diagnostics, hook artifacts,
-  // and the isolated Codex/Claude homes (and any reattachable host state).
+  // isolated provider homes, and any reattachable host state.
   if (!args.some((arg) => arg === "--yes" || arg === "-y")) {
     process.stderr.write(
       `Refusing to reset without --yes. This deletes everything under ${DS}.\n\n` +
@@ -118,9 +124,10 @@ function reset(args) {
 function help() {
   process.stdout.write(
     [
-      "Usage: pnpm station:devbox [start|restart|status|logs|stop|reset]",
+      "Usage: pnpm station:devbox [start|dev|restart|status|logs|stop|reset]",
       "",
       "  start            (default) build if needed, then start the isolated Station sandbox",
+      "  dev, --hot       build if needed, then start the isolated Station sandbox with UI HMR",
       "  restart          rebuild + recycle the isolated observer (persistent host/agents survive)",
       "  status           report the isolated observer/host + (read-only) the global observer",
       "  logs [--follow]  tail the isolated observer/host/cli logs",

--- a/scripts/tui-dev.mjs
+++ b/scripts/tui-dev.mjs
@@ -2,7 +2,8 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { closeSync, openSync, writeSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { copyFile, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -28,26 +29,33 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
 }
 
 export async function runTuiDev({ argv = process.argv.slice(2), env = process.env } = {}) {
-  const devSessionName = env.STATION_TUI_SESSION_NAME ?? defaultDevSessionName;
+  const runtime = await prepareTuiDevRuntime({ argv, env });
+  const devSessionName = runtime.env.STATION_TUI_SESSION_NAME ?? defaultDevSessionName;
   const devTuiCommand =
-    env.STATION_TUI_COMMAND ??
-    shellCommand(["env", "STATION_TUI_DEV=1", process.execPath, tuiWatchRunner, cliEntry]);
+    runtime.env.STATION_TUI_COMMAND ??
+    shellCommand([
+      "env",
+      ...devCommandEnvAssignments(runtime),
+      process.execPath,
+      tuiWatchRunner,
+      cliEntry,
+    ]);
   const devOwner = `${process.pid}:${Date.now()}:${randomUUID()}`;
   const registeredDevTuiCommand =
-    env.STATION_TUI_REGISTERED_COMMAND ??
+    runtime.env.STATION_TUI_REGISTERED_COMMAND ??
     appendShellArgs(devTuiCommand, [
-      ...globalOptionsFromArgs(argv),
+      ...globalOptionsFromArgs(runtime.argv),
       "tui",
       "--popup",
       "--persistent",
     ]);
-  const runDirectTui = shouldRunDirectTui(argv, env);
-  const keepAliveAfterLauncherExit = shouldKeepAliveAfterLauncherExit(argv, env);
+  const runDirectTui = shouldRunDirectTui(runtime.argv, runtime.env);
+  const keepAliveAfterLauncherExit = shouldKeepAliveAfterLauncherExit(runtime.argv, runtime.env);
 
   if (keepAliveAfterLauncherExit) {
     await guardAgainstForeignDevPopup({
       currentRoot: repoRoot,
-      env,
+      env: runtime.env,
     });
   }
 
@@ -60,11 +68,14 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     {
       cwd: repoRoot,
       stdio: "inherit",
-      env,
+      env: runtime.env,
     },
   );
   if (initialBuild.status !== 0) {
     process.exit(initialBuild.status ?? 1);
+  }
+  if (runtime.generated) {
+    installTuiDevHooks(runtime);
   }
 
   const logFd = openSync(logPath, "a");
@@ -91,21 +102,23 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     {
       cwd: repoRoot,
       stdio: ["ignore", logFd, logFd],
-      env,
+      env: runtime.env,
     },
   );
 
   const childEnv = {
-    ...env,
+    ...runtime.env,
     STATION_TUI_DEV: "1",
     STATION_TUI_COMMAND: devTuiCommand,
     STATION_TUI_DEV_OWNER: devOwner,
     STATION_TUI_SESSION_NAME: devSessionName,
   };
-  const nodeArgs = runDirectTui ? [tuiWatchRunner, cliEntry, ...argv] : [cliEntry, ...argv];
+  const nodeArgs = runDirectTui
+    ? [tuiWatchRunner, cliEntry, ...runtime.argv]
+    : [cliEntry, ...runtime.argv];
   if (keepAliveAfterLauncherExit) {
     registerDevPopupPreference({
-      env,
+      env: runtime.env,
       owner: devOwner,
       root: repoRoot,
       sessionName: devSessionName,
@@ -129,8 +142,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!launcherExited) {
       station.kill(signal);
     }
-    clearDevPopupPreference({ env, owner: devOwner });
-    cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+    clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+    cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     if (launcherExited) {
       closeLog();
       process.exitCode = 1;
@@ -148,8 +161,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!launcherExited) {
       station.kill("SIGTERM");
     }
-    clearDevPopupPreference({ env, owner: devOwner });
-    cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+    clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+    cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     closeLog();
     process.exitCode = signal === null ? (code ?? 1) : 1;
   });
@@ -165,8 +178,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!exiting) {
       exiting = true;
       buildWatcher.kill("SIGTERM");
-      clearDevPopupPreference({ env, owner: devOwner });
-      cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+      clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+      cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     }
     closeLog();
     if (signal !== null) {
@@ -175,6 +188,291 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     }
     process.exitCode = code ?? 0;
   });
+}
+
+export async function prepareTuiDevRuntime({ argv = [], env = process.env, root = repoRoot } = {}) {
+  const configFromArgs = configPathFromArgs(argv);
+  if (configFromArgs !== undefined) {
+    return {
+      argv,
+      env: envForExplicitConfig({ env, configPath: configFromArgs, root }),
+      configPath: configFromArgs,
+      generated: false,
+    };
+  }
+
+  const configFromEnv = env.STATION_CONFIG_PATH?.trim();
+  if (configFromEnv !== undefined && configFromEnv.length > 0) {
+    return {
+      argv: ["--config", configFromEnv, ...argv],
+      env: envForExplicitConfig({ env, configPath: configFromEnv, root }),
+      configPath: configFromEnv,
+      generated: false,
+    };
+  }
+
+  const generated = await writeTuiDevConfig({ env, root });
+  const hookEnv = await prepareTuiDevHookEnv({
+    env,
+    checkoutRoot: root,
+    stateRoot: generated.devRoot,
+  });
+  return {
+    argv: ["--config", generated.configPath, ...argv],
+    env: {
+      ...env,
+      ...hookEnv,
+      STATION_CONFIG_PATH: generated.configPath,
+      STATION_OBSERVER_SOCKET_PATH: generated.socketPath,
+    },
+    configPath: generated.configPath,
+    generated: true,
+  };
+}
+
+export async function writeTuiDevConfig({
+  env = process.env,
+  root = repoRoot,
+  readSource = readFile,
+  writeTarget = writeFile,
+  makeDir = mkdir,
+} = {}) {
+  const devRoot = join(root, ".dev-state", "tui-dev");
+  const stateDir = join(devRoot, "observer");
+  const socketPath = join(stateDir, "run", "observer.sock");
+  const configPath = join(devRoot, "config.toml");
+  const sourcePath = join(env.HOME ?? homedir(), ".config", "station", "config.toml");
+
+  let source;
+  try {
+    source = await readSource(sourcePath, "utf8");
+  } catch {
+    source = fallbackConfigSource();
+  }
+
+  const config = withObserverPaths(source, { socketPath, stateDir });
+  await makeDir(join(stateDir, "run"), { recursive: true });
+  await writeTarget(configPath, config, "utf8");
+  return { configPath, socketPath, stateDir, devRoot };
+}
+
+export function configPathFromArgs(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] !== "--config") {
+      continue;
+    }
+    const value = argv[index + 1];
+    return value === undefined || value.startsWith("--") ? undefined : value;
+  }
+  return undefined;
+}
+
+export function withObserverPaths(source, paths) {
+  let next = ensureTomlSection(source.trimEnd(), "observer");
+  next = setTomlStringKey(next, "observer", "socket_path", paths.socketPath);
+  next = setTomlStringKey(next, "observer", "state_dir", paths.stateDir);
+  next = setTomlStringKey(next, "defaults", "terminal", "noop-terminal");
+  next = setTomlBooleanKey(next, "feature_flags", "station_persistent_agents", true);
+  next = setTomlBooleanKey(next, "harness.codex", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.claude", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.cursor", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.opencode", "install_hooks", true);
+  return `${next.trimEnd()}\n`;
+}
+
+export async function prepareTuiDevHookEnv({
+  env = process.env,
+  checkoutRoot = repoRoot,
+  stateRoot = join(repoRoot, ".dev-state", "tui-dev"),
+} = {}) {
+  const homes = tuiDevProviderHomeEnv(stateRoot);
+  await mkdir(homes.CODEX_HOME, { recursive: true });
+  await mkdir(homes.CLAUDE_CONFIG_DIR, { recursive: true });
+  await mkdir(homes.STATION_CURSOR_HOME, { recursive: true });
+  await mkdir(homes.OPENCODE_CONFIG_DIR, { recursive: true });
+
+  const home = env.HOME ?? homedir();
+  await replaceSymlinkIfPresent(
+    join(home, ".codex", "auth.json"),
+    join(homes.CODEX_HOME, "auth.json"),
+  );
+  await copyFileIfMissing(
+    join(home, ".codex", "config.toml"),
+    join(homes.CODEX_HOME, "config.toml"),
+  );
+
+  return {
+    PATH: `${checkoutRoot}/bin${
+      env.PATH === undefined || env.PATH.length === 0 ? "" : `:${env.PATH}`
+    }`,
+    ...homes,
+  };
+}
+
+function envForExplicitConfig({ env, configPath, root }) {
+  const next = { ...env, STATION_CONFIG_PATH: configPath };
+  delete next.STATION_OBSERVER_SOCKET_PATH;
+
+  const generatedHomes = tuiDevProviderHomeEnv(join(root, ".dev-state", "tui-dev"));
+  for (const [name, value] of Object.entries(generatedHomes)) {
+    if (next[name] === value) {
+      delete next[name];
+    }
+  }
+  return next;
+}
+
+function tuiDevProviderHomeEnv(stateRoot) {
+  return {
+    CODEX_HOME: join(stateRoot, "codex-home"),
+    CLAUDE_CONFIG_DIR: join(stateRoot, "claude-home"),
+    STATION_CURSOR_HOME: join(stateRoot, "cursor-home"),
+    OPENCODE_CONFIG_DIR: join(stateRoot, "opencode-config"),
+  };
+}
+
+export function installTuiDevHooks(runtime, runCommand = spawnSync) {
+  for (const harness of ["codex", "claude", "cursor", "opencode"]) {
+    const result = runCommand(
+      process.execPath,
+      [cliEntry, "--config", runtime.configPath, "hooks", "install", harness, "--yes"],
+      {
+        cwd: repoRoot,
+        env: runtime.env,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if ((result.status ?? 1) === 0) {
+      continue;
+    }
+    const detail = [result.stderr, result.stdout]
+      .filter((text) => typeof text === "string" && text.trim().length > 0)
+      .map((text) => text.trim())
+      .join("\n");
+    process.stderr.write(
+      `warning: failed to install ${harness} hooks for isolated dev TUI${
+        detail.length === 0 ? "." : `:\n${detail}\n`
+      }`,
+    );
+  }
+}
+
+function devCommandEnvAssignments(runtime) {
+  const assignments = [["STATION_TUI_DEV", "1"]];
+  for (const name of [
+    "STATION_CONFIG_PATH",
+    "STATION_OBSERVER_SOCKET_PATH",
+    "CODEX_HOME",
+    "CLAUDE_CONFIG_DIR",
+    "STATION_CURSOR_HOME",
+    "OPENCODE_CONFIG_DIR",
+    "PATH",
+  ]) {
+    const value = runtime.env[name];
+    if (value !== undefined && value.length > 0) {
+      assignments.push([name, value]);
+    }
+  }
+  return assignments.map(([name, value]) => `${name}=${value}`);
+}
+
+async function replaceSymlinkIfPresent(source, target) {
+  try {
+    await readFile(source, "utf8");
+    await rm(target, { force: true });
+    await symlink(source, target);
+  } catch {
+    // Missing auth is fine; Codex will prompt/login according to its normal rules.
+  }
+}
+
+async function copyFileIfMissing(source, target) {
+  try {
+    await readFile(target, "utf8");
+    return;
+  } catch {
+    // Continue and copy from the real config if it exists.
+  }
+
+  try {
+    await copyFile(source, target);
+  } catch {
+    // A missing real config is acceptable for fresh machines and tests.
+  }
+}
+
+function fallbackConfigSource() {
+  return [
+    "schema_version = 1",
+    "projects = []",
+    "",
+    "[observer]",
+    'socket_path = ""',
+    'state_dir = ""',
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    'harness = "codex"',
+    'layout = "agent-shell"',
+    "",
+  ].join("\n");
+}
+
+function ensureTomlSection(source, section) {
+  if (tomlSectionBounds(source, section) !== undefined) {
+    return source;
+  }
+  return `${source.trimEnd()}\n\n[${section}]\n`;
+}
+
+function setTomlStringKey(source, section, key, value) {
+  return setTomlKey(source, section, key, JSON.stringify(value));
+}
+
+function setTomlBooleanKey(source, section, key, value) {
+  return setTomlKey(source, section, key, value ? "true" : "false");
+}
+
+function setTomlKey(source, section, key, renderedValue) {
+  const bounds = tomlSectionBounds(source, section);
+  if (bounds === undefined) {
+    return setTomlKey(ensureTomlSection(source, section), section, key, renderedValue);
+  }
+
+  const body = source.slice(bounds.headerEnd, bounds.bodyEnd);
+  const keyPattern = new RegExp(`^([ \\t]*${escapeRegExp(key)}[ \\t]*=[ \\t]*).*$`, "m");
+  const match = keyPattern.exec(body);
+  if (match !== null) {
+    const lineStart = bounds.headerEnd + match.index;
+    const lineEnd = lineStart + match[0].length;
+    return `${source.slice(0, lineStart)}${match[1]}${renderedValue}${source.slice(lineEnd)}`;
+  }
+
+  return `${source.slice(0, bounds.headerEnd)}\n${key} = ${renderedValue}${source.slice(
+    bounds.headerEnd,
+  )}`;
+}
+
+function tomlSectionBounds(source, section) {
+  const sectionPattern = new RegExp(`^[ \\t]*\\[${escapeRegExp(section)}\\][ \\t]*(?:#.*)?$`, "m");
+  const match = sectionPattern.exec(source);
+  if (match === null) {
+    return undefined;
+  }
+
+  const nextSectionPattern = /^[ \t]*\[.*\][ \t]*(?:#.*)?$/gm;
+  nextSectionPattern.lastIndex = match.index + match[0].length;
+  const next = nextSectionPattern.exec(source);
+  return {
+    headerEnd: match.index + match[0].length,
+    bodyEnd: next?.index ?? source.length,
+  };
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function commandFromArgs(argv) {

--- a/station/scripts/station-isolated.sh
+++ b/station/scripts/station-isolated.sh
@@ -12,6 +12,10 @@ DS="$ROOT/.dev-state"
 CFG="$DS/config.toml"
 STATION_DIR="$ROOT/station"
 CLI="$ROOT/apps/cli/dist/main.js"
+COMMAND="${1:-start}"
+if [ "$COMMAND" = "--hot" ]; then
+  COMMAND="dev"
+fi
 
 if [ ! -f "$CLI" ]; then
   echo "stn CLI is not built ($CLI missing). Run 'pnpm build' at the repo root first." >&2
@@ -20,7 +24,7 @@ fi
 
 mkdir -p "$DS/observer/run"
 
-if [ "${1:-}" = "stop" ]; then
+if [ "$COMMAND" = "stop" ]; then
   # Graceful stop can hang mid-reconcile, so finish with path-scoped SIGKILLs
   # against only this worktree's isolated observer and persistent host.
   node "$CLI" --config "$CFG" observer stop --timeout-ms 8000 >/dev/null 2>&1 || true
@@ -29,6 +33,11 @@ if [ "${1:-}" = "stop" ]; then
   rm -f "$DS/observer/run/observer.sock" "$DS/observer/run/station-host.sock"
   echo "isolated observer + host torn down."
   exit 0
+fi
+
+if [ "$COMMAND" != "start" ] && [ "$COMMAND" != "dev" ]; then
+  echo "Usage: $0 [start|dev|--hot|stop]" >&2
+  exit 1
 fi
 
 # Build the isolated config from the real one: observer state + socket relocated
@@ -45,16 +54,59 @@ fallback = (
     'harness = "codex"\nlayout = "agent-shell"\n'
 )
 cfg = open(src).read() if os.path.exists(src) else fallback
-cfg = re.sub(r'socket_path = "[^"]*"', f'socket_path = "{ds}/observer/run/observer.sock"', cfg, count=1)
-cfg = re.sub(r'state_dir = "[^"]*"', f'state_dir = "{ds}/observer"', cfg, count=1)
+def set_section_key(source, section, key, rendered):
+    header_pattern = rf'^\[{re.escape(section)}\]\s*$'
+    header = re.search(header_pattern, source, flags=re.M)
+    if not header:
+        return source.rstrip() + f"\n\n[{section}]\n{key} = {rendered}\n"
+    next_header = re.search(r'^\[.*\]\s*$', source[header.end():], flags=re.M)
+    body_end = len(source) if not next_header else header.end() + next_header.start()
+    body = source[header.end():body_end]
+    key_pattern = rf'^(\s*{re.escape(key)}\s*=\s*).*$'
+    if re.search(key_pattern, body, flags=re.M):
+        next_body = re.sub(key_pattern, rf'\1{rendered}', body, count=1, flags=re.M)
+    else:
+        next_body = f"\n{key} = {rendered}{body}"
+    return source[:header.end()] + next_body + source[body_end:]
+cfg = set_section_key(cfg, "observer", "socket_path", f'"{ds}/observer/run/observer.sock"')
+cfg = set_section_key(cfg, "observer", "state_dir", f'"{ds}/observer"')
 # Isolated Station must not enumerate machine-global tmux panes; that would mark
 # rows as already running. The station provider is still registered separately.
-cfg = re.sub(r'(\[defaults\][^\[]*?terminal = )"[^"]*"', r'\1"noop-terminal"', cfg, count=1, flags=re.S)
-if "station_persistent_agents" not in cfg and "stationPersistentAgents" not in cfg:
-    cfg = cfg.rstrip() + "\n\n[feature_flags]\nstation_persistent_agents = true\n"
+cfg = set_section_key(cfg, "defaults", "terminal", '"noop-terminal"')
+cfg = set_section_key(cfg, "feature_flags", "station_persistent_agents", "true")
 open(f"{ds}/config.toml", "w").write(cfg)
 PY
 fi
+
+python3 - "$CFG" "$DS" <<'PY'
+import os, re, sys
+path = sys.argv[1]
+ds = sys.argv[2]
+if not os.path.exists(path):
+    sys.exit(0)
+cfg = open(path).read()
+def set_section_key(source, section, key, rendered):
+    header_pattern = rf'^\[{re.escape(section)}\]\s*$'
+    header = re.search(header_pattern, source, flags=re.M)
+    if not header:
+        return source.rstrip() + f"\n\n[{section}]\n{key} = {rendered}\n"
+    next_header = re.search(r'^\[.*\]\s*$', source[header.end():], flags=re.M)
+    body_end = len(source) if not next_header else header.end() + next_header.start()
+    body = source[header.end():body_end]
+    key_pattern = rf'^(\s*{re.escape(key)}\s*=\s*).*$'
+    if re.search(key_pattern, body, flags=re.M):
+        next_body = re.sub(key_pattern, rf'\1{rendered}', body, count=1, flags=re.M)
+    else:
+        next_body = f"\n{key} = {rendered}{body}"
+    return source[:header.end()] + next_body + source[body_end:]
+cfg = set_section_key(cfg, "observer", "socket_path", f'"{ds}/observer/run/observer.sock"')
+cfg = set_section_key(cfg, "observer", "state_dir", f'"{ds}/observer"')
+cfg = set_section_key(cfg, "defaults", "terminal", '"noop-terminal"')
+cfg = set_section_key(cfg, "feature_flags", "station_persistent_agents", "true")
+for harness in ("codex", "claude", "cursor", "opencode"):
+    cfg = set_section_key(cfg, f"harness.{harness}", "install_hooks", "true")
+open(path, "w").write(cfg)
+PY
 
 # The observer (Node) spawns the Bun host on demand; it finds the host entry via
 # this env var (observerProviders.ts does not pass it, so the env is REQUIRED —
@@ -65,9 +117,9 @@ export STATION_OBSERVER_SOCKET_PATH="$DS/observer/run/observer.sock"
 # Station reads [tui.widgets] directly for its overlay header; point it at the
 # same isolated config as the observer instead of the user's global default.
 export STATION_CONFIG_PATH="$CFG"
-# Keep Codex hooks/auth isolated to this worktree and make generated hooks
-# resolve this checkout's `stn-ingress`. Launched agents inherit both, so status
-# reports target this observer instead of global station state.
+# Keep generated hooks/provider config isolated to this worktree and make hooks
+# resolve this checkout's `stn-ingress`. Launched agents inherit these env vars,
+# so status reports target this observer instead of global station state.
 export PATH="$ROOT/bin:$PATH"
 export CODEX_HOME="$DS/codex-home"
 # Seed isolated Codex auth/config: auth is a shared symlink, config is copied once
@@ -82,17 +134,25 @@ mkdir -p "$CODEX_HOME"
 export CLAUDE_CONFIG_DIR="$DS/claude-home"
 mkdir -p "$CLAUDE_CONFIG_DIR"
 
+export STATION_CURSOR_HOME="$DS/cursor-home"
+export OPENCODE_CONFIG_DIR="$DS/opencode-config"
+mkdir -p "$STATION_CURSOR_HOME" "$OPENCODE_CONFIG_DIR"
+
 # Idempotent: reuses a healthy observer, so reopening Station leaves agents alone.
 node "$CLI" --config "$CFG" observer start >/dev/null
 
 # Install status hooks against THIS observer so the launch guard lets these
 # harnesses spawn; each writes into its own isolated home/state, never globals.
-for harness in codex claude; do
+for harness in codex claude cursor opencode; do
   node "$CLI" --config "$CFG" hooks install "$harness" --yes >/dev/null 2>&1 || true
 done
 
 echo "Isolated observer up — $STATION_OBSERVER_SOCKET_PATH"
-echo "  Launch an agent, quit Station (q), re-run 'bun run station:isolated' → it reattaches."
+if [ "$COMMAND" = "dev" ]; then
+  echo "  Hot reload: edit station/src/**; Bun HMR updates the isolated UI."
+else
+  echo "  Launch an agent, quit Station (q), re-run 'bun run station:isolated' → it reattaches."
+fi
 echo "  Inspect agents:  bun run host:list -- --socket $DS/observer/run/station-host.sock"
 echo "  Host timeline:   tail -f $DS/observer/logs/station-host.jsonl"
 echo "  Stop everything: bun run station:isolated:stop"
@@ -105,4 +165,7 @@ if [ "${STATION_ISOLATED_NO_LAUNCH:-}" = "1" ]; then
 fi
 
 cd "$STATION_DIR"
+if [ "$COMMAND" = "dev" ]; then
+  exec bun run dev
+fi
 exec bun run station

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.5.0",
+  schemaVersion: "0.6.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -12,9 +12,9 @@ import type { StoreApi } from "zustand/vanilla";
 import type { ProviderId } from "@station/contracts";
 import {
   choiceValueByKey,
-  createNewSessionFlow,
   createNewSessionNameToken,
   generatedSessionBranch,
+  openProjectDefaultAgentPicker,
   selectDashboardViewport,
 } from "@station/dashboard-core";
 import { clampDashboardStateScroll, scrollDashboard } from "@station/dashboard-core";
@@ -271,25 +271,14 @@ export function resolveQuickSessionSubmit(
 }
 
 /**
- * Open the New Session wizard with the given project pre-selected (skips the
- * project-picker step, lands on the review screen). Pure store mutation —
- * no router outcome. Absent or unavailable projects are silently ignored.
+ * Open the project default-agent picker. Pure store mutation — no router
+ * outcome. Absent or unavailable projects are silently ignored.
  */
-export function openNewSessionForProject(store: StoreApi<TuiStore>, projectId: string): void {
-  const state = store.getState();
-  const snapshot = state.snapshot;
-  if (snapshot === undefined) {
-    return;
-  }
-  const project = snapshot.projects.find((candidate) => candidate.id === projectId);
-  if (project === undefined || project.health.status === "unavailable") {
-    return;
-  }
-  const flow = createNewSessionFlow(snapshot, createNewSessionNameToken(), projectId);
-  if (flow === undefined) {
-    return;
-  }
-  store.setState({ ...state, screen: { name: "newSession", flow } });
+export function openDefaultAgentPickerForProject(
+  store: StoreApi<TuiStore>,
+  projectId: string,
+): void {
+  store.setState(openProjectDefaultAgentPicker(store.getState(), projectId));
 }
 
 /**

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -13,7 +13,7 @@
 //    the transition reports dismissPopup/exitCode).
 import { describe, expect, it } from "bun:test";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
-import { createInitialTuiState } from "@station/dashboard-core";
+import { createInitialTuiState, openProjectDefaultAgentPicker } from "@station/dashboard-core";
 import type { TuiKey } from "@station/dashboard-core";
 import { handleTuiKey } from "@station/dashboard-core";
 import type { TuiState } from "@station/dashboard-core";
@@ -103,6 +103,7 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     newSessionEditName: drive(base, [{ input: "N" }, { input: "N" }]),
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
     newSessionPickAgent: drive(base, [{ input: "N" }, { input: "A" }]),
+    projectDefaultAgent: openProjectDefaultAgentPicker(base, "station"),
     addProject: drive(base, [{ input: "A" }]),
   };
 }

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -25,6 +25,7 @@ export type StationInputMode =
   | "newSessionEditName"
   | "newSessionPickProject"
   | "newSessionPickAgent"
+  | "projectDefaultAgent"
   | "addProject";
 
 export function deriveStationMode(state: TuiState): StationInputMode {
@@ -56,6 +57,8 @@ export function deriveStationMode(state: TuiState): StationInputMode {
       break;
     case "addProject":
       return "addProject";
+    case "projectDefaultAgent":
+      return "projectDefaultAgent";
   }
   return "dashboard";
 }
@@ -183,6 +186,10 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   newSessionPickAgent: [
     { id: "station.newSessionAgent.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
     { id: "station.newSessionAgent.choose", pattern: { kind: "slot" }, action: "station.newSession.chooseAgent", outcome: "handled", help: { keys: "1-9 a-z", label: "choose agent" } },
+  ],
+  projectDefaultAgent: [
+    { id: "station.projectDefaultAgent.cancel", pattern: { kind: "named", named: "escape" }, action: "station.projectDefaultAgent.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
+    { id: "station.projectDefaultAgent.choose", pattern: { kind: "slot" }, action: "station.projectDefaultAgent.choose", outcome: "handled", help: { keys: "1-9 a-z", label: "choose agent" } },
   ],
   // The add-project flow has internal modes (start/choose/review/success/
   // failed, with a slash filter and a name editor); this single table covers

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -382,7 +382,7 @@ describe("routeStationMouse", () => {
     }
   });
 
-  it("gates quick-session and harness-picker to dashboard mode", () => {
+  it("gates quick-session and default-agent picker to dashboard mode", () => {
     const store = makeStore();
     store.getState().handleKey({ input: "/" }); // enter search mode
 
@@ -390,7 +390,11 @@ describe("routeStationMouse", () => {
       routeStationMouse({ kind: "quickSessionForProject", projectId: "station" }, LEFT_DOWN, store),
     ).toEqual({ kind: "handled" });
     expect(
-      routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "station" }, LEFT_DOWN, store),
+      routeStationMouse(
+        { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+        LEFT_DOWN,
+        store,
+      ),
     ).toEqual({ kind: "handled" });
   });
 
@@ -401,25 +405,56 @@ describe("routeStationMouse", () => {
     ).toEqual({ kind: "handled" });
   });
 
-  it("opens the new-session wizard pre-configured to a project via [▾] harness picker", () => {
+  it("opens the project default-agent picker via [▾]", () => {
     const store = makeStore();
-    const outcome = routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "station" }, LEFT_DOWN, store);
-    // The outcome is handled (no router effect); the wizard screen is set on the store.
+    const outcome = routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
+    // The outcome is handled (no router effect); the picker screen is set on the store.
     expect(outcome).toEqual({ kind: "handled" });
     const screen = store.getState().screen;
     expect(screen).toBeDefined();
-    expect(screen?.name).toBe("newSession");
-    if (screen?.name === "newSession") {
-      expect(screen.flow.selectedProjectId).toBe("station");
-      expect(screen.flow.selectedHarness).toBe("codex");
+    expect(screen?.name).toBe("projectDefaultAgent");
+    if (screen?.name === "projectDefaultAgent") {
+      expect(screen.projectId).toBe("station");
     }
   });
 
-  it("silently ignores harness-picker on absent or unavailable project", () => {
+  it("selects a project default agent by clicking an agent picker row", async () => {
+    const fixture = makeStationTestStore({ terminalRows: 12 });
+    const store = fixture.store;
+    routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
+
+    const outcome = routeStationMouse({ kind: "sheetChoice", choiceKey: "2" }, LEFT_DOWN, store);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(outcome).toEqual({ kind: "handled" });
+    expect(
+      fixture.service.dispatched.some(
+        (command) =>
+          command.type === "project.setDefaultHarness" &&
+          command.payload.projectId === "station" &&
+          command.payload.harness === "opencode",
+      ),
+    ).toBe(true);
+  });
+
+  it("silently ignores default-agent picker on absent or unavailable project", () => {
     const store = makeStore();
     // Ghost project: no mutation, no router effect.
-    routeStationMouse({ kind: "showHarnessPickerForProject", projectId: "ghost" }, LEFT_DOWN, store);
-    expect(store.getState().screen?.name).not.toBe("newSession");
+    routeStationMouse(
+      { kind: "showDefaultAgentPickerForProject", projectId: "ghost" },
+      LEFT_DOWN,
+      store,
+    );
+    expect(store.getState().screen?.name).not.toBe("projectDefaultAgent");
   });
 });
 

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -14,7 +14,7 @@ import {
   dispatchBindingClick,
   dispatchRowSlot,
   dispatchStationKey,
-  openNewSessionForProject,
+  openDefaultAgentPickerForProject,
   representativeKeyForBinding,
   resolveNewSessionSubmit,
   resolveProjectPaneTarget,
@@ -39,8 +39,8 @@ export type StationMouseTarget =
   | { kind: "openShellForProject"; projectId: string }
   /** The `[+]` quick-session affordance on a project header. */
   | { kind: "quickSessionForProject"; projectId: string }
-  /** The `[▾]` harness-picker affordance on a project header. */
-  | { kind: "showHarnessPickerForProject"; projectId: string }
+  /** The `[▾]` default-agent affordance on a project header. */
+  | { kind: "showDefaultAgentPickerForProject"; projectId: string }
   | { kind: "body" }
   | { kind: "scrollIndicator"; direction: "up" | "down" }
   | { kind: "footerHint"; bindingId: string }
@@ -159,11 +159,11 @@ export function routeStationMouse(
         return { kind: "handled" };
       }
       return fromQuickSessionSubmit(resolveQuickSessionSubmit(store, target.projectId));
-    case "showHarnessPickerForProject":
+    case "showDefaultAgentPickerForProject":
       if (mode !== "dashboard") {
         return { kind: "handled" };
       }
-      openNewSessionForProject(store, target.projectId);
+      openDefaultAgentPickerForProject(store, target.projectId);
       return { kind: "handled" };
     case "scrollIndicator":
       if (!ROW_INTERACTIVE_MODES.has(mode)) {
@@ -230,6 +230,7 @@ export function stationMouseEventKind(event: StationMouseEvent): StationMouseEve
 const SHEET_CHOICE_MODES: ReadonlySet<StationInputMode> = new Set([
   "newSessionPickProject",
   "newSessionPickAgent",
+  "projectDefaultAgent",
 ]);
 
 function routeStationWheel(

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -45,8 +45,7 @@ const SHELL_AFFORDANCE_WIDTH_COMPACT = SHELL_AFFORDANCE_LABEL_COMPACT.length + 1
 
 // The per-project-header quick-session affordance sits after [shell] on project
 // rows: "[quick session]" creates a session (default harness), "[▾]" opens the
-// wizard pre-configured to this project. Compact mode uses "[qs]" when columns
-// are limited.
+// project default-agent picker. Compact mode uses "[qs]" when columns are limited.
 const QUICK_SESSION_AFFORDANCE_LABEL = "[quick session]";
 const QUICK_SESSION_AFFORDANCE_LABEL_COMPACT = "[qs]";
 // Reserved width: leading space + session label + space + [▾]
@@ -298,8 +297,8 @@ function ShellAffordance({
  * The trailing `[quick session] [▾]` (or `[qs] [▾]` in compact mode)
  * quick-session affordance on project headers. Two separate `<text>` elements
  * so each click target fires independently: the session label immediately
- * creates a session (default harness), `[▾]` opens the harness-picker wizard
- * pre-configured to this project.
+ * creates a session (default harness), `[▾]` opens the default-agent picker
+ * for this project.
  */
 function QuickSessionAffordance({
   projectId,
@@ -326,7 +325,7 @@ function QuickSessionAffordance({
       <text
         flexShrink={0}
         fg={pickerHover ? STATION_COLORS.green : STATION_COLORS.gray}
-        {...stationMouseProps(dispatch, { kind: "showHarnessPickerForProject", projectId })}
+        {...stationMouseProps(dispatch, { kind: "showDefaultAgentPickerForProject", projectId })}
         onMouseOver={() => setPickerHover(true)}
         onMouseOut={() => setPickerHover(false)}
       >

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -6,6 +6,7 @@ import type { TuiScreen } from "@station/dashboard-core";
 import { AddProjectSheetView } from "./sheets/AddProjectSheetView.js";
 import { HelpOverlayView } from "./HelpOverlayView.js";
 import { NewSessionSheetView } from "./sheets/NewSessionSheetView.js";
+import { ProjectDefaultAgentSheetView } from "./sheets/ProjectDefaultAgentSheetView.js";
 import { RenameSessionSheetView } from "./sheets/RenameSessionSheetView.js";
 import { RemoveSessionSheetView } from "./sheets/RemoveSessionSheetView.js";
 
@@ -26,6 +27,16 @@ export function OverlayHostView({ snapshot, screen, columns, rows }: OverlayHost
   if (screen.name === "newSession") {
     return (
       <NewSessionSheetView columns={columns} rows={rows} snapshot={snapshot} state={screen.flow} />
+    );
+  }
+  if (screen.name === "projectDefaultAgent") {
+    return (
+      <ProjectDefaultAgentSheetView
+        columns={columns}
+        rows={rows}
+        snapshot={snapshot}
+        screen={screen}
+      />
     );
   }
   if (screen.name === "renameSession" && screen.step === "editName") {

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -308,6 +308,34 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "
 `;
 
+exports[`modal flow golden frames renders the project default agent picker 1`] = `
+"station
+───────────────────────────────────────────────────────────────────────────────
+
+▼ station - 5 worktrees                                           [sh] [qs] [▾]
+ [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell]
+ [2] - docs-cleanup               -         no agent                    [shell]
+ [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell]
+ [4] + session-resume             codex     starting                    [shell]
+ [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell]
+
+▼ observer - 3 worktrees                                          [sh] [qs] [▾]
+ [6] x batch-export               opencode  exited                 #8 ✓ [shell]
+ [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell]
+ [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell]
+
+▼ scripts - 3 worktrees                                           [sh] [qs] [▾]
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Select Station Default Agent                                                 │
+│                                                                              │
+│ 1 codex unknown                                                              │
+│ 2 opencode unknown                                                           │
+│                                                                              │
+│ 1-9/a-z:select   Esc:cancel                                                  │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "station                                                                         
 ─────────────────────────────────────────────────────────────────────────────── 

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -7,6 +7,7 @@ import type { StoreApi } from "zustand/vanilla";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
+import { openProjectDefaultAgentPicker } from "@station/dashboard-core";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import { DashboardRoot } from "./DashboardRoot.js";
 
@@ -77,6 +78,15 @@ const CASES: ModalCase[] = [
     name: "new session pick agent",
     keys: [{ input: "N" }, { input: "A" }],
     expect: ["Choose Agent", "1-9/a-z:select   Esc:back", "codex"],
+  },
+  {
+    name: "project default agent picker",
+    keys: [],
+    prepare: (store) => {
+      store.setState(openProjectDefaultAgentPicker(store.getState(), "station"));
+    },
+    trimSnapshotTrailingWhitespace: true,
+    expect: ["Select Station Default Agent", "1-9/a-z:select   Esc:cancel", "codex"],
   },
   {
     name: "add project sheet",

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -1,0 +1,72 @@
+import type { KeyedChoice, NewSessionHarnessOption } from "@station/dashboard-core";
+import { useState } from "react";
+import { STATION_COLORS } from "../theme.js";
+import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
+import { spaces } from "./parts.js";
+
+export type AgentChoiceListViewProps = {
+  choices: readonly KeyedChoice<NewSessionHarnessOption>[];
+  width: number;
+};
+
+export function AgentChoiceListView({ choices, width }: AgentChoiceListViewProps) {
+  return (
+    <>
+      {choices.map((choice) => (
+        <AgentChoiceLine
+          key={choice.value.id}
+          choiceKey={choice.key}
+          label={choice.value.label}
+          detail={choice.value.status}
+          color={statusColor(choice.value.status)}
+          width={width}
+        />
+      ))}
+    </>
+  );
+}
+
+function AgentChoiceLine({
+  choiceKey,
+  label,
+  detail,
+  color,
+  width,
+}: {
+  choiceKey: string;
+  label: string;
+  detail: string;
+  color?: string | undefined;
+  width: number;
+}) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  const prefix = ` ${choiceKey} `;
+  const detailPrefix = `${label} `;
+  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
+  const visibleDetail = detail.slice(0, detailWidth);
+  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
+  return (
+    <text
+      fg={hover ? STATION_COLORS.green : STATION_COLORS.foreground}
+      {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {prefix}
+      {detailPrefix}
+      <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
+      {padding}
+    </text>
+  );
+}
+
+function statusColor(status: string | undefined): string | undefined {
+  if (status === "unavailable") {
+    return STATION_COLORS.red;
+  }
+  if (status === "degraded") {
+    return STATION_COLORS.yellow;
+  }
+  return undefined;
+}

--- a/station/src/station/view/sheets/NewSessionSheetView.tsx
+++ b/station/src/station/view/sheets/NewSessionSheetView.tsx
@@ -16,6 +16,7 @@ import { EditableTextInputView } from "../EditableTextInputView.js";
 import { STATION_COLORS } from "../theme.js";
 import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import { AgentChoiceListView } from "./AgentChoiceListView.js";
 import { SheetFooter, SheetLabelValue, SheetLine, spaces } from "./parts.js";
 
 export type NewSessionSheetViewProps = {
@@ -178,16 +179,7 @@ function AgentPicker({
   return (
     <>
       <SheetLine width={width}> </SheetLine>
-      {options.map((choice) => (
-        <ChoiceLine
-          key={choice.value.id}
-          choiceKey={choice.key}
-          label={choice.value.label}
-          detail={choice.value.status}
-          color={statusColor(choice.value.status)}
-          width={width}
-        />
-      ))}
+      <AgentChoiceListView choices={options} width={width} />
       <SheetLine width={width}> </SheetLine>
       <SheetFooter width={width}>{"1-9/a-z:select   Esc:back"}</SheetFooter>
     </>

--- a/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
@@ -1,0 +1,56 @@
+import type { StationSnapshot } from "@station/contracts";
+import {
+  bottomSheetContentWidth,
+  selectNewSessionHarnessChoices,
+  type KeyedChoice,
+  type NewSessionHarnessOption,
+  type TuiScreen,
+} from "@station/dashboard-core";
+import { AgentChoiceListView } from "./AgentChoiceListView.js";
+import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import { SheetFooter, SheetLine } from "./parts.js";
+
+export type ProjectDefaultAgentSheetViewProps = {
+  snapshot: StationSnapshot;
+  screen: Extract<TuiScreen, { name: "projectDefaultAgent" }>;
+  columns: number;
+  rows: number;
+};
+
+export function ProjectDefaultAgentSheetView({
+  snapshot,
+  screen,
+  columns,
+  rows,
+}: ProjectDefaultAgentSheetViewProps) {
+  const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
+  const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
+  const contentWidth = bottomSheetContentWidth(columns);
+  return (
+    <BottomSheetFrameView
+      columns={columns}
+      rows={rows}
+      title="Select Station Default Agent"
+      contentRows={choices.length + 4}
+    >
+      <ProjectDefaultAgentPicker choices={choices} width={contentWidth} />
+    </BottomSheetFrameView>
+  );
+}
+
+function ProjectDefaultAgentPicker({
+  choices,
+  width,
+}: {
+  choices: readonly KeyedChoice<NewSessionHarnessOption>[];
+  width: number;
+}) {
+  return (
+    <>
+      <SheetLine width={width}> </SheetLine>
+      <AgentChoiceListView choices={choices} width={width} />
+      <SheetLine width={width}> </SheetLine>
+      <SheetFooter width={width}>{"1-9/a-z:select   Esc:cancel"}</SheetFooter>
+    </>
+  );
+}

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -140,6 +140,13 @@
       "projectId": "web"
     }
   },
+  "projectSetDefaultHarness": {
+    "type": "project.setDefaultHarness",
+    "payload": {
+      "projectId": "web",
+      "harness": "codex"
+    }
+  },
   "hooksInstall": {
     "type": "hooks.install",
     "payload": {

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.0",
+  "schemaVersion": "0.6.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -24,7 +24,7 @@
     "alerts": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -109,7 +109,7 @@
     "alerts": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -158,7 +158,7 @@
     "alerts": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -228,7 +228,7 @@
     "alerts": []
   },
   "idleAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -355,7 +355,7 @@
     "alerts": []
   },
   "workingAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -440,7 +440,7 @@
     "alerts": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -524,7 +524,7 @@
     "alerts": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -609,7 +609,7 @@
     "alerts": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -691,7 +691,7 @@
     "alerts": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -775,7 +775,7 @@
     "alerts": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -809,7 +809,7 @@
     ]
   },
   "providerFailure": {
-    "schemaVersion": "0.5.0",
+    "schemaVersion": "0.6.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.5.0",
+          schemaVersion: "0.6.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -40,7 +40,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.5.0",
+        schemaVersion: "0.6.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -45,10 +45,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.5.0",
+      schemaVersion: "0.6.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -66,7 +66,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.5.0",
+    schemaVersion: "0.6.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,


### PR DESCRIPTION
## Summary

- make `pnpm dev` / `pnpm station:tui-dev` generate a worktree-local observer config by default
- carry isolated provider homes through Codex, Claude, Cursor, and OpenCode hook/install/launch paths
- add `pnpm station:devbox dev` for an isolated Station sandbox with Bun UI hot reload
- update development docs to name the current command lanes and reserve `station:dev` until it owns the full restart/reload boundary

## Why

Station dev was split across normal run, CLI watcher, Bun renderer hot reload, and isolated devbox paths. The default CLI-side dev path could still collide with global observer/provider state, while the isolated devbox lacked an explicit hot-reload lane. This keeps the small isolation slice and avoids a larger orchestration refactor.

## UX impact

`pnpm station:devbox dev` now starts the isolated observer/host/provider-hook setup and launches the Station UI with Bun HMR. `pnpm dev` remains a CLI/package-output watcher, but it defaults to `.dev-state/tui-dev` instead of the global observer.

## Validation

- `node --check scripts/tui-dev.mjs && node --check scripts/station-devbox.mjs && bash -n station/scripts/station-isolated.sh`
- `pnpm exec biome check . && node tools/lint/check-source-order.mjs`
- `pnpm typecheck`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/tui-dev-script.test.ts integrations/harness/claude/test/unit/launch.test.ts integrations/harness/codex/test/unit/launch.test.ts integrations/harness/cursor/test/unit/hooks.test.ts integrations/harness/cursor/test/unit/provider.test.ts integrations/harness/opencode/test/unit/pluginInstall.test.ts integrations/harness/opencode/test/unit/provider.test.ts`