### PR TITLE
refactor(theme): centralize Station product chrome colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "typecheck": "turbo run typecheck",
-    "lint": "biome check . && node tools/lint/check-source-order.mjs",
+    "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-station-hex.mjs",
     "format": "biome format --write .",
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",

--- a/packages/dashboard-core/src/components/WorktreeRow/layout.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/layout.ts
@@ -1,8 +1,8 @@
 import stringWidth from "string-width";
+import type { ColorRole } from "../../tokens/colors.js";
+import { ROW_GRID_CELLS } from "../../tokens/spacing.js";
 
-export const ROW_COLOR_PURPLE = "#d2a8ff";
-
-export type RowColor = "blue" | "gray" | "green" | "red" | "yellow" | typeof ROW_COLOR_PURPLE;
+export type RowColor = ColorRole;
 
 export type RowSegment =
   | {
@@ -106,9 +106,9 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
     {
       key: "identity",
       role: "fixed",
-      minCells: 7,
-      idealCells: 7,
-      maxCells: 7,
+      minCells: ROW_GRID_CELLS.identity,
+      idealCells: ROW_GRID_CELLS.identity,
+      maxCells: ROW_GRID_CELLS.identity,
       gapBefore: 0,
       dropPriority: 0,
       align: "left",
@@ -117,9 +117,9 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
     {
       key: "title",
       role: "flex",
-      minCells: 3,
-      idealCells: 22,
-      maxCells: 40,
+      minCells: ROW_GRID_CELLS.titleMin,
+      idealCells: ROW_GRID_CELLS.titleIdeal,
+      maxCells: ROW_GRID_CELLS.titleMax,
       gapBefore: 0,
       dropPriority: 0,
       align: "left",
@@ -128,10 +128,10 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
     {
       key: "agent",
       role: "soft",
-      minCells: 1,
-      idealCells: 8,
-      maxCells: 10,
-      gapBefore: 2,
+      minCells: ROW_GRID_CELLS.agentMin,
+      idealCells: ROW_GRID_CELLS.agentIdeal,
+      maxCells: ROW_GRID_CELLS.agentMax,
+      gapBefore: ROW_GRID_CELLS.agentGap,
       dropPriority: 30,
       align: "left",
       truncate: "end",
@@ -139,10 +139,10 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
     {
       key: "activity",
       role: "soft",
-      minCells: 4,
-      idealCells: 12,
-      maxCells: 16,
-      gapBefore: 2,
+      minCells: ROW_GRID_CELLS.activityMin,
+      idealCells: ROW_GRID_CELLS.activityIdeal,
+      maxCells: ROW_GRID_CELLS.activityMax,
+      gapBefore: ROW_GRID_CELLS.activityGap,
       dropPriority: 40,
       align: "left",
       truncate: "end",
@@ -151,7 +151,7 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
       key: "metadata",
       role: "right",
       minCells: 0,
-      gapBefore: 1,
+      gapBefore: ROW_GRID_CELLS.metadataGap,
       dropPriority: 20,
       align: "right",
       truncate: "none",

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -1,6 +1,10 @@
 import type { WorktreeRow as WorktreeRowModel } from "@station/contracts";
 import {
-  ROW_COLOR_PURPLE,
+  type MetadataAtom,
+  worktreeMetadataAtoms,
+  worktreeStatusAtom,
+} from "../../tokens/status.js";
+import {
   type RowColor,
   type RowGridCell,
   type RowGridCellImportance,
@@ -23,37 +27,32 @@ export function worktreeRowGridInput({
   slot: string | undefined;
   title?: string | undefined;
 }): RowGridRowInput {
-  const marker = statusMarker(row);
+  const status = worktreeStatusAtom(row);
   const displayTitle = title ?? row.branch;
-  const activity = activityCellForRow(row);
-  const ready = isReadyToRead(row);
-  const color = row.display.alert
-    ? "red"
-    : marker.kind === "text" && marker.text === "?"
-      ? "yellow"
-      : undefined;
   const input: Parameters<typeof worktreeStyleRowGridInput>[0] = {
     id: id ?? row.id,
     slot,
-    marker,
+    marker: status.marker,
     title: displayTitle,
     agent: row.agent?.harness ?? "-",
-    activity: activity.text,
-    activityImportance: activity.importance,
+    activity: status.activity,
+    activityImportance: status.activityImportance,
     // Let the status claim the row's trailing slack so it stretches to the end
     // instead of truncating while empty space remains, matching transient rows.
     activityOverflow: "rowSlack",
     metadataGroups: metadataGroups(row),
   };
-  if (ready) {
-    input.markerColor = "green";
-    input.activityColor = "green";
+  if (status.markerColor !== undefined) {
+    input.markerColor = status.markerColor;
   }
-  return color === undefined
+  if (status.activityColor !== undefined) {
+    input.activityColor = status.activityColor;
+  }
+  return status.rowColor === undefined
     ? worktreeStyleRowGridInput(input)
     : worktreeStyleRowGridInput({
         ...input,
-        color,
+        color: status.rowColor,
       });
 }
 
@@ -139,44 +138,6 @@ function identitySegments(
   return segments;
 }
 
-function activityCellForRow(row: WorktreeRowModel): {
-  text: string;
-  importance: RowGridCellImportance;
-} {
-  if (row.display.alert || row.display.warning === true) {
-    return {
-      text: row.display.reason ?? row.display.statusLabel,
-      importance: "meaningful",
-    };
-  }
-  if (isReadyToRead(row)) {
-    return {
-      text: "ready",
-      importance: "optional",
-    };
-  }
-  return {
-    text: row.display.statusLabel,
-    importance: "optional",
-  };
-}
-
-export function statusMarker(row: WorktreeRowModel): RowMarker {
-  const state = row.agent?.state ?? "none";
-  if (state === "needs_attention" || state === "stuck") return { kind: "text", text: "!" };
-  if (state === "working") return { kind: "throbber", variant: "braille" };
-  if (isReadyToRead(row)) return { kind: "text", text: "●" };
-  if (state === "idle") return { kind: "text", text: "○" };
-  if (state === "starting") return { kind: "text", text: "+" };
-  if (state === "unknown") return { kind: "text", text: "?" };
-  if (state === "exited") return { kind: "text", text: "x" };
-  return { kind: "text", text: "-" };
-}
-
-function isReadyToRead(row: WorktreeRowModel): boolean {
-  return row.agent?.state === "idle" && row.agent.turnReadiness?.state === "ready_to_read";
-}
-
 type MetadataSegment = {
   text: string;
   stale: boolean;
@@ -188,42 +149,7 @@ type MetadataSegment = {
 type MetadataColor = RowColor;
 
 export function metadataSegments(row: WorktreeRowModel): MetadataSegment[] {
-  const segments: MetadataSegment[] = [];
-  const { changeSummary, pr, checks } = row.worktree;
-  if (changeSummary !== undefined && (changeSummary.additions > 0 || changeSummary.deletions > 0)) {
-    if (changeSummary.additions > 0) {
-      segments.push({
-        text: `+${changeSummary.additions}`,
-        stale: changeSummary.stale === true,
-        color: "green",
-      });
-    }
-    if (changeSummary.deletions > 0) {
-      segments.push({
-        text: `-${changeSummary.deletions}`,
-        stale: changeSummary.stale === true,
-        color: "red",
-      });
-    }
-  }
-  if (pr === undefined) {
-    return segments;
-  }
-  segments.push({
-    text: `#${pr.number}`,
-    stale: pr.stale === true,
-    color: prMetadataColor(pr),
-    underline: true,
-    ...(pr.url === undefined ? {} : { url: pr.url }),
-  });
-  if (checks !== undefined) {
-    segments.push({
-      text: checksStateGlyph(checks),
-      stale: checks.stale === true,
-      color: checksStateColor(checks, pr),
-    });
-  }
-  return segments;
+  return worktreeMetadataAtoms(row).map(metadataSegmentFromAtom);
 }
 
 function metadataGroups(row: WorktreeRowModel): WorktreeRowMetadataGroups {
@@ -255,40 +181,17 @@ function rowSegmentFromMetadata(segment: MetadataSegment): RowSegment {
   });
 }
 
+function metadataSegmentFromAtom(atom: MetadataAtom): MetadataSegment {
+  const segment: MetadataSegment = {
+    text: atom.text,
+    stale: atom.stale,
+  };
+  if (atom.color !== undefined) segment.color = atom.color;
+  if (atom.underline === true) segment.underline = true;
+  if (atom.url !== undefined) segment.url = atom.url;
+  return segment;
+}
+
 function diffMetadataSegmentCount(row: WorktreeRowModel): number {
-  const { changeSummary } = row.worktree;
-  if (changeSummary === undefined) {
-    return 0;
-  }
-  let count = 0;
-  if (changeSummary.additions > 0) count += 1;
-  if (changeSummary.deletions > 0) count += 1;
-  return count;
-}
-
-function checksStateGlyph(checks: NonNullable<WorktreeRowModel["worktree"]["checks"]>) {
-  if (checks.state === "pass") return "✓";
-  if (checks.state === "fail") return failedChecksGlyph(checks.failed);
-  if (checks.state === "cancelled") return failedChecksGlyph(checks.cancelled);
-  if (checks.state === "running") return "…";
-  return "-";
-}
-
-function prMetadataColor(pr: NonNullable<WorktreeRowModel["worktree"]["pr"]>): MetadataColor {
-  return pr.state === "merged" ? ROW_COLOR_PURPLE : "blue";
-}
-
-function failedChecksGlyph(count: number | undefined): string {
-  return count === undefined || count <= 0 ? "x" : `x${count}`;
-}
-
-function checksStateColor(
-  checks: NonNullable<WorktreeRowModel["worktree"]["checks"]>,
-  pr: NonNullable<WorktreeRowModel["worktree"]["pr"]>,
-): MetadataColor {
-  if (pr.state === "merged" && checks.state === "pass") return ROW_COLOR_PURPLE;
-  if (checks.state === "pass") return "green";
-  if (checks.state === "fail" || checks.state === "cancelled") return "red";
-  if (checks.state === "running") return "yellow";
-  return "gray";
+  return worktreeMetadataAtoms(row).filter((atom) => atom.group === "diff").length;
 }

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -40,3 +40,4 @@ export * from "./state/screens/projectDefaultAgent.js";
 export * from "./state/screens/projectSettings.js";
 export * from "./state/screens/removeWorktree.js";
 export * from "./state/screens/sessionRows.js";
+export * from "./tokens/index.js";

--- a/packages/dashboard-core/src/tokens/colors.ts
+++ b/packages/dashboard-core/src/tokens/colors.ts
@@ -1,0 +1,1 @@
+export type ColorRole = "gray" | "red" | "yellow" | "green" | "blue" | "cyan" | "purple";

--- a/packages/dashboard-core/src/tokens/glyphs.ts
+++ b/packages/dashboard-core/src/tokens/glyphs.ts
@@ -1,0 +1,19 @@
+export const STATUS_GLYPHS = {
+  noAgent: "-",
+  starting: "+",
+  idle: "○",
+  ready: "●",
+  attention: "!",
+  exited: "x",
+  unknown: "?",
+} as const;
+
+export const CHECK_GLYPHS = {
+  pass: "✓",
+  running: "…",
+  fallback: "-",
+} as const;
+
+export const THROBBERS = {
+  working: { kind: "throbber", variant: "braille" },
+} as const;

--- a/packages/dashboard-core/src/tokens/index.ts
+++ b/packages/dashboard-core/src/tokens/index.ts
@@ -1,0 +1,4 @@
+export * from "./colors.js";
+export * from "./glyphs.js";
+export * from "./spacing.js";
+export * from "./status.js";

--- a/packages/dashboard-core/src/tokens/spacing.ts
+++ b/packages/dashboard-core/src/tokens/spacing.ts
@@ -1,0 +1,15 @@
+export const ROW_GRID_CELLS = {
+  identity: 7,
+  titleMin: 3,
+  titleIdeal: 22,
+  titleMax: 40,
+  agentMin: 1,
+  agentIdeal: 8,
+  agentMax: 10,
+  activityMin: 4,
+  activityIdeal: 12,
+  activityMax: 16,
+  agentGap: 2,
+  activityGap: 2,
+  metadataGap: 1,
+} as const;

--- a/packages/dashboard-core/src/tokens/status.ts
+++ b/packages/dashboard-core/src/tokens/status.ts
@@ -1,0 +1,197 @@
+import type { WorktreeChecksSummary, WorktreePullRequest, WorktreeRow } from "@station/contracts";
+import type { RowGridCellImportance } from "../components/WorktreeRow/layout.js";
+import type { ColorRole } from "./colors.js";
+import { CHECK_GLYPHS, STATUS_GLYPHS, THROBBERS } from "./glyphs.js";
+
+export type StatusMarkerAtom =
+  | {
+      kind: "text";
+      text: string;
+    }
+  | {
+      kind: "throbber";
+      variant: "braille" | "circle";
+    };
+
+export type WorktreeStatusAtom = {
+  marker: StatusMarkerAtom;
+  activity: string;
+  activityImportance: RowGridCellImportance;
+  rowColor?: ColorRole;
+  markerColor?: ColorRole;
+  activityColor?: ColorRole;
+};
+
+export type MetadataAtom = {
+  group: "diff" | "pr";
+  text: string;
+  stale: boolean;
+  color?: ColorRole;
+  underline?: true;
+  url?: string;
+};
+
+export function worktreeStatusAtom(row: WorktreeRow): WorktreeStatusAtom {
+  const state = row.agent?.state ?? "none";
+  const activity = activityForRow(row);
+  const atom: WorktreeStatusAtom = {
+    marker: markerForState(row),
+    activity: activity.text,
+    activityImportance: activity.importance,
+  };
+  if (row.display.alert || row.display.warning === true) {
+    atom.rowColor = row.display.alert ? "red" : "yellow";
+  } else if (state === "unknown") {
+    atom.rowColor = "yellow";
+  }
+  if (isReadyToRead(row)) {
+    atom.markerColor = "green";
+    atom.activityColor = "green";
+  }
+  return atom;
+}
+
+export function worktreeMetadataAtoms(row: WorktreeRow): MetadataAtom[] {
+  return [...diffMetadataAtoms(row), ...prMetadataAtoms(row)];
+}
+
+export function diffMetadataAtoms(row: WorktreeRow): MetadataAtom[] {
+  const { changeSummary } = row.worktree;
+  if (changeSummary === undefined) {
+    return [];
+  }
+  const atoms: MetadataAtom[] = [];
+  if (changeSummary.additions > 0) {
+    atoms.push({
+      group: "diff",
+      text: `+${changeSummary.additions}`,
+      stale: changeSummary.stale === true,
+      color: "green",
+    });
+  }
+  if (changeSummary.deletions > 0) {
+    atoms.push({
+      group: "diff",
+      text: `-${changeSummary.deletions}`,
+      stale: changeSummary.stale === true,
+      color: "red",
+    });
+  }
+  return atoms;
+}
+
+export function prMetadataAtoms(row: WorktreeRow): MetadataAtom[] {
+  const { checks, pr } = row.worktree;
+  if (pr === undefined) {
+    return [];
+  }
+  const atoms: MetadataAtom[] = [pullRequestMetadataAtom(pr)];
+  if (checks !== undefined) {
+    atoms.push(checkMetadataAtom(checks, pr));
+  }
+  return atoms;
+}
+
+export function pullRequestMetadataAtom(pr: WorktreePullRequest): MetadataAtom {
+  const atom: MetadataAtom = {
+    group: "pr",
+    text: `#${pr.number}`,
+    stale: pr.stale === true,
+    color: pr.state === "merged" ? "purple" : "blue",
+    underline: true,
+  };
+  if (pr.url !== undefined) {
+    atom.url = pr.url;
+  }
+  return atom;
+}
+
+export function checkMetadataAtom(
+  checks: WorktreeChecksSummary,
+  pr: WorktreePullRequest,
+): MetadataAtom {
+  return {
+    group: "pr",
+    text: checksStateGlyph(checks),
+    stale: checks.stale === true,
+    color: checksStateColor(checks, pr),
+  };
+}
+
+function activityForRow(row: WorktreeRow): {
+  text: string;
+  importance: RowGridCellImportance;
+} {
+  if (row.display.alert || row.display.warning === true) {
+    return {
+      text: row.display.reason ?? row.display.statusLabel,
+      importance: "meaningful",
+    };
+  }
+  if (isReadyToRead(row)) {
+    return {
+      text: "ready",
+      importance: "optional",
+    };
+  }
+  return {
+    text: row.display.statusLabel,
+    importance: "optional",
+  };
+}
+
+function markerForState(row: WorktreeRow): StatusMarkerAtom {
+  const state = row.agent?.state ?? "none";
+  switch (state) {
+    case "needs_attention":
+    case "stuck":
+      return { kind: "text", text: STATUS_GLYPHS.attention };
+    case "working":
+      return THROBBERS.working;
+    case "idle":
+      return isReadyToRead(row)
+        ? { kind: "text", text: STATUS_GLYPHS.ready }
+        : { kind: "text", text: STATUS_GLYPHS.idle };
+    case "starting":
+      return { kind: "text", text: STATUS_GLYPHS.starting };
+    case "unknown":
+      return { kind: "text", text: STATUS_GLYPHS.unknown };
+    case "exited":
+      return { kind: "text", text: STATUS_GLYPHS.exited };
+    case "none":
+      return { kind: "text", text: STATUS_GLYPHS.noAgent };
+  }
+}
+
+function isReadyToRead(row: WorktreeRow): boolean {
+  return row.agent?.state === "idle" && row.agent.turnReadiness?.state === "ready_to_read";
+}
+
+function checksStateGlyph(checks: WorktreeChecksSummary): string {
+  switch (checks.state) {
+    case "pass":
+      return CHECK_GLYPHS.pass;
+    case "fail":
+      return failedChecksGlyph(checks.failed);
+    case "cancelled":
+      return failedChecksGlyph(checks.cancelled);
+    case "running":
+      return CHECK_GLYPHS.running;
+    case "none":
+    case "unknown":
+    case "skipped":
+      return CHECK_GLYPHS.fallback;
+  }
+}
+
+function failedChecksGlyph(count: number | undefined): string {
+  return count === undefined || count <= 0 ? "x" : `x${count}`;
+}
+
+function checksStateColor(checks: WorktreeChecksSummary, pr: WorktreePullRequest): ColorRole {
+  if (pr.state === "merged" && checks.state === "pass") return "purple";
+  if (checks.state === "pass") return "green";
+  if (checks.state === "fail" || checks.state === "cancelled") return "red";
+  if (checks.state === "running") return "yellow";
+  return "gray";
+}

--- a/packages/dashboard-core/test/unit/components/worktreeRow/statusTokens.test.ts
+++ b/packages/dashboard-core/test/unit/components/worktreeRow/statusTokens.test.ts
@@ -1,0 +1,173 @@
+import type { WorktreeChecksSummary, WorktreePullRequest, WorktreeRow } from "@station/contracts";
+import {
+  checkMetadataAtom,
+  pullRequestMetadataAtom,
+  worktreeRowGridInput,
+  worktreeStatusAtom,
+} from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+import { fixtureNow, row } from "../../../fixtures/snapshots.js";
+
+function fixtureRow(state: "none" | NonNullable<WorktreeRow["agent"]>["state"]): WorktreeRow {
+  const built = row({
+    id: `wt_${state}`,
+    projectId: "web",
+    branch: `branch-${state}`,
+    state,
+  });
+  return {
+    ...built,
+    display: {
+      ...built.display,
+      statusLabel: statusLabel(state),
+    },
+  };
+}
+
+function statusLabel(state: "none" | NonNullable<WorktreeRow["agent"]>["state"]) {
+  switch (state) {
+    case "needs_attention":
+      return "needs attention";
+    case "none":
+      return "no agent";
+    default:
+      return state;
+  }
+}
+
+describe("worktree status tokens", () => {
+  it("emits semantic status atoms for every agent state", () => {
+    expect(worktreeStatusAtom(fixtureRow("none"))).toMatchObject({
+      marker: { kind: "text", text: "-" },
+      activity: "no agent",
+    });
+    expect(worktreeStatusAtom(fixtureRow("starting"))).toMatchObject({
+      marker: { kind: "text", text: "+" },
+      activity: "starting",
+    });
+    expect(worktreeStatusAtom(fixtureRow("idle"))).toMatchObject({
+      marker: { kind: "text", text: "○" },
+      activity: "idle",
+    });
+    expect(worktreeStatusAtom(fixtureRow("working"))).toMatchObject({
+      marker: { kind: "throbber", variant: "braille" },
+      activity: "working",
+    });
+    expect(worktreeStatusAtom(fixtureRow("needs_attention"))).toMatchObject({
+      marker: { kind: "text", text: "!" },
+      rowColor: "red",
+      activityImportance: "meaningful",
+    });
+    expect(worktreeStatusAtom(fixtureRow("stuck"))).toMatchObject({
+      marker: { kind: "text", text: "!" },
+      rowColor: "red",
+      activityImportance: "meaningful",
+    });
+    expect(worktreeStatusAtom(fixtureRow("exited"))).toMatchObject({
+      marker: { kind: "text", text: "x" },
+      activity: "exited",
+    });
+    expect(worktreeStatusAtom(fixtureRow("unknown"))).toMatchObject({
+      marker: { kind: "text", text: "?" },
+      rowColor: "yellow",
+      activity: "unknown",
+    });
+  });
+
+  it("colors idle ready-to-read rows with the ready role", () => {
+    const base = fixtureRow("idle");
+    const ready = {
+      ...base,
+      agent:
+        base.agent === undefined
+          ? undefined
+          : {
+              ...base.agent,
+              turnReadiness: {
+                state: "ready_to_read" as const,
+                token: "report_ready",
+                completedAt: fixtureNow,
+              },
+            },
+    } satisfies WorktreeRow;
+
+    expect(worktreeStatusAtom(ready)).toMatchObject({
+      marker: { kind: "text", text: "●" },
+      activity: "ready",
+      markerColor: "green",
+      activityColor: "green",
+    });
+  });
+});
+
+describe("worktree metadata tokens", () => {
+  const openPr = {
+    number: 12,
+    state: "open",
+    url: "https://github.com/example/station/pull/12",
+  } satisfies WorktreePullRequest;
+  const mergedPr = {
+    number: 73,
+    state: "merged",
+  } satisfies WorktreePullRequest;
+
+  it("keeps PR number as metadata and resolves merged PRs semantically", () => {
+    expect(pullRequestMetadataAtom(openPr)).toMatchObject({
+      text: "#12",
+      group: "pr",
+      color: "blue",
+      underline: true,
+      url: openPr.url,
+    });
+    expect(pullRequestMetadataAtom(mergedPr)).toMatchObject({
+      text: "#73",
+      group: "pr",
+      color: "purple",
+      underline: true,
+    });
+  });
+
+  it("emits semantic check glyphs and colors", () => {
+    expect(checkMetadataAtom(checks("pass"), openPr)).toMatchObject({
+      text: "✓",
+      color: "green",
+    });
+    expect(checkMetadataAtom(checks("pass"), mergedPr)).toMatchObject({
+      text: "✓",
+      color: "purple",
+    });
+    expect(checkMetadataAtom(checks("running"), openPr)).toMatchObject({
+      text: "…",
+      color: "yellow",
+    });
+    expect(checkMetadataAtom({ ...checks("fail"), failed: 2 }, openPr)).toMatchObject({
+      text: "x2",
+      color: "red",
+    });
+    expect(checkMetadataAtom({ ...checks("cancelled"), cancelled: 3 }, openPr)).toMatchObject({
+      text: "x3",
+      color: "red",
+    });
+  });
+
+  it("assembles row metadata without leaking hex into dashboard-core rows", () => {
+    const merged = fixtureRow("idle");
+    merged.worktree.pr = mergedPr;
+    merged.worktree.checks = checks("pass");
+
+    const input = worktreeRowGridInput({ row: merged, slot: "1" });
+    const colors = input.cells.metadata?.segments.flatMap((segment) =>
+      segment.kind === "text" && segment.color !== undefined ? [segment.color] : [],
+    );
+
+    expect(colors).toEqual(["purple", "purple"]);
+  });
+});
+
+function checks(state: WorktreeChecksSummary["state"]): WorktreeChecksSummary {
+  return {
+    state,
+    source: "github",
+    checkedAt: fixtureNow,
+  };
+}

--- a/station/src/contextMenu/ContextMenuSurface.tsx
+++ b/station/src/contextMenu/ContextMenuSurface.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from "@opentui/core";
 import { normalizeStationMouseEvent, type StationMouseEvent } from "../input/mouse.js";
 import type { MouseTargetRef } from "../input/router.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 import type { ContextMenuItem } from "./types.js";
 
 export type ContextMenuSurfaceProps = {
@@ -11,12 +12,12 @@ export type ContextMenuSurfaceProps = {
   dispatchMouse: (target: MouseTargetRef, event: StationMouseEvent) => boolean;
 };
 
-const MENU_BACKGROUND = "#15191e";
-const ROW_ACTIVE = "#2f3842";
-const ROW_TEXT = "#f4f4f5";
-const ROW_DISABLED = "#7a828c";
-const ROW_DANGER = "#fca5a5";
-const BORDER_TEXT = "#5b6470";
+const MENU_BACKGROUND = STATION_COLORS.chrome.menuBackground;
+const ROW_ACTIVE = STATION_COLORS.chrome.activeRow;
+const ROW_TEXT = STATION_COLORS.foreground;
+const ROW_DISABLED = STATION_COLORS.chrome.disabledForeground;
+const ROW_DANGER = STATION_COLORS.state.danger;
+const BORDER_TEXT = STATION_COLORS.chrome.border;
 
 export function ContextMenuSurface({
   items,

--- a/station/src/station/connectionLabel.test.ts
+++ b/station/src/station/connectionLabel.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import type { StationClientConnectionState } from "@station/client";
+import { presentConnection } from "./connectionLabel.js";
+import { STATION_COLORS } from "./view/theme.js";
+
+describe("presentConnection", () => {
+  it("maps connection states to shared Station theme colors", () => {
+    expect(presentConnection({ state: "idle" }).color).toBe(STATION_COLORS.gray);
+    expect(presentConnection({ state: "loading", since: 0 }).color).toBe(
+      STATION_COLORS.state.warning,
+    );
+    expect(presentConnection({ state: "connected", since: 0 }).color).toBe(
+      STATION_COLORS.state.success,
+    );
+    expect(presentConnection(connection("reconnecting")).color).toBe(
+      STATION_COLORS.state.warning,
+    );
+    expect(presentConnection(connection("displayOnly")).color).toBe(STATION_COLORS.state.warning);
+    expect(
+      presentConnection({
+        state: "halted",
+        since: 0,
+        lastError: {
+          tag: "ProtocolError",
+          code: "PROTOCOL_CONNECT_FAILED",
+          message: "socket failed",
+        },
+      }).color,
+    ).toBe(STATION_COLORS.state.danger);
+  });
+});
+
+function connection(
+  state: "reconnecting" | "displayOnly",
+): Extract<StationClientConnectionState, { state: typeof state }> {
+  return {
+    state,
+    since: 0,
+    lastError: {
+      tag: "ProtocolError",
+      code: "PROTOCOL_CONNECT_FAILED",
+      message: "socket failed",
+    },
+  } as Extract<StationClientConnectionState, { state: typeof state }>;
+}

--- a/station/src/station/connectionLabel.ts
+++ b/station/src/station/connectionLabel.ts
@@ -1,14 +1,15 @@
 import type { StationClientConnectionState } from "@station/client";
+import { STATION_COLORS } from "./view/theme.js";
 
 export type StationConnectionPresentation = {
   label: string;
   color: string;
 };
 
-const CONNECTED_COLOR = "#4ade80";
-const WAITING_COLOR = "#fbbf24";
-const HALTED_COLOR = "#f87171";
-const IDLE_COLOR = "#9ca3af";
+const CONNECTED_COLOR = STATION_COLORS.state.success;
+const WAITING_COLOR = STATION_COLORS.state.warning;
+const HALTED_COLOR = STATION_COLORS.state.danger;
+const IDLE_COLOR = STATION_COLORS.gray;
 
 /**
  * Calm, static status copy: no spinners and no per-second timers. Failure

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -204,6 +204,29 @@ describe("dashboard golden frames", () => {
     expect(((prSpan?.attributes ?? 0) & TextAttributes.UNDERLINE) !== 0).toBe(true);
   });
 
+  it("colors ready status green and merged PR metadata purple", async () => {
+    const setup = await renderDashboard({
+      width: 80,
+      height: 24,
+      snapshot: readyToReadSnapshot(),
+    });
+    const charFrame = setup.captureCharFrame();
+    const frame = setup.captureSpans();
+    const lines = charFrame.split("\n");
+
+    const readyRow = lines.findIndex((line) => line.includes("● pty-buffer"));
+    expect(readyRow).toBeGreaterThan(0);
+    const markerCol = lines[readyRow]?.indexOf("●") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, readyRow, markerCol))).toBe(STATION_COLORS.state.ready);
+    const readyCol = lines[readyRow]?.indexOf("ready") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, readyRow, readyCol))).toBe(STATION_COLORS.state.ready);
+
+    const prCol = lines[readyRow]?.indexOf("#73") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, readyRow, prCol))).toBe(STATION_COLORS.state.merged);
+    const checkCol = lines[readyRow]?.indexOf("✓") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, readyRow, checkCol))).toBe(STATION_COLORS.state.merged);
+  });
+
   it("routes PR number clicks through the link mouse target", async () => {
     const targets: StationMouseTarget[] = [];
     const setup = await renderDashboard({
@@ -267,3 +290,26 @@ describe("dashboard golden frames", () => {
     expect(spanBgHex(spanAtFrameCell(spans, row, 78))).toBe(STATION_COLORS.hoverBackground);
   });
 });
+
+function readyToReadSnapshot(): StationSnapshot {
+  const snapshot = manyProjectsSnapshot();
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row) => {
+      if (row.id !== "wt_station_idle" || row.agent === undefined) {
+        return row;
+      }
+      return {
+        ...row,
+        agent: {
+          ...row.agent,
+          turnReadiness: {
+            state: "ready_to_read",
+            token: "report_ready",
+            completedAt: row.agent.updatedAt,
+          },
+        },
+      };
+    }),
+  };
+}

--- a/station/src/station/view/theme.ts
+++ b/station/src/station/view/theme.ts
@@ -1,48 +1,95 @@
-// Ink color-name -> hex tokens for the STATION view. The shared layout speaks
-// Ink's named RowColor vocabulary (plus the literal purple hex); OpenTUI
-// takes fg hex strings. Values match the terminal-ish palette the rest of
-// Station already uses.
-import { ROW_COLOR_PURPLE, type RowColor } from "@station/dashboard-core";
+// Station product-chrome theme. Shared dashboard-core code emits semantic
+// color roles; OpenTUI render surfaces resolve them to hex here.
+import type { RowColor } from "@station/dashboard-core";
 import type { ProviderHealth } from "@station/contracts";
 
-export const STATION_COLORS = {
-  gray: "#9ca3af",
+const PRIMITIVE_COLORS = {
+  background: "#101316",
+  hoverBackground: "#1f242b",
+  foreground: "#e4e4e7",
+  muted: "#9ca3af",
   red: "#f87171",
   yellow: "#fbbf24",
   green: "#4ade80",
   blue: "#60a5fa",
   cyan: "#22d3ee",
-  purple: ROW_COLOR_PURPLE,
-  foreground: "#e4e4e7",
-  background: "#101316",
-  hoverBackground: "#1f242b",
-  overlayBackdrop: "#000000",
+  purple: "#d2a8ff",
 } as const;
 
+const CHROME_COLORS = {
+  menuBackground: "#15191e",
+  activeRow: "#2f3842",
+  border: "#5b6470",
+  mutedBorder: "#3f4750",
+  disabledForeground: "#7a828c",
+  overlayBackdrop: "#000000",
+  terminalSelectionBackground: "#264f78",
+  pane: {
+    primary: {
+      active: PRIMITIVE_COLORS.blue,
+      inactive: "#1d4ed8",
+    },
+    shellAccents: [
+      { active: PRIMITIVE_COLORS.green, inactive: "#14532d" },
+      { active: PRIMITIVE_COLORS.purple, inactive: "#581c87" },
+      { active: PRIMITIVE_COLORS.yellow, inactive: "#713f12" },
+      { active: PRIMITIVE_COLORS.cyan, inactive: "#164e63" },
+    ],
+  },
+  welcomeButton: {
+    background: "#1f2937",
+    mutedBackground: PRIMITIVE_COLORS.background,
+    hoverBackground: "#263142",
+    shimmerBackground: "#4a6a8c",
+    shimmerForeground: "#ffffff",
+  },
+} as const;
+
+const STATE_COLORS = {
+  success: PRIMITIVE_COLORS.green,
+  warning: PRIMITIVE_COLORS.yellow,
+  danger: PRIMITIVE_COLORS.red,
+  attention: PRIMITIVE_COLORS.red,
+  ready: PRIMITIVE_COLORS.green,
+  unknown: PRIMITIVE_COLORS.yellow,
+  merged: PRIMITIVE_COLORS.purple,
+} as const;
+
+export const STATION_COLORS = {
+  primitives: PRIMITIVE_COLORS,
+  chrome: CHROME_COLORS,
+  state: STATE_COLORS,
+  gray: PRIMITIVE_COLORS.muted,
+  red: PRIMITIVE_COLORS.red,
+  yellow: PRIMITIVE_COLORS.yellow,
+  green: PRIMITIVE_COLORS.green,
+  blue: PRIMITIVE_COLORS.blue,
+  cyan: PRIMITIVE_COLORS.cyan,
+  purple: PRIMITIVE_COLORS.purple,
+  foreground: PRIMITIVE_COLORS.foreground,
+  background: PRIMITIVE_COLORS.background,
+  hoverBackground: PRIMITIVE_COLORS.hoverBackground,
+  overlayBackdrop: CHROME_COLORS.overlayBackdrop,
+} as const;
+
+const ROW_COLOR_HEX: Record<RowColor, string> = {
+  gray: STATION_COLORS.gray,
+  red: STATION_COLORS.red,
+  yellow: STATION_COLORS.yellow,
+  green: STATION_COLORS.green,
+  blue: STATION_COLORS.blue,
+  cyan: STATION_COLORS.cyan,
+  purple: STATION_COLORS.purple,
+};
+
 export function rowColorToHex(color: RowColor | undefined): string | undefined {
-  switch (color) {
-    case undefined:
-      return undefined;
-    case "gray":
-      return STATION_COLORS.gray;
-    case "red":
-      return STATION_COLORS.red;
-    case "yellow":
-      return STATION_COLORS.yellow;
-    case "green":
-      return STATION_COLORS.green;
-    case "blue":
-      return STATION_COLORS.blue;
-    default:
-      // ROW_COLOR_PURPLE is already a hex literal.
-      return color;
-  }
+  return color === undefined ? undefined : ROW_COLOR_HEX[color];
 }
 
 const PROVIDER_HEALTH_STATUS_COLORS: Record<ProviderHealth["status"], string> = {
-  healthy: STATION_COLORS.green,
-  degraded: STATION_COLORS.yellow,
-  unavailable: STATION_COLORS.red,
+  healthy: STATION_COLORS.state.success,
+  degraded: STATION_COLORS.state.warning,
+  unavailable: STATION_COLORS.state.danger,
   unknown: STATION_COLORS.gray,
 };
 

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
+import { rgbToHex } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
+import { spanAtFrameCell } from "../terminal/testing/frameProbe.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 import { DynamicStationButton } from "./DynamicStationButton.js";
 import { ANIM_MS, STATION_ICON } from "./layout.js";
 
@@ -19,6 +22,26 @@ async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<str
   }
 }
 
+async function captureForegroundHexes(node: Parameters<typeof testRender>[0]): Promise<Set<string>> {
+  const setup = await testRender(node, SURFACE);
+  try {
+    await setup.flush();
+    const spans = setup.captureSpans();
+    const hexes = new Set<string>();
+    for (let row = 0; row < SURFACE.height; row += 1) {
+      for (let col = 0; col < SURFACE.width; col += 1) {
+        const span = spanAtFrameCell(spans, row, col);
+        if (span?.fg !== undefined) {
+          hexes.add(rgbToHex(span.fg as Parameters<typeof rgbToHex>[0]));
+        }
+      }
+    }
+    return hexes;
+  } finally {
+    setup.renderer.destroy();
+  }
+}
+
 describe("DynamicStationButton", () => {
   it("collapsed base shows only the station icon", async () => {
     const frame = await captureFrame(
@@ -26,6 +49,24 @@ describe("DynamicStationButton", () => {
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).not.toContain("session");
+  });
+
+  it("uses shared theme colors for base and attention states", async () => {
+    expect(
+      await captureForegroundHexes(
+        <DynamicStationButton attention={false} workingCount={2} idleCount={14} />,
+      ),
+    ).toContain(STATION_COLORS.state.ready);
+    expect(
+      await captureForegroundHexes(
+        <DynamicStationButton attention={true} workingCount={0} idleCount={0} />,
+      ),
+    ).toContain(STATION_COLORS.state.attention);
+    expect(
+      await captureForegroundHexes(
+        <DynamicStationButton attention={true} workingCount={0} idleCount={0} hovered />,
+      ),
+    ).toContain(STATION_COLORS.state.merged);
   });
 
   it("collapsed attention frames the icon with exclamation marks", async () => {

--- a/station/src/stationButton/colors.ts
+++ b/station/src/stationButton/colors.ts
@@ -1,6 +1,7 @@
+import { STATION_COLORS } from "../station/view/theme.js";
+
 // Themeable color tokens for the station button. border/icon/text are separate
-// tokens though equal per state, so a theme can diverge them later. Independent
-// status palette (green=healthy, blue=peek, red=alert, purple=actionable).
+// tokens though equal per state, so a theme can diverge them later.
 export type StationButtonStateColors = {
   border: string;
   icon: string;
@@ -12,19 +13,30 @@ export type DynamicStationButtonColors = {
   attention: { collapsed: StationButtonStateColors; expanded: StationButtonStateColors };
 };
 
-const GREEN = "#22c55e";
-const BLUE = "#60a5fa"; // light, readable on the dark background
-const RED = "#ef4444";
-const PURPLE = "#c084fc"; // light + distinctly purple, clearly apart from the blue
-
 export const dynamicStationButtonColors: DynamicStationButtonColors = {
   base: {
-    collapsed: { border: GREEN, icon: GREEN, text: GREEN },
-    expanded: { border: BLUE, icon: BLUE, text: BLUE },
+    collapsed: {
+      border: STATION_COLORS.state.ready,
+      icon: STATION_COLORS.state.ready,
+      text: STATION_COLORS.state.ready,
+    },
+    expanded: {
+      border: STATION_COLORS.blue,
+      icon: STATION_COLORS.blue,
+      text: STATION_COLORS.blue,
+    },
   },
   attention: {
-    collapsed: { border: RED, icon: RED, text: RED },
-    expanded: { border: PURPLE, icon: PURPLE, text: PURPLE },
+    collapsed: {
+      border: STATION_COLORS.state.attention,
+      icon: STATION_COLORS.state.attention,
+      text: STATION_COLORS.state.attention,
+    },
+    expanded: {
+      border: STATION_COLORS.state.merged,
+      icon: STATION_COLORS.state.merged,
+      text: STATION_COLORS.state.merged,
+    },
   },
 };
 

--- a/station/src/terminal/PaneGrid.tsx
+++ b/station/src/terminal/PaneGrid.tsx
@@ -19,6 +19,7 @@ import {
 import { usePaneRegistry } from "./registry/paneTerminalContext.js";
 import type { PtyRegistryView } from "./registry/ptyRegistry.js";
 import { PANE_BORDER_ACTIVE, PANE_BORDER_INACTIVE, TerminalPane } from "./TerminalPane.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 
 export type PaneGridProps = {
   store: StationStore;
@@ -132,10 +133,7 @@ type PaneAccent = {
 };
 
 const SHELL_ACCENTS: readonly PaneAccent[] = [
-  { active: "#34d399", inactive: "#14532d" },
-  { active: "#c084fc", inactive: "#581c87" },
-  { active: "#fbbf24", inactive: "#713f12" },
-  { active: "#22d3ee", inactive: "#164e63" },
+  ...STATION_COLORS.chrome.pane.shellAccents,
 ];
 
 function useStationSnapshot(store: StoreApi<TuiStore> | undefined): StationSnapshot | undefined {

--- a/station/src/terminal/TerminalPane.tsx
+++ b/station/src/terminal/TerminalPane.tsx
@@ -1,11 +1,12 @@
 import { basename } from "node:path";
 import "./TerminalScreenRenderable.js";
 import type { PaneId } from "../state/types.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 import { usePaneTerminal } from "./registry/paneTerminalContext.js";
 
 /** Primary-agent blue; split shells use non-blue accents from PaneGrid. */
-export const PANE_BORDER_INACTIVE = "#1d4ed8";
-export const PANE_BORDER_ACTIVE = "#60a5fa";
+export const PANE_BORDER_INACTIVE = STATION_COLORS.chrome.pane.primary.inactive;
+export const PANE_BORDER_ACTIVE = STATION_COLORS.chrome.pane.primary.active;
 
 export type TerminalPaneProps = {
   paneId: PaneId;

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -20,6 +20,7 @@ import {
   rowColumnsOrdered,
 } from "./vt/selection.js";
 import { lineRangeAt, wordRangeAt } from "./vt/wordBoundary.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 
 const MIN_COLS = 2;
 const MIN_ROWS = 1;
@@ -27,7 +28,7 @@ const MIN_ROWS = 1;
 type MouseModifiers = { shift: boolean; alt: boolean; ctrl: boolean };
 // Consecutive clicks within this window expand to word (2) / line (3).
 const MULTI_CLICK_MS = 400;
-const SELECTION_BG = "#264f78";
+const SELECTION_BG = STATION_COLORS.chrome.terminalSelectionBackground;
 
 export type TerminalScreenOptions = RenderableOptions<TerminalScreenRenderable> & {
   screen?: StationVtScreen | null;

--- a/station/src/welcome/WelcomeScreen.tsx
+++ b/station/src/welcome/WelcomeScreen.tsx
@@ -3,6 +3,7 @@ import { useRenderer, useTerminalDimensions } from "@opentui/react";
 import { type ReactNode, useEffect, useState } from "react";
 import { normalizeStationMouseEvent, type StationMouseEvent } from "../input/mouse.js";
 import type { MouseTargetRef } from "../input/router.js";
+import { STATION_COLORS } from "../station/view/theme.js";
 import { lerpColor } from "../stationButton/colors.js";
 import { useHoverPointer } from "../useHoverPointer.js";
 
@@ -17,12 +18,12 @@ const OPEN_LABEL = "Open project view";
 const CONTINUE_LABEL = "Continue →";
 // Width fits the longest label so both stacked CTAs align.
 const MIN_BUTTON_WIDTH = OPEN_LABEL.length + 8;
-const BUTTON_BG = "#1f2937";
-const BUTTON_BG_MUTED = "#101316";
-const BUTTON_BG_HOVER = "#263142";
+const BUTTON_BG = STATION_COLORS.chrome.welcomeButton.background;
+const BUTTON_BG_MUTED = STATION_COLORS.chrome.welcomeButton.mutedBackground;
+const BUTTON_BG_HOVER = STATION_COLORS.chrome.welcomeButton.hoverBackground;
 // Soft, desaturated peak so the looping shimmer reads as a gentle light pass
 // rather than a saturated cyan band sweeping the label.
-export const WELCOME_BUTTON_SHIMMER_BG = "#4a6a8c";
+export const WELCOME_BUTTON_SHIMMER_BG = STATION_COLORS.chrome.welcomeButton.shimmerBackground;
 const SHIMMER_WIDTH = 6;
 const SHIMMER_INTERVAL_MS = 80;
 const FULL_WORDMARK = [
@@ -118,7 +119,7 @@ function WelcomeButton({
   const shimmerFrame = useShimmerFrame(shimmer && hovered);
   const pointerProps = useHoverPointer({ onHoverChange: setHovered });
   const active = focused || hovered;
-  const borderFg = active ? "#60a5fa" : "#3f4750";
+  const borderFg = active ? STATION_COLORS.blue : STATION_COLORS.chrome.mutedBorder;
   const onMouseDown = (event: MouseEvent): void => {
     event.stopPropagation();
     dispatchMouse(target, normalizeStationMouseEvent(event));
@@ -154,26 +155,26 @@ function welcomeLines(columns: number, rows: number): readonly WelcomeLine[] {
   const canRenderFull = columns >= FULL_WORDMARK[0].length + 4 && rows >= 13;
   if (canRenderFull) {
     return [
-      { text: "+------------------------------+", fg: "#3f4750" },
-      { text: "Welcome to", fg: "#a1a1aa" },
-      ...FULL_WORDMARK.map((text) => ({ text, fg: "#f4f4f5" })),
+      { text: "+------------------------------+", fg: STATION_COLORS.chrome.mutedBorder },
+      { text: "Welcome to", fg: STATION_COLORS.gray },
+      ...FULL_WORDMARK.map((text) => ({ text, fg: STATION_COLORS.foreground })),
     ];
   }
   if (rows >= 7) {
     return [
-      { text: "Welcome to", fg: "#a1a1aa" },
-      ...COMPACT_WORDMARK.map((text) => ({ text, fg: "#f4f4f5" })),
-      { text: "----------------", fg: "#60a5fa" },
+      { text: "Welcome to", fg: STATION_COLORS.gray },
+      ...COMPACT_WORDMARK.map((text) => ({ text, fg: STATION_COLORS.foreground })),
+      { text: "----------------", fg: STATION_COLORS.blue },
     ];
   }
   if (rows >= 5) {
     return [
-      { text: "Welcome to", fg: "#a1a1aa" },
-      ...COMPACT_WORDMARK.map((text) => ({ text, fg: "#f4f4f5" })),
+      { text: "Welcome to", fg: STATION_COLORS.gray },
+      ...COMPACT_WORDMARK.map((text) => ({ text, fg: STATION_COLORS.foreground })),
     ];
   }
   if (rows >= 4) {
-    return COMPACT_WORDMARK.map((text) => ({ text, fg: "#f4f4f5" }));
+    return COMPACT_WORDMARK.map((text) => ({ text, fg: STATION_COLORS.foreground }));
   }
   return [];
 }
@@ -204,10 +205,14 @@ function ShimmerLabel({
             : baseBg;
         const fg =
           intensity > 0
-            ? lerpColor("#f4f4f5", "#ffffff", intensity)
+            ? lerpColor(
+                STATION_COLORS.foreground,
+                STATION_COLORS.chrome.welcomeButton.shimmerForeground,
+                intensity,
+              )
             : focused
-              ? "#f4f4f5"
-              : "#a1a1aa";
+              ? STATION_COLORS.foreground
+              : STATION_COLORS.gray;
         return (
           // biome-ignore lint/suspicious/noArrayIndexKey: fixed-width static button label
           <text key={index} fg={fg} bg={bg} onMouseDown={onMouseDown}>

--- a/tools/lint/check-station-hex.mjs
+++ b/tools/lint/check-station-hex.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const roots = ["station/src", "packages/dashboard-core/src"];
+const rawHexStringPattern = /(["'`])#[0-9a-fA-F]{6}\1/g;
+
+const violations = [];
+
+for (const root of roots) {
+  walk(join(repoRoot, root), (filePath) => {
+    const relPath = relativePath(filePath);
+    if (!/\.(ts|tsx)$/.test(relPath) || allowsRawHex(relPath)) {
+      return;
+    }
+    const source = readFileSync(filePath, "utf8");
+    for (const match of source.matchAll(rawHexStringPattern)) {
+      const index = match.index ?? 0;
+      const { line, column } = locationForIndex(source, index);
+      violations.push(`${relPath}:${line}:${column} ${match[0]}`);
+    }
+  });
+}
+
+if (violations.length > 0) {
+  console.error("Raw Station chrome hex literals must live in station/src/station/view/theme.ts.");
+  console.error(violations.join("\n"));
+  process.exit(1);
+}
+
+function walk(dir, visit) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(path, visit);
+    } else if (entry.isFile()) {
+      visit(path);
+    }
+  }
+}
+
+function allowsRawHex(relPath) {
+  return (
+    relPath === "station/src/station/view/theme.ts" ||
+    relPath.startsWith("station/src/terminal/vt/") ||
+    relPath.includes("/__snapshots__/") ||
+    relPath.includes("/fixtures/") ||
+    /\.(test|spec)\.(ts|tsx)$/.test(relPath)
+  );
+}
+
+function locationForIndex(source, index) {
+  const prefix = source.slice(0, index);
+  const lines = prefix.split("\n");
+  return {
+    line: lines.length,
+    column: (lines.at(-1)?.length ?? 0) + 1,
+  };
+}
+
+function relativePath(filePath) {
+  return relative(repoRoot, filePath).replaceAll("\\", "/");
+}


### PR DESCRIPTION
## Summary
- centralize Station product-chrome palette ownership in `station/src/station/view/theme.ts`
- add dashboard-core semantic color/status/metadata tokens and route worktree row assembly through them
- add a raw Station chrome hex lint guard plus focused status/color coverage

## UX
No dashboard layout or workflow redesign. Ready/status/check/merged/chrome colors should remain legible while resolving through one Station theme palette.

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm --filter @station/dashboard-core typecheck`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/dashboard-core/test/unit/components/worktreeRow`
- `cd station && bun run typecheck`
- `cd station && bun test src/stationButton/DynamicStationButton.test.tsx src/station/connectionLabel.test.ts src/contextMenu/ContextMenuSurface.test.tsx src/welcome/WelcomeScreen.test.tsx src/terminal/PaneGrid.test.tsx src/terminal/TerminalPane.test.tsx src/station/view/dashboard.golden.test.tsx src/station/view/modals.golden.test.tsx`