### PR TITLE
fix(terminal): replay reattach snapshots at their recorded size and nudge a repaint

### DIFF
--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -11,6 +11,7 @@ import type {
   StationTerminalDisposable,
   StationTerminalExit,
   StationTerminalProcess,
+  StationTerminalReplay,
   StationTerminalSize,
 } from "../types.js";
 
@@ -85,6 +86,7 @@ export function createHostAttachedTerminal(
   const dataListeners = new Set<(data: string) => void>();
   const exitListeners = new Set<(event: StationTerminalExit) => void>();
   const diagnosticListeners = new Set<(message: string) => void>();
+  const replayListeners = new Set<(replay: StationTerminalReplay) => void | Promise<void>>();
   const pendingData: string[] = [];
   const pendingWrites: string[] = [];
   let attachment: HostAttachment | undefined;
@@ -136,6 +138,25 @@ export function createHostAttachedTerminal(
       listener(message);
     }
   };
+  // Snapshot bytes were painted for the host PTY's recorded size, not this
+  // pane's. A wired replay listener gets them with that size and is awaited so
+  // live frames never interleave with the replay parse; with no listener the
+  // chunks fall back to the plain data path (recorded size unknown to it).
+  const emitReplay = async (
+    chunks: readonly string[],
+    recordedSize: StationTerminalSize,
+  ): Promise<void> => {
+    if (disposed) {
+      return;
+    }
+    if (replayListeners.size === 0) {
+      for (const chunk of chunks) {
+        emitData(chunk);
+      }
+      return;
+    }
+    await Promise.all([...replayListeners].map((listener) => listener({ size: recordedSize, chunks })));
+  };
 
   // Attach, replay scrollback once, then stream frames. A transient transport
   // failure — or the stream ending with no exit frame — reconnects with backoff;
@@ -166,22 +187,29 @@ export function createHostAttachedTerminal(
         // On a RECONNECT the ack snapshot is the current ring — it captured output
         // produced while we were detached — so repaint from it (clearing first so
         // the already-shown history isn't duplicated) rather than dropping the gap.
+        const recordedSize = { cols: opened.ack.cols, rows: opened.ack.rows };
         if (!replayed) {
-          for (const chunk of opened.ack.scrollback) {
-            emitData(chunk);
-          }
+          await emitReplay(opened.ack.scrollback, recordedSize);
           replayed = true;
         } else {
-          emitData(RECONNECT_REPAINT);
-          for (const chunk of opened.ack.scrollback) {
-            emitData(chunk);
-          }
+          await emitReplay([RECONNECT_REPAINT, ...opened.ack.scrollback], recordedSize);
         }
         // Sync the host PTY to THIS client's pane size on (re)attach — the host may
         // have spawned it at a different size — then flush input typed before attach
         // resolved. Expose `attachment` only AFTER the flush so later writes order
         // after the buffered ones.
         await opened.resize(size.cols, size.rows);
+        // A same-size resize is a no-op TIOCSWINSZ — no SIGWINCH — so a child
+        // whose replayed frame may be stale would never repaint; flap the rows
+        // to force one. A real size change above already delivers the signal.
+        if (
+          opened.ack.scrollback.length > 0 &&
+          opened.ack.cols === size.cols &&
+          opened.ack.rows === size.rows
+        ) {
+          await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
+          await opened.resize(size.cols, size.rows);
+        }
         // Drain front-to-back so a mid-flush failure leaves only the un-sent
         // writes to retry (no double-send on reconnect). New writes keep arriving
         // at the back while attachment is still undefined, preserving order.
@@ -311,6 +339,10 @@ export function createHostAttachedTerminal(
       diagnosticListeners.add(listener);
       return disposableFor(diagnosticListeners, listener);
     },
+    onReplay(listener) {
+      replayListeners.add(listener);
+      return disposableFor(replayListeners, listener);
+    },
     write(data) {
       if (disposed || exited) {
         return;
@@ -355,6 +387,7 @@ export function createHostAttachedTerminal(
       dataListeners.clear();
       exitListeners.clear();
       diagnosticListeners.clear();
+      replayListeners.clear();
       // DETACH, never kill: closing this pane's connection makes the host release
       // the stream (its socket-close handler) while keeping the PTY alive for the
       // next reattach. (Each pane owns its own client/connection, so closing it

--- a/station/src/terminal/pty/hostReplaySizing.test.ts
+++ b/station/src/terminal/pty/hostReplaySizing.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Reattach replay sizing, end to end through the real host socket and the real
+ * registry wiring. Previous bugs, each pinned here:
+ * - the scrollback snapshot (painted for the host PTY's recorded size, often
+ *   the 80x24 spawn default) was parsed at the pane's size, so erase/cursor
+ *   sequences landed on the wrong rows and mangled the replayed history;
+ * - a same-size attach issued only a no-op TIOCSWINSZ (no SIGWINCH), so the
+ *   child never repainted whatever the replay had left on screen;
+ * - startup probes recorded in the ring (CPR/DA1/OSC) were re-answered by the
+ *   fresh VT and written into the child's stdin as unsolicited input.
+ */
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createStationHostClient } from "@station/host";
+import { afterEach, describe, expect, it } from "bun:test";
+import { type StationHostInstance, startStationHost } from "../../host/startHost.js";
+import { createPtyRegistry } from "../registry/ptyRegistry.js";
+import { createScriptedTerminal, type ScriptedTerminal } from "../testing/scriptedTerminal.js";
+import { waitFor } from "../testing/waitFor.js";
+import type { StationVtScreen } from "../vt/screen.js";
+import { createHostAttachedTerminal } from "./hostAttachedTerminal.js";
+
+const noopLogger = { log: async () => undefined } as never;
+
+// Mirrors DEFAULT_COLS / DEFAULT_ROWS hardcoded in the station terminal provider.
+const HOST_SPAWN = { cols: 80, rows: 24 };
+const PANE = "pane-replay";
+
+const cleanups: Array<() => Promise<unknown> | unknown> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+async function startAgentHost(
+  scripted: ScriptedTerminal,
+): Promise<{ socketPath: string; ptyId: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "station-replay-sizing-"));
+  const socketPath = join(dir, "station-host.sock");
+  const host: StationHostInstance = await startStationHost({
+    socketPath,
+    stateDir: dir,
+    logger: noopLogger,
+    ptyTableOptions: { createTerminal: () => scripted.terminal },
+  });
+  cleanups.push(() => host.close());
+  const control = createStationHostClient({ socketPath });
+  cleanups.push(() => control.dispose());
+  const { ptyId } = await control.spawn({
+    terminalTargetId: "native:wt-replay",
+    worktreeId: "wt-replay",
+    projectId: "proj-replay",
+    sessionId: "ses-replay",
+    worktreePath: "/repo/wt-replay",
+    harnessProvider: "codex",
+    command: "codex",
+    args: [],
+    cwd: "/repo/wt-replay",
+    cols: HOST_SPAWN.cols,
+    rows: HOST_SPAWN.rows,
+  });
+  return { socketPath, ptyId };
+}
+
+/** Attach exactly as production does: registry entry with a host-attached override. */
+function attachPane(
+  socketPath: string,
+  ptyId: string,
+  size: { cols: number; rows: number },
+): StationVtScreen {
+  const registry = createPtyRegistry();
+  cleanups.push(() => registry.disposeAll());
+  registry.ensure(PANE, { cwd: "/repo/wt-replay" }, (spawn) =>
+    createHostAttachedTerminal({
+      hostSocketPath: socketPath,
+      ptyId,
+      size: { cols: spawn.size?.cols ?? 80, rows: spawn.size?.rows ?? 24 },
+    }),
+  );
+  registry.resize(PANE, size);
+  const screen = registry.get(PANE)?.screen;
+  if (screen == null) {
+    throw new Error("registry did not start a session");
+  }
+  return screen;
+}
+
+function visibleRows(screen: StationVtScreen, count: number): string[] {
+  return Array.from({ length: count }, (_, index) => screen.rowText(index));
+}
+
+const PROMPT = "PROMPT> run agent";
+
+/**
+ * Ink/log-update-style repaint stream from a child that believes the terminal
+ * is 80 cols: three 100-char logical lines hard-wrap into SIX physical rows at
+ * 80 cols, so the frame update erases with 6x (CSI 1A cursor-up + CSI 2K
+ * erase-line) before rewriting. Parsed at any other width, the six-row erase
+ * would land on the wrong rows.
+ */
+function inkRepaintStreamFor80Cols(): string {
+  const line = (ch: string): string => `${ch.repeat(100)}\r\n`;
+  const frame = (ch: string): string => line(ch) + line(ch) + line(ch);
+  const eraseSixPhysicalRows = "\x1b[1A\x1b[2K".repeat(6);
+  return `${PROMPT}\r\n${frame("X")}${eraseSixPhysicalRows}${frame("Y")}`;
+}
+
+describe("snapshot replay parses at the recorded size, then reflows to the pane", () => {
+  it("an 80-col ink repaint replayed into a 120x30 pane keeps the prompt and reflows the frame", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+    // Painted while no pane was attached; recorded verbatim into the ring.
+    scripted.helpers.emitData(inkRepaintStreamFor80Cols());
+
+    const screen = attachPane(socketPath, ptyId, { cols: 120, rows: 30 });
+    await waitFor(() => visibleRows(screen, 30).some((row) => row.includes("Y")));
+    await screen.whenIdle();
+    await waitFor(() => screen.bufferStats().cols === 120);
+
+    const rows = visibleRows(screen, 30);
+    // The prompt survives (the erase stayed inside the frame it belonged to)
+    // and the 100-char soft-wrapped rows rejoin at the wider pane.
+    expect(rows.some((row) => row === PROMPT)).toBe(true);
+    expect(rows.filter((row) => row === "Y".repeat(100)).length).toBe(3);
+    expect(rows.some((row) => row.includes("X"))).toBe(false);
+  });
+
+  it("the same replay at the recorded size renders identically (no reflow needed)", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+    scripted.helpers.emitData(inkRepaintStreamFor80Cols());
+
+    const screen = attachPane(socketPath, ptyId, { ...HOST_SPAWN });
+    await waitFor(() => screen.rowText(1).startsWith("Y"));
+    await screen.whenIdle();
+
+    expect(screen.rowText(0)).toBe(PROMPT);
+    expect(screen.rowText(1)).toBe("Y".repeat(80));
+    expect(screen.rowText(2)).toBe("Y".repeat(20));
+    expect(visibleRows(screen, 24).some((row) => row.includes("X"))).toBe(false);
+  });
+});
+
+describe("same-size attach forces a child repaint", () => {
+  it("flaps the rows so the child gets a real SIGWINCH after replaying history", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+    scripted.helpers.emitData("stale frame painted before reattach\r\n");
+
+    attachPane(socketPath, ptyId, { ...HOST_SPAWN });
+    await waitFor(() => scripted.helpers.resizes.length >= 3);
+
+    expect(scripted.helpers.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 80, rows: 23 },
+      { cols: 80, rows: 24 },
+    ]);
+  });
+
+  it("a different-size attach relies on its own real size change (no flap)", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+    scripted.helpers.emitData("stale frame painted before reattach\r\n");
+
+    attachPane(socketPath, ptyId, { cols: 120, rows: 30 });
+    await waitFor(() => scripted.helpers.resizes.length >= 1);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(scripted.helpers.resizes).toEqual([{ cols: 120, rows: 30 }]);
+  });
+
+  it("an empty ring skips the flap (nothing on screen to repaint)", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+
+    attachPane(socketPath, ptyId, { ...HOST_SPAWN });
+    await waitFor(() => scripted.helpers.resizes.length >= 1);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(scripted.helpers.resizes).toEqual([{ ...HOST_SPAWN }]);
+  });
+});
+
+describe("recorded startup probes are not re-answered on attach", () => {
+  // CPR + DA1 + OSC 11 background query — the burst a codex-style TUI emits once at startup.
+  const PROBE_BURST = "\x1b[6n\x1b[c\x1b]11;?\x07";
+  // Non-global on purpose: a /g regex is stateful across .test()/.match() calls.
+  const CPR_REPLY = /\x1b\[\d+;\d+R/;
+  const DA1_REPLY = /\x1b\[\?1;2c/;
+  const OSC11_REPLY = /\x1b\]11;rgb:/;
+  const countMatches = (haystack: string, pattern: RegExp): number =>
+    (haystack.match(new RegExp(pattern.source, "g")) ?? []).length;
+
+  it("replaying a pre-attach probe burst writes nothing to the child; a live probe is answered once", async () => {
+    const scripted = createScriptedTerminal({ ...HOST_SPAWN });
+    const { socketPath, ptyId } = await startAgentHost(scripted);
+    // The child probed at startup with no pane attached; the ring records it.
+    scripted.helpers.emitData(PROBE_BURST);
+
+    attachPane(socketPath, ptyId, { ...HOST_SPAWN });
+    // The rows flap marks the attach (replay included) as fully settled.
+    await waitFor(() => scripted.helpers.resizes.length >= 3);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(scripted.helpers.writes.join("")).toBe("");
+
+    scripted.helpers.emitData(PROBE_BURST);
+    await waitFor(() => countMatches(scripted.helpers.writes.join(""), OSC11_REPLY) >= 1);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const written = scripted.helpers.writes.join("");
+    expect(countMatches(written, CPR_REPLY)).toBe(1);
+    expect(countMatches(written, DA1_REPLY)).toBe(1);
+    expect(countMatches(written, OSC11_REPLY)).toBe(1);
+  });
+});

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -168,10 +168,18 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
   // the PTY at that same size so there is no corrective resize/SIGWINCH during
   // shell startup, and so panes that are never laid out never spawn a shell.
   const startSession = (entry: InternalEntry, size: StationTerminalSize): void => {
+    let replayingSnapshot = false;
     const screen = createStationVtScreen({
       size,
       ...(scrollOnOutput === undefined ? {} : { scrollOnOutput }),
       onResponse: (data) => {
+        // A replayed snapshot re-parses queries the child issued long ago
+        // (startup probes recorded in the ring); answering those would inject
+        // stale replies into the child's stdin, so drop replies until the
+        // replay settles.
+        if (replayingSnapshot) {
+          return;
+        }
         // Query replies (DA1/DSR/OSC...) go straight to the PTY: routing them
         // through the keyboard path would tangle them with chord filtering,
         // and TUIs block on these at startup.
@@ -202,6 +210,31 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
     }
     entry.terminal = terminal;
     entry.status = `pid ${terminal.pid}`;
+    if (terminal.onReplay !== undefined) {
+      entry.subscriptions.push(
+        terminal.onReplay(async ({ size: recordedSize, chunks }) => {
+          const current = entry.screen;
+          if (current === null) {
+            return;
+          }
+          // Parse the snapshot at the size it was painted for — erase/cursor
+          // sequences recorded at another width land on the wrong rows
+          // otherwise — then return to the pane size so xterm reflows the
+          // replayed rows. The terminal holds live frames until this resolves.
+          replayingSnapshot = true;
+          try {
+            current.resize(recordedSize);
+            for (const chunk of chunks) {
+              current.feed(chunk);
+            }
+            await current.whenIdle();
+          } finally {
+            replayingSnapshot = false;
+          }
+          current.resize(entry.appliedSize ?? size);
+        }),
+      );
+    }
     entry.subscriptions.push(
       terminal.onData((data) => {
         entry.screen?.feed(data);

--- a/station/src/terminal/types.ts
+++ b/station/src/terminal/types.ts
@@ -24,6 +24,12 @@ export type StationTerminalDisposable = {
   dispose(): void;
 };
 
+/** Recorded history handed over on (re)attach, with the size it was painted for. */
+export type StationTerminalReplay = {
+  size: StationTerminalSize;
+  chunks: readonly string[];
+};
+
 export type StationTerminalProcess = {
   readonly id: StationTerminalId;
   readonly command: string;
@@ -33,6 +39,15 @@ export type StationTerminalProcess = {
   onExit(listener: (event: StationTerminalExit) => void): StationTerminalDisposable;
   /** Transport/bridge diagnostics; never terminal output. */
   onDiagnostic(listener: (message: string) => void): StationTerminalDisposable;
+  /**
+   * Replayed snapshot delivery. When wired, snapshot bytes bypass onData and the
+   * terminal awaits the listener before streaming live data, so the consumer can
+   * parse the replay at its recorded size and reflow before live bytes arrive.
+   * Terminals without replayable history never emit this.
+   */
+  onReplay?(
+    listener: (replay: StationTerminalReplay) => void | Promise<void>,
+  ): StationTerminalDisposable;
   write(data: string): void;
   resize(size: StationTerminalSize): void;
   kill(signal?: string): void;


### PR DESCRIPTION
Fixes the reattach corruption that fired on every agent pane open/reopen/reconnect: the host scrollback snapshot — painted for the host PTY's recorded size (usually the 80x24 spawn default) — was parsed at the pane's size, so erase/cursor sequences recorded at one width landed on the wrong rows at another, mangling the replayed history. Runtime logs showed every attach in a full day of sessions hitting this path.

## Changes

- `StationTerminalProcess` gains an optional `onReplay` channel (`types.ts`): replayed history is delivered with the size it was painted for, and the terminal awaits the listener before streaming live frames, so replay parse and live bytes never interleave.
- `hostAttachedTerminal` reads the attach ack's `cols`/`rows` (previously carried by the protocol but read nowhere) and hands the snapshot to `onReplay`; on reconnect the clear-repaint precedes the snapshot inside the same replay so ordering is preserved. With no replay listener wired, behavior falls back to the previous data-path replay.
- `ptyRegistry.startSession` wires `onReplay`: resize the VT to the recorded size, feed the snapshot, await idle, then resize to the pane size so xterm reflows the replayed rows.
- Same-size attach: a resize to the size the PTY already has is a no-op `TIOCSWINSZ` (no `SIGWINCH`), so the child never repainted the replayed frame. When history was replayed at an unchanged size, the host PTY rows now flap once to force a repaint. No flap when the size actually changed or the ring was empty.
- Stale probe replies: startup probes recorded in the ring (CPR, DA1, OSC 10/11) were re-answered by the fresh VT and written into the child's stdin as unsolicited input (the `rgb:…` junk occasionally seen typed into composers). Query replies are now dropped while a snapshot replay is parsing; live probes answer exactly once as before.

Not in scope (follow-ups): spawning agent PTYs at the real pane size needs a `cols`/`rows` field threaded through the launch contracts (the pane doesn't exist yet at observer-spawn time — with this fix the 80x24 default replays correctly and reflows); escape-safe ScrollbackRing eviction (a truncated ring can still start mid-escape-sequence) remains open.

## UX implication + manual verify

Reopening an agent pane, hot-reloading the TUI, or surviving a host reconnect no longer mangles the transcript. Verify: launch an agent, let it paint, close the pane, resize the Station window, reopen the pane — the replayed history renders at the pane width with no staircased or truncated rows, and nothing gets \"typed\" into the composer.

## Tests

New `station/src/terminal/pty/hostReplaySizing.test.ts` (6 tests) drives the real host socket + real registry wiring: wrong-width replay reflows correctly with the prompt intact, same-size attach flaps rows exactly once, different-size/empty-ring attaches don't flap, recorded probes write nothing while live probes answer once. Full station lane: typecheck clean, 930 pass, PTY smokes pass.