### PR TITLE
fix(terminal): hold flushes during synchronized output and scissor pane paint

### DIFF
--- a/station/src/bun-env.d.ts
+++ b/station/src/bun-env.d.ts
@@ -2,4 +2,5 @@
 // avoids @types/bun to keep the experiment's type surface small.
 declare const Bun: {
   env: Record<string, string | undefined>;
+  stringWidth(input: string): number;
 };

--- a/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
@@ -1,0 +1,86 @@
+// The vt model measures cells with Unicode-11 tables while OpenTUI's native
+// drawText advances by modern grapheme widths, so emoji-bearing rows can paint
+// wider than the columns the renderable accounted for. A previous bug had no
+// scissor at the pane edge, so those tails escaped into the pane border and
+// neighboring panes; renderSelf now clips all paint to its own bounds.
+import { afterEach, describe, expect, it } from "bun:test";
+import { createElement } from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
+import "./TerminalScreenRenderable.js";
+
+const VS16_WARNING = "⚠️"; // U+26A0 + VS16: 1 cell in Unicode-11, painted 2
+const POST_U11_MELT = "\u{1FAE0}"; // 🫠 (Unicode 14): unknown to U11 tables, painted 2
+
+const PANE_COLS = 10;
+const FRAME = { width: 26, height: 3 };
+
+type Mounted = {
+  setup: Awaited<ReturnType<typeof testRender>>;
+  screen: StationVtScreen;
+};
+
+const teardowns: Array<() => void> = [];
+afterEach(() => {
+  for (const teardown of teardowns.splice(0)) {
+    teardown();
+  }
+});
+
+/** Mount the renderable at PANE_COLS wide inside a wider frame, as TerminalPane does. */
+async function mountNarrowPane(feed: string): Promise<Mounted> {
+  const screen = createStationVtScreen({ size: { cols: PANE_COLS, rows: FRAME.height } });
+  screen.feed(`\x1b[?25l${feed}`); // hide the cursor so only fed glyphs paint
+  await screen.whenIdle();
+  const setup = await testRender(
+    createElement("terminalScreen", { screen, width: PANE_COLS, height: "100%" }),
+    FRAME,
+  );
+  teardowns.push(() => {
+    setup.renderer.destroy();
+    screen.dispose();
+  });
+  await setup.flush();
+  return { setup, screen };
+}
+
+/**
+ * Rightmost painted cell column + 1 on frame row 0. Trailing blank cells emit
+ * one literal space char each in the char frame (wide-glyph continuation cells
+ * emit nothing), so counting trailing space chars is cell-accurate.
+ */
+function paintedExtent(setup: Mounted["setup"]): number {
+  const line = setup.captureCharFrame().split("\n")[0] ?? "";
+  const trailingSpaces = (/ *$/u.exec(line)?.[0] ?? "").length;
+  return FRAME.width - trailingSpaces;
+}
+
+describe("renderSelf scissors paint to the pane bounds", () => {
+  it("clips a VS16 emoji row that the vt model believes fits the pane exactly", async () => {
+    // 10 x ⚠️: span.width 10 (fills the pane, so no span-level clip) but the
+    // native paint is 2 cells each — the scissor must contain the overhang.
+    // Containment is asserted on the char frame (cell-accurate); captureSpans
+    // splits style runs mid-grapheme at the scissor edge and misattributes
+    // in-pane glyphs, so span-based checks are unreliable here.
+    const { setup } = await mountNarrowPane(VS16_WARNING.repeat(PANE_COLS));
+    expect(paintedExtent(setup)).toBeLessThanOrEqual(PANE_COLS);
+  });
+
+  it("clips a post-Unicode-11 emoji row the same way", async () => {
+    const { setup } = await mountNarrowPane(POST_U11_MELT.repeat(PANE_COLS));
+    expect(paintedExtent(setup)).toBeLessThanOrEqual(PANE_COLS);
+  });
+
+  it("control: an ASCII row filling the pane paints exactly to the pane edge", async () => {
+    const { setup } = await mountNarrowPane("ABCDEFGHIJ");
+    expect(setup.captureCharFrame().split("\n")[0] ?? "").toContain("ABCDEFGHIJ");
+    expect(paintedExtent(setup)).toBe(PANE_COLS);
+  });
+
+  it("control: a CJK row filling the pane paints exactly to the pane edge", async () => {
+    // 5 x 漢 = 10 cells in both width tables; agreement keeps the paint inside.
+    const { setup } = await mountNarrowPane("漢".repeat(5));
+    expect(setup.captureCharFrame().split("\n")[0] ?? "").toContain("漢漢漢漢漢");
+    expect(paintedExtent(setup)).toBe(PANE_COLS);
+  });
+});

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -457,42 +457,51 @@ export class TerminalScreenRenderable extends Renderable {
     // Order the selection once per frame, not once per row.
     const orderedSelection = this.#selection === null ? null : orderSelection(this.#selection);
     const rowLimit = Math.min(this.#rows.length, this.height);
-    for (let rowIndex = 0; rowIndex < rowLimit; rowIndex++) {
-      const row = this.#rows[rowIndex];
-      if (row === undefined) {
-        continue;
-      }
-      const selectedCols =
-        orderedSelection === null
-          ? null
-          : rowColumnsOrdered(orderedSelection, rowIndex, this.width);
-      let col = 0;
-      for (const span of row.spans) {
-        if (col >= this.width) {
-          break;
+    // Scissor to the pane bounds: span.width comes from the VT model's
+    // Unicode-11 tables while drawText advances by OpenTUI's modern grapheme
+    // widths, so emoji-bearing rows can paint wider than the columns accounted
+    // here and would otherwise escape into the border and neighboring panes.
+    buffer.pushScissorRect(this.x, this.y, this.width, this.height);
+    try {
+      for (let rowIndex = 0; rowIndex < rowLimit; rowIndex++) {
+        const row = this.#rows[rowIndex];
+        if (row === undefined) {
+          continue;
         }
-        // Spans can exceed the laid-out width only during a resize race
-        // (screen still at the old geometry); draw the part that fits rather
-        // than dropping the span or painting into neighboring UI.
-        const text =
-          col + span.width > this.width ? clipSpanText(span, this.width - col) : span.text;
-        if (text.length === 0) {
-          break;
+        const selectedCols =
+          orderedSelection === null
+            ? null
+            : rowColumnsOrdered(orderedSelection, rowIndex, this.width);
+        let col = 0;
+        for (const span of row.spans) {
+          if (col >= this.width) {
+            break;
+          }
+          // Spans can exceed the laid-out width only during a resize race
+          // (screen still at the old geometry); draw the part that fits rather
+          // than dropping the span or painting into neighboring UI.
+          const text =
+            col + span.width > this.width ? clipSpanText(span, this.width - col) : span.text;
+          if (text.length === 0) {
+            break;
+          }
+          // Highlight the selected sub-range of this span via drawText's selection
+          // arg (columns are char indices here; exact for single-width cells).
+          const selection = selectionForSpan(selectedCols, col, span.width, selectionBg);
+          buffer.drawText(
+            text,
+            this.x + col,
+            this.y + rowIndex,
+            span.fg === undefined ? defaultFg : rgbaForHex(span.fg),
+            span.bg === undefined ? undefined : rgbaForHex(span.bg),
+            span.attributes,
+            selection,
+          );
+          col += span.width;
         }
-        // Highlight the selected sub-range of this span via drawText's selection
-        // arg (columns are char indices here; exact for single-width cells).
-        const selection = selectionForSpan(selectedCols, col, span.width, selectionBg);
-        buffer.drawText(
-          text,
-          this.x + col,
-          this.y + rowIndex,
-          span.fg === undefined ? defaultFg : rgbaForHex(span.fg),
-          span.bg === undefined ? undefined : rgbaForHex(span.bg),
-          span.attributes,
-          selection,
-        );
-        col += span.width;
       }
+    } finally {
+      buffer.popScissorRect();
     }
   }
 

--- a/station/src/terminal/vt/screen.sync.test.ts
+++ b/station/src/terminal/vt/screen.sync.test.ts
@@ -1,0 +1,133 @@
+// Synchronized output (DECSET 2026): the engine advertises the mode via DECRQM,
+// so TUIs wrap repaints in BSU (?2026h) / ESU (?2026l) expecting atomic frames.
+// The flush path must hold listener notification between them — a previous bug
+// ignored the mode and notified renderers mid-frame, tearing every fast repaint.
+import { afterEach, describe, expect, it } from "bun:test";
+import { waitFor } from "../testing/waitFor.js";
+import { createStationVtScreen, type StationVtScreen } from "./screen.js";
+
+const SIZE = { cols: 20, rows: 5 };
+
+const frameARows = ["FRAME-A-ROW0", "FRAME-A-ROW1", "FRAME-A-ROW2", "FRAME-A-ROW3", "FRAME-A-ROW4"];
+const frameBRows = ["FRAME-B-ROW0", "FRAME-B-ROW1", "FRAME-B-ROW2", "FRAME-B-ROW3", "FRAME-B-ROW4"];
+
+const frameA = "\x1b[H\x1b[2J" + frameARows.join("\r\n");
+// BSU + clear + only the first two rows of frame B — the "atomic" frame is
+// left half-painted with NO ?2026l yet.
+const bsuPlusHalfB = "\x1b[?2026h\x1b[2J\x1b[H" + frameBRows.slice(0, 2).join("\r\n");
+const esuPlusRestB = "\x1b[?2026l" + "\r\n" + frameBRows.slice(2).join("\r\n");
+
+const gridText = (screen: StationVtScreen): string[] =>
+  Array.from({ length: SIZE.rows }, (_, index) => screen.rowText(index));
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const feedAndFlush = async (screen: StationVtScreen, data: string): Promise<void> => {
+  const before = screen.getVersion();
+  screen.feed(data);
+  await screen.whenIdle();
+  await waitFor(() => screen.getVersion() > before);
+};
+
+describe("synchronized output (DECSET 2026)", () => {
+  const cleanups: Array<() => void> = [];
+  const track = (screen: StationVtScreen): StationVtScreen => {
+    cleanups.push(() => {
+      screen.dispose();
+    });
+    return screen;
+  };
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) {
+      cleanup();
+    }
+  });
+
+  it("DECRQM ?2026$p replies recognized (;1/;2), not ;0", async () => {
+    const responses: string[] = [];
+    const screen = track(
+      createStationVtScreen({
+        size: SIZE,
+        onResponse: (data) => {
+          responses.push(data);
+        },
+      }),
+    );
+    screen.feed("\x1b[?2026$p");
+    await waitFor(() => responses.join("").includes("\x1b[?2026;"));
+    const reply = responses.join("");
+    expect(reply).toMatch(/\x1b\[\?2026;[12]\$y/);
+    expect(reply).not.toContain("\x1b[?2026;0$y");
+  });
+
+  it("holds listener notification while a synchronized update is open", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(screen, frameA);
+    expect(gridText(screen)).toEqual(frameARows);
+
+    const snapshots: Array<{ syncActive: boolean; rows: string[] }> = [];
+    screen.subscribe(() => {
+      snapshots.push({
+        syncActive: screen.unsafeEngine.modes.synchronizedOutputMode,
+        rows: gridText(screen),
+      });
+    });
+
+    screen.feed(bsuPlusHalfB);
+    await screen.whenIdle();
+    await sleep(200);
+
+    // The engine is mid-atomic-frame; renderers were not told to repaint.
+    // (Direct rowText reads still see the live buffer — only the notification
+    // path is gated, which is what drives TerminalScreenRenderable.)
+    expect(screen.unsafeEngine.modes.synchronizedOutputMode).toBe(true);
+    expect(snapshots).toEqual([]);
+  });
+
+  it("ESU promptly notifies with the complete frame, never a torn one", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(screen, frameA);
+
+    const snapshots: Array<{ syncActive: boolean; rows: string[] }> = [];
+    screen.subscribe(() => {
+      snapshots.push({
+        syncActive: screen.unsafeEngine.modes.synchronizedOutputMode,
+        rows: gridText(screen),
+      });
+    });
+
+    screen.feed(bsuPlusHalfB);
+    await screen.whenIdle();
+    screen.feed(esuPlusRestB);
+    await screen.whenIdle();
+    await waitFor(() => snapshots.length > 0);
+
+    expect(screen.unsafeEngine.modes.synchronizedOutputMode).toBe(false);
+    expect(gridText(screen)).toEqual(frameBRows);
+    // Every notified snapshot is post-ESU and complete — no torn frame.
+    for (const snapshot of snapshots) {
+      expect(snapshot.syncActive).toBe(false);
+      expect(snapshot.rows).toEqual(frameBRows);
+    }
+  });
+
+  it("a stuck BSU with no ESU still paints after the bounded hold", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(screen, frameA);
+
+    const notifiedAt: number[] = [];
+    const start = Date.now();
+    screen.subscribe(() => {
+      notifiedAt.push(Date.now() - start);
+    });
+
+    screen.feed(bsuPlusHalfB); // ESU never arrives
+    await screen.whenIdle();
+    await waitFor(() => notifiedAt.length > 0, 3_000);
+
+    // Held for the sync window, then the escape hatch painted the pane rather
+    // than freezing it forever.
+    expect(notifiedAt[0]).toBeGreaterThan(500);
+    expect(gridText(screen)).toEqual(["FRAME-B-ROW0", "FRAME-B-ROW1", "", "", ""]);
+  }, 10_000);
+});

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -13,6 +13,7 @@ import {
 } from "../protocol/mouse.js";
 
 const DEFAULT_FLUSH_INTERVAL_MS = 33;
+const SYNC_OUTPUT_HOLD_MAX_MS = 1000;
 // Scrollback is now viewable (wheel + copy-mode), but a modest buffer still
 // keeps resize reflow cheap; the depth is intentionally not yet configurable.
 const DEFAULT_SCROLLBACK_LINES = 1000;
@@ -201,6 +202,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   let disposed = false;
   let flushTimer: ReturnType<typeof setTimeout> | undefined;
   let lastFlushAt = 0;
+  let syncHoldUntil: number | undefined;
   // Lines scrolled up from the live bottom (0 = at the bottom).
   let scrollOffset = 0;
   let kittyKeyboardFlags = 0;
@@ -374,6 +376,19 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     flushTimer = undefined;
     if (disposed) {
       return;
+    }
+    // DECSET 2026 (synchronized output): between BSU and ESU the app is
+    // mid-frame, so hold listener notification rather than snapshot a torn
+    // buffer. Bounded so a client that never sends ESU cannot freeze the pane;
+    // once expired, flush at normal cadence until the mode clears.
+    if (terminal.modes.synchronizedOutputMode) {
+      syncHoldUntil ??= Date.now() + SYNC_OUTPUT_HOLD_MAX_MS;
+      if (Date.now() < syncHoldUntil) {
+        flushTimer = setTimeout(flush, flushIntervalMs);
+        return;
+      }
+    } else {
+      syncHoldUntil = undefined;
     }
     lastFlushAt = Date.now();
     applyScrollOnOutput();


### PR DESCRIPTION
Two embedded-pane render-corruption fixes, both proven by an audit that replayed byte captures from real `claude` and `codex` binaries through the production PTY bridge.

## Synchronized output (DECSET 2026)

The VT engine (xterm/headless 6) affirms mode 2026 via DECRQM, and codex brackets every paint in `?2026h`/`?2026l` (it enables the mode blind, without querying). The flush path never consulted `modes.synchronizedOutputMode`, so renderers were notified mid-"atomic" frame — a half-cleared grid roughly once per frame during fast streaming. `screen.ts` flush now defers notification while a synchronized update is open, bounded at 1s so a stuck BSU cannot freeze the pane.

## Pane paint containment

The vt model measures cells with Unicode-11 tables while OpenTUI's native `drawText` advances by modern grapheme widths, so rows with VS16/post-Unicode-11 emoji painted wider than the accounted columns and escaped the pane border into neighboring panes. OpenTUI's `overflow` prop scissors only children, never a renderable's own `renderSelf`, so `TerminalScreenRenderable.renderSelf` now pushes a scissor rect over its own bounds. (The model-level width divergence itself is a follow-up; this contains its blast radius.)

## UX implication + manual verify

- Streaming codex/claude panes stop flashing half-cleared/torn frames: stream fast output in a codex pane — no momentary blank or half rows.
- Emoji-dense rows stay inside the pane: run `printf '⚠️%.0s' {1..60}; echo` in a pane beside another — glyphs no longer cross the border.

## Tests

- New `station/src/terminal/vt/screen.sync.test.ts`: DECRQM reply, no notification mid-BSU, prompt complete-frame notification on ESU, bounded-hold escape hatch.
- New `station/src/terminal/TerminalScreenRenderable.clip.test.tsx`: emoji rows clipped at the pane edge (asserted on the cell-accurate char frame; `captureSpans` splits style runs mid-grapheme at scissor edges), ASCII/CJK controls paint exactly to the edge.
- `station` lane: typecheck clean, 930 pass full suite, PTY smoke lanes pass.
