### PR TITLE
refactor(theme): token foundation — hex-free core, unified resolver, no-raw-hex lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "typecheck": "turbo run typecheck",
-    "lint": "biome check . && node tools/lint/check-source-order.mjs",
+    "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs",
     "format": "biome format --write .",
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",

--- a/packages/dashboard-core/src/components/WorktreeRow/layout.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/layout.ts
@@ -1,8 +1,7 @@
 import stringWidth from "string-width";
 
-export const ROW_COLOR_PURPLE = "#d2a8ff";
-
-export type RowColor = "blue" | "gray" | "green" | "red" | "yellow" | typeof ROW_COLOR_PURPLE;
+// Semantic only — dashboard-core stays hex-free; view/theme.ts resolves to hex.
+export type RowColor = "blue" | "gray" | "green" | "red" | "yellow" | "purple";
 
 export type RowSegment =
   | {

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -1,6 +1,5 @@
 import type { WorktreeRow as WorktreeRowModel } from "@station/contracts";
 import {
-  ROW_COLOR_PURPLE,
   type RowColor,
   type RowGridCell,
   type RowGridCellImportance,
@@ -275,7 +274,7 @@ function checksStateGlyph(checks: NonNullable<WorktreeRowModel["worktree"]["chec
 }
 
 function prMetadataColor(pr: NonNullable<WorktreeRowModel["worktree"]["pr"]>): MetadataColor {
-  return pr.state === "merged" ? ROW_COLOR_PURPLE : "blue";
+  return pr.state === "merged" ? "purple" : "blue";
 }
 
 function failedChecksGlyph(count: number | undefined): string {
@@ -286,7 +285,7 @@ function checksStateColor(
   checks: NonNullable<WorktreeRowModel["worktree"]["checks"]>,
   pr: NonNullable<WorktreeRowModel["worktree"]["pr"]>,
 ): MetadataColor {
-  if (pr.state === "merged" && checks.state === "pass") return ROW_COLOR_PURPLE;
+  if (pr.state === "merged" && checks.state === "pass") return "purple";
   if (checks.state === "pass") return "green";
   if (checks.state === "fail" || checks.state === "cancelled") return "red";
   if (checks.state === "running") return "yellow";

--- a/station/src/contextMenu/ContextMenuSurface.tsx
+++ b/station/src/contextMenu/ContextMenuSurface.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from "@opentui/core";
 import { normalizeStationMouseEvent, type StationMouseEvent } from "../input/mouse.js";
 import type { MouseTargetRef } from "../input/router.js";
+import { MENU_COLORS } from "../station/view/theme.js";
 import type { ContextMenuItem } from "./types.js";
 
 export type ContextMenuSurfaceProps = {
@@ -10,13 +11,6 @@ export type ContextMenuSurfaceProps = {
   height: number;
   dispatchMouse: (target: MouseTargetRef, event: StationMouseEvent) => boolean;
 };
-
-const MENU_BACKGROUND = "#15191e";
-const ROW_ACTIVE = "#2f3842";
-const ROW_TEXT = "#f4f4f5";
-const ROW_DISABLED = "#7a828c";
-const ROW_DANGER = "#fca5a5";
-const BORDER_TEXT = "#5b6470";
 
 export function ContextMenuSurface({
   items,
@@ -31,14 +25,14 @@ export function ContextMenuSurface({
     <box
       width={width}
       height={height}
-      backgroundColor={MENU_BACKGROUND}
+      backgroundColor={MENU_COLORS.surface}
       flexDirection="column"
       overflow="hidden"
       onMouseDown={(event: MouseEvent) => {
         event.stopPropagation();
       }}
     >
-      <text fg={BORDER_TEXT}>{borderLine(contentWidth)}</text>
+      <text fg={MENU_COLORS.borderText}>{borderLine(contentWidth)}</text>
       {items.slice(0, visibleRows).map((item, index) => {
         const active = index === activeIndex;
         const disabled = item.disabled === true;
@@ -67,7 +61,7 @@ export function ContextMenuSurface({
             key={item.id}
             width="100%"
             height={1}
-            backgroundColor={active ? ROW_ACTIVE : MENU_BACKGROUND}
+            backgroundColor={active ? MENU_COLORS.selected : MENU_COLORS.surface}
             onMouseDown={onItemMouseDown}
             onMouseMove={onItemMouseMove}
           >
@@ -77,7 +71,7 @@ export function ContextMenuSurface({
           </box>
         );
       })}
-      <text fg={BORDER_TEXT}>{borderLine(contentWidth)}</text>
+      <text fg={MENU_COLORS.borderText}>{borderLine(contentWidth)}</text>
     </box>
   );
 }
@@ -88,9 +82,9 @@ function borderLine(width: number): string {
 
 function rowColor(item: ContextMenuItem, disabled: boolean): string {
   if (disabled) {
-    return ROW_DISABLED;
+    return MENU_COLORS.disabledText;
   }
-  return item.danger === true ? ROW_DANGER : ROW_TEXT;
+  return item.danger === true ? MENU_COLORS.danger : MENU_COLORS.text;
 }
 
 function fitLabel(label: string, width: number): string {

--- a/station/src/station/connectionLabel.ts
+++ b/station/src/station/connectionLabel.ts
@@ -1,14 +1,15 @@
 import type { StationClientConnectionState } from "@station/client";
+import { STATION_COLORS } from "./view/theme.js";
 
 export type StationConnectionPresentation = {
   label: string;
   color: string;
 };
 
-const CONNECTED_COLOR = "#4ade80";
-const WAITING_COLOR = "#fbbf24";
-const HALTED_COLOR = "#f87171";
-const IDLE_COLOR = "#9ca3af";
+const CONNECTED_COLOR = STATION_COLORS.green;
+const WAITING_COLOR = STATION_COLORS.yellow;
+const HALTED_COLOR = STATION_COLORS.red;
+const IDLE_COLOR = STATION_COLORS.gray;
 
 /**
  * Calm, static status copy: no spinners and no per-second timers. Failure

--- a/station/src/station/view/ToastOverlayView.tsx
+++ b/station/src/station/view/ToastOverlayView.tsx
@@ -4,7 +4,6 @@
 import { TextAttributes } from "@opentui/core";
 import {
   toastBorderColor,
-  type ToastBorderColorName,
   toastDetail,
   toastOverlayLayout,
   toastTextWidth,
@@ -12,7 +11,7 @@ import {
   truncateCells,
   type TuiToastEntry,
 } from "@station/dashboard-core";
-import { STATION_COLORS } from "./theme.js";
+import { STATION_COLORS, toastBorderColorHex } from "./theme.js";
 import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
 
 export type ToastOverlayViewProps = {
@@ -56,7 +55,7 @@ export function ToastOverlayView({
       height={layout.height}
       zIndex={20}
       border
-      borderColor={borderColorHex(toastBorderColor(toast))}
+      borderColor={toastBorderColorHex(toastBorderColor(toast))}
       backgroundColor={STATION_COLORS.background}
       flexDirection="column"
       {...stationMouseProps(dispatch, { kind: "toast" })}
@@ -72,14 +71,4 @@ export function ToastOverlayView({
       </box>
     </box>
   );
-}
-
-function borderColorHex(name: ToastBorderColorName): string {
-  if (name === "red") {
-    return STATION_COLORS.red;
-  }
-  if (name === "gray") {
-    return STATION_COLORS.gray;
-  }
-  return STATION_COLORS.green;
 }

--- a/station/src/station/view/settings/ProjectSettingsPanelView.tsx
+++ b/station/src/station/view/settings/ProjectSettingsPanelView.tsx
@@ -59,7 +59,7 @@ export function ProjectSettingsPanelView({
       height={height}
       zIndex={10}
       border
-      borderColor={STATION_COLORS.gray}
+      borderColor={STATION_COLORS.hairline}
       backgroundColor={STATION_COLORS.background}
       flexDirection="column"
       {...stationMouseProps(dispatch, { kind: "sheetBackdrop" })}

--- a/station/src/station/view/sheets/BottomSheetFrameView.tsx
+++ b/station/src/station/view/sheets/BottomSheetFrameView.tsx
@@ -46,7 +46,7 @@ export function BottomSheetFrameView({
       height={layout.height}
       zIndex={10}
       border
-      borderColor={STATION_COLORS.gray}
+      borderColor={STATION_COLORS.hairline}
       backgroundColor={STATION_COLORS.background}
       flexDirection="column"
       {...stationMouseProps(dispatch, { kind: "sheetBackdrop" })}

--- a/station/src/station/view/theme.ts
+++ b/station/src/station/view/theme.ts
@@ -1,9 +1,8 @@
-// Ink color-name -> hex tokens for the STATION view. The shared layout speaks
-// Ink's named RowColor vocabulary (plus the literal purple hex); OpenTUI
-// takes fg hex strings. Values match the terminal-ish palette the rest of
-// Station already uses.
-import { ROW_COLOR_PURPLE, type RowColor } from "@station/dashboard-core";
+// The single name -> hex resolver for the STATION view, and the one place in
+// station/src (outside terminal/*) allowed to hold raw hex — enforced by
+// tools/lint/check-no-raw-hex.mjs.
 import type { ProviderHealth } from "@station/contracts";
+import type { RowColor, ToastBorderColorName } from "@station/dashboard-core";
 
 export const STATION_COLORS = {
   gray: "#9ca3af",
@@ -12,11 +11,13 @@ export const STATION_COLORS = {
   green: "#4ade80",
   blue: "#60a5fa",
   cyan: "#22d3ee",
-  purple: ROW_COLOR_PURPLE,
+  purple: "#d2a8ff",
   foreground: "#e4e4e7",
   background: "#101316",
   hoverBackground: "#1f242b",
   overlayBackdrop: "#000000",
+  hairline: "#20252c",
+  frozenSurface: "#12161b",
 } as const;
 
 export function rowColorToHex(color: RowColor | undefined): string | undefined {
@@ -33,11 +34,30 @@ export function rowColorToHex(color: RowColor | undefined): string | undefined {
       return STATION_COLORS.green;
     case "blue":
       return STATION_COLORS.blue;
-    default:
-      // ROW_COLOR_PURPLE is already a hex literal.
-      return color;
+    case "purple":
+      return STATION_COLORS.purple;
   }
 }
+
+export function toastBorderColorHex(name: ToastBorderColorName): string {
+  if (name === "red") {
+    return STATION_COLORS.red;
+  }
+  if (name === "gray") {
+    return STATION_COLORS.gray;
+  }
+  return STATION_COLORS.green;
+}
+
+// Context-menu surface chrome.
+export const MENU_COLORS = {
+  surface: "#15191e",
+  selected: "#2f3842",
+  text: "#f4f4f5",
+  disabledText: "#7a828c",
+  danger: STATION_COLORS.red,
+  borderText: "#5b6470",
+} as const;
 
 const PROVIDER_HEALTH_STATUS_COLORS: Record<ProviderHealth["status"], string> = {
   healthy: STATION_COLORS.green,

--- a/station/src/stationButton/colors.ts
+++ b/station/src/stationButton/colors.ts
@@ -1,6 +1,7 @@
+import { STATION_COLORS } from "../station/view/theme.js";
+
 // Themeable color tokens for the station button. border/icon/text are separate
-// tokens though equal per state, so a theme can diverge them later. Independent
-// status palette (green=healthy, blue=peek, red=alert, purple=actionable).
+// tokens though equal per state, so a theme can diverge them later.
 export type StationButtonStateColors = {
   border: string;
   icon: string;
@@ -12,10 +13,12 @@ export type DynamicStationButtonColors = {
   attention: { collapsed: StationButtonStateColors; expanded: StationButtonStateColors };
 };
 
-const GREEN = "#22c55e";
-const BLUE = "#60a5fa"; // light, readable on the dark background
-const RED = "#ef4444";
-const PURPLE = "#c084fc"; // light + distinctly purple, clearly apart from the blue
+// green=rest, blue=expanded, red=alert, purple=actionable; the hover morph
+// lerps between the resting and expanded roles.
+const GREEN = STATION_COLORS.green;
+const BLUE = STATION_COLORS.blue;
+const RED = STATION_COLORS.red;
+const PURPLE = STATION_COLORS.purple;
 
 export const dynamicStationButtonColors: DynamicStationButtonColors = {
   base: {

--- a/tools/lint/check-no-raw-hex.mjs
+++ b/tools/lint/check-no-raw-hex.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+// Guardrail: station chrome resolves colour through the token hub
+// (station/src/station/view/theme.ts), never raw #rrggbb in the render layer.
+// biome ignores station/, so this can't be a biome rule.
+//
+// Allowed to hold raw hex (documented owners):
+//   - station/src/station/view/theme.ts  — the palette + resolver home
+//   - station/src/terminal/**            — the VT/xterm + pane palette owner
+//   - station/src/welcome/**             — reworked into the M3 Welcome in PR4
+// biome intentionally ignores station/, so this cannot be a biome rule.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const root = process.cwd();
+const ignoredDirs = new Set(["node_modules", "dist", ".turbo", "coverage"]);
+const allowedFiles = new Set(["station/src/station/view/theme.ts"]);
+const allowedDirs = ["station/src/terminal/", "station/src/welcome/"];
+const hexPattern = /#[0-9a-fA-F]{6}\b/;
+
+const targets = process.argv.slice(2);
+const roots = targets.length === 0 ? ["station/src"] : targets;
+
+let violations = 0;
+for (const target of roots) {
+  const absoluteTarget = join(root, target);
+  const files = statSync(absoluteTarget).isDirectory() ? walk(absoluteTarget) : [absoluteTarget];
+  for (const file of files) {
+    const rel = relative(root, file).split("\\").join("/");
+    if (shouldCheck(rel)) {
+      violations += checkFile(file, rel);
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `\nno-raw-hex: ${violations} raw colour literal(s) outside station/src/station/view/theme.ts.\n` +
+      "Move the value into STATION_COLORS (or a named token in theme.ts) and reference it by name.",
+  );
+  process.exitCode = 1;
+}
+
+function shouldCheck(rel) {
+  if (!/\.(ts|tsx)$/.test(rel) || /\.d\.ts$/.test(rel)) {
+    return false;
+  }
+  if (allowedFiles.has(rel)) {
+    return false;
+  }
+  return !allowedDirs.some((dir) => rel.startsWith(dir));
+}
+
+function checkFile(file, rel) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  let count = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    // Ignore hex that only appears in a comment (documentation, migration notes).
+    const code = line.replace(/\/\*.*?\*\//g, "").replace(/\/\/.*$/, "");
+    if (line.trimStart().startsWith("*")) {
+      continue;
+    }
+    const match = hexPattern.exec(code);
+    if (match !== null) {
+      count += 1;
+      console.error(`${rel}:${i + 1}:${match.index + 1} raw colour literal ${match[0]}`);
+    }
+  }
+  return count;
+}
+
+function walk(dir) {
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    if (ignoredDirs.has(name)) {
+      continue;
+    }
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) {
+      entries.push(...walk(path));
+    } else {
+      entries.push(path);
+    }
+  }
+  return entries.sort();
+}


### PR DESCRIPTION
PR1 of the Station UX upgrade (Atomics & Mockups). Formalizes the P2 token seam every later PR resolves through.

## What
- **dashboard-core is hex-free**: `RowColor` gains semantic `"purple"`; `ROW_COLOR_PURPLE` deleted. The render layer resolves it.
- **`theme.ts` is the sole name→hex resolver**: exhaustive `rowColorToHex`; add `hairline` (#20252c) + `frozenSurface` (#12161b) tokens; fold in the toast border resolver.
- **Drift collapsed onto `STATION_COLORS`**: island hues (D11), `connectionLabel`, context menu.
- **Frame borders** (sheet + settings) use the hairline token.
- **Guardrail**: `tools/lint/check-no-raw-hex.mjs` wired into `pnpm lint` (biome ignores station/).

## Deliberate scope (per plan)
Glyph registry → PR2; WelcomeScreen (reworked in PR4) and terminal-pane chrome are documented lint exclusions.

## Verify
vitest **195/195**; station typecheck clean; touched bun view/island tests **221 pass/0 fail**, snapshots unchanged (colour isn't in char-frames); full lint chain green. UX: island/pane hues 400-weight, sheet/settings borders hairline, menu danger = palette red.