### PR TITLE
feat(contracts): harness version probe → M10 update badge

### DIFF
--- a/apps/observer/src/providers/registry.ts
+++ b/apps/observer/src/providers/registry.ts
@@ -1,5 +1,6 @@
 import type {
   HarnessProvider,
+  HarnessVersionInfo,
   ProviderHookAdapter,
   ProviderId,
   RepositoryProvider,
@@ -96,4 +97,47 @@ export class ProviderRegistry {
     }
     return provider;
   }
+
+  /** Version probe results; snapshots read this synchronously and omit absentees. */
+  readonly harnessVersions = new Map<string, HarnessVersionInfo>();
+
+  /**
+   * Best-effort background probe (D17): fire-and-forget at boot. Each probe is
+   * timeboxed and a failure simply leaves the harness out of the cache, so
+   * reconciliation never waits on a CLI or the network.
+   */
+  async refreshHarnessVersions(options?: { timeoutMs?: number }): Promise<void> {
+    const timeoutMs = options?.timeoutMs ?? 15_000;
+    await Promise.all(
+      Array.from(this.harnesses.values()).map(async (provider) => {
+        if (provider.versionInfo === undefined) {
+          return;
+        }
+        try {
+          const info = await withTimeout(provider.versionInfo(), timeoutMs);
+          if (info.installedVersion !== undefined || info.latestVersion !== undefined) {
+            this.harnessVersions.set(provider.id, info);
+          }
+        } catch {
+          // Unknown stays unknown; consumers omit the badge.
+        }
+      }),
+    );
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("version probe timed out")), timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
 }

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -225,10 +225,20 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
 }
 
 export function harnessesFromRegistry(providers: ProviderRegistry): SnapshotHarness[] {
-  return Array.from(providers.harnesses.values()).map((provider) => ({
-    id: provider.id,
-    label: provider.id,
-  }));
+  return Array.from(providers.harnesses.values()).map((provider) => {
+    const harness: SnapshotHarness = { id: provider.id, label: provider.id };
+    const version = providers.harnessVersions.get(provider.id);
+    if (version?.installedVersion !== undefined) {
+      harness.installedVersion = version.installedVersion;
+    }
+    if (version?.latestVersion !== undefined) {
+      harness.latestVersion = version.latestVersion;
+    }
+    if (harness.installedVersion !== undefined && harness.latestVersion !== undefined) {
+      harness.updateAvailable = harness.installedVersion !== harness.latestVersion;
+    }
+    return harness;
+  });
 }
 
 function normalizeTerminalTargetsForCurrentWorktrees(input: {

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -82,6 +82,8 @@ export async function runObserverMain(
     providerOptions.configPath = loadedConfig.configPath;
   }
   const providers = deps.providerRegistryFactory(config, providerOptions);
+  // Fire-and-forget: version badges appear on a later snapshot when probes land.
+  void providers.refreshHarnessVersions();
   const featureFlags = createFeatureFlagEvaluator({
     ...(config.featureFlags === undefined ? {} : { overrides: config.featureFlags }),
     revisionSeed: loadedConfig.configPath,

--- a/apps/observer/test/unit/harness-versions.test.ts
+++ b/apps/observer/test/unit/harness-versions.test.ts
@@ -1,0 +1,90 @@
+import type { HarnessProvider } from "@station/contracts";
+import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
+import { describe, expect, it } from "vitest";
+import { ProviderRegistry } from "../../src/providers/registry.js";
+import { harnessesFromRegistry } from "../../src/reconcile/run.js";
+
+const now = "2026-06-19T12:00:00.000Z";
+
+function withVersionInfo(
+  provider: HarnessProvider,
+  versionInfo: HarnessProvider["versionInfo"],
+): HarnessProvider {
+  const wrapped = Object.create(provider) as HarnessProvider;
+  if (versionInfo !== undefined) {
+    wrapped.versionInfo = versionInfo;
+  }
+  return wrapped;
+}
+
+function registryWith(...harnesses: HarnessProvider[]): ProviderRegistry {
+  return new ProviderRegistry({
+    worktree: new FakeWorktreeProvider({ now, worktrees: [] }),
+    terminal: new FakeTerminalProvider({ now }),
+    harnesses,
+  });
+}
+
+describe("harness version cache", () => {
+  it("caches probe results and derives updateAvailable when both versions differ", async () => {
+    const outdated = withVersionInfo(new FakeHarnessProvider({ now }), async () => ({
+      installedVersion: "0.3.0",
+      latestVersion: "0.4.0",
+    }));
+    const registry = registryWith(outdated);
+    await registry.refreshHarnessVersions();
+
+    expect(harnessesFromRegistry(registry)).toEqual([
+      {
+        id: outdated.id,
+        label: outdated.id,
+        installedVersion: "0.3.0",
+        latestVersion: "0.4.0",
+        updateAvailable: true,
+      },
+    ]);
+  });
+
+  it("omits updateAvailable when versions match or half is unknown", async () => {
+    const fresh = withVersionInfo(new FakeHarnessProvider({ now }), async () => ({
+      installedVersion: "1.0.0",
+      latestVersion: "1.0.0",
+    }));
+    const registry = registryWith(fresh);
+    await registry.refreshHarnessVersions();
+    expect(harnessesFromRegistry(registry)[0]?.updateAvailable).toBe(false);
+
+    const partial = withVersionInfo(new FakeHarnessProvider({ now }), async () => ({
+      installedVersion: "1.0.0",
+    }));
+    const partialRegistry = registryWith(partial);
+    await partialRegistry.refreshHarnessVersions();
+    expect(harnessesFromRegistry(partialRegistry)[0]).toEqual({
+      id: partial.id,
+      label: partial.id,
+      installedVersion: "1.0.0",
+    });
+  });
+
+  it("leaves failing or capability-less providers out of the cache", async () => {
+    const failing = withVersionInfo(new FakeHarnessProvider({ now }), async () => {
+      throw new Error("probe exploded");
+    });
+    const registry = registryWith(failing);
+    await registry.refreshHarnessVersions();
+    expect(registry.harnessVersions.size).toBe(0);
+    expect(harnessesFromRegistry(registry)).toEqual([{ id: failing.id, label: failing.id }]);
+
+    const plain = new FakeHarnessProvider({ now });
+    const plainRegistry = registryWith(plain);
+    await plainRegistry.refreshHarnessVersions();
+    expect(plainRegistry.harnessVersions.size).toBe(0);
+  });
+
+  it("times out a hung probe without failing the refresh", async () => {
+    const hung = withVersionInfo(new FakeHarnessProvider({ now }), () => new Promise(() => {}));
+    const registry = registryWith(hung);
+    await registry.refreshHarnessVersions({ timeoutMs: 20 });
+    expect(registry.harnessVersions.size).toBe(0);
+  });
+});

--- a/integrations/harness/claude/src/provider.ts
+++ b/integrations/harness/claude/src/provider.ts
@@ -84,6 +84,7 @@ const claudeSpec: TerminalBoundHarnessProviderSpec<ClaudeHarnessProviderOptions>
   },
   doctorChecks,
   hooksStatus,
+  version: { latestPackage: "@anthropic-ai/claude-code" },
 };
 
 function command(options: ClaudeHarnessProviderOptions): string {

--- a/integrations/harness/codex/src/provider.ts
+++ b/integrations/harness/codex/src/provider.ts
@@ -82,6 +82,7 @@ const codexSpec: TerminalBoundHarnessProviderSpec<CodexHarnessProviderOptions> =
   },
   doctorChecks,
   hooksStatus,
+  version: { latestPackage: "@openai/codex" },
 };
 
 function command(options: CodexHarnessProviderOptions): string {

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -408,11 +408,24 @@ export interface TerminalReattachCapability {
   reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined>;
 }
 
+/** Best-effort version probe result; omit fields (or the method) when unknown. */
+export type HarnessVersionInfo = {
+  installedVersion?: string;
+  latestVersion?: string;
+};
+
 export interface HarnessProvider {
   id: ProviderId;
   capabilities(): HarnessCapabilities;
   health(): Promise<ProviderHealth>;
   doctorChecks?(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]>;
+  /**
+   * Best-effort, offline-safe version probe: installed from the local CLI,
+   * latest from a cached registry lookup. The observer calls this once in the
+   * background and caches the result — it must never gate reconciliation, and
+   * failures should resolve to an empty object rather than throw.
+   */
+  versionInfo?(): Promise<HarnessVersionInfo>;
   /**
    * Report whether this harness's status hooks are installed. Optional: a
    * harness that cannot determine hook installation omits it, and callers

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -214,6 +214,12 @@ export const SnapshotHarnessSchema = z
   .object({
     id: ProviderIdSchema,
     label: nonEmptyStringSchema,
+    /** Best-effort local CLI version; absent when the probe failed or hasn't run. */
+    installedVersion: nonEmptyStringSchema.optional(),
+    /** Best-effort registry version from a cached, offline-safe lookup. */
+    latestVersion: nonEmptyStringSchema.optional(),
+    /** Set only when both versions are known; consumers omit the badge otherwise. */
+    updateAvailable: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -4,6 +4,7 @@ import type {
   ProviderHealth,
   ProviderId,
   SessionView,
+  SnapshotHarness,
   StationSnapshot,
   WorktreeRow,
 } from "@station/contracts";
@@ -71,6 +72,8 @@ export type NewSessionHarnessOption = {
   status: ProviderHealth["status"];
   createBlocked: boolean;
   health?: ProviderHealth;
+  /** Set only when the snapshot knows both versions and they differ (M10 badge). */
+  update?: { installed: string; latest: string };
 };
 
 export function keyChoices<T>(values: readonly T[]): Array<KeyedChoice<T>> {
@@ -159,6 +162,7 @@ export function selectNewSessionHarnessOptions(
 ): NewSessionHarnessOption[] {
   const configured = configuredHarnesses(snapshot);
   const labels = new Map(configured.map((harness) => [harness.id, harness.label]));
+  const byId = new Map(configured.map((harness) => [harness.id, harness]));
   const orderedIds = configured.map((harness) => harness.id);
   const seen = new Set<string>();
   const options: NewSessionHarnessOption[] = [];
@@ -177,6 +181,14 @@ export function selectNewSessionHarnessOptions(
     };
     if (health !== undefined) {
       option.health = health;
+    }
+    const harness = byId.get(id);
+    if (
+      harness?.updateAvailable === true &&
+      harness.installedVersion !== undefined &&
+      harness.latestVersion !== undefined
+    ) {
+      option.update = { installed: harness.installedVersion, latest: harness.latestVersion };
     }
     options.push(option);
   }
@@ -274,7 +286,7 @@ function normalizeSearch(value: string): string {
   return value.trim().toLocaleLowerCase();
 }
 
-function configuredHarnesses(snapshot: StationSnapshot) {
+function configuredHarnesses(snapshot: StationSnapshot): readonly SnapshotHarness[] {
   if (snapshot.harnesses !== undefined) {
     return snapshot.harnesses;
   }

--- a/packages/dashboard-core/test/unit/selectors/selectors.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/selectors.test.ts
@@ -1,3 +1,4 @@
+import type { ProviderId } from "@station/contracts";
 import type { TuiViewState } from "@station/dashboard-core";
 import {
   choiceValueByKey,
@@ -7,6 +8,7 @@ import {
   SELECTION_KEYS,
   selectDashboardRowChoices,
   selectNewSessionHarnessChoices,
+  selectNewSessionHarnessOptions,
   selectNewSessionProjectChoices,
   selectProjectChoices,
   selectProjectGroups,
@@ -304,5 +306,34 @@ describe("TUI selectors", () => {
       ["2", "opencode"],
       ["3", "scripted"],
     ]);
+  });
+});
+
+describe("selectNewSessionHarnessOptions update badge", () => {
+  it("carries the update pair only when the snapshot knows both versions differ", () => {
+    const base = createDashboardSnapshot();
+    const snapshot = {
+      ...base,
+      harnesses: [
+        {
+          id: "codex" as ProviderId,
+          label: "codex",
+          installedVersion: "0.3.0",
+          latestVersion: "0.4.0",
+          updateAvailable: true,
+        },
+        { id: "opencode" as ProviderId, label: "opencode", installedVersion: "1.0.0" },
+      ],
+    };
+    const project = snapshot.projects[0];
+    if (project === undefined) {
+      throw new Error("fixture is expected to contain a project");
+    }
+    const options = selectNewSessionHarnessOptions(snapshot, project);
+    expect(options.find((option) => option.id === "codex")?.update).toEqual({
+      installed: "0.3.0",
+      latest: "0.4.0",
+    });
+    expect(options.find((option) => option.id === "opencode")?.update).toBeUndefined();
   });
 });

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -9,6 +9,7 @@ import type {
   HarnessProvider,
   HarnessRunObservation,
   HarnessStatusObservation,
+  HarnessVersionInfo,
   ProviderDoctorCheck,
   ProviderDoctorContext,
   ProviderHealth,
@@ -42,6 +43,13 @@ export type HarnessHealthSpec = {
   unavailableError: (error: unknown) => SafeError;
 };
 
+export type HarnessVersionSpec = {
+  /** CLI args that print the installed version; defaults to ["--version"]. */
+  args?: string[];
+  /** npm package consulted for the latest release; omit to skip the lookup. */
+  latestPackage?: string;
+};
+
 export type HarnessIngestSpec = {
   operation: string;
   errorCode: string;
@@ -70,6 +78,7 @@ export type TerminalBoundHarnessProviderSpec<TOpts extends CommonHarnessProvider
     options: TOpts,
     context?: ProviderDoctorContext,
   ) => Promise<ProviderDoctorCheck[]>;
+  version?: HarnessVersionSpec;
   hooksStatus?: (options: TOpts, context?: ProviderDoctorContext) => Promise<HarnessHooksStatus>;
 };
 
@@ -106,7 +115,65 @@ export function createTerminalBoundHarnessProvider<TOpts extends CommonHarnessPr
   if (hooksStatus) {
     provider.hooksStatus = (context) => hooksStatus(options, context);
   }
+  const version = spec.version;
+  if (version) {
+    provider.versionInfo = () => harnessVersionInfo(spec, version, options);
+  }
   return provider;
+}
+
+/**
+ * Best-effort per D17: each half runs under its own timeout and a failure
+ * simply omits the field — offline or missing npm yields no badge, never an
+ * error. The observer caches the result; this is not called per reconcile.
+ */
+async function harnessVersionInfo<TOpts extends CommonHarnessProviderOptions>(
+  spec: TerminalBoundHarnessProviderSpec<TOpts>,
+  version: HarnessVersionSpec,
+  options: TOpts,
+): Promise<HarnessVersionInfo> {
+  const info: HarnessVersionInfo = {};
+  try {
+    const result = await runExternalCommand(
+      {
+        command: harnessCommand(options, spec.commandEnvVar, spec.commandFallback),
+        args: version.args ?? ["--version"],
+        timeoutMs: options.timeoutMs ?? 5000,
+        maxOutputChars: 4096,
+      },
+      options.runner,
+    );
+    const installed = parseVersionToken(result.stdout);
+    if (installed !== undefined) {
+      info.installedVersion = installed;
+    }
+  } catch {
+    // Unknown stays unknown.
+  }
+  if (version.latestPackage !== undefined) {
+    try {
+      const result = await runExternalCommand(
+        {
+          command: "npm",
+          args: ["view", version.latestPackage, "version"],
+          timeoutMs: options.timeoutMs ?? 5000,
+          maxOutputChars: 4096,
+        },
+        options.runner,
+      );
+      const latest = parseVersionToken(result.stdout);
+      if (latest !== undefined) {
+        info.latestVersion = latest;
+      }
+    } catch {
+      // Unknown stays unknown.
+    }
+  }
+  return info;
+}
+
+function parseVersionToken(output: string): string | undefined {
+  return output.match(/\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?/)?.[0];
 }
 
 export function harnessCommand(

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -164,3 +164,44 @@ describe("createTerminalBoundHarnessProvider", () => {
     expect("hooksStatus" in provider).toBe(true);
   });
 });
+
+describe("versionInfo", () => {
+  it("stays absent when the spec declares no version block", () => {
+    const provider = createTerminalBoundHarnessProvider(baseSpec(), {});
+    expect(provider.versionInfo).toBeUndefined();
+  });
+
+  it("parses installed and latest version tokens from the probes", async () => {
+    const provider = createTerminalBoundHarnessProvider(
+      baseSpec({ version: { latestPackage: "@example/test-cli" } }),
+      {
+        now: () => now,
+        runner: async (input) => ({
+          stdout: input.command === "npm" ? "1.4.0\n" : "test-cli 1.2.3 (build abc)\n",
+          stderr: "",
+          exitCode: 0,
+        }),
+      },
+    );
+    await expect(provider.versionInfo?.()).resolves.toEqual({
+      installedVersion: "1.2.3",
+      latestVersion: "1.4.0",
+    });
+  });
+
+  it("omits whatever half fails and never rejects", async () => {
+    const provider = createTerminalBoundHarnessProvider(
+      baseSpec({ version: { latestPackage: "@example/test-cli" } }),
+      {
+        now: () => now,
+        runner: async (input) => {
+          if (input.command === "npm") {
+            throw new Error("offline");
+          }
+          return { stdout: "test-cli 1.2.3\n", stderr: "", exitCode: 0 };
+        },
+      },
+    );
+    await expect(provider.versionInfo?.()).resolves.toEqual({ installedVersion: "1.2.3" });
+  });
+});

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -316,7 +316,13 @@ function snapshotFromRows(rows: WorktreeRow[], extras: SnapshotExtras): StationS
     },
     providerHealth: extras.providerHealth ?? {},
     harnesses: [
-      { id: "codex", label: "codex" },
+      {
+        id: "codex",
+        label: "codex",
+        installedVersion: "0.3.0",
+        latestVersion: "0.4.0",
+        updateAvailable: true,
+      },
       { id: "opencode", label: "opencode" },
     ],
     projects,

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
    ┌────────────────────────────────────────────────────────────────────────┐   
 ▼ s│ Project settings                                                       │▾] 
  [1│ station                  │ Default agent                               │ ✓ 
- [2│▸ Default agent           │✓1 codex unknown                             │   
+ [2│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │   
  [3│  Remove project          │ 2 opencode unknown                          │ ✓ 
  [4│                          │                                             │   
  [5│                          │ ✓ current · 1-9/a-z select                  │ … 
@@ -174,7 +174,7 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
    ┌────────────────────────────────────────────────────────────────────────┐   
 ▼ s│ Project settings                                                       │▾] 
  [1│ station                  │ Default agent                               │ ✓ 
- [2│▸ Default agent           │ 1 codex unknown                             │   
+ [2│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │   
  [3│  Remove project          │✓2 opencode unknown                 updating…│ ✓ 
  [4│                          │                                             │   
  [5│                          │ ✓ current · 1-9/a-z select                  │ … 
@@ -468,7 +468,7 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
-│ 1 codex unknown                                                              │
+│ 1 codex ● update v0.3.0 → v0.4.0                                             │
 │ 2 opencode unknown                                                           │
 │                                                                              │
 │ 1-9/a-z:select   Esc:back                                                    │
@@ -496,7 +496,7 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
-│✓1 codex unknown                                                              │
+│✓1 codex ● update v0.3.0 → v0.4.0                                             │
 │ 2 opencode unknown                                                           │
 │                                                                              │
 │ ✓ current   1-9/a-z:select   Esc:cancel                                      │

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -137,7 +137,11 @@ const CASES: ModalCase[] = [
       store.setState(openProjectDefaultAgentPicker(store.getState(), "station"));
     },
     trimSnapshotTrailingWhitespace: true,
-    expect: ["Select default agent for station", "1-9/a-z:select   Esc:cancel", "codex"],
+    expect: [
+      "Select default agent for station",
+      "1-9/a-z:select   Esc:cancel",
+      "codex ● update v0.3.0 → v0.4.0",
+    ],
   },
   {
     name: "add project sheet",

--- a/station/src/station/view/sheets/AgentChoiceListView.tsx
+++ b/station/src/station/view/sheets/AgentChoiceListView.tsx
@@ -1,5 +1,5 @@
 import type { KeyedChoice, NewSessionHarnessOption } from "@station/dashboard-core";
-import { providerHealthStatusColor } from "../theme.js";
+import { providerHealthStatusColor, STATION_COLORS } from "../theme.js";
 import { SheetChoiceLine } from "./parts.js";
 
 export type AgentChoiceListViewProps = {
@@ -21,13 +21,27 @@ export function AgentChoiceListView({
     <>
       {choices.map((choice) => {
         const current = choice.value.id === currentId;
+        // The update nudge never displaces a problem status — unavailable or
+        // degraded providers keep their state as the row's detail.
+        const update =
+          choice.value.status === "healthy" || choice.value.status === "unknown"
+            ? choice.value.update
+            : undefined;
         return (
           <SheetChoiceLine
             key={choice.value.id}
             choiceKey={choice.key}
             label={choice.value.label}
-            detail={choice.value.status}
-            color={providerHealthStatusColor(choice.value.status)}
+            detail={
+              update === undefined
+                ? choice.value.status
+                : `● update v${update.installed} → v${update.latest}`
+            }
+            color={
+              update === undefined
+                ? providerHealthStatusColor(choice.value.status)
+                : STATION_COLORS.green
+            }
             width={width}
             current={current}
             {...(current && pending ? { note: "updating…" } : {})}


### PR DESCRIPTION
PR8(b) — the plan's final backend slice (D2, D17): best-effort harness versions powering the M10 picker's update badge.

## Contract

`SnapshotHarness` gains `installedVersion` / `latestVersion` / `updateAvailable` (all optional, strict). `updateAvailable` is set only when both versions are known and differ — consumers omit the badge otherwise (D17: never show a guess).

## Provider capability

`HarnessProvider.versionInfo?()` — implemented **once** in `harness-shared` behind a one-line spec opt-in:

- installed: the harness CLI's `--version` (spec-overridable args), semver token parsed from stdout
- latest: `npm view <latestPackage> version`
- each half under its own timeout; any failure resolves to an omitted field, never a rejection — offline or npm-less machines just get no badge
- `claude` (`@anthropic-ai/claude-code`) and `codex` (`@openai/codex`) opt in; the other harnesses fail open

## Observer

One fire-and-forget probe at boot into a registry-level cache; `harnessesFromRegistry` reads it synchronously, so version lookups can never gate reconciliation. A hung probe is timeboxed and simply stays out of the cache. Badges appear on the first snapshot after probes land.

## UI (M10)

The agent picker and the project-settings agent pane render `● update v0.3.0 → v0.4.0` in green. A problem status (unavailable/degraded) is never displaced by the nudge. Verified live in mock mode (fixture carries an outdated codex).

## Tests

`pnpm typecheck` / `lint` / `test:unit` (1073) green; station `bun test` (882) green after `pnpm build`. New: harness-shared versionInfo probes (parse/omit/never-reject), observer cache derivation + timeout isolation (4 cases), selector update-pair gating, picker golden pinned to the badge text.