### PR TITLE
feat(dashboard-core): arrow-navigate the project-settings agent picker and new-session review

### DIFF
--- a/packages/dashboard-core/src/components/NewSessionBottomSheet/layout.ts
+++ b/packages/dashboard-core/src/components/NewSessionBottomSheet/layout.ts
@@ -30,5 +30,6 @@ export function newSessionContentRowCount(state: NewSessionFlowState, optionCoun
   if (state.mode === "editName") {
     return 6;
   }
-  return 7;
+  // review: leading blank + Project/Name/Agent + blank + Create row + footer.
+  return 8;
 }

--- a/packages/dashboard-core/src/flows/newSession.ts
+++ b/packages/dashboard-core/src/flows/newSession.ts
@@ -333,10 +333,7 @@ function commitEditedName(state: NewSessionEditNameState): NewSessionReviewState
     return toReviewState(state);
   }
   return {
-    ...resetWizardStep(baseState(state), "review"),
-    reviewFocus: "create",
-    selectedProjectId: state.selectedProjectId,
-    selectedHarness: state.selectedHarness,
+    ...toReviewState(state),
     branch,
     nameSource: "custom",
   };
@@ -367,13 +364,11 @@ function applyChosenProject(
     return state;
   }
   return {
-    ...resetWizardStep(baseState(state), "review"),
-    reviewFocus: "create",
+    ...toReviewState(state),
     selectedProjectId: project.id,
     selectedHarness: harness.id,
     branch:
       state.nameSource === "generated" ? generatedSessionBranch(project.id, token) : state.branch,
-    nameSource: state.nameSource,
   };
 }
 
@@ -399,12 +394,8 @@ export function chooseNewSessionAgentById(
     return state;
   }
   return {
-    ...resetWizardStep(baseState(state), "review"),
-    reviewFocus: "create",
-    selectedProjectId: state.selectedProjectId,
+    ...toReviewState(state),
     selectedHarness: option.id,
-    branch: state.branch,
-    nameSource: state.nameSource,
   };
 }
 
@@ -416,6 +407,7 @@ function cancelNewSessionStep(state: NewSessionFlowState): NewSessionReviewState
   return toReviewState(previous);
 }
 
+// Every return-to-review path funnels here so the focus-reset policy has one owner.
 function toReviewState(state: NewSessionBaseState): NewSessionReviewState {
   return {
     ...resetWizardStep(baseState(state), "review"),

--- a/packages/dashboard-core/src/flows/newSession.ts
+++ b/packages/dashboard-core/src/flows/newSession.ts
@@ -27,8 +27,23 @@ type NewSessionBaseState = StepWizardState<NewSessionStep> & {
   nameSource: NewSessionNameSource;
 };
 
+/** The review menu's focus ring — which field ↵ acts on. */
+export type NewSessionReviewFocus = "name" | "project" | "agent" | "create";
+
+// Traversal order matches the review's top-to-bottom render (Project, Name,
+// Agent, then the Create action).
+const REVIEW_FIELDS: readonly NewSessionReviewFocus[] = ["project", "name", "agent", "create"];
+
+function cycleReviewFocus(current: NewSessionReviewFocus, dir: -1 | 1): NewSessionReviewFocus {
+  const index = REVIEW_FIELDS.indexOf(current);
+  const next = (index + dir + REVIEW_FIELDS.length) % REVIEW_FIELDS.length;
+  return REVIEW_FIELDS[next] ?? current;
+}
+
 export type NewSessionReviewState = NewSessionBaseState & {
   mode: "review";
+  /** Default "create" so ↵ still creates, preserving today's muscle memory. */
+  reviewFocus: NewSessionReviewFocus;
 };
 
 export type NewSessionEditNameState = NewSessionBaseState & {
@@ -56,6 +71,7 @@ export type NewSessionFlowAction =
   | { type: "commitName" }
   | { type: "pickProject" }
   | { type: "pickAgent" }
+  | { type: "reviewFocus"; dir: -1 | 1 }
   | { type: "cancel" };
 
 export type NewSessionInputKey = {
@@ -118,6 +134,7 @@ export function createNewSessionFlow(
   }
   return {
     ...createStepWizardState("review"),
+    reviewFocus: "create",
     selectedProjectId: project.id,
     selectedHarness: harness.id,
     branch: generatedSessionBranch(project.id, token),
@@ -154,6 +171,10 @@ export function transitionNewSessionFlow(
       return {
         ...enterWizardStep(baseState(state), "pickAgent"),
       } satisfies NewSessionPickAgentState;
+    case "reviewFocus":
+      return state.mode === "review"
+        ? { ...state, reviewFocus: cycleReviewFocus(state.reviewFocus, action.dir) }
+        : state;
   }
 }
 
@@ -166,7 +187,7 @@ export function newSessionIntentForInput(
   }
   switch (state.mode) {
     case "review":
-      return reviewInputIntent(input);
+      return reviewInputIntent(state, input);
     case "editName":
       return editNameInputIntent(input);
     // Pick steps are registered lists: the shared selectionMiddleware resolves
@@ -255,12 +276,29 @@ export function createNewSessionNameToken(unique = randomUUID()): string {
   return stableNameHash(["new-session", unique], 6);
 }
 
-function reviewInputIntent(input: NewSessionInput): NewSessionInputIntent {
+function reviewInputIntent(
+  state: NewSessionReviewState,
+  input: NewSessionInput,
+): NewSessionInputIntent {
+  if (input.key.upArrow === true) {
+    return transitionIntent({ type: "reviewFocus", dir: -1 });
+  }
+  if (input.key.downArrow === true) {
+    return transitionIntent({ type: "reviewFocus", dir: 1 });
+  }
   if (isReturn(input)) {
-    return { type: "submit" };
+    return reviewFocusIntents[state.reviewFocus];
   }
   return reviewKeyIntents[input.input] ?? { type: "none" };
 }
+
+// ↵ activates the focused field; "create" submits, the rest open their step.
+const reviewFocusIntents: Record<NewSessionReviewFocus, NewSessionInputIntent> = {
+  create: { type: "submit" },
+  name: transitionIntent({ type: "editName" }),
+  project: transitionIntent({ type: "pickProject" }),
+  agent: transitionIntent({ type: "pickAgent" }),
+};
 
 const reviewKeyIntents: Record<string, NewSessionInputIntent> = {
   N: transitionIntent({ type: "editName" }),
@@ -296,6 +334,7 @@ function commitEditedName(state: NewSessionEditNameState): NewSessionReviewState
   }
   return {
     ...resetWizardStep(baseState(state), "review"),
+    reviewFocus: "create",
     selectedProjectId: state.selectedProjectId,
     selectedHarness: state.selectedHarness,
     branch,
@@ -329,6 +368,7 @@ function applyChosenProject(
   }
   return {
     ...resetWizardStep(baseState(state), "review"),
+    reviewFocus: "create",
     selectedProjectId: project.id,
     selectedHarness: harness.id,
     branch:
@@ -360,6 +400,7 @@ export function chooseNewSessionAgentById(
   }
   return {
     ...resetWizardStep(baseState(state), "review"),
+    reviewFocus: "create",
     selectedProjectId: state.selectedProjectId,
     selectedHarness: option.id,
     branch: state.branch,
@@ -378,6 +419,7 @@ function cancelNewSessionStep(state: NewSessionFlowState): NewSessionReviewState
 function toReviewState(state: NewSessionBaseState): NewSessionReviewState {
   return {
     ...resetWizardStep(baseState(state), "review"),
+    reviewFocus: "create",
   };
 }
 

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -44,3 +44,5 @@ export * from "./state/screens/projectSettings.js";
 export * from "./state/screens/removeWorktree.js";
 export * from "./state/screens/sessionRows.js";
 export * from "./state/screens/widgetSettings.js";
+export * from "./state/selection/bindings.js";
+export * from "./state/selection/registry.js";

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -58,8 +58,8 @@ export function activateFocusedDashboardRow(state: TuiState): TuiTransition {
  * The focused row only when it is currently committable: present in the filtered
  * view (not collapsed or searched away) and not mid-operation. The choose-row
  * trio's ↵ resolves through this so it cannot act on a row the slot path and
- * dashboard activation both refuse — a pending row, or one scrolled/filtered
- * out of sight.
+ * dashboard activation both refuse — a pending row, or one filtered out of the
+ * view (viewport scroll does not unfocus; the cursor rule keeps it committable).
  */
 export function focusedSelectableRow(state: TuiState): WorktreeRow | undefined {
   if (state.snapshot === undefined) {

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -572,11 +572,24 @@ export const TUI_KEYMAP = {
       help: { keys: "esc", label: "cancel" },
     },
     {
+      id: "tui.newSession.reviewFocusUp",
+      pattern: { kind: "named", named: "up" },
+      action: "tui.newSession.reviewFocus",
+      outcome: "handled",
+    },
+    {
+      id: "tui.newSession.reviewFocusDown",
+      pattern: { kind: "named", named: "down" },
+      action: "tui.newSession.reviewFocus",
+      outcome: "handled",
+      help: { keys: "↑↓", label: "field" },
+    },
+    {
       id: "tui.newSession.create",
       pattern: { kind: "named", named: "return" },
       action: "tui.newSession.submit",
       outcome: "handled",
-      help: { keys: "enter", label: "create" },
+      help: { keys: "↵", label: "choose field" },
     },
     {
       id: "tui.newSession.editName",

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -20,6 +20,7 @@ export type TuiInputMode =
   | "newSessionPickProject"
   | "newSessionPickAgent"
   | "projectDefaultAgent"
+  | "projectSettings"
   | "addProject"
   | "widgetSettings";
 
@@ -58,6 +59,8 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
       return "addProject";
     case "projectDefaultAgent":
       return "projectDefaultAgent";
+    case "projectSettings":
+      return "projectSettings";
     case "widgetSettings":
       return "widgetSettings";
   }
@@ -643,6 +646,74 @@ export const TUI_KEYMAP = {
       help: { keys: "esc", label: "cancel" },
     },
     ...selectableListBindings("tui.projectDefaultAgent"),
+  ],
+  // Union table (like addProject): every key routes to one action and the
+  // machine decodes it against the panel's focus/activeId. The agent detail's
+  // ↑↓/↵/slot are additionally resolved by the shared selectionMiddleware.
+  projectSettings: [
+    {
+      id: "tui.projectSettings.cancel",
+      pattern: { kind: "named", named: "escape" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+      help: { keys: "esc", label: "back/close" },
+    },
+    {
+      id: "tui.projectSettings.confirm",
+      pattern: { kind: "named", named: "return" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+      help: { keys: "→/enter", label: "edit/choose" },
+    },
+    {
+      id: "tui.projectSettings.up",
+      pattern: { kind: "named", named: "up" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.down",
+      pattern: { kind: "named", named: "down" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+      help: { keys: "↑↓", label: "move" },
+    },
+    {
+      id: "tui.projectSettings.left",
+      pattern: { kind: "named", named: "left" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.right",
+      pattern: { kind: "named", named: "right" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.backspace",
+      pattern: { kind: "named", named: "backspace" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.delete",
+      pattern: { kind: "named", named: "delete" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.clearLine",
+      pattern: { kind: "char", char: "u", ctrl: true },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
+    {
+      id: "tui.projectSettings.type",
+      pattern: { kind: "text" },
+      action: "tui.projectSettings.key",
+      outcome: "handled",
+    },
   ],
   // One action; the widgetSettings screen handler decodes list-vs-picker focus.
   widgetSettings: [

--- a/packages/dashboard-core/src/state/screens/projectSettings.ts
+++ b/packages/dashboard-core/src/state/screens/projectSettings.ts
@@ -1,3 +1,4 @@
+import type { ProviderId } from "@station/contracts";
 import {
   createEditableTextInputState,
   type EditableTextInputInput,
@@ -21,11 +22,14 @@ import type { ProjectSettingsItemId, TuiState } from "../types.js";
 
 export type ProjectSettingsItem = { id: ProjectSettingsItemId; label: string };
 
+/** List id for the agent detail cursor on the shared selection engine. */
+export const PROJECT_SETTINGS_AGENT_LIST_ID = "projectSettingsAgent";
+
 /**
  * Ordered left-list registry for the two-pane Project Settings panel. The panel
  * engine is item-agnostic — extending it is adding an entry here (plus the
- * detail rendering and, for new fields, a persist vertical). Station/global
- * settings reuse the same engine with a different registry.
+ * detail rendering and, for new fields, a persist vertical). The agent detail is
+ * the only sub-list wired to the shared selection engine (via the list id above).
  */
 export const PROJECT_SETTINGS_ITEMS: readonly ProjectSettingsItem[] = [
   { id: "agent", label: "Default agent" },
@@ -71,7 +75,25 @@ export function focusProjectSettingsItem(state: TuiState, itemId: ProjectSetting
   if (itemId !== "remove") {
     screen.removeDraft = createEditableTextInputState("");
   }
-  return { ...state, screen };
+  return descend({ ...state, screen }, screen);
+}
+
+// Enter the detail pane, seeding the agent cursor to the current effective
+// default so ↑↓ start from what is selected and ↵ is immediately meaningful.
+function descend(state: TuiState, screen: ProjectSettingsScreen): TuiState {
+  if (screen.activeId !== "agent") {
+    return state;
+  }
+  const project = state.snapshot?.projects.find((candidate) => candidate.id === screen.projectId);
+  if (project === undefined) {
+    return state;
+  }
+  const selection = new Map(state.selection);
+  selection.set(
+    PROJECT_SETTINGS_AGENT_LIST_ID,
+    selectProjectDefaultHarness(state.localRows, project).harness,
+  );
+  return { ...state, selection };
 }
 
 export function handleProjectSettingsKey(state: TuiState, key: TuiKey): TuiTransition {
@@ -116,11 +138,15 @@ function handleListKey(state: TuiState, screen: ProjectSettingsScreen, key: TuiK
     return { state: moveActive(state, screen, 1) };
   }
   if (key.rightArrow === true || isReturnKey(key)) {
-    return { state: { ...state, screen: { ...screen, focus: "detail" } } };
+    const detail: ProjectSettingsScreen = { ...screen, focus: "detail" };
+    return { state: descend({ ...state, screen: detail }, detail) };
   }
   return { state };
 }
 
+// The cross-pane slot handler: resolve the harness from the slot key, then
+// commit through the shared path so keyboard slot, right-pane click, and the
+// engine cursor all produce the same optimistic change.
 function selectAgent(state: TuiState, screen: ProjectSettingsScreen, key: TuiKey): TuiTransition {
   const project = state.snapshot?.projects.find((candidate) => candidate.id === screen.projectId);
   if (state.snapshot === undefined || project === undefined) {
@@ -130,31 +156,44 @@ function selectAgent(state: TuiState, screen: ProjectSettingsScreen, key: TuiKey
     selectNewSessionHarnessChoices(state.snapshot, project),
     key.input,
   );
-  if (option === undefined) {
+  return option === undefined ? { state } : commitProjectSettingsAgentById(state, option.id);
+}
+
+/**
+ * Commit a default-agent choice by id — the single path shared by the engine
+ * cursor (↵), the keyboard slot, and the right-pane click. Compares against the
+ * effective (optimistic) default, not the snapshot: while a change is in flight
+ * the picked agent is what the user sees as current, so re-selecting it is a
+ * no-op-and-ascend and picking anything else overrides the pending change.
+ */
+export function commitProjectSettingsAgentById(
+  state: TuiState,
+  harness: ProviderId,
+): TuiTransition {
+  if (state.screen.name !== "projectSettings" || state.snapshot === undefined) {
     return { state };
   }
-  // Compare against the effective (optimistic) default, not the snapshot value:
-  // while a change is in flight the picked agent is what the user sees as current,
-  // so re-selecting it is a no-op and selecting anything else — even the snapshot
-  // default — is a real change that must override the pending one.
-  const effectiveDefault = selectProjectDefaultHarness(state.localRows, project).harness;
-  if (option.id === effectiveDefault) {
-    return { state: { ...state, screen: { ...screen, focus: "list" } } };
+  const screen = state.screen;
+  const project = state.snapshot.projects.find((candidate) => candidate.id === screen.projectId);
+  if (project === undefined) {
+    return { state: toDashboard(state) };
+  }
+  const ascended: TuiState = { ...state, screen: { ...screen, focus: "list" } };
+  if (harness === selectProjectDefaultHarness(state.localRows, project).harness) {
+    return { state: ascended };
   }
   // Move the marker to the picked agent immediately; the runner reverts this if
   // the command fails, and the next snapshot prunes it once the change lands.
   return {
-    state: addPendingProjectDefaultHarness(
-      { ...state, screen: { ...screen, focus: "list" } },
-      { projectId: project.id, harness: option.id, createdAt: new Date().toISOString() },
-    ),
+    state: addPendingProjectDefaultHarness(ascended, {
+      projectId: project.id,
+      harness,
+      createdAt: new Date().toISOString(),
+    }),
     operations: [
       {
         type: "setProjectDefaultHarness",
-        command: buildSetProjectDefaultHarnessCommand({
-          projectId: project.id,
-          harness: option.id,
-        }),
+        command: buildSetProjectDefaultHarnessCommand({ projectId: project.id, harness }),
       },
     ],
   };

--- a/packages/dashboard-core/src/state/selection/registry.ts
+++ b/packages/dashboard-core/src/state/selection/registry.ts
@@ -3,6 +3,7 @@ import type { TuiState } from "../types.js";
 import { newSessionPickAgentListSpec, newSessionPickProjectListSpec } from "./specs/newSession.js";
 import { projectCollapseListSpec, projectSettingsPickerListSpec } from "./specs/projectChoosers.js";
 import { projectDefaultAgentListSpec } from "./specs/projectDefaultAgent.js";
+import { projectSettingsAgentListSpec } from "./specs/projectSettingsAgent.js";
 import type { RegisteredListSpec } from "./types.js";
 
 /**
@@ -15,6 +16,7 @@ export const LIST_REGISTRY: Partial<Record<TuiInputMode, RegisteredListSpec>> = 
   newSessionPickAgent: newSessionPickAgentListSpec,
   projectCollapse: projectCollapseListSpec,
   projectSettingsPicker: projectSettingsPickerListSpec,
+  projectSettings: projectSettingsAgentListSpec,
 };
 
 export function listSpecForState(state: TuiState): RegisteredListSpec | undefined {

--- a/packages/dashboard-core/src/state/selection/specs/harnessPicker.ts
+++ b/packages/dashboard-core/src/state/selection/specs/harnessPicker.ts
@@ -1,0 +1,40 @@
+import type { ProjectView, ProviderId, StationSnapshot } from "@station/contracts";
+import { selectNewSessionHarnessChoices } from "../../../selectors/selectors.js";
+import type { TuiTransition } from "../../transition.js";
+import type { TuiState } from "../../types.js";
+import { flatPickerSpec } from "../flatPicker.js";
+import type { RegisteredListSpec } from "../types.js";
+
+/**
+ * The one "pick a harness/agent" list behind all three agent surfaces
+ * (new-session agent, project default, project-settings default). They are the
+ * same list — cursor, slot, and the shared AgentChoiceListView view — and
+ * differ only in which project the choices come from (`resolveProject`), what
+ * committing one does (`commit`), and whether it is gated to a sub-pane
+ * (`active`). Those are the props; everything else is identical.
+ */
+export function harnessPickerSpec(config: {
+  listId: string;
+  resolveProject: (snapshot: StationSnapshot, state: TuiState) => ProjectView | undefined;
+  commit: (state: TuiState, harness: ProviderId) => TuiTransition;
+  active?: (state: TuiState) => boolean;
+}): RegisteredListSpec {
+  return flatPickerSpec<ProviderId>({
+    listId: config.listId,
+    ...(config.active === undefined ? {} : { active: config.active }),
+    choices: (state) => {
+      if (state.snapshot === undefined) {
+        return [];
+      }
+      const project = config.resolveProject(state.snapshot, state);
+      if (project === undefined) {
+        return [];
+      }
+      return selectNewSessionHarnessChoices(state.snapshot, project).map((choice) => ({
+        key: choice.key,
+        value: choice.value.id,
+      }));
+    },
+    commit: config.commit,
+  });
+}

--- a/packages/dashboard-core/src/state/selection/specs/newSession.ts
+++ b/packages/dashboard-core/src/state/selection/specs/newSession.ts
@@ -1,16 +1,16 @@
-import type { ProjectId, ProviderId } from "@station/contracts";
+import type { ProjectId } from "@station/contracts";
 import {
   chooseNewSessionAgentById,
   chooseNewSessionProjectById,
   createNewSessionNameToken,
 } from "../../../flows/newSession.js";
 import {
-  selectNewSessionHarnessChoices,
   selectNewSessionProject,
   selectNewSessionProjectChoices,
 } from "../../../selectors/selectors.js";
 import type { TuiState } from "../../types.js";
 import { flatPickerSpec } from "../flatPicker.js";
+import { harnessPickerSpec } from "./harnessPicker.js";
 
 export const newSessionPickProjectListSpec = flatPickerSpec<ProjectId>({
   listId: "newSessionPickProject",
@@ -45,24 +45,13 @@ export const newSessionPickProjectListSpec = flatPickerSpec<ProjectId>({
   },
 });
 
-export const newSessionPickAgentListSpec = flatPickerSpec<ProviderId>({
+export const newSessionPickAgentListSpec = harnessPickerSpec({
   listId: "newSessionPickAgent",
-  choices: (state) => {
-    if (
-      state.screen.name !== "newSession" ||
-      state.screen.flow.mode !== "pickAgent" ||
-      state.snapshot === undefined
-    ) {
-      return [];
+  resolveProject: (snapshot, state) => {
+    if (state.screen.name !== "newSession" || state.screen.flow.mode !== "pickAgent") {
+      return undefined;
     }
-    const project = selectNewSessionProject(state.snapshot, state.screen.flow.selectedProjectId);
-    if (project === undefined) {
-      return [];
-    }
-    return selectNewSessionHarnessChoices(state.snapshot, project).map((choice) => ({
-      key: choice.key,
-      value: choice.value.id,
-    }));
+    return selectNewSessionProject(snapshot, state.screen.flow.selectedProjectId);
   },
   commit: (state, agentId) => {
     if (

--- a/packages/dashboard-core/src/state/selection/specs/projectDefaultAgent.ts
+++ b/packages/dashboard-core/src/state/selection/specs/projectDefaultAgent.ts
@@ -1,9 +1,8 @@
 import type { ProviderId } from "@station/contracts";
-import { selectNewSessionHarnessChoices } from "../../../selectors/selectors.js";
 import { buildSetProjectDefaultHarnessCommand } from "../../commandBuilders.js";
 import type { TuiTransition } from "../../transition.js";
 import type { TuiState } from "../../types.js";
-import { flatPickerSpec } from "../flatPicker.js";
+import { harnessPickerSpec } from "./harnessPicker.js";
 
 function toDashboard(state: TuiState): TuiState {
   return { ...state, screen: { name: "dashboard" } };
@@ -29,21 +28,14 @@ function commitProjectDefaultAgent(state: TuiState, harness: ProviderId): TuiTra
   };
 }
 
-export const projectDefaultAgentListSpec = flatPickerSpec<ProviderId>({
+export const projectDefaultAgentListSpec = harnessPickerSpec({
   listId: "projectDefaultAgent",
-  choices: (state) => {
-    if (state.screen.name !== "projectDefaultAgent" || state.snapshot === undefined) {
-      return [];
+  resolveProject: (snapshot, state) => {
+    if (state.screen.name !== "projectDefaultAgent") {
+      return undefined;
     }
     const { projectId } = state.screen;
-    const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
-    if (project === undefined) {
-      return [];
-    }
-    return selectNewSessionHarnessChoices(state.snapshot, project).map((choice) => ({
-      key: choice.key,
-      value: choice.value.id,
-    }));
+    return snapshot.projects.find((candidate) => candidate.id === projectId);
   },
   commit: commitProjectDefaultAgent,
 });

--- a/packages/dashboard-core/src/state/selection/specs/projectSettingsAgent.ts
+++ b/packages/dashboard-core/src/state/selection/specs/projectSettingsAgent.ts
@@ -1,0 +1,36 @@
+import type { ProviderId } from "@station/contracts";
+import { selectNewSessionHarnessChoices } from "../../../selectors/selectors.js";
+import {
+  commitProjectSettingsAgentById,
+  PROJECT_SETTINGS_AGENT_LIST_ID,
+} from "../../screens/projectSettings.js";
+import { flatPickerSpec } from "../flatPicker.js";
+
+/**
+ * The default-agent enum inside the two-pane Project Settings panel, hosted as an
+ * engine leaf. `active` gates it to the descended agent detail so ↑↓/↵/slot only
+ * act there; the list, remove detail, and the destructive disarm stay bespoke in
+ * the reducer. Commit routes through the same optimistic path as the slot/click.
+ */
+export const projectSettingsAgentListSpec = flatPickerSpec<ProviderId>({
+  listId: PROJECT_SETTINGS_AGENT_LIST_ID,
+  active: (state) =>
+    state.screen.name === "projectSettings" &&
+    state.screen.focus === "detail" &&
+    state.screen.activeId === "agent",
+  choices: (state) => {
+    if (state.screen.name !== "projectSettings" || state.snapshot === undefined) {
+      return [];
+    }
+    const { projectId } = state.screen;
+    const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
+    if (project === undefined) {
+      return [];
+    }
+    return selectNewSessionHarnessChoices(state.snapshot, project).map((choice) => ({
+      key: choice.key,
+      value: choice.value.id,
+    }));
+  },
+  commit: (state, harness) => commitProjectSettingsAgentById(state, harness),
+});

--- a/packages/dashboard-core/src/state/selection/specs/projectSettingsAgent.ts
+++ b/packages/dashboard-core/src/state/selection/specs/projectSettingsAgent.ts
@@ -1,10 +1,8 @@
-import type { ProviderId } from "@station/contracts";
-import { selectNewSessionHarnessChoices } from "../../../selectors/selectors.js";
 import {
   commitProjectSettingsAgentById,
   PROJECT_SETTINGS_AGENT_LIST_ID,
 } from "../../screens/projectSettings.js";
-import { flatPickerSpec } from "../flatPicker.js";
+import { harnessPickerSpec } from "./harnessPicker.js";
 
 /**
  * The default-agent enum inside the two-pane Project Settings panel, hosted as an
@@ -12,25 +10,18 @@ import { flatPickerSpec } from "../flatPicker.js";
  * act there; the list, remove detail, and the destructive disarm stay bespoke in
  * the reducer. Commit routes through the same optimistic path as the slot/click.
  */
-export const projectSettingsAgentListSpec = flatPickerSpec<ProviderId>({
+export const projectSettingsAgentListSpec = harnessPickerSpec({
   listId: PROJECT_SETTINGS_AGENT_LIST_ID,
   active: (state) =>
     state.screen.name === "projectSettings" &&
     state.screen.focus === "detail" &&
     state.screen.activeId === "agent",
-  choices: (state) => {
-    if (state.screen.name !== "projectSettings" || state.snapshot === undefined) {
-      return [];
+  resolveProject: (snapshot, state) => {
+    if (state.screen.name !== "projectSettings") {
+      return undefined;
     }
     const { projectId } = state.screen;
-    const project = state.snapshot.projects.find((candidate) => candidate.id === projectId);
-    if (project === undefined) {
-      return [];
-    }
-    return selectNewSessionHarnessChoices(state.snapshot, project).map((choice) => ({
-      key: choice.key,
-      value: choice.value.id,
-    }));
+    return snapshot.projects.find((candidate) => candidate.id === projectId);
   },
-  commit: (state, harness) => commitProjectSettingsAgentById(state, harness),
+  commit: commitProjectSettingsAgentById,
 });

--- a/packages/dashboard-core/src/state/selection/types.ts
+++ b/packages/dashboard-core/src/state/selection/types.ts
@@ -12,7 +12,7 @@ export type ListId = string;
 export type ListRow<TId extends string> = { selectable: true; id: TId } | { selectable: false };
 
 /** How a commit was reached — screens use this to keep slot vs cursor policy apart. */
-export type CommitVia = "cursor" | "slot" | "pointer";
+export type CommitVia = "cursor" | "slot";
 
 /**
  * The whole per-list contribution. A screen supplies data (rows, optional
@@ -23,8 +23,6 @@ export type ListSpec<TId extends string> = {
   listId: ListId;
   /** ↑↓ move a cursor and ↵ commits it. */
   cursor?: boolean;
-  /** Reserved for follow-scroll lists (the choose-row trio); unused by flat pickers. */
-  followScroll?: boolean;
   /** Gate for hybrid screens: when it returns false the middleware yields all keys. */
   active?: (state: TuiState) => boolean;
   /** Full ordered cursor space. */

--- a/packages/dashboard-core/test/unit/flows/newSession.test.ts
+++ b/packages/dashboard-core/test/unit/flows/newSession.test.ts
@@ -17,6 +17,7 @@ describe("new session flow", () => {
 
     expect(state).toEqual({
       mode: "review",
+      reviewFocus: "create",
       selectedProjectId: "web",
       selectedHarness: "codex",
       branch: "web-k7p3x9",
@@ -30,6 +31,47 @@ describe("new session flow", () => {
     expect(createNewSessionNameToken("source-a")).toMatch(/^[a-f0-9]{6}$/);
     expect(createNewSessionNameToken("source-a")).toBe(createNewSessionNameToken("source-a"));
     expect(createNewSessionNameToken("source-a")).not.toBe(createNewSessionNameToken("source-b"));
+  });
+
+  it("review menu: arrows cycle focus and enter activates the focused field", () => {
+    const snapshot = createHarnessSnapshot();
+    const opened = createNewSessionFlow(snapshot, "aaaaaa");
+    if (opened === undefined) throw new Error("expected a flow");
+    expect(opened.reviewFocus).toBe("create");
+
+    // Enter on the default "create" focus submits.
+    expect(newSessionIntentForInput(opened, input("\r", { return: true }))).toEqual({
+      type: "submit",
+    });
+
+    // Down cycles create → project (the top field); enter there opens the
+    // project picker, not submit.
+    expect(newSessionIntentForInput(opened, input("", { downArrow: true }))).toEqual({
+      type: "transition",
+      action: { type: "reviewFocus", dir: 1 },
+    });
+    const onProject = transitionNewSessionFlow(opened, { type: "reviewFocus", dir: 1 });
+    if (onProject?.mode !== "review") throw new Error("expected review");
+    expect(onProject.reviewFocus).toBe("project");
+    expect(newSessionIntentForInput(onProject, input("\r", { return: true }))).toEqual({
+      type: "transition",
+      action: { type: "pickProject" },
+    });
+
+    // Down again focuses Name; enter opens the name editor.
+    const onName = transitionNewSessionFlow(onProject, { type: "reviewFocus", dir: 1 });
+    if (onName?.mode !== "review") throw new Error("expected review");
+    expect(onName.reviewFocus).toBe("name");
+    expect(newSessionIntentForInput(onName, input("\r", { return: true }))).toEqual({
+      type: "transition",
+      action: { type: "editName" },
+    });
+
+    // Letter accelerators still work regardless of focus.
+    expect(newSessionIntentForInput(onName, input("A"))).toEqual({
+      type: "transition",
+      action: { type: "pickAgent" },
+    });
   });
 
   it("trims typed names and otherwise preserves branch text", () => {

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -6,6 +6,7 @@ import {
   handleTuiKey,
   matchingTuiBindings,
   openProjectDefaultAgentPicker,
+  openProjectSettings,
   TUI_KEYMAP,
   type TuiInputMode,
   type TuiTransition,
@@ -50,6 +51,19 @@ const ALLOWED_NOOP_BINDINGS = new Set([
   "tui.addProject.delete",
   "tui.addProject.clearLine",
   "tui.addProject.type",
+  // Project-settings metadata is a union table (like addProject); in the list-focus
+  // representative state several keys are inert (↑ clamps, left/backspace/delete/
+  // ctrl-u/non-harness printables do nothing).
+  "tui.projectSettings.cancel",
+  "tui.projectSettings.confirm",
+  "tui.projectSettings.up",
+  "tui.projectSettings.down",
+  "tui.projectSettings.left",
+  "tui.projectSettings.right",
+  "tui.projectSettings.backspace",
+  "tui.projectSettings.delete",
+  "tui.projectSettings.clearLine",
+  "tui.projectSettings.type",
   // Esc only dismisses when the runtime is showing a dismissible persistent popup.
   "tui.dashboard.dismissEsc",
   // Return only activates once a row is focused.
@@ -106,6 +120,7 @@ function representativeStates(): Record<TuiInputMode, TuiState> {
     newSessionPickProject: drive(base, [{ input: "N" }, { input: "P" }]),
     newSessionPickAgent: drive(base, [{ input: "N" }, { input: "A" }]),
     projectDefaultAgent: openProjectDefaultAgentPicker(base, "web"),
+    projectSettings: openProjectSettings(base, "web"),
     addProject: drive(base, [{ input: "A" }]),
     // Mid-list cursor over three widgets so every list binding (toggle,
     // both reorder directions, remove) visibly acts.

--- a/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts
@@ -60,6 +60,47 @@ describe("project settings panel", () => {
     expect(drive(panelState(), [ESC]).screen.name).toBe("dashboard");
   });
 
+  it("arrow-navigates the agent picker and commits the focused agent on enter", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("missing web project");
+    const other = selectNewSessionHarnessChoices(snapshot, project).find(
+      (choice) => choice.value.id !== project.defaults.harness,
+    );
+    if (other === undefined) throw new Error("no alternative harness in fixture");
+
+    // Descend into the agent detail; the cursor seeds at the current default.
+    const detail = drive(panelState(), [RIGHT]);
+    expect(detail.selection.get("projectSettingsAgent")).toBe(project.defaults.harness);
+
+    // Arrow to a different agent; the cursor moves.
+    const moved = drive(detail, [DOWN]);
+    expect(moved.selection.get("projectSettingsAgent")).toBe(other.value.id);
+
+    // Enter commits the focused agent and returns to the list.
+    const committed = handleTuiKey(moved, ENTER);
+    expect(committed.operations).toEqual([
+      expect.objectContaining({
+        type: "setProjectDefaultHarness",
+        command: expect.objectContaining({
+          payload: { projectId: "web", harness: other.value.id },
+        }),
+      }),
+    ]);
+    expect(committed.state.screen.name === "projectSettings" && committed.state.screen.focus).toBe(
+      "list",
+    );
+  });
+
+  it("enter on the unchanged focused agent closes to the list without dispatching", () => {
+    // Cursor seeds at the current default; committing it is a no-op-and-ascend.
+    const committed = handleTuiKey(drive(panelState(), [RIGHT]), ENTER);
+    expect(committed.operations ?? []).toEqual([]);
+    expect(committed.state.screen.name === "projectSettings" && committed.state.screen.focus).toBe(
+      "list",
+    );
+  });
+
   it("selecting a non-current agent emits setProjectDefaultHarness", () => {
     const snapshot = createDashboardSnapshot();
     const project = snapshot.projects.find((candidate) => candidate.id === "web");

--- a/packages/dashboard-core/test/unit/state/selection/engine.test.ts
+++ b/packages/dashboard-core/test/unit/state/selection/engine.test.ts
@@ -224,6 +224,7 @@ describe("list registry — migrated modes", () => {
       "newSessionPickProject",
       "projectCollapse",
       "projectDefaultAgent",
+      "projectSettings",
       "projectSettingsPicker",
     ]);
   });

--- a/station/src/station/input/newSessionSubmit.test.ts
+++ b/station/src/station/input/newSessionSubmit.test.ts
@@ -45,6 +45,18 @@ describe("resolveNewSessionSubmit", () => {
   it("does not submit from the dashboard (no wizard open)", () => {
     expect(resolveNewSessionSubmit(newStore()).kind).toBe("none");
   });
+
+  it("does not submit when the review focus ring is off 'create'", () => {
+    // Arrow the focus ring onto a field: Enter must reach the machine to open
+    // that field's step, not fire a hosted-launch create.
+    const store = storeOnNewSessionReview();
+    store.getState().handleKey({ input: "", downArrow: true });
+    const screen = store.getState().screen;
+    expect(screen.name === "newSession" && screen.flow.mode === "review" && screen.flow.reviewFocus).toBe(
+      "project",
+    );
+    expect(resolveNewSessionSubmit(store).kind).toBe("none");
+  });
 });
 
 describe("resolveKeyNewSessionSubmit", () => {

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -13,6 +13,7 @@ import type { ProviderId } from "@station/contracts";
 import {
   choiceValueByKey,
   createNewSessionNameToken,
+  newSessionIntentForInput,
   focusProjectSettingsItem as focusProjectSettingsItemState,
   generatedSessionBranch,
   openProjectDefaultAgentPicker,
@@ -250,13 +251,17 @@ export type NewSessionSubmitTarget =
  */
 export function resolveNewSessionSubmit(store: StoreApi<TuiStore>): NewSessionSubmitTarget {
   const state = store.getState();
-  if (
-    state.screen.name !== "newSession" ||
-    state.screen.flow.mode !== "review" ||
-    // ↵ only submits when the review focus ring is on "create"; on any other
-    // field it must reach the machine so ↵ opens that field's step instead.
-    state.screen.flow.reviewFocus !== "create"
-  ) {
+  if (state.screen.name !== "newSession") {
+    return { kind: "none" };
+  }
+  // The machine owns what ↵ means (reviewFocusIntents): submit only when it
+  // would submit, so a focused field's ↵ reaches the machine and opens its step.
+  const intent = newSessionIntentForInput(state.screen.flow, {
+    input: "\r",
+    key: { return: true },
+    token: "",
+  });
+  if (intent.type !== "submit") {
     return { kind: "none" };
   }
   if (state.snapshot === undefined) {

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -250,7 +250,13 @@ export type NewSessionSubmitTarget =
  */
 export function resolveNewSessionSubmit(store: StoreApi<TuiStore>): NewSessionSubmitTarget {
   const state = store.getState();
-  if (state.screen.name !== "newSession" || state.screen.flow.mode !== "review") {
+  if (
+    state.screen.name !== "newSession" ||
+    state.screen.flow.mode !== "review" ||
+    // ↵ only submits when the review focus ring is on "create"; on any other
+    // field it must reach the machine so ↵ opens that field's step instead.
+    state.screen.flow.reviewFocus !== "create"
+  ) {
     return { kind: "none" };
   }
   if (state.snapshot === undefined) {

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -36,31 +36,36 @@ const KEY_CONTEXT = { cwd: "/Users/example/Developer/station", homeDir: "/Users/
 const ADD_PROJECT_KEY_ACTION = "station.addProject.key";
 const PROJECT_SETTINGS_KEY_ACTION = "station.projectSettings.key";
 
+const ALLOWED_NOOP_BINDINGS = new Set([
+  // Return only acts once a row is focused; Tab only when a row needs attention.
+  "station.dashboard.focusActivate",
+  "station.dashboard.nextNeedsMe",
+  // Selection lists seed at the current choice, which is the top row in the
+  // fixtures, so ↑ clamps to a no-op in the representative state.
+  "station.collapse.cursorUp",
+  "station.projectSettingsPicker.cursorUp",
+  "station.newSessionProject.cursorUp",
+  "station.newSessionAgent.cursorUp",
+  "station.projectDefaultAgent.cursorUp",
+  // The choose-row trio's ↵ commits the focused row; with no cursor yet in the
+  // representative state it is a no-op, like station.dashboard.focusActivate.
+  "station.remove.activate",
+  "station.rename.activate",
+  "station.fork.activate",
+]);
+
 /**
  * Slot bindings are runtime-assigned, and the union-table modes (addProject,
  * projectSettings) route every key to one action and decode it in the machine,
  * so their bindings are checked by that shared action only — future distinct
- * stale actions still fail the audit.
+ * stale actions still fail the audit. Everything else must be allowlisted by
+ * exact id so a new dead cursor/activate binding cannot slip past the audit.
  */
 function allowedNoOpBinding(mode: StationInputMode, binding: StationBinding): boolean {
   if (binding.pattern.kind === "slot") {
     return true;
   }
-  // Return only acts once a row is focused; Tab only when a row needs attention.
-  if (
-    binding.id === "station.dashboard.focusActivate" ||
-    binding.id === "station.dashboard.nextNeedsMe"
-  ) {
-    return true;
-  }
-  // Selection lists seed at the current choice, which is the top row in the
-  // fixtures, so ↑ clamps to a no-op in the representative state.
-  if (binding.id.endsWith(".cursorUp")) {
-    return true;
-  }
-  // The choose-row trio's ↵ commits the focused row; with no cursor yet in the
-  // representative state it is a no-op, like station.dashboard.focusActivate.
-  if (binding.id.endsWith(".activate")) {
+  if (ALLOWED_NOOP_BINDINGS.has(binding.id)) {
     return true;
   }
   if (mode === "addProject" && binding.action === ADD_PROJECT_KEY_ACTION) {
@@ -221,6 +226,15 @@ describe("station keymap coverage", () => {
       }
     }
     expect(failures).toEqual([]);
+  });
+
+  it("keeps the no-op allowlist limited to bindings that exist", () => {
+    const knownIds = new Set(
+      Object.values(STATION_KEYMAP).flatMap((table) => table.map((binding) => binding.id)),
+    );
+    for (const id of ALLOWED_NOOP_BINDINGS) {
+      expect(knownIds.has(id)).toBe(true);
+    }
   });
 
   it("matches at most one specific binding per key (text catch-alls last)", () => {

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -256,7 +256,9 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
   ],
   newSessionReview: [
     { id: "station.newSession.cancel", pattern: { kind: "named", named: "escape" }, action: "station.newSession.cancel", outcome: "handled", help: { keys: "esc", label: "cancel" } },
-    { id: "station.newSession.create", pattern: { kind: "named", named: "return" }, action: "station.newSession.submit", outcome: "handled", help: { keys: "enter", label: "create" } },
+    { id: "station.newSession.reviewFocusUp", pattern: { kind: "named", named: "up" }, action: "station.newSession.reviewFocus", outcome: "handled" },
+    { id: "station.newSession.reviewFocusDown", pattern: { kind: "named", named: "down" }, action: "station.newSession.reviewFocus", outcome: "handled", help: { keys: "↑↓", label: "field" } },
+    { id: "station.newSession.create", pattern: { kind: "named", named: "return" }, action: "station.newSession.submit", outcome: "handled", help: { keys: "↵", label: "choose field" } },
     { id: "station.newSession.editName", pattern: { kind: "char", char: "N" }, action: "station.newSession.editName", outcome: "handled", help: { keys: "N", label: "name" } },
     { id: "station.newSession.pickProject", pattern: { kind: "char", char: "P" }, action: "station.newSession.pickProject", outcome: "handled", help: { keys: "P", label: "project" } },
     { id: "station.newSession.pickAgent", pattern: { kind: "char", char: "A" }, action: "station.newSession.pickAgent", outcome: "handled", help: { keys: "A", label: "agent" } },

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -8,7 +8,11 @@
 // Runtime keyboard dispatch does NOT branch on these tables; it always goes
 // through the machine, so a table omission can never change behavior — it
 // fails the coverage test instead.
-import { SELECTION_KEYS, type SelectionKey } from "@station/dashboard-core";
+import {
+  SELECTION_KEYS,
+  selectableListBindings as coreSelectableListBindings,
+  type SelectionKey,
+} from "@station/dashboard-core";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiState } from "@station/dashboard-core";
 
@@ -136,17 +140,12 @@ export function editableTextBindings(
 
 /**
  * The ↑↓/↵/slot binding block for a list migrated onto the shared selection
- * engine — the station-side mirror of dashboard-core's selectableListBindings.
+ * engine, reused verbatim from dashboard-core so the two keymaps cannot drift.
  * The engine (not this table) owns dispatch; these document the keys for the
  * coverage test, help overlay, and mouse chrome.
  */
 export function selectableListBindings(prefix: string): readonly StationBinding[] {
-  return [
-    { id: `${prefix}.cursorUp`, pattern: { kind: "named", named: "up" }, action: `${prefix}.cursorUp`, outcome: "handled" },
-    { id: `${prefix}.cursorDown`, pattern: { kind: "named", named: "down" }, action: `${prefix}.cursorDown`, outcome: "handled", help: { keys: "↑↓", label: "move cursor" } },
-    { id: `${prefix}.activate`, pattern: { kind: "named", named: "return" }, action: `${prefix}.activate`, outcome: "handled", help: { keys: "↵", label: "choose" } },
-    { id: `${prefix}.slot`, pattern: { kind: "slot" }, action: `${prefix}.slot`, outcome: "handled", help: { keys: "1-9 a-z", label: "jump to item" } },
-  ];
+  return coreSelectableListBindings(prefix);
 }
 
 export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]> = {

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -6,7 +6,7 @@
 // never touch the store.
 import type { StoreApi } from "zustand/vanilla";
 import type { ProviderId } from "@station/contracts";
-import { isRemoveProjectArmed } from "@station/dashboard-core";
+import { isRemoveProjectArmed, LIST_REGISTRY } from "@station/dashboard-core";
 import type { ProjectSettingsItemId, TuiStore } from "@station/dashboard-core";
 import type { PaneRole } from "../../state/types.js";
 import type { StationMouseEvent } from "../../input/mouse.js";
@@ -340,15 +340,11 @@ export function stationMouseEventKind(event: StationMouseEvent): StationMouseEve
   return undefined;
 }
 
-/** Modes whose sheets list slot-keyed choices a click can select. */
-const SHEET_CHOICE_MODES: ReadonlySet<StationInputMode> = new Set([
-  "newSessionPickProject",
-  "newSessionPickAgent",
-  "projectDefaultAgent",
-  "projectCollapse",
-  "projectSettingsPicker",
-  "projectSettings",
-]);
+// Modes whose sheets list slot-keyed choices a click can select — exactly the
+// registered selection lists, derived so this set cannot drift from the engine.
+const SHEET_CHOICE_MODES: ReadonlySet<StationInputMode> = new Set(
+  Object.keys(LIST_REGISTRY) as StationInputMode[],
+);
 
 function routeStationWheel(
   target: StationMouseTarget,

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -101,6 +101,7 @@ export function OverlayHostView({
         rows={rows}
         snapshot={snapshot}
         screen={screen}
+        selection={selection}
         localRows={localRows}
       />
     );

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -587,3 +587,31 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close
 "
 `;
+
+exports[`modal flow golden frames renders the collapse project sheet windows a long list 1`] = `
+"┌──────────────────────────────────────────────────────────────────────────────┐
+│ Collapse Project                                                             │
+│                                                                              │
+│ 1 station healthy                                                            │
+│ 2 observer healthy                                                           │
+│ 3 scripts healthy                                                            │
+│ 4 empty-project healthy                                                      │
+│ 5 filler-0 healthy                                                           │
+│ 6 filler-1 healthy                                                           │
+│ 7 filler-2 healthy                                                           │
+│ 8 filler-3 healthy                                                           │
+│ 9 filler-4 healthy                                                           │
+│ a filler-5 healthy                                                           │
+│ b filler-6 healthy                                                           │
+│ c filler-7 healthy                                                           │
+│ d filler-8 healthy                                                           │
+│ e filler-9 healthy                                                           │
+│ f filler-10 healthy                                                          │
+│ g filler-11 healthy                                                          │
+│ h filler-12 healthy                                                          │
+│ i filler-13 healthy                                                          │
+│                                                                              │
+│ ↑↓ move   ↵ select   1-18 of 25   Esc cancel                                 │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -121,7 +121,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [1│▸ Default agent           │✓1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
  [2│  Remove project          │ 2 opencode unknown                          │   
  [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 
@@ -177,7 +177,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [1│▸ Default agent           │ 1 codex ● update v0.3.0 → v0.4.0            │ ✓ 
  [2│  Remove project          │✓2 opencode unknown                 updating…│   
  [3│                          │                                             │ ✓ 
- [4│                          │ ✓ current · 1-9/a-z select                  │   
+ [4│                          │ ✓ current · ↑↓ ↵ · 1-9/a-z                  │   
  [5│                          │                                             │ … 
    │                          │                                             │   
 ▼ o│                          │                                             │▾] 

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -379,7 +379,6 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
  [6] x batch-export                       opencode  exited                 #8 ✓ 
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Create Session                                                               │
 │                                                                              │
@@ -387,7 +386,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Name       station-XXXXXX                                                    │
 │ Agent      codex unknown                                                     │
 │                                                                              │
-│ Enter:create N:name P:project A:agent Esc:cancel                             │
+│▸ Create session                                                              │
+│ ↑↓ field  ↵ choose  N/P/A  Esc:cancel                                        │
 └──────────────────────────────────────────────────────────────────────────────┘
 "
 `;

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -118,7 +118,7 @@ const CASES: ModalCase[] = [
   {
     name: "new session review",
     keys: [{ input: "N" }],
-    expect: ["Create Session", "Project", "Agent", "Enter:create N:name P:project A:agent Esc:cancel"],
+    expect: ["Create Session", "Project", "Agent", "Create session", "↑↓ field  ↵ choose  N/P/A  Esc:cancel"],
   },
   {
     name: "new session edit name",

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -47,6 +47,25 @@ const CASES: ModalCase[] = [
     expect: ["Collapse Project", "↑↓ move   ↵ select   1-9/a-z jump   Esc cancel", "station"],
   },
   {
+    name: "collapse project sheet windows a long list",
+    keys: [{ input: "C" }],
+    snapshot: () => {
+      const base = manyProjectsSnapshot();
+      const station = base.projects[0];
+      if (station === undefined) throw new Error("fixture has no projects");
+      const extras = Array.from({ length: 21 }, (_, index) => ({
+        ...station,
+        id: `filler-${index}` as typeof station.id,
+        label: `filler-${index}`,
+      }));
+      return { ...base, projects: [...base.projects, ...extras] };
+    },
+    trimSnapshotTrailingWhitespace: true,
+    // 25 projects at 24 rows: the list windows to 18 with a range footer instead
+    // of clipping rows the cursor could still reach.
+    expect: ["Collapse Project", "↑↓ move   ↵ select   1-18 of 25   Esc cancel", "station"],
+  },
+  {
     name: "project settings picker sheet",
     keys: [{ input: "P" }],
     trimSnapshotTrailingWhitespace: true,

--- a/station/src/station/view/settings/ProjectSettingsPanelView.tsx
+++ b/station/src/station/view/settings/ProjectSettingsPanelView.tsx
@@ -5,8 +5,10 @@
 // machine; this layer is render + mouse targets only.
 import { TextAttributes } from "@opentui/core";
 import type { StationSnapshot } from "@station/contracts";
+import type { ProviderId } from "@station/contracts";
 import {
   isRemoveProjectArmed,
+  PROJECT_SETTINGS_AGENT_LIST_ID,
   PROJECT_SETTINGS_ITEMS,
   projectSettingsPanelLayout,
   removeProjectConfirmPhrase,
@@ -14,6 +16,7 @@ import {
   selectProjectDefaultHarness,
   type TuiLocalRows,
   type TuiScreen,
+  type TuiSelectionState,
 } from "@station/dashboard-core";
 import { useState } from "react";
 import { EditableTextInputView } from "../EditableTextInputView.js";
@@ -27,6 +30,7 @@ type ProjectSettingsScreen = Extract<TuiScreen, { name: "projectSettings" }>;
 export type ProjectSettingsPanelViewProps = {
   snapshot: StationSnapshot;
   screen: ProjectSettingsScreen;
+  selection: TuiSelectionState;
   columns: number;
   rows: number;
   localRows: TuiLocalRows;
@@ -35,6 +39,7 @@ export type ProjectSettingsPanelViewProps = {
 export function ProjectSettingsPanelView({
   snapshot,
   screen,
+  selection,
   columns,
   rows,
   localRows,
@@ -48,7 +53,11 @@ export function ProjectSettingsPanelView({
   const projectLabel = project?.label ?? "Project";
   const title = "Project settings";
   const footer =
-    screen.focus === "list" ? "↑↓ move   →/enter edit   esc close" : "←/esc back";
+    screen.focus === "list"
+      ? "↑↓ move   →/enter edit   esc close"
+      : screen.activeId === "agent"
+        ? "↑↓ move   ↵ choose   ←/esc back"
+        : "←/esc back";
 
   return (
     <box
@@ -82,6 +91,7 @@ export function ProjectSettingsPanelView({
             width={rightWidth}
             focused={screen.focus === "detail"}
             localRows={localRows}
+            selectedAgentId={selection.get(PROJECT_SETTINGS_AGENT_LIST_ID) as ProviderId | undefined}
           />
         </box>
       </box>
@@ -146,12 +156,14 @@ function DetailPane({
   width,
   focused,
   localRows,
+  selectedAgentId,
 }: {
   snapshot: StationSnapshot;
   screen: ProjectSettingsScreen;
   width: number;
   focused: boolean;
   localRows: TuiLocalRows;
+  selectedAgentId?: ProviderId;
 }) {
   if (screen.activeId === "remove") {
     return <RemoveDetail screen={screen} width={width} focused={focused} />;
@@ -163,6 +175,7 @@ function DetailPane({
       width={width}
       focused={focused}
       localRows={localRows}
+      selectedAgentId={selectedAgentId}
     />
   );
 }
@@ -173,12 +186,14 @@ function AgentDetail({
   width,
   focused,
   localRows,
+  selectedAgentId,
 }: {
   snapshot: StationSnapshot;
   screen: ProjectSettingsScreen;
   width: number;
   focused: boolean;
   localRows: TuiLocalRows;
+  selectedAgentId?: ProviderId;
 }) {
   const project = snapshot.projects.find((candidate) => candidate.id === screen.projectId);
   const choices = project === undefined ? [] : selectNewSessionHarnessChoices(snapshot, project);
@@ -195,10 +210,11 @@ function AgentDetail({
             choices={choices}
             width={width}
             currentId={currentDefault?.harness}
+            selectedId={focused ? selectedAgentId : undefined}
             pending={currentDefault?.pending ?? false}
           />
           <SheetLine width={width}> </SheetLine>
-          <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(" ✓ current · 1-9/a-z select", width)}</text>
+          <text fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>{fit(" ✓ current · ↑↓ ↵ · 1-9/a-z", width)}</text>
         </>
       )}
     </>

--- a/station/src/station/view/sheets/NewSessionSheetView.tsx
+++ b/station/src/station/view/sheets/NewSessionSheetView.tsx
@@ -21,6 +21,7 @@ import { providerHealthStatusColor, STATION_COLORS } from "../theme.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import { AgentChoiceListView } from "./AgentChoiceListView.js";
 import {
+  fit,
   SheetChoiceLine,
   SheetFooter,
   SheetLabelValue,
@@ -117,15 +118,23 @@ function Review({
 }) {
   const harness =
     project === undefined ? undefined : selectedHarnessOption(snapshot, project, state);
+  const focus = state.mode === "review" ? state.reviewFocus : "create";
   return (
     <>
       <SheetLine width={width}> </SheetLine>
-      <SheetLabelValue width={width} label="Project" labelWidth={10} value={project?.label ?? "-"} />
+      <SheetLabelValue
+        width={width}
+        label="Project"
+        labelWidth={10}
+        value={project?.label ?? "-"}
+        focused={focus === "project"}
+      />
       <SheetLabelValue
         width={width}
         label="Name"
         labelWidth={10}
         value={state.branch}
+        focused={focus === "name"}
         {...(state.nameSource === "generated" ? { valueColor: STATION_COLORS.gray } : {})}
       />
       <SheetLabelValue
@@ -133,10 +142,14 @@ function Review({
         label="Agent"
         labelWidth={10}
         value={harness === undefined ? state.selectedHarness : `${harness.label} ${harness.status}`}
+        focused={focus === "agent"}
         {...colorProp(providerHealthStatusColor(harness?.status))}
       />
       <SheetLine width={width}> </SheetLine>
-      <SheetFooter width={width}>{"Enter:create N:name P:project A:agent Esc:cancel"}</SheetFooter>
+      <text fg={focus === "create" ? STATION_COLORS.cyan : STATION_COLORS.foreground}>
+        {fit(`${focus === "create" ? "▸" : " "} Create session`, width)}
+      </text>
+      <SheetFooter width={width}>{"↑↓ field  ↵ choose  N/P/A  Esc:cancel"}</SheetFooter>
     </>
   );
 }

--- a/station/src/station/view/sheets/ProjectChoiceSheetView.tsx
+++ b/station/src/station/view/sheets/ProjectChoiceSheetView.tsx
@@ -33,10 +33,19 @@ export function ProjectChoiceSheetView({
   const choices = selectProjectChooserChoices(snapshot);
   const width = bottomSheetContentWidth(columns);
   const selectedId = selection.get(mode) as ProjectId | undefined;
+  // Window the list to the frame so the cursor can never move onto a clipped
+  // row; the slice follows the cursor like AddProjectSheetView's folder picker.
+  const listHeight = Math.max(1, Math.min(choices.length, rows - 6));
+  const selectedIndex = Math.max(
+    0,
+    choices.findIndex((choice) => choice.value.id === selectedId),
+  );
+  const start = Math.max(0, Math.min(selectedIndex, choices.length - listHeight));
+  const visible = choices.slice(start, start + listHeight);
   return (
-    <BottomSheetFrameView columns={columns} rows={rows} title={TITLE[mode]} contentRows={choices.length + 4}>
+    <BottomSheetFrameView columns={columns} rows={rows} title={TITLE[mode]} contentRows={visible.length + 4}>
       <SheetLine width={width}> </SheetLine>
-      {choices.map((choice) => (
+      {visible.map((choice) => (
         <SheetChoiceLine
           key={choice.value.id}
           choiceKey={choice.key}
@@ -48,7 +57,11 @@ export function ProjectChoiceSheetView({
         />
       ))}
       <SheetLine width={width}> </SheetLine>
-      <SheetFooter width={width}>{"↑↓ move   ↵ select   1-9/a-z jump   Esc cancel"}</SheetFooter>
+      <SheetFooter width={width}>
+        {visible.length < choices.length
+          ? `↑↓ move   ↵ select   ${start + 1}-${start + visible.length} of ${choices.length}   Esc cancel`
+          : "↑↓ move   ↵ select   1-9/a-z jump   Esc cancel"}
+      </SheetFooter>
     </BottomSheetFrameView>
   );
 }

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -23,25 +23,33 @@ export function SheetLabelValue({
   labelWidth = 15,
   value,
   valueColor,
+  focused = false,
 }: {
   width: number;
   label: string;
   labelWidth?: number;
   value: string | ReactNode;
   valueColor?: string;
+  /** Marks the row under a focus ring — a ▸ marker + cyan label instead of dim. */
+  focused?: boolean;
 }) {
-  const labelText = ` ${label.padEnd(labelWidth)} `;
+  const labelText = `${focused ? "▸" : " "}${label.padEnd(labelWidth)} `;
+  const labelSpan = focused ? (
+    <span fg={STATION_COLORS.cyan}>{labelText}</span>
+  ) : (
+    <span attributes={TextAttributes.DIM}>{labelText}</span>
+  );
   if (isValidElement(value)) {
     return (
       <text fg={STATION_COLORS.foreground}>
-        <span attributes={TextAttributes.DIM}>{labelText}</span>
+        {labelSpan}
         {value}
       </text>
     );
   }
   return (
     <text fg={STATION_COLORS.foreground}>
-      <span attributes={TextAttributes.DIM}>{labelText}</span>
+      {labelSpan}
       <span {...(valueColor === undefined ? {} : { fg: valueColor })}>
         {fit(String(value), Math.max(1, width - labelText.length))}
       </span>


### PR DESCRIPTION
## What

Follow-up to #80. A research pass found only **two** screens still had dead arrow keys after #80; this closes both.

1. **Project Settings → Default agent** (the real one). The detail pane was slot-only — after descending with `→`/`↵`, `↑↓/↵` were dead no-ops. Now the agent enum is arrow-navigable: descend seeds the cursor at the current default, `↑↓` move it, `↵` commits.
2. **New Session → Review menu.** `↑↓` were dead keys. Now a focus ring cycles Project → Name → Agent → Create (default Create, so `↵` still creates); `↵` activates the focused field; `N/P/A` stay as accelerators.

Everything else (dashboard, fork, addProject, the y/n confirm, widgetSettings) is correctly bespoke or already arrow-navigable and is deliberately **not** touched.

## How

**Phase 1 (`927c8a4`)** — hosts the agent enum as an `active`-gated `flatPickerSpec` leaf on the existing engine (list id `projectSettingsAgent`), gated to `focus==="detail" && activeId==="agent"` so it never touches the left list or the destructive-confirm disarm. Keyboard slot, right-pane click, and the cursor now share one `commitProjectSettingsAgentById`, preserving the optimistic pending default. Wires `projectSettings` as a `TuiInputMode` + `deriveTuiInputMode` case + a `TUI_KEYMAP` union table (the Station side was already set up). Also removes two dead hooks from #80 (the unread `followScroll` field, the never-emitted `"pointer"` `CommitVia` arm) and corrects an aspirational comment.

**Phase 2 (`88cff60`)** — a screen-local focus ring on the review step (a form/menu, not the engine). **Blocker handled:** Station's `resolveNewSessionSubmit` intercepted `Enter` for any review state before the machine; it's now gated on `reviewFocus === "create"` so `↵` on a focused field opens that field's step instead of always-creating (guard-tested).

## Testing

- TDD; both lanes green: dashboard-core **270/270**, station **936/0**, typecheck (both packages) + lint clean. Goldens re-approved (settings panel + review footers/markers).
- The full vitest lane also shows pre-existing timing/env flakes in `apps/cli`, `packages/client`, `integrations/harness/claude` (observer startup, reconnect backoff, claude auth) — unrelated to this TUI change and untouched by it.
- **Manual TUI pass still recommended** for the review `↵` gate (the pure vitest path passes while a mis-gated Station path would regress): `N` → `↑↓` to a field → `↵` opens that field (must NOT create); `↑↓` to Create → `↵` creates.
