### PR TITLE
feat(cli): activate observer config after setup writes

### DIFF
--- a/apps/cli/src/commands/setup/configWriter.ts
+++ b/apps/cli/src/commands/setup/configWriter.ts
@@ -74,7 +74,6 @@ export function renderNewSetupConfig(
     "schema_version = 1",
     "",
     "[observer]",
-    'socket_path = "~/.local/state/station/observer.sock"',
     'state_dir = "~/.local/state/station"',
     "",
     "[defaults]",

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -1,4 +1,7 @@
+import { loadConfig, resolveObserverPaths } from "@station/config";
+import { type RuntimeSafeError, safeErrorFromUnknown } from "@station/runtime";
 import type { CliEnv } from "../../env.js";
+import { restartObserver } from "../../observerProcess.js";
 import type { applySetupPlan } from "./apply.js";
 import { commandEnv } from "./checks/env.js";
 import {
@@ -63,6 +66,77 @@ export function applyOptions(
     };
   }
   return options;
+}
+
+export async function activateCompletedConfigWrite(
+  plan: SetupPlan,
+  homeDir: string,
+  deps: SetupCommandDeps,
+): Promise<RuntimeSafeError | undefined> {
+  const completedWrite = plan.actions.find(
+    (action) => action.kind === "write-config" && action.status === "completed",
+  );
+  if (completedWrite === undefined) {
+    return undefined;
+  }
+
+  await write(deps, "Activating observer configuration...\n");
+  try {
+    if (completedWrite.path === undefined) {
+      throw observerActivationError();
+    }
+    await (deps.activateObserverConfig ?? activateObserverConfig)({
+      configPath: completedWrite.path,
+      homeDir,
+    });
+    await write(deps, "Observer configuration active.\n");
+    return undefined;
+  } catch (error) {
+    const safeError = safeErrorFromUnknown(error, observerActivationError());
+    await write(deps, renderObserverActivationFailure(safeError));
+    return safeError;
+  }
+}
+
+async function activateObserverConfig(input: {
+  configPath: string;
+  homeDir: string;
+}): Promise<void> {
+  try {
+    const loaded = await loadConfig({ configPath: input.configPath, homeDir: input.homeDir });
+    const paths = resolveObserverPaths(loaded.config, input.homeDir);
+    const status = await restartObserver({
+      config: loaded.config,
+      configPath: loaded.configPath,
+      paths,
+    });
+    if (status.status !== "running") {
+      throw safeErrorFromUnknown(status.error, observerActivationError());
+    }
+  } catch (error) {
+    throw safeErrorFromUnknown(error, observerActivationError());
+  }
+}
+
+function observerActivationError(): RuntimeSafeError {
+  return {
+    tag: "ObserverActivationError",
+    code: "OBSERVER_ACTIVATION_FAILED",
+    message: "Observer configuration could not be activated.",
+  };
+}
+
+function renderObserverActivationFailure(error: RuntimeSafeError): string {
+  const lines = [
+    "Config was written, but observer activation failed.",
+    error.message,
+    `Code: ${error.code}`,
+  ];
+  if (error.hint !== undefined) {
+    lines.push(`Hint: ${error.hint}`);
+  }
+  lines.push("Run: stn observer restart", "");
+  return lines.join("\n");
 }
 
 export function dependencyOptionsForCommand(

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -83,7 +83,7 @@ export async function activateCompletedConfigWrite(
   await write(deps, "Activating observer configuration...\n");
   try {
     if (completedWrite.path === undefined) {
-      throw observerActivationError();
+      throw observerActivationError;
     }
     await (deps.activateObserverConfig ?? activateObserverConfig)({
       configPath: completedWrite.path,
@@ -92,7 +92,7 @@ export async function activateCompletedConfigWrite(
     await write(deps, "Observer configuration active.\n");
     return undefined;
   } catch (error) {
-    const safeError = safeErrorFromUnknown(error, observerActivationError());
+    const safeError = safeErrorFromUnknown(error, observerActivationError);
     await write(deps, renderObserverActivationFailure(safeError));
     return safeError;
   }
@@ -111,20 +111,18 @@ async function activateObserverConfig(input: {
       paths,
     });
     if (status.status !== "running") {
-      throw safeErrorFromUnknown(status.error, observerActivationError());
+      throw safeErrorFromUnknown(status.error, observerActivationError);
     }
   } catch (error) {
-    throw safeErrorFromUnknown(error, observerActivationError());
+    throw safeErrorFromUnknown(error, observerActivationError);
   }
 }
 
-function observerActivationError(): RuntimeSafeError {
-  return {
-    tag: "ObserverActivationError",
-    code: "OBSERVER_ACTIVATION_FAILED",
-    message: "Observer configuration could not be activated.",
-  };
-}
+const observerActivationError: RuntimeSafeError = {
+  tag: "ObserverActivationError",
+  code: "OBSERVER_ACTIVATION_FAILED",
+  message: "Observer configuration could not be activated.",
+};
 
 function renderObserverActivationFailure(error: RuntimeSafeError): string {
   const lines = [

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -11,7 +11,12 @@ import {
 } from "./checks/system.js";
 import { renderOptions, write } from "./io.js";
 import type { SetupAction, SetupFacts, SetupMode, SetupPlan } from "./model.js";
-import { renderActionComplete, renderActionFailed, renderActionStart } from "./render.js";
+import {
+  formatCommand,
+  renderActionComplete,
+  renderActionFailed,
+  renderActionStart,
+} from "./render.js";
 import type { SetupCommandDeps, SetupCommandOptions } from "./types.js";
 
 export function collectForCommand(
@@ -93,7 +98,7 @@ export async function activateCompletedConfigWrite(
     return undefined;
   } catch (error) {
     const safeError = safeErrorFromUnknown(error, observerActivationError);
-    await write(deps, renderObserverActivationFailure(safeError));
+    await write(deps, renderObserverActivationFailure(safeError, completedWrite.path));
     return safeError;
   }
 }
@@ -124,7 +129,10 @@ const observerActivationError: RuntimeSafeError = {
   message: "Observer configuration could not be activated.",
 };
 
-function renderObserverActivationFailure(error: RuntimeSafeError): string {
+function renderObserverActivationFailure(
+  error: RuntimeSafeError,
+  configPath: string | undefined,
+): string {
   const lines = [
     "Config was written, but observer activation failed.",
     error.message,
@@ -133,7 +141,11 @@ function renderObserverActivationFailure(error: RuntimeSafeError): string {
   if (error.hint !== undefined) {
     lines.push(`Hint: ${error.hint}`);
   }
-  lines.push("Run: stn observer restart", "");
+  const restartCommand =
+    configPath === undefined
+      ? formatCommand(["stn", "observer", "restart"])
+      : formatCommand(["stn", "--config", configPath, "observer", "restart"]);
+  lines.push(`Run: ${restartCommand}`, "");
   return lines.join("\n");
 }
 

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -1,6 +1,7 @@
 import { applySetupPlan } from "../apply.js";
 import { planSetupConfigWrite } from "../configWriter.js";
 import {
+  activateCompletedConfigWrite,
   applyOptions,
   collectForCommand,
   coreReadyForConfigWrite,
@@ -17,7 +18,7 @@ import {
 } from "../harnessInstall.js";
 import { isSupportedHarnessId, selectSetupHarness } from "../harnessSelection.js";
 import { defaultPrompt, renderOptions, write } from "../io.js";
-import type { SetupAction, SetupFacts } from "../model.js";
+import type { SetupAction, SetupFacts, SetupPlan } from "../model.js";
 import { buildSetupPlan } from "../planner.js";
 import { formatCommand, renderSetupApplyResult, renderSetupPlan } from "../render.js";
 import type {
@@ -119,6 +120,7 @@ async function runGuidedSetupWithPrompt(
   }
 
   const configActions = plan.actions.filter(isConfigAction).filter((action) => action.selected);
+  let writtenPlan: SetupPlan | undefined;
   if (configActions.length > 0) {
     const accepted = await prompt.confirm("Write STATION project config?");
     if (!accepted) {
@@ -133,9 +135,11 @@ async function runGuidedSetupWithPrompt(
       await write(deps, "Config write failed. Run: stn setup plan\n");
       return { code: 1 };
     }
+    writtenPlan = writeResult.plan;
   }
 
   const hookActions = plan.actions.filter(isHookSetupAction).filter((action) => action.selected);
+  let hookInstallFailed = false;
   if (hookActions.length > 0) {
     const hookResult = await applySetupPlan(
       plan,
@@ -147,8 +151,16 @@ async function runGuidedSetupWithPrompt(
     );
     if (hookResult.failedAction !== undefined) {
       await write(deps, "Hook install failed. Fix the install error, then run: stn setup\n");
-      return { code: 1 };
+      hookInstallFailed = true;
     }
+  }
+
+  const activationError =
+    writtenPlan === undefined
+      ? undefined
+      : await activateCompletedConfigWrite(writtenPlan, facts.homeDir, deps);
+  if (hookInstallFailed || activationError !== undefined) {
+    return { code: 1 };
   }
 
   const shellIntegration = plan.actions.find(

--- a/apps/cli/src/commands/setup/flows/nonInteractive.ts
+++ b/apps/cli/src/commands/setup/flows/nonInteractive.ts
@@ -1,6 +1,7 @@
 import { applySetupPlan } from "../apply.js";
 import { planSetupConfigWrite } from "../configWriter.js";
 import {
+  activateCompletedConfigWrite,
   applyOptions,
   collectForCommand,
   coreReadyForConfigWrite,
@@ -56,10 +57,24 @@ export async function runNonInteractiveApply(
     refreshedPlan,
     applyOptions(deps, { actionFilter: isConfigAction, announceActions: true }),
   );
-  const outputPlan =
-    writeResult.failedAction === undefined
-      ? { ...writeResult.plan, summary: { ...writeResult.plan.summary, requiredOk: true } }
-      : writeResult.plan;
+  if (writeResult.failedAction !== undefined) {
+    await write(deps, renderSetupApplyResult(writeResult.plan, renderOptions(deps)));
+    return { code: 1 };
+  }
+
+  const activationError = await activateCompletedConfigWrite(
+    writeResult.plan,
+    refreshedFacts.homeDir,
+    deps,
+  );
+  if (activationError !== undefined) {
+    return { code: 1 };
+  }
+
+  const outputPlan = {
+    ...writeResult.plan,
+    summary: { ...writeResult.plan.summary, requiredOk: true },
+  };
   await write(deps, renderSetupApplyResult(outputPlan, renderOptions(deps)));
-  return { code: writeResult.failedAction === undefined ? 0 : 1 };
+  return { code: 0 };
 }

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -23,6 +23,7 @@ export type SetupCommandDeps = {
   env?: CliEnv;
   cwd?: string;
   homeDir?: string;
+  activateObserverConfig?: (input: { configPath: string; homeDir: string }) => Promise<void>;
   now?: () => Date;
   // Defaults to process.platform; injected by machine-state tests to drive the
   // macOS Command Line Tools check on any host.

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -101,6 +101,7 @@ describe("CLI setup command", () => {
     await mkdir(repo, { recursive: true });
     const calls: ExternalCommandInput[] = [];
     const fs = fakeFs({});
+    let activationCount = 0;
 
     const result = await runCli(
       ["--config", join(root, "config.toml"), "setup", "apply", "--dry-run"],
@@ -125,6 +126,9 @@ describe("CLI setup command", () => {
             "/fake/bin/delta",
           ]),
           fs,
+          activateObserverConfig: async () => {
+            activationCount += 1;
+          },
           writeStdout: () => undefined,
         },
       },
@@ -135,6 +139,107 @@ describe("CLI setup command", () => {
     expect(calls.some((call) => call.command === "brew" && call.args?.[0] === "install")).toBe(
       false,
     );
+    expect(activationCount).toBe(0);
+  });
+
+  it("activates an appended project with the normalized config path and setup home", async () => {
+    const root = await tempRoot(tempRoots);
+    const home = join(root, "home");
+    const repo = join(root, "repo");
+    const otherRepo = join(root, "other");
+    const configPath = join(home, "station", "config.toml");
+    await mkdir(repo, { recursive: true });
+    await mkdir(otherRepo, { recursive: true });
+    const fs = fakeFs({ [configPath]: setupConfigToml(otherRepo, { includeHarness: true }) });
+    const activations: Array<{ configPath: string; homeDir: string }> = [];
+
+    const result = await runCli(["--config", "~/station/config.toml", "setup", "apply", "--yes"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: home,
+        env: { PATH: "/fake/bin" },
+        runner: readySetupRunner(repo),
+        access: readySetupAccess(),
+        fs,
+        activateObserverConfig: async (input) => {
+          expect(fs.files[input.configPath]).toContain(`root = ${JSON.stringify(repo)}`);
+          activations.push(input);
+        },
+        writeStdout: () => undefined,
+      },
+    });
+
+    expect(result.code).toBe(0);
+    expect(activations).toEqual([{ configPath, homeDir: home }]);
+  });
+
+  it("activates a harness-only config write", async () => {
+    const root = await tempRoot(tempRoots);
+    const home = join(root, "home");
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [configPath]: setupConfigToml(repo) });
+    let activationCount = 0;
+
+    const result = await runCli(["--config", configPath, "setup", "apply", "--yes"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: home,
+        env: { PATH: "/fake/bin" },
+        runner: readySetupRunner(repo),
+        access: readySetupAccess(),
+        fs,
+        activateObserverConfig: async () => {
+          activationCount += 1;
+          expect(fs.files[configPath]).toContain("[harness.codex]");
+          expect(fs.files[configPath]?.match(/\[\[projects\]\]/g)).toHaveLength(1);
+        },
+        writeStdout: () => undefined,
+      },
+    });
+
+    expect(result.code).toBe(0);
+    expect(activationCount).toBe(1);
+  });
+
+  it("keeps a successful config write when observer activation fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const home = join(root, "home");
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    const chunks: string[] = [];
+
+    const result = await runCli(["--config", configPath, "setup", "apply", "--yes"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: home,
+        env: { PATH: "/fake/bin" },
+        runner: readySetupRunner(repo),
+        access: readySetupAccess(),
+        fs,
+        activateObserverConfig: async () => {
+          throw {
+            tag: "ObserverStartupError",
+            code: "OBSERVER_EXITED_ON_START",
+            message: "Observer exited during activation.",
+            hint: "Inspect the observer boot log.",
+          };
+        },
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    });
+
+    const output = chunks.join("");
+    expect(result.code).toBe(1);
+    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(output).toContain("Config was written, but observer activation failed.");
+    expect(output).toContain("Code: OBSERVER_EXITED_ON_START");
+    expect(output).toContain("Hint: Inspect the observer boot log.");
+    expect(output).toContain("Run: stn observer restart");
+    expect(output).not.toContain("Core setup complete.");
   });
 
   it("rejects bare setup --dry-run without writing files", async () => {
@@ -362,6 +467,48 @@ function fakeAccess(paths: readonly string[]): (path: string) => Promise<void> {
       throw Object.assign(new Error(`missing path: ${path}`), { code: "ENOENT" });
     }
   };
+}
+
+function readySetupRunner(repo: string) {
+  return fakeRunner([], {
+    "git rev-parse --show-toplevel": `${repo}\n`,
+    "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+    "wt --version": "worktrunk 1.2.3\n",
+    "tmux -V": "tmux 3.5a\n",
+    "brew --version": "Homebrew 4.0.0\n",
+    "codex --version": "codex 0.1.0\n",
+  });
+}
+
+function readySetupAccess(): (path: string) => Promise<void> {
+  return fakeAccess([
+    "/fake/bin/wt",
+    "/fake/bin/tmux",
+    "/fake/bin/bun",
+    "/fake/bin/diffnav",
+    "/fake/bin/delta",
+  ]);
+}
+
+function setupConfigToml(projectRoot: string, options: { includeHarness?: boolean } = {}): string {
+  return [
+    "schema_version = 1",
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    'harness = "codex"',
+    'layout = "agent-shell"',
+    "",
+    ...(options.includeHarness === true
+      ? ["[harness.codex]", "enabled = true", 'command = "codex"', ""]
+      : []),
+    "[[projects]]",
+    `id = ${JSON.stringify(basename(projectRoot))}`,
+    `label = ${JSON.stringify(basename(projectRoot))}`,
+    `root = ${JSON.stringify(projectRoot)}`,
+    "",
+  ].join("\n");
 }
 
 function readOnlyFs(files: Record<string, string>) {

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -207,7 +207,7 @@ describe("CLI setup command", () => {
     const root = await tempRoot(tempRoots);
     const home = join(root, "home");
     const repo = join(root, "repo");
-    const configPath = join(root, "config.toml");
+    const configPath = join(root, "custom config.toml");
     await mkdir(repo, { recursive: true });
     const fs = fakeFs({});
     const chunks: string[] = [];
@@ -238,7 +238,7 @@ describe("CLI setup command", () => {
     expect(output).toContain("Config was written, but observer activation failed.");
     expect(output).toContain("Code: OBSERVER_EXITED_ON_START");
     expect(output).toContain("Hint: Inspect the observer boot log.");
-    expect(output).toContain("Run: stn observer restart");
+    expect(output).toContain(`Run: stn --config '${configPath}' observer restart`);
     expect(output).not.toContain("Core setup complete.");
   });
 

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfigFromToml } from "@station/config";
+import { emptyConfig, loadConfigFromToml, resolveObserverPaths } from "@station/config";
 import { afterEach, describe, expect, it } from "vitest";
 import { planSetupConfigWrite } from "../../src/commands/setup/configWriter.js";
 import type { SetupFacts } from "../../src/commands/setup/model.js";
@@ -31,6 +31,7 @@ describe("setup config writer", () => {
 
     expect(write.operation).toBe("create");
     if (write.operation !== "create") throw new Error("expected create plan");
+    expect(write.content).not.toMatch(/^socket_path\s*=/m);
     const loaded = await loadConfigFromToml(write.content, {
       configPath: write.path,
       homeDir: root,
@@ -45,6 +46,43 @@ describe("setup config writer", () => {
       id: "repo",
       root: repo,
     });
+  });
+
+  it("keeps generated config on the first-run observer socket", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const write = await planSetupConfigWrite(
+      setupFacts(repo, {
+        config: {
+          status: "missing",
+          path: join(root, "config.toml"),
+          message: "missing",
+        },
+      }),
+    );
+
+    expect(write.operation).toBe("create");
+    if (write.operation !== "create") throw new Error("expected create plan");
+    const loaded = await loadConfigFromToml(write.content, {
+      configPath: write.path,
+      homeDir: root,
+    });
+    const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
+
+    try {
+      for (const runtimeDir of [undefined, join(root, "runtime")]) {
+        if (runtimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+        else process.env.XDG_RUNTIME_DIR = runtimeDir;
+
+        expect(resolveObserverPaths(loaded.config, root).socketPath).toBe(
+          resolveObserverPaths(emptyConfig(), root).socketPath,
+        );
+      }
+    } finally {
+      if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
+    }
   });
 
   it("writes hook flags when guided setup accepts hooks", async () => {

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -21,6 +21,7 @@ describe("guided setup command", () => {
     const calls: ExternalCommandInput[] = [];
     const fs = fakeFs({});
     const chunks: string[] = [];
+    const activations: { configPath: string; homeDir: string }[] = [];
 
     const result = await runSetupCommand(
       [],
@@ -45,6 +46,10 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: async (input) => {
+          expect(fs.files[input.configPath]).toContain("[[projects]]");
+          activations.push(input);
+        },
         prompt: prompt({ confirms: [false, false, true, false, false] }),
         writeStdout: (chunk) => chunks.push(chunk),
         now: () => new Date("2026-06-08T12:00:00.000Z"),
@@ -54,8 +59,10 @@ describe("guided setup command", () => {
     expect(result.code).toBe(0);
     const configPath = join(root, "home/.config/station/config.toml");
     expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(activations).toEqual([{ configPath, homeDir: join(root, "home") }]);
     expect(chunks.join("")).toContain(`Applying: Write STATION config (${configPath})`);
     expect(chunks.join("")).toContain("Completed: Write STATION config");
+    expect(chunks.join("")).toContain("Observer configuration active.");
     expect(chunks.join("")).toContain("Core setup complete.");
   });
 
@@ -90,6 +97,7 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, true, false] }),
         writeStdout: (chunk) => chunks.push(chunk),
       },
@@ -109,6 +117,7 @@ describe("guided setup command", () => {
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
     const fs = fakeFs({});
+    let activations = 0;
 
     const result = await runSetupCommand(
       [],
@@ -132,6 +141,9 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+        },
         prompt: prompt({ confirms: [false, false, false] }),
         writeStdout: () => undefined,
       },
@@ -139,6 +151,115 @@ describe("guided setup command", () => {
 
     expect(result.code).toBe(1);
     expect(Object.keys(fs.files)).toEqual([]);
+    expect(activations).toBe(0);
+  });
+
+  it("does not activate when the existing config needs no write", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [configPath]: configuredProjectToml(repo) });
+    let activations = 0;
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        ...readySetupDeps(repo),
+        fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+        },
+        prompt: prompt({ confirms: [false, false] }),
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(activations).toBe(0);
+    expect(fs.files[configPath]).toBe(configuredProjectToml(repo));
+  });
+
+  it("does not activate when the config write fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    fs.rename = async () => {
+      throw new Error("synthetic rename failure");
+    };
+    let activations = 0;
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        ...readySetupDeps(repo),
+        fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+        },
+        prompt: prompt({ confirms: [false, false, true] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    expect(result.code).toBe(1);
+    expect(activations).toBe(0);
+    expect(fs.files[join(root, "home/.config/station/config.toml")]).toBeUndefined();
+    expect(chunks.join("")).toContain("Config write failed.");
+  });
+
+  it("retains config and reports observer activation failure", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "home/.config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    const chunks: string[] = [];
+    let activations = 0;
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        ...readySetupDeps(repo),
+        fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+          throw {
+            tag: "ObserverStartupError",
+            code: "TEST_ACTIVATION_FAILED",
+            message: "The observer did not become healthy.",
+            hint: "Inspect observer logs.",
+          };
+        },
+        prompt: prompt({ confirms: [false, false, true] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    const output = chunks.join("");
+    expect(result.code).toBe(1);
+    expect(activations).toBe(1);
+    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(output).toContain("Config was written, but observer activation failed.");
+    expect(output).toContain("Code: TEST_ACTIVATION_FAILED");
+    expect(output).toContain("Hint: Inspect observer logs.");
+    expect(output).toContain("Run: stn observer restart");
+    expect(output).not.toContain("Core setup complete.");
   });
 
   it("selects among multiple available harnesses", async () => {
@@ -170,6 +291,7 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, false], selects: ["opencode"] }),
         writeStdout: () => undefined,
       },
@@ -208,6 +330,7 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, true] }),
         writeStdout: () => undefined,
       },
@@ -224,6 +347,16 @@ describe("guided setup command", () => {
     const fs = fakeFs({});
     const calls: ExternalCommandInput[] = [];
     const configPath = join(root, "home/.config/station/config.toml");
+    const order: string[] = [];
+    const runner = fakeRunner(calls, {
+      "git rev-parse --show-toplevel": repo,
+      "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      "wt --version": "worktrunk 1.2.3\n",
+      "tmux -V": "tmux 3.5a\n",
+      "codex --version": "codex 0.1.0\n",
+      [`stn --config ${configPath} hooks install worktrunk --yes --hook-bin stn-ingress`]: "",
+      [`stn --config ${configPath} hooks install codex --yes --hook-bin stn-ingress`]: "",
+    });
 
     const result = await runSetupCommand(
       [],
@@ -232,15 +365,13 @@ describe("guided setup command", () => {
         cwd: repo,
         homeDir: join(root, "home"),
         env: { PATH: "/fake/bin" },
-        runner: fakeRunner(calls, {
-          "git rev-parse --show-toplevel": repo,
-          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
-          "wt --version": "worktrunk 1.2.3\n",
-          "tmux -V": "tmux 3.5a\n",
-          "codex --version": "codex 0.1.0\n",
-          [`stn --config ${configPath} hooks install worktrunk --yes --hook-bin stn-ingress`]: "",
-          [`stn --config ${configPath} hooks install codex --yes --hook-bin stn-ingress`]: "",
-        }),
+        runner: async (input) => {
+          const result = await runner(input);
+          if (input.command === "stn" && input.args?.[2] === "hooks") {
+            order.push(`hook:${input.args[4]}`);
+          }
+          return result;
+        },
         access: fakeAccess([
           "/fake/bin/wt",
           "/fake/bin/tmux",
@@ -252,12 +383,16 @@ describe("guided setup command", () => {
           "/fake/bin/stn-tmux-popup",
         ]),
         fs,
+        activateObserverConfig: async () => {
+          order.push("activate");
+        },
         prompt: prompt({ confirms: [true, true, true, false, false] }),
         writeStdout: () => undefined,
       },
     );
 
     expect(result.code).toBe(0);
+    expect(order).toEqual(["hook:worktrunk", "hook:codex", "activate"]);
     expect(fs.files[configPath]).toContain("use_lifecycle_hooks = true");
     expect(fs.files[configPath]).toContain("install_hooks = true");
     expect(calls).toEqual(
@@ -292,6 +427,57 @@ describe("guided setup command", () => {
         }),
       ]),
     );
+  });
+
+  it("attempts activation after a hook install fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "home/.config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    const chunks: string[] = [];
+    let activations = 0;
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
+        ]),
+        fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+        },
+        prompt: prompt({ confirms: [true, false, true] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    const output = chunks.join("");
+    expect(result.code).toBe(1);
+    expect(activations).toBe(1);
+    expect(fs.files[configPath]).toContain("use_lifecycle_hooks = true");
+    expect(output).toContain("Hook install failed.");
+    expect(output).toContain("Observer configuration active.");
+    expect(output).not.toContain("Core setup complete.");
   });
 
   it("installs a selected agent CLI when no harness is available, then continues", async () => {
@@ -335,6 +521,7 @@ describe("guided setup command", () => {
           "/fake/bin/delta",
         ]),
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         // Accept the Codex install and the config write; decline the rest. Match on
         // message text so the test is robust to the exact prompt count (e.g. which
         // optional prompts fire depends on launcher detection on the host).
@@ -620,6 +807,7 @@ describe("guided setup command", () => {
           }
         },
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         // Accept the bootstrap, the core-tool installs, and the config write; decline
         // every optional extra. Matching on text keeps this robust to prompt ordering.
         prompt: {
@@ -746,6 +934,7 @@ describe("guided setup command", () => {
           }
         },
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         prompt: {
           async confirm(message: string) {
             return (
@@ -788,6 +977,52 @@ function prompt(input: { confirms: boolean[]; selects?: string[] }): SetupPrompt
       return selects.shift() ?? "codex";
     },
   };
+}
+
+function readySetupDeps(repo: string) {
+  return {
+    runner: fakeRunner([], {
+      "git rev-parse --show-toplevel": repo,
+      "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      "wt --version": "worktrunk 1.2.3\n",
+      "tmux -V": "tmux 3.5a\n",
+      "brew --version": "Homebrew 4.0.0\n",
+      "codex --version": "codex 0.1.0\n",
+    }),
+    access: fakeAccess([
+      "/fake/bin/wt",
+      "/fake/bin/tmux",
+      "/fake/bin/bun",
+      "/fake/bin/diffnav",
+      "/fake/bin/delta",
+    ]),
+  };
+}
+
+function configuredProjectToml(repo: string): string {
+  return [
+    "schema_version = 1",
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    'harness = "codex"',
+    'layout = "agent-shell"',
+    "",
+    "[harness.codex]",
+    "enabled = true",
+    'command = "codex"',
+    "",
+    "[[projects]]",
+    'id = "repo"',
+    'label = "repo"',
+    `root = ${JSON.stringify(repo)}`,
+    "",
+  ].join("\n");
+}
+
+function noopActivateObserverConfig(): Promise<void> {
+  return Promise.resolve();
 }
 
 function fakeRunner(

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -258,7 +258,7 @@ describe("guided setup command", () => {
     expect(output).toContain("Config was written, but observer activation failed.");
     expect(output).toContain("Code: TEST_ACTIVATION_FAILED");
     expect(output).toContain("Hint: Inspect observer logs.");
-    expect(output).toContain("Run: stn observer restart");
+    expect(output).toContain(`Run: stn --config ${configPath} observer restart`);
     expect(output).not.toContain("Core setup complete.");
   });
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,12 @@ If you only ever edit one thing, it is `~/.config/station/config.toml`.
 If that default file does not exist yet, `stn` and its `tui`/`popup` launch
 routes use in-memory first-run defaults, ensure the observer, and show the
 existing empty-state UI. They do not create a config file; `stn setup` remains
-the writer. This exception applies only to the implicit default path: a missing
-explicit `--config`, an unreadable file, malformed TOML, or invalid config still
-stops launch with an error.
+the writer. After every successful guided or non-interactive setup config write,
+setup starts or restarts the observer and waits for it to become healthy with
+the updated configuration. If activation fails, setup retains the config, exits
+nonzero, and points to `stn observer restart`. This exception applies only to the
+implicit default path: a missing explicit `--config`, an unreadable file,
+malformed TOML, or invalid config still stops launch with an error.
 
 > The annotated `examples/config.toml` is the copy-paste starting point;
 > `examples/project-local-config.toml` shows the project-local file. This page is

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -360,23 +360,20 @@ schema-mismatch UX — never an out-of-band kill.
 
 ### B-config — config activation (F4 — v1 was wrong)
 
-v1 claimed B3 closes the "config-less observer keeps serving
-`emptyConfig()` after `stn setup`" gap. It does not: B3 restarts only an
-**older-version** observer, so a same-version first-run `setup` leaves the
-observer on `emptyConfig()` indefinitely. Fix, one of (pick in
-implementation, prefer the first):
+**Status: implemented.** Guided `stn setup` and non-interactive
+`stn setup apply --yes` activate every successfully written config, including
+harness-only changes. Setup loads the completed file with its normalized path
+and setup home, resolves its observer paths, and starts or restarts the observer
+through the stable lifecycle facade. Completion is reported only after the
+observer is running with the written config. Activation stays outside the apply
+engine, so a lifecycle failure retains the successful write, exits nonzero,
+preserves the lifecycle error, and points to `stn observer restart`.
 
-1. **`stn setup` explicitly reloads/restarts the observer** on writing a
-   config that changes project membership — a targeted `restartObserver`
-   (same-version safe: stop via RPC works) after `configWriter` succeeds,
-   with a user-visible line.
-2. **Health exposes configuration identity** (config path + a content hash);
-   the CLI restarts when the running observer's config identity differs from
-   the on-disk config. This also generalizes to external edits.
-
-Either way, the first-run flow must guarantee the observer reflects the new
-project without a manual restart — that is the headline UX and must be in
-the acceptance suite.
+New setup configs omit `observer.socket_path` while retaining
+`observer.state_dir`. Config-less and configured startup therefore resolve the
+same default or XDG socket, so an open TUI reconnects to the configured observer
+without manual intervention. Existing configs and explicit socket overrides are
+untouched.
 
 ### B3 — version + schema UX (scoped down)
 
@@ -446,8 +443,9 @@ flow:
 1. Launch bare `stn` outside tmux in a sanitized, isolated env → real
    OpenTUI renderer draws, observer connects, first-run screen shows.
 2. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
-3. Run `stn setup` adding a project → the **same** observer reflects the new
-   project immediately (B-config), no manual restart.
+3. Run `stn setup` adding a project → the observer restarts on the **same
+   socket** and reflects the new project immediately (B-config); an open TUI
+   reconnects without a manual restart.
 4. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
 5. `stn-ingress` symlink delivers a provider hook event end to end.
 6. Upgrade the binary while **live host PTYs** exist → reattach without

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -3,11 +3,16 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { loadConfig } from "@station/config";
+import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
+import { waitForSocketClosed } from "../support/sockets";
 
 describe("setup core flow e2e", () => {
   it("creates core config from a temp git repo without real external tools", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-setup-e2e-"));
+    const runtimeDir = await mkdtemp(join(tmpdir(), "stn-r-"));
+    const observerSocket = join(runtimeDir, "station", "observer.sock");
+    const legacyObserverSocket = join(root, "home", ".local", "state", "station", "observer.sock");
     let passed = false;
     try {
       const home = join(root, "home");
@@ -46,9 +51,20 @@ describe("setup core flow e2e", () => {
       const env = {
         ...process.env,
         HOME: home,
+        XDG_RUNTIME_DIR: runtimeDir,
         PATH: `${bin}:${process.env.PATH ?? ""}`,
+        TMUX: "",
+        STATION_DASHBOARD_COMMAND: "true",
         STATION_FAST_POPUP_NO_FALLBACK: "1",
       };
+      const launch = runStation([], { cwd: repo, env });
+      expect(launch.status).toBe(0);
+      const observer = createObserverClient({ socketPath: observerSocket, timeoutMs: 1000 });
+      const beforeHealth = await observer.health();
+      const beforeSnapshot = await observer.getSnapshot();
+      expect(beforeHealth.pid).toBeTypeOf("number");
+      expect(beforeSnapshot).toMatchObject({ counts: { projects: 0 }, projects: [] });
+
       const firstCheck = runStation(["--config", configPath, "setup", "check", "--json"], {
         cwd: repo,
         env,
@@ -82,6 +98,15 @@ describe("setup core flow e2e", () => {
       expect(apply.stdout).toContain("Core setup complete.");
       await expect(readFile(configPath, "utf8")).resolves.toContain("[harness.codex]");
 
+      const afterHealth = await observer.health();
+      const afterSnapshot = await observer.getSnapshot();
+      expect(afterHealth.pid).toBeTypeOf("number");
+      expect(afterHealth.pid).not.toBe(beforeHealth.pid);
+      expect(afterSnapshot.projects).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: "repo" })]),
+      );
+      expect(afterSnapshot.counts.projects).toBe(1);
+
       const finalCheck = runStation(["--config", configPath, "setup", "check", "--json"], {
         cwd: repo,
         env,
@@ -99,14 +124,21 @@ describe("setup core flow e2e", () => {
       });
       passed = true;
     } finally {
+      await stopObserverCandidates([observerSocket, legacyObserverSocket]);
       if (passed || process.env.STATION_KEEP_SETUP_E2E_TEMP !== "1") {
-        await rm(root, { recursive: true, force: true });
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          rm(runtimeDir, { recursive: true, force: true }),
+        ]);
       }
     }
   });
 
   it("preserves custom Worktrunk and tmux commands in generated config", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-setup-e2e-"));
+    const runtimeDir = await mkdtemp(join(tmpdir(), "stn-r-"));
+    const observerSocket = join(runtimeDir, "station", "observer.sock");
+    const legacyObserverSocket = join(root, "home", ".local", "state", "station", "observer.sock");
     let passed = false;
     try {
       const home = join(root, "home");
@@ -142,6 +174,7 @@ describe("setup core flow e2e", () => {
       const env = {
         ...process.env,
         HOME: home,
+        XDG_RUNTIME_DIR: runtimeDir,
         PATH: `${bin}:${process.env.PATH ?? ""}`,
         STATION_FAST_POPUP_NO_FALLBACK: "1",
         STATION_WORKTRUNK_BIN: customWt,
@@ -158,8 +191,12 @@ describe("setup core flow e2e", () => {
       expect(config).toContain(`[terminal.tmux]\ncommand = ${JSON.stringify(customTmux)}`);
       passed = true;
     } finally {
+      await stopObserverCandidates([observerSocket, legacyObserverSocket]);
       if (passed || process.env.STATION_KEEP_SETUP_E2E_TEMP !== "1") {
-        await rm(root, { recursive: true, force: true });
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          rm(runtimeDir, { recursive: true, force: true }),
+        ]);
       }
     }
   });
@@ -295,6 +332,14 @@ async function writeShim(bin: string, name: string, body: string): Promise<void>
   const path = join(bin, name);
   await writeFile(path, `#!/bin/sh\n${body}`, "utf8");
   await chmod(path, 0o700);
+}
+
+async function stopObserverCandidates(socketPaths: readonly string[]): Promise<void> {
+  for (const socketPath of new Set(socketPaths)) {
+    const client = createObserverClient({ socketPath, timeoutMs: 1000 });
+    await client.stop().catch(() => undefined);
+    await waitForSocketClosed(socketPath, { timeoutMs: 5000 });
+  }
 }
 
 function runStation(

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -42,6 +42,7 @@ describe("setup core flow e2e", () => {
         "brew",
         'if [ "$1" = "--version" ]; then echo "Homebrew 4.0.0"; exit 0; fi\nexit 0\n',
       );
+      await writeShim(bin, "npm", "echo 0.1.0\n");
       // diffnav + delta are required; the checks only need the binaries on PATH.
       await writeShim(bin, "diffnav", "exit 0\n");
       await writeShim(bin, "delta", "exit 0\n");
@@ -165,6 +166,7 @@ describe("setup core flow e2e", () => {
         "codex",
         'if [ "$1" = "--version" ]; then echo "codex 0.1.0"; exit 0; fi\nexit 0\n',
       );
+      await writeShim(bin, "npm", "echo 0.1.0\n");
       // diffnav + delta are required; without them config write is blocked.
       await writeShim(bin, "diffnav", "exit 0\n");
       await writeShim(bin, "delta", "exit 0\n");

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -2,7 +2,9 @@ import { spawn } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
+import { waitForSocketClosed } from "../support/sockets";
 
 describe("setup guided feedback e2e", () => {
   it("exits instead of hanging when every agent install choice is declined", async () => {
@@ -92,6 +94,7 @@ type Fixture = {
 
 async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> {
   const root = await mkdtemp(join(tmpdir(), "station-setup-guided-feedback-"));
+  const runtimeDir = await mkdtemp(join(tmpdir(), "stn-setup-run-"));
   const home = join(root, "home");
   const repo = join(root, "repo");
   const bin = join(root, "bin");
@@ -170,6 +173,7 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
 
   const env: NodeJS.ProcessEnv = {
     HOME: home,
+    XDG_RUNTIME_DIR: runtimeDir,
     PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
     NO_COLOR: "1",
     STATION_WORKTRUNK_BIN: "wt",
@@ -191,9 +195,31 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
     configPath,
     env,
     async cleanup() {
-      await rm(root, { recursive: true, force: true });
+      try {
+        await stopObservers([
+          join(runtimeDir, "station", "observer.sock"),
+          join(home, ".local", "state", "station", "observer.sock"),
+        ]);
+      } finally {
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          rm(runtimeDir, { recursive: true, force: true }),
+        ]);
+      }
     },
   };
+}
+
+async function stopObservers(socketPaths: readonly string[]): Promise<void> {
+  const results = await Promise.allSettled(
+    socketPaths.map(async (socketPath) => {
+      const client = createObserverClient({ socketPath, timeoutMs: 1_000 });
+      await client.stop().catch(() => undefined);
+      await waitForSocketClosed(socketPath, { timeoutMs: 5_000 });
+    }),
+  );
+  const failed = results.find((result) => result.status === "rejected");
+  if (failed?.status === "rejected") throw failed.reason;
 }
 
 async function writeCodexShim(bin: string): Promise<void> {
@@ -226,7 +252,7 @@ function runStation(
     timeoutMs?: number;
   },
 ): Promise<StationProcessResult> {
-  const timeoutMs = options.timeoutMs ?? 5_000;
+  const timeoutMs = options.timeoutMs ?? 15_000;
   return new Promise((resolve) => {
     const child = spawn(join(process.cwd(), "bin", "stn"), [...args], {
       cwd: options.cwd,


### PR DESCRIPTION
This changes setup so every successful config write starts or restarts the observer with the exact written config.

That keeps an already-open TUI attached to the configured observer immediately after setup, instead of requiring a manual restart.

Validation: `pnpm build`, focused setup unit and integration tests, `pnpm test:e2e:setup`, `pnpm lint`, and `HOME="$(mktemp -d)" pnpm test:all` all passed.

UX: run `stn setup` from a fresh state, then the observer should come back on the same socket and show the new project without `stn observer restart`.
