### PR TITLE
feat(station): interactive fork session in the native UI

### DIFF
--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -353,6 +353,7 @@ function commandScope(command: StationCommand): string {
     case "session.resumeAgent":
       return `worktree:${command.payload.worktreeId}`;
     case "worktree.create":
+    case "worktree.fork":
     case "session.create":
     case "session.fork":
       return `project:${command.payload.projectId}`;

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -23,6 +23,7 @@ import type { SessionCommandIdFactory } from "./session/shared.js";
 import { createSessionStartAgentHandler } from "./session/startAgent.js";
 import { createTerminalCloseHandler, createTerminalFocusHandler } from "./terminal.js";
 import { createWorktreeCreateHandler } from "./worktree/create.js";
+import { createWorktreeForkHandler } from "./worktree/fork.js";
 import { createWorktreeRemoveHandler } from "./worktree/remove.js";
 
 export type RegisterObserverCommandHandlersOptions = {
@@ -171,6 +172,18 @@ export function registerObserverCommandHandlers(
     }),
   );
   options.queue.registerHandler(
+    "worktree.fork",
+    createWorktreeForkHandler({
+      getProjects,
+      providers: options.providers,
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      commandTimeoutMs: options.commandTimeoutMs,
+      logger: options.logger,
+    }),
+  );
+  options.queue.registerHandler(
     "worktree.remove",
     createWorktreeRemoveHandler({
       providers: options.providers,
@@ -225,6 +238,7 @@ export function registerObserverCommandHandlers(
       "session.rename",
       "session.acknowledgeTurn",
       "worktree.create",
+      "worktree.fork",
       "worktree.remove",
       "project.add",
       "project.remove",

--- a/apps/observer/src/commands/worktree/fork.ts
+++ b/apps/observer/src/commands/worktree/fork.ts
@@ -1,0 +1,94 @@
+import type { CreateWorktreeRequest, ProviderProjectConfig } from "@station/contracts";
+import type { JsonlLogger } from "@station/observability";
+import type { RuntimeClock } from "@station/runtime";
+import type { ProviderRegistry } from "../../providers/registry.js";
+import type { ObserverCore } from "../../reconcile/core.js";
+import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import { assertCommandType } from "../assertCommand.js";
+import type { CommandHandler } from "../queue.js";
+import { reconcileAndPublish } from "../reconcile.js";
+import {
+  commandValidationError,
+  findProjectOrThrow,
+  runProviderMutation,
+  throwIfAborted,
+  validateSnapshotRow,
+} from "../session/shared.js";
+
+export type WorktreeForkHandlerOptions = {
+  getProjects: () => readonly ProviderProjectConfig[];
+  providers: ProviderRegistry;
+  core: ObserverCore;
+  eventBus?: ObserverEventBus | undefined;
+  clock?: RuntimeClock | undefined;
+  commandTimeoutMs?: number | undefined;
+  logger?: JsonlLogger | undefined;
+};
+
+/**
+ * Worktree-only half of session.fork for Station: branch off the source
+ * worktree's HEAD and seed its working tree (when copyDirty), then let Station
+ * host the inherited harness itself via prepareExternalLaunch. Unlike
+ * session.fork it mints no session and launches no terminal. There is no
+ * live-agent guard on the source — the seed is a read-only snapshot.
+ */
+export function createWorktreeForkHandler(options: WorktreeForkHandlerOptions): CommandHandler {
+  return async (context) => {
+    assertCommandType(context, "worktree.fork");
+    throwIfAborted(context.signal);
+
+    const payload = context.command.payload;
+    const project = findProjectOrThrow(options.getProjects(), payload.projectId);
+
+    const sourceRow = options.core
+      .getSnapshot()
+      .rows.find((candidate) => candidate.id === payload.sourceWorktreeId);
+    validateSnapshotRow(sourceRow, payload.projectId);
+    if (sourceRow === undefined) {
+      throw commandValidationError({
+        code: "WORKTREE_NOT_FOUND",
+        message: "The source worktree to fork is not visible in the current snapshot.",
+        projectId: payload.projectId,
+        worktreeId: payload.sourceWorktreeId,
+      });
+    }
+
+    const copyDirty = payload.copyDirty ?? true;
+    // Pin the new branch base to the source branch HEAD so the seeded apply is
+    // conflict-free; an explicit base override may reintroduce conflicts.
+    const request: CreateWorktreeRequest = {
+      project,
+      branch: payload.branch,
+      base: payload.base ?? sourceRow.branch,
+    };
+    if (copyDirty) {
+      request.seedFrom = { path: sourceRow.path, worktreeId: sourceRow.id };
+    }
+
+    await runProviderMutation(
+      {
+        clock: options.clock,
+        commandTimeoutMs: options.commandTimeoutMs,
+        signal: context.signal,
+        trace: context.trace,
+        operation: `provider.${options.providers.worktree.id}.createWorktree`,
+        fallback: {
+          tag: "WorktreeProviderError",
+          code: "WORKTREE_CREATE_FAILED",
+          message: "The worktree provider failed to create the forked worktree.",
+          provider: options.providers.worktree.id,
+        },
+      },
+      () => options.providers.worktree.createWorktree(request),
+    );
+    throwIfAborted(context.signal);
+
+    await reconcileAndPublish({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      reason: "command:worktree.fork",
+      trace: context.trace,
+    });
+  };
+}

--- a/apps/observer/src/commands/worktree/fork.ts
+++ b/apps/observer/src/commands/worktree/fork.ts
@@ -26,11 +26,10 @@ export type WorktreeForkHandlerOptions = {
 };
 
 /**
- * Worktree-only half of session.fork for Station: branch off the source
- * worktree's HEAD and seed its working tree (when copyDirty), then let Station
- * host the inherited harness itself via prepareExternalLaunch. Unlike
- * session.fork it mints no session and launches no terminal. There is no
- * live-agent guard on the source — the seed is a read-only snapshot.
+ * Worktree-only half of session.fork: branch off the source HEAD and seed its
+ * working tree (when copyDirty), minting no session and launching no terminal so
+ * Station can host the inherited harness itself. No live-agent guard on the
+ * source — the seed is a read-only snapshot.
  */
 export function createWorktreeForkHandler(options: WorktreeForkHandlerOptions): CommandHandler {
   return async (context) => {

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1648,3 +1648,88 @@ describe("worktree.create command", () => {
     fixture.sqlite.close();
   });
 });
+
+describe("worktree.fork command", () => {
+  async function createSource(fixture: ReturnType<typeof createFixture>, branch: string) {
+    await fixture.queue.dispatch({
+      type: "worktree.create",
+      payload: { projectId: "web", branch },
+    });
+    await fixture.queue.drain();
+    const row = fixture.core.getSnapshot().rows.find((candidate) => candidate.branch === branch);
+    if (row === undefined) {
+      throw new Error(`source worktree ${branch} was not created`);
+    }
+    return row;
+  }
+
+  it("branches off the source and seeds its working tree, with no session or terminal", async () => {
+    // The native fork mirrors New Session: seed a worktree, then Station hosts the
+    // inherited harness itself — so this must NOT mint a session or launch a terminal.
+    const worktree = new FakeWorktreeProvider({ now });
+    const terminal = new FakeTerminalProvider({ now });
+    const fixture = createFixture({ worktree, terminal });
+    const source = await createSource(fixture, "feature");
+
+    const receipt = await fixture.queue.dispatch({
+      type: "worktree.fork",
+      payload: { projectId: "web", sourceWorktreeId: source.id, branch: "feature-fork" },
+    });
+    await fixture.queue.drain();
+
+    expect(receipt).toMatchObject({ accepted: true, status: "accepted" });
+
+    const rows = fixture.core.getSnapshot().rows;
+    expect(rows.map((row) => row.branch).sort()).toEqual(["feature", "feature-fork"]);
+    expect(rows.find((row) => row.branch === "feature-fork")?.agent).toBeUndefined();
+    expect(fixture.core.getSnapshot().sessions).toEqual([]);
+    expect(terminal.snapshot().launches).toHaveLength(0);
+
+    // The fork create pins base to the source branch HEAD and seeds from the source path.
+    const forkCreate = worktree.snapshot().created.find((req) => req.branch === "feature-fork");
+    expect(forkCreate).toMatchObject({
+      branch: "feature-fork",
+      base: "feature",
+      seedFrom: { path: source.path, worktreeId: source.id },
+    });
+    fixture.sqlite.close();
+  });
+
+  it("omits the seed when copyDirty is false", async () => {
+    const worktree = new FakeWorktreeProvider({ now });
+    const fixture = createFixture({ worktree });
+    const source = await createSource(fixture, "feature");
+
+    await fixture.queue.dispatch({
+      type: "worktree.fork",
+      payload: {
+        projectId: "web",
+        sourceWorktreeId: source.id,
+        branch: "feature-fork",
+        copyDirty: false,
+      },
+    });
+    await fixture.queue.drain();
+
+    const forkCreate = worktree.snapshot().created.find((req) => req.branch === "feature-fork");
+    expect(forkCreate?.seedFrom).toBeUndefined();
+    expect(forkCreate?.base).toBe("feature");
+    fixture.sqlite.close();
+  });
+
+  it("fails when the source worktree is not in the snapshot", async () => {
+    const fixture = createFixture({});
+    const receipt = await fixture.queue.dispatch({
+      type: "worktree.fork",
+      payload: { projectId: "web", sourceWorktreeId: "wt_missing", branch: "feature-fork" },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "WORKTREE_NOT_FOUND" },
+    });
+    expect(fixture.core.getSnapshot().rows).toEqual([]);
+    fixture.sqlite.close();
+  });
+});

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -39,10 +39,7 @@ export const RemoveWorktreePayloadSchema = z
 
 export type RemoveWorktreePayload = z.infer<typeof RemoveWorktreePayloadSchema>;
 
-// Worktree-only half of session.fork for Station: create a new branch off the
-// source worktree's HEAD and seed its working tree (when copyDirty), without
-// minting a session or launching a terminal. Station then hosts the inherited
-// harness itself via prepareExternalLaunch.
+// Fork a worktree: new branch off the source HEAD, optionally seeding its working tree.
 export const ForkWorktreePayloadSchema = z
   .object({
     projectId: ProjectIdSchema,

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -39,6 +39,22 @@ export const RemoveWorktreePayloadSchema = z
 
 export type RemoveWorktreePayload = z.infer<typeof RemoveWorktreePayloadSchema>;
 
+// Worktree-only half of session.fork for Station: create a new branch off the
+// source worktree's HEAD and seed its working tree (when copyDirty), without
+// minting a session or launching a terminal. Station then hosts the inherited
+// harness itself via prepareExternalLaunch.
+export const ForkWorktreePayloadSchema = z
+  .object({
+    projectId: ProjectIdSchema,
+    sourceWorktreeId: WorktreeIdSchema,
+    branch: nonEmptyStringSchema,
+    base: nonEmptyStringSchema.optional(),
+    copyDirty: z.boolean().optional(),
+  })
+  .strict();
+
+export type ForkWorktreePayload = z.infer<typeof ForkWorktreePayloadSchema>;
+
 export const HarnessCommandOptionsSchema = z
   .object({
     provider: ProviderIdSchema,
@@ -240,6 +256,7 @@ export type InstallHooksPayload = z.infer<typeof InstallHooksPayloadSchema>;
 
 export const StationCommandTypeSchema = z.enum([
   "worktree.create",
+  "worktree.fork",
   "worktree.remove",
   "session.create",
   "session.startAgent",
@@ -260,6 +277,10 @@ export const StationCommandTypeSchema = z.enum([
 
 export const CreateWorktreeCommandSchema = z
   .object({ type: z.literal("worktree.create"), payload: CreateWorktreePayloadSchema })
+  .strict();
+
+export const ForkWorktreeCommandSchema = z
+  .object({ type: z.literal("worktree.fork"), payload: ForkWorktreePayloadSchema })
   .strict();
 
 export const RemoveWorktreeCommandSchema = z
@@ -331,6 +352,7 @@ export const InstallHooksCommandSchema = z
 
 export const StationCommandSchema = z.discriminatedUnion("type", [
   CreateWorktreeCommandSchema,
+  ForkWorktreeCommandSchema,
   RemoveWorktreeCommandSchema,
   CreateSessionCommandSchema,
   StartAgentCommandSchema,

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -166,7 +166,7 @@ export function rowGridInputForViewportItem(
     slot: undefined,
     marker: { kind: "throbber", variant: "braille" },
     title: item.row.branch,
-    agent: item.row.harnessProvider,
+    agent: item.row.harnessProvider ?? "",
     activity: "starting session...",
     activityImportance: "meaningful",
     activityOverflow: "rowSlack",

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -35,6 +35,7 @@ export * from "./state/operations/renameSession.js";
 export * from "./state/operations/runtimeCommands.js";
 export * from "./state/operations/startAgent.js";
 export * from "./state/operations/types.js";
+export * from "./state/screens/fork.js";
 export * from "./state/screens/projectDefaultAgent.js";
 export * from "./state/screens/projectSettings.js";
 export * from "./state/screens/removeWorktree.js";

--- a/packages/dashboard-core/src/selectors/dashboardViewport.ts
+++ b/packages/dashboard-core/src/selectors/dashboardViewport.ts
@@ -246,7 +246,7 @@ function localRowMatchesSearch(
   if (query.length === 0) {
     return true;
   }
-  const harnessProvider = row.status === "pending" ? row.harnessProvider : "";
+  const harnessProvider = row.status === "pending" ? (row.harnessProvider ?? "") : "";
   return [row.branch, project.label, harnessProvider].some((value) =>
     value.toLocaleLowerCase().includes(query),
   );

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -713,7 +713,7 @@ export function dashboardFooterLabel({
 }): string {
   const full = firstRun
     ? `A:Add Project ${quitHint}`
-    : `N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help ${quitHint}`;
+    : `N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help ${quitHint}`;
   const compactClose = `${QUIT_HINT_CLOSE} N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help`;
   return quitHint === QUIT_HINT_CLOSE && full.length > columns ? compactClose : full;
 }

--- a/packages/dashboard-core/src/state/localRows.ts
+++ b/packages/dashboard-core/src/state/localRows.ts
@@ -12,7 +12,7 @@ export type PendingCreateSessionRow = {
   localId: string;
   projectId: string;
   branch: string;
-  harnessProvider: ProviderId;
+  harnessProvider?: ProviderId;
   createdAt: string;
   commandId?: CommandId;
 };

--- a/packages/dashboard-core/src/state/screens/fork.ts
+++ b/packages/dashboard-core/src/state/screens/fork.ts
@@ -39,7 +39,9 @@ export function validateForkSessionCreate(
   if (branch.length === 0) {
     return { ok: false, message: "Branch name cannot be empty." };
   }
-  if (snapshot.rows.some((row) => row.branch === branch)) {
+  // Branch names are unique per project/repo, not globally — only a worktree in
+  // the same project can collide.
+  if (snapshot.rows.some((row) => row.projectId === screen.projectId && row.branch === branch)) {
     return { ok: false, message: `A worktree on "${branch}" already exists.` };
   }
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
@@ -124,7 +126,9 @@ export function openForkDetailsForRow(
     sourceBranch: row.branch,
     sourceDirty: row.worktree.dirty === true,
     sourceAgentRunning: isRunningAgentState(row.agent?.state),
-    draftBranch: createEditableTextInputState(suggestForkBranch(row.branch, snapshot.rows)),
+    draftBranch: createEditableTextInputState(
+      suggestForkBranch(row.branch, snapshot.rows, row.projectId),
+    ),
     nameSource: "generated",
     copyDirty: true,
     focus: "branch",
@@ -135,8 +139,13 @@ export function openForkDetailsForRow(
   return { ...state, screen };
 }
 
-function suggestForkBranch(sourceBranch: string, rows: readonly WorktreeRow[]): string {
-  const taken = new Set(rows.map((row) => row.branch));
+function suggestForkBranch(
+  sourceBranch: string,
+  rows: readonly WorktreeRow[],
+  projectId: WorktreeRow["projectId"],
+): string {
+  // Only the source project's branches can collide (uniqueness is per repo).
+  const taken = new Set(rows.filter((row) => row.projectId === projectId).map((row) => row.branch));
   const base = `${sourceBranch}-fork`;
   // `taken` is finite, so an unused suffix is always found within taken.size + 1 tries.
   let candidate = base;

--- a/packages/dashboard-core/src/state/screens/fork.ts
+++ b/packages/dashboard-core/src/state/screens/fork.ts
@@ -15,7 +15,45 @@ import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
 import { scrollDeltaForKey } from "./dashboard.js";
 
-type ForkDetailsScreen = Extract<TuiState["screen"], { name: "fork"; step: "details" }>;
+export type ForkDetailsScreen = Extract<TuiState["screen"], { name: "fork"; step: "details" }>;
+
+type ForkSnapshot = NonNullable<TuiState["snapshot"]>;
+
+export type ForkSessionCreateValidation =
+  | {
+      ok: true;
+      project: ForkSnapshot["projects"][number];
+      sourceWorktreeId: ForkDetailsScreen["sourceWorktreeId"];
+      branch: string;
+      copyDirty: boolean;
+    }
+  | { ok: false; message: string };
+
+// Single source of truth for fork submit validation, shared by the machine's
+// submitFork (inline error) and the native station submit resolver (intercept).
+export function validateForkSessionCreate(
+  snapshot: ForkSnapshot,
+  screen: ForkDetailsScreen,
+): ForkSessionCreateValidation {
+  const branch = screen.draftBranch.value.trim();
+  if (branch.length === 0) {
+    return { ok: false, message: "Branch name cannot be empty." };
+  }
+  if (snapshot.rows.some((row) => row.branch === branch)) {
+    return { ok: false, message: `A worktree on "${branch}" already exists.` };
+  }
+  const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
+  if (project === undefined) {
+    return { ok: false, message: "The source project is no longer available." };
+  }
+  return {
+    ok: true,
+    project,
+    sourceWorktreeId: screen.sourceWorktreeId,
+    branch,
+    copyDirty: screen.copyDirty,
+  };
+}
 
 const FOCUS_ORDER = ["branch", "copyDirty", "submit"] as const;
 
@@ -162,28 +200,22 @@ function handleDetailsKey(state: TuiState, key: TuiKey, screen: ForkDetailsScree
 }
 
 function submitFork(state: TuiState, screen: ForkDetailsScreen): TuiTransition {
-  const branch = screen.draftBranch.value.trim();
-  if (branch.length === 0) {
-    return rejected(state, screen, "Branch name cannot be empty.");
-  }
-
-  const rows = state.snapshot?.rows ?? [];
-  if (rows.some((row) => row.branch === branch)) {
-    return rejected(state, screen, `A worktree on "${branch}" already exists.`);
-  }
-
-  const project = state.snapshot?.projects.find((candidate) => candidate.id === screen.projectId);
-  if (project === undefined) {
+  if (state.snapshot === undefined) {
     return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+
+  const validation = validateForkSessionCreate(state.snapshot, screen);
+  if (!validation.ok) {
+    return rejected(state, screen, validation.message);
   }
 
   // Omit base + harness so the observer pins base to the source HEAD and inherits the
   // source worktree's harness; copyDirty is passed explicitly from the toggle.
   const command = buildForkSessionCommand({
-    project,
-    sourceWorktreeId: screen.sourceWorktreeId,
-    branch,
-    copyDirty: screen.copyDirty,
+    project: validation.project,
+    sourceWorktreeId: validation.sourceWorktreeId,
+    branch: validation.branch,
+    copyDirty: validation.copyDirty,
   });
   if (command.type !== "session.fork") {
     return { state };
@@ -194,10 +226,10 @@ function submitFork(state: TuiState, screen: ForkDetailsScreen): TuiTransition {
     operations: [
       {
         type: "forkSession",
-        localId: `fork:${screen.sourceWorktreeId}:${branch}`,
+        localId: `fork:${validation.sourceWorktreeId}:${validation.branch}`,
         projectId: screen.projectId,
-        sourceWorktreeId: screen.sourceWorktreeId,
-        branch,
+        sourceWorktreeId: validation.sourceWorktreeId,
+        branch: validation.branch,
         command,
       },
     ],

--- a/packages/dashboard-core/test/unit/state/screens/fork.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/fork.test.ts
@@ -1,7 +1,12 @@
+import type { StationSnapshot } from "@station/contracts";
 import type { TuiKey, TuiState, TuiTransition } from "@station/dashboard-core";
-import { createInitialTuiState, handleTuiKey } from "@station/dashboard-core";
+import {
+  createInitialTuiState,
+  handleTuiKey,
+  openForkDetailsForRow,
+} from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+import { createDashboardSnapshot, row } from "../../../fixtures/snapshots.js";
 
 const CTX = { cwd: "/Users/example/Developer/station", homeDir: "/Users/example" };
 
@@ -118,6 +123,32 @@ describe("fork screen", () => {
     const transition = step(typed, ENTER);
     expect(transition.operations).toBeUndefined();
     expect(detailsScreen(transition.state).validationError).toContain(existing);
+  });
+
+  it("scopes branch collisions and suggestions to the source project", () => {
+    // A DIFFERENT project already holds the name this web fork would suggest.
+    // Branch uniqueness is per repo, so it must neither bump the suggestion nor
+    // block the submit. (wt_web_idle is on "fix-nav-mobile" → suggests "-fork".)
+    const base = createDashboardSnapshot();
+    const snapshot: StationSnapshot = {
+      ...base,
+      rows: [
+        ...base.rows,
+        row({ id: "wt_api_fork", projectId: "api", branch: "fix-nav-mobile-fork", state: "idle" }),
+      ],
+    };
+    const opened = openForkDetailsForRow(
+      createInitialTuiState({ initialSnapshot: snapshot }),
+      "wt_web_idle",
+    );
+    const screen = detailsScreen(opened);
+    expect(screen.draftBranch.value).toBe("fix-nav-mobile-fork");
+
+    const transition = step(opened, ENTER);
+    expect(transition.operations).toHaveLength(1);
+    const operation = transition.operations?.[0];
+    if (operation?.type !== "forkSession") throw new Error("expected fork operation");
+    expect(operation.branch).toBe("fix-nav-mobile-fork");
   });
 
   it("escapes from details back to chooseSlot, then to the dashboard", () => {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -295,6 +295,7 @@ export class FakeWorktreeProvider implements WorktreeProvider {
   readonly #now: FakeProviderClock | undefined;
   readonly #worktrees: WorktreeObservation[];
   readonly #removed: RemoveWorktreeRequest[] = [];
+  readonly #created: CreateWorktreeRequest[] = [];
   readonly #createPath: ((request: CreateWorktreeRequest) => string) | undefined;
   readonly #health: Partial<ProviderHealth> | undefined;
   readonly #capabilities: WorktreeCapabilities;
@@ -337,6 +338,7 @@ export class FakeWorktreeProvider implements WorktreeProvider {
 
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
     maybeThrow(this.#failures, "createWorktree");
+    this.#created.push(request);
     const path = this.#createPath?.(request) ?? request.path;
     const worktree = createFakeWorktree({
       provider: this.id,
@@ -382,10 +384,15 @@ export class FakeWorktreeProvider implements WorktreeProvider {
     );
   }
 
-  snapshot(): { worktrees: WorktreeObservation[]; removed: RemoveWorktreeRequest[] } {
+  snapshot(): {
+    worktrees: WorktreeObservation[];
+    removed: RemoveWorktreeRequest[];
+    created: CreateWorktreeRequest[];
+  } {
     return {
       worktrees: [...this.#worktrees],
       removed: this.#removed.map((request) => ({ ...request })),
+      created: this.#created.map((request) => ({ ...request })),
     };
   }
 }

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -154,6 +154,11 @@ describe("buildContextMenuItems", () => {
         action: { kind: "renameSession", rowId: "wt_station_idle" },
       },
       {
+        id: "station.forkSession",
+        label: "Fork Session",
+        action: { kind: "forkSession", rowId: "wt_station_idle" },
+      },
+      {
         id: "station.removeWorktree",
         label: "Delete Session",
         danger: true,
@@ -173,6 +178,11 @@ describe("buildContextMenuItems", () => {
         stationState,
       ),
     ).toEqual([
+      {
+        id: "station.forkSession",
+        label: "Fork Session",
+        action: { kind: "forkSession", rowId: "wt_station_none" },
+      },
       {
         id: "station.removeWorktree",
         label: "Delete Session",
@@ -207,6 +217,11 @@ describe("buildContextMenuItems", () => {
         id: "station.renameSession",
         label: "Rename Session",
         action: { kind: "renameSession", rowId: "wt_station_idle" },
+      },
+      {
+        id: "station.forkSession",
+        label: "Fork Session",
+        action: { kind: "forkSession", rowId: "wt_station_idle" },
       },
     ]);
   });

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -123,6 +123,12 @@ function buildStationItems(
       action: { kind: "renameSession", rowId: row.id },
     });
   }
+  // Any worktree can be forked (branch off its HEAD, copy its dirty tree).
+  items.push({
+    id: "station.forkSession",
+    label: "Fork Session",
+    action: { kind: "forkSession", rowId: row.id },
+  });
   if (project === undefined || !samePath(row.path, project.root)) {
     items.push({
       id: "station.removeWorktree",

--- a/station/src/contextMenu/types.ts
+++ b/station/src/contextMenu/types.ts
@@ -22,6 +22,7 @@ export type ContextMenuItemId =
   | "pane.splitBelow"
   | "pane.close"
   | "station.renameSession"
+  | "station.forkSession"
   | "station.removeWorktree"
   | "project.setDefaultAgent"
   | "project.openSettings"
@@ -34,6 +35,7 @@ export type ContextMenuItemAction =
   | { kind: "splitPane"; paneId: PaneId; direction: PaneSplitDirection }
   | { kind: "closePane"; paneId: PaneId }
   | { kind: "renameSession"; rowId: string }
+  | { kind: "forkSession"; rowId: string }
   | { kind: "removeWorktree"; rowId: string }
   | { kind: "setProjectDefaultAgent"; projectId: string }
   | { kind: "openProjectSettings"; projectId: string }

--- a/station/src/input/router.ts
+++ b/station/src/input/router.ts
@@ -77,6 +77,17 @@ export type RouteOutcome =
       branch: string;
       harness: ProviderId;
     }
+  /**
+   * Station Fork creates a seeded worktree off the source's HEAD (worktree.fork),
+   * then hosts the inherited harness in a Station pane instead of a tmux session.
+   */
+  | {
+      kind: "pane-launch-fork";
+      projectId: string;
+      sourceWorktreeId: string;
+      branch: string;
+      copyDirty: boolean;
+    }
   | { kind: "open-url"; url: string }
   | { kind: "swallowed" }
   | { kind: "ignored" };
@@ -115,6 +126,26 @@ export function paneLaunchNewSessionOutcome(target: {
     projectId: target.projectId,
     branch: target.branch,
     harness: target.harness,
+  };
+}
+
+/**
+ * The one place the fork-launch outcome is built — shared by the details
+ * screen's Enter (overlay layer) and a click on its fork button (mouse) so they
+ * can't drift.
+ */
+export function paneLaunchForkSessionOutcome(target: {
+  projectId: string;
+  sourceWorktreeId: string;
+  branch: string;
+  copyDirty: boolean;
+}): Extract<RouteOutcome, { kind: "pane-launch-fork" }> {
+  return {
+    kind: "pane-launch-fork",
+    projectId: target.projectId,
+    sourceWorktreeId: target.sourceWorktreeId,
+    branch: target.branch,
+    copyDirty: target.copyDirty,
   };
 }
 

--- a/station/src/input/stationBindings.ts
+++ b/station/src/input/stationBindings.ts
@@ -5,6 +5,7 @@ import { routeStationMouse } from "../station/input/stationMouse.js";
 import type { TuiStore } from "@station/dashboard-core";
 import { createKeymapStack, type KeymapLayer, type KeymapStack } from "./keymaps.js";
 import {
+  paneLaunchForkSessionOutcome,
   paneLaunchManagedOutcome,
   paneLaunchNewSessionOutcome,
   type MouseBindings,
@@ -282,6 +283,9 @@ export function createStationMouseBindings(stationViewStore?: StoreApi<TuiStore>
       }
       if (outcome.kind === "launch-new-session") {
         return paneLaunchNewSessionOutcome(outcome);
+      }
+      if (outcome.kind === "launch-fork") {
+        return paneLaunchForkSessionOutcome(outcome);
       }
       if (outcome.kind === "open-url") {
         return { kind: "open-url", url: outcome.url };

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -21,7 +21,7 @@ import type { AgentPrepareExternalLaunchResult } from "@station/client";
 import type { StationSnapshot, WorktreeRow } from "@station/contracts";
 import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
 import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
-import { resolveNewSessionSubmit } from "../station/input/stationActions.js";
+import { resolveForkSessionSubmit, resolveNewSessionSubmit } from "../station/input/stationActions.js";
 import type { StationMouseEvent } from "./mouse.js";
 import { createStationInputRuntime, nextSplitSeqFromPanes, normalizeSequence } from "./stationInput.js";
 
@@ -1602,6 +1602,174 @@ describe("createStationInputRuntime New Session hosted launch", () => {
     // No agent was launched: the create failed before any prepare.
     expect(harness.observerService.preparedLaunches).toEqual([]);
     expect(branch.length).toBeGreaterThan(0);
+  });
+});
+
+describe("createStationInputRuntime Fork hosted launch", () => {
+  // Driven end to end through the public runtime: open the overlay, "F" + a slot
+  // open the fork details, Enter submits as a Station-hosted launch (worktree.fork
+  // + a background managed launch) instead of the machine's tmux session.fork.
+  function forkPlan(worktreeId: string): AgentPrepareExternalLaunchResult {
+    return {
+      kind: "prepared",
+      sessionId: "ses_fork",
+      terminalTargetId: `native:${worktreeId}`,
+      launchPlan: {
+        provider: "codex",
+        command: "codex",
+        args: ["--exec"],
+        cwd: "/tmp/fork",
+        env: {},
+        mode: "interactive",
+      },
+    };
+  }
+
+  function forkHarness() {
+    const snapshot = manyProjectsSnapshot();
+    const observerService = new FakeTuiObserverService(snapshot);
+    const source = new FakeStationSource(snapshot);
+    const stationViewStore = createTuiStore({
+      source,
+      service: observerService,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      onDismiss: async () => {},
+      initialState: { terminalRows: 12 },
+    });
+    stationViewStore.getState().start();
+    const scripted = createScriptedTerminal();
+    const registry = createPtyRegistry({ createTerminal: () => scripted.terminal });
+    const store = createStationStore();
+    const runtime = createStationInputRuntime({
+      store,
+      shutdown: () => {},
+      stationViewStore,
+      registry,
+      observerService,
+    });
+    const pressKey = (sequence: string): boolean => runtime.handleSequence(sequence);
+    const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
+    return { store, runtime, observerService, source, stationViewStore, pressKey, settle, snapshot };
+  }
+
+  // Open fork details for the first row and read the submit the overlay drives on
+  // Enter (resolveForkSessionSubmit), without coupling to the screen shape.
+  function openForkAndCaptureSubmit(harness: ReturnType<typeof forkHarness>) {
+    harness.store.actions.openOverlay(STATION_OVERLAY_ID);
+    harness.pressKey("F");
+    harness.pressKey("1");
+    const submit = resolveForkSessionSubmit(harness.stationViewStore);
+    if (submit.kind !== "submit") {
+      throw new Error("expected the fork flow to be on the details screen");
+    }
+    return submit;
+  }
+
+  // The harness Station inherits for the fork: the source row's live/recovery
+  // harness, else the project default — the same resolution the executor uses.
+  function inheritedHarness(harness: ReturnType<typeof forkHarness>, submit: { projectId: string; sourceWorktreeId: string }) {
+    const sourceRow = harness.snapshot.rows.find((row) => row.id === submit.sourceWorktreeId);
+    const project = harness.snapshot.projects.find((candidate) => candidate.id === submit.projectId);
+    return sourceRow?.agent?.harness ?? sourceRow?.recovery?.provider ?? project?.defaults.harness;
+  }
+
+  function snapshotWithWorktree(
+    base: StationSnapshot,
+    projectId: string,
+    worktreeId: string,
+    branch: string,
+  ): StationSnapshot {
+    const template = base.rows.find((row) => row.projectId === projectId);
+    if (template === undefined) {
+      throw new Error(`fixture has no ${projectId} row to clone`);
+    }
+    const fresh: WorktreeRow = {
+      ...template,
+      id: worktreeId,
+      branch,
+      path: `/Users/example/.worktrees/${projectId}/${branch}`,
+      display: { ...template.display },
+    };
+    delete fresh.agent;
+    delete fresh.terminal;
+    return { ...base, rows: [...base.rows, fresh] };
+  }
+
+  it("forks the worktree, shows an optimistic row, and launches the inherited agent in the background", async () => {
+    const harness = forkHarness();
+    const worktreeId = "wt_forked";
+    harness.observerService.nextPreparedLaunch = forkPlan(worktreeId);
+    const submit = openForkAndCaptureSubmit(harness);
+    const localId = `station-fork:${submit.sourceWorktreeId}:${submit.branch}`;
+    const harnessProvider = inheritedHarness(harness, submit);
+
+    expect(harness.pressKey("\r")).toBe(true);
+    // Optimistic row appears synchronously on submit, carrying the inherited harness,
+    // before the real worktree reaches the snapshot (which would prune it).
+    expect(
+      harness.stationViewStore
+        .getState()
+        .localRows.pendingCreate.find((row) => row.localId === localId)?.harnessProvider,
+    ).toBe(harnessProvider);
+
+    await harness.settle();
+    harness.source.setSnapshot(
+      snapshotWithWorktree(harness.snapshot, submit.projectId, worktreeId, submit.branch),
+    );
+    await harness.settle();
+
+    const forkCommand = harness.observerService.dispatched.find(
+      (command) => command.type === "worktree.fork",
+    );
+    expect(forkCommand).toEqual({
+      type: "worktree.fork",
+      payload: {
+        projectId: submit.projectId,
+        sourceWorktreeId: submit.sourceWorktreeId,
+        branch: submit.branch,
+        copyDirty: true,
+      },
+    });
+    // The inherited harness is forwarded to the prepare for the new worktree.
+    expect(harness.observerService.preparedLaunches).toEqual([
+      { projectId: submit.projectId, worktreeId, harness: harnessProvider },
+    ]);
+    const agentPaneId = agentWorktreePaneId(worktreeId);
+    expect(harness.store.getState().workspace.panes.some((pane) => pane.id === agentPaneId)).toBe(
+      true,
+    );
+    // Background launch: the dashboard overlay stays up.
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
+  });
+
+  it("removes the optimistic row and toasts when the worktree fork is rejected", async () => {
+    const harness = forkHarness();
+    harness.observerService.nextReceipt = {
+      commandId: "cmd_tui_1",
+      accepted: false,
+      status: "rejected",
+      error: {
+        tag: "WorktreeProviderError",
+        code: "WORKTREE_CREATE_FAILED",
+        message: "Could not seed the fork.",
+      },
+    };
+    const submit = openForkAndCaptureSubmit(harness);
+    const localId = `station-fork:${submit.sourceWorktreeId}:${submit.branch}`;
+
+    expect(harness.pressKey("\r")).toBe(true);
+    await harness.settle();
+
+    expect(
+      harness.stationViewStore
+        .getState()
+        .localRows.pendingCreate.some((row) => row.localId === localId),
+    ).toBe(false);
+    const toast = harness.stationViewStore.getState().toasts.at(-1)?.toast;
+    expect(toast?.kind).toBe("error");
+    expect(toast?.message).toContain("Could not seed the fork.");
+    expect(harness.observerService.preparedLaunches).toEqual([]);
   });
 });
 

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -871,11 +871,29 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     });
   });
 
+  it("opens the fork details sheet from a row context menu", () => {
+    const { runtime, store, stationViewStore, rightClickRow } = contextMenuHarness();
+
+    rightClickRow();
+    // Menu order: Rename, Fork, Delete Session — one down reaches the fork.
+    expect(runtime.handleSequence("\x1b[B")).toBe(true);
+    expect(runtime.handleSequence("\r")).toBe(true);
+
+    expect(store.getState().input.contextMenu).toBeNull();
+    expect(stationViewStore.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      sourceWorktreeId: "wt_station_idle",
+      returnTo: "dashboard",
+    });
+  });
+
   it("opens the shared remove-session confirmation from a row context menu", () => {
     const { runtime, store, stationViewStore, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
-    // Menu order: Rename, Delete Session — one down reaches the delete.
+    // Menu order: Rename, Fork, Delete Session — two downs reach the delete.
+    expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\x1b[B")).toBe(true);
     expect(runtime.handleSequence("\r")).toBe(true);
 
@@ -894,6 +912,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
 
     rightClickRow();
     runtime.handleSequence("\x1b[B");
+    runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");
     stationViewStore.getState().handleKey({ input: "y" });
 
@@ -910,6 +929,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     const { runtime, stationViewStore, rightClickRow } = contextMenuHarness();
 
     rightClickRow();
+    runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");
     stationViewStore.getState().handleKey({ input: "", escape: true });

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -30,6 +30,7 @@ import { STATION_HOST_PROVIDER_ID } from "@station/host";
 import type { ProviderId, WorktreeRow, StationCommand, StationSnapshot } from "@station/contracts";
 import {
   addPendingCreateSessionRow,
+  openForkDetailsForRow,
   openProjectDefaultAgentPicker,
   openProjectSettings,
   openRemoveWorktreeConfirmForRow,
@@ -202,6 +203,17 @@ export type StationInputEffects = {
    * click uses; failures surface as a STATION toast.
    */
   launchHostedNewSession(target: { projectId: string; branch: string; harness: ProviderId }): void;
+  /**
+   * Seed a worktree off a source's HEAD (worktree.fork) and host the inherited
+   * harness in a Station pane (the Fork details screen's submit). Fire-and-forget
+   * like launchHostedNewSession; failures surface as a STATION toast.
+   */
+  launchHostedForkSession(target: {
+    projectId: string;
+    sourceWorktreeId: string;
+    branch: string;
+    copyDirty: boolean;
+  }): void;
   openExternalUrl(url: string): void;
 };
 
@@ -287,6 +299,14 @@ export function executeOutcome(outcome: RouteOutcome, effects: StationInputEffec
         projectId: outcome.projectId,
         branch: outcome.branch,
         harness: outcome.harness,
+      });
+      return true;
+    case "pane-launch-fork":
+      effects.launchHostedForkSession({
+        projectId: outcome.projectId,
+        sourceWorktreeId: outcome.sourceWorktreeId,
+        branch: outcome.branch,
+        copyDirty: outcome.copyDirty,
       });
       return true;
     case "open-url":
@@ -384,6 +404,18 @@ function waitForWorktreeByBranch(
  */
 function closeNewSessionWizard(store: StoreApi<TuiStore> | undefined): void {
   if (store !== undefined && store.getState().screen.name === "newSession") {
+    dispatchStationKey(store, { input: "", escape: true });
+  }
+}
+
+function closeForkSheet(store: StoreApi<TuiStore> | undefined): void {
+  if (store === undefined) {
+    return;
+  }
+  // The submit was intercepted before the machine ran submitFork, so unwind the
+  // fork sheet to the dashboard here. Esc steps details → chooseSlot → dashboard
+  // (≤2 hops); the cap stops a future screen change from spinning this loop.
+  for (let hop = 0; hop < 2 && store.getState().screen.name === "fork"; hop += 1) {
     dispatchStationKey(store, { input: "", escape: true });
   }
 }
@@ -490,6 +522,14 @@ function selectContextMenuItem(
     case "openProjectSettings":
       if (stationViewStore !== undefined) {
         stationViewStore.setState(openProjectSettings(stationViewStore.getState(), action.projectId));
+      }
+      return;
+    case "forkSession":
+      if (stationViewStore !== undefined) {
+        stationViewStore.setState(
+          openForkDetailsForRow(stationViewStore.getState(), action.rowId, "dashboard"),
+        );
+        effects.store.actions.openOverlay(STATION_OVERLAY_ID);
       }
       return;
   }
@@ -732,6 +772,14 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       }
       void runManagedNewSession(target, localId).catch((error) => {
         clearPendingCreateRow(localId);
+        pushLaunchError(error);
+      });
+    },
+    launchHostedForkSession: (target) => {
+      // Close the fork sheet, then seed the worktree and host its inherited
+      // harness in the background (mirrors launchHostedNewSession).
+      closeForkSheet(options.stationViewStore);
+      void runManagedFork(target).catch((error) => {
         pushLaunchError(error);
       });
     },
@@ -1046,6 +1094,74 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       harness: target.harness,
       background: true,
     });
+  }
+
+  // Fork in Station: seed a worktree off the source's HEAD (worktree.fork — no
+  // tmux), then host the inherited harness in a pane via the same managed launch.
+  async function runManagedFork(target: {
+    projectId: string;
+    sourceWorktreeId: string;
+    branch: string;
+    copyDirty: boolean;
+  }): Promise<void> {
+    const observerService = options.observerService;
+    if (observerService === undefined) {
+      pushLaunchToast("No observer connection; cannot fork the session.");
+      return;
+    }
+    const viewStore = options.stationViewStore;
+    if (viewStore === undefined) {
+      pushLaunchToast("The dashboard is not available; cannot fork the session.");
+      return;
+    }
+    // Capture the source's harness before forking: the seeded worktree has no
+    // remembered harness yet, so pass the source's through (else project default).
+    const sourceRow = findWorktreeRowById(viewStore, target.sourceWorktreeId);
+    const inheritedHarness = sourceRow?.agent?.harness ?? sourceRow?.recovery?.provider;
+
+    const forkCommand: Extract<StationCommand, { type: "worktree.fork" }> = {
+      type: "worktree.fork",
+      payload: {
+        projectId: target.projectId,
+        sourceWorktreeId: target.sourceWorktreeId,
+        branch: target.branch,
+        copyDirty: target.copyDirty,
+      },
+    };
+    const receipt = await observerService.dispatch(forkCommand);
+    if (!receipt.accepted) {
+      pushLaunchError(
+        receipt.error ?? {
+          tag: "ClientObserverError",
+          code: "STATION_WORKTREE_FORK_REJECTED",
+          message: "Station could not fork the worktree.",
+        },
+      );
+      return;
+    }
+    const completion = await observerService.waitForCommandCompletion(receipt.commandId);
+    if (completion.status === "failed") {
+      pushLaunchError(completion.error);
+      return;
+    }
+    const row = await waitForWorktreeByBranch(viewStore, target.projectId, target.branch);
+    if (row === undefined) {
+      pushLaunchToast(
+        "Forked the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.",
+        "info",
+      );
+      return;
+    }
+    const launchTarget: ManagedLaunchTarget = {
+      projectId: target.projectId,
+      worktreeId: row.id,
+      cwd: row.path,
+      background: true,
+    };
+    if (inheritedHarness !== undefined) {
+      launchTarget.harness = inheritedHarness;
+    }
+    await runManagedLaunch(agentWorktreePaneId(row.id), launchTarget);
   }
 
   function pushLaunchToast(message: string, kind: "info" | "error" = "error"): void {

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -340,6 +340,22 @@ function findWorktreeRowByBranch(
 }
 
 /**
+ * The harness Station hosts a fork under — the source's live/recovery harness,
+ * else the project default. New Session gets this from the wizard's pick; a fork
+ * inherits it, so resolve it once for both the optimistic row and the launch.
+ */
+function inheritedForkHarness(
+  store: StoreApi<TuiStore>,
+  projectId: string,
+  sourceWorktreeId: string,
+): ProviderId | undefined {
+  const snapshot = store.getState().snapshot;
+  const source = snapshot?.rows.find((row) => row.id === sourceWorktreeId);
+  const project = snapshot?.projects.find((candidate) => candidate.id === projectId);
+  return source?.agent?.harness ?? source?.recovery?.provider ?? project?.defaults.harness;
+}
+
+/**
  * The external (non-Station) terminal provider holding this worktree, or
  * undefined when it's Station-hosted (focusable/reattachable) or unknown. Used to
  * tell the user a tmux agent can't be shown in Station rather than focus it to no
@@ -776,10 +792,29 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       });
     },
     launchHostedForkSession: (target) => {
-      // Close the fork sheet, then seed the worktree and host its inherited
-      // harness in the background (mirrors launchHostedNewSession).
+      // Close the fork sheet, show an optimistic row, then seed the worktree and
+      // host its inherited harness in the background (mirrors launchHostedNewSession).
+      // The row is auto-pruned when the forked worktree reaches the snapshot.
       closeForkSheet(options.stationViewStore);
-      void runManagedFork(target).catch((error) => {
+      const viewStore = options.stationViewStore;
+      const localId = `station-fork:${target.sourceWorktreeId}:${target.branch}`;
+      const harness =
+        viewStore === undefined
+          ? undefined
+          : inheritedForkHarness(viewStore, target.projectId, target.sourceWorktreeId);
+      if (viewStore !== undefined && harness !== undefined) {
+        viewStore.setState(
+          addPendingCreateSessionRow(viewStore.getState(), {
+            localId,
+            projectId: target.projectId,
+            branch: target.branch,
+            harnessProvider: harness,
+            createdAt: new Date().toISOString(),
+          }),
+        );
+      }
+      void runManagedFork(target, localId, harness).catch((error) => {
+        clearPendingCreateRow(localId);
         pushLaunchError(error);
       });
     },
@@ -1098,14 +1133,14 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
 
   // Fork in Station: seed a worktree off the source's HEAD (worktree.fork — no
   // tmux), then host the inherited harness in a pane via the same managed launch.
-  async function runManagedFork(target: {
-    projectId: string;
-    sourceWorktreeId: string;
-    branch: string;
-    copyDirty: boolean;
-  }): Promise<void> {
+  async function runManagedFork(
+    target: { projectId: string; sourceWorktreeId: string; branch: string; copyDirty: boolean },
+    localId: string,
+    harness: ProviderId | undefined,
+  ): Promise<void> {
     const observerService = options.observerService;
     if (observerService === undefined) {
+      clearPendingCreateRow(localId);
       pushLaunchToast("No observer connection; cannot fork the session.");
       return;
     }
@@ -1114,11 +1149,6 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       pushLaunchToast("The dashboard is not available; cannot fork the session.");
       return;
     }
-    // Capture the source's harness before forking: the seeded worktree has no
-    // remembered harness yet, so pass the source's through (else project default).
-    const sourceRow = findWorktreeRowById(viewStore, target.sourceWorktreeId);
-    const inheritedHarness = sourceRow?.agent?.harness ?? sourceRow?.recovery?.provider;
-
     const forkCommand: Extract<StationCommand, { type: "worktree.fork" }> = {
       type: "worktree.fork",
       payload: {
@@ -1130,6 +1160,7 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
     };
     const receipt = await observerService.dispatch(forkCommand);
     if (!receipt.accepted) {
+      clearPendingCreateRow(localId);
       pushLaunchError(
         receipt.error ?? {
           tag: "ClientObserverError",
@@ -1141,11 +1172,15 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
     }
     const completion = await observerService.waitForCommandCompletion(receipt.commandId);
     if (completion.status === "failed") {
+      clearPendingCreateRow(localId);
       pushLaunchError(completion.error);
       return;
     }
+    // On success the optimistic row is auto-pruned once the forked worktree reaches the
+    // snapshot (pruneLocalRowsForSnapshot), which is also when this await resolves.
     const row = await waitForWorktreeByBranch(viewStore, target.projectId, target.branch);
     if (row === undefined) {
+      clearPendingCreateRow(localId);
       pushLaunchToast(
         "Forked the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.",
         "info",
@@ -1158,8 +1193,8 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       cwd: row.path,
       background: true,
     };
-    if (inheritedHarness !== undefined) {
-      launchTarget.harness = inheritedHarness;
+    if (harness !== undefined) {
+      launchTarget.harness = harness;
     }
     await runManagedLaunch(agentWorktreePaneId(row.id), launchTarget);
   }

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -1060,14 +1060,16 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
 
   function startHostedWorktreeLaunch(spec: HostedWorktreeLaunch): void {
     const viewStore = options.stationViewStore;
-    if (viewStore !== undefined && spec.harness !== undefined) {
+    if (viewStore !== undefined) {
       viewStore.setState(
         addPendingCreateSessionRow(viewStore.getState(), {
           localId: spec.localId,
           projectId: spec.projectId,
           branch: spec.branch,
-          harnessProvider: spec.harness,
           createdAt: new Date().toISOString(),
+          // Fork can inherit no harness (source has none, project has no default);
+          // the row still shows, agent column blank until the launch picks a default.
+          ...(spec.harness === undefined ? {} : { harnessProvider: spec.harness }),
         }),
       );
     }

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -339,11 +339,8 @@ function findWorktreeRowByBranch(
     .snapshot?.rows.find((row) => row.projectId === projectId && row.branch === branch);
 }
 
-/**
- * The harness Station hosts a fork under — the source's live/recovery harness,
- * else the project default. New Session gets this from the wizard's pick; a fork
- * inherits it, so resolve it once for both the optimistic row and the launch.
- */
+// The harness a fork inherits: the source's live/recovery harness, else the
+// project default — shared by the optimistic row and the launch.
 function inheritedForkHarness(
   store: StoreApi<TuiStore>,
   projectId: string,
@@ -428,9 +425,8 @@ function closeForkSheet(store: StoreApi<TuiStore> | undefined): void {
   if (store === undefined) {
     return;
   }
-  // The submit was intercepted before the machine ran submitFork, so unwind the
-  // fork sheet to the dashboard here. Esc steps details → chooseSlot → dashboard
-  // (≤2 hops); the cap stops a future screen change from spinning this loop.
+  // Submit is intercepted before submitFork runs, so unwind to the dashboard
+  // here. Esc steps details → chooseSlot → dashboard; the cap can't spin.
   for (let hop = 0; hop < 2 && store.getState().screen.name === "fork"; hop += 1) {
     dispatchStationKey(store, { input: "", escape: true });
   }
@@ -769,53 +765,34 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
       });
     },
     launchHostedNewSession: (target) => {
-      // Close the wizard but keep the overlay open: show an optimistic row, then create the worktree
-      // and host its agent in the background (mirrors session.create). The row is auto-pruned
-      // when the real worktree reaches the snapshot (pruneLocalRowsForSnapshot).
+      // Harness comes from the wizard pick; New Session keeps the overlay open.
       closeNewSessionWizard(options.stationViewStore);
-      const localId = `station-create:${target.projectId}:${target.branch}`;
-      const viewStore = options.stationViewStore;
-      if (viewStore !== undefined) {
-        viewStore.setState(
-          addPendingCreateSessionRow(viewStore.getState(), {
-            localId,
-            projectId: target.projectId,
-            branch: target.branch,
-            harnessProvider: target.harness,
-            createdAt: new Date().toISOString(),
-          }),
-        );
-      }
-      void runManagedNewSession(target, localId).catch((error) => {
-        clearPendingCreateRow(localId);
-        pushLaunchError(error);
+      startHostedWorktreeLaunch({
+        localId: `station-create:${target.projectId}:${target.branch}`,
+        projectId: target.projectId,
+        branch: target.branch,
+        harness: target.harness,
+        command: {
+          type: "worktree.create",
+          payload: { projectId: target.projectId, branch: target.branch },
+        },
+        verb: "create",
       });
     },
     launchHostedForkSession: (target) => {
-      // Close the fork sheet, show an optimistic row, then seed the worktree and
-      // host its inherited harness in the background (mirrors launchHostedNewSession).
-      // The row is auto-pruned when the forked worktree reaches the snapshot.
+      // Fork inherits the source's harness (the seeded worktree has none yet).
       closeForkSheet(options.stationViewStore);
       const viewStore = options.stationViewStore;
-      const localId = `station-fork:${target.sourceWorktreeId}:${target.branch}`;
-      const harness =
-        viewStore === undefined
-          ? undefined
-          : inheritedForkHarness(viewStore, target.projectId, target.sourceWorktreeId);
-      if (viewStore !== undefined && harness !== undefined) {
-        viewStore.setState(
-          addPendingCreateSessionRow(viewStore.getState(), {
-            localId,
-            projectId: target.projectId,
-            branch: target.branch,
-            harnessProvider: harness,
-            createdAt: new Date().toISOString(),
-          }),
-        );
-      }
-      void runManagedFork(target, localId, harness).catch((error) => {
-        clearPendingCreateRow(localId);
-        pushLaunchError(error);
+      startHostedWorktreeLaunch({
+        localId: `station-fork:${target.sourceWorktreeId}:${target.branch}`,
+        projectId: target.projectId,
+        branch: target.branch,
+        harness:
+          viewStore === undefined
+            ? undefined
+            : inheritedForkHarness(viewStore, target.projectId, target.sourceWorktreeId),
+        command: { type: "worktree.fork", payload: { ...target } },
+        verb: "fork",
       });
     },
     openExternalUrl: options.openExternalUrl ?? (() => {}),
@@ -1070,131 +1047,85 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
     }
   }
 
-  // New Session in Station: create the worktree only (no agent), then host its
-  // agent in a pane via the same managed launch a row click uses. The project
-  // default terminal is tmux, which Station can't render — so we deliberately do
-  // NOT let the wizard's session.create spawn the agent.
-  async function runManagedNewSession(
-    target: { projectId: string; branch: string; harness: ProviderId },
-    localId: string,
-  ): Promise<void> {
-    const observerService = options.observerService;
-    if (observerService === undefined) {
-      clearPendingCreateRow(localId);
-      pushLaunchToast("No observer connection; cannot create the session.");
-      return;
-    }
+  // Station hosts agents itself (worktree.create/fork + a managed launch), never
+  // the machine's session.create/fork — those spawn a tmux terminal it can't render.
+  type HostedWorktreeLaunch = {
+    localId: string;
+    projectId: string;
+    branch: string;
+    harness: ProviderId | undefined;
+    command: Extract<StationCommand, { type: "worktree.create" | "worktree.fork" }>;
+    verb: "create" | "fork";
+  };
+
+  function startHostedWorktreeLaunch(spec: HostedWorktreeLaunch): void {
     const viewStore = options.stationViewStore;
-    if (viewStore === undefined) {
-      pushLaunchToast("The dashboard is not available; cannot create the session.");
-      return;
-    }
-    const createCommand: Extract<StationCommand, { type: "worktree.create" }> = {
-      type: "worktree.create",
-      payload: { projectId: target.projectId, branch: target.branch },
-    };
-    const receipt = await observerService.dispatch(createCommand);
-    if (!receipt.accepted) {
-      clearPendingCreateRow(localId);
-      pushLaunchError(
-        receipt.error ?? {
-          tag: "ClientObserverError",
-          code: "STATION_WORKTREE_CREATE_REJECTED",
-          message: "Station could not create the worktree.",
-        },
+    if (viewStore !== undefined && spec.harness !== undefined) {
+      viewStore.setState(
+        addPendingCreateSessionRow(viewStore.getState(), {
+          localId: spec.localId,
+          projectId: spec.projectId,
+          branch: spec.branch,
+          harnessProvider: spec.harness,
+          createdAt: new Date().toISOString(),
+        }),
       );
-      return;
     }
-    const completion = await observerService.waitForCommandCompletion(receipt.commandId);
-    if (completion.status === "failed") {
-      clearPendingCreateRow(localId);
-      pushLaunchError(completion.error);
-      return;
-    }
-    // On success the optimistic row is auto-pruned once the real worktree reaches the snapshot
-    // (pruneLocalRowsForSnapshot), which is also when this await resolves.
-    const row = await waitForWorktreeByBranch(viewStore, target.projectId, target.branch);
-    if (row === undefined) {
-      clearPendingCreateRow(localId);
-      pushLaunchToast(
-        "Created the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.",
-        "info",
-      );
-      return;
-    }
-    await runManagedLaunch(agentWorktreePaneId(row.id), {
-      projectId: target.projectId,
-      worktreeId: row.id,
-      cwd: row.path,
-      harness: target.harness,
-      background: true,
+    void runHostedWorktreeLaunch(spec).catch((error) => {
+      clearPendingCreateRow(spec.localId);
+      pushLaunchError(error);
     });
   }
 
-  // Fork in Station: seed a worktree off the source's HEAD (worktree.fork — no
-  // tmux), then host the inherited harness in a pane via the same managed launch.
-  async function runManagedFork(
-    target: { projectId: string; sourceWorktreeId: string; branch: string; copyDirty: boolean },
-    localId: string,
-    harness: ProviderId | undefined,
-  ): Promise<void> {
+  async function runHostedWorktreeLaunch(spec: HostedWorktreeLaunch): Promise<void> {
     const observerService = options.observerService;
     if (observerService === undefined) {
-      clearPendingCreateRow(localId);
-      pushLaunchToast("No observer connection; cannot fork the session.");
+      clearPendingCreateRow(spec.localId);
+      pushLaunchToast(`No observer connection; cannot ${spec.verb} the session.`);
       return;
     }
     const viewStore = options.stationViewStore;
     if (viewStore === undefined) {
-      pushLaunchToast("The dashboard is not available; cannot fork the session.");
+      pushLaunchToast(`The dashboard is not available; cannot ${spec.verb} the session.`);
       return;
     }
-    const forkCommand: Extract<StationCommand, { type: "worktree.fork" }> = {
-      type: "worktree.fork",
-      payload: {
-        projectId: target.projectId,
-        sourceWorktreeId: target.sourceWorktreeId,
-        branch: target.branch,
-        copyDirty: target.copyDirty,
-      },
-    };
-    const receipt = await observerService.dispatch(forkCommand);
+    const receipt = await observerService.dispatch(spec.command);
     if (!receipt.accepted) {
-      clearPendingCreateRow(localId);
+      clearPendingCreateRow(spec.localId);
       pushLaunchError(
         receipt.error ?? {
           tag: "ClientObserverError",
-          code: "STATION_WORKTREE_FORK_REJECTED",
-          message: "Station could not fork the worktree.",
+          code: `STATION_WORKTREE_${spec.verb.toUpperCase()}_REJECTED`,
+          message: `Station could not ${spec.verb} the worktree.`,
         },
       );
       return;
     }
     const completion = await observerService.waitForCommandCompletion(receipt.commandId);
     if (completion.status === "failed") {
-      clearPendingCreateRow(localId);
+      clearPendingCreateRow(spec.localId);
       pushLaunchError(completion.error);
       return;
     }
-    // On success the optimistic row is auto-pruned once the forked worktree reaches the
-    // snapshot (pruneLocalRowsForSnapshot), which is also when this await resolves.
-    const row = await waitForWorktreeByBranch(viewStore, target.projectId, target.branch);
+    // The optimistic row auto-prunes when the worktree reaches the snapshot, which
+    // is also when this resolves.
+    const row = await waitForWorktreeByBranch(viewStore, spec.projectId, spec.branch);
     if (row === undefined) {
-      clearPendingCreateRow(localId);
+      clearPendingCreateRow(spec.localId);
       pushLaunchToast(
-        "Forked the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.",
+        `${spec.verb === "create" ? "Created" : "Forked"} the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.`,
         "info",
       );
       return;
     }
     const launchTarget: ManagedLaunchTarget = {
-      projectId: target.projectId,
+      projectId: spec.projectId,
       worktreeId: row.id,
       cwd: row.path,
       background: true,
     };
-    if (harness !== undefined) {
-      launchTarget.harness = harness;
+    if (spec.harness !== undefined) {
+      launchTarget.harness = spec.harness;
     }
     await runManagedLaunch(agentWorktreePaneId(row.id), launchTarget);
   }

--- a/station/src/station/input/forkSubmit.test.ts
+++ b/station/src/station/input/forkSubmit.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { createTuiStore } from "@station/dashboard-core";
+import { manyProjectsSnapshot } from "../fixtures/scenarios.js";
+import { FakeTuiObserverService } from "../test/support/fakeObserverService.js";
+import { FakeStationSource } from "../test/support/fakeStationSource.js";
+import { resolveForkSessionSubmit, resolveKeyForkSessionSubmit } from "./stationActions.js";
+
+// Station hosts a fork in a pane (worktree.fork + managed launch) rather than
+// the shared machine's tmux session.fork. These resolvers are the interception
+// point: Enter on the details screen becomes a hosted-launch submit; everything
+// else (including an invalid branch) falls through to the machine.
+function newStore() {
+  const snapshot = manyProjectsSnapshot();
+  return createTuiStore({
+    source: new FakeStationSource(snapshot),
+    service: new FakeTuiObserverService(snapshot),
+    initialSnapshot: snapshot,
+    persistentPopup: true,
+    onDismiss: async () => {},
+  });
+}
+
+function storeOnForkDetails() {
+  const store = newStore();
+  // "F" opens the fork chooseSlot step; the first slot opens details for that row.
+  store.getState().handleKey({ input: "F" });
+  store.getState().handleKey({ input: "1" });
+  return store;
+}
+
+describe("resolveForkSessionSubmit", () => {
+  it("resolves the details screen to a hosted-launch submit carrying the source + copyDirty", () => {
+    const store = storeOnForkDetails();
+    const screen = store.getState().screen;
+    if (screen.name !== "fork" || screen.step !== "details") {
+      throw new Error(`expected fork details, got ${screen.name}`);
+    }
+
+    const submit = resolveForkSessionSubmit(store);
+    expect(submit.kind).toBe("submit");
+    if (submit.kind === "submit") {
+      expect(submit.projectId).toBe(screen.projectId);
+      expect(submit.sourceWorktreeId).toBe(screen.sourceWorktreeId);
+      expect(submit.branch).toBe(screen.draftBranch.value.trim());
+      expect(submit.copyDirty).toBe(true);
+    }
+  });
+
+  it("does not submit from the dashboard (no fork sheet open)", () => {
+    expect(resolveForkSessionSubmit(newStore()).kind).toBe("none");
+  });
+
+  it("does not submit from the chooseSlot step", () => {
+    const store = newStore();
+    store.getState().handleKey({ input: "F" });
+    expect(store.getState().screen).toMatchObject({ name: "fork", step: "chooseSlot" });
+    expect(resolveForkSessionSubmit(store).kind).toBe("none");
+  });
+});
+
+describe("resolveKeyForkSessionSubmit", () => {
+  it("submits only on Enter", () => {
+    const store = storeOnForkDetails();
+    expect(resolveKeyForkSessionSubmit(store, "\r").kind).toBe("submit");
+    // A navigation/edit key on the details screen stays with the shared machine.
+    expect(resolveKeyForkSessionSubmit(store, "x").kind).toBe("none");
+  });
+});

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -20,7 +20,7 @@ import {
   type ProjectSettingsItemId,
 } from "@station/dashboard-core";
 import { clampDashboardStateScroll, scrollDashboard } from "@station/dashboard-core";
-import { validateNewSessionCreate } from "@station/dashboard-core";
+import { validateForkSessionCreate, validateNewSessionCreate } from "@station/dashboard-core";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiHandleKeyResult, TuiStore } from "@station/dashboard-core";
 import {
@@ -239,6 +239,54 @@ export function resolveKeyNewSessionSubmit(
     return { kind: "none" };
   }
   return resolveNewSessionSubmit(store);
+}
+
+export type ForkSessionSubmitTarget =
+  | {
+      kind: "submit";
+      projectId: string;
+      sourceWorktreeId: string;
+      branch: string;
+      copyDirty: boolean;
+    }
+  | { kind: "none" };
+
+/**
+ * Resolve the Fork details screen to its launch. `none` off the details step or
+ * when validation fails — both fall through to the shared machine, where
+ * submitFork re-validates and surfaces the inline error. The happy path is
+ * intercepted here so the launch hosts the agent in Station rather than running
+ * the machine's tmux-bound session.fork.
+ */
+export function resolveForkSessionSubmit(store: StoreApi<TuiStore>): ForkSessionSubmitTarget {
+  const state = store.getState();
+  if (state.screen.name !== "fork" || state.screen.step !== "details") {
+    return { kind: "none" };
+  }
+  if (state.snapshot === undefined) {
+    return { kind: "none" };
+  }
+  const validation = validateForkSessionCreate(state.snapshot, state.screen);
+  if (!validation.ok) {
+    return { kind: "none" };
+  }
+  return {
+    kind: "submit",
+    projectId: validation.project.id,
+    sourceWorktreeId: validation.sourceWorktreeId,
+    branch: validation.branch,
+    copyDirty: validation.copyDirty,
+  };
+}
+
+export function resolveKeyForkSessionSubmit(
+  store: StoreApi<TuiStore>,
+  sequence: string,
+): ForkSessionSubmitTarget {
+  if (sequenceToTuiKey(sequence)?.return !== true) {
+    return { kind: "none" };
+  }
+  return resolveForkSessionSubmit(store);
 }
 
 /**

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -23,6 +23,7 @@ import { handleTuiKey } from "@station/dashboard-core";
 import type { TuiState } from "@station/dashboard-core";
 import {
   deriveStationMode,
+  editableTextBindings,
   matchStationBinding,
   STATION_KEYMAP,
   type StationBinding,
@@ -110,6 +111,8 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     projectSettings: openProjectSettings(base, "station"),
     renameChooseSlot: drive(renameBase, [{ input: "R" }]),
     renameEdit: drive(renameBase, [{ input: "R" }, { input: "1" }]),
+    forkChooseSlot: drive(base, [{ input: "F" }]),
+    forkDetails: drive(base, [{ input: "F" }, { input: "1" }]),
     newSessionReview: drive(base, [{ input: "N" }]),
     newSessionEditName: drive(base, [{ input: "N" }, { input: "N" }]),
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
@@ -201,6 +204,31 @@ describe("station keymap coverage", () => {
         expect(`${mode}:${textIndex}`).toBe(`${mode}:${table.length - 1}`);
       }
     }
+  });
+});
+
+describe("editableTextBindings", () => {
+  it("produces the cursor + text catch-all block with the text binding last", () => {
+    const bindings = editableTextBindings("station.example", "station.example.edit");
+    expect(bindings.map((binding) => binding.id)).toEqual([
+      "station.example.cursorLeft",
+      "station.example.cursorRight",
+      "station.example.backspace",
+      "station.example.delete",
+      "station.example.type",
+    ]);
+    expect(bindings.every((binding) => binding.action === "station.example.edit")).toBe(true);
+    expect(bindings.at(-1)?.pattern).toEqual({ kind: "text" });
+    expect(bindings.every((binding) => binding.help === undefined)).toBe(true);
+  });
+
+  it("attaches optional help to the text binding only", () => {
+    const bindings = editableTextBindings("station.example", "station.example.edit", {
+      keys: "space",
+      label: "toggle",
+    });
+    expect(bindings.at(-1)?.help).toEqual({ keys: "space", label: "toggle" });
+    expect(bindings.slice(0, -1).every((binding) => binding.help === undefined)).toBe(true);
   });
 });
 

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -21,6 +21,8 @@ export type StationInputMode =
   | "removeConfirm"
   | "renameChooseSlot"
   | "renameEdit"
+  | "forkChooseSlot"
+  | "forkDetails"
   | "newSessionReview"
   | "newSessionEditName"
   | "newSessionPickProject"
@@ -44,6 +46,8 @@ export function deriveStationMode(state: TuiState): StationInputMode {
       return screen.step === "chooseSlot" ? "removeChooseSlot" : "removeConfirm";
     case "renameSession":
       return screen.step === "chooseSlot" ? "renameChooseSlot" : "renameEdit";
+    case "fork":
+      return screen.step === "chooseSlot" ? "forkChooseSlot" : "forkDetails";
     case "newSession":
       switch (screen.flow.mode) {
         case "review":
@@ -99,6 +103,31 @@ export type StationBinding = {
 
 const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
 
+/**
+ * The cursor/edit key block shared by every single-field edit mode: arrow
+ * cursor moves, backspace/delete, and the trailing text catch-all (kept last so
+ * specific named keys match first). All route the same edit action.
+ */
+export function editableTextBindings(
+  prefix: string,
+  action: string,
+  typeHelp?: { keys: string; label: string },
+): readonly StationBinding[] {
+  return [
+    { id: `${prefix}.cursorLeft`, pattern: { kind: "named", named: "left" }, action, outcome: "handled" },
+    { id: `${prefix}.cursorRight`, pattern: { kind: "named", named: "right" }, action, outcome: "handled" },
+    { id: `${prefix}.backspace`, pattern: { kind: "named", named: "backspace" }, action, outcome: "handled" },
+    { id: `${prefix}.delete`, pattern: { kind: "named", named: "delete" }, action, outcome: "handled" },
+    {
+      id: `${prefix}.type`,
+      pattern: { kind: "text" },
+      action,
+      outcome: "handled",
+      ...(typeHelp === undefined ? {} : { help: typeHelp }),
+    },
+  ];
+}
+
 export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]> = {
   dashboard: [
     { id: "station.dashboard.scrollUp", pattern: { kind: "named", named: "up" }, action: "station.view.scrollUp", outcome: "handled" },
@@ -109,6 +138,7 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
     { id: "station.dashboard.dismissEsc", pattern: { kind: "named", named: "escape" }, action: "station.overlay.dismiss", outcome: "close-overlay" },
     { id: "station.dashboard.search", pattern: { kind: "char", char: "/" }, action: "station.search.open", outcome: "handled", help: { keys: "/", label: "search" } },
     { id: "station.dashboard.rename", pattern: { kind: "char", char: "R" }, action: "station.rename.open", outcome: "handled", help: { keys: "R", label: "rename" } },
+    { id: "station.dashboard.fork", pattern: { kind: "char", char: "F" }, action: "station.fork.open", outcome: "handled", help: { keys: "F", label: "fork" } },
     { id: "station.dashboard.refresh", pattern: { kind: "char", char: "Z" }, action: "station.refresh", outcome: "handled", help: { keys: "Z", label: "refresh" } },
     { id: "station.dashboard.remove", pattern: { kind: "char", char: "X" }, action: "station.remove.open", outcome: "handled", help: { keys: "X", label: "delete session" } },
     { id: "station.dashboard.newSession", pattern: { kind: "char", char: "N" }, action: "station.newSession.open", outcome: "handled", help: { keys: "N", label: "new" } },
@@ -176,11 +206,20 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   renameEdit: [
     { id: "station.renameEdit.back", pattern: { kind: "named", named: "escape" }, action: "station.rename.back", outcome: "handled", help: { keys: "esc", label: "back" } },
     { id: "station.renameEdit.submit", pattern: { kind: "named", named: "return" }, action: "station.rename.submit", outcome: "handled", help: { keys: "enter", label: "rename" } },
-    { id: "station.renameEdit.backspace", pattern: { kind: "named", named: "backspace" }, action: "station.rename.edit", outcome: "handled" },
-    { id: "station.renameEdit.delete", pattern: { kind: "named", named: "delete" }, action: "station.rename.edit", outcome: "handled" },
-    { id: "station.renameEdit.cursorLeft", pattern: { kind: "named", named: "left" }, action: "station.rename.edit", outcome: "handled" },
-    { id: "station.renameEdit.cursorRight", pattern: { kind: "named", named: "right" }, action: "station.rename.edit", outcome: "handled" },
-    { id: "station.renameEdit.type", pattern: { kind: "text" }, action: "station.rename.edit", outcome: "handled" },
+    ...editableTextBindings("station.renameEdit", "station.rename.edit"),
+  ],
+  forkChooseSlot: [
+    { id: "station.fork.cancel", pattern: { kind: "named", named: "escape" }, action: "station.fork.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
+    { id: "station.fork.scrollUp", pattern: { kind: "named", named: "up" }, action: "station.view.scrollUp", outcome: "handled" },
+    { id: "station.fork.scrollDown", pattern: { kind: "named", named: "down" }, action: "station.view.scrollDown", outcome: "handled" },
+    { id: "station.fork.chooseSlot", pattern: { kind: "slot" }, action: "station.fork.chooseSlot", outcome: "handled", help: { keys: "1-9 a-z", label: "choose source" } },
+  ],
+  forkDetails: [
+    { id: "station.forkDetails.back", pattern: { kind: "named", named: "escape" }, action: "station.fork.back", outcome: "handled", help: { keys: "esc", label: "back" } },
+    { id: "station.forkDetails.submit", pattern: { kind: "named", named: "return" }, action: "station.fork.submit", outcome: "handled", help: { keys: "enter", label: "fork" } },
+    { id: "station.forkDetails.focusUp", pattern: { kind: "named", named: "up" }, action: "station.fork.focus", outcome: "handled" },
+    { id: "station.forkDetails.focusDown", pattern: { kind: "named", named: "down" }, action: "station.fork.focus", outcome: "handled", help: { keys: "↑↓", label: "field" } },
+    ...editableTextBindings("station.forkDetails", "station.fork.detailKey", { keys: "space", label: "toggle copy" }),
   ],
   newSessionReview: [
     { id: "station.newSession.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
@@ -192,11 +231,7 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   newSessionEditName: [
     { id: "station.newSessionEdit.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
     { id: "station.newSessionEdit.commit", pattern: { kind: "named", named: "return" }, action: "station.newSession.commitName", outcome: "handled", help: { keys: "enter", label: "use name" } },
-    { id: "station.newSessionEdit.backspace", pattern: { kind: "named", named: "backspace" }, action: "station.newSession.editInput", outcome: "handled" },
-    { id: "station.newSessionEdit.delete", pattern: { kind: "named", named: "delete" }, action: "station.newSession.editInput", outcome: "handled" },
-    { id: "station.newSessionEdit.cursorLeft", pattern: { kind: "named", named: "left" }, action: "station.newSession.editInput", outcome: "handled" },
-    { id: "station.newSessionEdit.cursorRight", pattern: { kind: "named", named: "right" }, action: "station.newSession.editInput", outcome: "handled" },
-    { id: "station.newSessionEdit.type", pattern: { kind: "text" }, action: "station.newSession.editInput", outcome: "handled" },
+    ...editableTextBindings("station.newSessionEdit", "station.newSession.editInput"),
   ],
   newSessionPickProject: [
     { id: "station.newSessionProject.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
@@ -244,7 +279,7 @@ export const STATION_HELP_CONTENT = [
   { text: "station project view", align: "center" as const },
   { key: "↑/↓ wheel", description: "scroll project list" },
   { key: "1-9/a-z", description: "start or focus row" },
-  { key: "N/A/R/C", description: "new/add/rename/fold" },
+  { key: "N/A/R/C/F", description: "new/add/rename/fold/fork" },
   { key: "X", description: "delete session" },
   { key: "/, Z", description: "search / refresh snapshot" },
   { key: "H/?", description: "help" },

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -169,6 +169,48 @@ describe("routeStationMouse", () => {
     expect(store.getState().localRows.pendingRemove).toEqual([]);
   });
 
+  it("chooses the clicked row in fork mode, same as the slot key", () => {
+    const clicked = makeStore();
+    const keyed = makeStore();
+    const rowId = "wt_station_working";
+    clicked.getState().handleKey({ input: "F" });
+    keyed.getState().handleKey({ input: "F" });
+    const slot = slotForRow(keyed, rowId);
+
+    routeStationMouse({ kind: "row", rowId }, LEFT_DOWN, clicked);
+    keyed.getState().handleKey({ input: slot });
+
+    expect(clicked.getState().screen).toEqual(keyed.getState().screen);
+    expect(clicked.getState().screen).toMatchObject({ name: "fork", step: "details" });
+  });
+
+  it("launches a fork from the sheet submit button", () => {
+    const store = makeStore();
+    const rowId = "wt_station_working";
+    store.getState().handleKey({ input: "F" });
+    store.getState().handleKey({ input: slotForRow(store, rowId) });
+    expect(store.getState().screen).toMatchObject({ name: "fork", step: "details" });
+
+    const outcome = routeStationMouse({ kind: "sheetSubmit" }, LEFT_DOWN, store);
+
+    expect(outcome.kind).toBe("launch-fork");
+    if (outcome.kind === "launch-fork") {
+      expect(outcome.projectId).toBe("station");
+      expect(outcome.sourceWorktreeId).toBe(rowId);
+      expect(outcome.copyDirty).toBe(true);
+      expect(outcome.branch.length).toBeGreaterThan(0);
+    }
+    // The submit is intercepted, not dispatched to the machine — the sheet stays open
+    // until the executor closes it, so the machine never ran the tmux session.fork.
+    expect(store.getState().screen).toMatchObject({ name: "fork", step: "details" });
+  });
+
+  it("ignores sheet submit outside fork details mode", () => {
+    const store = makeStore();
+    const outcome = routeStationMouse({ kind: "sheetSubmit" }, LEFT_DOWN, store);
+    expect(outcome).toEqual({ kind: "handled" });
+  });
+
   it("ignores row clicks in text-input modes", () => {
     const store = makeStore();
     store.getState().handleKey({ input: "/" });

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -18,6 +18,7 @@ import {
   focusProjectSettingsItem,
   openDefaultAgentPickerForProject,
   representativeKeyForBinding,
+  resolveForkSessionSubmit,
   resolveNewSessionSubmit,
   resolveProjectPaneTarget,
   resolveQuickSessionSubmit,
@@ -55,6 +56,8 @@ export type StationMouseTarget =
   | { kind: "projectSettingsItem"; itemId: ProjectSettingsItemId }
   /** The armed "Remove project (R)" action in the panel's detail pane. */
   | { kind: "projectSettingsConfirmRemove" }
+  /** A sheet's primary submit button (the fork details "Fork" action). */
+  | { kind: "sheetSubmit" }
   /** Sheets/prompts sit above the dashboard; their backdrop absorbs input. */
   | { kind: "sheetBackdrop" };
 
@@ -101,7 +104,19 @@ export type StationMouseOutcome =
    * Station pane. The create-hint click counterpart of the keyboard Enter on the
    * New Session review screen.
    */
-  | { kind: "launch-new-session"; projectId: string; branch: string; harness: ProviderId };
+  | { kind: "launch-new-session"; projectId: string; branch: string; harness: ProviderId }
+  /**
+   * Consumed; the router should seed a worktree off a source and host its agent
+   * in a Station pane. The fork-button click counterpart of the keyboard Enter on
+   * the Fork details screen.
+   */
+  | {
+      kind: "launch-fork";
+      projectId: string;
+      sourceWorktreeId: string;
+      branch: string;
+      copyDirty: boolean;
+    };
 
 const SCROLL_PAGE_ROWS = 5;
 
@@ -110,6 +125,7 @@ const ROW_INTERACTIVE_MODES: ReadonlySet<StationInputMode> = new Set([
   "dashboard",
   "removeChooseSlot",
   "renameChooseSlot",
+  "forkChooseSlot",
 ]);
 
 export function routeStationMouse(
@@ -228,6 +244,25 @@ export function routeStationMouse(
         return fromKeyOutcome(dispatchStationKey(store, { input: "r" }));
       }
       return { kind: "handled" };
+    }
+    case "sheetSubmit": {
+      // A click on the Fork details "Fork" button hosts the agent in Station,
+      // matching the keyboard Enter path (resolveKeyForkSessionSubmit) rather than
+      // dispatching the machine's tmux-bound session.fork.
+      if (mode !== "forkDetails") {
+        return { kind: "handled" };
+      }
+      const submit = resolveForkSessionSubmit(store);
+      if (submit.kind === "none") {
+        return { kind: "handled" };
+      }
+      return {
+        kind: "launch-fork",
+        projectId: submit.projectId,
+        sourceWorktreeId: submit.sourceWorktreeId,
+        branch: submit.branch,
+        copyDirty: submit.copyDirty,
+      };
     }
     case "body":
     case "sheetBackdrop":

--- a/station/src/station/input/stationOverlayLayer.ts
+++ b/station/src/station/input/stationOverlayLayer.ts
@@ -11,6 +11,7 @@
 import type { StoreApi } from "zustand/vanilla";
 import type { KeymapLayer } from "../../input/keymaps.js";
 import {
+  paneLaunchForkSessionOutcome,
   paneLaunchManagedOutcome,
   paneLaunchNewSessionOutcome,
   type RouteOutcome,
@@ -19,6 +20,7 @@ import { STATION_OVERLAY_ID } from "../../state/types.js";
 import type { TuiStore } from "@station/dashboard-core";
 import {
   handleStationSequence,
+  resolveKeyForkSessionSubmit,
   resolveKeyNewSessionSubmit,
   resolveKeyRowAgentTarget,
 } from "./stationActions.js";
@@ -44,6 +46,13 @@ export function createStationOverlayLayer(
       const submit = resolveKeyNewSessionSubmit(stationViewStore, key);
       if (submit.kind === "submit") {
         return paneLaunchNewSessionOutcome(submit);
+      }
+      // Enter on the Fork details screen seeds a worktree (worktree.fork) and
+      // hosts the inherited harness in Station, bypassing the machine's
+      // tmux-bound session.fork the same way New Session bypasses session.create.
+      const fork = resolveKeyForkSessionSubmit(stationViewStore, key);
+      if (fork.kind === "submit") {
+        return paneLaunchForkSessionOutcome(fork);
       }
       const outcome = handleStationSequence(stationViewStore, key);
       if (outcome.kind === "close-overlay") {

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -10,6 +10,7 @@ import { ProjectDefaultAgentSheetView } from "./sheets/ProjectDefaultAgentSheetV
 import { ProjectSettingsPanelView } from "./settings/ProjectSettingsPanelView.js";
 import { RenameSessionSheetView } from "./sheets/RenameSessionSheetView.js";
 import { RemoveSessionSheetView } from "./sheets/RemoveSessionSheetView.js";
+import { ForkSessionSheetView } from "./sheets/ForkSessionSheetView.js";
 
 export type OverlayHostViewProps = {
   snapshot: StationSnapshot;
@@ -50,6 +51,9 @@ export function OverlayHostView({ snapshot, screen, columns, rows }: OverlayHost
     return (
       <ProjectSettingsPanelView columns={columns} rows={rows} snapshot={snapshot} screen={screen} />
     );
+  }
+  if (screen.name === "fork") {
+    return <ForkSessionSheetView columns={columns} rows={rows} screen={screen} />;
   }
   return null;
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                         
+N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                  
 "
 `;
 
@@ -176,7 +176,7 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                         
+N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                  
 "
 `;
 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
         │                     station project view                     │        
 ▼ script│  ↑/↓ wheel  scroll project list                              │qs] [▾] 
  [9] ○ a│  1-9/a-z    start or focus row                               │[shell] 
- [a] ? m│  N/A/R/C    new/add/rename/fold                              │[shell] 
+ [a] ? m│  N/A/R/C/F  new/add/rename/fold/fork                         │[shell] 
  [b] - o│  X          delete session                                   │[shell] 
         │  /, Z       search / refresh snapshot                        │        
 ▼ empty-│  H/?        help                                             │qs] [▾] 
@@ -193,6 +193,62 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 │ Enter:rename   Esc:back                                                      │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
+exports[`modal flow golden frames renders the fork slot sheet 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+                                                                                
+▼ station - 5 worktrees                                           [sh] [qs] [▾] 
+ [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
+ [2] - docs-cleanup               -         no agent                    [shell] 
+ [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
+ [4] + session-resume             codex     starting                    [shell] 
+ [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+                                                                                
+▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
+ [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
+ [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
+ [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+                                                                                
+▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
+ [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
+┌────────────────────────────────────────────┐known           +3 -1 #10 [shell] 
+│ Select session to fork                     │ agent                    [shell] 
+│                                            │                                  
+│ Click a row or press slot key              │                    [sh] [qs] [▾] 
+│ Esc:cancel                                 │                                  
+│                                            │───────────────────────────────── 
+└────────────────────────────────────────────┘ X:delete session /:search H:help 
+"
+`;
+
+exports[`modal flow golden frames renders the fork details sheet 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+                                                                                
+▼ station - 5 worktrees                                           [sh] [qs] [▾] 
+ [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
+ [2] - docs-cleanup               -         no agent                    [shell] 
+ [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
+ [4] + session-resume             codex     starting                    [shell] 
+ [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+                                                                                
+▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
+ [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
+ [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
+ [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+┌────────────────────────────────────────────┐                                  
+│ Fork Session                               │                    [sh] [qs] [▾] 
+│ Source   station · cli-help-man            │le           +14 -6 #5 x1 [shell] 
+│ > Branch cli-help-man-fork|                │known           +3 -1 #10 [shell] 
+│   Copy   [x] uncommitted changes           │ agent                    [shell] 
+│ Source keeps running — copy is read-only.  │                                  
+│                                            │                    [sh] [qs] [▾] 
+│ Fork (enter)                               │                                  
+│ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
+└────────────────────────────────────────────┘ X:delete session /:search H:help 
 "
 `;
 

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -60,6 +60,16 @@ const CASES: ModalCase[] = [
     expect: ["Rename Session", "Name", "Enter:rename   Esc:back"],
   },
   {
+    name: "fork slot sheet",
+    keys: [{ input: "F" }],
+    expect: ["Select session to fork", "Click a row or press slot key", "Esc:cancel"],
+  },
+  {
+    name: "fork details sheet",
+    keys: [{ input: "F" }, { input: "1" }],
+    expect: ["Fork Session", "Source", "uncommitted changes", "Fork (enter)", "enter:fork"],
+  },
+  {
     name: "new session review",
     keys: [{ input: "N" }],
     expect: ["Create Session", "Project", "Agent", "Enter:create N:name P:project A:agent Esc:cancel"],

--- a/station/src/station/view/sheets/ForkSessionSheetView.tsx
+++ b/station/src/station/view/sheets/ForkSessionSheetView.tsx
@@ -1,0 +1,124 @@
+// OpenTUI bottom sheet for Fork Session: chooseSlot (pick a source row, mirrors
+// RemoveSessionSheetView) and details (branch field + copy-dirty toggle + submit,
+// mirrors NewSessionSheetView's EditName). The submit button is a click target so
+// the fork launches in Station (sheetSubmit → launch-fork), never the tmux path.
+import { bottomSheetContentWidth, type TuiScreen } from "@station/dashboard-core";
+import { EditableTextInputView } from "../EditableTextInputView.js";
+import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
+import {
+  compactSheetWidth,
+  SheetButton,
+  SheetFooter,
+  SheetLabelValue,
+  SheetLine,
+  SheetMessageLine,
+} from "./parts.js";
+
+type ForkScreen = Extract<TuiScreen, { name: "fork" }>;
+type ForkDetailsScreen = Extract<ForkScreen, { step: "details" }>;
+
+export type ForkSessionSheetViewProps = {
+  screen: ForkScreen;
+  columns: number;
+  rows: number;
+};
+
+const LABEL_WIDTH = 8;
+
+export function ForkSessionSheetView({ screen, columns, rows }: ForkSessionSheetViewProps) {
+  const sheetWidth = compactSheetWidth(columns);
+  const contentWidth = bottomSheetContentWidth(sheetWidth);
+  if (screen.step === "chooseSlot") {
+    return (
+      <BottomSheetFrameView
+        columns={columns}
+        rows={rows}
+        width={sheetWidth}
+        title="Select session to fork"
+        contentRows={5}
+        minHeight={7}
+      >
+        <SheetLine width={contentWidth}> </SheetLine>
+        <SheetMessageLine width={contentWidth}>Click a row or press slot key</SheetMessageLine>
+        <SheetFooter width={contentWidth}>Esc:cancel</SheetFooter>
+      </BottomSheetFrameView>
+    );
+  }
+  return <ForkDetails screen={screen} columns={columns} rows={rows} contentWidth={contentWidth} sheetWidth={sheetWidth} />;
+}
+
+function ForkDetails({
+  screen,
+  columns,
+  rows,
+  contentWidth,
+  sheetWidth,
+}: {
+  screen: ForkDetailsScreen;
+  columns: number;
+  rows: number;
+  contentWidth: number;
+  sheetWidth: number;
+}) {
+  const focus = screen.focus;
+  const branchValue =
+    focus === "branch" ? (
+      <EditableTextInputView {...screen.draftBranch} />
+    ) : (
+      screen.draftBranch.value
+    );
+  const extraRows = (screen.sourceAgentRunning ? 1 : 0) + (screen.validationError !== undefined ? 1 : 0);
+  return (
+    <BottomSheetFrameView
+      columns={columns}
+      rows={rows}
+      width={sheetWidth}
+      title="Fork Session"
+      contentRows={7 + extraRows}
+      minHeight={9}
+    >
+      <SheetLabelValue
+        width={contentWidth}
+        label="Source"
+        labelWidth={LABEL_WIDTH}
+        value={`${screen.projectLabel} · ${screen.sourceBranch}`}
+      />
+      <SheetLabelValue
+        width={contentWidth}
+        label={focusLabel("Branch", focus === "branch")}
+        labelWidth={LABEL_WIDTH}
+        value={branchValue}
+      />
+      <SheetLabelValue
+        width={contentWidth}
+        label={focusLabel("Copy", focus === "copyDirty")}
+        labelWidth={LABEL_WIDTH}
+        value={`[${screen.copyDirty ? "x" : " "}] uncommitted changes`}
+      />
+      {screen.sourceAgentRunning ? (
+        <SheetMessageLine width={contentWidth} tone="muted">
+          Source keeps running — copy is read-only.
+        </SheetMessageLine>
+      ) : null}
+      {screen.validationError !== undefined ? (
+        <SheetMessageLine width={contentWidth} tone="danger">
+          {screen.validationError}
+        </SheetMessageLine>
+      ) : null}
+      <SheetLine width={contentWidth}> </SheetLine>
+      <SheetButton
+        label={focus === "submit" ? "> Fork" : "Fork"}
+        shortcut="enter"
+        tone="success"
+        fixedWidth={Math.min(contentWidth, 18)}
+        mouseTarget={{ kind: "sheetSubmit" }}
+      />
+      <SheetFooter width={contentWidth}>↑↓:field space:toggle enter:fork esc:back</SheetFooter>
+    </BottomSheetFrameView>
+  );
+}
+
+/** Prefix a field label with a focus caret so the active field reads clearly. */
+function focusLabel(label: string, focused: boolean): string {
+  return `${focused ? ">" : " "} ${label}`;
+}


### PR DESCRIPTION
Phase B of the fork TUI. Makes the merged fork backend reachable from the Station dashboard.

> Supersedes #37, which GitHub auto-closed when its base branch (`feat/fork-tui-phase-a`, PR #36) was deleted on merge. Same branch/commits, now rebased onto `main` with the PR #34 (project context menu) conflicts in `stationInput.ts`, `stationMouse.ts`, and `OverlayHostView.tsx` resolved (both feature sets kept).

## What
Press **F** (or right-click → **Fork Session**) → pick a source row → edit the new branch + toggle copy-dirty → a native pane launches the inherited harness on a **seeded** worktree, source untouched.

## Observer capability
New **`worktree.fork`** command — the worktree-only half of `session.fork`: seeds the new branch off the source HEAD without minting a session or launching a terminal, so Station hosts the agent itself via `prepareExternalLaunch`. Seeding stays the read-only temp-index snapshot; `copyDirty` honored; base pinned to the source HEAD.

## Native flow (mirrors New Session)
- **Keymap**: `forkChooseSlot`/`forkDetails` modes, `F` dashboard binding, footer + help text. Cursor-binding boilerplate extracted into a shared `editableTextBindings` helper.
- **View**: `ForkSessionSheetView` — chooseSlot + details (branch field, copy toggle, live-source reassurance line, submit button).
- **Submit** intercepted (keyboard + sheet-button click) → `worktree.fork` dispatch + managed launch; never the tmux path.
- **Harness inherited** from the source row, else project default. When neither resolves a harness, the optimistic row still renders (blank agent column) — fixed in this branch.

## Verify (run locally; GitHub Actions is billing-disabled on this account)
standard-ci: build · typecheck 44/44 · lint · unit 1008 · contracts 24 · integration 284 · diagnostics 33 · scripted-agent 3 · e2e:setup 7.
station-bun: typecheck clean · **821 pass / 0 fail**.

## UX implication & manual verify
Dirty a worktree (edit a tracked file, stage another, add an untracked file). Press **F** → pick that row → accept the suggested `<branch>-fork` → keep copy ON → Enter. Expect: a native pane launches the inherited harness; `git status` in the fork shows the same staged/unstaged/untracked state; the source is unchanged and its agent still running.
