### PR TITLE
feat(hooks): observe sessions Station did not launch by correlating cwd

### DIFF
--- a/apps/cli/src/ingress/sender.ts
+++ b/apps/cli/src/ingress/sender.ts
@@ -25,6 +25,7 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { normalizeWorktrunkLifecycleEvent } from "@station/worktrunk";
+import { z } from "zod";
 import { deliverProviderHookWithSpooling, type ProviderDeliveryAttempt } from "./deliveryPolicy.js";
 import type { ProviderHookObserverStartupDeps } from "./observerStartup.js";
 import { writeProviderHookSpoolRecord } from "./spool.js";
@@ -154,7 +155,7 @@ export async function sendClaudeHookPayload(
     env: input.env ?? process.env,
   });
   const eventName = parseProviderHookEventName(enrichedPayload) ?? "unknown";
-  if (!hasStationOwnership(enrichedPayload)) {
+  if (!hasStationOwnership(enrichedPayload) && !hasCorrelatableCwd(enrichedPayload)) {
     return ignoredProviderHookReceipt({
       provider: "claude",
       event: eventName,
@@ -197,7 +198,7 @@ export async function sendCodexHookPayload(
     env: input.env ?? process.env,
   });
   const eventName = parseProviderHookEventName(enrichedPayload) ?? "unknown";
-  if (!hasStationOwnership(enrichedPayload)) {
+  if (!hasStationOwnership(enrichedPayload) && !hasCorrelatableCwd(enrichedPayload)) {
     return ignoredProviderHookReceipt({
       provider: "codex",
       event: eventName,
@@ -432,6 +433,16 @@ function payloadSummaryFor(payload: unknown): ProviderHookPayloadSummary {
     compacted: false,
     omittedFieldNames: [],
   };
+}
+
+// External sessions (no station env) are deliverable when the payload carries
+// a cwd the observer can correlate to a worktree; providers whose payloads
+// have no cwd keep the ownership gate. Pre-parse probe only — full event
+// schemas validate at the adapter boundary.
+const hookCwdProbeSchema = z.object({ cwd: z.string().min(1) }).loose();
+
+function hasCorrelatableCwd(payload: unknown): boolean {
+  return hookCwdProbeSchema.safeParse(payload).success;
 }
 
 function hasStationOwnership(payload: unknown): boolean {

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -264,7 +264,7 @@ describe("provider hook ingress command", () => {
     await expect(listHookSpoolFiles(fixture.hookSpoolDir)).resolves.toEqual([]);
   });
 
-  it("ignores Claude events without station ownership env", async () => {
+  it("delivers Claude events without station ownership env when the payload has a cwd", async () => {
     const fixture = await createTempState();
 
     const receipt = await runProviderIngressCommand(
@@ -276,6 +276,32 @@ describe("provider hook ingress command", () => {
       {
         clock: { now: () => new Date(now) },
         hookId: () => "report_claude_unowned_1",
+      },
+    );
+
+    // External sessions must reach the observer (spooled here — none is
+    // running) so cwd correlation can light their worktree row.
+    expect(receipt).toMatchObject({
+      status: "spooled",
+      provider: "claude",
+      event: "PreToolUse",
+    });
+    await expect(listHookSpoolFiles(fixture.hookSpoolDir)).resolves.toHaveLength(1);
+  });
+
+  it("ignores Claude events with neither station ownership env nor a payload cwd", async () => {
+    const fixture = await createTempState();
+    const { cwd: _cwd, ...payloadWithoutCwd } = claudePayload();
+
+    const receipt = await runProviderIngressCommand(
+      ["--socket", fixture.socketPath, "--state-dir", fixture.stateDir, "claude"],
+      {
+        stdin: JSON.stringify(payloadWithoutCwd),
+        env: {},
+      },
+      {
+        clock: { now: () => new Date(now) },
+        hookId: () => "report_claude_unowned_2",
       },
     );
 

--- a/apps/observer/src/reconcile/harnessEventStatus.ts
+++ b/apps/observer/src/reconcile/harnessEventStatus.ts
@@ -34,6 +34,90 @@ export function observerHarnessRunFromRun(run: HarnessRunObservation): ObserverH
   };
 }
 
+export function externalHarnessRunId(provider: string, nativeSessionId: string): string {
+  return `${provider}:external:${nativeSessionId}`;
+}
+
+/**
+ * Mint runs for sessions Station did not launch. Their hook events carry only
+ * native identity plus a cwd-resolved worktree — no station sessionId and no
+ * harnessRunId — so provider discovery never surfaces them and their status
+ * had nowhere to land. One run per (provider, native session), carrying the
+ * newest observed status; ended sessions (exited) synthesize nothing, so an
+ * external run disappears from rows once its session ends.
+ */
+export function synthesizeExternalHarnessRuns(input: {
+  runs: ObserverHarnessRun[];
+  observations: PersistedProviderObservation[];
+}): ObserverHarnessRun[] {
+  const existingIds = new Set(input.runs.map((run) => run.run.id));
+  const latestById = new Map<string, HarnessEventObservation>();
+
+  for (const observation of input.observations) {
+    if (observation.expired || observation.entityKind !== "harness_event") {
+      continue;
+    }
+    const event = parseHarnessEventObservation(observation);
+    if (event === undefined || event.provider !== observation.provider) {
+      continue;
+    }
+    // Station-launched sessions carry station identity (session, run, or
+    // terminal target); their runs come from provider discovery and must not
+    // be duplicated here.
+    if (
+      event.sessionId !== undefined ||
+      event.harnessRunId !== undefined ||
+      event.terminalTargetId !== undefined
+    ) {
+      continue;
+    }
+    if (event.nativeSessionId === undefined || event.worktreeId === undefined) {
+      continue;
+    }
+    if (event.status === undefined || event.status.value === "unknown") {
+      continue;
+    }
+    const id = externalHarnessRunId(event.provider, event.nativeSessionId);
+    if (existingIds.has(id)) {
+      continue;
+    }
+    const previous = latestById.get(id);
+    if (
+      previous?.status !== undefined &&
+      Date.parse(previous.status.updatedAt) >= Date.parse(event.status.updatedAt)
+    ) {
+      continue;
+    }
+    latestById.set(id, event);
+  }
+
+  const synthesized: ObserverHarnessRun[] = [];
+  for (const [id, event] of latestById) {
+    const status = event.status;
+    const worktreeId = event.worktreeId;
+    const nativeSessionId = event.nativeSessionId;
+    if (status === undefined || worktreeId === undefined || nativeSessionId === undefined) {
+      continue;
+    }
+    if (status.value === "exited") {
+      continue;
+    }
+    synthesized.push({
+      run: {
+        id,
+        provider: event.provider,
+        worktreeId,
+        state: status.value,
+        confidence: status.confidence,
+        reason: status.reason,
+        observedAt: event.observedAt,
+      },
+      status,
+    });
+  }
+  return [...input.runs, ...synthesized];
+}
+
 // A busy status is a claim that signals are still flowing. A run whose newest
 // signal is older than this window has gone dark — harness killed mid-turn,
 // hooks undelivered, stale ingress — and must not read as active forever;

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -33,6 +33,7 @@ import {
   applyHarnessEventStatusOverlays,
   decayStaleBusyStatuses,
   type ObserverHarnessRun,
+  synthesizeExternalHarnessRuns,
 } from "./harnessEventStatus.js";
 
 export type ProviderReadOptions = {
@@ -688,7 +689,7 @@ async function harnessRunsWithPersistedEventStatus(input: {
     now: input.now,
   });
   return applyHarnessEventStatusOverlays({
-    runs: input.harnessRuns,
+    runs: synthesizeExternalHarnessRuns({ runs: input.harnessRuns, observations }),
     observations,
   });
 }

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -7,6 +7,7 @@ import type {
   StationSnapshot,
   WorktreeRow,
 } from "@station/contracts";
+import { pathIsSameOrInside } from "@station/runtime";
 import { countsForRows, statusPolicy } from "./statusPolicy.js";
 
 type WorktreeAgent = NonNullable<WorktreeRow["agent"]>;
@@ -25,6 +26,55 @@ type ProjectionTarget = {
   rowIndex: number;
   correlatedBy: CorrelatedBy;
 };
+
+/**
+ * Resolve a cwd-only correlation into a worktreeId at the ingress boundary.
+ * cwd is the weakest identity (dropped when ambiguous); resolving it here once
+ * means live projection AND the persisted observation both correlate by the
+ * contract field, so the status survives reconcile overlays. Stronger
+ * correlation fields, when present, are left untouched.
+ */
+export function withWorktreeCorrelationFromCwd(
+  report: HarnessEventReport,
+  snapshot: StationSnapshot,
+): HarnessEventReport {
+  const correlation = report.correlation;
+  if (
+    correlation?.cwd === undefined ||
+    correlation.harnessRunId !== undefined ||
+    correlation.sessionId !== undefined ||
+    correlation.worktreeId !== undefined
+  ) {
+    return report;
+  }
+  const worktreeId = rowIdForCwd(snapshot.rows, correlation.cwd);
+  if (worktreeId === undefined) {
+    return report;
+  }
+  return { ...report, correlation: { ...correlation, worktreeId } };
+}
+
+// Deepest containing worktree wins; a tie at the same depth is ambiguous and
+// resolves to nothing (mirrors resolveWorktreeByProjectPath in run.ts).
+function rowIdForCwd(rows: readonly WorktreeRow[], cwd: string): string | undefined {
+  const matches = rows
+    .filter((row) => pathIsSameOrInside(cwd, row.path))
+    .sort(
+      (left, right) =>
+        right.path.length - left.path.length ||
+        left.id.localeCompare(right.id) ||
+        left.path.localeCompare(right.path),
+    );
+  const match = matches[0];
+  if (match === undefined) {
+    return undefined;
+  }
+  const next = matches[1];
+  if (next !== undefined && next.path.length === match.path.length) {
+    return undefined;
+  }
+  return match.id;
+}
 
 export function projectHarnessEventReportOntoSnapshot(input: {
   snapshot: StationSnapshot;

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -4,6 +4,7 @@ import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, runRuntimeBoundary } from "@station/runtime";
 import type { HarnessEventReportIngestion } from "../hooks/ingestion.js";
 import type { ObserverCore } from "../reconcile/core.js";
+import { withWorktreeCorrelationFromCwd } from "../reconcile/statusProjection.js";
 import type { ObserverEventBus } from "./eventBus.js";
 
 export type HarnessReportProcessorDeps = {
@@ -37,8 +38,11 @@ function reportDecisionFields(report: HarnessEventReport): Record<string, unknow
 
 export async function processHarnessIngressReport(
   deps: HarnessReportProcessorDeps,
-  report: HarnessEventReport,
+  rawReport: HarnessEventReport,
 ): Promise<HarnessReportProcessResult> {
+  // Resolve cwd-only correlation before ingest so the persisted observation
+  // carries the worktreeId too, not just this projection pass.
+  const report = withWorktreeCorrelationFromCwd(rawReport, deps.core.getSnapshot());
   const receipt = await deps.harnessEventReportIngestion.ingest(report, {
     triggerReconcile: false,
   });

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -358,6 +358,56 @@ describe("observer reconcile persistence", () => {
     sqlite.close();
   });
 
+  it("mints a run for an external session and lights its worktree row", async () => {
+    const dbPath = await tempDbPath();
+    const eventAt = "2026-05-20T12:00:01.000Z";
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({
+        now,
+        worktrees: [createFakeWorktree({ id: "wt_web_main", projectId: "web", now })],
+      }),
+      terminal: new FakeTerminalProvider({ now, targets: [] }),
+      harnesses: [new FakeHarnessProvider({ now, runs: [] })],
+    });
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config,
+      providers,
+      clock: { now: () => new Date(now) },
+      sqlitePath: dbPath,
+    });
+    await persistence.recordProviderObservation({
+      provider: "fake-harness",
+      providerType: "harness",
+      entityKind: "harness_event",
+      entityKey: "native_ext_1",
+      observedAt: eventAt,
+      payload: {
+        provider: "fake-harness",
+        worktreeId: "wt_web_main",
+        nativeSessionId: "native_ext_1",
+        rawEventType: "UserPromptSubmit",
+        status: {
+          value: "working",
+          confidence: "medium",
+          reason: "Prompt submitted.",
+          source: "harness_event",
+          updatedAt: eventAt,
+        },
+        observedAt: eventAt,
+      },
+    });
+
+    const snapshot = await core.reconcile("external-session");
+
+    expect(snapshot.rows[0]?.agent).toMatchObject({
+      harness: "fake-harness",
+      state: "working",
+      runId: "fake-harness:external:native_ext_1",
+    });
+    expect(snapshot.counts).toMatchObject({ working: 1 });
+    sqlite.close();
+  });
+
   it("attaches cached current change summaries to hot snapshots", async () => {
     const { sqlite, persistence, core } = createTestObserverCore({
       config,

--- a/apps/observer/test/unit/harnessEventStatus.test.ts
+++ b/apps/observer/test/unit/harnessEventStatus.test.ts
@@ -10,8 +10,10 @@ import type { PersistedProviderObservation } from "../../src/persistence";
 import {
   applyHarnessEventStatusOverlays,
   decayStaleBusyStatuses,
+  externalHarnessRunId,
   type ObserverHarnessRun,
   observerHarnessRunFromRun,
+  synthesizeExternalHarnessRuns,
 } from "../../src/reconcile/harnessEventStatus";
 
 const runObservedAt = "2026-05-21T12:00:00.000Z";
@@ -180,6 +182,82 @@ describe("harness event status overlays", () => {
   });
 });
 
+describe("external run synthesis", () => {
+  const externalObservation = (input: {
+    nativeSessionId?: string;
+    sessionId?: string;
+    harnessRunId?: string;
+    worktreeId?: string;
+    value?: "working" | "idle" | "exited";
+    updatedAt?: string;
+  }) =>
+    observation({
+      nativeSessionId: input.nativeSessionId ?? "native_1",
+      ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+      ...(input.harnessRunId === undefined ? {} : { harnessRunId: input.harnessRunId }),
+      worktreeId: input.worktreeId ?? "wt_1",
+      rawEventType: "UserPromptSubmit",
+      status: status(
+        input.value ?? "working",
+        "medium",
+        "Prompt submitted.",
+        input.updatedAt ?? eventObservedAt,
+      ),
+    });
+
+  it("mints a run for an external session from its worktree-resolved events", () => {
+    const result = synthesizeExternalHarnessRuns({
+      runs: [],
+      observations: [externalObservation({})],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.run).toMatchObject({
+      id: externalHarnessRunId("codex", "native_1"),
+      provider: "codex",
+      worktreeId: "wt_1",
+      state: "working",
+    });
+    expect(result[0]?.status).toMatchObject({ value: "working", updatedAt: eventObservedAt });
+  });
+
+  it("never duplicates station-identified sessions or existing runs", () => {
+    const stationOwned = synthesizeExternalHarnessRuns({
+      runs: [],
+      observations: [
+        externalObservation({ sessionId: "ses_1" }),
+        externalObservation({ harnessRunId: "run_1", nativeSessionId: "native_2" }),
+      ],
+    });
+    expect(stationOwned).toHaveLength(0);
+
+    const existing = run({ id: externalHarnessRunId("codex", "native_1"), state: "working" });
+    const alreadyPresent = synthesizeExternalHarnessRuns({
+      runs: [existing],
+      observations: [externalObservation({})],
+    });
+    expect(alreadyPresent).toEqual([existing]);
+  });
+
+  it("keeps the newest status per native session and drops ended sessions", () => {
+    const superseded = synthesizeExternalHarnessRuns({
+      runs: [],
+      observations: [
+        externalObservation({ value: "working", updatedAt: "2026-05-21T12:00:01.000Z" }),
+        externalObservation({ value: "idle", updatedAt: "2026-05-21T12:00:05.000Z" }),
+      ],
+    });
+    expect(superseded).toHaveLength(1);
+    expect(superseded[0]?.status).toMatchObject({ value: "idle" });
+
+    const ended = synthesizeExternalHarnessRuns({
+      runs: [],
+      observations: [externalObservation({ value: "exited" })],
+    });
+    expect(ended).toHaveLength(0);
+  });
+});
+
 describe("stale busy status decay", () => {
   // runObservedAt + 15 minutes exactly, and one millisecond past it.
   const atWindow = "2026-05-21T12:15:00.000Z";
@@ -307,6 +385,7 @@ function observation(
     harnessRunId?: string | undefined;
     sessionId?: string | undefined;
     worktreeId?: string | undefined;
+    nativeSessionId?: string | undefined;
     rawEventType?: string;
     observedAt?: string;
   },
@@ -321,6 +400,7 @@ function observation(
   if (input.harnessRunId !== undefined) payload.harnessRunId = input.harnessRunId;
   if (input.sessionId !== undefined) payload.sessionId = input.sessionId;
   if (input.worktreeId !== undefined) payload.worktreeId = input.worktreeId;
+  if (input.nativeSessionId !== undefined) payload.nativeSessionId = input.nativeSessionId;
   if (input.rawEventType !== undefined) payload.rawEventType = input.rawEventType;
 
   return persistedObservation(payload, {

--- a/apps/observer/test/unit/statusProjection.test.ts
+++ b/apps/observer/test/unit/statusProjection.test.ts
@@ -13,7 +13,10 @@ import {
 import { describe, expect, it } from "vitest";
 import { buildStationSnapshot } from "../../src/reconcile/graph";
 import { observerHarnessRunFromRun } from "../../src/reconcile/harnessEventStatus";
-import { projectHarnessEventReportOntoSnapshot } from "../../src/reconcile/statusProjection";
+import {
+  projectHarnessEventReportOntoSnapshot,
+  withWorktreeCorrelationFromCwd,
+} from "../../src/reconcile/statusProjection";
 
 const now = "2026-05-21T12:00:00.000Z";
 const eventAt = "2026-05-21T12:00:01.000Z";
@@ -230,6 +233,96 @@ describe("live harness status projection", () => {
     });
   });
 });
+
+describe("cwd correlation resolution", () => {
+  it("resolves a cwd-only report to the containing worktree and projects it", () => {
+    const snapshot = snapshotFor();
+    const enriched = withWorktreeCorrelationFromCwd(
+      report({
+        status: status("working", "medium", "Codex is about to use Bash."),
+        correlation: { cwd: "/tmp/station/web/task/src/deep" },
+      }),
+      snapshot,
+    );
+
+    expect(enriched.correlation).toMatchObject({
+      worktreeId: "wt_web_task",
+      cwd: "/tmp/station/web/task/src/deep",
+    });
+
+    const result = projectHarnessEventReportOntoSnapshot({
+      snapshot,
+      report: enriched,
+      projectedAt: eventAt,
+    });
+    expect(result.projected).toBe(true);
+    expect(result.correlatedBy).toBe("worktreeId");
+    expect(result.snapshot.rows[0]?.agent).toMatchObject({ state: "working" });
+  });
+
+  it("leaves reports with stronger correlation or an unknown cwd untouched", () => {
+    const snapshot = snapshotFor();
+    const strong = report({
+      status: status("working", "medium", "Codex is about to use Bash."),
+      correlation: { sessionId: "ses_other", cwd: "/tmp/station/web/task" },
+    });
+    expect(withWorktreeCorrelationFromCwd(strong, snapshot)).toBe(strong);
+
+    const elsewhere = report({
+      status: status("working", "medium", "Codex is about to use Bash."),
+      correlation: { cwd: "/somewhere/unrelated" },
+    });
+    expect(withWorktreeCorrelationFromCwd(elsewhere, snapshot)).toBe(elsewhere);
+  });
+
+  it("picks the deepest containing worktree and drops ties as ambiguous", () => {
+    const snapshot = snapshotForRows([
+      { id: "wt_web_root", path: "/tmp/station/web" },
+      { id: "wt_web_task", path: "/tmp/station/web/task" },
+    ]);
+    const nested = withWorktreeCorrelationFromCwd(
+      report({
+        status: status("working", "medium", "Codex is about to use Bash."),
+        correlation: { cwd: "/tmp/station/web/task/src" },
+      }),
+      snapshot,
+    );
+    expect(nested.correlation?.worktreeId).toBe("wt_web_task");
+
+    const duplicated = snapshotForRows([
+      { id: "wt_a", path: "/tmp/station/web/task" },
+      { id: "wt_b", path: "/tmp/station/web/task" },
+    ]);
+    const ambiguous = report({
+      status: status("working", "medium", "Codex is about to use Bash."),
+      correlation: { cwd: "/tmp/station/web/task" },
+    });
+    expect(withWorktreeCorrelationFromCwd(ambiguous, duplicated)).toBe(ambiguous);
+  });
+});
+
+function snapshotForRows(rows: Array<{ id: string; path: string }>) {
+  return buildStationSnapshot({
+    generatedAt: now,
+    observer: { pid: 4242, startedAt: now, version: "0.0.0", healthy: true },
+    projects: [
+      {
+        id: "web",
+        label: "web",
+        root: "/tmp/station/web",
+        defaults: { harness: "codex", terminal: "tmux", layout: "agent-shell" },
+        worktrunk: { enabled: true },
+      },
+    ],
+    worktreeProviderId: "fake-worktree",
+    providerHealth: {},
+    worktrees: rows.map((row) =>
+      createFakeWorktree({ id: row.id, projectId: "web", branch: row.id, path: row.path, now }),
+    ),
+    terminalTargets: [],
+    harnessRuns: [],
+  });
+}
 
 function snapshotFor(input: { state?: AgentState; confidence?: Confidence; now?: string } = {}) {
   const worktrees = [

--- a/integrations/harness/claude/src/hookAdapter.ts
+++ b/integrations/harness/claude/src/hookAdapter.ts
@@ -14,6 +14,7 @@ import {
   ProviderHookEventSchema,
   parseStationHookIdentityPayload,
 } from "@station/contracts";
+import { z } from "zod";
 import { compactClaudeHookPayload } from "./compaction.js";
 import { claudeHookPayloadReportId, claudeHookPayloadToHarnessEventReport } from "./events.js";
 import { isClaudeForwardedEventType } from "./ingressRules.js";
@@ -27,24 +28,29 @@ export const claudeHookAdapter: ProviderHookAdapter = {
   toHarnessEventReport: claudeHookEventReport,
 };
 
+// Pre-parse probe for the scope decision only; the full event schema validates
+// later in toHarnessEventReport.
+const hookCwdProbeSchema = z.object({ cwd: z.string().min(1) }).loose();
+
 function decideClaudeHookScope(event: ProviderHookEvent): ProviderHookScopeDecision {
   if (event.kind !== "harness") {
     return { action: "accept", reason: "not-required" };
-  }
-
-  const payload = parseStationHookIdentityPayload(event.payload);
-  if (payload === undefined) {
-    return { action: "ignore", reason: "missing-station-env" };
-  }
-  if (payload.station_session_id === undefined || payload.station_worktree_id === undefined) {
-    return { action: "ignore", reason: "missing-station-env" };
   }
   // A fallback global install can surface user-added hook events; unlisted
   // event types are dropped, never errors.
   if (!isClaudeForwardedEventType(event.event)) {
     return { action: "ignore", reason: "event-not-forwarded" };
   }
-  return { action: "accept", reason: "station-env" };
+  const payload = parseStationHookIdentityPayload(event.payload);
+  if (payload?.station_session_id !== undefined && payload.station_worktree_id !== undefined) {
+    return { action: "accept", reason: "station-env" };
+  }
+  // Sessions Station did not launch carry no station env; the observer
+  // correlates their events by cwd (dropped there when ambiguous).
+  if (hookCwdProbeSchema.safeParse(event.payload).success) {
+    return { action: "accept", reason: "cwd" };
+  }
+  return { action: "ignore", reason: "missing-station-env" };
 }
 
 function compactClaudeHookEventPayload(

--- a/integrations/harness/claude/test/unit/hookScope.test.ts
+++ b/integrations/harness/claude/test/unit/hookScope.test.ts
@@ -1,0 +1,47 @@
+import type { ProviderHookEvent } from "@station/contracts";
+import { STATION_SCHEMA_VERSION } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { claudeHookAdapter } from "../../src/hookAdapter";
+
+const receivedAt = "2026-05-21T12:00:00.000Z";
+
+function hookEvent(payload: unknown, event = "PreToolUse"): ProviderHookEvent {
+  return {
+    schemaVersion: STATION_SCHEMA_VERSION,
+    provider: "claude",
+    kind: "harness",
+    event,
+    receivedAt,
+    payload,
+  };
+}
+
+describe("claude hook scope decision", () => {
+  it("accepts station-launched sessions by env identity", () => {
+    const decision = claudeHookAdapter.decideScope?.(
+      hookEvent({
+        cwd: "/repo/wt",
+        station_session_id: "ses_web_task",
+        station_worktree_id: "wt_web_task",
+      }),
+    );
+    expect(decision).toEqual({ action: "accept", reason: "station-env" });
+  });
+
+  it("accepts external sessions by payload cwd", () => {
+    const decision = claudeHookAdapter.decideScope?.(hookEvent({ cwd: "/repo/wt" }));
+    expect(decision).toEqual({ action: "accept", reason: "cwd" });
+  });
+
+  it("ignores payloads with neither station env nor cwd", () => {
+    const decision = claudeHookAdapter.decideScope?.(hookEvent({ session_id: "abc" }));
+    expect(decision).toEqual({ action: "ignore", reason: "missing-station-env" });
+  });
+
+  it("ignores unlisted event types before any identity check", () => {
+    const decision = claudeHookAdapter.decideScope?.(
+      hookEvent({ cwd: "/repo/wt" }, "SomeUserAddedHook"),
+    );
+    expect(decision).toEqual({ action: "ignore", reason: "event-not-forwarded" });
+  });
+});

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -70,7 +70,7 @@ describe("Claude hook setup", () => {
     expect(settings.hooks.Stop?.[0]).not.toHaveProperty("matcher");
   });
 
-  it("installs the artifact and script idempotently with the env guard", async () => {
+  it("installs the artifact and script idempotently without a station-env gate", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-claude-hooks-"));
     const claudeConfigDir = join(root, "claude-home");
     const settingsPath = join(root, "state", "hooks", "station-claude-settings.json");
@@ -98,9 +98,9 @@ describe("Claude hook setup", () => {
     expect(first.changed).toBe(true);
     expect(second.changed).toBe(false);
     expect(Object.keys(settings.hooks)).toEqual(expectedEvents);
-    expect(script).toContain(
-      `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    );
+    // External sessions carry no station env; the script must deliver anyway
+    // and leave scope decisions to the provider adapter.
+    expect(script).not.toContain("STATION_SESSION_ID");
     expect(script).toContain("--config /tmp/station/config.toml");
     expect(script).toContain("claude > /dev/null");
     expect(script).not.toContain("payload_file=");
@@ -112,31 +112,40 @@ describe("Claude hook setup", () => {
     });
   });
 
-  it("generated script exits before payload parsing or hook invocation without ownership env", async () => {
+  it("generated script delivers to stn-ingress even without ownership env", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-claude-hooks-"));
     const settingsPath = join(root, "state", "hooks", "station-claude-settings.json");
     const hookScriptPath = join(root, "state", "hooks", "station-claude-hook.sh");
+    const hookBin = join(root, "stn-ingress");
+    const argsLog = join(root, "hook.args");
+    await writeFile(
+      hookBin,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf '%s\\n' "$*" >> ${shellQuote(argsLog)}`,
+        "cat > /dev/null",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
 
     await installClaudeHooks({
       claudeSettingsPath: settingsPath,
       claudeConfigDir: join(root, "claude-home"),
       hookScriptPath,
-      hookBin: join(root, "missing-stn-ingress"),
+      stationConfigPath: "/tmp/station/config.toml",
+      hookBin,
       env: {},
     });
 
-    for (const env of [
-      {},
-      { STATION_SESSION_ID: "ses_web_task" },
-      { STATION_WORKTREE_ID: "wt_web_task" },
-    ]) {
-      const result = await runHookScript(hookScriptPath, "{ invalid json", {
-        TMPDIR: root,
-        ...env,
-      });
+    const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
 
-      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
-    }
+    expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+    await expect(readFile(argsLog, "utf8")).resolves.toBe(
+      "--config /tmp/station/config.toml claude\n",
+    );
   });
 
   it("generated script invokes stn-ingress with Claude stdin when ownership env is present", async () => {

--- a/integrations/harness/codex/src/hookAdapter.ts
+++ b/integrations/harness/codex/src/hookAdapter.ts
@@ -14,6 +14,7 @@ import {
   ProviderHookEventSchema,
   parseStationHookIdentityPayload,
 } from "@station/contracts";
+import { z } from "zod";
 import { compactCodexHookPayload } from "./compaction.js";
 import { codexHookPayloadReportId, codexHookPayloadToHarnessEventReport } from "./events.js";
 
@@ -26,17 +27,23 @@ export const codexHookAdapter: ProviderHookAdapter = {
   toHarnessEventReport: codexHookEventReport,
 };
 
+// Pre-parse probe for the scope decision only; the full event schema validates
+// later in toHarnessEventReport.
+const hookCwdProbeSchema = z.object({ cwd: z.string().min(1) }).loose();
+
 function decideCodexHookScope(event: ProviderHookEvent): ProviderHookScopeDecision {
   if (event.kind !== "harness") {
     return { action: "accept", reason: "not-required" };
   }
 
   const payload = parseStationHookIdentityPayload(event.payload);
-  if (payload === undefined) {
-    return { action: "ignore", reason: "missing-station-env" };
-  }
-  if (payload.station_session_id !== undefined && payload.station_worktree_id !== undefined) {
+  if (payload?.station_session_id !== undefined && payload.station_worktree_id !== undefined) {
     return { action: "accept", reason: "station-env" };
+  }
+  // Sessions Station did not launch carry no station env; the observer
+  // correlates their events by cwd (dropped there when ambiguous).
+  if (hookCwdProbeSchema.safeParse(event.payload).success) {
+    return { action: "accept", reason: "cwd" };
   }
   return { action: "ignore", reason: "missing-station-env" };
 }

--- a/integrations/harness/codex/test/unit/hookScope.test.ts
+++ b/integrations/harness/codex/test/unit/hookScope.test.ts
@@ -1,0 +1,40 @@
+import type { ProviderHookEvent } from "@station/contracts";
+import { STATION_SCHEMA_VERSION } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { codexHookAdapter } from "../../src/hookAdapter";
+
+const receivedAt = "2026-05-21T12:00:00.000Z";
+
+function hookEvent(payload: unknown): ProviderHookEvent {
+  return {
+    schemaVersion: STATION_SCHEMA_VERSION,
+    provider: "codex",
+    kind: "harness",
+    event: "PreToolUse",
+    receivedAt,
+    payload,
+  };
+}
+
+describe("codex hook scope decision", () => {
+  it("accepts station-launched sessions by env identity", () => {
+    const decision = codexHookAdapter.decideScope?.(
+      hookEvent({
+        cwd: "/repo/wt",
+        station_session_id: "ses_web_task",
+        station_worktree_id: "wt_web_task",
+      }),
+    );
+    expect(decision).toEqual({ action: "accept", reason: "station-env" });
+  });
+
+  it("accepts external sessions by payload cwd", () => {
+    const decision = codexHookAdapter.decideScope?.(hookEvent({ cwd: "/repo/wt" }));
+    expect(decision).toEqual({ action: "accept", reason: "cwd" });
+  });
+
+  it("ignores payloads with neither station env nor cwd", () => {
+    const decision = codexHookAdapter.decideScope?.(hookEvent({ session_id: "abc" }));
+    expect(decision).toEqual({ action: "ignore", reason: "missing-station-env" });
+  });
+});

--- a/integrations/harness/codex/test/unit/hooks.test.ts
+++ b/integrations/harness/codex/test/unit/hooks.test.ts
@@ -101,9 +101,9 @@ describe("Codex hook setup", () => {
     expect(script).toContain("CONFIG_ARG=(--config /tmp/station/config.toml)");
     expect(script).toContain("STATE_DIR_ARG=(--state-dir /tmp/station/state)");
     expect(script).toContain("SPOOL_DIR_ARG=(--spool-dir /tmp/station/state/spool/hooks)");
-    expect(script).toContain(
-      `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    );
+    // External sessions carry no station env; the script must deliver anyway
+    // and leave scope decisions to the provider adapter.
+    expect(script).not.toContain("STATION_SESSION_ID");
     expect(script).not.toContain("payload_file=");
     expect(script).toContain("codex > /dev/null");
     expect(scriptMode).toBe(0o700);
@@ -125,31 +125,40 @@ describe("Codex hook setup", () => {
     });
   });
 
-  it("generated script exits before payload parsing or hook invocation without ownership env", async () => {
+  it("generated script delivers to stn-ingress even without ownership env", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-codex-hooks-"));
     const env = codexEnv(root);
     const configPath = join(root, "codex", "config.toml");
     const hookScriptPath = join(root, "state", "hooks", "station-codex-hook.sh");
+    const hookBin = join(root, "stn-ingress");
+    const argsLog = join(root, "hook.args");
+    await writeFile(
+      hookBin,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf '%s\\n' "$*" >> ${shellQuote(argsLog)}`,
+        "cat > /dev/null",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
 
     await installCodexHooks({
       codexConfigPath: configPath,
       hookScriptPath,
-      hookBin: join(root, "missing-stn-ingress"),
+      stationConfigPath: "/tmp/station/config.toml",
+      hookBin,
       env,
     });
 
-    for (const env of [
-      {},
-      { STATION_SESSION_ID: "ses_web_task" },
-      { STATION_WORKTREE_ID: "wt_web_task" },
-    ]) {
-      const result = await runHookScript(hookScriptPath, "{ invalid json", {
-        TMPDIR: root,
-        ...env,
-      });
+    const payload = JSON.stringify({ hook_event_name: "PreToolUse" });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
 
-      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
-    }
+    expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+    await expect(readFile(argsLog, "utf8")).resolves.toBe(
+      "--config /tmp/station/config.toml codex\n",
+    );
   });
 
   it("generated script invokes stn-ingress with Codex stdin when ownership env is present", async () => {

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -117,9 +117,9 @@ describe("Cursor hook setup", () => {
     expect(script).toContain("CONFIG_ARG=(--config /tmp/station/config.toml)");
     expect(providerHookScriptRoutesByStationEnv(script, "cursor")).toBe(true);
     expect(script).toContain("--no-auto-start cursor");
-    expect(script).toContain(
-      `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    );
+    // External sessions carry no station env; the script must deliver anyway
+    // and leave scope decisions to the provider adapter.
+    expect(script).not.toContain("STATION_SESSION_ID");
     expect(script).toContain("cursor > /dev/null");
     expect(scriptMode).toBe(0o700);
     await expect(
@@ -177,29 +177,38 @@ describe("Cursor hook setup", () => {
     });
   });
 
-  it("generated script exits before hook invocation without ownership env", async () => {
+  it("generated script delivers to stn-ingress even without ownership env", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
     const hooksPath = join(root, "cursor", "hooks.json");
     const hookScriptPath = join(root, "state", "hooks", "station-cursor-hook.sh");
+    const hookBin = join(root, "stn-ingress");
+    const argsLog = join(root, "hook.args");
+    await writeFile(
+      hookBin,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `printf '%s\\n' "$*" >> ${shellQuote(argsLog)}`,
+        "cat > /dev/null",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    );
 
     await installCursorHooks({
       cursorHooksPath: hooksPath,
       hookScriptPath,
-      hookBin: join(root, "missing-stn-ingress"),
+      stationConfigPath: "/tmp/station/config.toml",
+      hookBin,
     });
 
-    for (const env of [
-      {},
-      { STATION_SESSION_ID: "ses_web_task" },
-      { STATION_WORKTREE_ID: "wt_web_task" },
-    ]) {
-      const result = await runHookScript(hookScriptPath, "{ invalid json", {
-        TMPDIR: root,
-        ...env,
-      });
+    const payload = JSON.stringify({ hook_event_name: "beforeShellExecution" });
+    const result = await runHookScript(hookScriptPath, payload, { TMPDIR: root });
 
-      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
-    }
+    expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+    await expect(readFile(argsLog, "utf8")).resolves.toBe(
+      "--config /tmp/station/config.toml cursor\n",
+    );
   });
 
   it("generated script invokes stn-ingress with Cursor stdin when ownership env is present", async () => {

--- a/packages/contracts/src/hooks.ts
+++ b/packages/contracts/src/hooks.ts
@@ -170,7 +170,7 @@ export function parseProviderHookEventName(payload: unknown): string | undefined
 export type ProviderHookScopeDecision =
   | {
       action: "accept";
-      reason: "not-required" | "station-env";
+      reason: "not-required" | "station-env" | "cwd";
     }
   | {
       action: "ignore";

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -234,12 +234,12 @@ export function expectedProviderHookScript(input: {
   const suffix = input.ignoreFailure === true ? " || true" : "";
   const redirect = input.redirectStderr === true ? " > /dev/null 2>&1" : " > /dev/null";
   const options = input.options ?? {};
+  // No station-env gate: sessions Station did not launch (plain `claude` or
+  // `codex` in any terminal) still deliver, and the provider adapter decides
+  // scope — the observer correlates env-less events by their payload cwd.
   return [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
-    `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    "  exit 0",
-    "fi",
     ...dynamicHookArg(
       "SOCKET_ARG",
       "STATION_OBSERVER_SOCKET_PATH",
@@ -264,9 +264,6 @@ export function expectedProviderHookScript(input: {
 
 export function providerHookScriptRoutesByStationEnv(script: string, provider: string): boolean {
   return (
-    script.includes(
-      `if [ -z "\${STATION_SESSION_ID:-}" ] || [ -z "\${STATION_WORKTREE_ID:-}" ]; then`,
-    ) &&
     script.includes("STATION_OBSERVER_SOCKET_PATH") &&
     script.includes("STATION_CONFIG_PATH") &&
     script.includes("STATION_STATE_DIR") &&

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -111,10 +111,11 @@ describe("runtime hookSetup", () => {
       });
       expect(ignoreAndRedirect).toContain("claude > /dev/null 2>&1 || true\n");
 
-      // The session/worktree ownership guard must survive: no env -> exit 0 before invoking.
-      expect(plain).toContain("STATION_SESSION_ID");
-      expect(plain).toContain("STATION_WORKTREE_ID");
-      expect(plain).toContain("  exit 0");
+      // No ownership gate: external sessions (no station env) must deliver so
+      // the observer can correlate them by cwd; scope lives in the adapters.
+      expect(plain).not.toContain("STATION_SESSION_ID");
+      expect(plain).not.toContain("STATION_WORKTREE_ID");
+      expect(plain).not.toContain("  exit 0");
     });
 
     it("builds provider-neutral ingress commands and generated scripts", () => {


### PR DESCRIPTION
Fixes the root cause of "this pane doesn't show working when claude is working": status observation only functioned for agents Station launched into its own panes. Any session started any other way — a plain `claude` or `codex` in a terminal, a background/remote session — was invisible by construction, so its row never showed working, never went idle, and never raised needs_attention. This was the actual blocker behind clarifying-question notifications.

## The three gates, now one supported path

1. **Hook script** (`hookSetup.ts`): the generated script exited immediately without `STATION_SESSION_ID`/`STATION_WORKTREE_ID`. It now always delivers and leaves scope to the provider adapters.
2. **CLI sender** (`ingress/sender.ts`): silently ignored env-less payloads before any adapter ran (an unlogged receipt — why this was so hard to see). claude/codex now accept payloads carrying a `cwd`; cursor/pi keep the ownership gate.
3. **Adapters** (`claude`/`codex` `hookAdapter.ts`): scope decision accepts `station-env` (unchanged, strongest) or `cwd` (new); payloads with neither are still ignored. New `"cwd"` accept reason in the contract union.

Then the observer resolves cwd once at the report boundary (`withWorktreeCorrelationFromCwd` in `statusProjection.ts`, wired in `harnessReportProcessor.ts` before ingest): deepest containing worktree row wins, equal-depth ties drop as ambiguous — implementing the correlation ladder's documented "cwd as last resort". Because enrichment happens before persistence, both live projection and reconcile overlays correlate by `worktreeId` with no changes downstream. Station-launched sessions keep their stronger env-derived identity untouched.

## Live proof (this machine)

A real one-shot `claude -p` with **no station env** in a worktree drove its row through `starting → working → idle → exited`, every event `projected: true, correlatedBy: worktreeId`. Immediately after, the interactive session that authored this PR began lighting its own row on every tool call ("working — Claude Code is about to use Bash") — the first time that pane has ever shown truth. Its hooks had been firing all along; the script was exiting at the gate.

## UX implication + manual verify

Rows now track any claude/codex session running inside a known worktree, not just Station-launched panes — working while it works, idle on Stop, needs_attention events flow for notifications. Verify: `claude -p "hi"` in any project worktree (no station env) and watch the row light up; `stn debug logs` shows the events with `correlatedBy: worktreeId`.

## Tests

- New adapter scope pins (claude + codex): station-env accept, cwd accept, neither → ignore, unlisted event types ignored first.
- `statusProjection.test.ts`: cwd resolves to the containing row and projects end-to-end; stronger correlation and unknown cwds untouched; deepest-row wins, ties ambiguous.
- `ingress-command.test.ts`: env-less claude events with cwd deliver (spool when no observer); without cwd still ignored.
- Hook-setup pins flipped: script has no gate and delivers env-less across claude/codex/cursor.
- Lanes: typecheck clean, unit 1105 pass, integration 301 pass.

## Notes for rollout

- The hook events must be present in `~/.claude/settings.json` (or wherever a session loads hooks) for arbitrary sessions to report; `stn hooks install claude` currently writes only the Station-owned settings file passed to pane launches — a user-level install path is a follow-up.
- Follow-up landed in this PR: reconcile mints one run per (provider, native session) for external sessions, so rows with no agent record — or one bound to a stale run from another provider — light up too; a working external run takes the row by the graph's existing status-priority selection, and ended sessions leave rows once they exit. Proven live: a codex session drove an agent-less row none → codex/working → codex/idle and the agent-state notification event hook fired on the transition.
- Every claude/codex session on a machine now spawns one short-lived `stn-ingress` per hook event; unmatched-cwd events are dropped at the observer with a logged `projected: false`.
