### PR TITLE
feat(dashboard): breathing row above FLEET + column headers back below the divider

### DIFF
--- a/apps/observer/src/providers/registry.ts
+++ b/apps/observer/src/providers/registry.ts
@@ -7,6 +7,7 @@ import type {
   TerminalProvider,
   WorktreeProvider,
 } from "@station/contracts";
+import { withTimeout } from "@station/runtime";
 import { createTerminalIntentRunner, type TerminalIntentRunner } from "./terminalIntentRunner.js";
 
 export type ProviderRegistryInput = {
@@ -110,11 +111,26 @@ export class ProviderRegistry {
     const timeoutMs = options?.timeoutMs ?? 15_000;
     await Promise.all(
       Array.from(this.harnesses.values()).map(async (provider) => {
-        if (provider.versionInfo === undefined) {
+        const versionInfo = provider.versionInfo;
+        if (versionInfo === undefined) {
           return;
         }
         try {
-          const info = await withTimeout(provider.versionInfo(), timeoutMs);
+          const info = await withTimeout(() => versionInfo(), {
+            timeoutMs,
+            error: {
+              tag: "RuntimeError",
+              code: "HARNESS_VERSION_PROBE_FAILED",
+              message: "Harness version probe failed.",
+              provider: provider.id,
+            },
+            timeoutError: {
+              tag: "TimeoutError",
+              code: "HARNESS_VERSION_PROBE_TIMEOUT",
+              message: "Harness version probe timed out.",
+              provider: provider.id,
+            },
+          });
           if (info.installedVersion !== undefined || info.latestVersion !== undefined) {
             this.harnessVersions.set(provider.id, info);
           }
@@ -124,20 +140,4 @@ export class ProviderRegistry {
       }),
     );
   }
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error("version probe timed out")), timeoutMs);
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error) => {
-        clearTimeout(timer);
-        reject(error);
-      },
-    );
-  });
 }

--- a/packages/dashboard-core/src/components/Dashboard/layout.ts
+++ b/packages/dashboard-core/src/components/Dashboard/layout.ts
@@ -1,5 +1,6 @@
 // The title/widgets live on the frame's top border row, outside these rows.
 export const DASHBOARD_FIXED_ROW_HEIGHTS = {
+  topSpacer: 1,
   fleetBar: 1,
   topDivider: 1,
   topScrollIndicator: 1,

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -38,15 +38,15 @@ describe("dashboard viewport selector", () => {
     });
     const viewport = selectDashboardViewport(snapshot, state);
 
-    expect(viewport.bodyRows).toBe(4);
+    expect(viewport.bodyRows).toBe(3);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(6);
+    expect(viewport.hiddenBelow).toBe(7);
     expect(
       viewport.visibleItems.map((item) =>
         item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited", "wt_web_no_agent"]);
+    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
   });
 
   it("uses only viewport-visible worktrees for row choices", () => {
@@ -61,7 +61,6 @@ describe("dashboard viewport selector", () => {
       ["1", "wt_web_no_agent"],
       ["2", "wt_web_idle"],
       ["3", "wt_web_unknown"],
-      ["4", "wt_web_stuck"],
     ]);
   });
 
@@ -75,8 +74,8 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(7);
-    expect(viewport.hiddenAbove).toBe(7);
+    expect(viewport.clampedScrollOffset).toBe(8);
+    expect(viewport.hiddenAbove).toBe(8);
     expect(viewport.hiddenBelow).toBe(0);
     expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
   });

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -26,17 +26,17 @@ describe("dashboard focus cursor", () => {
 
   it("enters upward on the last visible session row", () => {
     const entered = handleTuiKey(state({ terminalRows: 12 }), UP).state;
-    // terminalRows 12 -> bodyRows 6: header + five session rows visible.
-    expect(entered.focusedRowId).toBe("wt_web_idle");
+    // terminalRows 12 -> bodyRows 5: header + four session rows visible.
+    expect(entered.focusedRowId).toBe("wt_web_no_agent");
   });
 
   it("scrolls the viewport to keep the cursor visible when walking past the bottom", () => {
     let current = state({ terminalRows: 12 });
-    for (let presses = 0; presses < 6; presses += 1) {
+    for (let presses = 0; presses < 5; presses += 1) {
       current = handleTuiKey(current, DOWN).state;
     }
-    expect(current.focusedRowId).toBe("wt_web_unknown");
-    // Item index 6 must sit inside the 6-row window: offset = 6 - 6 + 1.
+    expect(current.focusedRowId).toBe("wt_web_idle");
+    // Item index 5 must sit inside the 5-row window: offset = 5 - 5 + 1.
     expect(current.scrollOffset).toBe(1);
   });
 
@@ -62,8 +62,8 @@ describe("dashboard focus cursor", () => {
 
     const second = handleTuiKey(first, NEXT_NEEDS_ME).state;
     expect(second.focusedRowId).toBe("wt_web_stuck");
-    // The stuck row (item index 7) scrolled into the 6-row window.
-    expect(second.scrollOffset).toBe(2);
+    // The stuck row (item index 7) scrolled into the 5-row window.
+    expect(second.scrollOffset).toBe(3);
 
     const wrapped = handleTuiKey(second, NEXT_NEEDS_ME).state;
     expect(wrapped.focusedRowId).toBe("wt_web_attention");

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -50,7 +50,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(7);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(8);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", mouseScroll: "up" }).state
         .scrollOffset,
@@ -676,6 +676,6 @@ describe("TUI screen transitions", () => {
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.collapsedProjectIds.has("web")).toBe(true);
-    expect(transition.state.scrollOffset).toBe(0);
+    expect(transition.state.scrollOffset).toBe(1);
   });
 });

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -78,8 +78,8 @@ export function DashboardView({
   const firstRun = snapshot.projects.length === 0;
   const fleet = selectFleetSummary(snapshot);
   const keyByRow = new Map(viewport.displayRowChoices.map((choice) => [choice.value.id, choice.key]));
-  const { layoutByItem } = firstRun
-    ? { layoutByItem: new Map<string, RowGridLayout>() }
+  const { headerLayout, layoutByItem } = firstRun
+    ? { headerLayout: undefined, layoutByItem: new Map<string, RowGridLayout>() }
     : dashboardRowLayouts(viewport.visibleItems, keyByRow, contentColumns, viewState.focusedRowId);
   return (
     <box
@@ -89,11 +89,17 @@ export function DashboardView({
       paddingRight={1}
       onMouseScroll={stationMouseProps(dispatch, { kind: "body" }).onMouseScroll}
     >
+      <text> </text>
       {firstRun ? null : (
         <FleetBar summary={fleet} counts={snapshot.counts} columns={contentColumns} />
       )}
       <Divider columns={contentColumns} />
-      <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
+      {/* One shared row: column headers at rest, the above-overflow count while scrolled. */}
+      {viewport.sessionOverflow.above > 0 || headerLayout === undefined ? (
+        <ScrollIndicatorRow direction="above" overflow={viewport.sessionOverflow} />
+      ) : (
+        <ColumnHeaderRow layout={headerLayout} />
+      )}
       {firstRun ? (
         <box flexDirection="column" flexGrow={1}>
           <text fg={STATION_COLORS.foreground}>{truncateCells(FIRST_RUN_BODY_LABEL, contentColumns)}</text>
@@ -174,6 +180,16 @@ function FleetBar({
         ))}
       </text>
       {totals.length > 0 ? <text fg={STATION_COLORS.gray}>{totals}</text> : null}
+    </box>
+  );
+}
+
+function ColumnHeaderRow({ layout }: { layout: RowGridLayout }) {
+  return (
+    <box height={1} width="100%" overflow="hidden">
+      <text fg={STATION_COLORS.gray}>
+        <Segments segments={layout.segments} />
+      </text>
     </box>
   );
 }

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -1,9 +1,10 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -21,7 +22,6 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -29,9 +29,10 @@ exports[`dashboard golden frames renders many-projects at 80x24 1`] = `
 `;
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
+"                                                                                                                        
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-                                                                                                                        
+       SESSION                                   AGENT     STATUS                                             DIFF · PR 
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
  [2] - docs-cleanup                              -         no agent                                                     
@@ -66,16 +67,16 @@ exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
 exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
+"                                                            
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
-                                                            
+       SESSION                 AGENT     STATUS          PR 
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ○ cli-help-man            codex     idle         #70 ✓ 
  [2] - docs-cleanup            -         no agent           
@@ -85,33 +86,33 @@ exports[`dashboard golden frames renders many-projects at 60x16 1`] = `
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
  [6] x batch-export            opencode  exited        #8 ✓ 
- [7] ⠋ provider-hooks          opencode  working      #16 … 
-▼ 4 below · showing 7 of 11                                 
+▼ 5 below · showing 6 of 11                                 
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
 exports[`dashboard golden frames renders many-projects at 40x12 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0      
+"                                        
+FLEET  ● 0 ready  ⠋ 2 working  ! 0      
 ─────────────────────────────────────── 
-                                        
+       SESSION             STATUS       
 ▼ station  5 sessions · … [sh] [qs] [▾] 
  [1] ○ cli-help-man        idle         
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
  [4] + session-resume      starting     
- [5] ⠋ station-overlay     working      
-▼ 6 below · showing 5 of 11             
+▼ 7 below · showing 4 of 11             
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
-"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                        AGENT     STATUS                DIFF · PR 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
  [2] ? metadata-refresh               codex     unknown                   +3 -1 
@@ -130,16 +131,16 @@ exports[`dashboard golden frames renders attention-and-failures at 80x24 1`] = `
                                                                                 
                                                                                 
                                                                                 
-                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = `
-"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
+"                                                                                                                        
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle      2 projects · 6 sessions · 6 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-                                                                                                                        
+       SESSION                                   AGENT     STATUS                                             DIFF · PR 
 ▼ station  4 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ! hook-scope                                codex     Agent needs approval.                           +8 -2 #12 x2 
  [2] ? metadata-refresh                          codex     unknown                                                +3 -1 
@@ -174,16 +175,16 @@ exports[`dashboard golden frames renders attention-and-failures at 120x40 1`] = 
                                                                                                                         
                                                                                                                         
                                                                                                                         
-                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close                                          
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
-"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
+"                                                            
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown   
 ─────────────────────────────────────────────────────────── 
-                                                            
+       SESSION            AGENT     STATUS               PR 
 ▼ station  4 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ! hook-scope         codex     Agent needs app… #12 x2 
  [2] ? metadata-refresh   codex     unknown                 
@@ -194,22 +195,21 @@ exports[`dashboard golden frames renders attention-and-failures at 60x16 1`] = `
  [5] x done-run           opencode  exited                  
  [6] ! sqlite-cleanup     opencode  Agent needs appr… #6 x1 
                                                             
-                                                            
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
 `;
 
 exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
-"FLEET  ● 0 ready  ⠋ 1 working  ! 3      
+"                                        
+FLEET  ● 0 ready  ⠋ 1 working  ! 3      
 ─────────────────────────────────────── 
-                                        
+       SESSION                          
 ▼ station  4 sessions · … [sh] [qs] [▾] 
  [1] ! hook-scope                       
  [2] ? metadata-refresh                 
  [3] ! popup-latency                    
  [4] ⠋ pr-info                          
-                                        
 ▼ 2 below · showing 4 of 6              
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
@@ -217,10 +217,10 @@ exports[`dashboard golden frames renders attention-and-failures at 40x12 1`] = `
 `;
 
 exports[`dashboard golden frames renders no-projects at 80x24 1`] = `
-"─────────────────────────────────────────────────────────────────────────────── 
+"                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
 No projects configured yet.                                                     
-                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -245,10 +245,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 120x40 1`] = `
-"─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+"                                                                                                                        
+─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
 No projects configured yet.                                                                                             
-                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -289,10 +289,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 60x16 1`] = `
-"─────────────────────────────────────────────────────────── 
+"                                                            
+─────────────────────────────────────────────────────────── 
                                                             
 No projects configured yet.                                 
-                                                            
                                                             
                                                             
                                                             
@@ -309,10 +309,10 @@ A add project  Q/esc:close
 `;
 
 exports[`dashboard golden frames renders no-projects at 40x12 1`] = `
-"─────────────────────────────────────── 
+"                                        
+─────────────────────────────────────── 
                                         
 No projects configured yet.             
-                                        
                                         
                                         
                                         

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -1,27 +1,27 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`modal flow golden frames renders the help overlay 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-─────────────────────────────────────────────────────────────────────────────── 
-        ╭──────────────────────────────────────────────────────────────╮        
-▼ statio│                         station help                         │qs] [▾] 
- [1] ○ c│                                                              │6 #70 ✓ 
- [2] - d│  Ctrl-O     open/close project view                          │        
- [3] ○ p│  Ctrl-Q     quit Station                                     │  #73 ✓ 
- [4] + s│  Ctrl-\\     split pane right                                 │        
- [5] ⠋ s│  Ctrl-^     split pane below (Ctrl-6)                        │6 #76 … 
-        │  Ctrl-]     focus next pane                                  │        
-▼ observ│  Ctrl-/     close split pane (Ctrl-_)                        │qs] [▾] 
- [6] x b│  Enter/Sp   open project view on welcome                     │   #8 ✓ 
- [7] ⠋ p│  Esc/↑↓     context menu close/move                          │8 #16 … 
- [8] ○ t│  Enter/Sp   context menu select                              │-1 #4 ✓ 
-        │                     station project view                     │        
-▼ script│  ↑/↓        move cursor                                      │qs] [▾] 
- [9] ○ a│  ↵          open focused session                             │6 #5 x1 
- [a] ? m│  tab        next session needing you                         │ -1 #10 
- [b] - o│  wheel      scroll project list                              │        
-        │  1-9/a-z    start or focus row                               │        
-▼ empty-│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │qs] [▾] 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+────────╭──────────────────────────────────────────────────────────────╮─────── 
+       S│                         station help                         │FF · PR 
+▼ statio│                                                              │qs] [▾] 
+ [1] ○ c│  Ctrl-O     open/close project view                          │6 #70 ✓ 
+ [2] - d│  Ctrl-Q     quit Station                                     │        
+ [3] ○ p│  Ctrl-\\     split pane right                                 │  #73 ✓ 
+ [4] + s│  Ctrl-^     split pane below (Ctrl-6)                        │        
+ [5] ⠋ s│  Ctrl-]     focus next pane                                  │6 #76 … 
+        │  Ctrl-/     close split pane (Ctrl-_)                        │        
+▼ observ│  Enter/Sp   open project view on welcome                     │qs] [▾] 
+ [6] x b│  Esc/↑↓     context menu close/move                          │   #8 ✓ 
+ [7] ⠋ p│  Enter/Sp   context menu select                              │8 #16 … 
+ [8] ○ t│                     station project view                     │-1 #4 ✓ 
+        │  ↑/↓        move cursor                                      │        
+▼ script│  ↵          open focused session                             │qs] [▾] 
+ [9] ○ a│  tab        next session needing you                         │6 #5 x1 
+ [a] ? m│  wheel      scroll project list                              │ -1 #10 
+ [b] - o│  1-9/a-z    start or focus row                               │        
+        │  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -29,9 +29,10 @@ exports[`modal flow golden frames renders the help overlay 1`] = `
 `;
 
 exports[`modal flow golden frames renders the search prompt 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -48,8 +49,7 @@ exports[`modal flow golden frames renders the search prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-                                                                                
-search: apiject  0 sessions                                       [sh] [qs] [▾] 
+search: api                                                                     
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -57,9 +57,10 @@ search: apiject  0 sessions                                       [sh] [qs] [▾
 `;
 
 exports[`modal flow golden frames renders the collapse prompt 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -76,8 +77,7 @@ exports[`modal flow golden frames renders the collapse prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-                                                                                
-collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾] 
+collapse project: 1:station 2:observer 3:scripts 4:empty-project                
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -85,9 +85,10 @@ collapse project: 1:station 2:observer 3:scripts 4:empty-project  [sh] [qs] [▾
 `;
 
 exports[`modal flow golden frames renders the project settings picker prompt 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -104,8 +105,7 @@ exports[`modal flow golden frames renders the project settings picker prompt 1`]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-                                                                                
-settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾] 
+settings for project: 1:station 2:observer 3:scripts 4:empty-project            
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -113,15 +113,16 @@ settings for project: 1:station 2:observer 3:scripts 4:empty-projecth] [qs] [▾
 `;
 
 exports[`modal flow golden frames renders the project settings panel 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Default agent                               │ ✓ 
- [2│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │   
- [3│  Remove project          │ 2 opencode unknown                          │ ✓ 
- [4│                          │                                             │   
- [5│                          │ ✓ current · 1-9/a-z select                  │ … 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │PR 
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
+ [2│  Remove project          │ 2 opencode unknown                          │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
@@ -132,8 +133,7 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+   │ ↑↓ move   →/enter edit   esc close                                     │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -141,18 +141,19 @@ exports[`modal flow golden frames renders the project settings panel 1`] = `
 `;
 
 exports[`modal flow golden frames renders the project settings remove pane 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Remove project                              │ ✓ 
- [2│  Default agent           │ Removes it from Station.                    │   
- [3│▸ Remove project          │ Worktrees & files stay on disk.             │ ✓ 
- [4│                          │                                             │   
- [5│                          │ Type "delete station" to confirm            │ … 
-   │                          │ ▸ |delete station                           │   
-▼ o│                          │                                             │▾] 
- [6│                          │ [ Remove project (R) ]                      │ ✓ 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │PR 
+▼ s│ station                  │ Remove project                              │▾] 
+ [1│  Default agent           │ Removes it from Station.                    │ ✓ 
+ [2│▸ Remove project          │ Worktrees & files stay on disk.             │   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ Type "delete station" to confirm            │   
+ [5│                          │ ▸ |delete station                           │ … 
+   │                          │                                             │   
+▼ o│                          │ [ Remove project (R) ]                      │▾] 
+ [6│                          │                                             │ ✓ 
  [7│                          │                                             │ … 
  [8│                          │                                             │ ✓ 
    │                          │                                             │   
@@ -160,8 +161,7 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │                          │                                             │   
-▼ e│ ←/esc back                                                             │▾] 
+   │ ←/esc back                                                             │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -169,15 +169,16 @@ exports[`modal flow golden frames renders the project settings remove pane 1`] =
 `;
 
 exports[`modal flow golden frames renders the project settings optimistic default 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
-─────────────────────────────────────────────────────────────────────────────── 
-   ┌────────────────────────────────────────────────────────────────────────┐   
-▼ s│ Project settings                                                       │▾] 
- [1│ station                  │ Default agent                               │ ✓ 
- [2│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │   
- [3│  Remove project          │✓2 opencode unknown                 updating…│ ✓ 
- [4│                          │                                             │   
- [5│                          │ ✓ current · 1-9/a-z select                  │ … 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+───┌────────────────────────────────────────────────────────────────────────┐── 
+   │ Project settings                                                       │PR 
+▼ s│ station                  │ Default agent                               │▾] 
+ [1│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
+ [2│  Remove project          │✓2 opencode unknown                 updating…│   
+ [3│                          │                                             │ ✓ 
+ [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
  [6│                          │                                             │ ✓ 
@@ -188,8 +189,7 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
  [b│                          │                                             │   
-   │                          │                                             │   
-▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
+   │ ↑↓ move   →/enter edit   esc close                                     │   
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -197,9 +197,10 @@ exports[`modal flow golden frames renders the project settings optimistic defaul
 `;
 
 exports[`modal flow golden frames renders the remove slot sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -213,11 +214,10 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
-┌────────────────────────────────────────────┐code  unknown           +3 -1 #10 
-│ Select session to delete                   │      no agent                    
-│                                            │                                  
-│ Click a row or press slot key              │                    [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to delete                   │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -225,9 +225,10 @@ exports[`modal flow golden frames renders the remove slot sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -239,13 +240,12 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
-┌────────────────────────────────────────────┐                    [sh] [qs] [▾] 
-│ Delete session?                            │code  idle           +14 -6 #5 x1 
-│ Session  cli-help-man                      │code  unknown           +3 -1 #10 
-│ Removes agent, worktree, and panes.        │      no agent                    
-│                                            │                                  
-│ Yes (y)     No (n)                         │                    [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐                                  
+│ Delete session?                            │                    [sh] [qs] [▾] 
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Yes (y)     No (n)                         │                                  
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -253,9 +253,10 @@ exports[`modal flow golden frames renders the remove confirm sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the rename slot prompt 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -272,8 +273,7 @@ exports[`modal flow golden frames renders the rename slot prompt 1`] = `
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
-                                                                                
-Choose the slot to rename: 1-9/a-z                                [sh] [qs] [▾] 
+Choose the slot to rename: 1-9/a-z                                              
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -281,9 +281,10 @@ Choose the slot to rename: 1-9/a-z                                [sh] [qs] [▾
 `;
 
 exports[`modal flow golden frames renders the rename sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                        AGENT     STATUS                DIFF · PR 
 ▼ station  4 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ! hook-scope                     codex     Agent needs appro… +8 -2 #12 x2 
  [2] ? metadata-refresh               codex     unknown                   +3 -1 
@@ -293,7 +294,6 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 ▼ observer  2 sessions · 2 agents                                 [sh] [qs] [▾] 
  [5] x done-run                       opencode  exited                          
  [6] ! sqlite-cleanup                 opencode  Agent needs appro… +19 -2 #6 x1 
-                                                                                
                                                                                 
                                                                                 
                                                                                 
@@ -309,9 +309,10 @@ exports[`modal flow golden frames renders the rename sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the fork slot sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -325,11 +326,10 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
 ▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
- [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
-┌────────────────────────────────────────────┐code  unknown           +3 -1 #10 
-│ Select session to fork                     │      no agent                    
-│                                            │                                  
-│ Click a row or press slot key              │                    [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
+│ Select session to fork                     │code  unknown           +3 -1 #10 
+│                                            │      no agent                    
+│ Click a row or press slot key              │                                  
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -337,9 +337,10 @@ exports[`modal flow golden frames renders the fork slot sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the fork details sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -350,14 +351,13 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-┌────────────────────────────────────────────┐                                  
-│ Fork Session                               │                    [sh] [qs] [▾] 
-│ Source   station · cli-help-man            │code  idle           +14 -6 #5 x1 
-│ > Branch cli-help-man-fork|                │code  unknown           +3 -1 #10 
-│   Copy   [x] uncommitted changes           │      no agent                    
-│ Source keeps running — copy is read-only.  │                                  
-│                                            │                    [sh] [qs] [▾] 
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
+│ Fork Session                               │                                  
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
+│ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
+│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
+│ Source keeps running — copy is read-only.  │      no agent                    
+│                                            │                                  
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -365,9 +365,10 @@ exports[`modal flow golden frames renders the fork details sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the new session review 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -379,7 +380,6 @@ exports[`modal flow golden frames renders the new session review 1`] = `
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
-                                                                                
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -393,9 +393,10 @@ exports[`modal flow golden frames renders the new session review 1`] = `
 `;
 
 exports[`modal flow golden frames renders the new session edit name 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -408,7 +409,6 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Set Session Name                                                             │
 │                                                                              │
@@ -421,9 +421,10 @@ exports[`modal flow golden frames renders the new session edit name 1`] = `
 `;
 
 exports[`modal flow golden frames renders the new session pick project 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -434,7 +435,6 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Project                                                               │
 │                                                                              │
@@ -449,9 +449,10 @@ exports[`modal flow golden frames renders the new session pick project 1`] = `
 `;
 
 exports[`modal flow golden frames renders the new session pick agent 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
@@ -464,7 +465,6 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Choose Agent                                                                 │
 │                                                                              │
@@ -477,9 +477,10 @@ exports[`modal flow golden frames renders the new session pick agent 1`] = `
 `;
 
 exports[`modal flow golden frames renders the project default agent picker 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
+"
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
 ───────────────────────────────────────────────────────────────────────────────
-
+       SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
  [2] - docs-cleanup                       -         no agent
@@ -492,7 +493,6 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾]
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Select default agent for station                                             │
 │                                                                              │
@@ -505,12 +505,12 @@ exports[`modal flow golden frames renders the project default agent picker 1`] =
 `;
 
 exports[`modal flow golden frames renders the add project sheet 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Add Project                                                                  │
 │ Start location                                                               │
@@ -533,27 +533,27 @@ exports[`modal flow golden frames renders the add project sheet 1`] = `
 `;
 
 exports[`modal flow golden frames renders the widget settings panel 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-r┌──────────────────────────────────────────────┐                
- [5] ⠋ station-o│ widgets                                      │ +412 -96 #76 … 
-                │ session only · persist in config.toml        │                
-▼ observer  3 se│ ▸ [on ] time                               × │  [sh] [qs] [▾] 
- [6] x batch-exp│   [off] weather NYC                        × │           #8 ✓ 
- [7] ⠋ provider-│   [on ] moon                               × │   +32 -8 #16 … 
- [8] ○ trace-bun│   [ + add widget ]                           │     +1 -1 #4 ✓ 
-                │ ↵ toggle   [ ] reorder   x remove   a add   e│                
-▼ scripts  3 ses└──────────────────────────────────────────────┘  [sh] [qs] [▾] 
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓ 
+ [4] + session-r│ widgets                                      │                
+ [5] ⠋ station-o│ session only · persist in config.toml        │ +412 -96 #76 … 
+                │ ▸ [on ] time                               × │                
+▼ observer  3 se│   [off] weather NYC                        × │  [sh] [qs] [▾] 
+ [6] x batch-exp│   [on ] moon                               × │           #8 ✓ 
+ [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 … 
+ [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓ 
+                └──────────────────────────────────────────────┘                
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -561,27 +561,27 @@ exports[`modal flow golden frames renders the widget settings panel 1`] = `
 `;
 
 exports[`modal flow golden frames renders the widget settings picker 1`] = `
-"FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
 ─────────────────────────────────────────────────────────────────────────────── 
-                                                                                
+       SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
  [2] - docs-cleanup                       -         no agent                    
- [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
- [4] + session-r┌──────────────────────────────────────────────┐                
- [5] ⠋ station-o│ add widget                                   │ +412 -96 #76 … 
-                │ weather and tz are added in config.toml      │                
-▼ observer  3 se│ ▸ time                                       │  [sh] [qs] [▾] 
- [6] x batch-exp│   fleet                                      │           #8 ✓ 
- [7] ⠋ provider-│   open PRs                                   │   +32 -8 #16 … 
- [8] ○ trace-bun│   moon                                       │     +1 -1 #4 ✓ 
-                │ ↵ add   esc back                             │                
-▼ scripts  3 ses└──────────────────────────────────────────────┘  [sh] [qs] [▾] 
+ [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓ 
+ [4] + session-r│ add widget                                   │                
+ [5] ⠋ station-o│ weather and tz are added in config.toml      │ +412 -96 #76 … 
+                │ ▸ time                                       │                
+▼ observer  3 se│   fleet                                      │  [sh] [qs] [▾] 
+ [6] x batch-exp│   open PRs                                   │           #8 ✓ 
+ [7] ⠋ provider-│   moon                                       │   +32 -8 #16 … 
+ [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓ 
+                └──────────────────────────────────────────────┘                
+▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
  [b] - old-experiment                     -         no agent                    
                                                                                 
-▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -56,10 +56,10 @@ describe("setup guided feedback e2e", () => {
       const result = await runStation(["--config", fixture.configPath, "setup"], {
         cwd: fixture.repo,
         env: fixture.env,
-        // Prompt order: install codex (y), decline cursor/opencode/pi/claude, decline
-        // link-launchers + Worktrunk-hooks + codex-hooks, accept Write config (y),
-        // decline shell-integration + popup. (Crush removal dropped one harness prompt.)
-        answers: ["y", "n", "n", "n", "n", "n", "n", "n", "y", "n", "n"],
+        // Prompt order: install codex (y), decline cursor/opencode/pi/claude,
+        // decline Worktrunk-hooks + codex-hooks, accept Write config (y),
+        // decline shell-integration + popup.
+        answers: ["y", "n", "n", "n", "n", "n", "n", "y", "n", "n"],
       });
 
       expect(result.timedOut).toBe(false);
@@ -67,7 +67,6 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("No supported agent CLI is available.");
       expect(result.stdout).toContain("Running: sh -c");
       expect(result.stdout).toContain("fake codex installer ran");
-      expect(result.stdout).toContain("Link STATION launchers globally?");
       expect(result.stdout).toContain("Install Worktrunk lifecycle hooks?");
       expect(result.stdout).toContain("Install Codex agent hooks?");
       expect(result.stdout).toContain("Applying: Write STATION config");
@@ -145,6 +144,9 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
     await writeCodexShim(bin);
   }
   if (input.harness === "installable-codex") {
+    await writeShim(bin, "stn", "exit 0\n");
+    await writeShim(bin, "stn-ingress", "exit 0\n");
+    await writeShim(bin, "stn-tmux-popup", "exit 0\n");
     await writeShim(
       bin,
       "sh",


### PR DESCRIPTION
Two spacing tweaks from live feedback.

```
┌─ station · overview ──────────── 10:09 AM · NYC · --° 🫥 [+] ─┐
│                                                               │   ← new breathing row
│FLEET  ● 0 ready  ⠏ 2 working  ! 0 needs you  ? 1 unknown ...  │
│────────────────────────────────────────────────────────────── │
│       SESSION           AGENT     STATUS            DIFF · PR │   ← headers return here
│▼ station  5 sessions · 4 agents                 [sh] [qs] [▾] │
```

- One spacer row between the frame's title row and FLEET.
- The column headers return in the previously blank row under the divider. That row is **shared with the above-overflow indicator**: while scrolled, `▲ N sessions above` takes precedence (the count is the more useful fact mid-list); at rest you get the headers. Net body rows unchanged versus before the header was hidden.
- `topSpacer` joins `DASHBOARD_FIXED_ROW_HEIGHTS`; the usual eight windowing tests shift by one.

Verified live in mock mode. `pnpm typecheck` / `lint` / `test:unit` (1073) green; station `bun test` (882) green after `pnpm build`; goldens regenerated.