### PR TITLE
refactor(runtime): establish single-binary A1 foundation

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -64,6 +64,8 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+      - name: Test cross-runtime SQLite compatibility
+        run: pnpm test:sqlite:bun
       - name: Install (bun)
         run: bun install
         working-directory: station

--- a/apps/cli/src/commandRegistry.ts
+++ b/apps/cli/src/commandRegistry.ts
@@ -29,9 +29,10 @@ export type {
 export const cliCommandRegistry: CliCommandNode = {
   name: "stn",
   description: "STATION is a terminal-native control plane for AI-agent worktree sessions.",
-  usage: ["stn [--config <path>] [command]", "stn --help", "stn --man"],
+  usage: ["stn [--config <path>] [command]", "stn --version", "stn --help", "stn --man"],
   options: [
     { name: "--config <path>", description: "Use a specific STATION config file." },
+    { name: "--version", description: "Print the STATION build version." },
     { name: "-h, --help", description: "Print concise help for a command path." },
     { name: "--man", description: "Print the fuller manual for a command path." },
   ],

--- a/apps/cli/src/help.ts
+++ b/apps/cli/src/help.ts
@@ -16,7 +16,7 @@ export function renderCliHelpFromArgs(args: readonly string[]): CliHelpResult | 
     return undefined;
   }
   const mode: CliHelpMode = args.includes("--man") ? "man" : "help";
-  const topicPath = helpTopicPath(args.filter((arg) => !isCliHelpFlag(arg)));
+  const topicPath = helpTopicPath(args.filter((arg) => !isCliHelpFlag(arg) && arg !== "--version"));
   return {
     mode,
     text: renderCliCommandHelpTopic(topicPath, mode),

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "@station/config";
-import { isSafeError, type RuntimeSafeError } from "@station/runtime";
+import { isSafeError, type RuntimeSafeError, stationBuildInfo } from "@station/runtime";
 import { parseRequiredOptionValue } from "./args.js";
 import type { CliRunOptions, CliRunResult } from "./cliTypes.js";
 import {
@@ -24,6 +24,9 @@ export async function runCli(
   const help = renderCliHelpFromArgs(args);
   if (help !== undefined) {
     return { code: 0, output: help.text, outputFormat: "text" };
+  }
+  if (args.length === 1 && args[0] === "--version") {
+    return { code: 0, output: stationBuildInfo().version, outputFormat: "text" };
   }
   const command = args[0] ?? defaultCommand(defaultCommandEnv(options));
   const commandArgs = args[0] === undefined ? [] : args.slice(1);

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -108,6 +108,26 @@ describe("CLI manual-smoke commands", () => {
     expect(text).toContain("setup");
   });
 
+  it("returns the exact source build version without loading config", async () => {
+    const direct = await runCli(["--version"]);
+    const withMissingConfig = await runCli([
+      "--config",
+      "/tmp/station-missing-config.toml",
+      "--version",
+    ]);
+
+    expect(direct).toEqual({ code: 0, output: "0.0.0-dev", outputFormat: "text" });
+    expect(withMissingConfig).toEqual(direct);
+  });
+
+  it("keeps help ahead of version and treats version as top-level only", async () => {
+    const help = await runCli(["--version", "--help"]);
+
+    expect(help).toMatchObject({ code: 0, outputFormat: "text" });
+    expect(textOutput(help)).toContain("Usage:\n  stn [--config <path>] [command]");
+    await expect(runCli(["--version", "doctor"])).rejects.toThrow("Unknown command: --version");
+  });
+
   it("returns root manual with behavior notes and verification examples", async () => {
     const result = await runCli(["--man"]);
 

--- a/apps/observer/src/internal.ts
+++ b/apps/observer/src/internal.ts
@@ -32,4 +32,5 @@ export * from "./runtime/logging.js";
 export * from "./runtime/main.js";
 export * from "./runtime/reconcileScheduler.js";
 export * from "./runtime/server.js";
+export type { SqlDatabase, SqlParam, SqlRunResult, SqlStatement } from "./sqlite/driver.js";
 export * from "./sqlite.js";

--- a/apps/observer/src/persistence/commands.ts
+++ b/apps/observer/src/persistence/commands.ts
@@ -1,4 +1,3 @@
-import type { DatabaseSync } from "node:sqlite";
 import type {
   CommandId,
   DiagnosticDetail,
@@ -7,6 +6,7 @@ import type {
   StationCommand,
 } from "@station/contracts";
 import { ErrorEnvelopeSchema, SafeErrorSchema, StationCommandSchema } from "@station/contracts";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import { stringifyJson } from "./json.js";
 import {
   commandErrorFromRow,
@@ -17,7 +17,7 @@ import {
 import type { PersistedCommand, PersistedCommandError } from "./types.js";
 
 export function recordCommandAccepted(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     commandId: CommandId;
     command: StationCommand;
@@ -46,7 +46,7 @@ export function recordCommandAccepted(
 }
 
 export function markCommandStarted(
-  database: DatabaseSync,
+  database: SqlDatabase,
   commandId: CommandId,
   startedAt: string,
 ): PersistedCommand {
@@ -57,7 +57,7 @@ export function markCommandStarted(
 }
 
 export function markCommandSucceeded(
-  database: DatabaseSync,
+  database: SqlDatabase,
   commandId: CommandId,
   finishedAt: string,
 ): PersistedCommand {
@@ -70,7 +70,7 @@ export function markCommandSucceeded(
 }
 
 export function markCommandFailed(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     commandId: CommandId;
     safeError: SafeError;
@@ -95,7 +95,7 @@ export function markCommandFailed(
 }
 
 export function getCommand(
-  database: DatabaseSync,
+  database: SqlDatabase,
   commandId: CommandId,
 ): PersistedCommand | undefined {
   const row = getCommandRow(database, commandId);
@@ -104,7 +104,7 @@ export function getCommand(
     : commandWithDiagnostics(commandFromRow(row), commandErrorRows(database, commandId));
 }
 
-export function listCommands(database: DatabaseSync): PersistedCommand[] {
+export function listCommands(database: SqlDatabase): PersistedCommand[] {
   const rows = database
     .prepare("SELECT * FROM commands ORDER BY created_at, id")
     .all() as SqliteCommandRow[];
@@ -133,7 +133,7 @@ export function listCommands(database: DatabaseSync): PersistedCommand[] {
 }
 
 export function listCommandErrors(
-  database: DatabaseSync,
+  database: SqlDatabase,
   commandId?: CommandId,
 ): PersistedCommandError[] {
   const rows =
@@ -147,7 +147,7 @@ export function listCommandErrors(
   return rows.map(commandErrorFromRow);
 }
 
-function readCommand(database: DatabaseSync, commandId: string): PersistedCommand {
+function readCommand(database: SqlDatabase, commandId: string): PersistedCommand {
   const row = getCommandRow(database, commandId);
   if (row === undefined) {
     throw new Error(`Command ${commandId} was not found.`);
@@ -155,13 +155,13 @@ function readCommand(database: DatabaseSync, commandId: string): PersistedComman
   return commandWithDiagnostics(commandFromRow(row), commandErrorRows(database, commandId));
 }
 
-function getCommandRow(database: DatabaseSync, commandId: string): SqliteCommandRow | undefined {
+function getCommandRow(database: SqlDatabase, commandId: string): SqliteCommandRow | undefined {
   return database.prepare("SELECT * FROM commands WHERE id = ?").get(commandId) as
     | SqliteCommandRow
     | undefined;
 }
 
-function commandErrorRows(database: DatabaseSync, commandId?: CommandId): SqliteCommandErrorRow[] {
+function commandErrorRows(database: SqlDatabase, commandId?: CommandId): SqliteCommandErrorRow[] {
   return commandId === undefined
     ? (database
         .prepare("SELECT * FROM command_errors ORDER BY created_at, id")

--- a/apps/observer/src/persistence/correlations.ts
+++ b/apps/observer/src/persistence/correlations.ts
@@ -1,4 +1,3 @@
-import type { DatabaseSync } from "node:sqlite";
 import type {
   HarnessRunObservation,
   ProviderProjectConfig,
@@ -10,6 +9,7 @@ import {
   TerminalTargetObservationSchema,
   WorktreeObservationSchema,
 } from "@station/contracts";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import { maxIso, optionalJson } from "./json.js";
 import { insertProviderObservation } from "./observations.js";
 import { providerObservationExpiresAt } from "./retention.js";
@@ -44,7 +44,7 @@ type ProjectPersistenceInput = {
 };
 
 export function persistReconcileResult(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: PersistReconcileResultInput,
   options: { observedAt: string; idFactory: ObserverIdFactory },
 ): void {
@@ -120,19 +120,19 @@ function expiresAtFor(input: PersistReconcileResultInput, observedAt: string): s
   return input.expiresAt;
 }
 
-export function listProjects(database: DatabaseSync): PersistedProject[] {
+export function listProjects(database: SqlDatabase): PersistedProject[] {
   return (database.prepare("SELECT * FROM projects ORDER BY id").all() as SqliteProjectRow[]).map(
     projectFromRow,
   );
 }
 
-export function listWorktrees(database: DatabaseSync): PersistedWorktree[] {
+export function listWorktrees(database: SqlDatabase): PersistedWorktree[] {
   return (database.prepare("SELECT * FROM worktrees ORDER BY id").all() as SqliteWorktreeRow[]).map(
     worktreeFromRow,
   );
 }
 
-export function listTerminalTargets(database: DatabaseSync): PersistedTerminalTarget[] {
+export function listTerminalTargets(database: SqlDatabase): PersistedTerminalTarget[] {
   return (
     database
       .prepare("SELECT * FROM terminal_targets ORDER BY id")
@@ -140,20 +140,20 @@ export function listTerminalTargets(database: DatabaseSync): PersistedTerminalTa
   ).map(terminalTargetFromRow);
 }
 
-export function listHarnessRuns(database: DatabaseSync): PersistedHarnessRun[] {
+export function listHarnessRuns(database: SqlDatabase): PersistedHarnessRun[] {
   return (
     database.prepare("SELECT * FROM harness_runs ORDER BY id").all() as SqliteHarnessRunRow[]
   ).map(harnessRunFromRow);
 }
 
-export function listSessions(database: DatabaseSync): PersistedSession[] {
+export function listSessions(database: SqlDatabase): PersistedSession[] {
   return (database.prepare("SELECT * FROM sessions ORDER BY id").all() as SqliteSessionRow[]).map(
     sessionFromRow,
   );
 }
 
 export function renameSession(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: { sessionId: string; title: string },
 ): PersistedSession | undefined {
   database.prepare("UPDATE sessions SET title = ? WHERE id = ?").run(input.title, input.sessionId);
@@ -164,7 +164,7 @@ export function renameSession(
 }
 
 export function seedSessionTitle(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     sessionId: string;
     projectId: string;
@@ -205,13 +205,13 @@ export function seedSessionTitle(
   return sessionFromRow(row);
 }
 
-export function deleteSessionTitleSeed(database: DatabaseSync, sessionId: string): number {
+export function deleteSessionTitleSeed(database: SqlDatabase, sessionId: string): number {
   const result = database.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
   return Number(result.changes);
 }
 
 function upsertProject(
-  database: DatabaseSync,
+  database: SqlDatabase,
   project: ProjectPersistenceInput,
   lastSeenAt: string,
 ): void {
@@ -238,7 +238,7 @@ function projectPersistenceInput(project: ProviderProjectConfig): ProjectPersist
   };
 }
 
-function upsertWorktree(database: DatabaseSync, worktree: WorktreeObservation): void {
+function upsertWorktree(database: SqlDatabase, worktree: WorktreeObservation): void {
   database
     .prepare(
       `
@@ -271,7 +271,7 @@ function upsertWorktree(database: DatabaseSync, worktree: WorktreeObservation): 
     );
 }
 
-function upsertTerminalTarget(database: DatabaseSync, target: TerminalTargetObservation): void {
+function upsertTerminalTarget(database: SqlDatabase, target: TerminalTargetObservation): void {
   database
     .prepare(
       `
@@ -302,7 +302,7 @@ function upsertTerminalTarget(database: DatabaseSync, target: TerminalTargetObse
     );
 }
 
-function upsertHarnessRun(database: DatabaseSync, run: HarnessRunObservation): void {
+function upsertHarnessRun(database: SqlDatabase, run: HarnessRunObservation): void {
   database
     .prepare(
       `
@@ -342,7 +342,7 @@ function upsertHarnessRun(database: DatabaseSync, run: HarnessRunObservation): v
 }
 
 function upsertSessions(
-  database: DatabaseSync,
+  database: SqlDatabase,
   terminalTargets: TerminalTargetObservation[],
   harnessRuns: HarnessRunObservation[],
   worktrees: WorktreeObservation[],

--- a/apps/observer/src/persistence/events.ts
+++ b/apps/observer/src/persistence/events.ts
@@ -1,16 +1,16 @@
-import type { DatabaseSync } from "node:sqlite";
 import type { CommandId, StationEvent } from "@station/contracts";
 import {
   StationEventSchema,
   stationEventCommandId,
   stationEventTimestamp,
 } from "@station/contracts";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import { stringifyJson } from "./json.js";
 import { eventFromRow, type SqliteEventRow } from "./rows.js";
 import type { PersistedEvent } from "./types.js";
 
 export function recordEvent(
-  database: DatabaseSync,
+  database: SqlDatabase,
   event: StationEvent,
   options: {
     eventId: string;
@@ -43,7 +43,7 @@ export function recordEvent(
 }
 
 export function listEvents(
-  database: DatabaseSync,
+  database: SqlDatabase,
   filter: {
     commandId?: CommandId;
     type?: StationEvent["type"];
@@ -74,7 +74,7 @@ export function eventTimestamp(event: StationEvent): string | undefined {
   return stationEventTimestamp(event);
 }
 
-function readEvent(database: DatabaseSync, eventId: string): PersistedEvent {
+function readEvent(database: SqlDatabase, eventId: string): PersistedEvent {
   const row = database.prepare("SELECT * FROM events WHERE id = ?").get(eventId) as SqliteEventRow;
   return eventFromRow(row);
 }

--- a/apps/observer/src/persistence/index.ts
+++ b/apps/observer/src/persistence/index.ts
@@ -1,6 +1,6 @@
-import type { DatabaseSync } from "node:sqlite";
 import { StationEventSchema } from "@station/contracts";
 import { Effect, systemClock, toIsoTimestamp } from "@station/runtime";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import { runSqliteTransactionEffect } from "../sqlite.js";
 import * as commandStore from "./commands.js";
 import * as correlationStore from "./correlations.js";
@@ -29,7 +29,7 @@ export function createObserverPersistence(
   const clock = options.clock ?? systemClock;
   const idFactory = { ...defaultIdFactory, ...options.idFactory };
   const now = () => toIsoTimestamp(clock.now());
-  const transaction = <T>(task: (database: DatabaseSync) => T): Promise<T> =>
+  const transaction = <T>(task: (database: SqlDatabase) => T): Promise<T> =>
     Effect.runPromise(runSqliteTransactionEffect(options.sqlite, task));
 
   return {

--- a/apps/observer/src/persistence/ingressDedupe.ts
+++ b/apps/observer/src/persistence/ingressDedupe.ts
@@ -1,8 +1,8 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import type { IngressDedupeKey } from "./types.js";
 
 export function claimIngressDedupeKey(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: IngressDedupeKey & {
     eventId: string;
     createdAt: string;

--- a/apps/observer/src/persistence/observations.ts
+++ b/apps/observer/src/persistence/observations.ts
@@ -1,4 +1,3 @@
-import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import type { ProviderId } from "@station/contracts";
 import {
   HarnessEventObservationSchema,
@@ -6,6 +5,7 @@ import {
   TerminalTargetObservationSchema,
   WorktreeObservationSchema,
 } from "@station/contracts";
+import type { SqlDatabase, SqlParam } from "../sqlite/driver.js";
 import { isRecord } from "../utils/guards.js";
 import { parseJson, stringifyJson } from "./json.js";
 import { providerObservationFromRow, type SqliteProviderObservationRow } from "./rows.js";
@@ -18,7 +18,7 @@ import type {
 } from "./types.js";
 
 export function insertProviderObservation(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     id: string;
     provider: ProviderId;
@@ -79,7 +79,7 @@ export function insertProviderObservation(
 }
 
 export function listProviderObservations(
-  database: DatabaseSync,
+  database: SqlDatabase,
   options: {
     entityKind?: ProviderObservationKind | readonly ProviderObservationKind[];
     includeExpired?: boolean;
@@ -94,7 +94,7 @@ export function listProviderObservations(
 }
 
 export function listCurrentProviderEntityObservations(
-  database: DatabaseSync,
+  database: SqlDatabase,
   options: {
     entityKind?: CurrentProviderObservationKind | readonly CurrentProviderObservationKind[];
     includeExpired?: boolean;
@@ -108,7 +108,7 @@ export function listCurrentProviderEntityObservations(
 }
 
 export function pruneExpiredProviderObservations(
-  database: DatabaseSync,
+  database: SqlDatabase,
   expiresBefore: string,
 ): number {
   const expiredResult = database
@@ -121,7 +121,7 @@ function buildCurrentProviderEntityObservationQuery(options: {
   entityKind?: CurrentProviderObservationKind | readonly CurrentProviderObservationKind[];
   includeExpired?: boolean;
   referenceTime: string;
-}): { sql: string; params: SQLInputValue[] } {
+}): { sql: string; params: SqlParam[] } {
   const kinds =
     options.entityKind === undefined
       ? (["worktree", "terminal_target"] satisfies CurrentProviderObservationKind[])
@@ -148,7 +148,7 @@ function buildCurrentProviderEntityObservationQuery(options: {
   }
   const latestExpiryClause =
     options.includeExpired === true ? "" : " AND (i.expires_at IS NULL OR i.expires_at > ?)";
-  const params: SQLInputValue[] = options.includeExpired === true ? [] : [options.referenceTime];
+  const params: SqlParam[] = options.includeExpired === true ? [] : [options.referenceTime];
   return {
     sql: `
       WITH keys AS (
@@ -196,9 +196,9 @@ function buildProviderObservationQuery(options: {
   includeExpired?: boolean;
   latestOnly?: boolean;
   referenceTime: string;
-}): { sql: string; params: SQLInputValue[] } {
+}): { sql: string; params: SqlParam[] } {
   const clauses: string[] = [];
-  const params: SQLInputValue[] = [];
+  const params: SqlParam[] = [];
 
   if (options.entityKind !== undefined) {
     const kinds =
@@ -256,7 +256,7 @@ function buildProviderObservationQuery(options: {
 }
 
 function latestProviderObservationRow(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     provider: ProviderId;
     providerType: ProviderObservationType;
@@ -281,7 +281,7 @@ function latestProviderObservationRow(
     | undefined;
 }
 
-function readProviderObservation(database: DatabaseSync, id: string): SqliteProviderObservationRow {
+function readProviderObservation(database: SqlDatabase, id: string): SqliteProviderObservationRow {
   return database
     .prepare("SELECT * FROM provider_observations WHERE id = ?")
     .get(id) as SqliteProviderObservationRow;

--- a/apps/observer/src/persistence/recoveryBreadcrumbs.ts
+++ b/apps/observer/src/persistence/recoveryBreadcrumbs.ts
@@ -1,10 +1,10 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import { stringifyJson } from "./json.js";
 import { recoveryBreadcrumbFromRow, type SqliteRecoveryBreadcrumbRow } from "./rows.js";
 import type { PersistedRecoveryBreadcrumb } from "./types.js";
 
 export function recordRecoveryBreadcrumb(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     id: string;
     projectId: string;
@@ -39,7 +39,7 @@ export function recordRecoveryBreadcrumb(
   return readRecoveryBreadcrumb(database, input.id);
 }
 
-export function listRecoveryBreadcrumbs(database: DatabaseSync): PersistedRecoveryBreadcrumb[] {
+export function listRecoveryBreadcrumbs(database: SqlDatabase): PersistedRecoveryBreadcrumb[] {
   return (
     database
       .prepare("SELECT * FROM recovery_breadcrumbs ORDER BY last_seen_at, id")
@@ -48,7 +48,7 @@ export function listRecoveryBreadcrumbs(database: DatabaseSync): PersistedRecove
 }
 
 function readRecoveryBreadcrumb(
-  database: DatabaseSync,
+  database: SqlDatabase,
   breadcrumbId: string,
 ): PersistedRecoveryBreadcrumb {
   return recoveryBreadcrumbFromRow(

--- a/apps/observer/src/persistence/sessionRecoveryHandles.ts
+++ b/apps/observer/src/persistence/sessionRecoveryHandles.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
-import type { DatabaseSync } from "node:sqlite";
 import type { SessionRecoveryHandle } from "@station/contracts";
 import { SessionRecoveryHandleSchema } from "@station/contracts";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import type { ListSessionRecoveryHandlesOptions } from "./types.js";
 
 type SqliteSessionRecoveryHandleRow = {
@@ -20,7 +20,7 @@ type SqliteSessionRecoveryHandleRow = {
 };
 
 export function upsertSessionRecoveryHandle(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: SessionRecoveryHandle,
 ): SessionRecoveryHandle {
   // Ingress report ids are per event. Recovery handles need a stable identity
@@ -82,7 +82,7 @@ export function upsertSessionRecoveryHandle(
 }
 
 export function getSessionRecoveryHandle(
-  database: DatabaseSync,
+  database: SqlDatabase,
   handleId: string,
 ): SessionRecoveryHandle | undefined {
   const row = database
@@ -92,7 +92,7 @@ export function getSessionRecoveryHandle(
 }
 
 export function listSessionRecoveryHandles(
-  database: DatabaseSync,
+  database: SqlDatabase,
   options: ListSessionRecoveryHandlesOptions = {},
 ): SessionRecoveryHandle[] {
   const rows = database

--- a/apps/observer/src/persistence/sessionTurnReadiness.ts
+++ b/apps/observer/src/persistence/sessionTurnReadiness.ts
@@ -1,4 +1,4 @@
-import type { DatabaseSync } from "node:sqlite";
+import type { SqlDatabase } from "../sqlite/driver.js";
 import type { PersistedSessionTurnReadiness } from "./types.js";
 
 type SqliteSessionTurnReadinessRow = {
@@ -12,7 +12,7 @@ type SqliteSessionTurnReadinessRow = {
 };
 
 export function upsertSessionTurnReadiness(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: PersistedSessionTurnReadiness,
 ): PersistedSessionTurnReadiness {
   database
@@ -48,7 +48,7 @@ export function upsertSessionTurnReadiness(
 }
 
 export function getSessionTurnReadiness(
-  database: DatabaseSync,
+  database: SqlDatabase,
   sessionId: string,
 ): PersistedSessionTurnReadiness | undefined {
   const row = database
@@ -57,7 +57,7 @@ export function getSessionTurnReadiness(
   return row === undefined ? undefined : readinessFromRow(row);
 }
 
-export function listSessionTurnReadiness(database: DatabaseSync): PersistedSessionTurnReadiness[] {
+export function listSessionTurnReadiness(database: SqlDatabase): PersistedSessionTurnReadiness[] {
   const rows = database
     .prepare("SELECT * FROM session_turn_readiness ORDER BY completed_at DESC, session_id")
     .all() as SqliteSessionTurnReadinessRow[];
@@ -65,7 +65,7 @@ export function listSessionTurnReadiness(database: DatabaseSync): PersistedSessi
 }
 
 export function deleteSessionTurnReadiness(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: { sessionId: string; token?: string },
 ): number {
   const result =

--- a/apps/observer/src/persistence/worktreeMetadataCurrent.ts
+++ b/apps/observer/src/persistence/worktreeMetadataCurrent.ts
@@ -1,10 +1,10 @@
-import type { DatabaseSync, SQLInputValue } from "node:sqlite";
 import {
   SafeErrorSchema,
   WorktreeChangeSummarySchema,
   WorktreeChecksSummarySchema,
   WorktreePullRequestSchema,
 } from "@station/contracts";
+import type { SqlDatabase, SqlParam } from "../sqlite/driver.js";
 import { parseJson, stringifyJson } from "./json.js";
 import type {
   PersistedWorktreeMetadataCurrent,
@@ -24,7 +24,7 @@ type SqliteWorktreeMetadataCurrentRow = {
 };
 
 export function upsertWorktreeMetadataCurrent<TKind extends WorktreeMetadataCurrentKind>(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     worktreeId: string;
     kind: TKind;
@@ -73,7 +73,7 @@ export function upsertWorktreeMetadataCurrent<TKind extends WorktreeMetadataCurr
 }
 
 export function listWorktreeMetadataCurrent<TKind extends WorktreeMetadataCurrentKind>(
-  database: DatabaseSync,
+  database: SqlDatabase,
   options: {
     kind?: TKind | readonly TKind[];
     includeExpired?: boolean;
@@ -90,7 +90,7 @@ export function listWorktreeMetadataCurrent<TKind extends WorktreeMetadataCurren
 }
 
 export function deleteWorktreeMetadataCurrent(
-  database: DatabaseSync,
+  database: SqlDatabase,
   input: {
     worktreeId: string;
     kind?: WorktreeMetadataCurrentKind;
@@ -108,7 +108,7 @@ export function deleteWorktreeMetadataCurrent(
 }
 
 export function pruneExpiredWorktreeMetadataCurrent(
-  database: DatabaseSync,
+  database: SqlDatabase,
   expiresBefore: string,
 ): number {
   const result = database
@@ -123,9 +123,9 @@ function buildListWorktreeMetadataCurrentQuery<TKind extends WorktreeMetadataCur
   kind?: TKind | readonly TKind[];
   includeExpired?: boolean;
   referenceTime: string;
-}): { sql: string; params: SQLInputValue[] } {
+}): { sql: string; params: SqlParam[] } {
   const clauses: string[] = [];
-  const params: SQLInputValue[] = [];
+  const params: SqlParam[] = [];
 
   if (options.kind !== undefined) {
     const kinds = typeof options.kind === "string" ? [options.kind] : [...options.kind];
@@ -152,7 +152,7 @@ function buildListWorktreeMetadataCurrentQuery<TKind extends WorktreeMetadataCur
 }
 
 function readWorktreeMetadataCurrent(
-  database: DatabaseSync,
+  database: SqlDatabase,
   worktreeId: string,
   kind: WorktreeMetadataCurrentKind,
 ): SqliteWorktreeMetadataCurrentRow {

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { type LoadedStationConfig, loadConfig, type StationConfig } from "@station/config";
 import { componentLogPath } from "@station/observability";
-import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
+import { type RuntimeClock, stationBuildInfo, systemClock, toIsoTimestamp } from "@station/runtime";
 import { createCommandQueue } from "../commands/queue.js";
 import { registerObserverCommandHandlers } from "../commands/router.js";
 import { createFeatureFlagEvaluator } from "../features/evaluator.js";
@@ -106,6 +106,7 @@ export async function runObserverMain(
     clock: systemClock,
     logger,
     featureFlags,
+    version: stationBuildInfo().version,
   });
   registerObserverCommandHandlers({
     queue: commandQueue,

--- a/apps/observer/src/sqlite.ts
+++ b/apps/observer/src/sqlite.ts
@@ -1,4 +1,3 @@
-import { DatabaseSync } from "node:sqlite";
 import type { SafeError } from "@station/contracts";
 import {
   Effect,
@@ -9,6 +8,7 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { latestSchemaVersion, migrations } from "./migrations/index.js";
+import { openSqlDatabase, type SqlDatabase } from "./sqlite/driver.js";
 
 export type ObserverSqliteHealthStatus = "healthy" | "unavailable" | "closed";
 
@@ -29,7 +29,7 @@ export type ObserverSqliteHealth = {
 };
 
 export type ObserverSqliteHandle = {
-  database: DatabaseSync;
+  database: SqlDatabase;
   health(): ObserverSqliteHealth;
   recordFailure(error: SafeError): void;
   close(): void;
@@ -43,7 +43,7 @@ export type OpenObserverSqliteOptions = {
 export function openObserverSqlite(options: OpenObserverSqliteOptions = {}): ObserverSqliteHandle {
   const path = options.path ?? ":memory:";
   const clock = options.clock ?? systemClock;
-  const database = new DatabaseSync(path);
+  const database = openSqlDatabase(path);
   // WAL + synchronous=NORMAL keeps an unclean exit (SIGKILL of a wedged observer)
   // from corrupting the DB or losing committed rows; :memory: ignores WAL.
   if (path !== ":memory:") {
@@ -92,7 +92,7 @@ export function openObserverSqlite(options: OpenObserverSqliteOptions = {}): Obs
 
 export function runSqliteTransactionEffect<T>(
   sqlite: ObserverSqliteHandle,
-  task: (database: DatabaseSync) => T,
+  task: (database: SqlDatabase) => T,
 ): Effect.Effect<T, RuntimeSafeError> {
   return Effect.try({
     try: () => {
@@ -128,7 +128,7 @@ type SchemaVersionRow = {
   value: string;
 };
 
-function applyMigrations(database: DatabaseSync, clock: RuntimeClock): void {
+function applyMigrations(database: SqlDatabase, clock: RuntimeClock): void {
   database.exec(`
     CREATE TABLE IF NOT EXISTS observer_meta (
       key TEXT PRIMARY KEY,
@@ -175,7 +175,7 @@ function applyMigrations(database: DatabaseSync, clock: RuntimeClock): void {
     .run(String(latestSchemaVersion));
 }
 
-function readSchemaVersion(database: DatabaseSync, open: boolean): number {
+function readSchemaVersion(database: SqlDatabase, open: boolean): number {
   if (!open) {
     return latestSchemaVersion;
   }
@@ -187,7 +187,7 @@ function readSchemaVersion(database: DatabaseSync, open: boolean): number {
   return Number.isFinite(version) ? version : 0;
 }
 
-function readAppliedMigrations(database: DatabaseSync): AppliedObserverSqliteMigration[] {
+function readAppliedMigrations(database: SqlDatabase): AppliedObserverSqliteMigration[] {
   return (
     database
       .prepare("SELECT version, name, applied_at FROM observer_migrations ORDER BY version")

--- a/apps/observer/src/sqlite/driver.ts
+++ b/apps/observer/src/sqlite/driver.ts
@@ -1,0 +1,80 @@
+export type SqlParam = string | number | bigint | Uint8Array | null;
+
+export type SqlRunResult = {
+  changes: number;
+  lastInsertRowid: number | bigint;
+};
+
+export type SqlStatement = {
+  run(...params: SqlParam[]): SqlRunResult;
+  get(...params: SqlParam[]): unknown;
+  all(...params: SqlParam[]): unknown[];
+};
+
+export type SqlDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): SqlStatement;
+  close(): void;
+};
+
+type NativeSqliteRunResult = {
+  changes: number | bigint;
+  lastInsertRowid: number | bigint;
+};
+
+type NativeSqliteStatement = {
+  run(...params: SqlParam[]): NativeSqliteRunResult;
+  get(...params: SqlParam[]): unknown;
+  all(...params: SqlParam[]): unknown[];
+};
+
+type NativeSqliteDatabase = {
+  exec(sql: string): void;
+  prepare(sql: string): NativeSqliteStatement;
+  close(): void;
+};
+
+type NativeSqliteConstructor = new (path: string) => NativeSqliteDatabase;
+
+declare const Bun: object;
+
+// Import exactly one driver: loading node:sqlite terminates Bun before fallback is possible.
+const openSqlite =
+  typeof Bun !== "undefined"
+    ? // @ts-expect-error bun:sqlite is available only in the Bun runtime selected by this branch.
+      adaptBunSqlite((await import("bun:sqlite")).Database)
+    : adaptNodeSqlite((await import("node:sqlite")).DatabaseSync);
+
+export const openSqlDatabase = (path: string): SqlDatabase => openSqlite(path);
+
+function adaptNodeSqlite(Database: NativeSqliteConstructor): (path: string) => SqlDatabase {
+  return (path) => adaptDatabase(new Database(path), false);
+}
+
+function adaptBunSqlite(Database: NativeSqliteConstructor): (path: string) => SqlDatabase {
+  return (path) => adaptDatabase(new Database(path), true);
+}
+
+function adaptDatabase(database: NativeSqliteDatabase, normalizeMissingRow: boolean): SqlDatabase {
+  return {
+    exec: (sql) => database.exec(sql),
+    prepare: (sql) => {
+      const statement = database.prepare(sql);
+      return {
+        run: (...params) => {
+          const result = statement.run(...params);
+          return {
+            changes: Number(result.changes),
+            lastInsertRowid: result.lastInsertRowid,
+          };
+        },
+        get: (...params) => {
+          const row = statement.get(...params);
+          return normalizeMissingRow && row === null ? undefined : row;
+        },
+        all: (...params) => statement.all(...params),
+      };
+    },
+    close: () => database.close(),
+  };
+}

--- a/apps/observer/test/unit/build-version.test.ts
+++ b/apps/observer/test/unit/build-version.test.ts
@@ -1,0 +1,33 @@
+import type { StationConfig } from "@station/config";
+import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
+import { describe, expect, it } from "vitest";
+import { createObserverCore, ProviderRegistry } from "../../src/internal.js";
+
+const config: StationConfig = {
+  schemaVersion: 1,
+  defaults: {
+    worktreeProvider: "fake-worktree",
+    terminal: "fake-terminal",
+    harness: "fake-harness",
+    layout: "agent-shell",
+  },
+  projects: [],
+};
+
+describe("observer build version", () => {
+  it("uses the supplied build version while retaining the direct-construction fallback", () => {
+    const supplied = createObserverCore({ config, providers: providers(), version: "1.2.3" });
+    const fallback = createObserverCore({ config, providers: providers() });
+
+    expect(supplied.getSnapshot().observer.version).toBe("1.2.3");
+    expect(fallback.getSnapshot().observer.version).toBe("0.0.0");
+  });
+});
+
+function providers(): ProviderRegistry {
+  return new ProviderRegistry({
+    worktree: new FakeWorktreeProvider(),
+    terminal: new FakeTerminalProvider(),
+    harnesses: [new FakeHarnessProvider()],
+  });
+}

--- a/apps/observer/test/unit/sqlite-driver.test.ts
+++ b/apps/observer/test/unit/sqlite-driver.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { openSqlDatabase } from "../../src/sqlite/driver";
+
+describe("SQLite driver", () => {
+  it("normalizes Node SQLite statements to the shared contract", () => {
+    const database = openSqlDatabase(":memory:");
+
+    try {
+      database.exec("CREATE TABLE values_table (id INTEGER PRIMARY KEY, value INTEGER NOT NULL)");
+
+      const result = database.prepare("INSERT INTO values_table (value) VALUES (?)").run(42);
+
+      expect(result).toEqual({ changes: 1, lastInsertRowid: 1 });
+      expect(
+        database.prepare("SELECT value FROM values_table WHERE id = ?").get(999),
+      ).toBeUndefined();
+      expect(database.prepare("SELECT value FROM values_table ORDER BY id").all()).toEqual([
+        { value: 42 },
+      ]);
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,10 +50,16 @@ pnpm lint
 pnpm test:unit
 pnpm test:contracts
 pnpm test:integration
+pnpm test:sqlite:bun
 pnpm test:diagnostics
 pnpm test:agent:scripted
 pnpm smoke:release
 ```
+
+Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
+creates observer databases under Node and Bun, then reopens each database under
+the other runtime to verify the shared SQLite contract and migrations. The
+mandatory `station-bun` CI job runs this gate.
 
 For CI install parity, use:
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -180,6 +180,9 @@ checks are skipped when `isCompiledBinary()`.
 
 ### A1 — foundation: buildInfo + SQLite driver + real observer version
 
+**Status: implemented.** The mandatory `pnpm test:sqlite:bun` gate covers the
+SQLite driver contract and Node-to-Bun and Bun-to-Node database compatibility.
+
 `packages/runtime/src/buildInfo.ts` (dev-safe `typeof`-guarded defines;
 exported from the package index).
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",
     "test:integration": "pnpm build && vitest run --config config/vitest/vitest.integration.config.ts",
+    "test:sqlite:bun": "node scripts/test-runners/run-sqlite-cross-runtime.mjs",
     "test:diagnostics": "vitest run --config config/vitest/vitest.diagnostics.config.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
     "test:e2e": "vitest run --config config/vitest/vitest.e2e.config.ts",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -1,0 +1,18 @@
+declare const STATION_BUILD_VERSION: string;
+declare const STATION_BUILD_COMPILED: boolean;
+
+export type StationBuildInfo = {
+  version: string;
+  compiled: boolean;
+};
+
+export function stationBuildInfo(): StationBuildInfo {
+  return {
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-dev" : STATION_BUILD_VERSION,
+    compiled: typeof STATION_BUILD_COMPILED === "undefined" ? false : STATION_BUILD_COMPILED,
+  };
+}
+
+export function isCompiledBinary(): boolean {
+  return stationBuildInfo().compiled;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./boundary.js";
+export * from "./buildInfo.js";
 export * from "./concurrency.js";
 export * from "./effect.js";
 export * from "./errors.js";

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { isCompiledBinary, stationBuildInfo } from "../../src/buildInfo.js";
+
+describe("station build info", () => {
+  it("reports the source-mode defaults when compile-time defines are absent", () => {
+    expect(stationBuildInfo()).toEqual({ version: "0.0.0-dev", compiled: false });
+    expect(isCompiledBinary()).toBe(false);
+  });
+});

--- a/scripts/test-runners/run-sqlite-cross-runtime.mjs
+++ b/scripts/test-runners/run-sqlite-cross-runtime.mjs
@@ -1,0 +1,34 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const probePath = join(repoRoot, "scripts", "test-runners", "sqlite-runtime-probe.mjs");
+const tempRoot = mkdtempSync(join(tmpdir(), "station-sqlite-cross-runtime-"));
+
+try {
+  runProbe("node", "create", join(tempRoot, "node-created.sqlite"), "created-by-node");
+  runProbe("bun", "read", join(tempRoot, "node-created.sqlite"), "created-by-node");
+  runProbe("bun", "create", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
+  runProbe("node", "read", join(tempRoot, "bun-created.sqlite"), "created-by-bun");
+  console.log("Cross-runtime SQLite compatibility passed for Node and Bun.");
+} finally {
+  rmSync(tempRoot, { recursive: true, force: true });
+}
+
+function runProbe(runtime, action, databasePath, label) {
+  const result = spawnSync(runtime, [probePath, action, databasePath, label], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: "inherit",
+  });
+
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${runtime} SQLite ${action} probe exited with status ${result.status}.`);
+  }
+}

--- a/scripts/test-runners/sqlite-runtime-probe.mjs
+++ b/scripts/test-runners/sqlite-runtime-probe.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+
+const [, , action, databasePath, expectedLabel] = process.argv;
+assert.ok(action === "create" || action === "read", "Expected a create or read action.");
+assert.ok(databasePath, "Expected a SQLite database path.");
+assert.ok(expectedLabel, "Expected a probe label.");
+
+const { migrations, openObserverSqlite } = await import(
+  new URL("../../apps/observer/dist/internal.js", import.meta.url).href
+);
+const roundTripInteger = 2_147_483_648;
+const sqlite = openObserverSqlite({
+  path: databasePath,
+  clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
+});
+
+try {
+  const { database } = sqlite;
+  assert.equal(database.prepare("PRAGMA journal_mode").get()?.journal_mode, "wal");
+  assert.equal(database.prepare("PRAGMA synchronous").get()?.synchronous, 1);
+  assert.deepEqual(
+    sqlite.health().migrations.map(({ version, name }) => ({ version, name })),
+    migrations.map(({ version, name }) => ({ version, name })),
+  );
+  assert.equal(sqlite.health().schemaVersion, migrations.at(-1)?.version ?? 0);
+
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS station_runtime_probe (
+      label TEXT PRIMARY KEY,
+      value INTEGER NOT NULL
+    )
+  `);
+  assert.equal(
+    database.prepare("SELECT label FROM station_runtime_probe WHERE label = ?").get("missing"),
+    undefined,
+  );
+
+  if (action === "create") {
+    const result = database
+      .prepare("INSERT INTO station_runtime_probe (label, value) VALUES (?, ?)")
+      .run(expectedLabel, roundTripInteger);
+    assert.equal(result.changes, 1);
+    assert.equal(typeof result.changes, "number");
+    assert.ok(
+      typeof result.lastInsertRowid === "number" || typeof result.lastInsertRowid === "bigint",
+    );
+    assert.equal(Number(result.lastInsertRowid), 1);
+  }
+
+  const row = database
+    .prepare("SELECT label, value FROM station_runtime_probe WHERE label = ?")
+    .get(expectedLabel);
+  assert.equal(row?.label, expectedLabel);
+  assert.equal(row?.value, roundTripInteger);
+} finally {
+  sqlite.close();
+}


### PR DESCRIPTION
## Summary

- introduce a runtime-selected SQLite driver so observer persistence runs under Node or Bun without changing migrations, WAL, or transaction ownership
- add source-safe build metadata, wire the build version into observer health, and expose `stn --version`
- add a mandatory Node-to-Bun and Bun-to-Node SQLite compatibility gate and mark A1 implemented in the roadmap

## Why

A1 removes the first single-binary runtime blockers: the observer imported `node:sqlite` at module load and production snapshots used a placeholder version. The shared driver and build-info seam unblock later self-exec and compilation phases without changing the development workflow.

## UX

`stn --version` now prints the current build version. The production observer reports that same version through its existing snapshot, health, and diagnostics surfaces.

## Validation

- `HOME="$(mktemp -d)" pnpm test:all`
- `pnpm test:sqlite:bun`
- `pnpm stn --version` → `0.0.0-dev`
- compile-time define probe → `{"version":"1.2.3","compiled":true}`

The isolated HOME keeps this machine's installed Claude hooks from affecting an existing doctor fixture.