### PR TITLE
fix(observer): inject managed terminal lifecycle

### DIFF
--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -59,6 +59,11 @@ export type CreateProviderRegistryOptions = {
   commandTimeoutMs?: number | undefined;
 };
 
+/**
+ * COMPOSITION ROOT
+ *
+ * Constructs concrete integrations and assigns application roles for the observer.
+ */
 export function createProviderRegistry(
   config: StationConfig,
   options: CreateProviderRegistryOptions = {},
@@ -97,7 +102,7 @@ export function createProviderRegistry(
   return new ProviderRegistry({
     worktree,
     terminal,
-    terminals: [station],
+    managedTerminal: station,
     harnesses: harnessMap,
     repositories,
     hookAdapters: [

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -10,6 +10,22 @@ import { createProviderRegistry } from "../../src/observerProviders";
 const now = "2026-05-21T12:00:00.000Z";
 
 describe("observer providers", () => {
+  it("assigns one Station adapter to the managed lifecycle and terminal registry", () => {
+    const registry = createProviderRegistry(config);
+    const managedTerminal = registry.managedTerminal;
+
+    expect(managedTerminal).toBeDefined();
+    if (managedTerminal === undefined) {
+      throw new Error("managed terminal lifecycle was not registered");
+    }
+    expect(registry.terminals.get(managedTerminal.id)).toBe(managedTerminal);
+    expect(
+      [...registry.terminals.values()].filter((provider) => provider === managedTerminal),
+    ).toEqual([managedTerminal]);
+    expect(registry.defaultTerminalId).toBe(config.defaults.terminal);
+    expect(registry.terminal).not.toBe(managedTerminal);
+  });
+
   it("keeps explicit noop providers healthy for empty/test startup", async () => {
     const registry = createProviderRegistry({
       ...config,

--- a/apps/observer/src/providers/registry.ts
+++ b/apps/observer/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import type {
   HarnessProvider,
   HarnessVersionInfo,
+  ManagedTerminalLifecycle,
   ProviderHealth,
   ProviderHookAdapter,
   ProviderId,
@@ -16,13 +17,26 @@ import {
 } from "./healthCache.js";
 import { createTerminalIntentRunner, type TerminalIntentRunner } from "./terminalIntentRunner.js";
 
+function registerTerminal(
+  terminals: Map<string, TerminalProvider>,
+  provider: TerminalProvider,
+): void {
+  const registered = terminals.get(provider.id);
+  if (registered !== undefined && registered !== provider) {
+    throw new Error(`Duplicate terminal provider id: ${provider.id}`);
+  }
+  terminals.set(provider.id, provider);
+}
+
 export type ProviderRegistryInput = {
   worktree: WorktreeProvider;
   /** The default terminal provider (used for project-config back-compat). */
   terminal: TerminalProvider;
+  /** Terminal lifecycle used by Station's external-launch handshake. */
+  managedTerminal?: ManagedTerminalLifecycle | undefined;
   /**
-   * Additional terminal providers beyond the default (e.g. the externally-hosted
-   * "station" provider). The default is always registered; extras are merged in.
+   * Additional general terminal providers beyond the default. The default and
+   * managed lifecycle are always registered; extras are merged in.
    */
   terminals?: Iterable<TerminalProvider> | undefined;
   harnesses: Iterable<HarnessProvider> | Map<string, HarnessProvider>;
@@ -38,6 +52,7 @@ export class ProviderRegistry {
   readonly terminals: Map<string, TerminalProvider>;
   /** The default terminal provider id (project-config back-compat). */
   readonly defaultTerminalId: ProviderId;
+  readonly managedTerminal: ManagedTerminalLifecycle | undefined;
   readonly harnesses: Map<string, HarnessProvider>;
   readonly repositories: Map<string, RepositoryProvider>;
   readonly hookAdapters: Map<string, ProviderHookAdapter>;
@@ -48,12 +63,14 @@ export class ProviderRegistry {
     this.worktree = input.worktree;
 
     this.defaultTerminalId = input.terminal.id;
-    this.terminals = new Map([[input.terminal.id, input.terminal]]);
+    this.terminals = new Map();
+    registerTerminal(this.terminals, input.terminal);
     for (const provider of input.terminals ?? []) {
-      if (this.terminals.has(provider.id)) {
-        throw new Error(`Duplicate terminal provider id: ${provider.id}`);
-      }
-      this.terminals.set(provider.id, provider);
+      registerTerminal(this.terminals, provider);
+    }
+    this.managedTerminal = input.managedTerminal;
+    if (this.managedTerminal !== undefined) {
+      registerTerminal(this.terminals, this.managedTerminal);
     }
 
     if (input.harnesses instanceof Map) {

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -1,9 +1,4 @@
-import type {
-  SafeError,
-  TerminalProvider,
-  TerminalReattachCapability,
-  TerminalTargetId,
-} from "@station/contracts";
+import type { ManagedTerminalLifecycle, SafeError, TerminalTargetId } from "@station/contracts";
 import { terminalTargetObservationFromBinding, worktreeHasLiveAgent } from "@station/contracts";
 import type {
   AgentPrepareExternalLaunchParams,
@@ -29,48 +24,15 @@ import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import { nowIso } from "../utils/time.js";
 
-/**
- * The terminal provider id used for externally-hosted (Station-owned) targets.
- * Kept in sync with `@station/terminal`'s provider id by value, NOT by
- * import, so the observer stays free of `integrations/terminal/*` imports.
- */
-const EXTERNAL_TERMINAL_PROVIDER_ID = "native";
-
-type MarkExitableTerminalProvider = TerminalProvider & {
-  markExited(targetId: string): boolean;
-};
-
-function canMarkExited(provider: TerminalProvider): provider is MarkExitableTerminalProvider {
-  return typeof (provider as Partial<MarkExitableTerminalProvider>).markExited === "function";
-}
-
-/** Runtime feature-detect — the registry holds bare `TerminalProvider`; only the
- *  host-backed `native` provider implements `reattachInfo`. */
-function isReattachable(
-  provider: TerminalProvider,
-): provider is TerminalProvider & TerminalReattachCapability {
-  return "reattachInfo" in provider;
-}
-
-/**
- * Build a reattach handle if a live host PTY backs this worktree's Station target.
- * Stays decoupled from `@station/terminal`: the target id is derived by value
- * and `reattachInfo` is the optional persistence capability (absent ⇒ no handle,
- * the UI spawns the PTY locally).
- */
 async function resolveReattachHandle(
-  station: TerminalProvider,
-  worktreeId: string,
+  managedTerminal: ManagedTerminalLifecycle,
+  targetId: TerminalTargetId,
 ): Promise<AgentReattachHandle | undefined> {
-  if (!isReattachable(station)) {
-    return undefined;
-  }
-  const terminalTargetId = `${EXTERNAL_TERMINAL_PROVIDER_ID}:${worktreeId}` as TerminalTargetId;
-  const info = await station.reattachInfo(terminalTargetId);
+  const info = await managedTerminal.reattachInfo(targetId);
   if (info === undefined) {
     return undefined;
   }
-  return { ptyId: info.endpointId, terminalTargetId, hostSocketPath: info.socketPath };
+  return { ptyId: info.endpointId, terminalTargetId: targetId, hostSocketPath: info.socketPath };
 }
 
 export type ExternalLaunchDeps = {
@@ -88,8 +50,10 @@ export type ExternalLaunchOutcome<T> = {
 };
 
 /**
- * Prepare Station-hosted agent identity and launch plan without spawning; the
- * in-memory station target lets reconcile surface the session immediately.
+ * USE CASE
+ *
+ * Prepare Station-hosted agent identity, launch plan, and managed process handoff;
+ * the managed target lets reconcile surface the session immediately.
  */
 export async function prepareExternalLaunch(
   deps: ExternalLaunchDeps,
@@ -112,11 +76,18 @@ export async function prepareExternalLaunch(
     if (agent?.sessionId === undefined) {
       throw sessionAlreadyHasAgentError(row.id);
     }
-    const reattachStation = deps.providers.terminals.get(EXTERNAL_TERMINAL_PROVIDER_ID);
-    const reattachHandle =
-      reattachStation === undefined
+    const managedTerminal = deps.providers.managedTerminal;
+    const managedTarget =
+      managedTerminal === undefined
         ? undefined
-        : await resolveReattachHandle(reattachStation, params.worktreeId);
+        : (await managedTerminal.listTargets()).find(
+            (target) =>
+              target.worktreeId === params.worktreeId && target.sessionId === agent.sessionId,
+          );
+    const reattachHandle =
+      managedTerminal === undefined || managedTarget === undefined
+        ? undefined
+        : await resolveReattachHandle(managedTerminal, managedTarget.id);
     return {
       outcome: {
         kind: "existing-session",
@@ -154,9 +125,9 @@ export async function prepareExternalLaunch(
     deps.configPath === undefined ? {} : { stationConfigPath: deps.configPath },
   );
 
-  const station = deps.providers.terminals.get(EXTERNAL_TERMINAL_PROVIDER_ID);
-  if (station === undefined) {
-    throw externalProviderUnavailableError();
+  const managedTerminal = deps.providers.managedTerminal;
+  if (managedTerminal === undefined) {
+    throw managedTerminalUnavailableError();
   }
 
   // The snapshot's `row.agent` lags a concurrent prepare's registration (it is
@@ -166,20 +137,20 @@ export async function prepareExternalLaunch(
   // agent's stale target is intentionally NOT reused: `row.agent` is defined, so
   // this short-circuits to undefined and openWorkspace upserts the stale target
   // below, relaunching the agent.)
-  const concurrentStationTarget =
+  const concurrentManagedTarget =
     row.agent === undefined
-      ? (await station.listTargets()).find(
+      ? (await managedTerminal.listTargets()).find(
           (target) => target.worktreeId === params.worktreeId && target.sessionId !== undefined,
         )
       : undefined;
-  if (concurrentStationTarget?.sessionId !== undefined) {
-    const reattachHandle = await resolveReattachHandle(station, params.worktreeId);
+  if (concurrentManagedTarget?.sessionId !== undefined) {
+    const reattachHandle = await resolveReattachHandle(managedTerminal, concurrentManagedTarget.id);
     return {
       outcome: {
         kind: "existing-session",
-        sessionId: concurrentStationTarget.sessionId,
+        sessionId: concurrentManagedTarget.sessionId,
         harnessProvider:
-          concurrentStationTarget.harnessBinding?.harnessProvider ?? harnessProviderId,
+          concurrentManagedTarget.harnessBinding?.harnessProvider ?? harnessProviderId,
         ...(reattachHandle === undefined ? {} : { reattachHandle }),
       },
       reconcile: false,
@@ -188,16 +159,15 @@ export async function prepareExternalLaunch(
 
   // Accepted race: two *distinct* UIs racing prepare on the same worktree
   // can both pass the listTargets check above before either openWorkspace below
-  // runs. openWorkspace upserts by the deterministic `station:<worktreeId>` id, so
-  // the window resolves to exactly one target (the second session wins; the first
-  // is orphaned and reaped at the next reconcile) — never two targets/runs. A
-  // single UI is already covered by Station's `launchesInFlight` guard; a
-  // server-side lock is intentionally out of scope.
+  // runs. The managed lifecycle owns the one-target-per-worktree invariant, so
+  // the window resolves to one target (the second session may replace the first,
+  // which reconcile later reaps) rather than two targets. A single UI is already
+  // covered by Station's `launchesInFlight` guard; a server-side lock is out of scope.
   const sessionId = defaultSessionCommandIdFactory.sessionId();
 
-  let openedTargetId: string | undefined;
+  let openedTargetId: TerminalTargetId | undefined;
   try {
-    const opened = await station.openWorkspace({
+    const opened = await managedTerminal.openWorkspace({
       project,
       worktree,
       harness: harnessProviderId,
@@ -223,21 +193,19 @@ export async function prepareExternalLaunch(
     // UI PTY). `started: false` (no host / host unavailable) ⇒ no handle and the UI
     // spawns the PTY locally from launchPlan.
     let reattachHandle: AgentReattachHandle | undefined;
-    if (station.launchProcess !== undefined) {
-      const launched = await station.launchProcess({
-        project,
-        worktree,
-        terminalTarget: opened.target,
-        agentEndpointId: opened.agentEndpointId,
-        launchPlan,
-      });
-      if (launched.started && launched.reattach !== undefined) {
-        reattachHandle = {
-          ptyId: launched.reattach.endpointId,
-          terminalTargetId: opened.target.targetId,
-          hostSocketPath: launched.reattach.socketPath,
-        };
-      }
+    const launched = await managedTerminal.launchProcess({
+      project,
+      worktree,
+      terminalTarget: opened.target,
+      agentEndpointId: opened.agentEndpointId,
+      launchPlan,
+    });
+    if (launched.started) {
+      reattachHandle = {
+        ptyId: launched.reattach.endpointId,
+        terminalTargetId: opened.target.targetId,
+        hostSocketPath: launched.reattach.socketPath,
+      };
     }
 
     return {
@@ -253,14 +221,20 @@ export async function prepareExternalLaunch(
   } catch (error) {
     // Unregister the half-prepared target so a retry is not blocked by a dangling
     // session and reconcile does not surface a launch that never spawned.
-    if (openedTargetId !== undefined && canMarkExited(station)) {
-      station.markExited(openedTargetId);
+    if (openedTargetId !== undefined) {
+      try {
+        await managedTerminal.releaseTarget(openedTargetId);
+      } catch {
+        // Cleanup must not replace the launch failure that explains why the target was abandoned.
+      }
     }
     throw error;
   }
 }
 
 /**
+ * USE CASE
+ *
  * Drop an externally-hosted target when the Station UI reports its PTY exited, so
  * the next reconcile removes the session from both dashboards. Idempotent: an
  * unknown target id is acknowledged without a reconcile.
@@ -269,12 +243,8 @@ export async function reportExternalExit(
   deps: ExternalLaunchDeps,
   params: AgentReportExternalExitParams,
 ): Promise<ExternalLaunchOutcome<AgentReportExternalExitResult>> {
-  let acknowledged = false;
-  for (const provider of deps.providers.terminals.values()) {
-    if (canMarkExited(provider) && provider.markExited(params.terminalTargetId)) {
-      acknowledged = true;
-    }
-  }
+  const acknowledged =
+    (await deps.providers.managedTerminal?.releaseTarget(params.terminalTargetId)) ?? false;
   return {
     outcome: { acknowledged, terminalTargetId: params.terminalTargetId },
     reconcile: acknowledged,
@@ -301,12 +271,10 @@ function sessionAlreadyHasAgentError(worktreeId: string): SafeError {
   };
 }
 
-function externalProviderUnavailableError(): SafeError {
+function managedTerminalUnavailableError(): SafeError {
   return {
     tag: "TerminalProviderError",
     code: "TERMINAL_PROVIDER_UNAVAILABLE",
-    message:
-      "The Station terminal provider is not registered, so an external launch cannot be prepared.",
-    provider: EXTERNAL_TERMINAL_PROVIDER_ID,
+    message: "No managed terminal lifecycle is registered for external launch.",
   };
 }

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -98,7 +98,7 @@ function createFixture(spoolDir: string) {
       ],
     }),
     terminal: new FakeTerminalProvider({ now }),
-    terminals: [station],
+    managedTerminal: station,
     harnesses: [new FakeHarnessProvider({ now })],
   });
   const core = createObserverCore({ config, providers, persistence, sqlite, clock });

--- a/apps/observer/test/integration/reconcile-station-terminal.test.ts
+++ b/apps/observer/test/integration/reconcile-station-terminal.test.ts
@@ -84,7 +84,7 @@ describe("observer reconcile with a station-hosted target", () => {
     expect(stationRow?.terminal?.closeable).toBeUndefined();
 
     // Reporting exit drops only the station target; the tmux session survives.
-    expect(station.markExited(stationTargetId("wt_web_station"))).toBe(true);
+    await expect(station.releaseTarget(stationTargetId("wt_web_station"))).resolves.toBe(true);
     const afterExit = await core.reconcile("station-exit");
     expect(afterExit.sessions.map((session) => session.id)).toEqual(["ses_tmux"]);
     expect(afterExit.rows.find((row) => row.id === "wt_web_station")?.agent).toBeUndefined();
@@ -374,7 +374,7 @@ function providers(
         }),
       ],
     }),
-    terminals: [station],
+    managedTerminal: station,
     harnesses: [
       createClaudeHarnessProvider({
         now: () => new Date(now),

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -1,18 +1,29 @@
 import type {
   AgentState,
   HarnessHooksStatus,
+  ManagedTerminalLaunchProcessResult,
+  ManagedTerminalLifecycle,
+  OpenWorkspaceRequest,
+  OpenWorkspaceResult,
+  ProviderHealth,
+  ProviderId,
   ProviderProjectConfig,
+  SafeError,
   StationSnapshot,
   TerminalAttachment,
+  TerminalCapabilities,
+  TerminalLaunchProcessRequest,
+  TerminalReattachInfo,
+  TerminalTargetId,
+  TerminalTargetObservation,
   WorktreeRow,
 } from "@station/contracts";
-import type { HostListEntry, StationHostClient } from "@station/host";
 import {
-  createStationHostController,
-  StationTerminalProvider,
-  stationTargetId,
-} from "@station/terminal";
-import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
+  createFakeTerminalTarget,
+  FakeHarnessProvider,
+  FakeTerminalProvider,
+  FakeWorktreeProvider,
+} from "@station/testing";
 import { describe, expect, it } from "vitest";
 import type { ObserverPersistence } from "../../src/persistence/index";
 import { ProviderRegistry } from "../../src/providers/registry";
@@ -20,6 +31,158 @@ import type { ObserverCore } from "../../src/reconcile/core";
 import { prepareExternalLaunch, reportExternalExit } from "../../src/runtime/externalLaunch";
 
 const now = "2026-05-21T12:00:00.000Z";
+
+function managedTargetId(worktreeId: string): TerminalTargetId {
+  return `managed://${worktreeId}` as TerminalTargetId;
+}
+
+type FakeManagedTerminalOptions = {
+  started?: boolean;
+  reattach?: TerminalReattachInfo;
+  launchFailure?: SafeError;
+  releaseFailure?: SafeError;
+};
+
+/** Deliberately differs from the Station adapter in both provider id and target format. */
+class FakeManagedTerminalLifecycle implements ManagedTerminalLifecycle {
+  readonly id: ProviderId = "managed-test";
+  readonly released: TerminalTargetId[] = [];
+
+  readonly #targets: TerminalTargetObservation[] = [];
+  readonly #terminal: FakeTerminalProvider;
+  readonly #started: boolean;
+  readonly #reattach: TerminalReattachInfo | undefined;
+  readonly #launchFailure: SafeError | undefined;
+  readonly #releaseFailure: SafeError | undefined;
+
+  constructor(options: FakeManagedTerminalOptions = {}) {
+    this.#terminal = new FakeTerminalProvider({
+      id: this.id,
+      now: () => new Date(now),
+      targets: this.#targets,
+    });
+    this.#started = options.started ?? false;
+    this.#reattach = options.reattach;
+    this.#launchFailure = options.launchFailure;
+    this.#releaseFailure = options.releaseFailure;
+  }
+
+  capabilities(): TerminalCapabilities {
+    return this.#terminal.capabilities();
+  }
+
+  health(): Promise<ProviderHealth> {
+    return this.#terminal.health();
+  }
+
+  listTargets(): Promise<TerminalTargetObservation[]> {
+    return this.#terminal.listTargets();
+  }
+
+  async openWorkspace(request: OpenWorkspaceRequest): Promise<OpenWorkspaceResult> {
+    const targetId = managedTargetId(request.worktree.id);
+    const target = createFakeTerminalTarget({
+      id: targetId,
+      provider: this.id,
+      projectId: request.project.id,
+      worktreeId: request.worktree.id,
+      ...(request.sessionId === undefined ? {} : { sessionId: request.sessionId }),
+      now,
+      harnessBinding: {
+        role: "main-agent",
+        harnessProvider: request.harness,
+        worktreePath: request.worktree.path,
+      },
+    });
+    const existingIndex = this.#targets.findIndex(
+      (candidate) => candidate.worktreeId === request.worktree.id,
+    );
+    if (existingIndex < 0) {
+      this.#targets.push(target);
+    } else {
+      this.#targets[existingIndex] = target;
+    }
+    return {
+      target: {
+        provider: this.id,
+        targetId,
+        projectId: request.project.id,
+        worktreeId: request.worktree.id,
+        ...(request.sessionId === undefined ? {} : { sessionId: request.sessionId }),
+        harnessBinding: {
+          role: "main-agent",
+          harnessProvider: request.harness,
+          worktreePath: request.worktree.path,
+        },
+        confidence: "high",
+        reason: "Fake managed terminal registered a target.",
+      },
+      agentEndpointId: targetId,
+    };
+  }
+
+  async launchProcess(
+    request: TerminalLaunchProcessRequest,
+  ): Promise<ManagedTerminalLaunchProcessResult> {
+    if (this.#launchFailure !== undefined) {
+      throw this.#launchFailure;
+    }
+    const result = {
+      terminalTargetId: request.terminalTarget.targetId,
+      agentEndpointId: request.agentEndpointId,
+    };
+    if (!this.#started) {
+      return { ...result, started: false };
+    }
+    if (this.#reattach === undefined) {
+      throw new Error("Fake managed terminal needs reattach info when started.");
+    }
+    return { ...result, started: true, reattach: this.#reattach };
+  }
+
+  async reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined> {
+    return this.#targets.some((target) => target.id === targetId) ? this.#reattach : undefined;
+  }
+
+  async releaseTarget(targetId: TerminalTargetId): Promise<boolean> {
+    this.released.push(targetId);
+    if (this.#releaseFailure !== undefined) {
+      throw this.#releaseFailure;
+    }
+    const index = this.#targets.findIndex((target) => target.id === targetId);
+    if (index < 0) {
+      return false;
+    }
+    this.#targets.splice(index, 1);
+    return true;
+  }
+
+  focusTarget(targetId: TerminalTargetId): Promise<void> {
+    return this.#terminal.focusTarget(targetId);
+  }
+
+  closeTarget(targetId: TerminalTargetId): Promise<void> {
+    return this.#terminal.closeTarget(targetId);
+  }
+
+  seedTarget(input: { worktreeId: string; sessionId: string }): void {
+    this.#targets.push(
+      createFakeTerminalTarget({
+        id: managedTargetId(input.worktreeId),
+        provider: this.id,
+        projectId: project.id,
+        worktreeId: input.worktreeId,
+        sessionId: input.sessionId,
+        now,
+        harnessBinding: {
+          role: "main-agent",
+          harnessProvider: "fake-harness",
+          worktreePath: "/tmp/station/web/feature",
+        },
+      }),
+    );
+  }
+}
 
 const project: ProviderProjectConfig = {
   id: "web",
@@ -57,7 +220,7 @@ function row(
     };
   }
   if (overrides.terminalState !== undefined) {
-    base.terminal = { provider: "native", state: overrides.terminalState };
+    base.terminal = { provider: "managed-test", state: overrides.terminalState };
   }
   return base;
 }
@@ -106,7 +269,7 @@ class HookableHarness extends FakeHarnessProvider {
 type Harnesses = ConstructorParameters<typeof ProviderRegistry>[0]["harnesses"];
 
 function registryWith(
-  station: StationTerminalProvider,
+  managedTerminal: ManagedTerminalLifecycle,
   harnesses: Harnesses = [
     new FakeHarnessProvider({ id: "fake-harness", now: () => new Date(now) }),
   ],
@@ -114,15 +277,19 @@ function registryWith(
   return new ProviderRegistry({
     worktree: new FakeWorktreeProvider({ id: "fake-worktree" }),
     terminal: new FakeTerminalProvider({ now: () => new Date(now) }),
-    terminals: [station],
+    managedTerminal,
     harnesses,
   });
 }
 
-function deps(rows: WorktreeRow[], station: StationTerminalProvider, harnesses?: Harnesses) {
+function deps(
+  rows: WorktreeRow[],
+  managedTerminal: ManagedTerminalLifecycle,
+  harnesses?: Harnesses,
+) {
   return {
     core: fakeCore(rows),
-    providers: registryWith(station, harnesses),
+    providers: registryWith(managedTerminal, harnesses),
     persistence: fakePersistence,
     clock: { now: () => new Date(now) },
   };
@@ -130,16 +297,44 @@ function deps(rows: WorktreeRow[], station: StationTerminalProvider, harnesses?:
 
 const prepareParams = { projectId: "web", worktreeId: "wt_web_feature" };
 
+describe("ProviderRegistry managed terminal role", () => {
+  it("registers one adapter when the managed lifecycle is also the default terminal", () => {
+    const managedTerminal = new FakeManagedTerminalLifecycle();
+    const registry = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ id: "fake-worktree" }),
+      terminal: managedTerminal,
+      managedTerminal,
+      harnesses: [],
+    });
+
+    expect(registry.terminal).toBe(managedTerminal);
+    expect(registry.managedTerminal).toBe(managedTerminal);
+    expect([...registry.terminals.values()]).toEqual([managedTerminal]);
+  });
+
+  it("rejects a different terminal adapter with the managed lifecycle id", () => {
+    expect(
+      () =>
+        new ProviderRegistry({
+          worktree: new FakeWorktreeProvider({ id: "fake-worktree" }),
+          terminal: new FakeManagedTerminalLifecycle(),
+          managedTerminal: new FakeManagedTerminalLifecycle(),
+          harnesses: [],
+        }),
+    ).toThrow("Duplicate terminal provider id: managed-test");
+  });
+});
+
 describe("prepareExternalLaunch", () => {
-  it("mints one session + one station target + a launch plan", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+  it("mints one session + one managed target + a launch plan", async () => {
+    const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
 
     expect(result.reconcile).toBe(true);
     expect(result.outcome.kind).toBe("prepared");
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
     expect(result.outcome.sessionId).toMatch(/^ses_/);
-    expect(result.outcome.terminalTargetId).toBe(stationTargetId("wt_web_feature"));
+    expect(result.outcome.terminalTargetId).toBe(managedTargetId("wt_web_feature"));
     expect(result.outcome.launchPlan.provider).toBe("fake-harness");
     expect(result.outcome.launchPlan.env?.STATION_SESSION_ID).toBe(result.outcome.sessionId);
 
@@ -150,7 +345,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("rejects when the harness's status hooks are not installed", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     await expect(
       prepareExternalLaunch(deps([row()], station, [new HookableHarness(false)]), prepareParams),
     ).rejects.toMatchObject({
@@ -163,7 +358,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("passes the gate when hooks are installed", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(
       deps([row()], station, [new HookableHarness(true)]),
       prepareParams,
@@ -172,7 +367,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("guides the user to the config flag when hooks are not requested", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     // installed:false because requested:false — installing artifacts alone would
     // not satisfy the gate, so the hint must point at the config flag, not install.
     await expect(
@@ -188,7 +383,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("returns the already-registered session for a concurrent prepare (snapshot lags)", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     const first = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (first.outcome.kind !== "prepared") throw new Error("expected prepared");
 
@@ -208,7 +403,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("returns the existing session id instead of minting a second identity", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(
       deps([row({ agentSessionId: "ses_existing" })], station),
       prepareParams,
@@ -226,7 +421,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("relaunches an exited agent instead of returning its dead session", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     // A station agent whose PTY died (state "exited") must be relaunchable on a
     // re-click — not blocked as "already has a running agent".
     const result = await prepareExternalLaunch(
@@ -240,7 +435,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("relaunches an unknown-state agent whose terminal went stale (the `?` row)", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     // The dashboard `?` row: an agent reported "unknown" because its terminal is
     // stale (e.g. Station closed and the station target went stale). It is NOT
     // genuinely running, so a row-click must relaunch it — not noop as
@@ -259,7 +454,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("relaunches an unknown-state agent that has no terminal at all", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     // Unknown with a missing (undefined) terminal and no session id is the worst
     // case the old gate hit: it threw SESSION_ALREADY_HAS_AGENT, a dead-end noop.
     // It must now relaunch.
@@ -272,7 +467,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("still defers to a live unknown agent whose terminal is still open", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     // Unknown but with an open, focusable terminal is genuinely reachable — hand
     // back its session rather than launching a second agent.
     const result = await prepareExternalLaunch(
@@ -290,7 +485,7 @@ describe("prepareExternalLaunch", () => {
     expect(await station.listTargets()).toEqual([]);
   });
 
-  it("rejects when the station provider is not registered", async () => {
+  it("rejects when the managed terminal lifecycle is not registered", async () => {
     const registry = new ProviderRegistry({
       worktree: new FakeWorktreeProvider({ id: "fake-worktree" }),
       terminal: new FakeTerminalProvider({ now: () => new Date(now) }),
@@ -306,11 +501,40 @@ describe("prepareExternalLaunch", () => {
         },
         prepareParams,
       ),
-    ).rejects.toMatchObject({ code: "TERMINAL_PROVIDER_UNAVAILABLE", provider: "native" });
+    ).rejects.toMatchObject({
+      code: "TERMINAL_PROVIDER_UNAVAILABLE",
+      message: "No managed terminal lifecycle is registered for external launch.",
+    });
+  });
+
+  it("returns an existing live session without a managed lifecycle", async () => {
+    const registry = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ id: "fake-worktree" }),
+      terminal: new FakeTerminalProvider({ now: () => new Date(now) }),
+      harnesses: [new FakeHarnessProvider({ id: "fake-harness", now: () => new Date(now) })],
+    });
+    await expect(
+      prepareExternalLaunch(
+        {
+          core: fakeCore([row({ agentSessionId: "ses_existing" })]),
+          providers: registry,
+          persistence: fakePersistence,
+          clock: { now: () => new Date(now) },
+        },
+        prepareParams,
+      ),
+    ).resolves.toEqual({
+      outcome: {
+        kind: "existing-session",
+        sessionId: "ses_existing",
+        harnessProvider: "fake-harness",
+      },
+      reconcile: false,
+    });
   });
 
   it("rejects a worktree that belongs to another configured project", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     const otherProject: ProviderProjectConfig = { ...project, id: "other", label: "Other" };
     const core = {
       getProjects: () => [project, otherProject],
@@ -334,7 +558,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("rejects when the worktree is not in the snapshot", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     await expect(
       prepareExternalLaunch(deps([], station), { projectId: "web", worktreeId: "wt_ghost" }),
     ).rejects.toMatchObject({ code: "WORKTREE_NOT_FOUND" });
@@ -342,7 +566,7 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("rolls back the half-prepared target if buildLaunch fails", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     const failing = new FakeHarnessProvider({
       id: "fake-harness",
       now: () => new Date(now),
@@ -359,30 +583,75 @@ describe("prepareExternalLaunch", () => {
     ).rejects.toMatchObject({ code: "HARNESS_BUILD_LAUNCH_FAILED" });
     // openWorkspace registered a target; the failure rolled it back so a retry is clean.
     expect(await station.listTargets()).toEqual([]);
+    expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
+  });
+
+  it("releases the opened target when managed process launch fails", async () => {
+    const station = new FakeManagedTerminalLifecycle({
+      launchFailure: {
+        tag: "TerminalProviderError",
+        code: "MANAGED_LAUNCH_FAILED",
+        message: "launch failed",
+      },
+    });
+
+    await expect(
+      prepareExternalLaunch(deps([row()], station), prepareParams),
+    ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_FAILED" });
+    expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
+    expect(await station.listTargets()).toEqual([]);
+  });
+
+  it("preserves the launch failure when rollback release also fails", async () => {
+    const station = new FakeManagedTerminalLifecycle({
+      launchFailure: {
+        tag: "TerminalProviderError",
+        code: "MANAGED_LAUNCH_FAILED",
+        message: "launch failed",
+      },
+      releaseFailure: {
+        tag: "TerminalProviderError",
+        code: "MANAGED_RELEASE_FAILED",
+        message: "release failed",
+      },
+    });
+
+    await expect(
+      prepareExternalLaunch(deps([row()], station), prepareParams),
+    ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_FAILED" });
+    expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
   });
 });
 
 describe("reportExternalExit", () => {
   it("drops the registered target and asks for a reconcile", async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     await prepareExternalLaunch(deps([row()], station), prepareParams);
-    const targetId = stationTargetId("wt_web_feature");
+    const targetId = managedTargetId("wt_web_feature");
 
     const exit = await reportExternalExit(deps([row()], station), { terminalTargetId: targetId });
     expect(exit).toEqual({
       outcome: { acknowledged: true, terminalTargetId: targetId },
       reconcile: true,
     });
+    expect(station.released).toEqual([targetId]);
     expect(await station.listTargets()).toEqual([]);
+
+    await expect(
+      reportExternalExit(deps([row()], station), { terminalTargetId: targetId }),
+    ).resolves.toEqual({
+      outcome: { acknowledged: false, terminalTargetId: targetId },
+      reconcile: false,
+    });
   });
 
   it("acknowledges an unknown target without asking for a reconcile", async () => {
-    const station = new StationTerminalProvider();
+    const station = new FakeManagedTerminalLifecycle();
     const exit = await reportExternalExit(deps([row()], station), {
-      terminalTargetId: "native:nope",
+      terminalTargetId: "managed://nope",
     });
     expect(exit).toEqual({
-      outcome: { acknowledged: false, terminalTargetId: "native:nope" },
+      outcome: { acknowledged: false, terminalTargetId: "managed://nope" },
       reconcile: false,
     });
   });
@@ -410,7 +679,7 @@ describe("prepareExternalLaunch existing-agent state matrix", () => {
 
   for (const { state, expected } of matrix) {
     it(`a "${state}" agent → ${expected}`, async () => {
-      const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+      const station = new FakeManagedTerminalLifecycle();
       const result = await prepareExternalLaunch(
         deps([row({ agentSessionId: "ses_live", agentState: state })], station),
         prepareParams,
@@ -431,83 +700,32 @@ describe("prepareExternalLaunch existing-agent state matrix", () => {
   }
 
   it('"no agent" (undefined) → prepared', async () => {
-    const station = new StationTerminalProvider({ clock: { now: () => new Date(now) } });
+    const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
     expect(result.outcome.kind).toBe("prepared");
   });
 });
 
-function fakeHostClient(over: Partial<StationHostClient> = {}): StationHostClient {
-  return {
-    health: async () => ({ ok: true, protocolVersion: 1 }),
-    spawn: async () => ({ ptyId: "pty-1", pid: 99 }),
-    write: async () => undefined,
-    resize: async () => undefined,
-    list: async () => [],
-    focus: async () => undefined,
-    close: async () => ({ closed: true }),
-    attach: async () => {
-      throw new Error("unused");
-    },
-    dispose: () => undefined,
-    ...over,
-  };
-}
-
-function liveEntry(): HostListEntry {
-  return {
-    ptyId: "pty-1",
-    terminalTargetId: stationTargetId("wt_web_feature"),
-    worktreeId: "wt_web_feature",
-    projectId: "web",
-    sessionId: "ses_live",
-    worktreePath: "/tmp/station/web/feature",
-    harnessProvider: "fake-harness",
-    pid: 99,
-    alive: true,
-    cols: 80,
-    rows: 24,
-  };
-}
-
-function hostBackedStation(client: StationHostClient): StationTerminalProvider {
-  const controller = createStationHostController(
-    {
-      socketPath: `/tmp/ext-host-${process.pid}-${Math.random().toString(36).slice(2)}.sock`,
-      stateDir: "/tmp",
-      hostEntry: "/tmp/hostMain.ts",
-      timeoutMs: 50, // keep the host-unavailable path fast in tests
-    },
-    { clientFactory: () => client, spawnHost: () => ({ pid: 1, unref: () => undefined }) },
-  );
-  return new StationTerminalProvider({ clock: { now: () => new Date(now) }, host: controller });
-}
-
-describe("prepareExternalLaunch (host-backed)", () => {
+describe("prepareExternalLaunch reattachment", () => {
   it("attaches a reattachHandle to the prepared result", async () => {
-    // No host PTY yet (so the prepare isn't short-circuited to existing-session);
-    // launchProcess spawns one, then the prepared result carries its handle.
-    let spawned = false;
-    const station = hostBackedStation(
-      fakeHostClient({
-        spawn: async () => {
-          spawned = true;
-          return { ptyId: "pty-1", pid: 99 };
-        },
-        list: async () => (spawned ? [liveEntry()] : []),
-      }),
-    );
+    const station = new FakeManagedTerminalLifecycle({
+      started: true,
+      reattach: { endpointId: "endpoint-1", socketPath: "/tmp/managed-test.sock" },
+    });
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
     expect(result.outcome.reattachHandle).toMatchObject({
-      ptyId: "pty-1",
-      terminalTargetId: stationTargetId("wt_web_feature"),
+      ptyId: "endpoint-1",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+      hostSocketPath: "/tmp/managed-test.sock",
     });
-    expect(result.outcome.reattachHandle?.hostSocketPath).toContain("ext-host-");
   });
 
   it("attaches a reattachHandle to an existing-session result", async () => {
-    const station = hostBackedStation(fakeHostClient({ list: async () => [liveEntry()] }));
+    const station = new FakeManagedTerminalLifecycle({
+      reattach: { endpointId: "endpoint-1", socketPath: "/tmp/managed-test.sock" },
+    });
+    station.seedTarget({ worktreeId: "wt_web_feature", sessionId: "ses_live" });
     const result = await prepareExternalLaunch(
       deps([row({ agentSessionId: "ses_live" })], station),
       prepareParams,
@@ -516,19 +734,33 @@ describe("prepareExternalLaunch (host-backed)", () => {
       kind: "existing-session",
       sessionId: "ses_live",
       harnessProvider: "fake-harness",
-      reattachHandle: { ptyId: "pty-1" },
+      reattachHandle: {
+        ptyId: "endpoint-1",
+        terminalTargetId: managedTargetId("wt_web_feature"),
+      },
     });
   });
 
-  it("omits the reattachHandle when the host is unavailable (UI spawns locally)", async () => {
-    // launchProcess can't reach the host → started:false → no handle → Path A.
-    const station = hostBackedStation(
-      fakeHostClient({
-        health: async () => {
-          throw new Error("host down");
-        },
-      }),
-    );
+  it("does not attach a replacement target from a different session", async () => {
+    const station = new FakeManagedTerminalLifecycle({
+      reattach: { endpointId: "endpoint-new", socketPath: "/tmp/managed-test.sock" },
+    });
+    station.seedTarget({ worktreeId: "wt_web_feature", sessionId: "ses_replacement" });
+
+    await expect(
+      prepareExternalLaunch(deps([row({ agentSessionId: "ses_live" })], station), prepareParams),
+    ).resolves.toEqual({
+      outcome: {
+        kind: "existing-session",
+        sessionId: "ses_live",
+        harnessProvider: "fake-harness",
+      },
+      reconcile: false,
+    });
+  });
+
+  it("omits the reattachHandle when the managed adapter does not start the process", async () => {
+    const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
     expect(result.outcome.reattachHandle).toBeUndefined();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,6 +51,7 @@ When these disagree, reconcile from config, providers, and current observer stat
 ## Boundary Rules
 
 - Provider-specific behavior stays in `integrations/...` or provider-injected capabilities. Observer/core code aggregates through contracts, registries, and provider interfaces.
+- Station-managed terminal lifecycle is supplied as an explicit application role. Observer application code may forward target IDs returned by that role, but must not select its adapter by provider ID, reconstruct provider-owned target IDs, or discover lifecycle operations through runtime method probing.
 - The Station UI is a client. It renders snapshots/events and dispatches typed commands; it must not import providers, read SQLite, run `wt`, run `tmux`, run `git`/`gh`, or parse raw provider payloads for core behavior.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.

--- a/integrations/terminal/station/src/provider.ts
+++ b/integrations/terminal/station/src/provider.ts
@@ -1,4 +1,6 @@
 import type {
+  ManagedTerminalLaunchProcessResult,
+  ManagedTerminalLifecycle,
   OpenWorkspaceRequest,
   OpenWorkspaceResult,
   ProjectId,
@@ -9,9 +11,6 @@ import type {
   TerminalCapabilities,
   TerminalIdentityBinding,
   TerminalLaunchProcessRequest,
-  TerminalLaunchProcessResult,
-  TerminalProvider,
-  TerminalReattachCapability,
   TerminalReattachInfo,
   TerminalTargetId,
   TerminalTargetObservation,
@@ -38,11 +37,13 @@ export type StationTerminalProviderOptions = {
 };
 
 /**
+ * ADAPTER
+ *
  * Station terminal provider: UI-hosted mode is a registration shim; host-backed
  * mode uses `host.list` as liveness truth so reattach/restart re-derives the
  * same session instead of minting another.
  */
-export class StationTerminalProvider implements TerminalProvider, TerminalReattachCapability {
+export class StationTerminalProvider implements ManagedTerminalLifecycle {
   readonly id: ProviderId = STATION_TERMINAL_PROVIDER_ID;
 
   readonly #clock: RuntimeClock;
@@ -50,7 +51,7 @@ export class StationTerminalProvider implements TerminalProvider, TerminalReatta
   readonly #targets = new Map<TerminalTargetId, TerminalTargetObservation>();
   // Targets backed by a host PTY (spawned via launchProcess or rebuilt from
   // host.list). listTargets drops ONLY these when their PTY is gone; a UI-hosted
-  // fallback target (host was unavailable at launch) is kept until markExited.
+  // fallback target (host was unavailable at launch) is kept until releaseTarget.
   readonly #hostBackedTargets = new Set<string>();
 
   constructor(options: StationTerminalProviderOptions = {}) {
@@ -196,7 +197,9 @@ export class StationTerminalProvider implements TerminalProvider, TerminalReatta
    * UI. Returns `started: false` when not host-backed or the host is unavailable,
    * so the observer falls back to the UI spawning from the launch plan.
    */
-  async launchProcess(request: TerminalLaunchProcessRequest): Promise<TerminalLaunchProcessResult> {
+  async launchProcess(
+    request: TerminalLaunchProcessRequest,
+  ): Promise<ManagedTerminalLaunchProcessResult> {
     const base = {
       terminalTargetId: request.terminalTarget.targetId,
       agentEndpointId: request.agentEndpointId,
@@ -245,11 +248,10 @@ export class StationTerminalProvider implements TerminalProvider, TerminalReatta
   }
 
   /**
-   * Provider-local: drop a registered target when the PTY exited, so the next
-   * reconcile removes the session from both dashboards. (Host-backed liveness in
-   * `listTargets` is the other drop path.) Returns whether a target was removed.
+   * Drop an abandoned or exited target so the next reconcile removes the session.
+   * Host-backed liveness in `listTargets` is the other removal path.
    */
-  markExited(targetId: TerminalTargetId): boolean {
+  async releaseTarget(targetId: TerminalTargetId): Promise<boolean> {
     this.#hostBackedTargets.delete(targetId);
     return this.#targets.delete(targetId);
   }

--- a/integrations/terminal/station/test/unit/provider.test.ts
+++ b/integrations/terminal/station/test/unit/provider.test.ts
@@ -80,7 +80,7 @@ describe("StationTerminalProvider", () => {
       },
     });
     expect(result.started).toBe(false);
-    await expect(provider.reattachInfo?.("native:web-feature")).resolves.toBeUndefined();
+    await expect(provider.reattachInfo("native:web-feature")).resolves.toBeUndefined();
   });
 
   it("reports healthy", async () => {
@@ -142,15 +142,15 @@ describe("StationTerminalProvider", () => {
     expect(targets[0]?.sessionId).toBe("ses_two");
   });
 
-  it("markExited drops the target so reconcile stops observing it", async () => {
+  it("releaseTarget drops the target so reconcile stops observing it", async () => {
     const provider = new StationTerminalProvider({ clock });
     await provider.openWorkspace(openRequest());
     const targetId = stationTargetId(worktree.id);
 
-    expect(provider.markExited(targetId)).toBe(true);
+    await expect(provider.releaseTarget(targetId)).resolves.toBe(true);
     await expect(provider.listTargets()).resolves.toEqual([]);
     // Idempotent: a second exit report for the same target is a no-op.
-    expect(provider.markExited(targetId)).toBe(false);
+    await expect(provider.releaseTarget(targetId)).resolves.toBe(false);
   });
 
   it("rejects focusTarget with a typed station-hosted error (never a crash)", async () => {
@@ -262,6 +262,28 @@ describe("StationTerminalProvider (host-backed)", () => {
     });
   });
 
+  it("releaseTarget forgets host-backed bookkeeping without closing the process", async () => {
+    const close = vi.fn(async () => ({ closed: true }));
+    const provider = hostBackedProvider(fakeHostClient({ close }));
+    const opened = await provider.openWorkspace(openRequest());
+    await provider.launchProcess({
+      project,
+      worktree,
+      terminalTarget: opened.target,
+      agentEndpointId: opened.agentEndpointId,
+      launchPlan,
+    });
+
+    await expect(provider.releaseTarget(opened.target.targetId)).resolves.toBe(true);
+    expect(close).not.toHaveBeenCalled();
+    await expect(provider.listTargets()).resolves.toEqual([]);
+
+    await provider.openWorkspace(openRequest({ sessionId: "ses_ui_fallback" }));
+    await expect(provider.listTargets()).resolves.toMatchObject([
+      { id: opened.target.targetId, sessionId: "ses_ui_fallback" },
+    ]);
+  });
+
   it("never rebuilds an aux PTY into a terminal target (Station-UI-owned)", async () => {
     // A live aux shell + a live agent share host.list; only the agent surfaces.
     const provider = hostBackedProvider(
@@ -344,7 +366,7 @@ describe("StationTerminalProvider (host-backed)", () => {
     const targets = await provider.listTargets();
     expect(targets).toHaveLength(1);
     expect(targets[0]?.sessionId).toBe("ses_first");
-    await expect(provider.reattachInfo?.(stationTargetId(worktree.id))).resolves.toMatchObject({
+    await expect(provider.reattachInfo(stationTargetId(worktree.id))).resolves.toMatchObject({
       endpointId: "pty-first",
     });
   });
@@ -405,7 +427,7 @@ describe("StationTerminalProvider (host-backed)", () => {
 
   it("reattachInfo returns the live host PTY endpoint and socket", async () => {
     const provider = hostBackedProvider(fakeHostClient({ list: async () => [liveEntry()] }));
-    const info = await provider.reattachInfo?.(stationTargetId(worktree.id));
+    const info = await provider.reattachInfo(stationTargetId(worktree.id));
     expect(info).toMatchObject({ endpointId: "pty-1" });
     expect(info?.socketPath).toContain("station-host-");
   });

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -391,21 +391,33 @@ export interface TerminalProvider {
 }
 
 export type TerminalReattachInfo = {
-  /** Provider-opaque id of the live process to reattach to (e.g. a host PTY id). */
+  /** Provider-opaque id of the live process to reattach to. */
   endpointId: string;
-  /** Socket a client uses to reach the process's host. */
+  /** Endpoint a client uses to reach the process host. */
   socketPath: string;
 };
 
+export type ManagedTerminalLaunchProcessResult =
+  | (Omit<TerminalLaunchProcessResult, "started" | "reattach"> & {
+      started: false;
+      reattach?: never;
+    })
+  | (Omit<TerminalLaunchProcessResult, "started" | "reattach"> & {
+      started: true;
+      reattach: TerminalReattachInfo;
+    });
+
 /**
- * Optional persistence capability: reattaching to a live, out-of-client process.
- * Implemented only by the host-backed `native` station provider; tmux/zellij omit
- * it (their server/session is the backend). `launchProcess` deliberately stays on
- * `TerminalProvider` — launching is general (tmux respawns a pane); only the
- * reattach lookup is host-specific.
+ * DRIVEN PORT
+ *
+ * Owns the single managed terminal target used for an external Station launch.
+ * Target identity is adapter-owned and at most one target may exist per worktree.
  */
-export interface TerminalReattachCapability {
+export interface ManagedTerminalLifecycle extends TerminalProvider {
+  launchProcess(request: TerminalLaunchProcessRequest): Promise<ManagedTerminalLaunchProcessResult>;
   reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined>;
+  /** Forgets an abandoned or already-exited target without terminating its process. */
+  releaseTarget(targetId: TerminalTargetId): Promise<boolean>;
 }
 
 /** Best-effort version probe result; omit fields (or the method) when unknown. */

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -19,6 +19,7 @@ const observerConcreteProviderImports = [
   "@station/opencode",
   "@station/pi",
   "@station/scripted-harness",
+  "@station/terminal",
   "@station/github-repository",
 ];
 


### PR DESCRIPTION
## Summary

- add an explicit `ManagedTerminalLifecycle` driven port and assign the Station terminal adapter to that role in CLI composition
- remove copied `native` identity, target reconstruction, capability probing, and provider scanning from external launch
- prove substitution with a deliberately non-native fake and strengthen adapter, composition, integration, and architecture coverage

## Root cause

The original external-launch implementation treated “no concrete integration import” as provider neutrality. Observer code still copied the adapter ID and target format and discovered a private lifecycle method at runtime, while tests exercised only the concrete Station adapter.

The fix makes the application conversation explicit. Target identity is returned by the adapter, release is declared by the port, and a discriminated managed-launch result enforces `started: true` implies reattachment data.

## User impact

External launch, concurrent prepare, UI-hosted fallback, persistent-host reattachment, rollback, and idempotent exit reporting retain their existing behavior. There is no protocol or Station UI schema change.

## Validation

- focused unit: 79 tests passed, plus the final Station adapter regression test
- focused Observer integration: 7 tests passed
- boundary diagnostics: 3 tests passed
- `HOME=<isolated-temp> pnpm test:all`: passed
  - build and typecheck: 22 packages / 42 typecheck tasks
  - unit: 1,203
  - contracts: 24
  - integration: 314 passed, 1 skipped
  - diagnostics: 34
  - scripted agent: 3
  - setup e2e: 7
- `git diff --check`: passed

Running the unit lane against the normal user home still exposes a pre-existing Claude doctor fixture leak when generated Station hooks are installed but not requested; the isolated-home deterministic gate is green.

Closes #94