### PR TITLE
refactor(dashboard): drive key actions from keymap

### DIFF
--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -61,7 +61,7 @@ export type TuiKeyPattern =
 
 export type TuiBindingOutcome = "handled" | "exit" | "dismiss-popup";
 
-export type TuiBinding = {
+type TuiBindingSpec = {
   id: string;
   pattern: TuiKeyPattern;
   action: string;
@@ -78,7 +78,7 @@ const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
 // Dashboard dispatch resolves through this table before executing the binding's
 // action. Other mode tables feed copy/tests so documented chords cannot drift
 // silently from their screen machines.
-export const TUI_KEYMAP: Record<TuiInputMode, readonly TuiBinding[]> = {
+export const TUI_KEYMAP = {
   dashboard: [
     {
       id: "tui.dashboard.scrollUp",
@@ -585,16 +585,22 @@ export const TUI_KEYMAP: Record<TuiInputMode, readonly TuiBinding[]> = {
       outcome: "handled",
     },
   ],
-};
+} as const satisfies Record<TuiInputMode, readonly TuiBindingSpec[]>;
 
-export const TUI_GLOBAL_BINDINGS: readonly TuiBinding[] = [
+export const TUI_GLOBAL_BINDINGS = [
   {
     id: "tui.global.exitIntent",
     pattern: { kind: "char", char: "c", ctrl: true },
     action: "tui.exit",
     outcome: "exit",
   },
-];
+] as const satisfies readonly TuiBindingSpec[];
+
+export type TuiModeBinding<M extends TuiInputMode> = (typeof TUI_KEYMAP)[M][number];
+export type TuiGlobalBinding = (typeof TUI_GLOBAL_BINDINGS)[number];
+export type TuiBinding<M extends TuiInputMode = TuiInputMode> =
+  | TuiGlobalBinding
+  | TuiModeBinding<M>;
 
 export const TUI_HELP_CONTENT = [
   { text: "station help", align: "center" as const },
@@ -692,7 +698,10 @@ function matchesPattern(pattern: TuiKeyPattern, key: TuiKey): boolean {
   }
 }
 
-export function matchingTuiBindings(mode: TuiInputMode, key: TuiKey): readonly TuiBinding[] {
+export function matchingTuiBindings<M extends TuiInputMode>(
+  mode: M,
+  key: TuiKey,
+): readonly TuiBinding<M>[] {
   const globals = TUI_GLOBAL_BINDINGS.filter((binding) => matchesPattern(binding.pattern, key));
   if (globals.length > 0) {
     return globals;
@@ -700,6 +709,9 @@ export function matchingTuiBindings(mode: TuiInputMode, key: TuiKey): readonly T
   return TUI_KEYMAP[mode].filter((binding) => matchesPattern(binding.pattern, key));
 }
 
-export function matchTuiBinding(mode: TuiInputMode, key: TuiKey): TuiBinding | undefined {
+export function matchTuiBinding<M extends TuiInputMode>(
+  mode: M,
+  key: TuiKey,
+): TuiBinding<M> | undefined {
   return matchingTuiBindings(mode, key)[0];
 }

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -75,8 +75,9 @@ export type TuiHelpContentLine =
 
 const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
 
-// Metadata only: handleTuiKey remains the behavioral source. These tables feed
-// copy/tests so a documented chord cannot drift silently from the machine.
+// Dashboard dispatch resolves through this table before executing the binding's
+// action. Other mode tables feed copy/tests so documented chords cannot drift
+// silently from their screen machines.
 export const TUI_KEYMAP: Record<TuiInputMode, readonly TuiBinding[]> = {
   dashboard: [
     {

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -45,7 +45,7 @@ export function handleDashboardKey(
 function handleDashboardBinding(
   state: TuiState,
   key: TuiKey,
-  binding: TuiBinding,
+  binding: TuiBinding<"dashboard">,
   context: TuiKeyRuntimeContext,
 ): TuiTransition {
   switch (binding.action) {
@@ -107,8 +107,12 @@ function handleDashboardBinding(
     case "tui.row.activateSlot":
       return activateDashboardSlot(state, key);
     default:
-      return { state };
+      return assertNever(binding);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled dashboard binding: ${JSON.stringify(value)}`);
 }
 
 function exitOrDismissPopup(state: TuiState): TuiTransition {

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -14,6 +14,7 @@ import {
   buildStartAgentCommand,
 } from "../commandBuilders.js";
 import { scrollDashboard } from "../dashboardScroll.js";
+import { matchTuiBinding, type TuiBinding } from "../keymap.js";
 import type { TuiKey } from "../keys.js";
 import { addPendingStartAgentRow } from "../localRows.js";
 import { addTuiToast } from "../toasts.js";
@@ -26,88 +27,105 @@ export function handleDashboardKey(
   key: TuiKey,
   context: TuiKeyRuntimeContext,
 ): TuiTransition {
-  const scrollDelta = scrollDeltaForKey(key);
-  if (scrollDelta !== 0) {
+  const mouseScrollDelta = mouseScrollDeltaForKey(key);
+  if (mouseScrollDelta !== 0) {
     return {
-      state: scrollDashboard(state, scrollDelta),
+      state: scrollDashboard(state, mouseScrollDelta),
     };
   }
 
-  if (key.input === "H" || key.input === "?") {
-    return {
-      state: {
-        ...state,
-        screen: { name: "help" },
-      },
-    };
+  const binding = matchTuiBinding("dashboard", key);
+  if (binding === undefined) {
+    return { state };
   }
 
-  if (
-    state.runtime.persistentPopup &&
-    state.runtime.canDismissPopup &&
-    (key.input === "Q" || key.escape === true)
-  ) {
+  return handleDashboardBinding(state, key, binding, context);
+}
+
+function handleDashboardBinding(
+  state: TuiState,
+  key: TuiKey,
+  binding: TuiBinding,
+  context: TuiKeyRuntimeContext,
+): TuiTransition {
+  switch (binding.action) {
+    case "tui.view.scrollUp":
+      return {
+        state: scrollDashboard(state, -1),
+      };
+    case "tui.view.scrollDown":
+      return {
+        state: scrollDashboard(state, 1),
+      };
+    case "tui.help.open":
+      return {
+        state: {
+          ...state,
+          screen: { name: "help" },
+        },
+      };
+    case "tui.exit":
+      return exitOrDismissPopup(state);
+    case "tui.popup.dismiss":
+      return state.runtime.persistentPopup && state.runtime.canDismissPopup
+        ? { state, dismissPopup: true }
+        : { state };
+    case "tui.search.open":
+      return {
+        state: {
+          ...state,
+          screen: { name: "search", value: "" },
+        },
+      };
+    case "tui.rename.open":
+      return {
+        state: {
+          ...state,
+          screen: { name: "renameSession", step: "chooseSlot" },
+        },
+      };
+    case "tui.refresh":
+      return {
+        state,
+        reconcileReason: "tui-refresh",
+      };
+    case "tui.remove.open":
+      return {
+        state: {
+          ...state,
+          screen: { name: "removeWorktree", step: "chooseSlot" },
+        },
+      };
+    case "tui.newSession.open":
+      return openNewSession(state);
+    case "tui.addProject.open":
+      return {
+        state: openAddProject(state, context),
+      };
+    case "tui.collapse.open":
+      return openProjectCollapse(state);
+    case "tui.row.activateSlot":
+      return activateDashboardSlot(state, key);
+    default:
+      return { state };
+  }
+}
+
+function exitOrDismissPopup(state: TuiState): TuiTransition {
+  if (state.runtime.persistentPopup && state.runtime.canDismissPopup) {
     return {
       state,
       dismissPopup: true,
     };
   }
 
-  if (key.input === "Q") {
-    return {
-      state,
-      exitCode: 0,
-    };
-  }
+  return {
+    state,
+    exitCode: 0,
+  };
+}
 
-  if (key.input === "/") {
-    return {
-      state: {
-        ...state,
-        screen: { name: "search", value: "" },
-      },
-    };
-  }
-
-  if (key.input === "R") {
-    return {
-      state: {
-        ...state,
-        screen: { name: "renameSession", step: "chooseSlot" },
-      },
-    };
-  }
-
-  if (key.input === "Z") {
-    return {
-      state,
-      reconcileReason: "tui-refresh",
-    };
-  }
-
-  if (key.input === "X") {
-    return {
-      state: {
-        ...state,
-        screen: { name: "removeWorktree", step: "chooseSlot" },
-      },
-    };
-  }
-
-  if (key.input === "N") {
-    return openNewSession(state);
-  }
-
-  if (key.input === "A") {
-    return {
-      state: openAddProject(state, context),
-    };
-  }
-
-  if (key.input === "C") {
-    return openProjectCollapse(state);
-  }
-
+function activateDashboardSlot(state: TuiState, key: TuiKey): TuiTransition {
   if (state.snapshot === undefined) {
     return { state };
   }
@@ -151,6 +169,16 @@ export function scrollDeltaForKey(key: TuiKey): -1 | 0 | 1 {
     return -1;
   }
   if (key.downArrow === true || key.mouseScroll === "down") {
+    return 1;
+  }
+  return 0;
+}
+
+function mouseScrollDeltaForKey(key: TuiKey): -1 | 0 | 1 {
+  if (key.mouseScroll === "up") {
+    return -1;
+  }
+  if (key.mouseScroll === "down") {
     return 1;
   }
   return 0;


### PR DESCRIPTION
## Summary

- Route dashboard key handling through `TUI_KEYMAP` binding action ids before executing behavior.
- Keep mouse wheel scrolling as the non-keyboard path while arrow-key scrolling now resolves through keymap metadata.
- Update the keymap comment so the dashboard table is documented as behavioral, with other mode tables still acting as copy/test contracts.

## Why

This fixes the drift risk where dashboard bindings were declared in `TUI_KEYMAP` but behavior lived in parallel `key.input === ...` checks.

## UX impact

Dashboard shortcuts keep the same visible behavior (`H/?`, `Q/Esc`, `/`, `R`, `Z`, `X`, `N`, `A`, `C`, row slots), but changing a dashboard binding now changes the dispatch path instead of only the documentation.

## Validation

- `pnpm build`
- `pnpm exec vitest run packages/dashboard-core/test/unit/state/keymap.test.ts packages/dashboard-core/test/unit/state/transition.test.ts`