### PR TITLE
feat(dashboard): fleet summary bar + session relabel, drop per-row shell

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -96,11 +96,21 @@ function widgetStrip(widgets: readonly TopRowWidgetText[], visibleCount: number)
 }
 
 export function projectHeaderLabel(project: ProjectView, collapsed: boolean): string {
-  return `${collapsed ? "▶" : "▼"} ${project.label} - ${project.counts.worktrees} worktrees`;
+  const caret = collapsed ? "▶" : "▼";
+  const sessions = `${project.counts.worktrees} ${plural(project.counts.worktrees, "session")}`;
+  const agents =
+    project.counts.agents > 0
+      ? ` · ${project.counts.agents} ${plural(project.counts.agents, "agent")}`
+      : "";
+  return `${caret} ${project.label}  ${sessions}${agents}`;
 }
 
-export function emptyProjectLabel(project: ProjectView): string {
-  return ` ${project.counts.worktrees} worktrees`;
+export function emptyProjectLabel(): string {
+  return " no sessions yet · press A to add one";
+}
+
+function plural(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
 }
 
 export const FIRST_RUN_BODY_LABEL = "No projects configured yet.";

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -1,5 +1,6 @@
 export const DASHBOARD_FIXED_ROW_HEIGHTS = {
   header: 1,
+  fleetBar: 1,
   topDivider: 1,
   topScrollIndicator: 1,
   bottomScrollIndicator: 1,

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -185,7 +185,7 @@ export function statusMarker(row: WorktreeRowModel): RowMarker {
   return { kind: "text", text: "-" };
 }
 
-function isReadyToRead(row: WorktreeRowModel): boolean {
+export function isReadyToRead(row: WorktreeRowModel): boolean {
   return row.agent?.state === "idle" && row.agent.turnReadiness?.state === "ready_to_read";
 }
 

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -18,6 +18,7 @@ export * from "./flows/newSession.js";
 export * from "./flows/stepWizard.js";
 export * from "./selectors/dashboardViewport.js";
 export * from "./selectors/featureFlags.js";
+export * from "./selectors/fleetSummary.js";
 export * from "./selectors/selectors.js";
 export * from "./services/errors/errors.js";
 export * from "./services/folderService.js";

--- a/packages/dashboard-core/src/selectors/fleetSummary.ts
+++ b/packages/dashboard-core/src/selectors/fleetSummary.ts
@@ -1,0 +1,49 @@
+import type { StationSnapshot } from "@station/contracts";
+import { isReadyToRead } from "../components/WorktreeRow/rowInput.js";
+
+// Fleet triage counts derived client-side: the observer's snapshot.counts carry
+// only working/idle/attention/unknown and fold "ready" into idle, so the fleet
+// bar computes the full disjoint breakdown from the rows. "needsYou" = attention
+// OR stuck (snapshot.counts.attention deliberately excludes stuck).
+export type FleetSummary = {
+  ready: number;
+  working: number;
+  needsYou: number;
+  idle: number;
+  starting: number;
+  exited: number;
+  unknown: number;
+};
+
+export function selectFleetSummary(snapshot: StationSnapshot): FleetSummary {
+  const summary: FleetSummary = {
+    ready: 0,
+    working: 0,
+    needsYou: 0,
+    idle: 0,
+    starting: 0,
+    exited: 0,
+    unknown: 0,
+  };
+  for (const row of snapshot.rows) {
+    const state = row.agent?.state;
+    if (state === "needs_attention" || state === "stuck") {
+      summary.needsYou += 1;
+    } else if (state === "working") {
+      summary.working += 1;
+    } else if (isReadyToRead(row)) {
+      summary.ready += 1;
+    } else if (state === "idle") {
+      summary.idle += 1;
+    } else if (state === "starting") {
+      summary.starting += 1;
+    } else if (state === "exited") {
+      summary.exited += 1;
+    } else if (state === "unknown") {
+      summary.unknown += 1;
+    }
+    // No agent (state === undefined) is a session without a harness — not a
+    // fleet-status lane, so it is intentionally uncounted.
+  }
+  return summary;
+}

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -38,15 +38,15 @@ describe("dashboard viewport selector", () => {
     });
     const viewport = selectDashboardViewport(snapshot, state);
 
-    expect(viewport.bodyRows).toBe(4);
+    expect(viewport.bodyRows).toBe(3);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(6);
+    expect(viewport.hiddenBelow).toBe(7);
     expect(
       viewport.visibleItems.map((item) =>
         item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited", "wt_web_no_agent"]);
+    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
   });
 
   it("uses only viewport-visible worktrees for row choices", () => {
@@ -61,7 +61,6 @@ describe("dashboard viewport selector", () => {
       ["1", "wt_web_no_agent"],
       ["2", "wt_web_idle"],
       ["3", "wt_web_unknown"],
-      ["4", "wt_web_stuck"],
     ]);
   });
 
@@ -75,8 +74,8 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(7);
-    expect(viewport.hiddenAbove).toBe(7);
+    expect(viewport.clampedScrollOffset).toBe(8);
+    expect(viewport.hiddenAbove).toBe(8);
     expect(viewport.hiddenBelow).toBe(0);
     expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
   });

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -50,7 +50,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", downArrow: true }).state.scrollOffset).toBe(7);
+    expect(handleTuiKey(state, { input: "", downArrow: true }).state.scrollOffset).toBe(8);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", upArrow: true }).state.scrollOffset,
     ).toBe(0);
@@ -675,6 +675,6 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.collapsedProjectIds.has("web")).toBe(true);
-    expect(transition.state.scrollOffset).toBe(0);
+    expect(transition.state.scrollOffset).toBe(1);
   });
 });

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -45,8 +45,8 @@ describe("Station app composition", () => {
 
     station.setup.mockInput.pressKey("o", { ctrl: true });
     await waitFor(() => overlayVisible(station));
-    expect(await waitForFrame(station, (frame) => frame.includes("station - 5 worktrees"))).toContain(
-      "station - 5 worktrees",
+    expect(await waitForFrame(station, (frame) => frame.includes("station  5 sessions"))).toContain(
+      "station  5 sessions",
     );
 
     await station.setup.mockInput.typeText("blocked");
@@ -207,8 +207,8 @@ describe("Station app composition", () => {
 
     station.composition.stationInput.dispatchMouse({ kind: "welcomeOpenProjectView" }, LEFT_DOWN);
     await waitFor(() => overlayVisible(station));
-    expect(await waitForFrame(station, (frame) => frame.includes("station - 5 worktrees"))).toContain(
-      "station - 5 worktrees",
+    expect(await waitForFrame(station, (frame) => frame.includes("station  5 sessions"))).toContain(
+      "station  5 sessions",
     );
     expect(station.spawnCount()).toBe(0);
 

--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -94,7 +94,9 @@ describe("StationOverlay", () => {
     });
     const frame = setup.captureCharFrame();
     const lines = frame.split("\n");
-    const row = lines.findIndex((line) => line.includes("working"));
+    // Exclude the pinned FLEET bar (which also contains "working") so we target
+    // an actual working session row.
+    const row = lines.findIndex((line) => line.includes("working") && !line.includes("FLEET"));
     const col = lines[row]?.indexOf("working") ?? -1;
     expect(row).toBeGreaterThan(0);
     expect(col).toBeGreaterThan(0);

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -52,7 +52,9 @@ const SCROLL_UP: StationMouseEvent = {
 };
 
 function makeStore(snapshot?: StationSnapshot): StoreApi<TuiStore> {
-  return makeStationTestStore({ terminalRows: 12, ...(snapshot === undefined ? {} : { snapshot }) })
+  // 13 rows keeps the same visible window as before the pinned fleet bar (which
+  // consumes one body row) so the station-project rows stay slot-addressable.
+  return makeStationTestStore({ terminalRows: 13, ...(snapshot === undefined ? {} : { snapshot }) })
     .store;
 }
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -23,7 +23,9 @@ import {
 import {
   QUIT_HINT_CLOSE,
   selectDashboardViewport,
+  selectFleetSummary,
   type DashboardViewportItem,
+  type FleetSummary,
 } from "@station/dashboard-core";
 import type { TuiViewState } from "@station/dashboard-core";
 import type { StationMouseTarget } from "../input/stationMouse.js";
@@ -77,6 +79,7 @@ export function DashboardView({
   const viewport = selectDashboardViewport(snapshot, viewState);
   const contentColumns = Math.max(1, Math.floor(columns) - 1);
   const firstRun = snapshot.projects.length === 0;
+  const fleet = selectFleetSummary(snapshot);
   return (
     <box
       width="100%"
@@ -90,6 +93,7 @@ export function DashboardView({
         widgets={topRowWidgets}
         {...(observerStatus === undefined ? {} : { status: observerStatus })}
       />
+      {firstRun ? null : <FleetBar summary={fleet} />}
       <Divider columns={contentColumns} />
       <ScrollIndicatorRow direction="above" hiddenCount={viewport.hiddenAbove} />
       {firstRun ? (
@@ -143,6 +147,37 @@ export function Divider({ columns }: { columns: number }) {
   return <text fg={STATION_COLORS.gray}>{"─".repeat(Math.max(1, columns))}</text>;
 }
 
+// Pinned fleet triage bar: glyph + colour reinforce each status lane. ready/
+// working/needs-you/idle always show; unknown/exited appear only when non-zero.
+function FleetBar({ summary }: { summary: FleetSummary }) {
+  const parts: { glyph: string; color: string; label: string }[] = [
+    { glyph: "●", color: STATION_COLORS.green, label: `${summary.ready} ready` },
+    { glyph: "⠿", color: STATION_COLORS.blue, label: `${summary.working} working` },
+    { glyph: "!", color: STATION_COLORS.red, label: `${summary.needsYou} needs you` },
+    { glyph: "○", color: STATION_COLORS.gray, label: `${summary.idle} idle` },
+  ];
+  if (summary.unknown > 0) {
+    parts.push({ glyph: "?", color: STATION_COLORS.yellow, label: `${summary.unknown} unknown` });
+  }
+  if (summary.exited > 0) {
+    parts.push({ glyph: "x", color: STATION_COLORS.gray, label: `${summary.exited} exited` });
+  }
+  return (
+    <box height={1} width="100%" backgroundColor={STATION_COLORS.frozenSurface} overflow="hidden">
+      <text fg={STATION_COLORS.gray}>
+        <span attributes={TextAttributes.BOLD}>FLEET</span>
+        {parts.map((part) => (
+          <span key={part.label}>
+            {"  "}
+            <span fg={part.color}>{part.glyph}</span>
+            {` ${part.label}`}
+          </span>
+        ))}
+      </text>
+    </box>
+  );
+}
+
 function ScrollIndicatorRow({
   direction,
   hiddenCount,
@@ -181,10 +216,10 @@ function DashboardBody({
     const input = rowGridInputForViewportItem(item, keyByRow);
     return input === undefined ? [] : [input];
   });
-  // Lay rows out one affordance-width narrower so every row reserves the same
-  // right-hand column for `[+sh]`; rows keep their alignment whether or not
-  // the trailing affordance renders (worktree rows have it, create rows don't).
-  const gridColumns = Math.max(1, columns - SHELL_AFFORDANCE_WIDTH);
+  // Rows use the full content width: the per-row [shell] affordance was removed
+  // (it lives on the project header now), so the diff/PR metadata reclaims the
+  // right-hand column that used to be reserved for it.
+  const gridColumns = Math.max(1, columns);
   const rowLayouts = layoutWorktreeRowGrid({ columns: gridColumns, rows: rowInputs });
   const layoutByItem = new Map(rowLayouts.map((layout) => [layout.id, layout]));
   return (
@@ -216,7 +251,7 @@ function DashboardViewportRow({
     case "projectHeader":
       return <ProjectHeaderLine columns={columns} project={item.project} collapsed={item.collapsed} />;
     case "emptyProject":
-      return <text fg={STATION_COLORS.gray}>{truncateCells(emptyProjectLabel(item.project), columns)}</text>;
+      return <text fg={STATION_COLORS.gray}>{truncateCells(emptyProjectLabel(), columns)}</text>;
     case "worktree":
       return layout === undefined ? null : (
         <WorktreeRowLine rowId={item.row.id} layout={layout} />
@@ -251,7 +286,6 @@ function WorktreeRowLine({ rowId, layout }: { rowId: string; layout: RowGridLayo
         </text>
         <SegmentLinkTargets segments={layout.segments} />
       </box>
-      <ShellAffordance target={{ kind: "openShellForRow", rowId }} onHoverChange={setHover} />
     </box>
   );
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -2,27 +2,27 @@
 
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-overlay            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
- [b] - old-experiment             -         no agent                    [shell] 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
                                                                                 
-▼ empty-project - 0 worktrees                                     [sh] [qs] [▾] 
-↓ 1 hidden                                                                      
+↓ 2 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -30,28 +30,28 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "station                                                                                                                 
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
-▼ station - 5 worktrees                                                                     [shell] [quick session] [▾] 
- [1] ○ cli-help-man                              codex     idle                                    +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup                              -         no agent                                             [shell] 
- [3] ○ pty-buffer                                codex     idle                                           #73 ✓ [shell] 
- [4] + session-resume                            codex     starting                                             [shell] 
- [5] ⠋ station-overlay                           codex     working                               +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
+ [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
+ [2] - docs-cleanup                              -         no agent                                                     
+ [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
+ [4] + session-resume                            codex     starting                                                     
+ [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
                                                                                                                         
-▼ observer - 3 worktrees                                                                    [shell] [quick session] [▾] 
- [6] x batch-export                              opencode  exited                                          #8 ✓ [shell] 
- [7] ⠋ provider-hooks                            opencode  working                                 +32 -8 #16 … [shell] 
- [8] ○ trace-bundle                              opencode  idle                                      +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                                           [shell] [quick session] [▾] 
+ [6] x batch-export                              opencode  exited                                                  #8 ✓ 
+ [7] ⠋ provider-hooks                            opencode  working                                         +32 -8 #16 … 
+ [8] ○ trace-bundle                              opencode  idle                                              +1 -1 #4 ✓ 
                                                                                                                         
-▼ scripts - 3 worktrees                                                                     [shell] [quick session] [▾] 
- [9] ○ api-cache                                 opencode  idle                                    +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh                          opencode  unknown                                    +3 -1 #10 [shell] 
- [b] - old-experiment                            -         no agent                                             [shell] 
+▼ scripts  3 sessions · 2 agents                                                            [shell] [quick session] [▾] 
+ [9] ○ api-cache                                 opencode  idle                                            +14 -6 #5 x1 
+ [a] ? metadata-refresh                          opencode  unknown                                            +3 -1 #10 
+ [b] - old-experiment                            -         no agent                                                     
                                                                                                                         
-▼ empty-project - 0 worktrees                                                               [shell] [quick session] [▾] 
- 0 worktrees                                                                                                            
-                                                                                                                        
+▼ empty-project  0 sessions                                                                 [shell] [quick session] [▾] 
+ no sessions yet · press A to add one                                                                                   
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -74,19 +74,19 @@ N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:f
 
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 "station                                                     
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ?   
 ─────────────────────────────────────────────────────────── 
                                                             
-▼ station - 5 worktrees                       [sh] [qs] [▾] 
- [1] ○ cli-help-man          codex     idle         [shell] 
- [2] - docs-cleanup          -         no agent     [shell] 
- [3] ○ pty-buffer            codex     idle         [shell] 
- [4] + session-resume        codex     starting     [shell] 
- [5] ⠋ station-overlay       codex     working      [shell] 
+▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
+ [1] ○ cli-help-man            codex     idle         #70 ✓ 
+ [2] - docs-cleanup            -         no agent           
+ [3] ○ pty-buffer              codex     idle         #73 ✓ 
+ [4] + session-resume          codex     starting           
+ [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
-▼ observer - 3 worktrees                      [sh] [qs] [▾] 
- [6] x batch-export          opencode  exited       [shell] 
- [7] ⠋ provider-hooks        opencode  working      [shell] 
-↓ 9 hidden                                                  
+▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
+ [6] x batch-export            opencode  exited        #8 ✓ 
+↓ 10 hidden                                                 
 ─────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
 "
@@ -94,15 +94,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se…
 
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 "station                                 
+FLEET  ● 0 ready  ⠿ 2 working  ! 0      
 ─────────────────────────────────────── 
                                         
-▼ station - 5 worktrees   [sh] [qs] [▾] 
- [1] ○ cli-help-man             [shell] 
- [2] - docs-cleanup             [shell] 
- [3] ○ pty-buffer               [shell] 
- [4] + session-resume           [shell] 
- [5] ⠋ station-overlay          [shell] 
-↓ 13 hidden                             
+▼ station  5 sessions · … [sh] [qs] [▾] 
+ [1] ○ cli-help-man        idle         
+ [2] - docs-cleanup        no agent     
+ [3] ○ pty-buffer          idle         
+ [4] + session-resume      starting     
+↓ 14 hidden                             
 ─────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/… 
 "
@@ -110,18 +110,18 @@ Q/esc:close N:new A:add Z:refresh 1-9/…
 
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 4 worktrees                                           [sh] [qs] [▾] 
- [1] ! hook-scope             codex     Agent needs appro… +8 -2 #12 x2 [shell] 
- [2] ? metadata-refresh       codex     unknown                   +3 -1 [shell] 
- [3] ! popup-latency          codex     No progress was… +120 -44 #13 … [shell] 
- [4] ⠋ pr-info                codex     working                   #11 ✓ [shell] 
+▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
+ [2] ? metadata-refresh               codex     unknown                   +3 -1 
+ [3] ! popup-latency                  codex     No progress was… +120 -44 #13 … 
+ [4] ⠋ pr-info                        codex     working                   #11 ✓ 
                                                                                 
-▼ observer - 2 worktrees                                          [sh] [qs] [▾] 
- [5] x done-run               opencode  exited                          [shell] 
- [6] ! sqlite-cleanup         opencode  Agent needs appro… +19 -2 #6 x1 [shell] 
-                                                                                
+▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
+ [5] x done-run                       opencode  exited                          
+ [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
                                                                                 
                                                                                 
                                                                                 
@@ -138,18 +138,18 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
 "station                                                                                                                 
+FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
-▼ station - 4 worktrees                                                                     [shell] [quick session] [▾] 
- [1] ! hook-scope                                codex     Agent needs approval.                   +8 -2 #12 x2 [shell] 
- [2] ? metadata-refresh                          codex     unknown                                        +3 -1 [shell] 
- [3] ! popup-latency                             codex     No progress was observed recently.    +120 -44 #13 … [shell] 
- [4] ⠋ pr-info                                   codex     working                                        #11 ✓ [shell] 
+▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
+ [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
+ [2] ? metadata-refresh                          codex     unknown                                                +3 -1 
+ [3] ! popup-latency                             codex     No progress was observed recently.            +120 -44 #13 … 
+ [4] ⠋ pr-info                                   codex     working                                                #11 ✓ 
                                                                                                                         
-▼ observer - 2 worktrees                                                                    [shell] [quick session] [▾] 
- [5] x done-run                                  opencode  exited                                               [shell] 
- [6] ! sqlite-cleanup                            opencode  Agent needs approval.                   +19 -2 #6 x1 [shell] 
-                                                                                                                        
+▼ observer  2 sessions · 2 agents                                                           [shell] [quick session] [▾] 
+ [5] x done-run                                  opencode  exited                                                       
+ [6] ! sqlite-cleanup                            opencode  Agent needs approval.                           +19 -2 #6 x1 
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -182,18 +182,18 @@ N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:f
 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 "station                                                     
+FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ?   
 ─────────────────────────────────────────────────────────── 
                                                             
-▼ station - 4 worktrees                       [sh] [qs] [▾] 
- [1] ! hook-scope        codex     Agent needs app… [shell] 
- [2] ? metadata-refresh  codex     unknown          [shell] 
- [3] ! popup-latency     codex     No progress was… [shell] 
- [4] ⠋ pr-info           codex     working          [shell] 
+▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
+ [1] ! hook-scope         codex     Agent needs app… #12 x2 
+ [2] ? metadata-refresh   codex     unknown                 
+ [3] ! popup-latency      codex     No progress was … #13 … 
+ [4] ⠋ pr-info            codex     working           #11 ✓ 
                                                             
-▼ observer - 2 worktrees                      [sh] [qs] [▾] 
- [5] x done-run          opencode  exited           [shell] 
- [6] ! sqlite-cleanup    opencode  Agent needs app… [shell] 
-                                                            
+▼ observer  2 sessions · 2 agents             [sh] [qs] [▾] 
+ [5] x done-run           opencode  exited                  
+ [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
                                                             
 ─────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
@@ -202,15 +202,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se…
 
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 "station                                 
+FLEET  ● 0 ready  ⠿ 1 working  ! 3      
 ─────────────────────────────────────── 
                                         
-▼ station - 4 worktrees   [sh] [qs] [▾] 
- [1] ! hook-scope               [shell] 
- [2] ? metadata-refresh         [shell] 
- [3] ! popup-latency            [shell] 
- [4] ⠋ pr-info                  [shell] 
-                                        
-↓ 3 hidden                              
+▼ station  4 sessions · … [sh] [qs] [▾] 
+ [1] ! hook-scope                       
+ [2] ? metadata-refresh                 
+ [3] ! popup-latency                    
+ [4] ⠋ pr-info                          
+↓ 4 hidden                              
 ─────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/… 
 "

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -2,27 +2,27 @@
 
 exports[`modal flow golden frames renders the help overlay 1`] = `
 "station                                                                         
-─────────────────────────────────────────────────────────────────────────────── 
-        ╭──────────────────────────────────────────────────────────────╮        
-▼ statio│                         station help                         │qs] [▾] 
- [1] ○ c│                                                              │[shell] 
- [2] - d│  Ctrl-O     open/close project view                          │[shell] 
- [3] ○ p│  Ctrl-Q     quit Station                                     │[shell] 
- [4] + s│  Ctrl-\\     split pane right                                 │[shell] 
- [5] ⠋ s│  Ctrl-^     split pane below (Ctrl-6)                        │[shell] 
-        │  Ctrl-]     focus next pane                                  │        
-▼ observ│  Ctrl-/     close split pane (Ctrl-_)                        │qs] [▾] 
- [6] x b│  Enter/Sp   open project view on welcome                     │[shell] 
- [7] ⠋ p│  Esc/↑↓     context menu close/move                          │[shell] 
- [8] ○ t│  Enter/Sp   context menu select                              │[shell] 
-        │                     station project view                     │        
-▼ script│  ↑/↓ wheel  scroll project list                              │qs] [▾] 
- [9] ○ a│  1-9/a-z    start or focus row                               │[shell] 
- [a] ? m│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │[shell] 
- [b] - o│  X          delete session                                   │[shell] 
-        │  /, Z       search / refresh snapshot                        │        
-▼ empty-│  H/?        help                                             │qs] [▾] 
-↓ 1 hidd╰──────────────────────────────────────────────────────────────╯        
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+────────╭──────────────────────────────────────────────────────────────╮─────── 
+        │                         station help                         │        
+▼ statio│                                                              │qs] [▾] 
+ [1] ○ c│  Ctrl-O     open/close project view                          │6 #70 ✓ 
+ [2] - d│  Ctrl-Q     quit Station                                     │        
+ [3] ○ p│  Ctrl-\\     split pane right                                 │  #73 ✓ 
+ [4] + s│  Ctrl-^     split pane below (Ctrl-6)                        │        
+ [5] ⠋ s│  Ctrl-]     focus next pane                                  │6 #76 … 
+        │  Ctrl-/     close split pane (Ctrl-_)                        │        
+▼ observ│  Enter/Sp   open project view on welcome                     │qs] [▾] 
+ [6] x b│  Esc/↑↓     context menu close/move                          │   #8 ✓ 
+ [7] ⠋ p│  Enter/Sp   context menu select                              │8 #16 … 
+ [8] ○ t│                     station project view                     │-1 #4 ✓ 
+        │  ↑/↓ wheel  scroll project list                              │        
+▼ script│  1-9/a-z    start or focus row                               │qs] [▾] 
+ [9] ○ a│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │6 #5 x1 
+ [a] ? m│  X          delete session                                   │ -1 #10 
+ [b] - o│  /, Z       search / refresh snapshot                        │        
+        │  H/?        help                                             │        
+↓ 2 hidd╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -30,27 +30,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the search prompt 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
- [b] - old-experiment             -         no agent                    [shell] 
-                                                                                
-search: apiject - 0 worktrees                                     [sh] [qs] [▾] 
-↓ 1 hidden                                                                      
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
+search: api                                                                     
+↓ 2 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -58,27 +58,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
- [b] - old-experiment             -         no agent                    [shell] 
-                                                                                
-collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾] 
-↓ 1 hidden                                                                      
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
+collapse project: 1:station 2:observer 3:scripts 4:empty-project                
+↓ 2 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -86,27 +86,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
- [b] - old-experiment             -         no agent                    [shell] 
-                                                                                
-settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾] 
-↓ 1 hidden                                                                      
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
+settings for project: 1:station 2:observer 3:scripts 4:empty-project            
+↓ 2 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -114,27 +114,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings panel 1`] = `
 "station                                                                         
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Default agent                               │l] 
- [2│▸ Default agent           │✓1 codex unknown                             │l] 
- [3│  Remove project          │ 2 opencode unknown                          │l] 
- [4│                          │                                             │l] 
- [5│                          │ ✓ current · 1-9/a-z select                  │l] 
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │✓1 codex unknown                             │ ✓ 
+ [2│  Remove project          │ 2 opencode unknown                          │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
- [6│                          │                                             │l] 
- [7│                          │                                             │l] 
- [8│                          │                                             │l] 
+ [6│                          │                                             │ ✓ 
+ [7│                          │                                             │ … 
+ [8│                          │                                             │ ✓ 
    │                          │                                             │   
 ▼ s│                          │                                             │▾] 
- [9│                          │                                             │l] 
- [a│                          │                                             │l] 
- [b│                          │                                             │l] 
-   │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
-↓ 1└────────────────────────────────────────────────────────────────────────┘   
+ [9│                          │                                             │x1 
+ [a│                          │                                             │10 
+ [b│                          │                                             │   
+   │ ↑↓ move   →/enter edit   esc close                                     │   
+↓ 2└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -142,27 +142,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
 "station                                                                         
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Remove project                              │l] 
- [2│  Default agent           │ Removes it from Station.                    │l] 
- [3│▸ Remove project          │ Worktrees & files stay on disk.             │l] 
- [4│                          │                                             │l] 
- [5│                          │ Type "delete station" to confirm            │l] 
-   │                          │ ▸ |delete station                           │   
-▼ o│                          │                                             │▾] 
- [6│                          │ [ Remove project (R) ]                      │l] 
- [7│                          │                                             │l] 
- [8│                          │                                             │l] 
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Remove project                              │▾] 
+ [1│  Default agent           │ Removes it from Station.                    │ ✓ 
+ [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ Type "delete station" to confirm            │   
+ [5│                          │ ▸ |delete station                           │ … 
+   │                          │                                             │   
+▼ o│                          │ [ Remove project (R) ]                      │▾] 
+ [6│                          │                                             │ ✓ 
+ [7│                          │                                             │ … 
+ [8│                          │                                             │ ✓ 
    │                          │                                             │   
 ▼ s│                          │                                             │▾] 
- [9│                          │                                             │l] 
- [a│                          │                                             │l] 
- [b│                          │                                             │l] 
-   │                          │                                             │   
-▼ e│ ←/esc back                                                             │▾] 
-↓ 1└────────────────────────────────────────────────────────────────────────┘   
+ [9│                          │                                             │x1 
+ [a│                          │                                             │10 
+ [b│                          │                                             │   
+   │ ←/esc back                                                             │   
+↓ 2└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -170,27 +170,27 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
 "station                                                                         
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Default agent                               │l] 
- [2│▸ Default agent           │ 1 codex unknown                             │l] 
- [3│  Remove project          │✓2 opencode unknown                 updating…│l] 
- [4│                          │                                             │l] 
- [5│                          │ ✓ current · 1-9/a-z select                  │l] 
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │ 1 codex unknown                             │ ✓ 
+ [2│  Remove project          │✓2 opencode unknown                 updating…│   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
- [6│                          │                                             │l] 
- [7│                          │                                             │l] 
- [8│                          │                                             │l] 
+ [6│                          │                                             │ ✓ 
+ [7│                          │                                             │ … 
+ [8│                          │                                             │ ✓ 
    │                          │                                             │   
 ▼ s│                          │                                             │▾] 
- [9│                          │                                             │l] 
- [a│                          │                                             │l] 
- [b│                          │                                             │l] 
-   │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
-↓ 1└────────────────────────────────────────────────────────────────────────┘   
+ [9│                          │                                             │x1 
+ [a│                          │                                             │10 
+ [b│                          │                                             │   
+   │ ↑↓ move   →/enter edit   esc close                                     │   
+↓ 2└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -198,26 +198,26 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
-┌────────────────────────────────────────────┐known           +3 -1 #10 [shell] 
-│ Select session to delete                   │ agent                    [shell] 
-│                                            │                                  
-│ Click a row or press slot key              │                    [sh] [qs] [▾] 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to delete                   │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -226,26 +226,26 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
-                                                                                
-┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
-│ Delete session?                            │le           +14 -6 #5 x1 [shell] 
-│ Session  cli-help-man                      │known           +3 -1 #10 [shell] 
-│ Removes agent, worktree, and panes.        │ agent                    [shell] 
-│                                            │                                  
-│ Yes (y)     No (n)                         │                    [sh] [qs] [▾] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+┌────────────────────────────────────────────┐                                  
+│ Delete session?                            │                    [sh] [qs] [▾] 
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Yes (y)     No (n)                         │                                  
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -254,27 +254,27 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
- [a] ? metadata-refresh           opencode  unknown           +3 -1 #10 [shell] 
- [b] - old-experiment             -         no agent                    [shell] 
-                                                                                
-Choose the slot to rename: 1-9/a-z                                [sh] [qs] [▾] 
-↓ 1 hidden                                                                      
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+ [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
+Choose the slot to rename: 1-9/a-z                                              
+↓ 2 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -282,18 +282,18 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the rename sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 4 worktrees                                           [sh] [qs] [▾] 
- [1] ! hook-scope             codex     Agent needs appro… +8 -2 #12 x2 [shell] 
- [2] ? metadata-refresh       codex     unknown                   +3 -1 [shell] 
- [3] ! popup-latency          codex     No progress was… +120 -44 #13 … [shell] 
- [4] ⠋ pr-info                codex     working                   #11 ✓ [shell] 
+▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
+ [2] ? metadata-refresh               codex     unknown                   +3 -1 
+ [3] ! popup-latency                  codex     No progress was… +120 -44 #13 … 
+ [4] ⠋ pr-info                        codex     working                   #11 ✓ 
                                                                                 
-▼ observer - 2 worktrees                                          [sh] [qs] [▾] 
- [5] x done-run               opencode  exited                          [shell] 
- [6] ! sqlite-cleanup         opencode  Agent needs appro… +19 -2 #6 x1 [shell] 
-                                                                                
+▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
+ [5] x done-run                       opencode  exited                          
+ [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
                                                                                 
                                                                                 
                                                                                 
@@ -310,26 +310,26 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
- [9] ○ api-cache                  opencode  idle           +14 -6 #5 x1 [shell] 
-┌────────────────────────────────────────────┐known           +3 -1 #10 [shell] 
-│ Select session to fork                     │ agent                    [shell] 
-│                                            │                                  
-│ Click a row or press slot key              │                    [sh] [qs] [▾] 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to fork                     │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -338,26 +338,26 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
-┌────────────────────────────────────────────┐                                  
-│ Fork Session                               │                    [sh] [qs] [▾] 
-│ Source   station · cli-help-man            │le           +14 -6 #5 x1 [shell] 
-│ > Branch cli-help-man-fork|                │known           +3 -1 #10 [shell] 
-│   Copy   [x] uncommitted changes           │ agent                    [shell] 
-│ Source keeps running — copy is read-only.  │                                  
-│                                            │                    [sh] [qs] [▾] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
+│ Fork Session                               │                                  
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
+│ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
+│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
+│ Source keeps running — copy is read-only.  │      no agent                    
+│                                            │                                  
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -366,20 +366,20 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 
 exports[`modal flow golden frames renders the new session review 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
-                                                                                
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -394,21 +394,21 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 
 exports[`modal flow golden frames renders the new session edit name 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │                                                                              │
@@ -422,19 +422,19 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 
 exports[`modal flow golden frames renders the new session pick project 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -450,21 +450,21 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell] 
- [4] + session-resume             codex     starting                    [shell] 
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾] 
- [6] x batch-export               opencode  exited                 #8 ✓ [shell] 
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell] 
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell] 
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -478,21 +478,21 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
 "station
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
 ───────────────────────────────────────────────────────────────────────────────
 
-▼ station - 5 worktrees                                           [sh] [qs] [▾]
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell]
- [2] - docs-cleanup               -         no agent                    [shell]
- [3] ○ pty-buffer                 codex     idle                  #73 ✓ [shell]
- [4] + session-resume             codex     starting                    [shell]
- [5] ⠋ station-XXXXXXy            codex     working      +412 -96 #76 … [shell]
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
+ [2] - docs-cleanup                       -         no agent
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓
+ [4] + session-resume                     codex     starting
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
-▼ observer - 3 worktrees                                          [sh] [qs] [▾]
- [6] x batch-export               opencode  exited                 #8 ✓ [shell]
- [7] ⠋ provider-hooks             opencode  working        +32 -8 #16 … [shell]
- [8] ○ trace-bundle               opencode  idle             +1 -1 #4 ✓ [shell]
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ [6] x batch-export                       opencode  exited                 #8 ✓
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
 
-▼ scripts - 3 worktrees                                           [sh] [qs] [▾]
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -506,11 +506,11 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "station                                                                         
+FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-▼ station - 5 worktrees                                           [sh] [qs] [▾] 
- [1] ○ cli-help-man               codex     idle           +14 -6 #70 ✓ [shell] 
- [2] - docs-cleanup               -         no agent                    [shell] 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -173,9 +173,9 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("x2");
     expect(frame).toContain("✓");
     expect(frame).toContain("…");
-    // Project headers with the disclosure marker and harness suffix.
-    expect(frame).toContain("▼ station - 4 worktrees");
-    expect(frame).toContain("▼ observer - 2 worktrees");
+    // Project headers with the disclosure marker and session/agent counts.
+    expect(frame).toContain("▼ station  4 sessions");
+    expect(frame).toContain("▼ observer  2 sessions");
   });
 
   it("colors alert rows red and check glyphs by state", async () => {
@@ -274,12 +274,12 @@ describe("dashboard golden frames", () => {
   });
 
   it("assigns slots only to visible actionable rows", async () => {
-    const setup = await renderDashboard({ width: 80, height: 24, snapshot: manyProjectsSnapshot() });
+    const setup = await renderDashboard({ width: 80, height: 40, snapshot: manyProjectsSnapshot() });
     const frame = setup.captureCharFrame();
     expect(frame).toContain("[1]");
     // The starting row gets a slot too (it has a focusable terminal), but the
-    // empty project renders its zero-count line with no slot cell.
-    expect(frame).toContain("0 worktrees");
+    // empty project renders its calm empty-state line with no slot cell.
+    expect(frame).toContain("no sessions yet · press A to add one");
   });
 
   it("paints hovered worktree rows through the trailing action column", async () => {


### PR DESCRIPTION
PR4 of the Station UX upgrade — visible list-scaffolding parity (the triage core).

- **Fleet summary bar**: new client-side `selectFleetSummary` (ready split from idle; `needsYou` = attention+stuck, which `snapshot.counts` can't express) rendered as a pinned row with glyph+colour per lane; reserved via `DASHBOARD_FIXED_ROW_HEIGHTS.fleetBar` so the viewport/scroll math stays correct.
- **worktree→session relabel**: `▼ station  5 sessions · 4 agents` (agents omitted at 0); calm empty state `no sessions yet · press A to add one`.
- **Removed per-row `[shell]`**: rows reclaim the full width for diff/PR; `[shell]` stays on the project header only.

```
FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
 [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
```

Deferred to a follow-up (needs a layout restructure to align to the dynamic grid): the column header + header-line counts/attention flag.

Test churn handled: viewport/scroll windowing shifts by 1 body row (fleet bar); goldens regenerated; inline assertions worktrees→sessions; an overlay row-search disambiguated from the fleet bar's `working`. vitest 195/195; typecheck clean; bun 342/342; lint green.