### PR TITLE
perf(startup): unawait tui reconcile, cache provider health, resequence renderer boot

### DIFF
--- a/apps/cli/src/commands/popup.ts
+++ b/apps/cli/src/commands/popup.ts
@@ -1,4 +1,5 @@
 import type { StationConfig } from "@station/config";
+import { POPUP_OPEN_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { openTmuxPopup, type TmuxPopupOptions, type TmuxPopupResult } from "@station/tmux";
 import {
@@ -125,6 +126,6 @@ async function prepareObserverForPopup(
       socketPath: observer.paths.socketPath,
       timeoutMs: options.timeoutMs ?? 30_000,
     });
-  void client.reconcile("popup-open").catch(() => undefined);
+  void client.reconcile(POPUP_OPEN_RECONCILE_REASON).catch(() => undefined);
   return undefined;
 }

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -1,9 +1,12 @@
 import { spawn } from "node:child_process";
 import type { StationConfig } from "@station/config";
+import { TUI_STARTUP_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
+import { safeErrorFromUnknown, systemClock } from "@station/runtime";
 import { parsePositiveIntegerOption } from "../args.js";
 import type { CliEnv } from "../env.js";
 import {
+  logObserverLifecycleFailure,
   type ObserverProcessDeps,
   type ObserverStatus,
   startObserver,
@@ -95,11 +98,10 @@ export async function runTuiCommand(
   if (parsed.timeoutMs !== undefined) {
     startupReconcile.timeoutMs = parsed.timeoutMs;
   }
-  if (parsed.popupMode) {
-    scheduleReconcileBeforeTui(startupReconcile);
-  } else {
-    await reconcileBeforeTui(startupReconcile);
-  }
+  // Deferred and unawaited: the renderer resyncs from the observer's in-memory
+  // snapshot immediately, and the observer.reconciled event from this reconcile
+  // refreshes the live view when the scan lands.
+  scheduleReconcileBeforeTui(startupReconcile);
   // Bare terminal launches the native Station workspace (its own panes); inside a
   // tmux popup we keep the read-only dashboard, since tmux owns the panes there.
   return runRenderer(
@@ -164,7 +166,22 @@ function scheduleReconcileBeforeTui(input: {
   timeoutMs?: number;
 }): void {
   const timer = setTimeout(() => {
-    void reconcileBeforeTui(input).catch(() => undefined);
+    // The renderer owns the terminal by the time a deferred reconcile can fail, so
+    // the failure goes to cli.jsonl instead of stderr (which would corrupt the alt screen).
+    void reconcileBeforeTui(input).catch((error) =>
+      logObserverLifecycleFailure({
+        paths: input.paths,
+        operation: "tui.startup-reconcile",
+        trace: {},
+        error: safeErrorFromUnknown(error, {
+          tag: "ReconcileCommandError",
+          code: "RECONCILE_RPC_FAILED",
+          message: "TUI startup reconcile could not contact the observer.",
+        }),
+        deps: input.deps ?? {},
+        clock: systemClock,
+      }),
+    );
   }, 250);
   if (typeof timer === "object" && "unref" in timer && typeof timer.unref === "function") {
     timer.unref();
@@ -182,7 +199,7 @@ async function reconcileBeforeTui(input: {
       socketPath: input.paths.socketPath,
       timeoutMs: input.timeoutMs ?? 30_000,
     });
-  await client.reconcile("tui-startup");
+  await client.reconcile(TUI_STARTUP_RECONCILE_REASON);
 }
 
 type ParsedTuiArgs = {

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -302,7 +302,7 @@ function defaultSpawnObserver(input: SpawnObserverInput): ChildProcessLike {
   });
 }
 
-async function logObserverLifecycleFailure(input: {
+export async function logObserverLifecycleFailure(input: {
   paths: ObserverPaths;
   operation: string;
   trace: RuntimeTraceContext;

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -2,7 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { runCli } from "@station/cli";
 import { runTuiCommand } from "@station/cli/internal";
 import type { TuiConfig } from "@station/config";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -50,7 +50,7 @@ function emptySnapshot(reason: string) {
 }
 
 // A running observer whose health check passes once spawned. `reconcile`
-// records its reason (or hangs, to model the non-blocking popup path).
+// records its reason (or hangs, to model the non-blocking startup reconcile).
 function runningObserverDeps(options: { reconciles?: string[]; hangReconcile?: boolean } = {}) {
   let running = false;
   return {
@@ -102,7 +102,10 @@ describe("CLI tui command", () => {
 
     expect(result).toEqual({ code: 0, output: { status: "exited", code: 0 } });
     expect(envs).toEqual([{ STATION_OBSERVER_SOCKET_PATH: fixture.socketPath }]);
-    expect(reconciles).toEqual(["tui-startup"]);
+    // The startup reconcile is deferred and never awaited: not yet run when the
+    // renderer resolves, then fires as "tui-startup".
+    expect(reconciles).toEqual([]);
+    await vi.waitFor(() => expect(reconciles).toEqual(["tui-startup"]));
   });
 
   it("defaults bare station to the fullscreen renderer outside tmux", async () => {
@@ -218,6 +221,30 @@ describe("CLI tui command", () => {
 
     const result = await expectWithin(
       runCli(["--config", configPath, "tui", "--popup"], {
+        observerDeps: runningObserverDeps({ reconciles, hangReconcile: true }),
+        tuiDeps: {
+          spawnRenderer: async ({ env }) => {
+            envs.push(env);
+            return { status: "exited", code: 0 };
+          },
+        },
+      }),
+      100,
+    );
+
+    expect(result).toEqual({ code: 0, output: { status: "exited", code: 0 } });
+    expect(envs).toHaveLength(1);
+    expect(reconciles).toEqual([]);
+  });
+
+  it("does not block native renderer startup on observer reconcile", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const envs: Array<Record<string, string>> = [];
+    const reconciles: string[] = [];
+
+    const result = await expectWithin(
+      runCli(["--config", configPath, "tui"], {
         observerDeps: runningObserverDeps({ reconciles, hangReconcile: true }),
         tuiDeps: {
           spawnRenderer: async ({ env }) => {

--- a/apps/observer/src/internal.ts
+++ b/apps/observer/src/internal.ts
@@ -20,6 +20,7 @@ export * from "./metadata/refresh.js";
 export * from "./metadata/repositoryGit.js";
 export * from "./migrations/index.js";
 export * from "./persistence/index.js";
+export * from "./providers/healthCache.js";
 export * from "./providers/registry.js";
 export * from "./providers/terminalIntentRunner.js";
 export * from "./reconcile/core.js";

--- a/apps/observer/src/providers/healthCache.ts
+++ b/apps/observer/src/providers/healthCache.ts
@@ -1,0 +1,120 @@
+import type { ProviderHealth, ProviderId } from "@station/contracts";
+import { type RuntimeClock, runRuntimeBoundaryWithTimeout, systemClock } from "@station/runtime";
+
+export type ProviderHealthProbeTarget = {
+  providerId: ProviderId;
+  providerType: ProviderHealth["providerType"];
+  capabilities: () => Record<string, boolean>;
+  health: () => Promise<ProviderHealth>;
+};
+
+export type ProviderHealthCacheTuning = {
+  /** Entries older than this are served stale while a background probe refreshes them. */
+  ttlMs?: number;
+  timeoutMs?: number;
+  clock?: RuntimeClock;
+};
+
+export type ProviderHealthCacheOptions = ProviderHealthCacheTuning & {
+  targets: readonly ProviderHealthProbeTarget[];
+};
+
+type CacheEntry = {
+  health: ProviderHealth;
+  refreshedAtMs: number;
+};
+
+/**
+ * Out-of-band provider health cache: reconcile reads synchronously and never
+ * awaits a health probe. Probes run at boot, on TTL expiry
+ * (stale-while-revalidate), and eagerly after a provider read failure.
+ * `stn doctor` keeps probing providers live, bypassing this cache.
+ */
+export class ProviderHealthCache {
+  readonly #targets: Map<string, ProviderHealthProbeTarget>;
+  readonly #ttlMs: number;
+  readonly #timeoutMs: number;
+  readonly #clock: RuntimeClock;
+  readonly #entries = new Map<string, CacheEntry>();
+  readonly #inFlight = new Map<string, Promise<void>>();
+
+  constructor(options: ProviderHealthCacheOptions) {
+    this.#targets = new Map(options.targets.map((target) => [target.providerId, target]));
+    this.#ttlMs = options.ttlMs ?? 30_000;
+    this.#timeoutMs = options.timeoutMs ?? 15_000;
+    this.#clock = options.clock ?? systemClock;
+  }
+
+  /** Synchronous read; a missing or stale entry triggers one background probe. */
+  read(providerId: string): ProviderHealth | undefined {
+    const entry = this.#entries.get(providerId);
+    if (entry === undefined || this.#nowMs() - entry.refreshedAtMs >= this.#ttlMs) {
+      void this.refresh(providerId);
+    }
+    return entry?.health;
+  }
+
+  /** Probe one provider now, ignoring TTL. Never rejects; joins an in-flight probe. */
+  refresh(providerId: string): Promise<void> {
+    const inFlight = this.#inFlight.get(providerId);
+    if (inFlight !== undefined) {
+      return inFlight;
+    }
+    const target = this.#targets.get(providerId);
+    if (target === undefined) {
+      return Promise.resolve();
+    }
+    const probe = this.#probe(target).finally(() => {
+      this.#inFlight.delete(providerId);
+    });
+    this.#inFlight.set(providerId, probe);
+    return probe;
+  }
+
+  async refreshAll(): Promise<void> {
+    await Promise.all(Array.from(this.#targets.keys(), (providerId) => this.refresh(providerId)));
+  }
+
+  async #probe(target: ProviderHealthProbeTarget): Promise<void> {
+    const result = await runRuntimeBoundaryWithTimeout(
+      {
+        operation: `provider.${target.providerId}.health`,
+        clock: this.#clock,
+        timeoutMs: this.#timeoutMs,
+        error: {
+          tag: "ProviderUnavailableError",
+          code: "PROVIDER_HEALTH_FAILED",
+          message: "The provider health check failed.",
+          provider: target.providerId,
+        },
+        timeoutError: {
+          tag: "TimeoutError",
+          code: "PROVIDER_TIMEOUT",
+          message: "Provider health check timed out.",
+          provider: target.providerId,
+        },
+      },
+      () => target.health(),
+    );
+    const health: ProviderHealth = result.ok
+      ? {
+          ...result.value,
+          latencyMs: result.value.latencyMs ?? result.timing.durationMs,
+          capabilities: result.value.capabilities ?? target.capabilities(),
+        }
+      : {
+          providerId: target.providerId,
+          providerType: target.providerType,
+          status: "unavailable",
+          lastCheckedAt: result.timing.finishedAt,
+          lastError: result.error,
+          latencyMs: result.timing.durationMs,
+          capabilities: target.capabilities(),
+        };
+    this.#entries.set(target.providerId, { health, refreshedAtMs: this.#nowMs() });
+  }
+
+  #nowMs(): number {
+    return this.#clock.now().getTime();
+  }
+}

--- a/apps/observer/src/providers/registry.ts
+++ b/apps/observer/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import type {
   HarnessProvider,
   HarnessVersionInfo,
+  ProviderHealth,
   ProviderHookAdapter,
   ProviderId,
   RepositoryProvider,
@@ -8,6 +9,11 @@ import type {
   WorktreeProvider,
 } from "@station/contracts";
 import { withTimeout } from "@station/runtime";
+import {
+  ProviderHealthCache,
+  type ProviderHealthCacheTuning,
+  type ProviderHealthProbeTarget,
+} from "./healthCache.js";
 import { createTerminalIntentRunner, type TerminalIntentRunner } from "./terminalIntentRunner.js";
 
 export type ProviderRegistryInput = {
@@ -23,6 +29,7 @@ export type ProviderRegistryInput = {
   repositories?: Iterable<RepositoryProvider> | Map<string, RepositoryProvider>;
   hookAdapters?: Iterable<ProviderHookAdapter> | undefined;
   terminalIntentRunner?: TerminalIntentRunner | undefined;
+  healthCache?: ProviderHealthCacheTuning | undefined;
 };
 
 export class ProviderRegistry {
@@ -35,6 +42,7 @@ export class ProviderRegistry {
   readonly repositories: Map<string, RepositoryProvider>;
   readonly hookAdapters: Map<string, ProviderHookAdapter>;
   readonly terminalIntentRunner: TerminalIntentRunner;
+  readonly healthCache: ProviderHealthCache;
 
   constructor(input: ProviderRegistryInput) {
     this.worktree = input.worktree;
@@ -88,6 +96,11 @@ export class ProviderRegistry {
           harnesses: this.harnesses,
         },
       });
+
+    this.healthCache = new ProviderHealthCache({
+      targets: healthProbeTargets(this),
+      ...(input.healthCache ?? {}),
+    });
   }
 
   /** The default terminal provider. Retained for single-provider back-compat. */
@@ -140,4 +153,36 @@ export class ProviderRegistry {
       }),
     );
   }
+}
+
+type HealthProbeCapableProvider = {
+  id: ProviderId;
+  capabilities(): Record<string, boolean>;
+  health(): Promise<ProviderHealth>;
+};
+
+function healthProbeTargets(registry: ProviderRegistry): ProviderHealthProbeTarget[] {
+  const targets: ProviderHealthProbeTarget[] = [probeTarget(registry.worktree, "worktree")];
+  for (const provider of registry.terminals.values()) {
+    targets.push(probeTarget(provider, "terminal"));
+  }
+  for (const provider of registry.harnesses.values()) {
+    targets.push(probeTarget(provider, "harness"));
+  }
+  for (const provider of registry.repositories.values()) {
+    targets.push(probeTarget(provider, "repository"));
+  }
+  return targets;
+}
+
+function probeTarget(
+  provider: HealthProbeCapableProvider,
+  providerType: ProviderHealth["providerType"],
+): ProviderHealthProbeTarget {
+  return {
+    providerId: provider.id,
+    providerType,
+    capabilities: () => provider.capabilities(),
+    health: () => provider.health(),
+  };
 }

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -16,6 +16,7 @@ import type {
 import type { JsonlLogger } from "@station/observability";
 import {
   durationMs,
+  forEachConcurrent,
   pathIsSameOrInside,
   type RuntimeClock,
   runRuntimeBoundaryWithRetryAndTimeout,
@@ -36,6 +37,9 @@ export type ProviderReadOptions = {
   retries: number;
   logger?: JsonlLogger;
 };
+
+// Caps concurrent provider subprocesses (wt list / listTargets) per reconcile.
+const providerReadConcurrency = 4;
 
 export type ReconcileOnceInput = {
   reason: string;
@@ -98,19 +102,22 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
   const errors: SafeError[] = [];
   const providerHealth: Record<string, ProviderHealth> = {};
 
-  const worktreeResult = await readWorktreeObservations({
-    providers: input.providers,
-    projects: input.projects,
-    read: input.read,
-    providerHealth,
-    errors,
-  });
-  const terminalResult = await readTerminalTargetObservations({
-    providers: input.providers,
-    read: input.read,
-    providerHealth,
-    errors,
-  });
+  // Worktree and terminal reads are independent of each other.
+  const [worktreeResult, terminalResult] = await Promise.all([
+    readWorktreeObservations({
+      providers: input.providers,
+      projects: input.projects,
+      read: input.read,
+      providerHealth,
+      errors,
+    }),
+    readTerminalTargetObservations({
+      providers: input.providers,
+      read: input.read,
+      providerHealth,
+      errors,
+    }),
+  ]);
   const terminalTargets = normalizeTerminalTargetsForCurrentWorktrees({
     terminalTargets: terminalResult.terminalTargets,
     worktrees: worktreeResult.worktrees,
@@ -124,11 +131,10 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     providerHealth,
     errors,
   });
-  await readRepositoryProviderHealth({
+  readRepositoryProviderHealth({
     providers: input.providers,
     read: input.read,
     providerHealth,
-    errors,
   });
 
   const finishedAt = toIsoTimestamp(input.read.clock.now());
@@ -380,59 +386,67 @@ async function readWorktreeObservations(input: {
 }> {
   const provider = input.providers.worktree;
   const capabilities = provider.capabilities();
-  const worktrees: WorktreeObservation[] = [];
-  let projectsScanned = 0;
 
-  input.providerHealth[provider.id] = await readProviderHealth({
+  input.providerHealth[provider.id] = cachedProviderHealth({
+    providers: input.providers,
     providerId: provider.id,
     providerType: "worktree",
     capabilities,
     clock: input.read.clock,
-    timeoutMs: input.read.timeoutMs,
-    retries: input.read.retries,
-    health: () => provider.health(),
-    errors: input.errors,
   });
 
-  for (const project of input.projects) {
-    const result = await runProviderReadBoundary(
-      {
-        operation: `provider.${provider.id}.listWorktrees`,
-        clock: input.read.clock,
-        timeoutMs: input.read.timeoutMs,
-        retries: input.read.retries,
-        error: {
-          tag: "WorktreeProviderError",
-          code: "WORKTREE_LIST_FAILED",
-          message: "The worktree provider failed to list worktrees.",
-          provider: provider.id,
+  // Indexed collection keeps worktree order deterministic (config project order)
+  // while listWorktrees calls run concurrently.
+  const worktreesByProject: WorktreeObservation[][] = input.projects.map(() => []);
+  let projectsScanned = 0;
+  // One provider-level failure stops the remaining project scans: a hung
+  // provider would otherwise burn its full timeout budget once per project.
+  let providerFailed = false;
+  await forEachConcurrent(
+    input.projects,
+    { concurrency: providerReadConcurrency },
+    async (project, index) => {
+      if (providerFailed) {
+        return;
+      }
+      const result = await runProviderReadBoundary(
+        {
+          operation: `provider.${provider.id}.listWorktrees`,
+          clock: input.read.clock,
+          timeoutMs: input.read.timeoutMs,
+          retries: input.read.retries,
+          error: {
+            tag: "WorktreeProviderError",
+            code: "WORKTREE_LIST_FAILED",
+            message: "The worktree provider failed to list worktrees.",
+            provider: provider.id,
+          },
         },
-      },
-      () => provider.listWorktrees(project),
-    );
-    if (!result.ok) {
-      input.errors.push(result.error);
-      await input.read.logger?.error("Worktree provider list failed.", {
-        provider: provider.id,
-        error: result.error,
-        durationMs: result.timing.durationMs,
-      });
-      input.providerHealth[provider.id] = failedProviderHealth({
-        providerId: provider.id,
-        providerType: "worktree",
-        lastCheckedAt: result.timing.finishedAt,
-        lastError: result.error,
-        latencyMs: result.timing.durationMs,
-        capabilities,
-      });
-      break;
-    }
+        () => provider.listWorktrees(project),
+      );
+      if (!result.ok) {
+        providerFailed = true;
+        await recordProviderReadFailure({
+          providers: input.providers,
+          providerId: provider.id,
+          providerType: "worktree",
+          message: "Worktree provider list failed.",
+          error: result.error,
+          timing: result.timing,
+          capabilities,
+          providerHealth: input.providerHealth,
+          errors: input.errors,
+          logger: input.read.logger,
+        });
+        return;
+      }
 
-    projectsScanned += 1;
-    worktrees.push(...result.value);
-  }
+      projectsScanned += 1;
+      worktreesByProject[index] = result.value;
+    },
+  );
 
-  return { worktrees, projectsScanned };
+  return { worktrees: worktreesByProject.flat(), projectsScanned };
 }
 
 async function readTerminalTargetObservations(input: {
@@ -443,58 +457,60 @@ async function readTerminalTargetObservations(input: {
 }): Promise<{
   terminalTargets: TerminalTargetObservation[];
 }> {
-  const terminalTargets: TerminalTargetObservation[] = [];
+  const providers = Array.from(input.providers.terminals.values());
+  // Indexed collection keeps target order deterministic (provider registration
+  // order) while listTargets calls run concurrently.
+  const targetsByProvider: TerminalTargetObservation[][] = providers.map(() => []);
 
-  for (const provider of input.providers.terminals.values()) {
-    const capabilities = provider.capabilities();
+  await forEachConcurrent(
+    providers,
+    { concurrency: providerReadConcurrency },
+    async (provider, index) => {
+      const capabilities = provider.capabilities();
 
-    input.providerHealth[provider.id] = await readProviderHealth({
-      providerId: provider.id,
-      providerType: "terminal",
-      capabilities,
-      clock: input.read.clock,
-      timeoutMs: input.read.timeoutMs,
-      retries: input.read.retries,
-      health: () => provider.health(),
-      errors: input.errors,
-    });
-
-    const result = await runProviderReadBoundary(
-      {
-        operation: `provider.${provider.id}.listTargets`,
-        clock: input.read.clock,
-        timeoutMs: input.read.timeoutMs,
-        retries: input.read.retries,
-        error: {
-          tag: "TerminalProviderError",
-          code: "TERMINAL_LIST_FAILED",
-          message: "The terminal provider failed to list targets.",
-          provider: provider.id,
-        },
-      },
-      () => provider.listTargets(),
-    );
-    if (result.ok) {
-      terminalTargets.push(...result.value);
-    } else {
-      input.errors.push(result.error);
-      await input.read.logger?.error("Terminal provider list failed.", {
-        provider: provider.id,
-        error: result.error,
-        durationMs: result.timing.durationMs,
-      });
-      input.providerHealth[provider.id] = failedProviderHealth({
+      input.providerHealth[provider.id] = cachedProviderHealth({
+        providers: input.providers,
         providerId: provider.id,
         providerType: "terminal",
-        lastCheckedAt: result.timing.finishedAt,
-        lastError: result.error,
-        latencyMs: result.timing.durationMs,
         capabilities,
+        clock: input.read.clock,
       });
-    }
-  }
 
-  return { terminalTargets };
+      const result = await runProviderReadBoundary(
+        {
+          operation: `provider.${provider.id}.listTargets`,
+          clock: input.read.clock,
+          timeoutMs: input.read.timeoutMs,
+          retries: input.read.retries,
+          error: {
+            tag: "TerminalProviderError",
+            code: "TERMINAL_LIST_FAILED",
+            message: "The terminal provider failed to list targets.",
+            provider: provider.id,
+          },
+        },
+        () => provider.listTargets(),
+      );
+      if (result.ok) {
+        targetsByProvider[index] = result.value;
+      } else {
+        await recordProviderReadFailure({
+          providers: input.providers,
+          providerId: provider.id,
+          providerType: "terminal",
+          message: "Terminal provider list failed.",
+          error: result.error,
+          timing: result.timing,
+          capabilities,
+          providerHealth: input.providerHealth,
+          errors: input.errors,
+          logger: input.read.logger,
+        });
+      }
+    },
+  );
+
+  return { terminalTargets: targetsByProvider.flat() };
 }
 
 async function readHarnessObservations(input: {
@@ -515,15 +531,12 @@ async function readHarnessObservations(input: {
   for (const provider of input.providers.harnesses.values()) {
     const capabilities = provider.capabilities();
     harnessCapabilities[provider.id] = capabilities;
-    input.providerHealth[provider.id] = await readProviderHealth({
+    input.providerHealth[provider.id] = cachedProviderHealth({
+      providers: input.providers,
       providerId: provider.id,
       providerType: "harness",
       capabilities,
       clock: input.read.clock,
-      timeoutMs: input.read.timeoutMs,
-      retries: input.read.retries,
-      health: () => provider.health(),
-      errors: input.errors,
     });
 
     const result = await runProviderReadBoundary(
@@ -549,6 +562,7 @@ async function readHarnessObservations(input: {
 
     if (result.ok) {
       const classifiedRuns = await classifyHarnessRuns({
+        providers: input.providers,
         provider,
         capabilities,
         runs: result.value,
@@ -563,47 +577,41 @@ async function readHarnessObservations(input: {
       continue;
     }
 
-    input.errors.push(result.error);
-    await input.read.logger?.error("Harness provider discovery failed.", {
-      provider: provider.id,
-      error: result.error,
-      durationMs: result.timing.durationMs,
-    });
-    input.providerHealth[provider.id] = failedProviderHealth({
+    await recordProviderReadFailure({
+      providers: input.providers,
       providerId: provider.id,
       providerType: "harness",
-      lastCheckedAt: result.timing.finishedAt,
-      lastError: result.error,
-      latencyMs: result.timing.durationMs,
+      message: "Harness provider discovery failed.",
+      error: result.error,
+      timing: result.timing,
       capabilities,
+      providerHealth: input.providerHealth,
+      errors: input.errors,
+      logger: input.read.logger,
     });
   }
 
   return { harnessRuns, harnessCapabilities };
 }
 
-async function readRepositoryProviderHealth(input: {
+function readRepositoryProviderHealth(input: {
   providers: ProviderRegistry;
   read: ProviderReadOptions;
   providerHealth: Record<string, ProviderHealth>;
-  errors: SafeError[];
-}): Promise<void> {
+}): void {
   for (const provider of input.providers.repositories.values()) {
-    const capabilities = provider.capabilities();
-    input.providerHealth[provider.id] = await readProviderHealth({
+    input.providerHealth[provider.id] = cachedProviderHealth({
+      providers: input.providers,
       providerId: provider.id,
       providerType: "repository",
-      capabilities,
+      capabilities: provider.capabilities(),
       clock: input.read.clock,
-      timeoutMs: input.read.timeoutMs,
-      retries: input.read.retries,
-      health: () => provider.health(),
-      errors: input.errors,
     });
   }
 }
 
 async function classifyHarnessRuns(input: {
+  providers: ProviderRegistry;
   provider: HarnessProvider;
   capabilities: HarnessCapabilities;
   runs: HarnessRunObservation[];
@@ -642,19 +650,17 @@ async function classifyHarnessRuns(input: {
       continue;
     }
 
-    input.errors.push(classification.error);
-    await input.read.logger?.error("Harness provider classification failed.", {
-      provider: input.provider.id,
-      error: classification.error,
-      durationMs: classification.timing.durationMs,
-    });
-    input.providerHealth[input.provider.id] = failedProviderHealth({
+    await recordProviderReadFailure({
+      providers: input.providers,
       providerId: input.provider.id,
       providerType: "harness",
-      lastCheckedAt: classification.timing.finishedAt,
-      lastError: classification.error,
-      latencyMs: classification.timing.durationMs,
+      message: "Harness provider classification failed.",
+      error: classification.error,
+      timing: classification.timing,
       capabilities: input.capabilities,
+      providerHealth: input.providerHealth,
+      errors: input.errors,
+      logger: input.read.logger,
     });
   }
 
@@ -776,49 +782,26 @@ async function worktreesWithCachedMetadata(input: {
   });
 }
 
-async function readProviderHealth(input: {
+// Reconcile never awaits a health probe: it reads the out-of-band cache and
+// reports "unknown" until the first probe lands.
+function cachedProviderHealth(input: {
+  providers: ProviderRegistry;
   providerId: ProviderId;
   providerType: ProviderHealth["providerType"];
   capabilities: Record<string, boolean>;
   clock: RuntimeClock;
-  timeoutMs: number;
-  retries: number;
-  health: () => Promise<ProviderHealth>;
-  errors: SafeError[];
-}): Promise<ProviderHealth> {
-  const result = await runProviderReadBoundary(
-    {
-      operation: `provider.${input.providerId}.health`,
-      clock: input.clock,
-      timeoutMs: input.timeoutMs,
-      retries: input.retries,
-      error: {
-        tag: "ProviderUnavailableError",
-        code: "PROVIDER_HEALTH_FAILED",
-        message: "The provider health check failed.",
-        provider: input.providerId,
-      },
-    },
-    input.health,
-  );
-
-  if (result.ok) {
-    return {
-      ...result.value,
-      latencyMs: result.value.latencyMs ?? result.timing.durationMs,
-      capabilities: result.value.capabilities ?? input.capabilities,
-    };
+}): ProviderHealth {
+  const cached = input.providers.healthCache.read(input.providerId);
+  if (cached !== undefined) {
+    return cached;
   }
-
-  input.errors.push(result.error);
-  return failedProviderHealth({
+  return {
     providerId: input.providerId,
     providerType: input.providerType,
-    lastCheckedAt: result.timing.finishedAt,
-    lastError: result.error,
-    latencyMs: result.timing.durationMs,
+    status: "unknown",
+    lastCheckedAt: toIsoTimestamp(input.clock.now()),
     capabilities: input.capabilities,
-  });
+  };
 }
 
 function runProviderReadBoundary<T>(
@@ -855,6 +838,39 @@ function runProviderReadBoundary<T>(
     },
     task,
   );
+}
+
+async function recordProviderReadFailure(input: {
+  providers: ProviderRegistry;
+  providerId: ProviderId;
+  providerType: ProviderHealth["providerType"];
+  message: string;
+  error: SafeError;
+  timing: { finishedAt: string; durationMs: number };
+  capabilities: Record<string, boolean>;
+  providerHealth: Record<string, ProviderHealth>;
+  errors: SafeError[];
+  logger: JsonlLogger | undefined;
+}): Promise<void> {
+  input.errors.push(input.error);
+  await input.logger?.error(input.message, {
+    provider: input.providerId,
+    error: input.error,
+    durationMs: input.timing.durationMs,
+  });
+  input.providerHealth[input.providerId] = failedProviderHealth({
+    providerId: input.providerId,
+    providerType: input.providerType,
+    lastCheckedAt: input.timing.finishedAt,
+    lastError: input.error,
+    latencyMs: input.timing.durationMs,
+    capabilities: input.capabilities,
+  });
+  // Re-probe only when the cache still says healthy; a fresh cached failure
+  // needs no confirmation, and read() already schedules stale refreshes.
+  if (input.providers.healthCache.read(input.providerId)?.status === "healthy") {
+    void input.providers.healthCache.refresh(input.providerId);
+  }
 }
 
 function failedProviderHealth(input: {

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -13,10 +13,11 @@ import type {
   ObserverStopReceipt,
   ProviderHookEvent,
   ProviderHookReceipt,
+  ReconcileReceipt,
   StationCommand,
   StationEvent,
 } from "@station/contracts";
-import { STATION_SCHEMA_VERSION } from "@station/contracts";
+import { STARTUP_RECONCILE_REASONS, STATION_SCHEMA_VERSION } from "@station/contracts";
 import type { JsonlLogger } from "@station/observability";
 import type { ObserverApi } from "@station/protocol";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
@@ -168,6 +169,31 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   };
 
+  // Launch reconciles that arrive while the observer.startup scan is still
+  // running join that flight (reason rewrapped) instead of queueing a redundant
+  // full scan. All other reconciles — scheduler, hooks, external launches, bare
+  // `stn reconcile` — must keep the "scan starts at or after the request" property.
+  let startupFlight: Promise<ReconcileReceipt> | undefined;
+  const startupJoinableReasons = new Set<string>(STARTUP_RECONCILE_REASONS);
+  const reconcile = (reason?: string): Promise<ReconcileReceipt> => {
+    if (startupFlight !== undefined && reason !== undefined && startupJoinableReasons.has(reason)) {
+      return startupFlight.then((receipt) => ({ ...receipt, reason }));
+    }
+    const flight = runReconcile(reconcileDeps, reconciling, reason);
+    if (reason === "observer.startup") {
+      startupFlight = flight;
+      void flight
+        .catch(() => undefined)
+        .finally(() => {
+          // Identity guard: only the flight that set the stash may clear it.
+          if (startupFlight === flight) {
+            startupFlight = undefined;
+          }
+        });
+    }
+    return flight;
+  };
+
   const api: ObserverApi = {
     health: () => buildHealth(options, clock, harnessIngressQueue),
     stop: () => buildStop(options, harnessIngressQueue, metadataRefresh, clock),
@@ -182,7 +208,7 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
       diagnosticOptions?: DiagnosticCollectionOptions,
     ): Promise<DiagnosticSnapshot> =>
       collectDiagnosticSnapshot(buildDiagnosticDeps(options, clock), diagnosticOptions),
-    reconcile: (reason) => runReconcile(reconcileDeps, reconciling, reason),
+    reconcile,
     ingestProviderHookEvent: (event: ProviderHookEvent): Promise<ProviderHookReceipt> =>
       providerHookIngress.ingest(event),
     reportHarnessEvent: async (report: HarnessEventReport): Promise<HarnessEventReportReceipt> =>

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -82,8 +82,9 @@ export async function runObserverMain(
     providerOptions.configPath = loadedConfig.configPath;
   }
   const providers = deps.providerRegistryFactory(config, providerOptions);
-  // Fire-and-forget: version badges appear on a later snapshot when probes land.
+  // Fire-and-forget boot probes: snapshots read cached results and fill in as they land.
   void providers.refreshHarnessVersions();
+  void providers.healthCache.refreshAll();
   const featureFlags = createFeatureFlagEvaluator({
     ...(config.featureFlags === undefined ? {} : { overrides: config.featureFlags }),
     revisionSeed: loadedConfig.configPath,

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -26,6 +26,7 @@ describe("observer diagnostics collector", () => {
       sqlitePath: join(stateDir, "observer.sqlite"),
     });
 
+    await providers.healthCache.refreshAll();
     await core.reconcile("diagnostics-test");
     const deps = {
       config,

--- a/apps/observer/test/integration/reconcile-claude-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-claude-harness.test.ts
@@ -18,14 +18,16 @@ const now = "2026-06-11T12:00:00.000Z";
 
 describe("observer reconcile with Claude harness", () => {
   it("observes a tmux-bound Claude target as a provider-neutral harness run", async () => {
+    const providers = claudeProviders();
     const core = createObserverCore({
       config,
-      providers: claudeProviders(),
+      providers,
       clock: {
         now: () => new Date(now),
       },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("claude-terminal-binding");
 
     expect(snapshot.rows[0]?.agent).toMatchObject({

--- a/apps/observer/test/integration/reconcile-codex-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-codex-harness.test.ts
@@ -32,51 +32,53 @@ describe("observer reconcile with Codex harness", () => {
         exitCode: 0,
       }),
     });
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({
+        now,
+        worktrees: [
+          createFakeWorktree({
+            id: "wt_web_task",
+            projectId: "web",
+            branch: "task",
+            path: "/tmp/station/web/task",
+            now,
+          }),
+        ],
+      }),
+      terminal: new FakeTerminalProvider({
+        now,
+        targets: [
+          createFakeTerminalTarget({
+            id: "tmux:station:@1:%2",
+            provider: "tmux",
+            projectId: "web",
+            worktreeId: "wt_web_task",
+            sessionId: "ses_web_task",
+            now,
+            harnessBinding: {
+              role: "main-agent",
+              harnessProvider: "codex",
+              currentCommand: "codex",
+            },
+            providerData: {
+              sessionName: "station",
+              windowId: "@1",
+              paneId: "%2",
+            },
+          }),
+        ],
+      }),
+      harnesses: [provider],
+    });
     const core = createObserverCore({
       config,
-      providers: new ProviderRegistry({
-        worktree: new FakeWorktreeProvider({
-          now,
-          worktrees: [
-            createFakeWorktree({
-              id: "wt_web_task",
-              projectId: "web",
-              branch: "task",
-              path: "/tmp/station/web/task",
-              now,
-            }),
-          ],
-        }),
-        terminal: new FakeTerminalProvider({
-          now,
-          targets: [
-            createFakeTerminalTarget({
-              id: "tmux:station:@1:%2",
-              provider: "tmux",
-              projectId: "web",
-              worktreeId: "wt_web_task",
-              sessionId: "ses_web_task",
-              now,
-              harnessBinding: {
-                role: "main-agent",
-                harnessProvider: "codex",
-                currentCommand: "codex",
-              },
-              providerData: {
-                sessionName: "station",
-                windowId: "@1",
-                paneId: "%2",
-              },
-            }),
-          ],
-        }),
-        harnesses: [provider],
-      }),
+      providers,
       clock: {
         now: () => new Date(now),
       },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("codex-terminal-binding");
 
     expect(snapshot.rows[0]?.agent).toMatchObject({

--- a/apps/observer/test/integration/reconcile-fake-providers.test.ts
+++ b/apps/observer/test/integration/reconcile-fake-providers.test.ts
@@ -163,6 +163,7 @@ describe("observer reconcile with fake providers", () => {
       },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("integration-test");
     const health = core.getHealth();
 
@@ -505,20 +506,22 @@ describe("observer reconcile with fake providers", () => {
         active -= 1;
       }
     };
+    const providers = new ProviderRegistry({
+      worktree,
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+    });
     const core = createObserverCore({
       config,
       providerTimeoutMs: 100,
       providerReadRetries: 1,
-      providers: new ProviderRegistry({
-        worktree,
-        terminal: new FakeTerminalProvider({ now }),
-        harnesses: [new FakeHarnessProvider({ now })],
-      }),
+      providers,
       clock: {
         now: () => new Date(now),
       },
     });
 
+    await providers.healthCache.refreshAll();
     const [first, second] = await Promise.all([
       core.reconcile("concurrent-a"),
       core.reconcile("concurrent-b"),
@@ -527,6 +530,45 @@ describe("observer reconcile with fake providers", () => {
     expect(first.providerHealth["fake-worktree"]?.status).toBe("healthy");
     expect(second.providerHealth["fake-worktree"]?.status).toBe("healthy");
     expect(attempts).toBeGreaterThan(config.projects.length);
-    expect(maxActive).toBe(1);
+    // Serialized reconciles: concurrent listWorktrees stay within one
+    // reconcile's per-project fan-out instead of doubling across both.
+    expect(maxActive).toBeLessThanOrEqual(config.projects.length);
+  });
+
+  it("reads provider health from the cache without awaiting probes", async () => {
+    const worktree = new FakeWorktreeProvider({
+      now,
+      worktrees: [createFakeWorktree({ id: "wt_web_idle", projectId: "web", now })],
+    });
+    worktree.health = () => new Promise<never>(() => undefined);
+    const providers = new ProviderRegistry({
+      worktree,
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+      healthCache: { timeoutMs: 20 },
+    });
+    const core = createObserverCore({
+      config,
+      providers,
+      clock: {
+        now: () => new Date(now),
+      },
+    });
+
+    const snapshot = await core.reconcile("hung-health-probe");
+
+    expect(StationSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+    expect(snapshot.providerHealth["fake-worktree"]?.status).toBe("unknown");
+    expect(snapshot.rows.map((row) => row.id)).toEqual(["wt_web_idle"]);
+
+    // The hung probe times out in the background; live reads keep degrading it.
+    await providers.healthCache.refreshAll();
+    const after = await core.reconcile("after-probes");
+    expect(after.providerHealth["fake-terminal"]?.status).toBe("healthy");
+    expect(after.providerHealth["fake-harness"]?.status).toBe("healthy");
+    expect(after.providerHealth["fake-worktree"]).toMatchObject({
+      status: "unavailable",
+      lastError: { code: "PROVIDER_TIMEOUT" },
+    });
   });
 });

--- a/apps/observer/test/integration/reconcile-opencode-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-opencode-harness.test.ts
@@ -15,14 +15,16 @@ const now = "2026-05-20T12:00:00.000Z";
 
 describe("observer reconcile with OpenCode harness", () => {
   it("observes a tmux-bound OpenCode target as a provider-neutral harness run", async () => {
+    const providers = opencodeProviders();
     const core = createObserverCore({
       config,
-      providers: opencodeProviders(),
+      providers,
       clock: {
         now: () => new Date(now),
       },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("opencode-terminal-binding");
 
     expect(snapshot.rows[0]?.agent).toMatchObject({

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
+import { ProviderHealthSchema, StationSnapshotSchema } from "@station/contracts";
 import {
   createFakeHarnessRun,
   createFakeTerminalTarget,
@@ -102,13 +103,16 @@ function providersWithOneSession() {
 describe("observer reconcile persistence", () => {
   it("persists provider observations, session correlations, and reconcile events", async () => {
     const dbPath = await tempDbPath();
+    const providers = providersWithOneSession();
     const { sqlite, persistence, core } = createTestObserverCore({
       config,
-      providers: providersWithOneSession(),
+      providers,
       clock: { now: () => new Date(now) },
       sqlitePath: dbPath,
     });
 
+    // Warm the health cache so both reconciles persist identical health rows.
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("persistence-test");
 
     expect(snapshot.rows.map((row) => row.id)).toEqual(["wt_web_main"]);
@@ -160,6 +164,32 @@ describe("observer reconcile persistence", () => {
       }),
     ]);
     reopened.close();
+  });
+
+  it("persists 'unknown' provider health before the first background probe lands", async () => {
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers: providersWithOneSession(),
+      clock: { now: () => new Date(now) },
+    });
+
+    const snapshot = await core.reconcile("cold-health-cache");
+
+    expect(StationSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+    expect(snapshot.observer.healthy).toBe(true);
+    expect(Object.values(snapshot.providerHealth).map((health) => health.status)).toEqual([
+      "unknown",
+      "unknown",
+      "unknown",
+    ]);
+    const observations = await persistence.listProviderObservations();
+    const healthRows = observations.filter((item) => item.entityKind === "provider_health");
+    expect(healthRows.map((row) => ProviderHealthSchema.parse(row.payload).status)).toEqual([
+      "unknown",
+      "unknown",
+      "unknown",
+    ]);
+    sqlite.close();
   });
 
   it("does not hydrate the live graph from stale SQLite records", async () => {

--- a/apps/observer/test/integration/reconcile-pi-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-pi-harness.test.ts
@@ -18,14 +18,16 @@ const now = "2026-05-27T12:00:00.000Z";
 
 describe("observer reconcile with Pi harness", () => {
   it("observes a tmux-bound Pi target as a provider-neutral harness run", async () => {
+    const providers = piProviders();
     const core = createObserverCore({
       config,
-      providers: piProviders(),
+      providers,
       clock: {
         now: () => new Date(now),
       },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("pi-terminal-binding");
 
     expect(snapshot.rows[0]?.agent).toMatchObject({

--- a/apps/observer/test/integration/reconcile-worktrunk-provider.test.ts
+++ b/apps/observer/test/integration/reconcile-worktrunk-provider.test.ts
@@ -35,6 +35,7 @@ describe("observer reconcile with Worktrunk provider", () => {
       clock: { now: () => new Date(now) },
     });
 
+    await providers.healthCache.refreshAll();
     const snapshot = await core.reconcile("worktrunk-provider");
 
     expect(snapshot.rows).toEqual([

--- a/apps/observer/test/support/testObserver.ts
+++ b/apps/observer/test/support/testObserver.ts
@@ -1,4 +1,6 @@
 import type { StationConfig } from "@station/config";
+import { STATION_SCHEMA_VERSION, type StationSnapshot } from "@station/contracts";
+import type { CommandQueue } from "../../src/commands/queue";
 import {
   createCommandQueue,
   createObserverApi,
@@ -8,8 +10,53 @@ import {
   openObserverSqlite,
   type ProviderRegistry,
 } from "../../src/internal";
+import type { ObserverPersistence } from "../../src/persistence";
 
 export type TestClock = { now: () => Date };
+
+export function fakeObserverPersistence(): ObserverPersistence {
+  return {
+    recordEventWithIngressDedupe: async () => ({ deduped: false }),
+  } as unknown as ObserverPersistence;
+}
+
+export function fakeObserverCommandQueue(): CommandQueue {
+  return {
+    dispatch: async () => {
+      throw new Error("dispatch is not used by this test.");
+    },
+    drain: async () => undefined,
+    shutdown: async () => undefined,
+    registerHandler: () => undefined,
+  };
+}
+
+export function emptyStationSnapshot(generatedAt: string): StationSnapshot {
+  return {
+    schemaVersion: STATION_SCHEMA_VERSION,
+    generatedAt,
+    observer: {
+      pid: 1,
+      startedAt: generatedAt,
+      version: "0.0.0",
+      healthy: true,
+    },
+    providerHealth: {},
+    projects: [],
+    rows: [],
+    sessions: [],
+    counts: {
+      projects: 0,
+      worktrees: 0,
+      agents: 0,
+      working: 0,
+      idle: 0,
+      attention: 0,
+      unknown: 0,
+    },
+    alerts: [],
+  };
+}
 
 /** Sequential id factory mirroring the per-file `ids()` helper the tests used to inline. */
 export function createTestIdFactory() {

--- a/apps/observer/test/unit/providerHealthCache.test.ts
+++ b/apps/observer/test/unit/providerHealthCache.test.ts
@@ -1,0 +1,157 @@
+import type { ProviderHealth } from "@station/contracts";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderHealthCache, type ProviderHealthProbeTarget } from "../../src/internal";
+
+const now = "2026-05-20T12:00:00.000Z";
+
+function healthyResult(providerId: string): ProviderHealth {
+  return {
+    providerId,
+    providerType: "harness",
+    status: "healthy",
+    lastCheckedAt: now,
+    latencyMs: 1,
+    capabilities: { canLaunch: true },
+  };
+}
+
+function target(
+  providerId: string,
+  health: () => Promise<ProviderHealth>,
+): ProviderHealthProbeTarget {
+  return {
+    providerId,
+    providerType: "harness",
+    capabilities: () => ({ canLaunch: true }),
+    health,
+  };
+}
+
+function testClock(startMs = 0) {
+  let ms = startMs;
+  return {
+    clock: { now: () => new Date(ms) },
+    advance: (deltaMs: number) => {
+      ms += deltaMs;
+    },
+  };
+}
+
+describe("provider health cache", () => {
+  it("returns undefined before the first probe and populates in the background", async () => {
+    const probe = vi.fn(async () => healthyResult("fake"));
+    const cache = new ProviderHealthCache({ targets: [target("fake", probe)] });
+
+    expect(cache.read("fake")).toBeUndefined();
+
+    // Joins the background probe the read triggered.
+    await cache.refresh("fake");
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(cache.read("fake")?.status).toBe("healthy");
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes every registered provider on refreshAll", async () => {
+    const first = vi.fn(async () => healthyResult("one"));
+    const second = vi.fn(async () => healthyResult("two"));
+    const cache = new ProviderHealthCache({
+      targets: [target("one", first), target("two", second)],
+    });
+
+    await cache.refreshAll();
+
+    expect(cache.read("one")?.status).toBe("healthy");
+    expect(cache.read("two")?.status).toBe("healthy");
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves stale entries past the TTL while revalidating once in the background", async () => {
+    const { clock, advance } = testClock();
+    let resolveRevalidation: (value: ProviderHealth) => void = () => undefined;
+    const probe = vi.fn((): Promise<ProviderHealth> => {
+      if (probe.mock.calls.length === 1) {
+        return Promise.resolve(healthyResult("fake"));
+      }
+      return new Promise((resolve) => {
+        resolveRevalidation = resolve;
+      });
+    });
+    const cache = new ProviderHealthCache({
+      targets: [target("fake", probe)],
+      ttlMs: 1000,
+      clock,
+    });
+    await cache.refreshAll();
+
+    advance(1001);
+    expect(cache.read("fake")?.status).toBe("healthy");
+    expect(cache.read("fake")?.status).toBe("healthy");
+    // Both stale reads share one in-flight revalidation (the probe itself
+    // starts on a later tick inside the runtime boundary).
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+
+    resolveRevalidation({ ...healthyResult("fake"), status: "degraded" });
+    await vi.waitFor(() => expect(cache.read("fake")?.status).toBe("degraded"));
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches a failed probe as unavailable with the error", async () => {
+    const cache = new ProviderHealthCache({
+      targets: [
+        target("fake", async () => {
+          throw {
+            tag: "ProviderUnavailableError",
+            code: "FAKE_HEALTH_FAILED",
+            message: "The fake provider health check failed.",
+            provider: "fake",
+          };
+        }),
+      ],
+    });
+
+    await cache.refreshAll();
+
+    expect(cache.read("fake")).toMatchObject({
+      status: "unavailable",
+      lastError: { code: "FAKE_HEALTH_FAILED" },
+      capabilities: { canLaunch: true },
+    });
+  });
+
+  it("times out hung probes instead of caching forever", async () => {
+    const cache = new ProviderHealthCache({
+      targets: [target("fake", () => new Promise<never>(() => undefined))],
+      timeoutMs: 20,
+    });
+
+    await cache.refresh("fake");
+
+    expect(cache.read("fake")).toMatchObject({
+      status: "unavailable",
+      lastError: { code: "PROVIDER_TIMEOUT" },
+    });
+  });
+
+  it("re-probes on eager refresh even when the entry is fresh", async () => {
+    const statuses: ProviderHealth["status"][] = ["healthy", "unavailable"];
+    const probe = vi.fn(async () => ({
+      ...healthyResult("fake"),
+      status: statuses[Math.min(probe.mock.calls.length - 1, 1)] ?? "unavailable",
+    }));
+    const cache = new ProviderHealthCache({ targets: [target("fake", probe)] });
+    await cache.refreshAll();
+    expect(cache.read("fake")?.status).toBe("healthy");
+
+    await cache.refresh("fake");
+
+    expect(probe).toHaveBeenCalledTimes(2);
+    expect(cache.read("fake")?.status).toBe("unavailable");
+  });
+
+  it("resolves refresh for unknown providers without probing", async () => {
+    const cache = new ProviderHealthCache({ targets: [] });
+    await expect(cache.refresh("missing")).resolves.toBeUndefined();
+    expect(cache.read("missing")).toBeUndefined();
+  });
+});

--- a/apps/observer/test/unit/reconcileProfiling.test.ts
+++ b/apps/observer/test/unit/reconcileProfiling.test.ts
@@ -1,12 +1,14 @@
-import type { StationSnapshot } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
 import type { JsonlLogger } from "@station/observability";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { CommandQueue } from "../../src/commands/queue";
-import type { ObserverPersistence } from "../../src/persistence";
 import type { ObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
+import {
+  emptyStationSnapshot,
+  fakeObserverCommandQueue,
+  fakeObserverPersistence,
+} from "../support/testObserver";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -101,8 +103,8 @@ function createProfilingApi(input: {
   const eventBus = createObserverEventBus();
   const options = {
     core: fakeCore(input.reconcileDelayMs),
-    persistence: fakePersistence(),
-    commandQueue: fakeCommandQueue(),
+    persistence: fakeObserverPersistence(),
+    commandQueue: fakeObserverCommandQueue(),
     eventBus,
     clock: { now: () => new Date(now) },
     logger: input.logger,
@@ -124,34 +126,17 @@ function fakeCore(reconcileDelayMs: number): ObserverCore {
       if (reconcileDelayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, reconcileDelayMs));
       }
-      return snapshot();
+      return emptyStationSnapshot(now);
     },
     projectHarnessEventStatus: async () => ({ projected: false, events: [] }),
     updateConfig: () => undefined,
     getProjects: () => [],
-    getSnapshot: snapshot,
+    getSnapshot: () => emptyStationSnapshot(now),
     getHealth: () => ({
       status: "healthy",
       startedAt: now,
       providerHealth: {},
     }),
-  };
-}
-
-function fakePersistence(): ObserverPersistence {
-  return {
-    recordEventWithIngressDedupe: async () => ({ deduped: false }),
-  } as unknown as ObserverPersistence;
-}
-
-function fakeCommandQueue(): CommandQueue {
-  return {
-    dispatch: async () => {
-      throw new Error("dispatch is not used by reconcile profiling tests.");
-    },
-    drain: async () => undefined,
-    shutdown: async () => undefined,
-    registerHandler: () => undefined,
   };
 }
 
@@ -210,32 +195,5 @@ function logReturn(
     level,
     message,
     ...(attributes === undefined ? {} : { attributes }),
-  };
-}
-
-function snapshot(): StationSnapshot {
-  return {
-    schemaVersion: STATION_SCHEMA_VERSION,
-    generatedAt: now,
-    observer: {
-      pid: 1,
-      startedAt: now,
-      version: "0.0.0",
-      healthy: true,
-    },
-    providerHealth: {},
-    projects: [],
-    rows: [],
-    sessions: [],
-    counts: {
-      projects: 0,
-      worktrees: 0,
-      agents: 0,
-      working: 0,
-      idle: 0,
-      attention: 0,
-      unknown: 0,
-    },
-    alerts: [],
   };
 }

--- a/apps/observer/test/unit/reconcileStartupJoin.test.ts
+++ b/apps/observer/test/unit/reconcileStartupJoin.test.ts
@@ -1,0 +1,120 @@
+import type { StationSnapshot } from "@station/contracts";
+import { describe, expect, it, vi } from "vitest";
+import type { ObserverCore } from "../../src/reconcile/core";
+import { createObserverApi } from "../../src/runtime/api";
+import { createObserverEventBus } from "../../src/runtime/eventBus";
+import {
+  emptyStationSnapshot,
+  fakeObserverCommandQueue,
+  fakeObserverPersistence,
+} from "../support/testObserver";
+
+const now = "2026-05-20T12:00:00.000Z";
+
+describe("observer startup reconcile join", () => {
+  it("joins startup reasons onto the in-flight startup scan and rewraps the reason", async () => {
+    const { core, scans } = controllableCore();
+    const api = createJoinApi(core);
+
+    const startup = api.reconcile("observer.startup");
+    const joined = api.reconcile("tui-startup");
+    const popup = api.reconcile("popup-open");
+
+    await vi.waitFor(() => expect(scans).toHaveLength(1));
+    scans[0]?.resolve(scans[0].snapshot);
+
+    const [startupReceipt, joinedReceipt, popupReceipt] = await Promise.all([
+      startup,
+      joined,
+      popup,
+    ]);
+
+    expect(scans.map((scan) => scan.reason)).toEqual(["observer.startup"]);
+    expect(startupReceipt.reason).toBe("observer.startup");
+    expect(joinedReceipt.reason).toBe("tui-startup");
+    expect(popupReceipt.reason).toBe("popup-open");
+    expect(joinedReceipt.snapshot).toBe(startupReceipt.snapshot);
+    expect(popupReceipt.snapshot).toBe(startupReceipt.snapshot);
+    expect(joinedReceipt.reconciledAt).toBe(startupReceipt.reconciledAt);
+  });
+
+  it("never joins bare or scheduler reasons and stops joining once the flight settles", async () => {
+    const { core, scans } = controllableCore();
+    const api = createJoinApi(core);
+
+    const startup = api.reconcile("observer.startup");
+    const interval = api.reconcile("interval");
+    const unnamed = api.reconcile();
+    // Non-joinable reconciles run their own scans while startup is pending
+    // (a bare reconcile reaches the core with the "manual" default).
+    await vi.waitFor(() => expect(scans).toHaveLength(3));
+    expect(scans.map((scan) => scan.reason).sort()).toEqual([
+      "interval",
+      "manual",
+      "observer.startup",
+    ]);
+
+    for (const scan of scans) {
+      scan.resolve(scan.snapshot);
+    }
+    const [startupReceipt, intervalReceipt, unnamedReceipt] = await Promise.all([
+      startup,
+      interval,
+      unnamed,
+    ]);
+    expect(intervalReceipt.reason).toBe("interval");
+    expect(intervalReceipt.snapshot).not.toBe(startupReceipt.snapshot);
+    expect(unnamedReceipt.snapshot).not.toBe(startupReceipt.snapshot);
+
+    // Let the settled flight's clear handler run before the late reconcile.
+    await new Promise((resolve) => setImmediate(resolve));
+    const late = api.reconcile("tui-startup");
+    await vi.waitFor(() => expect(scans.map((scan) => scan.reason)).toContain("tui-startup"));
+    const lateScan = scans.find((scan) => scan.reason === "tui-startup");
+    lateScan?.resolve(lateScan.snapshot);
+    const lateReceipt = await late;
+    expect(lateReceipt.reason).toBe("tui-startup");
+    expect(lateReceipt.snapshot).not.toBe(startupReceipt.snapshot);
+  });
+});
+
+type ControlledScan = {
+  reason: string | undefined;
+  snapshot: StationSnapshot;
+  resolve: (value: StationSnapshot) => void;
+};
+
+function controllableCore(): { core: ObserverCore; scans: ControlledScan[] } {
+  const scans: ControlledScan[] = [];
+  const core: ObserverCore = {
+    reconcile: (reason) =>
+      new Promise<StationSnapshot>((resolve) => {
+        scans.push({ reason, snapshot: emptyStationSnapshot(now), resolve });
+      }),
+    projectHarnessEventStatus: async () => ({ projected: false, events: [] }),
+    clearTurnReadiness: () => undefined,
+    updateConfig: () => undefined,
+    getProjects: () => [],
+    getSnapshot: () => emptyStationSnapshot(now),
+    getHealth: () => ({
+      status: "healthy",
+      startedAt: now,
+      providerHealth: {},
+    }),
+  };
+  return { core, scans };
+}
+
+function createJoinApi(core: ObserverCore) {
+  return createObserverApi({
+    core,
+    persistence: fakeObserverPersistence(),
+    commandQueue: fakeObserverCommandQueue(),
+    eventBus: createObserverEventBus(),
+    clock: { now: () => new Date(now) },
+    metadataRefresh: {
+      refresh: async () => undefined,
+      shutdown: async () => undefined,
+    },
+  });
+}

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -98,3 +98,12 @@ export const ReconcileReceiptSchema = z
   .strict();
 
 export type ReconcileReceipt = z.infer<typeof ReconcileReceiptSchema>;
+
+// Freshness-insensitive launch reconciles: the observer may satisfy these by
+// joining an in-flight observer.startup scan instead of running a new one.
+export const TUI_STARTUP_RECONCILE_REASON = "tui-startup";
+export const POPUP_OPEN_RECONCILE_REASON = "popup-open";
+export const STARTUP_RECONCILE_REASONS = [
+  TUI_STARTUP_RECONCILE_REASON,
+  POPUP_OPEN_RECONCILE_REASON,
+] as const;

--- a/packages/runtime/src/effect.ts
+++ b/packages/runtime/src/effect.ts
@@ -1,15 +1,14 @@
-export {
-  Cause,
-  Context,
-  Deferred,
-  Duration,
-  Effect,
-  Exit,
-  Fiber,
-  Layer,
-  Logger,
-  Queue,
-  Ref,
-  Schedule,
-  Scope,
-} from "effect";
+// Subpath re-exports keep the "effect" barrel (and its fast-check dependency) out of every process.
+export * as Cause from "effect/Cause";
+export * as Context from "effect/Context";
+export * as Deferred from "effect/Deferred";
+export * as Duration from "effect/Duration";
+export * as Effect from "effect/Effect";
+export * as Exit from "effect/Exit";
+export * as Fiber from "effect/Fiber";
+export * as Layer from "effect/Layer";
+export * as Logger from "effect/Logger";
+export * as Queue from "effect/Queue";
+export * as Ref from "effect/Ref";
+export * as Schedule from "effect/Schedule";
+export * as Scope from "effect/Scope";

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -91,16 +91,19 @@ const stationClient = createStationClient(Bun.env, {
     playStationAttentionSound();
   },
 });
-// Loaded before the renderer takes the screen so a config warning is still
-// readable on the normal terminal. A broken/absent file degrades to defaults.
-const stationConfig = await loadStationConfig({ env: Bun.env });
-if (stationConfig.warning !== undefined) {
-  console.error(`[station] ${stationConfig.warning}`);
-}
-const tuiConfig = await loadStationTuiConfig({ env: Bun.env });
-if (tuiConfig.warning !== undefined) {
-  console.error(`[station] ${tuiConfig.warning}`);
-}
+// Started now so the observer subscribe + snapshot resync overlaps the boot
+// phases below and the first painted frame is already populated. createStation's
+// lifecycle calls start() again — a guarded no-op.
+stationClient.start();
+
+const configsLoading = Promise.all([
+  loadStationConfig({ env: Bun.env }),
+  loadStationTuiConfig({ env: Bun.env }),
+]);
+
+// Kicked after configsLoading so its synchronous ps calls don't delay the config
+// reads; awaited before raw mode below.
+const rivalsReaped = terminateRivalStationUIs();
 
 const stationGlobalSlots = stationHotSlots();
 
@@ -130,13 +133,15 @@ try {
 }
 
 // Warm-reattach live host PTYs when a host is up, else cold-respawn fresh shells.
-let restorePlan: LayoutRestorePlan | undefined;
+let restorePlanLoading: LayoutRestorePlan | Promise<LayoutRestorePlan> | undefined;
 if (restoredLayout !== undefined) {
   if (hostSocketPath === undefined) {
-    restorePlan = planLayoutRestoreColdShells(restoredLayout, { cwdExists: savedCwdExists });
+    restorePlanLoading = planLayoutRestoreColdShells(restoredLayout, {
+      cwdExists: savedCwdExists,
+    });
   } else {
     const socket = hostSocketPath;
-    restorePlan = await buildBootRestorePlan(restoredLayout, {
+    restorePlanLoading = buildBootRestorePlan(restoredLayout, {
       cwdExists: savedCwdExists,
       listHost: () => listLiveHostPtys(socket),
       makeHostTerminal: (entry) => (options) =>
@@ -151,6 +156,19 @@ if (restoredLayout !== undefined) {
       resolveAuxShellPlacement: resolveAuxShellPlacement(socket),
     });
   }
+}
+
+const [[stationConfig, tuiConfig], restorePlan] = await Promise.all([
+  configsLoading,
+  restorePlanLoading,
+]);
+// Warnings print before the renderer takes the screen so they stay readable on
+// the normal terminal. A broken/absent file degrades to defaults.
+if (stationConfig.warning !== undefined) {
+  console.error(`[station] ${stationConfig.warning}`);
+}
+if (tuiConfig.warning !== undefined) {
+  console.error(`[station] ${tuiConfig.warning}`);
 }
 
 // HMR recreates renderer, input handlers, and observer subscriptions, but keeps
@@ -212,11 +230,10 @@ let rootForShutdown: { unmount(): void } | undefined;
 // since module locals reset.
 stationGlobalSlots.__stationHotRenderer?.destroy();
 
-// Reap any other Station UI still attached to this terminal before we put stdin
-// into raw mode. Two readers on one tty tear multi-byte key sequences apart
-// (Shift+Enter and friends), so this enforces one UI per terminal. See
-// singleInstance.ts.
-terminateRivalStationUIs();
+// No rival stdin reader may survive past this line: createCliRenderer claims
+// raw mode next, and two readers on one tty tear multi-byte key sequences
+// apart (Shift+Enter and friends). See singleInstance.ts.
+await rivalsReaped;
 
 const renderer = await createCliRenderer({
   exitOnCtrlC: false,

--- a/station/src/singleInstance.test.ts
+++ b/station/src/singleInstance.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { parsePsListing, selectRivalStationUiPids } from "./singleInstance.js";
+import {
+  parsePsListing,
+  type ReapDeps,
+  selectRivalStationUiPids,
+  terminate,
+  type TerminateDeps,
+  terminateRivalStationUIs,
+} from "./singleInstance.js";
 
 describe("selectRivalStationUiPids", () => {
   const SELF = 7588;
@@ -44,5 +51,162 @@ describe("parsePsListing", () => {
       { pid: 5018, tty: "ttys001", command: "bun --hot src/main.tsx" },
       { pid: 321, tty: "??", command: "/sbin/launchd" },
     ]);
+  });
+});
+
+function recordingKill(record: Array<"SIGTERM" | "SIGKILL" | 0>, alive: () => boolean) {
+  const deps: TerminateDeps = {
+    kill: (_pid, signal) => {
+      record.push(signal);
+      if (signal === 0 && !alive()) {
+        throw new Error("ESRCH");
+      }
+    },
+    sleep: () => Promise.resolve(),
+  };
+  return deps;
+}
+
+describe("terminate", () => {
+  it("sends SIGTERM and stops polling once the pid is gone", async () => {
+    const calls: Array<"SIGTERM" | "SIGKILL" | 0> = [];
+    await terminate(42, recordingKill(calls, () => false));
+    expect(calls).toEqual(["SIGTERM", 0]);
+  });
+
+  it("returns without polling when the pid is already gone", async () => {
+    const calls: Array<"SIGTERM" | "SIGKILL" | 0> = [];
+    let slept = 0;
+    await terminate(42, {
+      kill: (_pid, signal) => {
+        calls.push(signal);
+        throw new Error("ESRCH");
+      },
+      sleep: () => {
+        slept += 1;
+        return Promise.resolve();
+      },
+    });
+    expect(calls).toEqual(["SIGTERM"]);
+    expect(slept).toBe(0);
+  });
+
+  it("escalates to SIGKILL at the grace cap when SIGTERM is ignored, then stops", async () => {
+    const calls: Array<"SIGTERM" | "SIGKILL" | 0> = [];
+    await terminate(42, recordingKill(calls, () => true));
+    const sigkillIndex = calls.indexOf("SIGKILL");
+    expect(calls[0]).toBe("SIGTERM");
+    expect(sigkillIndex).toBeGreaterThan(1);
+    expect(calls.lastIndexOf("SIGKILL")).toBe(sigkillIndex);
+    expect(calls.slice(1, sigkillIndex).every((call) => call === 0)).toBe(true);
+    // Polls after SIGKILL, then gives up on an unkillable pid rather than spinning.
+    expect(calls.length).toBeGreaterThan(sigkillIndex + 1);
+    expect(calls.slice(sigkillIndex + 1).every((call) => call === 0)).toBe(true);
+  });
+
+  it("stops the escalation poll once SIGKILL lands", async () => {
+    const calls: Array<"SIGTERM" | "SIGKILL" | 0> = [];
+    await terminate(
+      42,
+      recordingKill(calls, () => !calls.includes("SIGKILL")),
+    );
+    expect(calls[0]).toBe("SIGTERM");
+    expect(calls.filter((call) => call === "SIGKILL")).toHaveLength(1);
+    // One probe observes the death and ends the poll.
+    expect(calls.slice(calls.indexOf("SIGKILL") + 1)).toEqual([0]);
+  });
+});
+
+function reapDeps(overrides: Partial<ReapDeps>, reaped: number[]): ReapDeps {
+  return {
+    isTty: () => true,
+    lookupSelfTty: () => "ttys001",
+    listTtyProcesses: () => [],
+    terminate: (pid) => {
+      reaped.push(pid);
+      return Promise.resolve();
+    },
+    ...overrides,
+  };
+}
+
+describe("terminateRivalStationUIs", () => {
+  it("skips the tty lookup when stdout is not a tty", async () => {
+    let lookedUp = false;
+    const reaped: number[] = [];
+    await terminateRivalStationUIs(
+      reapDeps(
+        {
+          isTty: () => false,
+          lookupSelfTty: () => {
+            lookedUp = true;
+            return "ttys001";
+          },
+        },
+        reaped,
+      ),
+    );
+    expect(lookedUp).toBe(false);
+    expect(reaped).toEqual([]);
+  });
+
+  it("does not scan or reap when the self tty is '??' or empty", async () => {
+    for (const tty of ["??", ""]) {
+      let scanned = false;
+      const reaped: number[] = [];
+      await terminateRivalStationUIs(
+        reapDeps(
+          {
+            lookupSelfTty: () => tty,
+            listTtyProcesses: () => {
+              scanned = true;
+              return [];
+            },
+          },
+          reaped,
+        ),
+      );
+      expect(scanned).toBe(false);
+      expect(reaped).toEqual([]);
+    }
+  });
+
+  it("skips reaping when ps is unavailable", async () => {
+    const reaped: number[] = [];
+    await terminateRivalStationUIs(
+      reapDeps(
+        {
+          lookupSelfTty: () => {
+            throw new Error("ps unavailable");
+          },
+        },
+        reaped,
+      ),
+    );
+    expect(reaped).toEqual([]);
+  });
+
+  it("resolves only after every same-tty rival's terminate completes", async () => {
+    const rival = process.pid + 1;
+    const reaped: number[] = [];
+    let settled = false;
+    await terminateRivalStationUIs(
+      reapDeps(
+        {
+          listTtyProcesses: () => [
+            { pid: rival, tty: "ttys001", command: "bun --hot src/main.tsx" },
+            { pid: process.pid, tty: "ttys001", command: "bun --hot src/main.tsx" },
+          ],
+          terminate: async (pid) => {
+            reaped.push(pid);
+            await Promise.resolve();
+            settled = true;
+          },
+        },
+        reaped,
+      ),
+    );
+    expect(reaped).toEqual([rival]);
+    expect(settled).toBe(true);
   });
 });

--- a/station/src/singleInstance.ts
+++ b/station/src/singleInstance.ts
@@ -12,8 +12,6 @@
 
 import { execFileSync } from "node:child_process";
 
-declare const Bun: { sleepSync(ms: number): void };
-
 export type ProcEntry = { pid: number; tty: string; command: string };
 
 function isBunExecutable(command: string): boolean {
@@ -55,50 +53,106 @@ export function parsePsListing(output: string): ProcEntry[] {
   return entries;
 }
 
-function listProcesses(): ProcEntry[] {
-  // `tty=` prints `ttys001` for an attached process and `??` for none, so the
-  // self lookup and the rival comparison share one identical tty format.
-  const output = execFileSync("ps", ["-axo", "pid=,tty=,command="], { encoding: "utf8" });
+function lookupSelfTty(): string {
+  // `tty=` prints `ttys001` for an attached process and `??` for none — the
+  // same format `ps -t` echoes back, so the rival comparison needs no
+  // translation.
+  return execFileSync("ps", ["-p", String(process.pid), "-o", "tty="], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function listTtyProcesses(tty: string): ProcEntry[] {
+  // Scoping to one tty keeps the scan ~15ms where a full `ps -axo` costs
+  // 200-290ms on a busy box.
+  const output = execFileSync("ps", ["-t", tty, "-o", "pid=,tty=,command="], {
+    encoding: "utf8",
+  });
   return parsePsListing(output);
 }
 
-function terminate(pid: number): void {
+export type TerminateDeps = {
+  kill: (pid: number, signal: "SIGTERM" | "SIGKILL" | 0) => void;
+  sleep: (ms: number) => Promise<void>;
+};
+
+const defaultTerminateDeps: TerminateDeps = {
+  kill: (pid, signal) => process.kill(pid, signal),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+const POLL_INTERVAL_MS = 10;
+const SIGTERM_GRACE_MS = 250;
+const SIGKILL_GRACE_MS = 50;
+
+async function pollUntilGone(pid: number, capMs: number, deps: TerminateDeps): Promise<boolean> {
+  for (let waited = 0; waited < capMs; waited += POLL_INTERVAL_MS) {
+    await deps.sleep(POLL_INTERVAL_MS);
+    try {
+      deps.kill(pid, 0);
+    } catch {
+      return true; // ESRCH: exited
+    }
+  }
+  return false;
+}
+
+export async function terminate(
+  pid: number,
+  deps: TerminateDeps = defaultTerminateDeps,
+): Promise<void> {
   try {
-    process.kill(pid, "SIGTERM");
+    deps.kill(pid, "SIGTERM");
   } catch {
     return; // already gone
   }
-  // The orphan traps no signals, so SIGTERM normally lands; escalate only if it
-  // is somehow still alive after a short grace, then stop — stdin frees as it dies.
-  Bun.sleepSync(250);
-  try {
-    process.kill(pid, 0);
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // exited within the grace window
+  // The orphan traps no signals, so SIGTERM normally lands within a poll tick;
+  // escalate only if it is somehow still alive at the grace cap, then stop —
+  // stdin frees as it dies.
+  if (await pollUntilGone(pid, SIGTERM_GRACE_MS, deps)) {
+    return;
   }
+  try {
+    deps.kill(pid, "SIGKILL");
+  } catch {
+    return;
+  }
+  await pollUntilGone(pid, SIGKILL_GRACE_MS, deps);
 }
+
+export type ReapDeps = {
+  isTty: () => boolean;
+  lookupSelfTty: () => string;
+  listTtyProcesses: (tty: string) => ProcEntry[];
+  terminate: (pid: number) => Promise<void>;
+};
+
+const defaultReapDeps: ReapDeps = {
+  isTty: () => process.stdout.isTTY === true,
+  lookupSelfTty,
+  listTtyProcesses,
+  terminate: (pid) => terminate(pid),
+};
 
 /**
  * Best-effort: terminate any other Station UI holding this terminal's stdin.
  * No-op unless stdin is a real tty (a piped or test run skips it), and never
- * blocks startup if `ps` is unavailable.
+ * blocks startup if `ps` is unavailable. Callers must await the result before
+ * putting stdin into raw mode — a surviving rival reader tears key sequences.
  */
-export function terminateRivalStationUIs(): void {
-  if (process.stdout.isTTY !== true) {
+export async function terminateRivalStationUIs(deps: ReapDeps = defaultReapDeps): Promise<void> {
+  if (!deps.isTty()) {
     return;
   }
-  let processes: ProcEntry[];
+  let rivals: number[];
   try {
-    processes = listProcesses();
+    const myTty = deps.lookupSelfTty();
+    if (myTty === "" || myTty === "??") {
+      return;
+    }
+    rivals = selectRivalStationUiPids(deps.listTtyProcesses(myTty), process.pid, myTty);
   } catch {
     return;
   }
-  const self = processes.find((p) => p.pid === process.pid);
-  if (self === undefined || self.tty === "??" || self.tty === "") {
-    return;
-  }
-  for (const pid of selectRivalStationUiPids(processes, process.pid, self.tty)) {
-    terminate(pid);
-  }
+  await Promise.all(rivals.map((pid) => deps.terminate(pid)));
 }

--- a/tests/diagnostics/debug-bundle/claude-provider.test.ts
+++ b/tests/diagnostics/debug-bundle/claude-provider.test.ts
@@ -30,29 +30,31 @@ describe("Claude provider debug bundle diagnostics", () => {
       clock,
       idFactory: ids(),
     });
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [
+        createClaudeHarnessProvider({
+          command: "claude-missing",
+          now: () => new Date(now),
+          runner: async () => {
+            throw Object.assign(new Error("ANTHROPIC_API_KEY=sk-claudeSecret000000 missing"), {
+              code: "ENOENT",
+              stderr: "ANTHROPIC_API_KEY=sk-claudeSecret000000 claude-missing: not found",
+            });
+          },
+        }),
+      ],
+    });
     const core = createObserverCore({
       config,
-      providers: new ProviderRegistry({
-        worktree: new FakeWorktreeProvider({ now }),
-        terminal: new FakeTerminalProvider({ now }),
-        harnesses: [
-          createClaudeHarnessProvider({
-            command: "claude-missing",
-            now: () => new Date(now),
-            runner: async () => {
-              throw Object.assign(new Error("ANTHROPIC_API_KEY=sk-claudeSecret000000 missing"), {
-                code: "ENOENT",
-                stderr: "ANTHROPIC_API_KEY=sk-claudeSecret000000 claude-missing: not found",
-              });
-            },
-          }),
-        ],
-      }),
+      providers,
       persistence,
       sqlite,
       clock,
     });
 
+    await providers.healthCache.refreshAll();
     await core.reconcile("claude-health-failure");
     const snapshot = await collectDiagnosticSnapshot({
       config,

--- a/tests/diagnostics/debug-bundle/codex-provider.test.ts
+++ b/tests/diagnostics/debug-bundle/codex-provider.test.ts
@@ -30,29 +30,31 @@ describe("Codex provider debug bundle diagnostics", () => {
       clock,
       idFactory: ids(),
     });
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [
+        createCodexHarnessProvider({
+          command: "codex-missing",
+          now: () => new Date(now),
+          runner: async () => {
+            throw Object.assign(new Error("OPENAI_API_KEY=sk-codexSecret000000 missing"), {
+              code: "ENOENT",
+              stderr: "OPENAI_API_KEY=sk-codexSecret000000 codex-missing: not found",
+            });
+          },
+        }),
+      ],
+    });
     const core = createObserverCore({
       config,
-      providers: new ProviderRegistry({
-        worktree: new FakeWorktreeProvider({ now }),
-        terminal: new FakeTerminalProvider({ now }),
-        harnesses: [
-          createCodexHarnessProvider({
-            command: "codex-missing",
-            now: () => new Date(now),
-            runner: async () => {
-              throw Object.assign(new Error("OPENAI_API_KEY=sk-codexSecret000000 missing"), {
-                code: "ENOENT",
-                stderr: "OPENAI_API_KEY=sk-codexSecret000000 codex-missing: not found",
-              });
-            },
-          }),
-        ],
-      }),
+      providers,
       persistence,
       sqlite,
       clock,
     });
 
+    await providers.healthCache.refreshAll();
     await core.reconcile("codex-health-failure");
     const snapshot = await collectDiagnosticSnapshot({
       config,

--- a/tests/diagnostics/debug-bundle/worktrunk-dependency.test.ts
+++ b/tests/diagnostics/debug-bundle/worktrunk-dependency.test.ts
@@ -46,6 +46,7 @@ describe("Worktrunk dependency debug bundle diagnostics", () => {
       clock,
     });
 
+    await providers.healthCache.refreshAll();
     await core.reconcile("worktrunk-dependency");
     const snapshot = await collectDiagnosticSnapshot({
       config,


### PR DESCRIPTION
## Summary

Cuts warm bare-`stn` launch from ~1.8s to ~0.42s to first frame (populated fleet 1.91s → 0.52s) and cold launch from ~3.3s to ~0.78s (medians, isolated per-variant observers, n=3 per cell; n=5 CLI floor).

| Metric | Before | After |
|---|---|---|
| Warm TUI first frame | 1812ms | 416ms |
| Warm TUI populated rows | 1910ms | 520ms |
| Cold TUI first frame (observer auto-spawn) | 3284ms | 778ms |
| Cold TUI populated rows | 3388ms | 891ms |
| Reconcile scan | ~1120ms | ~170ms |
| CLI floor (`--help`) | 230ms | 150ms |

## Changes

- **cli/tui**: the `tui-startup` reconcile fires deferred and unawaited (the popup path's existing pattern, now unconditional). The renderer resyncs from the observer's in-memory snapshot immediately and converges when the scan's `observer.reconciled` event lands. Failures log one structured line to `cli.jsonl` via the shared lifecycle logger — stderr would corrupt the alt screen.
- **observer**: provider health probes (five harness `--version` execs, ~900ms of every ~2s reconcile) move into a TTL cache probed at boot and out-of-band; reconcile reads it synchronously and reports `unknown` until the first probe lands. Worktree/terminal list reads run with bounded concurrency (4). A launch reconcile arriving while the `observer.startup` scan is in flight joins that scan instead of queueing a redundant identical one; joinable reasons are shared constants in `@station/contracts`.
- **renderer (station/)**: the rival-UI scan is scoped to the current tty (`ps -t`, was a ~228ms full-process `ps -axo`) and reaps with an async poll instead of `Bun.sleepSync`; the observer subscription starts before opentui init so the first painted frame is populated; config loads and the restore-plan build overlap the reap.
- **runtime**: `packages/runtime/src/effect.ts` re-exports the 13 used effect modules per-subpath instead of the barrel, dropping `fast-check` and ~440 unused modules from every CLI/observer/hook process (−75ms each).

## Behavior notes

- A hard startup-reconcile failure no longer aborts launch with stderr + exit 1; it logs to `cli.jsonl` (visible via `stn debug logs`, operation `tui.startup-reconcile`). The TUI's connection states remain the in-terminal error surface.
- Reconcile scans now finish in ~170ms, below the ≥1s profiler gate, so `Reconcile profile.` lines stop appearing for routine scans — expected, not a regression.
- On a slow machine a cold start can briefly show an empty-but-connected fleet until the (now ~180ms) startup scan lands; previously that time was a blank terminal.

## Verify

- `pnpm build && pnpm turbo typecheck && pnpm lint` — clean (42/42).
- Lanes: unit 1082 pass, integration 299 pass + 1 skip, diagnostics 34 pass, station bun lane 904 pass / 0 fail.
- Manual: run `stn` in a terminal — first paint should land well under a second showing the last-known fleet, with rows refreshing ~1–2s later as the deferred reconcile lands. Cold start (no observer) should paint in under a second.