### PR TITLE
feat(dashboard): frame & chrome — border-embedded title, fleet totals, attention flag

### DIFF
--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -22,66 +22,31 @@ export type TopRowWidgetText = {
   compact?: string;
 };
 
-export function dashboardHeaderLine({
-  productLabel,
-  columns,
-  status,
+/**
+ * The frame's right-embedded strip: observer status (when present) then the
+ * widget ladder, widest candidate that fits. Empty string when nothing fits.
+ */
+export function headerStrip({
   widgets,
+  status,
+  maxWidth,
 }: {
-  productLabel: string;
-  columns: number;
+  widgets: readonly TopRowWidgetText[];
   status?: DashboardHeaderStatus;
-  widgets: readonly TopRowWidgetText[];
+  maxWidth: number;
 }): string {
-  const safeColumns = Math.max(1, columns);
-  const productWidth = stringWidth(productLabel);
-  if (productWidth >= safeColumns) {
-    return productLabel;
-  }
-
-  if (status !== undefined) {
-    return dashboardHeaderLineWithStatus({
-      productLabel,
-      productWidth,
-      safeColumns,
-      status,
-      widgets,
-    });
-  }
-
-  if (widgets.length === 0) {
-    return productLabel;
-  }
-
-  for (const strip of widgetStripCandidates(widgets)) {
-    const stripWidth = stringWidth(strip);
-    const gapWidth = safeColumns - productWidth - stripWidth;
-    if (gapWidth >= 1) {
-      return `${productLabel}${" ".repeat(gapWidth)}${strip}`;
-    }
-  }
-
-  return productLabel;
-}
-
-function dashboardHeaderLineWithStatus(input: {
-  productLabel: string;
-  productWidth: number;
-  safeColumns: number;
-  status: DashboardHeaderStatus;
-  widgets: readonly TopRowWidgetText[];
-}): string {
-  for (const statusText of statusTextCandidates(input.status)) {
-    for (const widgets of [...widgetStripCandidates(input.widgets), ""]) {
-      const strip = widgets.length === 0 ? statusText : `${statusText}  ${widgets}`;
-      const stripWidth = stringWidth(strip);
-      const gapWidth = input.safeColumns - input.productWidth - stripWidth;
-      if (gapWidth >= 1) {
-        return `${input.productLabel}${" ".repeat(gapWidth)}${strip}`;
+  for (const statusText of status === undefined ? [""] : statusTextCandidates(status)) {
+    for (const strip of [...widgetStripCandidates(widgets), ""]) {
+      const joined = [statusText, strip].filter((part) => part.length > 0).join(" · ");
+      if (joined.length === 0) {
+        continue;
+      }
+      if (stringWidth(joined) <= maxWidth) {
+        return joined;
       }
     }
   }
-  return input.productLabel;
+  return "";
 }
 
 function statusTextCandidates(status: DashboardHeaderStatus): string[] {
@@ -102,13 +67,29 @@ function* widgetStripCandidates(widgets: readonly TopRowWidgetText[]): Generator
   }
   const full = widgets.map((widget) => widget.text);
   const compact = widgets.map((widget) => widget.compact ?? widget.text);
-  yield full.join("  ");
+  yield full.join(" · ");
   if (compact.some((text, i) => text !== full[i])) {
-    yield compact.join("  ");
+    yield compact.join(" · ");
   }
   for (let visibleCount = widgets.length - 1; visibleCount > 0; visibleCount -= 1) {
-    yield compact.slice(0, visibleCount).join("  ");
+    yield compact.slice(0, visibleCount).join(" · ");
   }
+}
+
+/** Right side of the FLEET row; falls back to bare numbers, then to nothing. */
+export function fleetCountsLabel(
+  counts: { projects: number; sessions: number; agents: number },
+  maxWidth: number,
+): string {
+  const full = `${counts.projects} ${plural(counts.projects, "project")} · ${counts.sessions} ${plural(
+    counts.sessions,
+    "session",
+  )} · ${counts.agents} ${plural(counts.agents, "agent")}`;
+  if (full.length <= maxWidth) {
+    return full;
+  }
+  const compact = `${counts.projects} · ${counts.sessions} · ${counts.agents}`;
+  return compact.length <= maxWidth ? compact : "";
 }
 
 export function projectHeaderLabel(project: ProjectView, collapsed: boolean): string {

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -1,5 +1,5 @@
+// The title/widgets live on the frame's top border row, outside these rows.
 export const DASHBOARD_FIXED_ROW_HEIGHTS = {
-  header: 1,
   fleetBar: 1,
   columnHeader: 1,
   topDivider: 1,

--- a/packages/dashboard-core/src/widgets/weather.ts
+++ b/packages/dashboard-core/src/widgets/weather.ts
@@ -14,18 +14,18 @@ export function weatherLabel(config: TuiWeatherWidgetConfig): string {
 }
 
 export function renderWeatherLoading(config: TuiWeatherWidgetConfig): string {
-  return `${weatherLabel(config)} --° ${WEATHER_LOADING_EMOJI}`;
+  return `${weatherLabel(config)} · --° ${WEATHER_LOADING_EMOJI}`;
 }
 
 export function renderWeatherError(config: TuiWeatherWidgetConfig): string {
-  return `${weatherLabel(config)} --° ${WEATHER_ERROR_EMOJI}`;
+  return `${weatherLabel(config)} · --° ${WEATHER_ERROR_EMOJI}`;
 }
 
 export function renderWeatherSuccess(
   config: TuiWeatherWidgetConfig,
   conditions: WeatherCurrentConditions,
 ): string {
-  return `${weatherLabel(config)} ${Math.round(conditions.temperature)}° ${weatherEmoji(
+  return `${weatherLabel(config)} · ${Math.round(conditions.temperature)}° ${weatherEmoji(
     conditions.weatherCode,
     conditions.isDay,
   )}`;

--- a/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
+++ b/packages/dashboard-core/test/unit/components/dashboardHeaderLine.test.ts
@@ -1,29 +1,55 @@
 import { describe, expect, it } from "vitest";
-import { dashboardHeaderLine } from "../../../src/components/Dashboard/content.js";
+import { fleetCountsLabel, headerStrip } from "../../../src/components/Dashboard/content.js";
 
 const WIDGETS = [
   { text: "NYC 08:00 · TYO 21:00", compact: "NYC 08:00" },
   { text: "🌕 full moon", compact: "🌕" },
 ];
 
-function line(columns: number): string {
-  return dashboardHeaderLine({ productLabel: "station", columns, widgets: WIDGETS });
+function strip(maxWidth: number): string {
+  return headerStrip({ widgets: WIDGETS, maxWidth });
 }
 
-describe("dashboardHeaderLine widget strip", () => {
-  it("shows every widget in full when the width allows", () => {
-    expect(line(80)).toBe(`station${" ".repeat(38)}NYC 08:00 · TYO 21:00  🌕 full moon`);
+describe("headerStrip", () => {
+  it("joins every widget in full with middots when the width allows", () => {
+    expect(strip(60)).toBe("NYC 08:00 · TYO 21:00 · 🌕 full moon");
   });
 
   it("compacts every widget before dropping any", () => {
-    expect(line(40)).toBe(`station${" ".repeat(20)}NYC 08:00  🌕`);
+    expect(strip(20)).toBe("NYC 08:00 · 🌕");
   });
 
   it("drops widgets from the right once compact forms no longer fit", () => {
-    expect(line(17)).toBe(`station${" ".repeat(1)}NYC 08:00`);
+    expect(strip(10)).toBe("NYC 08:00");
   });
 
-  it("falls back to the product label alone at minimum widths", () => {
-    expect(line(10)).toBe("station");
+  it("returns nothing at minimum widths", () => {
+    expect(strip(4)).toBe("");
+  });
+
+  it("prefixes the observer status, compacting it before the widgets vanish", () => {
+    const status = {
+      full: "observer reconnecting · display-only snapshot",
+      compact: "observer reconnecting",
+    };
+    expect(headerStrip({ widgets: WIDGETS, status, maxWidth: 90 })).toBe(
+      "observer reconnecting · display-only snapshot · NYC 08:00 · TYO 21:00 · 🌕 full moon",
+    );
+    expect(headerStrip({ widgets: WIDGETS, status, maxWidth: 24 })).toBe("observer reconnecting");
+  });
+});
+
+describe("fleetCountsLabel", () => {
+  it("spells the totals out, compacts to bare numbers, then yields", () => {
+    const counts = { projects: 4, sessions: 10, agents: 6 };
+    expect(fleetCountsLabel(counts, 60)).toBe("4 projects · 10 sessions · 6 agents");
+    expect(fleetCountsLabel(counts, 20)).toBe("4 · 10 · 6");
+    expect(fleetCountsLabel(counts, 5)).toBe("");
+  });
+
+  it("uses singular nouns for counts of one", () => {
+    expect(fleetCountsLabel({ projects: 1, sessions: 1, agents: 1 }, 60)).toBe(
+      "1 project · 1 session · 1 agent",
+    );
   });
 });

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -38,15 +38,15 @@ describe("dashboard viewport selector", () => {
     });
     const viewport = selectDashboardViewport(snapshot, state);
 
-    expect(viewport.bodyRows).toBe(2);
+    expect(viewport.bodyRows).toBe(3);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(8);
+    expect(viewport.hiddenBelow).toBe(7);
     expect(
       viewport.visibleItems.map((item) =>
         item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention"]);
+    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
   });
 
   it("uses only viewport-visible worktrees for row choices", () => {
@@ -60,6 +60,7 @@ describe("dashboard viewport selector", () => {
     expect(viewport.rowChoices.map((choice) => [choice.key, choice.value.id])).toEqual([
       ["1", "wt_web_no_agent"],
       ["2", "wt_web_idle"],
+      ["3", "wt_web_unknown"],
     ]);
   });
 
@@ -73,8 +74,8 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(9);
-    expect(viewport.hiddenAbove).toBe(9);
+    expect(viewport.clampedScrollOffset).toBe(8);
+    expect(viewport.hiddenAbove).toBe(8);
     expect(viewport.hiddenBelow).toBe(0);
     expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
   });

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -26,17 +26,17 @@ describe("dashboard focus cursor", () => {
 
   it("enters upward on the last visible session row", () => {
     const entered = handleTuiKey(state({ terminalRows: 12 }), UP).state;
-    // terminalRows 12 -> bodyRows 4: header + working/attention/exited visible.
-    expect(entered.focusedRowId).toBe("wt_web_exited");
+    // terminalRows 12 -> bodyRows 5: header + working/attention/exited/no-agent visible.
+    expect(entered.focusedRowId).toBe("wt_web_no_agent");
   });
 
   it("scrolls the viewport to keep the cursor visible when walking past the bottom", () => {
     let current = state({ terminalRows: 12 });
-    for (let presses = 0; presses < 4; presses += 1) {
+    for (let presses = 0; presses < 5; presses += 1) {
       current = handleTuiKey(current, DOWN).state;
     }
-    expect(current.focusedRowId).toBe("wt_web_no_agent");
-    // Item index 4 must sit inside the 4-row window: offset = 4 - 4 + 1.
+    expect(current.focusedRowId).toBe("wt_web_idle");
+    // Item index 5 must sit inside the 5-row window: offset = 5 - 5 + 1.
     expect(current.scrollOffset).toBe(1);
   });
 
@@ -62,8 +62,8 @@ describe("dashboard focus cursor", () => {
 
     const second = handleTuiKey(first, NEXT_NEEDS_ME).state;
     expect(second.focusedRowId).toBe("wt_web_stuck");
-    // The stuck row (item index 7) scrolled into the 4-row window.
-    expect(second.scrollOffset).toBe(4);
+    // The stuck row (item index 7) scrolled into the 5-row window.
+    expect(second.scrollOffset).toBe(3);
 
     const wrapped = handleTuiKey(second, NEXT_NEEDS_ME).state;
     expect(wrapped.focusedRowId).toBe("wt_web_attention");

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -50,7 +50,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(9);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(8);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", mouseScroll: "up" }).state
         .scrollOffset,
@@ -676,6 +676,6 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.collapsedProjectIds.has("web")).toBe(true);
-    expect(transition.state.scrollOffset).toBe(2);
+    expect(transition.state.scrollOffset).toBe(1);
   });
 });

--- a/packages/dashboard-core/test/unit/widgets/useTopRowWidgets.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/useTopRowWidgets.test.ts
@@ -28,7 +28,7 @@ describe("refreshWeatherWidget", () => {
       setText: (text) => texts.push(text),
     });
     expect(getCurrentWeather).not.toHaveBeenCalled();
-    expect(texts).toEqual(["ATX 72° ☀️"]);
+    expect(texts).toEqual(["ATX · 72° ☀️"]);
   });
 
   it("refetches and re-caches once the entry is older than the refresh interval", async () => {
@@ -45,7 +45,7 @@ describe("refreshWeatherWidget", () => {
     });
     expect(getCurrentWeather).toHaveBeenCalledTimes(1);
     expect(cache.get("austin:fahrenheit")?.conditions).toEqual(fresh);
-    expect(texts.at(-1)).toBe("ATX 50° ☁️");
+    expect(texts.at(-1)).toBe("ATX · 50° ☁️");
   });
 
   it("renders the error glyph when the client rejects", async () => {
@@ -57,7 +57,7 @@ describe("refreshWeatherWidget", () => {
       weatherClient: client(() => Promise.reject(new Error("boom"))),
       setText: (text) => texts.push(text),
     });
-    expect(texts).toEqual(["ATX --° 🫥"]);
+    expect(texts).toEqual(["ATX · --° 🫥"]);
   });
 
   it("suppresses output when cancelled after the fetch resolves", async () => {

--- a/packages/dashboard-core/test/unit/widgets/weather.test.ts
+++ b/packages/dashboard-core/test/unit/widgets/weather.test.ts
@@ -19,10 +19,10 @@ describe("weather widget rendering", () => {
 
   it("renders loading, error, and success lines", () => {
     const config = { type: "weather", city: "Austin", label: "ATX" } as const;
-    expect(renderWeatherLoading(config)).toBe("ATX --° ⏳");
-    expect(renderWeatherError(config)).toBe("ATX --° 🫥");
+    expect(renderWeatherLoading(config)).toBe("ATX · --° ⏳");
+    expect(renderWeatherError(config)).toBe("ATX · --° 🫥");
     expect(renderWeatherSuccess(config, { temperature: 72.4, weatherCode: 0, isDay: true })).toBe(
-      "ATX 72° ☀️",
+      "ATX · 72° ☀️",
     );
   });
 });

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -116,10 +116,10 @@ describe("Station app composition", () => {
 
     station.setup.mockInput.pressKey("o", { ctrl: true });
     await waitFor(() => overlayVisible(station));
-    const frame = await waitForFrame(station, (candidate) => candidate.includes("NYC 72°"));
+    const frame = await waitForFrame(station, (candidate) => candidate.includes("NYC · 72°"));
 
     expect(frame).toContain("10:42");
-    expect(frame).toContain("NYC 72°");
+    expect(frame).toContain("NYC · 72°");
   });
 
   it("closes STATION on click-away without writing mouse bytes to the pane underneath", async () => {

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -131,9 +131,10 @@ describe("createStationInputRuntime", () => {
     expect(scripted.helpers.writes.join("")).toBe("\x1b[13;2u");
   });
 
-  it.each(["codex", "pi"] as const)(
-    "preserves xterm Shift+Enter for a warm-attached %s primary-agent pane",
-    (provider) => {
+  // Plain loop, not it.each: bun's bundled `it` type has no `.each`, so the
+  // station-bun typecheck step rejects it even though it runs.
+  for (const provider of ["codex", "pi"] as const) {
+    it(`preserves xterm Shift+Enter for a warm-attached ${provider} primary-agent pane`, () => {
       const baseSnapshot = manyProjectsSnapshot();
       const snapshot = {
         ...baseSnapshot,
@@ -169,8 +170,8 @@ describe("createStationInputRuntime", () => {
 
       expect(runtime.handleSequence("\x1b[27;2;13~")).toBe(true);
       expect(scripted.helpers.writes.join("")).toBe("\x1b[13;2u");
-    },
-  );
+    });
+  }
 
   it("matches arrow-key bytes to the focused pane's cursor-key mode", async () => {
     const { runtime, scripted, registry } = harness();

--- a/station/src/station/StationOverlay.tsx
+++ b/station/src/station/StationOverlay.tsx
@@ -7,6 +7,7 @@ import type { MouseTargetRef } from "../input/router.js";
 import type { StationMouseTarget } from "./input/stationMouse.js";
 import type { TuiStore } from "@station/dashboard-core";
 import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
+import { DashboardFrameTitle } from "./view/DashboardFrameTitle.js";
 import { DashboardRoot } from "./view/DashboardRoot.js";
 import { STATION_COLORS } from "./view/theme.js";
 import { StationMouseProvider, type StationMouseDispatch } from "./view/stationMouseContext.js";
@@ -105,19 +106,20 @@ export function StationOverlay({ store, topRowWidgets = [], dispatchMouse }: Sta
         height={layout.height}
         zIndex={30}
         border
-        borderColor={STATION_COLORS.gray}
+        borderColor={STATION_COLORS.hairline}
         backgroundColor={STATION_COLORS.background}
         flexDirection="column"
         onMouseDown={stopPopupMouse}
         onMouseScroll={stopPopupMouse}
       >
-        <DashboardRoot
-          store={store}
-          columns={innerColumns}
-          rows={innerRows}
-          topRowWidgets={topRowWidgets}
-        />
+        <DashboardRoot store={store} columns={innerColumns} rows={innerRows} />
       </box>
+      <DashboardFrameTitle
+        store={store}
+        frame={{ left: layout.left, top: layout.top, width: layout.width }}
+        topRowWidgets={topRowWidgets}
+        zIndex={31}
+      />
     </StationMouseProvider>
   );
 }

--- a/station/src/station/view/DashboardFrameTitle.test.tsx
+++ b/station/src/station/view/DashboardFrameTitle.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { rgbToHex } from "@opentui/core";
+import { testRender } from "@opentui/react/test-utils";
+import { spanAtFrameCell } from "../../terminal/testing/frameProbe.js";
+import {
+  attentionAndFailuresSnapshot,
+  manyProjectsSnapshot,
+  scenarioState,
+} from "../fixtures/scenarios.js";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
+import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
+import { DashboardFrameTitle } from "./DashboardFrameTitle.js";
+import { STATION_COLORS } from "./theme.js";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+
+const SIZE = { width: 80, height: 4 };
+const FRAME = { left: 0, top: 0, width: 80 };
+
+function spanHex(span: ReturnType<typeof spanAtFrameCell>): string | undefined {
+  return span?.fg === undefined ? undefined : rgbToHex(span.fg);
+}
+
+describe("DashboardFrameTitle", () => {
+  const teardowns: Array<() => void> = [];
+  afterEach(() => {
+    for (const teardown of teardowns.splice(0)) {
+      teardown();
+    }
+  });
+
+  async function renderTitle(input: {
+    snapshot?: ReturnType<typeof manyProjectsSnapshot>;
+    connection?: ReturnType<typeof scenarioState>["connection"];
+    widgets?: readonly TopRowWidgetView[];
+  }) {
+    const { store } = makeStationTestStore({
+      snapshot: input.snapshot ?? null,
+      connection: input.connection,
+      seedInitialSnapshot: false,
+    });
+    store.getState().start();
+    const setup = await testRender(
+      <DashboardFrameTitle
+        store={store}
+        frame={FRAME}
+        topRowWidgets={input.widgets ?? []}
+        zIndex={1}
+      />,
+      SIZE,
+    );
+    teardowns.push(() => {
+      setup.renderer.destroy();
+    });
+    await setup.renderOnce();
+    return setup;
+  }
+
+  it("shows the identity, the overview subtitle, and the widget strip as gray chrome", async () => {
+    const setup = await renderTitle({
+      snapshot: manyProjectsSnapshot(),
+      widgets: [
+        { id: "time:0", text: "10:42 AM" },
+        { id: "moon:1", text: "🌖 waning gibbous", compact: "🌖" },
+      ],
+    });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("station · overview");
+    expect(frame).toContain("10:42 AM · 🌖 waning gibbous");
+    expect(frame).toContain("[+]");
+
+    const lines = frame.split("\n");
+    const spans = setup.captureSpans();
+    const subtitleCol = lines[0]?.indexOf("· overview") ?? -1;
+    expect(spanHex(spanAtFrameCell(spans, 0, subtitleCol))).toBe(STATION_COLORS.gray);
+    const stripCol = lines[0]?.indexOf("10:42 AM") ?? -1;
+    expect(spanHex(spanAtFrameCell(spans, 0, stripCol))).toBe(STATION_COLORS.gray);
+  });
+
+  it("swaps the subtitle to a red needs-you flag when sessions ask", async () => {
+    const setup = await renderTitle({ snapshot: attentionAndFailuresSnapshot() });
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("station ! 3 need you");
+    expect(frame).not.toContain("· overview");
+
+    const lines = frame.split("\n");
+    const spans = setup.captureSpans();
+    const flagCol = lines[0]?.indexOf("! 3 need you") ?? -1;
+    expect(spanHex(spanAtFrameCell(spans, 0, flagCol))).toBe(STATION_COLORS.red);
+  });
+
+  it("carries the display-only reconnect status in the strip", async () => {
+    const disconnected = scenarioState("disconnected");
+    const setup = await renderTitle({
+      snapshot: disconnected.snapshot,
+      connection: disconnected.connection,
+    });
+    expect(setup.captureCharFrame()).toContain("observer reconnecting · display-only snapshot");
+  });
+
+  it("resolves snapshot widgets against the live snapshot", async () => {
+    const setup = await renderTitle({
+      snapshot: manyProjectsSnapshot(),
+      widgets: [{ id: "fleet:0", text: "", data: "fleet" }],
+    });
+    expect(setup.captureCharFrame()).toContain("7 agents");
+  });
+});

--- a/station/src/station/view/DashboardFrameTitle.tsx
+++ b/station/src/station/view/DashboardFrameTitle.tsx
@@ -1,0 +1,102 @@
+import { TextAttributes } from "@opentui/core";
+import { useState } from "react";
+import { useStore } from "zustand/react";
+import type { StoreApi } from "zustand/vanilla";
+import stringWidth from "string-width";
+import {
+  headerStrip,
+  observerHeaderStatusForConnection,
+  selectFleetSummary,
+  type TuiStore,
+} from "@station/dashboard-core";
+import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
+import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
+import { STATION_COLORS } from "./theme.js";
+import { stationMouseProps, useStationMouse } from "./stationMouseContext.js";
+
+const PRODUCT_LABEL = "station";
+const OVERVIEW_SUBTITLE = "· overview";
+const WIDGET_SETTINGS_AFFORDANCE = "[+]";
+// One corner + one border dash on each flank of an embedded run of text.
+const EDGE = 2;
+
+export type DashboardFrameTitleProps = {
+  store: StoreApi<TuiStore>;
+  /** The popup box the title row overlays; texts paint over its top border. */
+  frame: { left: number; top: number; width: number };
+  topRowWidgets?: readonly TopRowWidgetView[];
+  zIndex: number;
+};
+
+/**
+ * The frame's top border carries the identity and the widget strip, mock-style:
+ * `╭─ station · overview ────── 5:07 PM · NYC · 18°⛅ [+] ─╮`. When sessions
+ * need the user, the subtitle swaps to a red `! N need you` flag.
+ */
+export function DashboardFrameTitle({
+  store,
+  frame,
+  topRowWidgets = [],
+  zIndex,
+}: DashboardFrameTitleProps) {
+  const dispatch = useStationMouse();
+  const [hover, setHover] = useState(false);
+  const snapshot = useStore(store, (state) => state.snapshot);
+  const observerConnectionStatus = useStore(store, (state) => state.observerConnectionStatus);
+
+  const needsYou = snapshot === undefined ? 0 : selectFleetSummary(snapshot).needsYou;
+  const subtitle =
+    needsYou > 0
+      ? { text: `! ${needsYou} need you`, color: STATION_COLORS.red }
+      : { text: OVERVIEW_SUBTITLE, color: STATION_COLORS.gray };
+  const title = ` ${PRODUCT_LABEL} ${subtitle.text} `;
+
+  const status = observerHeaderStatusForConnection(observerConnectionStatus, snapshot !== undefined);
+  const affordance = ` ${WIDGET_SETTINGS_AFFORDANCE} `;
+  const stripBudget =
+    frame.width - 2 * EDGE - stringWidth(title) - stringWidth(affordance) - 2;
+  const strip = headerStrip({
+    widgets: resolveTopRowWidgets(topRowWidgets, snapshot),
+    ...(status === undefined ? {} : { status }),
+    maxWidth: Math.max(0, stripBudget),
+  });
+  const right = strip.length > 0 ? ` ${strip}${affordance}` : affordance;
+  const rightLeft = frame.left + frame.width - EDGE - stringWidth(right);
+
+  return (
+    <>
+      <text
+        position="absolute"
+        left={frame.left + EDGE}
+        top={frame.top}
+        zIndex={zIndex}
+        bg={STATION_COLORS.background}
+      >
+        <span fg={STATION_COLORS.foreground} attributes={TextAttributes.BOLD}>
+          {` ${PRODUCT_LABEL} `}
+        </span>
+        <span fg={subtitle.color}>{`${subtitle.text} `}</span>
+      </text>
+      <box
+        position="absolute"
+        left={rightLeft}
+        top={frame.top}
+        zIndex={zIndex}
+        flexDirection="row"
+      >
+        {strip.length > 0 ? (
+          <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background}>{` ${strip}`}</text>
+        ) : null}
+        <text
+          fg={hover ? STATION_COLORS.cyan : STATION_COLORS.gray}
+          bg={STATION_COLORS.background}
+          {...stationMouseProps(dispatch, { kind: "widgetSettingsOpen" })}
+          onMouseOver={() => setHover(true)}
+          onMouseOut={() => setHover(false)}
+        >
+          {affordance}
+        </text>
+      </box>
+    </>
+  );
+}

--- a/station/src/station/view/DashboardRoot.tsx
+++ b/station/src/station/view/DashboardRoot.tsx
@@ -9,15 +9,12 @@ import { useStore } from "zustand/react";
 import {
   commandPromptRows,
   isModalOverlayActive,
-  observerHeaderStatusForConnection,
   snapshotLoadingLines,
 } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
-import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
-import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { activeTuiToast, nextTuiToastExpiry, QUIT_HINT_CLOSE } from "@station/dashboard-core";
 import { CommandPromptView } from "./CommandPromptView.js";
-import { DashboardHeaderRow, DashboardView, Divider } from "./DashboardView.js";
+import { DashboardView, Divider } from "./DashboardView.js";
 import { OverlayHostView } from "./OverlayHostView.js";
 import { ToastOverlayView } from "./ToastOverlayView.js";
 import { STATION_COLORS } from "./theme.js";
@@ -29,10 +26,9 @@ export type DashboardRootProps = {
   /** The overlay's content area, in terminal cells. */
   columns: number;
   rows: number;
-  topRowWidgets?: readonly TopRowWidgetView[];
 };
 
-export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: DashboardRootProps) {
+export function DashboardRoot({ store, columns, rows }: DashboardRootProps) {
   const snapshot = useStore(store, (state) => state.snapshot);
   const loading = useStore(store, (state) => state.loading);
   const screen = useStore(store, (state) => state.screen);
@@ -88,11 +84,6 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
   if (loading || snapshot === undefined) {
     return (
       <box width="100%" flexGrow={1} flexDirection="column" paddingRight={1}>
-        <DashboardHeaderRow
-          columns={contentColumns}
-          widgets={resolveTopRowWidgets(topRowWidgets, snapshot)}
-        />
-        <Divider columns={contentColumns} />
         <box flexDirection="column" flexGrow={1}>
           {snapshotLoadingLines(loading, observerConnectionStatus).map((line, index) => (
             <text
@@ -110,7 +101,6 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
     );
   }
 
-  const observerStatus = observerHeaderStatusForConnection(observerConnectionStatus, true);
   return (
     <box width="100%" flexGrow={1} flexDirection="column">
       <DashboardView
@@ -124,8 +114,6 @@ export function DashboardRoot({ store, columns, rows, topRowWidgets = [] }: Dash
           ...(focusedRowId === undefined ? {} : { focusedRowId }),
         }}
         columns={columns}
-        topRowWidgets={topRowWidgets}
-        {...(observerStatus === undefined ? {} : { observerStatus })}
       />
       <CommandPromptView screen={screen} />
       {toastOverlay}

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -4,17 +4,14 @@
 import { TextAttributes } from "@opentui/core";
 import type { ProjectView, StationSnapshot, WorktreeId } from "@station/contracts";
 import { useState } from "react";
-import stringWidth from "string-width";
 import {
   dashboardFooterLabel,
-  dashboardHeaderLine,
+  fleetCountsLabel,
   emptyProjectLabel,
   FIRST_RUN_BODY_LABEL,
   projectHeaderLabelParts,
   rowGridInputForViewportItem,
   scrollIndicatorLabel,
-  type DashboardHeaderStatus,
-  type TopRowWidgetText,
 } from "@station/dashboard-core";
 import {
   layoutWorktreeRowGrid,
@@ -32,8 +29,6 @@ import {
   type FleetSummary,
 } from "@station/dashboard-core";
 import type { TuiViewState } from "@station/dashboard-core";
-import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
-import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 import { SegmentLinkTargets, Segments } from "./segments.js";
 import { Throbber } from "./Throbber.js";
@@ -68,19 +63,14 @@ export type DashboardViewProps = {
   snapshot: StationSnapshot;
   viewState: TuiViewState;
   columns?: number;
-  topRowWidgets?: readonly TopRowWidgetView[];
-  observerStatus?: DashboardHeaderStatus;
 };
 
-const PRODUCT_LABEL = "station";
 const QUIT_HINT = QUIT_HINT_CLOSE;
 
 export function DashboardView({
   snapshot,
   viewState,
   columns = 80,
-  topRowWidgets = [],
-  observerStatus,
 }: DashboardViewProps) {
   const dispatch = useStationMouse();
   const viewport = selectDashboardViewport(snapshot, viewState);
@@ -99,13 +89,10 @@ export function DashboardView({
       paddingRight={1}
       onMouseScroll={stationMouseProps(dispatch, { kind: "body" }).onMouseScroll}
     >
-      <DashboardHeaderRow
-        columns={contentColumns}
-        widgets={resolveTopRowWidgets(topRowWidgets, snapshot)}
-        {...(observerStatus === undefined ? {} : { status: observerStatus })}
-      />
-      {firstRun ? null : <FleetBar summary={fleet} />}
-      <Divider columns={contentColumns} />
+      {firstRun ? null : (
+        <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
+      )}
+      <text> </text>
       {firstRun || headerLayout === undefined ? null : <ColumnHeaderRow layout={headerLayout} />}
       <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
       {firstRun ? (
@@ -132,56 +119,22 @@ export function DashboardView({
   );
 }
 
-// Width reserved for the trailing " [+]" widget-settings affordance.
-const WIDGET_SETTINGS_AFFORDANCE = " [+]";
-
-export function DashboardHeaderRow({
-  columns,
-  widgets,
-  status,
-}: {
-  columns: number;
-  widgets: readonly TopRowWidgetText[];
-  status?: DashboardHeaderStatus;
-}) {
-  const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
-  const stripColumns = columns - WIDGET_SETTINGS_AFFORDANCE.length;
-  const headerLine = dashboardHeaderLine({
-    productLabel: PRODUCT_LABEL,
-    columns: stripColumns,
-    widgets,
-    ...(status === undefined ? {} : { status }),
-  });
-  // Right-anchor the affordance even when no widgets/status fill the line.
-  const pad = " ".repeat(Math.max(0, stripColumns - stringWidth(headerLine)));
-  const suffix = headerLine.startsWith(PRODUCT_LABEL) ? headerLine.slice(PRODUCT_LABEL.length) : "";
-  return (
-    <box flexDirection="row">
-      <text fg={STATION_COLORS.foreground}>
-        <span attributes={TextAttributes.BOLD}>{PRODUCT_LABEL}</span>
-        {/* Widgets/status are calm chrome: gray, so the body's status colours stay the loud ones. */}
-        <span fg={STATION_COLORS.gray}>{`${suffix}${pad}`}</span>
-      </text>
-      <text
-        fg={hover ? STATION_COLORS.cyan : STATION_COLORS.gray}
-        {...stationMouseProps(dispatch, { kind: "widgetSettingsOpen" })}
-        onMouseOver={() => setHover(true)}
-        onMouseOut={() => setHover(false)}
-      >
-        {WIDGET_SETTINGS_AFFORDANCE}
-      </text>
-    </box>
-  );
-}
-
 export function Divider({ columns }: { columns: number }) {
   return <text fg={STATION_COLORS.gray}>{"─".repeat(Math.max(1, columns))}</text>;
 }
 
 // Pinned fleet triage bar: glyph + colour reinforce each status lane. ready/
-// working/needs-you/idle always show; unknown/exited appear only when non-zero.
-function FleetBar({ summary }: { summary: FleetSummary }) {
+// working/needs-you/idle always show; unknown/exited appear only when non-zero
+// (M2's lane order — before idle). The right side carries the fleet totals.
+function FleetBar({
+  summary,
+  counts,
+  columns,
+}: {
+  summary: FleetSummary;
+  counts: { projects: number; worktrees: number; agents: number };
+  columns: number;
+}) {
   const parts: { glyph: string; color: string; label: string; animate?: boolean }[] = [
     { glyph: "●", color: STATION_COLORS.green, label: `${summary.ready} ready` },
     {
@@ -191,7 +144,6 @@ function FleetBar({ summary }: { summary: FleetSummary }) {
       animate: summary.working > 0,
     },
     { glyph: "!", color: STATION_COLORS.red, label: `${summary.needsYou} needs you` },
-    { glyph: "○", color: STATION_COLORS.gray, label: `${summary.idle} idle` },
   ];
   if (summary.unknown > 0) {
     parts.push({ glyph: "?", color: STATION_COLORS.yellow, label: `${summary.unknown} unknown` });
@@ -199,9 +151,16 @@ function FleetBar({ summary }: { summary: FleetSummary }) {
   if (summary.exited > 0) {
     parts.push({ glyph: "x", color: STATION_COLORS.gray, label: `${summary.exited} exited` });
   }
+  parts.push({ glyph: "○", color: STATION_COLORS.gray, label: `${summary.idle} idle` });
+  const lanesWidth =
+    "FLEET".length + parts.reduce((total, part) => total + 3 + 1 + part.label.length, 0);
+  const totals = fleetCountsLabel(
+    { projects: counts.projects, sessions: counts.worktrees, agents: counts.agents },
+    Math.max(0, columns - lanesWidth - 2),
+  );
   return (
-    <box height={1} width="100%" backgroundColor={STATION_COLORS.frozenSurface} overflow="hidden">
-      <text fg={STATION_COLORS.gray}>
+    <box height={1} width="100%" flexDirection="row" overflow="hidden">
+      <text flexGrow={1} fg={STATION_COLORS.gray}>
         <span attributes={TextAttributes.BOLD}>FLEET</span>
         {parts.map((part) => (
           <span key={part.label}>
@@ -215,6 +174,7 @@ function FleetBar({ summary }: { summary: FleetSummary }) {
           </span>
         ))}
       </text>
+      {totals.length > 0 ? <text fg={STATION_COLORS.gray}>{totals}</text> : null}
     </box>
   );
 }
@@ -286,7 +246,7 @@ function dashboardRowLayouts(
 
 function ColumnHeaderRow({ layout }: { layout: RowGridLayout }) {
   return (
-    <box height={1} width="100%" backgroundColor={STATION_COLORS.frozenSurface} overflow="hidden">
+    <box height={1} width="100%" overflow="hidden">
       <text fg={STATION_COLORS.gray}>
         <Segments segments={layout.segments} />
       </text>

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -1,9 +1,8 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -23,15 +22,15 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
-"station                                                                                                             [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited                                         
-─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
+                                                                                                                        
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
@@ -67,15 +66,15 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
                                                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
-"station                                                 [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ?   
-─────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
+                                                            
        SESSION          AGENT     STATUS                 PR 
                                                             
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
@@ -86,32 +85,32 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ?
  [5] ⠋ station-overlay  codex     working             #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
-▼ 6 below · showing 5 of 11                                 
+ [6] x batch-export     opencode  exited               #8 ✓ 
+▼ 5 below · showing 6 of 11                                 
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
-"station                             [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0      
-─────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0      
+                                        
        SESSION             STATUS       
                                         
 ▼ station  5 sessions · … [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
-▼ 8 below · showing 3 of 11             
+ [4] + session-resume      starting     
+▼ 7 below · showing 4 of 11             
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
+                                                                                
        SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -131,15 +130,15 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                 
                                                                                 
                                                                                 
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
-"station                                                                                                             [+] 
-FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited                                         
-─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
+                                                                                                                        
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
@@ -175,15 +174,15 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
-"station                                                 [+] 
-FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ?   
-─────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
+                                                            
        SESSION            AGENT     STATUS               PR 
                                                             
 ▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
@@ -194,33 +193,34 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ?
                                                             
 ▼ observer  2 sessions · 2 agents             [sh] [qs] [▾] 
  [5] x done-run           opencode  exited                  
-▼ 1 below · showing 5 of 6                                  
+ [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
+                                                            
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
-"station                             [+] 
-FLEET  ● 0 ready  ⠋ 1 working  ! 3      
-─────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 1 working  ! 3      
+                                        
        SESSION                          
                                         
 ▼ station  4 sessions · … [sh] [qs] [▾] 
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
-▼ 3 below · showing 3 of 6              
+ [4] ⠋ pr-info                          
+▼ 2 below · showing 4 of 6              
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
 "
 `;
 
 exports[`dashboard golden frames renders no-projects at 80x24 1`] = `
-"station                                                                     [+] 
-─────────────────────────────────────────────────────────────────────────────── 
+"                                                                                
                                                                                 
 No projects configured yet.                                                     
+                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -245,10 +245,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 120x40 1`] = `
-"station                                                                                                             [+] 
-─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+"                                                                                                                        
                                                                                                                         
 No projects configured yet.                                                                                             
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -289,10 +289,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 60x16 1`] = `
-"station                                                 [+] 
-─────────────────────────────────────────────────────────── 
+"                                                            
                                                             
 No projects configured yet.                                 
+                                                            
                                                             
                                                             
                                                             
@@ -309,10 +309,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 40x12 1`] = `
-"station                             [+] 
-─────────────────────────────────────── 
+"                                        
                                         
 No projects configured yet.             
+                                        
                                         
                                         
                                         

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -1,27 +1,27 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`modal flow golden frames renders the help overlay 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-────────╭──────────────────────────────────────────────────────────────╮─────── 
-       S│                         station help                         │FF · PR 
-        │                                                              │        
-▼ statio│  Ctrl-O     open/close project view                          │qs] [▾] 
- [1] ○ c│  Ctrl-Q     quit Station                                     │6 #70 ✓ 
- [2] - d│  Ctrl-\\     split pane right                                 │        
- [3] ○ p│  Ctrl-^     split pane below (Ctrl-6)                        │erged ✓ 
- [4] + s│  Ctrl-]     focus next pane                                  │        
- [5] ⠋ s│  Ctrl-/     close split pane (Ctrl-_)                        │6 #76 … 
-        │  Enter/Sp   open project view on welcome                     │        
-▼ observ│  Esc/↑↓     context menu close/move                          │qs] [▾] 
- [6] x b│  Enter/Sp   context menu select                              │   #8 ✓ 
- [7] ⠋ p│                     station project view                     │8 #16 … 
- [8] ○ t│  ↑/↓        move cursor                                      │-1 #4 ✓ 
-        │  ↵          open focused session                             │        
-▼ script│  tab        next session needing you                         │qs] [▾] 
- [9] ○ a│  wheel      scroll project list                              │6 #5 x1 
- [a] ? m│  1-9/a-z    start or focus row                               │ -1 #10 
- [b] - o│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
+       S╭──────────────────────────────────────────────────────────────╮FF · PR 
+        │                         station help                         │        
+▼ statio│                                                              │qs] [▾] 
+ [1] ○ c│  Ctrl-O     open/close project view                          │6 #70 ✓ 
+ [2] - d│  Ctrl-Q     quit Station                                     │        
+ [3] ○ p│  Ctrl-\\     split pane right                                 │erged ✓ 
+ [4] + s│  Ctrl-^     split pane below (Ctrl-6)                        │        
+ [5] ⠋ s│  Ctrl-]     focus next pane                                  │6 #76 … 
+        │  Ctrl-/     close split pane (Ctrl-_)                        │        
+▼ observ│  Enter/Sp   open project view on welcome                     │qs] [▾] 
+ [6] x b│  Esc/↑↓     context menu close/move                          │   #8 ✓ 
+ [7] ⠋ p│  Enter/Sp   context menu select                              │8 #16 … 
+ [8] ○ t│                     station project view                     │-1 #4 ✓ 
+        │  ↑/↓        move cursor                                      │        
+▼ script│  ↵          open focused session                             │qs] [▾] 
+ [9] ○ a│  tab        next session needing you                         │6 #5 x1 
+ [a] ? m│  wheel      scroll project list                              │ -1 #10 
+ [b] - o│  1-9/a-z    start or focus row                               │        
+        │  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -29,9 +29,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the search prompt 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -49,7 +48,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-search: apiexperiment                     -         no agent                    
+ [b] - old-experiment                     -         no agent                    
+search: api                                                                     
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -57,9 +57,8 @@ search: apiexperiment                     -         no agent
 `;
 
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -77,6 +76,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
 collapse project: 1:station 2:observer 3:scripts 4:empty-project                
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -85,9 +85,8 @@ collapse project: 1:station 2:observer 3:scripts 4:empty-project
 `;
 
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -105,6 +104,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
+ [b] - old-experiment                     -         no agent                    
 settings for project: 1:station 2:observer 3:scripts 4:empty-project            
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
@@ -113,16 +113,15 @@ settings for project: 1:station 2:observer 3:scripts 4:empty-project
 `;
 
 exports[`modal flow golden frames renders the project settings panel 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │PR 
-   │ station                  │ Default agent                               │   
-▼ s│▸ Default agent           │✓1 codex unknown                             │▾] 
- [1│  Remove project          │ 2 opencode unknown                          │ ✓ 
- [2│                          │                                             │   
- [3│                          │ ✓ current · 1-9/a-z select                  │ ✓ 
- [4│                          │                                             │   
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
+   ┌────────────────────────────────────────────────────────────────────────┐PR 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │✓1 codex unknown                             │ ✓ 
+ [2│  Remove project          │ 2 opencode unknown                          │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
@@ -133,7 +132,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│ ↑↓ move   →/enter edit   esc close                                     │   
+ [b│                          │                                             │   
+   │ ↑↓ move   →/enter edit   esc close                                     │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -141,19 +141,18 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │PR 
-   │ station                  │ Remove project                              │   
-▼ s│  Default agent           │ Removes it from Station.                    │▾] 
- [1│▸ Remove project          │ Worktrees & files stay on disk.             │ ✓ 
- [2│                          │                                             │   
- [3│                          │ Type "delete station" to confirm            │ ✓ 
- [4│                          │ ▸ |delete station                           │   
- [5│                          │                                             │ … 
-   │                          │ [ Remove project (R) ]                      │   
-▼ o│                          │                                             │▾] 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
+   ┌────────────────────────────────────────────────────────────────────────┐PR 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Remove project                              │▾] 
+ [1│  Default agent           │ Removes it from Station.                    │ ✓ 
+ [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ Type "delete station" to confirm            │   
+ [5│                          │ ▸ |delete station                           │ … 
+   │                          │                                             │   
+▼ o│                          │ [ Remove project (R) ]                      │▾] 
  [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
@@ -161,7 +160,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│ ←/esc back                                                             │   
+ [b│                          │                                             │   
+   │ ←/esc back                                                             │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -169,16 +169,15 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-───┌────────────────────────────────────────────────────────────────────────┐── 
-   │ Project settings                                                       │PR 
-   │ station                  │ Default agent                               │   
-▼ s│▸ Default agent           │ 1 codex unknown                             │▾] 
- [1│  Remove project          │✓2 opencode unknown                 updating…│ ✓ 
- [2│                          │                                             │   
- [3│                          │ ✓ current · 1-9/a-z select                  │ ✓ 
- [4│                          │                                             │   
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
+   ┌────────────────────────────────────────────────────────────────────────┐PR 
+   │ Project settings                                                       │   
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │ 1 codex unknown                             │ ✓ 
+ [2│  Remove project          │✓2 opencode unknown                 updating…│   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
@@ -189,7 +188,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│ ↑↓ move   →/enter edit   esc close                                     │   
+ [b│                          │                                             │   
+   │ ↑↓ move   →/enter edit   esc close                                     │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -197,9 +197,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -214,10 +213,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
-│ Select session to delete                   │code  idle           +14 -6 #5 x1 
-│                                            │code  unknown           +3 -1 #10 
-│ Click a row or press slot key              │      no agent                    
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to delete                   │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -225,9 +225,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -240,12 +239,13 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Delete session?                            │                                  
-│ Session  cli-help-man                      │                    [sh] [qs] [▾] 
-│ Removes agent, worktree, and panes.        │code  idle           +14 -6 #5 x1 
-│                                            │code  unknown           +3 -1 #10 
-│ Yes (y)     No (n)                         │      no agent                    
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+┌────────────────────────────────────────────┐                                  
+│ Delete session?                            │                    [sh] [qs] [▾] 
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Yes (y)     No (n)                         │                                  
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -253,9 +253,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -273,7 +272,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
-Choose the slot to rename: 1-9/a-z        -         no agent                    
+ [b] - old-experiment                     -         no agent                    
+Choose the slot to rename: 1-9/a-z                                              
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -281,9 +281,8 @@ Choose the slot to rename: 1-9/a-z        -         no agent
 `;
 
 exports[`modal flow golden frames renders the rename sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
+                                                                                
        SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -298,6 +297,7 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
                                                                                 
                                                                                 
                                                                                 
+                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Rename Session                                                               │
 │                                                                              │
@@ -309,9 +309,8 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ○ 0 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -326,10 +325,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
-│ Select session to fork                     │code  idle           +14 -6 #5 x1 
-│                                            │code  unknown           +3 -1 #10 
-│ Click a row or press slot key              │      no agent                    
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to fork                     │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -337,37 +337,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
-       SESSION                            AGENT     STATUS            DIFF · PR 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
- [4] + session-resume                     codex     starting                    
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
-                                                                                
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
- [6] x batch-export                       opencode  exited                 #8 ✓ 
-┌────────────────────────────────────────────┐code  working        +32 -8 #16 … 
-│ Fork Session                               │code  idle             +1 -1 #4 ✓ 
-│ Source   station · cli-help-man            │                                  
-│ > Branch cli-help-man-fork|                │                    [sh] [qs] [▾] 
-│   Copy   [x] uncommitted changes           │code  idle           +14 -6 #5 x1 
-│ Source keeps running — copy is read-only.  │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Fork (enter)                               │                                  
-│ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
-└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
-"
-`;
-
-exports[`modal flow golden frames renders the new session review 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -380,6 +351,35 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
+│ Fork Session                               │                                  
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
+│ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
+│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
+│ Source keeps running — copy is read-only.  │      no agent                    
+│                                            │                                  
+│ Fork (enter)                               │                                  
+│ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
+└────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
+"
+`;
+
+exports[`modal flow golden frames renders the new session review 1`] = `
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
+                                                                                
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
+                                                                                
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -393,9 +393,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the new session edit name 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -409,6 +408,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │                                                                              │
@@ -421,9 +421,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the new session pick project 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -435,6 +434,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
                                                                                 
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -449,9 +449,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
@@ -465,6 +464,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -477,9 +477,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
-"station                                                                     [+]
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited
-───────────────────────────────────────────────────────────────────────────────
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
+
        SESSION                            AGENT     STATUS            DIFF · PR
 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
@@ -493,6 +492,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
  [6] x batch-export                       opencode  exited                 #8 ✓
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
+
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -505,12 +505,12 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the add project sheet 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │
@@ -533,27 +533,27 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the widget settings panel 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-clea┌──────────────────────────────────────────────┐                
- [3] ○ pty-buffe│ widgets                                      │   #73 merged ✓ 
- [4] + session-r│ session only · persist in config.toml        │                
- [5] ⠋ station-o│ ▸ [on ] time                               × │ +412 -96 #76 … 
-                │   [off] weather NYC                        × │                
-▼ observer  3 se│   [on ] moon                               × │  [sh] [qs] [▾] 
- [6] x batch-exp│   [ + add widget ]                           │           #8 ✓ 
- [7] ⠋ provider-│ ↵ toggle   [ ] reorder   x remove   a add   e│   +32 -8 #16 … 
- [8] ○ trace-bun└──────────────────────────────────────────────┘     +1 -1 #4 ✓ 
-                                                                                
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐   #73 merged ✓ 
+ [4] + session-r│ widgets                                      │                
+ [5] ⠋ station-o│ session only · persist in config.toml        │ +412 -96 #76 … 
+                │ ▸ [on ] time                               × │                
+▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾] 
+ [6] x batch-exp│   [on ] moon                               × │           #8 ✓ 
+ [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 … 
+ [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓ 
+                └──────────────────────────────────────────────┘                
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
+                                                                                
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -561,27 +561,27 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 e
 `;
 
 exports[`modal flow golden frames renders the widget settings picker 1`] = `
-"station                                                                     [+] 
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ○ 4 idle  ? 1 unknown  x 1 exited 
-─────────────────────────────────────────────────────────────────────────────── 
+"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+                                                                                
        SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-clea┌──────────────────────────────────────────────┐                
- [3] ○ pty-buffe│ add widget                                   │   #73 merged ✓ 
- [4] + session-r│ weather and tz are added in config.toml      │                
- [5] ⠋ station-o│ ▸ time                                       │ +412 -96 #76 … 
-                │   fleet                                      │                
-▼ observer  3 se│   open PRs                                   │  [sh] [qs] [▾] 
- [6] x batch-exp│   moon                                       │           #8 ✓ 
- [7] ⠋ provider-│ ↵ add   esc back                             │   +32 -8 #16 … 
- [8] ○ trace-bun└──────────────────────────────────────────────┘     +1 -1 #4 ✓ 
-                                                                                
+ [2] - docs-cleanup                       -         no agent                    
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐   #73 merged ✓ 
+ [4] + session-r│ add widget                                   │                
+ [5] ⠋ station-o│ weather and tz are added in config.toml      │ +412 -96 #76 … 
+                │ ▸ time                                       │                
+▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾] 
+ [6] x batch-exp│   open PRs                                   │           #8 ✓ 
+ [7] ⠋ provider-│   moon                                       │   +32 -8 #16 … 
+ [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓ 
+                └──────────────────────────────────────────────┘                
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
+                                                                                
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -16,7 +16,6 @@ import {
 } from "../fixtures/scenarios.js";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import type { StationMouseTarget } from "../input/stationMouse.js";
-import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { DashboardRoot } from "./DashboardRoot.js";
 import { STATION_COLORS } from "./theme.js";
 import { StationMouseProvider } from "./stationMouseContext.js";
@@ -57,7 +56,6 @@ describe("dashboard golden frames", () => {
     height: number;
     snapshot?: StationSnapshot;
     connection?: StationClientConnectionState;
-    topRowWidgets?: readonly TopRowWidgetView[];
     dispatchMouse?: (target: StationMouseTarget) => void;
   }): Promise<RenderedDashboard> {
     const { store } = makeStationTestStore({
@@ -71,7 +69,6 @@ describe("dashboard golden frames", () => {
         store={store}
         columns={input.width}
         rows={input.height}
-        {...(input.topRowWidgets === undefined ? {} : { topRowWidgets: input.topRowWidgets })}
       />
     );
     const setup = await testRender(
@@ -111,25 +108,6 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("Q/esc:close");
   });
 
-  it("renders widgets in the loading-state header as gray chrome", async () => {
-    const setup = await renderDashboard({
-      width: 80,
-      height: 24,
-      connection: { state: "loading", since: Date.now() },
-      topRowWidgets: [{ id: "time:0", text: "10:42 AM" }],
-    });
-    const frame = setup.captureCharFrame();
-    expect(frame).toContain("10:42 AM");
-    expect(frame).toContain("Loading observer snapshot...");
-
-    const lines = frame.split("\n");
-    const headerRow = lines.findIndex((line) => line.includes("10:42 AM"));
-    const widgetCol = lines[headerRow]?.indexOf("10:42 AM") ?? -1;
-    expect(widgetCol).toBeGreaterThan(0);
-    const spans = setup.captureSpans();
-    expect(spanHex(spanAtFrameCell(spans, headerRow, widgetCol))).toBe(STATION_COLORS.gray);
-  });
-
   it("renders the waiting-for-observer state on cold reconnects", async () => {
     const setup = await renderDashboard({
       width: 80,
@@ -148,18 +126,6 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("waiting for observer");
     expect(frame).toContain("retrying connection");
     expect(frame).toContain("The dashboard will appear when the observer is ready.");
-  });
-
-  it("shows the display-only reconnect status in the header", async () => {
-    const disconnected = scenarioState("disconnected");
-    const setup = await renderDashboard({
-      width: 80,
-      height: 24,
-      snapshot: disconnected.snapshot,
-      connection: disconnected.connection,
-    });
-    const frame = setup.captureCharFrame();
-    expect(frame).toContain("observer reconnecting · display-only snapshot");
   });
 
   it("renders the parity-critical status presentation", async () => {


### PR DESCRIPTION
Bucket B of the post-PR7 mockup delta audit, plus the two PR4 leftovers it naturally absorbs. Frontend-only. Also carries a one-commit drive-by that unbreaks the station-bun lane on main (red since #61: `it.each` isn't in bun's types — now a plain loop).

## The frame (B5)

The popup border becomes the mock's frame. A new `DashboardFrameTitle` paints the identity and the widget strip **over the top border row**:

```
┌─ station · overview ─────────── 5:07 PM · NYC · 18°⛅ [+] ─┐
┌─ station ! 3 need you ── 12:15 AM · 4 agents · 4 PRs [+] ─┐   (attention)
```

- subtitle swaps to a red `! N need you` flag when sessions ask (M2) — the PR4 title-flag leftover
- texts paint an opaque background so the border `─` never bleeds through word gaps (found live: spaces are transparent in OpenTUI text)
- the `[+]` widget-settings affordance rides the border, same mouse target
- observer display-only status joins the strip via the new `headerStrip` ladder (status → widgets, middot-joined, compact-before-drop)
- the in-body header row + the `────` divider under FLEET are deleted; body gains a row (`DASHBOARD_FIXED_ROW_HEIGHTS` drops the `header` slot; windowing tests shifted by one)
- overlay border gray → hairline token

## Chrome (B6–B8 + C)

- **Fleet totals** on the FLEET row's right: `N projects · N sessions · N agents`, compacting to `4 · 10 · 6` — the PR4 header-counts leftover
- **Fleet lane canon**: M2 order (unknown/exited before idle, still hidden at zero); frozen-surface bands dropped from FLEET + column header (mocks: plain bg, dim text)
- **Middot separators** across the widget strip and inside the weather label (`NYC · 72° ☀️`)
- `dashboardHeaderLine`/`DashboardHeaderRow` deleted (station was the only consumer); replaced by `headerStrip` + `fleetCountsLabel` with fresh unit tests

## Verified live (mock, attention scenario)

Frame renders as above; `DIFF · PR`, reordered fleet lanes, and totals all present; strip compacts correctly at narrow popup widths.

## Tests

`pnpm typecheck` / `lint` / `test:unit` (1065) green; station `bun test` (879) green after `pnpm build`. New `DashboardFrameTitle` span-colour tests (subtitle gray, flag red, strip gray, snapshot-widget resolution, display-only status); goldens regenerated (header row removal + lane reorder + totals churn).