### PR TITLE
feat(contracts): PR title through the provider boundary + island inversion + lane feedback

### DIFF
--- a/integrations/repository/github/src/provider.ts
+++ b/integrations/repository/github/src/provider.ts
@@ -47,6 +47,7 @@ const checksStatusExitCodes = [1, 8];
 const GithubPullRequestSchema = z
   .object({
     number: z.number().int().positive(),
+    title: z.string().nullable().optional(),
     url: z.string().nullable().optional(),
     state: z.string().nullable().optional(),
     baseRefName: z.string().nullable().optional(),
@@ -156,6 +157,7 @@ export class GithubRepositoryProvider implements RepositoryProvider {
           "--json",
           [
             "number",
+            "title",
             "url",
             "state",
             "baseRefName",
@@ -350,6 +352,10 @@ function toWorktreePullRequest(
   };
   if (pullRequest.url !== undefined && pullRequest.url !== null && pullRequest.url.length > 0) {
     result.url = pullRequest.url;
+  }
+  const title = pullRequest.title?.trim();
+  if (title !== undefined && title.length > 0) {
+    result.title = title;
   }
   const state = pullRequestState(pullRequest);
   if (state !== undefined) result.state = state;

--- a/integrations/repository/github/test/unit/provider.test.ts
+++ b/integrations/repository/github/test/unit/provider.test.ts
@@ -15,10 +15,11 @@ describe("GitHub repository provider", () => {
   it("discovers a unique pull request with gh pr list", async () => {
     const calls: string[] = [];
     const provider = providerWithResponses(calls, {
-      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
+      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,title,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
         JSON.stringify([
           {
             number: 42,
+            title: "feat(web): expand the search",
             url: "https://github.com/example/web/pull/42",
             state: "OPEN",
             baseRefName: "main",
@@ -44,6 +45,7 @@ describe("GitHub repository provider", () => {
       }),
     ).resolves.toEqual({
       number: 42,
+      title: "feat(web): expand the search",
       url: "https://github.com/example/web/pull/42",
       host: "github.com",
       state: "open",
@@ -57,7 +59,7 @@ describe("GitHub repository provider", () => {
 
   it("returns null when no pull request matches", async () => {
     const provider = providerWithResponses([], {
-      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
+      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,title,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
         "[]",
     });
 
@@ -72,7 +74,7 @@ describe("GitHub repository provider", () => {
 
   it("rejects ambiguous pull request matches as a safe provider error", async () => {
     const provider = providerWithResponses([], {
-      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
+      "pr list --repo github.com/example/web --head feature --state all --limit 5 --json number,title,url,state,baseRefName,headRefName,headRefOid,isDraft,updatedAt,headRepository,headRepositoryOwner":
         JSON.stringify([
           {
             number: 1,

--- a/packages/contracts/src/observations.ts
+++ b/packages/contracts/src/observations.ts
@@ -58,6 +58,7 @@ export type RepositoryRemote = z.infer<typeof RepositoryRemoteSchema>;
 export const WorktreePullRequestSchema = z
   .object({
     number: z.number().int().positive(),
+    title: nonEmptyStringSchema.optional(),
     url: z.string().url().optional(),
     host: nonEmptyStringSchema.optional(),
     state: z.enum(["open", "closed", "merged", "draft", "unknown"]).optional(),

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -1,7 +1,6 @@
 // The title/widgets live on the frame's top border row, outside these rows.
 export const DASHBOARD_FIXED_ROW_HEIGHTS = {
   fleetBar: 1,
-  columnHeader: 1,
   topDivider: 1,
   topScrollIndicator: 1,
   bottomScrollIndicator: 1,

--- a/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
+++ b/packages/dashboard-core/src/components/WorktreeRow/rowInput.ts
@@ -243,7 +243,7 @@ export function metadataSegments(row: WorktreeRowModel): MetadataSegment[] {
     return segments;
   }
   segments.push({
-    text: pr.state === "merged" ? `#${pr.number} merged` : `#${pr.number}`,
+    text: `#${pr.number}`,
     stale: pr.stale === true,
     color: prMetadataColor(pr),
     underline: true,

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -38,15 +38,15 @@ describe("dashboard viewport selector", () => {
     });
     const viewport = selectDashboardViewport(snapshot, state);
 
-    expect(viewport.bodyRows).toBe(3);
+    expect(viewport.bodyRows).toBe(4);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(7);
+    expect(viewport.hiddenBelow).toBe(6);
     expect(
       viewport.visibleItems.map((item) =>
         item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
+    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited", "wt_web_no_agent"]);
   });
 
   it("uses only viewport-visible worktrees for row choices", () => {
@@ -61,6 +61,7 @@ describe("dashboard viewport selector", () => {
       ["1", "wt_web_no_agent"],
       ["2", "wt_web_idle"],
       ["3", "wt_web_unknown"],
+      ["4", "wt_web_stuck"],
     ]);
   });
 
@@ -74,8 +75,8 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(8);
-    expect(viewport.hiddenAbove).toBe(8);
+    expect(viewport.clampedScrollOffset).toBe(7);
+    expect(viewport.hiddenAbove).toBe(7);
     expect(viewport.hiddenBelow).toBe(0);
     expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
   });

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -26,17 +26,17 @@ describe("dashboard focus cursor", () => {
 
   it("enters upward on the last visible session row", () => {
     const entered = handleTuiKey(state({ terminalRows: 12 }), UP).state;
-    // terminalRows 12 -> bodyRows 5: header + working/attention/exited/no-agent visible.
-    expect(entered.focusedRowId).toBe("wt_web_no_agent");
+    // terminalRows 12 -> bodyRows 6: header + five session rows visible.
+    expect(entered.focusedRowId).toBe("wt_web_idle");
   });
 
   it("scrolls the viewport to keep the cursor visible when walking past the bottom", () => {
     let current = state({ terminalRows: 12 });
-    for (let presses = 0; presses < 5; presses += 1) {
+    for (let presses = 0; presses < 6; presses += 1) {
       current = handleTuiKey(current, DOWN).state;
     }
-    expect(current.focusedRowId).toBe("wt_web_idle");
-    // Item index 5 must sit inside the 5-row window: offset = 5 - 5 + 1.
+    expect(current.focusedRowId).toBe("wt_web_unknown");
+    // Item index 6 must sit inside the 6-row window: offset = 6 - 6 + 1.
     expect(current.scrollOffset).toBe(1);
   });
 
@@ -62,8 +62,8 @@ describe("dashboard focus cursor", () => {
 
     const second = handleTuiKey(first, NEXT_NEEDS_ME).state;
     expect(second.focusedRowId).toBe("wt_web_stuck");
-    // The stuck row (item index 7) scrolled into the 5-row window.
-    expect(second.scrollOffset).toBe(3);
+    // The stuck row (item index 7) scrolled into the 6-row window.
+    expect(second.scrollOffset).toBe(2);
 
     const wrapped = handleTuiKey(second, NEXT_NEEDS_ME).state;
     expect(wrapped.focusedRowId).toBe("wt_web_attention");

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -50,7 +50,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(8);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(7);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", mouseScroll: "up" }).state
         .scrollOffset,
@@ -676,6 +676,6 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.collapsedProjectIds.has("web")).toBe(true);
-    expect(transition.state.scrollOffset).toBe(1);
+    expect(transition.state.scrollOffset).toBe(0);
   });
 });

--- a/station/src/station/StationOverlay.tsx
+++ b/station/src/station/StationOverlay.tsx
@@ -106,7 +106,7 @@ export function StationOverlay({ store, topRowWidgets = [], dispatchMouse }: Sta
         height={layout.height}
         zIndex={30}
         border
-        borderColor={STATION_COLORS.hairline}
+        borderColor={STATION_COLORS.gray}
         backgroundColor={STATION_COLORS.background}
         flexDirection="column"
         onMouseDown={stopPopupMouse}

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -78,8 +78,8 @@ export function DashboardView({
   const firstRun = snapshot.projects.length === 0;
   const fleet = selectFleetSummary(snapshot);
   const keyByRow = new Map(viewport.displayRowChoices.map((choice) => [choice.value.id, choice.key]));
-  const { headerLayout, layoutByItem } = firstRun
-    ? { headerLayout: undefined, layoutByItem: new Map<string, RowGridLayout>() }
+  const { layoutByItem } = firstRun
+    ? { layoutByItem: new Map<string, RowGridLayout>() }
     : dashboardRowLayouts(viewport.visibleItems, keyByRow, contentColumns, viewState.focusedRowId);
   return (
     <box
@@ -93,7 +93,6 @@ export function DashboardView({
         <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
       )}
       <text> </text>
-      {firstRun || headerLayout === undefined ? null : <ColumnHeaderRow layout={headerLayout} />}
       <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
       {firstRun ? (
         <box flexDirection="column" flexGrow={1}>
@@ -244,15 +243,7 @@ function dashboardRowLayouts(
   return { headerLayout, layoutByItem };
 }
 
-function ColumnHeaderRow({ layout }: { layout: RowGridLayout }) {
-  return (
-    <box height={1} width="100%" overflow="hidden">
-      <text fg={STATION_COLORS.gray}>
-        <Segments segments={layout.segments} />
-      </text>
-    </box>
-  );
-}
+
 
 function DashboardBody({
   columns,

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -92,7 +92,7 @@ export function DashboardView({
       {firstRun ? null : (
         <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
       )}
-      <text> </text>
+      <Divider columns={contentColumns} />
       <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
       {firstRun ? (
         <box flexDirection="column" flexGrow={1}>

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -30,7 +30,7 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
-                                                                                                                        
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
@@ -74,7 +74,7 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
-                                                            
+─────────────────────────────────────────────────────────── 
                                                             
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ○ cli-help-man            codex     idle         #70 ✓ 
@@ -94,7 +94,7 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0      
-                                        
+─────────────────────────────────────── 
                                         
 ▼ station  5 sessions · … [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
@@ -110,7 +110,7 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -138,7 +138,7 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
-                                                                                                                        
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
@@ -182,7 +182,7 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
-                                                            
+─────────────────────────────────────────────────────────── 
                                                             
 ▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ! hook-scope         codex     Agent needs app… #12 x2 
@@ -202,7 +202,7 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3      
-                                        
+─────────────────────────────────────── 
                                         
 ▼ station  4 sessions · … [sh] [qs] [▾] 
  [1] ! hook-scope                       
@@ -217,7 +217,7 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 `;
 
 exports[`dashboard golden frames renders no-projects at 80x24 1`] = `
-"                                                                                
+"─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 No projects configured yet.                                                     
                                                                                 
@@ -245,7 +245,7 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 120x40 1`] = `
-"                                                                                                                        
+"─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
 No projects configured yet.                                                                                             
                                                                                                                         
@@ -289,7 +289,7 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 60x16 1`] = `
-"                                                            
+"─────────────────────────────────────────────────────────── 
                                                             
 No projects configured yet.                                 
                                                             
@@ -309,7 +309,7 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 40x12 1`] = `
-"                                        
+"─────────────────────────────────────── 
                                         
 No projects configured yet.             
                                         

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -3,12 +3,11 @@
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -22,6 +21,7 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -31,12 +31,11 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
                                                                                                                         
-       SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
  [2] - docs-cleanup                              -         no agent                                                     
- [3] ○ pty-buffer                                codex     idle                                            #73 merged ✓ 
+ [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
  [4] + session-resume                            codex     starting                                                     
  [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
                                                                                                                         
@@ -67,6 +66,7 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
                                                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
@@ -75,18 +75,18 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
                                                             
-       SESSION          AGENT     STATUS                 PR 
                                                             
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
- [1] ○ cli-help-man     codex     idle                #70 ✓ 
- [2] - docs-cleanup     -         no agent                  
- [3] ○ pty-buffer       codex     idle         #73 merged ✓ 
- [4] + session-resume   codex     starting                  
- [5] ⠋ station-overlay  codex     working             #76 … 
+ [1] ○ cli-help-man            codex     idle         #70 ✓ 
+ [2] - docs-cleanup            -         no agent           
+ [3] ○ pty-buffer              codex     idle         #73 ✓ 
+ [4] + session-resume          codex     starting           
+ [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
- [6] x batch-export     opencode  exited               #8 ✓ 
-▼ 5 below · showing 6 of 11                                 
+ [6] x batch-export            opencode  exited        #8 ✓ 
+ [7] ⠋ provider-hooks          opencode  working      #16 … 
+▼ 4 below · showing 7 of 11                                 
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
@@ -95,14 +95,14 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0      
                                         
-       SESSION             STATUS       
                                         
 ▼ station  5 sessions · … [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
  [4] + session-resume      starting     
-▼ 7 below · showing 4 of 11             
+ [5] ⠋ station-overlay     working      
+▼ 6 below · showing 5 of 11             
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
 "
@@ -111,7 +111,6 @@ exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
                                                                                 
-       SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -131,6 +130,7 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
                                                                                 
                                                                                 
                                                                                 
+                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
@@ -139,7 +139,6 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
                                                                                                                         
-       SESSION                                   AGENT     STATUS                                             DIFF · PR 
                                                                                                                         
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
@@ -175,6 +174,7 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
                                                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
@@ -183,7 +183,6 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
                                                             
-       SESSION            AGENT     STATUS               PR 
                                                             
 ▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ! hook-scope         codex     Agent needs app… #12 x2 
@@ -195,6 +194,7 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
  [5] x done-run           opencode  exited                  
  [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
                                                             
+                                                            
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
@@ -203,13 +203,13 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3      
                                         
-       SESSION                          
                                         
 ▼ station  4 sessions · … [sh] [qs] [▾] 
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
  [4] ⠋ pr-info                          
+                                        
 ▼ 2 below · showing 4 of 6              
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -3,25 +3,25 @@
 exports[`modal flow golden frames renders the help overlay 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       S╭──────────────────────────────────────────────────────────────╮FF · PR 
-        │                         station help                         │        
-▼ statio│                                                              │qs] [▾] 
- [1] ○ c│  Ctrl-O     open/close project view                          │6 #70 ✓ 
- [2] - d│  Ctrl-Q     quit Station                                     │        
- [3] ○ p│  Ctrl-\\     split pane right                                 │erged ✓ 
- [4] + s│  Ctrl-^     split pane below (Ctrl-6)                        │        
- [5] ⠋ s│  Ctrl-]     focus next pane                                  │6 #76 … 
-        │  Ctrl-/     close split pane (Ctrl-_)                        │        
-▼ observ│  Enter/Sp   open project view on welcome                     │qs] [▾] 
- [6] x b│  Esc/↑↓     context menu close/move                          │   #8 ✓ 
- [7] ⠋ p│  Enter/Sp   context menu select                              │8 #16 … 
- [8] ○ t│                     station project view                     │-1 #4 ✓ 
-        │  ↑/↓        move cursor                                      │        
-▼ script│  ↵          open focused session                             │qs] [▾] 
- [9] ○ a│  tab        next session needing you                         │6 #5 x1 
- [a] ? m│  wheel      scroll project list                              │ -1 #10 
- [b] - o│  1-9/a-z    start or focus row                               │        
-        │  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
+        ╭──────────────────────────────────────────────────────────────╮        
+▼ statio│                         station help                         │qs] [▾] 
+ [1] ○ c│                                                              │6 #70 ✓ 
+ [2] - d│  Ctrl-O     open/close project view                          │        
+ [3] ○ p│  Ctrl-Q     quit Station                                     │  #73 ✓ 
+ [4] + s│  Ctrl-\\     split pane right                                 │        
+ [5] ⠋ s│  Ctrl-^     split pane below (Ctrl-6)                        │6 #76 … 
+        │  Ctrl-]     focus next pane                                  │        
+▼ observ│  Ctrl-/     close split pane (Ctrl-_)                        │qs] [▾] 
+ [6] x b│  Enter/Sp   open project view on welcome                     │   #8 ✓ 
+ [7] ⠋ p│  Esc/↑↓     context menu close/move                          │8 #16 … 
+ [8] ○ t│  Enter/Sp   context menu select                              │-1 #4 ✓ 
+        │                     station project view                     │        
+▼ script│  ↑/↓        move cursor                                      │qs] [▾] 
+ [9] ○ a│  ↵          open focused session                             │6 #5 x1 
+ [a] ? m│  tab        next session needing you                         │ -1 #10 
+ [b] - o│  wheel      scroll project list                              │        
+        │  1-9/a-z    start or focus row                               │        
+▼ empty-│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │qs] [▾] 
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -31,12 +31,11 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 exports[`modal flow golden frames renders the search prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -49,7 +48,8 @@ exports[`modal flow golden frames renders the search prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-search: api                                                                     
+                                                                                
+search: apiject  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -59,12 +59,11 @@ search: api
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -77,7 +76,8 @@ exports[`modal flow golden frames renders the collapse prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-collapse project: 1:station 2:observer 3:scripts 4:empty-project                
+                                                                                
+collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -87,12 +87,11 @@ collapse project: 1:station 2:observer 3:scripts 4:empty-project
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -105,7 +104,8 @@ exports[`modal flow golden frames renders the project settings picker prompt 1`]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-settings for project: 1:station 2:observer 3:scripts 4:empty-project            
+                                                                                
+settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -115,14 +115,13 @@ settings for project: 1:station 2:observer 3:scripts 4:empty-project
 exports[`modal flow golden frames renders the project settings panel 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-   ┌────────────────────────────────────────────────────────────────────────┐PR 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │✓1 codex unknown                             │ ✓ 
- [2│  Remove project          │ 2 opencode unknown                          │   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
- [5│                          │                                             │ … 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Default agent                               │ ✓ 
+ [2│▸ Default agent           │✓1 codex unknown                             │   
+ [3│  Remove project          │ 2 opencode unknown                          │ ✓ 
+ [4│                          │                                             │   
+ [5│                          │ ✓ current · 1-9/a-z select                  │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
@@ -133,7 +132,8 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -143,17 +143,16 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-   ┌────────────────────────────────────────────────────────────────────────┐PR 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Remove project                              │▾] 
- [1│  Default agent           │ Removes it from Station.                    │ ✓ 
- [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
- [3│                          │                                             │ ✓ 
- [4│                          │ Type "delete station" to confirm            │   
- [5│                          │ ▸ |delete station                           │ … 
-   │                          │                                             │   
-▼ o│                          │ [ Remove project (R) ]                      │▾] 
- [6│                          │                                             │ ✓ 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Remove project                              │ ✓ 
+ [2│  Default agent           │ Removes it from Station.                    │   
+ [3│▸ Remove project          │ Worktrees & files stay on disk.             │ ✓ 
+ [4│                          │                                             │   
+ [5│                          │ Type "delete station" to confirm            │ … 
+   │                          │ ▸ |delete station                           │   
+▼ o│                          │                                             │▾] 
+ [6│                          │ [ Remove project (R) ]                      │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
    │                          │                                             │   
@@ -161,7 +160,8 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │ ←/esc back                                                             │   
+   │                          │                                             │   
+▼ e│ ←/esc back                                                             │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -171,14 +171,13 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-   ┌────────────────────────────────────────────────────────────────────────┐PR 
-   │ Project settings                                                       │   
-▼ s│ station                  │ Default agent                               │▾] 
- [1│▸ Default agent           │ 1 codex unknown                             │ ✓ 
- [2│  Remove project          │✓2 opencode unknown                 updating…│   
- [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
- [5│                          │                                             │ … 
+   ┌────────────────────────────────────────────────────────────────────────┐   
+▼ s│ Project settings                                                       │▾] 
+ [1│ station                  │ Default agent                               │ ✓ 
+ [2│▸ Default agent           │ 1 codex unknown                             │   
+ [3│  Remove project          │✓2 opencode unknown                 updating…│ ✓ 
+ [4│                          │                                             │   
+ [5│                          │ ✓ current · 1-9/a-z select                  │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
@@ -189,7 +188,8 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -199,12 +199,11 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -214,10 +213,11 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to delete                   │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Click a row or press slot key              │                                  
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+┌────────────────────────────────────────────┐code  unknown           +3 -1 #10 
+│ Select session to delete                   │      no agent                    
+│                                            │                                  
+│ Click a row or press slot key              │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -227,12 +227,11 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -240,12 +239,13 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-┌────────────────────────────────────────────┐                                  
-│ Delete session?                            │                    [sh] [qs] [▾] 
-│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
-│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Yes (y)     No (n)                         │                                  
+                                                                                
+┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
+│ Delete session?                            │code  idle           +14 -6 #5 x1 
+│ Session  cli-help-man                      │code  unknown           +3 -1 #10 
+│ Removes agent, worktree, and panes.        │      no agent                    
+│                                            │                                  
+│ Yes (y)     No (n)                         │                    [sh] [qs] [▾] 
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -255,12 +255,11 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -273,7 +272,8 @@ exports[`modal flow golden frames renders the rename slot prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-Choose the slot to rename: 1-9/a-z                                              
+                                                                                
+Choose the slot to rename: 1-9/a-z                                [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -283,7 +283,6 @@ Choose the slot to rename: 1-9/a-z
 exports[`modal flow golden frames renders the rename sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
                                                                                 
-       SESSION                        AGENT     STATUS                DIFF · PR 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -294,6 +293,7 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 ▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [5] x done-run                       opencode  exited                          
  [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
+                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -311,12 +311,11 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -326,10 +325,11 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
-┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
-│ Select session to fork                     │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Click a row or press slot key              │                                  
+ [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
+┌────────────────────────────────────────────┐code  unknown           +3 -1 #10 
+│ Select session to fork                     │      no agent                    
+│                                            │                                  
+│ Click a row or press slot key              │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -339,25 +339,25 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
-┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
-│ Fork Session                               │                                  
-│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
-│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │      no agent                    
-│                                            │                                  
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+┌────────────────────────────────────────────┐                                  
+│ Fork Session                               │                    [sh] [qs] [▾] 
+│ Source   station · cli-help-man            │code  idle           +14 -6 #5 x1 
+│ > Branch cli-help-man-fork|                │code  unknown           +3 -1 #10 
+│   Copy   [x] uncommitted changes           │      no agent                    
+│ Source keeps running — copy is read-only.  │                                  
+│                                            │                    [sh] [qs] [▾] 
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -367,12 +367,11 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 exports[`modal flow golden frames renders the new session review 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -380,6 +379,7 @@ exports[`modal flow golden frames renders the new session review 1`] = `
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -395,12 +395,11 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 exports[`modal flow golden frames renders the new session edit name 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -409,6 +408,7 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │                                                                              │
@@ -423,18 +423,18 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 exports[`modal flow golden frames renders the new session pick project 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -451,12 +451,11 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓ 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
                                                                                 
@@ -465,6 +464,7 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -479,12 +479,11 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 
-       SESSION                            AGENT     STATUS            DIFF · PR
 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       -         no agent
- [3] ○ pty-buffer                         codex     idle           #73 merged ✓
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
 
@@ -493,6 +492,7 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
 
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾]
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -507,10 +507,10 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       -         no agent                    
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │
@@ -535,25 +535,25 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 exports[`modal flow golden frames renders the widget settings panel 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffe┌──────────────────────────────────────────────┐   #73 merged ✓ 
- [4] + session-r│ widgets                                      │                
- [5] ⠋ station-o│ session only · persist in config.toml        │ +412 -96 #76 … 
-                │ ▸ [on ] time                               × │                
-▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾] 
- [6] x batch-exp│   [on ] moon                               × │           #8 ✓ 
- [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 … 
- [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓ 
-                └──────────────────────────────────────────────┘                
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-r┌──────────────────────────────────────────────┐                
+ [5] ⠋ station-o│ widgets                                      │ +412 -96 #76 … 
+                │ session only · persist in config.toml        │                
+▼ observer  3 se│ ▸ [on ] time                               × │  [sh] [qs] [▾] 
+ [6] x batch-exp│   [off] weather NYC                        × │           #8 ✓ 
+ [7] ⠋ provider-│   [on ] moon                               × │   +32 -8 #16 … 
+ [8] ○ trace-bun│   [ + add widget ]                           │     +1 -1 #4 ✓ 
+                │ ↵ toggle   [ ] reorder   x remove   a add   e│                
+▼ scripts  3 ses└──────────────────────────────────────────────┘  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -563,25 +563,25 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 exports[`modal flow golden frames renders the widget settings picker 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
                                                                                 
-       SESSION                            AGENT     STATUS            DIFF · PR 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffe┌──────────────────────────────────────────────┐   #73 merged ✓ 
- [4] + session-r│ add widget                                   │                
- [5] ⠋ station-o│ weather and tz are added in config.toml      │ +412 -96 #76 … 
-                │ ▸ time                                       │                
-▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾] 
- [6] x batch-exp│   open PRs                                   │           #8 ✓ 
- [7] ⠋ provider-│   moon                                       │   +32 -8 #16 … 
- [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓ 
-                └──────────────────────────────────────────────┘                
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-r┌──────────────────────────────────────────────┐                
+ [5] ⠋ station-o│ add widget                                   │ +412 -96 #76 … 
+                │ weather and tz are added in config.toml      │                
+▼ observer  3 se│ ▸ time                                       │  [sh] [qs] [▾] 
+ [6] x batch-exp│   fleet                                      │           #8 ✓ 
+ [7] ⠋ provider-│   open PRs                                   │   +32 -8 #16 … 
+ [8] ○ trace-bun│   moon                                       │     +1 -1 #4 ✓ 
+                │ ↵ add   esc back                             │                
+▼ scripts  3 ses└──────────────────────────────────────────────┘  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`modal flow golden frames renders the help overlay 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
         ╭──────────────────────────────────────────────────────────────╮        
 ▼ statio│                         station help                         │qs] [▾] 
  [1] ○ c│                                                              │6 #70 ✓ 
@@ -30,7 +30,7 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 
 exports[`modal flow golden frames renders the search prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -58,7 +58,7 @@ search: apiject  0 sessions                                       [sh] [qs] [▾
 
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -86,7 +86,7 @@ collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾
 
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -114,7 +114,7 @@ settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾
 
 exports[`modal flow golden frames renders the project settings panel 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
    ┌────────────────────────────────────────────────────────────────────────┐   
 ▼ s│ Project settings                                                       │▾] 
  [1│ station                  │ Default agent                               │ ✓ 
@@ -142,7 +142,7 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
 
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
    ┌────────────────────────────────────────────────────────────────────────┐   
 ▼ s│ Project settings                                                       │▾] 
  [1│ station                  │ Remove project                              │ ✓ 
@@ -170,7 +170,7 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
 
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
    ┌────────────────────────────────────────────────────────────────────────┐   
 ▼ s│ Project settings                                                       │▾] 
  [1│ station                  │ Default agent                               │ ✓ 
@@ -198,7 +198,7 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
 
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -226,7 +226,7 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -254,7 +254,7 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -282,7 +282,7 @@ Choose the slot to rename: 1-9/a-z                                [sh] [qs] [▾
 
 exports[`modal flow golden frames renders the rename sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
@@ -310,7 +310,7 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -338,7 +338,7 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -366,7 +366,7 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 
 exports[`modal flow golden frames renders the new session review 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -394,7 +394,7 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 
 exports[`modal flow golden frames renders the new session edit name 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -422,7 +422,7 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 
 exports[`modal flow golden frames renders the new session pick project 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -450,7 +450,7 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -478,7 +478,7 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
-
+───────────────────────────────────────────────────────────────────────────────
 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
@@ -506,7 +506,7 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 
 exports[`modal flow golden frames renders the add project sheet 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -534,7 +534,7 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 
 exports[`modal flow golden frames renders the widget settings panel 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
@@ -562,7 +562,7 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 
 exports[`modal flow golden frames renders the widget settings picker 1`] = `
 "FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
 import { DynamicStationButton } from "./DynamicStationButton.js";
-import { ANIM_MS, STATION_ICON } from "./layout.js";
+import { ANIM_MS, STATION_ICON, type IslandDisplayInput } from "./layout.js";
+import type { StationButtonStatus } from "./status.js";
 
 // OpenTUI's reconciler commits async layout updates outside React's act(),
 // matching the StationApp integration test's stance for these render checks.
@@ -9,7 +10,20 @@ import { ANIM_MS, STATION_ICON } from "./layout.js";
 
 const SURFACE = { width: 40, height: 12 };
 
-const CALM = { attention: false, needsYouCount: 0, workingCount: 0, readyCount: 0, idleCount: 0 };
+const CALM_STATUS: StationButtonStatus = {
+  attention: false,
+  needsYouCount: 0,
+  workingCount: 0,
+  readyCount: 0,
+  idleCount: 0,
+};
+
+function input(
+  status: Partial<StationButtonStatus> = {},
+  extra: Omit<IslandDisplayInput, "status"> = {},
+): IslandDisplayInput {
+  return { status: { ...CALM_STATUS, ...status }, ...extra };
+}
 
 async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<string> {
   const setup = await testRender(node, SURFACE);
@@ -24,7 +38,7 @@ async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<str
 describe("DynamicStationButton", () => {
   it("collapsed base shows only the station icon", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton {...CALM} workingCount={2} idleCount={14} />,
+      <DynamicStationButton input={input({ workingCount: 2, idleCount: 14 })} />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).not.toContain("session");
@@ -33,10 +47,7 @@ describe("DynamicStationButton", () => {
   it("collapsed attention frames the icon with exclamation marks", async () => {
     const frame = await captureFrame(
       <DynamicStationButton
-        {...CALM}
-        attention={true}
-        needsYouCount={1}
-        sessionName="hook-scope"
+        input={input({ attention: true, needsYouCount: 1, sessionName: "hook-scope" })}
       />,
     );
     expect(frame).toContain(STATION_ICON);
@@ -47,7 +58,7 @@ describe("DynamicStationButton", () => {
 
   it("collapsed rest counts paint the fleet lanes", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton {...CALM} readyCount={1} idleCount={6} restCounts={true} />,
+      <DynamicStationButton input={input({ readyCount: 1, idleCount: 6 }, { restCounts: true })} />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("⠿0 ●1 ○6");
@@ -56,7 +67,7 @@ describe("DynamicStationButton", () => {
 
   it("collapsed celebration announces the merged PR", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton {...CALM} idleCount={3} celebration={{ prNumber: 42 }} />,
+      <DynamicStationButton input={input({ idleCount: 3 }, { celebration: { prNumber: 42 } })} />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("✓ #42 merged");
@@ -65,11 +76,10 @@ describe("DynamicStationButton", () => {
   it("attention wins over the celebration", async () => {
     const frame = await captureFrame(
       <DynamicStationButton
-        {...CALM}
-        attention={true}
-        needsYouCount={1}
-        sessionName="hook-scope"
-        celebration={{ prNumber: 42 }}
+        input={input(
+          { attention: true, needsYouCount: 1, sessionName: "hook-scope" },
+          { celebration: { prNumber: 42 } },
+        )}
       />,
     );
     expect(frame).toContain("!!!!");
@@ -78,7 +88,7 @@ describe("DynamicStationButton", () => {
 
   it("expanded base shows the working/idle summary", async () => {
     const frame = await captureFrame(
-      <DynamicStationButton {...CALM} workingCount={2} readyCount={5} idleCount={9} hovered />,
+      <DynamicStationButton input={input({ workingCount: 2, readyCount: 5, idleCount: 9 })} hovered />,
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("2 sessions working");
@@ -97,7 +107,7 @@ describe("DynamicStationButton", () => {
       { projectId: "p7", name: "tools", status: "idle" as const },
     ];
     const frame = await captureFrame(
-      <DynamicStationButton {...CALM} projectRollup={projects} hovered />,
+      <DynamicStationButton input={input({ projectRollup: projects })} hovered />,
     );
     expect(frame).toContain("! station");
     expect(frame).toContain("○ docs");
@@ -110,10 +120,7 @@ describe("DynamicStationButton", () => {
   it("expanded attention shows the session name and intervention message", async () => {
     const frame = await captureFrame(
       <DynamicStationButton
-        {...CALM}
-        attention={true}
-        needsYouCount={1}
-        sessionName="hook-scope"
+        input={input({ attention: true, needsYouCount: 1, sessionName: "hook-scope" })}
         hovered
       />,
     );
@@ -136,10 +143,7 @@ describe("DynamicStationButton", () => {
   it("expanded attention shows the queue when several sessions ask", async () => {
     const frame = await captureFrame(
       <DynamicStationButton
-        {...CALM}
-        attention={true}
-        needsYouCount={3}
-        sessionName="hook-scope"
+        input={input({ attention: true, needsYouCount: 3, sessionName: "hook-scope" })}
         hovered
       />,
     );
@@ -149,7 +153,7 @@ describe("DynamicStationButton", () => {
 
   it("switches the mouse pointer to a hand on hover and back on leave", async () => {
     const setup = await testRender(
-      <DynamicStationButton {...CALM} workingCount={1} idleCount={2} />,
+      <DynamicStationButton input={input({ workingCount: 1, idleCount: 2 })} />,
       SURFACE,
     );
     try {

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -28,6 +28,9 @@ import {
   ICON_COLS,
   ICON_PAD,
   type IslandCelebration,
+  type IslandDisplay,
+  islandDisplay,
+  type IslandDisplayInput,
   lerp,
   paintedCount,
   ROLLUP_MAX_LINES,
@@ -38,19 +41,8 @@ import {
 } from "./layout.js";
 
 export type DynamicStationButtonProps = {
-  attention: boolean;
-  /** Sessions asking for the user; >1 swaps the attention card to the queue line. */
-  needsYouCount: number;
-  workingCount: number;
-  readyCount: number;
-  idleCount: number;
-  sessionName?: string | undefined;
-  /** C3 opt-in: the collapsed rest state paints fleet counts, not the bare mark. */
-  restCounts?: boolean | undefined;
-  /** C2 opt-in: the hovered card lists each project's worst status. */
-  projectRollup?: readonly ProjectRollupEntry[] | undefined;
-  /** A just-merged PR to celebrate; replaces the collapsed rest content while set. */
-  celebration?: IslandCelebration | undefined;
+  /** Everything the display ladder needs; islandDisplay decides what paints. */
+  input: IslandDisplayInput;
   /** Force-expand from external hover state; internal mouse hover also expands. */
   hovered?: boolean | undefined;
   focused?: boolean | undefined;
@@ -65,7 +57,8 @@ export type DynamicStationButtonProps = {
 };
 
 export function DynamicStationButton(props: DynamicStationButtonProps): ReactNode {
-  const { attention, onHoverChange } = props;
+  const { input, onHoverChange } = props;
+  const attention = input.status.attention;
   const [internalHover, setInternalHover] = useState(false);
   const expanded = (props.hovered ?? false) || (props.focused ?? false) || internalHover;
   const handleHoverChange = (hovering: boolean): void => {
@@ -75,12 +68,13 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
   const pointerProps = useHoverPointer({ onHoverChange: handleHoverChange });
 
   const open = useOpenAmount(expanded ? 1 : 0);
-  const collapsed = targetDims(false, props);
-  const opened = targetDims(true, props);
+  const collapsed = targetDims(islandDisplay(input, false));
+  const opened = targetDims(islandDisplay(input, true));
   const dims: Dims = {
     width: Math.round(lerp(collapsed.width, opened.width, open)),
     height: Math.round(lerp(collapsed.height, opened.height, open)),
   };
+  const display = islandDisplay(input, expanded);
 
   // Border/icon morph between the two state colors; expanded text fades up from
   // the background while collapsed marks/icon stay fully visible.
@@ -138,20 +132,11 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
       onMouseDown={handleMouseDown}
     >
       <StationButtonContent
-        attention={attention}
-        expanded={expanded}
+        display={display}
         color={color}
         iconPadX={iconPadX}
         iconPadY={iconPadY}
         reveal={textReveal}
-        needsYouCount={props.needsYouCount}
-        workingCount={props.workingCount}
-        readyCount={props.readyCount}
-        idleCount={props.idleCount}
-        sessionName={props.sessionName}
-        restCounts={props.restCounts}
-        projectRollup={props.projectRollup}
-        celebration={props.celebration}
       />
       {/* Keeps one stable hit target above morphing text/icon children during expand/collapse. */}
       <box
@@ -168,75 +153,62 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
 }
 
 function StationButtonContent(props: {
-  attention: boolean;
-  expanded: boolean;
+  display: IslandDisplay;
   color: StationButtonStateColors;
   iconPadX: number;
   iconPadY: number;
   reveal: number;
-  needsYouCount: number;
-  workingCount: number;
-  readyCount: number;
-  idleCount: number;
-  sessionName?: string | undefined;
-  restCounts?: boolean | undefined;
-  projectRollup?: readonly ProjectRollupEntry[] | undefined;
-  celebration?: IslandCelebration | undefined;
 }): ReactNode {
-  const { attention, expanded, color, iconPadX, iconPadY, reveal } = props;
-  if (!expanded) {
-    if (attention) {
+  const { display, color, iconPadX, iconPadY, reveal } = props;
+  switch (display.kind) {
+    case "mark":
+      return <CollapsedBase color={color} iconPadX={iconPadX} iconPadY={iconPadY} />;
+    case "alertMark":
       return <CollapsedAttention color={color} />;
-    }
-    if (props.celebration !== undefined) {
-      return <CollapsedCelebration celebration={props.celebration} />;
-    }
-    if (props.restCounts === true) {
+    case "counts":
       return (
         <CollapsedCounts
           iconColor={color.icon}
-          workingCount={props.workingCount}
-          readyCount={props.readyCount}
-          idleCount={props.idleCount}
+          working={display.working}
+          ready={display.ready}
+          idle={display.idle}
         />
       );
-    }
-    return <CollapsedBase color={color} iconPadX={iconPadX} iconPadY={iconPadY} />;
+    case "celebration":
+      return <CollapsedCelebration celebration={display.celebration} />;
+    case "alertCard":
+      return (
+        <ExpandedAttention
+          color={color}
+          iconPadX={iconPadX}
+          iconPadY={iconPadY}
+          reveal={reveal}
+          needsYouCount={display.needsYouCount}
+          sessionName={display.sessionName}
+        />
+      );
+    case "rollup":
+      return (
+        <ExpandedRollup
+          color={color}
+          iconPadX={iconPadX}
+          iconPadY={iconPadY}
+          reveal={reveal}
+          entries={display.entries}
+        />
+      );
+    case "summary":
+      return (
+        <ExpandedBase
+          color={color}
+          iconPadX={iconPadX}
+          iconPadY={iconPadY}
+          reveal={reveal}
+          working={display.working}
+          idle={display.idle}
+        />
+      );
   }
-  if (attention) {
-    return (
-      <ExpandedAttention
-        color={color}
-        iconPadX={iconPadX}
-        iconPadY={iconPadY}
-        reveal={reveal}
-        needsYouCount={props.needsYouCount}
-        sessionName={props.sessionName}
-      />
-    );
-  }
-  if (props.projectRollup !== undefined && props.projectRollup.length > 0) {
-    return (
-      <ExpandedRollup
-        color={color}
-        iconPadX={iconPadX}
-        iconPadY={iconPadY}
-        reveal={reveal}
-        entries={props.projectRollup}
-      />
-    );
-  }
-  return (
-    <ExpandedBase
-      color={color}
-      iconPadX={iconPadX}
-      iconPadY={iconPadY}
-      reveal={reveal}
-      workingCount={props.workingCount}
-      readyCount={props.readyCount}
-      idleCount={props.idleCount}
-    />
-  );
 }
 
 function IconGlyph({ color }: { color: string }): ReactNode {
@@ -325,23 +297,23 @@ function CollapsedAttention({ color }: { color: StationButtonStateColors }): Rea
 // animated while any), ● ready (green), ○ idle (gray).
 function CollapsedCounts(props: {
   iconColor: string;
-  workingCount: number;
-  readyCount: number;
-  idleCount: number;
+  working: number;
+  ready: number;
+  idle: number;
 }): ReactNode {
   return (
     <box flexDirection="row" paddingLeft={ICON_PAD}>
       <IconGlyph color={props.iconColor} />
       <text>
         <span> </span>
-        {props.workingCount > 0 ? (
+        {props.working > 0 ? (
           <Throbber variant="braille" fg={STATION_COLORS.blue} />
         ) : (
           <span fg={STATION_COLORS.blue}>⠿</span>
         )}
-        <span fg={STATION_COLORS.blue}>{`${paintedCount(props.workingCount)} `}</span>
-        <span fg={STATION_COLORS.green}>{`●${paintedCount(props.readyCount)} `}</span>
-        <span fg={STATION_COLORS.gray}>{`○${paintedCount(props.idleCount)}`}</span>
+        <span fg={STATION_COLORS.blue}>{`${paintedCount(props.working)} `}</span>
+        <span fg={STATION_COLORS.green}>{`●${paintedCount(props.ready)} `}</span>
+        <span fg={STATION_COLORS.gray}>{`○${paintedCount(props.idle)}`}</span>
       </text>
     </box>
   );
@@ -361,9 +333,8 @@ function ExpandedBase(props: {
   iconPadX: number;
   iconPadY: number;
   reveal: number;
-  workingCount: number;
-  readyCount: number;
-  idleCount: number;
+  working: number;
+  idle: number;
 }): ReactNode {
   const { color, reveal } = props;
   return (
@@ -371,13 +342,12 @@ function ExpandedBase(props: {
       <IconRow color={color.icon} padX={props.iconPadX} padY={props.iconPadY} />
       <box flexDirection="column" paddingLeft={CONTENT_INDENT}>
         <GradientText
-          text={sessionSummary(props.workingCount, "working")}
+          text={sessionSummary(props.working, "working")}
           reveal={reveal}
           color={color.text}
         />
         <GradientText
-          // Ready sessions read as idle in the totals (the fleet breakdown keeps them disjoint).
-          text={sessionSummary(props.readyCount + props.idleCount, "idle")}
+          text={sessionSummary(props.idle, "idle")}
           reveal={reveal}
           color={color.text}
         />
@@ -439,7 +409,7 @@ function ExpandedAttention(props: {
   iconPadY: number;
   reveal: number;
   needsYouCount: number;
-  sessionName?: string | undefined;
+  sessionName: string;
 }): ReactNode {
   const { color, reveal } = props;
   return (
@@ -447,7 +417,7 @@ function ExpandedAttention(props: {
       <IconRow color={color.icon} padX={props.iconPadX} padY={props.iconPadY} />
       <box flexDirection="column" paddingLeft={CONTENT_INDENT}>
         <GradientText
-          text={clampSessionName(props.sessionName ?? "session")}
+          text={clampSessionName(props.sessionName)}
           reveal={reveal}
           color={color.text}
         />

--- a/station/src/stationButton/StationButton.tsx
+++ b/station/src/stationButton/StationButton.tsx
@@ -72,15 +72,7 @@ export function StationButton({ store, stationViewStore, dispatchMouse, island }
 
   return (
     <DynamicStationButton
-      attention={status.attention}
-      needsYouCount={status.needsYouCount}
-      workingCount={status.workingCount}
-      readyCount={status.readyCount}
-      idleCount={status.idleCount}
-      sessionName={status.sessionName}
-      restCounts={island?.restCounts}
-      projectRollup={status.projectRollup}
-      celebration={celebration}
+      input={{ status, restCounts: island?.restCounts, celebration }}
       onHoverChange={store.actions.setStationButtonHover}
       onToggleStation={onHeader}
       onContextMenu={onHeader}

--- a/station/src/stationButton/layout.test.ts
+++ b/station/src/stationButton/layout.test.ts
@@ -1,58 +1,128 @@
 import { describe, expect, it } from "bun:test";
-import { attentionLines, COLLAPSED_BASE_COLS, COLLAPSED_COUNTS_COLS, targetDims } from "./layout.js";
+import {
+  attentionLines,
+  celebrationText,
+  COLLAPSED_BASE_COLS,
+  COLLAPSED_COUNTS_COLS,
+  islandDisplay,
+  type IslandDisplayInput,
+  targetDims,
+} from "./layout.js";
+import type { StationButtonStatus } from "./status.js";
 
-const CALM = { attention: false, workingCount: 0, readyCount: 0, idleCount: 0 } as const;
+const CALM_STATUS: StationButtonStatus = {
+  attention: false,
+  needsYouCount: 0,
+  workingCount: 0,
+  readyCount: 0,
+  idleCount: 0,
+};
+
+function input(
+  status: Partial<StationButtonStatus> = {},
+  extra: Omit<IslandDisplayInput, "status"> = {},
+): IslandDisplayInput {
+  return { status: { ...CALM_STATUS, ...status }, ...extra };
+}
+
+function dims(value: IslandDisplayInput, expanded: boolean) {
+  return targetDims(islandDisplay(value, expanded));
+}
+
+describe("islandDisplay", () => {
+  it("ranks attention over celebration over counts over the bare mark", () => {
+    const celebration = { prNumber: 42 };
+    expect(
+      islandDisplay(input({ attention: true }, { celebration, restCounts: true }), false).kind,
+    ).toBe("alertMark");
+    expect(islandDisplay(input({}, { celebration, restCounts: true }), false).kind).toBe(
+      "celebration",
+    );
+    expect(islandDisplay(input({}, { restCounts: true }), false).kind).toBe("counts");
+    expect(islandDisplay(input(), false).kind).toBe("mark");
+  });
+
+  it("expands to the alert card, the roll-up, or the totals", () => {
+    expect(islandDisplay(input({ attention: true, needsYouCount: 2 }), true).kind).toBe(
+      "alertCard",
+    );
+    const rollup = [{ projectId: "p1", name: "station", status: "idle" as const }];
+    expect(islandDisplay(input({ projectRollup: rollup }), true).kind).toBe("rollup");
+    const summary = islandDisplay(input({ workingCount: 2, readyCount: 1, idleCount: 3 }), true);
+    // Ready folds into the idle total.
+    expect(summary).toEqual({ kind: "summary", working: 2, idle: 4 });
+  });
+});
 
 describe("targetDims", () => {
-  it("keeps the expanded card width stable as live counts change", () => {
+  it("keeps the summary card width stable as live counts change", () => {
     const width = (workingCount: number, idleCount: number): number =>
-      targetDims(true, { ...CALM, workingCount, idleCount }).width;
-    // The card is anchored top-right, so any width change slides it out from
-    // under a stationary cursor (reads as a hover leave). Counts crossing the
-    // singular/plural ("1 session" -> "2 sessions") or digit (9 -> 10) boundary
-    // must not resize it.
+      dims(input({ workingCount, idleCount }), true).width;
     expect(width(1, 1)).toBe(width(2, 14));
     expect(width(2, 14)).toBe(width(9, 99));
     expect(width(0, 0)).toBe(width(12, 7));
   });
 
-  it("keeps the attention card width stable as the session name changes", () => {
+  it("keeps the alert card width stable as the session name changes", () => {
     const width = (sessionName: string): number =>
-      targetDims(true, { ...CALM, attention: true, sessionName }).width;
-    // A live snapshot shortening (or lengthening) a branch name must not resize
-    // the top-right-anchored card out from under a hovering cursor.
+      dims(input({ attention: true, sessionName }), true).width;
     expect(width("feature/a-quite-long-branch-name")).toBe(width("x"));
     expect(width("x")).toBe(width("main"));
     expect(width("main")).toBe(width("another/long-feature-branch-name-here"));
   });
 
   it("keeps the collapsed counts box width stable as counts tick", () => {
-    const dims = (workingCount: number, readyCount: number, idleCount: number) =>
-      targetDims(false, { ...CALM, workingCount, readyCount, idleCount, restCounts: true });
-    expect(dims(0, 0, 0)).toEqual(dims(9, 10, 99));
-    expect(dims(1, 1, 1).width).toBe(COLLAPSED_COUNTS_COLS);
-    expect(dims(1, 1, 1).width).toBeGreaterThan(COLLAPSED_BASE_COLS);
-    // Counts past the 2-digit paint budget must not overflow either (painted as 99).
-    expect(dims(150, 0, 0)).toEqual(dims(0, 0, 0));
+    const at = (workingCount: number, readyCount: number, idleCount: number) =>
+      dims(input({ workingCount, readyCount, idleCount }, { restCounts: true }), false);
+    expect(at(0, 0, 0)).toEqual(at(9, 10, 99));
+    expect(at(1, 1, 1).width).toBe(COLLAPSED_COUNTS_COLS);
+    expect(at(1, 1, 1).width).toBeGreaterThan(COLLAPSED_BASE_COLS);
+    expect(at(150, 0, 0)).toEqual(at(0, 0, 0));
   });
 
-  it("keeps the expanded roll-up card width fixed while height tracks project count", () => {
-    const dims = (projects: number) =>
-      targetDims(true, { ...CALM, projectRollup: Array.from({ length: projects }) });
-    expect(dims(1).width).toBe(dims(8).width);
-    expect(dims(2).height).toBe(dims(1).height + 1);
-    // Past the fold the card shows ROLLUP_MAX_LINES entries plus one "+N more" line.
-    expect(dims(6).height).toBe(dims(9).height);
+  it("keeps the roll-up card width fixed while height tracks project count", () => {
+    const at = (projects: number) =>
+      dims(
+        input({
+          projectRollup: Array.from({ length: projects }, (_, i) => ({
+            projectId: `p${i}`,
+            name: `proj-${i}`,
+            status: "idle" as const,
+          })),
+        }),
+        true,
+      );
+    expect(at(1).width).toBe(at(8).width);
+    expect(at(2).height).toBe(at(1).height + 1);
+    expect(at(6).height).toBe(at(9).height);
     // An empty roll-up falls back to the totals card.
-    expect(dims(0)).toEqual(targetDims(true, CALM));
+    expect(at(0)).toEqual(dims(input(), true));
   });
 
-  it("sizes the celebration box to its PR number and stays put while it shows", () => {
-    const celebrate = (prNumber: number) =>
-      targetDims(false, { ...CALM, celebration: { prNumber } });
-    expect(celebrate(42)).toEqual(celebrate(42));
-    expect(celebrate(12345).width).toBe(celebrate(42).width + 3);
-    expect(celebrate(42).height).toBe(targetDims(false, CALM).height);
+  it("sizes the celebration box to its text and stays put while it shows", () => {
+    const at = (celebration: { prNumber: number; title?: string }) =>
+      dims(input({}, { celebration }), false);
+    expect(at({ prNumber: 42 })).toEqual(at({ prNumber: 42 }));
+    expect(at({ prNumber: 12345 }).width).toBe(at({ prNumber: 42 }).width + 3);
+    expect(at({ prNumber: 42 }).height).toBe(dims(input(), false).height);
+    expect(at({ prNumber: 42, title: "fix things" }).width).toBe(
+      at({ prNumber: 42 }).width + " · fix things".length,
+    );
+  });
+});
+
+describe("celebrationText", () => {
+  it("appends the PR title, clamped to the stable budget", () => {
+    expect(celebrationText({ prNumber: 42 })).toBe("✓ #42 merged");
+    expect(celebrationText({ prNumber: 42, title: "fix the hooks" })).toBe(
+      "✓ #42 merged · fix the hooks",
+    );
+    const long = celebrationText({
+      prNumber: 42,
+      title: "a very long pull request title that keeps going",
+    });
+    expect(long.endsWith("…")).toBe(true);
+    expect(long.length).toBe("✓ #42 merged · ".length + 28);
   });
 });
 
@@ -60,7 +130,6 @@ describe("attentionLines", () => {
   it("swaps to the queue line only when several sessions ask", () => {
     expect(attentionLines(1)).toEqual(["needs your attention", "↵ or click to focus"]);
     expect(attentionLines(3)).toEqual(["! 3 need you ›", "↵ or click to focus"]);
-    // The painted queue depth clamps to the 2-digit width budget.
     expect(attentionLines(120)[0]).toBe("! 99 need you ›");
   });
 });

--- a/station/src/stationButton/layout.ts
+++ b/station/src/stationButton/layout.ts
@@ -1,5 +1,7 @@
 // Geometry and sizing math for the station button (no React, no colors).
 
+import type { ProjectRollupEntry, StationButtonStatus } from "./status.js";
+
 // Terminal glyph form of the black vector mark in station/assets/station-icon.svg.
 export const STATION_ICON = "⧉";
 export const ATTENTION_MARK = "!";
@@ -38,6 +40,7 @@ const MAX_PAINTED_COUNT = 99;
 /** Per-project roll-up lines before the card folds the rest into "+N more". */
 export const ROLLUP_MAX_LINES = 5;
 const ROLLUP_GLYPH_COLS = 2; // status glyph + space before the project name
+const CELEBRATION_TITLE_COLS = 28;
 
 // Above the panes and the centered STATION popup (z30); below the app toast (z100).
 export const STATION_BUTTON_Z_INDEX = 50;
@@ -48,20 +51,62 @@ export const GRADIENT_EDGE = 4; // chars of soft fade at the text's revealing fr
 
 export type Dims = { width: number; height: number };
 
-export type IslandCelebration = { prNumber: number };
+export type IslandCelebration = { prNumber: number; title?: string | undefined };
 
-export type ButtonContent = {
-  attention: boolean;
-  workingCount: number;
-  readyCount: number;
-  idleCount: number;
-  sessionName?: string | undefined;
+export type IslandDisplayInput = {
+  status: StationButtonStatus;
   /** C3 opt-in: the collapsed rest state paints fleet counts, not the bare mark. */
   restCounts?: boolean | undefined;
-  /** C2 opt-in roll-up entries; the count drives the expanded card's height. */
-  projectRollup?: readonly unknown[] | undefined;
   celebration?: IslandCelebration | undefined;
 };
+
+/** What the island paints; one value drives both the content and targetDims. */
+export type IslandDisplay =
+  | { kind: "mark" }
+  | { kind: "alertMark" }
+  | { kind: "counts"; working: number; ready: number; idle: number }
+  | { kind: "celebration"; celebration: IslandCelebration }
+  | { kind: "alertCard"; sessionName: string; needsYouCount: number }
+  | { kind: "rollup"; entries: readonly ProjectRollupEntry[] }
+  | { kind: "summary"; working: number; idle: number };
+
+/** The island's single display-priority ladder, per hover state. */
+export function islandDisplay(input: IslandDisplayInput, expanded: boolean): IslandDisplay {
+  const status = input.status;
+  if (expanded) {
+    if (status.attention) {
+      return {
+        kind: "alertCard",
+        sessionName: status.sessionName ?? "session",
+        needsYouCount: status.needsYouCount,
+      };
+    }
+    if (status.projectRollup !== undefined && status.projectRollup.length > 0) {
+      return { kind: "rollup", entries: status.projectRollup };
+    }
+    return {
+      kind: "summary",
+      working: status.workingCount,
+      // Ready sessions read as idle in the totals (the fleet breakdown keeps them disjoint).
+      idle: status.readyCount + status.idleCount,
+    };
+  }
+  if (status.attention) {
+    return { kind: "alertMark" };
+  }
+  if (input.celebration !== undefined) {
+    return { kind: "celebration", celebration: input.celebration };
+  }
+  if (input.restCounts === true) {
+    return {
+      kind: "counts",
+      working: status.workingCount,
+      ready: status.readyCount,
+      idle: status.idleCount,
+    };
+  }
+  return { kind: "mark" };
+}
 
 export function sessionSummary(count: number, verb: string): string {
   return `${count} session${count === 1 ? "" : "s"} ${verb}`;
@@ -79,7 +124,16 @@ export function attentionLines(needsYouCount: number): readonly [string, string]
 }
 
 export function celebrationText(celebration: IslandCelebration): string {
-  return `✓ #${celebration.prNumber} merged`;
+  const base = `✓ #${celebration.prNumber} merged`;
+  const title = celebration.title?.trim();
+  if (title === undefined || title.length === 0) {
+    return base;
+  }
+  const clamped =
+    title.length <= CELEBRATION_TITLE_COLS
+      ? title
+      : `${title.slice(0, CELEBRATION_TITLE_COLS - 1)}…`;
+  return `${base} · ${clamped}`;
 }
 
 /** Painted roll-up rows: the first ROLLUP_MAX_LINES entries, plus one "+N more" fold. */
@@ -93,25 +147,48 @@ export function clampSessionName(name: string): string {
   return name.length <= STABLE_NAME_COLS ? name : `${name.slice(0, STABLE_NAME_COLS - 1)}…`;
 }
 
-export function targetDims(expanded: boolean, content: ButtonContent): Dims {
-  const { attention } = content;
-  if (!expanded) {
-    if (attention) {
+export function targetDims(display: IslandDisplay): Dims {
+  switch (display.kind) {
+    case "mark":
+      return { width: COLLAPSED_BASE_COLS, height: COLLAPSED_BASE_ROWS };
+    case "alertMark":
       return { width: COLLAPSED_ATTENTION_COLS, height: COLLAPSED_ATTENTION_ROWS };
-    }
-    if (content.celebration !== undefined) {
-      const interior = ICON_COLS + 1 + celebrationText(content.celebration).length;
+    case "counts":
+      return { width: COLLAPSED_COUNTS_COLS, height: COLLAPSED_BASE_ROWS };
+    case "celebration": {
+      const interior = ICON_COLS + 1 + celebrationText(display.celebration).length;
       return { width: interior + 2 * ICON_PAD + 2, height: COLLAPSED_BASE_ROWS };
     }
-    if (content.restCounts === true) {
-      return { width: COLLAPSED_COUNTS_COLS, height: COLLAPSED_BASE_ROWS };
+    case "alertCard": {
+      // Clamp the name's contribution so the card width never tracks the live
+      // session name (the painted name is truncated to match — clampSessionName).
+      const nameCols = Math.min(display.sessionName.length, STABLE_NAME_COLS);
+      const iconRow = ICON_COLS + 1 + nameCols;
+      const body = CONTENT_INDENT + longest(ATTENTION_LINES);
+      return {
+        width: Math.max(iconRow, body) + EXPANDED_RIGHT_PAD + 2,
+        height: EXPANDED_ATTENTION_ROWS,
+      };
     }
-    return { width: COLLAPSED_BASE_COLS, height: COLLAPSED_BASE_ROWS };
+    case "rollup":
+      // Fixed name budget (names clamp to match), so renames/new projects only
+      // ever change the card's height, never its width.
+      return {
+        width: CONTENT_INDENT + ROLLUP_GLYPH_COLS + STABLE_NAME_COLS + EXPANDED_RIGHT_PAD + 2,
+        height:
+          EXPANDED_BORDER_ROWS + 1 + rollupLineCount(display.entries.length) + EXPANDED_BOTTOM_PAD_ROWS,
+      };
+    case "summary": {
+      // Measure with a stable count, not the live values: the card is anchored top-right, so a width
+      // change on a count tick slides it out from under a stationary cursor and reads as a hover leave.
+      const body =
+        CONTENT_INDENT + Math.max(summaryColumns("working"), summaryColumns("idle"));
+      return {
+        width: Math.max(ICON_COLS, body) + EXPANDED_RIGHT_PAD + 2,
+        height: EXPANDED_BASE_ROWS,
+      };
+    }
   }
-  return {
-    width: expandedInteriorWidth(content) + EXPANDED_RIGHT_PAD + 2,
-    height: expandedRows(content),
-  };
 }
 
 // The collapsed counts row measures with 2-digit lanes (`⠿88 ●88 ○88`) so live
@@ -119,40 +196,6 @@ export function targetDims(expanded: boolean, content: ButtonContent): Dims {
 const STABLE_COUNT_LANES_COLS = 3 * (1 + 2) + 2;
 export const COLLAPSED_COUNTS_COLS =
   ICON_COLS + 1 + STABLE_COUNT_LANES_COLS + 2 * ICON_PAD + 2;
-
-function expandedRows(content: ButtonContent): number {
-  if (content.attention) {
-    return EXPANDED_ATTENTION_ROWS;
-  }
-  const rollupLines = rollupLineCount(content.projectRollup?.length ?? 0);
-  if (rollupLines > 0) {
-    return EXPANDED_BORDER_ROWS + 1 + rollupLines + EXPANDED_BOTTOM_PAD_ROWS;
-  }
-  return EXPANDED_BASE_ROWS;
-}
-
-// Widest content row inside the card (borders/right pad excluded).
-function expandedInteriorWidth(content: ButtonContent): number {
-  if (content.attention) {
-    // Clamp the name's contribution so the card width never tracks the live
-    // session name (the painted name is truncated to match — clampSessionName).
-    const nameCols = Math.min((content.sessionName ?? "session").length, STABLE_NAME_COLS);
-    const iconRow = ICON_COLS + 1 + nameCols;
-    const body = CONTENT_INDENT + longest(ATTENTION_LINES);
-    return Math.max(iconRow, body);
-  }
-  if ((content.projectRollup?.length ?? 0) > 0) {
-    // Fixed name budget (names clamp to match), so renames/new projects only
-    // ever change the card's height, never its width.
-    return CONTENT_INDENT + ROLLUP_GLYPH_COLS + STABLE_NAME_COLS;
-  }
-  // Measure with a stable count, not the live values: the card is anchored top-right, so a width
-  // change on a count tick slides it out from under a stationary cursor and reads as a hover leave.
-  const body =
-    CONTENT_INDENT +
-    Math.max(summaryColumns("working"), summaryColumns("idle"));
-  return Math.max(ICON_COLS, body);
-}
 
 function summaryColumns(verb: string): number {
   return sessionSummary(STABLE_SUMMARY_COUNT, verb).length;

--- a/station/src/stationButton/useMergeCelebration.test.tsx
+++ b/station/src/stationButton/useMergeCelebration.test.tsx
@@ -20,7 +20,13 @@ function CelebrationProbe({
   ttlMs: number;
 }) {
   const celebration = useMergeCelebration(store, ttlMs);
-  return <text>{celebration === undefined ? "quiet" : `pr:${celebration.prNumber}`}</text>;
+  return (
+    <text>
+      {celebration === undefined
+        ? "quiet"
+        : `pr:${celebration.prNumber}:${celebration.title ?? ""}`}
+    </text>
+  );
 }
 
 function withMergedPr(snapshot: StationSnapshot, worktreeId: string): StationSnapshot {
@@ -31,7 +37,7 @@ function withMergedPr(snapshot: StationSnapshot, worktreeId: string): StationSna
       if (row.id !== worktreeId || pr === undefined) {
         return row;
       }
-      return { ...row, worktree: { ...row.worktree, pr: { ...pr, state: "merged" as const } } };
+      return { ...row, worktree: { ...row.worktree, pr: { ...pr, state: "merged" as const, title: "ship it" } } };
     }),
   };
 }
@@ -63,7 +69,7 @@ describe("useMergeCelebration", () => {
       // The state update commits on the next macrotask beat.
       await new Promise((resolve) => setTimeout(resolve, 20));
       await setup.flush();
-      expect(setup.captureCharFrame()).toContain("pr:76");
+      expect(setup.captureCharFrame()).toContain("pr:76:ship it");
 
       await new Promise((resolve) => setTimeout(resolve, 120));
       await setup.flush();

--- a/station/src/stationButton/useMergeCelebration.ts
+++ b/station/src/stationButton/useMergeCelebration.ts
@@ -44,7 +44,7 @@ export function useMergeCelebration(
           before.number === pr.number &&
           before.state !== "merged"
         ) {
-          merged = { prNumber: pr.number };
+          merged = { prNumber: pr.number, ...(pr.title === undefined ? {} : { title: pr.title }) };
         }
       }
       seen.current = next;


### PR DESCRIPTION
PR8(a) slice 1 plus two fixes from live screenshot feedback.

## PR title (backend slice)

- `WorktreePullRequest.title` (optional, strict) — added to the `gh pr list` field set and mapped at the provider boundary with the existing typed-builder pattern; provider test asserts the mapping.
- The island merge celebration reads **`✓ #42 merged · <title>`** (clamped to 28 cols so the card width stays stable for its lifetime); `useMergeCelebration` captures the title at the merged transition.
- `fastForward`/`mergeMethod` deliberately deferred: the fast-forward fact derives from ahead/behind already in the snapshot, and there's no M7 card surface to consume a merge method yet.

## IslandDisplay inversion (owner-flagged in the plan)

`islandDisplay(input, expanded)` computes one discriminated union (`mark / alertMark / counts / celebration / alertCard / rollup / summary`); the display-priority ladder now exists once, `targetDims` switches on the same value the renderer paints, and `DynamicStationButton` props collapse from ~14 fields to `input` + handlers.

## Live feedback fixes

- **`#N merged` word removed from the PR lane** — with several merged PRs on screen it read as noise (the mock only ever showed one); purple carries merged again.
- **Column header hidden for now** — the synthetic header row stays in the grid solve so lane minimums and column geometry hold; only the painted row and its height slot are gone (body +1 row, windowing tests shifted).

## Tests

`pnpm typecheck` / `lint` / `test:unit` (1065) green; station `bun test` (882) green after `pnpm build`; github provider suite green with the title fixture. New coverage: `islandDisplay` ladder ranking, celebration title clamp, title capture at the merged transition. Goldens regenerated (header row removal). Verified live in mock mode.