### PR TITLE
feat(dev): isolate Station dev runtime flows

### DIFF
--- a/apps/cli/test/unit/tui-dev-script.test.ts
+++ b/apps/cli/test/unit/tui-dev-script.test.ts
@@ -1,0 +1,331 @@
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadConfig } from "@station/config";
+import { afterEach, describe, expect, it } from "vitest";
+
+type TuiDevScript = {
+  installTuiDevHooks: (
+    runtime: { configPath?: string; env: Record<string, string>; generated: boolean },
+    runCommand?: (
+      command: string,
+      args: string[],
+      options: { env: Record<string, string>; cwd: string },
+    ) => { status?: number; stdout?: string; stderr?: string },
+  ) => void;
+  prepareTuiDevRuntime: (input: {
+    argv?: string[];
+    env?: Record<string, string>;
+    root?: string;
+  }) => Promise<{
+    argv: string[];
+    env: Record<string, string>;
+    configPath?: string;
+    generated: boolean;
+  }>;
+  tuiDevObserverSocketPath: (root: string) => string;
+};
+
+const tempRoots: string[] = [];
+
+async function loadScript(): Promise<TuiDevScript> {
+  return (await import("../../../../scripts/tui-dev.mjs")) as TuiDevScript;
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix));
+  tempRoots.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("tui-dev launcher runtime", () => {
+  it("generates a worktree-local observer config by default", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    const configDir = join(home, ".config", "station");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        'socket_path = "~/.local/state/station/observer.sock"',
+        'state_dir = "~/.local/state/station"',
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { prepareTuiDevRuntime, tuiDevObserverSocketPath } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    const configPath = join(root, ".dev-state", "tui-dev", "config.toml");
+    const stateDir = join(root, ".dev-state", "tui-dev", "observer");
+    const socketPath = tuiDevObserverSocketPath(root);
+
+    expect(runtime).toMatchObject({
+      argv: ["--config", configPath, "tui"],
+      configPath,
+      generated: true,
+      env: {
+        STATION_CONFIG_PATH: configPath,
+        STATION_OBSERVER_SOCKET_PATH: socketPath,
+      },
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toContain(
+      `socket_path = ${JSON.stringify(socketPath)}`,
+    );
+    expect(socketPath.startsWith(root)).toBe(false);
+    expect(socketPath.length).toBeLessThan(104);
+    await expect(readFile(configPath, "utf8")).resolves.toContain(
+      `state_dir = ${JSON.stringify(stateDir)}`,
+    );
+    await expect(readFile(configPath, "utf8")).resolves.toContain('terminal = "noop-terminal"');
+    for (const section of ["codex", "claude", "cursor", "opencode"]) {
+      await expect(readFile(configPath, "utf8")).resolves.toContain(`[harness.${section}]`);
+    }
+    expect(runtime.env.CODEX_HOME).toBe(join(root, ".dev-state", "tui-dev", "codex-home"));
+    expect(runtime.env.CLAUDE_CONFIG_DIR).toBe(join(root, ".dev-state", "tui-dev", "claude-home"));
+    expect(runtime.env.STATION_CURSOR_HOME).toBe(
+      join(root, ".dev-state", "tui-dev", "cursor-home"),
+    );
+    expect(runtime.env.OPENCODE_CONFIG_DIR).toBe(
+      join(root, ".dev-state", "tui-dev", "opencode-config"),
+    );
+  });
+
+  it("writes generated config that loads through the real config loader", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    const configDir = join(home, ".config", "station");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        'socket_path = "~/.local/state/station/observer.sock"',
+        'state_dir = "~/.local/state/station"',
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { prepareTuiDevRuntime, tuiDevObserverSocketPath } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    if (runtime.configPath === undefined) throw new Error("expected generated config path");
+
+    const loaded = await loadConfig({ configPath: runtime.configPath, homeDir: home });
+
+    expect(loaded.config.observer).toMatchObject({
+      socketPath: tuiDevObserverSocketPath(root),
+      stateDir: join(root, ".dev-state", "tui-dev", "observer"),
+    });
+    expect(loaded.config.defaults.terminal).toBe("noop-terminal");
+    expect(loaded.config.featureFlags?.stationPersistentAgents).toBe(true);
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+    expect(loaded.config.harness?.claude?.installHooks).toBe(true);
+    expect(loaded.config.harness?.cursor?.installHooks).toBe(true);
+    expect(loaded.config.harness?.opencode?.installHooks).toBe(true);
+  });
+
+  it("keeps generated socket paths short for long worktree roots", async () => {
+    const parent = await tempDir("station-tui-dev-root-");
+    const root = join(parent, "nested", "a".repeat(90), "checkout");
+    const home = await tempDir("station-tui-dev-home-");
+    await mkdir(root, { recursive: true });
+
+    const { prepareTuiDevRuntime, tuiDevObserverSocketPath } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    const socketPath = tuiDevObserverSocketPath(root);
+
+    expect(runtime.env.STATION_OBSERVER_SOCKET_PATH).toBe(socketPath);
+    expect(socketPath.startsWith(root)).toBe(false);
+    expect(socketPath.length).toBeLessThan(104);
+  });
+
+  it("expands inline harness tables before forcing isolated hook install", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    const configDir = join(home, ".config", "station");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(
+      join(configDir, "config.toml"),
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "  [observer] # local dev",
+        'socket_path = "~/.local/state/station/observer.sock"',
+        'state_dir = "~/.local/state/station"',
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "codex"',
+        'layout = "agent-shell"',
+        "",
+        "[harness]",
+        'codex = { command = "codex-dev", install_hooks = false }',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const { prepareTuiDevRuntime } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    if (runtime.configPath === undefined) throw new Error("expected generated config path");
+
+    const config = await readFile(runtime.configPath, "utf8");
+    expect(config).not.toContain("codex = {");
+    expect(config).toContain("[harness.codex]");
+    expect(config).toContain('command = "codex-dev"');
+    expect(config).toContain("install_hooks = true");
+
+    const loaded = await loadConfig({ configPath: runtime.configPath, homeDir: home });
+    expect(loaded.config.harness?.codex?.command).toBe("codex-dev");
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+  });
+
+  it("seeds Cursor isolated HOME with git identity links", async () => {
+    const root = await tempDir("station-tui-dev-root-");
+    const home = await tempDir("station-tui-dev-home-");
+    await mkdir(join(home, ".ssh"), { recursive: true });
+    await mkdir(join(home, ".config", "git"), { recursive: true });
+    await writeFile(join(home, ".gitconfig"), "[user]\n  name = Dev\n", "utf8");
+    await writeFile(join(home, ".git-credentials"), "https://example.invalid\n", "utf8");
+    await writeFile(join(home, ".ssh", "config"), "Host *\n", "utf8");
+    await writeFile(join(home, ".config", "git", "config"), "[safe]\n", "utf8");
+
+    const { prepareTuiDevRuntime } = await loadScript();
+    const runtime = await prepareTuiDevRuntime({ argv: ["tui"], env: { HOME: home }, root });
+    const cursorHome = runtime.env.STATION_CURSOR_HOME;
+    if (cursorHome === undefined) throw new Error("expected Cursor home");
+
+    for (const [target, source] of [
+      [join(cursorHome, ".gitconfig"), join(home, ".gitconfig")],
+      [join(cursorHome, ".git-credentials"), join(home, ".git-credentials")],
+      [join(cursorHome, ".ssh"), join(home, ".ssh")],
+      [join(cursorHome, ".config", "git"), join(home, ".config", "git")],
+    ]) {
+      const stats = await lstat(target);
+      expect(stats.isSymbolicLink()).toBe(true);
+      await expect(readlink(target)).resolves.toBe(source);
+    }
+  });
+
+  it("respects explicit config choices", async () => {
+    const { prepareTuiDevRuntime } = await loadScript();
+
+    await expect(
+      prepareTuiDevRuntime({
+        argv: ["--config", "/tmp/custom.toml", "tui"],
+        env: {},
+        root: "/tmp/repo",
+      }),
+    ).resolves.toMatchObject({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      configPath: "/tmp/custom.toml",
+      generated: false,
+      env: { STATION_CONFIG_PATH: "/tmp/custom.toml" },
+    });
+
+    await expect(
+      prepareTuiDevRuntime({
+        argv: ["tui"],
+        env: { STATION_CONFIG_PATH: "/tmp/env.toml" },
+        root: "/tmp/repo",
+      }),
+    ).resolves.toMatchObject({
+      argv: ["--config", "/tmp/env.toml", "tui"],
+      configPath: "/tmp/env.toml",
+      generated: false,
+    });
+  });
+
+  it("scrubs generated dev env when an explicit config is selected", async () => {
+    const { prepareTuiDevRuntime } = await loadScript();
+    const root = "/tmp/repo";
+    const generatedRoot = join(root, ".dev-state", "tui-dev");
+
+    const runtime = await prepareTuiDevRuntime({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      env: {
+        STATION_CONFIG_PATH: "/tmp/stale.toml",
+        STATION_OBSERVER_SOCKET_PATH: "/tmp/stale.sock",
+        CODEX_HOME: join(generatedRoot, "codex-home"),
+        CLAUDE_CONFIG_DIR: "/tmp/intentional-claude-home",
+      },
+      root,
+    });
+
+    expect(runtime).toMatchObject({
+      argv: ["--config", "/tmp/custom.toml", "tui"],
+      configPath: "/tmp/custom.toml",
+      generated: false,
+      env: {
+        STATION_CONFIG_PATH: "/tmp/custom.toml",
+        CLAUDE_CONFIG_DIR: "/tmp/intentional-claude-home",
+      },
+    });
+    expect(runtime.env.STATION_OBSERVER_SOCKET_PATH).toBeUndefined();
+    expect(runtime.env.CODEX_HOME).toBeUndefined();
+  });
+
+  it("installs supported isolated harness hooks", async () => {
+    const { installTuiDevHooks } = await loadScript();
+    const calls: Array<{ command: string; args: string[]; env: Record<string, string> }> = [];
+    const env = {
+      CODEX_HOME: "/tmp/codex-home",
+      CLAUDE_CONFIG_DIR: "/tmp/claude-home",
+      STATION_CURSOR_HOME: "/tmp/cursor-home",
+      OPENCODE_CONFIG_DIR: "/tmp/opencode-config",
+    };
+
+    installTuiDevHooks(
+      { configPath: "/tmp/station.toml", env, generated: true },
+      (command, args, options) => {
+        calls.push({ command, args, env: options.env });
+        return { status: 0 };
+      },
+    );
+
+    expect(calls.map((call) => call.args.slice(-2, -1)[0])).toEqual([
+      "codex",
+      "claude",
+      "cursor",
+      "opencode",
+    ]);
+    for (const call of calls) {
+      expect(call.args).toEqual([
+        expect.any(String),
+        "--config",
+        "/tmp/station.toml",
+        "hooks",
+        "install",
+        expect.any(String),
+        "--yes",
+      ]);
+      expect(call.env).toBe(env);
+    }
+  });
+});

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,11 +11,23 @@ Status: current living doc for development, test, and documentation workflow.
 
 ## Local TUI Workflow
 
+| Need | Command | Boundary |
+| --- | --- | --- |
+| Normal run | `pnpm stn` / `pnpm stn tui` | Built CLI, configured observer |
+| UI hot reload against the selected observer | `pnpm station:ui-dev` | Bun renderer only |
+| CLI/package-output watcher | `pnpm dev` / `pnpm station:tui-dev` | Isolated by default, not Bun HMR |
+| Isolated Station sandbox | `pnpm station:devbox` | Isolated observer, host, state, and supported hooks |
+| Isolated Station sandbox with UI HMR | `pnpm station:devbox dev` | Same devbox isolation, Bun renderer hot reload |
+
+Do not use `station:dev` as a catch-all name until it truthfully owns the UI,
+CLI/package, observer, provider, protocol, and host restart boundaries.
+
 - `pnpm stn` opens the normal station popup from the current checkout's built CLI when run inside tmux.
 - `pnpm stn tui` opens the normal station TUI fullscreen from the current checkout's built CLI.
 - Normal tmux popup fast-path registrations are scoped to the checkout root that created them. A popup launcher from another checkout ignores and clears stale normal popup metadata before falling back to that checkout's CLI.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
-- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
+- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
+- `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.
 - `pnpm station:reset` clears station tmux popup registrations for the current checkout and opens station normally from built code. Inside tmux that means a fresh popup; outside tmux that means the fullscreen TUI.
 - `pnpm station:reset:tmux-tui` is the heavier tmux TUI refresh for this checkout. It requires clean `main`, pulls `origin/main`, clears only station TUI/popup tmux state, rebuilds, restarts the observer, then opens station from the rebuilt checkout. It does not kill worktree sessions or harness agents.
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -22,9 +22,10 @@ and the observer is configured by `~/.config/station/config.toml`. If you run yo
 checkout against that, you are sharing state with — and can disrupt — your real
 day-to-day agents.
 
-**Isolation = point at a config whose observer `state_dir` + `socket_path` live
-under the worktree.** There is **no `STATION_STATE_DIR` env var**; isolation is
-config-only. The selector is the **global `--config <path>` flag**, which must
+**Isolation = point at a config whose observer `state_dir` is worktree-local and
+whose `socket_path` is unique to that checkout.** There is **no
+`STATION_STATE_DIR` env var**; isolation is config-only. The selector is the
+**global `--config <path>` flag**, which must
 come **before** the subcommand and applies to *every* observer-backed command:
 
 ```bash
@@ -42,13 +43,14 @@ schema_version = 1
 
 [observer]
 state_dir   = "/abs/worktree/.dev-state/observer"
-socket_path = "/abs/worktree/.dev-state/observer/run/observer.sock"
+socket_path = "/tmp/stn-example-checkout/observer.sock"
 # ...your real [defaults], [worktree.worktrunk], [harness.*] ...
 ```
 
 Convention: keep all worktree-local runtime state under **`.dev-state/`** at the
-worktree root. It is gitignored. The observer's station-host socket auto-follows
-to `<state_dir>/run/station-host.sock`.
+worktree root. It is gitignored. Keep Unix sockets on a short path when the
+checkout root is long; macOS rejects overlong socket paths. The observer's
+station-host socket auto-follows beside the configured observer socket.
 
 ### ⚠️ The tmux gotcha (why "everything already has an agent")
 
@@ -86,6 +88,7 @@ the same running agent), one command does everything:
 ```bash
 # preferred: one command from any checkout/worktree root (builds first if needed)
 pnpm station:devbox               # start the isolated observer + Station
+pnpm station:devbox dev           # same sandbox, with Bun hot reload for station/src/**
 pnpm station:devbox restart       # rebuild + recycle the observer (agents survive)
 pnpm station:devbox status        # which observer/host am I on? (+ global, read-only)
 pnpm station:devbox logs --follow # tail the isolated observer/host/cli logs
@@ -99,12 +102,15 @@ remain the implementation and still work directly from the package dir:
 ```bash
 cd station
 bun run station:isolated          # isolated observer + persistence flag + Station
+bun run station:isolated dev      # same sandbox, with Bun hot reload
 bun run station:isolated:stop     # tear down the observer + host for this worktree
 ```
 
 `station:isolated` does everything needed for a self-contained sandbox:
-- generates a worktree-local config (`.dev-state/config.toml`: state/socket
-  relocated, `terminal = "noop-terminal"`, persistence flag on);
+- generates a worktree-local config (`.dev-state/config.toml`: state relocated
+  under `.dev-state`, socket relocated under a short checkout-keyed temp path,
+  `terminal = "noop-terminal"`, persistence flag on, supported
+  harness hook flags on);
 - exports `STATION_HOST_ENTRY` (so the host can spawn) and
   `STATION_OBSERVER_SOCKET_PATH` (so Station connects to this observer);
 - sets `CODEX_HOME=.dev-state/codex-home`, seeds it with a symlink to your real
@@ -118,21 +124,30 @@ bun run station:isolated:stop     # tear down the observer + host for this workt
   `CLAUDE_CONFIG_DIR=.dev-state/claude-home` so that install never touches your
   global `~/.claude` and the launched claude reads an isolated config; auth is not
   seeded (see note below);
+- sets `STATION_CURSOR_HOME=.dev-state/cursor-home`, seeds git identity/SSH
+  links into that isolated Cursor home, and sets
+  `OPENCODE_CONFIG_DIR=.dev-state/opencode-config`, then installs Cursor and
+  OpenCode hooks there as well;
 - starts the isolated observer and opens Station.
+
+Use `pnpm station:devbox dev` for the same isolated stack with `bun --hot` UI
+reload. It keeps the observer, state, hooks, and host under `.dev-state`, but UI
+edits under `station/src/**` reload in place.
 
 The observer + agents are left running when Station exits, so close/reopen
 reattaches.
 
-> Both **codex** and **claude** get isolated hooks. For claude the script installs
-> the station status hook for the isolated observer — the artifact + script land under
-> `.dev-state/observer`, which is what the launch guard checks, so a claude-default
-> worktree clears the guard. It also exports `CLAUDE_CONFIG_DIR=.dev-state/claude-home`
-> so that install never touches your global `~/.claude/settings.json` and the
-> launched claude reads an isolated config (the observer inherits the env and the
-> host→PTY spawn merges it down). Auth is **not** seeded: on macOS claude keeps
-> credentials in the Keychain (machine-global, not under `CLAUDE_CONFIG_DIR`), so
-> the sandbox stays logged in; on a file-credential platform expect a one-time
-> `claude` login. Your global `~/.claude/settings.json` is never modified.
+> Codex, Claude, Cursor, and OpenCode get isolated hooks/provider homes. For
+> Claude the script installs the station status hook for the isolated observer —
+> the artifact + script land under `.dev-state/observer`, which is what the
+> launch guard checks, so a claude-default worktree clears the guard. It also
+> exports `CLAUDE_CONFIG_DIR=.dev-state/claude-home` so that install never
+> touches your global `~/.claude/settings.json` and the launched claude reads an
+> isolated config (the observer inherits the env and the host→PTY spawn merges it
+> down). Auth is **not** seeded: on macOS claude keeps credentials in the Keychain
+> (machine-global, not under `CLAUDE_CONFIG_DIR`), so the sandbox stays logged in;
+> on a file-credential platform expect a one-time `claude` login. Your global
+> `~/.claude/settings.json` is never modified.
 
 Test the persistence loop:
 1. Open a worktree row → launches a fresh host-backed agent.
@@ -142,7 +157,7 @@ Test the persistence loop:
 Inspect what the host owns / watch the timeline:
 
 ```bash
-bun run host:list -- --socket .dev-state/observer/run/station-host.sock
+pnpm station:devbox status
 tail -f .dev-state/observer/logs/station-host.jsonl
 ```
 
@@ -225,19 +240,24 @@ input file and it reloads in place. The split:
 ## 3. Launching via the CLI (`stn tui`)
 
 ```bash
-pnpm dev                                  # rebuild @station/cli on change, then stn tui
-pnpm dev --config /abs/iso-config.toml    # ...against an isolated observer
+pnpm dev                                  # rebuild @station/cli on change, isolated by default
+pnpm dev --config /abs/other-config.toml  # ...against a specific observer/config
 node apps/cli/dist/main.js --config /abs/iso-config.toml tui   # one-shot, no watcher
 ```
 
-`pnpm dev` rebuilds `@station/cli` on change and launches `stn tui`. The CLI
-shells out to the Bun renderer in `station/`: a bare terminal launches the
-**native Station workspace** (its own PTY panes); inside tmux it opens the
-**read-only dashboard** in a tmux popup (tmux owns the panes there). It passes
-`--config` straight through, and `stn tui` auto-starts the observer for the
-configured socket. Because tmux is global, an isolated-state tmux-popup dashboard
-still shows your real tmux agents — that is correct for testing the tmux
-integration (see the tmux gotcha in §1).
+`pnpm dev` rebuilds `@station/cli` on change and launches `stn tui`. With no
+explicit config it generates `.dev-state/tui-dev/config.toml` from your real
+config, relocates the observer `state_dir` under this checkout, uses a short
+checkout-keyed temp socket path, and preconfigures isolated Codex, Claude,
+Cursor, and OpenCode hooks for that observer. The CLI shells out to the Bun renderer in `station/`: a bare terminal
+launches the **native Station workspace** (its own PTY panes); inside tmux it
+opens the **read-only dashboard** in a tmux popup (tmux owns the panes there). It
+passes explicit `--config` choices straight through, and `stn tui` auto-starts
+the observer for the configured socket. The generated default config uses
+`terminal = "noop-terminal"`, so it avoids machine-global tmux pane discovery.
+If you pass an explicit config with `terminal = "tmux"` for tmux-integration
+testing, the popup dashboard can still show your real tmux agents (see the tmux
+gotcha in §1).
 
 > `pnpm dev` rebuilds the **Node CLI**, not the Bun renderer. To hot-reload the
 > Station UI itself as you edit `station/src/**`, use `pnpm station:ui-dev` from §2b.
@@ -299,23 +319,23 @@ snapshots (`*.golden.test.tsx.snap`); `bun test` does not typecheck, so run
 - **"<harness> status hooks are not installed" on launch** → the launch path
   (`externalLaunch.ts` → `assertHooksInstalledOrThrow`) refuses to spawn an agent
   whose status hooks aren't installed *for this observer*, so it never spawns a
-  half-wired agent. codex/claude hooks normally live in your **global** harness
-  home, so you can't install them for the isolated observer without clobbering it.
-  The fix (codex): point `CODEX_HOME` at a wt-local dir and install the hook there
-  — `hooks install` writes `$CODEX_HOME/station.config.toml` + a script under the
-  isolated state dir, never touching `~/.codex`. The agent still needs your login,
-  so seed the isolated home with a symlink to `~/.codex/auth.json` and a copy of
-  `config.toml`. The fix (claude): install the station status hook for the isolated
-  observer — its artifact + script land under the isolated state dir, which is what
-  the guard checks — and set `CLAUDE_CONFIG_DIR` to a wt-local home so the install
-  stays off your global `~/.claude` and the launched claude reads an isolated config;
-  auth isn't seeded because claude stores credentials in the macOS Keychain
-  (machine-global), so the sandbox stays logged in. `station:isolated` does all of
-  this. The generated hooks only fire for STATION-launched sessions (they early-exit
-  unless `STATION_SESSION_ID` and `STATION_WORKTREE_ID` are set), so they never disturb
-  your global agents.
+  half-wired agent. Supported provider hooks normally live in global provider
+  homes (`~/.codex`, `~/.claude`, `~/.cursor`, or `~/.config/opencode`), so the
+  isolated lanes redirect those homes before installing hooks. Codex uses
+  `CODEX_HOME`; Claude uses `CLAUDE_CONFIG_DIR`; Cursor uses `STATION_CURSOR_HOME`;
+  OpenCode uses `OPENCODE_CONFIG_DIR`. Codex auth is a symlink to your real
+  `~/.codex/auth.json`; Cursor gets symlinks for git identity and SSH material
+  so commits still work from its isolated `HOME`; Claude auth usually comes from the macOS Keychain.
+  The generated hooks only fire for STATION-launched sessions (they early-exit
+  unless `STATION_SESSION_ID` and `STATION_WORKTREE_ID` are set), so they never
+  disturb your global agents.
+  `pnpm dev` / `pnpm station:tui-dev` and `pnpm station:devbox` both do this
+  preflight for Codex, Claude, Cursor, and OpenCode under their own `.dev-state`
+  roots, and launched agents carry the same isolated provider-home env. Crush is
+  cwd-config based (`.crush.json`), so a central dev launcher cannot preconfigure
+  every worktree without writing into those worktrees.
 - **Station connects to the wrong observer** → it reads `STATION_OBSERVER_SOCKET_PATH`;
-  point it at the isolated socket. `station:isolated` exports it.
+  point it at the isolated socket. `station:isolated` exports it and prints it.
 - **`observer stop` hangs / `OBSERVER_STOP_FAILED`** → an observer mid-reconcile
   can outlast the stop poll window; SIGTERM triggers the same graceful path.
   `station:isolated:stop` does a best-effort graceful stop then SIGKILLs the

--- a/integrations/harness/claude/src/launch.ts
+++ b/integrations/harness/claude/src/launch.ts
@@ -21,6 +21,7 @@ export type ClaudeLaunchOptions = {
   defaultApprovalPolicy?: string;
   defaultSandboxMode?: string;
   hookSettingsPath?: string;
+  env?: NodeJS.ProcessEnv;
 };
 
 const CLAUDE_YOLO_FLAG = "--dangerously-skip-permissions";
@@ -73,11 +74,21 @@ function buildClaudeResumeLaunchPlan(
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("claude", request),
+    env: claudeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Claude`,
     providerData,
   };
+}
+
+function claudeLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: ClaudeLaunchOptions,
+): Record<string, string> {
+  return harnessLaunchEnv("claude", request, {
+    env: options.env,
+    carryEnv: [{ from: "CLAUDE_CONFIG_DIR" }],
+  });
 }
 
 export function buildClaudeLaunchPlan(
@@ -134,7 +145,7 @@ export function buildClaudeLaunchPlan(
     command: options.command ?? "claude",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("claude", request),
+    env: claudeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Claude`,
     providerData,

--- a/integrations/harness/claude/test/unit/launch.test.ts
+++ b/integrations/harness/claude/test/unit/launch.test.ts
@@ -122,6 +122,25 @@ describe("buildClaudeLaunchPlan", () => {
     });
   });
 
+  it("carries an isolated CLAUDE_CONFIG_DIR into the launch env", () => {
+    const previous = process.env.CLAUDE_CONFIG_DIR;
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/station/claude-home";
+    try {
+      const plan = buildClaudeLaunchPlan(request());
+
+      expect(plan.env).toMatchObject({
+        STATION_HARNESS_PROVIDER: "claude",
+        CLAUDE_CONFIG_DIR: "/tmp/station/claude-home",
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = previous;
+      }
+    }
+  });
+
   it("builds non-interactive claude print plans with streamed JSON events", () => {
     const plan = buildClaudeLaunchPlan(
       {

--- a/integrations/harness/codex/src/launch.ts
+++ b/integrations/harness/codex/src/launch.ts
@@ -20,6 +20,7 @@ export type CodexLaunchOptions = {
   defaultApprovalPolicy?: string;
   defaultSandboxMode?: string;
   noAltScreen?: boolean;
+  env?: NodeJS.ProcessEnv;
 };
 
 const CODEX_YOLO_FLAG = "--dangerously-bypass-approvals-and-sandbox";
@@ -80,7 +81,7 @@ export function buildCodexLaunchPlan(
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("codex", request),
+    env: codexLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Codex`,
     providerData,
@@ -133,7 +134,7 @@ function buildCodexResumeLaunchPlan(
     command: options.command ?? "codex",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("codex", request),
+    env: codexLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Codex`,
     providerData,
@@ -173,6 +174,16 @@ function appendCodexOptions(
   if (options.noAltScreen === true) {
     args.push("--no-alt-screen");
   }
+}
+
+function codexLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: CodexLaunchOptions,
+): Record<string, string> {
+  return harnessLaunchEnv("codex", request, {
+    env: options.env,
+    carryEnv: [{ from: "CODEX_HOME" }],
+  });
 }
 
 function codexProviderData(

--- a/integrations/harness/codex/test/unit/launch.test.ts
+++ b/integrations/harness/codex/test/unit/launch.test.ts
@@ -162,6 +162,25 @@ describe("buildCodexLaunchPlan", () => {
     });
   });
 
+  it("carries an isolated CODEX_HOME into the launch env", () => {
+    const previous = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/tmp/station/codex-home";
+    try {
+      const plan = buildCodexLaunchPlan(request());
+
+      expect(plan.env).toMatchObject({
+        STATION_HARNESS_PROVIDER: "codex",
+        CODEX_HOME: "/tmp/station/codex-home",
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previous;
+      }
+    }
+  });
+
   it("builds non-interactive codex exec plans with JSON events", () => {
     const plan = buildCodexLaunchPlan(
       {

--- a/integrations/harness/cursor/src/hooks/hookPaths.ts
+++ b/integrations/harness/cursor/src/hooks/hookPaths.ts
@@ -14,6 +14,17 @@ export function resolveCursorHooksPath(options: CursorHookPathOptions = {}): str
   if (options.cursorHooksPath !== undefined) {
     return resolveLocalPath(options.cursorHooksPath, options.homeDir);
   }
+  const env = options.env ?? process.env;
+  if (env.STATION_CURSOR_HOOKS_PATH !== undefined && env.STATION_CURSOR_HOOKS_PATH.length > 0) {
+    return resolveLocalPath(env.STATION_CURSOR_HOOKS_PATH, options.homeDir);
+  }
+  if (env.STATION_CURSOR_HOME !== undefined && env.STATION_CURSOR_HOME.length > 0) {
+    return join(
+      resolveLocalPath(env.STATION_CURSOR_HOME, options.homeDir),
+      ".cursor",
+      CURSOR_HOOKS_FILE,
+    );
+  }
   return resolveLocalPath(join("~", ".cursor", CURSOR_HOOKS_FILE), options.homeDir);
 }
 

--- a/integrations/harness/cursor/src/launch.ts
+++ b/integrations/harness/cursor/src/launch.ts
@@ -9,7 +9,18 @@ import { CursorHarnessProviderError } from "./errors.js";
 
 export type CursorLaunchOptions = {
   command?: string;
+  cursorHome?: string;
 };
+
+function cursorLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: CursorLaunchOptions,
+): Record<string, string> {
+  return harnessLaunchEnv("cursor", request, {
+    env: { STATION_CURSOR_HOME: options.cursorHome },
+    carryEnv: [{ from: "STATION_CURSOR_HOME", to: "HOME" }],
+  });
+}
 
 export function buildCursorLaunchPlan(
   request: BuildHarnessLaunchRequest,
@@ -63,7 +74,7 @@ export function buildCursorLaunchPlan(
     command: options.command ?? "agent",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("cursor", request),
+    env: cursorLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} Cursor`,
     providerData,

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -51,6 +51,21 @@ describe("Cursor hook setup", () => {
     await expect(readFile(hookScriptPath, "utf8")).rejects.toThrow();
   });
 
+  it("resolves hook config from STATION_CURSOR_HOME", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
+    const cursorHome = join(root, "cursor-home");
+
+    const plan = await planCursorHooks({
+      env: { STATION_CURSOR_HOME: cursorHome },
+      stationConfigPath: "/tmp/station/config.toml",
+      observerSocketPath: "/tmp/station/run/observer.sock",
+      stateDir: "/tmp/station/state",
+      hookSpoolDir: "/tmp/station/state/spool/hooks",
+    });
+
+    expect(plan.hooksPath).toBe(join(cursorHome, ".cursor", "hooks.json"));
+  });
+
   it("installs, merges hooks.json, writes a 0700 script, and is idempotent", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
     const hooksPath = join(root, "cursor", "hooks.json");

--- a/integrations/harness/cursor/test/unit/provider.test.ts
+++ b/integrations/harness/cursor/test/unit/provider.test.ts
@@ -78,8 +78,8 @@ describe("CursorHarnessProvider", () => {
       homeDir: root,
     });
 
-    const previousHome = process.env.HOME;
-    process.env.HOME = root;
+    const previousCursorHome = process.env.STATION_CURSOR_HOME;
+    process.env.STATION_CURSOR_HOME = root;
     try {
       const provider = createCursorHarnessProvider({
         installHooks: true,
@@ -97,10 +97,10 @@ describe("CursorHarnessProvider", () => {
         }),
       );
     } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
+      if (previousCursorHome === undefined) {
+        delete process.env.STATION_CURSOR_HOME;
       } else {
-        process.env.HOME = previousHome;
+        process.env.STATION_CURSOR_HOME = previousCursorHome;
       }
     }
   });
@@ -130,6 +130,27 @@ describe("CursorHarnessProvider", () => {
         terminalTargetId: "tmux:station:@1:%2",
       },
     });
+  });
+
+  it("launches Cursor with the isolated dev home when configured", async () => {
+    const previousCursorHome = process.env.STATION_CURSOR_HOME;
+    process.env.STATION_CURSOR_HOME = "/tmp/station/cursor-home";
+    try {
+      const provider = createCursorHarnessProvider({ command: "agent-test" });
+
+      await expect(provider.buildLaunch(request())).resolves.toMatchObject({
+        env: {
+          HOME: "/tmp/station/cursor-home",
+          STATION_HARNESS_PROVIDER: "cursor",
+        },
+      });
+    } finally {
+      if (previousCursorHome === undefined) {
+        delete process.env.STATION_CURSOR_HOME;
+      } else {
+        process.env.STATION_CURSOR_HOME = previousCursorHome;
+      }
+    }
   });
 
   it("launches interactive Cursor resume with the native session id", async () => {

--- a/integrations/harness/opencode/src/launch.ts
+++ b/integrations/harness/opencode/src/launch.ts
@@ -22,6 +22,7 @@ export type OpenCodeLaunchOptions = {
   observerSocketPath?: string;
   stateDir?: string;
   hookSpoolDir?: string;
+  env?: NodeJS.ProcessEnv;
 };
 
 export function buildOpenCodeLaunchPlan(
@@ -71,7 +72,7 @@ export function buildOpenCodeLaunchPlan(
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("opencode", request, options),
+    env: openCodeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
     providerData: commonProviderData(providerDataInput),
@@ -109,7 +110,7 @@ function buildOpenCodeResumeLaunchPlan(
     command: options.command ?? "opencode",
     args,
     cwd: request.worktree.path,
-    env: harnessLaunchEnv("opencode", request, options),
+    env: openCodeLaunchEnv(request, options),
     mode,
     displayTitle: `${request.project.label} OpenCode`,
     providerData: commonProviderData({
@@ -119,6 +120,16 @@ function buildOpenCodeResumeLaunchPlan(
       resumeTargetKind: request.resume.target.kind,
     }),
   };
+}
+
+function openCodeLaunchEnv(
+  request: BuildHarnessLaunchRequest,
+  options: OpenCodeLaunchOptions,
+): Record<string, string> {
+  return harnessLaunchEnv("opencode", request, {
+    ...options,
+    carryEnv: [{ from: "OPENCODE_CONFIG_DIR" }],
+  });
 }
 
 function interactiveArgs(_request: BuildHarnessLaunchRequest): string[] {

--- a/integrations/harness/opencode/src/pluginInstall.ts
+++ b/integrations/harness/opencode/src/pluginInstall.ts
@@ -145,11 +145,9 @@ export function resolveOpenCodeConfigDir(options: OpenCodePluginPlanOptions = {}
   if (options.opencodeConfigDir !== undefined) {
     return options.opencodeConfigDir;
   }
-  if (
-    options.env?.OPENCODE_CONFIG_DIR !== undefined &&
-    options.env.OPENCODE_CONFIG_DIR.length > 0
-  ) {
-    return options.env.OPENCODE_CONFIG_DIR;
+  const env = options.env ?? process.env;
+  if (env.OPENCODE_CONFIG_DIR !== undefined && env.OPENCODE_CONFIG_DIR.length > 0) {
+    return env.OPENCODE_CONFIG_DIR;
   }
   return join(options.homeDir ?? homedir(), ".config", "opencode");
 }

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -110,6 +110,9 @@ function buildLaunch(
   if (options.hookSpoolDir !== undefined) {
     launchOptions.hookSpoolDir = options.hookSpoolDir;
   }
+  if (options.env !== undefined) {
+    launchOptions.env = options.env;
+  }
   return buildOpenCodeLaunchPlan(request, launchOptions);
 }
 

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -8,6 +8,7 @@ import {
   doctorOpenCodePlugin,
   installOpenCodePlugin,
   planOpenCodePlugin,
+  resolveOpenCodeConfigDir,
   resolveOpenCodePluginPath,
   uninstallOpenCodePlugin,
 } from "../../src/pluginInstall";
@@ -43,6 +44,20 @@ describe("OpenCode plugin setup", () => {
     expect(plan.after).toContain('"session.next.tool.input.delta"');
     expect(plan.after).toContain("/tmp/station/run/observer.sock");
     await expect(readFile(pluginPath, "utf8")).rejects.toThrow();
+  });
+
+  it("resolves config dir from OPENCODE_CONFIG_DIR in process env", async () => {
+    const previous = process.env.OPENCODE_CONFIG_DIR;
+    process.env.OPENCODE_CONFIG_DIR = "/tmp/station/opencode-config";
+    try {
+      expect(resolveOpenCodeConfigDir()).toBe("/tmp/station/opencode-config");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR;
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = previous;
+      }
+    }
   });
 
   it("installs, reports idempotence, and uninstalls only the generated plugin", async () => {

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -161,6 +161,27 @@ describe("OpenCodeHarnessProvider", () => {
     });
   });
 
+  it("carries an isolated OPENCODE_CONFIG_DIR into the launch env", async () => {
+    const previous = process.env.OPENCODE_CONFIG_DIR;
+    process.env.OPENCODE_CONFIG_DIR = "/tmp/station/opencode-config";
+    try {
+      const provider = createOpenCodeHarnessProvider();
+
+      await expect(provider.buildLaunch(request())).resolves.toMatchObject({
+        env: {
+          STATION_HARNESS_PROVIDER: "opencode",
+          OPENCODE_CONFIG_DIR: "/tmp/station/opencode-config",
+        },
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCODE_CONFIG_DIR;
+      } else {
+        process.env.OPENCODE_CONFIG_DIR = previous;
+      }
+    }
+  });
+
   it("launches interactive OpenCode resume with the native session id", async () => {
     const provider = createOpenCodeHarnessProvider({
       command: "opencode-test",

--- a/packages/harness-shared/src/launch.ts
+++ b/packages/harness-shared/src/launch.ts
@@ -5,10 +5,17 @@ import type {
 } from "@station/contracts";
 
 export type CommonLaunchEnvOptions = {
-  configPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
+  configPath?: string | undefined;
+  observerSocketPath?: string | undefined;
+  stateDir?: string | undefined;
+  hookSpoolDir?: string | undefined;
+  env?: Record<string, string | undefined> | undefined;
+  carryEnv?: readonly LaunchEnvCarry[] | undefined;
+};
+
+export type LaunchEnvCarry = {
+  from: string;
+  to?: string | undefined;
 };
 
 export type CommonProviderDataInput = {
@@ -48,7 +55,21 @@ export function harnessLaunchEnv(
   }
   if (options.stateDir !== undefined) env.STATION_OBSERVER_STATE_DIR = options.stateDir;
   if (options.hookSpoolDir !== undefined) env.STATION_HOOK_SPOOL_DIR = options.hookSpoolDir;
+  for (const carry of options.carryEnv ?? []) {
+    carryLaunchEnv(env, carry, options.env);
+  }
   return env;
+}
+
+function carryLaunchEnv(
+  env: Record<string, string>,
+  carry: LaunchEnvCarry,
+  source?: Record<string, string | undefined>,
+): void {
+  const value = source?.[carry.from] ?? process.env[carry.from];
+  if (value !== undefined && value.length > 0) {
+    env[carry.to ?? carry.from] = value;
+  }
 }
 
 export function commonProviderData(input: CommonProviderDataInput): Record<string, unknown> {

--- a/packages/harness-shared/test/unit/launch.test.ts
+++ b/packages/harness-shared/test/unit/launch.test.ts
@@ -1,0 +1,97 @@
+import type { BuildHarnessLaunchRequest } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { harnessLaunchEnv } from "../../src/launch";
+
+describe("harnessLaunchEnv", () => {
+  it("carries a non-empty injected env value", () => {
+    const env = harnessLaunchEnv("codex", request(), {
+      env: { CODEX_HOME: "/tmp/codex-home" },
+      carryEnv: [{ from: "CODEX_HOME" }],
+    });
+
+    expect(env).toMatchObject({
+      STATION_HARNESS_PROVIDER: "codex",
+      CODEX_HOME: "/tmp/codex-home",
+    });
+  });
+
+  it("falls back to process env when the source omits the key", () => {
+    const previous = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/tmp/process-codex-home";
+    try {
+      const env = harnessLaunchEnv("codex", request(), {
+        env: {},
+        carryEnv: [{ from: "CODEX_HOME" }],
+      });
+
+      expect(env).toMatchObject({
+        CODEX_HOME: "/tmp/process-codex-home",
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previous;
+      }
+    }
+  });
+
+  it("treats an empty injected value as an intentional unset", () => {
+    const previous = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = "/tmp/process-codex-home";
+    try {
+      const env = harnessLaunchEnv("codex", request(), {
+        env: { CODEX_HOME: "" },
+        carryEnv: [{ from: "CODEX_HOME" }],
+      });
+
+      expect(env.CODEX_HOME).toBeUndefined();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = previous;
+      }
+    }
+  });
+
+  it("can copy an env value to a different launch key", () => {
+    const env = harnessLaunchEnv("cursor", request(), {
+      env: { STATION_CURSOR_HOME: "/tmp/cursor-home" },
+      carryEnv: [{ from: "STATION_CURSOR_HOME", to: "HOME" }],
+    });
+
+    expect(env).toMatchObject({
+      STATION_HARNESS_PROVIDER: "cursor",
+      HOME: "/tmp/cursor-home",
+    });
+  });
+});
+
+function request(): BuildHarnessLaunchRequest {
+  return {
+    project: {
+      id: "web",
+      label: "web",
+      root: "/tmp/station/web",
+      defaults: {
+        harness: "codex",
+        terminal: "tmux",
+        layout: "agent-shell",
+      },
+      worktrunk: {
+        enabled: true,
+      },
+    },
+    worktree: {
+      id: "wt_web_task",
+      provider: "worktrunk",
+      projectId: "web",
+      branch: "task",
+      path: "/tmp/station/web/task",
+      state: "exists",
+      source: "worktrunk",
+      observedAt: "2026-06-03T12:00:00.000Z",
+    },
+  };
+}

--- a/scripts/station-devbox.mjs
+++ b/scripts/station-devbox.mjs
@@ -5,7 +5,9 @@
 // Repo root is resolved from THIS script's own location, so a worktree root
 // targets its own .dev-state, never the main checkout's.
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -13,15 +15,20 @@ const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const DS = join(repoRoot, ".dev-state");
 const CFG = join(DS, "config.toml");
 const CLI = join(repoRoot, "apps", "cli", "dist", "main.js");
-const HOST_SOCK = join(DS, "observer", "run", "station-host.sock");
+const SOCKET_DIR = join(
+  tmpdir(),
+  `stn-db-${createHash("sha256").update(repoRoot).digest("hex").slice(0, 12)}`,
+);
+const HOST_SOCK = join(SOCKET_DIR, "station-host.sock");
 const LOG_DIR = join(DS, "observer", "logs");
 const STATION_DIR = join(repoRoot, "station");
 const ISOLATED_SCRIPT = join(repoRoot, "station", "scripts", "station-isolated.sh");
 
-const handlers = { start, restart, status, logs, stop, reset, help };
+const handlers = { start, dev, restart, status, logs, stop, reset, help };
 
 const [rawVerb = "start", ...rest] = process.argv.slice(2);
-const verb = rawVerb === "-h" || rawVerb === "--help" ? "help" : rawVerb;
+const verb =
+  rawVerb === "-h" || rawVerb === "--help" ? "help" : rawVerb === "--hot" ? "dev" : rawVerb;
 const handler = handlers[verb];
 if (handler === undefined) {
   process.stderr.write(`Unknown station:devbox command: ${verb}\n\n`);
@@ -40,6 +47,11 @@ function start() {
   // Station UI links are never stale — `station:devbox` needs no separate build.
   run("pnpm", ["build"], { cwd: repoRoot });
   process.exit(run("bun", ["run", "station:isolated"], { cwd: STATION_DIR, check: false }));
+}
+
+function dev() {
+  run("pnpm", ["build"], { cwd: repoRoot });
+  process.exit(run("bun", ["run", "station:isolated", "dev"], { cwd: STATION_DIR, check: false }));
 }
 
 function restart() {
@@ -102,7 +114,7 @@ function stop() {
 
 function reset(args) {
   // Guarded: this deletes the isolated observer DB, diagnostics, hook artifacts,
-  // and the isolated Codex/Claude homes (and any reattachable host state).
+  // isolated provider homes, and any reattachable host state.
   if (!args.some((arg) => arg === "--yes" || arg === "-y")) {
     process.stderr.write(
       `Refusing to reset without --yes. This deletes everything under ${DS}.\n\n` +
@@ -118,9 +130,10 @@ function reset(args) {
 function help() {
   process.stdout.write(
     [
-      "Usage: pnpm station:devbox [start|restart|status|logs|stop|reset]",
+      "Usage: pnpm station:devbox [start|dev|restart|status|logs|stop|reset]",
       "",
       "  start            (default) build if needed, then start the isolated Station sandbox",
+      "  dev, --hot       build if needed, then start the isolated Station sandbox with UI HMR",
       "  restart          rebuild + recycle the isolated observer (persistent host/agents survive)",
       "  status           report the isolated observer/host + (read-only) the global observer",
       "  logs [--follow]  tail the isolated observer/host/cli logs",

--- a/scripts/test-runners/run-station-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-devbox-smoke.mjs
@@ -7,7 +7,9 @@
 // Warning: runs against the real .dev-state for this checkout — it starts and
 // then STOPS the devbox, so a live devbox here will be stopped.
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -19,8 +21,12 @@ const wrapper = join(repoRoot, "scripts", "station-devbox.mjs");
 const cli = join(repoRoot, "apps", "cli", "dist", "main.js");
 const ds = join(repoRoot, ".dev-state");
 const cfg = join(ds, "config.toml");
-const observerSock = join(ds, "observer", "run", "observer.sock");
-const hostSock = join(ds, "observer", "run", "station-host.sock");
+const socketDir = join(
+  tmpdir(),
+  `stn-db-${createHash("sha256").update(repoRoot).digest("hex").slice(0, 12)}`,
+);
+const observerSock = join(socketDir, "observer.sock");
+const hostSock = join(socketDir, "station-host.sock");
 const hooksDir = join(ds, "observer", "hooks");
 const globalStateFragment = join(".local", "state", "station");
 

--- a/scripts/tui-dev.mjs
+++ b/scripts/tui-dev.mjs
@@ -2,7 +2,8 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import { closeSync, openSync, writeSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { copyFile, lstat, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -28,26 +29,33 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
 }
 
 export async function runTuiDev({ argv = process.argv.slice(2), env = process.env } = {}) {
-  const devSessionName = env.STATION_TUI_SESSION_NAME ?? defaultDevSessionName;
+  const runtime = await prepareTuiDevRuntime({ argv, env });
+  const devSessionName = runtime.env.STATION_TUI_SESSION_NAME ?? defaultDevSessionName;
   const devTuiCommand =
-    env.STATION_TUI_COMMAND ??
-    shellCommand(["env", "STATION_TUI_DEV=1", process.execPath, tuiWatchRunner, cliEntry]);
+    runtime.env.STATION_TUI_COMMAND ??
+    shellCommand([
+      "env",
+      ...devCommandEnvAssignments(runtime),
+      process.execPath,
+      tuiWatchRunner,
+      cliEntry,
+    ]);
   const devOwner = `${process.pid}:${Date.now()}:${randomUUID()}`;
   const registeredDevTuiCommand =
-    env.STATION_TUI_REGISTERED_COMMAND ??
+    runtime.env.STATION_TUI_REGISTERED_COMMAND ??
     appendShellArgs(devTuiCommand, [
-      ...globalOptionsFromArgs(argv),
+      ...globalOptionsFromArgs(runtime.argv),
       "tui",
       "--popup",
       "--persistent",
     ]);
-  const runDirectTui = shouldRunDirectTui(argv, env);
-  const keepAliveAfterLauncherExit = shouldKeepAliveAfterLauncherExit(argv, env);
+  const runDirectTui = shouldRunDirectTui(runtime.argv, runtime.env);
+  const keepAliveAfterLauncherExit = shouldKeepAliveAfterLauncherExit(runtime.argv, runtime.env);
 
   if (keepAliveAfterLauncherExit) {
     await guardAgainstForeignDevPopup({
       currentRoot: repoRoot,
-      env,
+      env: runtime.env,
     });
   }
 
@@ -60,11 +68,14 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     {
       cwd: repoRoot,
       stdio: "inherit",
-      env,
+      env: runtime.env,
     },
   );
   if (initialBuild.status !== 0) {
     process.exit(initialBuild.status ?? 1);
+  }
+  if (runtime.generated) {
+    installTuiDevHooks(runtime);
   }
 
   const logFd = openSync(logPath, "a");
@@ -91,21 +102,23 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     {
       cwd: repoRoot,
       stdio: ["ignore", logFd, logFd],
-      env,
+      env: runtime.env,
     },
   );
 
   const childEnv = {
-    ...env,
+    ...runtime.env,
     STATION_TUI_DEV: "1",
     STATION_TUI_COMMAND: devTuiCommand,
     STATION_TUI_DEV_OWNER: devOwner,
     STATION_TUI_SESSION_NAME: devSessionName,
   };
-  const nodeArgs = runDirectTui ? [tuiWatchRunner, cliEntry, ...argv] : [cliEntry, ...argv];
+  const nodeArgs = runDirectTui
+    ? [tuiWatchRunner, cliEntry, ...runtime.argv]
+    : [cliEntry, ...runtime.argv];
   if (keepAliveAfterLauncherExit) {
     registerDevPopupPreference({
-      env,
+      env: runtime.env,
       owner: devOwner,
       root: repoRoot,
       sessionName: devSessionName,
@@ -129,8 +142,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!launcherExited) {
       station.kill(signal);
     }
-    clearDevPopupPreference({ env, owner: devOwner });
-    cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+    clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+    cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     if (launcherExited) {
       closeLog();
       process.exitCode = 1;
@@ -148,8 +161,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!launcherExited) {
       station.kill("SIGTERM");
     }
-    clearDevPopupPreference({ env, owner: devOwner });
-    cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+    clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+    cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     closeLog();
     process.exitCode = signal === null ? (code ?? 1) : 1;
   });
@@ -165,8 +178,8 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     if (!exiting) {
       exiting = true;
       buildWatcher.kill("SIGTERM");
-      clearDevPopupPreference({ env, owner: devOwner });
-      cleanupDevUiSession(devSessionName, env, defaultDevSessionName);
+      clearDevPopupPreference({ env: runtime.env, owner: devOwner });
+      cleanupDevUiSession(devSessionName, runtime.env, defaultDevSessionName);
     }
     closeLog();
     if (signal !== null) {
@@ -175,6 +188,425 @@ export async function runTuiDev({ argv = process.argv.slice(2), env = process.en
     }
     process.exitCode = code ?? 0;
   });
+}
+
+export async function prepareTuiDevRuntime({ argv = [], env = process.env, root = repoRoot } = {}) {
+  const configFromArgs = configPathFromArgs(argv);
+  if (configFromArgs !== undefined) {
+    return {
+      argv,
+      env: envForExplicitConfig({ env, configPath: configFromArgs, root }),
+      configPath: configFromArgs,
+      generated: false,
+    };
+  }
+
+  const configFromEnv = env.STATION_CONFIG_PATH?.trim();
+  if (configFromEnv !== undefined && configFromEnv.length > 0) {
+    return {
+      argv: ["--config", configFromEnv, ...argv],
+      env: envForExplicitConfig({ env, configPath: configFromEnv, root }),
+      configPath: configFromEnv,
+      generated: false,
+    };
+  }
+
+  const generated = await writeTuiDevConfig({ env, root });
+  const hookEnv = await prepareTuiDevHookEnv({
+    env,
+    checkoutRoot: root,
+    stateRoot: generated.devRoot,
+  });
+  return {
+    argv: ["--config", generated.configPath, ...argv],
+    env: {
+      ...env,
+      ...hookEnv,
+      STATION_CONFIG_PATH: generated.configPath,
+      STATION_OBSERVER_SOCKET_PATH: generated.socketPath,
+    },
+    configPath: generated.configPath,
+    generated: true,
+  };
+}
+
+export async function writeTuiDevConfig({
+  env = process.env,
+  root = repoRoot,
+  readSource = readFile,
+  writeTarget = writeFile,
+  makeDir = mkdir,
+} = {}) {
+  const devRoot = join(root, ".dev-state", "tui-dev");
+  const stateDir = join(devRoot, "observer");
+  const socketPath = tuiDevObserverSocketPath(root);
+  const configPath = join(devRoot, "config.toml");
+  const sourcePath = join(env.HOME ?? homedir(), ".config", "station", "config.toml");
+
+  let source;
+  try {
+    source = await readSource(sourcePath, "utf8");
+  } catch {
+    source = fallbackConfigSource();
+  }
+
+  const config = withObserverPaths(source, { socketPath, stateDir });
+  await makeDir(stateDir, { recursive: true });
+  await makeDir(dirname(socketPath), { recursive: true });
+  await writeTarget(configPath, config, "utf8");
+  return { configPath, socketPath, stateDir, devRoot };
+}
+
+export function configPathFromArgs(argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] !== "--config") {
+      continue;
+    }
+    const value = argv[index + 1];
+    return value === undefined || value.startsWith("--") ? undefined : value;
+  }
+  return undefined;
+}
+
+export function withObserverPaths(source, paths) {
+  let next = ensureTomlSection(source.trimEnd(), "observer");
+  next = setTomlStringKey(next, "observer", "socket_path", paths.socketPath);
+  next = setTomlStringKey(next, "observer", "state_dir", paths.stateDir);
+  next = setTomlStringKey(next, "defaults", "terminal", "noop-terminal");
+  next = setTomlBooleanKey(next, "feature_flags", "station_persistent_agents", true);
+  next = setTomlBooleanKey(next, "harness.codex", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.claude", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.cursor", "install_hooks", true);
+  next = setTomlBooleanKey(next, "harness.opencode", "install_hooks", true);
+  return `${next.trimEnd()}\n`;
+}
+
+export async function prepareTuiDevHookEnv({
+  env = process.env,
+  checkoutRoot = repoRoot,
+  stateRoot = join(repoRoot, ".dev-state", "tui-dev"),
+} = {}) {
+  const homes = tuiDevProviderHomeEnv(stateRoot);
+  await mkdir(homes.CODEX_HOME, { recursive: true });
+  await mkdir(homes.CLAUDE_CONFIG_DIR, { recursive: true });
+  await mkdir(homes.STATION_CURSOR_HOME, { recursive: true });
+  await mkdir(homes.OPENCODE_CONFIG_DIR, { recursive: true });
+
+  const home = env.HOME ?? homedir();
+  await replaceSymlinkIfPresent(
+    join(home, ".codex", "auth.json"),
+    join(homes.CODEX_HOME, "auth.json"),
+  );
+  await copyFileIfMissing(
+    join(home, ".codex", "config.toml"),
+    join(homes.CODEX_HOME, "config.toml"),
+  );
+  await seedCursorHome(home, homes.STATION_CURSOR_HOME);
+
+  return {
+    PATH: `${checkoutRoot}/bin${
+      env.PATH === undefined || env.PATH.length === 0 ? "" : `:${env.PATH}`
+    }`,
+    ...homes,
+  };
+}
+
+function envForExplicitConfig({ env, configPath, root }) {
+  const next = { ...env, STATION_CONFIG_PATH: configPath };
+  delete next.STATION_OBSERVER_SOCKET_PATH;
+
+  const generatedHomes = tuiDevProviderHomeEnv(join(root, ".dev-state", "tui-dev"));
+  for (const [name, value] of Object.entries(generatedHomes)) {
+    if (next[name] === value) {
+      delete next[name];
+    }
+  }
+  return next;
+}
+
+function tuiDevProviderHomeEnv(stateRoot) {
+  return {
+    CODEX_HOME: join(stateRoot, "codex-home"),
+    CLAUDE_CONFIG_DIR: join(stateRoot, "claude-home"),
+    STATION_CURSOR_HOME: join(stateRoot, "cursor-home"),
+    OPENCODE_CONFIG_DIR: join(stateRoot, "opencode-config"),
+  };
+}
+
+export function installTuiDevHooks(runtime, runCommand = spawnSync) {
+  for (const harness of ["codex", "claude", "cursor", "opencode"]) {
+    const result = runCommand(
+      process.execPath,
+      [cliEntry, "--config", runtime.configPath, "hooks", "install", harness, "--yes"],
+      {
+        cwd: repoRoot,
+        env: runtime.env,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if ((result.status ?? 1) === 0) {
+      continue;
+    }
+    const detail = [result.stderr, result.stdout]
+      .filter((text) => typeof text === "string" && text.trim().length > 0)
+      .map((text) => text.trim())
+      .join("\n");
+    process.stderr.write(
+      `warning: failed to install ${harness} hooks for isolated dev TUI${
+        detail.length === 0 ? ".\n" : `:\n${detail}\n`
+      }`,
+    );
+  }
+}
+
+function devCommandEnvAssignments(runtime) {
+  const assignments = [["STATION_TUI_DEV", "1"]];
+  for (const name of [
+    "STATION_CONFIG_PATH",
+    "STATION_OBSERVER_SOCKET_PATH",
+    "CODEX_HOME",
+    "CLAUDE_CONFIG_DIR",
+    "STATION_CURSOR_HOME",
+    "OPENCODE_CONFIG_DIR",
+    "PATH",
+  ]) {
+    const value = runtime.env[name];
+    if (value !== undefined && value.length > 0) {
+      assignments.push([name, value]);
+    }
+  }
+  return assignments.map(([name, value]) => `${name}=${value}`);
+}
+
+async function replaceSymlinkIfPresent(source, target, type) {
+  try {
+    await lstat(source);
+    await mkdir(dirname(target), { recursive: true });
+    await rm(target, { recursive: true, force: true });
+    await symlink(source, target, type);
+  } catch {
+    // Missing identity/auth files are fine; providers will prompt or use local config.
+  }
+}
+
+async function copyFileIfMissing(source, target) {
+  try {
+    await readFile(target, "utf8");
+    return;
+  } catch {
+    // Continue and copy from the real config if it exists.
+  }
+
+  try {
+    await copyFile(source, target);
+  } catch {
+    // A missing real config is acceptable for fresh machines and tests.
+  }
+}
+
+async function seedCursorHome(home, cursorHome) {
+  await replaceSymlinkIfPresent(join(home, ".gitconfig"), join(cursorHome, ".gitconfig"));
+  await replaceSymlinkIfPresent(
+    join(home, ".git-credentials"),
+    join(cursorHome, ".git-credentials"),
+  );
+  await replaceSymlinkIfPresent(join(home, ".ssh"), join(cursorHome, ".ssh"), "dir");
+  await replaceSymlinkIfPresent(
+    join(home, ".config", "git"),
+    join(cursorHome, ".config", "git"),
+    "dir",
+  );
+}
+
+function fallbackConfigSource() {
+  return [
+    "schema_version = 1",
+    "projects = []",
+    "",
+    "[observer]",
+    'socket_path = ""',
+    'state_dir = ""',
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    'harness = "codex"',
+    'layout = "agent-shell"',
+    "",
+  ].join("\n");
+}
+
+function ensureTomlSection(source, section) {
+  if (tomlSectionBounds(source, section) !== undefined) {
+    return source;
+  }
+  const expanded = expandInlineTomlTableSection(source, section);
+  if (tomlSectionBounds(expanded, section) !== undefined) {
+    return expanded;
+  }
+  return `${expanded.trimEnd()}\n\n[${section}]\n`;
+}
+
+function setTomlStringKey(source, section, key, value) {
+  return setTomlKey(source, section, key, JSON.stringify(value));
+}
+
+function setTomlBooleanKey(source, section, key, value) {
+  return setTomlKey(source, section, key, value ? "true" : "false");
+}
+
+function setTomlKey(source, section, key, renderedValue) {
+  const bounds = tomlSectionBounds(source, section);
+  if (bounds === undefined) {
+    return setTomlKey(ensureTomlSection(source, section), section, key, renderedValue);
+  }
+
+  const body = source.slice(bounds.headerEnd, bounds.bodyEnd);
+  const keyPattern = new RegExp(`^([ \\t]*${escapeRegExp(key)}[ \\t]*=[ \\t]*).*$`, "m");
+  const match = keyPattern.exec(body);
+  if (match !== null) {
+    const lineStart = bounds.headerEnd + match.index;
+    const lineEnd = lineStart + match[0].length;
+    return `${source.slice(0, lineStart)}${match[1]}${renderedValue}${source.slice(lineEnd)}`;
+  }
+
+  return `${source.slice(0, bounds.headerEnd)}\n${key} = ${renderedValue}${source.slice(
+    bounds.headerEnd,
+  )}`;
+}
+
+function tomlSectionBounds(source, section) {
+  const sectionPattern = new RegExp(`^[ \\t]*\\[${escapeRegExp(section)}\\][ \\t]*(?:#.*)?$`, "m");
+  const match = sectionPattern.exec(source);
+  if (match === null) {
+    return undefined;
+  }
+
+  const nextSectionPattern = /^[ \t]*\[.*\][ \t]*(?:#.*)?$/gm;
+  nextSectionPattern.lastIndex = match.index + match[0].length;
+  const next = nextSectionPattern.exec(source);
+  return {
+    headerEnd: match.index + match[0].length,
+    bodyEnd: next?.index ?? source.length,
+  };
+}
+
+function expandInlineTomlTableSection(source, section) {
+  const separator = section.lastIndexOf(".");
+  if (separator === -1) {
+    return source;
+  }
+
+  const parentSection = section.slice(0, separator);
+  const tableKey = section.slice(separator + 1);
+  const parentBounds = tomlSectionBounds(source, parentSection);
+  if (parentBounds === undefined) {
+    return source;
+  }
+
+  const parentBody = source.slice(parentBounds.headerEnd, parentBounds.bodyEnd);
+  const inlinePattern = new RegExp(
+    `^([ \\t]*)${escapeRegExp(tableKey)}[ \\t]*=[ \\t]*\\{(.*)\\}[ \\t]*(?:#.*)?$`,
+    "m",
+  );
+  const match = inlinePattern.exec(parentBody);
+  if (match === null) {
+    return source;
+  }
+
+  const entries = inlineTableBodyToTomlLines(match[2]);
+  if (entries.length === 0) {
+    return source;
+  }
+
+  const lineStart = parentBounds.headerEnd + match.index;
+  const lineEnd = lineStart + match[0].length;
+  const removeEnd = source[lineEnd] === "\n" ? lineEnd + 1 : lineEnd;
+  const withoutInline = `${source.slice(0, lineStart)}${source.slice(removeEnd)}`;
+  const insertionIndex = parentBounds.bodyEnd - (removeEnd - lineStart);
+  return `${withoutInline.slice(0, insertionIndex).trimEnd()}\n\n[${section}]\n${entries.join(
+    "\n",
+  )}\n${withoutInline.slice(insertionIndex).replace(/^\n+/, "\n")}`;
+}
+
+function inlineTableBodyToTomlLines(body) {
+  return splitTopLevelCommas(body)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .map((part) => {
+      const equals = findTopLevelEquals(part);
+      if (equals === -1) {
+        return undefined;
+      }
+      return `${part.slice(0, equals).trim()} = ${part.slice(equals + 1).trim()}`;
+    })
+    .filter((line) => line !== undefined);
+}
+
+function splitTopLevelCommas(source) {
+  const parts = [];
+  let start = 0;
+  const state = { quote: undefined, escaped: false, squareDepth: 0, braceDepth: 0 };
+  for (let index = 0; index < source.length; index += 1) {
+    updateTomlInlineScannerState(state, source[index]);
+    if (
+      source[index] === "," &&
+      state.quote === undefined &&
+      state.squareDepth === 0 &&
+      state.braceDepth === 0
+    ) {
+      parts.push(source.slice(start, index));
+      start = index + 1;
+    }
+  }
+  parts.push(source.slice(start));
+  return parts;
+}
+
+function findTopLevelEquals(source) {
+  const state = { quote: undefined, escaped: false, squareDepth: 0, braceDepth: 0 };
+  for (let index = 0; index < source.length; index += 1) {
+    if (
+      source[index] === "=" &&
+      state.quote === undefined &&
+      state.squareDepth === 0 &&
+      state.braceDepth === 0
+    ) {
+      return index;
+    }
+    updateTomlInlineScannerState(state, source[index]);
+  }
+  return -1;
+}
+
+function updateTomlInlineScannerState(state, char) {
+  if (state.quote !== undefined) {
+    if (state.quote === '"' && char === "\\" && !state.escaped) {
+      state.escaped = true;
+      return;
+    }
+    if (char === state.quote && !state.escaped) {
+      state.quote = undefined;
+    }
+    state.escaped = false;
+    return;
+  }
+  if (char === '"' || char === "'") {
+    state.quote = char;
+  } else if (char === "[") {
+    state.squareDepth += 1;
+  } else if (char === "]") {
+    state.squareDepth = Math.max(0, state.squareDepth - 1);
+  } else if (char === "{") {
+    state.braceDepth += 1;
+  } else if (char === "}") {
+    state.braceDepth = Math.max(0, state.braceDepth - 1);
+  }
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function commandFromArgs(argv) {
@@ -230,6 +662,11 @@ export function defaultDevSessionNameForRoot(root) {
     .slice(0, 32);
   const hash = createHash("sha256").update(root).digest("hex").slice(0, 8);
   return `_station-ui-dev-${slug.length === 0 ? "checkout" : slug}-${hash}`;
+}
+
+export function tuiDevObserverSocketPath(root) {
+  const hash = createHash("sha256").update(root).digest("hex").slice(0, 12);
+  return join(tmpdir(), `stn-td-${hash}`, "observer.sock");
 }
 
 export function parseDevPopupOwnerPid(owner) {

--- a/station/scripts/station-isolated.sh
+++ b/station/scripts/station-isolated.sh
@@ -12,62 +12,204 @@ DS="$ROOT/.dev-state"
 CFG="$DS/config.toml"
 STATION_DIR="$ROOT/station"
 CLI="$ROOT/apps/cli/dist/main.js"
+SOCKET_DIR="$(python3 - "$ROOT" <<'PY'
+import hashlib, os, sys, tempfile
+root = sys.argv[1]
+digest = hashlib.sha256(root.encode()).hexdigest()[:12]
+print(os.path.join(tempfile.gettempdir(), f"stn-db-{digest}"))
+PY
+)"
+OBSERVER_SOCK="$SOCKET_DIR/observer.sock"
+HOST_SOCK="$SOCKET_DIR/station-host.sock"
+COMMAND="${1:-start}"
+if [ "$COMMAND" = "--hot" ]; then
+  COMMAND="dev"
+fi
 
 if [ ! -f "$CLI" ]; then
   echo "stn CLI is not built ($CLI missing). Run 'pnpm build' at the repo root first." >&2
   exit 1
 fi
 
-mkdir -p "$DS/observer/run"
+mkdir -p "$DS/observer" "$SOCKET_DIR"
 
-if [ "${1:-}" = "stop" ]; then
+if [ "$COMMAND" = "stop" ]; then
   # Graceful stop can hang mid-reconcile, so finish with path-scoped SIGKILLs
   # against only this worktree's isolated observer and persistent host.
   node "$CLI" --config "$CFG" observer stop --timeout-ms 8000 >/dev/null 2>&1 || true
   pkill -9 -f "observerMain\.js.*$DS/observer" 2>/dev/null && echo "stopped isolated observer." || true
   pkill -9 -f "hostMain\.ts.*$DS/observer" 2>/dev/null && echo "stopped persistent host." || true
-  rm -f "$DS/observer/run/observer.sock" "$DS/observer/run/station-host.sock"
+  rm -f "$OBSERVER_SOCK" "$HOST_SOCK" "$DS/observer/run/observer.sock" "$DS/observer/run/station-host.sock"
   echo "isolated observer + host torn down."
   exit 0
 fi
 
-# Build the isolated config from the real one: observer state + socket relocated
-# to .dev-state, the persistence flag on. Everything else (worktrunk discovery,
-# harness config) is inherited so Station shows the same worktree rows.
-if [ ! -f "$CFG" ]; then
-  python3 - "$DS" <<'PY'
+if [ "$COMMAND" != "start" ] && [ "$COMMAND" != "dev" ]; then
+  echo "Usage: $0 [start|dev|--hot|stop]" >&2
+  exit 1
+fi
+
+# Build the isolated config from the real one: durable observer state relocated
+# to .dev-state and sockets relocated to a short temp path. Everything else
+# (worktrunk discovery, harness config) is inherited so Station shows the same
+# worktree rows.
+python3 - "$CFG" "$DS" "$OBSERVER_SOCK" <<'PY'
 import os, re, sys
-ds = sys.argv[1]
+path = sys.argv[1]
+ds = sys.argv[2]
+observer_sock = sys.argv[3]
 src = os.path.expanduser("~/.config/station/config.toml")
 fallback = (
     'schema_version = 1\n\n[observer]\nsocket_path = ""\nstate_dir = ""\n\n'
     '[defaults]\nworktree_provider = "worktrunk"\nterminal = "tmux"\n'
     'harness = "codex"\nlayout = "agent-shell"\n'
 )
-cfg = open(src).read() if os.path.exists(src) else fallback
-cfg = re.sub(r'socket_path = "[^"]*"', f'socket_path = "{ds}/observer/run/observer.sock"', cfg, count=1)
-cfg = re.sub(r'state_dir = "[^"]*"', f'state_dir = "{ds}/observer"', cfg, count=1)
+cfg = open(path).read() if os.path.exists(path) else open(src).read() if os.path.exists(src) else fallback
+
+def section_bounds(source, section):
+    header_pattern = rf'^[ \t]*\[{re.escape(section)}\][ \t]*(?:#.*)?$'
+    header = re.search(header_pattern, source, flags=re.M)
+    if not header:
+        return None
+    next_header = re.search(r'^[ \t]*\[.*\][ \t]*(?:#.*)?$', source[header.end():], flags=re.M)
+    body_end = len(source) if not next_header else header.end() + next_header.start()
+    return header, body_end
+
+def split_top_level_commas(source):
+    parts = []
+    start = 0
+    quote = None
+    escaped = False
+    square_depth = 0
+    brace_depth = 0
+    for index, char in enumerate(source):
+        if quote:
+            if quote == '"' and char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == quote and not escaped:
+                quote = None
+            escaped = False
+            continue
+        if char in ('"', "'"):
+            quote = char
+        elif char == "[":
+            square_depth += 1
+        elif char == "]":
+            square_depth = max(0, square_depth - 1)
+        elif char == "{":
+            brace_depth += 1
+        elif char == "}":
+            brace_depth = max(0, brace_depth - 1)
+        elif char == "," and square_depth == 0 and brace_depth == 0:
+            parts.append(source[start:index])
+            start = index + 1
+    parts.append(source[start:])
+    return parts
+
+def top_level_equals(source):
+    quote = None
+    escaped = False
+    square_depth = 0
+    brace_depth = 0
+    for index, char in enumerate(source):
+        if quote:
+            if quote == '"' and char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == quote and not escaped:
+                quote = None
+            escaped = False
+            continue
+        if char == "=" and square_depth == 0 and brace_depth == 0:
+            return index
+        if char in ('"', "'"):
+            quote = char
+        elif char == "[":
+            square_depth += 1
+        elif char == "]":
+            square_depth = max(0, square_depth - 1)
+        elif char == "{":
+            brace_depth += 1
+        elif char == "}":
+            brace_depth = max(0, brace_depth - 1)
+    return -1
+
+def inline_table_lines(body):
+    lines = []
+    for part in split_top_level_commas(body):
+        part = part.strip()
+        if not part:
+            continue
+        equals = top_level_equals(part)
+        if equals == -1:
+            continue
+        lines.append(f"{part[:equals].strip()} = {part[equals + 1:].strip()}")
+    return lines
+
+def expand_inline_table_section(source, section):
+    if "." not in section:
+        return source
+    parent, key = section.rsplit(".", 1)
+    bounds = section_bounds(source, parent)
+    if not bounds:
+        return source
+    header, body_end = bounds
+    body = source[header.end():body_end]
+    inline = re.search(rf'^[ \t]*{re.escape(key)}[ \t]*=[ \t]*\{{(.*)\}}[ \t]*(?:#.*)?$', body, flags=re.M)
+    if not inline:
+        return source
+    lines = inline_table_lines(inline.group(1))
+    if not lines:
+        return source
+    line_start = header.end() + inline.start()
+    line_end = line_start + len(inline.group(0))
+    remove_end = line_end + 1 if line_end < len(source) and source[line_end] == "\n" else line_end
+    without_inline = source[:line_start] + source[remove_end:]
+    insertion = body_end - (remove_end - line_start)
+    suffix = re.sub(r'^\n+', '\n', without_inline[insertion:])
+    return without_inline[:insertion].rstrip() + f"\n\n[{section}]\n" + "\n".join(lines) + "\n" + suffix
+
+def set_section_key(source, section, key, rendered):
+    bounds = section_bounds(source, section)
+    if not bounds:
+        expanded = expand_inline_table_section(source, section)
+        bounds = section_bounds(expanded, section)
+        if bounds:
+            return set_section_key(expanded, section, key, rendered)
+        return source.rstrip() + f"\n\n[{section}]\n{key} = {rendered}\n"
+    header, body_end = bounds
+    body = source[header.end():body_end]
+    key_pattern = rf'^(\s*{re.escape(key)}\s*=\s*).*$'
+    if re.search(key_pattern, body, flags=re.M):
+        next_body = re.sub(key_pattern, rf'\1{rendered}', body, count=1, flags=re.M)
+    else:
+        next_body = f"\n{key} = {rendered}{body}"
+    return source[:header.end()] + next_body + source[body_end:]
+cfg = set_section_key(cfg, "observer", "socket_path", f'"{observer_sock}"')
+cfg = set_section_key(cfg, "observer", "state_dir", f'"{ds}/observer"')
 # Isolated Station must not enumerate machine-global tmux panes; that would mark
 # rows as already running. The station provider is still registered separately.
-cfg = re.sub(r'(\[defaults\][^\[]*?terminal = )"[^"]*"', r'\1"noop-terminal"', cfg, count=1, flags=re.S)
-if "station_persistent_agents" not in cfg and "stationPersistentAgents" not in cfg:
-    cfg = cfg.rstrip() + "\n\n[feature_flags]\nstation_persistent_agents = true\n"
-open(f"{ds}/config.toml", "w").write(cfg)
+cfg = set_section_key(cfg, "defaults", "terminal", '"noop-terminal"')
+cfg = set_section_key(cfg, "feature_flags", "station_persistent_agents", "true")
+for harness in ("codex", "claude", "cursor", "opencode"):
+    cfg = set_section_key(cfg, f"harness.{harness}", "install_hooks", "true")
+os.makedirs(os.path.dirname(path), exist_ok=True)
+open(path, "w").write(cfg)
 PY
-fi
 
 # The observer (Node) spawns the Bun host on demand; it finds the host entry via
 # this env var (observerProviders.ts does not pass it, so the env is REQUIRED —
 # without it the host is silently "unavailable" and PTYs fall back to non-persistent).
 export STATION_HOST_ENTRY="$STATION_DIR/src/host/hostMain.ts"
 # Station (Bun) connects to the isolated observer (not the global one) via this env.
-export STATION_OBSERVER_SOCKET_PATH="$DS/observer/run/observer.sock"
+export STATION_OBSERVER_SOCKET_PATH="$OBSERVER_SOCK"
 # Station reads [tui.widgets] directly for its overlay header; point it at the
 # same isolated config as the observer instead of the user's global default.
 export STATION_CONFIG_PATH="$CFG"
-# Keep Codex hooks/auth isolated to this worktree and make generated hooks
-# resolve this checkout's `stn-ingress`. Launched agents inherit both, so status
-# reports target this observer instead of global station state.
+# Keep generated hooks/provider config isolated to this worktree and make hooks
+# resolve this checkout's `stn-ingress`. Launched agents inherit these env vars,
+# so status reports target this observer instead of global station state.
 export PATH="$ROOT/bin:$PATH"
 export CODEX_HOME="$DS/codex-home"
 # Seed isolated Codex auth/config: auth is a shared symlink, config is copied once
@@ -82,18 +224,37 @@ mkdir -p "$CODEX_HOME"
 export CLAUDE_CONFIG_DIR="$DS/claude-home"
 mkdir -p "$CLAUDE_CONFIG_DIR"
 
+export STATION_CURSOR_HOME="$DS/cursor-home"
+export OPENCODE_CONFIG_DIR="$DS/opencode-config"
+mkdir -p "$STATION_CURSOR_HOME" "$OPENCODE_CONFIG_DIR"
+
+seed_cursor_link() {
+  [ -e "$1" ] || return 0
+  rm -rf "$2"
+  mkdir -p "$(dirname "$2")"
+  ln -s "$1" "$2"
+}
+seed_cursor_link "$HOME/.gitconfig" "$STATION_CURSOR_HOME/.gitconfig"
+seed_cursor_link "$HOME/.git-credentials" "$STATION_CURSOR_HOME/.git-credentials"
+seed_cursor_link "$HOME/.ssh" "$STATION_CURSOR_HOME/.ssh"
+seed_cursor_link "$HOME/.config/git" "$STATION_CURSOR_HOME/.config/git"
+
 # Idempotent: reuses a healthy observer, so reopening Station leaves agents alone.
 node "$CLI" --config "$CFG" observer start >/dev/null
 
 # Install status hooks against THIS observer so the launch guard lets these
 # harnesses spawn; each writes into its own isolated home/state, never globals.
-for harness in codex claude; do
+for harness in codex claude cursor opencode; do
   node "$CLI" --config "$CFG" hooks install "$harness" --yes >/dev/null 2>&1 || true
 done
 
 echo "Isolated observer up — $STATION_OBSERVER_SOCKET_PATH"
-echo "  Launch an agent, quit Station (q), re-run 'bun run station:isolated' → it reattaches."
-echo "  Inspect agents:  bun run host:list -- --socket $DS/observer/run/station-host.sock"
+if [ "$COMMAND" = "dev" ]; then
+  echo "  Hot reload: edit station/src/**; Bun HMR updates the isolated UI."
+else
+  echo "  Launch an agent, quit Station (q), re-run 'bun run station:isolated' → it reattaches."
+fi
+echo "  Inspect agents:  bun run host:list -- --socket $HOST_SOCK"
 echo "  Host timeline:   tail -f $DS/observer/logs/station-host.jsonl"
 echo "  Stop everything: bun run station:isolated:stop"
 echo
@@ -105,4 +266,7 @@ if [ "${STATION_ISOLATED_NO_LAUNCH:-}" = "1" ]; then
 fi
 
 cd "$STATION_DIR"
+if [ "$COMMAND" = "dev" ]; then
+  exec bun run dev
+fi
 exec bun run station


### PR DESCRIPTION
## Summary
- make `pnpm dev` / `pnpm station:tui-dev` generate an isolated dev runtime config with repo-local observer state, short checkout-keyed Unix socket paths, and Codex, Claude, Cursor, and OpenCode hook/provider homes
- add `pnpm station:devbox dev` / `--hot` for the nested Station host hot loop with the same short-socket and provider-home isolation
- harden generated TOML edits for indented/commented headers and inline `[harness]` provider tables, collapse the duplicated devbox TOML editor pass, and centralize carried provider env in `harnessLaunchEnv`
- seed Cursor’s isolated `HOME` with git identity/SSH links so isolated Cursor agents keep commit/SSH behavior without writing hooks into global Cursor config

## Validation
- `node --check scripts/tui-dev.mjs && node --check scripts/station-devbox.mjs && node --check scripts/test-runners/run-station-devbox-smoke.mjs && bash -n station/scripts/station-isolated.sh`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/harness-shared/test/unit/launch.test.ts apps/cli/test/unit/tui-dev-script.test.ts integrations/harness/claude/test/unit/launch.test.ts integrations/harness/codex/test/unit/launch.test.ts integrations/harness/cursor/test/unit/hooks.test.ts integrations/harness/cursor/test/unit/provider.test.ts integrations/harness/opencode/test/unit/pluginInstall.test.ts integrations/harness/opencode/test/unit/provider.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check origin/main...HEAD`
- local Unix socket bind check: `tui-dev observer` 82 bytes, `devbox observer` 82 bytes, `devbox host` 86 bytes

## UX implication
Dev runs now keep durable observer/provider state under repo-local `.dev-state`, but keep Unix sockets on short checkout-keyed temp paths so long worktree roots still auto-start correctly. Cursor dev agents also inherit git/SSH identity through their isolated home.