### PR TITLE
fix(dashboard-core): row colour fidelity — foreground names, idle · ready, DIFF · PR, #N merged

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -112,13 +112,21 @@ function* widgetStripCandidates(widgets: readonly TopRowWidgetText[]): Generator
 }
 
 export function projectHeaderLabel(project: ProjectView, collapsed: boolean): string {
+  const parts = projectHeaderLabelParts(project, collapsed);
+  return `${parts.title}${parts.counts}`;
+}
+
+export function projectHeaderLabelParts(
+  project: ProjectView,
+  collapsed: boolean,
+): { title: string; counts: string } {
   const caret = collapsed ? "▶" : "▼";
   const sessions = `${project.counts.worktrees} ${plural(project.counts.worktrees, "session")}`;
   const agents =
     project.counts.agents > 0
       ? ` · ${project.counts.agents} ${plural(project.counts.agents, "agent")}`
       : "";
-  return `${caret} ${project.label}  ${sessions}${agents}`;
+  return { title: `${caret} ${project.label}`, counts: `  ${sessions}${agents}` };
 }
 
 export function emptyProjectLabel(): string {

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -29,12 +29,6 @@ export function worktreeRowGridInput({
   const activity = activityCellForRow(row);
   const ready = isReadyToRead(row);
   const state = row.agent?.state ?? "none";
-  // Colour reinforces the glyph + status label; the session name stays foreground.
-  const color = row.display.alert
-    ? "red"
-    : marker.kind === "text" && marker.text === "?"
-      ? "yellow"
-      : undefined;
   const input: Parameters<typeof worktreeStyleRowGridInput>[0] = {
     id: id ?? row.id,
     slot,
@@ -48,19 +42,15 @@ export function worktreeRowGridInput({
     activityOverflow: "rowSlack",
     metadataGroups: metadataGroups(row),
   };
-  if (ready) {
-    input.markerColor = "green";
-    input.activityColor = "green";
-  } else if (state === "working") {
-    input.markerColor = "blue";
-    input.activityColor = "blue";
-  } else if (!row.display.alert && state !== "unknown") {
-    // Calm states (idle · starting · exited · no agent): status + agent recede to gray.
+  // Tone colors the glyph + status label only — the session name must stay
+  // foreground in every state (D12/D13).
+  const tone = rowStatusTone(row, ready, state);
+  if (tone === "gray") {
     input.activityColor = "gray";
     input.agentColor = "gray";
-  }
-  if (color !== undefined) {
-    input.color = color;
+  } else {
+    input.markerColor = tone;
+    input.activityColor = tone;
   }
   if (focused === true) {
     input.focused = true;
@@ -181,7 +171,7 @@ function activityCellForRow(row: WorktreeRowModel): {
   }
   if (isReadyToRead(row)) {
     return {
-      text: "ready",
+      text: "idle · ready",
       importance: "optional",
     };
   }
@@ -189,6 +179,19 @@ function activityCellForRow(row: WorktreeRowModel): {
     text: row.display.statusLabel,
     importance: "optional",
   };
+}
+
+// Keep the branch order in sync with statusMarker's ladder.
+function rowStatusTone(
+  row: WorktreeRowModel,
+  ready: boolean,
+  state: string,
+): "red" | "yellow" | "green" | "blue" | "gray" {
+  if (row.display.alert) return "red";
+  if (state === "working") return "blue";
+  if (ready) return "green";
+  if (state === "unknown") return "yellow";
+  return "gray";
 }
 
 export function statusMarker(row: WorktreeRowModel): RowMarker {
@@ -240,7 +243,7 @@ export function metadataSegments(row: WorktreeRowModel): MetadataSegment[] {
     return segments;
   }
   segments.push({
-    text: `#${pr.number}`,
+    text: pr.state === "merged" ? `#${pr.number} merged` : `#${pr.number}`,
     stale: pr.stale === true,
     color: prMetadataColor(pr),
     underline: true,

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -10,7 +10,7 @@ import {
   dashboardHeaderLine,
   emptyProjectLabel,
   FIRST_RUN_BODY_LABEL,
-  projectHeaderLabel,
+  projectHeaderLabelParts,
   rowGridInputForViewportItem,
   scrollIndicatorLabel,
   type DashboardHeaderStatus,
@@ -256,7 +256,9 @@ function columnHeaderRowInput(): RowGridRowInput {
       agent: { key: "agent", segments: [textSegment("AGENT")], importance: "optional" },
       activity: { key: "activity", segments: [textSegment("STATUS")], importance: "optional" },
     },
-    metadataGroups: { diff: [textSegment("DIFF")], pr: [textSegment("PR")] },
+    // The trailing middot composes to "DIFF · PR" via the groups' joining space,
+    // and the ladder sheds diff first, so the dot can never be orphaned.
+    metadataGroups: { diff: [textSegment("DIFF ·")], pr: [textSegment("PR")] },
   };
 }
 
@@ -512,15 +514,15 @@ function ProjectHeaderLine({
       <text
         flexGrow={1}
         fg={STATION_COLORS.foreground}
-        attributes={TextAttributes.BOLD}
         {...stationMouseProps(dispatch, { kind: "projectHeader", projectId: project.id })}
         onMouseOver={() => setHover(true)}
         onMouseOut={() => setHover(false)}
       >
-        {truncateCells(
-          projectHeaderLabel(project, collapsed),
-          Math.max(1, columns - shellWidth - quickSessionWidth),
-        )}
+        <ProjectHeaderLabel
+          project={project}
+          collapsed={collapsed}
+          width={Math.max(1, columns - shellWidth - quickSessionWidth)}
+        />
       </text>
       <ShellAffordance
         target={{ kind: "openShellForProject", projectId: project.id }}
@@ -529,5 +531,26 @@ function ProjectHeaderLine({
       />
       <QuickSessionAffordance projectId={project.id} compact={compact} />
     </box>
+  );
+}
+
+function ProjectHeaderLabel({
+  project,
+  collapsed,
+  width,
+}: {
+  project: ProjectView;
+  collapsed: boolean;
+  width: number;
+}) {
+  const parts = projectHeaderLabelParts(project, collapsed);
+  const combined = truncateCells(`${parts.title}${parts.counts}`, width);
+  const title = combined.slice(0, parts.title.length);
+  const counts = combined.slice(parts.title.length);
+  return (
+    <>
+      <span attributes={TextAttributes.BOLD}>{title}</span>
+      <span fg={STATION_COLORS.gray}>{counts}</span>
+    </>
   );
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -32,12 +32,12 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "station                                                                                                             [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-       SESSION                                   AGENT     STATUS                                               DIFF PR 
+       SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
  [2] - docs-cleanup                              -         no agent                                                     
- [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
+ [3] ○ pty-buffer                                codex     idle                                            #73 merged ✓ 
  [4] + session-resume                            codex     starting                                                     
  [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
                                                                                                                         
@@ -76,14 +76,14 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 "station                                                 [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ?   
 ─────────────────────────────────────────────────────────── 
-       SESSION                 AGENT     STATUS          PR 
+       SESSION          AGENT     STATUS                 PR 
                                                             
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
- [1] ○ cli-help-man            codex     idle         #70 ✓ 
- [2] - docs-cleanup            -         no agent           
- [3] ○ pty-buffer              codex     idle         #73 ✓ 
- [4] + session-resume          codex     starting           
- [5] ⠋ station-overlay         codex     working      #76 … 
+ [1] ○ cli-help-man     codex     idle                #70 ✓ 
+ [2] - docs-cleanup     -         no agent                  
+ [3] ○ pty-buffer       codex     idle         #73 merged ✓ 
+ [4] + session-resume   codex     starting                  
+ [5] ⠋ station-overlay  codex     working             #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
 ▼ 6 below · showing 5 of 11                                 
@@ -112,7 +112,7 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                        AGENT     STATUS                  DIFF PR 
+       SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -140,7 +140,7 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
 "station                                                                                                             [+] 
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-       SESSION                                   AGENT     STATUS                                               DIFF PR 
+       SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -4,12 +4,12 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│                         station help                         │DIFF PR 
+       S│                         station help                         │FF · PR 
         │                                                              │        
 ▼ statio│  Ctrl-O     open/close project view                          │qs] [▾] 
  [1] ○ c│  Ctrl-Q     quit Station                                     │6 #70 ✓ 
  [2] - d│  Ctrl-\\     split pane right                                 │        
- [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │  #73 ✓ 
+ [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │erged ✓ 
  [4] + s│  Ctrl-]     focus next pane                                  │        
  [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                        │6 #76 … 
         │  Enter/Sp   open project view on welcome                     │        
@@ -32,12 +32,12 @@ exports[`modal flow golden frames renders the search prompt 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -60,12 +60,12 @@ exports[`modal flow golden frames renders the collapse prompt 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -88,12 +88,12 @@ exports[`modal flow golden frames renders the project settings picker prompt 1`]
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -200,12 +200,12 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -228,12 +228,12 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -256,12 +256,12 @@ exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -284,7 +284,7 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                        AGENT     STATUS                  DIFF PR 
+       SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -312,12 +312,12 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -340,12 +340,12 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -368,12 +368,12 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -396,12 +396,12 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -424,12 +424,12 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -452,12 +452,12 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -480,12 +480,12 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 "station                                                                     [+]
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
 ───────────────────────────────────────────────────────────────────────────────
-       SESSION                            AGENT     STATUS              DIFF PR
+       SESSION                            AGENT     STATUS            DIFF · PR
 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       -         no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
@@ -508,7 +508,7 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
@@ -536,12 +536,12 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-clea┌──────────────────────────────────────────────┐                
- [3] ○ pty-buffe│ widgets                                      │          #73 ✓ 
+ [3] ○ pty-buffe│ widgets                                      │   #73 merged ✓ 
  [4] + session-r│ session only · persist in config.toml        │                
  [5] ⠋ station-o│ ▸ [on ] time                               × │ +412 -96 #76 … 
                 │   [off] weather NYC                        × │                
@@ -564,12 +564,12 @@ exports[`modal flow golden frames renders the widget settings picker 1`] = `
 "station                                                                     [+] 
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
 ─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS              DIFF PR 
+       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-clea┌──────────────────────────────────────────────┐                
- [3] ○ pty-buffe│ add widget                                   │          #73 ✓ 
+ [3] ○ pty-buffe│ add widget                                   │   #73 merged ✓ 
  [4] + session-r│ weather and tz are added in config.toml      │                
  [5] ⠋ station-o│ ▸ time                                       │ +412 -96 #76 … 
                 │   fleet                                      │                

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -242,6 +242,34 @@ describe("dashboard golden frames", () => {
     expect(spanHex(spanAtFrameCell(frame, exitedRow, exitedNameCol))).not.toBe(STATION_COLORS.gray);
   });
 
+  it("keeps alert and unknown session names foreground while their status carries the colour", async () => {
+    const setup = await renderDashboard({
+      width: 80,
+      height: 24,
+      snapshot: attentionAndFailuresSnapshot(),
+    });
+    const frame = setup.captureSpans();
+    const lines = setup.captureCharFrame().split("\n");
+
+    const attentionRow = lines.findIndex((line) => line.includes("hook-scope"));
+    expect(attentionRow).toBeGreaterThan(0);
+    const attentionNameCol = lines[attentionRow]?.indexOf("hook-scope") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, attentionRow, attentionNameCol))).toBe(
+      STATION_COLORS.foreground,
+    );
+
+    const unknownRow = lines.findIndex((line) => line.includes("metadata-refresh"));
+    expect(unknownRow).toBeGreaterThan(0);
+    const unknownWordCol = lines[unknownRow]?.indexOf("unknown") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, unknownRow, unknownWordCol))).toBe(STATION_COLORS.yellow);
+    const unknownMarkCol = lines[unknownRow]?.indexOf("?") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, unknownRow, unknownMarkCol))).toBe(STATION_COLORS.yellow);
+    const unknownNameCol = lines[unknownRow]?.indexOf("metadata-refresh") ?? -1;
+    expect(spanHex(spanAtFrameCell(frame, unknownRow, unknownNameCol))).toBe(
+      STATION_COLORS.foreground,
+    );
+  });
+
   it("routes PR number clicks through the link mouse target", async () => {
     const targets: StationMouseTarget[] = [];
     const setup = await renderDashboard({


### PR DESCRIPTION
Bucket A (+ quick-win B9) of the post-PR7 mockup delta audit. Frontend-only; no config or contract change.

## Fixes

1. **Alert/unknown rows kept their session name readable.** They previously painted the *whole row* red/yellow (slot, name, agent) via a row-level `color`, contradicting D12/D13 and the comment above the code. Now a single `rowStatusTone` (branch order mirrors `statusMarker`'s ladder) colours the marker + status label only: alert→red, working→blue, ready→green, unknown→yellow, calm→gray (status + agent recede). A new span-level test locks names to foreground on alert and unknown rows.
2. **Ready rows** read **`idle · ready`** (the mock compound) instead of bare `ready`.
3. **Project headers**: name stays bold-foreground, `N sessions · M agents` recedes to gray (`projectHeaderLabelParts` split; `projectHeaderLabel` unchanged for other callers).
4. **Column header** composes **`DIFF · PR`**. The middot rides the `DIFF` label — the ladder sheds diff before PR, so a narrow header reads a clean `PR`, never an orphaned `·`.
5. **Merged PRs** read **`#96 merged`** in the PR lane (M2 mock) — `pr.state` was already in the contract; only the word was missing.

## Verified

- Live (mock, attention scenario): escape-code capture shows `?`/`unknown` in `#fbbf24` with slot/name/agent in `#e4e4e7`.
- Goldens regenerated across both files — churn is label/width only (`idle · ready`, `#N merged`, `DIFF · PR`).
- Lanes: `pnpm typecheck` / `lint` / `test:unit` (1062) green; station `bun test` (876) green after `pnpm build`.