### PR TITLE
fix(observer): force-exit backstop so a wedged drain cannot hang shutdown

### DIFF
--- a/apps/observer/src/runtime/gracefulExit.ts
+++ b/apps/observer/src/runtime/gracefulExit.ts
@@ -1,0 +1,28 @@
+export type ForcedExitTimer = { unref(): void };
+
+export type ForcedExitDeps = {
+  exit: (code: number) => void;
+  setTimer: (fn: () => void, ms: number) => ForcedExitTimer;
+  clearTimer: (timer: ForcedExitTimer) => void;
+};
+
+/**
+ * Runs a shutdown sequence but guarantees the process still exits if a step
+ * hangs. A command handler that ignores its abort would otherwise leave
+ * `commandQueue.shutdown()` (and therefore the whole stop) pending forever,
+ * keeping a stopping observer alive. The backstop is armed BEFORE the first
+ * step and cleared only if the drain completes.
+ */
+export async function runShutdownWithBackstop(
+  drain: () => Promise<void>,
+  budgetMs: number,
+  deps: ForcedExitDeps,
+): Promise<void> {
+  const timer = deps.setTimer(() => deps.exit(0), budgetMs);
+  timer.unref();
+  try {
+    await drain();
+  } finally {
+    deps.clearTimer(timer);
+  }
+}

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -20,6 +20,7 @@ import { openObserverSqlite } from "../sqlite.js";
 import { createObserverApi } from "./api.js";
 import { emptyConfig } from "./emptyConfig.js";
 import { createObserverEventBus } from "./eventBus.js";
+import { runShutdownWithBackstop } from "./gracefulExit.js";
 import { createObserverLogger } from "./logging.js";
 import { type ObserverServer, startObserverServer } from "./server.js";
 import {
@@ -27,6 +28,10 @@ import {
   type SocketOwnershipWatch,
   watchSocketOwnership,
 } from "./socketOwnership.js";
+
+// Ceiling on a graceful stop; a wedged drain (a handler ignoring its abort)
+// force-exits at this point instead of keeping the observer alive forever.
+const STOP_BACKSTOP_MS = 5000;
 
 export type ObserverProviderRegistryFactoryOptions = {
   configPath?: string | undefined;
@@ -125,13 +130,21 @@ export async function runObserverMain(
   });
   let stopping: Promise<void> | undefined;
   const stopObserver = async () => {
-    stopping ??= (async () => {
-      ownership?.stop();
-      await commandQueue.shutdown();
-      await eventHooks?.shutdown();
-      await server?.close();
-      stopResolve();
-    })();
+    stopping ??= runShutdownWithBackstop(
+      async () => {
+        ownership?.stop();
+        await commandQueue.shutdown();
+        await eventHooks?.shutdown();
+        await server?.close();
+        stopResolve();
+      },
+      STOP_BACKSTOP_MS,
+      {
+        exit: (code) => process.exit(code),
+        setTimer: (fn, ms) => setTimeout(fn, ms),
+        clearTimer: (timer) => clearTimeout(timer as NodeJS.Timeout),
+      },
+    );
     await stopping;
   };
   const api = createObserverApi({
@@ -192,7 +205,7 @@ export async function runObserverMain(
       });
       // A displaced observer must not linger: its loops would keep draining
       // spool events and firing hooks for a state dir it no longer serves.
-      setTimeout(() => process.exit(0), 2000).unref();
+      // stopObserver's backstop guarantees the exit even if the drain hangs.
       void api.stop();
     },
   });

--- a/apps/observer/test/unit/gracefulExit.test.ts
+++ b/apps/observer/test/unit/gracefulExit.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type ForcedExitDeps, runShutdownWithBackstop } from "../../src/runtime/gracefulExit.js";
+
+function deps(exit: (code: number) => void): ForcedExitDeps {
+  return {
+    exit,
+    setTimer: (fn, ms) => setTimeout(fn, ms),
+    clearTimer: (timer) => clearTimeout(timer as NodeJS.Timeout),
+  };
+}
+
+describe("runShutdownWithBackstop", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("force-exits when a shutdown step hangs past the budget", async () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    // Never-resolving drain simulates a command handler that ignores its abort.
+    void runShutdownWithBackstop(() => new Promise<void>(() => undefined), 5000, deps(exit));
+    expect(exit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("does not force-exit when the drain completes in time", async () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    await runShutdownWithBackstop(() => Promise.resolve(), 5000, deps(exit));
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("clears the backstop even if the drain rejects", async () => {
+    vi.useFakeTimers();
+    const exit = vi.fn();
+    await expect(
+      runShutdownWithBackstop(() => Promise.reject(new Error("drain failed")), 5000, deps(exit)),
+    ).rejects.toThrow("drain failed");
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(exit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Phase 3, step 1 of the observer-singleton work.** Phase 3 (explicit step-down negotiation) is large and high-risk, so I'm landing it as small, independently-green sub-PRs. This is the foundational one: make self-stop terminal.

## The problem

`stopObserver` awaited `commandQueue.shutdown() → eventHooks.shutdown() → server.close()` with no ceiling, and the process exit was gated on `await stopped`. A command handler that ignores its abort leaves the drain — and therefore the whole stop — pending forever, so **`observer.stop` and SIGTERM both hang; only SIGKILL is terminal** (confirmed in the spike: normal `observer.stop` exits ~194ms, but a wedged drain never does). That directly blocks the later eviction step, which trusts `observer.stop` to actually kill the incumbent.

## The fix

- New `runShutdownWithBackstop(drain, budgetMs, {exit, setTimer, clearTimer})` — arms a force-exit timer **before** the first shutdown step and clears it only if the drain completes. `stopObserver` runs through it with a 5s ceiling, so self-stop exits even under a wedged handler.
- `onLost` (Phase 2's displacement path) drops its own now-redundant force-exit timer; the shared backstop covers displacement too.

Injected `exit`/`setTimer`/`clearTimer` keep the helper unit-testable (and keep the raw `setTimeout` at the allowlisted `main.ts` call site, not in the new module).

## Tests

`apps/observer/test/unit/gracefulExit.test.ts`: backstop **fires** on a never-resolving drain (fake timers, advance to budget → `exit(0)`); stays **clear** on a completing drain and on a rejecting drain.

Lanes: build 22/22, typecheck 42/42, lint clean; integration 302 (real observer spawn+stop exercises the normal path), diagnostics 34, bun 933. Unit lane's one failure is the **pre-existing** env-dependent `claude doctorChecks` test (reads real `~/.claude/settings.json`); passes in CI's clean env.

## Next in Phase 3

3b never-unlink-a-live-socket (transport bind-first + reprobe), 3c pidfile, 3d the explicit step-down negotiation + claim lock + version-gated evict + kill ladder (the big concurrency piece — depends on this backstop being in place), 3e unify hook auto-start onto the lock.