### PR TITLE
docs(single-binary): v1.1 — spike evidence + audit corrections

### DIFF
--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -1,305 +1,200 @@
 # Single-binary Station
 
-How STATION becomes one compiled `stn` binary (CLI + observer + ingress + TUI
-renderer + station-host) whose first run always lands in a working native
-station TUI with a healthy observer connected — no brew toolchain, no
-`pnpm build`, no separate `bun install`, no manual observer step. Pick up
-stages from "Landing order" — each phase is independently landable and
-CI-green.
+> **Status: v1.1 (current).** v1 was feasibility evidence, not an
+> implementation-ready roadmap; an adversarial audit of commit `e0d4307`
+> found 11 blocking issues, all reproduced and confirmed (see
+> [Audit findings](#audit-findings-all-confirmed)). v1.1 is subtractive:
+> it corrects the SQLite contract and dispatch boundary, removes the
+> observer-eviction design in favor of the canonical singleton roadmap,
+> pins platform/artifact/security policy, and defines config activation,
+> station-host upgrade, checksum-verified install, and real-UX acceptance.
+> The Stage 0 spike evidence (S1–S4) is preserved verbatim in the
+> [Evidence appendix](#evidence-appendix-spikes-s1s4). v1's phase text is
+> superseded by the phases below.
+
+How STATION becomes one compiled `stn` binary (CLI + observer + ingress +
+TUI renderer + station-host) whose first run always lands in a working
+native station TUI with a healthy observer connected — no brew toolchain,
+no `pnpm build`, no separate `bun install`, no manual observer step. Pick
+up phases from the [Dependency graph](#dependency-graph); each is
+independently landable and CI-green.
 
 ## Goal and non-goals
 
-Goal: download one file, run `stn`, get the native TUI connected to a live
-observer. Everything else (worktrunk, tmux, diffnav, git-delta, agent CLIs)
-gates *features*, never launch.
+Goal: download one verified file, run `stn`, get the native TUI connected
+to a live observer. Everything else (worktrunk, tmux, diffnav, git-delta,
+agent CLIs) gates *features*, never launch — captured precisely by the
+`launchReady` vs `workflowReady` split below.
 
-Non-goals for this plan:
+Non-goals:
 
-- Public distribution. The repo is private; binaries ship as private GitHub
-  release assets with a gh-authenticated install script. Public
-  curl-install / homebrew-core wait on the repo opening up
-  (see [Homebrew packaging](homebrew.md) blockers).
-- Windows targets.
-- The full observer-singleton 3d claim-lock hand-off
-  ([observer-singleton](observer-singleton.md)) — this plan's eviction logic
-  is deliberately narrower and forward-compatible with it.
-- Replacing the dev workflow. Dev mode (tsc dist under Node + `bun --hot`
-  TUI from source) stays byte-identical; compiled mode is a new dispatch
-  layered on build-time defines.
+- **Public distribution.** The repo is private; binaries ship as private
+  GitHub release assets fetched by an authenticated install script. A
+  binary Homebrew formula is **deferred** until a tested private-asset
+  download strategy exists (see A5); the authenticated script is the only
+  binary channel meanwhile.
+- **Windows targets.**
+- **Any observer replacement / eviction in this roadmap.** Coordinated
+  single-observer behavior is owned entirely by
+  [observer-singleton](observer-singleton.md). This plan *depends on* that
+  roadmap's 3c/3d/3e + version-order phases; it does not add a second,
+  uncoordinated eviction path (v1 did — removed, see F3).
+- **Replacing the dev workflow.** Dev mode (tsc dist under Node +
+  `bun --hot` TUI from source) stays byte-identical; compiled mode is new
+  dispatch layered on build-time defines.
 
-## Why this is now feasible (empirical facts, verified 2026-07-09, bun 1.3.14, darwin-arm64)
+## Supported platforms, versions, and artifact policy
 
-Re-run these probes after any bun upgrade; each unlocks a load-bearing
-decision.
+Pinned so the release job, install script, and acceptance suite agree.
 
-- **`@opentui/core` 0.4.1 supports `bun build --compile` natively.** The
-  platform packages' `index.bun.js` is
-  `await import("./libopentui.dylib", { with: { type: "file" } })` and core
-  handles bunfs paths (`isBunfsPath` in its bundle). The TUI's native dylib
-  embeds automatically — no extract-and-dlopen shim needed.
-- **`Bun.Terminal` provides real PTYs.** Probe:
+| Axis | Policy |
+|------|--------|
+| Targets | `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. No Windows. |
+| Build runners | Native per target (no cross-compile — only the host-matching `@opentui/core-*` optional dep installs). Use *currently available* GitHub-hosted labels resolved at implementation time; do **not** hard-code `macos-13` (F9 — Intel macOS labels are being retired). Pin exact labels in the workflow with a comment naming the check date. |
+| macOS floor | Match the oldest OS the chosen Intel/arm runners image supports; state it in release notes. |
+| Linux floor | glibc only for v1.1 (bun's default). Declare the built-against glibc version (the runner's) as the floor; musl is a later target, not silently implied. |
+| CPU | x64 baseline = bun's default (no AVX-512 assumption); arm64 = Apple/ARMv8. |
+| Artifact | `stn-v{ver}-{darwin|linux}-{arm64|x64}.tar.gz`. **Manifest below is exhaustive.** |
 
-  ```bash
-  bun -e 'const t = new Bun.Terminal({ cols: 80, rows: 24, data(_, c) { out += new TextDecoder().decode(c); } });
-  let out = ""; const p = Bun.spawn(["/bin/echo", "hi"], { terminal: t });
-  p.exited.then((code) => setTimeout(() => { console.log(out.includes("hi") && code === 0 ? "ok" : "bad"); t.close(); }, 200));'
-  ```
+**Artifact manifest** (every file the binary needs on disk that
+`bun build --compile` does *not* embed — F8):
 
-  Prints `ok`. Instance API: `close, closed, controlFlags, inputFlags,
-  localFlags, outputFlags, ref, unref, resize, setRawMode, write`. This
-  replaces node-pty, its `spawn-helper` binary, `localPtyBridge.cjs`, and the
-  hidden **Node runtime dependency** (`station/src/terminal/pty/localPtyTerminal.ts`
-  spawns `node` for the bridge today).
-- **node-pty hangs under bun** — `pty.spawn` never fires `onData`/`onExit`
-  (probe: same echo test via `require("node-pty")`; times out). This is why
-  the Node bridge subprocess exists; it cannot be kept in a bun-only binary.
-- **`require("node:sqlite")` under bun silently kills the process** — exit 0,
-  no output, no throw (probe: `bun -e 'process.stdout.write("before\n");
-  require("node:sqlite"); process.stdout.write("after\n")'` prints only
-  `before`). The observer's sqlite layer must branch on runtime and must
-  never *evaluate* the `node:sqlite` import under bun. `bun:sqlite` works.
-- **`node:net` unix-socket server + client work under bun** (probe: bind a
-  socket in tmpdir, round-trip a payload). `packages/protocol/src/transport.ts`
-  ports as-is.
-- **Known bundler hazard:** `apps/cli/tsconfig.json` maps `@station/*` paths
-  to **`.d.ts` files** — if bun's bundler honors nearest-tsconfig paths for
-  files under `apps/cli/`, imports resolve to declaration files (spike S1).
-- `station/scripts/link-station-packages.sh` already symlinks built
-  `@station/*` dists into `station/node_modules/@station/`; `runCli` is
-  already exported from `apps/cli/src/main.ts`.
+- `stn` — the compiled binary.
+- `stn-ingress` — symlink → `stn` (argv0 dispatch).
+- `stn-tmux-popup` — the tmux popup toggle. Today a separate bin
+  (`package.json` → `integrations/terminal/tmux/bin/stn-popup`); the popup
+  keybinding and setup depend on it. Either ship it as a third symlink →
+  `stn` routed to an internal `__tmux-popup` mode, or vendor the script.
+  Decide in A4; it is **not** optional.
+- `LICENSE` — required. FSL-1.1 (LICENSE:67) obliges every redistributed
+  copy to include the Terms or a link and keep copyright notices. The
+  archive must carry it.
+- **Extracted-at-runtime integration assets** (see A4 extraction policy):
+  the Pi extension file (`integrations/harness/pi/src/piExtension.ts` is
+  resolved as an on-disk `../dist/piExtension.js` via
+  `new URL(import.meta.url)` and handed to the external `pi` CLI — it must
+  exist as a real file, so it is embedded via a file import and extracted
+  to a stable per-version cache dir), and the ctty helper (A2). The
+  scripted-harness `.mjs` is test-only and may stay dev-mode-only.
+
+## Security: no ambient config in compiled mode (F1 — confirmed RCE vector)
+
+`bun build --compile` **auto-loads `.env` and `bunfig.toml` from the
+process CWD by default** (`--compile-autoload-dotenv` /
+`--compile-autoload-bunfig`, both default `true` — verified: a compiled
+probe run in a directory containing `.env` with `F1_INJECTED=…` saw the
+value in `process.env`). Because Station reads behavior from env
+(`STATION_DASHBOARD_COMMAND` is spawned with `shell: true` at
+`apps/cli/src/commands/tui.ts:152`; also `STATION_*_BIN`, `STATION_NODE`,
+`STATION_HOST_ENTRY`, `STATION_PTY_IMPL`, …), running `stn` inside an
+untrusted checkout would let that repo's `.env` inject an arbitrary shell
+command — remote code execution on `stn` launch.
+
+Mandatory in every compile invocation (A4):
+
+```
+bun build --compile --no-compile-autoload-dotenv --no-compile-autoload-bunfig …
+```
+
+Acceptance (A4 + release): a hostile-directory test — a checkout carrying
+`.env` (`STATION_DASHBOARD_COMMAND=touch /tmp/PWNED`) and a `bunfig.toml`;
+launching the binary there must **not** create the marker and must not
+honor either file. This is a release-blocking gate, not a smoke check.
 
 ## Target architecture
 
 ```
-stn (bun build --compile, per platform)
-├── default argv        → CLI (runCli — commands, setup, doctor, …)
-│     └── auto-start:     spawn(process.execPath, ["__observer", …], detached)
-├── __observer           → runCliObserverMain (bun:sqlite driver)
-├── __ingress            → ingress main; also selected when basename(argv0) == "stn-ingress"
-├── __tui / __dashboard  → TUI renderer child: spawn(process.execPath, ["__tui"])
-└── __station-host       → persistent-PTY host (feature-flagged)
+stn (bun build --compile, per platform, no ambient env)
+│  raw-argv dispatch (BEFORE runCli — F5):
+├── argv0 == "stn-ingress"  → ingress main (owns raw stdin)
+├── __observer              → runCliObserverMain (bun:sqlite driver; own --config/--socket parse)
+├── __ingress               → ingress main (owns raw stdin)
+├── __tui / __dashboard     → TUI renderer (re-exec self: spawn(execPath, ["__tui"]))
+├── __station-host          → persistent-PTY host
+├── __tmux-popup            → popup toggle (replaces stn-tmux-popup bin)
+└── else                    → runCli (commands, setup, doctor, …)
+       └── auto-start observer: spawn(process.execPath, ["__observer", …], detached)
 ```
 
+- **Raw-argv dispatch, not hidden CLI commands (F5).** v1 registered
+  `__observer`/`__ingress` in the normal command registry. That is wrong:
+  `parseGlobalOptions` (`apps/cli/src/main.ts:150`) strips global `--config`
+  before route execution, but the observer needs its own `--config` /
+  `--socket` / `--state-dir` parsing (`runObserverMain`); and ingress owns
+  **raw stdin** (`apps/cli/src/ingressMain.ts` → `readStdinIfAvailable`).
+  All internal modes are dispatched from raw `process.argv` in the compile
+  entry **before** `runCli`, each delegating to the same function today's
+  dedicated entry (`observerMain.ts`/`ingressMain.ts`) calls. Testability
+  under dev Node is preserved by exporting those run-functions and calling
+  the dispatcher directly in vitest — not by making them registry commands.
 - **Compile entry** `station/src/bin/stnMain.ts`, compiled from the
-  `station/` workspace so one graph resolves both worlds: station source
-  (bun bundles TS/TSX directly) and `@station/*` pnpm packages **from built
-  dist**, via `link-station-packages.sh` extended to also link
-  `apps/cli` → `@station/cli` and `apps/observer` → `@station/observer`.
-  Renderer/host entries dispatch *before* the CLI so renderer children never
-  execute CLI config loading.
-- **Internal dispatch** uses hidden `__`-prefixed subcommands registered in
-  the normal CLI command registry — they work under dev Node too
-  (`node dist/main.js __observer …`), which makes dispatch vitest-testable
-  without compiling.
-- **Runtime-mode seam**: `packages/runtime/src/buildInfo.ts` reads build-time
+  `station/` workspace so one graph resolves station source (bun bundles
+  TS/TSX directly) and `@station/*` pnpm packages from built dist, via
+  `link-station-packages.sh` extended to link `apps/cli` → `@station/cli`
+  and `apps/observer` → `@station/observer`. (S1 confirmed the bundler
+  resolves through `exports` and the feared `.d.ts` `paths` hazard does not
+  fire.)
+- **Runtime-mode seam** `packages/runtime/src/buildInfo.ts`: build-time
   defines `STATION_BUILD_VERSION` / `STATION_BUILD_COMPILED` behind `typeof`
-  guards, so dev tsc output stays valid under Node and reports
-  `{ version: "0.0.0-dev", compiled: false }`. Every self-spawn site asks one
-  helper (`selfExecArgv(entry)`): compiled → `[process.execPath, entry]`,
-  dev → today's exact behavior.
-- **TUI stays a child process in compiled mode** (re-exec self, not
-  in-process): keeps crash isolation and terminal-restore semantics, the env
-  contract (`STATION_OBSERVER_SOCKET_PATH`, `STATION_TUI_POPUP`, focus-origin
-  vars), and the `STATION_DASHBOARD_COMMAND` override. Same binary, so the
-  cost is one fork + shared page cache.
-- **PTY**: in-process `Bun.Terminal` adapter behind the existing
-  `StationTerminalProcess` interface, in both dev and compiled modes (the PTY
-  consumer always runs under bun already). `STATION_PTY_IMPL=bridge` keeps
-  the legacy bridge for one release as an escape hatch.
-- **SQLite**: `apps/observer/src/sqlite/driver.ts` chooses the driver at
-  module load on `typeof Bun !== "undefined"` — `bun:sqlite` under bun,
-  `node:sqlite` under Node (vitest lanes unchanged).
-- **Hooks**: generated provider hook scripts keep the PATH-name
-  `stn-ingress` default — a name survives binary upgrades where an absolute
-  versioned path would not. Every install channel ships `stn-ingress` as a
-  symlink to `stn`; the binary routes on argv0.
+  guards; dev tsc reports `{ version: "0.0.0-dev", compiled: false }`.
+  Self-spawns route through `selfExecArgv(entry)`: compiled →
+  `[process.execPath, entry]`, dev → today's command. All
+  `import.meta.url === file://${process.argv[1]}` self-exec guards become
+  `import.meta.main` (S1 proved the legacy form double-executes under
+  compile; S4 proved `import.meta.main` is correct everywhere).
+- **TUI as a re-exec child** in compiled mode: crash isolation, terminal
+  restore, unchanged env contract, `STATION_DASHBOARD_COMMAND` override
+  honored (but ambient `.env` no longer feeds it — see Security).
+- **PTY** = in-process `Bun.Terminal` **plus a controlling-terminal helper**
+  (S2, F6): a per-platform `setsid()+TIOCSCTTY+execvp` trampoline embedded
+  and extracted, without which shell panes lose Ctrl-Z job control and
+  orphan on a Station crash. `STATION_PTY_IMPL=bridge` is **dev-only** (it
+  needs Node + node-pty native assets a binary doesn't ship) — the binary's
+  in-field PTY fallback is instead `STATION_PTY_IMPL=bun-nocctty` (the plain
+  adapter without job control) plus reverting the A2b default flip. The doc
+  must not promise the bridge as a binary rollback.
+- **SQLite** = `apps/observer/src/sqlite/driver.ts`, runtime-branched
+  (`bun:sqlite` under bun, `node:sqlite` under Node), with the **full
+  contract** below (F2).
+- **Hooks** keep the PATH-name `stn-ingress` default; every channel ships
+  the symlink.
 
-## Stage 0 — Spikes
+## `launchReady` vs `workflowReady` (F11 — don't weaken setup truth)
 
-Timebox each to half a day; record findings in this doc under a `## Spike
-results` section (create it with the first result). Work happens on a scratch
-branch that is never merged; only the doc update lands.
+Rather than move required checks to `recommended` (v1's B4, which erodes
+what "required" means), split the setup summary into two truths:
 
-### S1 — Bundle graph (highest risk; unblocks A4)
+- `launchReady` — the binary can start the TUI + observer. Needs: the
+  binary itself, a writable state dir. Nothing else. Bare `stn` gates on
+  this.
+- `workflowReady` — full worktree workflow: worktrunk, tmux, diffnav,
+  git-delta, an agent CLI, git repo cwd, a project in config. `stn setup`
+  reports these as unmet *capabilities*, not as "broken."
 
-Procedure:
+Each check keeps its real status; `stn setup check --json` gains both
+booleans. `stn` launches whenever `launchReady`; the TUI surfaces unmet
+`workflowReady` capabilities inline. Bun/station-UI/`rendererRuntimeCheck`
+checks are skipped when `isCompiledBinary()`.
 
-1. `pnpm build`; extend the link script by hand:
-   `ln -sfn ../../../apps/cli station/node_modules/@station/cli` (and
-   observer).
-2. Scratch entry `station/src/bin/spike.ts`:
-   `import { runCli } from "@station/cli"` + `import` of
-   `../dashboardRenderer/main.tsx`, dispatching on argv.
-3. `bun build --compile --define STATION_BUILD_VERSION='"0.0.0-spike"' --define STATION_BUILD_COMPILED=true station/src/bin/spike.ts --outfile /tmp/stn-spike`.
-4. Run `/tmp/stn-spike --version` from an empty directory, and the dashboard
-   entry with `STATION_SOURCE=mock`.
+## Phases
 
-Pass: binary builds; `--version` prints; dashboard renders against the mock
-source; no module resolves to a `.d.ts`. Fail modes and fix ladder for the
-`.d.ts` `paths` hazard: (a) delete the `paths` block from
-`apps/cli/tsconfig.json` and let `moduleResolution: bundler` resolve through
-node_modules `exports` (verify `tsc --noEmit` still passes — the block may be
-legacy); (b) repoint entries at `dist/index.js`; (c) last resort, a
-`Bun.build()` JS-API pass with a resolver plugin. Also confirm here:
-`jsxImportSource: "@opentui/react"` applies to bundled `.tsx`, and the
-opentui dylib is embedded (run from a machine path with no
-`node_modules` nearby).
+### A1 — foundation: buildInfo + SQLite driver + real observer version
 
-### S2 — `Bun.Terminal` flow control and drain ordering (unblocks A2)
+`packages/runtime/src/buildInfo.ts` (dev-safe `typeof`-guarded defines;
+exported from the package index).
 
-Procedure: spawn `cat /tmp/500mb-file` into a `Bun.Terminal` whose `data`
-callback sleeps 5ms per chunk; watch RSS.
-
-Pass criteria:
-
-- Memory stays bounded (kernel PTY backpressure) OR the instance exposes a
-  usable pause/resume (probe `controlFlags`/`inputFlags`/`localFlags` and any
-  undocumented methods).
-- Short-lived commands (`printf` burst then exit) deliver **complete** output
-  before the exit event — the bridge's drain-before-exit comment exists
-  because `process.exit` used to truncate final bursts.
-- `resize` below the bridge floors (cols 2 / rows 1) doesn't throw — else the
-  adapter clamps like the bridge does.
-- Closing the terminal while the child lives kills the child (this replaces
-  the bridge's stdin-close backstop); no orphaned shells after the harness
-  process is SIGKILLed.
-
-### S3 — macOS Gatekeeper (unblocks A5)
-
-Ad-hoc `codesign` per bun's compile docs (JIT entitlements), then simulate a
-download: `xattr -w com.apple.quarantine "0081;…" stn` and launch. Pass: runs
-without a Gatekeeper block on macOS 14+. Notarization is out of scope; note
-findings for the release checklist.
-
-### S4 — `import.meta.main` under bundling (unblocks A3)
-
-Bundle an entry importing a module that guards top-level execution with
-`if (import.meta.main)`. Pass: entry sees `true`, imported module sees
-`false`, and the same file still runs standalone under `bun --hot`.
-
-### S5 — Detached self-spawn on Linux (folds into A4's CI smoke)
-
-`spawn(process.execPath, ["__observer", …], { detached: true })` from the
-compiled binary on ubuntu; observer survives parent exit. Expected fine;
-cheap to confirm in CI rather than locally.
-
-## Spike results (2026-07-09, bun 1.3.14, darwin-arm64)
-
-S1–S4 ran against a scratch clone of merged main (`pnpm build` + station
-`bun install` + hand-linked `@station/cli`/`@station/observer`); S5 stays
-deferred to A4's CI smoke.
-
-### S1 — PASS (bundle graph works; the `.d.ts` hazard did not materialize)
-
-807 modules bundled in ~70ms, 73MB binary. Bun's bundler resolved every
-`@station/*` import through node_modules `exports` and ignored
-`apps/cli/tsconfig.json`'s `.d.ts` `paths` — no empty modules, no resolver
-plugin needed. `jsxImportSource` applied to bundled `.tsx`, the opentui
-dylib embedded automatically, and the compiled binary rendered the
-dashboard entry under a PTY (live alt-screen + terminal-capability output).
-Real CLI machinery ran end to end: `setup check --json` in a temp HOME
-executed genuine probes. Two defects surfaced, both already mapped to
-phases:
-
-- Top-level `node:sqlite` kills compiled startup (`No such built-in
-  module`). Confirmed the swap surface is **exactly one value-import** in
-  the whole dist (`apps/observer/dist/sqlite.js`); a hand-patched
-  `bun:sqlite` shim there made everything work — A1's driver as specced.
-- `apps/cli/src/main.ts`'s self-exec guard
-  (`import.meta.url === file://${process.argv[1]}`) fires for **every
-  bundled module** in compiled mode (argv[1] is the bunfs root, which is
-  every module's URL) → `runCli` executes twice per invocation. Fix
-  verified by S4; A3 swaps the guard to `import.meta.main`.
-
-### S2 — PASS with a required A2 amendment (ctty trampoline)
-
-- **Completeness**: a short-lived child's full output, including the final
-  bytes, is delivered *before* `p.exited` resolves — no drain race, the
-  bridge's drain-before-exit concern doesn't apply in-process.
-- **Backpressure**: kernel PTY flow control just works. A deliberately slow
-  `data` callback throttled a 200MB `cat` to 44MB/90s with **peak RSS
-  31MB** — the consumer's pace blocks the child; no pause/resume machinery
-  needed. (`TerminalOptions` also exposes a `drain` callback for write-side
-  backpressure.)
-- **Resize**: cols/rows of 0 throw; 1 works. Keep the bridge's 2/1 clamps.
-- **`terminal.close()` does NOT kill the attached child** — dispose must
-  `child.kill()` explicitly.
-- **No controlling terminal**: children get the pty on stdio but not as
-  ctty (`ps` shows `TTY ??`, TPGID 0). Consequences measured: Ctrl-Z
-  arrives as literal `^Z` (job control broken — unacceptable for shell
-  panes), and pty children **orphan** when the parent exits or is
-  SIGKILLed.
-- **A setsid+TIOCSCTTY trampoline between spawn and payload fixes both**:
-  with the ctty acquired, Ctrl-Z suspends correctly and children die with
-  the parent (SIGHUP on master close) even under SIGKILL — pure kernel
-  semantics replace the bridge's stdin-close backstop.
-
-**A2 design amendment**: the adapter is in-process `Bun.Terminal` **plus a
-ctty trampoline** wrapping the payload command. Recommended shape: a tiny
-per-platform C helper (`setsid(); ioctl(0, TIOCSCTTY); execvp(payload)`),
-modeled on node-pty's `spawn-helper`, embedded in the binary and extracted
-with the runtime assets — true exec-replace, no extra process per pane.
-Fallback without native code: a self-exec `stn __pty-exec` internal command
-doing the same via `bun:ffi` then spawn-and-forward (leaves one shim
-process per pane). Worth tracking upstream: Bun may grow a
-controlling-terminal option on `Terminal`/`spawn`.
-
-### S3 — PASS for the planned install path (quarantine is the boundary)
-
-`bun build --compile` output is already ad-hoc linker-signed
-(`flags=adhoc,linker-signed`, identifier `a.out`) and runs unmodified. With
-`com.apple.quarantine` set (simulating a browser download), macOS SIGKILLs
-it (exit 137). curl/`gh` downloads set no quarantine, so the A5 install
-script path is unaffected; the script should still defensively
-`xattr -d com.apple.quarantine`, and the release job should
-`codesign --force --sign -` with a real identifier (cosmetic). Developer ID
-signing + notarization only become necessary for browser-download
-distribution — deferred with public distro.
-
-### S4 — PASS (`import.meta.main` is the correct guard everywhere)
-
-Dev-imported `false` / dev-standalone `true` / compiled-entry `true` /
-compiled-imported `false`. The legacy `file://argv[1]` comparison is `true`
-for imported modules under compile and must not survive A3.
-
-## Stage 1 — Foundation (Track A, phase A1)
-
-Lands green on today's CI with zero behavior change. No compile anywhere yet.
-
-**Create `packages/runtime/src/buildInfo.ts`** (export from
-`packages/runtime/src/index.ts`):
+`apps/observer/src/sqlite/driver.ts` — **corrected contract (F2).** The
+persistence layer reads `result.changes` (`ingressDedupe.ts:19`,
+`observations.ts:117`, `worktreeMetadataCurrent.ts:107,119`,
+`correlations.ts:210`, …). `run()` returning `void` cannot typecheck.
+Verified both drivers: `run()` yields `{changes, lastInsertRowid}`
+(bun:sqlite: `number`; node:sqlite: `number | bigint`). Contract:
 
 ```ts
-// Injected by `bun build --compile --define STATION_BUILD_VERSION=... --define STATION_BUILD_COMPILED=true`.
-declare const STATION_BUILD_VERSION: string | undefined;
-declare const STATION_BUILD_COMPILED: boolean | undefined;
-
-export type StationBuildInfo = { version: string; compiled: boolean };
-
-export function stationBuildInfo(): StationBuildInfo {
-  return {
-    version: typeof STATION_BUILD_VERSION === "string" ? STATION_BUILD_VERSION : "0.0.0-dev",
-    compiled: typeof STATION_BUILD_COMPILED === "boolean" && STATION_BUILD_COMPILED,
-  };
-}
-
-export function isCompiledBinary(): boolean {
-  return stationBuildInfo().compiled;
-}
-```
-
-Scalar defines, not a JSON object; the `typeof` guards keep dev tsc output
-valid under Node, and the expression survives verbatim into
-`packages/runtime/dist`, where a later compile's `--define` still rewrites it.
-
-**Create `apps/observer/src/sqlite/driver.ts`** plus a minimal ambient
-`bun:sqlite` module declaration (so tsc needs no `@types/bun`):
-
-```ts
-export type SqlParam = string | number | bigint | null | Uint8Array;
+export type SqlRunResult = { changes: number; lastInsertRowid: number | bigint };
 export type SqlStatement = {
-  run(...params: SqlParam[]): void;
-  get(...params: SqlParam[]): unknown; // normalized: undefined when no row
+  run(...params: SqlParam[]): SqlRunResult;       // was void — WRONG in v1
+  get(...params: SqlParam[]): unknown;            // normalized: undefined when no row
   all(...params: SqlParam[]): unknown[];
 };
 export type SqlDatabase = {
@@ -308,314 +203,336 @@ export type SqlDatabase = {
   close(): void;
 };
 
-// Branch on runtime, NOT on import failure: require("node:sqlite") under bun
-// silently exits the process, so it must never be evaluated there.
+// Branch on runtime, never on import failure (node:sqlite silently kills bun).
 export const openSqlDatabase: (path: string) => SqlDatabase =
   typeof Bun !== "undefined"
     ? adaptBunSqlite((await import("bun:sqlite")).Database)
     : adaptNodeSqlite((await import("node:sqlite")).DatabaseSync);
 ```
 
-The bun adapter normalizes `get()` `null` → `undefined` and maps
-`exec`/`prepare`/`close` 1:1 — the whole consumed surface, verified against
-`apps/observer/src/sqlite.ts`.
+The bun adapter normalizes `get()` `null → undefined` and coerces
+`changes` to `number` (callers already wrap in `Number(...)`; keep that).
+The driver must also assert, once at open: WAL mode set, `synchronous`,
+and that migrations run identically — the observer's `openObserverSqlite`
+already applies `PRAGMA journal_mode = WAL` and migrations, so the driver
+only needs to guarantee both `exec` and `prepare().run()` semantics match.
 
-**Modify:**
+Feed `stationBuildInfo().version` into `createObserverCore` (fixes the
+hardcoded `"0.0.0"` in `reconcile/core.ts`), surfacing a real version in
+observer health. `stn --version`.
 
-- `apps/observer/src/sqlite.ts` — `DatabaseSync` → `SqlDatabase` via the
-  driver; `ObserverSqliteHandle.database: SqlDatabase`.
-- `apps/observer/src/persistence/*.ts` (~10 files) — type-import swap only;
-  they use nothing beyond exec/prepare/run/get/all.
-- `apps/observer/src/runtime/main.ts` — pass
-  `version: stationBuildInfo().version` into `createObserverCore`, fixing the
-  hardcoded `"0.0.0"` default (`apps/observer/src/reconcile/core.ts`) so
-  observer health carries a real version (contract field already exists).
-- `apps/cli` — `stn --version` prints `stationBuildInfo().version`.
+**Tests:** vitest driver-mapping units (node); a bun-lane test (`bun test`)
+for the bun driver asserting `run().changes`, `get()`-no-row `undefined`,
+integer round-trip, and WAL; and a **cross-runtime test**: a DB *created*
+by the node driver, then *opened and read* by the bun driver (and vice
+versa), proving migration/schema compatibility across the two engines.
 
-**Tests:** vitest driver-mapping units (node driver — lanes unchanged); one
-bun-lane test file run by the station-bun CI job (`bun test`) opening the bun
-driver, running a migration-shaped exec/prepare round trip, and asserting
-`get()` with no row is `undefined`; observer-core unit asserting health
-`version` equals the injected build version.
-
-## Track A — packaging (remaining phases)
-
-### A2 — `Bun.Terminal` PTY adapter (two PRs: opt-in, then default flip)
+### A2 — `Bun.Terminal` PTY adapter + controlling-terminal helper (two PRs)
 
 `station/src/terminal/pty/bunTerminalProcess.ts` implementing
-`StationTerminalProcess` (same MIN_COLS=2/MIN_ROWS=1 clamps as the bridge);
-extract the listener/pending-data/diagnostic machinery from
-`LocalPtyTerminalProcess` into a shared emitter module;
-`createLocalPtyTerminal` becomes a selector. Per the S2 results, the
-adapter spawns the payload through a **ctty trampoline**
-(setsid + TIOCSCTTY + exec; embedded per-platform helper, see the S2
-amendment) — without it job control breaks and pty children orphan on a
-Station crash. **A2a** lands the adapter opt-in only
-(`STATION_PTY_IMPL=bun` selects it; default stays the bridge) so it can be
-daily-driven without commitment. **A2b** is a one-line default
-flip (`Bun.Terminal` present and `STATION_PTY_IMPL !== "bridge"` → adapter)
-after at least a week of real use with no bridge fallbacks — flipping back
-is a one-line revert, and `STATION_PTY_IMPL=bridge` stays the in-field undo
-that needs no rebuild.
-`defaultShell`/`defaultShellArgs`/`createPtyEnv` stay put (host reuses them).
-Flow control per S2 findings; cap the pre-listener pending buffer
-(drop-oldest + diagnostic) so a listener-less pane can't OOM. A2a runs the
-new adapter cases (completeness-on-fast-exit, clamp, kill-on-dispose,
-env-scrub) against the opt-in path; A2b repoints the default pty tests
-(`localPtyTerminal.test.ts`, `ptyPipeline.smoke.test.ts`) at the adapter.
-Bridge and its hardening test stay until A6.
+`StationTerminalProcess`; shared emitter extracted from
+`LocalPtyTerminalProcess`. The payload command is spawned through a **ctty
+helper** (S2, F6): `setsid()`, `ioctl(0, TIOCSCTTY)`, `execvp(payload)`.
 
-### A3 — self-exec seam + hidden dispatch (dev behavior unchanged)
+Helper lifecycle (all required before the A2b default flip):
 
-`apps/cli/src/selfExec.ts` (`selfExecArgv(entry)` returning
-`[process.execPath, entry]` when compiled, `undefined` in dev). Register
-hidden registry routes `__observer` (→ `runCliObserverMain`) and `__ingress`;
-argv0 compat in `apps/cli/src/main.ts`
-(`basename(process.argv0) === "stn-ingress"` → `__ingress`). Replace every
-`import.meta.url === file://argv[1]` self-exec guard with
-`import.meta.main` — S1 proved the legacy form double-executes `runCli` in
-compiled mode, and S4 proved `import.meta.main` is correct in all contexts. Rewrite each
-spawn site as `selfExecArgv(...) ?? <current dev command>`:
+- **Source + build**: a tiny C source per platform (arm64/x64 × darwin/
+  linux), compiled in release CI, checked in as source. `TIOCSCTTY` differs
+  per platform (macOS `0x20007461`); no magic constants in TS.
+- **Embedding + extraction**: embedded via file import; extracted to a
+  per-version, per-user cache dir (e.g. `<stateDir>/run/helpers/<ver>/`)
+  with `0700`, `chmod +x`, and an integrity check (size/hash) before use.
+- **Concurrency**: extraction is idempotent and lock-guarded (two panes
+  racing must not observe a half-written helper). Reuse if present + valid.
+- **`noexec` policy**: if the cache dir is on a `noexec` mount, fall back
+  to a temp exec-capable dir or surface a clear diagnostic; never silently
+  drop to the no-ctty path.
+- **Cleanup**: stale-version helpers pruned on observer start.
 
-- `apps/cli/src/observerProcess.ts` `defaultSpawnObserver` (also introduce a
-  single `resolveObserverSpawnCommand` seam — Track B2 reuses it for boot
-  logging).
-- `apps/cli/src/ingress/observerStartup.ts` + `ingress/command.ts` —
-  generalize `observerEntryPath` to `observerCommand: string[]`.
-- `apps/cli/src/commands/tui.ts` `spawnRenderer` — compiled:
-  `[process.execPath, "__tui"|"__dashboard"]`, skipping the
-  `isStationUiInstalled()` preflight; dev: `bun run --cwd station` as today;
-  `STATION_DASHBOARD_COMMAND` wins in both modes.
-- `apps/cli/src/observerProviders.ts` `resolveStationHostEntry` +
-  `integrations/terminal/station/src/host/ensureHostRunning.ts` — generalize
-  `{bunCommand, hostEntry}` to `hostCommand: string[]`.
-- `apps/cli/src/commands/notify/focusAction.ts` and
-  `commands/registry/popup.ts` — compiled: `[process.execPath]` alone (never
-  bake a bunfs argv[1] into a command string).
-- `integrations/harness/scripted/src/launch.ts` — compiled: `"node"` on PATH
-  (test-only integration); dev: `process.execPath`.
+`createLocalPtyTerminal` becomes a selector. **A2a**: adapter opt-in
+(`STATION_PTY_IMPL=bun`), default stays the bridge. **A2b**: default flip,
+gated on ≥1 week daily-driving A2a and the acceptance below. In-field undo
+for binary users is `STATION_PTY_IMPL=bun-nocctty` + reverting the flip —
+**not** the bridge (dev-only).
 
-Refactor `station/src/main.tsx`, `station/src/dashboardRenderer/main.tsx`,
-`station/src/host/hostMain.ts` into exported run functions executed under
-`if (import.meta.main)` (per S4), and swap the ~8 `Bun.env` uses to
-`process.env`.
+**Per-platform job-control + orphan tests (release-blocking):** on every
+target, in a real PTY, verify Ctrl-Z suspends and resumes (`fg`), that a
+`SIGKILL` of the Station process leaves **no** orphaned pane children, and
+that `terminal.close()` is paired with an explicit `child.kill()` (S2:
+close alone does not kill).
 
-### A4 — compile entry + build script + CI smoke
+### A3 — self-exec seam + raw-argv dispatch
 
-`station/src/bin/stnMain.ts` (dispatch `__tui`/`__dashboard`/
-`__station-host` before delegating everything else to `runCli`);
-`scripts/build-binary.mjs` + root `build:binary` script:
-`pnpm build` → extended `link-station-packages.sh` (adds `@station/cli`,
-`@station/observer` app links) → `bun build --compile --minify --sourcemap
---define … station/src/bin/stnMain.ts --outfile dist-bin/stn` → smoke
-`dist-bin/stn --version`. New CI `binary-smoke` job: version/help,
-`stn setup check --json` in a temp HOME, an observer round trip through the
-binary in an isolated state dir, and an ingress receipt. Note:
-`apps/cli/src/observerReap.ts`'s ps-matcher must learn the compiled argv
-shape (`["stn", "__observer", …]`) alongside `observerMain.js`.
+`apps/cli/src/selfExec.ts`; raw-argv dispatcher in the compile entry and a
+dev-mode equivalent, routing `__observer`/`__ingress`/`__tui`/`__dashboard`/
+`__station-host`/`__tmux-popup` **before** `runCli` (F5). Export the
+run-functions from `observerMain.ts`/`ingressMain.ts`/renderer/host so
+dispatch is unit-testable. Swap every self-exec guard to `import.meta.main`.
+Rewrite spawn sites (`observerProcess.ts`, `ingress/observerStartup.ts`,
+`commands/tui.ts`, `observerProviders.ts` + `ensureHostRunning.ts`,
+`notify/focusAction.ts`, `registry/popup.ts`, `scripted/launch.ts`) through
+`selfExecArgv`. `Bun.env → process.env` in `station/src`.
 
-### A5 — release pipeline (private distribution)
+### A4 — compile entry + build script + asset extraction + CI smoke
 
-`.github/workflows/release.yml` on `v*` tags; native-runner matrix
-(macos-14 → darwin-arm64, macos-13 → darwin-x64, ubuntu-24.04 → linux-x64,
-ubuntu-24.04-arm → linux-arm64 — native runners avoid cross-compile issues
-with per-platform `@opentui/core-*` optional deps); per job: build → ad-hoc
-codesign (macOS, per S3) → `stn-v{ver}-{os}-{arch}.tar.gz` containing `stn` +
-`stn-ingress` symlink; fan-in writes `SHA256SUMS` and `gh release create`.
-Distribution while private: `scripts/install.sh` downloads via
-authenticated `gh api` (documented requirement: `gh auth login` or a token);
-binary Homebrew formula `packaging/homebrew/station-bin.rb.template` with
-per-platform url/sha blocks and `bin.install_symlink "stn" => "stn-ingress"`
-(tap needs a token-backed download strategy until the repo is public); the
-source formula template gets a superseded header. Public curl-install is
-deferred by decision, not design — the same artifacts serve it later.
+`station/src/bin/stnMain.ts`; `scripts/build-binary.mjs` + `build:binary`.
+Compile command carries **both** ambient-config disable flags (F1) and the
+version/compiled defines. Asset-extraction module resolves the Pi extension
+and ctty helper from embedded files to the per-version cache on first use.
+`link-station-packages.sh` extended for the app links.
 
-### A6 — cleanup (after one release on the new PTY path)
+CI `binary-smoke` (ubuntu): `--version`, `--help`, `setup check --json`
+(asserting the `launchReady`/`workflowReady` split), an **observer round
+trip through the binary** in an isolated state dir, an ingress receipt via
+the `stn-ingress` symlink, the **hostile-directory RCE test** (F1), and the
+**detached self-spawn** check (folds in S5). Note: `observerReap.ts`'s
+ps-matcher must learn the compiled argv shape.
 
-Delete `localPtyBridge.cjs`, the bridge selector branch,
-`ensureSpawnHelperExecutable`, `repair-node-pty`, the `node-pty` dependency,
-`localPtyBridgeHardening.test.ts`, `STATION_PTY_IMPL`, and `STATION_NODE`.
-Keep `STATION_HOST_ENTRY`/`STATION_BUN`/`STATION_DASHBOARD_COMMAND` as dev
-escape hatches.
+### A5 — release pipeline (private, deterministic, verifiable)
+
+`.github/workflows/release.yml` on `v*` tags, native-runner matrix
+(labels resolved at build time per the platform table — not `macos-13`).
+Requirements v1 omitted:
+
+- **Reuse the existing gate**: tag builds must run the same deterministic
+  checks as `standard-ci` + `pnpm smoke:release`, not bypass them.
+- **Checksums**: emit `SHA256SUMS`, sign or at least publish it; the
+  install script verifies each artifact against it before extraction.
+- **License**: include `LICENSE` in every archive (F9 / LICENSE:67).
+- **Homebrew (F10)**: a release created with the default `GITHUB_TOKEN`
+  **does not** trigger the existing `release: published` bump workflow
+  (`homebrew-bump.yml`). Either fold the tap update into `release.yml` (with
+  a PAT / `COMMITTER_TOKEN`) or dispatch it explicitly. **Until a tested
+  private-asset download strategy exists, defer the binary formula** and
+  ship only the authenticated install script.
+- **Rollback**: deleting a published tag is **not** rollback. Define
+  immutable rollback = publish a superseding patch release pointing the
+  install script / `latest` at the prior good version; never mutate or
+  delete a published artifact.
+- `scripts/install.sh`: authenticated `gh api` download → checksum verify →
+  `xattr -d com.apple.quarantine` (defensive; gh/curl set none per S3) →
+  install to `~/.local/bin` with the `stn-ingress` symlink → PATH hint.
+
+### A6 — cleanup (after one release on the ctty PTY path)
+
+Delete the bridge, node-pty, `repair-node-pty`, `STATION_NODE`, and their
+tests, once the per-platform acceptance has been green for a full release
+cycle. Keep `STATION_DASHBOARD_COMMAND` / `STATION_HOST_ENTRY` /
+`STATION_BUN` as dev escape hatches.
 
 ## Track B — first-run guarantee
 
-Independent of Track A until B3; B1/B2 improve today's source install
-immediately.
+### B1 — config-tolerant launch
 
-### B1 — config-tolerant launch (bare `stn` reaches the TUI)
+In-memory defaults, write-on-configure (no auto-written stub — it poisons
+`stn setup`'s clean create path). Lift `emptyConfig` to
+`packages/config/src/firstRun.ts`; add `handleConfigError` hooks on
+`registry/tui.ts` + `registry/popup.ts` that degrade **only**
+`CONFIG_FILE_NOT_FOUND` without an explicit `--config`; broken config and
+explicit `--config` keep the hard error. The renderer's empty-state is the
+first-run screen.
 
-Decision: **in-memory defaults, write-on-configure** — never auto-write a
-config stub. A stub poisons `stn setup`'s clean create path
-(`configWriter.ts` only takes `renderNewSetupConfig` when config status is
-`missing`, and the append path's guard rejects a stub that can't declare a
-harness). The renderer (`station/src/config/stationConfig.ts`) and the
-observer (`emptyConfig()` when spawned without `--config`) already tolerate
-missing config; the CLI front door is the only intolerant layer.
+### B2 — observer boot guarantee (no eviction — F3)
 
-Lift `emptyConfig` into `packages/config/src/firstRun.ts`
-(`firstRunConfig()`); add `handleConfigError` hooks (existing mechanism,
-pattern: `registry/doctor.ts`) to `registry/tui.ts` and `registry/popup.ts`
-that catch **only** `CONFIG_FILE_NOT_FOUND` **without** an explicit
-`--config`, print a one-line "starting with defaults — run `stn setup` to
-add projects" notice, and run the tui/popup command with `firstRunConfig()`
-plus `STATION_FIRST_RUN=1` in the renderer env. Broken config and explicit
-`--config` keep the hard error. The renderer's existing empty-state
-("No projects configured yet." + welcome intro) is the first-run screen.
-Known gap: a config-less observer keeps serving `emptyConfig` after the user
-later writes a config — B3's restart machinery closes this; until then the
-setup success message says to restart.
+Boot log `<stateDir>/logs/observer-boot.log` replacing `stdio:"ignore"`;
+child-exit race → immediate `OBSERVER_EXITED_ON_START` with a boot-log
+tail (kills the silent 30s hang); default health wait 30s → 10s with
+progressive stderr from the tui/popup call sites only.
 
-### B2 — observer boot guarantee
+**Removed from v1:** the client-side unhealthy-incumbent SIGTERM eviction.
+It conflicts with [observer-singleton](observer-singleton.md), which is
+explicitly consolidating to **one** socket-relative `observer.claim.lock`
+with process-identity revalidation, total version ordering, and spool
+safety (3d/3e + Phase 4). Adding a second, uncoordinated client killer is
+exactly what that roadmap removes. **Dependency, not duplication:** the
+version-aware upgrade behavior this plan needs (B3) is delivered by the
+singleton roadmap's version-order phase. If that lands, B3 consumes it; if
+not, B3 ships **only** the same-version restart in B-config below and the
+schema-mismatch UX — never an out-of-band kill.
 
-All in `apps/cli/src/observerProcess.ts` unless noted:
+### B-config — config activation (F4 — v1 was wrong)
 
-- **Boot log**: replace `stdio: "ignore"` with stdout/stderr → 
-  `<stateDir>/logs/observer-boot.log` (rewritten per boot attempt, 0600,
-  header line with the exact spawn command).
-- **Fail-fast**: race `waitForObserverHealth` against child exit; a child
-  that dies pre-health yields immediate `OBSERVER_EXITED_ON_START` with a
-  15-line boot-log tail in the hint — kills the silent 30s hang (missing
-  entry, bad node, crashed migration).
-- **Bounded wait**: default health timeout 30s → 10s; progressive stderr
-  messages at ~1.5s ("Starting Station observer…") and ~5s (points at the
-  boot log) from the tui/popup call sites only (the other seven
-  `startObserver` sites and the hook path stay silent).
-- **Minimal incumbent eviction**: on `startObserver` finding an unhealthy
-  socket, evict **only** when the probe error is `PROTOCOL_SCHEMA_MISMATCH`
-  with a provably **older** incumbent schema (plumb the incumbent's
-  `schemaVersion` onto the mismatch SafeError in
-  `packages/protocol/src/client.ts`): best-effort `stop` RPC, then SIGTERM
-  the socket holder via the reap module's socket-holder lookup, wait ≤3s,
-  reclaim. Never evict hung-but-possibly-healthy or newer-schema incumbents
-  (newer → "upgrade stn" error). Escape hatch `STATION_NO_OBSERVER_EVICT=1`.
-  Forward-compatible with singleton 3d: the SIGTERM becomes a negotiated
-  step-down behind the same function.
+v1 claimed B3 closes the "config-less observer keeps serving
+`emptyConfig()` after `stn setup`" gap. It does not: B3 restarts only an
+**older-version** observer, so a same-version first-run `setup` leaves the
+observer on `emptyConfig()` indefinitely. Fix, one of (pick in
+implementation, prefer the first):
 
-### B3 — version-aware upgrades (needs A1's real version)
+1. **`stn setup` explicitly reloads/restarts the observer** on writing a
+   config that changes project membership — a targeted `restartObserver`
+   (same-version safe: stop via RPC works) after `configWriter` succeeds,
+   with a user-visible line.
+2. **Health exposes configuration identity** (config path + a content hash);
+   the CLI restarts when the running observer's config identity differs from
+   the on-disk config. This also generalizes to external edits.
 
-- `startObserver` on a **running** observer: if the CLI is a real release
-  (`!== "0.0.0-dev"`) and the observer's health version is older, one-shot
-  `restartObserver` (self-terminating: the restarted observer reports the
-  new version). Dev builds never auto-evict, so parallel checkouts sharing
-  the default socket don't fight.
-- Renderer exit code 86 = "restart observer": on `halted` +
-  `PROTOCOL_SCHEMA_MISMATCH` the TUI offers "press R to restart the
-  observer"; R exits 86; the CLI parent restarts the observer and respawns
-  the renderer exactly once (a second 86 exits with upgrade copy — the
-  mid-session mismatch case usually means a newer stn owns the socket).
+Either way, the first-run flow must guarantee the observer reflects the new
+project without a manual restart — that is the headline UX and must be in
+the acceptance suite.
 
-### B4 — setup and doctor re-tiering (surgical)
+### B3 — version + schema UX (scoped down)
 
-In `apps/cli/src/commands/setup/planner.ts`: worktrunk, tmux, diffnav,
-git-delta, agent CLI, git-project, and config-**missing** move
-`required` → `recommended`, each message naming the feature it gates
-("worktree sessions", "See diff (split right)", …); config-**invalid** stays
-required. Bun + station-UI checks and doctor's `rendererRuntimeCheck`
-(`BUN_RUNTIME_MISSING`/`STATION_UI_NOT_INSTALLED`) are skipped when
-`isCompiledBinary()`. `nextSteps` puts bare `stn` first once required-ok.
-Update `setup-profiles` fixtures; add a container-lane `binary-only` profile
-(docs/setup-testing.md) asserting launchable-but-features-missing, plus a
-first-run smoke: bare `stn tui` with `STATION_DASHBOARD_COMMAND=true` so the
-config-less boot + observer spawn + health path runs unmocked in CI without
-a TTY.
+Same-version config activation via B-config. Renderer exit code 86 =
+"restart observer" on a `halted` + `PROTOCOL_SCHEMA_MISMATCH` state → the
+CLI parent restarts once and respawns the renderer. Older-binary-version
+auto-restart is **deferred to the singleton version-order phase**; this
+plan does not implement its own version eviction.
 
-## Landing order
+### B-host — station-host upgrade behavior (F7 — was undefined)
+
+`ensureHostRunning` reuses an existing host if health responds, but host
+health carries only `{ok, protocolVersion}` (`packages/station-host/src/
+protocol.ts`). An upgraded binary would keep talking to an old host process
+driving **live PTYs**. Define:
+
+- Host health must carry the build version (mirror A1's observer fix).
+- Compatibility rule: reuse iff `protocolVersion` matches **and** version is
+  compatible; otherwise graceful replacement.
+- Live-PTY policy: what happens to existing PTYs + scrollback on
+  replacement — either a reattach/handoff (preferred; the host already
+  snapshots scrollback on attach) or an explicit, announced session end.
+  Undefined behavior here means silent session loss on upgrade; the
+  acceptance suite exercises upgrade-with-live-host.
+
+## Dependency graph
+
+One graph replaces v1's two prose landing-orders.
 
 ```
-A1 foundation ─┬─► A2a/A2b pty adapter ─► A3 self-exec ─► A4 compile+smoke ─► A5 release ─► A6 cleanup
-               └─► B3 version-aware upgrades
-B1 config-tolerant launch ─► B2 observer boot guarantee ─► B3 ─► B4 re-tiering
+A1 ─────────────┬─► A2a ─► A2b ──────────────┐
+ (buildInfo,     │   (ctty helper + per-       │
+  sqlite,        │    platform job-control     │
+  real version)  │    acceptance)              │
+                 ├─► A3 ─► A4 ─► A5 ─► A6       │
+                 │   (raw dispatch; compile +   (delete bridge after
+                 │    RCE gate; release;         one green release)
+                 │    checksum/license/brew)
+                 │
+                 └─► B3 (schema/version UX) ◄── observer-singleton version-order phase
+B1 ─► B2 ─► B-config ─► B3
+              (config activation — headline UX)
+B-host  (independent; needed before upgrade is advertised safe)
+
+External dependency: observer-singleton 3c/3d/3e + version order
+  → required before any older-version observer handoff is claimed safe.
 ```
 
-Suggested merge order: A1 → B1 → B2 → A2a → A3 → B3 → A4 → A2b → B4 → A5 → A6.
-Stage 0 spikes precede A2/A3/A4/A5 as marked; S1 findings may add a small
-"fix tsconfig paths" pre-phase.
+Suggested merge order: A1 → B1 → B2 → B-config → A2a → A3 → A4 → A2b →
+B-host → A5 → A6, with B3's version half gated on the singleton roadmap.
 
-## Experimentation and exit strategy
+## Verification (F11 — prove the headline UX, not a proxy)
 
-The plan's safety model is not "be careful" — it is that every phase has a
-defined place to experiment, a merge gate, and an undo that does not depend
-on memory. Three global rules, then the per-phase table.
+Unit/integration (every PR): vitest fake-seam tests; bun-lane driver + PTY
+tests; the cross-runtime SQLite test (A1).
 
-**Experimentation protocol (applies to every spike and phase):**
+CI smoke (A4): the binary end-to-end minus TTY, **including** the
+hostile-directory RCE gate and detached self-spawn.
 
-1. Exploratory work happens in a scratch clone or worktree on a throwaway
-   branch. Experimental builds are never `pnpm link --global`ed, never run
-   `stn hooks install`, and always run against an isolated state dir and
-   socket (`--state-dir`/`--socket` into a scratch path;
-   `station/scripts/station-isolated.sh` and the container lane in
-   [setup-testing](setup-testing.md) exist for this). The directory is not
-   the isolation mechanism — the env is: the catastrophe mode is an
-   experimental observer binding the shared default socket and draining
-   real spool events.
-2. No phase in this plan adds a sqlite migration or rewrites external
-   provider hook configs. That is a constraint, not an observation — the
-   PATH-name `stn-ingress` decision exists precisely so upgrades *and
-   rollbacks* never touch files outside the repo and state dir. A phase
-   that needs to violate this gets re-designed or split first.
-3. Every phase is one PR (A2 is two) whose revert must not require
-   reverting a later phase. Seams introduced early (`selfExecArgv`, the
-   sqlite driver, the pty selector) default to legacy behavior, so
-   reverting a consumer never strands a seam.
+**Release acceptance (every target, on a clean box with no Node/Bun/
+node_modules on PATH):** this is the gate v1 lacked. `STATION_DASHBOARD_
+COMMAND=true` and `HOME=$(mktemp -d)` do **not** count — and note
+`mktemp` HOME can still inherit an `XDG_RUNTIME_DIR` socket, so the harness
+must scrub `XDG_RUNTIME_DIR`/`XDG_STATE_HOME` too. The manual/automated
+flow:
 
-| Phase | Experiment where | Merge gate | Undo after merge | Abandon signal |
-|-------|-----------------|------------|------------------|----------------|
-| S1–S5 | Scratch clone, isolated state dir; binaries stay in `/tmp` | Nothing merges except findings in `## Spike results` | Delete the clone | Any hard fail → regroup at the doc level before writing code |
-| A1 | Normal PR branch | Both CI lanes green + bun driver test; zero behavior change asserted by existing suites | `git revert` — no schema change, health `version` is additive | bun:sqlite drift the adapter can't normalize |
-| B1 | Normal PR branch | Integration tests: missing-config launches, broken-config still exits 1 | `git revert` — no persisted state | — |
-| B2 | Scratch clone for real-spawn testing (isolated state dir), then PR | Container first-run profile passes unmocked | `git revert`; in-field: `STATION_NO_OBSERVER_EVICT=1`, `--timeout-ms`; leftover `observer-boot.log` is inert | Eviction ever firing outside a schema mismatch |
-| A2a | Daily-drive via `STATION_PTY_IMPL=bun` in your own shell | Adapter test cases green; S2 criteria met | Default untouched — stop setting the env var | Any pane corruption/orphan → stay on bridge, record in doc |
-| A2b | — (one-line flip) | ≥1 week daily driving A2a with zero bridge fallbacks | One-line revert; in-field: `STATION_PTY_IMPL=bridge` without rebuild | — |
-| A3 | Normal PR branch | Existing integration suites byte-identical (dev mode returns `undefined` from `selfExecArgv`); dispatch unit tests | `git revert` — compiled mode doesn't exist yet, so the code is dormant | — |
-| B3 | Normal PR branch | Version-compare unit + renderer-86 loop tests | `git revert`; dormant on dev builds (`0.0.0-dev` never restarts) until A5 ships real versions | — |
-| A4 | Scratch clone for compile iteration; PR adds entry + script + CI job | `binary-smoke` job green | `git revert` / delete the job — source installs untouched, binary is an artifact nobody installs | S1-class bundler failure resurfacing → back to spike |
-| B4 | Normal PR branch | setup-profiles fixtures + container `binary-only` profile | `git revert` — tier constants and fixtures only | — |
-| A5 | Tag on a scratch prerelease (`v0.x.y-rc.N`) | Install script round-trips on a clean machine/VM via gh auth | Delete release + tag; nothing auto-updates, formula/installer are opt-in | Gatekeeper or install ergonomics unresolvable → stay on source installs |
-| A6 | — | **Point of no easy return** (deletes bridge, node-pty, repair scripts): require one full release cycle daily-driven on the `Bun.Terminal` path with zero `STATION_PTY_IMPL=bridge` fallbacks | Restoring the bridge means reverting a deletion PR — possible but demoted to code archaeology after upstream drift | — |
+1. Launch bare `stn` outside tmux in a sanitized, isolated env → real
+   OpenTUI renderer draws, observer connects, first-run screen shows.
+2. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
+3. Run `stn setup` adding a project → the **same** observer reflects the new
+   project immediately (B-config), no manual restart.
+4. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
+5. `stn-ingress` symlink delivers a provider hook event end to end.
+6. Upgrade the binary while **live host PTYs** exist → reattach without
+   session loss (B-host).
+7. Rollback → install script returns to the prior good version (immutable).
 
-Until A6, abandoning the entire effort at any point leaves main in a state
-that is strictly better than today (A1's real version, B1/B2's first-run
-fixes stand alone) with no dead machinery beyond dormant seams.
+## Audit findings (all confirmed)
 
-## Risk register (ranked)
+Against `e0d4307`, reproduced this session (bun 1.3.14, darwin-arm64):
 
-1. ~~**Bundler vs `apps/cli` `.d.ts` `paths`**~~ — **retired by S1**: the
-   bundler resolves through node_modules `exports` and ignores the paths
-   block; no fix needed.
-2. ~~**`Bun.Terminal` flow control / drain ordering**~~ — **retired by
-   S2**: kernel backpressure bounds memory and output is complete at exit.
-   Replaced by a smaller risk: the **ctty trampoline** (per-platform helper
-   build in release CI; job control and orphan-cleanup regressions if the
-   trampoline is wrong). The bridge stays selectable for one release.
-3. **macOS Gatekeeper** for downloaded binaries — **scoped by S3**: only
-   quarantined (browser-download) copies are killed; curl/`gh` installs are
-   clean. Installer strips the xattr defensively; notarization deferred.
-4. **Private-repo distribution ergonomics** — gh-auth requirement for
-   installs; tap needs a token-backed download strategy. Accepted by
-   decision; artifacts are public-ready.
-5. **bun:sqlite semantic drift** (null vs undefined, integer width) —
-   covered by the bun-lane driver test.
-6. **Cross-schema eviction on shared dev sockets** — mitigated: evict only
-   provably-older-schema, never dev builds, `STATION_NO_OBSERVER_EVICT=1`,
-   everything logged.
-7. **10s health timeout on slow cold starts** — progressive message names
-   the boot log; `--timeout-ms` still overrides; fail-fast means only
-   genuinely slow (not dead) observers reach the timeout.
-8. **Renderer exit-code 86 collision** — a crash exiting 86 triggers one
-   spurious observer restart; bounded to a single retry.
+1. **Ambient `.env`/`bunfig` RCE** — compiled binary auto-loads cwd `.env`
+   into `process.env` (proven); `STATION_DASHBOARD_COMMAND` runs with
+   `shell: true`. Fix: `--no-compile-autoload-dotenv` +
+   `--no-compile-autoload-bunfig` (both exist, default true) + hostile-dir
+   gate. Arguably broader than reported — the whole `STATION_*` env surface
+   is attacker-controlled, not just the dashboard command.
+2. **SQLite facade wrong** — `run(): void` cannot typecheck against
+   `result.changes` (6+ sites). Both engines return
+   `{changes, lastInsertRowid}`. Corrected in A1.
+3. **Eviction conflicts with the singleton design** — removed; deferred to
+   observer-singleton (B2/B3). Design-coherence issue, not a runtime bug,
+   but real.
+4. **First-run config stays stale** — B3 only restarts older versions;
+   same-version `setup` leaves `emptyConfig()`. New B-config.
+5. **Internal modes misrouted** — `parseGlobalOptions` strips `--config`;
+   ingress owns raw stdin. Dispatch from raw argv before `runCli` (A3).
+6. **PTY rollback promise false** — `STATION_PTY_IMPL=bridge` needs Node +
+   node-pty assets a binary lacks; ctty helper had no lifecycle. Fixed in
+   A2 + architecture.
+7. **station-host upgrades undefined** — health is protocol-number-only.
+   New B-host.
+8. **Artifact inventory incomplete** — `stn-tmux-popup`, Pi extension file,
+   LICENSE. New manifest + extraction policy.
+9. **Release not shippable** — runner label, OS/CPU/glibc floors, gate
+   bypass, checksums, license, real rollback. Fixed in A5 + platform table.
+   (Sub-claim "`macos-13` retired": consistent with GitHub's Intel-macOS
+   deprecation; **not independently verified from this environment** — pin
+   available labels at implementation time rather than trust the name.)
+10. **Homebrew automation diverges** — `GITHUB_TOKEN`-created releases don't
+    trigger `release: published`. Fold in or dispatch; defer the formula.
+11. **Verification proves a proxy, not the UX** — new release-acceptance
+    suite on clean boxes.
 
-## Verification strategy
+## Evidence appendix: spikes S1–S4
 
-- Per-phase vitest fake-seam integration tests
-  (`apps/cli/test/integration/`, the `runCli(argv, { observerDeps, tuiDeps })`
-  pattern) — dispatch, config-error hooks, fail-fast, eviction, version
-  restart, renderer-86 loop.
-- Bun-lane tests (`station/` + the A1 bun driver test) for sqlite driver and
-  PTY adapter behavior.
-- CI `binary-smoke` job (A4) exercising the compiled binary end to end
-  minus TTY.
-- Container-lane `binary-only` profile (B4) running the real first-run path
-  unmocked.
-- Manual fresh-machine smoke: `HOME=$(mktemp -d) stn` must reach the TUI
-  with a connected observer and the first-run screen.
+Verified 2026-07-09, bun 1.3.14, darwin-arm64, against a scratch clone of
+merged main (`pnpm build` + station `bun install` + hand-linked
+`@station/cli`/`@station/observer`). S5 stays deferred to A4's CI smoke.
+These are load-bearing evidence for v1.1; the probes are runnable.
+
+**Feasibility probes (re-run after any bun upgrade):**
+
+- `@opentui/core` 0.4.1 compiles: platform `index.bun.js` is
+  `await import("./libopentui.dylib", { with: { type: "file" } })`; core
+  handles bunfs paths. Dylib embeds automatically.
+- `Bun.Terminal` real PTY:
+  `bun -e 'const t=new Bun.Terminal({cols:80,rows:24,data(_,c){out+=new TextDecoder().decode(c)}});let out="";const p=Bun.spawn(["/bin/echo","hi"],{terminal:t});p.exited.then(c=>setTimeout(()=>{console.log(out.includes("hi")&&c===0?"ok":"bad");t.close()},200))'`
+  → `ok`.
+- node-pty hangs under bun (same echo via `require("node-pty")` times out).
+- `require("node:sqlite")` silently kills bun:
+  `bun -e 'process.stdout.write("before\n");require("node:sqlite");process.stdout.write("after\n")'`
+  prints only `before`. → runtime-branched driver.
+- `node:net` unix sockets work under bun.
+
+**S1 — PASS (bundle graph).** 807 modules → 73MB in ~70ms. Bundler
+resolved every `@station/*` import via node_modules `exports`; the
+`apps/cli/tsconfig.json` `.d.ts` `paths` hazard did **not** fire.
+`jsxImportSource` applied to bundled `.tsx`; opentui dylib embedded; the
+binary rendered the dashboard under a PTY (live alt-screen). Two defects,
+both mapped: top-level `node:sqlite` kills startup (one value-import in
+`apps/observer/dist/sqlite.js`; hand-shimming `bun:sqlite` there made it
+work — A1); and `main.ts`'s `file://${argv[1]}` self-exec guard fires for
+every bundled module under compile → `runCli` runs twice (A3 → `import.meta.main`).
+
+**S2 — PASS with the A2 ctty amendment.** Output complete before
+`p.exited` resolves (no drain race). Kernel PTY backpressure bounds
+memory: a slow `data` callback throttled a 200MB `cat` to peak RSS 31MB
+(`TerminalOptions` also exposes a `drain` callback). Resize: 0 throws, 1
+works → keep 2/1 clamps. `terminal.close()` does **not** kill the child
+(dispose must). No controlling terminal by default (`ps` → `TTY ??`,
+TPGID 0): Ctrl-Z arrives as literal `^Z` and children **orphan** on parent
+exit/SIGKILL. A `setsid()+TIOCSCTTY` trampoline fixes both — verified:
+Ctrl-Z suspends and children die with the parent even under SIGKILL. →
+A2's ctty helper (F6).
+
+**S3 — PASS for the install path.** Compiled output is ad-hoc
+linker-signed (`flags=adhoc,linker-signed`) and runs unmodified; a
+`com.apple.quarantine` xattr (browser-download simulation) makes macOS
+SIGKILL it (exit 137). gh/curl set no quarantine → A5 path unaffected;
+installer strips defensively. Developer-ID + notarization only for
+browser-download distribution (deferred).
+
+**S4 — PASS.** `import.meta.main`: dev-imported `false` / dev-standalone
+`true` / compiled-entry `true` / compiled-imported `false`. The legacy
+`file://argv[1]` guard is `true` for imported modules under compile and
+must not survive A3.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -183,6 +183,85 @@ Bundle an entry importing a module that guards top-level execution with
 compiled binary on ubuntu; observer survives parent exit. Expected fine;
 cheap to confirm in CI rather than locally.
 
+## Spike results (2026-07-09, bun 1.3.14, darwin-arm64)
+
+S1–S4 ran against a scratch clone of merged main (`pnpm build` + station
+`bun install` + hand-linked `@station/cli`/`@station/observer`); S5 stays
+deferred to A4's CI smoke.
+
+### S1 — PASS (bundle graph works; the `.d.ts` hazard did not materialize)
+
+807 modules bundled in ~70ms, 73MB binary. Bun's bundler resolved every
+`@station/*` import through node_modules `exports` and ignored
+`apps/cli/tsconfig.json`'s `.d.ts` `paths` — no empty modules, no resolver
+plugin needed. `jsxImportSource` applied to bundled `.tsx`, the opentui
+dylib embedded automatically, and the compiled binary rendered the
+dashboard entry under a PTY (live alt-screen + terminal-capability output).
+Real CLI machinery ran end to end: `setup check --json` in a temp HOME
+executed genuine probes. Two defects surfaced, both already mapped to
+phases:
+
+- Top-level `node:sqlite` kills compiled startup (`No such built-in
+  module`). Confirmed the swap surface is **exactly one value-import** in
+  the whole dist (`apps/observer/dist/sqlite.js`); a hand-patched
+  `bun:sqlite` shim there made everything work — A1's driver as specced.
+- `apps/cli/src/main.ts`'s self-exec guard
+  (`import.meta.url === file://${process.argv[1]}`) fires for **every
+  bundled module** in compiled mode (argv[1] is the bunfs root, which is
+  every module's URL) → `runCli` executes twice per invocation. Fix
+  verified by S4; A3 swaps the guard to `import.meta.main`.
+
+### S2 — PASS with a required A2 amendment (ctty trampoline)
+
+- **Completeness**: a short-lived child's full output, including the final
+  bytes, is delivered *before* `p.exited` resolves — no drain race, the
+  bridge's drain-before-exit concern doesn't apply in-process.
+- **Backpressure**: kernel PTY flow control just works. A deliberately slow
+  `data` callback throttled a 200MB `cat` to 44MB/90s with **peak RSS
+  31MB** — the consumer's pace blocks the child; no pause/resume machinery
+  needed. (`TerminalOptions` also exposes a `drain` callback for write-side
+  backpressure.)
+- **Resize**: cols/rows of 0 throw; 1 works. Keep the bridge's 2/1 clamps.
+- **`terminal.close()` does NOT kill the attached child** — dispose must
+  `child.kill()` explicitly.
+- **No controlling terminal**: children get the pty on stdio but not as
+  ctty (`ps` shows `TTY ??`, TPGID 0). Consequences measured: Ctrl-Z
+  arrives as literal `^Z` (job control broken — unacceptable for shell
+  panes), and pty children **orphan** when the parent exits or is
+  SIGKILLed.
+- **A setsid+TIOCSCTTY trampoline between spawn and payload fixes both**:
+  with the ctty acquired, Ctrl-Z suspends correctly and children die with
+  the parent (SIGHUP on master close) even under SIGKILL — pure kernel
+  semantics replace the bridge's stdin-close backstop.
+
+**A2 design amendment**: the adapter is in-process `Bun.Terminal` **plus a
+ctty trampoline** wrapping the payload command. Recommended shape: a tiny
+per-platform C helper (`setsid(); ioctl(0, TIOCSCTTY); execvp(payload)`),
+modeled on node-pty's `spawn-helper`, embedded in the binary and extracted
+with the runtime assets — true exec-replace, no extra process per pane.
+Fallback without native code: a self-exec `stn __pty-exec` internal command
+doing the same via `bun:ffi` then spawn-and-forward (leaves one shim
+process per pane). Worth tracking upstream: Bun may grow a
+controlling-terminal option on `Terminal`/`spawn`.
+
+### S3 — PASS for the planned install path (quarantine is the boundary)
+
+`bun build --compile` output is already ad-hoc linker-signed
+(`flags=adhoc,linker-signed`, identifier `a.out`) and runs unmodified. With
+`com.apple.quarantine` set (simulating a browser download), macOS SIGKILLs
+it (exit 137). curl/`gh` downloads set no quarantine, so the A5 install
+script path is unaffected; the script should still defensively
+`xattr -d com.apple.quarantine`, and the release job should
+`codesign --force --sign -` with a real identifier (cosmetic). Developer ID
+signing + notarization only become necessary for browser-download
+distribution — deferred with public distro.
+
+### S4 — PASS (`import.meta.main` is the correct guard everywhere)
+
+Dev-imported `false` / dev-standalone `true` / compiled-entry `true` /
+compiled-imported `false`. The legacy `file://argv[1]` comparison is `true`
+for imported modules under compile and must not survive A3.
+
 ## Stage 1 — Foundation (Track A, phase A1)
 
 Lands green on today's CI with zero behavior change. No compile anywhere yet.
@@ -267,9 +346,13 @@ driver, running a migration-shaped exec/prepare round trip, and asserting
 `StationTerminalProcess` (same MIN_COLS=2/MIN_ROWS=1 clamps as the bridge);
 extract the listener/pending-data/diagnostic machinery from
 `LocalPtyTerminalProcess` into a shared emitter module;
-`createLocalPtyTerminal` becomes a selector. **A2a** lands the adapter
-opt-in only (`STATION_PTY_IMPL=bun` selects it; default stays the bridge)
-so it can be daily-driven without commitment. **A2b** is a one-line default
+`createLocalPtyTerminal` becomes a selector. Per the S2 results, the
+adapter spawns the payload through a **ctty trampoline**
+(setsid + TIOCSCTTY + exec; embedded per-platform helper, see the S2
+amendment) — without it job control breaks and pty children orphan on a
+Station crash. **A2a** lands the adapter opt-in only
+(`STATION_PTY_IMPL=bun` selects it; default stays the bridge) so it can be
+daily-driven without commitment. **A2b** is a one-line default
 flip (`Bun.Terminal` present and `STATION_PTY_IMPL !== "bridge"` → adapter)
 after at least a week of real use with no bridge fallbacks — flipping back
 is a one-line revert, and `STATION_PTY_IMPL=bridge` stays the in-field undo
@@ -288,7 +371,10 @@ Bridge and its hardening test stay until A6.
 `[process.execPath, entry]` when compiled, `undefined` in dev). Register
 hidden registry routes `__observer` (→ `runCliObserverMain`) and `__ingress`;
 argv0 compat in `apps/cli/src/main.ts`
-(`basename(process.argv0) === "stn-ingress"` → `__ingress`). Rewrite each
+(`basename(process.argv0) === "stn-ingress"` → `__ingress`). Replace every
+`import.meta.url === file://argv[1]` self-exec guard with
+`import.meta.main` — S1 proved the legacy form double-executes `runCli` in
+compiled mode, and S4 proved `import.meta.main` is correct in all contexts. Rewrite each
 spawn site as `selfExecArgv(...) ?? <current dev command>`:
 
 - `apps/cli/src/observerProcess.ts` `defaultSpawnObserver` (also introduce a
@@ -494,13 +580,17 @@ fixes stand alone) with no dead machinery beyond dormant seams.
 
 ## Risk register (ranked)
 
-1. **Bundler vs `apps/cli` `.d.ts` `paths`** — silent empty modules in the
-   compile graph. Spike S1; likely fix is deleting the legacy paths block.
-2. **`Bun.Terminal` flow control / drain ordering** — unbounded memory on
-   firehose panes; truncated output of short-lived commands. Spike S2; the
-   bridge stays selectable for one release.
-3. **macOS Gatekeeper** for downloaded binaries. Spike S3; ad-hoc sign in
-   CI, notarization deferred.
+1. ~~**Bundler vs `apps/cli` `.d.ts` `paths`**~~ — **retired by S1**: the
+   bundler resolves through node_modules `exports` and ignores the paths
+   block; no fix needed.
+2. ~~**`Bun.Terminal` flow control / drain ordering**~~ — **retired by
+   S2**: kernel backpressure bounds memory and output is complete at exit.
+   Replaced by a smaller risk: the **ctty trampoline** (per-platform helper
+   build in release CI; job control and orphan-cleanup regressions if the
+   trampoline is wrong). The bridge stays selectable for one release.
+3. **macOS Gatekeeper** for downloaded binaries — **scoped by S3**: only
+   quarantined (browser-download) copies are killed; curl/`gh` installs are
+   clean. Installer strips the xattr defensively; notarization deferred.
 4. **Private-repo distribution ergonomics** — gh-auth requirement for
    installs; tap needs a token-backed download strategy. Accepted by
    decision; artifacts are public-ready.


### PR DESCRIPTION
## Summary

Two things landed on this branch: the Stage 0 spike results (S1–S4, all pass) **and** a full v1.1 rewrite that folds in an 11-point adversarial audit of the roadmap. v1 is marked superseded in the same file; nothing competing was created.

I adversarially verified every audit finding against `e0d4307` this session and reproduced each — the audit was correct on all 11.

## Confirmed findings (proof)

- **F1 (RCE) — confirmed empirically.** A compiled bun binary auto-loads cwd `.env` into `process.env` (default-on `--compile-autoload-dotenv`); `STATION_DASHBOARD_COMMAND` runs with `shell: true` (`tui.ts:152`). Running `stn` in an untrusted checkout = arbitrary command execution. Both disable flags exist and are now mandatory in the build, with a release-blocking hostile-directory gate. (Arguably broader than reported: the whole `STATION_*` env surface is injectable.)
- **F2 (SQLite contract) — confirmed.** Persistence reads `result.changes` at 6+ sites (`ingressDedupe.ts:19`, `observations.ts:117`, `worktreeMetadataCurrent.ts:107,119`, `correlations.ts:210`); `run(): void` cannot typecheck. Both engines return `{changes, lastInsertRowid}`. Corrected, plus a cross-runtime (node-created / bun-opened) test.
- **F3, F5, F4 — confirmed by code.** Eviction conflicts with the singleton roadmap (removed, delegated). `parseGlobalOptions` strips `--config` and ingress owns raw stdin, so internal modes must dispatch from raw argv before `runCli`. B3 only restarts older versions → same-version `setup` leaves `emptyConfig()` (new B-config phase).
- **F6–F11 — confirmed.** Bridge rollback needs Node the binary lacks (ctty helper gains a full lifecycle); host health is protocol-number-only (new B-host); `stn-tmux-popup` + Pi extension + LICENSE were missing from the artifact manifest; `GITHUB_TOKEN` releases don't trigger `homebrew-bump.yml`; release lacked checksums/gate/rollback; verification proved a proxy not the UX.

One sub-claim I could **not** independently verify from this environment: that `macos-13` is a retired runner label. It's consistent with GitHub's Intel-macOS deprecation; v1.1 says to pin available labels at implementation time rather than trust the name.

## What v1.1 changes

Mandatory ambient-config disable flags + hostile-dir gate; corrected SQLite contract; raw-argv dispatch; ctty helper lifecycle (build/embed/extract/concurrency/noexec/cleanup); eviction removed → observer-singleton dependency; new B-config and B-host phases; platform/artifact/security policy (LICENSE + asset manifest); checksum-verified release with immutable rollback and the homebrew-trigger fix; `launchReady` vs `workflowReady`; a single dependency graph; and a clean-box release-acceptance suite that exercises the real renderer, PTY job control, config activation, popup, ingress, upgrade, and rollback. S1–S4 preserved as a runnable evidence appendix.

## Verify

Read `docs/single-binary.md` top-to-bottom (v1.1 is the whole body now). The RCE repro: compile any probe with `bun build --compile`, run it in a dir containing `.env`, observe the value in `process.env`; then rebuild with `--no-compile-autoload-dotenv` and confirm it's gone.