### PR TITLE
fix(setup): restore launcher installation with pnpm 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ station keeps track of everything that's running and makes it visible:
 
 ### macOS: one command
 
-From a fresh clone, one script installs the system dependencies via Homebrew, builds **both** lanes (the pnpm/Node CLI + observer *and* the Bun terminal UI), and links `stn`:
+From a fresh clone, one script installs the system dependencies via Homebrew, builds **both** lanes (the pnpm/Node CLI + observer *and* the Bun terminal UI), and links all three checkout launchers:
 
 ```sh
 ./scripts/setup/bootstrap.sh
@@ -74,7 +74,7 @@ pnpm stn reconcile --reason manual
 pnpm stn
 ```
 
-To use bare `stn` from any directory, link the CLI globally (the macOS script already does this):
+To use bare `stn`, `stn-ingress`, and `stn-tmux-popup` from any directory, link the checkout globally (the macOS script already does this):
 
 ```sh
 pnpm station:link

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -153,7 +153,7 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
     tier: "recommended",
     status: "ok",
     label: "STATION launchers",
-    message: "station, stn-ingress, and stn-tmux-popup are available on PATH.",
+    message: "stn, stn-ingress, and stn-tmux-popup are available on PATH.",
     details,
   };
 }
@@ -609,8 +609,8 @@ function setupActions(
       tier: "recommended",
       selected: false,
       label: "Link STATION launchers",
-      message: "Link station, stn-ingress, and stn-tmux-popup globally for bare terminal commands.",
-      command: ["pnpm", "--dir", facts.launchers.packageRoot, "link", "--global"],
+      message: "Link stn, stn-ingress, and stn-tmux-popup globally for bare terminal commands.",
+      command: ["pnpm", "--dir", facts.launchers.packageRoot, "station:link"],
     });
   }
   actions.push({

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { afterEach, describe, expect, it } from "vitest";
+import { setupPackageRoot } from "../../src/commands/setup/checks/launchers.js";
 import { runSetupCommand, type SetupPromptAdapter } from "../../src/commands/setup/index.js";
 
 describe("guided setup command", () => {
@@ -57,6 +58,67 @@ describe("guided setup command", () => {
     expect(chunks.join("")).toContain(`Applying: Write STATION config (${configPath})`);
     expect(chunks.join("")).toContain("Completed: Write STATION config");
     expect(chunks.join("")).toContain("Core setup complete.");
+  });
+
+  it("continues with all three checkout launchers when global installation fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({});
+    const chunks: string[] = [];
+    const packageRoot = setupPackageRoot();
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "brew --version": "Homebrew 4.0.0\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          join(packageRoot, "bin/stn"),
+          join(packageRoot, "bin/stn-ingress"),
+          join(packageRoot, "integrations/terminal/tmux/bin/stn-popup"),
+        ]),
+        fs,
+        prompt: {
+          async confirm(message: string) {
+            return (
+              message.includes("Link STATION launchers") ||
+              message.includes("Write STATION project config")
+            );
+          },
+          async select() {
+            return "codex";
+          },
+        },
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(calls.find((call) => call.command === "pnpm")).toMatchObject({
+      args: ["--dir", packageRoot, "station:link"],
+      stdio: "inherit",
+    });
+    expect(chunks.join("")).toContain(
+      "STATION launcher link failed. Continuing with checkout launcher paths.",
+    );
+    expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain("[[projects]]");
   });
 
   it("runs Worktrunk shell integration non-interactively after the STATION prompt", async () => {

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -206,6 +206,46 @@ describe("setup planner", () => {
     });
   });
 
+  it("installs checkout launchers through the pnpm 11-compatible package script", () => {
+    const base = facts();
+    const plan = buildSetupPlan(
+      facts({
+        launchers: {
+          ...base.launchers,
+          station: {
+            ...base.launchers.station,
+            source: "checkout",
+            command: base.launchers.station.checkoutPath,
+          },
+          ingress: {
+            ...base.launchers.ingress,
+            source: "checkout",
+            command: base.launchers.ingress.checkoutPath,
+          },
+          tmuxPopup: {
+            ...base.launchers.tmuxPopup,
+            source: "checkout",
+            command: base.launchers.tmuxPopup.checkoutPath,
+          },
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
+      status: "warning",
+      details: {
+        station: "/tmp/station/bin/stn",
+        ingress: "/tmp/station/bin/stn-ingress",
+        tmuxPopup: "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
+      },
+    });
+    expect(plan.actions.find((action) => action.id === "link-station-launchers")).toMatchObject({
+      kind: "run-command",
+      selected: false,
+      command: ["pnpm", "--dir", "/tmp/station", "station:link"],
+    });
+  });
+
   it("plans a safe append for an existing config", () => {
     const plan = buildSetupPlan(facts(), {
       configWrite: {

--- a/bin/stn
+++ b/bin/stn
@@ -11,7 +11,8 @@ while [ -h "$script" ]; do
   esac
 done
 
-root=$(CDPATH= cd -- "$(dirname -- "$script")/.." && pwd)
+# pnpm's global shim enters through a symlinked package directory, so resolve the checkout itself.
+root=$(CDPATH= cd -- "$(dirname -- "$script")/.." && pwd -P)
 tmux_popup=$root/integrations/terminal/tmux/bin/stn-popup
 entry=$root/apps/cli/dist/main.js
 

--- a/bin/stn-ingress
+++ b/bin/stn-ingress
@@ -11,7 +11,8 @@ while [ -h "$script" ]; do
   esac
 done
 
-root=$(CDPATH= cd -- "$(dirname -- "$script")/.." && pwd)
+# pnpm's global shim enters through a symlinked package directory, so resolve the checkout itself.
+root=$(CDPATH= cd -- "$(dirname -- "$script")/.." && pwd -P)
 entry=$root/apps/cli/dist/ingressMain.js
 
 if [ ! -f "$entry" ]; then

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@ Status: current living doc for development, test, and documentation workflow.
 
 - Use Node.js 24.x and pnpm 11. The root `package.json` pins `node: 24.x`, `pnpm: 11.0.0`, and `packageManager: pnpm@11.0.0`.
 - Use the repo-local command during development: `pnpm stn ...`.
-- Use `pnpm station:link` only when you intentionally want the current checkout linked as the global `stn`.
+- Use `pnpm station:link` only when you intentionally want all three launchers globally bound to the current checkout.
 - External tools are optional unless the lane needs them: Worktrunk for real worktree workflows, tmux for the reference terminal provider, and Claude Code, Codex, Cursor, Pi, or OpenCode for real harness workflows.
 
 ## Local TUI Workflow

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,7 +4,7 @@ This setup path is for a local development checkout. station remains a private w
 
 ## Quick start (macOS)
 
-From a fresh clone, one script installs the system dependencies via Homebrew, builds the workspace, and links the `stn` command:
+From a fresh clone, one script installs the system dependencies via Homebrew, builds the workspace, and links all three checkout launchers onto `PATH`:
 
 ```bash
 ./scripts/setup/bootstrap.sh
@@ -12,7 +12,7 @@ stn setup
 stn
 ```
 
-`bootstrap.sh` runs `brew bundle` (Node 24, Bun, Worktrunk, tmux, diffnav, git-delta), then `pnpm install`, `pnpm build`, the Bun UI install (`cd station && bun install && bun run link:station && bun run repair:node-pty`), and `pnpm link --global`. The Bun step matters: `station/` is a separate Bun workspace, not a pnpm-workspace member, so `pnpm install` never installs it — skip it and bare `stn` refuses to launch with an install hint (the underlying failure is "@opentui not found"). If you manage your own runtimes, the manual steps below are equivalent. A single prebuilt binary is the post-alpha goal — the design and phased roadmap live in [Single-binary Station](single-binary.md); until then, the draft Homebrew tap path is documented in [Homebrew packaging](homebrew.md).
+`bootstrap.sh` runs `brew bundle` (Node 24, Bun, Worktrunk, tmux, diffnav, git-delta), then `pnpm install`, `pnpm build`, the Bun UI install (`cd station && bun install && bun run link:station && bun run repair:node-pty`), and `pnpm station:link`. That final command uses pnpm 11's supported global-add path to expose `stn`, `stn-ingress`, and `stn-tmux-popup` while keeping them bound to the checkout. The Bun step matters: `station/` is a separate Bun workspace, not a pnpm-workspace member, so `pnpm install` never installs it — skip it and bare `stn` refuses to launch with an install hint (the underlying failure is "@opentui not found"). If you manage your own runtimes, the manual steps below are equivalent. A single prebuilt binary is the post-alpha goal — the design and phased roadmap live in [Single-binary Station](single-binary.md); until then, the draft Homebrew tap path is documented in [Homebrew packaging](homebrew.md).
 
 ## Requirements
 
@@ -57,7 +57,7 @@ Optional integrations can be added later.
 
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
-Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. When bare `stn` launchers are not on `PATH`, setup uses launcher paths from the current checkout for generated tmux and hook commands and offers `pnpm --dir <checkout> link --global` as the convenience path for bare terminal commands.
+Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. When bare `stn` launchers are not on `PATH`, setup uses launcher paths from the current checkout for generated tmux and hook commands and offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 
 Useful smoke options:
 
@@ -78,14 +78,14 @@ pnpm stn snapshot --json
 pnpm stn
 ```
 
-or link the built CLI after setup:
+or link all three checkout launchers after setup:
 
 ```bash
 pnpm station:link
 stn doctor
 ```
 
-The tmux popup binding and generated provider hooks no longer require a global link when setup can resolve the current checkout launchers. Linking is still useful when you want to type bare `stn` from arbitrary directories.
+The tmux popup binding and generated provider hooks no longer require a global link when setup can resolve the current checkout launchers. Linking is still useful when you want bare `stn`, `stn-ingress`, and `stn-tmux-popup` from arbitrary directories.
 
 ## Local Real Config
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -284,7 +284,7 @@ node apps/cli/dist/main.js --config /abs/iso-config.toml debug logs
   code (`pnpm build`, or `pnpm dev` which watches `@station/cli`).
 - **Run this checkout's CLI** with `pnpm stn …` or `node apps/cli/dist/main.js …`
   from the worktree root — not a globally-installed `stn`, which may point
-  elsewhere. (`pnpm station:link` mutates the global `stn`; avoid it for isolated dev.)
+  elsewhere. (`pnpm station:link` mutates all three global launchers; avoid it for isolated dev.)
 - **Station (Bun) workspace** is off the pnpm/Node build. After a root `pnpm build`:
   `cd station && bun install && bun run link:station && bun run repair:node-pty`.
   The `bun run station*`/`host*`/`e2e:persist` scripts do the link/repair for you.

--- a/integrations/terminal/tmux/bin/stn-popup
+++ b/integrations/terminal/tmux/bin/stn-popup
@@ -16,7 +16,8 @@ while [ -h "$script" ]; do
     *) script=$script_dir/$link ;;
   esac
 done
-root=$(CDPATH= cd -- "$(dirname -- "$script")/../../../.." 2>/dev/null && pwd || true)
+# pnpm's global shim enters through a symlinked package directory, so resolve the checkout itself.
+root=$(CDPATH= cd -- "$(dirname -- "$script")/../../../.." 2>/dev/null && pwd -P || true)
 
 clear_popup_client_if_current() {
   tmux_bin=$1

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "station:tui-dev": "node scripts/tui-dev.mjs",
     "station:ui-dev": "cd station && bun run dev",
     "stn-ingress": "bin/stn-ingress",
-    "station:link": "pnpm link --global",
+    "station:link": "pnpm add --global .",
     "dev": "node scripts/tui-dev.mjs",
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # One-command setup for a fresh Station checkout (macOS).
-# Installs system dependencies via Homebrew, builds the workspace, and links `stn`.
+# Installs system dependencies via Homebrew, builds the workspace, and links the launchers.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -74,8 +74,8 @@ step "Installing the Station UI (Bun workspace)"
   bun run repair:node-pty
 )
 
-step "Linking 'stn' onto your PATH"
-pnpm link --global
+step "Linking STATION launchers onto your PATH"
+pnpm station:link
 
 cat <<'EOF'
 

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -1,11 +1,147 @@
 import { spawnSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { loadConfig } from "@station/config";
 import { describe, expect, it } from "vitest";
 
 describe("setup core flow e2e", () => {
+  it("bootstraps setup and runs all checkout launchers with the pinned pnpm", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-launcher-install-e2e-"));
+    try {
+      const repoRoot = process.cwd();
+      const home = join(root, "home");
+      const pnpmHome = join(root, "pnpm-home");
+      const bin = join(root, "bin");
+      const pnpmBin = run("/bin/sh", ["-c", "command -v pnpm"], {
+        cwd: repoRoot,
+      }).stdout.trim();
+      await mkdir(bin, { recursive: true });
+      await writeShim(
+        bin,
+        "pnpm",
+        [
+          'case "$1" in',
+          "  install|build) exit 0 ;;",
+          `  station:link) exec ${shellQuote(pnpmBin)} --dir "$PWD" station:link ;;`,
+          `  add|--version) exec ${shellQuote(pnpmBin)} "$@" ;;`,
+          "esac",
+          'echo "unexpected pnpm $*" >&2',
+          "exit 2",
+          "",
+        ].join("\n"),
+      );
+      await writeShim(
+        bin,
+        "brew",
+        [
+          'if [ "$1" = "--version" ]; then echo "Homebrew 4.0.0"; exit 0; fi',
+          'if [ "$1" = "bundle" ]; then exit 0; fi',
+          'if [ "$1 $2" = "--prefix node@24" ]; then exit 1; fi',
+          'echo "unexpected brew $*" >&2',
+          "exit 2",
+          "",
+        ].join("\n"),
+      );
+      await writeShim(bin, "corepack", "exit 0\n");
+      await writeShim(
+        bin,
+        "xcode-select",
+        'if [ "$1" = "-p" ]; then echo "/Library/Developer/CommandLineTools"; exit 0; fi\nexit 2\n',
+      );
+      await writeShim(
+        bin,
+        "bun",
+        'if [ "$1" = "--version" ]; then echo "1.2.0"; exit 0; fi\nexit 0\n',
+      );
+      await writeShim(
+        bin,
+        "wt",
+        'if [ "$1" = "--version" ]; then echo "worktrunk 1.2.3"; exit 0; fi\nexit 0\n',
+      );
+      await writeShim(
+        bin,
+        "tmux",
+        'if [ "$1" = "-V" ]; then echo "tmux 3.5a"; exit 0; fi\nexit 0\n',
+      );
+      await writeShim(
+        bin,
+        "codex",
+        'if [ "$1" = "--version" ]; then echo "codex 0.1.0"; exit 0; fi\nexit 0\n',
+      );
+      await writeShim(bin, "diffnav", "exit 0\n");
+      await writeShim(bin, "delta", "exit 0\n");
+      const env = {
+        ...process.env,
+        HOME: home,
+        PNPM_HOME: pnpmHome,
+        XDG_CONFIG_HOME: join(root, "xdg-config"),
+        XDG_DATA_HOME: join(root, "xdg-data"),
+        XDG_CACHE_HOME: join(root, "xdg-cache"),
+        XDG_STATE_HOME: join(root, "xdg-state"),
+        COREPACK_HOME: join(root, "corepack"),
+        PATH: `${join(pnpmHome, "bin")}:${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+        NO_COLOR: "1",
+        STATION_FAST_POPUP_NO_FALLBACK: "1",
+      };
+      await Promise.all([
+        mkdir(home, { recursive: true }),
+        mkdir(join(pnpmHome, "bin"), { recursive: true }),
+        mkdir(env.XDG_CONFIG_HOME, { recursive: true }),
+        mkdir(env.XDG_DATA_HOME, { recursive: true }),
+        mkdir(env.XDG_CACHE_HOME, { recursive: true }),
+        mkdir(env.XDG_STATE_HOME, { recursive: true }),
+        mkdir(env.COREPACK_HOME, { recursive: true }),
+      ]);
+
+      expect(run("pnpm", ["--version"], { cwd: repoRoot, env }).stdout.trim()).toBe("11.0.0");
+      const bootstrap = run(join(repoRoot, "scripts/setup/bootstrap.sh"), [], { cwd: root, env });
+      expect(bootstrap.stdout).toContain("Linking STATION launchers onto your PATH");
+      expect(bootstrap.stdout).toContain("Station is installed.");
+
+      const globalStation = await findGlobalStationLink(pnpmHome);
+      await expect(realpath(globalStation)).resolves.toBe(repoRoot);
+      expect(run("stn", ["--help"], { cwd: root, env }).stdout).toContain("stn --help");
+
+      const project = join(root, "project");
+      const configPath = join(home, ".config", "station", "config.toml");
+      await mkdir(project, { recursive: true });
+      run("git", ["init", "-b", "main"], { cwd: project, env });
+      const setup = run("stn", ["--config", configPath, "setup", "apply", "--yes", "--no-brew"], {
+        cwd: project,
+        env,
+      });
+      expect(setup.stdout).toContain("Core setup complete.");
+      await expect(readFile(configPath, "utf8")).resolves.toContain("[harness.codex]");
+
+      const ingress = run("stn-ingress", [], { cwd: root, env, allowFailure: true });
+      expect(ingress.status).toBe(1);
+      expect(ingress.stderr).toContain("Usage: stn-ingress [options] <provider> [event]");
+
+      const popup = run("stn-tmux-popup", [], {
+        cwd: root,
+        env: {
+          ...env,
+          STATION_DISABLE_FAST_POPUP: "1",
+          STATION_FAST_POPUP_NO_FALLBACK: "0",
+          STATION_POPUP_FALLBACK_COMMAND: 'printf "stn-tmux-popup ok\\n"',
+        },
+      });
+      expect(popup.stdout.trim()).toBe("stn-tmux-popup ok");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("creates core config from a temp git repo without real external tools", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-setup-e2e-"));
     let passed = false;
@@ -290,6 +426,20 @@ describe("setup core flow e2e", () => {
     }
   });
 });
+
+async function findGlobalStationLink(pnpmHome: string): Promise<string> {
+  const globalRoot = join(pnpmHome, "global", "v11");
+  for (const entry of await readdir(globalRoot)) {
+    const candidate = join(globalRoot, entry, "node_modules", "station");
+    try {
+      await realpath(candidate);
+      return candidate;
+    } catch {
+      // pnpm v11 keeps global installs beside non-package metadata in this directory.
+    }
+  }
+  throw new Error(`Global station link was not found under ${globalRoot}.`);
+}
 
 async function writeShim(bin: string, name: string, body: string): Promise<void> {
   const path = join(bin, name);


### PR DESCRIPTION
## Summary

- replace pnpm 11's removed `pnpm link --global` flow with the supported checkout-bound `pnpm add --global .` mechanism behind `pnpm station:link`
- route bootstrap and guided setup through that canonical script while preserving checkout-local launcher fallback
- resolve launcher roots physically so pnpm's generated global shims execute `stn`, `stn-ingress`, and `stn-tmux-popup` from the intended checkout
- update install/development guidance and add focused planner, fallback, bootstrap, and launcher coverage

## Root cause

pnpm 11 removed `pnpm link --global`, so bootstrap and the guided setup action failed before installing any launchers. The supported global-add replacement creates command shims through a symlinked package directory; the existing launchers retained that logical path, which caused the Node entrypoint guard to skip execution.

## UX impact

Fresh-checkout bootstrap and accepted setup linking now put all three bare launchers on `PATH` and keep them bound to the checkout. If linking is declined or fails, setup still generates hooks and tmux commands with checkout-local launcher paths.

## Validation

- `pnpm build` — 22/22 tasks
- `pnpm typecheck` — 42/42 tasks
- `pnpm lint` — clean
- isolated `pnpm test:unit` — 152 files, 1,197 tests
- `pnpm test:e2e:setup` — 2 files, 8 tests
- isolated pnpm 11 bootstrap/setup proof verifies the global package realpaths to this checkout and all three bare launchers execute

Fixes #87
