### PR TITLE
fix(observer,cli): merged review — resurrection, delivery gate, honest force-close

### DIFF
--- a/apps/cli/src/ingress/command.ts
+++ b/apps/cli/src/ingress/command.ts
@@ -1,9 +1,15 @@
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadConfig, type ObserverPaths, resolveObserverPaths, resolvePath } from "@station/config";
+import {
+  loadConfig,
+  type ObserverPaths,
+  resolveObserverPaths,
+  resolvePath,
+  type StationConfig,
+} from "@station/config";
 import type { ProviderHookReceipt } from "@station/contracts";
 import { ProviderHookReceiptSchema, STATION_SCHEMA_VERSION } from "@station/contracts";
-import { systemClock, toIsoTimestamp } from "@station/runtime";
+import { resolveLocalPath, systemClock, toIsoTimestamp } from "@station/runtime";
 import {
   type ProviderHookSenderDeps,
   type ProviderHookSenderOptions,
@@ -31,6 +37,8 @@ type ParsedOptions = {
   providerArgs: string[];
   paths: ObserverPaths;
   configPath?: string;
+  /** Roots a session cwd must fall under to be worth delivering; undefined = permissive. */
+  projectRoots?: string[];
   observerEntryPath?: string;
   autoStart?: boolean;
   deliveryTimeoutMs?: number;
@@ -230,10 +238,19 @@ async function parseArgs(argv: string[]): Promise<ParsedOptions> {
     }
   }
 
-  const defaults =
-    configPath === undefined
-      ? resolveObserverPaths()
-      : resolveObserverPaths((await loadConfig(configPath)).config);
+  // Load config once: it resolves the observer paths AND the roots under which
+  // an env-less (external) session's cwd is worth delivering. `undefined` roots
+  // (no --config) keep the permissive fallback; an empty array (config with no
+  // projects) drops env-less events rather than spooling them everywhere.
+  let projectRoots: string[] | undefined;
+  let defaults: ObserverPaths;
+  if (configPath === undefined) {
+    defaults = resolveObserverPaths();
+  } else {
+    const loaded = await loadConfig(configPath);
+    defaults = resolveObserverPaths(loaded.config);
+    projectRoots = deliveryRootsFromConfig(loaded.config);
+  }
   const paths = {
     ...defaults,
     ...(stateDir === undefined ? {} : { stateDir }),
@@ -246,12 +263,29 @@ async function parseArgs(argv: string[]): Promise<ParsedOptions> {
 
   const parsed: ParsedOptions = { providerArgs, paths };
   if (configPath !== undefined) parsed.configPath = configPath;
+  if (projectRoots !== undefined) parsed.projectRoots = projectRoots;
   if (observerEntryPath !== undefined) parsed.observerEntryPath = observerEntryPath;
   if (autoStart !== undefined) parsed.autoStart = autoStart;
   if (deliveryTimeoutMs !== undefined) parsed.deliveryTimeoutMs = deliveryTimeoutMs;
   if (startupTimeoutMs !== undefined) parsed.startupTimeoutMs = startupTimeoutMs;
   if (rateLimitMs !== undefined) parsed.rateLimitMs = rateLimitMs;
   return parsed;
+}
+
+// Roots under which a session's cwd can correlate to a worktree: the project
+// repo plus its managed-worktree and base directories (worktrees often live
+// outside the repo root). A cwd under none of these is an unrelated session
+// whose events would never project, so it is not worth delivering or spooling.
+function deliveryRootsFromConfig(config: StationConfig): string[] {
+  const roots = new Set<string>();
+  for (const project of config.projects) {
+    for (const root of [project.root, project.worktrunk.managedRoot, project.worktrunk.base]) {
+      if (root !== undefined && root.length > 0) {
+        roots.add(resolveLocalPath(root));
+      }
+    }
+  }
+  return [...roots];
 }
 
 function senderOptionsFromParsed(
@@ -262,6 +296,7 @@ function senderOptionsFromParsed(
     paths: parsed.paths,
   };
   if (parsed.configPath !== undefined) senderOptions.configPath = parsed.configPath;
+  if (parsed.projectRoots !== undefined) senderOptions.projectRoots = parsed.projectRoots;
   const observerEntryPath = options.observerEntryPath ?? parsed.observerEntryPath;
   if (observerEntryPath !== undefined) senderOptions.observerEntryPath = observerEntryPath;
   if (parsed.autoStart !== undefined) senderOptions.autoStart = parsed.autoStart;

--- a/apps/cli/src/ingress/sender.ts
+++ b/apps/cli/src/ingress/sender.ts
@@ -18,6 +18,7 @@ import {
 import { componentLogPath, createJsonlLogger, type JsonlLogger } from "@station/observability";
 import { createObserverClient } from "@station/protocol";
 import {
+  pathIsSameOrInside,
   type RuntimeClock,
   runRuntimeBoundaryWithTimeout,
   safeErrorFromUnknown,
@@ -38,6 +39,12 @@ export type ProviderHookSenderOptions = {
   deliveryTimeoutMs?: number;
   startupTimeoutMs?: number;
   rateLimitMs?: number;
+  /**
+   * Roots (project repos + managed-worktree dirs) an env-less session's cwd
+   * must fall under to be worth delivering. Undefined keeps the permissive
+   * fallback (any cwd); provided (even empty) gates on membership.
+   */
+  projectRoots?: readonly string[];
 };
 
 type ProviderHookClientFactoryOptions = {
@@ -155,7 +162,10 @@ export async function sendClaudeHookPayload(
     env: input.env ?? process.env,
   });
   const eventName = parseProviderHookEventName(enrichedPayload) ?? "unknown";
-  if (!hasStationOwnership(enrichedPayload) && !hasCorrelatableCwd(enrichedPayload)) {
+  if (
+    !hasStationOwnership(enrichedPayload) &&
+    !hasCorrelatableCwd(enrichedPayload, input.projectRoots)
+  ) {
     return ignoredProviderHookReceipt({
       provider: "claude",
       event: eventName,
@@ -198,7 +208,10 @@ export async function sendCodexHookPayload(
     env: input.env ?? process.env,
   });
   const eventName = parseProviderHookEventName(enrichedPayload) ?? "unknown";
-  if (!hasStationOwnership(enrichedPayload) && !hasCorrelatableCwd(enrichedPayload)) {
+  if (
+    !hasStationOwnership(enrichedPayload) &&
+    !hasCorrelatableCwd(enrichedPayload, input.projectRoots)
+  ) {
     return ignoredProviderHookReceipt({
       provider: "codex",
       event: eventName,
@@ -435,14 +448,26 @@ function payloadSummaryFor(payload: unknown): ProviderHookPayloadSummary {
   };
 }
 
-// External sessions (no station env) are deliverable when the payload carries
-// a cwd the observer can correlate to a worktree; providers whose payloads
-// have no cwd keep the ownership gate. Pre-parse probe only — full event
-// schemas validate at the adapter boundary.
+// External sessions (no station env) are deliverable when the payload cwd falls
+// under a configured project/worktree root — an unrelated dir would never
+// correlate at the observer, so delivering (and spooling) its events is waste.
+// Pre-parse probe only; full event schemas validate at the adapter boundary.
 const hookCwdProbeSchema = z.object({ cwd: z.string().min(1) }).loose();
 
-function hasCorrelatableCwd(payload: unknown): boolean {
-  return hookCwdProbeSchema.safeParse(payload).success;
+function hasCorrelatableCwd(
+  payload: unknown,
+  projectRoots: readonly string[] | undefined,
+): boolean {
+  const parsed = hookCwdProbeSchema.safeParse(payload);
+  if (!parsed.success) {
+    return false;
+  }
+  // No configured roots (config absent): keep the permissive fallback rather
+  // than dropping everything.
+  if (projectRoots === undefined) {
+    return true;
+  }
+  return projectRoots.some((root) => pathIsSameOrInside(parsed.data.cwd, root));
 }
 
 function hasStationOwnership(payload: unknown): boolean {

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -1,8 +1,44 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { ProviderHookEvent, ProviderHookReceipt } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import { listHookSpoolFiles, readHookSpoolRecord } from "../../../../tests/support/spool";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 import { runProviderIngressCommand } from "../../src/ingress/command.js";
+
+// A config with one project rooted at `projectRoot`, so the delivery gate for
+// env-less sessions can be exercised (writeConfigToml hardcodes empty projects).
+async function writeConfigWithProject(root: string, projectRoot: string): Promise<string> {
+  const path = join(root, "config-project.toml");
+  await writeFile(
+    path,
+    [
+      "schema_version = 1",
+      "",
+      "[defaults]",
+      'worktree_provider = "fake-worktree"',
+      'terminal = "fake-terminal"',
+      'harness = "fake-harness"',
+      'layout = "agent-shell"',
+      "",
+      "[[projects]]",
+      'id = "web"',
+      'label = "web"',
+      `root = ${JSON.stringify(projectRoot)}`,
+      "",
+      "[projects.defaults]",
+      'harness = "fake-harness"',
+      'terminal = "fake-terminal"',
+      'layout = "agent-shell"',
+      "",
+      "[projects.worktrunk]",
+      "enabled = true",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return path;
+}
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -310,6 +346,41 @@ describe("provider hook ingress command", () => {
       provider: "claude",
       event: "PreToolUse",
     });
+    await expect(listHookSpoolFiles(fixture.hookSpoolDir)).resolves.toEqual([]);
+  });
+
+  it("delivers an env-less Claude event whose cwd falls under a configured project root", async () => {
+    const fixture = await createTempState();
+    // The project root must exist on disk; the payload cwd is compared as a
+    // string, so a subdir of the root need not exist.
+    const configPath = await writeConfigWithProject(fixture.root, fixture.root);
+
+    const receipt = await runProviderIngressCommand(
+      ["--config", configPath, "--no-auto-start", "claude"],
+      {
+        stdin: JSON.stringify({ ...claudePayload(), cwd: join(fixture.root, "web", "task") }),
+        env: {},
+      },
+      { clock: { now: () => new Date(now) }, hookId: () => "report_claude_in_root" },
+    );
+
+    expect(receipt.status).toBe("spooled");
+  });
+
+  it("ignores an env-less Claude event whose cwd is under no configured project root", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigWithProject(fixture.root, fixture.root);
+
+    const receipt = await runProviderIngressCommand(
+      ["--config", configPath, "--no-auto-start", "claude"],
+      {
+        stdin: JSON.stringify({ ...claudePayload(), cwd: "/tmp/unrelated/elsewhere" }),
+        env: {},
+      },
+      { clock: { now: () => new Date(now) }, hookId: () => "report_claude_out_of_root" },
+    );
+
+    expect(receipt).toMatchObject({ status: "ignored", provider: "claude" });
     await expect(listHookSpoolFiles(fixture.hookSpoolDir)).resolves.toEqual([]);
   });
 

--- a/apps/observer/src/commands/cleanup/operations.ts
+++ b/apps/observer/src/commands/cleanup/operations.ts
@@ -37,12 +37,14 @@ export async function closeSessionResources(
   } & CleanupRuntime,
 ): Promise<void> {
   if (input.mode === "harness" || input.mode === "all") {
+    // Only tolerate an unsupported stop when there is a terminal-close fallback
+    // that will actually retire the session. Otherwise force must NOT report a
+    // hollow success on a stop-less provider — the process keeps running and the
+    // row reappears each reconcile; error honestly instead (a stale/ghost row is
+    // cleared by busy-status decay, not by a fake stop).
     await stopHarnessForSession({
       ...input,
-      // Force means "retire the session even if the provider cannot stop the
-      // process" — without this, force dead-ends on stop-less providers.
-      allowUnsupportedStop:
-        input.force || (input.mode === "all" && canUseTerminalCloseFallbackForSession(input)),
+      allowUnsupportedStop: input.mode === "all" && canUseTerminalCloseFallbackForSession(input),
     });
   }
   throwIfAborted(input.context.signal);

--- a/apps/observer/src/reconcile/harnessEventStatus.ts
+++ b/apps/observer/src/reconcile/harnessEventStatus.ts
@@ -35,7 +35,10 @@ export function observerHarnessRunFromRun(run: HarnessRunObservation): ObserverH
 }
 
 export function externalHarnessRunId(provider: string, nativeSessionId: string): string {
-  return `${provider}:external:${nativeSessionId}`;
+  // nativeSessionId is untrusted (straight from the hook payload); encode both
+  // parts so a value containing ':' or 'external:' cannot collide with another
+  // session's id or shadow it.
+  return `${encodeURIComponent(provider)}:external:${encodeURIComponent(nativeSessionId)}`;
 }
 
 /**
@@ -52,6 +55,10 @@ export function synthesizeExternalHarnessRuns(input: {
 }): ObserverHarnessRun[] {
   const existingIds = new Set(input.runs.map((run) => run.run.id));
   const latestById = new Map<string, HarnessEventObservation>();
+  // Any exited observation retires the session for good; tracked separately so
+  // event reordering (updatedAt vs ingest observedAt divergence, out-of-order
+  // delivery) can't let a surviving `working` event resurrect an ended run.
+  const endedIds = new Set<string>();
 
   for (const observation of input.observations) {
     if (observation.expired || observation.entityKind !== "harness_event") {
@@ -74,18 +81,24 @@ export function synthesizeExternalHarnessRuns(input: {
     if (event.nativeSessionId === undefined || event.worktreeId === undefined) {
       continue;
     }
-    if (event.status === undefined || event.status.value === "unknown") {
+    if (event.status === undefined) {
       continue;
     }
     const id = externalHarnessRunId(event.provider, event.nativeSessionId);
+    if (event.status.value === "exited") {
+      endedIds.add(id);
+      continue;
+    }
+    if (event.status.value === "unknown") {
+      continue;
+    }
     if (existingIds.has(id)) {
       continue;
     }
     const previous = latestById.get(id);
-    if (
-      previous?.status !== undefined &&
-      Date.parse(previous.status.updatedAt) >= Date.parse(event.status.updatedAt)
-    ) {
+    // Rank by the strongest available timestamp so a freshly-ingested but
+    // clock-lagged event is not passed over.
+    if (previous?.status !== undefined && eventOrdinal(previous) >= eventOrdinal(event)) {
       continue;
     }
     latestById.set(id, event);
@@ -99,7 +112,7 @@ export function synthesizeExternalHarnessRuns(input: {
     if (status === undefined || worktreeId === undefined || nativeSessionId === undefined) {
       continue;
     }
-    if (status.value === "exited") {
+    if (endedIds.has(id)) {
       continue;
     }
     synthesized.push({
@@ -215,6 +228,15 @@ function parseHarnessEventObservation(
     return undefined;
   }
   return result.data;
+}
+
+// The strongest available ordering timestamp: the harness-assigned status time,
+// or the ingest time when that is later, so a clock-lagged event is not ranked
+// behind an older one.
+function eventOrdinal(event: HarnessEventObservation): number {
+  const updated = event.status === undefined ? 0 : Date.parse(event.status.updatedAt);
+  const observed = Date.parse(event.observedAt);
+  return Math.max(Number.isFinite(updated) ? updated : 0, Number.isFinite(observed) ? observed : 0);
 }
 
 function correlateHarnessEvent(

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -47,7 +47,7 @@ describe("cleanup command handlers", () => {
     fixture.sqlite.close();
   });
 
-  it("force-closes a harness session even when the provider cannot stop runs", async () => {
+  it("errors honestly on force close-harness when the provider cannot stop runs", async () => {
     const fixture = createFixture({ state: "working", harnessStopSupported: false });
     await fixture.core.reconcile("pre-cleanup");
 
@@ -61,13 +61,14 @@ describe("cleanup command handlers", () => {
     });
     await fixture.queue.drain();
 
-    // Nothing to stop and nothing closed — but the command completes instead of
-    // dead-ending on HARNESS_STOP_UNSUPPORTED, which left unstoppable sessions
-    // impossible to retire.
+    // A hollow "success" would leave the still-running agent in place and the
+    // row reappearing each reconcile; mode:harness has no terminal-close
+    // fallback, so the command must fail rather than pretend to have stopped it.
     expect(fixture.harness.snapshot().stopped).toEqual([]);
     expect(fixture.terminal.snapshot().closed).toEqual([]);
     await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
-      status: "succeeded",
+      status: "failed",
+      error: { code: "HARNESS_STOP_UNSUPPORTED" },
     });
     fixture.sqlite.close();
   });

--- a/apps/observer/test/unit/harnessEventStatus.test.ts
+++ b/apps/observer/test/unit/harnessEventStatus.test.ts
@@ -256,6 +256,26 @@ describe("external run synthesis", () => {
     });
     expect(ended).toHaveLength(0);
   });
+
+  it("does not resurrect a run when a surviving working event outranks the exited one", () => {
+    // An exited observation retires the session even if another event has a
+    // later timestamp (out-of-order delivery / observedAt vs updatedAt skew).
+    const result = synthesizeExternalHarnessRuns({
+      runs: [],
+      observations: [
+        externalObservation({ value: "exited", updatedAt: "2026-05-21T12:00:01.000Z" }),
+        externalObservation({ value: "working", updatedAt: "2026-05-21T12:00:09.000Z" }),
+      ],
+    });
+    expect(result).toHaveLength(0);
+  });
+
+  it("encodes untrusted native session ids so they cannot collide", () => {
+    expect(externalHarnessRunId("codex", "external:victim")).toBe(
+      "codex:external:external%3Avictim",
+    );
+    expect(externalHarnessRunId("codex", "plain_1")).toBe("codex:external:plain_1");
+  });
 });
 
 describe("stale busy status decay", () => {


### PR DESCRIPTION
Confirmed correctness findings from an independent review of the merged PRs #73 and #74, applying the decided fixes (honest force-close; gate external delivery on project roots). All contained observer/CLI changes, no overlap with the in-flight telemetry branch.

## #74 — external-run resurrection & id collision

`synthesizeExternalHarnessRuns` picked latest status by `updatedAt` and skipped synthesis only when *that* pick was `exited`. Because expiry keys on ingest `observedAt`, reordering (out-of-order delivery, a spool drain re-stamping `observedAt`, or the `exited` observation expiring before a later `working` one) could re-light an ended session. Now any non-expired `exited` observation retires the id outright, and ranking uses `max(updatedAt, observedAt)`. `externalHarnessRunId` also encodes both parts so an untrusted `nativeSessionId` containing `:` or `external:` can't collide with or shadow another run.

## #74 — unbounded external hook delivery

`hasCorrelatableCwd` only checked that a `cwd` field existed — always true, since `cwd` is required in every claude/codex payload — so the relaxed gate filtered nothing and every session anywhere delivered and spooled (unbounded when the observer was down). The gate now checks the payload cwd against the configured project roots (repo root plus worktrunk `managed_root` and `base`, since worktrees live outside the repo). No configured roots keeps the permissive fallback; the observer still drops anything uncorrelated.

## #73 — honest force-close

`session.close --mode harness --force` on a provider that can't stop runs (all real providers) reported `succeeded` while doing nothing — the agent kept running and the row reappeared each reconcile. With no terminal-close fallback it now fails with `HARNESS_STOP_UNSUPPORTED`. Ghost/stale rows are cleared by the busy-status decay (from #73), not by a fake stop.

## Tests

- `harnessEventStatus.test.ts`: a later `working` event doesn't resurrect a run with an `exited` observation; ids are encoded.
- `ingress-command.test.ts`: env-less claude event under a project root delivers; outside all roots is ignored.
- `cleanup-commands.test.ts`: force close-harness on a stop-less provider fails honestly.
- Observer + CLI lanes green (unrelated pre-existing timing flakes in release-doctor / observe, and an env-dependent claude auth-doctor unit test).

## Still open from the #70–74 review (tracked separately)

- **#70/#71** (sync-hold stale deadline, replay-listener rejection killing a healthy PTY, empty-ring reconnect blanking a pane) — station-app files that conflict with the in-flight telemetry PR; land after it merges.
- **PID-liveness** for decay (long single tool call false-decays a live agent) and external phantom-run age-out — needs a liveness signal; a design follow-up.
- Minor: cwd case-insensitive/symlink correlation on APFS; cursor/pi wasted env-less spawns.
