### PR TITLE
fix(observer): decay stale busy statuses and let force retire stop-less sessions

### DIFF
--- a/apps/observer/src/commands/cleanup/operations.ts
+++ b/apps/observer/src/commands/cleanup/operations.ts
@@ -39,7 +39,10 @@ export async function closeSessionResources(
   if (input.mode === "harness" || input.mode === "all") {
     await stopHarnessForSession({
       ...input,
-      allowUnsupportedStop: input.mode === "all" && canUseTerminalCloseFallbackForSession(input),
+      // Force means "retire the session even if the provider cannot stop the
+      // process" — without this, force dead-ends on stop-less providers.
+      allowUnsupportedStop:
+        input.force || (input.mode === "all" && canUseTerminalCloseFallbackForSession(input)),
     });
   }
   throwIfAborted(input.context.signal);

--- a/apps/observer/src/reconcile/harnessEventStatus.ts
+++ b/apps/observer/src/reconcile/harnessEventStatus.ts
@@ -34,6 +34,46 @@ export function observerHarnessRunFromRun(run: HarnessRunObservation): ObserverH
   };
 }
 
+// A busy status is a claim that signals are still flowing. A run whose newest
+// signal is older than this window has gone dark — harness killed mid-turn,
+// hooks undelivered, stale ingress — and must not read as active forever;
+// unknown is the honest projection and the next real event restores truth.
+// Attention states are exempt: a question legitimately waits on the user.
+const BUSY_STATUS_DECAY_MS = 15 * 60 * 1000;
+const BUSY_STATUS_VALUES = new Set<ObservedStatus["value"]>(["working", "starting"]);
+
+export function decayStaleBusyStatuses(input: {
+  runs: ObserverHarnessRun[];
+  now: string;
+}): ObserverHarnessRun[] {
+  const cutoff = Date.parse(input.now) - BUSY_STATUS_DECAY_MS;
+  if (!Number.isFinite(cutoff)) {
+    return input.runs;
+  }
+  return input.runs.map((run) => {
+    if (!BUSY_STATUS_VALUES.has(run.status.value)) {
+      return run;
+    }
+    const updatedAt = Date.parse(run.status.updatedAt);
+    if (!Number.isFinite(updatedAt) || updatedAt >= cutoff) {
+      return run;
+    }
+    const decayed: ObservedStatus = {
+      value: "unknown",
+      confidence: "low",
+      reason: `No ${run.run.provider} signals since ${run.status.updatedAt}; the run may have ended without reporting.`,
+      source: "reconcile",
+      // Keep the last-signal timestamp so repeated reconciles project this
+      // exact status instead of minting a fresh one per pass.
+      updatedAt: run.status.updatedAt,
+    };
+    return {
+      run: runObservationWithStatus(run.run, decayed),
+      status: decayed,
+    };
+  });
+}
+
 export function applyHarnessEventStatusOverlays(input: {
   runs: ObserverHarnessRun[];
   observations: PersistedProviderObservation[];

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -29,7 +29,11 @@ import { providerObservationRetentionDays } from "../persistence/retention.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ReconcileTiming } from "./core.js";
 import { buildStationSnapshot, safeErrorToProviderHealth } from "./graph.js";
-import { applyHarnessEventStatusOverlays, type ObserverHarnessRun } from "./harnessEventStatus.js";
+import {
+  applyHarnessEventStatusOverlays,
+  decayStaleBusyStatuses,
+  type ObserverHarnessRun,
+} from "./harnessEventStatus.js";
 
 export type ProviderReadOptions = {
   clock: RuntimeClock;
@@ -149,7 +153,10 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
   if (input.persistence !== undefined) {
     harnessStatusInput.persistence = input.persistence;
   }
-  const harnessRunsWithStatus = await harnessRunsWithPersistedEventStatus(harnessStatusInput);
+  const harnessRunsWithStatus = decayStaleBusyStatuses({
+    runs: await harnessRunsWithPersistedEventStatus(harnessStatusInput),
+    now: finishedAt,
+  });
   const harnessRuns = normalizeHarnessRunsForCurrentWorktrees({
     harnessRuns: harnessRunsWithStatus,
     worktrees: worktreeResult.worktrees,

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -47,6 +47,31 @@ describe("cleanup command handlers", () => {
     fixture.sqlite.close();
   });
 
+  it("force-closes a harness session even when the provider cannot stop runs", async () => {
+    const fixture = createFixture({ state: "working", harnessStopSupported: false });
+    await fixture.core.reconcile("pre-cleanup");
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.close",
+      payload: {
+        sessionId: "ses_web_cleanup",
+        mode: "harness",
+        force: true,
+      },
+    });
+    await fixture.queue.drain();
+
+    // Nothing to stop and nothing closed — but the command completes instead of
+    // dead-ending on HARNESS_STOP_UNSUPPORTED, which left unstoppable sessions
+    // impossible to retire.
+    expect(fixture.harness.snapshot().stopped).toEqual([]);
+    expect(fixture.terminal.snapshot().closed).toEqual([]);
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    fixture.sqlite.close();
+  });
+
   it("rejects terminal close for an active agent without force", async () => {
     const fixture = createFixture({ state: "working" });
     await fixture.core.reconcile("pre-cleanup");

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -306,6 +306,58 @@ describe("observer reconcile persistence", () => {
     sqlite.close();
   });
 
+  it("decays a busy status whose newest signal is older than the decay window", async () => {
+    const dbPath = await tempDbPath();
+    const lastSignalAt = "2026-05-20T11:00:00.000Z"; // an hour before `now`
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers: providersWithOneSession(),
+      clock: { now: () => new Date(now) },
+      sqlitePath: dbPath,
+    });
+    await persistence.recordProviderObservation({
+      provider: "fake-harness",
+      providerType: "harness",
+      entityKind: "harness_event",
+      entityKey: "run_web_main",
+      observedAt: lastSignalAt,
+      payload: {
+        provider: "fake-harness",
+        harnessRunId: "run_web_main",
+        worktreeId: "wt_web_main",
+        sessionId: "ses_web_main",
+        rawEventType: "UserPromptSubmit",
+        status: {
+          value: "working",
+          confidence: "high",
+          reason: "Prompt submitted.",
+          source: "harness_event",
+          updatedAt: lastSignalAt,
+        },
+        observedAt: lastSignalAt,
+      },
+    });
+
+    const snapshot = await core.reconcile("stale-busy-decay");
+
+    expect(snapshot.rows[0]?.agent).toMatchObject({
+      state: "unknown",
+      confidence: "low",
+      updatedAt: lastSignalAt,
+    });
+    expect(snapshot.sessions[0]?.status).toMatchObject({
+      value: "unknown",
+      source: "reconcile",
+      updatedAt: lastSignalAt,
+    });
+    expect(snapshot.counts).toMatchObject({
+      working: 0,
+      attention: 0,
+      unknown: 1,
+    });
+    sqlite.close();
+  });
+
   it("attaches cached current change summaries to hot snapshots", async () => {
     const { sqlite, persistence, core } = createTestObserverCore({
       config,

--- a/apps/observer/test/unit/harnessEventStatus.test.ts
+++ b/apps/observer/test/unit/harnessEventStatus.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import type { PersistedProviderObservation } from "../../src/persistence";
 import {
   applyHarnessEventStatusOverlays,
+  decayStaleBusyStatuses,
   type ObserverHarnessRun,
   observerHarnessRunFromRun,
 } from "../../src/reconcile/harnessEventStatus";
@@ -176,6 +177,85 @@ describe("harness event status overlays", () => {
       confidence: "high",
       reason: "Harness process exited.",
     });
+  });
+});
+
+describe("stale busy status decay", () => {
+  // runObservedAt + 15 minutes exactly, and one millisecond past it.
+  const atWindow = "2026-05-21T12:15:00.000Z";
+  const pastWindow = "2026-05-21T12:15:00.001Z";
+
+  it("decays a working run with no signals past the window to unknown", () => {
+    const result = decayStaleBusyStatuses({
+      runs: [run({ state: "working", confidence: "high", reason: "Codex is running Bash." })],
+      now: pastWindow,
+    });
+
+    expect(result[0]?.status).toMatchObject({
+      value: "unknown",
+      confidence: "low",
+      source: "reconcile",
+      updatedAt: runObservedAt,
+    });
+    expect(result[0]?.status.reason).toContain(runObservedAt);
+    expect(result[0]?.run).toMatchObject({ state: "unknown", confidence: "low" });
+  });
+
+  it("decays a starting run the same way", () => {
+    const result = decayStaleBusyStatuses({
+      runs: [run({ state: "starting", reason: "Codex is starting." })],
+      now: pastWindow,
+    });
+
+    expect(result[0]?.status.value).toBe("unknown");
+  });
+
+  it("keeps a busy status at or inside the window", () => {
+    const result = decayStaleBusyStatuses({
+      runs: [run({ state: "working", reason: "Codex is running Bash." })],
+      now: atWindow,
+    });
+
+    expect(result[0]?.status.value).toBe("working");
+  });
+
+  it("never decays attention, idle, exited, or unknown statuses", () => {
+    for (const state of ["needs_attention", "idle", "exited", "unknown"] as const) {
+      const result = decayStaleBusyStatuses({
+        runs: [run({ state, reason: "State under test." })],
+        now: "2026-05-28T12:00:00.000Z",
+      });
+
+      expect(result[0]?.status.value).toBe(state);
+    }
+  });
+
+  it("decays overlaid event statuses and is stable across repeated reconciles", () => {
+    const overlaid = overlay({
+      runs: [run()],
+      observations: [
+        observation({
+          harnessRunId: "run_1",
+          rawEventType: "UserPromptSubmit",
+          status: status("working", "medium", "Prompt submitted."),
+        }),
+      ],
+    });
+
+    const once = decayStaleBusyStatuses({ runs: overlaid, now: "2026-05-21T13:00:00.000Z" });
+    const twice = decayStaleBusyStatuses({ runs: once, now: "2026-05-21T14:00:00.000Z" });
+
+    expect(once[0]?.status).toMatchObject({ value: "unknown", updatedAt: eventObservedAt });
+    expect(twice).toEqual(once);
+  });
+
+  it("leaves unparseable status timestamps alone", () => {
+    const result = decayStaleBusyStatuses({
+      runs: [run({ state: "working", reason: "Bad clock.", observedAt: "not-a-timestamp" })],
+      now: pastWindow,
+    });
+
+    expect(result[0]?.status.value).toBe("working");
   });
 });
 

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -71,6 +71,11 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
 6. **Evolution is additive.** New fields optional, enums keep catch-all
    members (`input`), schema stamps (`schemaVersion`) travel with payloads.
    New signal kinds require census evidence, not speculation.
+7. **Busy statuses decay.** `working`/`starting` are claims that signals are
+   still flowing; reconcile projects a run whose newest signal is older than
+   15 minutes to `unknown` (low confidence, source `reconcile`) instead of
+   trusting it forever. Attention and idle states never decay, and the next
+   real event restores live status.
 
 ## Target Taxonomy (HarnessSignal)
 


### PR DESCRIPTION
Fixes the ghost-status class diagnosed live today: a session showed "working" for 4.5+ hours (and would have forever) after its harness stopped reporting — the status was event-sourced with no expiry, survived three observer restarts via persistence, and no supported command could clear it.

## Status decay

A working/starting status is a claim that signals are still flowing. Reconcile now projects a run whose newest signal is older than 15 minutes to unknown (low confidence, source reconcile) instead of trusting it forever:

- Applied at the single status choke point (after persisted-event overlays, before worktree normalization), so provider-process statuses and hook-event overlays both decay.
- The decayed status keeps the last-signal timestamp, so repeated reconciles project the identical status instead of minting a new one per pass (no event churn).
- needs_attention never decays — a question legitimately waits on the user indefinitely. idle/exited/unknown are untouched.
- Self-healing: the next real event overlays a fresh status and the run reads live again. A long quiet tool call may briefly read unknown; it flips back on the next hook event.

Real-world triggers seen in today's logs, all of which strand a busy status: harness killed mid-turn, hooks not firing for background sessions, hook events consumed by stale observers, and delivery through a version-mismatched stn-ingress.

## Force-close for stop-less providers

`session.close --mode harness` on a provider without stop support failed with HARNESS_STOP_UNSUPPORTED, whose own hint says to retry with force — and force failed identically, making such sessions impossible to retire. Force now tolerates an unsupported stop (the existing `allowUnsupportedStop` seam) and completes the close.

## UX implication + manual verify

FLEET stops counting dead harnesses as working; a stranded row degrades to `? unknown` within 15 minutes of its last signal instead of showing `⋮ working` forever. Verify: mark a session working via a hook event, deliver nothing further, trigger reconciles past the window (or wait) — the row reads unknown with reason "No <provider> signals since <timestamp>…"; any new event flips it back.

## Tests

- Unit (`harnessEventStatus.test.ts`, +6): decay of working/starting past the window, at-window boundary kept, attention/idle/exited/unknown exempt, overlaid statuses decay idempotently across repeated reconciles, unparseable timestamps left alone.
- Integration (`reconcile-persistence.test.ts`, +1): a persisted stale working hook observation projects as unknown/low/reconcile with preserved timestamp through a real `core.reconcile`, counts flip working→unknown.
- Integration (`cleanup-commands.test.ts`, +1): force session.close succeeds on a stop-less provider (previously HARNESS_STOP_UNSUPPORTED).
- Lanes: typecheck clean, unit 1094 pass, integration 301 pass (1 pre-existing skip).

Docs: `harness-signals.md` gains invariant 7 (busy statuses decay).