### PR TITLE
feat(island): opt-in rest modes + attention queue, ↵ jump, merge celebration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -260,6 +260,14 @@ Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 - **`type = "weather"`** — required `city`; optional `label`, `temperature_unit`
   (`fahrenheit` \| `celsius`), `refresh_interval_minutes` (int > 0).
 
+`[tui.island]` — opt-in display modes for the floating Station island (top-right
+button). Both default off:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| `rest_counts` | bool | Collapsed island shows live fleet counts (`⠿ working · ● ready · ○ idle`) instead of the bare mark. |
+| `project_rollup` | bool | Hovering the island lists each project's worst agent status instead of the working/idle totals. |
+
 ### `[repository.github]` — repository metadata provider (optional)
 
 Enabled by default when omitted. Set `enabled = false` to disable GitHub metadata.

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -121,7 +121,15 @@ function normalizeHooksConfig(value: unknown): unknown {
 }
 
 function normalizeTuiConfig(value: unknown): unknown {
-  return normalizeObject(value, {}, { widgets: normalizeTuiWidgetConfigs });
+  return normalizeObject(
+    value,
+    {},
+    { widgets: normalizeTuiWidgetConfigs, island: normalizeTuiIslandConfig },
+  );
+}
+
+function normalizeTuiIslandConfig(value: unknown): unknown {
+  return normalizeObject(value);
 }
 
 function normalizeTuiWidgetConfigs(value: unknown): unknown {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -244,9 +244,21 @@ export const TuiWidgetConfigSchema = z.discriminatedUnion("type", [
 
 export type TuiWidgetConfig = z.infer<typeof TuiWidgetConfigSchema>;
 
+export const TuiIslandConfigSchema = z
+  .object({
+    /** Collapsed island shows live fleet counts (working/ready/idle) instead of the bare mark. */
+    restCounts: z.boolean().optional(),
+    /** Hovered island lists each project's worst agent status instead of the totals summary. */
+    projectRollup: z.boolean().optional(),
+  })
+  .strict();
+
+export type TuiIslandConfig = z.infer<typeof TuiIslandConfigSchema>;
+
 export const TuiConfigSchema = z
   .object({
     widgets: z.array(TuiWidgetConfigSchema).optional(),
+    island: TuiIslandConfigSchema.optional(),
   })
   .strict();
 

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -550,6 +550,32 @@ ${projectToml("web", root)}
     expect(omitted.config.tui).toEqual({});
   });
 
+  it("loads [tui.island] display modes with snake_case keys", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+
+    const loaded = await loadConfigFromToml(
+      `
+schema_version = 1
+
+[defaults]
+worktree_provider = "worktrunk"
+terminal = "tmux"
+harness = "codex"
+layout = "agent-build-shell"
+
+[tui.island]
+rest_counts = true
+project_rollup = false
+
+${projectToml("web", root)}
+`,
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.tui?.island).toEqual({ restCounts: true, projectRollup: false });
+  });
+
   it.each([
     [
       "unknown widget type",

--- a/packages/dashboard-core/src/widgets/types.ts
+++ b/packages/dashboard-core/src/widgets/types.ts
@@ -1,7 +1,7 @@
-import type { TuiConfig, TuiWidgetConfig } from "@station/config";
+import type { TuiConfig, TuiIslandConfig, TuiWidgetConfig } from "@station/config";
 import type { TopRowWidgetText } from "../components/Dashboard/content.js";
 
-export type { TuiConfig, TuiWidgetConfig };
+export type { TuiConfig, TuiIslandConfig, TuiWidgetConfig };
 
 export type TopRowWidgetView = TopRowWidgetText & {
   id: string;

--- a/station/src/app/StationApp.tsx
+++ b/station/src/app/StationApp.tsx
@@ -36,6 +36,7 @@ export function StationApp({
   onCopySelection,
   automations,
   widgets = EMPTY_WIDGETS,
+  island,
   topRowWidgetDeps,
 }: StationAppProps) {
   const overlayVisible = useStoreValue(store, selectStationOverlayVisible);
@@ -80,7 +81,12 @@ export function StationApp({
       <StationToast store={store} />
       {/* Floats at the top-right above everything; only its own hitbox captures
           mouse events, so clicks elsewhere reach the panes underneath. */}
-      <StationButton store={store} stationViewStore={stationViewStore} dispatchMouse={dispatchMouse} />
+      <StationButton
+        store={store}
+        stationViewStore={stationViewStore}
+        dispatchMouse={dispatchMouse}
+        island={island}
+      />
     </box>
   );
 }

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -315,6 +315,10 @@ function buildViewProps(
   if (widgets !== undefined) {
     viewProps.widgets = widgets;
   }
+  const island = options.tuiConfig?.island;
+  if (island !== undefined) {
+    viewProps.island = island;
+  }
   if (options.topRowWidgetDeps !== undefined) {
     viewProps.topRowWidgetDeps = options.topRowWidgetDeps;
   }

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -2,6 +2,7 @@ import type { TuiStore } from "@station/dashboard-core";
 import type {
   TopRowWidgetRuntimeDeps,
   TuiConfig,
+  TuiIslandConfig,
   TuiWidgetConfig,
 } from "@station/dashboard-core/widgets/types";
 import type { StoreApi } from "zustand/vanilla";
@@ -27,6 +28,8 @@ export type StationAppProps = {
   /** Configured automations surfaced in the pane context menu. */
   automations: readonly Automation[];
   widgets?: readonly TuiWidgetConfig[];
+  /** Opt-in island display modes from `[tui.island]`. */
+  island?: TuiIslandConfig;
   topRowWidgetDeps?: TopRowWidgetRuntimeDeps;
 };
 

--- a/station/src/input/keymaps.ts
+++ b/station/src/input/keymaps.ts
@@ -6,14 +6,16 @@ export type LayerId =
   | "command-palette"
   | "context-menu"
   | "overlay"
+  | "station-button"
   | "terminal"
   | "workspace"
   | "base";
 
 /**
- * The documented priority order, highest first. All seven slots are named so
- * a future layer is a registration into an existing slot; only layers that
- * are actually registered participate in resolution.
+ * The documented priority order, highest first. All slots are named so a
+ * future layer is a registration into an existing slot; only layers that
+ * are actually registered participate in resolution. station-button sits
+ * above terminal so the hovered island can claim ↵ before pane passthrough.
  */
 export const LAYER_PRIORITY: readonly LayerId[] = [
   "resize-drag",
@@ -21,6 +23,7 @@ export const LAYER_PRIORITY: readonly LayerId[] = [
   "command-palette",
   "context-menu",
   "overlay",
+  "station-button",
   "terminal",
   "workspace",
   "base",

--- a/station/src/input/router.test.ts
+++ b/station/src/input/router.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "bun:test";
+import { createTuiStore } from "@station/dashboard-core";
+import type { StationSnapshot } from "@station/contracts";
+import {
+  attentionAndFailuresSnapshot,
+  manyProjectsSnapshot,
+} from "../station/fixtures/scenarios.js";
+import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
+import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
 import { createStationStore } from "../state/store.js";
-import { MAIN_PANE_ID, STATION_OVERLAY_ID, type StationState } from "../state/types.js";
+import {
+  agentWorktreePaneId,
+  MAIN_PANE_ID,
+  STATION_OVERLAY_ID,
+  type StationState,
+} from "../state/types.js";
 import type { StationMouseEvent } from "./mouse.js";
 import { routeKey, routeMouse, routePaste, type StationCommandId } from "./router.js";
 import {
@@ -322,5 +335,84 @@ describe("routePaste", () => {
 
   it("swallows paste while on welcome with no pane", () => {
     expect(routePaste("hello", welcomeState())).toEqual({ kind: "swallowed" });
+  });
+});
+
+describe("the station-button layer (island ↵ jump)", () => {
+  function keymapFor(snapshot: StationSnapshot) {
+    const stationViewStore = createTuiStore({
+      source: new FakeStationSource(snapshot),
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      onDismiss: async () => {},
+    });
+    return createStationKeymap(stationViewStore);
+  }
+
+  function flaggedRowId(snapshot: StationSnapshot): string {
+    const row = snapshot.rows.find(
+      (candidate) =>
+        candidate.display.statusLabel === "needs attention" ||
+        candidate.display.statusLabel === "stuck",
+    );
+    if (row === undefined) {
+      throw new Error("fixture is expected to contain a flagged row");
+    }
+    return row.id;
+  }
+
+  it("opens the overlay on ↵ while hovering the alerting island with no local agent pane", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const store = createStationStore();
+    store.actions.setStationButtonHover(true);
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "overlay-open",
+      overlayId: STATION_OVERLAY_ID,
+    });
+  });
+
+  it("focuses the flagged session's agent pane on ↵ when it is hosted locally", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const paneId = agentWorktreePaneId(flaggedRowId(snapshot));
+    const store = createStationStore();
+    store.actions.createPane(paneId, { role: "primary-agent" });
+    store.actions.setStationButtonHover(true);
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "focus",
+      target: { kind: "pane", paneId },
+    });
+  });
+
+  it("leaves ↵ with the focused pane when the island is not hovered", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const store = createStationStore();
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "terminal-write",
+      paneId: MAIN_PANE_ID,
+      bytes: "\r",
+    });
+  });
+
+  it("leaves ↵ with the focused pane when nothing needs the user", () => {
+    const snapshot = manyProjectsSnapshot();
+    const store = createStationStore();
+    store.actions.setStationButtonHover(true);
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "terminal-write",
+      paneId: MAIN_PANE_ID,
+      bytes: "\r",
+    });
+  });
+
+  it("passes other keys through to the pane even while the jump is armed", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const store = createStationStore();
+    store.actions.setStationButtonHover(true);
+    expect(routeKey("a", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "terminal-write",
+      paneId: MAIN_PANE_ID,
+      bytes: "a",
+    });
   });
 });

--- a/station/src/input/stationBindings.ts
+++ b/station/src/input/stationBindings.ts
@@ -1,7 +1,9 @@
 import type { StoreApi } from "zustand/vanilla";
-import { STATION_OVERLAY_ID, type StationState } from "../state/types.js";
+import { agentWorktreePaneId, STATION_OVERLAY_ID, type StationState } from "../state/types.js";
+import { selectPaneRecord } from "../state/selectors.js";
 import { createStationOverlayLayer } from "../station/input/stationOverlayLayer.js";
 import { routeStationMouse } from "../station/input/stationMouse.js";
+import { rowNeedsUser } from "../stationButton/status.js";
 import type { TuiStore } from "@station/dashboard-core";
 import { createKeymapStack, type KeymapLayer, type KeymapStack } from "./keymaps.js";
 import {
@@ -128,6 +130,43 @@ const contextMenuLayer: KeymapLayer<RouteOutcome> = {
   catchAll: () => ({ kind: "swallowed" }),
 };
 
+/**
+ * The island's ↵ jump (C6): active only while the mouse is over the island, a
+ * session is asking for the user, and no overlay owns the screen — the narrow
+ * window where the expanded attention card is showing "↵ or click to focus".
+ * Everywhere else Enter falls through to terminal passthrough untouched.
+ */
+function createStationButtonLayer(
+  stationViewStore: StoreApi<TuiStore>,
+): KeymapLayer<RouteOutcome> {
+  const attentionRow = () => stationViewStore.getState().snapshot?.rows.find(rowNeedsUser);
+  return {
+    id: "station-button",
+    isActive: (state) =>
+      state.input.stationButtonHover &&
+      state.input.activeOverlay === null &&
+      attentionRow() !== undefined,
+    bindings: [
+      {
+        keys: [ENTER_LEGACY],
+        action: (state) => {
+          const row = attentionRow();
+          if (row === undefined) {
+            return { kind: "swallowed" };
+          }
+          // Mirror the island's click: focus the flagged session's live agent
+          // pane, else open the dashboard so the user can act on it.
+          const paneId = agentWorktreePaneId(row.id);
+          if (selectPaneRecord(state, paneId)?.role === "primary-agent") {
+            return { kind: "focus", target: { kind: "pane", paneId } };
+          }
+          return { kind: "overlay-open", overlayId: STATION_OVERLAY_ID };
+        },
+      },
+    ],
+  };
+}
+
 const workspaceLayer: KeymapLayer<RouteOutcome> = {
   id: "workspace",
   isActive: () => true,
@@ -174,7 +213,17 @@ export function createStationKeymap(
 ): KeymapStack<RouteOutcome> {
   const overlayLayer =
     stationViewStore === undefined ? placeholderOverlayLayer : createStationOverlayLayer(stationViewStore);
-  return createKeymapStack([contextMenuLayer, overlayLayer, terminalLayer, workspaceLayer, welcomeLayer]);
+  const layers: KeymapLayer<RouteOutcome>[] = [
+    contextMenuLayer,
+    overlayLayer,
+    terminalLayer,
+    workspaceLayer,
+    welcomeLayer,
+  ];
+  if (stationViewStore !== undefined) {
+    layers.push(createStationButtonLayer(stationViewStore));
+  }
+  return createKeymapStack(layers);
 }
 
 /**

--- a/station/src/state/initialState.ts
+++ b/station/src/state/initialState.ts
@@ -48,6 +48,7 @@ function workspaceState(workspace: WorkspaceSlice): StationState {
       activeOverlay: null,
       overlayReturnFocus: null,
       contextMenu: null,
+      stationButtonHover: false,
     },
     feedback: { toast: null },
   };
@@ -65,6 +66,7 @@ function emptyInitialState(): StationState {
       activeOverlay: null,
       overlayReturnFocus: null,
       contextMenu: null,
+      stationButtonHover: false,
     },
     feedback: { toast: null },
   };

--- a/station/src/state/store.ts
+++ b/station/src/state/store.ts
@@ -67,6 +67,8 @@ export type StationStoreActions = {
   openContextMenu(target: ContextMenuTarget, anchor: ContextMenuAnchor): void;
   closeContextMenu(): void;
   setContextMenuActiveIndex(activeIndex: number): void;
+  /** Track mouse-over on the floating island (gates its hover-scoped ↵ jump). */
+  setStationButtonHover(hovered: boolean): void;
   /** Show a bottom-right app toast (e.g. a copy confirmation). */
   showToast(message: string, kind?: "info" | "error"): void;
   /** Clear the toast if it still carries `token` (ignores a superseded timer). */
@@ -309,6 +311,12 @@ export function createStationStore(options?: StationStoreOptions): StationStore 
             contextMenu: { ...contextMenu, activeIndex },
           },
         });
+      },
+      setStationButtonHover: (hovered) => {
+        if (state.input.stationButtonHover === hovered) {
+          return;
+        }
+        setState({ ...state, input: { ...state.input, stationButtonHover: hovered } });
       },
       showToast: (message, kind = "info") => {
         toastToken += 1;

--- a/station/src/state/types.ts
+++ b/station/src/state/types.ts
@@ -121,6 +121,8 @@ export type InputSlice = {
   /** Focus to restore when the overlay closes; only pane focus is recorded. */
   overlayReturnFocus: FocusTarget | null;
   contextMenu: ContextMenuState | null;
+  /** Mouse is over the floating island; scopes its ↵ jump so Enter never leaves a pane otherwise. */
+  stationButtonHover: boolean;
 };
 
 /**

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -9,6 +9,8 @@ import { ANIM_MS, STATION_ICON } from "./layout.js";
 
 const SURFACE = { width: 40, height: 12 };
 
+const CALM = { attention: false, needsYouCount: 0, workingCount: 0, readyCount: 0, idleCount: 0 };
+
 async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<string> {
   const setup = await testRender(node, SURFACE);
   try {
@@ -22,7 +24,7 @@ async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<str
 describe("DynamicStationButton", () => {
   it("collapsed base shows only the station icon", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton attention={false} workingCount={2} idleCount={14} />,
+      <DynamicStationButton {...CALM} workingCount={2} idleCount={14} />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).not.toContain("session");
@@ -30,7 +32,12 @@ describe("DynamicStationButton", () => {
 
   it("collapsed attention frames the icon with exclamation marks", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton attention={true} workingCount={0} idleCount={0} sessionName="hook-scope" />,
+      <DynamicStationButton
+        {...CALM}
+        attention={true}
+        needsYouCount={1}
+        sessionName="hook-scope"
+      />,
     );
     expect(frame).toContain(STATION_ICON);
     // Framed alert: solid "!" rows top and bottom around the centered icon.
@@ -38,28 +45,81 @@ describe("DynamicStationButton", () => {
     expect(frame).not.toContain("needs user");
   });
 
+  it("collapsed rest counts paint the fleet lanes", async () => {
+    const frame = await captureFrame(
+      <DynamicStationButton {...CALM} readyCount={1} idleCount={6} restCounts={true} />,
+    );
+    expect(frame).toContain(STATION_ICON);
+    expect(frame).toContain("⠿0 ●1 ○6");
+    expect(frame).not.toContain("session");
+  });
+
+  it("collapsed celebration announces the merged PR", async () => {
+    const frame = await captureFrame(
+      <DynamicStationButton {...CALM} idleCount={3} celebration={{ prNumber: 42 }} />,
+    );
+    expect(frame).toContain(STATION_ICON);
+    expect(frame).toContain("✓ #42 merged");
+  });
+
+  it("attention wins over the celebration", async () => {
+    const frame = await captureFrame(
+      <DynamicStationButton
+        {...CALM}
+        attention={true}
+        needsYouCount={1}
+        sessionName="hook-scope"
+        celebration={{ prNumber: 42 }}
+      />,
+    );
+    expect(frame).toContain("!!!!");
+    expect(frame).not.toContain("#42");
+  });
+
   it("expanded base shows the working/idle summary", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton attention={false} workingCount={2} idleCount={14} hovered />,
+      <DynamicStationButton {...CALM} workingCount={2} readyCount={5} idleCount={9} hovered />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("2 sessions working");
+    // Ready sessions read as idle in the totals card (5 ready + 9 idle).
     expect(frame).toContain("14 sessions idle");
+  });
+
+  it("expanded roll-up lists each project's worst status and folds the rest", async () => {
+    const projects = [
+      { projectId: "p1", name: "station", status: "needsYou" as const },
+      { projectId: "p2", name: "docs", status: "idle" as const },
+      { projectId: "p3", name: "web", status: "ready" as const },
+      { projectId: "p4", name: "cli", status: "idle" as const },
+      { projectId: "p5", name: "api", status: "idle" as const },
+      { projectId: "p6", name: "infra", status: "idle" as const },
+      { projectId: "p7", name: "tools", status: "idle" as const },
+    ];
+    const frame = await captureFrame(
+      <DynamicStationButton {...CALM} projectRollup={projects} hovered />,
+    );
+    expect(frame).toContain("! station");
+    expect(frame).toContain("○ docs");
+    expect(frame).toContain("● web");
+    expect(frame).toContain("+2 more");
+    expect(frame).not.toContain("tools");
+    expect(frame).not.toContain("sessions working");
   });
 
   it("expanded attention shows the session name and intervention message", async () => {
     const frame = await captureFrame(
       <DynamicStationButton
+        {...CALM}
         attention={true}
-        workingCount={0}
-        idleCount={0}
+        needsYouCount={1}
         sessionName="hook-scope"
         hovered
       />,
     );
     expect(frame).toContain("hook-scope");
     expect(frame).toContain("needs your attention");
-    expect(frame).toContain("click to focus");
+    expect(frame).toContain("↵ or click to focus");
 
     const lines = frame.split("\n");
     const [topBorder, iconRow, titleRow] = lines;
@@ -73,9 +133,23 @@ describe("DynamicStationButton", () => {
     expect(lines[bottomBorder - 1]?.slice(buttonLeft).replace(/[│ ]/g, "")).toBe("");
   });
 
+  it("expanded attention shows the queue when several sessions ask", async () => {
+    const frame = await captureFrame(
+      <DynamicStationButton
+        {...CALM}
+        attention={true}
+        needsYouCount={3}
+        sessionName="hook-scope"
+        hovered
+      />,
+    );
+    expect(frame).toContain("! 3 need you ›");
+    expect(frame).not.toContain("needs your attention");
+  });
+
   it("switches the mouse pointer to a hand on hover and back on leave", async () => {
     const setup = await testRender(
-      <DynamicStationButton attention={false} workingCount={1} idleCount={2} />,
+      <DynamicStationButton {...CALM} workingCount={1} idleCount={2} />,
       SURFACE,
     );
     try {

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -9,11 +9,14 @@ import {
 } from "../input/mouse.js";
 import { useHoverPointer } from "../useHoverPointer.js";
 import { STATION_COLORS } from "../station/view/theme.js";
+import { Throbber } from "../station/view/Throbber.js";
 import { lerpColor, type StationButtonStateColors, stationButtonColors } from "./colors.js";
+import type { ProjectRollupEntry, ProjectRollupStatus } from "./status.js";
 import {
   ANIM_MS,
-  ATTENTION_LINES,
   ATTENTION_MARK,
+  attentionLines,
+  celebrationText,
   clampSessionName,
   COLLAPSED_ATTENTION_COLS,
   COLLAPSED_BASE_COLS,
@@ -23,7 +26,11 @@ import {
   FRAME_MS,
   GRADIENT_EDGE,
   ICON_COLS,
+  ICON_PAD,
+  type IslandCelebration,
   lerp,
+  paintedCount,
+  ROLLUP_MAX_LINES,
   sessionSummary,
   STATION_BUTTON_Z_INDEX,
   STATION_ICON,
@@ -32,12 +39,23 @@ import {
 
 export type DynamicStationButtonProps = {
   attention: boolean;
+  /** Sessions asking for the user; >1 swaps the attention card to the queue line. */
+  needsYouCount: number;
   workingCount: number;
+  readyCount: number;
   idleCount: number;
   sessionName?: string | undefined;
+  /** C3 opt-in: the collapsed rest state paints fleet counts, not the bare mark. */
+  restCounts?: boolean | undefined;
+  /** C2 opt-in: the hovered card lists each project's worst status. */
+  projectRollup?: readonly ProjectRollupEntry[] | undefined;
+  /** A just-merged PR to celebrate; replaces the collapsed rest content while set. */
+  celebration?: IslandCelebration | undefined;
   /** Force-expand from external hover state; internal mouse hover also expands. */
   hovered?: boolean | undefined;
   focused?: boolean | undefined;
+  /** Reports mouse-over so the app can scope island keyboard actions to hover. */
+  onHoverChange?: ((hovered: boolean) => void) | undefined;
   /** Left-click in a base state (no attention) — opens/closes the STATION overlay. */
   onToggleStation?: ((event: StationMouseEvent) => void) | undefined;
   /** Left-click in an attention state — focus the flagged session. */
@@ -47,10 +65,14 @@ export type DynamicStationButtonProps = {
 };
 
 export function DynamicStationButton(props: DynamicStationButtonProps): ReactNode {
-  const { attention, workingCount, idleCount, sessionName } = props;
+  const { attention, onHoverChange } = props;
   const [internalHover, setInternalHover] = useState(false);
   const expanded = (props.hovered ?? false) || (props.focused ?? false) || internalHover;
-  const pointerProps = useHoverPointer({ onHoverChange: setInternalHover });
+  const handleHoverChange = (hovering: boolean): void => {
+    setInternalHover(hovering);
+    onHoverChange?.(hovering);
+  };
+  const pointerProps = useHoverPointer({ onHoverChange: handleHoverChange });
 
   const open = useOpenAmount(expanded ? 1 : 0);
   const collapsed = targetDims(false, props);
@@ -122,9 +144,14 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
         iconPadX={iconPadX}
         iconPadY={iconPadY}
         reveal={textReveal}
-        workingCount={workingCount}
-        idleCount={idleCount}
-        sessionName={sessionName}
+        needsYouCount={props.needsYouCount}
+        workingCount={props.workingCount}
+        readyCount={props.readyCount}
+        idleCount={props.idleCount}
+        sessionName={props.sessionName}
+        restCounts={props.restCounts}
+        projectRollup={props.projectRollup}
+        celebration={props.celebration}
       />
       {/* Keeps one stable hit target above morphing text/icon children during expand/collapse. */}
       <box
@@ -147,17 +174,34 @@ function StationButtonContent(props: {
   iconPadX: number;
   iconPadY: number;
   reveal: number;
+  needsYouCount: number;
   workingCount: number;
+  readyCount: number;
   idleCount: number;
   sessionName?: string | undefined;
+  restCounts?: boolean | undefined;
+  projectRollup?: readonly ProjectRollupEntry[] | undefined;
+  celebration?: IslandCelebration | undefined;
 }): ReactNode {
   const { attention, expanded, color, iconPadX, iconPadY, reveal } = props;
   if (!expanded) {
-    return attention ? (
-      <CollapsedAttention color={color} />
-    ) : (
-      <CollapsedBase color={color} iconPadX={iconPadX} iconPadY={iconPadY} />
-    );
+    if (attention) {
+      return <CollapsedAttention color={color} />;
+    }
+    if (props.celebration !== undefined) {
+      return <CollapsedCelebration celebration={props.celebration} />;
+    }
+    if (props.restCounts === true) {
+      return (
+        <CollapsedCounts
+          iconColor={color.icon}
+          workingCount={props.workingCount}
+          readyCount={props.readyCount}
+          idleCount={props.idleCount}
+        />
+      );
+    }
+    return <CollapsedBase color={color} iconPadX={iconPadX} iconPadY={iconPadY} />;
   }
   if (attention) {
     return (
@@ -166,7 +210,19 @@ function StationButtonContent(props: {
         iconPadX={iconPadX}
         iconPadY={iconPadY}
         reveal={reveal}
+        needsYouCount={props.needsYouCount}
         sessionName={props.sessionName}
+      />
+    );
+  }
+  if (props.projectRollup !== undefined && props.projectRollup.length > 0) {
+    return (
+      <ExpandedRollup
+        color={color}
+        iconPadX={iconPadX}
+        iconPadY={iconPadY}
+        reveal={reveal}
+        entries={props.projectRollup}
       />
     );
   }
@@ -177,6 +233,7 @@ function StationButtonContent(props: {
       iconPadY={iconPadY}
       reveal={reveal}
       workingCount={props.workingCount}
+      readyCount={props.readyCount}
       idleCount={props.idleCount}
     />
   );
@@ -264,12 +321,48 @@ function CollapsedAttention({ color }: { color: StationButtonStateColors }): Rea
   );
 }
 
+// Fleet-lane vocabulary shared with the dashboard's FLEET bar: ⠿ working (blue,
+// animated while any), ● ready (green), ○ idle (gray).
+function CollapsedCounts(props: {
+  iconColor: string;
+  workingCount: number;
+  readyCount: number;
+  idleCount: number;
+}): ReactNode {
+  return (
+    <box flexDirection="row" paddingLeft={ICON_PAD}>
+      <IconGlyph color={props.iconColor} />
+      <text>
+        <span> </span>
+        {props.workingCount > 0 ? (
+          <Throbber variant="braille" fg={STATION_COLORS.blue} />
+        ) : (
+          <span fg={STATION_COLORS.blue}>⠿</span>
+        )}
+        <span fg={STATION_COLORS.blue}>{`${paintedCount(props.workingCount)} `}</span>
+        <span fg={STATION_COLORS.green}>{`●${paintedCount(props.readyCount)} `}</span>
+        <span fg={STATION_COLORS.gray}>{`○${paintedCount(props.idleCount)}`}</span>
+      </text>
+    </box>
+  );
+}
+
+function CollapsedCelebration({ celebration }: { celebration: IslandCelebration }): ReactNode {
+  return (
+    <box flexDirection="row" paddingLeft={ICON_PAD}>
+      <IconGlyph color={STATION_COLORS.green} />
+      <text fg={STATION_COLORS.green}>{` ${celebrationText(celebration)}`}</text>
+    </box>
+  );
+}
+
 function ExpandedBase(props: {
   color: StationButtonStateColors;
   iconPadX: number;
   iconPadY: number;
   reveal: number;
   workingCount: number;
+  readyCount: number;
   idleCount: number;
 }): ReactNode {
   const { color, reveal } = props;
@@ -283,10 +376,58 @@ function ExpandedBase(props: {
           color={color.text}
         />
         <GradientText
-          text={sessionSummary(props.idleCount, "idle")}
+          // Ready sessions read as idle in the totals (the fleet breakdown keeps them disjoint).
+          text={sessionSummary(props.readyCount + props.idleCount, "idle")}
           reveal={reveal}
           color={color.text}
         />
+      </box>
+    </box>
+  );
+}
+
+const ROLLUP_MARKS: Record<Exclude<ProjectRollupStatus, "working">, { glyph: string; color: string }> = {
+  needsYou: { glyph: "!", color: STATION_COLORS.red },
+  ready: { glyph: "●", color: STATION_COLORS.green },
+  idle: { glyph: "○", color: STATION_COLORS.gray },
+};
+
+function RollupGlyph({ status }: { status: ProjectRollupStatus }): ReactNode {
+  if (status === "working") {
+    return (
+      <text>
+        <Throbber variant="braille" fg={STATION_COLORS.blue} />
+        <span> </span>
+      </text>
+    );
+  }
+  const mark = ROLLUP_MARKS[status];
+  return <text fg={mark.color}>{`${mark.glyph} `}</text>;
+}
+
+function ExpandedRollup(props: {
+  color: StationButtonStateColors;
+  iconPadX: number;
+  iconPadY: number;
+  reveal: number;
+  entries: readonly ProjectRollupEntry[];
+}): ReactNode {
+  const { color, reveal, entries } = props;
+  const shown = entries.slice(0, ROLLUP_MAX_LINES);
+  const folded = entries.length - shown.length;
+  return (
+    <box flexDirection="column">
+      <IconRow color={color.icon} padX={props.iconPadX} padY={props.iconPadY} />
+      <box flexDirection="column" paddingLeft={CONTENT_INDENT}>
+        {shown.map((entry) => (
+          <box key={entry.projectId} flexDirection="row">
+            <RollupGlyph status={entry.status} />
+            <GradientText text={clampSessionName(entry.name)} reveal={reveal} color={color.text} />
+          </box>
+        ))}
+        {folded > 0 ? (
+          <GradientText text={`+${folded} more`} reveal={reveal} color={color.text} />
+        ) : null}
       </box>
     </box>
   );
@@ -297,6 +438,7 @@ function ExpandedAttention(props: {
   iconPadX: number;
   iconPadY: number;
   reveal: number;
+  needsYouCount: number;
   sessionName?: string | undefined;
 }): ReactNode {
   const { color, reveal } = props;
@@ -309,7 +451,7 @@ function ExpandedAttention(props: {
           reveal={reveal}
           color={color.text}
         />
-        {ATTENTION_LINES.map((line) => (
+        {attentionLines(props.needsYouCount).map((line) => (
           <GradientText
             key={line}
             text={line}

--- a/station/src/stationButton/StationButton.tsx
+++ b/station/src/stationButton/StationButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useSyncExternalStore } from "react";
 import type { StoreApi } from "zustand/vanilla";
+import type { TuiIslandConfig } from "@station/config";
 import type { TuiStore } from "@station/dashboard-core";
 import type { StationMouseEvent } from "../input/mouse.js";
 import type { MouseTargetRef } from "../input/router.js";
@@ -12,6 +13,7 @@ import {
   type StationButtonStatus,
   stationButtonStatusEqual,
 } from "./status.js";
+import { useMergeCelebration } from "./useMergeCelebration.js";
 
 export type StationButtonProps = {
   /** Coordination store: pane focus + STATION overlay visibility. */
@@ -20,18 +22,21 @@ export type StationButtonProps = {
   stationViewStore: StoreApi<TuiStore>;
   /** Station input runtime entry point, reused for the header toggle/context menu. */
   dispatchMouse: (target: MouseTargetRef, event: StationMouseEvent) => boolean;
+  /** Opt-in island display modes from `[tui.island]`. */
+  island?: TuiIslandConfig | undefined;
 };
 
 // Reuses the existing `{ kind: "header" }` mouse path so the route to STATION mode
 // survives the header's removal (some terminals never deliver Ctrl-O). Attention
 // clicks focus the flagged session instead of toggling.
-export function StationButton({ store, stationViewStore, dispatchMouse }: StationButtonProps) {
-  const getStatus = useStableStatus(stationViewStore);
+export function StationButton({ store, stationViewStore, dispatchMouse, island }: StationButtonProps) {
+  const getStatus = useStableStatus(stationViewStore, island?.projectRollup === true);
   const subscribe = useCallback(
     (onChange: () => void) => stationViewStore.subscribe(onChange),
     [stationViewStore],
   );
   const status = useSyncExternalStore(subscribe, getStatus, getStatus);
+  const celebration = useMergeCelebration(stationViewStore);
 
   const onHeader = useCallback(
     (event: StationMouseEvent) => {
@@ -68,9 +73,15 @@ export function StationButton({ store, stationViewStore, dispatchMouse }: Statio
   return (
     <DynamicStationButton
       attention={status.attention}
+      needsYouCount={status.needsYouCount}
       workingCount={status.workingCount}
+      readyCount={status.readyCount}
       idleCount={status.idleCount}
       sessionName={status.sessionName}
+      restCounts={island?.restCounts}
+      projectRollup={status.projectRollup}
+      celebration={celebration}
+      onHoverChange={store.actions.setStationButtonHover}
       onToggleStation={onHeader}
       onContextMenu={onHeader}
       onFocusSession={onFocusSession}
@@ -80,15 +91,18 @@ export function StationButton({ store, stationViewStore, dispatchMouse }: Statio
 
 // Returns the same reference until a field changes, so useSyncExternalStore
 // (Object.is-compared) doesn't loop on the fresh object built each call.
-function useStableStatus(stationViewStore: StoreApi<TuiStore>): () => StationButtonStatus {
+function useStableStatus(
+  stationViewStore: StoreApi<TuiStore>,
+  projectRollup: boolean,
+): () => StationButtonStatus {
   const cache = useRef<StationButtonStatus | undefined>(undefined);
   return useCallback(() => {
-    const next = selectStationButtonStatus(stationViewStore.getState());
+    const next = selectStationButtonStatus(stationViewStore.getState(), { projectRollup });
     const prev = cache.current;
     if (prev !== undefined && stationButtonStatusEqual(prev, next)) {
       return prev;
     }
     cache.current = next;
     return next;
-  }, [stationViewStore]);
+  }, [stationViewStore, projectRollup]);
 }

--- a/station/src/stationButton/layout.test.ts
+++ b/station/src/stationButton/layout.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { targetDims } from "./layout.js";
+import { attentionLines, COLLAPSED_BASE_COLS, COLLAPSED_COUNTS_COLS, targetDims } from "./layout.js";
+
+const CALM = { attention: false, workingCount: 0, readyCount: 0, idleCount: 0 } as const;
 
 describe("targetDims", () => {
   it("keeps the expanded card width stable as live counts change", () => {
     const width = (workingCount: number, idleCount: number): number =>
-      targetDims(true, { attention: false, workingCount, idleCount }).width;
+      targetDims(true, { ...CALM, workingCount, idleCount }).width;
     // The card is anchored top-right, so any width change slides it out from
     // under a stationary cursor (reads as a hover leave). Counts crossing the
     // singular/plural ("1 session" -> "2 sessions") or digit (9 -> 10) boundary
@@ -16,11 +18,49 @@ describe("targetDims", () => {
 
   it("keeps the attention card width stable as the session name changes", () => {
     const width = (sessionName: string): number =>
-      targetDims(true, { attention: true, workingCount: 0, idleCount: 0, sessionName }).width;
+      targetDims(true, { ...CALM, attention: true, sessionName }).width;
     // A live snapshot shortening (or lengthening) a branch name must not resize
     // the top-right-anchored card out from under a hovering cursor.
     expect(width("feature/a-quite-long-branch-name")).toBe(width("x"));
     expect(width("x")).toBe(width("main"));
     expect(width("main")).toBe(width("another/long-feature-branch-name-here"));
+  });
+
+  it("keeps the collapsed counts box width stable as counts tick", () => {
+    const dims = (workingCount: number, readyCount: number, idleCount: number) =>
+      targetDims(false, { ...CALM, workingCount, readyCount, idleCount, restCounts: true });
+    expect(dims(0, 0, 0)).toEqual(dims(9, 10, 99));
+    expect(dims(1, 1, 1).width).toBe(COLLAPSED_COUNTS_COLS);
+    expect(dims(1, 1, 1).width).toBeGreaterThan(COLLAPSED_BASE_COLS);
+    // Counts past the 2-digit paint budget must not overflow either (painted as 99).
+    expect(dims(150, 0, 0)).toEqual(dims(0, 0, 0));
+  });
+
+  it("keeps the expanded roll-up card width fixed while height tracks project count", () => {
+    const dims = (projects: number) =>
+      targetDims(true, { ...CALM, projectRollup: Array.from({ length: projects }) });
+    expect(dims(1).width).toBe(dims(8).width);
+    expect(dims(2).height).toBe(dims(1).height + 1);
+    // Past the fold the card shows ROLLUP_MAX_LINES entries plus one "+N more" line.
+    expect(dims(6).height).toBe(dims(9).height);
+    // An empty roll-up falls back to the totals card.
+    expect(dims(0)).toEqual(targetDims(true, CALM));
+  });
+
+  it("sizes the celebration box to its PR number and stays put while it shows", () => {
+    const celebrate = (prNumber: number) =>
+      targetDims(false, { ...CALM, celebration: { prNumber } });
+    expect(celebrate(42)).toEqual(celebrate(42));
+    expect(celebrate(12345).width).toBe(celebrate(42).width + 3);
+    expect(celebrate(42).height).toBe(targetDims(false, CALM).height);
+  });
+});
+
+describe("attentionLines", () => {
+  it("swaps to the queue line only when several sessions ask", () => {
+    expect(attentionLines(1)).toEqual(["needs your attention", "↵ or click to focus"]);
+    expect(attentionLines(3)).toEqual(["! 3 need you ›", "↵ or click to focus"]);
+    // The painted queue depth clamps to the 2-digit width budget.
+    expect(attentionLines(120)[0]).toBe("! 99 need you ›");
   });
 });

--- a/station/src/stationButton/layout.ts
+++ b/station/src/stationButton/layout.ts
@@ -7,7 +7,7 @@ export const ATTENTION_MARK = "!";
 // The glyph measures as 1 cell but the font paints it ~2 wide, so reserve a
 // fixed slot rather than trust the measured width (else neighbors/borders overlap).
 export const ICON_COLS = 2;
-const ICON_PAD = 1;
+export const ICON_PAD = 1;
 
 // Collapsed base centers the icon at rest; it glides to the top-left (its
 // expanded spot) as the card opens. Attention keeps the icon top-left + "!".
@@ -23,12 +23,21 @@ const EXPANDED_BASE_ROWS = EXPANDED_BORDER_ROWS + 1 + 2 + EXPANDED_BOTTOM_PAD_RO
 const EXPANDED_ATTENTION_ROWS = EXPANDED_BORDER_ROWS + 1 + 1 + 2 + EXPANDED_BOTTOM_PAD_ROWS;
 const EXPANDED_RIGHT_PAD = 3;
 export const CONTENT_INDENT = ICON_COLS + 1; // body clears the corner icon
-export const ATTENTION_LINES = ["needs your attention", "click to focus"] as const;
+const ATTENTION_SINGLE_LINE = "needs your attention";
+const ATTENTION_HINT_LINE = "↵ or click to focus";
+// Width budget only; the painted first line comes from attentionLines (queue-aware).
+const ATTENTION_LINES = [ATTENTION_SINGLE_LINE, ATTENTION_HINT_LINE] as const;
 // Stable count (2 digits, plural) so card width doesn't resize under cursor on count changes.
 const STABLE_SUMMARY_COUNT = 88;
 // Fixed name budget so a live session-name change can't resize this top-right-anchored card out
 // from under a hovering cursor (painted name is truncated to match — clampSessionName).
 const STABLE_NAME_COLS = 20;
+// Counts and queue depths paint at most two digits so no live tick can outgrow
+// the stable width budgets.
+const MAX_PAINTED_COUNT = 99;
+/** Per-project roll-up lines before the card folds the rest into "+N more". */
+export const ROLLUP_MAX_LINES = 5;
+const ROLLUP_GLYPH_COLS = 2; // status glyph + space before the project name
 
 // Above the panes and the centered STATION popup (z30); below the app toast (z100).
 export const STATION_BUTTON_Z_INDEX = 50;
@@ -39,15 +48,43 @@ export const GRADIENT_EDGE = 4; // chars of soft fade at the text's revealing fr
 
 export type Dims = { width: number; height: number };
 
+export type IslandCelebration = { prNumber: number };
+
 export type ButtonContent = {
   attention: boolean;
   workingCount: number;
+  readyCount: number;
   idleCount: number;
   sessionName?: string | undefined;
+  /** C3 opt-in: the collapsed rest state paints fleet counts, not the bare mark. */
+  restCounts?: boolean | undefined;
+  /** C2 opt-in roll-up entries; the count drives the expanded card's height. */
+  projectRollup?: readonly unknown[] | undefined;
+  celebration?: IslandCelebration | undefined;
 };
 
 export function sessionSummary(count: number, verb: string): string {
   return `${count} session${count === 1 ? "" : "s"} ${verb}`;
+}
+
+export function paintedCount(count: number): number {
+  return Math.min(count, MAX_PAINTED_COUNT);
+}
+
+/** The attention card's message lines; the first swaps to the queue when several ask. */
+export function attentionLines(needsYouCount: number): readonly [string, string] {
+  const first =
+    needsYouCount > 1 ? `! ${paintedCount(needsYouCount)} need you ›` : ATTENTION_SINGLE_LINE;
+  return [first, ATTENTION_HINT_LINE];
+}
+
+export function celebrationText(celebration: IslandCelebration): string {
+  return `✓ #${celebration.prNumber} merged`;
+}
+
+/** Painted roll-up rows: the first ROLLUP_MAX_LINES entries, plus one "+N more" fold. */
+function rollupLineCount(entryCount: number): number {
+  return entryCount <= ROLLUP_MAX_LINES ? entryCount : ROLLUP_MAX_LINES + 1;
 }
 
 // Truncate the attention card's session name to the reserved column budget so
@@ -59,14 +96,39 @@ export function clampSessionName(name: string): string {
 export function targetDims(expanded: boolean, content: ButtonContent): Dims {
   const { attention } = content;
   if (!expanded) {
-    return attention
-      ? { width: COLLAPSED_ATTENTION_COLS, height: COLLAPSED_ATTENTION_ROWS }
-      : { width: COLLAPSED_BASE_COLS, height: COLLAPSED_BASE_ROWS };
+    if (attention) {
+      return { width: COLLAPSED_ATTENTION_COLS, height: COLLAPSED_ATTENTION_ROWS };
+    }
+    if (content.celebration !== undefined) {
+      const interior = ICON_COLS + 1 + celebrationText(content.celebration).length;
+      return { width: interior + 2 * ICON_PAD + 2, height: COLLAPSED_BASE_ROWS };
+    }
+    if (content.restCounts === true) {
+      return { width: COLLAPSED_COUNTS_COLS, height: COLLAPSED_BASE_ROWS };
+    }
+    return { width: COLLAPSED_BASE_COLS, height: COLLAPSED_BASE_ROWS };
   }
   return {
     width: expandedInteriorWidth(content) + EXPANDED_RIGHT_PAD + 2,
-    height: attention ? EXPANDED_ATTENTION_ROWS : EXPANDED_BASE_ROWS,
+    height: expandedRows(content),
   };
+}
+
+// The collapsed counts row measures with 2-digit lanes (`⠿88 ●88 ○88`) so live
+// count ticks can't slide the box out from under an approaching cursor.
+const STABLE_COUNT_LANES_COLS = 3 * (1 + 2) + 2;
+export const COLLAPSED_COUNTS_COLS =
+  ICON_COLS + 1 + STABLE_COUNT_LANES_COLS + 2 * ICON_PAD + 2;
+
+function expandedRows(content: ButtonContent): number {
+  if (content.attention) {
+    return EXPANDED_ATTENTION_ROWS;
+  }
+  const rollupLines = rollupLineCount(content.projectRollup?.length ?? 0);
+  if (rollupLines > 0) {
+    return EXPANDED_BORDER_ROWS + 1 + rollupLines + EXPANDED_BOTTOM_PAD_ROWS;
+  }
+  return EXPANDED_BASE_ROWS;
 }
 
 // Widest content row inside the card (borders/right pad excluded).
@@ -78,6 +140,11 @@ function expandedInteriorWidth(content: ButtonContent): number {
     const iconRow = ICON_COLS + 1 + nameCols;
     const body = CONTENT_INDENT + longest(ATTENTION_LINES);
     return Math.max(iconRow, body);
+  }
+  if ((content.projectRollup?.length ?? 0) > 0) {
+    // Fixed name budget (names clamp to match), so renames/new projects only
+    // ever change the card's height, never its width.
+    return CONTENT_INDENT + ROLLUP_GLYPH_COLS + STABLE_NAME_COLS;
   }
   // Measure with a stable count, not the live values: the card is anchored top-right, so a width
   // change on a count tick slides it out from under a stationary cursor and reads as a hover leave.

--- a/station/src/stationButton/status.test.ts
+++ b/station/src/stationButton/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createInitialTuiState } from "@station/dashboard-core";
+import { createInitialTuiState, selectFleetSummary } from "@station/dashboard-core";
 import {
   attentionAndFailuresSnapshot,
   manyProjectsSnapshot,
@@ -10,32 +10,41 @@ describe("selectStationButtonStatus", () => {
   it("is empty before a snapshot arrives", () => {
     expect(selectStationButtonStatus(createInitialTuiState())).toEqual({
       attention: false,
+      needsYouCount: 0,
       workingCount: 0,
+      readyCount: 0,
       idleCount: 0,
     });
   });
 
-  it("reports working/idle totals and no attention for a healthy snapshot", () => {
+  it("reports the client-side fleet breakdown and no attention for a healthy snapshot", () => {
     const snapshot = manyProjectsSnapshot();
     const status = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
+    const fleet = selectFleetSummary(snapshot);
 
-    expect(status.workingCount).toBe(snapshot.counts.working);
-    expect(status.idleCount).toBe(snapshot.counts.idle);
+    expect(status.workingCount).toBe(fleet.working);
+    expect(status.readyCount).toBe(fleet.ready);
+    expect(status.idleCount).toBe(fleet.idle);
+    // The classic totals stay intact: ready + idle covers the contract's idle count.
+    expect(status.readyCount + status.idleCount).toBe(snapshot.counts.idle);
     expect(status.attention).toBe(false);
+    expect(status.needsYouCount).toBe(0);
     expect(status.sessionName).toBeUndefined();
     expect(status.attentionWorktreeId).toBeUndefined();
+    expect(status.projectRollup).toBeUndefined();
   });
 
-  it("flags the first session needing the user", () => {
+  it("flags the first session needing the user and counts the queue", () => {
     const snapshot = attentionAndFailuresSnapshot();
     const status = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
-    const firstFlagged = snapshot.rows.find(
+    const flagged = snapshot.rows.filter(
       (row) =>
         row.display.statusLabel === "needs attention" || row.display.statusLabel === "stuck",
     );
 
     expect(status.attention).toBe(true);
-    expect(status.attentionWorktreeId).toBe(firstFlagged?.id);
+    expect(status.needsYouCount).toBe(flagged.length);
+    expect(status.attentionWorktreeId).toBe(flagged[0]?.id);
     expect(typeof status.sessionName).toBe("string");
   });
 
@@ -51,15 +60,53 @@ describe("selectStationButtonStatus", () => {
     const status = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
 
     expect(status.attention).toBe(true);
+    expect(status.needsYouCount).toBe(1);
     expect(status.attentionWorktreeId).toBe(stuckRow.id);
+  });
+
+  it("builds the per-project roll-up only when asked, keeping the worst status", () => {
+    const snapshot = attentionAndFailuresSnapshot();
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const status = selectStationButtonStatus(state, { projectRollup: true });
+    const rollup = status.projectRollup;
+    if (rollup === undefined) {
+      throw new Error("expected a roll-up when the option is on");
+    }
+
+    // One entry per project holding sessions, in row display order.
+    const projectIds = [...new Set(snapshot.rows.map((row) => row.projectId))];
+    expect(rollup.map((entry) => entry.projectId)).toEqual(projectIds);
+
+    // A project with a flagged session rolls up to needsYou even when it also
+    // has calmer sessions.
+    const flagged = snapshot.rows.find(
+      (row) =>
+        row.display.statusLabel === "needs attention" || row.display.statusLabel === "stuck",
+    );
+    const flaggedEntry = rollup.find((entry) => entry.projectId === flagged?.projectId);
+    expect(flaggedEntry?.status).toBe("needsYou");
   });
 
   it("compares field-wise so the snapshot reference can stay stable", () => {
     const snapshot = manyProjectsSnapshot();
-    const a = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
-    const b = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const a = selectStationButtonStatus(state, { projectRollup: true });
+    const b = selectStationButtonStatus(state, { projectRollup: true });
 
     expect(stationButtonStatusEqual(a, b)).toBe(true);
     expect(stationButtonStatusEqual(a, { ...a, workingCount: a.workingCount + 1 })).toBe(false);
+    // Roll-up presence and content participate in the comparison.
+    expect(stationButtonStatusEqual(a, { ...a, projectRollup: undefined })).toBe(false);
+    if (a.projectRollup !== undefined && a.projectRollup.length > 0) {
+      const [first, ...rest] = a.projectRollup;
+      if (first !== undefined) {
+        expect(
+          stationButtonStatusEqual(a, {
+            ...a,
+            projectRollup: [{ ...first, status: "needsYou" }, ...rest],
+          }),
+        ).toBe(a.projectRollup[0]?.status === "needsYou");
+      }
+    }
   });
 });

--- a/station/src/stationButton/status.ts
+++ b/station/src/stationButton/status.ts
@@ -1,56 +1,149 @@
 import type { WorktreeId, WorktreeRow } from "@station/contracts";
-import { type TuiState, worktreeRowDisplayTitle } from "@station/dashboard-core";
+import {
+  isReadyToRead,
+  selectFleetSummary,
+  type TuiState,
+  worktreeRowDisplayTitle,
+} from "@station/dashboard-core";
+
+/** Worst agent status across a project's sessions, calmest last. */
+export type ProjectRollupStatus = "needsYou" | "working" | "ready" | "idle";
+
+export type ProjectRollupEntry = {
+  projectId: string;
+  name: string;
+  status: ProjectRollupStatus;
+};
 
 // Flat scalars so the memoized useSyncExternalStore snapshot can compare fields
 // (a fresh object each read would loop the subscription).
 export type StationButtonStatus = {
   attention: boolean;
+  /** Sessions asking for the user (needs-attention OR stuck) — the queue depth. */
+  needsYouCount: number;
   workingCount: number;
+  readyCount: number;
+  /** Disjoint from ready; the totals summary shows ready + idle as "idle". */
   idleCount: number;
   sessionName?: string;
   /** The worktree behind the attention state, so a click can focus its pane. */
   attentionWorktreeId?: WorktreeId;
+  /** Worst status per project, in row display order; built only when requested. */
+  projectRollup?: readonly ProjectRollupEntry[];
 };
 
 const EMPTY_STATUS: StationButtonStatus = {
   attention: false,
+  needsYouCount: 0,
   workingCount: 0,
+  readyCount: 0,
   idleCount: 0,
 };
 
-function needsUser(row: WorktreeRow): boolean {
+/** The row is asking for the user (needs-attention or stuck) — the island's alert predicate. */
+export function rowNeedsUser(row: WorktreeRow): boolean {
   return row.display.statusLabel === "needs attention" || row.display.statusLabel === "stuck";
 }
 
-// Totals come from the snapshot's pre-aggregated counts; the attention identity
-// is the first row asking for the user (rows are already in display order).
-export function selectStationButtonStatus(state: TuiState): StationButtonStatus {
+// Counts come from the client-side fleet breakdown, not snapshot.counts: the
+// contract folds ready into idle and its attention count excludes stuck.
+export function selectStationButtonStatus(
+  state: TuiState,
+  options?: { projectRollup?: boolean },
+): StationButtonStatus {
   const snapshot = state.snapshot;
   if (snapshot === undefined) {
     return EMPTY_STATUS;
   }
-  // Derive from the flagged row (needs-attention OR stuck), not snapshot.counts.attention: that
-  // count excludes stuck, which would leave a stuck session showing no alert.
-  const attentionRow = snapshot.rows.find(needsUser);
+  const fleet = selectFleetSummary(snapshot);
+  // The attention identity is the first row asking for the user (rows are
+  // already in display order).
+  const attentionRow = snapshot.rows.find(rowNeedsUser);
   const status: StationButtonStatus = {
     attention: attentionRow !== undefined,
-    workingCount: snapshot.counts.working,
-    idleCount: snapshot.counts.idle,
+    needsYouCount: fleet.needsYou,
+    workingCount: fleet.working,
+    readyCount: fleet.ready,
+    idleCount: fleet.idle,
   };
   if (attentionRow !== undefined) {
     status.sessionName = worktreeRowDisplayTitle(attentionRow, snapshot.sessions, state.localRows);
     status.attentionWorktreeId = attentionRow.id;
   }
+  if (options?.projectRollup === true) {
+    status.projectRollup = rollupProjects(snapshot.rows);
+  }
   return status;
+}
+
+const ROLLUP_SEVERITY: Record<ProjectRollupStatus, number> = {
+  needsYou: 3,
+  working: 2,
+  ready: 1,
+  idle: 0,
+};
+
+function rowRollupStatus(row: WorktreeRow): ProjectRollupStatus {
+  const state = row.agent?.state;
+  if (state === "needs_attention" || state === "stuck") {
+    return "needsYou";
+  }
+  if (state === "working") {
+    return "working";
+  }
+  if (isReadyToRead(row)) {
+    return "ready";
+  }
+  // Calm lanes (idle/starting/exited/unknown/no agent) all read as idle here;
+  // the island roll-up is a triage summary, not a full state readout.
+  return "idle";
+}
+
+function rollupProjects(rows: readonly WorktreeRow[]): readonly ProjectRollupEntry[] {
+  const byProject = new Map<string, ProjectRollupEntry>();
+  for (const row of rows) {
+    const status = rowRollupStatus(row);
+    const existing = byProject.get(row.projectId);
+    if (existing === undefined) {
+      byProject.set(row.projectId, { projectId: row.projectId, name: row.projectLabel, status });
+    } else if (ROLLUP_SEVERITY[status] > ROLLUP_SEVERITY[existing.status]) {
+      existing.status = status;
+    }
+  }
+  return [...byProject.values()];
 }
 
 /** Field-wise equality so the memoized snapshot keeps a stable reference. */
 export function stationButtonStatusEqual(a: StationButtonStatus, b: StationButtonStatus): boolean {
   return (
     a.attention === b.attention &&
+    a.needsYouCount === b.needsYouCount &&
     a.workingCount === b.workingCount &&
+    a.readyCount === b.readyCount &&
     a.idleCount === b.idleCount &&
     a.sessionName === b.sessionName &&
-    a.attentionWorktreeId === b.attentionWorktreeId
+    a.attentionWorktreeId === b.attentionWorktreeId &&
+    rollupEqual(a.projectRollup, b.projectRollup)
+  );
+}
+
+function rollupEqual(
+  a: readonly ProjectRollupEntry[] | undefined,
+  b: readonly ProjectRollupEntry[] | undefined,
+): boolean {
+  if (a === undefined || b === undefined) {
+    return a === b;
+  }
+  return (
+    a.length === b.length &&
+    a.every((entry, i) => {
+      const other = b[i];
+      return (
+        other !== undefined &&
+        entry.projectId === other.projectId &&
+        entry.name === other.name &&
+        entry.status === other.status
+      );
+    })
   );
 }

--- a/station/src/stationButton/useMergeCelebration.test.tsx
+++ b/station/src/stationButton/useMergeCelebration.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { testRender } from "@opentui/react/test-utils";
+import { createTuiStore, type TuiStore } from "@station/dashboard-core";
+import type { StationSnapshot } from "@station/contracts";
+import type { StoreApi } from "zustand/vanilla";
+import { manyProjectsSnapshot } from "../station/fixtures/scenarios.js";
+import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
+import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
+import { useMergeCelebration } from "./useMergeCelebration.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+
+const SURFACE = { width: 30, height: 4 };
+
+function CelebrationProbe({
+  store,
+  ttlMs,
+}: {
+  store: StoreApi<TuiStore>;
+  ttlMs: number;
+}) {
+  const celebration = useMergeCelebration(store, ttlMs);
+  return <text>{celebration === undefined ? "quiet" : `pr:${celebration.prNumber}`}</text>;
+}
+
+function withMergedPr(snapshot: StationSnapshot, worktreeId: string): StationSnapshot {
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row) => {
+      const pr = row.worktree.pr;
+      if (row.id !== worktreeId || pr === undefined) {
+        return row;
+      }
+      return { ...row, worktree: { ...row.worktree, pr: { ...pr, state: "merged" as const } } };
+    }),
+  };
+}
+
+describe("useMergeCelebration", () => {
+  it("celebrates a PR flipping to merged, then quiets after the TTL", async () => {
+    const snapshot = manyProjectsSnapshot();
+    const source = new FakeStationSource(snapshot);
+    const store = createTuiStore({
+      source,
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      onDismiss: async () => {},
+    });
+    // Snapshots flow from the source only once the store is started.
+    const detach = store.getState().start();
+    const setup = await testRender(<CelebrationProbe store={store} ttlMs={60} />, SURFACE);
+    try {
+      await setup.flush();
+      // Let the hook's effect mount and seed its baseline from the initial
+      // snapshot before any update arrives.
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      // The initial snapshot already holds a merged PR (wt_station_idle #73):
+      // first sight never celebrates.
+      expect(setup.captureCharFrame()).toContain("quiet");
+
+      source.setSnapshot(withMergedPr(snapshot, "wt_station_working"));
+      // The state update commits on the next macrotask beat.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      await setup.flush();
+      expect(setup.captureCharFrame()).toContain("pr:76");
+
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await setup.flush();
+      expect(setup.captureCharFrame()).toContain("quiet");
+    } finally {
+      detach();
+      setup.renderer.destroy();
+    }
+  });
+});

--- a/station/src/stationButton/useMergeCelebration.ts
+++ b/station/src/stationButton/useMergeCelebration.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import type { StoreApi } from "zustand/vanilla";
+import type { TuiStore } from "@station/dashboard-core";
+import type { IslandCelebration } from "./layout.js";
+
+export const CELEBRATION_MS = 4_000;
+
+type SeenPr = { number: number; state: string };
+
+/**
+ * A just-merged PR to celebrate on the island, cleared after `ttlMs`.
+ * Transition-only: the first snapshot seen, a row first appearing, or a row
+ * whose PR was already merged never celebrates — a restart amid merged rows
+ * stays quiet.
+ */
+export function useMergeCelebration(
+  stationViewStore: StoreApi<TuiStore>,
+  ttlMs: number = CELEBRATION_MS,
+): IslandCelebration | undefined {
+  const [celebration, setCelebration] = useState<IslandCelebration | undefined>(undefined);
+  const seen = useRef<Map<string, SeenPr> | undefined>(undefined);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const check = (): void => {
+      const rows = stationViewStore.getState().snapshot?.rows;
+      if (rows === undefined) {
+        return;
+      }
+      const prior = seen.current;
+      const next = new Map<string, SeenPr>();
+      let merged: IslandCelebration | undefined;
+      for (const row of rows) {
+        const pr = row.worktree.pr;
+        if (pr === undefined) {
+          continue;
+        }
+        const state = pr.state ?? "unknown";
+        next.set(row.id, { number: pr.number, state });
+        const before = prior?.get(row.id);
+        if (
+          state === "merged" &&
+          before !== undefined &&
+          before.number === pr.number &&
+          before.state !== "merged"
+        ) {
+          merged = { prNumber: pr.number };
+        }
+      }
+      seen.current = next;
+      if (merged === undefined) {
+        return;
+      }
+      setCelebration(merged);
+      clearTimeout(timer);
+      timer = setTimeout(() => setCelebration(undefined), ttlMs);
+    };
+    check();
+    const unsubscribe = stationViewStore.subscribe(check);
+    return () => {
+      unsubscribe();
+      clearTimeout(timer);
+    };
+  }, [stationViewStore, ttlMs]);
+
+  return celebration;
+}


### PR DESCRIPTION
PR6 of the Atomics & Mockups UX plan (D5, D14). The island's palette was already tokenized in PR1, so this PR delivers the variant modes. No backend, no contract change.

## What's new

**Opt-in modes** — gated behind a new `[tui.island]` config section (both default off, documented in `docs/configuration.md`):
- **C3 rest counts** (`rest_counts = true`): the collapsed island paints live fleet lanes — `⧉ ⠿2 ●1 ○6` — in the same glyph/colour vocabulary as the dashboard FLEET bar (working blue + shared-clock throbber, ready green, idle gray). Width is measured with 2-digit lanes so count ticks never slide the box out from under an approaching cursor.
- **C2 project roll-up** (`project_rollup = true`): the hovered card lists each project's worst agent status (needsYou > working > ready > idle), fixed width, capped at 5 lines plus a `+N more` fold.

**Always-on behaviors:**
- **C5 attention queue**: when several sessions ask, the attention card's message swaps to `! N need you ›`. Counts `needs_attention || stuck` via the client-side fleet breakdown — never `counts.attention` (which excludes stuck).
- **C6 ↵ jump**: a new `station-button` keymap layer above terminal passthrough claims Enter **only** while the island is hovered, a session needs the user, and no overlay is open — exactly the window where the card reads `↵ or click to focus`. It resolves to the same focus-pane / open-overlay outcomes as the island click. Everywhere else Enter reaches the pane untouched.
- **C9 merge celebration**: a transition-only detector (`useMergeCelebration`) watches rows' `worktree.pr.state`; on open→merged the collapsed island shows `✓ #42 merged` in green for 4s. First-sight/restart never celebrates. (PR title enrichment lands with PR8a.)

Island counts now derive from `selectFleetSummary` (one source with the FLEET bar); the totals card keeps its old numbers by rendering ready+idle as "idle".

Kept per D14: rounded corners, `⧉` mark, hover colour-morph, the shipped grow tween.

## UX implications + manual verify

`STATION_SOURCE=mock bun run station`, then:
- hover the island → attention card now hints `↵ or click to focus`; with >1 flagged session it reads `! N need you ›`; pressing Enter while hovering focuses the flagged agent pane (or opens the dashboard)
- add `[tui.island] rest_counts = true` → collapsed island shows `⠿ ● ○` counts; `project_rollup = true` → hover lists projects by worst status
- typing Enter in a pane with the mouse anywhere else is unchanged (layer is hover-scoped)

## Tests

- `pnpm typecheck` (43/43), `pnpm lint`, `pnpm test:unit` (1032) green
- station lane: `bun run typecheck` + `bun test` (847) green after `pnpm build`
- new coverage: island geometry stability (counts/roll-up/celebration dims), variant rendering, queue line, ↵-jump routing (5 cases incl. fall-through), merge-celebration TTL, `[tui.island]` TOML load with snake_case keys