### PR TITLE
fix(dashboard-core): reorder the row narrowing ladder to spec

### DIFF
--- a/packages/dashboard-core/src/components/WorktreeRow/layout.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/layout.ts
@@ -132,7 +132,8 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
       idealCells: 8,
       maxCells: 10,
       gapBefore: 2,
-      dropPriority: 30,
+      // Spec narrowing ladder: agent sheds before the status word (activity).
+      dropPriority: 40,
       align: "left",
       truncate: "end",
     },
@@ -143,7 +144,7 @@ export const DEFAULT_WORKTREE_ROW_GRID: RowGridConfig = {
       idealCells: 12,
       maxCells: 16,
       gapBefore: 2,
-      dropPriority: 40,
+      dropPriority: 30,
       align: "left",
       truncate: "end",
     },
@@ -200,7 +201,12 @@ export function layoutWorktreeRowGrid(input: {
   const config = input.config ?? DEFAULT_WORKTREE_ROW_GRID;
   const specs = config.columns;
   const rightSpec = specs.find((spec) => spec.key === "metadata");
+  const allLeftColumns = activeLeftColumnSets(config, input.rows);
+  const fullLeftSet = allLeftColumns[0] ?? [];
 
+  // Narrowing ladder (spec): keep the jump key, status glyph and session NAME
+  // intact, shedding lanes in order — diff, then PR (the metadata modes), then
+  // agent, then the status word (soft columns) — before ever truncating the name.
   for (const metadataMode of METADATA_MODES) {
     const metadata = input.rows.map((row) => metadataForMode(row, metadataMode));
     const rightReserve = Math.max(0, ...metadata.map((layout) => segmentsWidth(layout.segments)));
@@ -211,9 +217,10 @@ export function layoutWorktreeRowGrid(input: {
       continue;
     }
 
-    const activeSets = activeLeftColumnSets(config, input.rows);
-    const protectedKeys = meaningfulSoftColumnKeys(config, input.rows);
-    const desiredLayouts = layoutActiveSets({
+    // While any metadata remains, hold every left column; only once metadata is
+    // gone do we start dropping agent, then the status word.
+    const activeSets = metadataMode === "none" ? allLeftColumns : [fullLeftSet];
+    const layouts = layoutActiveSets({
       activeSets,
       columns,
       config,
@@ -221,29 +228,35 @@ export function layoutWorktreeRowGrid(input: {
       metadata,
       rows: input.rows,
       widthMode: "desired",
+      requireFullTitle: true,
     });
-    if (desiredLayouts !== undefined) {
-      return desiredLayouts;
+    if (layouts !== undefined) {
+      return layouts;
     }
+  }
 
-    const minimumSets =
-      protectedKeys.length === 0
-        ? activeSets
-        : activeSets
-            .filter((keys) => protectedKeys.every((key) => keys.includes(key)))
-            .sort((left, right) => left.length - right.length);
-    const minimumLayouts = layoutActiveSets({
-      activeSets: minimumSets,
-      columns,
-      config,
-      leftBudget,
-      metadata,
-      rows: input.rows,
-      widthMode: "minimum",
-    });
-    if (minimumLayouts !== undefined) {
-      return minimumLayouts;
-    }
+  // Last resort: nothing kept the name intact, so truncate the title with
+  // metadata gone and soft columns minimized (meaningful ones still protected).
+  const noneMetadata = input.rows.map((row) => metadataForMode(row, "none"));
+  const protectedKeys = meaningfulSoftColumnKeys(config, input.rows);
+  const minimumSets =
+    protectedKeys.length === 0
+      ? allLeftColumns
+      : allLeftColumns
+          .filter((keys) => protectedKeys.every((key) => keys.includes(key)))
+          .sort((left, right) => left.length - right.length);
+  const minimumLayouts = layoutActiveSets({
+    activeSets: minimumSets,
+    columns,
+    config,
+    leftBudget: columns,
+    metadata: noneMetadata,
+    rows: input.rows,
+    widthMode: "minimum",
+    requireFullTitle: false,
+  });
+  if (minimumLayouts !== undefined) {
+    return minimumLayouts;
   }
 
   return fallbackLayouts(columns, input.rows);
@@ -340,6 +353,7 @@ function layoutActiveSets(input: {
   metadata: readonly MetadataLayout[];
   rows: readonly RowGridRowInput[];
   widthMode: WidthMode;
+  requireFullTitle: boolean;
 }): RowGridLayout[] | undefined {
   for (const activeKeys of input.activeSets) {
     const widths = assignLeftWidths({
@@ -348,6 +362,7 @@ function layoutActiveSets(input: {
       leftBudget: input.leftBudget,
       rows: input.rows,
       widthMode: input.widthMode,
+      requireFullTitle: input.requireFullTitle,
     });
     if (widths === undefined) {
       continue;
@@ -421,6 +436,7 @@ function assignLeftWidths(input: {
   leftBudget: number;
   rows: readonly RowGridRowInput[];
   widthMode: WidthMode;
+  requireFullTitle: boolean;
 }): Map<RowGridCellKey, number> | undefined {
   const activeSpecs = sortKeysByConfig(input.config, [...input.activeKeys]).map((key) =>
     requiredSpec(input.config, key),
@@ -464,6 +480,10 @@ function assignLeftWidths(input: {
     const available = remaining - laterMin;
     const min = normalizeCells(spec.minCells);
     if (available < min) {
+      return undefined;
+    }
+    // Title priority: fail (so an upstream lane sheds) rather than truncate the name.
+    if (input.requireFullTitle && available < flexDesiredWidth(spec, input.rows)) {
       return undefined;
     }
     const max = spec.maxCells === undefined ? available : normalizeCells(spec.maxCells);
@@ -788,6 +808,18 @@ function desiredSoftColumnWidth(spec: RowGridColumnSpec, rows: readonly RowGridR
     return desired;
   }
   return Math.min(desired, normalizeCells(spec.maxCells));
+}
+
+// Width the flex title needs to show its content untruncated (clamped to the
+// column's min/max). Used to keep the name intact until droppable lanes shed.
+function flexDesiredWidth(spec: RowGridColumnSpec, rows: readonly RowGridRowInput[]): number {
+  const content = Math.max(
+    0,
+    ...rows.map((row) => segmentsWidth(row.cells[spec.key]?.segments ?? [])),
+  );
+  const min = normalizeCells(spec.minCells);
+  const max = spec.maxCells === undefined ? content : normalizeCells(spec.maxCells);
+  return Math.min(max, Math.max(min, content));
 }
 
 function fixedColumnWidth(spec: RowGridColumnSpec): number {

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -77,15 +77,15 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 ─────────────────────────────────────────────────────────── 
                                                             
 ▼ station - 5 worktrees                       [sh] [qs] [▾] 
- [1] ○ cli-…  codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs…  -         no agent                    [shell] 
- [3] ○ pty-…  codex     idle                  #73 ✓ [shell] 
- [4] + sess…  codex     starting                    [shell] 
- [5] ⠋ stat…  codex     working      +412 -96 #76 … [shell] 
+ [1] ○ cli-help-man          codex     idle         [shell] 
+ [2] - docs-cleanup          -         no agent     [shell] 
+ [3] ○ pty-buffer            codex     idle         [shell] 
+ [4] + session-resume        codex     starting     [shell] 
+ [5] ⠋ station-overlay       codex     working      [shell] 
                                                             
 ▼ observer - 3 worktrees                      [sh] [qs] [▾] 
- [6] x batc…  opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ prov…  opencode  working        +32 -8 #16 … [shell] 
+ [6] x batch-export          opencode  exited       [shell] 
+ [7] ⠋ provider-hooks        opencode  working      [shell] 
 ↓ 9 hidden                                                  
 ─────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
@@ -97,11 +97,11 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 ─────────────────────────────────────── 
                                         
 ▼ station - 5 worktrees   [sh] [qs] [▾] 
- [1] ○ cli-help…   +14 -6 #70 ✓ [shell] 
- [2] - docs-cle…                [shell] 
- [3] ○ pty-buff…          #73 ✓ [shell] 
- [4] + session-…                [shell] 
- [5] ⠋ station-… +412 -96 #76 … [shell] 
+ [1] ○ cli-help-man             [shell] 
+ [2] - docs-cleanup             [shell] 
+ [3] ○ pty-buffer               [shell] 
+ [4] + session-resume           [shell] 
+ [5] ⠋ station-overlay          [shell] 
 ↓ 13 hidden                             
 ─────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/… 
@@ -185,14 +185,14 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 ─────────────────────────────────────────────────────────── 
                                                             
 ▼ station - 4 worktrees                       [sh] [qs] [▾] 
- [1] ! hook-scope   Agent needs appro… +8 -2 #12 x2 [shell] 
- [2] ? metadata-r…  unknown                   +3 -1 [shell] 
- [3] ! popup-late…  No progress was… +120 -44 #13 … [shell] 
- [4] ⠋ pr-info      working                   #11 ✓ [shell] 
+ [1] ! hook-scope        codex     Agent needs app… [shell] 
+ [2] ? metadata-refresh  codex     unknown          [shell] 
+ [3] ! popup-latency     codex     No progress was… [shell] 
+ [4] ⠋ pr-info           codex     working          [shell] 
                                                             
 ▼ observer - 2 worktrees                      [sh] [qs] [▾] 
- [5] x done-run     exited                          [shell] 
- [6] ! sqlite-cle…  Agent needs appro… +19 -2 #6 x1 [shell] 
+ [5] x done-run          opencode  exited           [shell] 
+ [6] ! sqlite-cleanup    opencode  Agent needs app… [shell] 
                                                             
                                                             
 ─────────────────────────────────────────────────────────── 
@@ -205,10 +205,10 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 ─────────────────────────────────────── 
                                         
 ▼ station - 4 worktrees   [sh] [qs] [▾] 
- [1] ! hook-sco…   +8 -2 #12 x2 [shell] 
- [2] ? metadata…          +3 -1 [shell] 
- [3] ! popup-la… +120 -44 #13 … [shell] 
- [4] ⠋ pr-info            #11 ✓ [shell] 
+ [1] ! hook-scope               [shell] 
+ [2] ? metadata-refresh         [shell] 
+ [3] ! popup-latency            [shell] 
+ [4] ⠋ pr-info                  [shell] 
                                         
 ↓ 3 hidden                              
 ─────────────────────────────────────── 


### PR DESCRIPTION
PR3 of the Station UX upgrade. Corrects the inverted narrowing ladder so identity + session name survive longest.

**Before → after** (many-projects, 40×12):
```
BEFORE   [1] ○ cli-help…   +14 -6 #70 ✓ [shell]
AFTER    [1] ○ cli-help-man             [shell]
```

Drop order is now spec: **diff → PR → agent → status word → truncate name last**; jump key / status glyph / name never dropped.

- metadata (diff→PR) degrades before dropping left columns (was an outer loop after left-min)
- `requireFullTitle` pass: the flex title fails (shedding an upstream lane) rather than truncating, until every droppable lane is gone
- agent/activity drop-priority swapped so agent sheds before the status word

Only the 4 narrow frames change (60×16, 40×12); 80×24 + 120×40 identical. vitest 195/195; typecheck clean; bun view 41/41; lint green. Product-signed-off.