### PR TITLE
fix(protocol): claim the observer socket by binding, never by pre-unlinking

### DIFF
--- a/packages/protocol/src/transport.ts
+++ b/packages/protocol/src/transport.ts
@@ -65,7 +65,6 @@ export async function listenUnixSocket(
   options: ListenUnixSocketOptions,
 ): Promise<UnixSocketServer> {
   await ensureSocketDirectory(options.socketPath);
-  await removeStaleSocket(options.socketPath);
 
   const sockets = new Set<Socket>();
 
@@ -78,19 +77,7 @@ export async function listenUnixSocket(
     void options.onConnection(connection);
   });
 
-  await new Promise<void>((resolve, reject) => {
-    const onError = (error: Error) => {
-      server.off("listening", onListening);
-      reject(error);
-    };
-    const onListening = () => {
-      server.off("error", onError);
-      resolve();
-    };
-    server.once("error", onError);
-    server.once("listening", onListening);
-    server.listen(options.socketPath);
-  });
+  await bindWithStaleReclaim(server, options.socketPath);
 
   try {
     await chmod(options.socketPath, 0o600);
@@ -102,6 +89,42 @@ export async function listenUnixSocket(
     socketPath: options.socketPath,
     close: () => closeServer(server, options.socketPath, sockets),
   };
+}
+
+// Claims the socket path by binding, never by pre-emptively unlinking. A stale
+// file is removed only after a bind fails AND a reconnect confirms nobody is
+// listening — so a socket that another observer is actively serving is never
+// unlinked out from under it (the check-then-unlink race this replaces).
+async function bindWithStaleReclaim(server: Server, socketPath: string): Promise<void> {
+  try {
+    await listenOnce(server, socketPath);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EADDRINUSE") {
+      throw error;
+    }
+    if (!(await isSocketStale(socketPath))) {
+      throw error; // a live server owns it — we lost the race
+    }
+    await unlink(socketPath);
+    await listenOnce(server, socketPath); // retry once; a fresh EADDRINUSE now surfaces
+  }
+}
+
+function listenOnce(server: Server, socketPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(socketPath);
+  });
 }
 
 export function connectUnixSocket(

--- a/packages/protocol/test/unit/transport.test.ts
+++ b/packages/protocol/test/unit/transport.test.ts
@@ -55,6 +55,31 @@ describe("Unix socket NDJSON transport", () => {
     await server.close();
   });
 
+  it("reclaims a stale socket file on its own during listen", async () => {
+    const { socketPath } = await createTempSocketPath();
+    await mkdir(dirname(socketPath), { recursive: true, mode: 0o700 });
+    await createStaleSocketFile(socketPath);
+    await expect(isSocketStale(socketPath)).resolves.toBe(true);
+
+    // No prior removeStaleSocket: listen must reclaim the dead socket itself.
+    const server = await listenUnixSocket({ socketPath, onConnection: () => undefined });
+    await expect(isSocketStale(socketPath)).resolves.toBe(false);
+    await server.close();
+  });
+
+  it("refuses to bind (and never unlinks) while another server is live on the path", async () => {
+    const { socketPath } = await createTempSocketPath();
+    const live = await listenUnixSocket({ socketPath, onConnection: () => undefined });
+
+    await expect(
+      listenUnixSocket({ socketPath, onConnection: () => undefined }),
+    ).rejects.toMatchObject({ code: "EADDRINUSE" });
+    // The live server is untouched and still accepting.
+    await expect(isSocketStale(socketPath)).resolves.toBe(false);
+
+    await live.close();
+  });
+
   it("relays frames both ways over an in-memory connection pair", async () => {
     const { client, server } = inMemoryNdjsonConnectionPair();
     const serverIterator = server.messages()[Symbol.asyncIterator]();


### PR DESCRIPTION
**Phase 3, step 2** of the observer-singleton work.

## The race

`listenUnixSocket` called `removeStaleSocket()` before binding — a **check-then-unlink** that isn't atomic. `removeStaleSocket` probes `isSocketStale` (a connect) and then `unlink`s; a socket that another observer binds in the window between the probe and the unlink gets unlinked out from under the live server. That's a way two observers end up fighting over one path.

## The fix

`bindWithStaleReclaim` claims the path by **binding**, never by pre-emptively unlinking:
1. `listen` directly.
2. Only on `EADDRINUSE`, reprobe with `isSocketStale`.
3. If a server is live → surface `EADDRINUSE` (we lost the race; never unlink it).
4. If nobody's listening → unlink the dead file and retry `listen` once.

Equivalent to the old behavior for the non-concurrent cases (fresh bind, stale-file reclaim, live refusal) but race-safe: a live socket is never removed.

## Tests

`packages/protocol/test/unit/transport.test.ts`:
- `listen` reclaims a stale socket on its own (no prior `removeStaleSocket`);
- `listen` refuses with `EADDRINUSE` and leaves a live server untouched and still accepting.

Lanes: build 22/22, typecheck 42/42, lint clean; integration 302 (protocol client/server + event subscription spawn real sockets), diagnostics 34, bun 933. Unit lane's one failure is the **pre-existing** env-dependent `claude doctorChecks` test.

## Next

3c pidfile (write+fsync before health, remove on stop), then 3d the explicit step-down negotiation + claim lock + version-gated evict + kill ladder — which builds on this race-safe bind plus the 3a force-exit backstop.