### PR TITLE
feat(cli): add fail-fast observer boot diagnostics

### DIFF
--- a/apps/cli/src/commands/popup.ts
+++ b/apps/cli/src/commands/popup.ts
@@ -110,6 +110,7 @@ async function prepareObserverForPopup(
     {
       config: options.config,
       paths,
+      onStartupProgress: (message) => process.stderr.write(`${message}\n`),
       ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
     },

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -72,6 +72,7 @@ export async function runTuiCommand(
     {
       ...options,
       paths,
+      onStartupProgress: (message) => process.stderr.write(`${message}\n`),
       ...(parsed.timeoutMs === undefined ? {} : { timeoutMs: parsed.timeoutMs }),
     },
     deps.observer,

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -1,78 +1,32 @@
-import { type ChildProcess, spawn } from "node:child_process";
-import { lstat, mkdir, open } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import type { StationConfig } from "@station/config";
-import type { ObserverHealth, ObserverStopReceipt, SafeError } from "@station/contracts";
-import {
-  componentLogPath,
-  createJsonlLogger,
-  createTraceContext,
-  type JsonlLogger,
-  redactString,
-} from "@station/observability";
+import { lstat } from "node:fs/promises";
+import type { ObserverStopReceipt, SafeError } from "@station/contracts";
+import { componentLogPath, createJsonlLogger, createTraceContext } from "@station/observability";
 import { createObserverClient, isSocketStale, removeStaleSocket } from "@station/protocol";
 import {
-  Effect,
   type RuntimeClock,
   type RuntimeTraceContext,
   runRuntimeBoundaryWithRetryAndTimeout,
-  runRuntimeBoundaryWithTimeout,
   safeErrorFromUnknown,
   systemClock,
 } from "@station/runtime";
+import { defaultClientFactory } from "./observerProcess/health.js";
+import { startObserverProcess } from "./observerProcess/startup.js";
+import type {
+  ObserverProcessDeps,
+  ObserverProcessOptions,
+  ObserverStatus,
+} from "./observerProcess/types.js";
 import { type ObserverPaths, resolveObserverPaths } from "./paths.js";
 
-export type ObserverStatus =
-  | {
-      status: "running";
-      paths: ObserverPaths;
-      health: ObserverHealth;
-    }
-  | {
-      status: "stopped" | "stale" | "unhealthy";
-      paths: ObserverPaths;
-      error?: SafeError;
-    };
-
-export type ObserverProcessDeps = {
-  clientFactory?: (socketPath: string) => ReturnType<typeof createObserverClient>;
-  spawnObserver?: (input: SpawnObserverInput) => ChildProcessLike | Promise<ChildProcessLike>;
-  clock?: RuntimeClock;
-  sleep?: (ms: number) => Promise<void>;
-  logger?: JsonlLogger;
-};
-
-export type SpawnObserverInput = {
-  paths: ObserverPaths;
-  configPath?: string;
-};
-
-type ChildProcessExit = {
-  type: "exit";
-  code: number | null;
-  signal: NodeJS.Signals | null;
-};
-
-type ChildProcessSpawnError = {
-  type: "spawn_error";
-  error: Error;
-};
-
-type ChildExitResult = ChildProcessExit | ChildProcessSpawnError;
-
-export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
-  kill?: ChildProcess["kill"];
-  exited?: Promise<ChildExitResult>;
-  disposeExitWait?: () => void;
-};
-
-export type ObserverProcessOptions = {
-  config?: StationConfig;
-  configPath?: string;
-  paths?: ObserverPaths;
-  timeoutMs?: number;
-  onStartupProgress?: (message: string) => void;
-};
+export { waitForObserverHealth } from "./observerProcess/health.js";
+// Commands intentionally keep one stable lifecycle import while implementation lives in observerProcess/.
+export type {
+  ChildProcessLike,
+  ObserverProcessDeps,
+  ObserverProcessOptions,
+  ObserverStatus,
+  SpawnObserverInput,
+} from "./observerProcess/types.js";
 
 export async function getObserverStatus(
   options: ObserverProcessOptions = {},
@@ -125,46 +79,19 @@ export async function startObserver(
     return existing;
   }
 
-  const progressTimers = scheduleObserverStartupProgress(options.onStartupProgress, paths);
-  // Spawning only starts the daemon; report running only after the socket health check succeeds.
-  let child: ChildProcessLike | undefined;
-  const result = await runRuntimeBoundaryWithTimeout(
+  const result = await startObserverProcess(
     {
-      operation: "cli.observer.start",
-      clock,
+      paths,
       timeoutMs,
-      error: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_START_FAILED",
-        message: "Observer startup failed.",
-        hint: `Run station debug trace ${trace.traceId}.`,
-        traceId: trace.traceId,
-      },
-      timeoutError: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_START_FAILED",
-        message: "Observer did not become healthy before the startup timeout.",
-        hint: `Run station debug trace ${trace.traceId}.`,
-        traceId: trace.traceId,
-      },
       trace,
+      clock,
+      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
+      ...(options.onStartupProgress === undefined
+        ? {}
+        : { onStartupProgress: options.onStartupProgress }),
     },
-    async ({ signal }) => {
-      await mkdir(paths.stateDir, { recursive: true, mode: 0o700 });
-      await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
-      child = await (deps.spawnObserver ?? defaultSpawnObserver)({
-        paths,
-        ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      });
-      if (signal.aborted) {
-        child.kill?.();
-        throw observerHealthWaitCancelledError();
-      }
-      child.unref?.();
-      return waitForStartedObserver({ child, paths, timeoutMs, trace, signal }, deps);
-    },
-  ).finally(() => clearObserverStartupProgress(progressTimers));
-
+    deps,
+  );
   if (result.ok) {
     return {
       status: "running",
@@ -173,9 +100,6 @@ export async function startObserver(
     };
   }
 
-  if (result.error.code !== "OBSERVER_EXITED_ON_START") {
-    child?.kill?.();
-  }
   await logObserverLifecycleFailure({
     paths,
     operation: "cli.observer.start",
@@ -242,67 +166,6 @@ export async function restartObserver(
   return startObserver({ ...options, paths: status.paths }, deps);
 }
 
-export async function waitForObserverHealth(
-  options: {
-    paths: ObserverPaths;
-    timeoutMs?: number;
-    trace?: RuntimeTraceContext;
-    signal?: AbortSignal;
-  },
-  deps: ObserverProcessDeps = {},
-): Promise<ObserverHealth> {
-  const timeoutMs = options.timeoutMs ?? 2000;
-  const retries = Math.max(1, Math.ceil(timeoutMs / 25));
-  const client = (deps.clientFactory ?? defaultClientFactory)(options.paths.socketPath);
-  const result = await runRuntimeBoundaryWithRetryAndTimeout(
-    {
-      operation: "cli.observer.waitForHealth",
-      timeoutMs,
-      error: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_HEALTH_FAILED",
-        message: "Observer health check failed.",
-        ...(options.trace?.traceId === undefined
-          ? {}
-          : {
-              hint: `Run station debug trace ${options.trace.traceId}.`,
-              traceId: options.trace.traceId,
-            }),
-      },
-      timeoutError: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_HEALTH_TIMEOUT",
-        message: "Observer did not report healthy before the timeout.",
-        ...(options.trace?.traceId === undefined
-          ? {}
-          : {
-              hint: `Run station debug trace ${options.trace.traceId}.`,
-              traceId: options.trace.traceId,
-            }),
-      },
-      retry: {
-        retries,
-        delayMs: 25,
-        shouldRetry: (error, attempt) =>
-          error.code !== "OBSERVER_HEALTH_WAIT_CANCELLED" && attempt < retries,
-      },
-      trace: options.trace,
-    },
-    async ({ signal }) => {
-      const signals = [signal, options.signal].filter(isAbortSignal);
-      if (signals.some((candidate) => candidate.aborted)) {
-        throw observerHealthWaitCancelledError();
-      }
-      return abortableObserverHealth(client.health(), signals);
-    },
-  );
-
-  if (!result.ok) {
-    throw result.error;
-  }
-  return result.value;
-}
-
 export function observerStatusErrorMessage(
   status: Exclude<ObserverStatus, { status: "running" }>,
 ): string {
@@ -319,320 +182,6 @@ export function observerStatusErrorMessage(
     lines.push(`Code: ${error.code}`);
   }
   return lines.join("\n");
-}
-
-function defaultClientFactory(socketPath: string) {
-  return createObserverClient({ socketPath, timeoutMs: 500 });
-}
-
-async function defaultSpawnObserver(input: SpawnObserverInput): Promise<ChildProcessLike> {
-  const argv = observerSpawnArgv(input);
-  const bootLogPath = observerBootLogPath(input.paths);
-  await mkdir(dirname(bootLogPath), { recursive: true, mode: 0o700 });
-  const bootLog = await open(bootLogPath, "w", 0o600);
-  let child: ChildProcess | undefined;
-  let startedChild: ChildProcessLike;
-  try {
-    await bootLog.chmod(0o600);
-    await bootLog.writeFile(`${JSON.stringify({ command: argv })}\n`, "utf8");
-    const [command, ...args] = argv;
-    child = spawn(command, args, {
-      detached: true,
-      stdio: ["ignore", bootLog.fd, bootLog.fd],
-    });
-    startedChild = childWithExit(child);
-  } catch (error) {
-    await bootLog.close().catch(() => undefined);
-    throw error;
-  }
-  try {
-    await bootLog.close();
-  } catch (error) {
-    child.kill();
-    throw error;
-  }
-  return startedChild;
-}
-
-function observerSpawnArgv(input: SpawnObserverInput): [string, ...string[]] {
-  const observerEntry = new URL("../dist/observerMain.js", import.meta.url);
-  return [
-    process.execPath,
-    observerEntry.pathname,
-    "--socket",
-    input.paths.socketPath,
-    "--state-dir",
-    input.paths.stateDir,
-    ...(input.configPath === undefined ? [] : ["--config", input.configPath]),
-  ];
-}
-
-function childWithExit(child: ChildProcess): ChildProcessLike {
-  let disposeExitWait!: () => void;
-  const exited = new Promise<ChildExitResult>((resolve) => {
-    let settled = false;
-    const finish = (result: ChildExitResult) => {
-      if (settled) return;
-      settled = true;
-      disposeExitWait();
-      resolve(result);
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      finish({ type: "exit", code, signal });
-    };
-    const onError = (error: Error) => {
-      finish({ type: "spawn_error", error });
-    };
-    disposeExitWait = () => {
-      child.off("exit", onExit);
-      child.off("error", onError);
-    };
-    child.once("exit", onExit);
-    child.once("error", onError);
-  });
-  return Object.assign(child, { exited, disposeExitWait });
-}
-
-async function waitForStartedObserver(
-  input: {
-    child: ChildProcessLike;
-    paths: ObserverPaths;
-    timeoutMs: number;
-    trace: RuntimeTraceContext;
-    signal: AbortSignal;
-  },
-  deps: ObserverProcessDeps,
-): Promise<ObserverHealth> {
-  const healthController = new AbortController();
-  const cancelHealth = () => healthController.abort();
-  input.signal.addEventListener("abort", cancelHealth, { once: true });
-  const healthPromise = waitForObserverHealth(
-    {
-      paths: input.paths,
-      timeoutMs: input.timeoutMs,
-      trace: input.trace,
-      signal: healthController.signal,
-    },
-    deps,
-  );
-
-  try {
-    const childExit = input.child.exited;
-    if (childExit === undefined) {
-      return await healthPromise;
-    }
-
-    const outcome = await Effect.runPromise(
-      Effect.raceFirst(
-        Effect.tryPromise({
-          try: () => healthPromise,
-          catch: (error) => error,
-        }).pipe(
-          Effect.match({
-            onFailure: (error) => ({ type: "error" as const, error }),
-            onSuccess: (health) => ({ type: "healthy" as const, health }),
-          }),
-        ),
-        Effect.tryPromise({
-          try: () => childExit,
-          catch: (error) => error,
-        }).pipe(
-          Effect.match({
-            onFailure: (error) => ({ type: "error" as const, error }),
-            onSuccess: (exit) => ({ type: "exited" as const, exit }),
-          }),
-        ),
-      ),
-    );
-    if (outcome.type === "error") {
-      throw outcome.error;
-    }
-    if (outcome.type === "healthy") {
-      return outcome.health;
-    }
-
-    healthController.abort();
-    try {
-      // A competing observer may have won the socket immediately before this child exited.
-      return await probeObserverHealth(input.paths, deps, input.signal);
-    } catch {
-      if (input.signal.aborted) {
-        throw observerHealthWaitCancelledError();
-      }
-    }
-    throw await observerExitedOnStartError(input.paths, outcome.exit, input.trace);
-  } finally {
-    input.signal.removeEventListener("abort", cancelHealth);
-    healthController.abort();
-    input.child.disposeExitWait?.();
-    void healthPromise.catch(() => undefined);
-  }
-}
-
-function probeObserverHealth(
-  paths: ObserverPaths,
-  deps: ObserverProcessDeps,
-  signal: AbortSignal,
-): Promise<ObserverHealth> {
-  const client = (deps.clientFactory ?? defaultClientFactory)(paths.socketPath);
-  return abortableObserverHealth(client.health(), [signal]);
-}
-
-async function observerExitedOnStartError(
-  paths: ObserverPaths,
-  exit: ChildExitResult,
-  trace: RuntimeTraceContext,
-): Promise<SafeError> {
-  const bootLogHint = await observerBootLogHint(paths);
-  const traceHint =
-    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
-  const error: SafeError = {
-    tag: "ObserverStartupError",
-    code: "OBSERVER_EXITED_ON_START",
-    message: `Observer exited before becoming healthy (${childExitDescription(exit)}).`,
-    hint: `${bootLogHint}${traceHint}`,
-  };
-  if (trace.traceId !== undefined) {
-    error.traceId = trace.traceId;
-  }
-  return error;
-}
-
-function childExitDescription(exit: ChildExitResult): string {
-  if (exit.type === "spawn_error") {
-    return `spawn error: ${redactString(exit.error.message)}`;
-  }
-  if (exit.signal !== null) {
-    return `signal ${exit.signal}`;
-  }
-  if (exit.code !== null) {
-    return `exit code ${exit.code}`;
-  }
-  return "unknown exit status";
-}
-
-async function observerBootLogHint(paths: ObserverPaths): Promise<string> {
-  const path = observerBootLogPath(paths);
-  const pathHint = `Observer boot log: ${path}`;
-  try {
-    const tail = await readObserverBootLogTail(path);
-    if (tail === undefined) {
-      return pathHint;
-    }
-    return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
-  } catch {
-    return pathHint;
-  }
-}
-
-async function readObserverBootLogTail(path: string): Promise<string | undefined> {
-  const maxBytes = 64 * 1024;
-  const bootLog = await open(path, "r");
-  try {
-    const { size } = await bootLog.stat();
-    if (size === 0) return undefined;
-    const length = Math.min(size, maxBytes);
-    const buffer = Buffer.alloc(length);
-    const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
-    let content = buffer.subarray(0, bytesRead).toString("utf8");
-    if (size > length) {
-      const firstNewline = content.indexOf("\n");
-      if (firstNewline !== -1) content = content.slice(firstNewline + 1);
-    }
-    content = content.trimEnd();
-    if (content.trim().length === 0) return undefined;
-    return content.split(/\r?\n/).slice(-15).join("\n");
-  } finally {
-    await bootLog.close();
-  }
-}
-
-function observerBootLogPath(paths: ObserverPaths): string {
-  return join(paths.stateDir, "logs", "observer-boot.log");
-}
-
-function scheduleObserverStartupProgress(
-  onProgress: ObserverProcessOptions["onStartupProgress"],
-  paths: ObserverPaths,
-): Array<ReturnType<typeof setTimeout>> {
-  if (onProgress === undefined) {
-    return [];
-  }
-  return [
-    setTimeout(() => emitObserverStartupProgress(onProgress, "Starting STATION observer…"), 1_500),
-    setTimeout(
-      () =>
-        emitObserverStartupProgress(
-          onProgress,
-          `Still waiting for STATION observer; boot log: ${observerBootLogPath(paths)}`,
-        ),
-      5_000,
-    ),
-  ];
-}
-
-function emitObserverStartupProgress(
-  onProgress: NonNullable<ObserverProcessOptions["onStartupProgress"]>,
-  message: string,
-): void {
-  try {
-    onProgress(message);
-  } catch {
-    // Progress output must not turn a successful observer launch into a startup failure.
-  }
-}
-
-function clearObserverStartupProgress(timers: readonly ReturnType<typeof setTimeout>[]): void {
-  for (const timer of timers) {
-    clearTimeout(timer);
-  }
-}
-
-function abortableObserverHealth(
-  health: Promise<ObserverHealth>,
-  signals: readonly AbortSignal[],
-): Promise<ObserverHealth> {
-  if (signals.some((signal) => signal.aborted)) {
-    void health.catch(() => undefined);
-    return Promise.reject(observerHealthWaitCancelledError());
-  }
-
-  return new Promise<ObserverHealth>((resolve, reject) => {
-    const cleanup = () => {
-      for (const signal of signals) {
-        signal.removeEventListener("abort", onAbort);
-      }
-    };
-    const onAbort = () => {
-      cleanup();
-      reject(observerHealthWaitCancelledError());
-    };
-    for (const signal of signals) {
-      signal.addEventListener("abort", onAbort, { once: true });
-    }
-    void health.then(
-      (value) => {
-        cleanup();
-        resolve(value);
-      },
-      (error: unknown) => {
-        cleanup();
-        reject(error);
-      },
-    );
-  });
-}
-
-function observerHealthWaitCancelledError(): SafeError {
-  return {
-    tag: "CancellationError",
-    code: "OBSERVER_HEALTH_WAIT_CANCELLED",
-    message: "Observer health wait was cancelled.",
-  };
-}
-
-function isAbortSignal(value: AbortSignal | undefined): value is AbortSignal {
-  return value !== undefined;
 }
 
 export async function logObserverLifecycleFailure(input: {

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -47,16 +47,18 @@ export type SpawnObserverInput = {
   configPath?: string;
 };
 
-type ChildExitResult =
-  | {
-      type: "exit";
-      code: number | null;
-      signal: NodeJS.Signals | null;
-    }
-  | {
-      type: "spawn_error";
-      error: Error;
-    };
+type ChildProcessExit = {
+  type: "exit";
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+type ChildProcessSpawnError = {
+  type: "spawn_error";
+  error: Error;
+};
+
+type ChildExitResult = ChildProcessExit | ChildProcessSpawnError;
 
 export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
   kill?: ChildProcess["kill"];

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -1,6 +1,6 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { lstat, mkdir } from "node:fs/promises";
-import { dirname } from "node:path";
+import { lstat, mkdir, open } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import type { StationConfig } from "@station/config";
 import type { ObserverHealth, ObserverStopReceipt, SafeError } from "@station/contracts";
 import {
@@ -8,9 +8,11 @@ import {
   createJsonlLogger,
   createTraceContext,
   type JsonlLogger,
+  redactString,
 } from "@station/observability";
 import { createObserverClient, isSocketStale, removeStaleSocket } from "@station/protocol";
 import {
+  Effect,
   type RuntimeClock,
   type RuntimeTraceContext,
   runRuntimeBoundaryWithRetryAndTimeout,
@@ -45,8 +47,21 @@ export type SpawnObserverInput = {
   configPath?: string;
 };
 
+type ChildExitResult =
+  | {
+      type: "exit";
+      code: number | null;
+      signal: NodeJS.Signals | null;
+    }
+  | {
+      type: "spawn_error";
+      error: Error;
+    };
+
 export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
   kill?: ChildProcess["kill"];
+  exited?: Promise<ChildExitResult>;
+  disposeExitWait?: () => void;
 };
 
 export type ObserverProcessOptions = {
@@ -54,6 +69,7 @@ export type ObserverProcessOptions = {
   configPath?: string;
   paths?: ObserverPaths;
   timeoutMs?: number;
+  onStartupProgress?: (message: string) => void;
 };
 
 export async function getObserverStatus(
@@ -93,7 +109,7 @@ export async function startObserver(
   deps: ObserverProcessDeps = {},
 ): Promise<ObserverStatus> {
   const paths = options.paths ?? resolveObserverPaths(options.config);
-  const timeoutMs = options.timeoutMs ?? 30_000;
+  const timeoutMs = options.timeoutMs ?? 10_000;
   const clock = deps.clock ?? systemClock;
   const trace = createTraceContext({ operation: "cli.observer.start" });
   const existing = await getObserverStatus({ ...options, paths }, deps);
@@ -107,6 +123,7 @@ export async function startObserver(
     return existing;
   }
 
+  const progressTimers = scheduleObserverStartupProgress(options.onStartupProgress, paths);
   // Spawning only starts the daemon; report running only after the socket health check succeeds.
   let child: ChildProcessLike | undefined;
   const result = await runRuntimeBoundaryWithTimeout(
@@ -130,17 +147,21 @@ export async function startObserver(
       },
       trace,
     },
-    async () => {
+    async ({ signal }) => {
       await mkdir(paths.stateDir, { recursive: true, mode: 0o700 });
       await mkdir(dirname(paths.socketPath), { recursive: true, mode: 0o700 });
       child = await (deps.spawnObserver ?? defaultSpawnObserver)({
         paths,
         ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       });
+      if (signal.aborted) {
+        child.kill?.();
+        throw observerHealthWaitCancelledError();
+      }
       child.unref?.();
-      return waitForObserverHealth({ paths, timeoutMs, trace }, deps);
+      return waitForStartedObserver({ child, paths, timeoutMs, trace, signal }, deps);
     },
-  );
+  ).finally(() => clearObserverStartupProgress(progressTimers));
 
   if (result.ok) {
     return {
@@ -150,7 +171,9 @@ export async function startObserver(
     };
   }
 
-  child?.kill?.();
+  if (result.error.code !== "OBSERVER_EXITED_ON_START") {
+    child?.kill?.();
+  }
   await logObserverLifecycleFailure({
     paths,
     operation: "cli.observer.start",
@@ -218,10 +241,16 @@ export async function restartObserver(
 }
 
 export async function waitForObserverHealth(
-  options: { paths: ObserverPaths; timeoutMs?: number; trace?: RuntimeTraceContext },
+  options: {
+    paths: ObserverPaths;
+    timeoutMs?: number;
+    trace?: RuntimeTraceContext;
+    signal?: AbortSignal;
+  },
   deps: ObserverProcessDeps = {},
 ): Promise<ObserverHealth> {
   const timeoutMs = options.timeoutMs ?? 2000;
+  const retries = Math.max(1, Math.ceil(timeoutMs / 25));
   const client = (deps.clientFactory ?? defaultClientFactory)(options.paths.socketPath);
   const result = await runRuntimeBoundaryWithRetryAndTimeout(
     {
@@ -250,12 +279,20 @@ export async function waitForObserverHealth(
             }),
       },
       retry: {
-        retries: Math.max(1, Math.ceil(timeoutMs / 25)),
+        retries,
         delayMs: 25,
+        shouldRetry: (error, attempt) =>
+          error.code !== "OBSERVER_HEALTH_WAIT_CANCELLED" && attempt < retries,
       },
       trace: options.trace,
     },
-    async () => client.health(),
+    async ({ signal }) => {
+      const signals = [signal, options.signal].filter(isAbortSignal);
+      if (signals.some((candidate) => candidate.aborted)) {
+        throw observerHealthWaitCancelledError();
+      }
+      return abortableObserverHealth(client.health(), signals);
+    },
   );
 
   if (!result.ok) {
@@ -286,9 +323,39 @@ function defaultClientFactory(socketPath: string) {
   return createObserverClient({ socketPath, timeoutMs: 500 });
 }
 
-function defaultSpawnObserver(input: SpawnObserverInput): ChildProcessLike {
+async function defaultSpawnObserver(input: SpawnObserverInput): Promise<ChildProcessLike> {
+  const argv = observerSpawnArgv(input);
+  const bootLogPath = observerBootLogPath(input.paths);
+  await mkdir(dirname(bootLogPath), { recursive: true, mode: 0o700 });
+  const bootLog = await open(bootLogPath, "w", 0o600);
+  let child: ChildProcess | undefined;
+  let startedChild: ChildProcessLike;
+  try {
+    await bootLog.chmod(0o600);
+    await bootLog.writeFile(`${JSON.stringify({ command: argv })}\n`, "utf8");
+    const [command, ...args] = argv;
+    child = spawn(command, args, {
+      detached: true,
+      stdio: ["ignore", bootLog.fd, bootLog.fd],
+    });
+    startedChild = childWithExit(child);
+  } catch (error) {
+    await bootLog.close().catch(() => undefined);
+    throw error;
+  }
+  try {
+    await bootLog.close();
+  } catch (error) {
+    child.kill();
+    throw error;
+  }
+  return startedChild;
+}
+
+function observerSpawnArgv(input: SpawnObserverInput): [string, ...string[]] {
   const observerEntry = new URL("../dist/observerMain.js", import.meta.url);
-  const args = [
+  return [
+    process.execPath,
     observerEntry.pathname,
     "--socket",
     input.paths.socketPath,
@@ -296,10 +363,274 @@ function defaultSpawnObserver(input: SpawnObserverInput): ChildProcessLike {
     input.paths.stateDir,
     ...(input.configPath === undefined ? [] : ["--config", input.configPath]),
   ];
-  return spawn(process.execPath, args, {
-    detached: true,
-    stdio: "ignore",
+}
+
+function childWithExit(child: ChildProcess): ChildProcessLike {
+  let disposeExitWait!: () => void;
+  const exited = new Promise<ChildExitResult>((resolve) => {
+    let settled = false;
+    const finish = (result: ChildExitResult) => {
+      if (settled) return;
+      settled = true;
+      disposeExitWait();
+      resolve(result);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish({ type: "exit", code, signal });
+    };
+    const onError = (error: Error) => {
+      finish({ type: "spawn_error", error });
+    };
+    disposeExitWait = () => {
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.once("exit", onExit);
+    child.once("error", onError);
   });
+  return Object.assign(child, { exited, disposeExitWait });
+}
+
+async function waitForStartedObserver(
+  input: {
+    child: ChildProcessLike;
+    paths: ObserverPaths;
+    timeoutMs: number;
+    trace: RuntimeTraceContext;
+    signal: AbortSignal;
+  },
+  deps: ObserverProcessDeps,
+): Promise<ObserverHealth> {
+  const healthController = new AbortController();
+  const cancelHealth = () => healthController.abort();
+  input.signal.addEventListener("abort", cancelHealth, { once: true });
+  const healthPromise = waitForObserverHealth(
+    {
+      paths: input.paths,
+      timeoutMs: input.timeoutMs,
+      trace: input.trace,
+      signal: healthController.signal,
+    },
+    deps,
+  );
+
+  try {
+    const childExit = input.child.exited;
+    if (childExit === undefined) {
+      return await healthPromise;
+    }
+
+    const outcome = await Effect.runPromise(
+      Effect.raceFirst(
+        Effect.tryPromise({
+          try: () => healthPromise,
+          catch: (error) => error,
+        }).pipe(
+          Effect.match({
+            onFailure: (error) => ({ type: "error" as const, error }),
+            onSuccess: (health) => ({ type: "healthy" as const, health }),
+          }),
+        ),
+        Effect.tryPromise({
+          try: () => childExit,
+          catch: (error) => error,
+        }).pipe(
+          Effect.match({
+            onFailure: (error) => ({ type: "error" as const, error }),
+            onSuccess: (exit) => ({ type: "exited" as const, exit }),
+          }),
+        ),
+      ),
+    );
+    if (outcome.type === "error") {
+      throw outcome.error;
+    }
+    if (outcome.type === "healthy") {
+      return outcome.health;
+    }
+
+    healthController.abort();
+    try {
+      // A competing observer may have won the socket immediately before this child exited.
+      return await probeObserverHealth(input.paths, deps, input.signal);
+    } catch {
+      if (input.signal.aborted) {
+        throw observerHealthWaitCancelledError();
+      }
+    }
+    throw await observerExitedOnStartError(input.paths, outcome.exit, input.trace);
+  } finally {
+    input.signal.removeEventListener("abort", cancelHealth);
+    healthController.abort();
+    input.child.disposeExitWait?.();
+    void healthPromise.catch(() => undefined);
+  }
+}
+
+function probeObserverHealth(
+  paths: ObserverPaths,
+  deps: ObserverProcessDeps,
+  signal: AbortSignal,
+): Promise<ObserverHealth> {
+  const client = (deps.clientFactory ?? defaultClientFactory)(paths.socketPath);
+  return abortableObserverHealth(client.health(), [signal]);
+}
+
+async function observerExitedOnStartError(
+  paths: ObserverPaths,
+  exit: ChildExitResult,
+  trace: RuntimeTraceContext,
+): Promise<SafeError> {
+  const bootLogHint = await observerBootLogHint(paths);
+  const traceHint =
+    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
+  const error: SafeError = {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXITED_ON_START",
+    message: `Observer exited before becoming healthy (${childExitDescription(exit)}).`,
+    hint: `${bootLogHint}${traceHint}`,
+  };
+  if (trace.traceId !== undefined) {
+    error.traceId = trace.traceId;
+  }
+  return error;
+}
+
+function childExitDescription(exit: ChildExitResult): string {
+  if (exit.type === "spawn_error") {
+    return `spawn error: ${redactString(exit.error.message)}`;
+  }
+  if (exit.signal !== null) {
+    return `signal ${exit.signal}`;
+  }
+  if (exit.code !== null) {
+    return `exit code ${exit.code}`;
+  }
+  return "unknown exit status";
+}
+
+async function observerBootLogHint(paths: ObserverPaths): Promise<string> {
+  const path = observerBootLogPath(paths);
+  const pathHint = `Observer boot log: ${path}`;
+  try {
+    const tail = await readObserverBootLogTail(path);
+    if (tail === undefined) {
+      return pathHint;
+    }
+    return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
+  } catch {
+    return pathHint;
+  }
+}
+
+async function readObserverBootLogTail(path: string): Promise<string | undefined> {
+  const maxBytes = 64 * 1024;
+  const bootLog = await open(path, "r");
+  try {
+    const { size } = await bootLog.stat();
+    if (size === 0) return undefined;
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
+    let content = buffer.subarray(0, bytesRead).toString("utf8");
+    if (size > length) {
+      const firstNewline = content.indexOf("\n");
+      if (firstNewline !== -1) content = content.slice(firstNewline + 1);
+    }
+    content = content.trimEnd();
+    if (content.trim().length === 0) return undefined;
+    return content.split(/\r?\n/).slice(-15).join("\n");
+  } finally {
+    await bootLog.close();
+  }
+}
+
+function observerBootLogPath(paths: ObserverPaths): string {
+  return join(paths.stateDir, "logs", "observer-boot.log");
+}
+
+function scheduleObserverStartupProgress(
+  onProgress: ObserverProcessOptions["onStartupProgress"],
+  paths: ObserverPaths,
+): Array<ReturnType<typeof setTimeout>> {
+  if (onProgress === undefined) {
+    return [];
+  }
+  return [
+    setTimeout(() => emitObserverStartupProgress(onProgress, "Starting STATION observer…"), 1_500),
+    setTimeout(
+      () =>
+        emitObserverStartupProgress(
+          onProgress,
+          `Still waiting for STATION observer; boot log: ${observerBootLogPath(paths)}`,
+        ),
+      5_000,
+    ),
+  ];
+}
+
+function emitObserverStartupProgress(
+  onProgress: NonNullable<ObserverProcessOptions["onStartupProgress"]>,
+  message: string,
+): void {
+  try {
+    onProgress(message);
+  } catch {
+    // Progress output must not turn a successful observer launch into a startup failure.
+  }
+}
+
+function clearObserverStartupProgress(timers: readonly ReturnType<typeof setTimeout>[]): void {
+  for (const timer of timers) {
+    clearTimeout(timer);
+  }
+}
+
+function abortableObserverHealth(
+  health: Promise<ObserverHealth>,
+  signals: readonly AbortSignal[],
+): Promise<ObserverHealth> {
+  if (signals.some((signal) => signal.aborted)) {
+    void health.catch(() => undefined);
+    return Promise.reject(observerHealthWaitCancelledError());
+  }
+
+  return new Promise<ObserverHealth>((resolve, reject) => {
+    const cleanup = () => {
+      for (const signal of signals) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(observerHealthWaitCancelledError());
+    };
+    for (const signal of signals) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    void health.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+function observerHealthWaitCancelledError(): SafeError {
+  return {
+    tag: "CancellationError",
+    code: "OBSERVER_HEALTH_WAIT_CANCELLED",
+    message: "Observer health wait was cancelled.",
+  };
+}
+
+function isAbortSignal(value: AbortSignal | undefined): value is AbortSignal {
+  return value !== undefined;
 }
 
 export async function logObserverLifecycleFailure(input: {

--- a/apps/cli/src/observerProcess/health.ts
+++ b/apps/cli/src/observerProcess/health.ts
@@ -1,0 +1,125 @@
+import type { ObserverHealth, SafeError } from "@station/contracts";
+import { createObserverClient } from "@station/protocol";
+import { type RuntimeTraceContext, runRuntimeBoundaryWithRetryAndTimeout } from "@station/runtime";
+import type { ObserverProcessDeps, SpawnObserverInput } from "./types.js";
+
+export function defaultClientFactory(socketPath: string) {
+  return createObserverClient({ socketPath, timeoutMs: 500 });
+}
+
+export async function waitForObserverHealth(
+  options: {
+    paths: SpawnObserverInput["paths"];
+    timeoutMs?: number;
+    trace?: RuntimeTraceContext;
+    signal?: AbortSignal;
+  },
+  deps: ObserverProcessDeps = {},
+): Promise<ObserverHealth> {
+  const timeoutMs = options.timeoutMs ?? 2000;
+  const retries = Math.max(1, Math.ceil(timeoutMs / 25));
+  const client = (deps.clientFactory ?? defaultClientFactory)(options.paths.socketPath);
+  const result = await runRuntimeBoundaryWithRetryAndTimeout(
+    {
+      operation: "cli.observer.waitForHealth",
+      timeoutMs,
+      error: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_HEALTH_FAILED",
+        message: "Observer health check failed.",
+        ...(options.trace?.traceId === undefined
+          ? {}
+          : {
+              hint: `Run station debug trace ${options.trace.traceId}.`,
+              traceId: options.trace.traceId,
+            }),
+      },
+      timeoutError: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_HEALTH_TIMEOUT",
+        message: "Observer did not report healthy before the timeout.",
+        ...(options.trace?.traceId === undefined
+          ? {}
+          : {
+              hint: `Run station debug trace ${options.trace.traceId}.`,
+              traceId: options.trace.traceId,
+            }),
+      },
+      retry: {
+        retries,
+        delayMs: 25,
+        shouldRetry: (error, attempt) =>
+          error.code !== "OBSERVER_HEALTH_WAIT_CANCELLED" && attempt < retries,
+      },
+      trace: options.trace,
+    },
+    async ({ signal }) => {
+      const signals = [signal, options.signal].filter(isAbortSignal);
+      if (signals.some((candidate) => candidate.aborted)) {
+        throw observerHealthWaitCancelledError();
+      }
+      return abortableObserverHealth(client.health(), signals);
+    },
+  );
+
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.value;
+}
+
+export function probeObserverHealth(
+  paths: SpawnObserverInput["paths"],
+  deps: ObserverProcessDeps,
+  signal: AbortSignal,
+): Promise<ObserverHealth> {
+  const client = (deps.clientFactory ?? defaultClientFactory)(paths.socketPath);
+  return abortableObserverHealth(client.health(), [signal]);
+}
+
+function abortableObserverHealth(
+  health: Promise<ObserverHealth>,
+  signals: readonly AbortSignal[],
+): Promise<ObserverHealth> {
+  if (signals.some((signal) => signal.aborted)) {
+    void health.catch(() => undefined);
+    return Promise.reject(observerHealthWaitCancelledError());
+  }
+
+  return new Promise<ObserverHealth>((resolve, reject) => {
+    const cleanup = () => {
+      for (const signal of signals) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(observerHealthWaitCancelledError());
+    };
+    for (const signal of signals) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    void health.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+export function observerHealthWaitCancelledError(): SafeError {
+  return {
+    tag: "CancellationError",
+    code: "OBSERVER_HEALTH_WAIT_CANCELLED",
+    message: "Observer health wait was cancelled.",
+  };
+}
+
+function isAbortSignal(value: AbortSignal | undefined): value is AbortSignal {
+  return value !== undefined;
+}

--- a/apps/cli/src/observerProcess/health.ts
+++ b/apps/cli/src/observerProcess/health.ts
@@ -20,61 +20,14 @@ export async function waitForObserverHealth(
   const retries = Math.max(1, Math.ceil(timeoutMs / 25));
   const client = (deps.clientFactory ?? defaultClientFactory)(options.paths.socketPath);
   const result = await runRuntimeBoundaryWithRetryAndTimeout(
-    {
-      operation: "cli.observer.waitForHealth",
-      timeoutMs,
-      error: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_HEALTH_FAILED",
-        message: "Observer health check failed.",
-        ...(options.trace?.traceId === undefined
-          ? {}
-          : {
-              hint: `Run station debug trace ${options.trace.traceId}.`,
-              traceId: options.trace.traceId,
-            }),
-      },
-      timeoutError: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_HEALTH_TIMEOUT",
-        message: "Observer did not report healthy before the timeout.",
-        ...(options.trace?.traceId === undefined
-          ? {}
-          : {
-              hint: `Run station debug trace ${options.trace.traceId}.`,
-              traceId: options.trace.traceId,
-            }),
-      },
-      retry: {
-        retries,
-        delayMs: 25,
-        shouldRetry: (error, attempt) =>
-          error.code !== "OBSERVER_HEALTH_WAIT_CANCELLED" && attempt < retries,
-      },
-      trace: options.trace,
-    },
-    async ({ signal }) => {
-      const signals = [signal, options.signal].filter(isAbortSignal);
-      if (signals.some((candidate) => candidate.aborted)) {
-        throw observerHealthWaitCancelledError();
-      }
-      return abortableObserverHealth(client.health(), signals);
-    },
+    observerHealthBoundaryOptions(timeoutMs, retries, options.trace),
+    ({ signal }) => requestObserverHealth(() => client.health(), [signal, options.signal]),
   );
 
   if (!result.ok) {
     throw result.error;
   }
   return result.value;
-}
-
-export function probeObserverHealth(
-  paths: SpawnObserverInput["paths"],
-  deps: ObserverProcessDeps,
-  signal: AbortSignal,
-): Promise<ObserverHealth> {
-  const client = (deps.clientFactory ?? defaultClientFactory)(paths.socketPath);
-  return abortableObserverHealth(client.health(), [signal]);
 }
 
 function abortableObserverHealth(
@@ -122,4 +75,52 @@ export function observerHealthWaitCancelledError(): SafeError {
 
 function isAbortSignal(value: AbortSignal | undefined): value is AbortSignal {
   return value !== undefined;
+}
+
+function observerHealthBoundaryOptions(
+  timeoutMs: number,
+  retries: number,
+  trace: RuntimeTraceContext | undefined,
+): Parameters<typeof runRuntimeBoundaryWithRetryAndTimeout>[0] {
+  const traceFields =
+    trace?.traceId === undefined
+      ? {}
+      : {
+          hint: `Run station debug trace ${trace.traceId}.`,
+          traceId: trace.traceId,
+        };
+  return {
+    operation: "cli.observer.waitForHealth",
+    timeoutMs,
+    error: {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_HEALTH_FAILED",
+      message: "Observer health check failed.",
+      ...traceFields,
+    },
+    timeoutError: {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_HEALTH_TIMEOUT",
+      message: "Observer did not report healthy before the timeout.",
+      ...traceFields,
+    },
+    retry: {
+      retries,
+      delayMs: 25,
+      shouldRetry: (error, attempt) =>
+        error.code !== "OBSERVER_HEALTH_WAIT_CANCELLED" && attempt < retries,
+    },
+    trace,
+  };
+}
+
+function requestObserverHealth(
+  health: () => Promise<ObserverHealth>,
+  candidates: readonly (AbortSignal | undefined)[],
+): Promise<ObserverHealth> {
+  const signals = candidates.filter(isAbortSignal);
+  if (signals.some((candidate) => candidate.aborted)) {
+    return Promise.reject(observerHealthWaitCancelledError());
+  }
+  return abortableObserverHealth(health(), signals);
 }

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -1,0 +1,101 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdir, open } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { ChildExitResult, ChildProcessLike, SpawnObserverInput } from "./types.js";
+
+export async function defaultSpawnObserver(input: SpawnObserverInput): Promise<ChildProcessLike> {
+  const argv = observerSpawnArgv(input);
+  const bootLogPath = observerBootLogPath(input.paths);
+  await mkdir(dirname(bootLogPath), { recursive: true, mode: 0o700 });
+  const bootLog = await open(bootLogPath, "w", 0o600);
+  let child: ChildProcess | undefined;
+  let startedChild: ChildProcessLike;
+  try {
+    await bootLog.chmod(0o600);
+    await bootLog.writeFile(`${JSON.stringify({ command: argv })}\n`, "utf8");
+    const [command, ...args] = argv;
+    child = spawn(command, args, {
+      detached: true,
+      stdio: ["ignore", bootLog.fd, bootLog.fd],
+    });
+    startedChild = childWithExit(child);
+  } catch (error) {
+    await bootLog.close().catch(() => undefined);
+    throw error;
+  }
+  try {
+    await bootLog.close();
+  } catch (error) {
+    child.kill();
+    throw error;
+  }
+  return startedChild;
+}
+
+function observerSpawnArgv(input: SpawnObserverInput): [string, ...string[]] {
+  // Compiled dist/observerProcess/spawn.js must resolve ../observerMain.js; source-alias tests launch the built entry instead.
+  const observerEntry = import.meta.url.endsWith(".ts")
+    ? new URL("../../dist/observerMain.js", import.meta.url)
+    : new URL("../observerMain.js", import.meta.url);
+  return [
+    process.execPath,
+    observerEntry.pathname,
+    "--socket",
+    input.paths.socketPath,
+    "--state-dir",
+    input.paths.stateDir,
+    ...(input.configPath === undefined ? [] : ["--config", input.configPath]),
+  ];
+}
+
+function childWithExit(child: ChildProcess): ChildProcessLike {
+  let disposeExitWait!: () => void;
+  const exited = new Promise<ChildExitResult>((resolve) => {
+    let settled = false;
+    const finish = (result: ChildExitResult) => {
+      if (settled) return;
+      settled = true;
+      disposeExitWait();
+      resolve(result);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish({ type: "exit", code, signal });
+    };
+    const onError = (error: Error) => {
+      finish({ type: "spawn_error", error });
+    };
+    disposeExitWait = () => {
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+  return Object.assign(child, { exited, disposeExitWait });
+}
+
+export async function readObserverBootLogTail(path: string): Promise<string | undefined> {
+  const maxBytes = 64 * 1024;
+  const bootLog = await open(path, "r");
+  try {
+    const { size } = await bootLog.stat();
+    if (size === 0) return undefined;
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
+    let content = buffer.subarray(0, bytesRead).toString("utf8");
+    if (size > length) {
+      const firstNewline = content.indexOf("\n");
+      if (firstNewline !== -1) content = content.slice(firstNewline + 1);
+    }
+    content = content.trimEnd();
+    if (content.trim().length === 0) return undefined;
+    return content.split(/\r?\n/).slice(-15).join("\n");
+  } finally {
+    await bootLog.close();
+  }
+}
+
+export function observerBootLogPath(paths: SpawnObserverInput["paths"]): string {
+  return join(paths.stateDir, "logs", "observer-boot.log");
+}

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -1,35 +1,45 @@
 import { type ChildProcess, spawn } from "node:child_process";
-import { mkdir, open } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { type FileHandle, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type { ChildExitResult, ChildProcessLike, SpawnObserverInput } from "./types.js";
 
 export async function defaultSpawnObserver(input: SpawnObserverInput): Promise<ChildProcessLike> {
   const argv = observerSpawnArgv(input);
   const bootLogPath = observerBootLogPath(input.paths);
+  const pendingBootLogPath = observerPendingBootLogPath(input.paths);
   await mkdir(dirname(bootLogPath), { recursive: true, mode: 0o700 });
-  const bootLog = await open(bootLogPath, "w", 0o600);
+  const bootLog = await open(pendingBootLogPath, "wx", 0o600);
   let child: ChildProcess | undefined;
-  let startedChild: ChildProcessLike;
+  let bootLogReader: FileHandle | undefined;
+  let published = false;
   try {
     await bootLog.chmod(0o600);
     await bootLog.writeFile(`${JSON.stringify({ command: argv })}\n`, "utf8");
+    bootLogReader = await open(pendingBootLogPath, "r");
+    // Atomic replacement keeps the latest path coherent while each child writes to its own inherited inode.
+    await rename(pendingBootLogPath, bootLogPath);
+    published = true;
     const [command, ...args] = argv;
     child = spawn(command, args, {
       detached: true,
       stdio: ["ignore", bootLog.fd, bootLog.fd],
     });
-    startedChild = childWithExit(child);
-  } catch (error) {
-    await bootLog.close().catch(() => undefined);
-    throw error;
-  }
-  try {
+    const startedChild = Object.assign(
+      childWithExit(child),
+      observerBootLogDiagnostics(bootLogReader),
+    );
     await bootLog.close();
+    return startedChild;
   } catch (error) {
-    child.kill();
+    child?.kill();
+    await bootLog.close().catch(() => undefined);
+    await bootLogReader?.close().catch(() => undefined);
+    if (!published) {
+      await unlink(pendingBootLogPath).catch(() => undefined);
+    }
     throw error;
   }
-  return startedChild;
 }
 
 function observerSpawnArgv(input: SpawnObserverInput): [string, ...string[]] {
@@ -75,22 +85,9 @@ function childWithExit(child: ChildProcess): ChildProcessLike {
 }
 
 export async function readObserverBootLogTail(path: string): Promise<string | undefined> {
-  const maxBytes = 64 * 1024;
   const bootLog = await open(path, "r");
   try {
-    const { size } = await bootLog.stat();
-    if (size === 0) return undefined;
-    const length = Math.min(size, maxBytes);
-    const buffer = Buffer.alloc(length);
-    const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
-    let content = buffer.subarray(0, bytesRead).toString("utf8");
-    if (size > length) {
-      const firstNewline = content.indexOf("\n");
-      if (firstNewline !== -1) content = content.slice(firstNewline + 1);
-    }
-    content = content.trimEnd();
-    if (content.trim().length === 0) return undefined;
-    return content.split(/\r?\n/).slice(-15).join("\n");
+    return await readObserverBootLogTailFromHandle(bootLog);
   } finally {
     await bootLog.close();
   }
@@ -98,4 +95,43 @@ export async function readObserverBootLogTail(path: string): Promise<string | un
 
 export function observerBootLogPath(paths: SpawnObserverInput["paths"]): string {
   return join(paths.stateDir, "logs", "observer-boot.log");
+}
+
+function observerPendingBootLogPath(paths: SpawnObserverInput["paths"]): string {
+  return join(
+    dirname(observerBootLogPath(paths)),
+    `.observer-boot.${process.pid}.${randomUUID()}.tmp`,
+  );
+}
+
+function observerBootLogDiagnostics(bootLog: FileHandle): {
+  readBootLogTail: () => Promise<string | undefined>;
+  disposeBootLog: () => Promise<void>;
+} {
+  let disposed = false;
+  return {
+    readBootLogTail: () => readObserverBootLogTailFromHandle(bootLog),
+    disposeBootLog: async () => {
+      if (disposed) return;
+      disposed = true;
+      await bootLog.close();
+    },
+  };
+}
+
+async function readObserverBootLogTailFromHandle(bootLog: FileHandle): Promise<string | undefined> {
+  const maxBytes = 64 * 1024;
+  const { size } = await bootLog.stat();
+  if (size === 0) return undefined;
+  const length = Math.min(size, maxBytes);
+  const buffer = Buffer.alloc(length);
+  const { bytesRead } = await bootLog.read(buffer, 0, length, size - length);
+  let content = buffer.subarray(0, bytesRead).toString("utf8");
+  if (size > length) {
+    const firstNewline = content.indexOf("\n");
+    if (firstNewline !== -1) content = content.slice(firstNewline + 1);
+  }
+  content = content.trimEnd();
+  if (content.trim().length === 0) return undefined;
+  return content.split(/\r?\n/).slice(-15).join("\n");
 }

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -8,12 +8,9 @@ import {
   type RuntimeClock,
   type RuntimeTraceContext,
   runRuntimeBoundaryWithTimeout,
+  withTimeout,
 } from "@station/runtime";
-import {
-  observerHealthWaitCancelledError,
-  probeObserverHealth,
-  waitForObserverHealth,
-} from "./health.js";
+import { observerHealthWaitCancelledError, waitForObserverHealth } from "./health.js";
 import { defaultSpawnObserver, observerBootLogPath, readObserverBootLogTail } from "./spawn.js";
 import type {
   ChildExitResult,
@@ -22,6 +19,8 @@ import type {
   ObserverProcessOptions,
   SpawnObserverInput,
 } from "./types.js";
+
+const incumbentHealthGraceMs = 1_000;
 
 export async function startObserverProcess(
   input: {
@@ -86,6 +85,7 @@ export async function startObserverProcess(
   if (!result.ok && result.error.code !== "OBSERVER_EXITED_ON_START") {
     child?.kill?.();
   }
+  await disposeObserverBootLog(child);
   return result;
 }
 
@@ -148,16 +148,15 @@ async function waitForStartedObserver(
       return outcome.health;
     }
 
-    healthController.abort();
     try {
-      // A competing observer may have won the socket immediately before this child exited.
-      return await probeObserverHealth(input.paths, deps, input.signal);
+      // A losing child can exit just before the winning observer becomes healthy, so preserve its retry loop briefly.
+      return await waitForIncumbentHealth(healthPromise, healthController);
     } catch {
       if (input.signal.aborted) {
         throw observerHealthWaitCancelledError();
       }
     }
-    throw await observerExitedOnStartError(input.paths, outcome.exit, input.trace);
+    throw await observerExitedOnStartError(input.paths, input.child, outcome.exit, input.trace);
   } finally {
     input.signal.removeEventListener("abort", cancelHealth);
     healthController.abort();
@@ -168,10 +167,11 @@ async function waitForStartedObserver(
 
 async function observerExitedOnStartError(
   paths: SpawnObserverInput["paths"],
+  child: ChildProcessLike,
   exit: ChildExitResult,
   trace: RuntimeTraceContext,
 ): Promise<SafeError> {
-  const bootLogHint = await observerBootLogHint(paths);
+  const bootLogHint = await observerBootLogHint(paths, child);
   const traceHint =
     trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
   const error: SafeError = {
@@ -199,8 +199,21 @@ function childExitDescription(exit: ChildExitResult): string {
   return "unknown exit status";
 }
 
-async function observerBootLogHint(paths: SpawnObserverInput["paths"]): Promise<string> {
+async function observerBootLogHint(
+  paths: SpawnObserverInput["paths"],
+  child: ChildProcessLike,
+): Promise<string> {
   const path = observerBootLogPath(paths);
+  if (child.readBootLogTail !== undefined) {
+    const pathHint = `Latest observer boot log: ${path}`;
+    try {
+      const tail = await child.readBootLogTail();
+      if (tail === undefined) return pathHint;
+      return `${pathHint}\nThis attempt's last 15 lines (redacted):\n${redactString(tail)}`;
+    } catch {
+      return pathHint;
+    }
+  }
   const pathHint = `Observer boot log: ${path}`;
   try {
     const tail = await readObserverBootLogTail(path);
@@ -210,6 +223,44 @@ async function observerBootLogHint(paths: SpawnObserverInput["paths"]): Promise<
     return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
   } catch {
     return pathHint;
+  }
+}
+
+function waitForIncumbentHealth(
+  healthPromise: Promise<ObserverHealth>,
+  healthController: AbortController,
+): Promise<ObserverHealth> {
+  return withTimeout(
+    async ({ signal }) => {
+      const cancelHealth = () => healthController.abort();
+      signal.addEventListener("abort", cancelHealth, { once: true });
+      try {
+        return await healthPromise;
+      } finally {
+        signal.removeEventListener("abort", cancelHealth);
+      }
+    },
+    {
+      timeoutMs: incumbentHealthGraceMs,
+      error: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_INCUMBENT_HEALTH_FAILED",
+        message: "Competing observer health check failed.",
+      },
+      timeoutError: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_INCUMBENT_HEALTH_TIMEOUT",
+        message: "Competing observer did not become healthy during startup convergence.",
+      },
+    },
+  );
+}
+
+async function disposeObserverBootLog(child: ChildProcessLike | undefined): Promise<void> {
+  try {
+    await child?.disposeBootLog?.();
+  } catch {
+    // Diagnostic handle cleanup must not replace the observer startup result.
   }
 }
 

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -1,0 +1,251 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ObserverHealth, SafeError } from "@station/contracts";
+import { redactString } from "@station/observability";
+import {
+  Effect,
+  type RuntimeBoundaryResult,
+  type RuntimeClock,
+  type RuntimeTraceContext,
+  runRuntimeBoundaryWithTimeout,
+} from "@station/runtime";
+import {
+  observerHealthWaitCancelledError,
+  probeObserverHealth,
+  waitForObserverHealth,
+} from "./health.js";
+import { defaultSpawnObserver, observerBootLogPath, readObserverBootLogTail } from "./spawn.js";
+import type {
+  ChildExitResult,
+  ChildProcessLike,
+  ObserverProcessDeps,
+  ObserverProcessOptions,
+  SpawnObserverInput,
+} from "./types.js";
+
+export async function startObserverProcess(
+  input: {
+    paths: SpawnObserverInput["paths"];
+    timeoutMs: number;
+    trace: RuntimeTraceContext;
+    clock: RuntimeClock;
+    configPath?: string;
+    onStartupProgress?: ObserverProcessOptions["onStartupProgress"];
+  },
+  deps: ObserverProcessDeps,
+): Promise<RuntimeBoundaryResult<ObserverHealth>> {
+  const progressTimers = scheduleObserverStartupProgress(input.onStartupProgress, input.paths);
+  let child: ChildProcessLike | undefined;
+  const result = await runRuntimeBoundaryWithTimeout(
+    {
+      operation: "cli.observer.start",
+      clock: input.clock,
+      timeoutMs: input.timeoutMs,
+      error: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_START_FAILED",
+        message: "Observer startup failed.",
+        hint: `Run station debug trace ${input.trace.traceId}.`,
+        traceId: input.trace.traceId,
+      },
+      timeoutError: {
+        tag: "ObserverStartupError",
+        code: "OBSERVER_START_FAILED",
+        message: "Observer did not become healthy before the startup timeout.",
+        hint: `Run station debug trace ${input.trace.traceId}.`,
+        traceId: input.trace.traceId,
+      },
+      trace: input.trace,
+    },
+    async ({ signal }) => {
+      await mkdir(input.paths.stateDir, { recursive: true, mode: 0o700 });
+      await mkdir(dirname(input.paths.socketPath), { recursive: true, mode: 0o700 });
+      const spawnInput: SpawnObserverInput = { paths: input.paths };
+      if (input.configPath !== undefined) {
+        spawnInput.configPath = input.configPath;
+      }
+      child = await (deps.spawnObserver ?? defaultSpawnObserver)(spawnInput);
+      if (signal.aborted) {
+        child.kill?.();
+        throw observerHealthWaitCancelledError();
+      }
+      child.unref?.();
+      return waitForStartedObserver(
+        {
+          child,
+          paths: input.paths,
+          timeoutMs: input.timeoutMs,
+          trace: input.trace,
+          signal,
+        },
+        deps,
+      );
+    },
+  ).finally(() => clearObserverStartupProgress(progressTimers));
+
+  if (!result.ok && result.error.code !== "OBSERVER_EXITED_ON_START") {
+    child?.kill?.();
+  }
+  return result;
+}
+
+async function waitForStartedObserver(
+  input: {
+    child: ChildProcessLike;
+    paths: SpawnObserverInput["paths"];
+    timeoutMs: number;
+    trace: RuntimeTraceContext;
+    signal: AbortSignal;
+  },
+  deps: ObserverProcessDeps,
+): Promise<ObserverHealth> {
+  const healthController = new AbortController();
+  const cancelHealth = () => healthController.abort();
+  input.signal.addEventListener("abort", cancelHealth, { once: true });
+  const healthPromise = waitForObserverHealth(
+    {
+      paths: input.paths,
+      timeoutMs: input.timeoutMs,
+      trace: input.trace,
+      signal: healthController.signal,
+    },
+    deps,
+  );
+
+  try {
+    const childExit = input.child.exited;
+    if (childExit === undefined) {
+      return await healthPromise;
+    }
+
+    // Early child termination must preempt the health timeout.
+    const outcome = await Effect.runPromise(
+      Effect.raceFirst(
+        Effect.tryPromise({
+          try: () => healthPromise,
+          catch: (error) => error,
+        }).pipe(
+          Effect.match({
+            onFailure: (error) => ({ type: "error" as const, error }),
+            onSuccess: (health) => ({ type: "healthy" as const, health }),
+          }),
+        ),
+        Effect.tryPromise({
+          try: () => childExit,
+          catch: (error) => error,
+        }).pipe(
+          Effect.match({
+            onFailure: (error) => ({ type: "error" as const, error }),
+            onSuccess: (exit) => ({ type: "exited" as const, exit }),
+          }),
+        ),
+      ),
+    );
+    if (outcome.type === "error") {
+      throw outcome.error;
+    }
+    if (outcome.type === "healthy") {
+      return outcome.health;
+    }
+
+    healthController.abort();
+    try {
+      // A competing observer may have won the socket immediately before this child exited.
+      return await probeObserverHealth(input.paths, deps, input.signal);
+    } catch {
+      if (input.signal.aborted) {
+        throw observerHealthWaitCancelledError();
+      }
+    }
+    throw await observerExitedOnStartError(input.paths, outcome.exit, input.trace);
+  } finally {
+    input.signal.removeEventListener("abort", cancelHealth);
+    healthController.abort();
+    input.child.disposeExitWait?.();
+    void healthPromise.catch(() => undefined);
+  }
+}
+
+async function observerExitedOnStartError(
+  paths: SpawnObserverInput["paths"],
+  exit: ChildExitResult,
+  trace: RuntimeTraceContext,
+): Promise<SafeError> {
+  const bootLogHint = await observerBootLogHint(paths);
+  const traceHint =
+    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
+  const error: SafeError = {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_EXITED_ON_START",
+    message: `Observer exited before becoming healthy (${childExitDescription(exit)}).`,
+    hint: `${bootLogHint}${traceHint}`,
+  };
+  if (trace.traceId !== undefined) {
+    error.traceId = trace.traceId;
+  }
+  return error;
+}
+
+function childExitDescription(exit: ChildExitResult): string {
+  if (exit.type === "spawn_error") {
+    return `spawn error: ${redactString(exit.error.message)}`;
+  }
+  if (exit.signal !== null) {
+    return `signal ${exit.signal}`;
+  }
+  if (exit.code !== null) {
+    return `exit code ${exit.code}`;
+  }
+  return "unknown exit status";
+}
+
+async function observerBootLogHint(paths: SpawnObserverInput["paths"]): Promise<string> {
+  const path = observerBootLogPath(paths);
+  const pathHint = `Observer boot log: ${path}`;
+  try {
+    const tail = await readObserverBootLogTail(path);
+    if (tail === undefined) {
+      return pathHint;
+    }
+    return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
+  } catch {
+    return pathHint;
+  }
+}
+
+function scheduleObserverStartupProgress(
+  onProgress: ObserverProcessOptions["onStartupProgress"],
+  paths: SpawnObserverInput["paths"],
+): Array<ReturnType<typeof setTimeout>> {
+  if (onProgress === undefined) {
+    return [];
+  }
+  return [
+    setTimeout(() => emitObserverStartupProgress(onProgress, "Starting STATION observer…"), 1_500),
+    setTimeout(
+      () =>
+        emitObserverStartupProgress(
+          onProgress,
+          `Still waiting for STATION observer; boot log: ${observerBootLogPath(paths)}`,
+        ),
+      5_000,
+    ),
+  ];
+}
+
+function emitObserverStartupProgress(
+  onProgress: NonNullable<ObserverProcessOptions["onStartupProgress"]>,
+  message: string,
+): void {
+  try {
+    onProgress(message);
+  } catch {
+    // Progress output must not turn a successful observer launch into a startup failure.
+  }
+}
+
+function clearObserverStartupProgress(timers: readonly ReturnType<typeof setTimeout>[]): void {
+  for (const timer of timers) {
+    clearTimeout(timer);
+  }
+}

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -1,0 +1,60 @@
+import type { ChildProcess } from "node:child_process";
+import type { StationConfig } from "@station/config";
+import type { ObserverHealth, SafeError } from "@station/contracts";
+import type { JsonlLogger } from "@station/observability";
+import type { createObserverClient } from "@station/protocol";
+import type { RuntimeClock } from "@station/runtime";
+import type { ObserverPaths } from "../paths.js";
+
+// Shared types keep the facade and leaf modules connected without introducing runtime import cycles.
+export type ObserverStatus =
+  | {
+      status: "running";
+      paths: ObserverPaths;
+      health: ObserverHealth;
+    }
+  | {
+      status: "stopped" | "stale" | "unhealthy";
+      paths: ObserverPaths;
+      error?: SafeError;
+    };
+
+export type ObserverProcessDeps = {
+  clientFactory?: (socketPath: string) => ReturnType<typeof createObserverClient>;
+  spawnObserver?: (input: SpawnObserverInput) => ChildProcessLike | Promise<ChildProcessLike>;
+  clock?: RuntimeClock;
+  sleep?: (ms: number) => Promise<void>;
+  logger?: JsonlLogger;
+};
+
+export type SpawnObserverInput = {
+  paths: ObserverPaths;
+  configPath?: string;
+};
+
+export type ChildProcessExit = {
+  type: "exit";
+  code: number | null;
+  signal: NodeJS.Signals | null;
+};
+
+export type ChildProcessSpawnError = {
+  type: "spawn_error";
+  error: Error;
+};
+
+export type ChildExitResult = ChildProcessExit | ChildProcessSpawnError;
+
+export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
+  kill?: ChildProcess["kill"];
+  exited?: Promise<ChildExitResult>;
+  disposeExitWait?: () => void;
+};
+
+export type ObserverProcessOptions = {
+  config?: StationConfig;
+  configPath?: string;
+  paths?: ObserverPaths;
+  timeoutMs?: number;
+  onStartupProgress?: (message: string) => void;
+};

--- a/apps/cli/src/observerProcess/types.ts
+++ b/apps/cli/src/observerProcess/types.ts
@@ -49,6 +49,8 @@ export type ChildProcessLike = Pick<ChildProcess, "pid" | "unref"> & {
   kill?: ChildProcess["kill"];
   exited?: Promise<ChildExitResult>;
   disposeExitWait?: () => void;
+  readBootLogTail?: () => Promise<string | undefined>;
+  disposeBootLog?: () => Promise<void>;
 };
 
 export type ObserverProcessOptions = {

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -8,7 +8,7 @@ import {
   shouldSuppressCliProcessOutput,
 } from "@station/cli/internal";
 import type { TmuxPopupOptions } from "@station/tmux";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -67,6 +67,131 @@ describe("CLI popup command", () => {
     });
   });
 
+  it("reports slow observer startup before opening the popup", async () => {
+    const fixture = await createTempState();
+    fixture.config.defaults.terminal = "tmux";
+    let spawned = false;
+    let markSpawned = () => undefined;
+    let releaseHealth = () => undefined;
+    const observerSpawned = new Promise<void>((resolve) => {
+      markSpawned = resolve;
+    });
+    const healthReady = new Promise<void>((resolve) => {
+      releaseHealth = resolve;
+    });
+    const openTmuxPopup = vi.fn(async () => ({ opened: true }));
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.useFakeTimers();
+
+    try {
+      const resultPromise = runPopupCommand(
+        [],
+        {
+          config: fixture.config,
+          env: { TMUX: "/tmp/tmux-501/default,123,0" },
+        },
+        {
+          observer: {
+            spawnObserver: async () => {
+              spawned = true;
+              markSpawned();
+              return { pid: 1234, unref: () => undefined };
+            },
+            clientFactory: () =>
+              ({
+                health: async () => {
+                  if (!spawned) throw new Error("stopped");
+                  await healthReady;
+                  return {
+                    schemaVersion: "0.6.0",
+                    status: "healthy",
+                    pid: 1234,
+                    startedAt: now,
+                    version: "0.0.0",
+                  };
+                },
+                reconcile: async () => emptySnapshot("popup-open"),
+              }) as never,
+          },
+          openTmuxPopup,
+        },
+      );
+
+      await observerSpawned;
+      await vi.advanceTimersByTimeAsync(1_499);
+      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(openTmuxPopup).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stderrWrite).toHaveBeenNthCalledWith(1, "Starting STATION observer…\n");
+
+      await vi.advanceTimersByTimeAsync(3_499);
+      expect(stderrWrite).toHaveBeenCalledTimes(1);
+      expect(openTmuxPopup).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stderrWrite).toHaveBeenNthCalledWith(
+        2,
+        `Still waiting for STATION observer; boot log: ${join(
+          fixture.stateDir,
+          "logs/observer-boot.log",
+        )}\n`,
+      );
+      expect(openTmuxPopup).not.toHaveBeenCalled();
+
+      releaseHealth();
+      await expect(resultPromise).resolves.toEqual({ opened: true });
+      expect(openTmuxPopup).toHaveBeenCalledOnce();
+    } finally {
+      releaseHealth();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      stderrWrite.mockRestore();
+    }
+  });
+
+  it("keeps warm observer attachment silent", async () => {
+    const fixture = await createTempState();
+    fixture.config.defaults.terminal = "tmux";
+    const openTmuxPopup = vi.fn(async () => ({ opened: true }));
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      await expect(
+        runPopupCommand(
+          [],
+          {
+            config: fixture.config,
+            env: { TMUX: "/tmp/tmux-501/default,123,0" },
+          },
+          {
+            observer: {
+              spawnObserver: async () => {
+                throw new Error("observer should not spawn for a warm attachment");
+              },
+              clientFactory: () =>
+                ({
+                  health: async () => ({
+                    schemaVersion: "0.6.0",
+                    status: "healthy",
+                    pid: 1234,
+                    startedAt: now,
+                    version: "0.0.0",
+                  }),
+                  reconcile: async () => emptySnapshot("popup-open"),
+                }) as never,
+            },
+            openTmuxPopup,
+          },
+        ),
+      ).resolves.toEqual({ opened: true });
+      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(openTmuxPopup).toHaveBeenCalledOnce();
+    } finally {
+      stderrWrite.mockRestore();
+    }
+  });
+
   it("keeps an explicitly missing popup config as a hard error", async () => {
     const fixture = await createTempState();
     const configPath = join(fixture.root, "missing.toml");
@@ -88,16 +213,18 @@ describe("CLI popup command", () => {
     ).rejects.toMatchObject({ code: "CONFIG_FILE_NOT_FOUND", configPath });
   });
 
-  it("does not open a first-run popup when the observer fails to start", async () => {
+  it("does not open a first-run popup when the observer exits during startup", async () => {
     const fixture = await createTempState();
-    let popupOpened = false;
+    const openTmuxPopup = vi.fn(async () => ({ opened: true }));
 
     const result = await withIsolatedHome(fixture.root, () =>
       runCli([], {
         observerDeps: {
-          spawnObserver: async () => {
-            throw new Error("observer failed to start");
-          },
+          spawnObserver: async () => ({
+            pid: 1234,
+            unref: () => undefined,
+            exited: Promise.resolve({ type: "exit" as const, code: 1, signal: null }),
+          }),
           clientFactory: () =>
             ({
               health: async () => {
@@ -107,19 +234,22 @@ describe("CLI popup command", () => {
         },
         popupDeps: {
           env: { TMUX: "/tmp/tmux-501/default,123,0" },
-          openTmuxPopup: async () => {
-            popupOpened = true;
-            return { opened: true };
-          },
+          openTmuxPopup,
         },
       }),
     );
 
     expect(result).toMatchObject({
       code: 1,
-      output: { status: "unavailable", observer: { status: "unhealthy" } },
+      output: {
+        status: "unavailable",
+        observer: {
+          status: "unhealthy",
+          error: { code: "OBSERVER_EXITED_ON_START" },
+        },
+      },
     });
-    expect(popupOpened).toBe(false);
+    expect(openTmuxPopup).not.toHaveBeenCalled();
   });
 
   it("keeps a malformed implicit popup config as a hard error", async () => {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -177,6 +177,123 @@ describe("CLI tui command", () => {
     await vi.waitFor(() => expect(reconciles).toEqual(["tui-startup"]));
   });
 
+  it("reports slow observer startup before opening the native renderer", async () => {
+    const fixture = await createTempState();
+    let spawned = false;
+    let markSpawned = () => undefined;
+    let releaseHealth = () => undefined;
+    const observerSpawned = new Promise<void>((resolve) => {
+      markSpawned = resolve;
+    });
+    const healthReady = new Promise<void>((resolve) => {
+      releaseHealth = resolve;
+    });
+    const spawnRenderer = vi.fn(async () => ({ status: "exited" as const, code: 0 }));
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.useFakeTimers();
+
+    try {
+      const resultPromise = runTuiCommand(
+        [],
+        { config: fixture.config },
+        {
+          observer: {
+            spawnObserver: async () => {
+              spawned = true;
+              markSpawned();
+              return { pid: 1234, unref: () => undefined };
+            },
+            clientFactory: () =>
+              ({
+                health: async () => {
+                  if (!spawned) throw new Error("stopped");
+                  await healthReady;
+                  return {
+                    schemaVersion: "0.6.0",
+                    status: "healthy",
+                    pid: 1234,
+                    startedAt: now,
+                    version: "0.0.0",
+                  };
+                },
+                reconcile: async () => emptySnapshot("tui-startup"),
+              }) as never,
+          },
+          spawnRenderer,
+        },
+      );
+
+      await observerSpawned;
+      await vi.advanceTimersByTimeAsync(1_499);
+      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(spawnRenderer).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stderrWrite).toHaveBeenNthCalledWith(1, "Starting STATION observer…\n");
+
+      await vi.advanceTimersByTimeAsync(3_499);
+      expect(stderrWrite).toHaveBeenCalledTimes(1);
+      expect(spawnRenderer).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(stderrWrite).toHaveBeenNthCalledWith(
+        2,
+        `Still waiting for STATION observer; boot log: ${join(
+          fixture.stateDir,
+          "logs/observer-boot.log",
+        )}\n`,
+      );
+      expect(spawnRenderer).not.toHaveBeenCalled();
+
+      releaseHealth();
+      await expect(resultPromise).resolves.toEqual({ status: "exited", code: 0 });
+      expect(spawnRenderer).toHaveBeenCalledOnce();
+    } finally {
+      releaseHealth();
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      stderrWrite.mockRestore();
+    }
+  });
+
+  it("keeps warm observer attachment silent", async () => {
+    const fixture = await createTempState();
+    const spawnRenderer = vi.fn(async () => ({ status: "exited" as const, code: 0 }));
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      await expect(
+        runTuiCommand(
+          [],
+          { config: fixture.config },
+          {
+            observer: {
+              spawnObserver: async () => {
+                throw new Error("observer should not spawn for a warm attachment");
+              },
+              clientFactory: () =>
+                ({
+                  health: async () => ({
+                    schemaVersion: "0.6.0",
+                    status: "healthy",
+                    pid: 1234,
+                    startedAt: now,
+                    version: "0.0.0",
+                  }),
+                  reconcile: async () => emptySnapshot("tui-startup"),
+                }) as never,
+            },
+            spawnRenderer,
+          },
+        ),
+      ).resolves.toEqual({ status: "exited", code: 0 });
+      expect(stderrWrite).not.toHaveBeenCalled();
+      expect(spawnRenderer).toHaveBeenCalledOnce();
+    } finally {
+      stderrWrite.mockRestore();
+    }
+  });
+
   it("defaults bare station to the fullscreen renderer outside tmux", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
@@ -330,29 +447,36 @@ describe("CLI tui command", () => {
     expect(reconciles).toEqual([]);
   });
 
-  it("returns a nonzero result when observer startup is unavailable", async () => {
+  it("does not open the renderer when the observer exits during startup", async () => {
     const fixture = await createTempState();
+    const spawnRenderer = vi.fn(async () => ({ status: "exited" as const, code: 0 }));
     const result = await runTuiCommand(
       [],
-      { config: fixture.config, timeoutMs: 1 },
+      { config: fixture.config },
       {
         observer: {
-          spawnObserver: async () => ({ pid: 1234, unref: () => undefined }),
+          spawnObserver: async () => ({
+            pid: 1234,
+            unref: () => undefined,
+            exited: Promise.resolve({ type: "exit" as const, code: 1, signal: null }),
+          }),
           clientFactory: () =>
             ({
               health: async () => {
                 throw new Error("still down");
               },
             }) as never,
-          sleep: async () => undefined,
         },
-        spawnRenderer: async () => {
-          throw new Error("renderer should not run when observer is unavailable.");
-        },
+        spawnRenderer,
       },
     );
 
-    expect(result).toMatchObject({ status: "unavailable", code: 1 });
+    expect(result).toMatchObject({
+      status: "unavailable",
+      code: 1,
+      observer: { error: { code: "OBSERVER_EXITED_ON_START" } },
+    });
+    expect(spawnRenderer).not.toHaveBeenCalled();
   });
 
   it("runs the mock dashboard without observer startup or startup reconcile", async () => {

--- a/apps/cli/test/unit/observer-process.test.ts
+++ b/apps/cli/test/unit/observer-process.test.ts
@@ -1,14 +1,56 @@
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getObserverStatus, startObserver } from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
 import { listenUnixSocket } from "@station/protocol";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createStaleSocketFile } from "../../../../tests/support/sockets";
 import { fileExists } from "../../../../tests/support/spool";
 import { createTempState } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
+
+const healthyObserver = (pid = 1234) =>
+  ({
+    schemaVersion: "0.6.0",
+    status: "healthy",
+    pid,
+    startedAt: now,
+    version: "0.0.0",
+  }) as const;
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function observerBootLogPath(stateDir: string): string {
+  return join(stateDir, "logs", "observer-boot.log");
+}
+
+async function writeObserverBootLog(stateDir: string, content: string): Promise<string> {
+  await mkdir(join(stateDir, "logs"), { recursive: true });
+  const path = observerBootLogPath(stateDir);
+  await writeFile(path, content, "utf8");
+  return path;
+}
+
+function fakeChild(overrides: Partial<ChildProcessLike> = {}): ChildProcessLike {
+  return { pid: 1234, unref: () => undefined, ...overrides };
+}
+
+function fakeClientFactory(health: () => Promise<unknown>) {
+  return () => ({ health }) as never;
+}
+
+function unavailableClientFactory(message = "stopped") {
+  return fakeClientFactory(async () => {
+    throw new Error(message);
+  });
+}
 
 describe("CLI observer process helpers", () => {
   it("maps stale sockets distinctly from stopped observers", async () => {
@@ -70,6 +112,206 @@ describe("CLI observer process helpers", () => {
         status: "healthy",
       },
     });
+  });
+
+  it("keeps the spawned child alive when health wins and clears delayed progress", async () => {
+    const fixture = await createTempState();
+    const neverExits = new Promise<never>(() => undefined);
+    const progress: string[] = [];
+    let spawned = false;
+    let kills = 0;
+
+    vi.useFakeTimers();
+    try {
+      const result = await startObserver(
+        {
+          config: fixture.config,
+          timeoutMs: 10_000,
+          onStartupProgress: (message) => progress.push(message),
+        },
+        {
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawned = true;
+            return fakeChild({
+              exited: neverExits,
+              kill: () => {
+                kills += 1;
+                return true;
+              },
+            });
+          },
+          clientFactory: fakeClientFactory(async () => {
+            if (!spawned) throw new Error("stopped");
+            return healthyObserver();
+          }),
+        },
+      );
+
+      expect(result).toMatchObject({ status: "running", health: { pid: 1234 } });
+      expect(kills).toBe(0);
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(progress).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails immediately when the child exits and includes only a redacted 15-line tail", async () => {
+    const fixture = await createTempState();
+    const lines = Array.from({ length: 20 }, (_, index) => `boot-line-${index + 1}`);
+    lines[19] = "API_TOKEN=super-secret-value";
+    const noisyPrefix = "x".repeat(70 * 1024);
+    let healthCalls = 0;
+    const bootLogPath = await writeObserverBootLog(
+      fixture.stateDir,
+      `${noisyPrefix}\n${lines.join("\n")}\n`,
+    );
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            exited: Promise.resolve({ type: "exit", code: 17, signal: null }),
+          }),
+        clientFactory: fakeClientFactory(async () => {
+          healthCalls += 1;
+          throw new Error("stopped");
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining("exit code 17"),
+        hint: expect.stringContaining(`Observer boot log: ${bootLogPath}`),
+      },
+    });
+    expect(result.error?.hint).toContain("boot-line-6");
+    expect(result.error?.hint).not.toContain("boot-line-5\n");
+    expect(result.error?.hint).toContain("API_TOKEN=[REDACTED]");
+    expect(result.error?.hint).not.toContain("super-secret-value");
+    await expect(readFile(bootLogPath, "utf8")).resolves.toContain("super-secret-value");
+    const healthCallsAtExit = healthCalls;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(healthCalls).toBe(healthCallsAtExit);
+  });
+
+  it("attaches to a concurrent incumbent when the spawned child exits", async () => {
+    const fixture = await createTempState();
+    const exited = deferred<{ type: "exit"; code: number; signal: null }>();
+    const pendingHealth = new Promise<never>(() => undefined);
+    let healthCalls = 0;
+    let kills = 0;
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            exited: exited.promise,
+            kill: () => {
+              kills += 1;
+              return true;
+            },
+          }),
+        clientFactory: fakeClientFactory(async () => {
+          healthCalls += 1;
+          if (healthCalls === 1) throw new Error("initially stopped");
+          if (healthCalls === 2) {
+            exited.resolve({ type: "exit", code: 1, signal: null });
+            return pendingHealth;
+          }
+          return healthyObserver(9876);
+        }),
+      },
+    );
+
+    expect(result).toMatchObject({ status: "running", health: { pid: 9876 } });
+    expect(healthCalls).toBe(3);
+    expect(kills).toBe(0);
+  });
+
+  it("reports a redacted child spawn error", async () => {
+    const fixture = await createTempState();
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            pid: undefined,
+            exited: Promise.resolve({
+              type: "spawn_error",
+              error: new Error("spawn failed with API_TOKEN=super-secret-value"),
+            }),
+          }),
+        clientFactory: unavailableClientFactory(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining("spawn error: spawn failed with API_TOKEN=[REDACTED]"),
+        hint: expect.stringContaining(observerBootLogPath(fixture.stateDir)),
+      },
+    });
+    expect(result.error?.message).not.toContain("super-secret-value");
+  });
+
+  it("reports the signal when the child is terminated during startup", async () => {
+    const fixture = await createTempState();
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            exited: Promise.resolve({ type: "exit", code: null, signal: "SIGTERM" }),
+          }),
+        clientFactory: unavailableClientFactory(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining("signal SIGTERM"),
+      },
+    });
+  });
+
+  it.each([
+    "missing",
+    "empty",
+    "unreadable",
+  ] as const)("still reports the boot log path when the log is %s", async (logState) => {
+    const fixture = await createTempState();
+    const bootLogPath = observerBootLogPath(fixture.stateDir);
+    if (logState === "empty") {
+      await writeObserverBootLog(fixture.stateDir, "");
+    } else if (logState === "unreadable") {
+      await mkdir(bootLogPath, { recursive: true });
+    }
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        spawnObserver: async (): Promise<ChildProcessLike> =>
+          fakeChild({
+            exited: Promise.resolve({ type: "exit", code: 1, signal: null }),
+          }),
+        clientFactory: unavailableClientFactory(),
+      },
+    );
+
+    expect(result.error?.hint).toContain(`Observer boot log: ${bootLogPath}`);
+    expect(result.error?.hint).not.toContain("Last 15 lines");
   });
 
   it("removes a stale socket before spawning the observer", async () => {
@@ -175,6 +417,127 @@ describe("CLI observer process helpers", () => {
         },
       },
     });
+  });
+
+  it("emits delayed startup progress at 1.5s and 5s, then clears its timers", async () => {
+    const fixture = await createTempState();
+    const spawnedSignal = deferred<void>();
+    const progress: string[] = [];
+    let spawned = false;
+    let ready = false;
+
+    vi.useFakeTimers();
+    try {
+      const startup = startObserver(
+        {
+          config: fixture.config,
+          timeoutMs: 20_000,
+          onStartupProgress: (message) => progress.push(message),
+        },
+        {
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawned = true;
+            spawnedSignal.resolve(undefined);
+            return fakeChild();
+          },
+          clientFactory: fakeClientFactory(async () => {
+            if (!spawned || !ready) throw new Error("not ready");
+            return healthyObserver();
+          }),
+        },
+      );
+      await spawnedSignal.promise;
+
+      await vi.advanceTimersByTimeAsync(1_499);
+      expect(progress).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(progress).toEqual(["Starting STATION observer…"]);
+      await vi.advanceTimersByTimeAsync(3_499);
+      expect(progress).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(progress).toEqual([
+        "Starting STATION observer…",
+        `Still waiting for STATION observer; boot log: ${observerBootLogPath(fixture.stateDir)}`,
+      ]);
+
+      ready = true;
+      await vi.advanceTimersByTimeAsync(25);
+      await expect(startup).resolves.toMatchObject({ status: "running" });
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(progress).toHaveLength(2);
+
+      let warmSpawned = false;
+      const warmProgress: string[] = [];
+      await expect(
+        startObserver(
+          {
+            config: fixture.config,
+            onStartupProgress: (message) => warmProgress.push(message),
+          },
+          {
+            spawnObserver: async () => {
+              warmSpawned = true;
+              return fakeChild({ pid: 5678 });
+            },
+            clientFactory: fakeClientFactory(async () => healthyObserver()),
+          },
+        ),
+      ).resolves.toMatchObject({ status: "running" });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(warmSpawned).toBe(false);
+      expect(warmProgress).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { label: "the 10s default", timeoutMs: undefined, beforeMs: 9_999, finalMs: 2 },
+    { label: "an explicit override", timeoutMs: 12_000, beforeMs: 10_000, finalMs: 2_001 },
+  ])("uses $label and kills only its spawned child on timeout", async (testCase) => {
+    const fixture = await createTempState();
+    const spawnedSignal = deferred<void>();
+    let spawnedKills = 0;
+    let settled = false;
+
+    vi.useFakeTimers();
+    try {
+      const startup = startObserver(
+        {
+          config: fixture.config,
+          ...(testCase.timeoutMs === undefined ? {} : { timeoutMs: testCase.timeoutMs }),
+        },
+        {
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawnedSignal.resolve(undefined);
+            return fakeChild({
+              kill: () => {
+                spawnedKills += 1;
+                return true;
+              },
+            });
+          },
+          clientFactory: unavailableClientFactory("still down"),
+        },
+      );
+      void startup.then(() => {
+        settled = true;
+      });
+      await spawnedSignal.promise;
+
+      await vi.advanceTimersByTimeAsync(testCase.beforeMs);
+      expect(settled).toBe(false);
+      expect(spawnedKills).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(testCase.finalMs);
+      await expect(startup).resolves.toMatchObject({
+        status: "unhealthy",
+        error: { code: "OBSERVER_START_FAILED" },
+      });
+      expect(spawnedKills).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not spawn over a present incompatible observer socket", async () => {

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -1,0 +1,275 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { getObserverStatus, startObserver } from "@station/cli";
+import type { ChildProcessLike } from "@station/cli/internal";
+import { listenUnixSocket } from "@station/protocol";
+import { describe, expect, it } from "vitest";
+import { createStaleSocketFile } from "../../../../../tests/support/sockets";
+import { fileExists } from "../../../../../tests/support/spool";
+import { createTempState } from "../../../../../tests/support/temp-projects";
+
+const now = "2026-05-20T12:00:00.000Z";
+
+describe("CLI observer process lifecycle", () => {
+  it("maps stale sockets distinctly from stopped observers", async () => {
+    const fixture = await createTempState();
+    await createStaleSocketFile(fixture.socketPath);
+
+    await expect(
+      getObserverStatus({
+        config: fixture.config,
+      }),
+    ).resolves.toMatchObject({
+      status: "stale",
+      paths: {
+        socketPath: fixture.socketPath,
+      },
+    });
+  });
+
+  it("spawns the observer and waits for health when it is stopped", async () => {
+    const fixture = await createTempState();
+    let spawned = false;
+    let healthAttempts = 0;
+
+    const result = await startObserver(
+      {
+        config: fixture.config,
+        timeoutMs: 200,
+      },
+      {
+        clock: { now: () => new Date(now) },
+        spawnObserver: async (): Promise<ChildProcessLike> => {
+          spawned = true;
+          return { pid: 1234, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              healthAttempts += 1;
+              if (healthAttempts === 1) {
+                throw new Error("not yet");
+              }
+              return {
+                schemaVersion: "0.6.0",
+                status: "healthy",
+                pid: 1234,
+                startedAt: now,
+                version: "0.0.0",
+              };
+            },
+          }) as never,
+        sleep: async () => undefined,
+      },
+    );
+
+    expect(spawned).toBe(true);
+    expect(result).toMatchObject({
+      status: "running",
+      health: {
+        status: "healthy",
+      },
+    });
+  });
+
+  it("removes a stale socket before spawning the observer", async () => {
+    const fixture = await createTempState();
+    await createStaleSocketFile(fixture.socketPath);
+    let spawned = false;
+
+    const result = await startObserver(
+      {
+        config: fixture.config,
+        timeoutMs: 200,
+      },
+      {
+        clock: { now: () => new Date(now) },
+        spawnObserver: async (): Promise<ChildProcessLike> => {
+          spawned = true;
+          return { pid: 1234, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              if (!spawned) {
+                throw new Error("not running");
+              }
+              return {
+                schemaVersion: "0.6.0",
+                status: "healthy",
+                pid: 1234,
+                startedAt: now,
+                version: "0.0.0",
+              };
+            },
+          }) as never,
+        sleep: async () => undefined,
+      },
+    );
+
+    expect(spawned).toBe(true);
+    expect(result.status).toBe("running");
+    await expect(fileExists(fixture.socketPath)).resolves.toBe(false);
+  });
+
+  it("returns a safe startup error when health does not arrive before timeout", async () => {
+    const fixture = await createTempState();
+    let spawned = false;
+    let killed = false;
+
+    const result = await startObserver(
+      {
+        config: fixture.config,
+        timeoutMs: 20,
+      },
+      {
+        clock: { now: () => new Date(now) },
+        spawnObserver: async (): Promise<ChildProcessLike> => {
+          spawned = true;
+          return {
+            pid: 1234,
+            unref: () => undefined,
+            kill: () => {
+              killed = true;
+              return true;
+            },
+          };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              throw new Error("raw process failure\n    at internal-frame");
+            },
+          }) as never,
+        sleep: async () => new Promise((resolve) => setTimeout(resolve, 1)),
+      },
+    );
+
+    expect(spawned).toBe(true);
+    expect(killed).toBe(true);
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        tag: "ObserverStartupError",
+        traceId: expect.stringMatching(/^trc_/),
+        hint: expect.stringMatching(/^Run station debug trace trc_/),
+      },
+    });
+    expect(result.error?.message).not.toContain("internal-frame");
+
+    const logs = await readFile(join(fixture.stateDir, "logs", "cli.jsonl"), "utf8");
+    const records = logs
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      level: "error",
+      component: "cli",
+      message: "Observer lifecycle failed.",
+      traceId: result.error?.traceId,
+      attributes: {
+        operation: "cli.observer.start",
+        error: {
+          traceId: result.error?.traceId,
+        },
+      },
+    });
+  });
+
+  it("does not spawn over a present incompatible observer socket", async () => {
+    const fixture = await createTempState();
+    const server = await listenUnixSocket({
+      socketPath: fixture.socketPath,
+      onConnection: () => undefined,
+    });
+    let spawned = false;
+
+    try {
+      const result = await startObserver(
+        {
+          config: fixture.config,
+          timeoutMs: 200,
+        },
+        {
+          clock: { now: () => new Date(now) },
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawned = true;
+            return { pid: 1234, unref: () => undefined };
+          },
+          clientFactory: () =>
+            ({
+              health: async () => {
+                throw {
+                  tag: "ProtocolError",
+                  code: "PROTOCOL_SCHEMA_MISMATCH",
+                  message:
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
+                  hint: "A different STATION checkout may own the observer socket.",
+                };
+              },
+            }) as never,
+          sleep: async () => undefined,
+        },
+      );
+
+      expect(spawned).toBe(false);
+      expect(result).toMatchObject({
+        status: "unhealthy",
+        error: {
+          code: "PROTOCOL_SCHEMA_MISMATCH",
+          hint: "A different STATION checkout may own the observer socket.",
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not spawn over a present observer socket when health times out", async () => {
+    const fixture = await createTempState();
+    const server = await listenUnixSocket({
+      socketPath: fixture.socketPath,
+      onConnection: () => undefined,
+    });
+    let spawned = false;
+
+    try {
+      const result = await startObserver(
+        {
+          config: fixture.config,
+          timeoutMs: 200,
+        },
+        {
+          clock: { now: () => new Date(now) },
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawned = true;
+            return { pid: 1234, unref: () => undefined };
+          },
+          clientFactory: () =>
+            ({
+              health: async () => {
+                throw {
+                  tag: "TimeoutError",
+                  code: "PROTOCOL_REQUEST_TIMEOUT",
+                  message: "Observer protocol request timed out.",
+                };
+              },
+            }) as never,
+          sleep: async () => undefined,
+        },
+      );
+
+      expect(spawned).toBe(false);
+      expect(result).toMatchObject({
+        status: "unhealthy",
+        error: {
+          code: "OBSERVER_HEALTH_TIMEOUT",
+          message: expect.stringContaining("health request timed out"),
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -1,12 +1,9 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getObserverStatus, startObserver } from "@station/cli";
+import { startObserver } from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
-import { listenUnixSocket } from "@station/protocol";
 import { describe, expect, it, vi } from "vitest";
-import { createStaleSocketFile } from "../../../../tests/support/sockets";
-import { fileExists } from "../../../../tests/support/spool";
-import { createTempState } from "../../../../tests/support/temp-projects";
+import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -52,68 +49,7 @@ function unavailableClientFactory(message = "stopped") {
   });
 }
 
-describe("CLI observer process helpers", () => {
-  it("maps stale sockets distinctly from stopped observers", async () => {
-    const fixture = await createTempState();
-    await createStaleSocketFile(fixture.socketPath);
-
-    await expect(
-      getObserverStatus({
-        config: fixture.config,
-      }),
-    ).resolves.toMatchObject({
-      status: "stale",
-      paths: {
-        socketPath: fixture.socketPath,
-      },
-    });
-  });
-
-  it("spawns the observer and waits for health when it is stopped", async () => {
-    const fixture = await createTempState();
-    let spawned = false;
-    let healthAttempts = 0;
-
-    const result = await startObserver(
-      {
-        config: fixture.config,
-        timeoutMs: 200,
-      },
-      {
-        clock: { now: () => new Date(now) },
-        spawnObserver: async (): Promise<ChildProcessLike> => {
-          spawned = true;
-          return { pid: 1234, unref: () => undefined };
-        },
-        clientFactory: () =>
-          ({
-            health: async () => {
-              healthAttempts += 1;
-              if (healthAttempts === 1) {
-                throw new Error("not yet");
-              }
-              return {
-                schemaVersion: "0.6.0",
-                status: "healthy",
-                pid: 1234,
-                startedAt: now,
-                version: "0.0.0",
-              };
-            },
-          }) as never,
-        sleep: async () => undefined,
-      },
-    );
-
-    expect(spawned).toBe(true);
-    expect(result).toMatchObject({
-      status: "running",
-      health: {
-        status: "healthy",
-      },
-    });
-  });
-
+describe("CLI observer process startup", () => {
   it("keeps the spawned child alive when health wins and clears delayed progress", async () => {
     const fixture = await createTempState();
     const neverExits = new Promise<never>(() => undefined);
@@ -314,111 +250,6 @@ describe("CLI observer process helpers", () => {
     expect(result.error?.hint).not.toContain("Last 15 lines");
   });
 
-  it("removes a stale socket before spawning the observer", async () => {
-    const fixture = await createTempState();
-    await createStaleSocketFile(fixture.socketPath);
-    let spawned = false;
-
-    const result = await startObserver(
-      {
-        config: fixture.config,
-        timeoutMs: 200,
-      },
-      {
-        clock: { now: () => new Date(now) },
-        spawnObserver: async (): Promise<ChildProcessLike> => {
-          spawned = true;
-          return { pid: 1234, unref: () => undefined };
-        },
-        clientFactory: () =>
-          ({
-            health: async () => {
-              if (!spawned) {
-                throw new Error("not running");
-              }
-              return {
-                schemaVersion: "0.6.0",
-                status: "healthy",
-                pid: 1234,
-                startedAt: now,
-                version: "0.0.0",
-              };
-            },
-          }) as never,
-        sleep: async () => undefined,
-      },
-    );
-
-    expect(spawned).toBe(true);
-    expect(result.status).toBe("running");
-    await expect(fileExists(fixture.socketPath)).resolves.toBe(false);
-  });
-
-  it("returns a safe startup error when health does not arrive before timeout", async () => {
-    const fixture = await createTempState();
-    let spawned = false;
-    let killed = false;
-
-    const result = await startObserver(
-      {
-        config: fixture.config,
-        timeoutMs: 20,
-      },
-      {
-        clock: { now: () => new Date(now) },
-        spawnObserver: async (): Promise<ChildProcessLike> => {
-          spawned = true;
-          return {
-            pid: 1234,
-            unref: () => undefined,
-            kill: () => {
-              killed = true;
-              return true;
-            },
-          };
-        },
-        clientFactory: () =>
-          ({
-            health: async () => {
-              throw new Error("raw process failure\n    at internal-frame");
-            },
-          }) as never,
-        sleep: async () => new Promise((resolve) => setTimeout(resolve, 1)),
-      },
-    );
-
-    expect(spawned).toBe(true);
-    expect(killed).toBe(true);
-    expect(result).toMatchObject({
-      status: "unhealthy",
-      error: {
-        tag: "ObserverStartupError",
-        traceId: expect.stringMatching(/^trc_/),
-        hint: expect.stringMatching(/^Run station debug trace trc_/),
-      },
-    });
-    expect(result.error?.message).not.toContain("internal-frame");
-
-    const logs = await readFile(join(fixture.stateDir, "logs", "cli.jsonl"), "utf8");
-    const records = logs
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
-    expect(records).toHaveLength(1);
-    expect(records[0]).toMatchObject({
-      level: "error",
-      component: "cli",
-      message: "Observer lifecycle failed.",
-      traceId: result.error?.traceId,
-      attributes: {
-        operation: "cli.observer.start",
-        error: {
-          traceId: result.error?.traceId,
-        },
-      },
-    });
-  });
-
   it("emits delayed startup progress at 1.5s and 5s, then clears its timers", async () => {
     const fixture = await createTempState();
     const spawnedSignal = deferred<void>();
@@ -537,102 +368,6 @@ describe("CLI observer process helpers", () => {
       expect(spawnedKills).toBe(1);
     } finally {
       vi.useRealTimers();
-    }
-  });
-
-  it("does not spawn over a present incompatible observer socket", async () => {
-    const fixture = await createTempState();
-    const server = await listenUnixSocket({
-      socketPath: fixture.socketPath,
-      onConnection: () => undefined,
-    });
-    let spawned = false;
-
-    try {
-      const result = await startObserver(
-        {
-          config: fixture.config,
-          timeoutMs: 200,
-        },
-        {
-          clock: { now: () => new Date(now) },
-          spawnObserver: async (): Promise<ChildProcessLike> => {
-            spawned = true;
-            return { pid: 1234, unref: () => undefined };
-          },
-          clientFactory: () =>
-            ({
-              health: async () => {
-                throw {
-                  tag: "ProtocolError",
-                  code: "PROTOCOL_SCHEMA_MISMATCH",
-                  message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
-                  hint: "A different STATION checkout may own the observer socket.",
-                };
-              },
-            }) as never,
-          sleep: async () => undefined,
-        },
-      );
-
-      expect(spawned).toBe(false);
-      expect(result).toMatchObject({
-        status: "unhealthy",
-        error: {
-          code: "PROTOCOL_SCHEMA_MISMATCH",
-          hint: "A different STATION checkout may own the observer socket.",
-        },
-      });
-    } finally {
-      await server.close();
-    }
-  });
-
-  it("does not spawn over a present observer socket when health times out", async () => {
-    const fixture = await createTempState();
-    const server = await listenUnixSocket({
-      socketPath: fixture.socketPath,
-      onConnection: () => undefined,
-    });
-    let spawned = false;
-
-    try {
-      const result = await startObserver(
-        {
-          config: fixture.config,
-          timeoutMs: 200,
-        },
-        {
-          clock: { now: () => new Date(now) },
-          spawnObserver: async (): Promise<ChildProcessLike> => {
-            spawned = true;
-            return { pid: 1234, unref: () => undefined };
-          },
-          clientFactory: () =>
-            ({
-              health: async () => {
-                throw {
-                  tag: "TimeoutError",
-                  code: "PROTOCOL_REQUEST_TIMEOUT",
-                  message: "Observer protocol request timed out.",
-                };
-              },
-            }) as never,
-          sleep: async () => undefined,
-        },
-      );
-
-      expect(spawned).toBe(false);
-      expect(result).toMatchObject({
-        status: "unhealthy",
-        error: {
-          code: "OBSERVER_HEALTH_TIMEOUT",
-          message: expect.stringContaining("health request timed out"),
-        },
-      });
-    } finally {
-      await server.close();
     }
   });
 });

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -56,6 +56,7 @@ describe("CLI observer process startup", () => {
     const progress: string[] = [];
     let spawned = false;
     let kills = 0;
+    let bootLogDisposals = 0;
 
     vi.useFakeTimers();
     try {
@@ -74,6 +75,9 @@ describe("CLI observer process startup", () => {
                 kills += 1;
                 return true;
               },
+              disposeBootLog: async () => {
+                bootLogDisposals += 1;
+              },
             });
           },
           clientFactory: fakeClientFactory(async () => {
@@ -85,6 +89,7 @@ describe("CLI observer process startup", () => {
 
       expect(result).toMatchObject({ status: "running", health: { pid: 1234 } });
       expect(kills).toBe(0);
+      expect(bootLogDisposals).toBe(1);
       await vi.advanceTimersByTimeAsync(5_000);
       expect(progress).toEqual([]);
     } finally {
@@ -92,55 +97,77 @@ describe("CLI observer process startup", () => {
     }
   });
 
-  it("fails immediately when the child exits and includes only a redacted 15-line tail", async () => {
+  it("waits briefly for an incumbent, then reports the failed child's redacted tail", async () => {
     const fixture = await createTempState();
     const lines = Array.from({ length: 20 }, (_, index) => `boot-line-${index + 1}`);
     lines[19] = "API_TOKEN=super-secret-value";
-    const noisyPrefix = "x".repeat(70 * 1024);
+    const attemptTail = lines.slice(-15).join("\n");
     let healthCalls = 0;
-    const bootLogPath = await writeObserverBootLog(
-      fixture.stateDir,
-      `${noisyPrefix}\n${lines.join("\n")}\n`,
-    );
+    let bootLogDisposals = 0;
+    let settled = false;
+    const spawnedSignal = deferred<void>();
+    const bootLogPath = await writeObserverBootLog(fixture.stateDir, "winning-attempt\n");
 
-    const result = await startObserver(
-      { config: fixture.config, timeoutMs: 5_000 },
-      {
-        spawnObserver: async (): Promise<ChildProcessLike> =>
-          fakeChild({
-            exited: Promise.resolve({ type: "exit", code: 17, signal: null }),
+    vi.useFakeTimers();
+    try {
+      const startup = startObserver(
+        { config: fixture.config, timeoutMs: 5_000 },
+        {
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawnedSignal.resolve(undefined);
+            return fakeChild({
+              exited: Promise.resolve({ type: "exit", code: 17, signal: null }),
+              readBootLogTail: async () => attemptTail,
+              disposeBootLog: async () => {
+                bootLogDisposals += 1;
+              },
+            });
+          },
+          clientFactory: fakeClientFactory(async () => {
+            healthCalls += 1;
+            throw new Error("stopped");
           }),
-        clientFactory: fakeClientFactory(async () => {
-          healthCalls += 1;
-          throw new Error("stopped");
-        }),
-      },
-    );
+        },
+      );
+      void startup.then(() => {
+        settled = true;
+      });
+      await spawnedSignal.promise;
+      await vi.advanceTimersByTimeAsync(999);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(2);
+      const result = await startup;
 
-    expect(result).toMatchObject({
-      status: "unhealthy",
-      error: {
-        code: "OBSERVER_EXITED_ON_START",
-        message: expect.stringContaining("exit code 17"),
-        hint: expect.stringContaining(`Observer boot log: ${bootLogPath}`),
-      },
-    });
-    expect(result.error?.hint).toContain("boot-line-6");
-    expect(result.error?.hint).not.toContain("boot-line-5\n");
-    expect(result.error?.hint).toContain("API_TOKEN=[REDACTED]");
-    expect(result.error?.hint).not.toContain("super-secret-value");
-    await expect(readFile(bootLogPath, "utf8")).resolves.toContain("super-secret-value");
-    const healthCallsAtExit = healthCalls;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(healthCalls).toBe(healthCallsAtExit);
+      expect(result).toMatchObject({
+        status: "unhealthy",
+        error: {
+          code: "OBSERVER_EXITED_ON_START",
+          message: expect.stringContaining("exit code 17"),
+          hint: expect.stringContaining(`Latest observer boot log: ${bootLogPath}`),
+        },
+      });
+      expect(result.error?.hint).toContain("This attempt's last 15 lines (redacted):");
+      expect(result.error?.hint).toContain("boot-line-6");
+      expect(result.error?.hint).not.toContain("boot-line-5\n");
+      expect(result.error?.hint).toContain("API_TOKEN=[REDACTED]");
+      expect(result.error?.hint).not.toContain("super-secret-value");
+      expect(result.error?.hint).not.toContain("winning-attempt");
+      await expect(readFile(bootLogPath, "utf8")).resolves.toBe("winning-attempt\n");
+      expect(bootLogDisposals).toBe(1);
+      const healthCallsAtExit = healthCalls;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(healthCalls).toBe(healthCallsAtExit);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("attaches to a concurrent incumbent when the spawned child exits", async () => {
     const fixture = await createTempState();
     const exited = deferred<{ type: "exit"; code: number; signal: null }>();
-    const pendingHealth = new Promise<never>(() => undefined);
     let healthCalls = 0;
     let kills = 0;
+    let exitWaitDisposals = 0;
 
     const result = await startObserver(
       { config: fixture.config, timeoutMs: 5_000 },
@@ -152,22 +179,76 @@ describe("CLI observer process startup", () => {
               kills += 1;
               return true;
             },
+            disposeExitWait: () => {
+              exitWaitDisposals += 1;
+            },
           }),
         clientFactory: fakeClientFactory(async () => {
           healthCalls += 1;
           if (healthCalls === 1) throw new Error("initially stopped");
           if (healthCalls === 2) {
             exited.resolve({ type: "exit", code: 1, signal: null });
-            return pendingHealth;
+            throw new Error("winner still booting");
           }
+          if (healthCalls === 3) throw new Error("winner not ready yet");
           return healthyObserver(9876);
         }),
       },
     );
 
     expect(result).toMatchObject({ status: "running", health: { pid: 9876 } });
-    expect(healthCalls).toBe(3);
+    expect(healthCalls).toBe(4);
     expect(kills).toBe(0);
+    expect(exitWaitDisposals).toBe(1);
+  });
+
+  it("lets the outer startup timeout preempt incumbent convergence", async () => {
+    const fixture = await createTempState();
+    const spawnedSignal = deferred<void>();
+    let healthCalls = 0;
+    let kills = 0;
+    let settled = false;
+
+    vi.useFakeTimers();
+    try {
+      const startup = startObserver(
+        { config: fixture.config, timeoutMs: 100 },
+        {
+          spawnObserver: async (): Promise<ChildProcessLike> => {
+            spawnedSignal.resolve(undefined);
+            return fakeChild({
+              exited: Promise.resolve({ type: "exit", code: 1, signal: null }),
+              kill: () => {
+                kills += 1;
+                return true;
+              },
+            });
+          },
+          clientFactory: fakeClientFactory(async () => {
+            healthCalls += 1;
+            throw new Error("still down");
+          }),
+        },
+      );
+      void startup.then(() => {
+        settled = true;
+      });
+      await spawnedSignal.promise;
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(2);
+      await expect(startup).resolves.toMatchObject({
+        status: "unhealthy",
+        error: { code: "OBSERVER_START_FAILED" },
+      });
+      expect(kills).toBe(1);
+      const healthCallsAtTimeout = healthCalls;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(healthCalls).toBe(healthCallsAtTimeout);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports a redacted child spawn error", async () => {

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -150,7 +150,7 @@ spool/hooks/
 
 ## Reading Evidence
 
-- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt rewrites it at mode `0600` with a JSON-encoded command header followed by the child stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes its path and, when available, only a redacted final 15-line tail.
+- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes the latest path and, when available, a redacted final 15-line tail captured from its own failed child.
 - `diagnostic-index.json` is the fastest summary for root-cause codes and correlated evidence.
 - `commands.jsonl` is the command lifecycle record. Failed commands can include redacted provider command diagnostics when an error envelope was persisted for the command.
 - `errors.jsonl` carries safe error envelopes, diagnostic IDs, trace IDs, provider context, and redacted diagnostic details when available.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -135,6 +135,7 @@ Important files and directories:
 
 ```text
 observer.sqlite
+logs/observer-boot.log
 logs/observer.jsonl
 logs/hooks.jsonl
 logs/cli.jsonl
@@ -149,6 +150,7 @@ spool/hooks/
 
 ## Reading Evidence
 
+- `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt rewrites it at mode `0600` with a JSON-encoded command header followed by the child stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes its path and, when available, only a redacted final 15-line tail.
 - `diagnostic-index.json` is the fastest summary for root-cause codes and correlated evidence.
 - `commands.jsonl` is the command lifecycle record. Failed commands can include redacted provider command diagnostics when an error envelope was persisted for the command.
 - `errors.jsonl` carries safe error envelopes, diagnostic IDs, trace IDs, provider context, and redacted diagnostic details when available.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -340,12 +340,12 @@ first-run screen.
 
 ### B2 — observer boot guarantee (no eviction — F3)
 
-**Status: implemented.** Observer launch rewrites the private boot log at
+**Status: implemented.** Observer launch atomically rewrites the private boot log at
 `<stateDir>/logs/observer-boot.log`, captures a JSON-encoded command header plus
 child stdout/stderr, and races health readiness against child exit. It reports
-`OBSERVER_EXITED_ON_START` immediately with a redacted log tail unless a
-concurrent observer became healthy. The default health wait is 10 seconds;
-only TUI and popup launches show delayed progress.
+`OBSERVER_EXITED_ON_START` after a short convergence grace with that child's
+redacted log tail unless a concurrent observer became healthy. The default
+health wait is 10 seconds; only TUI and popup launches show delayed progress.
 
 **Removed from v1:** the client-side unhealthy-incumbent SIGTERM eviction.
 It conflicts with [observer-singleton](observer-singleton.md), which is

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -340,10 +340,12 @@ first-run screen.
 
 ### B2 — observer boot guarantee (no eviction — F3)
 
-Boot log `<stateDir>/logs/observer-boot.log` replacing `stdio:"ignore"`;
-child-exit race → immediate `OBSERVER_EXITED_ON_START` with a boot-log
-tail (kills the silent 30s hang); default health wait 30s → 10s with
-progressive stderr from the tui/popup call sites only.
+**Status: implemented.** Observer launch rewrites the private boot log at
+`<stateDir>/logs/observer-boot.log`, captures a JSON-encoded command header plus
+child stdout/stderr, and races health readiness against child exit. It reports
+`OBSERVER_EXITED_ON_START` immediately with a redacted log tail unless a
+concurrent observer became healthy. The default health wait is 10 seconds;
+only TUI and popup launches show delayed progress.
 
 **Removed from v1:** the client-side unhealthy-incumbent SIGTERM eviction.
 It conflicts with [observer-singleton](observer-singleton.md), which is

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -66,7 +66,7 @@ const setTimeoutAllowlist = new Map([
     "SIGTERM-to-SIGKILL grace delay for reaping duplicate observer processes is OS signal timing, not observer command timeout or retry plumbing.",
   ],
   [
-    "apps/cli/src/observerProcess.ts",
+    "apps/cli/src/observerProcess/startup.ts",
     "UI-only progress timers report a runtime-bounded observer launch; they do not implement startup timeout or retry control.",
   ],
 ]);

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -65,6 +65,10 @@ const setTimeoutAllowlist = new Map([
     "apps/cli/src/observerReap.ts",
     "SIGTERM-to-SIGKILL grace delay for reaping duplicate observer processes is OS signal timing, not observer command timeout or retry plumbing.",
   ],
+  [
+    "apps/cli/src/observerProcess.ts",
+    "UI-only progress timers report a runtime-bounded observer launch; they do not implement startup timeout or retry control.",
+  ],
 ]);
 
 const setIntervalAllowlist = new Map([

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { access } from "node:fs/promises";
+import { access, chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { startObserver } from "@station/cli";
 import { emptyConfig } from "@station/config";
@@ -10,6 +10,10 @@ import { createTempState, writeConfigToml } from "../support/temp-projects";
 describe("observer lifecycle e2e", () => {
   it("boots a real observer with in-memory defaults and no config file", async () => {
     const fixture = await createTempState();
+    const bootLogPath = join(fixture.stateDir, "logs", "observer-boot.log");
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    await writeFile(bootLogPath, "stale observer boot output\n", "utf8");
+    await chmod(bootLogPath, 0o666);
     const config = {
       ...emptyConfig(),
       observer: {
@@ -40,12 +44,56 @@ describe("observer lifecycle e2e", () => {
       await expect(access(join(fixture.root, "config.toml"))).rejects.toMatchObject({
         code: "ENOENT",
       });
+
+      const bootLog = await readFile(bootLogPath, "utf8");
+      expect(bootLog).not.toContain("stale observer boot output");
+      const header = bootLog.split(/\r?\n/, 1)[0];
+      expect(JSON.parse(header ?? "")).toEqual({
+        command: [
+          process.execPath,
+          expect.stringMatching(/observerMain\.js$/),
+          "--socket",
+          fixture.socketPath,
+          "--state-dir",
+          fixture.stateDir,
+        ],
+      });
+      expect((await stat(bootLogPath)).mode & 0o777).toBe(0o600);
     } finally {
       if (started) {
         await client.stop();
         await waitForSocketClosed(fixture.socketPath);
       }
     }
+  });
+
+  it("reports a malformed-config child exit without waiting for the startup timeout", async () => {
+    const fixture = await createTempState();
+    const configPath = join(fixture.root, "malformed.toml");
+    const bootLogPath = join(fixture.stateDir, "logs", "observer-boot.log");
+    await writeFile(configPath, "not = [valid toml", "utf8");
+
+    const startedAt = Date.now();
+    const status = await startObserver({
+      config: fixture.config,
+      configPath,
+      timeoutMs: 30_000,
+    });
+    const durationMs = Date.now() - startedAt;
+
+    expect(durationMs).toBeLessThan(10_000);
+    expect(status).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining("exit code 1"),
+        hint: expect.stringContaining(`Observer boot log: ${bootLogPath}`),
+      },
+    });
+    expect(status.error?.hint).toContain("Station config file is not valid TOML.");
+    await expect(readFile(bootLogPath, "utf8")).resolves.toContain(
+      "Station config file is not valid TOML.",
+    );
   });
 
   it("starts a real observer process, serves protocol requests, and stops cleanly", async () => {

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -67,6 +67,38 @@ describe("observer lifecycle e2e", () => {
     }
   });
 
+  it("converges concurrent cold starts on one healthy observer", async () => {
+    const fixture = await createTempState();
+    const config = {
+      ...emptyConfig(),
+      observer: {
+        stateDir: fixture.stateDir,
+        socketPath: fixture.socketPath,
+      },
+    };
+    const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    let started = false;
+
+    try {
+      const statuses = await Promise.all(
+        Array.from({ length: 5 }, () => startObserver({ config, timeoutMs: 30_000 })),
+      );
+      started = statuses.some((status) => status.status === "running");
+
+      expect(statuses.every((status) => status.status === "running")).toBe(true);
+      const pids = statuses.map((status) =>
+        status.status === "running" ? status.health.pid : undefined,
+      );
+      expect(new Set(pids).size).toBe(1);
+      expect(pids[0]).toBeTypeOf("number");
+    } finally {
+      if (started) {
+        await client.stop();
+        await waitForSocketClosed(fixture.socketPath);
+      }
+    }
+  });
+
   it("reports a malformed-config child exit without waiting for the startup timeout", async () => {
     const fixture = await createTempState();
     const configPath = join(fixture.root, "malformed.toml");
@@ -87,13 +119,62 @@ describe("observer lifecycle e2e", () => {
       error: {
         code: "OBSERVER_EXITED_ON_START",
         message: expect.stringContaining("exit code 1"),
-        hint: expect.stringContaining(`Observer boot log: ${bootLogPath}`),
+        hint: expect.stringContaining(`Latest observer boot log: ${bootLogPath}`),
       },
     });
     expect(status.error?.hint).toContain("Station config file is not valid TOML.");
     await expect(readFile(bootLogPath, "utf8")).resolves.toContain(
       "Station config file is not valid TOML.",
     );
+  });
+
+  it("keeps concurrent failed startup diagnostics isolated and publishes one coherent latest log", async () => {
+    const fixture = await createTempState();
+    const malformedConfigPath = join(fixture.root, "malformed.toml");
+    const missingConfigPath = join(fixture.root, "missing.toml");
+    const bootLogPath = join(fixture.stateDir, "logs", "observer-boot.log");
+    await writeFile(malformedConfigPath, "not = [valid toml", "utf8");
+
+    const [malformedStatus, missingStatus] = await Promise.all([
+      startObserver({
+        config: fixture.config,
+        configPath: malformedConfigPath,
+        timeoutMs: 30_000,
+      }),
+      startObserver({
+        config: fixture.config,
+        configPath: missingConfigPath,
+        timeoutMs: 30_000,
+      }),
+    ]);
+
+    expect(malformedStatus).toMatchObject({
+      status: "unhealthy",
+      error: { code: "OBSERVER_EXITED_ON_START" },
+    });
+    expect(malformedStatus.error?.hint).toContain("Station config file is not valid TOML.");
+    expect(malformedStatus.error?.hint).not.toContain("Station config file was not found.");
+    expect(missingStatus).toMatchObject({
+      status: "unhealthy",
+      error: { code: "OBSERVER_EXITED_ON_START" },
+    });
+    expect(missingStatus.error?.hint).toContain("Station config file was not found.");
+    expect(missingStatus.error?.hint).not.toContain("Station config file is not valid TOML.");
+
+    const bootLog = await readFile(bootLogPath, "utf8");
+    const [header = "", ...bodyLines] = bootLog.split(/\r?\n/);
+    const command = JSON.parse(header).command as string[];
+    const configPath = command[command.indexOf("--config") + 1];
+    const body = bodyLines.join("\n");
+    if (configPath === malformedConfigPath) {
+      expect(body).toContain("Station config file is not valid TOML.");
+      expect(body).not.toContain("Station config file was not found.");
+    } else {
+      expect(configPath).toBe(missingConfigPath);
+      expect(body).toContain("Station config file was not found.");
+      expect(body).not.toContain("Station config file is not valid TOML.");
+    }
+    expect((await stat(bootLogPath)).mode & 0o777).toBe(0o600);
   });
 
   it("starts a real observer process, serves protocol requests, and stops cleanly", async () => {


### PR DESCRIPTION
## Summary

- capture each observer startup command and child output in a private `observer-boot.log`
- race health readiness against child termination and surface `OBSERVER_EXITED_ON_START` with a redacted log tail
- preserve concurrent-start convergence with one final health probe
- reduce the default startup timeout to 10 seconds and show delayed progress only for TUI/popup launches
- document the boot log and add unit, integration, diagnostics, and real lifecycle coverage

## Why

Detached observer startup previously discarded stdout/stderr and waited for the full health timeout even when the child had already exited. That made malformed configuration and other early boot failures look like a silent hang.

## UX impact

Slow cold TUI and popup launches now explain the wait after 1.5 and 5 seconds. Early observer boot failures return immediately without opening the UI, while warm attachment and non-UI callers remain silent.

## Verification

- `pnpm test:all` with a clean isolated `HOME`
- `pnpm exec vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts`
- focused observer-process unit and TUI/popup integration suites
- pre-commit lint hook

The normal developer `HOME` has installed Station Claude hook artifacts, which makes one existing Claude doctor fixture report `warn` instead of `ok`; the full deterministic gate passes in an isolated `HOME`.