### PR TITLE
feat(cli): launch first-run UI without config

### DIFF
--- a/apps/cli/src/commands/popup.ts
+++ b/apps/cli/src/commands/popup.ts
@@ -29,6 +29,7 @@ export type PopupCommandDeps = Partial<
 export type PopupCommandOptions = {
   config?: StationConfig;
   configPath?: string;
+  firstRun?: boolean;
   checkoutRoot?: TmuxPopupOptions["checkoutRoot"];
   timeoutMs?: number;
   runner?: TmuxPopupOptions["runner"];
@@ -57,7 +58,10 @@ export async function runPopupCommand(
     throw new Error(`Unknown popup option: ${args[0] ?? ""}`);
   }
 
+  const hasFirstRunConfig = options.firstRun === true && options.config?.projects.length === 0;
+  // A config-less launch has no project terminal to validate; the popup route itself selects tmux.
   if (
+    !hasFirstRunConfig &&
     options.config?.defaults.terminal !== undefined &&
     options.config.defaults.terminal !== "tmux"
   ) {

--- a/apps/cli/src/commands/registry/popup.ts
+++ b/apps/cli/src/commands/registry/popup.ts
@@ -1,7 +1,13 @@
 import { dirname, join } from "node:path";
+import { emptyConfig } from "@station/config";
 import type { CliEnv } from "../../env.js";
 import { loadedCommandOptions } from "../cliCommand/helpers.js";
-import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
+import type {
+  CliCommandConfigErrorContext,
+  CliCommandNode,
+  CliCommandRunContext,
+} from "../cliCommand/types.js";
+import { isConfigError } from "../configDiagnostics.js";
 import { type PopupCommandDeps, type PopupCommandOptions, runPopupCommand } from "../popup.js";
 
 export const popupCliCommand: CliCommandNode = {
@@ -9,6 +15,7 @@ export const popupCliCommand: CliCommandNode = {
   description: "Open the terminal popup dashboard.",
   requiresConfig: true,
   run: runPopupCliCommand,
+  handleConfigError: handlePopupConfigError,
   usage: ["stn popup [--persistent]"],
   options: [
     {
@@ -19,7 +26,19 @@ export const popupCliCommand: CliCommandNode = {
   examples: ["pnpm stn popup", "pnpm stn popup --persistent"],
 };
 
-async function runPopupCliCommand(context: CliCommandRunContext) {
+async function handlePopupConfigError(error: unknown, context: CliCommandConfigErrorContext) {
+  if (
+    !isConfigError(error) ||
+    error.code !== "CONFIG_FILE_NOT_FOUND" ||
+    context.configPath !== undefined
+  ) {
+    return undefined;
+  }
+  // Keep the resolved path absent so the nested TUI does not receive --config for a missing file.
+  return runPopupCliCommand({ ...context, config: emptyConfig() }, true);
+}
+
+async function runPopupCliCommand(context: CliCommandRunContext, firstRun = false) {
   const popupEnv = context.options.popupDeps?.env ?? context.options.env;
   const defaultPopupEnv = popupEnv ?? process.env;
   const hasExplicitPopupUi =
@@ -43,6 +62,9 @@ async function runPopupCliCommand(context: CliCommandRunContext) {
     popupDeps.observer = context.options.observerDeps;
   }
   const popupOptions: PopupCommandOptions = loadedCommandOptions(context);
+  if (firstRun) {
+    popupOptions.firstRun = true;
+  }
   popupOptions.tuiCommand = tuiCommand;
   if (popupEnv !== undefined) {
     popupOptions.env = popupEnv;

--- a/apps/cli/src/commands/registry/tui.ts
+++ b/apps/cli/src/commands/registry/tui.ts
@@ -1,5 +1,11 @@
+import { emptyConfig } from "@station/config";
 import { loadedCommandOptions } from "../cliCommand/helpers.js";
-import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
+import type {
+  CliCommandConfigErrorContext,
+  CliCommandNode,
+  CliCommandRunContext,
+} from "../cliCommand/types.js";
+import { isConfigError } from "../configDiagnostics.js";
 import { runTuiCommand, type TuiCommandDeps } from "../tui.js";
 
 export const tuiCliCommand: CliCommandNode = {
@@ -7,6 +13,7 @@ export const tuiCliCommand: CliCommandNode = {
   description: "Open the fullscreen or popup TUI.",
   requiresConfig: true,
   run: runTuiCliCommand,
+  handleConfigError: handleTuiConfigError,
   usage: ["stn tui [--popup] [--persistent]"],
   options: [
     { name: "--popup", description: "Run in popup mode." },
@@ -17,6 +24,17 @@ export const tuiCliCommand: CliCommandNode = {
   ],
   examples: ["pnpm stn tui", "pnpm stn tui --popup --persistent"],
 };
+
+async function handleTuiConfigError(error: unknown, context: CliCommandConfigErrorContext) {
+  if (
+    !isConfigError(error) ||
+    error.code !== "CONFIG_FILE_NOT_FOUND" ||
+    context.configPath !== undefined
+  ) {
+    return undefined;
+  }
+  return runTuiCliCommand({ ...context, config: emptyConfig() });
+}
 
 async function runTuiCliCommand(context: CliCommandRunContext) {
   const tuiDeps: TuiCommandDeps = {};

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -1,3 +1,5 @@
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runCli } from "@station/cli";
 import {
@@ -13,6 +15,133 @@ const now = "2026-05-20T12:00:00.000Z";
 const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url)).replace(/\/$/, "");
 
 describe("CLI popup command", () => {
+  it("ensures the observer before opening a config-less first-run popup", async () => {
+    const fixture = await createTempState();
+    const calls: TmuxPopupOptions[] = [];
+    const lifecycle: string[] = [];
+    let running = false;
+    const observerDeps: ObserverProcessDeps = {
+      spawnObserver: async () => {
+        lifecycle.push("observer-spawn");
+        running = true;
+        return { pid: 1234, unref: () => undefined };
+      },
+      clientFactory: () =>
+        ({
+          health: async () => {
+            if (!running) throw new Error("stopped");
+            return {
+              schemaVersion: "0.6.0",
+              status: "healthy",
+              pid: 1234,
+              startedAt: now,
+              version: "0.0.0",
+            };
+          },
+          reconcile: async () => emptySnapshot("popup-open"),
+        }) as never,
+      sleep: async () => undefined,
+    };
+
+    const result = await withIsolatedHome(fixture.root, () =>
+      runCli([], {
+        observerDeps,
+        popupDeps: {
+          env: { TMUX: "/tmp/tmux-501/default,123,0" },
+          openTmuxPopup: async (options) => {
+            lifecycle.push("popup-open");
+            calls.push(options);
+            return { opened: true };
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ code: 0, output: { opened: true } });
+    expect(lifecycle).toEqual(["observer-spawn", "popup-open"]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.tuiCommand).toContain("tui --popup --persistent");
+    expect(calls[0]?.tuiCommand).not.toContain("--config");
+    await expect(access(join(fixture.root, ".config/station/config.toml"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps an explicitly missing popup config as a hard error", async () => {
+    const fixture = await createTempState();
+    const configPath = join(fixture.root, "missing.toml");
+
+    await expect(
+      runCli(["--config", configPath, "popup"], {
+        observerDeps: {
+          spawnObserver: async () => {
+            throw new Error("observer should not start for an explicit missing config");
+          },
+        },
+        popupDeps: {
+          env: { TMUX: "/tmp/tmux-501/default,123,0" },
+          openTmuxPopup: async () => {
+            throw new Error("popup should not open for an explicit missing config");
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "CONFIG_FILE_NOT_FOUND", configPath });
+  });
+
+  it("does not open a first-run popup when the observer fails to start", async () => {
+    const fixture = await createTempState();
+    let popupOpened = false;
+
+    const result = await withIsolatedHome(fixture.root, () =>
+      runCli([], {
+        observerDeps: {
+          spawnObserver: async () => {
+            throw new Error("observer failed to start");
+          },
+          clientFactory: () =>
+            ({
+              health: async () => {
+                throw new Error("stopped");
+              },
+            }) as never,
+        },
+        popupDeps: {
+          env: { TMUX: "/tmp/tmux-501/default,123,0" },
+          openTmuxPopup: async () => {
+            popupOpened = true;
+            return { opened: true };
+          },
+        },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      code: 1,
+      output: { status: "unavailable", observer: { status: "unhealthy" } },
+    });
+    expect(popupOpened).toBe(false);
+  });
+
+  it("keeps a malformed implicit popup config as a hard error", async () => {
+    const fixture = await createTempState();
+    const configPath = join(fixture.root, ".config/station/config.toml");
+    await mkdir(join(fixture.root, ".config/station"), { recursive: true });
+    await writeFile(configPath, "not = [valid toml", "utf8");
+
+    await expect(
+      withIsolatedHome(fixture.root, () =>
+        runCli([], {
+          popupDeps: {
+            env: { TMUX: "/tmp/tmux-501/default,123,0" },
+            openTmuxPopup: async () => {
+              throw new Error("popup should not open for malformed config");
+            },
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "CONFIG_TOML_PARSE_FAILED", configPath });
+  });
+
   it("delegates popup opening to the tmux integration", async () => {
     const fixture = await createTempState();
     fixture.config.defaults.terminal = "tmux";
@@ -309,34 +438,53 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
         }),
         reconcile: async (reason: string) => {
           reconciles.push(reason);
-          return {
-            schemaVersion: "0.6.0",
-            reason,
-            reconciledAt: now,
-            snapshot: {
-              schemaVersion: "0.6.0",
-              generatedAt: now,
-              observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
-              providerHealth: {},
-              projects: [],
-              rows: [],
-              sessions: [],
-              counts: {
-                projects: 0,
-                worktrees: 0,
-                agents: 0,
-                working: 0,
-                idle: 0,
-                attention: 0,
-                unknown: 0,
-              },
-              alerts: [],
-            },
-          };
+          return emptySnapshot(reason);
         },
       }) as never,
     sleep: async () => undefined,
   };
+}
+
+function emptySnapshot(reason: string) {
+  return {
+    schemaVersion: "0.6.0",
+    reason,
+    reconciledAt: now,
+    snapshot: {
+      schemaVersion: "0.6.0",
+      generatedAt: now,
+      observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
+      providerHealth: {},
+      projects: [],
+      rows: [],
+      sessions: [],
+      counts: {
+        projects: 0,
+        worktrees: 0,
+        agents: 0,
+        working: 0,
+        idle: 0,
+        attention: 0,
+        unknown: 0,
+      },
+      alerts: [],
+    },
+  };
+}
+
+async function withIsolatedHome<T>(home: string, run: () => Promise<T>): Promise<T> {
+  const previousHome = process.env.HOME;
+  const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  process.env.HOME = home;
+  delete process.env.XDG_RUNTIME_DIR;
+  try {
+    return await run();
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+    else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
+  }
 }
 
 function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProcessDeps {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -1,6 +1,7 @@
-import { writeFile } from "node:fs/promises";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { runCli } from "@station/cli";
-import { runTuiCommand } from "@station/cli/internal";
+import { type ObserverProcessDeps, runTuiCommand } from "@station/cli/internal";
 import type { TuiConfig } from "@station/config";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
@@ -51,10 +52,15 @@ function emptySnapshot(reason: string) {
 
 // A running observer whose health check passes once spawned. `reconcile`
 // records its reason (or hangs, to model the non-blocking startup reconcile).
-function runningObserverDeps(options: { reconciles?: string[]; hangReconcile?: boolean } = {}) {
+type SpawnObserverInput = Parameters<NonNullable<ObserverProcessDeps["spawnObserver"]>>[0];
+
+function runningObserverDeps(
+  options: { reconciles?: string[]; hangReconcile?: boolean; spawns?: SpawnObserverInput[] } = {},
+) {
   let running = false;
   return {
-    spawnObserver: async () => {
+    spawnObserver: async (input: SpawnObserverInput) => {
+      options.spawns?.push(input);
       running = true;
       return { pid: 1234, unref: () => undefined };
     },
@@ -83,6 +89,69 @@ function runningObserverDeps(options: { reconciles?: string[]; hangReconcile?: b
 }
 
 describe("CLI tui command", () => {
+  it("launches the native first-run TUI without writing an implicit config", async () => {
+    const fixture = await createTempState();
+    const envs: Array<Record<string, string>> = [];
+    const spawns: SpawnObserverInput[] = [];
+
+    const result = await withIsolatedHome(fixture.root, () =>
+      runCli([], {
+        env: {},
+        observerDeps: runningObserverDeps({ spawns }),
+        tuiDeps: {
+          spawnRenderer: async ({ env }) => {
+            envs.push(env);
+            return { status: "exited", code: 0 };
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ code: 0, output: { status: "exited", code: 0 } });
+    expect(spawns).toEqual([
+      {
+        paths: expect.objectContaining({
+          stateDir: join(fixture.root, ".local/state/station"),
+          socketPath: join(fixture.root, ".local/state/station/run/observer.sock"),
+        }),
+      },
+    ]);
+    expect(envs).toEqual([
+      {
+        STATION_OBSERVER_SOCKET_PATH: join(fixture.root, ".local/state/station/run/observer.sock"),
+      },
+    ]);
+    await expect(access(join(fixture.root, ".config/station/config.toml"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps explicit missing and malformed implicit configs as hard errors", async () => {
+    const fixture = await createTempState();
+    const explicitPath = join(fixture.root, "missing.toml");
+    const observerDeps: ObserverProcessDeps = {
+      spawnObserver: async () => {
+        throw new Error("observer should not start for config errors");
+      },
+    };
+    const tuiDeps = {
+      spawnRenderer: async () => {
+        throw new Error("renderer should not start for config errors");
+      },
+    };
+
+    await expect(
+      runCli(["--config", explicitPath, "tui"], { observerDeps, tuiDeps }),
+    ).rejects.toMatchObject({ code: "CONFIG_FILE_NOT_FOUND", configPath: explicitPath });
+
+    const implicitPath = join(fixture.root, ".config/station/config.toml");
+    await mkdir(join(fixture.root, ".config/station"), { recursive: true });
+    await writeFile(implicitPath, "not = [valid toml", "utf8");
+    await expect(
+      withIsolatedHome(fixture.root, () => runCli([], { env: {}, observerDeps, tuiDeps })),
+    ).rejects.toMatchObject({ code: "CONFIG_TOML_PARSE_FAILED", configPath: implicitPath });
+  });
+
   it("starts or connects the observer and hands its socket to the renderer", async () => {
     const fixture = await createTempState();
     fixture.config.tui = tuiConfig;
@@ -436,5 +505,20 @@ async function expectWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<
     if (timeout !== undefined) {
       clearTimeout(timeout);
     }
+  }
+}
+
+async function withIsolatedHome<T>(home: string, run: () => Promise<T>): Promise<T> {
+  const previousHome = process.env.HOME;
+  const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
+  process.env.HOME = home;
+  delete process.env.XDG_RUNTIME_DIR;
+  try {
+    return await run();
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+    else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
   }
 }

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -1,4 +1,4 @@
-import type { ConfigDiagnostic, StationConfig } from "@station/config";
+import { type ConfigDiagnostic, emptyConfig, type StationConfig } from "@station/config";
 import type {
   CommandId,
   CommandRecord,
@@ -47,7 +47,6 @@ import {
 import type { ObserverPersistence } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import { type ObserverCore, providerProjectsFromConfig } from "../reconcile/core.js";
-import { emptyConfig } from "./emptyConfig.js";
 import type { ObserverEventBus } from "./eventBus.js";
 import {
   type ExternalLaunchDeps,

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -2,7 +2,12 @@
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { type LoadedStationConfig, loadConfig, type StationConfig } from "@station/config";
+import {
+  emptyConfig,
+  type LoadedStationConfig,
+  loadConfig,
+  type StationConfig,
+} from "@station/config";
 import { componentLogPath } from "@station/observability";
 import { type RuntimeClock, stationBuildInfo, systemClock, toIsoTimestamp } from "@station/runtime";
 import { createCommandQueue } from "../commands/queue.js";
@@ -18,7 +23,6 @@ import type { ProviderRegistry } from "../providers/registry.js";
 import { createObserverCore, providerProjectsFromConfig } from "../reconcile/core.js";
 import { openObserverSqlite } from "../sqlite.js";
 import { createObserverApi } from "./api.js";
-import { emptyConfig } from "./emptyConfig.js";
 import { createObserverEventBus } from "./eventBus.js";
 import { runShutdownWithBackstop } from "./gracefulExit.js";
 import { createObserverLogger } from "./logging.js";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,6 +7,13 @@ reads it, where it lives, and how to relocate it.
 
 If you only ever edit one thing, it is `~/.config/station/config.toml`.
 
+If that default file does not exist yet, `stn` and its `tui`/`popup` launch
+routes use in-memory first-run defaults, ensure the observer, and show the
+existing empty-state UI. They do not create a config file; `stn setup` remains
+the writer. This exception applies only to the implicit default path: a missing
+explicit `--config`, an unreadable file, malformed TOML, or invalid config still
+stops launch with an error.
+
 > The annotated `examples/config.toml` is the copy-paste starting point;
 > `examples/project-local-config.toml` shows the project-local file. This page is
 > the field-by-field reference.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -327,6 +327,9 @@ cycle. Keep `STATION_DASHBOARD_COMMAND` / `STATION_HOST_ENTRY` /
 
 ### B1 — config-tolerant launch
 
+**Status: implemented.** Native and tmux launch routes both ensure the singleton
+observer before presenting their first-run UI.
+
 In-memory defaults, write-on-configure (no auto-written stub — it poisons
 `stn setup`'s clean create path). Lift `emptyConfig` to
 `packages/config/src/firstRun.ts`; add `handleConfigError` hooks on

--- a/packages/config/src/firstRun.ts
+++ b/packages/config/src/firstRun.ts
@@ -1,5 +1,6 @@
-import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "./schema.js";
 
+// First-run boot must not imply external provider readiness; the UI launch mode owns native/tmux.
 export function emptyConfig(): StationConfig {
   return {
     schemaVersion: 1,

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./firstRun.js";
 export * from "./hooks/index.js";
 export * from "./loadConfig.js";
 export * from "./observerPaths.js";

--- a/packages/config/test/unit/first-run.test.ts
+++ b/packages/config/test/unit/first-run.test.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_WORKSPACE_CONFIG, emptyConfig } from "@station/config";
+import { describe, expect, it } from "vitest";
+
+describe("first-run config", () => {
+  it("provides safe in-memory defaults without projects", () => {
+    expect(emptyConfig()).toEqual({
+      schemaVersion: 1,
+      defaults: {
+        worktreeProvider: "noop-worktree",
+        terminal: "noop-terminal",
+        harness: "noop-harness",
+        layout: "agent-shell",
+      },
+      workspace: DEFAULT_WORKSPACE_CONFIG,
+      projects: [],
+    });
+  });
+});

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1,10 +1,53 @@
+import { access } from "node:fs/promises";
+import { join } from "node:path";
 import { startObserver } from "@station/cli";
+import { emptyConfig } from "@station/config";
 import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
 import { waitForSocketClosed } from "../support/sockets";
 import { createTempState, writeConfigToml } from "../support/temp-projects";
 
 describe("observer lifecycle e2e", () => {
+  it("boots a real observer with in-memory defaults and no config file", async () => {
+    const fixture = await createTempState();
+    const config = {
+      ...emptyConfig(),
+      observer: {
+        stateDir: fixture.stateDir,
+        socketPath: fixture.socketPath,
+      },
+    };
+    const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    let started = false;
+
+    try {
+      const status = await startObserver({ config, timeoutMs: 30_000 });
+      expect(status).toMatchObject({
+        status: "running",
+        paths: { socketPath: fixture.socketPath },
+      });
+      started = true;
+
+      await expect(client.health()).resolves.toMatchObject({
+        status: "healthy",
+        socketPath: fixture.socketPath,
+        stateDir: fixture.stateDir,
+      });
+      await expect(client.getSnapshot()).resolves.toMatchObject({
+        schemaVersion: "0.6.0",
+        counts: { projects: 0 },
+      });
+      await expect(access(join(fixture.root, "config.toml"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      if (started) {
+        await client.stop();
+        await waitForSocketClosed(fixture.socketPath);
+      }
+    }
+  });
+
   it("starts a real observer process, serves protocol requests, and stops cleanly", async () => {
     const fixture = await createTempState();
     const config = {


### PR DESCRIPTION
## Summary

- move the safe first-run config into `@station/config` and reuse it from the observer
- let native and tmux UI routes recover only from a missing implicit config
- ensure the singleton observer is healthy before either first-run UI opens
- keep explicit, unreadable, malformed, and invalid configs as hard errors
- document the behavior and add real-process, failure-ordering, and strictness coverage

## Why

Bare `stn` currently stops at config loading before it can start the observer or render the existing first-run empty state. B1 treats an absent default config as an unconfigured launch state without weakening authored-config validation or writing a stub that would interfere with `stn setup`.

## UX

Outside tmux, a config-less launch opens the full native TUI. Inside tmux, it opens the control-center popup. Both routes ensure the same observer first, and neither creates `~/.config/station/config.toml`.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- focused config unit and TUI/popup integration tests
- real observer lifecycle e2e with no config path
- full unit suite under an isolated `HOME`: 1,183 passed
- contracts, diagnostics, scripted-agent, and setup-e2e lanes passed

## Validation notes

- A full integration rerun had one parallel `release-hardening-doctor` protocol-validation flake; the test passed immediately when rerun alone. The other 309 integration tests passed.
- Full `pnpm test:e2e` passed 12 tests including the new observer lifecycle case, but the existing release-smoke test failed because its fake Worktrunk help does not advertise the configured `--no-hooks` capability.
