### PR TITLE
fix(station): disable widget settings text selection

### DIFF
--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -2,6 +2,7 @@
 // the parity checklist, reached by driving the real machine with real keys,
 // rendered over the dashboard at 80x24. Snapshots live in __snapshots__.
 import { afterEach, describe, expect, it } from "bun:test";
+import { TextRenderable, type BaseRenderable } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
 import type { StoreApi } from "zustand/vanilla";
 import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
@@ -14,6 +15,8 @@ import {
 } from "@station/dashboard-core";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import { DashboardRoot } from "./DashboardRoot.js";
+import { StationMouseProvider } from "./stationMouseContext.js";
+import { WidgetSettingsPanelView } from "./settings/WidgetSettingsPanelView.js";
 
 const SIZE = { width: 80, height: 24 };
 
@@ -229,4 +232,35 @@ describe("modal flow golden frames", () => {
       expect(frame).toMatchSnapshot();
     });
   }
+
+  it("keeps widget settings text out of OpenTUI selection", async () => {
+    const setup = await testRender(
+      <StationMouseProvider value={() => {}}>
+        <WidgetSettingsPanelView
+          screen={{ name: "widgetSettings", focus: "list", cursor: 0, pickerCursor: 0 }}
+          widgets={[{ type: "time" }, { type: "moon", enabled: false }]}
+          widgetsPersisted
+          columns={SIZE.width}
+          rows={SIZE.height}
+        />
+      </StationMouseProvider>,
+      SIZE,
+    );
+    teardowns.push(() => {
+      setup.renderer.destroy();
+    });
+    await setup.renderOnce();
+
+    const textRenderables = collectTextRenderables(setup.renderer.root);
+    expect(textRenderables.length).toBeGreaterThan(0);
+    expect(textRenderables.every((renderable) => renderable.selectable === false)).toBe(true);
+  });
 });
+
+function collectTextRenderables(renderable: BaseRenderable): TextRenderable[] {
+  const collected = renderable instanceof TextRenderable ? [renderable] : [];
+  for (const child of renderable.getChildren()) {
+    collected.push(...collectTextRenderables(child));
+  }
+  return collected;
+}

--- a/station/src/station/view/settings/WidgetSettingsPanelView.tsx
+++ b/station/src/station/view/settings/WidgetSettingsPanelView.tsx
@@ -12,6 +12,8 @@ import { fit } from "../sheets/parts.js";
 import { STATION_COLORS } from "../theme.js";
 import { stationMouseProps, useStationMouse } from "../stationMouseContext.js";
 
+const UNSELECTABLE_TEXT = { selectable: false } as const;
+
 export type WidgetSettingsPanelViewProps = {
   screen: Extract<TuiScreen, { name: "widgetSettings" }>;
   widgets: readonly TuiWidgetConfig[];
@@ -48,10 +50,15 @@ export function WidgetSettingsPanelView({
       flexDirection="column"
       {...stationMouseProps(dispatch, { kind: "sheetBackdrop" })}
     >
-      <text fg={STATION_COLORS.foreground} bg={STATION_COLORS.background} attributes={TextAttributes.BOLD}>
+      <text
+        fg={STATION_COLORS.foreground}
+        bg={STATION_COLORS.background}
+        attributes={TextAttributes.BOLD}
+        {...UNSELECTABLE_TEXT}
+      >
         {fit(` ${model.title}`, innerWidth)}
       </text>
-      <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background}>
+      <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background} {...UNSELECTABLE_TEXT}>
         {fit(` ${model.note}`, innerWidth)}
       </text>
       {model.lines.map((line) => (
@@ -66,6 +73,7 @@ export function WidgetSettingsPanelView({
         fg={STATION_COLORS.foreground}
         bg={STATION_COLORS.background}
         attributes={TextAttributes.DIM}
+        {...UNSELECTABLE_TEXT}
       >
         {fit(` ${model.footer}`, innerWidth)}
       </text>
@@ -96,7 +104,7 @@ function PanelLine({
   const [hover, setHover] = useState(false);
   if (line.kind === "empty") {
     return (
-      <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background}>
+      <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background} {...UNSELECTABLE_TEXT}>
         {fit(`   ${line.label}`, width)}
       </text>
     );
@@ -106,6 +114,7 @@ function PanelLine({
       <text
         fg={STATION_COLORS.cyan}
         bg={hover ? STATION_COLORS.hoverBackground : STATION_COLORS.background}
+        {...UNSELECTABLE_TEXT}
         {...stationMouseProps(dispatch, { kind: "widgetSettingsAdd" })}
         onMouseOver={() => setHover(true)}
         onMouseOut={() => setHover(false)}
@@ -126,6 +135,7 @@ function PanelLine({
       <text
         fg={line.active ? STATION_COLORS.cyan : STATION_COLORS.foreground}
         bg={background}
+        {...UNSELECTABLE_TEXT}
         {...stationMouseProps(dispatch, { kind: "widgetSettingsPickerChoice", index: line.index })}
         onMouseOver={() => setHover(true)}
         onMouseOut={() => setHover(false)}
@@ -149,6 +159,7 @@ function PanelLine({
       <text
         fg={rowColor}
         bg={hover && !dimmed ? STATION_COLORS.hoverBackground : STATION_COLORS.background}
+        {...UNSELECTABLE_TEXT}
         {...stationMouseProps(dispatch, { kind: "widgetSettingsRow", index: line.index })}
         onMouseOver={() => setHover(true)}
         onMouseOut={() => setHover(false)}
@@ -168,6 +179,7 @@ function RemoveMark({ index, rowHovered }: { index: number; rowHovered: boolean 
     <text
       fg={hover ? STATION_COLORS.red : rowHovered ? STATION_COLORS.gray : STATION_COLORS.hairline}
       bg={STATION_COLORS.background}
+      {...UNSELECTABLE_TEXT}
       {...stationMouseProps(dispatch, { kind: "widgetSettingsRemove", index })}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}


### PR DESCRIPTION
## Summary

- Mark widget settings panel text renderables as non-selectable so dragging across the panel does not select the whole overlay.
- Add a regression assertion that every widget settings text renderable opts out of OpenTUI selection.

## UX Impact

Opening widget settings via `W` or the header `[+]` still allows normal row/add/remove clicks, but drag gestures over the panel no longer show text selection/highlight.

## Validation

- `git diff --check`
- `cd station && bun test src/station/view/modals.golden.test.tsx`
- `cd station && bun run typecheck`
- pre-commit hook: `biome check .`, `check-source-order`, `check-no-raw-hex`