### PR TITLE
fix(observer): seed the socket-ownership watcher so displaced observers exit

### DIFF
--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -22,7 +22,11 @@ import { emptyConfig } from "./emptyConfig.js";
 import { createObserverEventBus } from "./eventBus.js";
 import { createObserverLogger } from "./logging.js";
 import { type ObserverServer, startObserverServer } from "./server.js";
-import { type SocketOwnershipWatch, watchSocketOwnership } from "./socketOwnership.js";
+import {
+  readSocketIdentity,
+  type SocketOwnershipWatch,
+  watchSocketOwnership,
+} from "./socketOwnership.js";
 
 export type ObserverProviderRegistryFactoryOptions = {
   configPath?: string | undefined;
@@ -154,7 +158,14 @@ export async function runObserverMain(
   });
 
   try {
-    server = await startObserverServer({ socketPath, api, clock: systemClock });
+    // Bind only; the startup reconcile runs below, after the ownership watch is
+    // armed, so a takeover during that ~1s scan is detected rather than missed.
+    server = await startObserverServer({
+      socketPath,
+      api,
+      clock: systemClock,
+      drainOnStart: false,
+    });
   } catch (error) {
     await logger.error("Observer server could not start; shutting down runtime services.", {
       socketPath,
@@ -168,8 +179,12 @@ export async function runObserverMain(
     setTimeout(() => process.exit(1), 2000).unref();
     return 1;
   }
+  // Seed the watcher with the just-bound socket identity so it never adopts a
+  // rival's socket as its baseline (the failure that let displaced observers linger).
+  const boundIdentity = await readSocketIdentity(socketPath);
   ownership = watchSocketOwnership({
     socketPath,
+    ...(boundIdentity === undefined ? {} : { expectedIdentity: boundIdentity }),
     onLost: () => {
       void logger.warn("Observer socket was taken over by another process; shutting down.", {
         socketPath,
@@ -177,7 +192,7 @@ export async function runObserverMain(
       });
       // A displaced observer must not linger: its loops would keep draining
       // spool events and firing hooks for a state dir it no longer serves.
-      setTimeout(() => process.exit(0), 5000).unref();
+      setTimeout(() => process.exit(0), 2000).unref();
       void api.stop();
     },
   });
@@ -186,6 +201,9 @@ export async function runObserverMain(
   };
   process.once("SIGINT", stopFromSignal);
   process.once("SIGTERM", stopFromSignal);
+
+  // Startup reconcile now that the ownership watch is live.
+  await api.reconcile("observer.startup");
 
   await stopped;
   sqlite.close();

--- a/apps/observer/src/runtime/socketOwnership.ts
+++ b/apps/observer/src/runtime/socketOwnership.ts
@@ -7,6 +7,13 @@ export type SocketOwnershipWatch = {
 export type WatchSocketOwnershipOptions = {
   socketPath: string;
   intervalMs?: number;
+  /**
+   * The identity of the socket this process just bound. Seeding it means the
+   * watcher knows what it owns from the first tick, so a takeover that happened
+   * before the watch was armed is detected instead of being adopted as the
+   * baseline. Omit to baseline from the first probe (legacy behavior).
+   */
+  expectedIdentity?: SocketIdentity;
   onLost(): void;
 };
 
@@ -16,11 +23,21 @@ export type WatchSocketOwnershipOptions = {
 // Inode number alone is ambiguous: a recreated path can reuse the just-freed
 // inode (ext4 does this routinely), so identity pairs it with the birth time.
 // Filesystems without btime report 0n for both files, degrading to inode-only.
-type SocketIdentity = { ino: bigint; birthtimeNs: bigint };
+export type SocketIdentity = { ino: bigint; birthtimeNs: bigint };
+
+/** Reads the current identity of a bound socket, for seeding the watcher. */
+export async function readSocketIdentity(socketPath: string): Promise<SocketIdentity | undefined> {
+  try {
+    const stats = await lstat(socketPath, { bigint: true });
+    return { ino: stats.ino, birthtimeNs: stats.birthtimeNs };
+  } catch {
+    return undefined;
+  }
+}
 
 export function watchSocketOwnership(options: WatchSocketOwnershipOptions): SocketOwnershipWatch {
   const intervalMs = options.intervalMs ?? 5000;
-  let owned: SocketIdentity | undefined;
+  let owned: SocketIdentity | undefined = options.expectedIdentity;
   let fired = false;
 
   const lose = () => {

--- a/apps/observer/test/unit/socketOwnership.test.ts
+++ b/apps/observer/test/unit/socketOwnership.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { watchSocketOwnership } from "../../src/runtime/socketOwnership.js";
+import { readSocketIdentity, watchSocketOwnership } from "../../src/runtime/socketOwnership.js";
 
 describe("watchSocketOwnership", () => {
   let dir: string;
@@ -60,6 +60,51 @@ describe("watchSocketOwnership", () => {
 
     await unlink(socketPath);
     await waitFor(() => lost);
+    watch.stop();
+  });
+
+  it("seeded with its own identity does not fire on its own socket", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-ownership-"));
+    const socketPath = join(dir, "observer.sock");
+    await writeFile(socketPath, "");
+    const identity = await readSocketIdentity(socketPath);
+    expect(identity).toBeDefined();
+
+    let lost = false;
+    const watch = watchSocketOwnership({
+      socketPath,
+      intervalMs: 20,
+      ...(identity === undefined ? {} : { expectedIdentity: identity }),
+      onLost: () => {
+        lost = true;
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(lost).toBe(false);
+    watch.stop();
+  });
+
+  it("seeded watcher detects a takeover that happened before it was armed", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-ownership-"));
+    const socketPath = join(dir, "observer.sock");
+    await writeFile(socketPath, "");
+    const identity = await readSocketIdentity(socketPath);
+    if (identity === undefined) throw new Error("expected a socket identity");
+    // The live socket already differs from what this process thinks it bound (a
+    // rival rebound it before the watch was armed). Deterministic — no reliance
+    // on filesystem inode reuse.
+    const staleSeed = { ino: identity.ino + 1n, birthtimeNs: identity.birthtimeNs };
+
+    let lost = false;
+    const watch = watchSocketOwnership({
+      socketPath,
+      intervalMs: 20,
+      expectedIdentity: staleSeed,
+      onLost: () => {
+        lost = true;
+      },
+    });
+    await waitFor(() => lost); // fires on the first probe
     watch.stop();
   });
 


### PR DESCRIPTION
Phase 2 of the observer-singleton work. Fixes the actual root cause of the zombie accumulation: displaced observers that never learned they lost the socket.

## The bug

`watchSocketOwnership` baselined ownership from its **own first probe** (`owned = current` on tick one). Combined with the boot order — the watcher was armed only *after* the ~1s `observer.startup` reconcile — a takeover that landed during that window was adopted as the baseline and never detected. That's why 29 displaced observers sat at 0% CPU forever instead of exiting.

## The fix

- **Seed the watcher** with `expectedIdentity` — the inode+birthtime the process just bound (new `readSocketIdentity` helper). It compares against that from the first tick, so a takeover-before-arm fires `onLost` immediately instead of being baselined away.
- **Reorder boot**: bind with `drainOnStart:false`, arm the seeded watcher, *then* run `observer.startup` reconcile — the takeover window is now watched.
- **Prompt exit**: `onLost` routes through the shared stop path with a 2s backstop (was a 5s delay), consistent with the normal-stop timer. (Phase 3 moves that backstop into `stopObserver` itself so a wedged drain can't hang the exit.)

## Tests

`apps/observer/test/unit/socketOwnership.test.ts`:
- seeded watcher does **not** fire on its own socket (steady state);
- seeded watcher **fires on the first probe** when the live socket already differs from the seed (takeover-before-arm) — deterministic, no reliance on filesystem inode reuse;
- existing inode-change / disappearance / post-stop cases unchanged.

Lanes: build 22/22, typecheck 42/42, lint clean; integration 302 pass (observer boot reorder verified), diagnostics 34, station bun 933. Unit lane has the one **pre-existing** environment-dependent `claude` `doctorChecks` failure (reads the real `~/.claude/settings.json`) — passes in CI's clean env.

## Scope

No spawn/eviction change here (that's Phase 3 — explicit step-down). This phase only makes the passive backstop actually work, so future displacements self-heal even before the step-down lands.