### PR TITLE
feat(dashboard): project settings picker with optimistic default-agent selection

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -251,11 +251,18 @@ function textPromptForScreen(screen: TuiScreen): { label: string; value: string 
   if (screen.name === "projectCollapse") {
     return { label: "collapse project", value: screen.value };
   }
+  if (screen.name === "projectSettingsPicker") {
+    return { label: "settings for project", value: screen.value };
+  }
   return undefined;
 }
 
 export function commandPromptRows(screen: TuiScreen): number {
-  if (screen.name === "search" || screen.name === "projectCollapse") {
+  if (
+    screen.name === "search" ||
+    screen.name === "projectCollapse" ||
+    screen.name === "projectSettingsPicker"
+  ) {
     return 2;
   }
   if (screen.name === "renameSession" && screen.step === "chooseSlot") {

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -7,7 +7,11 @@ import type {
   StationSnapshot,
   WorktreeRow,
 } from "@station/contracts";
-import { pendingRenameTitles, type TuiLocalRows } from "../state/localRows.js";
+import {
+  pendingProjectDefaultHarnesses,
+  pendingRenameTitles,
+  type TuiLocalRows,
+} from "../state/localRows.js";
 import type { TuiViewState } from "../state/types.js";
 
 export const SELECTION_KEYS = [
@@ -211,6 +215,23 @@ export function worktreeRowDisplayTitle(
     return row.branch;
   }
   return pendingRenameTitles(localRows)[session.id]?.title ?? session.title;
+}
+
+/**
+ * The default harness to render as a project's current selection: the optimistic
+ * pending value (set the moment a new agent is picked) until the snapshot
+ * confirms it, otherwise the snapshot value. `pending` drives the "updating…"
+ * cue while the change is in flight.
+ */
+export function selectProjectDefaultHarness(
+  localRows: TuiLocalRows,
+  project: ProjectView,
+): { harness: ProviderId; pending: boolean } {
+  const pending = pendingProjectDefaultHarnesses(localRows)[project.id];
+  if (pending === undefined) {
+    return { harness: project.defaults.harness, pending: false };
+  }
+  return { harness: pending.harness, pending: true };
 }
 
 function compareRows(

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -7,6 +7,7 @@ export type TuiInputMode =
   | "help"
   | "search"
   | "projectCollapse"
+  | "projectSettingsPicker"
   | "removeChooseSlot"
   | "removeConfirm"
   | "renameChooseSlot"
@@ -29,6 +30,8 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
       return "search";
     case "projectCollapse":
       return "projectCollapse";
+    case "projectSettingsPicker":
+      return "projectSettingsPicker";
     case "removeWorktree":
       return screen.step === "chooseSlot" ? "removeChooseSlot" : "removeConfirm";
     case "renameSession":
@@ -171,6 +174,13 @@ export const TUI_KEYMAP = {
       help: { keys: "C", label: "fold" },
     },
     {
+      id: "tui.dashboard.projectSettings",
+      pattern: { kind: "char", char: "P" },
+      action: "tui.projectSettings.openPicker",
+      outcome: "handled",
+      help: { keys: "P", label: "settings" },
+    },
+    {
       id: "tui.dashboard.slotActivate",
       pattern: { kind: "slot" },
       action: "tui.row.activateSlot",
@@ -253,6 +263,22 @@ export const TUI_KEYMAP = {
       action: "tui.collapse.toggleSlot",
       outcome: "handled",
       help: { keys: "1-9 a-z", label: "toggle project" },
+    },
+  ],
+  projectSettingsPicker: [
+    {
+      id: "tui.projectSettingsPicker.cancel",
+      pattern: { kind: "named", named: "escape" },
+      action: "tui.projectSettings.pickerCancel",
+      outcome: "handled",
+      help: { keys: "esc", label: "cancel" },
+    },
+    {
+      id: "tui.projectSettingsPicker.choose",
+      pattern: { kind: "slot" },
+      action: "tui.projectSettings.pick",
+      outcome: "handled",
+      help: { keys: "1-9 a-z", label: "open settings" },
     },
   ],
   removeChooseSlot: [
@@ -630,6 +656,7 @@ export const TUI_HELP_CONTENT = [
   { key: "R", description: "rename session" },
   { key: "X", description: "delete session" },
   { key: "C", description: "collapse project" },
+  { key: "P", description: "project settings" },
   { key: "/", description: "search" },
   { key: "Z", description: "refresh snapshot" },
   { key: "H / ?", description: "help" },
@@ -656,7 +683,7 @@ export function dashboardFooterLabel({
 }): string {
   const full = firstRun
     ? `A:Add Project ${quitHint}`
-    : `N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help ${quitHint}`;
+    : `N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help ${quitHint}`;
   const compactClose = `${QUIT_HINT_CLOSE} N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help`;
   return quitHint === QUIT_HINT_CLOSE && full.length > columns ? compactClose : full;
 }

--- a/packages/dashboard-core/src/state/localRows.ts
+++ b/packages/dashboard-core/src/state/localRows.ts
@@ -1,5 +1,6 @@
 import type {
   CommandId,
+  ProjectId,
   ProviderId,
   SafeError,
   SessionId,
@@ -51,12 +52,24 @@ export type PendingRenameSessionTitle = {
   commandId?: CommandId;
 };
 
+/**
+ * Optimistic "default agent" change for a project: the picked harness shown as
+ * current before the observer round-trip lands. Pruned when the snapshot's
+ * default matches, removed (reverted) if the command fails.
+ */
+export type PendingProjectDefaultHarness = {
+  projectId: ProjectId;
+  harness: ProviderId;
+  createdAt: string;
+};
+
 export type TuiLocalRows = {
   pendingCreate: PendingCreateSessionRow[];
   failedCreate: FailedCreateSessionRow[];
   pendingRemove: PendingRemoveWorktreeRow[];
   pendingStart: PendingStartAgentRow[];
   pendingRenameTitles?: Readonly<Record<SessionId, PendingRenameSessionTitle>>;
+  pendingProjectDefaults?: Readonly<Record<ProjectId, PendingProjectDefaultHarness>>;
 };
 
 export function createEmptyTuiLocalRows(): TuiLocalRows {
@@ -66,6 +79,7 @@ export function createEmptyTuiLocalRows(): TuiLocalRows {
     pendingRemove: [],
     pendingStart: [],
     pendingRenameTitles: {},
+    pendingProjectDefaults: {},
   };
 }
 
@@ -284,6 +298,41 @@ export function removePendingRenameSessionTitle(state: TuiState, sessionId: Sess
   };
 }
 
+export function addPendingProjectDefaultHarness(
+  state: TuiState,
+  row: PendingProjectDefaultHarness,
+): TuiState {
+  return {
+    ...state,
+    localRows: withPendingProjectDefaults(state.localRows, {
+      ...pendingProjectDefaultHarnesses(state.localRows),
+      [row.projectId]: row,
+    }),
+  };
+}
+
+export function removePendingProjectDefaultHarness(
+  state: TuiState,
+  projectId: ProjectId,
+): TuiState {
+  const pending = pendingProjectDefaultHarnesses(state.localRows);
+  if (pending[projectId] === undefined) {
+    return state;
+  }
+  const nextPending = { ...pending };
+  delete nextPending[projectId];
+  return {
+    ...state,
+    localRows: withPendingProjectDefaults(state.localRows, nextPending),
+  };
+}
+
+export function pendingProjectDefaultHarnesses(
+  localRows: TuiLocalRows,
+): Readonly<Record<ProjectId, PendingProjectDefaultHarness>> {
+  return localRows.pendingProjectDefaults ?? {};
+}
+
 export function pruneLocalRowsForSnapshot(
   localRows: TuiLocalRows,
   snapshot: StationSnapshot,
@@ -292,7 +341,7 @@ export function pruneLocalRowsForSnapshot(
   const realWorktreeIds = new Set(snapshot.rows.map((row) => row.id));
   const rowsByWorktreeId = new Map(snapshot.rows.map((row) => [row.id, row]));
   const sessionWorktreeIds = new Set(snapshot.sessions.map((session) => session.worktreeId));
-  return withPendingRenameTitles(
+  const pruned = withPendingRenameTitles(
     {
       ...localRows,
       pendingCreate: localRows.pendingCreate.filter(
@@ -310,6 +359,7 @@ export function pruneLocalRowsForSnapshot(
     },
     prunePendingRenameTitles(localRows, snapshot),
   );
+  return withPendingProjectDefaults(pruned, prunePendingProjectDefaults(localRows, snapshot));
 }
 
 export function pendingRenameTitles(
@@ -342,6 +392,34 @@ function withPendingRenameTitles(
     next.pendingRenameTitles = titles;
   } else {
     delete next.pendingRenameTitles;
+  }
+  return next;
+}
+
+function prunePendingProjectDefaults(
+  localRows: TuiLocalRows,
+  snapshot: StationSnapshot,
+): Record<ProjectId, PendingProjectDefaultHarness> {
+  const projectsById = new Map(snapshot.projects.map((project) => [project.id, project]));
+  return Object.fromEntries(
+    Object.entries(pendingProjectDefaultHarnesses(localRows)).filter(([projectId, pending]) => {
+      const project = projectsById.get(projectId);
+      return project !== undefined && project.defaults.harness !== pending.harness;
+    }),
+  );
+}
+
+function withPendingProjectDefaults(
+  localRows: TuiLocalRows,
+  defaults: Readonly<Record<ProjectId, PendingProjectDefaultHarness>>,
+): TuiLocalRows {
+  const next: TuiLocalRows = {
+    ...localRows,
+  };
+  if (Object.keys(defaults).length > 0) {
+    next.pendingProjectDefaults = defaults;
+  } else {
+    delete next.pendingProjectDefaults;
   }
   return next;
 }

--- a/packages/dashboard-core/src/state/operations/localOperationRunner.ts
+++ b/packages/dashboard-core/src/state/operations/localOperationRunner.ts
@@ -6,6 +6,7 @@ import type { TuiObserverService } from "../../services/types.js";
 import {
   failPendingCreateSessionRow,
   removeCreateSessionLocalRow,
+  removePendingProjectDefaultHarness,
   removePendingRemoveWorktreeRow,
   removePendingRenameSessionTitle,
   removePendingStartAgentRow,
@@ -269,9 +270,14 @@ async function runSetProjectDefaultHarnessOperation(
   clientLabel: string,
   markCommandFailureHandled: (commandId: CommandId) => void,
 ): Promise<void> {
+  // Roll the optimistic marker back to the snapshot's default; success leaves it
+  // for the next snapshot to prune once the change has landed.
+  const revertOptimistic = () =>
+    store.setState(removePendingProjectDefaultHarness(store.getState(), command.payload.projectId));
   try {
     const receipt = await service.dispatch(command);
     if (!receipt.accepted) {
+      revertOptimistic();
       addSafeCommandToast(
         store,
         receipt.error ?? {
@@ -288,6 +294,7 @@ async function runSetProjectDefaultHarnessOperation(
     markCommandFailureHandled(receipt.commandId);
     const completion = await service.waitForCommandCompletion(receipt.commandId);
     if (completion.status === "failed") {
+      revertOptimistic();
       addSafeCommandToast(store, completion.error);
       return;
     }
@@ -299,6 +306,7 @@ async function runSetProjectDefaultHarnessOperation(
       }),
     );
   } catch (error: unknown) {
+    revertOptimistic();
     addSafeCommandToast(store, toSafeError(error, { clientLabel }));
   }
 }

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -1,10 +1,6 @@
 import { createNewSessionFlow, createNewSessionNameToken } from "../../flows/newSession.js";
 import { selectDashboardViewport } from "../../selectors/dashboardViewport.js";
-import {
-  choiceValueByKey,
-  type KeyedChoice,
-  selectProjectChoices,
-} from "../../selectors/selectors.js";
+import { choiceValueByKey } from "../../selectors/selectors.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
 import { scrollDashboard } from "../dashboardScroll.js";
 import { matchTuiBinding, type TuiBinding } from "../keymap.js";
@@ -14,6 +10,7 @@ import { addTuiToast } from "../toasts.js";
 import type { TuiKeyRuntimeContext, TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
 import { openAddProject } from "./addProjectScreen.js";
+import { openProjectSlotPicker } from "./projectSlotPicker.js";
 
 export function handleDashboardKey(
   state: TuiState,
@@ -96,7 +93,9 @@ function handleDashboardBinding(
         state: openAddProject(state, context),
       };
     case "tui.collapse.open":
-      return openProjectCollapse(state);
+      return openProjectSlotPicker(state, "projectCollapse");
+    case "tui.projectSettings.openPicker":
+      return openProjectSlotPicker(state, "projectSettingsPicker");
     case "tui.row.activateSlot":
       return activateDashboardSlot(state, key);
     default:
@@ -184,23 +183,4 @@ function openNewSession(state: TuiState): TuiTransition {
       screen: { name: "newSession", flow },
     },
   };
-}
-
-function openProjectCollapse(state: TuiState): TuiTransition {
-  if (state.snapshot === undefined) {
-    return { state };
-  }
-  return {
-    state: {
-      ...state,
-      screen: {
-        name: "projectCollapse",
-        value: formatProjectChoicePrompt(selectProjectChoices(state.snapshot, state)),
-      },
-    },
-  };
-}
-
-function formatProjectChoicePrompt(choices: ReadonlyArray<KeyedChoice<{ label: string }>>): string {
-  return choices.map((choice) => `${choice.key}:${choice.value.label}`).join(" ");
 }

--- a/packages/dashboard-core/src/state/screens/projectCollapse.ts
+++ b/packages/dashboard-core/src/state/screens/projectCollapse.ts
@@ -1,44 +1,23 @@
-import { choiceValueByKey, selectProjectChoices } from "../../selectors/selectors.js";
 import { clampDashboardStateScroll } from "../dashboardScroll.js";
 import type { TuiKey } from "../keys.js";
 import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
+import { handleProjectSlotPickerKey } from "./projectSlotPicker.js";
 
 export function handleProjectCollapseKey(state: TuiState, key: TuiKey): TuiTransition {
-  if (state.screen.name !== "projectCollapse") {
-    return { state };
-  }
-
-  if (key.escape === true) {
+  return handleProjectSlotPickerKey(state, key, "projectCollapse", (current, project) => {
+    const collapsedProjectIds = new Set(current.collapsedProjectIds);
+    if (collapsedProjectIds.has(project.id)) {
+      collapsedProjectIds.delete(project.id);
+    } else {
+      collapsedProjectIds.add(project.id);
+    }
     return {
-      state: {
-        ...state,
+      state: clampDashboardStateScroll({
+        ...current,
+        collapsedProjectIds,
         screen: { name: "dashboard" },
-      },
+      }),
     };
-  }
-
-  if (state.snapshot === undefined) {
-    return { state };
-  }
-
-  const project = choiceValueByKey(selectProjectChoices(state.snapshot, state), key.input);
-  if (project === undefined) {
-    return { state };
-  }
-
-  const collapsedProjectIds = new Set(state.collapsedProjectIds);
-  if (collapsedProjectIds.has(project.id)) {
-    collapsedProjectIds.delete(project.id);
-  } else {
-    collapsedProjectIds.add(project.id);
-  }
-
-  return {
-    state: clampDashboardStateScroll({
-      ...state,
-      collapsedProjectIds,
-      screen: { name: "dashboard" },
-    }),
-  };
+  });
 }

--- a/packages/dashboard-core/src/state/screens/projectSettings.ts
+++ b/packages/dashboard-core/src/state/screens/projectSettings.ts
@@ -8,6 +8,7 @@ import {
   choiceValueByKey,
   isSelectionKey,
   selectNewSessionHarnessChoices,
+  selectProjectDefaultHarness,
 } from "../../selectors/selectors.js";
 import {
   buildRemoveProjectCommand,
@@ -132,8 +133,12 @@ function selectAgent(state: TuiState, screen: ProjectSettingsScreen, key: TuiKey
   if (option === undefined) {
     return { state };
   }
-  // Selecting the current default is a no-op edit; just return to the list.
-  if (option.id === project.defaults.harness) {
+  // Compare against the effective (optimistic) default, not the snapshot value:
+  // while a change is in flight the picked agent is what the user sees as current,
+  // so re-selecting it is a no-op and selecting anything else — even the snapshot
+  // default — is a real change that must override the pending one.
+  const effectiveDefault = selectProjectDefaultHarness(state.localRows, project).harness;
+  if (option.id === effectiveDefault) {
     return { state: { ...state, screen: { ...screen, focus: "list" } } };
   }
   // Move the marker to the picked agent immediately; the runner reverts this if

--- a/packages/dashboard-core/src/state/screens/projectSettings.ts
+++ b/packages/dashboard-core/src/state/screens/projectSettings.ts
@@ -14,6 +14,7 @@ import {
   buildSetProjectDefaultHarnessCommand,
 } from "../commandBuilders.js";
 import { isReturnKey, type TuiKey } from "../keys.js";
+import { addPendingProjectDefaultHarness } from "../localRows.js";
 import type { TuiTransition } from "../transition.js";
 import type { ProjectSettingsItemId, TuiState } from "../types.js";
 
@@ -135,8 +136,13 @@ function selectAgent(state: TuiState, screen: ProjectSettingsScreen, key: TuiKey
   if (option.id === project.defaults.harness) {
     return { state: { ...state, screen: { ...screen, focus: "list" } } };
   }
+  // Move the marker to the picked agent immediately; the runner reverts this if
+  // the command fails, and the next snapshot prunes it once the change lands.
   return {
-    state: { ...state, screen: { ...screen, focus: "list" } },
+    state: addPendingProjectDefaultHarness(
+      { ...state, screen: { ...screen, focus: "list" } },
+      { projectId: project.id, harness: option.id, createdAt: new Date().toISOString() },
+    ),
     operations: [
       {
         type: "setProjectDefaultHarness",

--- a/packages/dashboard-core/src/state/screens/projectSettingsPicker.ts
+++ b/packages/dashboard-core/src/state/screens/projectSettingsPicker.ts
@@ -1,0 +1,16 @@
+import type { TuiKey } from "../keys.js";
+import type { TuiTransition } from "../transition.js";
+import type { TuiState } from "../types.js";
+import { openProjectSettings } from "./projectSettings.js";
+import { handleProjectSlotPickerKey } from "./projectSlotPicker.js";
+
+/**
+ * Slot-key project chooser reached by `P`. Mirrors projectCollapse: esc backs
+ * out to the dashboard, a slot key resolves the project and drops straight into
+ * its settings panel via the shared openProjectSettings transition.
+ */
+export function handleProjectSettingsPickerKey(state: TuiState, key: TuiKey): TuiTransition {
+  return handleProjectSlotPickerKey(state, key, "projectSettingsPicker", (current, project) => ({
+    state: openProjectSettings(current, project.id),
+  }));
+}

--- a/packages/dashboard-core/src/state/screens/projectSlotPicker.ts
+++ b/packages/dashboard-core/src/state/screens/projectSlotPicker.ts
@@ -1,0 +1,61 @@
+import type { ProjectView } from "@station/contracts";
+import {
+  choiceValueByKey,
+  type KeyedChoice,
+  selectProjectChoices,
+} from "../../selectors/selectors.js";
+import type { TuiKey } from "../keys.js";
+import type { TuiTransition } from "../transition.js";
+import type { TuiState } from "../types.js";
+
+/**
+ * Shared skeleton for the dashboard's slot-key project choosers (`C` collapse,
+ * `P` settings). They differ only in what a picked project does, so the screen
+ * name and the on-pick transition are the parameters; everything else — the
+ * snapshot guard, esc-to-dashboard, and slot resolution — stays in one place so
+ * the pickers cannot drift apart.
+ */
+export type ProjectPickerScreen = "projectCollapse" | "projectSettingsPicker";
+
+export function formatProjectChoicePrompt(
+  choices: ReadonlyArray<KeyedChoice<{ label: string }>>,
+): string {
+  return choices.map((choice) => `${choice.key}:${choice.value.label}`).join(" ");
+}
+
+export function openProjectSlotPicker(state: TuiState, name: ProjectPickerScreen): TuiTransition {
+  if (state.snapshot === undefined) {
+    return { state };
+  }
+  return {
+    state: {
+      ...state,
+      screen: {
+        name,
+        value: formatProjectChoicePrompt(selectProjectChoices(state.snapshot, state)),
+      },
+    },
+  };
+}
+
+export function handleProjectSlotPickerKey(
+  state: TuiState,
+  key: TuiKey,
+  name: ProjectPickerScreen,
+  onPick: (state: TuiState, project: ProjectView) => TuiTransition,
+): TuiTransition {
+  if (state.screen.name !== name) {
+    return { state };
+  }
+  if (key.escape === true) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  if (state.snapshot === undefined) {
+    return { state };
+  }
+  const project = choiceValueByKey(selectProjectChoices(state.snapshot, state), key.input);
+  if (project === undefined) {
+    return { state };
+  }
+  return onPick(state, project);
+}

--- a/packages/dashboard-core/src/state/transition.ts
+++ b/packages/dashboard-core/src/state/transition.ts
@@ -8,6 +8,7 @@ import { handleNewSessionKey } from "./screens/newSession.js";
 import { handleProjectCollapseKey } from "./screens/projectCollapse.js";
 import { handleProjectDefaultAgentKey } from "./screens/projectDefaultAgent.js";
 import { handleProjectSettingsKey } from "./screens/projectSettings.js";
+import { handleProjectSettingsPickerKey } from "./screens/projectSettingsPicker.js";
 import { handleRemoveWorktreeKey } from "./screens/removeWorktree.js";
 import { handleRenameSessionKey } from "./screens/renameSession.js";
 import { handleSearchKey } from "./screens/search.js";
@@ -48,6 +49,8 @@ export function handleTuiKey(
       return handleSearchKey(state, key);
     case "projectCollapse":
       return handleProjectCollapseKey(state, key);
+    case "projectSettingsPicker":
+      return handleProjectSettingsPickerKey(state, key);
     case "removeWorktree":
       return handleRemoveWorktreeKey(state, key);
     case "renameSession":

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -56,6 +56,7 @@ export type TuiScreen =
   | { name: "help" }
   | { name: "search"; value: string }
   | { name: "projectCollapse"; value: string }
+  | { name: "projectSettingsPicker"; value: string }
   | { name: "removeWorktree"; step: "chooseSlot" }
   | {
       name: "removeWorktree";

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -19,6 +19,7 @@ const ALLOWED_NOOP_BINDINGS = new Set([
   // the current viewport, selected picker, and row data.
   "tui.dashboard.slotActivate",
   "tui.collapse.toggleSlot",
+  "tui.projectSettingsPicker.choose",
   "tui.remove.chooseSlot",
   "tui.rename.chooseSlot",
   "tui.newSessionProject.choose",
@@ -77,6 +78,7 @@ function representativeStates(): Record<TuiInputMode, TuiState> {
     help: drive(base, [{ input: "H" }]),
     search: drive(base, [{ input: "/" }, { input: "ab" }]),
     projectCollapse: drive(base, [{ input: "C" }]),
+    projectSettingsPicker: drive(base, [{ input: "P" }]),
     removeChooseSlot: drive(base, [{ input: "X" }]),
     removeConfirm: drive(base, [{ input: "X" }, { input: "1" }]),
     renameChooseSlot: drive(base, [{ input: "R" }]),

--- a/packages/dashboard-core/test/unit/state/screens/projectCollapse.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/projectCollapse.test.ts
@@ -1,0 +1,65 @@
+import type { TuiKey, TuiState } from "@station/dashboard-core";
+import { createInitialTuiState, handleTuiKey, selectProjectChoices } from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+
+// projectCollapse shares the projectSlotPicker skeleton with the settings picker;
+// these lock its toggle behavior so a refactor of the shared helper can't quietly
+// change collapse semantics.
+function dashboardState(): TuiState {
+  return createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+}
+
+function drive(state: TuiState, keys: TuiKey[]): TuiState {
+  let current = state;
+  for (const key of keys) {
+    current = handleTuiKey(current, key).state;
+  }
+  return current;
+}
+
+function firstProject(state: TuiState) {
+  const snapshot = state.snapshot;
+  if (snapshot === undefined) throw new Error("snapshot missing");
+  const [choice] = selectProjectChoices(snapshot, state);
+  if (choice === undefined) throw new Error("no projects in fixture");
+  return choice;
+}
+
+const C: TuiKey = { input: "C" };
+const ESC: TuiKey = { input: "", escape: true };
+
+describe("project collapse picker", () => {
+  it("C opens the collapse picker prompt", () => {
+    expect(drive(dashboardState(), [C]).screen.name).toBe("projectCollapse");
+  });
+
+  it("choosing a slot collapses the project and returns to the dashboard", () => {
+    const base = dashboardState();
+    const project = firstProject(base);
+    const after = drive(base, [C, { input: project.key }]);
+    expect(after.screen.name).toBe("dashboard");
+    expect(after.collapsedProjectIds.has(project.value.id)).toBe(true);
+  });
+
+  it("choosing the same slot again expands it (toggle off)", () => {
+    const base = dashboardState();
+    const project = firstProject(base);
+    const collapsed = drive(base, [C, { input: project.key }]);
+    expect(collapsed.collapsedProjectIds.has(project.value.id)).toBe(true);
+    const expanded = drive(collapsed, [C, { input: project.key }]);
+    expect(expanded.collapsedProjectIds.has(project.value.id)).toBe(false);
+  });
+
+  it("esc backs out to the dashboard without changing collapse state", () => {
+    const after = drive(dashboardState(), [C, ESC]);
+    expect(after.screen.name).toBe("dashboard");
+    expect([...after.collapsedProjectIds]).toEqual([]);
+  });
+
+  it("an unmapped slot key is a no-op and stays in the picker", () => {
+    const after = drive(dashboardState(), [C, { input: "z" }]);
+    expect(after.screen.name).toBe("projectCollapse");
+    expect([...after.collapsedProjectIds]).toEqual([]);
+  });
+});

--- a/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
@@ -1,11 +1,15 @@
-import type { TuiKey, TuiState } from "@station/dashboard-core";
+import type { StationSnapshot, TuiKey, TuiState } from "@station/dashboard-core";
 import {
   createInitialTuiState,
   focusProjectSettingsItem,
   handleTuiKey,
   openProjectSettings,
+  pendingProjectDefaultHarnesses,
+  pruneLocalRowsForSnapshot,
+  removePendingProjectDefaultHarness,
   removeProjectConfirmPhrase,
   selectNewSessionHarnessChoices,
+  selectProjectDefaultHarness,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
@@ -78,6 +82,53 @@ describe("project settings panel", () => {
     expect(
       transition.state.screen.name === "projectSettings" && transition.state.screen.focus,
     ).toBe("list");
+  });
+
+  it("marks the picked agent as the optimistic default until the snapshot confirms", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("missing web project");
+    const other = selectNewSessionHarnessChoices(snapshot, project).find(
+      (choice) => choice.value.id !== project.defaults.harness,
+    );
+    if (other === undefined) throw new Error("no alternative harness in fixture");
+
+    const { state } = handleTuiKey(drive(panelState(), [RIGHT]), { input: other.key });
+
+    // The marker jumps to the picked agent right away, flagged pending.
+    expect(selectProjectDefaultHarness(state.localRows, project)).toEqual({
+      harness: other.value.id,
+      pending: true,
+    });
+
+    // A snapshot that reflects the new default prunes the optimistic entry.
+    const confirmed: StationSnapshot = {
+      ...snapshot,
+      projects: snapshot.projects.map((candidate) =>
+        candidate.id === "web"
+          ? { ...candidate, defaults: { ...candidate.defaults, harness: other.value.id } }
+          : candidate,
+      ),
+    };
+    const pruned = pruneLocalRowsForSnapshot(state.localRows, confirmed);
+    expect(pendingProjectDefaultHarnesses(pruned)).toEqual({});
+  });
+
+  it("reverting the optimistic default falls back to the snapshot value", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("missing web project");
+    const other = selectNewSessionHarnessChoices(snapshot, project).find(
+      (choice) => choice.value.id !== project.defaults.harness,
+    );
+    if (other === undefined) throw new Error("no alternative harness in fixture");
+
+    const { state } = handleTuiKey(drive(panelState(), [RIGHT]), { input: other.key });
+    const reverted = removePendingProjectDefaultHarness(state, "web");
+    expect(selectProjectDefaultHarness(reverted.localRows, project)).toEqual({
+      harness: project.defaults.harness,
+      pending: false,
+    });
   });
 
   it("requires typing the confirm phrase before removal is armed", () => {

--- a/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
@@ -114,6 +114,56 @@ describe("project settings panel", () => {
     expect(pendingProjectDefaultHarnesses(pruned)).toEqual({});
   });
 
+  it("does not re-dispatch when re-selecting the agent that is already optimistically current", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("missing web project");
+    const other = selectNewSessionHarnessChoices(snapshot, project).find(
+      (choice) => choice.value.id !== project.defaults.harness,
+    );
+    if (other === undefined) throw new Error("no alternative harness in fixture");
+
+    const picked = handleTuiKey(drive(panelState(), [RIGHT]), { input: other.key });
+    expect(picked.operations).toHaveLength(1);
+
+    // It is now the optimistic default, so re-selecting it is a no-op edit — not
+    // a duplicate setProjectDefaultHarness command for a change already in flight.
+    const again = handleTuiKey(picked.state, { input: other.key });
+    expect(again.operations ?? []).toEqual([]);
+  });
+
+  it("overrides an in-flight change when the snapshot default is re-selected", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("missing web project");
+    const choices = selectNewSessionHarnessChoices(snapshot, project);
+    const current = choices.find((choice) => choice.value.id === project.defaults.harness);
+    const other = choices.find((choice) => choice.value.id !== project.defaults.harness);
+    if (current === undefined || other === undefined) {
+      throw new Error("fixture needs the default plus one alternative harness");
+    }
+
+    // Pick the alternative (optimistic pending), then pick the snapshot default
+    // again before the change lands.
+    const pendingOther = handleTuiKey(drive(panelState(), [RIGHT]), { input: other.key }).state;
+    const revert = handleTuiKey(pendingOther, { input: current.key });
+
+    // The final choice must win: dispatch the default and re-point the optimistic
+    // marker, not silently drop it because it matches the stale snapshot value.
+    expect(revert.operations).toEqual([
+      expect.objectContaining({
+        type: "setProjectDefaultHarness",
+        command: expect.objectContaining({
+          payload: { projectId: "web", harness: project.defaults.harness },
+        }),
+      }),
+    ]);
+    expect(selectProjectDefaultHarness(revert.state.localRows, project)).toEqual({
+      harness: project.defaults.harness,
+      pending: true,
+    });
+  });
+
   it("reverting the optimistic default falls back to the snapshot value", () => {
     const snapshot = createDashboardSnapshot();
     const project = snapshot.projects.find((candidate) => candidate.id === "web");

--- a/packages/dashboard-core/test/unit/state/screens/projectSettingsPicker.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/projectSettingsPicker.test.ts
@@ -1,0 +1,52 @@
+import type { TuiKey, TuiState } from "@station/dashboard-core";
+import { createInitialTuiState, handleTuiKey, selectProjectChoices } from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+
+function dashboardState(): TuiState {
+  return createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+}
+
+function drive(state: TuiState, keys: TuiKey[]): TuiState {
+  let current = state;
+  for (const key of keys) {
+    current = handleTuiKey(current, key).state;
+  }
+  return current;
+}
+
+const P: TuiKey = { input: "P" };
+const ESC: TuiKey = { input: "", escape: true };
+
+describe("project settings picker", () => {
+  it("P opens a project picker prompt listing the projects", () => {
+    const picker = drive(dashboardState(), [P]).screen;
+    expect(picker.name).toBe("projectSettingsPicker");
+    if (picker.name !== "projectSettingsPicker") return;
+    // The inline command row renders this slot:label list.
+    expect(picker.value.length).toBeGreaterThan(0);
+  });
+
+  it("choosing a slot opens that project's settings panel", () => {
+    const base = dashboardState();
+    const { snapshot } = base;
+    expect(snapshot).toBeDefined();
+    if (snapshot === undefined) return;
+    const picker = drive(base, [P]);
+    const [first] = selectProjectChoices(snapshot, picker);
+    expect(first).toBeDefined();
+    if (first === undefined) return;
+
+    const opened = drive(base, [P, { input: first.key }]).screen;
+    expect(opened).toMatchObject({
+      name: "projectSettings",
+      projectId: first.value.id,
+      focus: "list",
+      activeId: "agent",
+    });
+  });
+
+  it("esc backs out of the picker to the dashboard", () => {
+    expect(drive(dashboardState(), [P, ESC]).screen.name).toBe("dashboard");
+  });
+});

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -105,6 +105,7 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     help: drive(base, [{ input: "H" }]),
     search: drive(base, [{ input: "/" }, { input: "ab" }]),
     projectCollapse: drive(base, [{ input: "C" }]),
+    projectSettingsPicker: drive(base, [{ input: "P" }]),
     removeChooseSlot: drive(base, [{ input: "X" }]),
     removeConfirm: drive(base, [{ input: "X" }, { input: "1" }]),
     projectSettings: openProjectSettings(base, "station"),

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -17,6 +17,7 @@ export type StationInputMode =
   | "help"
   | "search"
   | "projectCollapse"
+  | "projectSettingsPicker"
   | "removeChooseSlot"
   | "removeConfirm"
   | "renameChooseSlot"
@@ -40,6 +41,8 @@ export function deriveStationMode(state: TuiState): StationInputMode {
       return "search";
     case "projectCollapse":
       return "projectCollapse";
+    case "projectSettingsPicker":
+      return "projectSettingsPicker";
     case "removeWorktree":
       return screen.step === "chooseSlot" ? "removeChooseSlot" : "removeConfirm";
     case "renameSession":
@@ -114,6 +117,7 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
     { id: "station.dashboard.newSession", pattern: { kind: "char", char: "N" }, action: "station.newSession.open", outcome: "handled", help: { keys: "N", label: "new" } },
     { id: "station.dashboard.addProject", pattern: { kind: "char", char: "A" }, action: "station.addProject.open", outcome: "handled", help: { keys: "A", label: "add" } },
     { id: "station.dashboard.collapse", pattern: { kind: "char", char: "C" }, action: "station.collapse.open", outcome: "handled", help: { keys: "C", label: "fold" } },
+    { id: "station.dashboard.projectSettings", pattern: { kind: "char", char: "P" }, action: "station.projectSettings.openPicker", outcome: "handled", help: { keys: "P", label: "settings" } },
     { id: "station.dashboard.slotActivate", pattern: { kind: "slot" }, action: "station.row.activateSlot", outcome: "handled", help: slotHelp },
   ],
   help: [
@@ -132,6 +136,10 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   projectCollapse: [
     { id: "station.collapse.cancel", pattern: { kind: "named", named: "escape" }, action: "station.collapse.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
     { id: "station.collapse.toggleSlot", pattern: { kind: "slot" }, action: "station.collapse.toggleSlot", outcome: "handled", help: { keys: "1-9 a-z", label: "toggle project" } },
+  ],
+  projectSettingsPicker: [
+    { id: "station.projectSettingsPicker.cancel", pattern: { kind: "named", named: "escape" }, action: "station.projectSettings.pickerCancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
+    { id: "station.projectSettingsPicker.choose", pattern: { kind: "slot" }, action: "station.projectSettings.pick", outcome: "handled", help: { keys: "1-9 a-z", label: "open settings" } },
   ],
   removeChooseSlot: [
     { id: "station.remove.cancel", pattern: { kind: "named", named: "escape" }, action: "station.remove.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
@@ -244,7 +252,7 @@ export const STATION_HELP_CONTENT = [
   { text: "station project view", align: "center" as const },
   { key: "↑/↓ wheel", description: "scroll project list" },
   { key: "1-9/a-z", description: "start or focus row" },
-  { key: "N/A/R/C", description: "new/add/rename/fold" },
+  { key: "N/A/R/C/P", description: "new/add/rename/fold/settings" },
   { key: "X", description: "delete session" },
   { key: "/, Z", description: "search / refresh snapshot" },
   { key: "H/?", description: "help" },

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -115,7 +115,13 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
       />
       <CommandPromptView screen={screen} />
       {toastOverlay}
-      <OverlayHostView snapshot={snapshot} screen={screen} columns={columns} rows={rows} />
+      <OverlayHostView
+        snapshot={snapshot}
+        screen={screen}
+        columns={columns}
+        rows={rows}
+        localRows={localRows}
+      />
     </box>
   );
 }

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -2,7 +2,7 @@
 // its overlay (help panel, bottom sheets) in an absolute layer above the
 // dashboard. The dashboard never reflows for overlays.
 import type { StationSnapshot } from "@station/contracts";
-import type { TuiScreen } from "@station/dashboard-core";
+import type { TuiLocalRows, TuiScreen } from "@station/dashboard-core";
 import { AddProjectSheetView } from "./sheets/AddProjectSheetView.js";
 import { HelpOverlayView } from "./HelpOverlayView.js";
 import { NewSessionSheetView } from "./sheets/NewSessionSheetView.js";
@@ -16,9 +16,16 @@ export type OverlayHostViewProps = {
   screen: TuiScreen;
   columns: number;
   rows: number;
+  localRows: TuiLocalRows;
 };
 
-export function OverlayHostView({ snapshot, screen, columns, rows }: OverlayHostViewProps) {
+export function OverlayHostView({
+  snapshot,
+  screen,
+  columns,
+  rows,
+  localRows,
+}: OverlayHostViewProps) {
   if (screen.name === "help") {
     return <HelpOverlayView columns={columns} rows={rows} />;
   }
@@ -48,7 +55,13 @@ export function OverlayHostView({ snapshot, screen, columns, rows }: OverlayHost
   }
   if (screen.name === "projectSettings") {
     return (
-      <ProjectSettingsPanelView columns={columns} rows={rows} snapshot={snapshot} screen={screen} />
+      <ProjectSettingsPanelView
+        columns={columns}
+        rows={rows}
+        snapshot={snapshot}
+        screen={screen}
+        localRows={localRows}
+      />
     );
   }
   return null;

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                         
+N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help Q/esc:close              
 "
 `;
 
@@ -176,7 +176,7 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold H:help Q/esc:close                         
+N:new A:add R:rename Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help Q/esc:close              
 "
 `;
 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
         │                     station project view                     │        
 ▼ script│  ↑/↓ wheel  scroll project list                              │qs] [▾] 
  [9] ○ a│  1-9/a-z    start or focus row                               │[shell] 
- [a] ? m│  N/A/R/C    new/add/rename/fold                              │[shell] 
+ [a] ? m│  N/A/R/C/P  new/add/rename/fold/settings                     │[shell] 
  [b] - o│  X          delete session                                   │[shell] 
         │  /, Z       search / refresh snapshot                        │        
 ▼ empty-│  H/?        help                                             │qs] [▾] 
@@ -79,6 +79,118 @@ exports[`modal flow golden frames renders the collapse prompt 1`] = `
                                                                                 
 collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾] 
 ↓ 1 hidden                                                                      
+─────────────────────────────────────────────────────────────────────────────── 
+Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+"
+`;
+
+exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+                                                                                
+▼ station - 5 worktrees                                           [sh] [qs] [▾] 
+ [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
+ [2] - docs-cleanup               -         no agent                    [shell] 
+ [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
+ [4] + session-resume             codex     starting                    [shell] 
+ [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+                                                                                
+▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
+ [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
+ [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
+ [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+                                                                                
+▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
+ [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
+ [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
+ [b] - old-experiment             -         no agent                    [shell] 
+                                                                                
+settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾] 
+↓ 1 hidden                                                                      
+─────────────────────────────────────────────────────────────────────────────── 
+Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+"
+`;
+
+exports[`modal flow golden frames renders the project settings panel 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Default agent                               │l] 
+ [2│▸ Default agent           │✓1 codex unknown                             │l] 
+ [3│  Remove project          │ 2 opencode unknown                          │l] 
+ [4│                          │                                             │l] 
+ [5│                          │ ✓ current · 1-9/a-z select                  │l] 
+   │                          │                                             │   
+▼ o│                          │                                             │▾] 
+ [6│                          │                                             │l] 
+ [7│                          │                                             │l] 
+ [8│                          │                                             │l] 
+   │                          │                                             │   
+▼ s│                          │                                             │▾] 
+ [9│                          │                                             │l] 
+ [a│                          │                                             │l] 
+ [b│                          │                                             │l] 
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+↓ 1└────────────────────────────────────────────────────────────────────────┘   
+─────────────────────────────────────────────────────────────────────────────── 
+Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+"
+`;
+
+exports[`modal flow golden frames renders the project settings remove pane 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Remove project                              │l] 
+ [2│  Default agent           │ Removes it from Station.                    │l] 
+ [3│▸ Remove project          │ Worktrees & files stay on disk.             │l] 
+ [4│                          │                                             │l] 
+ [5│                          │ Type "delete station" to confirm            │l] 
+   │                          │ ▸ |delete station                           │   
+▼ o│                          │                                             │▾] 
+ [6│                          │ [ Remove project (R) ]                      │l] 
+ [7│                          │                                             │l] 
+ [8│                          │                                             │l] 
+   │                          │                                             │   
+▼ s│                          │                                             │▾] 
+ [9│                          │                                             │l] 
+ [a│                          │                                             │l] 
+ [b│                          │                                             │l] 
+   │                          │                                             │   
+▼ e│ ←/esc back                                                             │▾] 
+↓ 1└────────────────────────────────────────────────────────────────────────┘   
+─────────────────────────────────────────────────────────────────────────────── 
+Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+"
+`;
+
+exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
+"station                                                                         
+─────────────────────────────────────────────────────────────────────────────── 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Default agent                               │l] 
+ [2│▸ Default agent           │ 1 codex unknown                             │l] 
+ [3│  Remove project          │✓2 opencode unknown                 updating…│l] 
+ [4│                          │                                             │l] 
+ [5│                          │ ✓ current · 1-9/a-z select                  │l] 
+   │                          │                                             │   
+▼ o│                          │                                             │▾] 
+ [6│                          │                                             │l] 
+ [7│                          │                                             │l] 
+ [8│                          │                                             │l] 
+   │                          │                                             │   
+▼ s│                          │                                             │▾] 
+ [9│                          │                                             │l] 
+ [a│                          │                                             │l] 
+ [b│                          │                                             │l] 
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+↓ 1└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -328,10 +440,10 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
-│ 1 codex unknown                                                              │
+│✓1 codex unknown                                                              │
 │ 2 opencode unknown                                                           │
 │                                                                              │
-│ 1-9/a-z:select   Esc:cancel                                                  │
+│ ✓ current   1-9/a-z:select   Esc:cancel                                      │
 └──────────────────────────────────────────────────────────────────────────────┘
 "
 `;

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -7,7 +7,11 @@ import type { StoreApi } from "zustand/vanilla";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
-import { openProjectDefaultAgentPicker } from "@station/dashboard-core";
+import {
+  addPendingProjectDefaultHarness,
+  openProjectDefaultAgentPicker,
+  openProjectSettings,
+} from "@station/dashboard-core";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import { DashboardRoot } from "./DashboardRoot.js";
 
@@ -37,6 +41,43 @@ const CASES: ModalCase[] = [
     name: "collapse prompt",
     keys: [{ input: "C" }],
     expect: ["collapse project:"],
+  },
+  {
+    name: "project settings picker prompt",
+    keys: [{ input: "P" }],
+    expect: ["settings for project:"],
+  },
+  {
+    name: "project settings panel",
+    keys: [{ input: "P" }, { input: "1" }],
+    expect: ["Project settings", "Default agent", "Remove project", "✓ current"],
+  },
+  {
+    name: "project settings remove pane",
+    keys: [
+      { input: "P" },
+      { input: "1" },
+      { input: "", downArrow: true },
+      { input: "\r", return: true },
+    ],
+    expect: ["Remove project", "Worktrees & files stay on disk.", "[ Remove project (R) ]"],
+  },
+  {
+    name: "project settings optimistic default",
+    keys: [],
+    prepare: (store) => {
+      store.setState(openProjectSettings(store.getState(), "station"));
+      // Optimistic state the picker sets the moment a new agent is chosen,
+      // before the observer round-trip lands (station's real default is codex).
+      store.setState(
+        addPendingProjectDefaultHarness(store.getState(), {
+          projectId: "station",
+          harness: "opencode",
+          createdAt: "2026-06-28T00:00:00.000Z",
+        }),
+      );
+    },
+    expect: ["Default agent", "updating…"],
   },
   {
     name: "remove slot sheet",

--- a/station/src/station/view/settings/ProjectSettingsPanelView.tsx
+++ b/station/src/station/view/settings/ProjectSettingsPanelView.tsx
@@ -11,8 +11,11 @@ import {
   projectSettingsPanelLayout,
   removeProjectConfirmPhrase,
   selectNewSessionHarnessChoices,
+  selectProjectDefaultHarness,
+  type TuiLocalRows,
   type TuiScreen,
 } from "@station/dashboard-core";
+import { useState } from "react";
 import { EditableTextInputView } from "../EditableTextInputView.js";
 import { AgentChoiceListView } from "../sheets/AgentChoiceListView.js";
 import { fit, SheetLine } from "../sheets/parts.js";
@@ -26,6 +29,7 @@ export type ProjectSettingsPanelViewProps = {
   screen: ProjectSettingsScreen;
   columns: number;
   rows: number;
+  localRows: TuiLocalRows;
 };
 
 export function ProjectSettingsPanelView({
@@ -33,6 +37,7 @@ export function ProjectSettingsPanelView({
   screen,
   columns,
   rows,
+  localRows,
 }: ProjectSettingsPanelViewProps) {
   const dispatch = useStationMouse();
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
@@ -40,7 +45,8 @@ export function ProjectSettingsPanelView({
   const { top, left, width, height, innerWidth, contentHeight, leftWidth, rightWidth } =
     projectSettingsPanelLayout(columns, rows);
 
-  const title = project === undefined ? "Project settings" : `Project settings · ${project.label}`;
+  const projectLabel = project?.label ?? "Project";
+  const title = "Project settings";
   const footer =
     screen.focus === "list" ? "↑↓ move   →/enter edit   esc close" : "←/esc back";
 
@@ -61,11 +67,22 @@ export function ProjectSettingsPanelView({
       <text fg={STATION_COLORS.foreground} attributes={TextAttributes.BOLD}>{fit(` ${title}`, innerWidth)}</text>
       <box flexDirection="row" width={innerWidth} height={contentHeight}>
         <box flexDirection="column" width={leftWidth}>
-          <ItemList screen={screen} width={leftWidth} />
+          <ItemList
+            screen={screen}
+            width={leftWidth}
+            headerLabel={projectLabel}
+            focused={screen.focus === "list"}
+          />
         </box>
-        <box width={1} />
+        <VerticalDivider height={contentHeight} />
         <box flexDirection="column" width={rightWidth}>
-          <DetailPane snapshot={snapshot} screen={screen} width={rightWidth} />
+          <DetailPane
+            snapshot={snapshot}
+            screen={screen}
+            width={rightWidth}
+            focused={screen.focus === "detail"}
+            localRows={localRows}
+          />
         </box>
       </box>
       <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(` ${footer}`, innerWidth)}</text>
@@ -73,23 +90,53 @@ export function ProjectSettingsPanelView({
   );
 }
 
-function ItemList({ screen, width }: { screen: ProjectSettingsScreen; width: number }) {
-  const dispatch = useStationMouse();
+function ItemList({
+  screen,
+  width,
+  headerLabel,
+  focused,
+}: {
+  screen: ProjectSettingsScreen;
+  width: number;
+  headerLabel: string;
+  focused: boolean;
+}) {
   return (
     <>
-      {PROJECT_SETTINGS_ITEMS.map((item) => {
-        const active = item.id === screen.activeId;
-        return (
-          <text
-            key={item.id}
-            fg={active ? STATION_COLORS.cyan : STATION_COLORS.foreground}
-            {...stationMouseProps(dispatch, { kind: "projectSettingsItem", itemId: item.id })}
-          >
-            {fit(`${active ? "▸ " : "  "}${item.label}`, width)}
-          </text>
-        );
-      })}
+      <PaneHeader label={headerLabel} width={width} focused={focused} />
+      {PROJECT_SETTINGS_ITEMS.map((item) => (
+        <SettingsItemRow
+          key={item.id}
+          item={item}
+          active={item.id === screen.activeId}
+          width={width}
+        />
+      ))}
     </>
+  );
+}
+
+function SettingsItemRow({
+  item,
+  active,
+  width,
+}: {
+  item: (typeof PROJECT_SETTINGS_ITEMS)[number];
+  active: boolean;
+  width: number;
+}) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  return (
+    <text
+      fg={active ? STATION_COLORS.cyan : STATION_COLORS.foreground}
+      {...(hover ? { bg: STATION_COLORS.hoverBackground } : {})}
+      {...stationMouseProps(dispatch, { kind: "projectSettingsItem", itemId: item.id })}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {fit(`${active ? "▸ " : "  "}${item.label}`, width)}
+    </text>
   );
 }
 
@@ -97,52 +144,81 @@ function DetailPane({
   snapshot,
   screen,
   width,
+  focused,
+  localRows,
 }: {
   snapshot: StationSnapshot;
   screen: ProjectSettingsScreen;
   width: number;
+  focused: boolean;
+  localRows: TuiLocalRows;
 }) {
   if (screen.activeId === "remove") {
-    return <RemoveDetail screen={screen} width={width} />;
+    return <RemoveDetail screen={screen} width={width} focused={focused} />;
   }
-  return <AgentDetail snapshot={snapshot} screen={screen} width={width} />;
+  return (
+    <AgentDetail
+      snapshot={snapshot}
+      screen={screen}
+      width={width}
+      focused={focused}
+      localRows={localRows}
+    />
+  );
 }
 
 function AgentDetail({
   snapshot,
   screen,
   width,
+  focused,
+  localRows,
 }: {
   snapshot: StationSnapshot;
   screen: ProjectSettingsScreen;
   width: number;
+  focused: boolean;
+  localRows: TuiLocalRows;
 }) {
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
   const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
+  const currentDefault =
+    project === undefined ? undefined : selectProjectDefaultHarness(localRows, project);
   return (
     <>
-      <text fg={STATION_COLORS.foreground} attributes={TextAttributes.BOLD}>{fit(" Default agent", width)}</text>
-      <SheetLine width={width}> </SheetLine>
+      <PaneHeader label="Default agent" width={width} focused={focused} />
       {choices.length === 0 ? (
         <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(" No agents available", width)}</text>
       ) : (
         <>
-          <AgentChoiceListView choices={choices} width={width} />
+          <AgentChoiceListView
+            choices={choices}
+            width={width}
+            currentId={currentDefault?.harness}
+            pending={currentDefault?.pending ?? false}
+          />
           <SheetLine width={width}> </SheetLine>
-          <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(" 1-9/a-z select", width)}</text>
+          <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(" ✓ current · 1-9/a-z select", width)}</text>
         </>
       )}
     </>
   );
 }
 
-function RemoveDetail({ screen, width }: { screen: ProjectSettingsScreen; width: number }) {
-  const dispatch = useStationMouse();
+function RemoveDetail({
+  screen,
+  width,
+  focused,
+}: {
+  screen: ProjectSettingsScreen;
+  width: number;
+  focused: boolean;
+}) {
   const armed = isRemoveProjectArmed(screen);
   const phrase = removeProjectConfirmPhrase(screen.projectId);
   return (
     <>
-      <text fg={STATION_COLORS.red} attributes={TextAttributes.BOLD}>{fit(" Remove project", width)}</text>
+      <PaneHeader label="Remove project" width={width} focused={focused} danger />
       <text fg={STATION_COLORS.foreground}>{fit(" Removes it from Station.", width)}</text>
       <text fg={STATION_COLORS.foreground}>{fit(" Worktrees & files stay on disk.", width)}</text>
       <SheetLine width={width}> </SheetLine>
@@ -152,13 +228,80 @@ function RemoveDetail({ screen, width }: { screen: ProjectSettingsScreen; width:
         <EditableTextInputView {...screen.removeDraft} placeholder={phrase} />
       </text>
       <SheetLine width={width}> </SheetLine>
-      <text
-        fg={armed ? STATION_COLORS.red : STATION_COLORS.gray}
-        attributes={armed ? TextAttributes.BOLD : TextAttributes.DIM}
-        {...stationMouseProps(dispatch, { kind: "projectSettingsConfirmRemove" })}
-      >
-        {fit(" [ Remove project (R) ]", width)}
-      </text>
+      <RemoveButton armed={armed} width={width} />
     </>
+  );
+}
+
+// The highlight hugs the button label (not the full row), so the indent space
+// sits outside the colored span. Hover only lights up while armed (enabled); a
+// disarmed button stays dim so hover never implies it can be clicked. The label
+// is truncated (never padded) to width minus the indent so it cannot overflow a
+// narrow pane while the highlight still hugs the visible text.
+function RemoveButton({ armed, width }: { armed: boolean; width: number }) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  const hot = armed && hover;
+  const label = "[ Remove project (R) ]".slice(0, Math.max(0, width - 1));
+  return (
+    <box flexDirection="row">
+      <text>{" "}</text>
+      <text
+        fg={hot ? STATION_COLORS.background : armed ? STATION_COLORS.red : STATION_COLORS.gray}
+        attributes={armed ? TextAttributes.BOLD : TextAttributes.DIM}
+        {...(hot ? { bg: STATION_COLORS.red } : {})}
+        {...stationMouseProps(dispatch, { kind: "projectSettingsConfirmRemove" })}
+        onMouseOver={() => setHover(true)}
+        onMouseOut={() => setHover(false)}
+      >
+        {label}
+      </text>
+    </box>
+  );
+}
+
+// The focused pane's header renders as a filled accent bar (fit() pads to full
+// width, so bg fills the row); the unfocused pane keeps a plain bold label. The
+// remove section stays red either way so the header keeps its danger cue.
+function PaneHeader({
+  label,
+  width,
+  focused,
+  danger = false,
+}: {
+  label: string;
+  width: number;
+  focused: boolean;
+  danger?: boolean;
+}) {
+  const accent = danger ? STATION_COLORS.red : STATION_COLORS.cyan;
+  if (focused) {
+    return (
+      <text fg={STATION_COLORS.background} bg={accent} attributes={TextAttributes.BOLD}>
+        {fit(` ${label}`, width)}
+      </text>
+    );
+  }
+  return (
+    <text
+      fg={danger ? STATION_COLORS.red : STATION_COLORS.foreground}
+      attributes={TextAttributes.BOLD}
+    >
+      {fit(` ${label}`, width)}
+    </text>
+  );
+}
+
+// One-column gray rule between the two panes. Stays width 1 so the layout's
+// reserved spacer column (rightWidth = innerWidth - leftWidth - 1) is unchanged.
+function VerticalDivider({ height }: { height: number }) {
+  return (
+    <box flexDirection="column" width={1}>
+      {Array.from({ length: height }, (_, row) => (
+        <text key={row} fg={STATION_COLORS.gray}>
+          │
+        </text>
+      ))}
+    </box>
   );
 }

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -5,21 +5,35 @@ import { SheetChoiceLine } from "./parts.js";
 export type AgentChoiceListViewProps = {
   choices: readonly KeyedChoice<NewSessionHarnessOption>[];
   width: number;
+  /** The option to mark as current (a project's default harness), if any. */
+  currentId?: NewSessionHarnessOption["id"];
+  /** When true, the current option shows an "updating…" cue (change in flight). */
+  pending?: boolean;
 };
 
-export function AgentChoiceListView({ choices, width }: AgentChoiceListViewProps) {
+export function AgentChoiceListView({
+  choices,
+  width,
+  currentId,
+  pending = false,
+}: AgentChoiceListViewProps) {
   return (
     <>
-      {choices.map((choice) => (
-        <SheetChoiceLine
-          key={choice.value.id}
-          choiceKey={choice.key}
-          label={choice.value.label}
-          detail={choice.value.status}
-          color={providerHealthStatusColor(choice.value.status)}
-          width={width}
-        />
-      ))}
+      {choices.map((choice) => {
+        const current = choice.value.id === currentId;
+        return (
+          <SheetChoiceLine
+            key={choice.value.id}
+            choiceKey={choice.key}
+            label={choice.value.label}
+            detail={choice.value.status}
+            color={providerHealthStatusColor(choice.value.status)}
+            width={width}
+            current={current}
+            {...(current && pending ? { note: "updating…" } : {})}
+          />
+        );
+      })}
     </>
   );
 }

--- a/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectDefaultAgentSheetView.tsx
@@ -35,7 +35,11 @@ export function ProjectDefaultAgentSheetView({
       title={title}
       contentRows={choices.length + 4}
     >
-      <ProjectDefaultAgentPicker choices={choices} width={contentWidth} />
+      <ProjectDefaultAgentPicker
+        choices={choices}
+        width={contentWidth}
+        currentId={project?.defaults.harness}
+      />
     </BottomSheetFrameView>
   );
 }
@@ -43,16 +47,18 @@ export function ProjectDefaultAgentSheetView({
 function ProjectDefaultAgentPicker({
   choices,
   width,
+  currentId,
 }: {
   choices: readonly KeyedChoice<NewSessionHarnessOption>[];
   width: number;
+  currentId?: NewSessionHarnessOption["id"];
 }) {
   return (
     <>
       <SheetLine width={width}> </SheetLine>
-      <AgentChoiceListView choices={choices} width={width} />
+      <AgentChoiceListView choices={choices} width={width} currentId={currentId} />
       <SheetLine width={width}> </SheetLine>
-      <SheetFooter width={width}>{"1-9/a-z:select   Esc:cancel"}</SheetFooter>
+      <SheetFooter width={width}>{"✓ current   1-9/a-z:select   Esc:cancel"}</SheetFooter>
     </>
   );
 }

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -82,31 +82,47 @@ export function SheetChoiceLine({
   detail,
   color,
   width,
+  current = false,
+  note,
 }: {
   choiceKey: string;
   label: string;
   detail: string;
   color?: string | undefined;
   width: number;
+  /** Marks the row as the currently-selected option (e.g. a project's default). */
+  current?: boolean;
+  /** Right-aligned dim status (e.g. "updating…") shown in the row's free space. */
+  note?: string | undefined;
 }) {
   const dispatch = useStationMouse();
   const [hover, setHover] = useState(false);
-  const prefix = ` ${choiceKey} `;
+  // The marker reuses the prefix's leading margin column so the key/label
+  // columns stay aligned and the row width is unchanged whether or not it is set.
+  const marker = current ? "✓" : " ";
+  const keyPrefix = `${choiceKey} `;
   const detailPrefix = `${label} `;
-  const detailWidth = Math.max(0, width - prefix.length - detailPrefix.length);
+  const detailWidth = Math.max(0, width - 1 - keyPrefix.length - detailPrefix.length);
   const visibleDetail = detail.slice(0, detailWidth);
-  const padding = spaces(Math.max(0, detailWidth - visibleDetail.length));
+  // Whatever the detail leaves unused is split into a gap then the right-aligned
+  // note, so the row stays exactly `width` wide whether or not a note is set.
+  const free = Math.max(0, detailWidth - visibleDetail.length);
+  const visibleNote = (note ?? "").slice(0, free);
+  const gap = spaces(free - visibleNote.length);
   return (
     <text
       fg={hover ? STATION_COLORS.green : STATION_COLORS.foreground}
+      {...(hover ? { bg: STATION_COLORS.hoverBackground } : {})}
       {...stationMouseProps(dispatch, { kind: "sheetChoice", choiceKey })}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
-      {prefix}
+      <span {...(current ? { fg: STATION_COLORS.cyan } : {})}>{marker}</span>
+      {keyPrefix}
       {detailPrefix}
       <span {...(color === undefined ? {} : { fg: color })}>{visibleDetail}</span>
-      {padding}
+      {gap}
+      <span attributes={TextAttributes.DIM}>{visibleNote}</span>
     </text>
   );
 }


### PR DESCRIPTION
## Summary

Adds a `P` dashboard chord that opens a slot-key project picker and drops into the
existing two-pane Project Settings panel, and makes a project's **default agent**
visible and responsive — marked in the list and updated optimistically.

## What's in it

- **Picker:** new `projectSettingsPicker` screen wired through the shared machine
  (core + station keymaps, derive-mode, command prompt, footer, help). The
  duplicated collapse/settings skeleton is factored into a shared
  `projectSlotPicker` (open transition + slot handler), so the next slot-picker is
  a one-liner instead of ~8 parallel edits.
- **Panel restyle:** filled accent `PaneHeader`, a vertical divider between panes,
  and hover cues; the Remove button truncates to width so it can't overflow a
  narrow pane.
- **Current default:** a cyan check marks the project's default agent in the
  Default-agent list and the standalone default-agent sheet.
- **Optimistic update:** picking a new agent moves the check immediately with an
  `updating…` cue (new `pendingProjectDefaults` local state, mirroring
  `pendingRenameTitles`), reverting on failure and pruning once the snapshot
  confirms.

## UX implication & how to verify

Run Station → press `P` → pick a project → in **Default agent**, press a non-current
agent's slot key. The check jumps to it instantly with `updating…`; a beat later
`updating…` clears and the existing `Default agent set to …` success toast fires.
Kill the observer first to see the revert + error path.

## Tests

- dashboard-core unit coverage for the picker and the optimistic flow (set →
  prune-on-confirm; revert → snapshot fallback).
- station golden frames for the picker prompt, the panel, the remove pane, and the
  optimistic `updating…` state.
- Full CI run locally (both lanes), all green: build · typecheck · lint ·
  unit/contracts/integration/diagnostics/agent:scripted/e2e:setup · station bun
  typecheck + tests. (GitHub Actions billing is currently down, hence the local run.)

## Notes

Branch is based on the latest `main` (merged in), so the diff above is just this
feature. Includes a merge commit that combines this work with the recently-landed
fork feature (footer/help list both `F:fork` and `P:settings`; goldens regenerated).
