### PR TITLE
fix(observer): key socket ownership on inode + birth time

### DIFF
--- a/apps/observer/src/runtime/socketOwnership.ts
+++ b/apps/observer/src/runtime/socketOwnership.ts
@@ -13,9 +13,14 @@ export type WatchSocketOwnershipOptions = {
 // A newer observer claims the socket path by unlinking and rebinding it, which
 // gives the displaced process no signal. Watching the file's inode is the only
 // way it can learn it lost ownership and must shut down instead of lingering.
+// Inode number alone is ambiguous: a recreated path can reuse the just-freed
+// inode (ext4 does this routinely), so identity pairs it with the birth time.
+// Filesystems without btime report 0n for both files, degrading to inode-only.
+type SocketIdentity = { ino: bigint; birthtimeNs: bigint };
+
 export function watchSocketOwnership(options: WatchSocketOwnershipOptions): SocketOwnershipWatch {
   const intervalMs = options.intervalMs ?? 5000;
-  let ownedInode: bigint | undefined;
+  let owned: SocketIdentity | undefined;
   let fired = false;
 
   const lose = () => {
@@ -28,17 +33,18 @@ export function watchSocketOwnership(options: WatchSocketOwnershipOptions): Sock
   };
 
   const probe = async () => {
-    let currentInode: bigint | undefined;
+    let current: SocketIdentity | undefined;
     try {
-      currentInode = (await lstat(options.socketPath, { bigint: true })).ino;
+      const stats = await lstat(options.socketPath, { bigint: true });
+      current = { ino: stats.ino, birthtimeNs: stats.birthtimeNs };
     } catch {
-      currentInode = undefined;
+      current = undefined;
     }
-    if (ownedInode === undefined) {
-      ownedInode = currentInode;
+    if (owned === undefined) {
+      owned = current;
       return;
     }
-    if (currentInode !== ownedInode) {
+    if (current?.ino !== owned.ino || current?.birthtimeNs !== owned.birthtimeNs) {
       lose();
     }
   };


### PR DESCRIPTION
Deflakes the `watchSocketOwnership` unit test that failed main's first re-enabled standard-ci run (`fires onLost when the socket path is replaced by another inode` → waitFor timeout).

Root cause is real, not just test flake: the probe compared inode numbers alone, and a recreated socket path can reuse the just-freed inode (routine on ext4 — why CI failed; APFS allocates monotonically — why local runs passed). A displaced observer would never notice such a takeover. Identity is now inode + birth time; filesystems without btime report 0n for both sides, degrading safely to the old comparison.

Flagged as a PLAUSIBLE inode-reuse weakness in the pre-merge review of #56; CI proved it within the hour.

## Verify
- `apps/observer/test/unit/socketOwnership.test.ts` — 3/3 pass locally.
- Full `pnpm typecheck` clean after rebuild.

UX: none directly; displaced observers on ext4-style filesystems now reliably self-evict (fewer zombie observers stealing spool events).