### PR TITLE
feat(terminal): detect, log, and capture actual pane corruption

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -143,6 +143,7 @@ diagnostics/*/diagnostic-index.json
 diagnostics/*/commands.jsonl
 diagnostics/*/errors.jsonl
 diagnostics/*/logs/observer.jsonl
+diagnostics/panes/
 spool/hooks/
 ```
 
@@ -152,6 +153,8 @@ spool/hooks/
 - `commands.jsonl` is the command lifecycle record. Failed commands can include redacted provider command diagnostics when an error envelope was persisted for the command.
 - `errors.jsonl` carries safe error envelopes, diagnostic IDs, trace IDs, provider context, and redacted diagnostic details when available.
 - `logs/observer.jsonl` and `logs/hooks.jsonl` explain runtime events around reconcile, command execution, hook delivery, projection, spool fallback, and provider health.
+- `logs/tui.jsonl` carries pane corruption telemetry from the native workspace: `Terminal corruption signal.` lines with `kind` (`unhandled_sequence`, `replacement_char`, `escape_fragment`, `geometry_divergence`, `overflow_clip`, `terminal_diagnostic`, `parse_error`), the pane, and a rate-limited count. `escape_fragment` is a heuristic — a pane that prints ANSI codes as text trips it.
+- `diagnostics/panes/` holds pane evidence dumps written when a detector trips: the visible grid plus the raw byte tail that produced it. Feed `rawTail` back through `createStationVtScreen` to replay the corruption offline.
 - SQLite is observer-owned runtime history; inspect through existing debug/diagnostic surfaces unless a task explicitly needs database-level investigation.
 - Logs and bundles are diagnostic evidence only. Reconcile from config/providers/current observer state before treating old evidence as current truth.
 - Provider hook logs are delivery/setup evidence, not runtime truth. Use observer health, reconcile output, and snapshots to verify the current graph.

--- a/station/src/config/stationConfig.test.ts
+++ b/station/src/config/stationConfig.test.ts
@@ -46,7 +46,9 @@ root = ${JSON.stringify(root)}
 describe("loadStationConfig", () => {
   it("returns silent defaults when the config file is absent", async () => {
     const result = await loadStationConfig({ path: "/definitely/not/here/config.toml" });
-    expect(result).toEqual({ config: DEFAULT_WORKSPACE_CONFIG, source: "defaults" });
+    expect(result.config).toEqual(DEFAULT_WORKSPACE_CONFIG);
+    expect(result.source).toBe("defaults");
+    expect(result.stateDir).toContain("/state/station");
   });
 
   it("reads the [workspace] section out of the runtime config", async () => {

--- a/station/src/config/stationConfig.ts
+++ b/station/src/config/stationConfig.ts
@@ -1,4 +1,10 @@
-import { ConfigError, DEFAULT_WORKSPACE_CONFIG, loadConfig, type WorkspaceConfig } from "@station/config";
+import {
+  ConfigError,
+  DEFAULT_WORKSPACE_CONFIG,
+  loadConfig,
+  resolveObserverPaths,
+  type WorkspaceConfig,
+} from "@station/config";
 import { safeErrorFromUnknown } from "@station/runtime";
 
 // Native Station workspace settings are the `[workspace]` section of the single
@@ -19,6 +25,8 @@ export type StationConfigSource = "file" | "defaults";
 export type StationConfigLoadResult = {
   config: WorkspaceConfig;
   source: StationConfigSource;
+  /** Runtime state dir (config-relocatable); TUI logs and pane dumps live under it. */
+  stateDir: string;
   /** Set when a present-but-broken config forced a fallback to defaults. */
   warning?: string;
 };
@@ -38,7 +46,11 @@ export async function loadStationConfig(options?: {
   const configPath = options?.path ?? configPathFromEnv(options?.env);
   try {
     const loaded = configPath === undefined ? await loadConfig() : await loadConfig({ configPath });
-    const result: StationConfigLoadResult = { config: loaded.config.workspace, source: "file" };
+    const result: StationConfigLoadResult = {
+      config: loaded.config.workspace,
+      source: "file",
+      stateDir: resolveObserverPaths(loaded.config).stateDir,
+    };
     // The config loaded, but a typo'd [workspace] was best-effort dropped to
     // defaults — surface that as a warning rather than swallowing it silently.
     const sectionWarning = loaded.diagnostics.find(
@@ -51,7 +63,11 @@ export async function loadStationConfig(options?: {
   } catch (cause) {
     // A missing config is the common first-run case: silent defaults.
     if (cause instanceof ConfigError && cause.code === "CONFIG_FILE_NOT_FOUND") {
-      return { config: DEFAULT_WORKSPACE_CONFIG, source: "defaults" };
+      return {
+        config: DEFAULT_WORKSPACE_CONFIG,
+        source: "defaults",
+        stateDir: resolveObserverPaths().stateDir,
+      };
     }
     const error =
       cause instanceof ConfigError
@@ -64,6 +80,7 @@ export async function loadStationConfig(options?: {
     return {
       config: DEFAULT_WORKSPACE_CONFIG,
       source: "defaults",
+      stateDir: resolveObserverPaths().stateDir,
       warning: `${error.message}; using defaults.`,
     };
   }

--- a/station/src/hmr/stationHotRuntime.ts
+++ b/station/src/hmr/stationHotRuntime.ts
@@ -6,7 +6,9 @@ import { createPtyRegistry, type PtyRegistry } from "../terminal/registry/ptyReg
 // Bump only when a code change makes a preserved store/registry unsafe to reuse
 // across a hot reload (e.g. an incompatible store-state shape). A mismatch
 // triggers a clean reboot rather than reusing stale in-memory state.
-export const STATION_HOT_RUNTIME_VERSION = 2;
+// v3: registry/screens gained corruption detectors and geometry checks; a
+// preserved v2 registry would leave hot-reloaded panes without them.
+export const STATION_HOT_RUNTIME_VERSION = 3;
 
 export type StationHotRenderer = { destroy(): void };
 

--- a/station/src/host/scrollbackRing.ts
+++ b/station/src/host/scrollbackRing.ts
@@ -1,3 +1,4 @@
+import { ChunkRing } from "../terminal/chunkRing.js";
 import { TerminalModeTracker } from "./modeTracker.js";
 
 /**
@@ -9,39 +10,31 @@ import { TerminalModeTracker } from "./modeTracker.js";
  * TUI whose setup scrolled past the budget would replay into a normal-screen VT.
  */
 export class ScrollbackRing {
-  readonly #chunks: string[] = [];
-  #bytes = 0;
-  #truncated = false;
   readonly #modes = new TerminalModeTracker();
+  readonly #ring: ChunkRing;
 
-  constructor(private readonly maxBytes: number) {}
+  constructor(maxBytes: number) {
+    this.#ring = new ChunkRing(
+      maxBytes,
+      (chunk) => Buffer.byteLength(chunk, "utf8"),
+      (dropped) => this.#modes.feed(dropped),
+    );
+  }
 
   push(chunk: string): void {
-    if (chunk.length === 0) {
-      return;
-    }
-    this.#chunks.push(chunk);
-    this.#bytes += Buffer.byteLength(chunk, "utf8");
-    while (this.#bytes > this.maxBytes && this.#chunks.length > 1) {
-      const dropped = this.#chunks.shift();
-      if (dropped === undefined) {
-        break;
-      }
-      this.#modes.feed(dropped);
-      this.#bytes -= Buffer.byteLength(dropped, "utf8");
-      this.#truncated = true;
-    }
+    this.#ring.push(chunk);
   }
 
   snapshot(): { scrollback: string[]; truncated: boolean } {
     // Prepend a mode-restore preamble so the modes set by dropped chunks are
     // re-established before the surviving chunks replay over them.
     const preamble = this.#modes.restoreSequence();
-    const scrollback = preamble.length > 0 ? [preamble, ...this.#chunks] : [...this.#chunks];
-    return { scrollback, truncated: this.#truncated };
+    const chunks = [...this.#ring.chunks()];
+    const scrollback = preamble.length > 0 ? [preamble, ...chunks] : chunks;
+    return { scrollback, truncated: this.#ring.evicted };
   }
 
   get byteLength(): number {
-    return this.#bytes;
+    return this.#ring.total;
   }
 }

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -1,6 +1,8 @@
 import { spawn } from "node:child_process";
+import { join } from "node:path";
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
+import { componentLogPath, createJsonlLogger } from "@station/observability";
 import { Profiler } from "react";
 import { loadStationConfig } from "./config/stationConfig.js";
 import { loadStationTuiConfig } from "./config/tuiConfig.js";
@@ -24,6 +26,7 @@ import type { LayoutRestorePlan } from "./state/layout/restoreLayout.js";
 import { readLayoutSnapshotSync } from "./state/layout/layoutPersistence.js";
 import { applyRestoreSeeds, planLayoutRestoreColdShells } from "./state/layout/restoreLayout.js";
 import { savedCwdExists } from "./state/layout/savedCwdExists.js";
+import { wireTerminalDiagnostics } from "./terminal/diagnostics.js";
 import { resolveAuxShellPlacement } from "./terminal/pty/auxShellPlacement.js";
 import { createHostAttachedTerminal } from "./terminal/pty/hostAttachedTerminal.js";
 import { playStationAttentionSound } from "./sources/attentionSound.js";
@@ -170,6 +173,17 @@ if (stationConfig.warning !== undefined) {
 if (tuiConfig.warning !== undefined) {
   console.error(`[station] ${tuiConfig.warning}`);
 }
+
+// Corruption telemetry sink: detectors count regardless; with this wired they
+// also log to logs/tui.jsonl and write pane evidence dumps under
+// diagnostics/panes/.
+wireTerminalDiagnostics({
+  logger: createJsonlLogger({
+    component: "tui",
+    path: componentLogPath(stationConfig.stateDir, "tui"),
+  }),
+  dumpDir: join(stationConfig.stateDir, "diagnostics", "panes"),
+});
 
 // HMR recreates renderer, input handlers, and observer subscriptions, but keeps
 // coordination state plus live PTYs so a code edit returns to the active session

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -7,7 +7,6 @@ import {
   RGBA,
 } from "@opentui/core";
 import { extend } from "@opentui/react";
-import { reportTerminalCorruption } from "./diagnostics.js";
 import type { StationTerminalSize } from "./types.js";
 import { buildMouseReportSequence } from "./input/mouseReport.js";
 import { type MouseButtonName, MouseTracking } from "./protocol/mouse.js";
@@ -481,14 +480,8 @@ export class TerminalScreenRenderable extends Renderable {
           // Spans can exceed the laid-out width only during a resize race
           // (screen still at the old geometry); draw the part that fits rather
           // than dropping the span or painting into neighboring UI.
-          const overflows = col + span.width > this.width;
-          if (overflows) {
-            reportTerminalCorruption({
-              kind: "overflow_clip",
-              attributes: { width: this.width, col, spanWidth: span.width },
-            });
-          }
-          const text = overflows ? clipSpanText(span, this.width - col) : span.text;
+          const text =
+            col + span.width > this.width ? clipSpanText(span, this.width - col) : span.text;
           if (text.length === 0) {
             break;
           }

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -7,6 +7,7 @@ import {
   RGBA,
 } from "@opentui/core";
 import { extend } from "@opentui/react";
+import { reportTerminalCorruption } from "./diagnostics.js";
 import type { StationTerminalSize } from "./types.js";
 import { buildMouseReportSequence } from "./input/mouseReport.js";
 import { type MouseButtonName, MouseTracking } from "./protocol/mouse.js";
@@ -480,8 +481,14 @@ export class TerminalScreenRenderable extends Renderable {
           // Spans can exceed the laid-out width only during a resize race
           // (screen still at the old geometry); draw the part that fits rather
           // than dropping the span or painting into neighboring UI.
-          const text =
-            col + span.width > this.width ? clipSpanText(span, this.width - col) : span.text;
+          const overflows = col + span.width > this.width;
+          if (overflows) {
+            reportTerminalCorruption({
+              kind: "overflow_clip",
+              attributes: { width: this.width, col, spanWidth: span.width },
+            });
+          }
+          const text = overflows ? clipSpanText(span, this.width - col) : span.text;
           if (text.length === 0) {
             break;
           }

--- a/station/src/terminal/chunkRing.ts
+++ b/station/src/terminal/chunkRing.ts
@@ -1,0 +1,51 @@
+/**
+ * FIFO of whole string chunks bounded by a total measure. Over budget it drops
+ * oldest whole chunks (never partial), always keeps the newest, and reports
+ * whether anything was dropped. `measure` defaults to code-unit length; pass
+ * `Buffer.byteLength` for a byte budget. `onEvict` observes dropped chunks (e.g.
+ * to track sticky terminal modes before they scroll out).
+ */
+export class ChunkRing {
+  readonly #chunks: string[] = [];
+  #total = 0;
+  #evicted = false;
+
+  constructor(
+    private readonly maxTotal: number,
+    private readonly measure: (chunk: string) => number = (chunk) => chunk.length,
+    private readonly onEvict?: (chunk: string) => void,
+  ) {}
+
+  push(chunk: string): void {
+    if (chunk.length === 0) {
+      return;
+    }
+    this.#chunks.push(chunk);
+    this.#total += this.measure(chunk);
+    while (this.#total > this.maxTotal && this.#chunks.length > 1) {
+      const dropped = this.#chunks.shift();
+      if (dropped === undefined) {
+        break;
+      }
+      this.onEvict?.(dropped);
+      this.#total -= this.measure(dropped);
+      this.#evicted = true;
+    }
+  }
+
+  chunks(): readonly string[] {
+    return this.#chunks;
+  }
+
+  join(): string {
+    return this.#chunks.join("");
+  }
+
+  get evicted(): boolean {
+    return this.#evicted;
+  }
+
+  get total(): number {
+    return this.#total;
+  }
+}

--- a/station/src/terminal/diagnostics.test.ts
+++ b/station/src/terminal/diagnostics.test.ts
@@ -1,0 +1,112 @@
+import { readdirSync } from "node:fs";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  reportTerminalCorruption,
+  resetTerminalDiagnosticsForTest,
+  terminalCorruptionCounters,
+  wireTerminalDiagnostics,
+  writePaneEvidenceDump,
+} from "./diagnostics.js";
+
+type LoggedRecord = { message: string; attributes: Record<string, unknown> };
+const logged: LoggedRecord[] = [];
+const fakeLogger = {
+  path: "/tmp/fake-tui.jsonl",
+  log: async () => ({}) as never,
+  debug: async () => ({}) as never,
+  info: async () => ({}) as never,
+  warn: async (message: string, attributes?: Record<string, unknown>) => {
+    logged.push({ message, attributes: attributes ?? {} });
+    return {} as never;
+  },
+  error: async () => ({}) as never,
+};
+
+let dumpDir: string;
+beforeEach(async () => {
+  resetTerminalDiagnosticsForTest();
+  logged.length = 0;
+  dumpDir = await mkdtemp(join(tmpdir(), "station-diag-"));
+  wireTerminalDiagnostics({ logger: fakeLogger, dumpDir });
+});
+afterEach(() => {
+  resetTerminalDiagnosticsForTest();
+});
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("reportTerminalCorruption", () => {
+  it("nests detector detail so it cannot clobber reserved record fields", () => {
+    reportTerminalCorruption({
+      kind: "replacement_char",
+      pane: "pane-1",
+      // A detail field named like a reserved key must not overwrite it.
+      detail: { kind: "spoofed", count: 999, pane: "spoofed" },
+    });
+    const record = logged.find((entry) => entry.message === "Terminal corruption signal.");
+    expect(record?.attributes.kind).toBe("replacement_char");
+    expect(record?.attributes.count).toBe(1);
+    expect(record?.attributes.pane).toBe("pane-1");
+    expect(record?.attributes.detail).toMatchObject({ kind: "spoofed", count: 999 });
+  });
+
+  it("folds excess distinct keyed buckets into one overflow bucket", () => {
+    for (let index = 0; index < 400; index += 1) {
+      reportTerminalCorruption({ kind: "unhandled_sequence", key: `osc:${index}` });
+    }
+    const buckets = Object.keys(terminalCorruptionCounters());
+    expect(buckets.length).toBeLessThanOrEqual(300);
+    expect(buckets).toContain("unhandled_sequence:_overflow");
+  });
+});
+
+describe("writePaneEvidenceDump", () => {
+  it("redacts secrets in rows and the raw tail before writing", async () => {
+    writePaneEvidenceDump({
+      pane: "pane-secret",
+      trigger: "geometry_divergence",
+      evidence: {
+        rows: ["export GITHUB_TOKEN=ghp_abcdef0123456789abcdef"],
+        rawTail: "Authorization: Bearer sk-abcdefghijklmnop0123456789",
+      },
+    });
+    await waitFor(() => readdirSync(dumpDir).length >= 1);
+    const [name] = readdirSync(dumpDir);
+    const dump = JSON.parse(await readFile(join(dumpDir, name ?? ""), "utf8"));
+    expect(JSON.stringify(dump)).not.toContain("ghp_abcdef0123456789abcdef");
+    expect(JSON.stringify(dump)).not.toContain("sk-abcdefghijklmnop0123456789");
+    expect(JSON.stringify(dump)).toContain("[REDACTED]");
+  });
+
+  it("only rate-limits the pane once a write lands, and logs write failures", async () => {
+    wireTerminalDiagnostics({ logger: fakeLogger, dumpDir: join(dumpDir, "missing", "\0bad") });
+    writePaneEvidenceDump({
+      pane: "pane-fail",
+      trigger: "geometry_divergence",
+      evidence: { rows: [], rawTail: "" },
+    });
+    await waitFor(() => logged.some((r) => r.message === "Pane corruption evidence write failed."));
+    // The failed write must not have stamped the rate limit, so a later capture
+    // to a working dir still goes through.
+    wireTerminalDiagnostics({ logger: fakeLogger, dumpDir });
+    writePaneEvidenceDump({
+      pane: "pane-fail",
+      trigger: "geometry_divergence",
+      evidence: { rows: ["ok"], rawTail: "ok" },
+    });
+    await waitFor(() => readdirSync(dumpDir).length >= 1);
+  });
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("waitFor timed out");
+    }
+    await sleep(5);
+  }
+}

--- a/station/src/terminal/diagnostics.ts
+++ b/station/src/terminal/diagnostics.ts
@@ -1,0 +1,133 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { JsonlLogger } from "@station/observability";
+
+/**
+ * Corruption telemetry for the terminal path. Detectors report hard signals
+ * (invariant violations and high-signal heuristics) here; signals count always
+ * and log rate-limited when a logger is wired, so hot paths stay silent-cheap
+ * and a missing logger (tests, dashboard renderer) never throws.
+ */
+export type TerminalCorruptionKind =
+  | "unhandled_sequence"
+  | "parse_error"
+  | "replacement_char"
+  | "escape_fragment"
+  | "geometry_divergence"
+  | "overflow_clip"
+  | "terminal_diagnostic";
+
+export type TerminalCorruptionSignal = {
+  kind: TerminalCorruptionKind;
+  /** Pane label when the detector knows it; module-level detectors omit it. */
+  pane?: string;
+  /** Rate-limit bucket detail (e.g. a CSI ident) so distinct causes each log. */
+  key?: string;
+  attributes?: Record<string, unknown>;
+};
+
+// One log line per bucket per minute: corruption tends to fire per frame, and
+// the counters carry the volume — the log carries the existence and shape.
+const LOG_INTERVAL_MS = 60_000;
+const DUMP_INTERVAL_MS = 5 * 60_000;
+
+let logger: JsonlLogger | undefined;
+let dumpDir: string | undefined;
+const counters = new Map<string, number>();
+const lastLoggedAt = new Map<string, number>();
+const lastDumpAt = new Map<string, number>();
+
+export function wireTerminalDiagnostics(options: {
+  logger?: JsonlLogger | undefined;
+  /** Directory for pane evidence dumps, e.g. `<stateDir>/diagnostics/panes`. */
+  dumpDir?: string | undefined;
+}): void {
+  logger = options.logger;
+  dumpDir = options.dumpDir;
+}
+
+export function terminalCorruptionCounters(): Readonly<Record<string, number>> {
+  return Object.fromEntries(counters);
+}
+
+export function resetTerminalDiagnosticsForTest(): void {
+  logger = undefined;
+  dumpDir = undefined;
+  counters.clear();
+  lastLoggedAt.clear();
+  lastDumpAt.clear();
+}
+
+export function reportTerminalCorruption(signal: TerminalCorruptionSignal): void {
+  const bucket = signal.key === undefined ? signal.kind : `${signal.kind}:${signal.key}`;
+  const count = (counters.get(bucket) ?? 0) + 1;
+  counters.set(bucket, count);
+  if (logger === undefined) {
+    return;
+  }
+  const now = Date.now();
+  const last = lastLoggedAt.get(bucket);
+  if (last !== undefined && now - last < LOG_INTERVAL_MS) {
+    return;
+  }
+  lastLoggedAt.set(bucket, now);
+  void logger
+    .warn("Terminal corruption signal.", {
+      kind: signal.kind,
+      count,
+      ...(signal.pane === undefined ? {} : { pane: signal.pane }),
+      ...(signal.key === undefined ? {} : { key: signal.key }),
+      ...signal.attributes,
+    })
+    .catch(() => {});
+}
+
+/**
+ * Forensic capture at the moment of detection: the visible grid plus the raw
+ * byte tail that produced it, replayable offline through the VT screen. Rate
+ * limited per pane so a corruption storm cannot fill the disk.
+ */
+export function writePaneEvidenceDump(input: {
+  pane: string;
+  trigger: TerminalCorruptionKind;
+  evidence: { rows: string[]; rawTail: string };
+  attributes?: Record<string, unknown>;
+}): void {
+  if (dumpDir === undefined) {
+    return;
+  }
+  const now = Date.now();
+  const last = lastDumpAt.get(input.pane);
+  if (last !== undefined && now - last < DUMP_INTERVAL_MS) {
+    return;
+  }
+  lastDumpAt.set(input.pane, now);
+  const dir = dumpDir;
+  const stamp = new Date(now).toISOString().replaceAll(":", "-");
+  const safePane = input.pane.replaceAll(/[^A-Za-z0-9_-]/g, "_");
+  const path = join(dir, `${stamp}-${safePane}.json`);
+  void (async () => {
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify(
+        {
+          pane: input.pane,
+          trigger: input.trigger,
+          capturedAt: new Date(now).toISOString(),
+          counters: terminalCorruptionCounters(),
+          ...input.attributes,
+          rows: input.evidence.rows,
+          rawTail: input.evidence.rawTail,
+        },
+        null,
+        2,
+      ),
+    );
+    await logger?.warn("Pane corruption evidence written.", {
+      pane: input.pane,
+      trigger: input.trigger,
+      path,
+    });
+  })().catch(() => {});
+}

--- a/station/src/terminal/diagnostics.ts
+++ b/station/src/terminal/diagnostics.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { JsonlLogger } from "@station/observability";
+import { redactString } from "@station/observability";
 
 /**
  * Corruption telemetry for the terminal path. Detectors report hard signals
@@ -14,7 +15,6 @@ export type TerminalCorruptionKind =
   | "replacement_char"
   | "escape_fragment"
   | "geometry_divergence"
-  | "overflow_clip"
   | "terminal_diagnostic";
 
 export type TerminalCorruptionSignal = {
@@ -23,13 +23,22 @@ export type TerminalCorruptionSignal = {
   pane?: string;
   /** Rate-limit bucket detail (e.g. a CSI ident) so distinct causes each log. */
   key?: string;
-  attributes?: Record<string, unknown>;
+  /** Detector-specific fields; logged under `detail` so they cannot clobber. */
+  detail?: Record<string, unknown>;
 };
 
 // One log line per bucket per minute: corruption tends to fire per frame, and
 // the counters carry the volume — the log carries the existence and shape.
 const LOG_INTERVAL_MS = 60_000;
 const DUMP_INTERVAL_MS = 5 * 60_000;
+// Bucket keys can include idents taken from untrusted terminal output (OSC
+// identifiers are arbitrary integers); cap distinct buckets so a hostile or
+// random stream cannot grow the Maps or flood the log without bound. Beyond the
+// cap, further distinct keys fold into one overflow bucket per kind.
+const MAX_BUCKETS = 256;
+// Keep only the most recent dumps so a pane that trips repeatedly cannot fill
+// the state dir.
+const MAX_DUMP_FILES = 50;
 
 let logger: JsonlLogger | undefined;
 let dumpDir: string | undefined;
@@ -58,8 +67,22 @@ export function resetTerminalDiagnosticsForTest(): void {
   lastDumpAt.clear();
 }
 
+// Resolve the rate-limit/counter bucket, folding excess distinct keys into one
+// overflow bucket per kind once the cap is reached (so an unbounded key space
+// from terminal output cannot grow the Maps).
+function bucketFor(signal: TerminalCorruptionSignal): string {
+  if (signal.key === undefined) {
+    return signal.kind;
+  }
+  const bucket = `${signal.kind}:${signal.key}`;
+  if (counters.has(bucket) || counters.size < MAX_BUCKETS) {
+    return bucket;
+  }
+  return `${signal.kind}:_overflow`;
+}
+
 export function reportTerminalCorruption(signal: TerminalCorruptionSignal): void {
-  const bucket = signal.key === undefined ? signal.kind : `${signal.kind}:${signal.key}`;
+  const bucket = bucketFor(signal);
   const count = (counters.get(bucket) ?? 0) + 1;
   counters.set(bucket, count);
   if (logger === undefined) {
@@ -71,29 +94,37 @@ export function reportTerminalCorruption(signal: TerminalCorruptionSignal): void
     return;
   }
   lastLoggedAt.set(bucket, now);
-  void logger
-    .warn("Terminal corruption signal.", {
-      kind: signal.kind,
-      count,
-      ...(signal.pane === undefined ? {} : { pane: signal.pane }),
-      ...(signal.key === undefined ? {} : { key: signal.key }),
-      ...signal.attributes,
-    })
-    .catch(() => {});
+  // Reserved fields are assigned last so a detector's detail can never overwrite
+  // them; detail is nested rather than spread for the same reason.
+  const attributes: Record<string, unknown> = {};
+  if (signal.detail !== undefined) {
+    attributes.detail = signal.detail;
+  }
+  attributes.kind = signal.kind;
+  attributes.count = count;
+  if (signal.pane !== undefined) {
+    attributes.pane = signal.pane;
+  }
+  if (signal.key !== undefined) {
+    attributes.key = signal.key;
+  }
+  void logger.warn("Terminal corruption signal.", attributes).catch(() => {});
 }
 
 /**
  * Forensic capture at the moment of detection: the visible grid plus the raw
- * byte tail that produced it, replayable offline through the VT screen. Rate
- * limited per pane so a corruption storm cannot fill the disk.
+ * byte tail that produced it, replayable offline through the VT screen. Content
+ * is redacted (the same pass as debug bundles) and both the per-pane rate limit
+ * and directory retention are enforced so this cannot fill disk or leak secrets.
  */
 export function writePaneEvidenceDump(input: {
   pane: string;
   trigger: TerminalCorruptionKind;
   evidence: { rows: string[]; rawTail: string };
-  attributes?: Record<string, unknown>;
+  detail?: Record<string, unknown>;
 }): void {
-  if (dumpDir === undefined) {
+  const dir = dumpDir;
+  if (dir === undefined) {
     return;
   }
   const now = Date.now();
@@ -101,33 +132,53 @@ export function writePaneEvidenceDump(input: {
   if (last !== undefined && now - last < DUMP_INTERVAL_MS) {
     return;
   }
-  lastDumpAt.set(input.pane, now);
-  const dir = dumpDir;
   const stamp = new Date(now).toISOString().replaceAll(":", "-");
   const safePane = input.pane.replaceAll(/[^A-Za-z0-9_-]/g, "_");
   const path = join(dir, `${stamp}-${safePane}.json`);
-  void (async () => {
-    await mkdir(dir, { recursive: true });
-    await writeFile(
-      path,
-      JSON.stringify(
-        {
-          pane: input.pane,
-          trigger: input.trigger,
-          capturedAt: new Date(now).toISOString(),
-          counters: terminalCorruptionCounters(),
-          ...input.attributes,
-          rows: input.evidence.rows,
-          rawTail: input.evidence.rawTail,
-        },
-        null,
-        2,
-      ),
-    );
-    await logger?.warn("Pane corruption evidence written.", {
+  const body = JSON.stringify(
+    {
       pane: input.pane,
       trigger: input.trigger,
-      path,
-    });
-  })().catch(() => {});
+      capturedAt: new Date(now).toISOString(),
+      counters: terminalCorruptionCounters(),
+      ...(input.detail === undefined ? {} : { detail: input.detail }),
+      rows: input.evidence.rows.map((row) => redactString(row)),
+      rawTail: redactString(input.evidence.rawTail),
+    },
+    null,
+    2,
+  );
+  void (async () => {
+    try {
+      await mkdir(dir, { recursive: true });
+      await writeFile(path, body);
+      // Only mark the pane rate-limited once a write actually lands, so a
+      // failing directory does not silently swallow every later capture too.
+      lastDumpAt.set(input.pane, now);
+      await pruneDumpDir(dir);
+      await logger?.warn("Pane corruption evidence written.", {
+        pane: input.pane,
+        trigger: input.trigger,
+        path,
+      });
+    } catch (error) {
+      await logger
+        ?.warn("Pane corruption evidence write failed.", {
+          pane: input.pane,
+          message: error instanceof Error ? error.message : String(error),
+        })
+        .catch(() => {});
+    }
+  })();
+}
+
+async function pruneDumpDir(dir: string): Promise<void> {
+  const names = (await readdir(dir)).filter((name) => name.endsWith(".json")).sort();
+  const excess = names.length - MAX_DUMP_FILES;
+  for (let index = 0; index < excess; index += 1) {
+    const name = names[index];
+    if (name !== undefined) {
+      await rm(join(dir, name), { force: true });
+    }
+  }
 }

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -91,6 +91,7 @@ export function createHostAttachedTerminal(
   const pendingWrites: string[] = [];
   let attachment: HostAttachment | undefined;
   let size = options.size;
+  let ackedSize: StationTerminalSize | undefined;
   let pid = 0;
   let exited = false;
   let disposed = false;
@@ -210,6 +211,7 @@ export function createHostAttachedTerminal(
           await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
           await opened.resize(size.cols, size.rows);
         }
+        ackedSize = { cols: size.cols, rows: size.rows };
         // Drain front-to-back so a mid-flush failure leaves only the un-sent
         // writes to retry (no double-send on reconnect). New writes keep arriving
         // at the back while attachment is still undefined, preserving order.
@@ -362,9 +364,17 @@ export function createHostAttachedTerminal(
         // Applied to the host PTY on attach via `size`.
         return;
       }
-      attachment.resize(next.cols, next.rows).catch((error) => {
-        emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
-      });
+      attachment
+        .resize(next.cols, next.rows)
+        .then(() => {
+          ackedSize = next;
+        })
+        .catch((error) => {
+          emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
+        });
+    },
+    get ackedSize() {
+      return ackedSize;
     },
     kill() {
       if (!ownsPty) {

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -91,7 +91,12 @@ export function createHostAttachedTerminal(
   const pendingWrites: string[] = [];
   let attachment: HostAttachment | undefined;
   let size = options.size;
+  // The size the host PTY last CONFIRMED applying (not the size we asked for);
+  // a persistent gap between this and `size` is geometry divergence.
   let ackedSize: StationTerminalSize | undefined;
+  // Monotonic so only the newest resize's ack stamps `ackedSize` — out-of-order
+  // resolutions from concurrent resizes cannot pin it to a stale geometry.
+  let resizeSeq = 0;
   let pid = 0;
   let exited = false;
   let disposed = false;
@@ -159,6 +164,28 @@ export function createHostAttachedTerminal(
     await Promise.all([...replayListeners].map((listener) => listener({ size: recordedSize, chunks })));
   };
 
+  // Send a resize to the attached host PTY and stamp `ackedSize` to the size
+  // that was actually sent — but only if this remains the newest resize, so a
+  // slow ack cannot revert `ackedSize` to a superseded geometry. No-ops while
+  // detached; the size is (re)sent by the attach loop once `attachment` is set.
+  const applyHostResize = (target: StationTerminalSize): void => {
+    const opened = attachment;
+    if (opened === undefined) {
+      return;
+    }
+    const seq = (resizeSeq += 1);
+    opened
+      .resize(target.cols, target.rows)
+      .then(() => {
+        if (seq === resizeSeq) {
+          ackedSize = target;
+        }
+      })
+      .catch((error) => {
+        emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
+      });
+  };
+
   // Attach, replay scrollback once, then stream frames. A transient transport
   // failure — or the stream ending with no exit frame — reconnects with backoff;
   // only a genuinely-gone PTY (or exhausted retries) ends the pane.
@@ -211,7 +238,9 @@ export function createHostAttachedTerminal(
           await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
           await opened.resize(size.cols, size.rows);
         }
-        ackedSize = { cols: size.cols, rows: size.rows };
+        // The size the host was just driven to; a resize arriving during the
+        // write drain below only updates `size` (resize() no-ops while detached).
+        const attachSentSize: StationTerminalSize = { cols: size.cols, rows: size.rows };
         // Drain front-to-back so a mid-flush failure leaves only the un-sent
         // writes to retry (no double-send on reconnect). New writes keep arriving
         // at the back while attachment is still undefined, preserving order.
@@ -224,6 +253,13 @@ export function createHostAttachedTerminal(
           pendingWrites.shift();
         }
         attachment = opened;
+        if (size.cols !== attachSentSize.cols || size.rows !== attachSentSize.rows) {
+          // A resize arrived during attach; resize() no-op'd then, so send it now.
+          applyHostResize(size);
+        } else {
+          // Host is at the size we just drove it to; record it as confirmed.
+          ackedSize = attachSentSize;
+        }
         connectedAt = now();
         for await (const frame of opened.frames) {
           if (frame.type === "data") {
@@ -254,8 +290,10 @@ export function createHostAttachedTerminal(
         emitDiagnostic(safe.message);
       }
       // Transient: clear attachment so write() re-buffers, then drop the dead
-      // client and dial a fresh one before the next attempt.
+      // client and dial a fresh one before the next attempt. Clear ackedSize so
+      // a geometry check during the reconnect window does not read a stale ack.
       attachment = undefined;
+      ackedSize = undefined;
       if (disposed || closeRequested) {
         return;
       }
@@ -360,18 +398,9 @@ export function createHostAttachedTerminal(
     },
     resize(next) {
       size = next;
-      if (attachment === undefined) {
-        // Applied to the host PTY on attach via `size`.
-        return;
-      }
-      attachment
-        .resize(next.cols, next.rows)
-        .then(() => {
-          ackedSize = next;
-        })
-        .catch((error) => {
-          emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
-        });
+      // Applied (and acked) via applyHostResize; a no-op while detached, then
+      // (re)sent by the attach loop once attachment is set.
+      applyHostResize(next);
     },
     get ackedSize() {
       return ackedSize;

--- a/station/src/terminal/registry/ptyRegistry.diagnostics.test.ts
+++ b/station/src/terminal/registry/ptyRegistry.diagnostics.test.ts
@@ -109,8 +109,8 @@ describe("geometry divergence detection", () => {
 
     await waitFor(() => (terminalCorruptionCounters().geometry_divergence ?? 0) >= 1);
     const record = logged.find((entry) => entry.attributes.kind === "geometry_divergence");
-    expect(record?.attributes).toMatchObject({
-      pane: PANE,
+    expect(record?.attributes.pane).toBe(PANE);
+    expect(record?.attributes.detail).toMatchObject({
       paneSize: "48x12",
       screenSize: "48x12",
       ptySize: "80x24",
@@ -143,7 +143,9 @@ describe("transport diagnostics", () => {
 
     await waitFor(() => (terminalCorruptionCounters().terminal_diagnostic ?? 0) >= 1);
     const record = logged.find((entry) => entry.attributes.kind === "terminal_diagnostic");
-    expect(record?.attributes.message).toBe("The station host request failed.");
+    expect((record?.attributes.detail as { message: string }).message).toBe(
+      "The station host request failed.",
+    );
     expect(record?.attributes.pane).toBe(PANE);
   });
 });

--- a/station/src/terminal/registry/ptyRegistry.diagnostics.test.ts
+++ b/station/src/terminal/registry/ptyRegistry.diagnostics.test.ts
@@ -1,0 +1,149 @@
+// Registry-side corruption telemetry: transport diagnostics get a subscriber,
+// and a settled disagreement between pane, screen, and PTY-acked geometry is
+// reported with pane evidence captured.
+import { readdirSync } from "node:fs";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  resetTerminalDiagnosticsForTest,
+  terminalCorruptionCounters,
+  wireTerminalDiagnostics,
+} from "../diagnostics.js";
+import type { StationTerminalProcess, StationTerminalSize } from "../types.js";
+import { waitFor } from "../testing/waitFor.js";
+import { createPtyRegistry, type PtyRegistry } from "./ptyRegistry.js";
+
+const PANE = "pane-geometry";
+const SIZE: StationTerminalSize = { cols: 48, rows: 12 };
+
+type LoggedRecord = { message: string; attributes: Record<string, unknown> };
+const logged: LoggedRecord[] = [];
+const fakeLogger = {
+  path: "/tmp/fake-tui.jsonl",
+  log: async () => ({}) as never,
+  debug: async () => ({}) as never,
+  info: async () => ({}) as never,
+  warn: async (message: string, attributes?: Record<string, unknown>) => {
+    logged.push({ message, attributes: attributes ?? {} });
+    return {} as never;
+  },
+  error: async () => ({}) as never,
+};
+
+let dumpDir: string;
+const registries: PtyRegistry[] = [];
+
+beforeEach(async () => {
+  resetTerminalDiagnosticsForTest();
+  logged.length = 0;
+  dumpDir = await mkdtemp(join(tmpdir(), "station-pane-dumps-"));
+  wireTerminalDiagnostics({ logger: fakeLogger, dumpDir });
+});
+afterEach(() => {
+  for (const registry of registries.splice(0)) {
+    registry.disposeAll();
+  }
+  resetTerminalDiagnosticsForTest();
+});
+
+/** Fake PTY whose acked size either mirrors resizes (healthy) or sticks (diverged). */
+function ackTerminal(mode: "mirror" | "stuck") {
+  const diagnosticListeners = new Set<(message: string) => void>();
+  let size: StationTerminalSize = { cols: 80, rows: 24 };
+  const stuck: StationTerminalSize = { cols: 80, rows: 24 };
+  const terminal: StationTerminalProcess = {
+    id: "fake-ack",
+    command: "/bin/fake",
+    pid: 4242,
+    get size() {
+      return size;
+    },
+    get ackedSize() {
+      return mode === "mirror" ? size : stuck;
+    },
+    onData: () => ({ dispose: () => {} }),
+    onExit: () => ({ dispose: () => {} }),
+    onDiagnostic(listener) {
+      diagnosticListeners.add(listener);
+      return { dispose: () => diagnosticListeners.delete(listener) };
+    },
+    write() {},
+    resize(next) {
+      size = next;
+    },
+    kill() {},
+    dispose() {},
+  };
+  return {
+    terminal,
+    emitDiagnostic: (message: string) => {
+      for (const listener of [...diagnosticListeners]) {
+        listener(message);
+      }
+    },
+  };
+}
+
+function registryFor(terminal: StationTerminalProcess): PtyRegistry {
+  const registry = createPtyRegistry({
+    resizeDebounceMs: 5,
+    geometrySettleMs: 25,
+    createTerminal: (spawn) => {
+      // Real PTYs spawn at the laid-out size; mirror that so only the acked
+      // size (the divergence under test) can disagree.
+      terminal.resize({ cols: spawn.size?.cols ?? 80, rows: spawn.size?.rows ?? 24 });
+      return terminal;
+    },
+  });
+  registries.push(registry);
+  return registry;
+}
+
+describe("geometry divergence detection", () => {
+  it("reports a PTY stuck at a stale acked size and captures pane evidence", async () => {
+    const { terminal } = ackTerminal("stuck");
+    const registry = registryFor(terminal);
+    registry.resize(PANE, SIZE);
+
+    await waitFor(() => (terminalCorruptionCounters().geometry_divergence ?? 0) >= 1);
+    const record = logged.find((entry) => entry.attributes.kind === "geometry_divergence");
+    expect(record?.attributes).toMatchObject({
+      pane: PANE,
+      paneSize: "48x12",
+      screenSize: "48x12",
+      ptySize: "80x24",
+    });
+
+    await waitFor(() => readdirSync(dumpDir).length >= 1);
+    const [dumpName] = readdirSync(dumpDir);
+    const dump = JSON.parse(await readFile(join(dumpDir, dumpName ?? ""), "utf8"));
+    expect(dump).toMatchObject({ pane: PANE, trigger: "geometry_divergence" });
+    expect(Array.isArray(dump.rows)).toBe(true);
+  });
+
+  it("stays silent when pane, screen, and acked PTY size agree", async () => {
+    const { terminal } = ackTerminal("mirror");
+    const registry = registryFor(terminal);
+    registry.resize(PANE, SIZE);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(terminalCorruptionCounters().geometry_divergence).toBeUndefined();
+    expect(readdirSync(dumpDir)).toEqual([]);
+  });
+});
+
+describe("transport diagnostics", () => {
+  it("logs terminal diagnostics that previously had zero listeners", async () => {
+    const { terminal, emitDiagnostic } = ackTerminal("mirror");
+    const registry = registryFor(terminal);
+    registry.resize(PANE, SIZE);
+    emitDiagnostic("The station host request failed.");
+
+    await waitFor(() => (terminalCorruptionCounters().terminal_diagnostic ?? 0) >= 1);
+    const record = logged.find((entry) => entry.attributes.kind === "terminal_diagnostic");
+    expect(record?.attributes.message).toBe("The station host request failed.");
+    expect(record?.attributes.pane).toBe(PANE);
+  });
+});

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -117,6 +117,9 @@ type InternalEntry = {
   appliedSize: StationTerminalSize | null;
   resizeTimer: ReturnType<typeof setTimeout> | undefined;
   geometryCheckTimer: ReturnType<typeof setTimeout> | undefined;
+  // True while a recorded snapshot is being parsed at its own size; the screen
+  // is intentionally off pane size then, so the geometry check must not fire.
+  replayingSnapshot: boolean;
   lastResizeAt: number;
   pendingSize: StationTerminalSize | null;
   spawnOptions: StationTerminalSpawnOptions | undefined;
@@ -162,6 +165,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       appliedSize: null,
       resizeTimer: undefined,
       geometryCheckTimer: undefined,
+      replayingSnapshot: false,
       lastResizeAt: 0,
       pendingSize: null,
       spawnOptions,
@@ -177,23 +181,16 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
   // the PTY at that same size so there is no corrective resize/SIGWINCH during
   // shell startup, and so panes that are never laid out never spawn a shell.
   const startSession = (entry: InternalEntry, size: StationTerminalSize): void => {
-    let replayingSnapshot = false;
     const screen = createStationVtScreen({
       size,
       ...(scrollOnOutput === undefined ? {} : { scrollOnOutput }),
       diagnosticsLabel: entry.paneId,
-      onCorruptionDetected: (kind) => {
-        const evidence = entries.get(entry.paneId)?.screen?.corruptionEvidence();
-        if (evidence !== undefined) {
-          writePaneEvidenceDump({ pane: entry.paneId, trigger: kind, evidence });
-        }
-      },
       onResponse: (data) => {
         // A replayed snapshot re-parses queries the child issued long ago
         // (startup probes recorded in the ring); answering those would inject
         // stale replies into the child's stdin, so drop replies until the
         // replay settles.
-        if (replayingSnapshot) {
+        if (entry.replayingSnapshot) {
           return;
         }
         // Query replies (DA1/DSR/OSC...) go straight to the PTY: routing them
@@ -240,7 +237,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
           // sequences recorded at another width land on the wrong rows
           // otherwise — then return to the pane size so xterm reflows the
           // replayed rows. The terminal holds live frames until this resolves.
-          replayingSnapshot = true;
+          entry.replayingSnapshot = true;
           try {
             current.resize(recordedSize);
             for (const chunk of chunks) {
@@ -248,20 +245,23 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
             }
             await current.whenIdle();
           } finally {
-            replayingSnapshot = false;
+            entry.replayingSnapshot = false;
           }
           current.resize(entry.appliedSize ?? size);
+          // Re-check now that the screen is back at pane size; a check that fired
+          // during the replay was suppressed.
+          scheduleGeometryCheck(entry);
         }),
       );
     }
     entry.subscriptions.push(
-      // Transport faults (failed host resizes, reconnects) were previously
-      // emitted to zero listeners; they are load-bearing divergence evidence.
+      // Transport faults (failed host resizes, reconnects) feed the divergence
+      // detector; without a subscriber they would be dropped silently.
       terminal.onDiagnostic((message) => {
         reportTerminalCorruption({
           kind: "terminal_diagnostic",
           pane: entry.paneId,
-          attributes: { message },
+          detail: { message },
         });
       }),
       terminal.onData((data) => {
@@ -302,6 +302,13 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       if (entries.get(entry.paneId) !== entry || entry.exited) {
         return;
       }
+      // A pending resize or an in-flight replay intentionally holds the screen
+      // off pane size; either would report a transient as divergence. The
+      // resize path and the replay handler each re-schedule a check when they
+      // settle, so skipping here loses no real signal.
+      if (entry.replayingSnapshot || entry.resizeTimer !== undefined) {
+        return;
+      }
       const applied = entry.appliedSize;
       const stats = entry.screen?.bufferStats();
       const acked = entry.terminal?.ackedSize;
@@ -322,7 +329,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       reportTerminalCorruption({
         kind: "geometry_divergence",
         pane: entry.paneId,
-        attributes: sizes,
+        detail: sizes,
       });
       const evidence = entry.screen?.corruptionEvidence();
       if (evidence !== undefined) {
@@ -330,7 +337,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
           pane: entry.paneId,
           trigger: "geometry_divergence",
           evidence,
-          attributes: sizes,
+          detail: sizes,
         });
       }
     }, geometrySettleMs);

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -1,5 +1,6 @@
 import type { ScrollOnOutputMode } from "../../config/stationConfig.js";
 import type { PaneId } from "../../state/types.js";
+import { reportTerminalCorruption, writePaneEvidenceDump } from "../diagnostics.js";
 import { createLocalPtyTerminal } from "../pty/localPtyTerminal.js";
 import type {
   StationTerminalExit,
@@ -10,6 +11,9 @@ import type {
 import { createStationVtScreen, type StationVtScreen } from "../vt/screen.js";
 
 const DEFAULT_RESIZE_DEBOUNCE_MS = 75;
+// Grace for the async resize path (debounce, bridge hop, host ack) before a
+// screen/PTY/pane size disagreement counts as divergence rather than transit.
+const GEOMETRY_SETTLE_MS = 2_000;
 
 /**
  * The read-only view a pane id resolves to. `screen` and `terminal` are null
@@ -90,6 +94,8 @@ export type PtyRegistryOptions = {
   createTerminal?: (options: StationTerminalSpawnOptions) => StationTerminalProcess;
   /** Injectable for deterministic resize-debounce tests. */
   resizeDebounceMs?: number;
+  /** Injectable for deterministic geometry-divergence tests. */
+  geometrySettleMs?: number;
   /**
    * Notified when a pane's PTY process exits. Used to report a managed primary
    * agent's exit back to the observer. The registry knows only the pane id; the
@@ -110,6 +116,7 @@ type InternalEntry = {
   cwd: string | undefined;
   appliedSize: StationTerminalSize | null;
   resizeTimer: ReturnType<typeof setTimeout> | undefined;
+  geometryCheckTimer: ReturnType<typeof setTimeout> | undefined;
   lastResizeAt: number;
   pendingSize: StationTerminalSize | null;
   spawnOptions: StationTerminalSpawnOptions | undefined;
@@ -125,6 +132,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
   let createTerminal = options.createTerminal ?? createLocalPtyTerminal;
   let scrollOnOutput = options.scrollOnOutput;
   const resizeDebounceMs = options.resizeDebounceMs ?? DEFAULT_RESIZE_DEBOUNCE_MS;
+  const geometrySettleMs = options.geometrySettleMs ?? GEOMETRY_SETTLE_MS;
   const entries = new Map<PaneId, InternalEntry>();
   const listeners = new Set<() => void>();
   let onPaneExit = options.onPaneExit;
@@ -153,6 +161,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       status: "starting shell",
       appliedSize: null,
       resizeTimer: undefined,
+      geometryCheckTimer: undefined,
       lastResizeAt: 0,
       pendingSize: null,
       spawnOptions,
@@ -172,6 +181,13 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
     const screen = createStationVtScreen({
       size,
       ...(scrollOnOutput === undefined ? {} : { scrollOnOutput }),
+      diagnosticsLabel: entry.paneId,
+      onCorruptionDetected: (kind) => {
+        const evidence = entries.get(entry.paneId)?.screen?.corruptionEvidence();
+        if (evidence !== undefined) {
+          writePaneEvidenceDump({ pane: entry.paneId, trigger: kind, evidence });
+        }
+      },
       onResponse: (data) => {
         // A replayed snapshot re-parses queries the child issued long ago
         // (startup probes recorded in the ring); answering those would inject
@@ -210,6 +226,9 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
     }
     entry.terminal = terminal;
     entry.status = `pid ${terminal.pid}`;
+    // Covers PTYs diverged from birth (e.g. a host PTY spawned at a default
+    // size); later resizes re-schedule their own checks.
+    scheduleGeometryCheck(entry);
     if (terminal.onReplay !== undefined) {
       entry.subscriptions.push(
         terminal.onReplay(async ({ size: recordedSize, chunks }) => {
@@ -236,6 +255,15 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       );
     }
     entry.subscriptions.push(
+      // Transport faults (failed host resizes, reconnects) were previously
+      // emitted to zero listeners; they are load-bearing divergence evidence.
+      terminal.onDiagnostic((message) => {
+        reportTerminalCorruption({
+          kind: "terminal_diagnostic",
+          pane: entry.paneId,
+          attributes: { message },
+        });
+      }),
       terminal.onData((data) => {
         entry.screen?.feed(data);
       }),
@@ -258,12 +286,64 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
     if (!entry.exited) {
       entry.terminal?.resize(size);
     }
+    scheduleGeometryCheck(entry);
+  };
+
+  // Divergence detector: after a resize settles, the pane's asserted size, the
+  // screen model, and the PTY's acked size must agree. A persistent mismatch
+  // is the stuck-width corruption observed directly, so it logs and captures
+  // pane evidence.
+  const scheduleGeometryCheck = (entry: InternalEntry): void => {
+    if (entry.geometryCheckTimer !== undefined) {
+      clearTimeout(entry.geometryCheckTimer);
+    }
+    entry.geometryCheckTimer = setTimeout(() => {
+      entry.geometryCheckTimer = undefined;
+      if (entries.get(entry.paneId) !== entry || entry.exited) {
+        return;
+      }
+      const applied = entry.appliedSize;
+      const stats = entry.screen?.bufferStats();
+      const acked = entry.terminal?.ackedSize;
+      if (applied === null || stats === undefined) {
+        return;
+      }
+      const screenMismatch = stats.cols !== applied.cols || stats.rows !== applied.rows;
+      const ackMismatch =
+        acked !== undefined && (acked.cols !== applied.cols || acked.rows !== applied.rows);
+      if (!screenMismatch && !ackMismatch) {
+        return;
+      }
+      const sizes = {
+        paneSize: `${applied.cols}x${applied.rows}`,
+        screenSize: `${stats.cols}x${stats.rows}`,
+        ...(acked === undefined ? {} : { ptySize: `${acked.cols}x${acked.rows}` }),
+      };
+      reportTerminalCorruption({
+        kind: "geometry_divergence",
+        pane: entry.paneId,
+        attributes: sizes,
+      });
+      const evidence = entry.screen?.corruptionEvidence();
+      if (evidence !== undefined) {
+        writePaneEvidenceDump({
+          pane: entry.paneId,
+          trigger: "geometry_divergence",
+          evidence,
+          attributes: sizes,
+        });
+      }
+    }, geometrySettleMs);
   };
 
   const disposeEntry = (entry: InternalEntry): void => {
     if (entry.resizeTimer !== undefined) {
       clearTimeout(entry.resizeTimer);
       entry.resizeTimer = undefined;
+    }
+    if (entry.geometryCheckTimer !== undefined) {
+      clearTimeout(entry.geometryCheckTimer);
+      entry.geometryCheckTimer = undefined;
     }
     for (const subscription of entry.subscriptions) {
       subscription.dispose();

--- a/station/src/terminal/types.ts
+++ b/station/src/terminal/types.ts
@@ -35,6 +35,12 @@ export type StationTerminalProcess = {
   readonly command: string;
   readonly pid: number;
   readonly size: StationTerminalSize;
+  /**
+   * The last size the backing PTY acknowledged applying, when the transport
+   * confirms resizes (host-attached terminals). `size` is the pane's asserted
+   * size; a persistent gap between the two is geometry divergence.
+   */
+  readonly ackedSize?: StationTerminalSize | undefined;
   onData(listener: (data: string) => void): StationTerminalDisposable;
   onExit(listener: (event: StationTerminalExit) => void): StationTerminalDisposable;
   /** Transport/bridge diagnostics; never terminal output. */

--- a/station/src/terminal/vt/screen.corruption.test.ts
+++ b/station/src/terminal/vt/screen.corruption.test.ts
@@ -81,20 +81,19 @@ describe("replacement character detection", () => {
 
     expect(terminalCorruptionCounters().replacement_char).toBe(1);
     const record = logged.find((entry) => entry.attributes.kind === "replacement_char");
-    expect(record?.attributes.count).toBe(2);
+    // Bucket count (cumulative) is top-level; the per-chunk char count is nested
+    // under detail so it can never clobber the record's own fields.
+    expect(record?.attributes.count).toBe(1);
+    expect((record?.attributes.detail as { count: number }).count).toBe(2);
   });
 });
 
 describe("escape fragment detection", () => {
   it("fires when ANSI guts land in the grid as visible text", async () => {
-    const detected: string[] = [];
     const screen = track(
       createStationVtScreen({
         size: { cols: 60, rows: 6 },
         flushIntervalMs: 1,
-        onCorruptionDetected: (kind) => {
-          detected.push(kind);
-        },
       }),
     );
     // The literal tail an over-erased truecolor SGR leaves behind — no ESC byte.
@@ -103,14 +102,17 @@ describe("escape fragment detection", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(terminalCorruptionCounters().escape_fragment).toBeGreaterThanOrEqual(1);
-    expect(detected).toContain("escape_fragment");
+    const record = logged.find((entry) => entry.attributes.kind === "escape_fragment");
+    expect(record).toBeDefined();
   });
 
-  it("stays quiet for properly escaped styling", async () => {
+  it("stays quiet for properly escaped styling and benign numeric text", async () => {
     const screen = track(
       createStationVtScreen({ size: { cols: 60, rows: 6 }, flushIntervalMs: 1 }),
     );
-    screen.feed("\x1b[38;2;255;107;97mstyled\x1b[0m plain ?2004h [1] (3;4)");
+    // Properly escaped SGR, plus CSV-like numbers that the loose form used to
+    // false-positive on ("10;20;30mm" measurements).
+    screen.feed("\x1b[38;2;255;107;97mstyled\x1b[0m 10;20;30mm 1;2;3m rows");
     await screen.whenIdle();
     await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -127,5 +129,21 @@ describe("corruption evidence", () => {
     const evidence = screen.corruptionEvidence();
     expect(evidence.rows[0]).toContain("hello evidence");
     expect(evidence.rawTail).toContain("\x1b[31mhello");
+  });
+});
+
+describe("bucket bounding for untrusted idents", () => {
+  it("caps distinct unhandled-sequence buckets so terminal output cannot grow the maps unbounded", async () => {
+    const screen = track(createStationVtScreen({ size: { cols: 40, rows: 6 } }));
+    // OSC identifiers are arbitrary integers from the byte stream; a hostile or
+    // random stream would otherwise mint one bucket (and one log line) each.
+    for (let osc = 0; osc < 400; osc += 1) {
+      screen.feed(`\x1b]${9000 + osc};x\x07`);
+    }
+    await screen.whenIdle();
+
+    const buckets = Object.keys(terminalCorruptionCounters());
+    expect(buckets.length).toBeLessThanOrEqual(300);
+    expect(buckets).toContain("unhandled_sequence:_overflow");
   });
 });

--- a/station/src/terminal/vt/screen.corruption.test.ts
+++ b/station/src/terminal/vt/screen.corruption.test.ts
@@ -1,0 +1,131 @@
+// Corruption detectors: hard signals that the grid is (or is about to be)
+// wrong — unhandled sequences the engine swallowed, bytes destroyed upstream,
+// and ANSI guts rendered as visible text — counted always, logged when wired.
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  resetTerminalDiagnosticsForTest,
+  terminalCorruptionCounters,
+  wireTerminalDiagnostics,
+} from "../diagnostics.js";
+import { createStationVtScreen, type StationVtScreen } from "./screen.js";
+
+type LoggedRecord = { message: string; attributes: Record<string, unknown> };
+
+const logged: LoggedRecord[] = [];
+const fakeLogger = {
+  path: "/tmp/fake-tui.jsonl",
+  log: async () => ({}) as never,
+  debug: async () => ({}) as never,
+  info: async () => ({}) as never,
+  warn: async (message: string, attributes?: Record<string, unknown>) => {
+    logged.push({ message, attributes: attributes ?? {} });
+    return {} as never;
+  },
+  error: async () => ({}) as never,
+};
+
+const cleanups: Array<() => void> = [];
+const track = (screen: StationVtScreen): StationVtScreen => {
+  cleanups.push(() => {
+    screen.dispose();
+  });
+  return screen;
+};
+
+beforeEach(() => {
+  resetTerminalDiagnosticsForTest();
+  logged.length = 0;
+  wireTerminalDiagnostics({ logger: fakeLogger });
+});
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) {
+    cleanup();
+  }
+  resetTerminalDiagnosticsForTest();
+});
+
+const countersMatching = (prefix: string): number =>
+  Object.entries(terminalCorruptionCounters())
+    .filter(([key]) => key.startsWith(prefix))
+    .reduce((sum, [, value]) => sum + value, 0);
+
+describe("unhandled sequence detection", () => {
+  it("counts CSI/OSC/DCS sequences the engine has no handler for", async () => {
+    const screen = track(
+      createStationVtScreen({ size: { cols: 40, rows: 6 }, diagnosticsLabel: "pane-test" }),
+    );
+    screen.feed("\x1b[1;2y"); // DECTST — no headless handler
+    screen.feed("\x1b]777;notify;title;body\x07"); // urxvt notify extension
+    screen.feed("\x1bP+q544e\x1b\\"); // XTGETTCAP
+    await screen.whenIdle();
+
+    expect(countersMatching("unhandled_sequence:")).toBeGreaterThanOrEqual(3);
+    const record = logged.find((entry) => entry.attributes.kind === "unhandled_sequence");
+    expect(record?.attributes.pane).toBe("pane-test");
+  });
+
+  it("does not count sequences the screen handles", async () => {
+    const screen = track(createStationVtScreen({ size: { cols: 40, rows: 6 } }));
+    screen.feed("\x1b[31mred\x1b[0m\x1b[2J\x1b[H\x1b[?2004h\x1b]0;title\x07");
+    await screen.whenIdle();
+
+    expect(countersMatching("unhandled_sequence:")).toBe(0);
+  });
+});
+
+describe("replacement character detection", () => {
+  it("counts U+FFFD arriving in the feed", async () => {
+    const screen = track(createStationVtScreen({ size: { cols: 40, rows: 6 } }));
+    screen.feed("ok��ok");
+    await screen.whenIdle();
+
+    expect(terminalCorruptionCounters().replacement_char).toBe(1);
+    const record = logged.find((entry) => entry.attributes.kind === "replacement_char");
+    expect(record?.attributes.count).toBe(2);
+  });
+});
+
+describe("escape fragment detection", () => {
+  it("fires when ANSI guts land in the grid as visible text", async () => {
+    const detected: string[] = [];
+    const screen = track(
+      createStationVtScreen({
+        size: { cols: 60, rows: 6 },
+        flushIntervalMs: 1,
+        onCorruptionDetected: (kind) => {
+          detected.push(kind);
+        },
+      }),
+    );
+    // The literal tail an over-erased truecolor SGR leaves behind — no ESC byte.
+    screen.feed("[38;2;255;107;97mghost text");
+    await screen.whenIdle();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(terminalCorruptionCounters().escape_fragment).toBeGreaterThanOrEqual(1);
+    expect(detected).toContain("escape_fragment");
+  });
+
+  it("stays quiet for properly escaped styling", async () => {
+    const screen = track(
+      createStationVtScreen({ size: { cols: 60, rows: 6 }, flushIntervalMs: 1 }),
+    );
+    screen.feed("\x1b[38;2;255;107;97mstyled\x1b[0m plain ?2004h [1] (3;4)");
+    await screen.whenIdle();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(terminalCorruptionCounters().escape_fragment).toBeUndefined();
+  });
+});
+
+describe("corruption evidence", () => {
+  it("captures the visible grid and the raw byte tail", async () => {
+    const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));
+    screen.feed("\x1b[31mhello\x1b[0m evidence");
+    await screen.whenIdle();
+
+    const evidence = screen.corruptionEvidence();
+    expect(evidence.rows[0]).toContain("hello evidence");
+    expect(evidence.rawTail).toContain("\x1b[31mhello");
+  });
+});

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -1,7 +1,12 @@
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { type IMarker, Terminal } from "@xterm/headless";
 import type { ScrollOnOutputMode } from "../../config/stationConfig.js";
-import { reportTerminalCorruption, type TerminalCorruptionKind } from "../diagnostics.js";
+import { ChunkRing } from "../chunkRing.js";
+import {
+  reportTerminalCorruption,
+  type TerminalCorruptionKind,
+  writePaneEvidenceDump,
+} from "../diagnostics.js";
 import type { StationTerminalSize } from "../types.js";
 import { buildVisibleRows, type VtRow } from "./rows.js";
 import { type StationVtTheme, stationVtTheme } from "./theme.js";
@@ -24,7 +29,7 @@ const FRAGMENT_SCAN_MIN_INTERVAL_MS = 1_000;
 // that PRINTS escape codes as text (log viewers) trips it, so it only ever
 // counts and logs, never alerts.
 const ESCAPE_FRAGMENT_PATTERN =
-  /\[\??\d{1,4}(?:;\d{1,4}){1,7}[A-Za-z]|\d{1,3};\d{1,3};\d{1,3}m|;rgb:[0-9a-fA-F]{2}|\[\?\d{2,4}[hl]/;
+  /\[\??\d{1,4}(?:;\d{1,4}){1,7}[A-Za-z]|\b(?:38|48);[25];\d{1,3};\d{1,3};\d{1,3}m|;rgb:[0-9a-fA-F]{2}|\[\?\d{2,4}[hl]/;
 // Scrollback is now viewable (wheel + copy-mode), but a modest buffer still
 // keeps resize reflow cheap; the depth is intentionally not yet configurable.
 const DEFAULT_SCROLLBACK_LINES = 1000;
@@ -48,10 +53,8 @@ export type StationVtScreenOptions = {
    * on them at startup.
    */
   onResponse?: (data: string) => void;
-  /** Pane label attached to corruption telemetry from this screen. */
+  /** Pane label attached to corruption telemetry and evidence dumps. */
   diagnosticsLabel?: string;
-  /** Fired when a detector trips, so the owner can capture pane evidence. */
-  onCorruptionDetected?: (kind: TerminalCorruptionKind) => void;
 };
 
 export type VtCursor = {
@@ -223,32 +226,24 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   let flushTimer: ReturnType<typeof setTimeout> | undefined;
   let lastFlushAt = 0;
   let syncHoldUntil: number | undefined;
-  const rawRing: string[] = [];
-  let rawRingChars = 0;
+  const rawRing = new ChunkRing(RAW_RING_LIMIT_CHARS);
   let lastFragmentScanAt = 0;
 
-  const pushRawRing = (data: string): void => {
-    rawRing.push(data);
-    rawRingChars += data.length;
-    while (rawRingChars > RAW_RING_LIMIT_CHARS && rawRing.length > 1) {
-      const evicted = rawRing.shift();
-      if (evicted === undefined) {
-        break;
-      }
-      rawRingChars -= evicted.length;
-    }
-  };
+  const corruptionEvidence = (): { rows: string[]; rawTail: string } => ({
+    rows: Array.from({ length: terminal.rows }, (_, index) => visibleRowText(index)),
+    rawTail: rawRing.join(),
+  });
 
   const reportCorruption = (
     kind: TerminalCorruptionKind,
     key?: string,
-    attributes?: Record<string, unknown>,
+    detail?: Record<string, unknown>,
   ): void => {
     reportTerminalCorruption({
       kind,
       ...(options.diagnosticsLabel === undefined ? {} : { pane: options.diagnosticsLabel }),
       ...(key === undefined ? {} : { key }),
-      ...(attributes === undefined ? {} : { attributes }),
+      ...(detail === undefined ? {} : { detail }),
     });
   };
 
@@ -271,7 +266,13 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
           row: index,
           excerpt: text.slice(Math.max(0, match.index - 8), match.index + 24),
         });
-        options.onCorruptionDetected?.("escape_fragment");
+        if (options.diagnosticsLabel !== undefined) {
+          writePaneEvidenceDump({
+            pane: options.diagnosticsLabel,
+            trigger: "escape_fragment",
+            evidence: corruptionEvidence(),
+          });
+        }
         return;
       }
     }
@@ -468,6 +469,11 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
         };
       }
     )._core?._inputHandler?._parser;
+    if (parser === undefined) {
+      // An engine bump moved the private path; make the silent loss of
+      // unhandled-sequence detection observable instead of trusting empty counters.
+      reportCorruption("parse_error", "fallback-wiring-unavailable");
+    }
     parser?.setCsiHandlerFallback((ident, params) => {
       reportCorruption("unhandled_sequence", `csi:${ident}`, {
         family: "csi",
@@ -493,7 +499,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       }
     });
   } catch {
-    reportCorruption("parse_error", "fallback-wiring-unavailable");
+    reportCorruption("parse_error", "fallback-wiring-threw");
   }
 
   const flush = (): void => {
@@ -536,7 +542,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       if (disposed) {
         return;
       }
-      pushRawRing(data);
+      rawRing.push(data);
       // U+FFFD in the feed means bytes were already destroyed upstream (the
       // bridge's UTF-8 decode of split or invalid sequences).
       if (data.includes("�")) {
@@ -673,10 +679,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     isApplicationCursorKeys: () => terminal.modes.applicationCursorKeysMode,
     isKittyKeyboardEnabled: () => kittyKeyboardFlags !== 0,
     rowText: (index) => visibleRowText(index),
-    corruptionEvidence: () => ({
-      rows: Array.from({ length: terminal.rows }, (_, index) => visibleRowText(index)),
-      rawTail: rawRing.join(""),
-    }),
+    corruptionEvidence,
     cursor: () => {
       const buffer = terminal.buffer.active;
       return { x: buffer.cursorX, y: buffer.cursorY };

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -1,6 +1,7 @@
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { type IMarker, Terminal } from "@xterm/headless";
 import type { ScrollOnOutputMode } from "../../config/stationConfig.js";
+import { reportTerminalCorruption, type TerminalCorruptionKind } from "../diagnostics.js";
 import type { StationTerminalSize } from "../types.js";
 import { buildVisibleRows, type VtRow } from "./rows.js";
 import { type StationVtTheme, stationVtTheme } from "./theme.js";
@@ -14,6 +15,16 @@ import {
 
 const DEFAULT_FLUSH_INTERVAL_MS = 33;
 const SYNC_OUTPUT_HOLD_MAX_MS = 1000;
+// Raw feed tail kept for corruption dumps: enough history to replay how the
+// visible grid got into its state, small enough for dozens of live panes.
+const RAW_RING_LIMIT_CHARS = 128 * 1024;
+const FRAGMENT_SCAN_MIN_INTERVAL_MS = 1_000;
+// ANSI guts rendered as visible text — multi-param CSI bodies, truecolor SGR
+// tails, OSC color replies, private-mode toggles. Heuristic by nature: a pane
+// that PRINTS escape codes as text (log viewers) trips it, so it only ever
+// counts and logs, never alerts.
+const ESCAPE_FRAGMENT_PATTERN =
+  /\[\??\d{1,4}(?:;\d{1,4}){1,7}[A-Za-z]|\d{1,3};\d{1,3};\d{1,3}m|;rgb:[0-9a-fA-F]{2}|\[\?\d{2,4}[hl]/;
 // Scrollback is now viewable (wheel + copy-mode), but a modest buffer still
 // keeps resize reflow cheap; the depth is intentionally not yet configurable.
 const DEFAULT_SCROLLBACK_LINES = 1000;
@@ -37,6 +48,10 @@ export type StationVtScreenOptions = {
    * on them at startup.
    */
   onResponse?: (data: string) => void;
+  /** Pane label attached to corruption telemetry from this screen. */
+  diagnosticsLabel?: string;
+  /** Fired when a detector trips, so the owner can capture pane evidence. */
+  onCorruptionDetected?: (kind: TerminalCorruptionKind) => void;
 };
 
 export type VtCursor = {
@@ -172,6 +187,11 @@ export type StationVtScreen = {
   /** Resolves after everything fed so far has been parsed. */
   whenIdle(): Promise<void>;
   /**
+   * Forensic snapshot for corruption dumps: the visible grid plus the raw byte
+   * tail that produced it (replayable offline through a fresh screen).
+   */
+  corruptionEvidence(): { rows: string[]; rawTail: string };
+  /**
    * Test/diagnostic-only escape hatch to the underlying engine. Production
    * code must consume the view methods above instead.
    */
@@ -203,6 +223,59 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   let flushTimer: ReturnType<typeof setTimeout> | undefined;
   let lastFlushAt = 0;
   let syncHoldUntil: number | undefined;
+  const rawRing: string[] = [];
+  let rawRingChars = 0;
+  let lastFragmentScanAt = 0;
+
+  const pushRawRing = (data: string): void => {
+    rawRing.push(data);
+    rawRingChars += data.length;
+    while (rawRingChars > RAW_RING_LIMIT_CHARS && rawRing.length > 1) {
+      const evicted = rawRing.shift();
+      if (evicted === undefined) {
+        break;
+      }
+      rawRingChars -= evicted.length;
+    }
+  };
+
+  const reportCorruption = (
+    kind: TerminalCorruptionKind,
+    key?: string,
+    attributes?: Record<string, unknown>,
+  ): void => {
+    reportTerminalCorruption({
+      kind,
+      ...(options.diagnosticsLabel === undefined ? {} : { pane: options.diagnosticsLabel }),
+      ...(key === undefined ? {} : { key }),
+      ...(attributes === undefined ? {} : { attributes }),
+    });
+  };
+
+  const visibleRowText = (index: number): string => {
+    const buffer = terminal.buffer.active;
+    return buffer.getLine(buffer.baseY + index)?.translateToString(true) ?? "";
+  };
+
+  const scanForEscapeFragments = (): void => {
+    const now = Date.now();
+    if (now - lastFragmentScanAt < FRAGMENT_SCAN_MIN_INTERVAL_MS) {
+      return;
+    }
+    lastFragmentScanAt = now;
+    for (let index = 0; index < terminal.rows; index += 1) {
+      const text = visibleRowText(index);
+      const match = ESCAPE_FRAGMENT_PATTERN.exec(text);
+      if (match !== null) {
+        reportCorruption("escape_fragment", undefined, {
+          row: index,
+          excerpt: text.slice(Math.max(0, match.index - 8), match.index + 24),
+        });
+        options.onCorruptionDetected?.("escape_fragment");
+        return;
+      }
+    }
+  };
   // Lines scrolled up from the live bottom (0 = at the bottom).
   let scrollOffset = 0;
   let kittyKeyboardFlags = 0;
@@ -372,6 +445,57 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     return true;
   });
 
+  // Sequences the engine swallows without handling are exactly where silent
+  // corruption starts; count and log them. The public parser API has no
+  // fallback hook, so this reaches into engine internals — an engine bump that
+  // moves them turns detection off instead of breaking the screen.
+  try {
+    const parser = (
+      terminal as unknown as {
+        _core?: {
+          _inputHandler?: {
+            _parser?: {
+              setCsiHandlerFallback(
+                callback: (ident: number, params: { toArray(): unknown[] }) => void,
+              ): void;
+              setEscHandlerFallback(callback: (ident: number) => void): void;
+              setOscHandlerFallback(
+                callback: (identifier: number, action: string, data: string) => void,
+              ): void;
+              setDcsHandlerFallback(callback: (ident: number, action: string) => void): void;
+            };
+          };
+        };
+      }
+    )._core?._inputHandler?._parser;
+    parser?.setCsiHandlerFallback((ident, params) => {
+      reportCorruption("unhandled_sequence", `csi:${ident}`, {
+        family: "csi",
+        ident,
+        params: params.toArray(),
+      });
+    });
+    parser?.setEscHandlerFallback((ident) => {
+      reportCorruption("unhandled_sequence", `esc:${ident}`, { family: "esc", ident });
+    });
+    parser?.setOscHandlerFallback((identifier, action, data) => {
+      if (action === "START") {
+        reportCorruption("unhandled_sequence", `osc:${identifier}`, {
+          family: "osc",
+          ident: identifier,
+          data: String(data).slice(0, 40),
+        });
+      }
+    });
+    parser?.setDcsHandlerFallback((ident, action) => {
+      if (action === "HOOK") {
+        reportCorruption("unhandled_sequence", `dcs:${ident}`, { family: "dcs", ident });
+      }
+    });
+  } catch {
+    reportCorruption("parse_error", "fallback-wiring-unavailable");
+  }
+
   const flush = (): void => {
     flushTimer = undefined;
     if (disposed) {
@@ -394,6 +518,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     applyScrollOnOutput();
     clampScrollOffset();
     notifyListeners();
+    scanForEscapeFragments();
   };
 
   const scheduleFlush = (): void => {
@@ -410,6 +535,18 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     feed: (data) => {
       if (disposed) {
         return;
+      }
+      pushRawRing(data);
+      // U+FFFD in the feed means bytes were already destroyed upstream (the
+      // bridge's UTF-8 decode of split or invalid sequences).
+      if (data.includes("�")) {
+        let count = 0;
+        for (const char of data) {
+          if (char === "�") {
+            count += 1;
+          }
+        }
+        reportCorruption("replacement_char", undefined, { count });
       }
       terminal.write(data);
     },
@@ -535,10 +672,11 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     },
     isApplicationCursorKeys: () => terminal.modes.applicationCursorKeysMode,
     isKittyKeyboardEnabled: () => kittyKeyboardFlags !== 0,
-    rowText: (index) => {
-      const buffer = terminal.buffer.active;
-      return buffer.getLine(buffer.baseY + index)?.translateToString(true) ?? "";
-    },
+    rowText: (index) => visibleRowText(index),
+    corruptionEvidence: () => ({
+      rows: Array.from({ length: terminal.rows }, (_, index) => visibleRowText(index)),
+      rawTail: rawRing.join(""),
+    }),
     cursor: () => {
       const buffer = terminal.buffer.active;
       return { x: buffer.cursorX, y: buffer.cursorY };


### PR DESCRIPTION
Until now, pane corruption only existed as user screenshots: the entire terminal path had no logger, `logs/tui.jsonl` had never been written, and transport diagnostics were emitted to zero listeners. This PR makes corruption a measured fact — detectors report hard signals, and high-signal detections capture replayable evidence.

## Detectors

**Definitive (invariant violations):**
- `unhandled_sequence` / `parse_error` — parser fallbacks (CSI/ESC/OSC/DCS) count every sequence the engine swallows without handling, keyed by ident, with the raw shape logged.
- `replacement_char` — U+FFFD in the feed means bytes were destroyed upstream (the bridge's UTF-8 decode gap).
- `geometry_divergence` — after a resize settles (2s), the pane's asserted size, the VT screen, and the PTY's **acked** size must agree. Host-attached terminals now record the size the host acknowledged applying (`ackedSize`), so a swallowed resize failure becomes a logged mismatch with all three sizes — the stuck-width bug observed directly. Checked at spawn (catches PTYs diverged from birth, e.g. hard-coded 80x24 spawns) and after every resize.
- `overflow_clip` — spans wider than the pane at draw time (the width-table drift firing in practice).
- `terminal_diagnostic` — failed host resizes and reconnects finally have a subscriber.

**Heuristic:**
- `escape_fragment` — ANSI guts rendered as visible grid text (`38;2;255;107;97m`, `[?2004h`, `;rgb:…`) — the fingerprint of over-erase and truncated-replay corruption. Sampled at most once per second per pane; a pane that legitimately prints escape codes as text trips it, so it logs and never alerts.

## Evidence capture

`escape_fragment` and `geometry_divergence` write a pane dump to `diagnostics/panes/`: the visible grid plus a 128KB rolling raw-byte tail. Feeding `rawTail` back through `createStationVtScreen` replays the corruption deterministically — a screenshot becomes a repro. Dumps are rate-limited (1 per pane per 5 minutes); log lines are rate-limited per signal bucket (1/minute) with always-on counters carrying volume.

Everything counts even when no logger is wired (tests, dashboard renderer); `main.tsx` wires the sink to `logs/tui.jsonl` + `diagnostics/panes/` under the config-resolved state dir.

## Why now

This lands before the resize-divergence fix on purpose: a few days of baseline counters turn that fix into a measured before/after (geometry_divergence must drop to zero) instead of a vibes-based one. Live host inspection today found 30 PTYs across 7 geometries (three matching no possible pane) and 15+ PTYs with historical concurrent-attachment overlap — this telemetry sees all of that per-pane, continuously.

## UX implication + manual verify

No visible UI change. Verify: run Station, then `tail -f ~/.local/state/station/logs/tui.jsonl` — corruption signals appear as `Terminal corruption signal.` lines with kind/pane/count; `cat` a file containing literal ANSI fragments into a pane to trip `escape_fragment` deliberately and find the dump under `diagnostics/panes/`.

## Tests

- `screen.corruption.test.ts` (6): unhandled CSI/OSC/DCS counted with pane labels, handled sequences stay silent, U+FFFD counted, fragment scanner fires on raw fragments and stays quiet for properly escaped styling, evidence captures grid + raw tail.
- `ptyRegistry.diagnostics.test.ts` (3): stuck acked size reports divergence with all three sizes and writes a dump; agreeing sizes stay silent; transport diagnostics logged.
- Live-proven outside the harness: real `createJsonlLogger` sink writes `tui.jsonl` with all three detector kinds.
- Station lane: typecheck clean, 958 pass, PTY smokes pass.