### PR TITLE
feat(widgets): widget foundation — fleet/prs/tz/moon, enabled flag, width-aware strip

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -254,11 +254,19 @@ Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 > clock/weather strip; `[workspace]` is interaction behavior (scroll, welcome,
 > automations). They never overlap.
 
-`[tui].widgets` is an array discriminated on `type`:
+`[tui].widgets` is an array discriminated on `type`. Every widget accepts an
+optional `enabled` (bool; default true — `false` keeps the entry in config but
+hides it). Array order is display order, left to right:
 
 - **`type = "time"`** — optional `time_format` (`12h` \| `24h`).
 - **`type = "weather"`** — required `city`; optional `label`, `temperature_unit`
   (`fahrenheit` \| `celsius`), `refresh_interval_minutes` (int > 0).
+- **`type = "fleet"`** — live-agent count, derived from the observer snapshot.
+- **`type = "prs"`** — open-PR count across sessions, derived from the snapshot.
+- **`type = "tz"`** — a timezone pair; required `zones` (1–2 of
+  `{ label, time_zone }`, IANA names — an unknown zone renders `--:--`);
+  optional `time_format` (`12h` \| `24h`).
+- **`type = "moon"`** — current moon phase.
 
 `[tui.island]` — opt-in display modes for the floating Station island (top-right
 button). Both default off:

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -140,7 +140,14 @@ function normalizeTuiWidgetConfigs(value: unknown): unknown {
 }
 
 function normalizeTuiWidgetConfig(value: unknown): unknown {
-  return normalizeObject(value);
+  return normalizeObject(value, {}, { zones: normalizeTuiTimezoneZones });
+}
+
+function normalizeTuiTimezoneZones(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  return value.map((zone) => normalizeObject(zone));
 }
 
 function normalizeEventHookConfigs(value: unknown): unknown {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -219,6 +219,7 @@ export type HooksConfig = z.infer<typeof HooksConfigSchema>;
 export const TuiTimeWidgetConfigSchema = z
   .object({
     type: z.literal("time"),
+    enabled: z.boolean().optional(),
     timeFormat: z.enum(["12h", "24h"]).optional(),
   })
   .strict();
@@ -228,6 +229,7 @@ export type TuiTimeWidgetConfig = z.infer<typeof TuiTimeWidgetConfigSchema>;
 export const TuiWeatherWidgetConfigSchema = z
   .object({
     type: z.literal("weather"),
+    enabled: z.boolean().optional(),
     city: nonEmptyStringSchema,
     label: nonEmptyStringSchema.optional(),
     temperatureUnit: z.enum(["fahrenheit", "celsius"]).optional(),
@@ -237,9 +239,63 @@ export const TuiWeatherWidgetConfigSchema = z
 
 export type TuiWeatherWidgetConfig = z.infer<typeof TuiWeatherWidgetConfigSchema>;
 
+/** Live-agent count derived from the snapshot; no external data source. */
+export const TuiFleetWidgetConfigSchema = z
+  .object({
+    type: z.literal("fleet"),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export type TuiFleetWidgetConfig = z.infer<typeof TuiFleetWidgetConfigSchema>;
+
+/** Open-PR count derived from the snapshot; no external data source. */
+export const TuiPrsWidgetConfigSchema = z
+  .object({
+    type: z.literal("prs"),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export type TuiPrsWidgetConfig = z.infer<typeof TuiPrsWidgetConfigSchema>;
+
+export const TuiTimezoneZoneSchema = z
+  .object({
+    label: nonEmptyStringSchema,
+    /** IANA zone name; an unknown zone renders as "--:--" rather than failing the section. */
+    timeZone: nonEmptyStringSchema,
+  })
+  .strict();
+
+export type TuiTimezoneZone = z.infer<typeof TuiTimezoneZoneSchema>;
+
+export const TuiTimezoneWidgetConfigSchema = z
+  .object({
+    type: z.literal("tz"),
+    enabled: z.boolean().optional(),
+    zones: z.array(TuiTimezoneZoneSchema).min(1).max(2),
+    timeFormat: z.enum(["12h", "24h"]).optional(),
+  })
+  .strict();
+
+export type TuiTimezoneWidgetConfig = z.infer<typeof TuiTimezoneWidgetConfigSchema>;
+
+export const TuiMoonWidgetConfigSchema = z
+  .object({
+    type: z.literal("moon"),
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export type TuiMoonWidgetConfig = z.infer<typeof TuiMoonWidgetConfigSchema>;
+
 export const TuiWidgetConfigSchema = z.discriminatedUnion("type", [
   TuiTimeWidgetConfigSchema,
   TuiWeatherWidgetConfigSchema,
+  TuiFleetWidgetConfigSchema,
+  TuiPrsWidgetConfigSchema,
+  TuiTimezoneWidgetConfigSchema,
+  TuiMoonWidgetConfigSchema,
 ]);
 
 export type TuiWidgetConfig = z.infer<typeof TuiWidgetConfigSchema>;

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -550,6 +550,62 @@ ${projectToml("web", root)}
     expect(omitted.config.tui).toEqual({});
   });
 
+  it("loads the snapshot/clock widget types with snake_case keys", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+
+    const loaded = await loadConfigFromToml(
+      `
+schema_version = 1
+
+[defaults]
+worktree_provider = "worktrunk"
+terminal = "tmux"
+harness = "codex"
+layout = "agent-build-shell"
+
+[[tui.widgets]]
+type = "fleet"
+
+[[tui.widgets]]
+type = "prs"
+enabled = false
+
+[[tui.widgets]]
+type = "tz"
+time_format = "24h"
+
+[[tui.widgets.zones]]
+label = "NYC"
+time_zone = "America/New_York"
+
+[[tui.widgets.zones]]
+label = "TYO"
+time_zone = "Asia/Tokyo"
+
+[[tui.widgets]]
+type = "moon"
+
+${projectToml("web", root)}
+`,
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.tui?.widgets).toEqual([
+      { type: "fleet" },
+      { type: "prs", enabled: false },
+      {
+        type: "tz",
+        timeFormat: "24h",
+        zones: [
+          { label: "NYC", timeZone: "America/New_York" },
+          { label: "TYO", timeZone: "Asia/Tokyo" },
+        ],
+      },
+      { type: "moon" },
+    ]);
+  });
+
   it("loads [tui.island] display modes with snake_case keys", async () => {
     const tempDir = await makeTempDir();
     const root = await makeProjectRoot(tempDir, "web");
@@ -581,7 +637,7 @@ ${projectToml("web", root)}
       "unknown widget type",
       `
 [[tui.widgets]]
-type = "moon"
+type = "crypto"
 `,
     ],
     [

--- a/packages/dashboard-core/package.json
+++ b/packages/dashboard-core/package.json
@@ -28,9 +28,21 @@
       "types": "./dist/state/*.d.ts",
       "import": "./dist/state/*.js"
     },
+    "./widgets/moon": {
+      "types": "./dist/widgets/moon.d.ts",
+      "import": "./dist/widgets/moon.js"
+    },
+    "./widgets/snapshotWidgets": {
+      "types": "./dist/widgets/snapshotWidgets.d.ts",
+      "import": "./dist/widgets/snapshotWidgets.js"
+    },
     "./widgets/time": {
       "types": "./dist/widgets/time.d.ts",
       "import": "./dist/widgets/time.js"
+    },
+    "./widgets/timezone": {
+      "types": "./dist/widgets/timezone.d.ts",
+      "import": "./dist/widgets/timezone.js"
     },
     "./widgets/types": {
       "types": "./dist/widgets/types.d.ts",

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -18,6 +18,8 @@ export type DashboardHeaderStatus = {
 
 export type TopRowWidgetText = {
   text: string;
+  /** Narrower form tried before the strip starts dropping widgets outright. */
+  compact?: string;
 };
 
 export function dashboardHeaderLine({
@@ -51,8 +53,7 @@ export function dashboardHeaderLine({
     return productLabel;
   }
 
-  for (let visibleCount = widgets.length; visibleCount > 0; visibleCount -= 1) {
-    const strip = widgetStrip(widgets, visibleCount);
+  for (const strip of widgetStripCandidates(widgets)) {
     const stripWidth = stringWidth(strip);
     const gapWidth = safeColumns - productWidth - stripWidth;
     if (gapWidth >= 1) {
@@ -71,8 +72,7 @@ function dashboardHeaderLineWithStatus(input: {
   widgets: readonly TopRowWidgetText[];
 }): string {
   for (const statusText of statusTextCandidates(input.status)) {
-    for (let visibleCount = input.widgets.length; visibleCount >= 0; visibleCount -= 1) {
-      const widgets = widgetStrip(input.widgets, visibleCount);
+    for (const widgets of [...widgetStripCandidates(input.widgets), ""]) {
       const strip = widgets.length === 0 ? statusText : `${statusText}  ${widgets}`;
       const stripWidth = stringWidth(strip);
       const gapWidth = input.safeColumns - input.productWidth - stripWidth;
@@ -91,11 +91,24 @@ function statusTextCandidates(status: DashboardHeaderStatus): string[] {
   return [status.full, status.compact];
 }
 
-function widgetStrip(widgets: readonly TopRowWidgetText[], visibleCount: number): string {
-  return widgets
-    .slice(0, visibleCount)
-    .map((widget) => widget.text)
-    .join("  ");
+/**
+ * Widest-first strip candidates: every widget full, then every widget in its
+ * compact form, then dropping widgets from the right (still compact) — so the
+ * strip narrows before it loses information.
+ */
+function* widgetStripCandidates(widgets: readonly TopRowWidgetText[]): Generator<string> {
+  if (widgets.length === 0) {
+    return;
+  }
+  const full = widgets.map((widget) => widget.text);
+  const compact = widgets.map((widget) => widget.compact ?? widget.text);
+  yield full.join("  ");
+  if (compact.some((text, i) => text !== full[i])) {
+    yield compact.join("  ");
+  }
+  for (let visibleCount = widgets.length - 1; visibleCount > 0; visibleCount -= 1) {
+    yield compact.slice(0, visibleCount).join("  ");
+  }
 }
 
 export function projectHeaderLabel(project: ProjectView, collapsed: boolean): string {

--- a/packages/dashboard-core/src/widgets/moon.ts
+++ b/packages/dashboard-core/src/widgets/moon.ts
@@ -1,0 +1,38 @@
+export type MoonPhase = {
+  glyph: string;
+  name: string;
+};
+
+// Reference new moon (2000-01-06 18:14 UTC) + mean synodic month. The
+// approximation drifts by hours over decades — fine for a phase glyph.
+const NEW_MOON_EPOCH_MS = Date.UTC(2000, 0, 6, 18, 14);
+const SYNODIC_MONTH_DAYS = 29.530588853;
+const DAY_MS = 86_400_000;
+
+const PHASES: readonly MoonPhase[] = [
+  { glyph: "🌑", name: "new moon" },
+  { glyph: "🌒", name: "waxing crescent" },
+  { glyph: "🌓", name: "first quarter" },
+  { glyph: "🌔", name: "waxing gibbous" },
+  { glyph: "🌕", name: "full moon" },
+  { glyph: "🌖", name: "waning gibbous" },
+  { glyph: "🌗", name: "last quarter" },
+  { glyph: "🌘", name: "waning crescent" },
+];
+
+export function moonPhase(date: Date): MoonPhase {
+  const daysSinceEpoch = (date.getTime() - NEW_MOON_EPOCH_MS) / DAY_MS;
+  const ageDays = positiveModulo(daysSinceEpoch, SYNODIC_MONTH_DAYS);
+  // Each phase owns 1/8 of the cycle, centered on its exact moment.
+  const index = Math.round((ageDays / SYNODIC_MONTH_DAYS) * PHASES.length) % PHASES.length;
+  return PHASES[index] ?? { glyph: "🌑", name: "new moon" };
+}
+
+function positiveModulo(value: number, divisor: number): number {
+  return ((value % divisor) + divisor) % divisor;
+}
+
+export function formatMoonWidget(date: Date): { text: string; compact: string } {
+  const phase = moonPhase(date);
+  return { text: `${phase.glyph} ${phase.name}`, compact: phase.glyph };
+}

--- a/packages/dashboard-core/src/widgets/snapshotWidgets.ts
+++ b/packages/dashboard-core/src/widgets/snapshotWidgets.ts
@@ -1,0 +1,42 @@
+import type { StationSnapshot } from "@station/contracts";
+import { selectFleetSummary } from "../selectors/fleetSummary.js";
+import type { TopRowWidgetView } from "./types.js";
+
+/**
+ * Fill in snapshot-derived widgets (fleet / open-PR counts) right before
+ * render, where the snapshot lives. Without a snapshot they drop out of the
+ * strip rather than painting stale or empty text.
+ */
+export function resolveTopRowWidgets(
+  widgets: readonly TopRowWidgetView[],
+  snapshot: StationSnapshot | undefined,
+): TopRowWidgetView[] {
+  return widgets.flatMap((widget) => {
+    if (widget.data === undefined) {
+      return [widget];
+    }
+    if (snapshot === undefined) {
+      return [];
+    }
+    if (widget.data === "fleet") {
+      const fleet = selectFleetSummary(snapshot);
+      const live = fleet.working + fleet.ready + fleet.needsYou + fleet.idle + fleet.starting;
+      return [{ ...widget, text: `${live} ${plural(live, "agent")}` }];
+    }
+    const open = snapshot.rows.filter((row) => {
+      const state = row.worktree.pr?.state;
+      return state === "open" || state === "draft";
+    }).length;
+    return [
+      {
+        ...widget,
+        text: `${open} open ${plural(open, "PR")}`,
+        compact: `${open} ${plural(open, "PR")}`,
+      },
+    ];
+  });
+}
+
+function plural(count: number, noun: string): string {
+  return count === 1 ? noun : `${noun}s`;
+}

--- a/packages/dashboard-core/src/widgets/timezone.ts
+++ b/packages/dashboard-core/src/widgets/timezone.ts
@@ -1,0 +1,40 @@
+import type { TuiTimezoneWidgetConfig, TuiTimezoneZone } from "@station/config";
+
+const INVALID_ZONE_TIME = "--:--";
+
+/** Wall-clock time in an IANA zone, formatted like the time widget; "--:--" on an unknown zone. */
+export function zoneTime(date: Date, zone: TuiTimezoneZone, timeFormat: "12h" | "24h"): string {
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: zone.timeZone,
+      hour: "numeric",
+      minute: "2-digit",
+      hourCycle: timeFormat === "24h" ? "h23" : "h12",
+    }).formatToParts(date);
+  } catch {
+    return INVALID_ZONE_TIME;
+  }
+  const get = (type: Intl.DateTimeFormatPart["type"]): string =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  const hour = get("hour");
+  const minute = get("minute");
+  if (hour === "" || minute === "") {
+    return INVALID_ZONE_TIME;
+  }
+  if (timeFormat === "24h") {
+    return `${hour.padStart(2, "0")}:${minute}`;
+  }
+  return `${hour}:${minute} ${get("dayPeriod").toUpperCase()}`;
+}
+
+export function formatTimezoneWidget(
+  date: Date,
+  config: TuiTimezoneWidgetConfig,
+): { text: string; compact: string } {
+  const timeFormat = config.timeFormat ?? "12h";
+  const rendered = config.zones.map((zone) => `${zone.label} ${zoneTime(date, zone, timeFormat)}`);
+  const text = rendered.join(" · ");
+  // Compact keeps only the first zone — the pair's anchor.
+  return { text, compact: rendered[0] ?? text };
+}

--- a/packages/dashboard-core/src/widgets/types.ts
+++ b/packages/dashboard-core/src/widgets/types.ts
@@ -3,8 +3,13 @@ import type { TopRowWidgetText } from "../components/Dashboard/content.js";
 
 export type { TuiConfig, TuiIslandConfig, TuiWidgetConfig };
 
+/** Widgets whose text is derived from the observer snapshot at render time. */
+export type SnapshotWidgetKind = "fleet" | "prs";
+
 export type TopRowWidgetView = TopRowWidgetText & {
   id: string;
+  /** Set for snapshot-derived widgets; resolveTopRowWidgets fills their text. */
+  data?: SnapshotWidgetKind;
 };
 
 export type TimeWidgetRuntime = {

--- a/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
+++ b/packages/dashboard-core/src/widgets/useTopRowWidgets.ts
@@ -1,5 +1,7 @@
 import type { TuiWeatherWidgetConfig, TuiWidgetConfig } from "@station/config";
+import { formatMoonWidget } from "./moon.js";
 import { formatTimeWidget, millisecondsUntilNextMinute } from "./time.js";
+import { formatTimezoneWidget } from "./timezone.js";
 import type {
   TopRowWidgetRuntimeDeps,
   TopRowWidgetView,
@@ -55,17 +57,28 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
       });
     }, []);
 
-    const hasTimeWidget = widgets.some((widget) => widget.type === "time");
+    // Disabled widgets drop out entirely; ids keep the config index so a
+    // toggle elsewhere in the array never re-keys live widget state.
+    const activeWidgets = hooks.useMemo(
+      () =>
+        widgets
+          .map((widget, index) => ({ widget, index }))
+          .filter((entry) => entry.widget.enabled !== false),
+      [widgets],
+    );
+    const needsClock = activeWidgets.some(
+      ({ widget }) => widget.type === "time" || widget.type === "tz" || widget.type === "moon",
+    );
     const weatherEntries = hooks.useMemo(
       () =>
-        widgets.flatMap((widget, index): WeatherWidgetEntry[] =>
+        activeWidgets.flatMap(({ widget, index }): WeatherWidgetEntry[] =>
           widget.type === "weather" ? [{ id: `weather:${index}`, config: widget }] : [],
         ),
-      [widgets],
+      [activeWidgets],
     );
 
     hooks.useEffect(() => {
-      if (!hasTimeWidget) {
+      if (!needsClock) {
         return;
       }
 
@@ -83,7 +96,7 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
           clearInterval(interval);
         }
       };
-    }, [hasTimeWidget, now]);
+    }, [needsClock, now]);
 
     hooks.useEffect(() => {
       if (weatherEntries.length === 0) {
@@ -133,7 +146,7 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
 
     return hooks.useMemo(
       () =>
-        widgets.map((widget, index): TopRowWidgetView => {
+        activeWidgets.map(({ widget, index }): TopRowWidgetView => {
           switch (widget.type) {
             case "time":
               return {
@@ -147,11 +160,21 @@ export function createUseTopRowWidgets(hooks: TopRowWidgetHookRuntime) {
                 text: weatherTexts[id] ?? renderWeatherLoading(widget),
               };
             }
+            case "tz":
+              return { id: `tz:${index}`, ...formatTimezoneWidget(currentMinute, widget) };
+            case "moon":
+              return { id: `moon:${index}`, ...formatMoonWidget(currentMinute) };
+            // Snapshot-derived widgets: text resolves at render, where the
+            // snapshot lives (resolveTopRowWidgets).
+            case "fleet":
+              return { id: `fleet:${index}`, text: "", data: "fleet" };
+            case "prs":
+              return { id: `prs:${index}`, text: "", data: "prs" };
           }
           const exhaustive: never = widget;
           return exhaustive;
         }),
-      [currentMinute, weatherTexts, widgets],
+      [activeWidgets, currentMinute, weatherTexts],
     );
   };
 }

--- a/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { dashboardHeaderLine } from "../../../src/components/Dashboard/content.js";
+
+const WIDGETS = [
+  { text: "NYC 08:00 · TYO 21:00", compact: "NYC 08:00" },
+  { text: "🌕 full moon", compact: "🌕" },
+];
+
+function line(columns: number): string {
+  return dashboardHeaderLine({ productLabel: "station", columns, widgets: WIDGETS });
+}
+
+describe("dashboardHeaderLine widget strip", () => {
+  it("shows every widget in full when the width allows", () => {
+    expect(line(80)).toBe(`station${" ".repeat(38)}NYC 08:00 · TYO 21:00  🌕 full moon`);
+  });
+
+  it("compacts every widget before dropping any", () => {
+    expect(line(40)).toBe(`station${" ".repeat(20)}NYC 08:00  🌕`);
+  });
+
+  it("drops widgets from the right once compact forms no longer fit", () => {
+    expect(line(17)).toBe(`station${" ".repeat(1)}NYC 08:00`);
+  });
+
+  it("falls back to the product label alone at minimum widths", () => {
+    expect(line(10)).toBe("station");
+  });
+});

--- a/packages/dashboard-core/test/unit/widgets/moon.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/moon.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatMoonWidget, moonPhase } from "../../../src/widgets/moon.js";
+
+describe("moonPhase", () => {
+  it("hits the anchor phases of the reference cycle", () => {
+    // The epoch new moon itself, then quarter offsets of the synodic month.
+    expect(moonPhase(new Date(Date.UTC(2000, 0, 6, 18, 14))).name).toBe("new moon");
+    expect(moonPhase(new Date(Date.UTC(2000, 0, 14, 2, 0))).name).toBe("first quarter");
+    expect(moonPhase(new Date(Date.UTC(2000, 0, 21, 5, 0))).name).toBe("full moon");
+    expect(moonPhase(new Date(Date.UTC(2000, 0, 28, 8, 0))).name).toBe("last quarter");
+  });
+
+  it("handles dates before the epoch", () => {
+    // One full synodic month earlier is a new moon again.
+    expect(moonPhase(new Date(Date.UTC(1999, 11, 8, 5, 30))).name).toBe("new moon");
+  });
+});
+
+describe("formatMoonWidget", () => {
+  it("pairs the glyph with the phase name, compacting to the glyph alone", () => {
+    const widget = formatMoonWidget(new Date(Date.UTC(2000, 0, 21, 5, 0)));
+    expect(widget).toEqual({ text: "🌕 full moon", compact: "🌕" });
+  });
+});

--- a/packages/dashboard-core/test/unit/widgets/snapshotWidgets.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/snapshotWidgets.test.ts
@@ -1,0 +1,66 @@
+import type { StationSnapshot } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { resolveTopRowWidgets } from "../../../src/widgets/snapshotWidgets.js";
+import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+
+function withPrStates(snapshot: StationSnapshot): StationSnapshot {
+  const states = new Map<string, "open" | "draft" | "merged">([
+    ["wt_web_working", "open"],
+    ["wt_web_idle", "draft"],
+    ["wt_api_working", "merged"],
+  ]);
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row) => {
+      const state = states.get(row.id);
+      if (state === undefined) {
+        return row;
+      }
+      return { ...row, worktree: { ...row.worktree, pr: { number: 7, state } } };
+    }),
+  };
+}
+
+describe("resolveTopRowWidgets", () => {
+  it("fills fleet and open-PR counts from the snapshot", () => {
+    const snapshot = withPrStates(createDashboardSnapshot());
+    const resolved = resolveTopRowWidgets(
+      [
+        { id: "time:0", text: "10:42 AM" },
+        { id: "fleet:1", text: "", data: "fleet" },
+        { id: "prs:2", text: "", data: "prs" },
+      ],
+      snapshot,
+    );
+    expect(resolved.map((widget) => widget.text)).toEqual([
+      "10:42 AM",
+      // Fixture rows: 2 working + attention + stuck + 1 idle are live;
+      // exited/unknown/no-agent are not.
+      "5 agents",
+      // open + draft count as open PRs; merged does not.
+      "2 open PRs",
+    ]);
+    expect(resolved[2]?.compact).toBe("2 PRs");
+  });
+
+  it("drops snapshot widgets when no snapshot has arrived", () => {
+    const resolved = resolveTopRowWidgets(
+      [
+        { id: "fleet:0", text: "", data: "fleet" },
+        { id: "time:1", text: "10:42 AM" },
+      ],
+      undefined,
+    );
+    expect(resolved).toEqual([{ id: "time:1", text: "10:42 AM" }]);
+  });
+
+  it("uses singular nouns for counts of one", () => {
+    const base = createDashboardSnapshot();
+    const oneAgent: StationSnapshot = {
+      ...base,
+      rows: base.rows.filter((row) => row.id === "wt_web_working"),
+    };
+    const resolved = resolveTopRowWidgets([{ id: "fleet:0", text: "", data: "fleet" }], oneAgent);
+    expect(resolved[0]?.text).toBe("1 agent");
+  });
+});

--- a/packages/dashboard-core/test/unit/widgets/timezone.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/timezone.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatTimezoneWidget, zoneTime } from "../../../src/widgets/timezone.js";
+
+// 2026-06-12T12:00Z → 08:00 in New York (EDT), 21:00 in Tokyo.
+const NOON_UTC = new Date(Date.UTC(2026, 5, 12, 12, 0));
+
+const NYC = { label: "NYC", timeZone: "America/New_York" };
+const TYO = { label: "TYO", timeZone: "Asia/Tokyo" };
+
+describe("zoneTime", () => {
+  it("formats 12h and 24h wall time in the zone", () => {
+    expect(zoneTime(NOON_UTC, NYC, "12h")).toBe("8:00 AM");
+    expect(zoneTime(NOON_UTC, NYC, "24h")).toBe("08:00");
+    expect(zoneTime(NOON_UTC, TYO, "12h")).toBe("9:00 PM");
+    expect(zoneTime(NOON_UTC, TYO, "24h")).toBe("21:00");
+  });
+
+  it("renders an unknown zone as --:-- instead of throwing", () => {
+    expect(zoneTime(NOON_UTC, { label: "??", timeZone: "Not/AZone" }, "12h")).toBe("--:--");
+  });
+});
+
+describe("formatTimezoneWidget", () => {
+  it("joins the pair and compacts to the first zone", () => {
+    const widget = formatTimezoneWidget(NOON_UTC, {
+      type: "tz",
+      zones: [NYC, TYO],
+      timeFormat: "24h",
+    });
+    expect(widget).toEqual({ text: "NYC 08:00 · TYO 21:00", compact: "NYC 08:00" });
+  });
+
+  it("renders a single zone with the 12h default", () => {
+    const widget = formatTimezoneWidget(NOON_UTC, { type: "tz", zones: [NYC] });
+    expect(widget).toEqual({ text: "NYC 8:00 AM", compact: "NYC 8:00 AM" });
+  });
+});

--- a/packages/dashboard-core/test/unit/widgets/useTopRowWidgets.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/useTopRowWidgets.test.ts
@@ -1,6 +1,11 @@
+import type { TuiWidgetConfig } from "@station/config";
 import { describe, expect, it, vi } from "vitest";
 import type { WeatherClient, WeatherCurrentConditions } from "../../../src/widgets/types.js";
-import { refreshWeatherWidget } from "../../../src/widgets/useTopRowWidgets.js";
+import {
+  createUseTopRowWidgets,
+  refreshWeatherWidget,
+  type TopRowWidgetHookRuntime,
+} from "../../../src/widgets/useTopRowWidgets.js";
 
 const CONFIG = { type: "weather", city: "Austin", label: "ATX" } as const;
 const ENTRY = { id: "weather:0", config: CONFIG };
@@ -65,5 +70,57 @@ describe("refreshWeatherWidget", () => {
       setText: (text) => texts.push(text),
     });
     expect(texts).toEqual([]);
+  });
+});
+
+// One synchronous render: state stays initial, effects never run — enough to
+// assert the pure config → view mapping.
+function renderOnce(widgets: readonly TuiWidgetConfig[], now: () => Date) {
+  const hooks: TopRowWidgetHookRuntime = {
+    useCallback: (callback) => callback,
+    useEffect: () => {},
+    useMemo: (factory) => factory(),
+    useRef: (initialValue) => ({ current: initialValue }),
+    useState: (initialValue) => [
+      typeof initialValue === "function" ? (initialValue as () => never)() : initialValue,
+      () => {},
+    ],
+  };
+  return createUseTopRowWidgets(hooks)(widgets, { now });
+}
+
+describe("useTopRowWidgets config mapping", () => {
+  const noon = () => new Date(Date.UTC(2026, 5, 12, 12, 0));
+
+  it("drops disabled widgets while ids keep the config index", () => {
+    const views = renderOnce(
+      [{ type: "time" }, { type: "time", enabled: false }, { type: "moon" }],
+      noon,
+    );
+    expect(views.map((view) => view.id)).toEqual(["time:0", "moon:2"]);
+  });
+
+  it("emits snapshot placeholders for fleet and prs widgets", () => {
+    const views = renderOnce([{ type: "fleet" }, { type: "prs" }], noon);
+    expect(views).toEqual([
+      { id: "fleet:0", text: "", data: "fleet" },
+      { id: "prs:1", text: "", data: "prs" },
+    ]);
+  });
+
+  it("renders tz pairs and the moon phase from the shared clock", () => {
+    const views = renderOnce(
+      [
+        {
+          type: "tz",
+          zones: [{ label: "NYC", timeZone: "America/New_York" }],
+          timeFormat: "24h",
+        },
+        { type: "moon" },
+      ],
+      noon,
+    );
+    expect(views[0]?.text).toBe("NYC 08:00");
+    expect(views[1]?.compact).toBe(views[1]?.text.split(" ")[0]);
   });
 });

--- a/station/src/station/StationOverlay.tsx
+++ b/station/src/station/StationOverlay.tsx
@@ -5,7 +5,8 @@ import type { StoreApi } from "zustand/vanilla";
 import { normalizeStationMouseEvent, type StationMouseEvent } from "../input/mouse.js";
 import type { MouseTargetRef } from "../input/router.js";
 import type { StationMouseTarget } from "./input/stationMouse.js";
-import type { TopRowWidgetText, TuiStore } from "@station/dashboard-core";
+import type { TuiStore } from "@station/dashboard-core";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { DashboardRoot } from "./view/DashboardRoot.js";
 import { STATION_COLORS } from "./view/theme.js";
 import { StationMouseProvider, type StationMouseDispatch } from "./view/stationMouseContext.js";
@@ -13,7 +14,7 @@ import { StationMouseProvider, type StationMouseDispatch } from "./view/stationM
 export type StationOverlayProps = {
   /** Owned by main.tsx (HMR recreates store + renderer + handlers together). */
   store: StoreApi<TuiStore>;
-  topRowWidgets?: readonly TopRowWidgetText[];
+  topRowWidgets?: readonly TopRowWidgetView[];
   /** The Station input runtime's mouse entry point. */
   dispatchMouse: (target: MouseTargetRef, event: StationMouseEvent) => boolean;
 };

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -12,7 +12,9 @@ import {
   observerHeaderStatusForConnection,
   snapshotLoadingLines,
 } from "@station/dashboard-core";
-import type { TopRowWidgetText, TuiStore } from "@station/dashboard-core";
+import type { TuiStore } from "@station/dashboard-core";
+import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { activeTuiToast, nextTuiToastExpiry, QUIT_HINT_CLOSE } from "@station/dashboard-core";
 import { CommandPromptView } from "./CommandPromptView.js";
 import { DashboardHeaderRow, DashboardView, Divider } from "./DashboardView.js";
@@ -27,7 +29,7 @@ export type DashboardRootProps = {
   /** The overlay's content area, in terminal cells. */
   columns: number;
   rows: number;
-  topRowWidgets?: readonly TopRowWidgetText[];
+  topRowWidgets?: readonly TopRowWidgetView[];
 };
 
 export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: DashboardRootProps) {
@@ -85,7 +87,10 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
   if (loading || snapshot === undefined) {
     return (
       <box width="100%" flexGrow={1} flexDirection="column" paddingRight={1}>
-        <DashboardHeaderRow columns={contentColumns} widgets={topRowWidgets} />
+        <DashboardHeaderRow
+          columns={contentColumns}
+          widgets={resolveTopRowWidgets(topRowWidgets, snapshot)}
+        />
         <Divider columns={contentColumns} />
         <box flexDirection="column" flexGrow={1}>
           {snapshotLoadingLines(loading, observerConnectionStatus).map((line, index) => (

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -31,6 +31,8 @@ import {
   type FleetSummary,
 } from "@station/dashboard-core";
 import type { TuiViewState } from "@station/dashboard-core";
+import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 import { SegmentLinkTargets, Segments } from "./segments.js";
 import { Throbber } from "./Throbber.js";
@@ -65,7 +67,7 @@ export type DashboardViewProps = {
   snapshot: StationSnapshot;
   viewState: TuiViewState;
   columns?: number;
-  topRowWidgets?: readonly TopRowWidgetText[];
+  topRowWidgets?: readonly TopRowWidgetView[];
   observerStatus?: DashboardHeaderStatus;
 };
 
@@ -98,7 +100,7 @@ export function DashboardView({
     >
       <DashboardHeaderRow
         columns={contentColumns}
-        widgets={topRowWidgets}
+        widgets={resolveTopRowWidgets(topRowWidgets, snapshot)}
         {...(observerStatus === undefined ? {} : { status: observerStatus })}
       />
       {firstRun ? null : <FleetBar summary={fleet} />}
@@ -148,7 +150,8 @@ export function DashboardHeaderRow({
   return (
     <text fg={STATION_COLORS.foreground}>
       <span attributes={TextAttributes.BOLD}>{PRODUCT_LABEL}</span>
-      {suffix}
+      {/* Widgets/status are calm chrome: gray, so the body's status colours stay the loud ones. */}
+      <span fg={STATION_COLORS.gray}>{suffix}</span>
     </text>
   );
 }

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -16,7 +16,7 @@ import {
 } from "../fixtures/scenarios.js";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import type { StationMouseTarget } from "../input/stationMouse.js";
-import type { TopRowWidgetText } from "@station/dashboard-core";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { DashboardRoot } from "./DashboardRoot.js";
 import { STATION_COLORS } from "./theme.js";
 import { StationMouseProvider } from "./stationMouseContext.js";
@@ -57,7 +57,7 @@ describe("dashboard golden frames", () => {
     height: number;
     snapshot?: StationSnapshot;
     connection?: StationClientConnectionState;
-    topRowWidgets?: readonly TopRowWidgetText[];
+    topRowWidgets?: readonly TopRowWidgetView[];
     dispatchMouse?: (target: StationMouseTarget) => void;
   }): Promise<RenderedDashboard> {
     const { store } = makeStationTestStore({
@@ -111,16 +111,23 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("Q/esc:close");
   });
 
-  it("renders widgets in the loading-state header", async () => {
+  it("renders widgets in the loading-state header as gray chrome", async () => {
     const setup = await renderDashboard({
       width: 80,
       height: 24,
       connection: { state: "loading", since: Date.now() },
-      topRowWidgets: [{ text: "10:42 AM" }],
+      topRowWidgets: [{ id: "time:0", text: "10:42 AM" }],
     });
     const frame = setup.captureCharFrame();
     expect(frame).toContain("10:42 AM");
     expect(frame).toContain("Loading observer snapshot...");
+
+    const lines = frame.split("\n");
+    const headerRow = lines.findIndex((line) => line.includes("10:42 AM"));
+    const widgetCol = lines[headerRow]?.indexOf("10:42 AM") ?? -1;
+    expect(widgetCol).toBeGreaterThan(0);
+    const spans = setup.captureSpans();
+    expect(spanHex(spanAtFrameCell(spans, headerRow, widgetCol))).toBe(STATION_COLORS.gray);
   });
 
   it("renders the waiting-for-observer state on cold reconnects", async () => {


### PR DESCRIPTION
PR7a of the Atomics & Mockups UX plan (D6, D16) — the no-backend widget foundation. The Configure panel / `[+]` picker / reorder / hover `[×]` interaction surface follows as **PR7b** (same split precedent as PR4→PR4b). No backend, no contract change.

## What's new

**Config** (`[tui].widgets`, documented in `docs/configuration.md`):
- every widget accepts `enabled` (default true; `false` hides the entry without deleting it — the on/off primitive PR7b's panel will drive)
- new union members, all snapshot/clock-fed per D16: `fleet` (live-agent count), `prs` (open-PR count, open+draft), `tz` (1–2 IANA `zones` + `time_format`; unknown zone renders `--:--`, never fails the section), `moon` (phase glyph + name)

**Engine** (`dashboard-core/widgets`):
- tz + moon tick on the existing shared minute clock (no new timers)
- fleet/prs emit placeholders; `resolveTopRowWidgets(views, snapshot)` fills them at render where the snapshot lives — no snapshot → they drop, never paint stale
- disabled widgets keep config-index ids so toggling one never re-keys another's live state (weather cache etc.)

**Width-aware strip** (the "widget atom output" item):
- `TopRowWidgetText.compact`; the header ladder now tries every-widget-full → every-widget-compact → drop-from-the-right, so the strip narrows before it loses information (`7 open PRs`→`7 PRs`, `NYC 17:52 · TYO 06:52`→`NYC 17:52`, `🌖 waning gibbous`→`🌖`)
- widget/status suffix paints `STATION_COLORS.gray` (calm chrome; locked by a spanHex assertion — goldens are chars-only so nothing churned)

## UX implication + verified live (mock mode, real TOML)

Wide overlay header:
```
station    5:52 PM  7 agents  7 open PRs  NYC 17:52 · TYO 06:52  🌖 waning gibbous
```
Same config at ~68 cols compacts instead of dropping:
```
station    5:51 PM  7 agents  7 PRs  NYC 17:51  🌖
```
("7 agents" cross-checked against the fixture: 2 working + 4 idle + 1 starting.)

## Tests

- `pnpm typecheck`, `pnpm lint`, `pnpm test:unit` green; station lane `bun run typecheck` + `bun test` (847) green after `pnpm build`
- new: moon-phase anchors, tz 12h/24h + invalid-zone, snapshot resolution (counts, singular, no-snapshot drop), compact ladder, render-once hook mapping (enabled filter, stable ids, placeholders), TOML load for all new types with snake_case `zones`, gray-chrome span assertion