### PR TITLE
fix(station-button): hide idle lanes in fleet counts

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,7 +274,7 @@ button). Both default off:
 
 | Key | Type | Notes |
 | --- | --- | --- |
-| `rest_counts` | bool | Collapsed island shows live fleet counts (`⠿ working · ● ready · ○ idle`) instead of the bare mark. |
+| `rest_counts` | bool | Collapsed island shows active working/ready counts instead of the bare mark; idle and zero lanes are hidden. |
 | `project_rollup` | bool | Hovering the island lists each project's worst agent status instead of the working/idle totals. |
 
 ### `[repository.github]` — repository metadata provider (optional)

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -56,13 +56,45 @@ describe("DynamicStationButton", () => {
     expect(frame).not.toContain("needs user");
   });
 
-  it("collapsed rest counts paint the fleet lanes", async () => {
+  it("collapsed rest counts paint working without zero or idle lanes", async () => {
+    const frame = await captureFrame(
+      <DynamicStationButton
+        input={input({ workingCount: 2, idleCount: 6 }, { restCounts: true })}
+      />,
+    );
+    expect(frame).toContain(STATION_ICON);
+    expect(frame).toContain("2");
+    expect(frame).not.toContain("●");
+    expect(frame).not.toContain("○");
+    expect(frame).not.toContain("0");
+    expect(frame).not.toContain("session");
+  });
+
+  it("collapsed rest counts paint ready without working or idle lanes", async () => {
     const frame = await captureFrame(
       <DynamicStationButton input={input({ readyCount: 1, idleCount: 6 }, { restCounts: true })} />,
     );
     expect(frame).toContain(STATION_ICON);
-    expect(frame).toContain("⠿0 ●1 ○6");
+    expect(frame).toContain("●1");
+    expect(frame).not.toContain("⠿0");
+    expect(frame).not.toContain("○");
     expect(frame).not.toContain("session");
+  });
+
+  it("collapsed rest counts fall back to the glyph for zero or idle-only counts", async () => {
+    const zeroFrame = await captureFrame(
+      <DynamicStationButton input={input({}, { restCounts: true })} />,
+    );
+    const idleFrame = await captureFrame(
+      <DynamicStationButton input={input({ idleCount: 6 }, { restCounts: true })} />,
+    );
+
+    expect(zeroFrame).toContain(STATION_ICON);
+    expect(zeroFrame).not.toContain("0");
+    expect(zeroFrame).not.toContain("○");
+    expect(idleFrame).toContain(STATION_ICON);
+    expect(idleFrame).not.toContain("○6");
+    expect(idleFrame).not.toContain("●");
   });
 
   it("collapsed celebration announces the merged PR", async () => {

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -171,7 +171,6 @@ function StationButtonContent(props: {
           iconColor={color.icon}
           working={display.working}
           ready={display.ready}
-          idle={display.idle}
         />
       );
     case "celebration":
@@ -293,13 +292,11 @@ function CollapsedAttention({ color }: { color: StationButtonStateColors }): Rea
   );
 }
 
-// Fleet-lane vocabulary shared with the dashboard's FLEET bar: ⠿ working (blue,
-// animated while any), ● ready (green), ○ idle (gray).
+// Collapsed fleet counts show only active lanes: braille working and ● ready.
 function CollapsedCounts(props: {
   iconColor: string;
   working: number;
   ready: number;
-  idle: number;
 }): ReactNode {
   return (
     <box flexDirection="row" paddingLeft={ICON_PAD}>
@@ -307,13 +304,15 @@ function CollapsedCounts(props: {
       <text>
         <span> </span>
         {props.working > 0 ? (
-          <Throbber variant="braille" fg={STATION_COLORS.blue} />
-        ) : (
-          <span fg={STATION_COLORS.blue}>⠿</span>
-        )}
-        <span fg={STATION_COLORS.blue}>{`${paintedCount(props.working)} `}</span>
-        <span fg={STATION_COLORS.green}>{`●${paintedCount(props.ready)} `}</span>
-        <span fg={STATION_COLORS.gray}>{`○${paintedCount(props.idle)}`}</span>
+          <>
+            <Throbber variant="braille" fg={STATION_COLORS.blue} />
+            <span fg={STATION_COLORS.blue}>{paintedCount(props.working)}</span>
+          </>
+        ) : null}
+        {props.working > 0 && props.ready > 0 ? <span> </span> : null}
+        {props.ready > 0 ? (
+          <span fg={STATION_COLORS.green}>{`●${paintedCount(props.ready)}`}</span>
+        ) : null}
       </text>
     </box>
   );

--- a/station/src/stationButton/layout.test.ts
+++ b/station/src/stationButton/layout.test.ts
@@ -38,8 +38,17 @@ describe("islandDisplay", () => {
     expect(islandDisplay(input({}, { celebration, restCounts: true }), false).kind).toBe(
       "celebration",
     );
-    expect(islandDisplay(input({}, { restCounts: true }), false).kind).toBe("counts");
+    expect(islandDisplay(input({ readyCount: 1 }, { restCounts: true }), false).kind).toBe(
+      "counts",
+    );
     expect(islandDisplay(input(), false).kind).toBe("mark");
+  });
+
+  it("falls back to the bare mark for empty or idle-only rest counts", () => {
+    expect(islandDisplay(input({}, { restCounts: true }), false).kind).toBe("mark");
+    expect(islandDisplay(input({ idleCount: 3 }, { restCounts: true }), false).kind).toBe(
+      "mark",
+    );
   });
 
   it("expands to the alert card, the roll-up, or the totals", () => {
@@ -71,13 +80,21 @@ describe("targetDims", () => {
     expect(width("main")).toBe(width("another/long-feature-branch-name-here"));
   });
 
-  it("keeps the collapsed counts box width stable as counts tick", () => {
+  it("sizes collapsed counts by visible working and ready lanes", () => {
     const at = (workingCount: number, readyCount: number, idleCount: number) =>
       dims(input({ workingCount, readyCount, idleCount }, { restCounts: true }), false);
-    expect(at(0, 0, 0)).toEqual(at(9, 10, 99));
+    const workingOnly = at(1, 0, 0);
+    const readyOnly = at(0, 1, 0);
+
+    expect(at(0, 0, 0).width).toBe(COLLAPSED_BASE_COLS);
+    expect(at(0, 0, 9).width).toBe(COLLAPSED_BASE_COLS);
+    expect(workingOnly).toEqual(at(99, 0, 12));
+    expect(workingOnly).toEqual(at(150, 0, 0));
+    expect(readyOnly).toEqual(at(0, 99, 12));
+    expect(workingOnly.width).toBe(readyOnly.width);
+    expect(workingOnly.width).toBeGreaterThan(COLLAPSED_BASE_COLS);
+    expect(workingOnly.width).toBeLessThan(COLLAPSED_COUNTS_COLS);
     expect(at(1, 1, 1).width).toBe(COLLAPSED_COUNTS_COLS);
-    expect(at(1, 1, 1).width).toBeGreaterThan(COLLAPSED_BASE_COLS);
-    expect(at(150, 0, 0)).toEqual(at(0, 0, 0));
   });
 
   it("keeps the roll-up card width fixed while height tracks project count", () => {

--- a/station/src/stationButton/layout.ts
+++ b/station/src/stationButton/layout.ts
@@ -64,7 +64,7 @@ export type IslandDisplayInput = {
 export type IslandDisplay =
   | { kind: "mark" }
   | { kind: "alertMark" }
-  | { kind: "counts"; working: number; ready: number; idle: number }
+  | { kind: "counts"; working: number; ready: number }
   | { kind: "celebration"; celebration: IslandCelebration }
   | { kind: "alertCard"; sessionName: string; needsYouCount: number }
   | { kind: "rollup"; entries: readonly ProjectRollupEntry[] }
@@ -98,12 +98,13 @@ export function islandDisplay(input: IslandDisplayInput, expanded: boolean): Isl
     return { kind: "celebration", celebration: input.celebration };
   }
   if (input.restCounts === true) {
-    return {
-      kind: "counts",
-      working: status.workingCount,
-      ready: status.readyCount,
-      idle: status.idleCount,
-    };
+    if (status.workingCount > 0 || status.readyCount > 0) {
+      return {
+        kind: "counts",
+        working: status.workingCount,
+        ready: status.readyCount,
+      };
+    }
   }
   return { kind: "mark" };
 }
@@ -154,7 +155,7 @@ export function targetDims(display: IslandDisplay): Dims {
     case "alertMark":
       return { width: COLLAPSED_ATTENTION_COLS, height: COLLAPSED_ATTENTION_ROWS };
     case "counts":
-      return { width: COLLAPSED_COUNTS_COLS, height: COLLAPSED_BASE_ROWS };
+      return { width: collapsedCountCols(countLaneCount(display)), height: COLLAPSED_BASE_ROWS };
     case "celebration": {
       const interior = ICON_COLS + 1 + celebrationText(display.celebration).length;
       return { width: interior + 2 * ICON_PAD + 2, height: COLLAPSED_BASE_ROWS };
@@ -191,11 +192,24 @@ export function targetDims(display: IslandDisplay): Dims {
   }
 }
 
-// The collapsed counts row measures with 2-digit lanes (`⠿88 ●88 ○88`) so live
+// The collapsed counts row measures visible lanes with 2-digit counts so live
 // count ticks can't slide the box out from under an approaching cursor.
-const STABLE_COUNT_LANES_COLS = 3 * (1 + 2) + 2;
-export const COLLAPSED_COUNTS_COLS =
-  ICON_COLS + 1 + STABLE_COUNT_LANES_COLS + 2 * ICON_PAD + 2;
+const STABLE_COUNT_LANE_COLS = 1 + 2;
+const STABLE_COUNT_LANE_GAP_COLS = 1;
+export const COLLAPSED_COUNTS_COLS = collapsedCountCols(2);
+
+function countLaneCount(display: Extract<IslandDisplay, { kind: "counts" }>): number {
+  return Number(display.working > 0) + Number(display.ready > 0);
+}
+
+function collapsedCountCols(laneCount: number): number {
+  if (laneCount === 0) {
+    return COLLAPSED_BASE_COLS;
+  }
+  const laneCols =
+    laneCount * STABLE_COUNT_LANE_COLS + (laneCount - 1) * STABLE_COUNT_LANE_GAP_COLS;
+  return ICON_COLS + 1 + laneCols + 2 * ICON_PAD + 2;
+}
 
 function summaryColumns(verb: string): number {
   return sessionSummary(STABLE_SUMMARY_COUNT, verb).length;


### PR DESCRIPTION
## Summary

- Hide idle and zero-count lanes from the collapsed Station island fleet counts.
- Fall back to the glyph-only island when the fleet is empty or idle-only.
- Update the collapsed count sizing, render coverage, and `rest_counts` docs to match the new behavior.

## UX implication

With `[tui.island].rest_counts = true`, the collapsed button now shows only active working/ready counts: `2 working` appears as the Station glyph plus the working count, `1 ready` appears as the glyph plus `●1`, and all-zero or idle-only states show just the glyph.

## Root cause

The collapsed count display always rendered working, ready, and idle lanes, including zero values, so idle-only fleets still produced count chrome instead of the calm base island.

## Validation

- `cd station && bun test src/stationButton/layout.test.ts src/stationButton/DynamicStationButton.test.tsx`
- `cd station && bun run typecheck`
- `git diff --check`