### PR TITLE
refactor(dashboard): extract row activation policy

### DIFF
--- a/packages/dashboard-core/src/state/rowActivation.ts
+++ b/packages/dashboard-core/src/state/rowActivation.ts
@@ -1,0 +1,113 @@
+import type { TerminalFocusOrigin, WorktreeRow } from "@station/contracts";
+import { worktreeHasLiveAgent } from "@station/contracts";
+import { safeErrorToToast } from "../services/errors/errors.js";
+import {
+  buildFocusCommand,
+  buildResumeAgentCommand,
+  buildStartAgentCommand,
+} from "./commandBuilders.js";
+import { addPendingStartAgentRow } from "./localRows.js";
+import { addTuiToast } from "./toasts.js";
+import type { TuiTransition } from "./transition.js";
+import type { TuiState } from "./types.js";
+
+export function activateDashboardRow(state: TuiState, row: WorktreeRow): TuiTransition {
+  // Launch (or resume) unless the row has a genuinely live agent to focus. A "?"
+  // (unknown) row whose terminal is dead is launchable here, not a dead focus -
+  // the dashboard-side half of the observer's relaunch-unknown-rows fix.
+  if (row.recovery !== undefined || !worktreeHasLiveAgent(row)) {
+    return startOrResumeAgentForRow(state, row);
+  }
+
+  if (row.terminal !== undefined && row.terminal.focusable !== true) {
+    // The agent's terminal cannot be focused from the dashboard (e.g. it is
+    // hosted by Station, whose provider reports canFocusTarget:false). Surface a
+    // one-time notice instead of dispatching a focus the provider can only
+    // reject, which otherwise spams error toasts on every open keypress.
+    return {
+      state: addTuiToast(state, {
+        kind: "info",
+        message: `This agent runs in the "${row.terminal.provider}" terminal and can't be focused from the dashboard.`,
+      }),
+    };
+  }
+
+  return {
+    state,
+    commands: [buildFocusCommand(row, focusCommandOptions(state.runtime.focusOrigin))],
+  };
+}
+
+function startOrResumeAgentForRow(state: TuiState, row: WorktreeRow): TuiTransition {
+  const project = state.snapshot?.projects.find((candidate) => candidate.id === row.projectId);
+  if (project === undefined) {
+    return {
+      state: addTuiToast(
+        state,
+        safeErrorToToast({
+          tag: "CommandValidationError",
+          code: "PROJECT_NOT_FOUND",
+          message: `Project not found for worktree ${row.id}.`,
+        }),
+      ),
+    };
+  }
+
+  if (row.recovery !== undefined) {
+    const command = buildResumeAgentCommand(row, project);
+    const localId = `resume:${row.id}`;
+    return {
+      state: addPendingStartAgentRow(state, {
+        localId,
+        operation: "resumeAgent",
+        projectId: row.projectId,
+        worktreeId: row.id,
+        branch: row.branch,
+        createdAt: new Date().toISOString(),
+      }),
+      operations: [
+        {
+          type: "resumeAgent",
+          localId,
+          projectId: row.projectId,
+          worktreeId: row.id,
+          branch: row.branch,
+          command,
+        },
+      ],
+    };
+  }
+
+  const command = buildStartAgentCommand(row, project);
+  const localId = `start:${row.id}`;
+  return {
+    state: addPendingStartAgentRow(state, {
+      localId,
+      operation: "startAgent",
+      projectId: row.projectId,
+      worktreeId: row.id,
+      branch: row.branch,
+      createdAt: new Date().toISOString(),
+    }),
+    operations: [
+      {
+        type: "startAgent",
+        localId,
+        projectId: row.projectId,
+        worktreeId: row.id,
+        branch: row.branch,
+        command,
+      },
+    ],
+  };
+}
+
+function focusCommandOptions(focusOrigin: TerminalFocusOrigin | undefined): {
+  origin?: TerminalFocusOrigin;
+} {
+  const options: { origin?: TerminalFocusOrigin } = {};
+  if (focusOrigin !== undefined) {
+    options.origin = focusOrigin;
+  }
+  return options;
+}

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -1,5 +1,3 @@
-import type { TerminalFocusOrigin } from "@station/contracts";
-import { worktreeHasLiveAgent } from "@station/contracts";
 import { createNewSessionFlow, createNewSessionNameToken } from "../../flows/newSession.js";
 import { selectDashboardViewport } from "../../selectors/dashboardViewport.js";
 import {
@@ -8,15 +6,10 @@ import {
   selectProjectChoices,
 } from "../../selectors/selectors.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
-import {
-  buildFocusCommand,
-  buildResumeAgentCommand,
-  buildStartAgentCommand,
-} from "../commandBuilders.js";
 import { scrollDashboard } from "../dashboardScroll.js";
 import { matchTuiBinding, type TuiBinding } from "../keymap.js";
 import type { TuiKey } from "../keys.js";
-import { addPendingStartAgentRow } from "../localRows.js";
+import { activateDashboardRow } from "../rowActivation.js";
 import { addTuiToast } from "../toasts.js";
 import type { TuiKeyRuntimeContext, TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
@@ -138,30 +131,7 @@ function activateDashboardSlot(state: TuiState, key: TuiKey): TuiTransition {
     return { state };
   }
 
-  // Launch (or resume) unless the row has a genuinely live agent to focus. A "?"
-  // (unknown) row whose terminal is dead is launchable here, not a dead focus —
-  // the dashboard-side half of the observer's relaunch-unknown-rows fix.
-  if (row.recovery !== undefined || !worktreeHasLiveAgent(row)) {
-    return startOrResumeAgentForRow(state, row);
-  }
-
-  if (row.terminal !== undefined && row.terminal.focusable !== true) {
-    // The agent's terminal cannot be focused from the dashboard (e.g. it is
-    // hosted by Station, whose provider reports canFocusTarget:false). Surface a
-    // one-time notice instead of dispatching a focus the provider can only
-    // reject — which otherwise spams error toasts on every open keypress.
-    return {
-      state: addTuiToast(state, {
-        kind: "info",
-        message: `This agent runs in the "${row.terminal.provider}" terminal and can't be focused from the dashboard.`,
-      }),
-    };
-  }
-
-  return {
-    state,
-    commands: [buildFocusCommand(row, focusCommandOptions(state.runtime.focusOrigin))],
-  };
+  return activateDashboardRow(state, row);
 }
 
 export function scrollDeltaForKey(key: TuiKey): -1 | 0 | 1 {
@@ -227,83 +197,6 @@ function openProjectCollapse(state: TuiState): TuiTransition {
   };
 }
 
-function startOrResumeAgentForRow(
-  state: TuiState,
-  row: NonNullable<TuiState["snapshot"]>["rows"][number],
-): TuiTransition {
-  const project = state.snapshot?.projects.find((candidate) => candidate.id === row.projectId);
-  if (project === undefined) {
-    return {
-      state: addTuiToast(
-        state,
-        safeErrorToToast({
-          tag: "CommandValidationError",
-          code: "PROJECT_NOT_FOUND",
-          message: `Project not found for worktree ${row.id}.`,
-        }),
-      ),
-    };
-  }
-
-  if (row.recovery !== undefined) {
-    const command = buildResumeAgentCommand(row, project);
-    const localId = `resume:${row.id}`;
-    return {
-      state: addPendingStartAgentRow(state, {
-        localId,
-        operation: "resumeAgent",
-        projectId: row.projectId,
-        worktreeId: row.id,
-        branch: row.branch,
-        createdAt: new Date().toISOString(),
-      }),
-      operations: [
-        {
-          type: "resumeAgent",
-          localId,
-          projectId: row.projectId,
-          worktreeId: row.id,
-          branch: row.branch,
-          command,
-        },
-      ],
-    };
-  }
-
-  const command = buildStartAgentCommand(row, project);
-  const localId = `start:${row.id}`;
-  return {
-    state: addPendingStartAgentRow(state, {
-      localId,
-      operation: "startAgent",
-      projectId: row.projectId,
-      worktreeId: row.id,
-      branch: row.branch,
-      createdAt: new Date().toISOString(),
-    }),
-    operations: [
-      {
-        type: "startAgent",
-        localId,
-        projectId: row.projectId,
-        worktreeId: row.id,
-        branch: row.branch,
-        command,
-      },
-    ],
-  };
-}
-
 function formatProjectChoicePrompt(choices: ReadonlyArray<KeyedChoice<{ label: string }>>): string {
   return choices.map((choice) => `${choice.key}:${choice.value.label}`).join(" ");
-}
-
-function focusCommandOptions(focusOrigin: TerminalFocusOrigin | undefined): {
-  origin?: TerminalFocusOrigin;
-} {
-  const options: { origin?: TerminalFocusOrigin } = {};
-  if (focusOrigin !== undefined) {
-    options.origin = focusOrigin;
-  }
-  return options;
 }


### PR DESCRIPTION
## Summary

- Move dashboard row start/resume/focus policy into `state/rowActivation.ts`.
- Leave the dashboard screen handler responsible for viewport slot selection and delegate command/operation construction to the policy helper.
- Preserve existing start-agent, resume-agent, non-focusable-terminal notice, and focus-command behavior.

## Why

This separates UI key handling from runtime command policy so dashboard screen transitions do not directly build start/resume/focus commands.

## UX impact

No intended shortcut or row-open behavior changes. Manual verification: in the dashboard, pressing a visible row slot should still start/resume an agent when needed, focus live focusable rows, and show the existing notice for non-focusable terminals.

## Validation

- `pnpm build`
- `pnpm exec vitest run packages/dashboard-core/test/unit/state/transition.test.ts packages/dashboard-core/test/unit/state/keymap.test.ts packages/dashboard-core/test/unit/state/commandBuilders.test.ts`

## Stacking

Stacked on #28 (`refactor/dashboard-keymap-actions`) to avoid competing edits in `screens/dashboard.ts`.