### PR TITLE
docs(config): clarify workspace automation shell boundary

### DIFF
--- a/packages/config/src/workspace.ts
+++ b/packages/config/src/workspace.ts
@@ -46,7 +46,8 @@ const AutomationSchema = z
 
 export type Automation = z.infer<typeof AutomationSchema>;
 
-// diffnav's default watch command omits untracked files, so Station supplies one.
+// Pane automations are typed into a shell, not executed through an argv API.
+// Keep this POSIX-ish one-liner so diffnav's watcher includes untracked files.
 const DEFAULT_DIFF_WATCH_COMMAND = [
   'base="$(git merge-base origin/main HEAD 2>/dev/null || true)"',
   '[ -n "$base" ] || base=HEAD',


### PR DESCRIPTION
## Summary

Adds a short code comment above the default workspace diff automation command explaining that pane automations are typed into a shell rather than executed through an argv API.

## Why

The built-in `see-diff` automation carries a dense shell one-liner. The boundary is easy to accidentally break if a future edit treats it like structured command arguments instead of shell text.

## UX Implication

No runtime behavior change. The `See diff (split right)` automation should continue to appear in the pane context menu and run as before.

## Validation

- `pnpm exec vitest run packages/config/test/unit/config-schema.test.ts --config config/vitest/vitest.unit.config.ts`
- pre-commit hook: `biome check . && node tools/lint/check-source-order.mjs`