### PR TITLE
fix(pi): preserve modified enter soft newline

### DIFF
--- a/integrations/harness/pi/src/provider.ts
+++ b/integrations/harness/pi/src/provider.ts
@@ -34,7 +34,7 @@ const baseCapabilities: HarnessCapabilities = {
   canStop: false,
   canRunNonInteractive: false,
   canExposeApprovalState: false,
-  supportsModifiedEnterSoftNewline: false,
+  supportsModifiedEnterSoftNewline: true,
 };
 
 const piSpec: TerminalBoundHarnessProviderSpec<PiHarnessProviderOptions> = {

--- a/integrations/harness/pi/test/unit/provider.test.ts
+++ b/integrations/harness/pi/test/unit/provider.test.ts
@@ -23,7 +23,7 @@ describe("PiHarnessProvider", () => {
       canStop: false,
       canRunNonInteractive: false,
       canExposeApprovalState: false,
-      supportsModifiedEnterSoftNewline: false,
+      supportsModifiedEnterSoftNewline: true,
     });
   });
 

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -131,29 +131,46 @@ describe("createStationInputRuntime", () => {
     expect(scripted.helpers.writes.join("")).toBe("\x1b[13;2u");
   });
 
-  it("preserves xterm Shift+Enter for a warm-attached Codex primary-agent pane", () => {
-    const snapshot = manyProjectsSnapshot();
-    const stationViewStore = createTuiStore({
-      source: new FakeStationSource(snapshot),
-      service: new FakeTuiObserverService(snapshot),
-      initialSnapshot: snapshot,
-      persistentPopup: true,
-      onDismiss: async () => {},
-    });
-    const { runtime, scripted, store, registry } = harness({ stationViewStore });
-    const paneId = agentWorktreePaneId("wt_station_idle");
-    store.actions.createPane(paneId, { role: "primary-agent" });
-    store.actions.setPrimaryAgent(paneId, {
-      sessionId: "ses_wt_station_idle",
-      terminalTargetId: "native:wt_station_idle",
-      harnessProvider: "codex",
-    });
-    store.actions.focusPane(paneId);
-    registry.resize(paneId, { cols: 36, rows: 8 });
+  it.each(["codex", "pi"] as const)(
+    "preserves xterm Shift+Enter for a warm-attached %s primary-agent pane",
+    (provider) => {
+      const baseSnapshot = manyProjectsSnapshot();
+      const snapshot = {
+        ...baseSnapshot,
+        sessions: baseSnapshot.sessions.map((session) => ({
+          ...session,
+          harness: {
+            ...session.harness,
+            provider,
+            capabilities: {
+              ...session.harness.capabilities,
+              supportsModifiedEnterSoftNewline: session.id === "ses_wt_station_idle",
+            },
+          },
+        })),
+      };
+      const stationViewStore = createTuiStore({
+        source: new FakeStationSource(snapshot),
+        service: new FakeTuiObserverService(snapshot),
+        initialSnapshot: snapshot,
+        persistentPopup: true,
+        onDismiss: async () => {},
+      });
+      const { runtime, scripted, store, registry } = harness({ stationViewStore });
+      const paneId = agentWorktreePaneId("wt_station_idle");
+      store.actions.createPane(paneId, { role: "primary-agent" });
+      store.actions.setPrimaryAgent(paneId, {
+        sessionId: "ses_wt_station_idle",
+        terminalTargetId: "native:wt_station_idle",
+        harnessProvider: provider,
+      });
+      store.actions.focusPane(paneId);
+      registry.resize(paneId, { cols: 36, rows: 8 });
 
-    expect(runtime.handleSequence("\x1b[27;2;13~")).toBe(true);
-    expect(scripted.helpers.writes.join("")).toBe("\x1b[13;2u");
-  });
+      expect(runtime.handleSequence("\x1b[27;2;13~")).toBe(true);
+      expect(scripted.helpers.writes.join("")).toBe("\x1b[13;2u");
+    },
+  );
 
   it("matches arrow-key bytes to the focused pane's cursor-key mode", async () => {
     const { runtime, scripted, registry } = harness();


### PR DESCRIPTION
## Summary
- advertise Pi as supporting modified Enter soft-newline input
- preserve xterm/CSI-u Shift+Enter for warm-attached Pi primary-agent panes, matching Codex
- update provider and Station input tests for the Pi capability

## Tests
- `pnpm test:unit -- integrations/harness/pi/test/unit/provider.test.ts station/src/input/stationInput.test.ts`

## UX implication / manual verify
Shift+Enter in a Station-hosted Pi agent pane should insert a newline instead of submitting. Manually verify by launching Pi in Station, typing a first line, pressing Shift+Enter, typing a second line, and confirming the prompt has not submitted until plain Enter.