### PR TITLE
refactor(worktree): seed forks with read-only temp-index snapshot

### DIFF
--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -1,6 +1,6 @@
-import { constants as fsConstants } from "node:fs";
-import { copyFile, lstat, mkdir, readlink, symlink } from "node:fs/promises";
-import { dirname, isAbsolute, join, normalize, relative, resolve } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, normalize, relative, resolve } from "node:path";
 import type {
   CreateWorktreeRequest,
   DiagnosticDetail,
@@ -55,10 +55,6 @@ export type WorktrunkProviderOptions = {
   runner?: ExternalCommandRunner;
   clock?: RuntimeClock;
 };
-
-// The untracked-file list (paths only, .gitignore-filtered) is captured into memory;
-// generous cap so large dirty trees are not silently truncated.
-const SEED_LS_FILES_MAX_OUTPUT_CHARS = 16 * 1024 * 1024;
 
 const defaultCapabilities: WorktreeCapabilities = {
   canCreate: true,
@@ -267,63 +263,37 @@ export class WorktrunkProvider implements WorktreeProvider {
     return found;
   }
 
-  // Copies the source worktree's uncommitted working tree (staged, unstaged, and
-  // untracked) into the freshly created worktree. Worktrees in one repo share a
-  // single object store, so a stash commit created in the source is reachable from
-  // the target. The new branch must be based on the source's HEAD for a clean apply.
   async #seedWorkingTree(srcPath: string, tgtPath: string): Promise<void> {
-    const created = await this.#runSeedCommand("git", ["-C", srcPath, "stash", "create"]);
-    const stashSha = created.stdout.trim();
-    if (stashSha.length > 0) {
-      // --index preserves the staged/unstaged split and, on a divergent base,
-      // refuses atomically (leaving the target clean) instead of writing markers.
-      await this.#runSeedCommand("git", ["-C", tgtPath, "stash", "apply", "--index", stashSha]);
-    }
-    await this.#copyUntrackedFiles(srcPath, tgtPath);
-  }
-
-  // `git stash create` never captures untracked files, so copy them explicitly.
-  // ls-files emits NUL-separated paths relative to the source worktree (honoring
-  // .gitignore), copied file-by-file so any failure surfaces instead of being masked
-  // by a shell pipeline, and resolved against the source so cwd never matters.
-  async #copyUntrackedFiles(srcPath: string, tgtPath: string): Promise<void> {
-    const listed = await this.#runSeedCommand(
-      "git",
-      ["-C", srcPath, "ls-files", "--others", "--exclude-standard", "-z"],
-      SEED_LS_FILES_MAX_OUTPUT_CHARS,
-    );
-    const relativePaths = listed.stdout.split("\0").filter((entry) => entry.length > 0);
+    const indexDir = await mkdtemp(join(tmpdir(), "wt-seed-index-"));
+    // Snapshot the source's full working tree via a throwaway index, so `add -A` never
+    // writes the source's real index. Collapses the staged/unstaged split — everything
+    // lands staged in the target, which is fine for a fork.
+    const env = { GIT_INDEX_FILE: join(indexDir, "index") };
     try {
-      for (const relativePath of relativePaths) {
-        const from = join(srcPath, relativePath);
-        const to = join(tgtPath, relativePath);
-        await mkdir(dirname(to), { recursive: true });
-        const stats = await lstat(from);
-        if (stats.isSymbolicLink()) {
-          // Preserve the link instead of dereferencing it (and avoid failing on a
-          // dangling target). Keep an existing target (mirrors a no-clobber copy).
-          await keepExisting(symlink(await readlink(from), to));
-        } else {
-          await keepExisting(copyFile(from, to, fsConstants.COPYFILE_EXCL));
-        }
-      }
-    } catch (cause) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_SEED_FAILED",
-        "Worktrunk created the worktree but failed to copy untracked files from the source.",
-        { cause },
-      );
+      await this.#runSeedCommand("git", ["-C", srcPath, "read-tree", "HEAD"], { env });
+      await this.#runSeedCommand("git", ["-C", srcPath, "add", "-A"], { env });
+      const written = await this.#runSeedCommand("git", ["-C", srcPath, "write-tree"], { env });
+      const tree = written.stdout.trim();
+      // Materialize the snapshot in the target (incl. deletions); a clean source yields
+      // HEAD's tree, so this is a no-op.
+      await this.#runSeedCommand("git", ["-C", tgtPath, "read-tree", "-m", "-u", tree]);
+    } finally {
+      await rm(indexDir, { recursive: true, force: true });
     }
   }
 
-  async #runSeedCommand(command: string, args: string[], maxOutputChars?: number) {
+  async #runSeedCommand(
+    command: string,
+    args: string[],
+    options?: { env?: Record<string, string> },
+  ) {
     try {
       return await runExternalCommand(
         {
           command,
           args,
           timeoutMs: this.#timeoutMs,
-          ...(maxOutputChars === undefined ? {} : { maxOutputChars }),
+          ...(options?.env === undefined ? {} : { env: options.env }),
         },
         this.#runner,
       );
@@ -811,18 +781,6 @@ function isMainWorktree(project: ProviderProjectConfig, observation: WorktreeObs
     samePath(observation.path, project.root) ||
     (defaultBranch !== undefined && observation.branch === defaultBranch)
   );
-}
-
-// Treat an already-present target as success so files seeded by worktrunk lifecycle
-// hooks (e.g. copy-ignored) are not clobbered; any other error propagates.
-async function keepExisting(operation: Promise<unknown>): Promise<void> {
-  try {
-    await operation;
-  } catch (cause) {
-    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw cause;
-    }
-  }
 }
 
 function worktreePathEnv(

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { nodeExternalCommandRunner } from "@station/runtime";
 import { WorktrunkProvider } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 
@@ -297,9 +298,29 @@ describe("WorktrunkProvider", () => {
     const root = await mkdtemp(join(tmpdir(), "wt-seed-"));
     const srcPath = join(root, "source");
     const tgtPath = join(root, "feature");
+    const git = (cwd: string, ...args: string[]) =>
+      nodeExternalCommandRunner({ command: "git", args, cwd });
+
+    // Real source repo: a base commit, then a dirty working tree spanning every state
+    // the seed must carry (unstaged mod, staged mod, tracked deletion, untracked + nested).
+    await mkdir(srcPath, { recursive: true });
+    await git(srcPath, "init", "-q");
+    await git(srcPath, "config", "user.email", "t@example.com");
+    await git(srcPath, "config", "user.name", "t");
+    await git(srcPath, "config", "commit.gpgsign", "false");
+    await writeFile(join(srcPath, "tracked.txt"), "base\n");
+    await writeFile(join(srcPath, "staged.txt"), "base\n");
+    await writeFile(join(srcPath, "deleteme.txt"), "bye\n");
+    await git(srcPath, "add", ".");
+    await git(srcPath, "commit", "-qm", "init");
+    await writeFile(join(srcPath, "tracked.txt"), "base\nunstaged\n");
+    await writeFile(join(srcPath, "staged.txt"), "base\nstaged\n");
+    await git(srcPath, "add", "staged.txt");
+    await rm(join(srcPath, "deleteme.txt"));
     await mkdir(join(srcPath, "nested"), { recursive: true });
     await writeFile(join(srcPath, "untracked.txt"), "untracked-contents");
     await writeFile(join(srcPath, "nested", "deep.txt"), "deep-contents");
+    const srcStatusBefore = (await git(srcPath, "status", "--porcelain")).stdout;
 
     const calls: ExternalCommandInput[] = [];
     const provider = new WorktrunkProvider({
@@ -308,15 +329,18 @@ describe("WorktrunkProvider", () => {
       runner: async (input) => {
         calls.push(input);
         if (input.command === "wt" && input.args?.[0] === "switch") {
+          // Stand in for `wt switch --create`: a real linked worktree at the source HEAD
+          // so the seed can materialize the snapshot tree into it.
+          await git(srcPath, "worktree", "add", "-q", tgtPath, "-b", "feature", "HEAD");
           return result(input, JSON.stringify([{ path: tgtPath, branch: "feature" }]));
         }
         if (input.command === "wt" && input.args?.[0] === "list") {
           return result(input, JSON.stringify([{ path: tgtPath, branch: "feature", dirty: true }]));
         }
-        if (input.command === "git" && input.args?.includes("ls-files")) {
-          return result(input, "untracked.txt\0nested/deep.txt\0");
+        // Run the seed's git plumbing for real against the temp repos.
+        if (input.command === "git") {
+          return nodeExternalCommandRunner(input);
         }
-        // git stash create: no tracked changes in this fixture.
         return result(input, "");
       },
     });
@@ -332,21 +356,34 @@ describe("WorktrunkProvider", () => {
       // The post-seed re-list surfaces the copied dirty state on the returned observation.
       expect(created).toMatchObject({ branch: "feature", dirty: true });
 
-      // Untracked files (incl. nested) are really copied into the target worktree.
+      // The full working tree really lands in the target (git did the materialization):
+      // unstaged mod, staged mod, untracked (incl. nested), and the tracked deletion.
+      expect(await readFile(join(tgtPath, "tracked.txt"), "utf8")).toBe("base\nunstaged\n");
+      expect(await readFile(join(tgtPath, "staged.txt"), "utf8")).toBe("base\nstaged\n");
       expect(await readFile(join(tgtPath, "untracked.txt"), "utf8")).toBe("untracked-contents");
       expect(await readFile(join(tgtPath, "nested", "deep.txt"), "utf8")).toBe("deep-contents");
+      await expect(readFile(join(tgtPath, "deleteme.txt"))).rejects.toThrow();
 
-      // Tracked changes travel via a stash object; untracked via ls-files relative to the
-      // source (no cwd dependency, no shell pipeline to mask a failure).
-      const seedCommands = calls
-        .filter((call) => call.command === "git")
-        .map((call) => (call.args ?? []).join(" "));
-      expect(seedCommands).toEqual([
-        `-C ${srcPath} stash create`,
-        `-C ${srcPath} ls-files --others --exclude-standard -z`,
+      // The seed is read-only: the source worktree is byte-for-byte unchanged, so a live
+      // agent running there is never disturbed.
+      expect((await git(srcPath, "status", "--porcelain")).stdout).toBe(srcStatusBefore);
+
+      // The seed is a temp-index snapshot — read-tree HEAD -> add -A -> write-tree against
+      // a throwaway index in the source, materialized via read-tree -m -u in the target.
+      const seedCalls = calls.filter((call) => call.command === "git");
+      expect(seedCalls).toHaveLength(4);
+      expect(seedCalls.slice(0, 3).map((call) => call.args)).toEqual([
+        ["-C", srcPath, "read-tree", "HEAD"],
+        ["-C", srcPath, "add", "-A"],
+        ["-C", srcPath, "write-tree"],
       ]);
+      expect(
+        seedCalls.slice(0, 3).every((call) => typeof call.env?.GIT_INDEX_FILE === "string"),
+      ).toBe(true);
+      expect(seedCalls[3]?.args?.slice(0, 5)).toEqual(["-C", tgtPath, "read-tree", "-m", "-u"]);
+      expect(seedCalls[3]?.args?.[5]).toMatch(/^[0-9a-f]{40}$/);
 
-      // The fork's base is pinned to the source branch so the seeded apply is conflict-free.
+      // The fork's base is pinned to the source branch so the seed materializes cleanly.
       const switchCall = calls.find((c) => c.command === "wt" && c.args?.[0] === "switch");
       expect(switchCall?.args).toContain("source-branch");
     } finally {


### PR DESCRIPTION
Replaces the fork working-tree seed (`stash create` + `apply --index` + `ls-files` + manual fs copy) with a read-only **temp-index snapshot**: `read-tree HEAD` → `add -A` → `write-tree` against a throwaway `GIT_INDEX_FILE`, then `read-tree -m -u` to materialize the tree in the new worktree.

## Why
- Git handles modes, symlinks, deletions, and `.gitignore` natively — so `copyUntrackedFiles`, the EEXIST helper, the `ls-files` output cap, and the `node:fs` symlink/copy imports are deleted (**~83 → ~53 LOC**).
- The seed never mutates the source worktree (no `stash push`), so a **live agent running in the source is undisturbed**.

## Trade-off
The snapshot collapses the staged/unstaged split — everything lands **staged** in the fork. Immaterial for a fork's file contents.

## Tests
The provider unit test now drives **real git repos** to prove the full working tree (unstaged mod, staged mod, tracked deletion, untracked + nested) materializes in the target, the deletion propagates, and the **source is byte-for-byte unchanged**.

Verified locally: `turbo typecheck` 44/44, worktrunk unit 22/22, biome clean. (GitHub Actions intentionally skipped — out of minutes this week.)