### PR TITLE
fix(terminal): sync-hold re-arm, replay-error isolation, empty-ring reconnect nudge

### DIFF
--- a/station/src/terminal/pty/hostAttachedTerminal.test.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.test.ts
@@ -346,6 +346,92 @@ describe("createHostAttachedTerminal (Station-owned aux)", () => {
     expect(received).toEqual(["history-", RECONNECT_REPAINT, "history-", "gap-"]);
   });
 
+  it("nudges the child on an empty-ring reconnect so the pane is not left blank", async () => {
+    // Same-size reconnect with nothing in the ring: without a nudge the child
+    // never gets a SIGWINCH and the pane stays whatever it last showed.
+    const first = controllableAttachment(ack({ scrollback: [] }));
+    const second = controllableAttachment(ack({ scrollback: [] }));
+    let attachCalls = 0;
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () =>
+        ({
+          attach: async () => {
+            attachCalls += 1;
+            return attachCalls === 1 ? first.attachment : second.attachment;
+          },
+          dispose: () => {},
+          health: async () => ({ ok: true, protocolVersion: 1 }),
+          spawn: async () => ({ ptyId: "pty-1", pid: 4242 }),
+          write: async () => undefined,
+          resize: async () => undefined,
+          list: async () => [],
+          focus: async () => undefined,
+          close: async () => ({ closed: true }),
+        }) satisfies StationHostClient,
+    });
+    const exits: number[] = [];
+    terminal.onExit((event) => exits.push(event.exitCode));
+
+    await flush();
+    // First attach, empty ring: no flap (a fresh spawn need not be nudged).
+    expect(first.state.resizes).toEqual([{ cols: 80, rows: 24 }]);
+
+    first.endStream();
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(exits).toEqual([]);
+    // Reconnect flapped the rows (24 -> 23 -> 24) to force a repaint.
+    expect(second.state.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 80, rows: 23 },
+      { cols: 80, rows: 24 },
+    ]);
+  });
+
+  it("does not reconnect (or kill the pane) when a replay listener throws", async () => {
+    const ctrl = controllableAttachment(ack({ scrollback: ["hist-"] }));
+    let attachCalls = 0;
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () =>
+        ({
+          attach: async () => {
+            attachCalls += 1;
+            return ctrl.attachment;
+          },
+          dispose: () => {},
+          health: async () => ({ ok: true, protocolVersion: 1 }),
+          spawn: async () => ({ ptyId: "pty-1", pid: 4242 }),
+          write: async () => undefined,
+          resize: async () => undefined,
+          list: async () => [],
+          focus: async () => undefined,
+          close: async () => ({ closed: true }),
+        }) satisfies StationHostClient,
+    });
+    const diagnostics: string[] = [];
+    const exits: number[] = [];
+    terminal.onDiagnostic((message) => diagnostics.push(message));
+    terminal.onExit((event) => exits.push(event.exitCode));
+    // A render/VT error while parsing the replay must be isolated: previously it
+    // rejected the attach, was treated as a transport fault, and reconnected —
+    // re-feeding the snapshot and eventually killing a healthy PTY.
+    terminal.onReplay?.(() => {
+      throw new Error("vt parse blew up");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(attachCalls).toBe(1); // no reconnect from the listener throw
+    expect(exits).toEqual([]); // pane stayed alive
+    expect(diagnostics.length).toBeGreaterThan(0); // the failure was surfaced, not swallowed
+  });
+
   it("keeps reconnecting a long-lived pane across many drops (budget is consecutive, not lifetime)", async () => {
     // A pane that has streamed for a while then drops should earn a fresh retry
     // budget each time — otherwise the lifetime cap eventually kills a healthy

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -161,7 +161,19 @@ export function createHostAttachedTerminal(
       }
       return;
     }
-    await Promise.all([...replayListeners].map((listener) => listener({ size: recordedSize, chunks })));
+    // A listener that throws (a render/VT error while parsing the replay) must
+    // NOT reject here: the attach loop would treat it as a transport fault and
+    // reconnect, re-feeding the whole snapshot and eventually killing a healthy
+    // PTY. The async wrapper catches a synchronous throw as well as a rejection.
+    await Promise.all(
+      [...replayListeners].map(async (listener) => {
+        try {
+          await listener({ size: recordedSize, chunks });
+        } catch (error) {
+          emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
+        }
+      }),
+    );
   };
 
   // Send a resize to the attached host PTY and stamp `ackedSize` to the size
@@ -215,23 +227,28 @@ export function createHostAttachedTerminal(
         // On a RECONNECT the ack snapshot is the current ring — it captured output
         // produced while we were detached — so repaint from it (clearing first so
         // the already-shown history isn't duplicated) rather than dropping the gap.
+        const isReconnect = replayed;
         const recordedSize = { cols: opened.ack.cols, rows: opened.ack.rows };
         if (!replayed) {
           await emitReplay(opened.ack.scrollback, recordedSize);
           replayed = true;
-        } else {
+        } else if (opened.ack.scrollback.length > 0) {
           await emitReplay([RECONNECT_REPAINT, ...opened.ack.scrollback], recordedSize);
         }
+        // else: reconnect with an empty ring — clearing would just blank the pane
+        // with nothing to replay, so leave the shown frame and rely on the nudge.
         // Sync the host PTY to THIS client's pane size on (re)attach — the host may
         // have spawned it at a different size — then flush input typed before attach
         // resolved. Expose `attachment` only AFTER the flush so later writes order
         // after the buffered ones.
         await opened.resize(size.cols, size.rows);
         // A same-size resize is a no-op TIOCSWINSZ — no SIGWINCH — so a child
-        // whose replayed frame may be stale would never repaint; flap the rows
-        // to force one. A real size change above already delivers the signal.
+        // whose frame may be stale would never repaint; flap the rows to force
+        // one. Needed whenever there was history to reflow OR this is a reconnect
+        // (the child may have produced state while we were detached). A real size
+        // change above already delivers the signal.
         if (
-          opened.ack.scrollback.length > 0 &&
+          (isReconnect || opened.ack.scrollback.length > 0) &&
           opened.ack.cols === size.cols &&
           opened.ack.rows === size.rows
         ) {

--- a/station/src/terminal/vt/screen.sync.test.ts
+++ b/station/src/terminal/vt/screen.sync.test.ts
@@ -130,4 +130,40 @@ describe("synchronized output (DECSET 2026)", () => {
     expect(notifiedAt[0]).toBeGreaterThan(500);
     expect(gridText(screen)).toEqual(["FRAME-B-ROW0", "FRAME-B-ROW1", "", "", ""]);
   }, 10_000);
+
+  it("re-holds a synchronized frame after a prior escape-hatch expiry", async () => {
+    // Short hold window so the escape hatch fires quickly.
+    const screen = track(
+      createStationVtScreen({ size: SIZE, flushIntervalMs: 1, syncHoldMaxMs: 30 }),
+    );
+    await feedAndFlush(screen, frameA);
+
+    // Frame 1: a stuck BSU (no ESU) — held, then flushed by the escape hatch.
+    screen.feed(bsuPlusHalfB);
+    await screen.whenIdle();
+    await sleep(60); // past the 30ms deadline; escape hatch flushed and reset
+
+    // Frame 2 arrives as a single coalesced write that closes frame 1 (ESU) and
+    // immediately opens a new synchronized frame (BSU) then half-paints it. The
+    // stale-deadline bug reused frame 1's expired deadline and did NOT hold.
+    const snapshots: Array<{ syncActive: boolean; rows: string[] }> = [];
+    screen.subscribe(() => {
+      snapshots.push({
+        syncActive: screen.unsafeEngine.modes.synchronizedOutputMode,
+        rows: gridText(screen),
+      });
+    });
+    const closeThenReopen =
+      "\x1b[?2026l\x1b[?2026h\x1b[2J\x1b[H" + ["NEXT-ROW0", "NEXT-ROW1"].join("\r\n");
+    screen.feed(closeThenReopen);
+    await screen.whenIdle();
+    await sleep(10);
+
+    // The new frame is still open (deadline re-armed), so no torn snapshot with
+    // the half-painted NEXT frame was published within its hold window.
+    expect(screen.unsafeEngine.modes.synchronizedOutputMode).toBe(true);
+    expect(
+      snapshots.some((s) => s.rows[0] === "NEXT-ROW0" && s.rows.every((r) => !r.startsWith("FRAME"))),
+    ).toBe(false);
+  }, 10_000);
 });

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -46,6 +46,8 @@ export type StationVtScreenOptions = {
   scrollOnOutput?: ScrollOnOutputMode;
   /** Injectable for deterministic coalescing tests. */
   flushIntervalMs?: number;
+  /** Max hold for an open synchronized frame before the escape hatch flushes; injectable for tests. */
+  syncHoldMaxMs?: number;
   theme?: StationVtTheme;
   /**
    * Terminal query replies (DA1/DA2/DSR/CPR/DECRQM from xterm, OSC 10/11 from
@@ -205,6 +207,7 @@ export type StationVtScreen = {
 export function createStationVtScreen(options: StationVtScreenOptions): StationVtScreen {
   const theme = options.theme ?? stationVtTheme;
   const flushIntervalMs = options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+  const syncHoldMaxMs = options.syncHoldMaxMs ?? SYNC_OUTPUT_HOLD_MAX_MS;
   const terminal = new Terminal({
     cols: Math.max(options.size.cols, MIN_COLS),
     rows: Math.max(options.size.rows, MIN_ROWS),
@@ -509,17 +512,20 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     }
     // DECSET 2026 (synchronized output): between BSU and ESU the app is
     // mid-frame, so hold listener notification rather than snapshot a torn
-    // buffer. Bounded so a client that never sends ESU cannot freeze the pane;
-    // once expired, flush at normal cadence until the mode clears.
+    // buffer. Bounded so a client that never sends ESU cannot freeze the pane.
     if (terminal.modes.synchronizedOutputMode) {
-      syncHoldUntil ??= Date.now() + SYNC_OUTPUT_HOLD_MAX_MS;
+      syncHoldUntil ??= Date.now() + syncHoldMaxMs;
       if (Date.now() < syncHoldUntil) {
         flushTimer = setTimeout(flush, flushIntervalMs);
         return;
       }
-    } else {
-      syncHoldUntil = undefined;
     }
+    // Falling through means the mode is off or the escape-hatch deadline
+    // passed; clear it either way so the NEXT synchronized frame re-arms a
+    // fresh hold. Without this, a coalesced ESU+BSU that never let the mode be
+    // observed off would reuse a stale (already-expired) deadline and tear; a
+    // genuinely stuck frame just re-holds ~1s at a time.
+    syncHoldUntil = undefined;
     lastFlushAt = Date.now();
     applyScrollOnOutput();
     clampScrollOffset();


### PR DESCRIPTION
Three confirmed findings from the independent review of merged PRs #70 and #71 — station-app files, held until the corruption-telemetry PR (#75) landed to avoid conflicts.

## #70 — synchronized-output hold never re-armed after expiry

`syncHoldUntil` was only cleared when the mode was observed off. After the 1s escape-hatch fired on a stuck frame (mode still on), the deadline kept its past value, so a coalesced `ESU`+`BSU` — where the mode never appears off to a flush — reused the expired deadline and tore the next frame (the exact bug the hold exists to prevent). The deadline is now cleared whenever flush falls through (mode off *or* expired), so the next synchronized frame re-arms a fresh hold; a genuinely stuck frame just re-holds ~1s at a time. `syncHoldMaxMs` is now injectable for a fast regression test.

## #71 — a replay listener error killed a healthy PTY

If the registry's `onReplay` handler threw (a render/VT error parsing the snapshot), `emitReplay`'s `Promise.all` rejected into the attach loop's `catch`, which treated it as a transport fault: reconnect, re-feed the whole snapshot, and — with `replayed` still false — repeat until the retry budget was exhausted and a healthy PTY was killed. The listener call is now wrapped so both a synchronous throw and a rejection are caught and surfaced as a diagnostic; the attach continues normally.

## #71 — empty-ring reconnect blanked the pane

A same-size reconnect cleared the screen unconditionally but only flapped the rows (the SIGWINCH nudge) when the ring was non-empty. An empty-ring reconnect therefore cleared the pane and never nudged the child → permanent blank. Now the clear is skipped when there's nothing to replay, and the flap fires on any reconnect (the child may have produced state while detached). A first attach with an empty ring still does not flap (a fresh spawn needs no nudge).

## Tests

- `screen.sync.test.ts`: a synchronized frame re-holds after a prior escape-hatch expiry.
- `hostAttachedTerminal.test.ts`: a throwing replay listener does not reconnect/kill the pane (surfaces a diagnostic); an empty-ring reconnect flaps the rows while a first empty attach does not.
- typecheck clean; station suite 966 pass; PTY smokes pass.

Completes the #70–74 merged review. Remaining items (PID-liveness decay, external phantom-run age-out, cwd case-sensitivity, cursor/pi env-less spawns) are design/minor follow-ups tracked separately.