### PR TITLE
feat(observer): WAL-mode sqlite + safe `stn observer reap`

### DIFF
--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -9,11 +9,13 @@ import {
   startObserver,
   stopObserver,
 } from "../observerProcess.js";
+import { type ObserverReapDeps, type ReapOutcome, runObserverReap } from "../observerReap.js";
 import { type ObserverPaths, resolveObserverPaths } from "../paths.js";
 
 export type ObserverCommandResult =
   | ObserverStatus
   | ObserverStopReceipt
+  | ReapOutcome
   | {
       status: "foreground-exited";
       code: number;
@@ -24,6 +26,7 @@ export type ObserverCommandOptions = {
   config?: StationConfig;
   configPath?: string;
   timeoutMs?: number;
+  reapDeps?: ObserverReapDeps;
 };
 
 export async function runObserverCommand(
@@ -41,6 +44,8 @@ export async function runObserverCommand(
   };
 
   switch (action) {
+    case "reap":
+      return runObserverReap(paths.socketPath, { force: parsed.force }, options.reapDeps ?? {});
     case "status":
       return getObserverStatus(runtimeOptions, deps);
     case "start":
@@ -72,18 +77,22 @@ export async function runObserverCommand(
 function parseObserverArgs(
   args: string[],
   timeoutMs: number | undefined,
-): { action: string; timeoutMs?: number } {
+): { action: string; timeoutMs?: number; force: boolean } {
   const parsed = takeTimeoutOption(args, timeoutMs);
-  const flag = parsed.args.find((arg) => arg.startsWith("--"));
+  const force = parsed.args.includes("--force") || parsed.args.includes("--yes");
+  const rest = parsed.args.filter((arg) => arg !== "--force" && arg !== "--yes");
+
+  const flag = rest.find((arg) => arg.startsWith("--"));
   if (flag !== undefined) {
     throw new Error(`Unknown observer option: ${flag}`);
   }
-  if (parsed.args.length > 1) {
-    throw new Error(`Unknown observer option: ${parsed.args[1] ?? ""}`);
+  if (rest.length > 1) {
+    throw new Error(`Unknown observer option: ${rest[1] ?? ""}`);
   }
 
-  const result: { action: string; timeoutMs?: number } = {
-    action: parsed.args[0] ?? "status",
+  const result: { action: string; timeoutMs?: number; force: boolean } = {
+    action: rest[0] ?? "status",
+    force,
   };
   if (parsed.timeoutMs !== undefined) result.timeoutMs = parsed.timeoutMs;
   return result;
@@ -108,6 +117,20 @@ function takeTimeoutOption(
 }
 
 export function observerCommandSummary(result: ObserverCommandResult): unknown {
+  if ("plan" in result) {
+    const { plan, applied } = result;
+    return {
+      action: "reap",
+      socketPath: plan.socketPath,
+      keeper: plan.keeper ?? null,
+      duplicates: plan.duplicates,
+      targets: plan.targets.map((t) => t.pid),
+      refusals: plan.refusals,
+      applied,
+      ...(applied ? { killed: result.killed, survived: result.survived } : {}),
+      ...(result.aborted === undefined ? {} : { aborted: result.aborted }),
+    };
+  }
   if ("health" in result) {
     return {
       status: result.status,

--- a/apps/cli/src/commands/registry/observer.ts
+++ b/apps/cli/src/commands/registry/observer.ts
@@ -7,7 +7,12 @@ export const observerCliCommand: CliCommandNode = {
   description: "Start, stop, or inspect the local observer process.",
   requiresConfig: true,
   run: runObserverCliCommand,
-  usage: ["stn observer start", "stn observer status", "stn observer stop"],
+  usage: [
+    "stn observer start",
+    "stn observer status",
+    "stn observer stop",
+    "stn observer reap [--force]",
+  ],
   options: [
     {
       name: "--timeout-ms <ms>",
@@ -34,6 +39,14 @@ export const observerCliCommand: CliCommandNode = {
       description: "Stop the observer for the configured socket.",
       usage: ["stn observer stop"],
       examples: ["pnpm stn observer stop"],
+    },
+    {
+      name: "reap",
+      description:
+        "List duplicate observers for the configured socket; --force terminates all but the live owner.",
+      usage: ["stn observer reap [--force]"],
+      options: [{ name: "--force", description: "Terminate the duplicates (default lists only)." }],
+      examples: ["pnpm stn observer reap", "pnpm stn observer reap --force"],
     },
   ],
 };

--- a/apps/cli/src/observerReap.ts
+++ b/apps/cli/src/observerReap.ts
@@ -1,0 +1,236 @@
+import { execFileSync } from "node:child_process";
+import { resolveObserverSocketForProcessArgs } from "@station/config";
+import { createObserverClient } from "@station/protocol";
+
+export type ObserverProcessEntry = {
+  pid: number;
+  argv: string[];
+  /** OS start-time token (ps lstart), compared verbatim to guard against PID reuse. */
+  startToken: string;
+  /** Socket the process would bind, resolved from its argv; undefined if unresolvable. */
+  socketPath?: string;
+};
+
+export type ReapTarget = { pid: number; startToken: string };
+
+export type ReapPlan = {
+  socketPath: string;
+  keeper?: number;
+  targets: ReapTarget[];
+  /** Bound holders we refuse to signal (cannot prove they are not the current binder). */
+  refusals: { pid: number; reason: string }[];
+  /** Same-socket observers beyond the keeper (the duplicate count). */
+  duplicates: number;
+};
+
+export type ObserverReapDeps = {
+  listObserverProcesses?: () => ObserverProcessEntry[];
+  socketHolders?: (socketPath: string) => number[];
+  processStartToken?: (pid: number) => string | undefined;
+  healthPid?: (socketPath: string) => Promise<number | undefined>;
+  signal?: (pid: number, sig: NodeJS.Signals | 0) => boolean;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+const SIGTERM_GRACE_MS = 3000;
+const SIGKILL_CONFIRM_MS = 500;
+
+/**
+ * Pure selection: who can be safely reaped for `socketPath`. Reaping requires a
+ * single, identifiable live binder (the keeper); anything else refuses so the
+ * caller never signals the wrong process. Every bound holder that is not the
+ * confirmed keeper is refused, never targeted.
+ */
+export function selectReapPlan(input: {
+  socketPath: string;
+  processes: ObserverProcessEntry[];
+  holders: number[];
+  healthPid?: number | undefined;
+}): ReapPlan {
+  const candidates = input.processes.filter((p) => p.socketPath === input.socketPath);
+  const holderSet = new Set(input.holders);
+  const refusals: { pid: number; reason: string }[] = [];
+
+  let keeper: number | undefined;
+  if (input.holders.length === 1) {
+    keeper = input.holders[0];
+  } else if (input.holders.length > 1) {
+    // Ambiguous binder: only the holder answering health is the keeper; the rest
+    // are bound and unexplained, so they are refused rather than targeted.
+    if (input.healthPid !== undefined && holderSet.has(input.healthPid)) {
+      keeper = input.healthPid;
+    }
+    for (const pid of input.holders) {
+      if (pid !== keeper) refusals.push({ pid, reason: "unconfirmed socket holder" });
+    }
+  }
+
+  const duplicates = candidates.filter((p) => p.pid !== keeper).length;
+
+  // With no confirmed keeper, refuse the whole reap: there is no anchor proving
+  // which process legitimately owns the socket.
+  if (keeper === undefined) {
+    return { socketPath: input.socketPath, targets: [], refusals, duplicates };
+  }
+
+  const targets: ReapTarget[] = [];
+  for (const p of candidates) {
+    if (p.pid === keeper || holderSet.has(p.pid)) continue;
+    if (p.startToken.length === 0) {
+      refusals.push({ pid: p.pid, reason: "no start-time token to re-verify" });
+      continue;
+    }
+    targets.push({ pid: p.pid, startToken: p.startToken });
+  }
+  return { socketPath: input.socketPath, keeper, targets, refusals, duplicates };
+}
+
+export type ReapOutcome = {
+  plan: ReapPlan;
+  applied: boolean;
+  aborted?: string;
+  killed: number[];
+  survived: number[];
+};
+
+export async function runObserverReap(
+  socketPath: string,
+  options: { force: boolean; graceMs?: number } = { force: false },
+  deps: ObserverReapDeps = {},
+): Promise<ReapOutcome> {
+  const list = deps.listObserverProcesses ?? defaultListObserverProcesses;
+  const holdersOf = deps.socketHolders ?? defaultSocketHolders;
+  const tokenOf = deps.processStartToken ?? defaultProcessStartToken;
+  const kill = deps.signal ?? defaultSignal;
+  const sleep = deps.sleep ?? defaultSleep;
+  const graceMs = options.graceMs ?? SIGTERM_GRACE_MS;
+
+  const processes = list();
+  const holders = holdersOf(socketPath);
+  const healthPid =
+    holders.length > 1 ? await (deps.healthPid ?? defaultHealthPid)(socketPath) : undefined;
+  const plan = selectReapPlan({ socketPath, processes, holders, healthPid });
+
+  if (!options.force || plan.keeper === undefined || plan.targets.length === 0) {
+    return { plan, applied: false, killed: [], survived: [] };
+  }
+
+  const keeper = plan.keeper;
+  // Owner set captured now; a change during the reap aborts it (a takeover is in flight).
+  const ownerBaseline = holders.slice().sort().join(",");
+  const ownerChanged = () => holdersOf(socketPath).slice().sort().join(",") !== ownerBaseline;
+
+  const stillTarget = (t: ReapTarget): boolean => {
+    if (holdersOf(socketPath).includes(t.pid)) return false; // became a binder
+    const token = tokenOf(t.pid);
+    return token !== undefined && token === t.startToken; // gone or PID-reused
+  };
+
+  const killed: number[] = [];
+  for (const t of plan.targets) {
+    if (ownerChanged())
+      return { plan, applied: true, aborted: "owner-changed", killed, survived: [] };
+    if (stillTarget(t)) kill(t.pid, "SIGTERM");
+  }
+  await sleep(graceMs);
+  for (const t of plan.targets) {
+    if (!kill(t.pid, 0)) continue; // already gone
+    if (ownerChanged())
+      return { plan, applied: true, aborted: "owner-changed", killed, survived: [] };
+    if (stillTarget(t)) kill(t.pid, "SIGKILL");
+  }
+  await sleep(SIGKILL_CONFIRM_MS);
+
+  const survived: number[] = [];
+  for (const t of plan.targets) {
+    if (kill(t.pid, 0)) survived.push(t.pid);
+    else killed.push(t.pid);
+  }
+  // Keeper must be untouched.
+  void keeper;
+  return { plan, applied: true, killed, survived };
+}
+
+// --- default seams (macOS/Linux; ps/lsof/kill) ---
+
+const LSTART_RE = /^\s*(\d+)\s+([A-Z][a-z]{2} [A-Z][a-z]{2}\s+\d+ \d\d:\d\d:\d\d \d{4})\s+(.+)$/;
+
+export function parseObserverPsOutput(output: string): ObserverProcessEntry[] {
+  const entries: ObserverProcessEntry[] = [];
+  for (const line of output.split("\n")) {
+    const match = LSTART_RE.exec(line);
+    if (match === null) continue;
+    const [, pidStr, tokenStr, command] = match;
+    if (pidStr === undefined || tokenStr === undefined || command === undefined) continue;
+    const pid = Number(pidStr);
+    const startToken = tokenStr.trim();
+    const argv = command.split(/\s+/).filter((token) => token.length > 0);
+    // Real observer only: argv[0] is a node binary running a …/observerMain.js
+    // script. Shell wrappers (/bin/zsh -c '…observerMain…') are excluded because
+    // their argv[0] is a shell, so grep/ps tooling never matches itself.
+    const exe = argv[0] ?? "";
+    const isNode = exe === "node" || exe.endsWith("/node");
+    const runsObserver = argv.some((token) => token.endsWith("observerMain.js"));
+    if (!Number.isInteger(pid) || !isNode || !runsObserver) continue;
+    const socketPath = resolveObserverSocketForProcessArgs(argv);
+    entries.push(
+      socketPath === undefined ? { pid, argv, startToken } : { pid, argv, startToken, socketPath },
+    );
+  }
+  return entries;
+}
+
+function defaultListObserverProcesses(): ObserverProcessEntry[] {
+  const output = execFileSync("ps", ["-axww", "-o", "pid=,lstart=,command="], {
+    encoding: "utf8",
+    maxBuffer: 8 * 1024 * 1024,
+  });
+  return parseObserverPsOutput(output);
+}
+
+function defaultSocketHolders(socketPath: string): number[] {
+  try {
+    const out = execFileSync("lsof", ["-t", socketPath], { encoding: "utf8" });
+    return out
+      .split("\n")
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch {
+    return []; // lsof exits non-zero when nobody holds the socket
+  }
+}
+
+function defaultProcessStartToken(pid: number): string | undefined {
+  try {
+    const out = execFileSync("ps", ["-ww", "-p", String(pid), "-o", "lstart="], {
+      encoding: "utf8",
+    }).trim();
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultHealthPid(socketPath: string): Promise<number | undefined> {
+  try {
+    const client = createObserverClient({ socketPath, timeoutMs: 1000 });
+    const health = await client.health();
+    return typeof health.pid === "number" ? health.pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultSignal(pid: number, sig: NodeJS.Signals | 0): boolean {
+  try {
+    process.kill(pid, sig);
+    return true;
+  } catch (error) {
+    // ESRCH: gone. EPERM: exists but not ours — treat as present, never as reaped.
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/cli/test/unit/observer-reap.test.ts
+++ b/apps/cli/test/unit/observer-reap.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ObserverProcessEntry,
+  parseObserverPsOutput,
+  runObserverReap,
+  selectReapPlan,
+} from "../../src/observerReap.js";
+
+const SOCK = "/Users/u/.local/state/station/observer.sock";
+const OTHER = "/Users/u/.local/state/wosm/observer.sock";
+
+function proc(
+  pid: number,
+  socketPath: string | undefined,
+  token = `t${pid}`,
+): ObserverProcessEntry {
+  const argv = ["/bin/node", "/repo/apps/cli/dist/observerMain.js", "--state-dir", "/x"];
+  return socketPath === undefined
+    ? { pid, argv, startToken: token }
+    : { pid, argv, startToken: token, socketPath };
+}
+
+describe("parseObserverPsOutput", () => {
+  it("keeps real node observerMain.js processes and resolves their socket", () => {
+    const out = [
+      " 3740 Sat Jul  4 17:45:33 2026 /opt/node/bin/node /repo/apps/cli/dist/observerMain.js --socket /a/o.sock",
+      "19359 Sat Jul  4 17:47:24 2026 /bin/zsh -c grep observerMain.js in some command",
+      "  501 Fri Jan  2 09:00:00 2026 /usr/bin/ssh -N host",
+    ].join("\n");
+    const entries = parseObserverPsOutput(out);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.pid).toBe(3740);
+    expect(entries[0]?.startToken).toBe("Sat Jul  4 17:45:33 2026");
+    expect(entries[0]?.socketPath).toBe("/a/o.sock");
+  });
+
+  it("excludes a shell wrapper whose argv mentions observerMain.js (self-match guard)", () => {
+    const out =
+      "88888 Sat Jul  4 17:47:24 2026 /bin/zsh -c ps -axww | grep observerMain.js --state-dir /x";
+    expect(parseObserverPsOutput(out)).toEqual([]);
+  });
+});
+
+describe("selectReapPlan", () => {
+  it("targets same-socket duplicates and never the keeper or other sockets", () => {
+    const plan = selectReapPlan({
+      socketPath: SOCK,
+      processes: [proc(100, SOCK), proc(200, SOCK), proc(300, OTHER), proc(400, undefined)],
+      holders: [100],
+    });
+    expect(plan.keeper).toBe(100);
+    expect(plan.targets.map((t) => t.pid)).toEqual([200]);
+    expect(plan.duplicates).toBe(1);
+  });
+
+  it("refuses the whole reap when no live owner holds the socket", () => {
+    const plan = selectReapPlan({ socketPath: SOCK, processes: [proc(200, SOCK)], holders: [] });
+    expect(plan.keeper).toBeUndefined();
+    expect(plan.targets).toEqual([]);
+  });
+
+  it("disambiguates multiple holders via health pid and refuses the rest", () => {
+    const plan = selectReapPlan({
+      socketPath: SOCK,
+      processes: [proc(100, SOCK), proc(101, SOCK), proc(200, SOCK)],
+      holders: [100, 101],
+      healthPid: 101,
+    });
+    expect(plan.keeper).toBe(101);
+    expect(plan.refusals.map((r) => r.pid)).toContain(100);
+    expect(plan.targets.map((t) => t.pid)).toEqual([200]); // holders never targeted
+  });
+
+  it("refuses everything when >1 holder and health does not name one of them", () => {
+    const plan = selectReapPlan({
+      socketPath: SOCK,
+      processes: [proc(100, SOCK), proc(101, SOCK), proc(200, SOCK)],
+      holders: [100, 101],
+      healthPid: 999,
+    });
+    expect(plan.keeper).toBeUndefined();
+    expect(plan.targets).toEqual([]);
+    expect(plan.refusals.map((r) => r.pid).sort()).toEqual([100, 101]);
+  });
+
+  it("refuses a candidate with no start-time token instead of killing blind", () => {
+    const plan = selectReapPlan({
+      socketPath: SOCK,
+      processes: [proc(100, SOCK), { pid: 200, argv: [], startToken: "", socketPath: SOCK }],
+      holders: [100],
+    });
+    expect(plan.targets).toEqual([]);
+    expect(plan.refusals.map((r) => r.reason)).toContain("no start-time token to re-verify");
+  });
+});
+
+describe("runObserverReap", () => {
+  const noop = () => Promise.resolve();
+
+  it("dry-run lists without signaling", async () => {
+    const signals: unknown[] = [];
+    const out = await runObserverReap(
+      SOCK,
+      { force: false },
+      {
+        listObserverProcesses: () => [proc(100, SOCK), proc(200, SOCK)],
+        socketHolders: () => [100],
+        signal: (pid, sig) => {
+          signals.push([pid, sig]);
+          return true;
+        },
+        sleep: noop,
+      },
+    );
+    expect(out.applied).toBe(false);
+    expect(out.plan.targets.map((t) => t.pid)).toEqual([200]);
+    expect(signals).toEqual([]);
+  });
+
+  it("force terminates duplicates and never the keeper", async () => {
+    const dead = new Set<number>();
+    const sent: Array<[number, string | number]> = [];
+    const out = await runObserverReap(
+      SOCK,
+      { force: true, graceMs: 0 },
+      {
+        listObserverProcesses: () => [proc(100, SOCK), proc(200, SOCK), proc(300, SOCK)],
+        socketHolders: () => [100],
+        processStartToken: (pid) => `t${pid}`,
+        signal: (pid, sig) => {
+          sent.push([pid, sig]);
+          if (sig === "SIGTERM" || sig === "SIGKILL") dead.add(pid);
+          return !dead.has(pid); // signal 0 after death -> false
+        },
+        sleep: noop,
+      },
+    );
+    expect(out.applied).toBe(true);
+    expect(out.killed.sort()).toEqual([200, 300]);
+    expect(out.survived).toEqual([]);
+    expect(sent.some(([pid]) => pid === 100)).toBe(false); // keeper untouched
+    expect(
+      sent
+        .filter(([, sig]) => sig === "SIGTERM")
+        .map(([pid]) => pid)
+        .sort(),
+    ).toEqual([200, 300]);
+  });
+
+  it("does not signal a PID whose start token changed (PID reuse)", async () => {
+    const sent: Array<[number, string | number]> = [];
+    const out = await runObserverReap(
+      SOCK,
+      { force: true, graceMs: 0 },
+      {
+        listObserverProcesses: () => [proc(100, SOCK), proc(200, SOCK, "old-token")],
+        socketHolders: () => [100],
+        processStartToken: (pid) => (pid === 200 ? "REUSED-different" : `t${pid}`),
+        signal: (pid, sig) => {
+          sent.push([pid, sig]);
+          return true;
+        },
+        sleep: noop,
+      },
+    );
+    expect(sent.some(([pid, sig]) => pid === 200 && sig === "SIGTERM")).toBe(false);
+    expect(out.applied).toBe(true);
+  });
+
+  it("aborts when the socket owner changes mid-reap", async () => {
+    let calls = 0;
+    const out = await runObserverReap(
+      SOCK,
+      { force: true, graceMs: 0 },
+      {
+        listObserverProcesses: () => [proc(100, SOCK), proc(200, SOCK)],
+        // First read (selection) = [100]; a later read shows a takeover to [999].
+        socketHolders: () => (calls++ === 0 ? [100] : [999]),
+        processStartToken: (pid) => `t${pid}`,
+        signal: () => true,
+        sleep: noop,
+      },
+    );
+    expect(out.aborted).toBe("owner-changed");
+  });
+});

--- a/apps/observer/src/sqlite.ts
+++ b/apps/observer/src/sqlite.ts
@@ -44,6 +44,12 @@ export function openObserverSqlite(options: OpenObserverSqliteOptions = {}): Obs
   const path = options.path ?? ":memory:";
   const clock = options.clock ?? systemClock;
   const database = new DatabaseSync(path);
+  // WAL + synchronous=NORMAL keeps an unclean exit (SIGKILL of a wedged observer)
+  // from corrupting the DB or losing committed rows; :memory: ignores WAL.
+  if (path !== ":memory:") {
+    database.exec("PRAGMA journal_mode = WAL");
+  }
+  database.exec("PRAGMA synchronous = NORMAL");
   let open = true;
   let lastError: SafeError | undefined;
   let appliedMigrations: AppliedObserverSqliteMigration[] = [];

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./hooks/index.js";
 export * from "./loadConfig.js";
 export * from "./observerPaths.js";
+export * from "./observerProcessArgs.js";
 export * from "./projects/index.js";
 export * from "./schema.js";
 export * from "./tui/index.js";

--- a/packages/config/src/observerProcessArgs.ts
+++ b/packages/config/src/observerProcessArgs.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parse as parseToml } from "smol-toml";
+import { z } from "zod";
+import { resolvePath } from "./observerPaths.js";
+
+export type ObserverProcessArgs = {
+  configPath?: string;
+  socketPath?: string;
+  stateDir?: string;
+};
+
+/** Mirrors runObserverMain's parseArgs so a candidate's socket resolves identically. */
+export function parseObserverProcessArgs(argv: readonly string[]): ObserverProcessArgs {
+  const result: ObserverProcessArgs = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = argv[index + 1];
+    if (value === undefined) continue;
+    if (arg === "--config") {
+      result.configPath = value;
+      index += 1;
+    } else if (arg === "--socket") {
+      result.socketPath = value;
+      index += 1;
+    } else if (arg === "--state-dir") {
+      result.stateDir = value;
+      index += 1;
+    }
+  }
+  return result;
+}
+
+const ObserverTomlSectionSchema = z
+  .object({ state_dir: z.string().optional(), socket_path: z.string().optional() })
+  .passthrough();
+
+export type ResolveObserverSocketDeps = {
+  homeDir?: string;
+  xdgRuntimeDir?: string | undefined;
+  readFile?: (path: string) => string;
+};
+
+/**
+ * The socket path a process WOULD bind, derived from its argv the same way
+ * runObserverMain does (`--socket` > config `socket_path` > XDG > stateDir/run).
+ * Returns undefined when it cannot be determined — the reaper must never target
+ * a process whose socket it cannot positively resolve (fail closed).
+ */
+export function resolveObserverSocketForProcessArgs(
+  argv: readonly string[],
+  deps: ResolveObserverSocketDeps = {},
+): string | undefined {
+  const home = deps.homeDir ?? homedir();
+  const args = parseObserverProcessArgs(argv);
+
+  let section: { stateDir?: string; socketPath?: string } = {};
+  // Only read the config when no explicit --socket already pins the path.
+  if (args.socketPath === undefined && args.configPath !== undefined) {
+    const read = readObserverTomlSection(args.configPath, deps.readFile);
+    if (read === undefined) return undefined;
+    section = read;
+  }
+
+  if (args.socketPath !== undefined) return resolvePath(args.socketPath, home);
+  if (section.socketPath !== undefined) return resolvePath(section.socketPath, home);
+
+  const xdg = deps.xdgRuntimeDir ?? process.env.XDG_RUNTIME_DIR;
+  if (xdg !== undefined && xdg.length > 0) return join(xdg, "station", "observer.sock");
+
+  const stateDir = resolvePath(args.stateDir ?? section.stateDir ?? "~/.local/state/station", home);
+  return join(stateDir, "run", "observer.sock");
+}
+
+function readObserverTomlSection(
+  configPath: string,
+  readFile?: (path: string) => string,
+): { stateDir?: string; socketPath?: string } | undefined {
+  let text: string;
+  try {
+    text = (readFile ?? ((path) => readFileSync(path, "utf8")))(configPath);
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseToml(text);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null || !("observer" in parsed)) {
+    return {};
+  }
+  const result = ObserverTomlSectionSchema.safeParse((parsed as Record<string, unknown>).observer);
+  if (!result.success) return {};
+  const section: { stateDir?: string; socketPath?: string } = {};
+  if (result.data.state_dir !== undefined) section.stateDir = result.data.state_dir;
+  if (result.data.socket_path !== undefined) section.socketPath = result.data.socket_path;
+  return section;
+}

--- a/packages/config/test/unit/observer-process-args.test.ts
+++ b/packages/config/test/unit/observer-process-args.test.ts
@@ -6,7 +6,9 @@ import {
 
 const HOME = "/home/u";
 
-function resolve(argv: string[], files: Record<string, string> = {}, xdg?: string) {
+function resolve(argv: string[], files: Record<string, string> = {}, xdg = "") {
+  // Pin XDG explicitly so a real XDG_RUNTIME_DIR in CI cannot leak into the
+  // non-XDG cases (empty string = no XDG override).
   return resolveObserverSocketForProcessArgs(argv, {
     homeDir: HOME,
     xdgRuntimeDir: xdg,

--- a/packages/config/test/unit/observer-process-args.test.ts
+++ b/packages/config/test/unit/observer-process-args.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseObserverProcessArgs,
+  resolveObserverSocketForProcessArgs,
+} from "../../src/observerProcessArgs.js";
+
+const HOME = "/home/u";
+
+function resolve(argv: string[], files: Record<string, string> = {}, xdg?: string) {
+  return resolveObserverSocketForProcessArgs(argv, {
+    homeDir: HOME,
+    xdgRuntimeDir: xdg,
+    readFile: (path) => {
+      const text = files[path];
+      if (text === undefined) throw new Error(`ENOENT ${path}`);
+      return text;
+    },
+  });
+}
+
+describe("parseObserverProcessArgs", () => {
+  it("extracts --config, --socket, --state-dir and ignores unrelated flags", () => {
+    expect(
+      parseObserverProcessArgs(["--config", "/c.toml", "--x", "y", "--state-dir", "/s"]),
+    ).toEqual({ configPath: "/c.toml", stateDir: "/s" });
+  });
+
+  it("ignores a trailing flag with no value", () => {
+    expect(parseObserverProcessArgs(["--socket"])).toEqual({});
+  });
+});
+
+describe("resolveObserverSocketForProcessArgs", () => {
+  it("prefers an explicit --socket over everything (no config read)", () => {
+    expect(resolve(["--socket", "/run/x.sock", "--config", "/missing.toml"])).toBe("/run/x.sock");
+  });
+
+  it("uses config [observer].socket_path when no --socket", () => {
+    expect(
+      resolve(["--config", "/c.toml"], { "/c.toml": '[observer]\nsocket_path = "/v/o.sock"\n' }),
+    ).toBe("/v/o.sock");
+  });
+
+  it("falls back to <state_dir>/run/observer.sock from config when no socket_path and no XDG", () => {
+    expect(
+      resolve(["--config", "/c.toml"], { "/c.toml": '[observer]\nstate_dir = "/data/st"\n' }),
+    ).toBe("/data/st/run/observer.sock");
+  });
+
+  it("lets --state-dir override the config state_dir", () => {
+    expect(
+      resolve(["--config", "/c.toml", "--state-dir", "/override"], {
+        "/c.toml": '[observer]\nstate_dir = "/data/st"\n',
+      }),
+    ).toBe("/override/run/observer.sock");
+  });
+
+  it("uses XDG runtime dir when set and no socket override", () => {
+    expect(resolve(["--state-dir", "/data/st"], {}, "/xdg")).toBe("/xdg/station/observer.sock");
+  });
+
+  it("expands ~ against the injected home dir", () => {
+    expect(
+      resolve(["--config", "/c.toml"], { "/c.toml": '[observer]\nstate_dir = "~/.state"\n' }),
+    ).toBe(`${HOME}/.state/run/observer.sock`);
+  });
+
+  it("defaults to ~/.local/state/station/run when no config, socket, or state dir", () => {
+    expect(resolve([])).toBe(`${HOME}/.local/state/station/run/observer.sock`);
+  });
+
+  it("fail-closes to undefined when the config file cannot be read", () => {
+    expect(resolve(["--config", "/gone.toml"])).toBeUndefined();
+  });
+
+  it("treats a config with no [observer] section as defaults, not a failure", () => {
+    expect(resolve(["--config", "/c.toml"], { "/c.toml": "schema_version = 1\n" })).toBe(
+      `${HOME}/.local/state/station/run/observer.sock`,
+    );
+  });
+
+  it("fail-closes on unparseable TOML rather than guessing", () => {
+    expect(resolve(["--config", "/c.toml"], { "/c.toml": "this is = = not toml" })).toBeUndefined();
+  });
+});

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -61,6 +61,10 @@ const setTimeoutAllowlist = new Map([
     "packages/station-host/src/client.ts",
     "Station host requests use per-request socket timeouts at the host protocol boundary, outside shared observer runtime helpers.",
   ],
+  [
+    "apps/cli/src/observerReap.ts",
+    "SIGTERM-to-SIGKILL grace delay for reaping duplicate observer processes is OS signal timing, not observer command timeout or retry plumbing.",
+  ],
 ]);
 
 const setIntervalAllowlist = new Map([


### PR DESCRIPTION
Phase 1 of the observer-singleton work — the safe, reversible foundation: make an unclean observer exit corruption-safe, and give operators a guarded command to clear duplicate observers. No change to spawn/takeover behavior yet (that's the later phases).

## Why

STATION accumulates zombie observers: on my machine, 30 processes shared one socket (`~/.local/state/station`), 29 of them displaced and idle-but-alive. A spike (isolated `/private/tmp` observer, never touching the live one) confirmed the mechanism this phase relies on:

- `observer.stop` exits a real observer process in **~194ms**; SIGTERM in ~257ms; SIGKILL in 42ms.
- `lsof -t <socket>` returns the single bound owner; `ps -o lstart` gives a start-time token (1s resolution).
- **`journal_mode` was `delete`** — the db read `ok` after SIGKILL only because it was idle, so a kill was *not* inherently corruption-safe. This PR fixes that prerequisite first.

## Changes

- **`apps/observer/src/sqlite.ts`** — open with `PRAGMA journal_mode=WAL` + `synchronous=NORMAL` so a SIGKILL of a wedged observer cannot corrupt the db or lose committed rows (`:memory:` keeps its default).
- **`@station/config` — `resolveObserverSocketForProcessArgs(argv)`** — resolves the socket a process *would* bind from its `--config`/`--socket`/`--state-dir`, mirroring `runObserverMain` precedence. Fail-closed (returns `undefined`) so the reaper never targets a process whose socket it can't positively resolve.
- **`stn observer reap`** (`apps/cli/src/observerReap.ts`) — dry-run/list by default, `--force` to signal:
  - Candidacy keyed on each process's **resolved socket**, not `--state-dir` (they diverge under XDG / explicit `socket_path` / `/run` default).
  - Keeper = the `lsof -t <socket>` holder; `health()` disambiguates the >1-holder case. **Any bound holder not provably a non-owner is refused, even under `--force`.**
  - Before every signal: re-read the owner (**abort on change**) and re-verify full argv + OS start-time token (**PID-reuse guard**). `SIGTERM → grace → SIGKILL → confirm`.
  - Shell/`grep` wrappers whose argv merely mentions `observerMain.js` are excluded (they matched naive `ps | grep` during the manual reap — a real hazard this encodes).

## Tests

- `packages/config` unit (12): argv→socket precedence, `~` expansion, XDG, fail-close on unreadable/unparseable config.
- `apps/cli` unit (11): `parseObserverPsOutput` (real vs shell-wrapper exclusion), `selectReapPlan` (keeper never targeted, other sockets excluded, >1-holder refusal, no-owner refusal, missing-token refusal), executor (dry-run no-op, force kills duplicates only, PID-reuse skip, owner-change abort). Pure logic over injected `ps`/`lsof`/`kill` seams.
- Lanes: build 22/22, typecheck 42/42, lint clean; vitest integration 302 pass; diagnostics 34 pass; station bun lane 933 pass. Unit lane has one **pre-existing, environment-dependent** failure (`claude` provider `doctorChecks` reads the real `~/.claude/settings.json`) — confirmed identical on clean `main` with this branch stashed; passes in CI's clean env.
- Manual: `stn observer reap` dry-run against the live socket correctly resolves it, identifies keeper `15703` via `lsof`, reports 0 duplicates. The `--force` kill path was validated by clearing the 29 real zombies (all exited on SIGTERM, keeper untouched, other projects' observers unaffected).

## Deliberately not here

The real-observer-spawn integration test is deferred (spawning competing observers against one socket is inherently racy → CI-flaky); the kill path is covered by the executor unit tests over seams plus the manual 29-process validation. Next phases: backstop-watcher fix (2), core step-down negotiation (3), version/spool hardening (4).