### PR TITLE
fix(station): keep row context menu during unrelated removals

### DIFF
--- a/station/src/state/reducers/paneRemoval.ts
+++ b/station/src/state/reducers/paneRemoval.ts
@@ -18,16 +18,18 @@ export function inputAfterPaneRemoval(
   const nextFocus = focus.kind === "pane" && isRemoved(focus.paneId) ? survivingFocus(state, workspace) : focus;
   // Drop an overlay-return pane that's now gone, else closeOverlay would restore it.
   const droppedReturn = overlayReturnFocus?.kind === "pane" && isRemoved(overlayReturnFocus.paneId);
+  const shouldCloseContextMenu =
+    contextMenu?.target.kind === "pane" && isRemoved(contextMenu.target.paneId);
 
   const next: InputSlice = {
     ...state.input,
     focus: nextFocus,
     overlayReturnFocus: droppedReturn ? null : overlayReturnFocus,
-    contextMenu: null,
+    contextMenu: shouldCloseContextMenu ? null : contextMenu,
   };
   // A context menu open over the removal closes; re-seat focus where it would
   // have returned (overlay / active pane).
-  if (contextMenu === null) {
+  if (!shouldCloseContextMenu) {
     return next;
   }
   return { ...next, focus: focusAfterContextMenu({ ...state, workspace, input: next }) };

--- a/station/src/state/store.test.ts
+++ b/station/src/state/store.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { selectWelcomeCanContinue, selectWelcomeVisible } from "./selectors.js";
 import { createStationStore } from "./store.js";
-import { MAIN_PANE_ID, STATION_OVERLAY_ID, type PaneRecord, type PaneRole } from "./types.js";
+import {
+  agentWorktreePaneId,
+  MAIN_PANE_ID,
+  STATION_OVERLAY_ID,
+  type PaneRecord,
+  type PaneRole,
+} from "./types.js";
 
 const AGENT_IDENTITY = { sessionId: "ses_a", terminalTargetId: "native:wt_a" };
 
@@ -720,6 +726,35 @@ describe("createStationStore", () => {
     store.actions.closeOverlay();
     expect(store.getState().input.contextMenu).toBeNull();
     expect(store.getState().input.focus).toEqual({ kind: "pane", paneId: MAIN_PANE_ID });
+  });
+
+  it("keeps a STATION row context menu when another session pane tree is removed", () => {
+    const store = createStationStore({ boot: "empty" });
+    const rowId = "wt-open";
+    const removedRowId = "wt-removed";
+    const paneId = agentWorktreePaneId(rowId);
+    const removedPaneId = agentWorktreePaneId(removedRowId);
+    const menu = {
+      target: { kind: "station" as const, target: { kind: "row" as const, rowId } },
+      anchor: { x: 12, y: 6 },
+      activeIndex: 0,
+    };
+
+    store.actions.createPane(paneId, { role: "primary-agent" });
+    store.actions.setPrimaryAgent(paneId, { sessionId: "ses-open", terminalTargetId: "native:wt-open" });
+    store.actions.createPane(removedPaneId, { role: "primary-agent" });
+    store.actions.setPrimaryAgent(removedPaneId, {
+      sessionId: "ses-removed",
+      terminalTargetId: "native:wt-removed",
+    });
+    store.actions.openOverlay(STATION_OVERLAY_ID);
+    store.actions.openContextMenu(menu.target, menu.anchor);
+
+    store.actions.closePaneTree(removedPaneId);
+
+    expect(store.getState().input.contextMenu).toEqual(menu);
+    expect(store.getState().input.focus).toEqual({ kind: "contextMenu" });
+    expect(store.getState().workspace.panes.map((pane) => pane.id)).toEqual([paneId]);
   });
 });
 


### PR DESCRIPTION
## Summary

Keep an open STATION row context menu in place when an unrelated Station-hosted session pane tree is removed.

## Root Cause

`inputAfterPaneRemoval` cleared `contextMenu` for every pane removal. When a worktree/session deletion finished asynchronously and another row left the UI, the session reaper removed that row's pane tree and unintentionally dismissed the currently open row context menu.

## Changes

- Only clear a context menu during pane removal when the menu is directly attached to the removed pane.
- Add a regression test for row A's context menu staying open when row B's pane tree is removed.

## UX Impact

Right-clicking a row keeps its menu open while a separate, previously deleting row disappears from the dashboard.

## Validation

- `bun test station/src/state/store.test.ts`
- `cd station && bun run typecheck`
- pre-commit: `biome check . && node tools/lint/check-source-order.mjs`