### PR TITLE
docs(config): document full configuration surface

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,7 @@ The state dir is **not** a config file — never edit anything under
 
 The one file, owned by the `@station/config` package. It is parsed (TOML), keys are
 normalized snake_case → camelCase, and validated against a **strict Zod schema**.
+Every key below is shown in the TOML spelling.
 
 - **Unknown/misspelled top-level or section keys fail the whole load** with
   `CONFIG_VALIDATION_FAILED` — a typo aborts startup. Exceptions: `[harness.*]`
@@ -74,24 +75,30 @@ A project omitting a field inherits the global value.
 validated only as non-empty strings — a typo passes config validation and fails
 later at runtime.
 
+Currently meaningful provider ids include `worktrunk` / `noop-worktree`,
+`tmux` / `noop-terminal`, and harness ids such as `claude`, `codex`, `cursor`,
+`opencode`, `pi`, `crush`, `scripted`, and `noop-harness`. Unknown ids are
+accepted by config validation but become unavailable providers at runtime.
+
 ### `[worktree.worktrunk]` — worktree provider (optional)
 
 | Key | Type | Notes |
 | --- | --- | --- |
-| `command` | string | Worktrunk CLI, e.g. `"wt"`. |
+| `command` | string | Worktrunk CLI, e.g. `"wt"`. Overrides `STATION_WORKTRUNK_BIN`; fallback is `wt`. |
 | `config_path` | string | Path to worktrunk's own config. `~` expands at load time. |
 | `managed_root` | string | Root for managed worktrees, e.g. `~/.worktrees`; `~` expands at load time. |
-| `base` | string | Default base branch for worktrees. |
-| `include_main` / `include_external` | bool | |
-| `use_lifecycle_hooks` | bool | |
-| `hook_mode` | `required-for-mvp` \| `disabled` | |
-| `breadcrumb_location` | `external` \| `worktree` \| `provider-native` \| `disabled` | |
+| `base` | string | Default base branch for Worktrunk project listings and new worktrees. Project entries inherit this unless `[projects.worktrunk].base` is set. |
+| `include_main` | bool | Default include-main policy for Worktrunk project listings. Project entries inherit this unless overridden. |
+| `include_external` | bool | Default include-external policy for Worktrunk project listings. Project entries inherit this unless overridden. |
+| `use_lifecycle_hooks` | bool | Worktrunk automation mode. `false` makes automated mutations pass `--no-hooks`; `true` passes `--yes`; unset uses Worktrunk defaults. |
+| `hook_mode` | `required-for-mvp` \| `disabled` | Worktrunk lifecycle hook setup expectation. |
+| `breadcrumb_location` | `external` \| `worktree` \| `provider-native` \| `disabled` | Default recovery breadcrumb location. |
 
 ### `[terminal.tmux]` — terminal provider (optional)
 
 | Key | Type | Notes |
 | --- | --- | --- |
-| `command` | string | tmux binary path/name. |
+| `command` | string | tmux binary path/name. Overrides `STATION_TMUX_BIN`; fallback is `tmux`. |
 | `session_prefix` | string | |
 | `topology` | `workbench` | Single-value enum. |
 | `workbench_session` | string | |
@@ -108,13 +115,24 @@ is silently accepted** as an unused harness.
 | Key | Type | Notes |
 | --- | --- | --- |
 | `enabled` | bool | |
-| `command` | string | e.g. `"claude"`, `"codex"`. |
+| `command` | string | e.g. `"claude"`, `"codex"`. Overrides provider-specific `STATION_*_BIN` fallbacks. |
 | `profile` | string | Named profile passed to the harness. |
 | `permission_mode` | `standard` \| `yolo` | **`auto` is accepted only under `[harness.claude]`.** |
 | `sandbox_mode` | string | Free-form, e.g. codex `"workspace-write"`. |
 | `approval_policy` | string | Free-form, e.g. codex `"on-request"`. |
 | `install_hooks` | bool | Whether STATION installs provider hooks for this harness. |
 | `resume` | bool | Whether to resume sessions. |
+
+Harness command fallback env vars:
+
+| Harness | Env var | Default command |
+| --- | --- | --- |
+| Claude Code | `STATION_CLAUDE_BIN` | `claude` |
+| Codex | `STATION_CODEX_BIN` | `codex` |
+| Cursor Agent | `STATION_CURSOR_AGENT_BIN` | `agent` |
+| OpenCode | `STATION_OPENCODE_BIN` | `opencode` |
+| Pi | `STATION_PI_BIN` | `pi` |
+| Crush | `STATION_CRUSH_BIN` | `crush` |
 
 ### `[[hooks.event]]` — observer event hooks (optional, repeatable)
 
@@ -129,6 +147,38 @@ hooks (how harnesses report events in — see [harness-ingress.md](./harness-ing
 | `args` | string[] | Command args. |
 | `timeout_ms` | int > 0 | |
 | `filter` | table | Optional narrowing (`agent_state`, `harness`, `change_source`, `harness_event_type`). |
+
+`events` must contain one or more `StationEvent` types:
+
+```text
+observer.started
+observer.reconciled
+project.updated
+worktree.added
+worktree.updated
+worktree.removed
+worktree.agentStateChanged
+session.created
+session.updated
+session.removed
+command.accepted
+command.started
+command.succeeded
+command.failed
+provider.healthChanged
+providerHook.ingested
+harness.eventReported
+providerHook.spoolDrained
+```
+
+`filter` accepts:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `agent_state` | `none` \| `starting` \| `idle` \| `working` \| `needs_attention` \| `stuck` \| `exited` \| `unknown` | Matches observed agent state on `worktree.agentStateChanged` events. |
+| `harness` | string | Harness provider id. |
+| `change_source` | `harness_event_report` \| `reconcile` | Where an agent-state change came from. |
+| `harness_event_type` | string | Native harness event type, when the event carried one. |
 
 ### `[[projects]]` — managed projects (REQUIRED array)
 
@@ -152,6 +202,27 @@ aliases, unique worktrunk managed roots, and **each `root` must exist at load ti
 | `[projects.recovery_breadcrumbs]` | table | `location` (same enum as `breadcrumb_location`), `path`. |
 | `[projects.local_config]` | table | Opt-in pointer to a project-local config file — see below. |
 
+Nested project tables:
+
+| Table | Key | Type | Notes |
+| --- | --- | --- | --- |
+| `[projects.defaults]` | `harness` | string | Per-project harness provider id. |
+| `[projects.defaults]` | `terminal` | string | Per-project terminal provider id. Not overridable by project-local config. |
+| `[projects.defaults]` | `layout` | string | Per-project layout id. |
+| `[projects.commands]` | any label | string | Label-to-command map. Labels are preserved as authored. |
+| `[projects.env]` | any key | string | Extra env for project launches; local overlays cannot set it. |
+| `[projects.display]` | `group` | string | Optional grouping label. |
+| `[projects.display]` | `sort_order` | int | Optional sort order. |
+| `[projects.worktrunk]` | `enabled` | bool | Defaults to `true` when omitted. |
+| `[projects.worktrunk]` | `base` | string | Overrides `[worktree.worktrunk].base` for this project. |
+| `[projects.worktrunk]` | `managed_root` | string | Per-project Worktrunk managed root; relative paths resolve against `project.root`. If omitted and global `managed_root` is set, STATION derives a unique project child directory. |
+| `[projects.worktrunk]` | `include_main` | bool | Overrides global `include_main`. |
+| `[projects.worktrunk]` | `include_external` | bool | Overrides global `include_external`. |
+| `[projects.recovery_breadcrumbs]` | `location` | `external` \| `worktree` \| `provider-native` \| `disabled` | Overrides global breadcrumb location. |
+| `[projects.recovery_breadcrumbs]` | `path` | string | Optional breadcrumb path. |
+| `[projects.local_config]` | `enabled` | bool | Required inside the table; only `true` reads the project-local file. |
+| `[projects.local_config]` | `path` | string | Required inside the table; `~/` expands against `$HOME`, anything else resolves against `project.root`. |
+
 ### `[workspace]` — native Station UI behavior (optional, best-effort)
 
 Read **only by the native Station TUI** (the observer and CLI ignore it). A bad value
@@ -161,7 +232,7 @@ degrades to defaults plus a diagnostic — it never crashes the daemon.
 | --- | --- | --- | --- |
 | `scroll_on_output` | `freeze` \| `shift` \| `follow` | `freeze` | Scroll behavior while scrolled up. `freeze` preserves visible lines; `shift` preserves distance from bottom; `follow` snaps to live. At the bottom, all modes track live. |
 | `welcome_on_boot` | bool | `true` | Show the welcome screen over the restored layout on cold boot. `false` boots straight in. |
-| `automations` | `Automation[]` | one `see-diff` automation | Named, user-triggerable pane layouts in the pane context menu. Omit the key to keep the built-in `see-diff`; set `automations = []` to disable it. |
+| `automations` | `Automation[]` | one `see-diff` automation | Named, user-triggerable pane layouts in the pane context menu. Omit the key to keep the built-in `see-diff`; set `automations = []` to disable it. Automation ids must be unique. |
 
 Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 `[[workspace.automations.steps]]` is `{ command, split?, anchor?, run?, focus? }`:
@@ -175,6 +246,7 @@ Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 | `focus` | bool | `false` | Whether to focus the new pane. |
 | (automation) `id` / `label` | string | **required** | Unique menu-row key / display label. |
 | (automation) `enabled` | bool | `true` | `false` hides it from the menu. |
+| (automation) `steps` | `AutomationStep[]` | **required** | One or more steps. |
 
 ### `[tui]` — runtime TUI widgets (optional, best-effort)
 
@@ -188,15 +260,57 @@ Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 - **`type = "weather"`** — required `city`; optional `label`, `temperature_unit`
   (`fahrenheit` \| `celsius`), `refresh_interval_minutes` (int > 0).
 
-### Other runtime sections (valid, not in the example file)
+### `[repository.github]` — repository metadata provider (optional)
 
-- `[repository.github]` — `enabled`, `command` (e.g. `"gh"`), `timeout_ms`.
-- `[observability.retention]` — log/db/bundle retention caps (`max_days`,
-  `max_total_mb`, `max_file_mb`, `max_files_per_component`, plus nested
-  `[...components]`, `[...sqlite]`, `[...debug_bundles]`, `[...hook_spool]`). See
-  [diagnostics.md](./diagnostics.md).
-- `[feature_flags]` — record of booleans; only `session_resume_agent` and
-  `station_persistent_agents` are allowed (both default `false`).
+Enabled by default when omitted. Set `enabled = false` to disable GitHub metadata.
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `enabled` | bool | `false` disables the GitHub provider entirely. |
+| `command` | string | GitHub CLI path/name. Overrides `STATION_GH_BIN`; fallback is `gh`. |
+| `timeout_ms` | int > 0 | Provider command timeout. Default is 3000 ms. |
+
+### `[observability.retention]` — log, DB, bundle, and spool caps (optional)
+
+Top-level retention caps:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `max_days` | int > 0 | Default age cap for retained files. |
+| `max_total_mb` | int > 0 | Total local-state size cap. |
+| `max_file_mb` | int > 0 | Per-file size cap. |
+| `max_files_per_component` | int > 0 | Per-component log count cap. |
+
+Nested retention tables:
+
+| Table | Key | Type | Notes |
+| --- | --- | --- | --- |
+| `[observability.retention.components]` | `observer_max_mb` | int > 0 | Observer log cap. |
+| `[observability.retention.components]` | `cli_max_mb` | int > 0 | CLI log cap. |
+| `[observability.retention.components]` | `tui_max_mb` | int > 0 | TUI log cap. |
+| `[observability.retention.components]` | `hook_runner_max_mb` | int > 0 | Hook-runner log cap. |
+| `[observability.retention.components]` | `provider_max_mb` | int > 0 | Provider log cap. |
+| `[observability.retention.sqlite]` | `events_max_days` | int > 0 | SQLite event-row age cap/reporting threshold. |
+| `[observability.retention.sqlite]` | `commands_max_days` | int > 0 | SQLite command-row age cap/reporting threshold. |
+| `[observability.retention.sqlite]` | `errors_max_days` | int > 0 | SQLite error-row age cap/reporting threshold. |
+| `[observability.retention.sqlite]` | `provider_observations_max_days` | int > 0 | SQLite provider-observation age cap/reporting threshold. |
+| `[observability.retention.debug_bundles]` | `max_bundles` | int > 0 | Debug bundle count cap. |
+| `[observability.retention.debug_bundles]` | `max_days` | int > 0 | Debug bundle age cap. |
+| `[observability.retention.hook_spool]` | `delivered_delete_immediately` | bool | Delete successfully delivered spool records immediately. |
+| `[observability.retention.hook_spool]` | `failed_max_days` | int > 0 | Failed spool age cap. |
+| `[observability.retention.hook_spool]` | `failed_max_items` | int > 0 | Failed spool item-count cap. |
+
+See [diagnostics.md](./diagnostics.md) for current enforcement notes; some SQLite
+limits are reported through diagnostics before pruning is implemented.
+
+### `[feature_flags]` — temporary behavior gates (optional)
+
+Strict boolean record. Unknown flag names are rejected.
+
+| Key | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `session_resume_agent` | bool | `false` | Enable resuming lost provider-native agent sessions. |
+| `station_persistent_agents` | bool | `false` | Host Station agents in the standalone `station-station-host` daemon so they survive UI close and can reattach. |
 
 ---
 
@@ -229,11 +343,12 @@ path = ".station/config.toml"
 Only these keys are accepted (strict — anything else makes the **whole local file**
 fail to load and emits a diagnostic, falling back to the bare project block):
 
-| Section | Allowed | Merge rule |
-| --- | --- | --- |
-| `[defaults]` | `harness`, `layout` **only** | Local **wins** over the project block. `terminal` is intentionally **not** overridable locally. |
-| `[commands]` | any command labels | **Additive only.** A label that already exists globally is **rejected** (kept at the global value, emits `CONFIG_LOCAL_COMMAND_OVERRIDE`). New labels are added. |
-| `[display]` | `group`, `sort_order` | Shallow merge; local keys **win**. |
+| Section | Allowed | Type | Merge rule |
+| --- | --- | --- | --- |
+| root | `schema_version` | exactly `1` | Required in every local file. |
+| `[defaults]` | `harness`, `layout` **only** | string | Local **wins** over the project block. `terminal` is intentionally **not** overridable locally. |
+| `[commands]` | any command labels | table<string,string> | **Additive only.** A label that already exists globally is **rejected** (kept at the global value, emits `CONFIG_LOCAL_COMMAND_OVERRIDE`). New labels are added. |
+| `[display]` | `group`, `sort_order` | string / int | Shallow merge; local keys **win**. |
 
 `env` cannot be set locally.
 
@@ -249,18 +364,71 @@ section in `config.toml`, which aborts the load. Surface project-local problems 
 
 ## Locations & environment variables
 
-| Variable | Relocates | Notes |
+Runtime path and socket overrides:
+
+| Variable | Relocates / selects | Notes |
 | --- | --- | --- |
 | `STATION_CONFIG_PATH` | the entire `config.toml` (incl. `[workspace]` and `[tui]`) | `stn --config <path>` is the CLI equivalent. One knob now moves all config — there is no separate workspace file to relocate. |
 | `XDG_RUNTIME_DIR` | observer + station-host **sockets** | When set, sockets move to `$XDG_RUNTIME_DIR/station/`. Does **not** move SQLite, logs, diagnostics, or hook spool. |
 | `STATION_OBSERVER_SOCKET_PATH` | observer socket the **TUI/harness connects to** | Connection-side override; parallel to `observer.socket_path` in config. |
-| `HOME` | the `~` anchor for every default path | `config.toml` (`~/.config`), state dir, sockets. |
+| `STATION_HOST_SOCKET_PATH` | native Station host socket | TUI-side override for warm reattach/listing. Otherwise it sits beside the observer socket. The observer's own host controller derives the host socket from config. |
+| `STATION_LAYOUT_PATH` | native Station layout snapshot | Overrides the TUI layout snapshot path. Without it, the TUI uses `$XDG_STATE_HOME/station/station/layout.json` or `~/.local/state/station/station/layout.json`. |
+| `XDG_STATE_HOME` | native Station layout default | Used only by the TUI layout resolver when `STATION_LAYOUT_PATH` is absent. |
+| `HOME` | the `~` anchor for every default path | `config.toml` (`~/.config`), state dir, sockets, provider home defaults. |
+
+Provider command overrides, used when the matching config `command` field is absent:
+
+| Variable | Provider | Fallback without env |
+| --- | --- | --- |
+| `STATION_WORKTRUNK_BIN` | Worktrunk | `wt` |
+| `STATION_TMUX_BIN` | tmux | `tmux` |
+| `STATION_GH_BIN` | GitHub repository provider | `gh` |
+| `STATION_CLAUDE_BIN` | Claude Code harness | `claude` |
+| `STATION_CODEX_BIN` | Codex harness | `codex` |
+| `STATION_CURSOR_AGENT_BIN` | Cursor Agent harness | `agent` |
+| `STATION_OPENCODE_BIN` | OpenCode harness | `opencode` |
+| `STATION_PI_BIN` | Pi harness | `pi` |
+| `STATION_CRUSH_BIN` | Crush harness | `crush` |
+
+Provider config/home overrides:
+
+| Variable | Used by | Notes |
+| --- | --- | --- |
+| `CODEX_HOME` | Codex hooks + launched Codex agents | Overrides the Codex config home. |
+| `CLAUDE_CONFIG_DIR` | Claude hooks + launched Claude agents | Overrides Claude settings/config dir. |
+| `STATION_CURSOR_HOME` | Cursor hooks + launched Cursor agents | Used as the isolated Cursor home; launch maps it to `HOME` for the agent process. |
+| `STATION_CURSOR_HOOKS_PATH` | Cursor hook setup | Directly overrides the Cursor hooks file path. |
+| `OPENCODE_CONFIG_DIR` | OpenCode plugin + launched OpenCode agents | Overrides OpenCode config dir. |
+
+Advanced development/demo overrides:
+
+| Variable | Used by | Accepted values / notes |
+| --- | --- | --- |
+| `STATION_SOURCE` | Native Station TUI data source | unset/empty/`observer` for live observer, `mock` for fixture data. |
+| `STATION_SCENARIO` | Native Station mock data | Fixture scenario name when `STATION_SOURCE=mock`; defaults to `baseline`. |
+| `STATION_NODE` | Station local PTY bridge | Node executable path/name; fallback is `node`. |
+| `STATION_BUN` | Station host controller | Bun executable path/name; fallback is `bun`. |
+| `STATION_HOST_ENTRY` | Station host controller | Non-standard override for the host entry file. Usually leave unset. |
+| `STATION_DASHBOARD_COMMAND` | CLI TUI launcher | Override command for the read-only dashboard renderer. Development/testing only. |
+| `STATION_TUI_COMMAND` / `STATION_TUI_SESSION_NAME` | tmux popup registry | Development popup routing overrides. |
+| `STATION_SHELL_AUTOCLOSE` | Native Station TUI | `1`/`true` or `0`/`false`; auto-close overlay when a `+sh` shell opens. |
+| `STATION_PROFILE` | Native Station TUI | `1`/`true` or `0`/`false`; enables dev render profiling. |
 
 Default state paths (all under `state_dir`, default `~/.local/state/station`):
 
 - `observer.sqlite`, `logs/`, `diagnostics/`, `spool/hooks/` follow `state_dir`.
 - `run/observer.sock` and sibling `run/station-host.sock` sit under a `run/` subdir of
   `state_dir`, **unless** `XDG_RUNTIME_DIR` is set (then `$XDG_RUNTIME_DIR/station/`).
+
+Generated launch/hook env vars are internal context, not hand-authored config:
+`STATION_PROJECT_ID`, `STATION_WORKTREE_ID`, `STATION_WORKTREE_PATH`,
+`STATION_SESSION_ID`, `STATION_HARNESS_PROVIDER`, `STATION_TERMINAL_PROVIDER`,
+`STATION_TERMINAL_TARGET_ID`, `STATION_OBSERVER_STATE_DIR`, `STATION_STATE_DIR`,
+`STATION_HOOK_SPOOL_DIR`, `STATION_TUI_POPUP`, `STATION_FOCUS_PROVIDER`, and
+`STATION_FOCUS_CLIENT_ID`. Hook scripts and launched agents receive these so they
+can report back to the right observer/session. `STATION_STATE_DIR` is a hook-script
+fallback for `stn-ingress --state-dir`; it is **not** a global observer relocation
+knob. Use `observer.state_dir` in config for isolation.
 
 ---
 


### PR DESCRIPTION
## Summary

- Expands `docs/configuration.md` into a complete config reference for runtime config, project-local config, and environment variables.
- Documents accepted enum/union values, provider command fallbacks, project nested tables, observer event hook filters, retention keys, and feature flags.
- Clarifies strict versus best-effort validation behavior and how users can verify config issues with Station diagnostics.

## Validation

- `git diff --check`
- `pnpm lint`

## UX implication

Users get a single alpha-ready configuration reference and can manually verify edited config with `stn doctor` or `stn setup check`.