### PR TITLE
test(input): pin split-cwd resolution for deep restored anchor chains

### DIFF
--- a/station/src/input/runtime/paneEffects.test.ts
+++ b/station/src/input/runtime/paneEffects.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { nextSplitSeqFromPanes } from "./paneEffects.js";
+import type { StoreApi } from "zustand/vanilla";
+import type { TuiStore } from "@station/dashboard-core";
+import { createStationStore } from "../../state/store.js";
+import { agentWorktreePaneId, type PaneId } from "../../state/types.js";
+import type { PtyRegistry } from "../../terminal/registry/ptyRegistry.js";
+import { createPaneEffects, nextSplitSeqFromPanes } from "./paneEffects.js";
 
 describe("nextSplitSeqFromPanes", () => {
   it("returns one past the highest pane-split-N", () => {
@@ -19,5 +24,57 @@ describe("nextSplitSeqFromPanes", () => {
 
   it("ignores non-numeric split suffixes", () => {
     expect(nextSplitSeqFromPanes([{ id: "pane-split-abc" }, { id: "pane-split-3" }])).toBe(4);
+  });
+});
+
+describe("split cwd resolution along the anchor chain", () => {
+  // Regression: the walk to the worktree-owning pane must follow the full split-anchor chain.
+  // A row-count-bounded guard wrongly returned undefined for a restored chain deeper than the
+  // snapshot's row count, spawning splits in the default cwd instead of the worktree root.
+  it("resolves the worktree root for a restored split chain deeper than the row count", () => {
+    const worktreeId = "wt_deep";
+    const worktreeRoot = "/wt/deep/root";
+    const store = createStationStore({ boot: "empty" });
+    const agentPaneId = agentWorktreePaneId(worktreeId);
+    store.actions.createPane(agentPaneId, { role: "primary-agent" });
+    // Three nested splits (chain depth 3) anchored back to the worktree's agent pane, against a
+    // single-row snapshot — the exact shape the old `depth > rows.length + 1` guard tripped on.
+    store.actions.createPane("pane-split-0" as PaneId, {
+      split: { anchorPaneId: agentPaneId, direction: "right" },
+    });
+    store.actions.createPane("pane-split-1" as PaneId, {
+      split: { anchorPaneId: "pane-split-0" as PaneId, direction: "right" },
+    });
+    store.actions.createPane("pane-split-2" as PaneId, {
+      split: { anchorPaneId: "pane-split-1" as PaneId, direction: "right" },
+    });
+
+    const stationViewStore = {
+      getState: () => ({ snapshot: { rows: [{ id: worktreeId, path: worktreeRoot }] } }),
+    } as unknown as StoreApi<TuiStore>;
+
+    const ensured: Array<{ id: PaneId; options: { cwd?: string } | undefined }> = [];
+    const registry = {
+      get: () => undefined,
+      ensure: (id: PaneId, options: { cwd?: string } | undefined) => {
+        ensured.push({ id, options });
+      },
+    } as unknown as PtyRegistry;
+
+    const effects = createPaneEffects({
+      store,
+      stationViewStore,
+      registry,
+      resolveAuxShellPlacement: undefined,
+      autoCloseOverlay: false,
+      automations: [],
+      writeToTerminal: undefined,
+      pasteToTerminal: undefined,
+    });
+
+    effects.splitPane("pane-split-2" as PaneId, "right");
+
+    expect(ensured).toHaveLength(1);
+    expect(ensured[0]?.options).toEqual({ cwd: worktreeRoot });
   });
 });


### PR DESCRIPTION
Salvaged from the local-main line while bringing it up to date: commit 90580aa there implemented the same `worktreeIdForPane` visited-set fix that landed via #45, but also wrote the regression test the #45 review noted was missing — three nested splits against a single-row snapshot, the exact shape the old `depth > rows.length + 1` guard truncated.

Test-only; passes 4/4 against main's implementation (bun lane 875/0 locally).

The rest of that local line (equivalent impl variant + an in-flight observer replace-owner / codex hookFeatureEnabled feature) is parked on `wip/observer-replace-owner-codex-hook-flag` with its own worktree.

UX implication: none directly — the test pins that a split opened from a deep restored chain spawns its shell in the worktree root, not the process default cwd. Manual check if desired: stack three splits on one worktree row, split again, confirm the new pane's cwd.