### PR TITLE
feat(interaction): focused-row cursor + next-needs-me + overflow labels

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -1,6 +1,9 @@
-import type { ProjectView } from "@station/contracts";
+import type { ProjectView, WorktreeId } from "@station/contracts";
 import stringWidth from "string-width";
-import type { DashboardViewportItem } from "../../selectors/dashboardViewport.js";
+import type {
+  DashboardSessionOverflow,
+  DashboardViewportItem,
+} from "../../selectors/dashboardViewport.js";
 
 export { dashboardFooterLabel } from "../../state/keymap.js";
 
@@ -115,16 +118,23 @@ function plural(count: number, noun: string): string {
 
 export const FIRST_RUN_BODY_LABEL = "No projects configured yet.";
 
-export function scrollIndicatorLabel(direction: "above" | "below", hiddenCount: number): string {
-  const marker = direction === "above" ? "↑" : "↓";
-  return `${marker} ${hiddenCount} hidden`;
+export function scrollIndicatorLabel(
+  direction: "above" | "below",
+  overflow: DashboardSessionOverflow,
+): string {
+  if (direction === "above") {
+    return `▲ ${overflow.above} ${plural(overflow.above, "session")} above`;
+  }
+  return `▼ ${overflow.below} below · showing ${overflow.visible} of ${overflow.total}`;
 }
 
 export function rowGridInputForViewportItem(
   item: DashboardViewportItem,
   keyByRow: ReadonlyMap<string, string>,
+  focusedRowId?: WorktreeId,
 ): RowGridRowInput | undefined {
   if (item.type === "worktree") {
+    const focused = focusedRowId !== undefined && item.row.id === focusedRowId;
     if (item.pendingRemove !== undefined) {
       return worktreeStyleRowGridInput({
         id: item.id,
@@ -134,6 +144,7 @@ export function rowGridInputForViewportItem(
         activity: "removing session...",
         activityImportance: "meaningful",
         activityOverflow: "rowSlack",
+        ...(focused ? { focused: true } : {}),
       });
     }
     if (item.pendingStart !== undefined) {
@@ -147,6 +158,7 @@ export function rowGridInputForViewportItem(
         activity,
         activityImportance: "meaningful",
         activityOverflow: "rowSlack",
+        ...(focused ? { focused: true } : {}),
       });
     }
     return worktreeRowGridInput({
@@ -154,6 +166,7 @@ export function rowGridInputForViewportItem(
       row: item.row,
       slot: keyByRow.get(item.row.id),
       title: item.displayTitle,
+      focused,
     });
   }
   if (item.type !== "createLocalRow") {

--- a/packages/dashboard-core/src/components/WorktreeRow/layout.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/layout.ts
@@ -1,7 +1,7 @@
 import stringWidth from "string-width";
 
 // Semantic only — dashboard-core stays hex-free; view/theme.ts resolves to hex.
-export type RowColor = "blue" | "gray" | "green" | "red" | "yellow" | "purple";
+export type RowColor = "blue" | "cyan" | "gray" | "green" | "red" | "yellow" | "purple";
 
 export type RowSegment =
   | {

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -16,11 +16,13 @@ export function worktreeRowGridInput({
   row,
   slot,
   title,
+  focused,
 }: {
   id?: string;
   row: WorktreeRowModel;
   slot: string | undefined;
   title?: string | undefined;
+  focused?: boolean | undefined;
 }): RowGridRowInput {
   const marker = statusMarker(row);
   const displayTitle = title ?? row.branch;
@@ -60,6 +62,9 @@ export function worktreeRowGridInput({
   if (color !== undefined) {
     input.color = color;
   }
+  if (focused === true) {
+    input.focused = true;
+  }
   return worktreeStyleRowGridInput(input);
 }
 
@@ -77,11 +82,18 @@ export function worktreeStyleRowGridInput(input: {
   activityColor?: RowColor;
   agentColor?: RowColor;
   metadataGroups?: WorktreeRowMetadataGroups;
+  focused?: true;
 }): RowGridRowInput {
   const cells: Partial<Record<RowGridCellKey, RowGridCell>> = {};
   cells.identity = {
     key: "identity",
-    segments: identitySegments(input.slot, input.marker, input.color, input.markerColor),
+    segments: identitySegments(
+      input.slot,
+      input.marker,
+      input.color,
+      input.markerColor,
+      input.focused,
+    ),
     importance: "required",
   };
   cells.title = {
@@ -135,8 +147,14 @@ function identitySegments(
   marker: RowMarker,
   color: RowColor | undefined,
   markerColor: RowColor | undefined,
+  focused: true | undefined,
 ): RowSegment[] {
-  const segments: RowSegment[] = [textSegment(` [${slot ?? " "}] `, { color })];
+  // The cursor reuses the identity cell's leading pad cell, so a focused row
+  // never shifts the shared grid geometry.
+  const segments: RowSegment[] = [
+    focused === true ? textSegment("▏", { color: "cyan" }) : textSegment(" ", { color }),
+    textSegment(`[${slot ?? " "}] `, { color }),
+  ];
   if (marker.kind === "throbber") {
     const throbberColor = markerColor ?? color;
     segments.push(

--- a/packages/dashboard-core/src/flows/newSession.ts
+++ b/packages/dashboard-core/src/flows/newSession.ts
@@ -17,6 +17,7 @@ import {
   selectNewSessionProject,
   selectNewSessionProjectChoices,
 } from "../selectors/selectors.js";
+import { isSlotKey } from "../state/keymap.js";
 import {
   backWizardStep,
   createStepWizardState,
@@ -302,7 +303,11 @@ function pickerInputIntent(
   input: NewSessionInput,
   choose: (key: SelectionKey) => NewSessionFlowAction,
 ): NewSessionInputIntent {
-  return isSelectionKey(input.input) ? transitionIntent(choose(input.input)) : { type: "none" };
+  // isSlotKey, not raw isSelectionKey: the keymap's slot-pattern exceptions
+  // (Tab/Ctrl-I) must apply here too or the keymap contract drifts.
+  return isSlotKey({ ...input.key, input: input.input }) && isSelectionKey(input.input)
+    ? transitionIntent(choose(input.input))
+    : { type: "none" };
 }
 
 function transitionIntent(action: NewSessionFlowAction): NewSessionInputIntent {

--- a/packages/dashboard-core/src/selectors/dashboardViewport.ts
+++ b/packages/dashboard-core/src/selectors/dashboardViewport.ts
@@ -58,6 +58,15 @@ export type DashboardViewport = {
   visibleItems: DashboardViewportItem[];
   rowChoices: Array<KeyedChoice<WorktreeRow>>;
   displayRowChoices: Array<KeyedChoice<WorktreeRow>>;
+  sessionOverflow: DashboardSessionOverflow;
+};
+
+/** Session-row counts (not raw item counts) for the scroll-overflow labels. */
+export type DashboardSessionOverflow = {
+  above: number;
+  below: number;
+  visible: number;
+  total: number;
 };
 
 export function selectDashboardViewport(
@@ -80,6 +89,9 @@ export function selectDashboardViewport(
       item.type === "worktree" && item.pendingStart !== undefined ? [item.row.id] : [],
     ),
   );
+  const above = countSessionRows(items.slice(0, clampedScrollOffset));
+  const visible = countSessionRows(visibleItems);
+  const total = countSessionRows(items);
   return {
     bodyRows,
     clampedScrollOffset,
@@ -89,7 +101,12 @@ export function selectDashboardViewport(
     visibleItems,
     rowChoices: displayRowChoices.filter((choice) => !pendingStartWorktreeIds.has(choice.value.id)),
     displayRowChoices,
+    sessionOverflow: { above, below: total - above - visible, visible, total },
   };
+}
+
+function countSessionRows(items: readonly DashboardViewportItem[]): number {
+  return items.filter((item) => item.type === "worktree" || item.type === "createLocalRow").length;
 }
 
 export function selectDashboardItems(

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -1,0 +1,132 @@
+import type { WorktreeRow } from "@station/contracts";
+import { clampDashboardScrollOffset, dashboardBodyRows } from "../components/Dashboard/layout.js";
+import {
+  type DashboardViewportItem,
+  selectDashboardItems,
+} from "../selectors/dashboardViewport.js";
+import { scrollDashboard } from "./dashboardScroll.js";
+import { activateDashboardRow } from "./rowActivation.js";
+import type { TuiTransition } from "./transition.js";
+import type { TuiState } from "./types.js";
+
+type WorktreeItem = Extract<DashboardViewportItem, { type: "worktree" }>;
+
+// Cursor rule (D9): the cursor is where you are — ↑↓/⇥ move it and the viewport
+// follows; jump keys and mouse clicks still teleport-and-activate directly.
+export function moveDashboardFocus(state: TuiState, delta: -1 | 1): TuiState {
+  if (state.snapshot === undefined) {
+    return scrollDashboard(state, delta);
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  const focusable = focusableIndexes(items);
+  if (focusable.length === 0) {
+    // No session rows (e.g. all projects empty) — arrows fall back to scrolling.
+    return scrollDashboard(state, delta);
+  }
+  const current = focusedItemIndex(items, state);
+  if (current === undefined) {
+    return focusItem(state, items, enterFocusIndex(state, items, focusable, delta));
+  }
+  const position = focusable.indexOf(current);
+  const next = focusable[position + delta] ?? current;
+  return focusItem(state, items, next);
+}
+
+export function focusNextNeedsMe(state: TuiState): TuiState {
+  if (state.snapshot === undefined) {
+    return state;
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  const candidates = focusableIndexes(items).filter((index) => {
+    const item = items[index] as WorktreeItem;
+    return rowNeedsYou(item.row);
+  });
+  if (candidates.length === 0) {
+    return state;
+  }
+  const current = focusedItemIndex(items, state) ?? -1;
+  const next = candidates.find((index) => index > current) ?? candidates[0];
+  return next === undefined ? state : focusItem(state, items, next);
+}
+
+export function activateFocusedDashboardRow(state: TuiState): TuiTransition {
+  if (state.snapshot === undefined) {
+    return { state };
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  const index = focusedItemIndex(items, state);
+  const item = index === undefined ? undefined : (items[index] as WorktreeItem);
+  // Pending rows mirror the slot-key rule: no activation while an operation is
+  // already in flight for the row.
+  if (item === undefined || item.pendingRemove !== undefined || item.pendingStart !== undefined) {
+    return { state };
+  }
+  return activateDashboardRow(state, item.row);
+}
+
+export function rowNeedsYou(row: WorktreeRow): boolean {
+  return row.agent?.state === "needs_attention" || row.agent?.state === "stuck";
+}
+
+function focusableIndexes(items: readonly DashboardViewportItem[]): number[] {
+  return items.flatMap((item, index) => (item.type === "worktree" ? [index] : []));
+}
+
+function focusedItemIndex(
+  items: readonly DashboardViewportItem[],
+  state: TuiState,
+): number | undefined {
+  if (state.focusedRowId === undefined) {
+    return undefined;
+  }
+  const index = items.findIndex(
+    (item) => item.type === "worktree" && item.row.id === state.focusedRowId,
+  );
+  return index === -1 ? undefined : index;
+}
+
+// With no cursor yet (or a stale one), enter the list where the user is
+// looking: the first/last session row inside the current viewport.
+function enterFocusIndex(
+  state: TuiState,
+  items: readonly DashboardViewportItem[],
+  focusable: readonly number[],
+  delta: -1 | 1,
+): number {
+  const { bodyRows, offset } = viewportWindow(state, items.length);
+  const visible = focusable.filter((index) => index >= offset && index < offset + bodyRows);
+  const fallback = delta > 0 ? focusable[0] : focusable[focusable.length - 1];
+  const entered = delta > 0 ? visible[0] : visible[visible.length - 1];
+  return entered ?? fallback ?? 0;
+}
+
+function focusItem(
+  state: TuiState,
+  items: readonly DashboardViewportItem[],
+  index: number,
+): TuiState {
+  const item = items[index];
+  if (item === undefined || item.type !== "worktree") {
+    return { ...state };
+  }
+  const { bodyRows, offset } = viewportWindow(state, items.length);
+  let scrollOffset = offset;
+  if (index < offset) {
+    scrollOffset = index;
+  } else if (index >= offset + bodyRows) {
+    scrollOffset = index - bodyRows + 1;
+  }
+  return { ...state, focusedRowId: item.row.id, scrollOffset };
+}
+
+function viewportWindow(state: TuiState, itemCount: number): { bodyRows: number; offset: number } {
+  const bodyRows = dashboardBodyRows(state.terminalRows);
+  return {
+    bodyRows,
+    offset: clampDashboardScrollOffset({
+      bodyRows,
+      itemCount,
+      scrollOffset: state.scrollOffset,
+    }),
+  };
+}

--- a/packages/dashboard-core/src/state/index.ts
+++ b/packages/dashboard-core/src/state/index.ts
@@ -1,4 +1,5 @@
 export * from "./commandBuilders.js";
+export * from "./dashboardFocus.js";
 export * from "./dashboardScroll.js";
 export * from "./keys.js";
 export * from "./screen.js";

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -134,16 +134,32 @@ const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
 export const TUI_KEYMAP = {
   dashboard: [
     {
-      id: "tui.dashboard.scrollUp",
+      id: "tui.dashboard.focusUp",
       pattern: { kind: "named", named: "up" },
-      action: "tui.view.scrollUp",
+      action: "tui.focus.up",
       outcome: "handled",
     },
     {
-      id: "tui.dashboard.scrollDown",
+      id: "tui.dashboard.focusDown",
       pattern: { kind: "named", named: "down" },
-      action: "tui.view.scrollDown",
+      action: "tui.focus.down",
       outcome: "handled",
+    },
+    {
+      id: "tui.dashboard.focusActivate",
+      pattern: { kind: "named", named: "return" },
+      action: "tui.focus.activate",
+      outcome: "handled",
+      help: { keys: "↵", label: "open focused session" },
+    },
+    {
+      // Tab reaches the dashboard as legacy \t, which the byte path folds to
+      // Ctrl-I (sequenceToTuiKey) — the two are indistinguishable by design.
+      id: "tui.dashboard.nextNeedsMe",
+      pattern: { kind: "char", char: "i", ctrl: true },
+      action: "tui.focus.nextNeedsMe",
+      outcome: "handled",
+      help: { keys: "⇥", label: "next session needing you" },
     },
     {
       id: "tui.dashboard.help",
@@ -707,7 +723,10 @@ export type TuiBinding<M extends TuiInputMode = TuiInputMode> =
 export const TUI_HELP_CONTENT = [
   { text: "station help", align: "center" as const },
   { text: "" },
-  { key: "↑/↓ wheel", description: "scroll dashboard" },
+  { key: "↑/↓", description: "move cursor" },
+  { key: "↵", description: "open focused session" },
+  { key: "tab", description: "next session needing you" },
+  { key: "wheel", description: "scroll dashboard" },
   { key: "1-9/a-z", description: "choose visible item" },
   { key: "N", description: "new session" },
   { key: "R", description: "rename session" },
@@ -738,16 +757,23 @@ export function dashboardFooterLabel({
   quitHint: string;
   firstRun?: boolean;
 }): string {
+  // Spec A5 triage keybar: the visible chords are the triage loop; everything
+  // else lives behind "? help".
   const full = firstRun
-    ? `A:Add Project ${quitHint}`
-    : `N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help ${quitHint}`;
-  const compactClose = `${QUIT_HINT_CLOSE} N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help`;
+    ? `A add project  ${quitHint}`
+    : `↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  ${quitHint}`;
+  const compactClose = `↵ open  N new  ⇥ next  / search  X delete  ? help  ${QUIT_HINT_CLOSE}`;
   return quitHint === QUIT_HINT_CLOSE && full.length > columns ? compactClose : full;
 }
 
 export function isSlotKey(key: TuiKey): boolean {
   // Ctrl is deliberately not excluded: row choice dispatch reads key.input, so
   // Ctrl-A still targets slot "a" after the global Ctrl-C exit binding runs.
+  // Ctrl-I is the exception — Tab folds to it in legacy encoding and the
+  // next-needs-me chord owns it; slot "i" stays reachable without ctrl.
+  if (key.ctrl === true && key.input === "i") {
+    return false;
+  }
   return (
     key.return !== true && key.escape !== true && SELECTION_KEYS.includes(key.input as SelectionKey)
   );

--- a/packages/dashboard-core/src/state/screen.ts
+++ b/packages/dashboard-core/src/state/screen.ts
@@ -19,6 +19,9 @@ export function createInitialTuiState(options: CreateInitialTuiStateOptions = {}
   if (options.initialSnapshot !== undefined) {
     state.snapshot = options.initialSnapshot;
   }
+  if (options.focusedRowId !== undefined) {
+    state.focusedRowId = options.focusedRowId;
+  }
   return state;
 }
 

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -2,6 +2,11 @@ import { createNewSessionFlow, createNewSessionNameToken } from "../../flows/new
 import { selectDashboardViewport } from "../../selectors/dashboardViewport.js";
 import { choiceValueByKey } from "../../selectors/selectors.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
+import {
+  activateFocusedDashboardRow,
+  focusNextNeedsMe,
+  moveDashboardFocus,
+} from "../dashboardFocus.js";
 import { scrollDashboard } from "../dashboardScroll.js";
 import { matchTuiBinding, type TuiBinding } from "../keymap.js";
 import type { TuiKey } from "../keys.js";
@@ -39,13 +44,19 @@ function handleDashboardBinding(
   context: TuiKeyRuntimeContext,
 ): TuiTransition {
   switch (binding.action) {
-    case "tui.view.scrollUp":
+    case "tui.focus.up":
       return {
-        state: scrollDashboard(state, -1),
+        state: moveDashboardFocus(state, -1),
       };
-    case "tui.view.scrollDown":
+    case "tui.focus.down":
       return {
-        state: scrollDashboard(state, 1),
+        state: moveDashboardFocus(state, 1),
+      };
+    case "tui.focus.activate":
+      return activateFocusedDashboardRow(state);
+    case "tui.focus.nextNeedsMe":
+      return {
+        state: focusNextNeedsMe(state),
       };
     case "tui.help.open":
       return {

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -27,6 +27,8 @@ export type TuiViewState = {
   scrollOffset: number;
   terminalRows: number;
   localRows: TuiLocalRows;
+  /** Persistent list cursor; a stale id (row gone) is harmless and simply unfocused. */
+  focusedRowId?: WorktreeId;
 };
 
 export type TuiState = TuiViewState & {
@@ -116,5 +118,6 @@ export type CreateInitialTuiStateOptions = {
   scrollOffset?: number;
   terminalRows?: number;
   localRows?: TuiLocalRows;
+  focusedRowId?: WorktreeId;
   runtime?: Partial<TuiRuntimeState>;
 };

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -1,0 +1,116 @@
+import type { TuiState } from "@station/dashboard-core";
+import { createInitialTuiState, handleTuiKey, selectDashboardItems } from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+
+const DOWN = { input: "", downArrow: true } as const;
+const UP = { input: "", upArrow: true } as const;
+const NEXT_NEEDS_ME = { input: "i", ctrl: true } as const;
+const RETURN = { input: "\r", return: true } as const;
+
+// Fixture worktree order under project web: working, attention, exited,
+// no_agent, idle, unknown, stuck — then project api: api_working.
+function state(options: Partial<Parameters<typeof createInitialTuiState>[0]> = {}): TuiState {
+  return createInitialTuiState({ initialSnapshot: createDashboardSnapshot(), ...options });
+}
+
+describe("dashboard focus cursor", () => {
+  it("enters on the first visible session row and walks rows, skipping headers", () => {
+    const first = handleTuiKey(state({ terminalRows: 12 }), DOWN).state;
+    expect(first.focusedRowId).toBe("wt_web_working");
+    expect(first.scrollOffset).toBe(0);
+
+    const second = handleTuiKey(first, DOWN).state;
+    expect(second.focusedRowId).toBe("wt_web_attention");
+  });
+
+  it("enters upward on the last visible session row", () => {
+    const entered = handleTuiKey(state({ terminalRows: 12 }), UP).state;
+    // terminalRows 12 -> bodyRows 4: header + working/attention/exited visible.
+    expect(entered.focusedRowId).toBe("wt_web_exited");
+  });
+
+  it("scrolls the viewport to keep the cursor visible when walking past the bottom", () => {
+    let current = state({ terminalRows: 12 });
+    for (let presses = 0; presses < 4; presses += 1) {
+      current = handleTuiKey(current, DOWN).state;
+    }
+    expect(current.focusedRowId).toBe("wt_web_no_agent");
+    // Item index 4 must sit inside the 4-row window: offset = 4 - 4 + 1.
+    expect(current.scrollOffset).toBe(1);
+  });
+
+  it("clamps at both ends of the session list", () => {
+    const top = handleTuiKey(handleTuiKey(state(), DOWN).state, UP).state;
+    expect(handleTuiKey(top, UP).state.focusedRowId).toBe("wt_web_working");
+
+    let bottom = state({ terminalRows: 40 });
+    for (let presses = 0; presses < 12; presses += 1) {
+      bottom = handleTuiKey(bottom, DOWN).state;
+    }
+    expect(bottom.focusedRowId).toBe("wt_api_working");
+  });
+
+  it("re-enters from the viewport when the focused row leaves the snapshot", () => {
+    const stale = { ...state({ terminalRows: 12 }), focusedRowId: "wt_gone" };
+    expect(handleTuiKey(stale, DOWN).state.focusedRowId).toBe("wt_web_working");
+  });
+
+  it("jumps to the next needs-attention or stuck row and wraps", () => {
+    const first = handleTuiKey(state({ terminalRows: 12 }), NEXT_NEEDS_ME).state;
+    expect(first.focusedRowId).toBe("wt_web_attention");
+
+    const second = handleTuiKey(first, NEXT_NEEDS_ME).state;
+    expect(second.focusedRowId).toBe("wt_web_stuck");
+    // The stuck row (item index 7) scrolled into the 4-row window.
+    expect(second.scrollOffset).toBe(4);
+
+    const wrapped = handleTuiKey(second, NEXT_NEEDS_ME).state;
+    expect(wrapped.focusedRowId).toBe("wt_web_attention");
+  });
+
+  it("activates the focused row with return", () => {
+    const focused = handleTuiKey(state(), DOWN).state;
+    const transition = handleTuiKey(focused, RETURN);
+    expect(transition.commands).toEqual([
+      {
+        type: "terminal.focus",
+        payload: { sessionId: "ses_wt_web_working" },
+      },
+    ]);
+  });
+
+  it("ignores return with no focused row", () => {
+    const initial = state();
+    const transition = handleTuiKey(initial, RETURN);
+    expect(transition.state).toBe(initial);
+    expect(transition.commands).toBeUndefined();
+  });
+
+  it("does not re-dispatch for a row whose start is already pending", () => {
+    const initial = state();
+    const items = selectDashboardItems(createDashboardSnapshot(), initial);
+    expect(items.some((item) => item.type === "worktree")).toBe(true);
+
+    const pending: TuiState = {
+      ...initial,
+      focusedRowId: "wt_web_no_agent",
+      localRows: {
+        ...initial.localRows,
+        pendingStart: [
+          {
+            localId: "start:wt_web_no_agent",
+            projectId: "web",
+            worktreeId: "wt_web_no_agent",
+            branch: "feature-auth",
+            operation: "startAgent",
+            createdAt: "2026-05-31T12:00:00.000Z",
+          },
+        ],
+      },
+    };
+    const transition = handleTuiKey(pending, RETURN);
+    expect(transition.commands).toBeUndefined();
+    expect(transition.operations).toBeUndefined();
+  });
+});

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -40,6 +40,8 @@ const ALLOWED_NOOP_BINDINGS = new Set([
   "tui.addProject.type",
   // Esc only dismisses when the runtime is showing a dismissible persistent popup.
   "tui.dashboard.dismissEsc",
+  // Return only activates once a row is focused.
+  "tui.dashboard.focusActivate",
 ]);
 
 function probeKeys(): TuiKey[] {

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -28,18 +28,18 @@ describe("TUI screen transitions", () => {
     expect(refresh.reconcileReason).toBe("tui-refresh");
   });
 
-  it("scrolls dashboard rows with arrow keys and mouse wheel events", () => {
+  it("scrolls dashboard rows with mouse wheel events", () => {
     const state = createInitialTuiState({
       initialSnapshot: createDashboardSnapshot(),
       terminalRows: 10,
     });
 
-    const down = handleTuiKey(state, { input: "", downArrow: true });
-    const wheelDown = handleTuiKey(down.state, { input: "", mouseScroll: "down" });
-    const wheelUp = handleTuiKey(wheelDown.state, { input: "", mouseScroll: "up" });
+    const wheelDown = handleTuiKey(state, { input: "", mouseScroll: "down" });
+    const wheelDownAgain = handleTuiKey(wheelDown.state, { input: "", mouseScroll: "down" });
+    const wheelUp = handleTuiKey(wheelDownAgain.state, { input: "", mouseScroll: "up" });
 
-    expect(down.state.scrollOffset).toBe(1);
-    expect(wheelDown.state.scrollOffset).toBe(2);
+    expect(wheelDown.state.scrollOffset).toBe(1);
+    expect(wheelDownAgain.state.scrollOffset).toBe(2);
     expect(wheelUp.state.scrollOffset).toBe(1);
   });
 
@@ -50,9 +50,10 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", downArrow: true }).state.scrollOffset).toBe(9);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(9);
     expect(
-      handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", upArrow: true }).state.scrollOffset,
+      handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", mouseScroll: "up" }).state
+        .scrollOffset,
     ).toBe(0);
   });
 
@@ -262,9 +263,9 @@ describe("TUI screen transitions", () => {
             initialSnapshot: createDashboardSnapshot(),
             terminalRows: 10,
           }),
-          { input: "", downArrow: true },
+          { input: "", mouseScroll: "down" },
         ).state,
-        { input: "", downArrow: true },
+        { input: "", mouseScroll: "down" },
       ).state,
       { input: "X" },
     );
@@ -286,9 +287,9 @@ describe("TUI screen transitions", () => {
             initialSnapshot: createDashboardSnapshot(),
             terminalRows: 10,
           }),
-          { input: "", downArrow: true },
+          { input: "", mouseScroll: "down" },
         ).state,
-        { input: "", downArrow: true },
+        { input: "", mouseScroll: "down" },
       ).state,
       { input: "R" },
     );

--- a/station/src/station/input/focusedRowActivate.test.ts
+++ b/station/src/station/input/focusedRowActivate.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { createTuiStore } from "@station/dashboard-core";
+import { manyProjectsSnapshot } from "../fixtures/scenarios.js";
+import { FakeTuiObserverService } from "../test/support/fakeObserverService.js";
+import { FakeStationSource } from "../test/support/fakeStationSource.js";
+import { resolveKeyFocusedRowAgentTarget } from "./stationActions.js";
+
+// Station opens rows as managed pane launches (not the machine's
+// terminal.focus, which Station-hosted panes can't honor). Enter on the
+// focused cursor row must resolve to the same RowAgentTarget a slot key or
+// click does; anything unresolved falls through to the shared machine.
+function newStore() {
+  const snapshot = manyProjectsSnapshot();
+  return createTuiStore({
+    source: new FakeStationSource(snapshot),
+    service: new FakeTuiObserverService(snapshot),
+    initialSnapshot: snapshot,
+    persistentPopup: true,
+    onDismiss: async () => {},
+  });
+}
+
+describe("resolveKeyFocusedRowAgentTarget", () => {
+  it("resolves Enter on the focused row to its managed launch", () => {
+    const store = newStore();
+    store.getState().handleKey({ input: "", downArrow: true });
+    const focusedRowId = store.getState().focusedRowId;
+    expect(focusedRowId).toBeDefined();
+
+    const target = resolveKeyFocusedRowAgentTarget(store, "\r");
+    expect(target).toMatchObject({ kind: "launch-managed", rowId: focusedRowId });
+  });
+
+  it("stays with the machine when nothing is focused or the key is not Enter", () => {
+    const unfocused = newStore();
+    expect(resolveKeyFocusedRowAgentTarget(unfocused, "\r").kind).toBe("none");
+
+    const focused = newStore();
+    focused.getState().handleKey({ input: "", downArrow: true });
+    expect(resolveKeyFocusedRowAgentTarget(focused, "x").kind).toBe("none");
+  });
+
+  it("is inert while an operation is pending on the focused row", () => {
+    const store = newStore();
+    store.getState().handleKey({ input: "", downArrow: true });
+    const focusedRowId = store.getState().focusedRowId;
+    if (focusedRowId === undefined) {
+      throw new Error("Expected a focused row.");
+    }
+    store.setState({
+      localRows: {
+        ...store.getState().localRows,
+        pendingStart: [
+          {
+            localId: `start:${focusedRowId}`,
+            operation: "startAgent",
+            projectId: "station",
+            worktreeId: focusedRowId,
+            branch: "station-overlay",
+            createdAt: "2026-07-02T12:00:00.000Z",
+          },
+        ],
+      },
+    });
+    expect(resolveKeyFocusedRowAgentTarget(store, "\r").kind).toBe("none");
+  });
+});

--- a/station/src/station/input/sequenceToTuiKey.ts
+++ b/station/src/station/input/sequenceToTuiKey.ts
@@ -36,9 +36,9 @@ export function sequenceToTuiKey(sequence: string): TuiKey | undefined {
   if (sequence.length === 1) {
     const code = sequence.charCodeAt(0);
     // Control bytes map to ctrl+letter (Ctrl-C = \x03 -> {input:"c", ctrl}).
-    // \t (Ctrl-I), \r/\n, and \x1b are named above or deliberately absent;
-    // legacy encoding cannot distinguish Tab from Ctrl-I, and the dashboard
-    // binds neither.
+    // \r/\n and \x1b are named above. Legacy encoding cannot distinguish Tab
+    // from Ctrl-I: \t reaches the dashboard as {input:"i", ctrl}, which the
+    // keymap's next-needs-me binding deliberately matches.
     if (code >= 0x01 && code <= 0x1a) {
       return { input: String.fromCharCode(code + 0x60), ctrl: true };
     }

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -16,6 +16,7 @@ import {
   focusProjectSettingsItem as focusProjectSettingsItemState,
   generatedSessionBranch,
   openProjectDefaultAgentPicker,
+  selectDashboardItems,
   selectDashboardViewport,
   type ProjectSettingsItemId,
 } from "@station/dashboard-core";
@@ -188,6 +189,42 @@ export function resolveKeyRowAgentTarget(
   }
   const row = choiceValueByKey(selectDashboardViewport(state.snapshot, state).rowChoices, sequence);
   return row === undefined ? { kind: "none" } : resolveRowAgentTarget(store, row.id);
+}
+
+/**
+ * Enter opens the focused row exactly as its slot key / click does: same
+ * RowAgentTarget, same managed-launch path. The shared machine's ↵ activation
+ * dispatches terminal.focus, which Station-hosted panes can't honor, so the
+ * overlay intercepts here. `none` when nothing is focused, the row left the
+ * snapshot, or an operation is already pending on it.
+ */
+export function resolveKeyFocusedRowAgentTarget(
+  store: StoreApi<TuiStore>,
+  sequence: string,
+): RowAgentTarget {
+  if (sequenceToTuiKey(sequence)?.return !== true) {
+    return { kind: "none" };
+  }
+  const state = store.getState();
+  if (state.snapshot === undefined || deriveStationMode(state) !== "dashboard") {
+    return { kind: "none" };
+  }
+  const focusedRowId = state.focusedRowId;
+  if (focusedRowId === undefined) {
+    return { kind: "none" };
+  }
+  const item = selectDashboardItems(state.snapshot, state).find(
+    (candidate) => candidate.type === "worktree" && candidate.row.id === focusedRowId,
+  );
+  if (
+    item === undefined ||
+    item.type !== "worktree" ||
+    item.pendingRemove !== undefined ||
+    item.pendingStart !== undefined
+  ) {
+    return { kind: "none" };
+  }
+  return resolveRowAgentTarget(store, focusedRowId);
 }
 
 /**

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -46,6 +46,13 @@ function allowedNoOpBinding(mode: StationInputMode, binding: StationBinding): bo
   if (binding.pattern.kind === "slot") {
     return true;
   }
+  // Return only acts once a row is focused; Tab only when a row needs attention.
+  if (
+    binding.id === "station.dashboard.focusActivate" ||
+    binding.id === "station.dashboard.nextNeedsMe"
+  ) {
+    return true;
+  }
   if (mode === "addProject" && binding.action === ADD_PROJECT_KEY_ACTION) {
     return true;
   }

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -133,8 +133,11 @@ export function editableTextBindings(
 
 export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]> = {
   dashboard: [
-    { id: "station.dashboard.scrollUp", pattern: { kind: "named", named: "up" }, action: "station.view.scrollUp", outcome: "handled" },
-    { id: "station.dashboard.scrollDown", pattern: { kind: "named", named: "down" }, action: "station.view.scrollDown", outcome: "handled" },
+    { id: "station.dashboard.focusUp", pattern: { kind: "named", named: "up" }, action: "station.focus.up", outcome: "handled" },
+    { id: "station.dashboard.focusDown", pattern: { kind: "named", named: "down" }, action: "station.focus.down", outcome: "handled" },
+    { id: "station.dashboard.focusActivate", pattern: { kind: "named", named: "return" }, action: "station.focus.activate", outcome: "handled", help: { keys: "↵", label: "open focused session" } },
+    // Tab folds to Ctrl-I in legacy encoding (sequenceToTuiKey); this chord is Tab.
+    { id: "station.dashboard.nextNeedsMe", pattern: { kind: "char", char: "i", ctrl: true }, action: "station.focus.nextNeedsMe", outcome: "handled", help: { keys: "⇥", label: "next session needing you" } },
     { id: "station.dashboard.help", pattern: { kind: "char", char: "H" }, action: "station.help.open", outcome: "handled", help: { keys: "H", label: "help" } },
     { id: "station.dashboard.helpAlias", pattern: { kind: "char", char: "?" }, action: "station.help.open", outcome: "handled" },
     { id: "station.dashboard.dismiss", pattern: { kind: "char", char: "Q" }, action: "station.overlay.dismiss", outcome: "close-overlay", help: { keys: "Q/esc", label: "close" } },
@@ -285,7 +288,10 @@ export const STATION_HELP_CONTENT = [
   { key: "Esc/↑↓", description: "context menu close/move" },
   { key: "Enter/Sp", description: "context menu select" },
   { text: "station project view", align: "center" as const },
-  { key: "↑/↓ wheel", description: "scroll project list" },
+  { key: "↑/↓", description: "move cursor" },
+  { key: "↵", description: "open focused session" },
+  { key: "tab", description: "next session needing you" },
+  { key: "wheel", description: "scroll project list" },
   { key: "1-9/a-z", description: "start or focus row" },
   { key: "N/A/R/C/F/P", description: "new/add/rename/fold/fork/settings" },
   { key: "X", description: "delete session" },
@@ -311,7 +317,11 @@ export const STATION_GLOBAL_BINDINGS: readonly StationBinding[] = [
 export function isSlotKey(key: TuiKey): boolean {
   // ctrl is not excluded: choice lookup in the machine reads key.input only,
   // so Ctrl-A activates slot "a" exactly as apps/tui does under Ink (the
-  // global Ctrl-C binding resolves first).
+  // global Ctrl-C binding resolves first). Ctrl-I is the exception — Tab folds
+  // to it and the next-needs-me chord owns it (mirrors the machine's isSlotKey).
+  if (key.ctrl === true && key.input === "i") {
+    return false;
+  }
   return (
     key.return !== true && key.escape !== true && SELECTION_KEYS.includes(key.input as SelectionKey)
   );

--- a/station/src/station/input/stationOverlayLayer.ts
+++ b/station/src/station/input/stationOverlayLayer.ts
@@ -20,6 +20,7 @@ import { STATION_OVERLAY_ID } from "../../state/types.js";
 import type { TuiStore } from "@station/dashboard-core";
 import {
   handleStationSequence,
+  resolveKeyFocusedRowAgentTarget,
   resolveKeyForkSessionSubmit,
   resolveKeyNewSessionSubmit,
   resolveKeyRowAgentTarget,
@@ -39,6 +40,12 @@ export function createStationOverlayLayer(
       const target = resolveKeyRowAgentTarget(stationViewStore, key);
       if (target.kind === "launch-managed") {
         return paneLaunchManagedOutcome(target);
+      }
+      // Enter on the focused row (dashboard cursor) takes the same managed
+      // launch; the machine's terminal.focus can't reach Station-hosted panes.
+      const focusedTarget = resolveKeyFocusedRowAgentTarget(stationViewStore, key);
+      if (focusedTarget.kind === "launch-managed") {
+        return paneLaunchManagedOutcome(focusedTarget);
       }
       // Enter on the New Session review screen hosts the agent in Station
       // (create worktree + managed launch) rather than the machine's tmux

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -37,6 +37,7 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
   const searchQuery = useStore(store, (state) => state.searchQuery);
   const collapsedProjectIds = useStore(store, (state) => state.collapsedProjectIds);
   const scrollOffset = useStore(store, (state) => state.scrollOffset);
+  const focusedRowId = useStore(store, (state) => state.focusedRowId);
   const localRows = useStore(store, (state) => state.localRows);
   const observerConnectionStatus = useStore(store, (state) => state.observerConnectionStatus);
   const activeToast = useStore(store, activeTuiToast);
@@ -108,7 +109,14 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
     <box width="100%" flexGrow={1} flexDirection="column">
       <DashboardView
         snapshot={snapshot}
-        viewState={{ searchQuery, collapsedProjectIds, scrollOffset, terminalRows: rows, localRows }}
+        viewState={{
+          searchQuery,
+          collapsedProjectIds,
+          scrollOffset,
+          terminalRows: rows,
+          localRows,
+          ...(focusedRowId === undefined ? {} : { focusedRowId }),
+        }}
         columns={columns}
         topRowWidgets={topRowWidgets}
         {...(observerStatus === undefined ? {} : { observerStatus })}

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -2,7 +2,7 @@
 // viewport selector. Mouse targets report through the station mouse context;
 // hover is component-local and color-only so golden frames stay layout-stable.
 import { TextAttributes } from "@opentui/core";
-import type { ProjectView, StationSnapshot } from "@station/contracts";
+import type { ProjectView, StationSnapshot, WorktreeId } from "@station/contracts";
 import { useState } from "react";
 import {
   dashboardFooterLabel,
@@ -26,6 +26,7 @@ import {
   QUIT_HINT_CLOSE,
   selectDashboardViewport,
   selectFleetSummary,
+  type DashboardSessionOverflow,
   type DashboardViewportItem,
   type FleetSummary,
 } from "@station/dashboard-core";
@@ -86,7 +87,7 @@ export function DashboardView({
   const keyByRow = new Map(viewport.displayRowChoices.map((choice) => [choice.value.id, choice.key]));
   const { headerLayout, layoutByItem } = firstRun
     ? { headerLayout: undefined, layoutByItem: new Map<string, RowGridLayout>() }
-    : dashboardRowLayouts(viewport.visibleItems, keyByRow, contentColumns);
+    : dashboardRowLayouts(viewport.visibleItems, keyByRow, contentColumns, viewState.focusedRowId);
   return (
     <box
       width="100%"
@@ -103,15 +104,20 @@ export function DashboardView({
       {firstRun ? null : <FleetBar summary={fleet} />}
       <Divider columns={contentColumns} />
       {firstRun || headerLayout === undefined ? null : <ColumnHeaderRow layout={headerLayout} />}
-      <ScrollIndicatorRow direction="above" hiddenCount={viewport.hiddenAbove} />
+      <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
       {firstRun ? (
         <box flexDirection="column" flexGrow={1}>
           <text fg={STATION_COLORS.foreground}>{truncateCells(FIRST_RUN_BODY_LABEL, contentColumns)}</text>
         </box>
       ) : (
-        <DashboardBody columns={contentColumns} items={viewport.visibleItems} layoutByItem={layoutByItem} />
+        <DashboardBody
+          columns={contentColumns}
+          items={viewport.visibleItems}
+          layoutByItem={layoutByItem}
+          focusedRowId={viewState.focusedRowId}
+        />
       )}
-      <ScrollIndicatorRow direction="below" hiddenCount={viewport.hiddenBelow} />
+      <ScrollIndicatorRow direction="below" overflow={viewport.sessionOverflow} />
       <Divider columns={contentColumns} />
       <text fg={STATION_COLORS.foreground}>
         {truncateCells(
@@ -193,15 +199,16 @@ function FleetBar({ summary }: { summary: FleetSummary }) {
 
 function ScrollIndicatorRow({
   direction,
-  hiddenCount,
+  overflow,
 }: {
   direction: "above" | "below";
-  hiddenCount: number;
+  overflow: DashboardSessionOverflow;
 }) {
   const dispatch = useStationMouse();
+  const hiddenSessions = direction === "above" ? overflow.above : overflow.below;
   return (
     <box height={1}>
-      {hiddenCount > 0 ? (
+      {hiddenSessions > 0 ? (
         <text
           fg={STATION_COLORS.gray}
           {...stationMouseProps(dispatch, {
@@ -209,7 +216,7 @@ function ScrollIndicatorRow({
             direction: direction === "above" ? "up" : "down",
           })}
         >
-          {scrollIndicatorLabel(direction, hiddenCount)}
+          {scrollIndicatorLabel(direction, overflow)}
         </text>
       ) : null}
     </box>
@@ -236,9 +243,10 @@ function dashboardRowLayouts(
   items: readonly DashboardViewportItem[],
   keyByRow: ReadonlyMap<string, string>,
   columns: number,
+  focusedRowId?: WorktreeId,
 ): { headerLayout: RowGridLayout | undefined; layoutByItem: Map<string, RowGridLayout> } {
   const rowInputs = items.flatMap((item) => {
-    const input = rowGridInputForViewportItem(item, keyByRow);
+    const input = rowGridInputForViewportItem(item, keyByRow, focusedRowId);
     return input === undefined ? [] : [input];
   });
   const layouts = layoutWorktreeRowGrid({
@@ -266,10 +274,12 @@ function DashboardBody({
   columns,
   items,
   layoutByItem,
+  focusedRowId,
 }: {
   columns: number;
   items: readonly DashboardViewportItem[];
   layoutByItem: ReadonlyMap<string, RowGridLayout>;
+  focusedRowId?: WorktreeId | undefined;
 }) {
   return (
     <box flexDirection="column" flexGrow={1}>
@@ -279,6 +289,7 @@ function DashboardBody({
           columns={columns}
           item={item}
           layout={layoutByItem.get(item.id)}
+          focusedRowId={focusedRowId}
         />
       ))}
     </box>
@@ -289,10 +300,12 @@ function DashboardViewportRow({
   columns,
   item,
   layout,
+  focusedRowId,
 }: {
   columns: number;
   item: DashboardViewportItem;
   layout: RowGridLayout | undefined;
+  focusedRowId?: WorktreeId | undefined;
 }) {
   switch (item.type) {
     case "projectGap":
@@ -308,7 +321,7 @@ function DashboardViewportRow({
       );
     case "worktree":
       return layout === undefined ? null : (
-        <WorktreeRowLine rowId={item.row.id} layout={layout} />
+        <WorktreeRowLine rowId={item.row.id} layout={layout} focused={item.row.id === focusedRowId} />
       );
     case "createLocalRow":
       // Local create rows have no slot and no activation target.
@@ -320,16 +333,25 @@ function DashboardViewportRow({
   }
 }
 
-function WorktreeRowLine({ rowId, layout }: { rowId: string; layout: RowGridLayout }) {
+function WorktreeRowLine({
+  rowId,
+  layout,
+  focused,
+}: {
+  rowId: string;
+  layout: RowGridLayout;
+  focused?: boolean;
+}) {
   const dispatch = useStationMouse();
   const [hover, setHover] = useState(false);
+  // Persistent cursor fill sits under the transient hover fill.
+  const background = hover
+    ? { backgroundColor: HOVER_BG }
+    : focused === true
+      ? { backgroundColor: STATION_COLORS.focusBackground }
+      : {};
   return (
-    <box
-      flexDirection="row"
-      width="100%"
-      height={1}
-      {...(hover ? { backgroundColor: HOVER_BG } : {})}
-    >
+    <box flexDirection="row" width="100%" height={1} {...background}>
       <box flexGrow={1} height={1} onMouseOver={() => setHover(true)} onMouseOut={() => setHover(false)}>
         <text
           width="100%"

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -22,9 +22,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-↓ 3 hidden                                                                      
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -68,7 +68,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help Q/esc:close       
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
@@ -86,9 +86,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ?
  [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
-↓ 11 hidden                                                 
+▼ 6 below · showing 5 of 11                                 
 ─────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
+↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
@@ -102,9 +102,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
-↓ 15 hidden                             
+▼ 8 below · showing 3 of 11             
 ─────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/… 
+↵ open  N new  ⇥ next  / search  X del… 
 "
 `;
 
@@ -132,7 +132,7 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -176,7 +176,7 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-N:new A:add R:rename F:fork Z:refresh 1-9/a-z:open X:delete session /:search C:fold P:settings H:help Q/esc:close       
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
@@ -194,9 +194,9 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ?
                                                             
 ▼ observer  2 sessions · 2 agents             [sh] [qs] [▾] 
  [5] x done-run           opencode  exited                  
-↓ 1 hidden                                                  
+▼ 1 below · showing 5 of 6                                  
 ─────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete se… 
+↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
@@ -210,9 +210,9 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
-↓ 5 hidden                              
+▼ 3 below · showing 3 of 6              
 ─────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/… 
+↵ open  N new  ⇥ next  / search  X del… 
 "
 `;
 
@@ -240,7 +240,7 @@ No projects configured yet.
                                                                                 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
-A:Add Project Q/esc:close                                                       
+A add project  Q/esc:close                                                      
 "
 `;
 
@@ -284,7 +284,7 @@ No projects configured yet.
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-A:Add Project Q/esc:close                                                                                               
+A add project  Q/esc:close                                                                                              
 "
 `;
 
@@ -304,7 +304,7 @@ No projects configured yet.
                                                             
                                                             
 ─────────────────────────────────────────────────────────── 
-A:Add Project Q/esc:close                                   
+A add project  Q/esc:close                                  
 "
 `;
 
@@ -320,6 +320,6 @@ No projects configured yet.
                                         
                                         
 ─────────────────────────────────────── 
-A:Add Project Q/esc:close               
+A add project  Q/esc:close              
 "
 `;

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -16,15 +16,15 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ observ│  Esc/↑↓     context menu close/move                          │qs] [▾] 
  [6] x b│  Enter/Sp   context menu select                              │   #8 ✓ 
  [7] ⠋ p│                     station project view                     │8 #16 … 
- [8] ○ t│  ↑/↓ wheel  scroll project list                              │-1 #4 ✓ 
-        │  1-9/a-z    start or focus row                               │        
-▼ script│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │qs] [▾] 
- [9] ○ a│  X          delete session                                   │6 #5 x1 
- [a] ? m│  /, Z       search / refresh snapshot                        │ -1 #10 
- [b] - o│  H/?        help                                             │        
-↓ 3 hidd╰──────────────────────────────────────────────────────────────╯        
+ [8] ○ t│  ↑/↓        move cursor                                      │-1 #4 ✓ 
+        │  ↵          open focused session                             │        
+▼ script│  tab        next session needing you                         │qs] [▾] 
+ [9] ○ a│  wheel      scroll project list                              │6 #5 x1 
+ [a] ? m│  1-9/a-z    start or focus row                               │ -1 #10 
+ [b] - o│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
+        ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -50,9 +50,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
 search: apiexperiment                     -         no agent                    
-↓ 3 hidden                                                                      
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -78,9 +78,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
 collapse project: 1:station 2:observer 3:scripts 4:empty-project                
-↓ 3 hidden                                                                      
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -106,9 +106,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
 settings for project: 1:station 2:observer 3:scripts 4:empty-project            
-↓ 3 hidden                                                                      
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -134,9 +134,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│ ↑↓ move   →/enter edit   esc close                                     │   
-↓ 3└────────────────────────────────────────────────────────────────────────┘   
+   └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -162,9 +162,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│ ←/esc back                                                             │   
-↓ 3└────────────────────────────────────────────────────────────────────────┘   
+   └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -190,9 +190,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│ ↑↓ move   →/enter edit   esc close                                     │   
-↓ 3└────────────────────────────────────────────────────────────────────────┘   
+   └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -220,7 +220,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 │ Click a row or press slot key              │      no agent                    
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
-└────────────────────────────────────────────┘ X:delete session /:search H:help 
+└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -248,7 +248,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 │ Yes (y)     No (n)                         │      no agent                    
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
-└────────────────────────────────────────────┘ X:delete session /:search H:help 
+└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -274,9 +274,9 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
 Choose the slot to rename: 1-9/a-z        -         no agent                    
-↓ 3 hidden                                                                      
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
-Q/esc:close N:new A:add Z:refresh 1-9/a-z:open X:delete session /:search H:help 
+↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -332,7 +332,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 │ Click a row or press slot key              │      no agent                    
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
-└────────────────────────────────────────────┘ X:delete session /:search H:help 
+└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
 "
 `;
 
@@ -360,7 +360,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 │                                            │      no agent                    
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
-└────────────────────────────────────────────┘ X:delete session /:search H:help 
+└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
 "
 `;
 

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -284,6 +284,38 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("[ + add session ]");
   });
 
+  it("renders the focus cursor and jumps it to the next session needing you", async () => {
+    const { store } = makeStationTestStore({
+      snapshot: attentionAndFailuresSnapshot(),
+      seedInitialSnapshot: false,
+    });
+    store.getState().start();
+    const setup = await testRender(<DashboardRoot store={store} columns={80} rows={24} />, {
+      width: 80,
+      height: 24,
+    });
+    teardowns.push(() => {
+      setup.renderer.destroy();
+    });
+    await setup.renderOnce();
+    expect(setup.captureCharFrame()).not.toContain("▏");
+
+    store.getState().handleKey({ input: "", downArrow: true });
+    await setup.flush();
+    let lines = setup.captureCharFrame().split("\n");
+    const cursorRow = lines.findIndex((line) => line.startsWith("▏"));
+    expect(lines[cursorRow]).toContain("hook-scope");
+    const spans = setup.captureSpans();
+    expect(spanHex(spanAtFrameCell(spans, cursorRow, 0))).toBe(STATION_COLORS.cyan);
+    expect(spanBgHex(spanAtFrameCell(spans, cursorRow, 0))).toBe(STATION_COLORS.focusBackground);
+
+    // Tab (Ctrl-I) jumps past the working/unknown rows to the stuck one.
+    store.getState().handleKey({ input: "i", ctrl: true });
+    await setup.flush();
+    lines = setup.captureCharFrame().split("\n");
+    expect(lines.find((line) => line.startsWith("▏"))).toContain("popup-latency");
+  });
+
   it("paints hovered worktree rows through the trailing action column", async () => {
     const setup = await renderDashboard({ width: 80, height: 24, snapshot: manyProjectsSnapshot() });
     const before = setup.captureCharFrame();

--- a/station/src/station/view/theme.ts
+++ b/station/src/station/view/theme.ts
@@ -18,6 +18,7 @@ export const STATION_COLORS = {
   overlayBackdrop: "#000000",
   hairline: "#20252c",
   frozenSurface: "#12161b",
+  focusBackground: "#15222e",
 } as const;
 
 export function rowColorToHex(color: RowColor | undefined): string | undefined {
@@ -34,6 +35,8 @@ export function rowColorToHex(color: RowColor | undefined): string | undefined {
       return STATION_COLORS.green;
     case "blue":
       return STATION_COLORS.blue;
+    case "cyan":
+      return STATION_COLORS.cyan;
     case "purple":
       return STATION_COLORS.purple;
   }


### PR DESCRIPTION
PR5 of the UX upgrade plan (D9, D10). Interaction layer for the overview screen.

## What
- **Focused-row cursor**: `focusedRowId` joins `TuiState`. ↑/↓ move a persistent cursor across session rows (headers/gaps skipped); the viewport scrolls to keep it visible. Entry point is the first/last *visible* session row, so the cursor lands where you're looking. Renders as a cyan `▏` in the identity pad cell (grid geometry never shifts) plus a `focusBackground` row fill distinct from the transient hover fill.
- **Cursor vs jump keys (D9)**: cursor = where you are (↵ activates it); jump keys and row clicks still teleport-and-activate directly. Rows with a pending start/remove don't re-dispatch on ↵.
- **`⇥ next-needs-me`**: Tab jumps the cursor to the next `needs_attention || stuck` row, wrapping. Tab folds to Ctrl-I in legacy encoding, so the chord is bound as ctrl+i and carved out of the slot-key pattern (slot "i" stays reachable without ctrl — machine + station mirror updated together).
- **Footer keybar → spec A5**: `↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help` (+ quit hint). Help overlays updated to match.
- **Scroll overflow labels (D10, labels only)**: `↑ N hidden` → `▲ N sessions above` / `▼ M below · showing X of Y`, counting session rows rather than raw viewport items. Wheel still scrolls without moving the cursor.

## Testing
- vitest: 204/204 (new `dashboardFocus.test.ts`: entry, walking, viewport-follow, clamping, stale-focus recovery, wrap, ↵ activation + pending no-op)
- bun: 828/828 (new golden asserting cyan `▏` + focus fill + Tab jump; goldens regenerated for footer/labels)
- keymap anti-drift suites (core + station mirror) green; `pnpm lint` + `pnpm typecheck` + station tsc clean

## UX implication & manual check
Arrow through the list — a cyan `▏` cursor tracks and the view follows past the fold; press ⇥ to hop between sessions that need you; ↵ opens the one under the cursor; the indicators read `▼ 6 below · showing 5 of 11` in an overflowing list (mock mode at 120×40, then shrink).