### PR TITLE
feat(dashboard-core): status colour reinforcement — working→blue, calm→gray

### DIFF
--- a/packages/dashboard-core/src/components/WorktreeRow/layout.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/layout.ts
@@ -15,6 +15,7 @@ export type RowSegment =
   | {
       kind: "throbber";
       variant: "braille" | "circle";
+      color?: RowColor;
     };
 
 export type RowMarker =

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -26,6 +26,8 @@ export function worktreeRowGridInput({
   const displayTitle = title ?? row.branch;
   const activity = activityCellForRow(row);
   const ready = isReadyToRead(row);
+  const state = row.agent?.state ?? "none";
+  // Colour reinforces the glyph + status label; the session name stays foreground.
   const color = row.display.alert
     ? "red"
     : marker.kind === "text" && marker.text === "?"
@@ -47,13 +49,18 @@ export function worktreeRowGridInput({
   if (ready) {
     input.markerColor = "green";
     input.activityColor = "green";
+  } else if (state === "working") {
+    input.markerColor = "blue";
+    input.activityColor = "blue";
+  } else if (!row.display.alert && state !== "unknown") {
+    // Calm states (idle · starting · exited · no agent): status + agent recede to gray.
+    input.activityColor = "gray";
+    input.agentColor = "gray";
   }
-  return color === undefined
-    ? worktreeStyleRowGridInput(input)
-    : worktreeStyleRowGridInput({
-        ...input,
-        color,
-      });
+  if (color !== undefined) {
+    input.color = color;
+  }
+  return worktreeStyleRowGridInput(input);
 }
 
 export function worktreeStyleRowGridInput(input: {
@@ -68,6 +75,7 @@ export function worktreeStyleRowGridInput(input: {
   color?: RowColor;
   markerColor?: RowColor;
   activityColor?: RowColor;
+  agentColor?: RowColor;
   metadataGroups?: WorktreeRowMetadataGroups;
 }): RowGridRowInput {
   const cells: Partial<Record<RowGridCellKey, RowGridCell>> = {};
@@ -84,7 +92,7 @@ export function worktreeStyleRowGridInput(input: {
   if (input.agent !== undefined) {
     cells.agent = {
       key: "agent",
-      segments: [textSegment(input.agent, { color: input.color })],
+      segments: [textSegment(input.agent, { color: input.agentColor ?? input.color })],
       importance: "optional",
     };
   }
@@ -130,7 +138,12 @@ function identitySegments(
 ): RowSegment[] {
   const segments: RowSegment[] = [textSegment(` [${slot ?? " "}] `, { color })];
   if (marker.kind === "throbber") {
-    segments.push({ kind: "throbber", variant: marker.variant });
+    const throbberColor = markerColor ?? color;
+    segments.push(
+      throbberColor === undefined
+        ? { kind: "throbber", variant: marker.variant }
+        : { kind: "throbber", variant: marker.variant, color: throbberColor },
+    );
   } else {
     segments.push(textSegment(marker.text, { color: markerColor ?? color }));
   }

--- a/station/src/station/view/Throbber.tsx
+++ b/station/src/station/view/Throbber.tsx
@@ -1,12 +1,10 @@
 // OpenTUI port of apps/tui's Throbber: one shared module-level animation
 // clock (120ms) drives every throbber via useSyncExternalStore, so all
 // markers tick in lockstep and the interval stops when the last throbber
-// unmounts. Frame families and the attention style cycle match upstream.
+// unmounts. Frame families match upstream.
 import { memo, useCallback, useSyncExternalStore } from "react";
-import { TextAttributes } from "@opentui/core";
-import { STATION_COLORS } from "./theme.js";
 
-export type ThrobberVariant = "circle" | "braille" | "attention" | "dots";
+export type ThrobberVariant = "circle" | "braille" | "dots";
 
 const DEFAULT_INTERVAL_MS = 120;
 
@@ -25,24 +23,17 @@ const BRAILLE_FRAMES = [
 ] as const satisfies NonEmptyList<string>;
 const DOT_FRAMES = [".  ", ".. ", "..."] as const satisfies NonEmptyList<string>;
 
-export const Throbber = memo(function Throbber({ variant }: { variant: ThrobberVariant }) {
-  const frameTick = useAnimationTick(variant === "attention" ? 2 : 1);
-
-  if (variant === "attention") {
-    // Style pulse on a stable "!": dim -> normal -> bold -> normal.
-    const phase = positiveModulo(frameTick, 4);
-    const attributes =
-      phase === 0 ? TextAttributes.DIM : phase === 2 ? TextAttributes.BOLD : TextAttributes.NONE;
-    return (
-      <span fg={STATION_COLORS.red} attributes={attributes}>
-        !
-      </span>
-    );
-  }
-
+export const Throbber = memo(function Throbber({
+  variant,
+  fg,
+}: {
+  variant: ThrobberVariant;
+  fg?: string;
+}) {
+  const frameTick = useAnimationTick(1);
   const frames =
     variant === "dots" ? DOT_FRAMES : variant === "circle" ? CIRCLE_FRAMES : BRAILLE_FRAMES;
-  return <span>{cycle(frames, frameTick)}</span>;
+  return <span {...(fg === undefined ? {} : { fg })}>{cycle(frames, frameTick)}</span>;
 });
 
 type NonEmptyList<T> = readonly [T, ...T[]];

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -204,6 +204,37 @@ describe("dashboard golden frames", () => {
     expect(((prSpan?.attributes ?? 0) & TextAttributes.UNDERLINE) !== 0).toBe(true);
   });
 
+  it("colours working rows blue and calm rows gray, leaving the name foreground", async () => {
+    const setup = await renderDashboard({
+      width: 80,
+      height: 24,
+      snapshot: attentionAndFailuresSnapshot(),
+    });
+    const frame = setup.captureSpans();
+    const lines = setup.captureCharFrame().split("\n");
+
+    // Working row: the braille throbber (first frame ⠋) + the "working" label read
+    // blue; the session name is not swept into the status colour.
+    const workingRow = lines.findIndex((line) => line.includes("pr-info"));
+    expect(workingRow).toBeGreaterThan(0);
+    const throbberCol = lines[workingRow]?.indexOf("⠋") ?? -1;
+    expect(throbberCol).toBeGreaterThan(0);
+    expect(spanHex(spanAtFrameCell(frame, workingRow, throbberCol))).toBe(STATION_COLORS.blue);
+    const workingWordCol = lines[workingRow]?.indexOf("working") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, workingRow, workingWordCol))).toBe(STATION_COLORS.blue);
+    const workingNameCol = lines[workingRow]?.indexOf("pr-info") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, workingRow, workingNameCol))).not.toBe(STATION_COLORS.blue);
+
+    // Calm (exited) row: the status label recedes to gray; the name does not.
+    const exitedRow = lines.findIndex((line) => line.includes("done-run"));
+    expect(exitedRow).toBeGreaterThan(0);
+    const exitedWordCol = lines[exitedRow]?.indexOf("exited") ?? -1;
+    expect(exitedWordCol).toBeGreaterThan(0);
+    expect(spanHex(spanAtFrameCell(frame, exitedRow, exitedWordCol))).toBe(STATION_COLORS.gray);
+    const exitedNameCol = lines[exitedRow]?.indexOf("done-run") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, exitedRow, exitedNameCol))).not.toBe(STATION_COLORS.gray);
+  });
+
   it("routes PR number clicks through the link mouse target", async () => {
     const targets: StationMouseTarget[] = [];
     const setup = await renderDashboard({

--- a/station/src/station/view/segments.tsx
+++ b/station/src/station/view/segments.tsx
@@ -71,7 +71,8 @@ function SegmentLinkTarget({ link }: { link: SegmentLink }) {
 
 function Segment({ segment }: { segment: RowSegment }) {
   if (segment.kind === "throbber") {
-    return <Throbber variant={segment.variant} />;
+    const fg = rowColorToHex(segment.color);
+    return <Throbber variant={segment.variant} {...(fg === undefined ? {} : { fg })} />;
   }
   const attributes = textSegmentAttributes(segment);
   const fg = rowColorToHex(segment.color);


### PR DESCRIPTION
PR2 of the Station UX upgrade. Applies the two defined-but-unapplied colour rules; colour reinforces the glyph + status label, the session name stays foreground.

- **working → blue**: braille throbber glyph + `working` label (throbber segment gains a colour; `Throbber` gains an `fg` prop). Agent + name foreground.
- **calm → gray** (idle/starting/exited/no-agent): status label + agent column recede via a new `agentColor`; name + marker foreground.
- **retire the dead `attention` throbber variant** (no callers; rows are static per spec). Keeps braille/circle/dots.
- **golden assertions** lock working=blue, calm=gray, name-not-swept.

Deferred (Rule-of-Three): the glyph registry (statusMarker is already the single source; no drift) and a standalone atom-catalog screen (targeted assertions cover it).

vitest 195/195; typecheck clean; bun view/island/menu 75/75, char-snapshots unchanged; lint green.