### PR TITLE
feat(dashboard): aligned column header + fleet animation + clickable empty state

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -106,7 +106,7 @@ export function projectHeaderLabel(project: ProjectView, collapsed: boolean): st
 }
 
 export function emptyProjectLabel(): string {
-  return " no sessions yet · press A to add one";
+  return " no sessions yet · ";
 }
 
 function plural(count: number, noun: string): string {

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -1,6 +1,7 @@
 export const DASHBOARD_FIXED_ROW_HEIGHTS = {
   header: 1,
   fleetBar: 1,
+  columnHeader: 1,
   topDivider: 1,
   topScrollIndicator: 1,
   bottomScrollIndicator: 1,

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -38,15 +38,15 @@ describe("dashboard viewport selector", () => {
     });
     const viewport = selectDashboardViewport(snapshot, state);
 
-    expect(viewport.bodyRows).toBe(3);
+    expect(viewport.bodyRows).toBe(2);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(7);
+    expect(viewport.hiddenBelow).toBe(8);
     expect(
       viewport.visibleItems.map((item) =>
         item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
+    ).toEqual(["wt_web_working", "wt_web_attention"]);
   });
 
   it("uses only viewport-visible worktrees for row choices", () => {
@@ -60,7 +60,6 @@ describe("dashboard viewport selector", () => {
     expect(viewport.rowChoices.map((choice) => [choice.key, choice.value.id])).toEqual([
       ["1", "wt_web_no_agent"],
       ["2", "wt_web_idle"],
-      ["3", "wt_web_unknown"],
     ]);
   });
 
@@ -74,8 +73,8 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(8);
-    expect(viewport.hiddenAbove).toBe(8);
+    expect(viewport.clampedScrollOffset).toBe(9);
+    expect(viewport.hiddenAbove).toBe(9);
     expect(viewport.hiddenBelow).toBe(0);
     expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
   });

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -50,7 +50,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", downArrow: true }).state.scrollOffset).toBe(8);
+    expect(handleTuiKey(state, { input: "", downArrow: true }).state.scrollOffset).toBe(9);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", upArrow: true }).state.scrollOffset,
     ).toBe(0);
@@ -675,6 +675,6 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.collapsedProjectIds.has("web")).toBe(true);
-    expect(transition.state.scrollOffset).toBe(1);
+    expect(transition.state.scrollOffset).toBe(2);
   });
 });

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -52,9 +52,9 @@ const SCROLL_UP: StationMouseEvent = {
 };
 
 function makeStore(snapshot?: StationSnapshot): StoreApi<TuiStore> {
-  // 13 rows keeps the same visible window as before the pinned fleet bar (which
-  // consumes one body row) so the station-project rows stay slot-addressable.
-  return makeStationTestStore({ terminalRows: 13, ...(snapshot === undefined ? {} : { snapshot }) })
+  // Enough rows to keep the same visible window as before the pinned fleet bar +
+  // column header, so the station-project rows stay slot-addressable.
+  return makeStationTestStore({ terminalRows: 14, ...(snapshot === undefined ? {} : { snapshot }) })
     .store;
 }
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -17,8 +17,10 @@ import {
 } from "@station/dashboard-core";
 import {
   layoutWorktreeRowGrid,
+  textSegment,
   truncateCells,
   type RowGridLayout,
+  type RowGridRowInput,
 } from "@station/dashboard-core";
 import {
   QUIT_HINT_CLOSE,
@@ -30,6 +32,7 @@ import {
 import type { TuiViewState } from "@station/dashboard-core";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 import { SegmentLinkTargets, Segments } from "./segments.js";
+import { Throbber } from "./Throbber.js";
 import { STATION_COLORS } from "./theme.js";
 import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
 
@@ -80,6 +83,10 @@ export function DashboardView({
   const contentColumns = Math.max(1, Math.floor(columns) - 1);
   const firstRun = snapshot.projects.length === 0;
   const fleet = selectFleetSummary(snapshot);
+  const keyByRow = new Map(viewport.displayRowChoices.map((choice) => [choice.value.id, choice.key]));
+  const { headerLayout, layoutByItem } = firstRun
+    ? { headerLayout: undefined, layoutByItem: new Map<string, RowGridLayout>() }
+    : dashboardRowLayouts(viewport.visibleItems, keyByRow, contentColumns);
   return (
     <box
       width="100%"
@@ -95,17 +102,14 @@ export function DashboardView({
       />
       {firstRun ? null : <FleetBar summary={fleet} />}
       <Divider columns={contentColumns} />
+      {firstRun || headerLayout === undefined ? null : <ColumnHeaderRow layout={headerLayout} />}
       <ScrollIndicatorRow direction="above" hiddenCount={viewport.hiddenAbove} />
       {firstRun ? (
         <box flexDirection="column" flexGrow={1}>
           <text fg={STATION_COLORS.foreground}>{truncateCells(FIRST_RUN_BODY_LABEL, contentColumns)}</text>
         </box>
       ) : (
-        <DashboardBody
-          columns={contentColumns}
-          items={viewport.visibleItems}
-          keyByRow={new Map(viewport.displayRowChoices.map((choice) => [choice.value.id, choice.key]))}
-        />
+        <DashboardBody columns={contentColumns} items={viewport.visibleItems} layoutByItem={layoutByItem} />
       )}
       <ScrollIndicatorRow direction="below" hiddenCount={viewport.hiddenBelow} />
       <Divider columns={contentColumns} />
@@ -150,9 +154,14 @@ export function Divider({ columns }: { columns: number }) {
 // Pinned fleet triage bar: glyph + colour reinforce each status lane. ready/
 // working/needs-you/idle always show; unknown/exited appear only when non-zero.
 function FleetBar({ summary }: { summary: FleetSummary }) {
-  const parts: { glyph: string; color: string; label: string }[] = [
+  const parts: { glyph: string; color: string; label: string; animate?: boolean }[] = [
     { glyph: "●", color: STATION_COLORS.green, label: `${summary.ready} ready` },
-    { glyph: "⠿", color: STATION_COLORS.blue, label: `${summary.working} working` },
+    {
+      glyph: "⠿",
+      color: STATION_COLORS.blue,
+      label: `${summary.working} working`,
+      animate: summary.working > 0,
+    },
     { glyph: "!", color: STATION_COLORS.red, label: `${summary.needsYou} needs you` },
     { glyph: "○", color: STATION_COLORS.gray, label: `${summary.idle} idle` },
   ];
@@ -169,7 +178,11 @@ function FleetBar({ summary }: { summary: FleetSummary }) {
         {parts.map((part) => (
           <span key={part.label}>
             {"  "}
-            <span fg={part.color}>{part.glyph}</span>
+            {part.animate === true ? (
+              <Throbber variant="braille" fg={part.color} />
+            ) : (
+              <span fg={part.color}>{part.glyph}</span>
+            )}
             {` ${part.label}`}
           </span>
         ))}
@@ -203,25 +216,61 @@ function ScrollIndicatorRow({
   );
 }
 
-function DashboardBody({
-  columns,
-  items,
-  keyByRow,
-}: {
-  columns: number;
-  items: readonly DashboardViewportItem[];
-  keyByRow: ReadonlyMap<string, string>;
-}) {
+const COLUMN_HEADER_ROW_ID = "__column_header__";
+
+function columnHeaderRowInput(): RowGridRowInput {
+  return {
+    id: COLUMN_HEADER_ROW_ID,
+    cells: {
+      identity: { key: "identity", segments: [textSegment(" ".repeat(7))], importance: "required" },
+      title: { key: "title", segments: [textSegment("SESSION")], importance: "required" },
+      agent: { key: "agent", segments: [textSegment("AGENT")], importance: "optional" },
+      activity: { key: "activity", segments: [textSegment("STATUS")], importance: "optional" },
+    },
+    metadataGroups: { diff: [textSegment("DIFF")], pr: [textSegment("PR")] },
+  };
+}
+
+// The header shares the rows' grid layout so its columns align and shed in lockstep.
+function dashboardRowLayouts(
+  items: readonly DashboardViewportItem[],
+  keyByRow: ReadonlyMap<string, string>,
+  columns: number,
+): { headerLayout: RowGridLayout | undefined; layoutByItem: Map<string, RowGridLayout> } {
   const rowInputs = items.flatMap((item) => {
     const input = rowGridInputForViewportItem(item, keyByRow);
     return input === undefined ? [] : [input];
   });
-  // Rows use the full content width: the per-row [shell] affordance was removed
-  // (it lives on the project header now), so the diff/PR metadata reclaims the
-  // right-hand column that used to be reserved for it.
-  const gridColumns = Math.max(1, columns);
-  const rowLayouts = layoutWorktreeRowGrid({ columns: gridColumns, rows: rowInputs });
-  const layoutByItem = new Map(rowLayouts.map((layout) => [layout.id, layout]));
+  const layouts = layoutWorktreeRowGrid({
+    columns: Math.max(1, columns),
+    rows: [columnHeaderRowInput(), ...rowInputs],
+  });
+  const headerLayout = layouts.find((layout) => layout.id === COLUMN_HEADER_ROW_ID);
+  const layoutByItem = new Map(
+    layouts.filter((layout) => layout.id !== COLUMN_HEADER_ROW_ID).map((layout) => [layout.id, layout]),
+  );
+  return { headerLayout, layoutByItem };
+}
+
+function ColumnHeaderRow({ layout }: { layout: RowGridLayout }) {
+  return (
+    <box height={1} width="100%" backgroundColor={STATION_COLORS.frozenSurface} overflow="hidden">
+      <text fg={STATION_COLORS.gray}>
+        <Segments segments={layout.segments} />
+      </text>
+    </box>
+  );
+}
+
+function DashboardBody({
+  columns,
+  items,
+  layoutByItem,
+}: {
+  columns: number;
+  items: readonly DashboardViewportItem[];
+  layoutByItem: ReadonlyMap<string, RowGridLayout>;
+}) {
   return (
     <box flexDirection="column" flexGrow={1}>
       {items.map((item) => (
@@ -251,7 +300,12 @@ function DashboardViewportRow({
     case "projectHeader":
       return <ProjectHeaderLine columns={columns} project={item.project} collapsed={item.collapsed} />;
     case "emptyProject":
-      return <text fg={STATION_COLORS.gray}>{truncateCells(emptyProjectLabel(), columns)}</text>;
+      return (
+        <box flexDirection="row" height={1}>
+          <text fg={STATION_COLORS.gray}>{emptyProjectLabel()}</text>
+          <EmptySessionButton projectId={item.project.id} />
+        </box>
+      );
     case "worktree":
       return layout === undefined ? null : (
         <WorktreeRowLine rowId={item.row.id} layout={layout} />
@@ -366,6 +420,27 @@ function QuickSessionAffordance({
         {" [▾]"}
       </text>
     </>
+  );
+}
+
+const EMPTY_SESSION_BUTTON_LABEL = "[ + add session ]";
+
+// Mouse-native empty-state action: one click creates a session (default agent)
+// for the project — the same command as the project header's [quick session].
+function EmptySessionButton({ projectId }: { projectId: string }) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  return (
+    <text
+      flexShrink={0}
+      fg={hover ? STATION_COLORS.background : STATION_COLORS.cyan}
+      {...(hover ? { backgroundColor: STATION_COLORS.cyan } : {})}
+      {...stationMouseProps(dispatch, { kind: "quickSessionForProject", projectId })}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}
+    >
+      {EMPTY_SESSION_BUTTON_LABEL}
+    </text>
   );
 }
 

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -2,8 +2,9 @@
 
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -21,8 +22,7 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-                                                                                
-↓ 2 hidden                                                                      
+↓ 3 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -30,8 +30,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "station                                                                                                                 
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited                                         
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+       SESSION                                   AGENT     STATUS                                               DIFF PR 
                                                                                                                         
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
@@ -51,8 +52,7 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [b] - old-experiment                            -         no agent                                                     
                                                                                                                         
 ▼ empty-project  0 sessions                                                                 [shell] [quick session] [▾] 
- no sessions yet · press A to add one                                                                                   
-                                                                                                                        
+ no sessions yet · [ + add session ]                                                                                    
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -74,8 +74,9 @@ N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:f
 
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 "station                                                     
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ?   
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ?   
 ─────────────────────────────────────────────────────────── 
+       SESSION                 AGENT     STATUS          PR 
                                                             
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ○ cli-help-man            codex     idle         #70 ✓ 
@@ -85,8 +86,7 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ?
  [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
- [6] x batch-export            opencode  exited        #8 ✓ 
-↓ 10 hidden                                                 
+↓ 11 hidden                                                 
 ─────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
 "
@@ -94,15 +94,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se…
 
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 "station                                 
-FLEET  ● 0 ready  ⠿ 2 working  ! 0      
+FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
+       SESSION             STATUS       
                                         
 ▼ station  5 sessions · … [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
- [4] + session-resume      starting     
-↓ 14 hidden                             
+↓ 15 hidden                             
 ─────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/… 
 "
@@ -110,8 +110,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/…
 
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                        AGENT     STATUS                  DIFF PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -130,7 +131,6 @@ FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                 
                                                                                 
                                                                                 
-                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -138,8 +138,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
 "station                                                                                                                 
-FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited                                         
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+       SESSION                                   AGENT     STATUS                                               DIFF PR 
                                                                                                                         
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
@@ -174,7 +175,6 @@ FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help Q/esc:close       
 "
@@ -182,8 +182,9 @@ N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:f
 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 "station                                                     
-FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ?   
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ?   
 ─────────────────────────────────────────────────────────── 
+       SESSION            AGENT     STATUS               PR 
                                                             
 ▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ! hook-scope         codex     Agent needs app… #12 x2 
@@ -193,8 +194,7 @@ FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ?
                                                             
 ▼ observer  2 sessions · 2 agents             [sh] [qs] [▾] 
  [5] x done-run           opencode  exited                  
- [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
-                                                            
+↓ 1 hidden                                                  
 ─────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
 "
@@ -202,15 +202,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se…
 
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 "station                                 
-FLEET  ● 0 ready  ⠿ 1 working  ! 3      
+FLEET  ● 0 ready  ⠋ 1 working  ! 3      
 ─────────────────────────────────────── 
+       SESSION                          
                                         
 ▼ station  4 sessions · … [sh] [qs] [▾] 
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
- [4] ⠋ pr-info                          
-↓ 4 hidden                              
+↓ 5 hidden                              
 ─────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/… 
 "

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -2,27 +2,27 @@
 
 exports[`modal flow golden frames renders the help overlay 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-        │                         station help                         │        
-▼ statio│                                                              │qs] [▾] 
- [1] ○ c│  Ctrl-O     open/close project view                          │6 #70 ✓ 
- [2] - d│  Ctrl-Q     quit Station                                     │        
- [3] ○ p│  Ctrl-\\     split pane right                                 │  #73 ✓ 
- [4] + s│  Ctrl-^     split pane below (Ctrl-6)                        │        
- [5] ⠋ s│  Ctrl-]     focus next pane                                  │6 #76 … 
-        │  Ctrl-/     close split pane (Ctrl-_)                        │        
-▼ observ│  Enter/Sp   open project view on welcome                     │qs] [▾] 
- [6] x b│  Esc/↑↓     context menu close/move                          │   #8 ✓ 
- [7] ⠋ p│  Enter/Sp   context menu select                              │8 #16 … 
- [8] ○ t│                     station project view                     │-1 #4 ✓ 
-        │  ↑/↓ wheel  scroll project list                              │        
-▼ script│  1-9/a-z    start or focus row                               │qs] [▾] 
- [9] ○ a│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │6 #5 x1 
- [a] ? m│  X          delete session                                   │ -1 #10 
- [b] - o│  /, Z       search / refresh snapshot                        │        
-        │  H/?        help                                             │        
-↓ 2 hidd╰──────────────────────────────────────────────────────────────╯        
+       S│                         station help                         │DIFF PR 
+        │                                                              │        
+▼ statio│  Ctrl-O     open/close project view                          │qs] [▾] 
+ [1] ○ c│  Ctrl-Q     quit Station                                     │6 #70 ✓ 
+ [2] - d│  Ctrl-\\     split pane right                                 │        
+ [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │  #73 ✓ 
+ [4] + s│  Ctrl-]     focus next pane                                  │        
+ [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                        │6 #76 … 
+        │  Enter/Sp   open project view on welcome                     │        
+▼ observ│  Esc/↑↓     context menu close/move                          │qs] [▾] 
+ [6] x b│  Enter/Sp   context menu select                              │   #8 ✓ 
+ [7] ⠋ p│                     station project view                     │8 #16 … 
+ [8] ○ t│  ↑/↓ wheel  scroll project list                              │-1 #4 ✓ 
+        │  1-9/a-z    start or focus row                               │        
+▼ script│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │qs] [▾] 
+ [9] ○ a│  X          delete session                                   │6 #5 x1 
+ [a] ? m│  /, Z       search / refresh snapshot                        │ -1 #10 
+ [b] - o│  H/?        help                                             │        
+↓ 3 hidd╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -30,8 +30,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the search prompt 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -48,9 +49,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
-search: api                                                                     
-↓ 2 hidden                                                                      
+search: apiexperiment                     -         no agent                    
+↓ 3 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -58,8 +58,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -76,9 +77,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
 collapse project: 1:station 2:observer 3:scripts 4:empty-project                
-↓ 2 hidden                                                                      
+↓ 3 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -86,8 +86,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -104,9 +105,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
 settings for project: 1:station 2:observer 3:scripts 4:empty-project            
-↓ 2 hidden                                                                      
+↓ 3 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -114,14 +114,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings panel 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │✓1 codex unknown                             │ ✓ 
- [2│  Remove project          │ 2 opencode unknown                          │   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
+   │ Project settings                                                       │PR 
+   │ station                  │ Default agent                               │   
+▼ s│▸ Default agent           │✓1 codex unknown                             │▾] 
+ [1│  Remove project          │ 2 opencode unknown                          │ ✓ 
+ [2│                          │                                             │   
+ [3│                          │ ✓ current · 1-9/a-z select                  │ ✓ 
+ [4│                          │                                             │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
@@ -132,9 +133,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
-↓ 2└────────────────────────────────────────────────────────────────────────┘   
+ [b│ ↑↓ move   →/enter edit   esc close                                     │   
+↓ 3└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -142,17 +142,18 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Remove project                              │▾] 
- [1│  Default agent           │ Removes it from Station.                    │ ✓ 
- [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
- [3│                          │                                             │ ✓ 
- [4│                          │ Type "delete station" to confirm            │   
- [5│                          │ ▸ |delete station                           │ … 
-   │                          │                                             │   
-▼ o│                          │ [ Remove project (R) ]                      │▾] 
+   │ Project settings                                                       │PR 
+   │ station                  │ Remove project                              │   
+▼ s│  Default agent           │ Removes it from Station.                    │▾] 
+ [1│▸ Remove project          │ Worktrees & files stay on disk.             │ ✓ 
+ [2│                          │                                             │   
+ [3│                          │ Type "delete station" to confirm            │ ✓ 
+ [4│                          │ ▸ |delete station                           │   
+ [5│                          │                                             │ … 
+   │                          │ [ Remove project (R) ]                      │   
+▼ o│                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
@@ -160,9 +161,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ←/esc back                                                             │   
-↓ 2└────────────────────────────────────────────────────────────────────────┘   
+ [b│ ←/esc back                                                             │   
+↓ 3└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -170,14 +170,15 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │ 1 codex unknown                             │ ✓ 
- [2│  Remove project          │✓2 opencode unknown                 updating…│   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
+   │ Project settings                                                       │PR 
+   │ station                  │ Default agent                               │   
+▼ s│▸ Default agent           │ 1 codex unknown                             │▾] 
+ [1│  Remove project          │✓2 opencode unknown                 updating…│ ✓ 
+ [2│                          │                                             │   
+ [3│                          │ ✓ current · 1-9/a-z select                  │ ✓ 
+ [4│                          │                                             │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
@@ -188,9 +189,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
-↓ 2└────────────────────────────────────────────────────────────────────────┘   
+ [b│ ↑↓ move   →/enter edit   esc close                                     │   
+↓ 3└────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -198,8 +198,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -213,11 +214,10 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to delete                   │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Click a row or press slot key              │                                  
+┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
+│ Select session to delete                   │code  idle           +14 -6 #5 x1 
+│                                            │code  unknown           +3 -1 #10 
+│ Click a row or press slot key              │      no agent                    
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -226,8 +226,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -239,13 +240,12 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-┌────────────────────────────────────────────┐                                  
-│ Delete session?                            │                    [sh] [qs] [▾] 
-│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
-│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Yes (y)     No (n)                         │                                  
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
+│ Delete session?                            │                                  
+│ Session  cli-help-man                      │                    [sh] [qs] [▾] 
+│ Removes agent, worktree, and panes.        │code  idle           +14 -6 #5 x1 
+│                                            │code  unknown           +3 -1 #10 
+│ Yes (y)     No (n)                         │      no agent                    
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -254,8 +254,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -272,9 +273,8 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
-Choose the slot to rename: 1-9/a-z                                              
-↓ 2 hidden                                                                      
+Choose the slot to rename: 1-9/a-z        -         no agent                    
+↓ 3 hidden                                                                      
 ─────────────────────────────────────────────────────────────────────────────── 
 Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
 "
@@ -282,8 +282,9 @@ Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help
 
 exports[`modal flow golden frames renders the rename sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                        AGENT     STATUS                  DIFF PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -294,7 +295,6 @@ FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
 ▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [5] x done-run                       opencode  exited                          
  [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
-                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -310,8 +310,9 @@ FLEET  ● 0 ready  ⠿ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -325,11 +326,10 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to fork                     │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Click a row or press slot key              │                                  
+┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
+│ Select session to fork                     │code  idle           +14 -6 #5 x1 
+│                                            │code  unknown           +3 -1 #10 
+│ Click a row or press slot key              │      no agent                    
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -338,8 +338,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -350,14 +351,13 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
                                                                                 
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Fork Session                               │                                  
-│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
-│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │      no agent                    
-│                                            │                                  
+┌────────────────────────────────────────────┐code  working        +32 -8 #16 … 
+│ Fork Session                               │code  idle             +1 -1 #4 ✓ 
+│ Source   station · cli-help-man            │                                  
+│ > Branch cli-help-man-fork|                │                    [sh] [qs] [▾] 
+│   Copy   [x] uncommitted changes           │code  idle           +14 -6 #5 x1 
+│ Source keeps running — copy is read-only.  │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
 └────────────────────────────────────────────┘ X:delete session /:search H:help 
@@ -366,8 +366,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the new session review 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -379,7 +380,6 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -394,8 +394,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the new session edit name 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -408,7 +409,6 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │                                                                              │
@@ -422,8 +422,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the new session pick project 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -434,7 +435,6 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
                                                                                 
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -450,8 +450,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -464,7 +465,6 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -478,8 +478,9 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
 "station
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
 ───────────────────────────────────────────────────────────────────────────────
+       SESSION                            AGENT     STATUS              DIFF PR
 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
@@ -492,7 +493,6 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
-
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -506,11 +506,11 @@ FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "station                                                                         
-FLEET  ● 0 ready  ⠿ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS              DIFF PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -278,8 +278,10 @@ describe("dashboard golden frames", () => {
     const frame = setup.captureCharFrame();
     expect(frame).toContain("[1]");
     // The starting row gets a slot too (it has a focusable terminal), but the
-    // empty project renders its calm empty-state line with no slot cell.
-    expect(frame).toContain("no sessions yet · press A to add one");
+    // empty project renders its calm empty-state line (with a click-to-add
+    // button) and no slot cell.
+    expect(frame).toContain("no sessions yet · ");
+    expect(frame).toContain("[ + add session ]");
   });
 
   it("paints hovered worktree rows through the trailing action column", async () => {


### PR DESCRIPTION
PR4b of the Station UX upgrade.

- **Aligned column header** (`SESSION AGENT STATUS … DIFF PR`) — a synthetic header row laid out through the same solver as the rows, so its columns align exactly and it **sheds lanes in lockstep** (drops `DIFF` at 60 cols, `AGENT` at 40). Pinned via `DASHBOARD_FIXED_ROW_HEIGHTS.columnHeader`; layout hoisted to `DashboardView` (computed once → header pinned + row layouts to the body).
- **Fleet-bar working glyph animates** (shared-clock `Throbber`, in phase with the row throbbers) when `working > 0`.
- **Empty state is a clickable button**: `no sessions yet · [ + add session ]` (dispatches the one-click `quickSessionForProject`).

Each pinned bar costs a body row, so the viewport/scroll windowing tests shifted and one mouse-test terminal height bumped. At 40×12 it's cramped but intact. vitest 195/195; typecheck clean; bun 342/342; lint green.