### PR TITLE
fix(tui): replace Bun prelaunch chatter with startup status

### DIFF
--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -133,7 +133,7 @@ function runRenderer(
 }
 
 async function spawnRenderer({ env, entry }: RendererSpawnOptions): Promise<TuiRunResult> {
-  const childEnv = { ...process.env, ...env };
+  const childEnv = { ...process.env, ...env, STATION_QUIET_PRELAUNCH: "1" };
   const override = process.env.STATION_DASHBOARD_COMMAND;
   // Bare stn shells into `bun run` against the station/ lane; if it was never
   // bun-installed the child dies with a raw "@opentui not found", so pre-flight the
@@ -142,10 +142,13 @@ async function spawnRenderer({ env, entry }: RendererSpawnOptions): Promise<TuiR
     process.stderr.write(`${stationUiInstallHint} Or run stn doctor.\n`);
     return { status: "exited", code: 1 };
   }
+  if (override === undefined) {
+    process.stderr.write(`Starting STATION ${entry === "dashboard" ? "dashboard" : "TUI"}…\n`);
+  }
   const child =
     override !== undefined
       ? spawn(override, { shell: true, stdio: "inherit", env: childEnv })
-      : spawn("bun", ["run", "--cwd", resolveStationWorkspaceDir(), entry], {
+      : spawn("bun", ["run", "--silent", "--cwd", resolveStationWorkspaceDir(), entry], {
           stdio: "inherit",
           env: childEnv,
         });

--- a/station/scripts/link-station-packages.sh
+++ b/station/scripts/link-station-packages.sh
@@ -45,5 +45,7 @@ for package in "${linked_packages[@]}"; do
   freshness="${freshness}${package}@${mtime}  "
 done
 
-echo "Linked @station packages (${linked_packages[*]}) into node_modules."
-echo "dist builds: ${freshness}"
+if [[ "${STATION_QUIET_PRELAUNCH:-}" != "1" ]]; then
+  echo "Linked @station packages (${linked_packages[*]}) into node_modules."
+  echo "dist builds: ${freshness}"
+fi


### PR DESCRIPTION
## Summary
- run the Bun renderer with `bun run --silent` from the CLI
- pass a quiet prelaunch env flag so package-link freshness output is hidden during normal `stn` startup
- show a concise `Starting STATION TUI/dashboard…` status instead of raw setup commands

## Tests
- `pnpm build`
- `pnpm test:integration -- apps/cli/test/integration/tui-command.test.ts`

## UX implication / manual verify
Bare `stn` should show a short startup status, then open the TUI without dumping Bun script/link/repair command chatter. Manually verify with `stn` from any directory.