### PR TITLE
fix(tui): explain unavailable external-agent removal

### DIFF
--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -11,6 +11,7 @@ export type TuiInputMode =
   | "projectSettingsPicker"
   | "removeChooseSlot"
   | "removeConfirm"
+  | "removeUnavailable"
   | "renameChooseSlot"
   | "renameEdit"
   | "forkChooseSlot"
@@ -38,7 +39,8 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
     case "projectSettingsPicker":
       return "projectSettingsPicker";
     case "removeWorktree":
-      return screen.step === "chooseSlot" ? "removeChooseSlot" : "removeConfirm";
+      if (screen.step === "chooseSlot") return "removeChooseSlot";
+      return screen.step === "unavailable" ? "removeUnavailable" : "removeConfirm";
     case "renameSession":
       return screen.step === "chooseSlot" ? "renameChooseSlot" : "renameEdit";
     case "fork":
@@ -438,6 +440,21 @@ export const TUI_KEYMAP = {
       id: "tui.removeConfirm.confirmCtrlY",
       pattern: { kind: "char", char: "y", ctrl: true },
       action: "tui.remove.confirm",
+      outcome: "handled",
+    },
+  ],
+  removeUnavailable: [
+    {
+      id: "tui.removeUnavailable.closeEsc",
+      pattern: { kind: "named", named: "escape" },
+      action: "tui.remove.close",
+      outcome: "handled",
+      help: { keys: "esc/enter", label: "close" },
+    },
+    {
+      id: "tui.removeUnavailable.closeEnter",
+      pattern: { kind: "named", named: "return" },
+      action: "tui.remove.close",
       outcome: "handled",
     },
   ],

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -1,4 +1,5 @@
-import { worktreeRowDisplayTitle } from "../../selectors/selectors.js";
+import { isRunningAgentState, type StationSnapshot, type WorktreeRow } from "@station/contracts";
+import { sessionForWorktreeRow, worktreeRowDisplayTitle } from "../../selectors/selectors.js";
 import { buildRemoveWorktreeCommand, cleanupForceRequired } from "../commandBuilders.js";
 import type { TuiKey } from "../keys.js";
 import { isReturnKey } from "../keys.js";
@@ -27,7 +28,33 @@ export function handleRemoveWorktreeKey(state: TuiState, key: TuiKey): TuiTransi
     }));
   }
 
+  if (state.screen.step === "unavailable") {
+    if (!isReturnKey(key)) {
+      return { state };
+    }
+    return {
+      state: {
+        ...state,
+        screen: { name: "dashboard" },
+      },
+    };
+  }
+
   return handleConfirmKey(state, key);
+}
+
+export function isExternalAgentRemovalUnavailable(
+  row: WorktreeRow,
+  snapshot: StationSnapshot,
+): boolean {
+  const agent = row.agent;
+  return (
+    agent !== undefined &&
+    isRunningAgentState(agent.state) &&
+    sessionForWorktreeRow(row, snapshot.sessions) === undefined &&
+    snapshot.providerHealth[agent.harness]?.capabilities?.canStop === false &&
+    row.terminal?.closeable !== true
+  );
 }
 
 export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: string): TuiState {
@@ -41,6 +68,15 @@ export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: string):
   const row = snapshot.rows.find((candidate) => candidate.id === rowId);
   if (row === undefined) {
     return state;
+  }
+  if (isExternalAgentRemovalUnavailable(row, snapshot)) {
+    return {
+      ...state,
+      screen: {
+        name: "removeWorktree",
+        step: "unavailable",
+      },
+    };
   }
   const label =
     worktreeRowDisplayTitle(row, snapshot.sessions, state.localRows).trim() || row.branch;

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -72,6 +72,7 @@ export type TuiScreen =
   | { name: "projectCollapse" }
   | { name: "projectSettingsPicker" }
   | { name: "removeWorktree"; step: "chooseSlot" }
+  | { name: "removeWorktree"; step: "unavailable" }
   | {
       name: "removeWorktree";
       step: "confirm";

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -77,6 +77,40 @@ export function createPromptCapableSnapshot(): StationSnapshot {
   };
 }
 
+export function createExternalAgentSnapshot(): StationSnapshot {
+  const snapshot = createDashboardSnapshot();
+  const externalRow = snapshot.rows.find((candidate) => candidate.id === "wt_web_idle");
+  if (externalRow?.agent === undefined) {
+    throw new Error("Fixture row wt_web_idle must have an agent.");
+  }
+  const rowWithoutStationOwnership: WorktreeRow = {
+    ...externalRow,
+    agent: { ...externalRow.agent },
+  };
+  delete rowWithoutStationOwnership.terminal;
+  delete rowWithoutStationOwnership.agent?.sessionId;
+
+  return {
+    ...snapshot,
+    providerHealth: {
+      ...snapshot.providerHealth,
+      codex: {
+        providerId: "codex",
+        providerType: "harness",
+        status: "healthy",
+        lastCheckedAt: fixtureNow,
+        capabilities: { ...defaultCapabilities, canStop: false },
+      },
+    },
+    rows: snapshot.rows.map((candidate) =>
+      candidate.id === rowWithoutStationOwnership.id ? rowWithoutStationOwnership : candidate,
+    ),
+    sessions: snapshot.sessions.filter(
+      (session) => session.worktreeId !== rowWithoutStationOwnership.id,
+    ),
+  };
+}
+
 export function createZeroWorktreeSnapshot(): StationSnapshot {
   return snapshotFromRows([]);
 }

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCommandSnapshot,
   createDashboardSnapshot,
+  createExternalAgentSnapshot,
   createZeroWorktreeSnapshot,
 } from "../../fixtures/snapshots.js";
 
@@ -266,6 +267,74 @@ describe("TUI screen transitions", () => {
       forceRequired: true,
       label: "fix-nav-mobile",
     });
+  });
+
+  it("opens removal information without dispatching for an external unstoppable agent", () => {
+    const snapshot = createExternalAgentSnapshot();
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "5" });
+
+    expect(opened.state.screen).toEqual({
+      name: "removeWorktree",
+      step: "unavailable",
+    });
+    expect(deriveTuiInputMode(opened.state)).toBe("removeUnavailable");
+
+    const attempted = handleTuiKey(opened.state, { input: "y" });
+    expect(attempted.state).toBe(opened.state);
+    expect(attempted.operations).toBeUndefined();
+    expect(attempted.state.localRows.pendingRemove).toEqual([]);
+
+    const closed = handleTuiKey(opened.state, { input: "\r", return: true });
+    expect(closed.state.screen).toEqual({ name: "dashboard" });
+    expect(closed.operations).toBeUndefined();
+
+    const escaped = handleTuiKey(opened.state, { input: "", escape: true });
+    expect(escaped.state.screen).toEqual({ name: "dashboard" });
+    expect(escaped.operations).toBeUndefined();
+  });
+
+  it("keeps removal confirmation when an external agent has an effective stop path", () => {
+    const stoppableSnapshot = createExternalAgentSnapshot();
+    const codexHealth = stoppableSnapshot.providerHealth.codex;
+    if (codexHealth?.capabilities === undefined) {
+      throw new Error("External-agent fixture must expose Codex capabilities.");
+    }
+    const withProviderStop = {
+      ...stoppableSnapshot,
+      providerHealth: {
+        ...stoppableSnapshot.providerHealth,
+        codex: {
+          ...codexHealth,
+          capabilities: { ...codexHealth.capabilities, canStop: true },
+        },
+      },
+    };
+    const withTerminalStop = {
+      ...stoppableSnapshot,
+      rows: stoppableSnapshot.rows.map((row) =>
+        row.id === "wt_web_idle"
+          ? {
+              ...row,
+              terminal: {
+                provider: "tmux",
+                state: "open" as const,
+                closeable: true,
+              },
+            }
+          : row,
+      ),
+    };
+
+    for (const snapshot of [withProviderStop, withTerminalStop]) {
+      const state = createInitialTuiState({ initialSnapshot: snapshot });
+      const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "5" });
+      expect(opened.state.screen).toMatchObject({
+        name: "removeWorktree",
+        step: "confirm",
+        rowId: "wt_web_idle",
+      });
+    }
   });
 
   it("confirms remove worktree with y and returns a remove operation", () => {

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "bun:test";
 import { createInitialTuiState } from "@station/dashboard-core";
 import { createStationStore } from "../state/store.js";
 import { agentWorktreePaneId, MAIN_PANE_ID, type StationState } from "../state/types.js";
-import { manyProjectsSnapshot } from "../station/fixtures/scenarios.js";
+import {
+  externalAgentSnapshot,
+  manyProjectsSnapshot,
+} from "../station/fixtures/scenarios.js";
 import type { Automation } from "../config/stationConfig.js";
 import { buildContextMenuItems, resolveContextMenuAction } from "./items.js";
 
@@ -190,6 +193,24 @@ describe("buildContextMenuItems", () => {
         action: { kind: "removeWorktree", rowId: "wt_station_none" },
       },
     ]);
+  });
+
+  it("labels external unstoppable-agent removal as a worktree action", () => {
+    const store = createStationStore();
+    const stationState = createInitialTuiState({ initialSnapshot: externalAgentSnapshot() });
+
+    const items = buildContextMenuItems(
+      { kind: "station", target: { kind: "row", rowId: "wt_station_idle" } },
+      store.getState(),
+      stationState,
+    );
+
+    expect(items.at(-1)).toEqual({
+      id: "station.removeWorktree",
+      label: "Delete Worktree…",
+      danger: true,
+      action: { kind: "removeWorktree", rowId: "wt_station_idle" },
+    });
   });
 
   it("hides remove-worktree for project root rows", () => {

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -3,6 +3,7 @@ import type { Automation } from "../config/stationConfig.js";
 import { MAIN_PANE_ID, worktreeIdFromAgentPaneId, type StationState } from "../state/types.js";
 import {
   selectDashboardViewport,
+  isExternalAgentRemovalUnavailable,
   sessionForWorktreeRow,
   type TuiState,
 } from "@station/dashboard-core";
@@ -132,7 +133,9 @@ function buildStationItems(
   if (project === undefined || !samePath(row.path, project.root)) {
     items.push({
       id: "station.removeWorktree",
-      label: "Delete Session",
+      label: isExternalAgentRemovalUnavailable(row, state.snapshot)
+        ? "Delete Worktree…"
+        : "Delete Session",
       danger: true,
       action: { kind: "removeWorktree", rowId: row.id },
     });

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -16,7 +16,10 @@ import { createPtyRegistry, type PtyRegistry } from "../terminal/registry/ptyReg
 import type { StationTerminalProcess, StationTerminalSpawnOptions } from "../terminal/types.js";
 import { createScriptedTerminal } from "../terminal/testing/scriptedTerminal.js";
 import { waitFor } from "../terminal/testing/waitFor.js";
-import { manyProjectsSnapshot } from "../station/fixtures/scenarios.js";
+import {
+  externalAgentSnapshot,
+  manyProjectsSnapshot,
+} from "../station/fixtures/scenarios.js";
 import type { AgentPrepareExternalLaunchResult } from "@station/client";
 import type { StationSnapshot, WorktreeRow } from "@station/contracts";
 import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
@@ -932,8 +935,7 @@ describe("createStationInputRuntime open-pane wiring", () => {
 });
 
 describe("createStationInputRuntime STATION context-menu actions", () => {
-  function contextMenuHarness() {
-    const snapshot = manyProjectsSnapshot();
+  function contextMenuHarness(snapshot: StationSnapshot = manyProjectsSnapshot()) {
     const stationViewStore = createTuiStore({
       source: new FakeStationSource(snapshot),
       service: new FakeTuiObserverService(snapshot),
@@ -1004,6 +1006,24 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
       forceRequired: true,
       label: "pty-buffer",
     });
+  });
+
+  it("opens removal information for an external unstoppable agent", () => {
+    const { runtime, stationViewStore, rightClickRow } = contextMenuHarness(
+      externalAgentSnapshot(),
+    );
+
+    rightClickRow();
+    // Menu order: Fork, Delete Worktree… — one down reaches the informational action.
+    runtime.handleSequence("\x1b[B");
+    runtime.handleSequence("\r");
+
+    expect(stationViewStore.getState().screen).toEqual({
+      name: "removeWorktree",
+      step: "unavailable",
+    });
+    stationViewStore.getState().handleKey({ input: "y" });
+    expect(stationViewStore.getState().localRows.pendingRemove).toEqual([]);
   });
 
   it("confirms right-click remove through the optimistic remove-worktree path", () => {

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -100,6 +100,40 @@ export function manyProjectsSnapshot(): StationSnapshot {
   );
 }
 
+export function externalAgentSnapshot(): StationSnapshot {
+  const snapshot = manyProjectsSnapshot();
+  const externalRow = snapshot.rows.find((candidate) => candidate.id === "wt_station_idle");
+  if (externalRow?.agent === undefined) {
+    throw new Error("Fixture row wt_station_idle must have an agent.");
+  }
+  const rowWithoutStationOwnership: WorktreeRow = {
+    ...externalRow,
+    agent: { ...externalRow.agent },
+  };
+  delete rowWithoutStationOwnership.terminal;
+  delete rowWithoutStationOwnership.agent?.sessionId;
+
+  return {
+    ...snapshot,
+    providerHealth: {
+      ...snapshot.providerHealth,
+      codex: {
+        providerId: "codex",
+        providerType: "harness",
+        status: "healthy",
+        lastCheckedAt: SCENARIO_NOW,
+        capabilities: { canStop: false },
+      },
+    },
+    rows: snapshot.rows.map((candidate) =>
+      candidate.id === rowWithoutStationOwnership.id ? rowWithoutStationOwnership : candidate,
+    ),
+    sessions: snapshot.sessions.filter(
+      (session) => session.worktreeId !== rowWithoutStationOwnership.id,
+    ),
+  };
+}
+
 /** First-run: no projects configured at all. */
 export function noProjectsSnapshot(): StationSnapshot {
   return snapshotFromRows([], { projects: [] });

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -12,9 +12,14 @@
 //    outcome derived from actually dispatching its key (close-overlay iff
 //    the transition reports dismissPopup/exitCode).
 import { describe, expect, it } from "bun:test";
-import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
+import {
+  attentionAndFailuresSnapshot,
+  externalAgentSnapshot,
+  manyProjectsSnapshot,
+} from "../fixtures/scenarios.js";
 import {
   createInitialTuiState,
+  openRemoveWorktreeConfirmForRow,
   openProjectDefaultAgentPicker,
   openProjectSettings,
 } from "@station/dashboard-core";
@@ -119,6 +124,10 @@ function drive(state: TuiState, keys: TuiKey[]): TuiState {
  */
 function representativeStates(): Record<StationInputMode, TuiState> {
   const base = dashboardState();
+  const externalBase = createInitialTuiState({
+    initialSnapshot: externalAgentSnapshot(),
+    runtime: { persistentPopup: true, canDismissPopup: true },
+  });
   const renameBase = createInitialTuiState({
     initialSnapshot: attentionAndFailuresSnapshot(),
     runtime: { persistentPopup: true, canDismissPopup: true },
@@ -131,6 +140,7 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     projectSettingsPicker: drive(base, [{ input: "P" }]),
     removeChooseSlot: drive(base, [{ input: "X" }]),
     removeConfirm: drive(base, [{ input: "X" }, { input: "1" }]),
+    removeUnavailable: openRemoveWorktreeConfirmForRow(externalBase, "wt_station_idle"),
     projectSettings: openProjectSettings(base, "station"),
     renameChooseSlot: drive(renameBase, [{ input: "R" }]),
     renameEdit: drive(renameBase, [{ input: "R" }, { input: "1" }]),

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -24,6 +24,7 @@ export type StationInputMode =
   | "projectSettingsPicker"
   | "removeChooseSlot"
   | "removeConfirm"
+  | "removeUnavailable"
   | "renameChooseSlot"
   | "renameEdit"
   | "forkChooseSlot"
@@ -51,7 +52,8 @@ export function deriveStationMode(state: TuiState): StationInputMode {
     case "projectSettingsPicker":
       return "projectSettingsPicker";
     case "removeWorktree":
-      return screen.step === "chooseSlot" ? "removeChooseSlot" : "removeConfirm";
+      if (screen.step === "chooseSlot") return "removeChooseSlot";
+      return screen.step === "unavailable" ? "removeUnavailable" : "removeConfirm";
     case "renameSession":
       return screen.step === "chooseSlot" ? "renameChooseSlot" : "renameEdit";
     case "fork":
@@ -210,6 +212,10 @@ export const STATION_KEYMAP: Record<StationInputMode, readonly StationBinding[]>
     // Ctrl-N/Ctrl-Y control bytes cancel/confirm too (upstream behavior).
     { id: "station.removeConfirm.cancelCtrlN", pattern: { kind: "char", char: "n", ctrl: true }, action: "station.remove.cancel", outcome: "handled" },
     { id: "station.removeConfirm.confirmCtrlY", pattern: { kind: "char", char: "y", ctrl: true }, action: "station.remove.confirm", outcome: "handled" },
+  ],
+  removeUnavailable: [
+    { id: "station.removeUnavailable.closeEsc", pattern: { kind: "named", named: "escape" }, action: "station.remove.close", outcome: "handled", help: { keys: "esc/enter", label: "close" } },
+    { id: "station.removeUnavailable.closeEnter", pattern: { kind: "named", named: "return" }, action: "station.remove.close", outcome: "handled" },
   ],
   // Two-pane Project Settings panel. Like addProject, every key routes to one
   // action and the dashboard-core machine decodes it against the panel's focus

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -615,3 +615,31 @@ exports[`modal flow golden frames renders the collapse project sheet windows a l
 └──────────────────────────────────────────────────────────────────────────────┘
 "
 `;
+
+exports[`modal flow golden frames renders the external agent removal information 1`] = `
+"
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
+───────────────────────────────────────────────────────────────────────────────
+       SESSION                            AGENT     STATUS            DIFF · PR
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
+ [2] - docs-cleanup                       -         no agent
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓
+ [4] + session-resume                     codex     starting
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
+
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ [6] x batch-export                       opencode  exited                 #8 ✓
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
+┌──────────────────────────────────────────────────────────────────┐
+│ Cannot delete worktree                                           │h] [qs] [▾]
+│ This agent was started outside Station.                          │14 -6 #5 x1
+│ Station can see its status, but cannot stop it.                  │  +3 -1 #10
+│                                                                  │
+│ Stop or remove it from its original terminal or external tooling.│
+│                                                                  │
+│ Esc/Enter:close                                                  │───────────
+└──────────────────────────────────────────────────────────────────┘/esc:close
+"
+`;

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -5,11 +5,16 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { TextRenderable, type BaseRenderable } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
 import type { StoreApi } from "zustand/vanilla";
-import { attentionAndFailuresSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
+import {
+  attentionAndFailuresSnapshot,
+  externalAgentSnapshot,
+  manyProjectsSnapshot,
+} from "../fixtures/scenarios.js";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
 import {
   addPendingProjectDefaultHarness,
+  openRemoveWorktreeConfirmForRow,
   openProjectDefaultAgentPicker,
   openProjectSettings,
 } from "@station/dashboard-core";
@@ -27,6 +32,7 @@ type ModalCase = {
   prepare?: (store: StoreApi<TuiStore>) => void;
   trimSnapshotTrailingWhitespace?: true;
   expect: string[];
+  reject?: string[];
 };
 
 const CASES: ModalCase[] = [
@@ -112,6 +118,23 @@ const CASES: ModalCase[] = [
     name: "remove confirm sheet",
     keys: [{ input: "X" }, { input: "1" }],
     expect: ["Delete session?", "Session", "cli-help-man", "Yes (y)", "No (n)"],
+  },
+  {
+    name: "external agent removal information",
+    keys: [],
+    snapshot: externalAgentSnapshot,
+    trimSnapshotTrailingWhitespace: true,
+    prepare: (store) => {
+      store.setState(openRemoveWorktreeConfirmForRow(store.getState(), "wt_station_idle"));
+    },
+    expect: [
+      "Cannot delete worktree",
+      "This agent was started outside Station.",
+      "Station can see its status, but cannot stop it.",
+      "Stop or remove it from its original terminal or external tooling.",
+      "Esc/Enter:close",
+    ],
+    reject: ["Yes (y)", "No (n)"],
   },
   {
     name: "rename slot prompt",
@@ -249,6 +272,9 @@ describe("modal flow golden frames", () => {
           : capturedFrame;
       for (const expected of modal.expect) {
         expect(frame).toContain(expected);
+      }
+      for (const rejected of modal.reject ?? []) {
+        expect(frame).not.toContain(rejected);
       }
       expect(frame).toMatchSnapshot();
     });

--- a/station/src/station/view/sheets/RemoveSessionSheetView.tsx
+++ b/station/src/station/view/sheets/RemoveSessionSheetView.tsx
@@ -18,7 +18,10 @@ export type RemoveSessionSheetViewProps = {
 };
 
 export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionSheetViewProps) {
-  const sheetWidth = compactSheetWidth(columns);
+  const sheetWidth =
+    screen.step === "unavailable"
+      ? Math.min(Math.max(1, Math.floor(columns)), 68)
+      : compactSheetWidth(columns);
   const contentWidth = bottomSheetContentWidth(sheetWidth);
   if (screen.step === "chooseSlot") {
     return (
@@ -33,6 +36,32 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
         <SheetLine width={contentWidth}> </SheetLine>
         <SheetMessageLine width={contentWidth}>↑↓ move · ↵ choose · slot or click</SheetMessageLine>
         <SheetFooter width={contentWidth}>Esc:cancel</SheetFooter>
+      </BottomSheetFrameView>
+    );
+  }
+
+  if (screen.step === "unavailable") {
+    return (
+      <BottomSheetFrameView
+        columns={columns}
+        rows={rows}
+        width={sheetWidth}
+        title="Cannot delete worktree"
+        contentRows={7}
+        minHeight={9}
+      >
+        <SheetMessageLine width={contentWidth}>
+          This agent was started outside Station.
+        </SheetMessageLine>
+        <SheetMessageLine width={contentWidth}>
+          Station can see its status, but cannot stop it.
+        </SheetMessageLine>
+        <SheetLine width={contentWidth}> </SheetLine>
+        <SheetMessageLine width={contentWidth}>
+          Stop or remove it from its original terminal or external tooling.
+        </SheetMessageLine>
+        <SheetLine width={contentWidth}> </SheetLine>
+        <SheetFooter width={contentWidth}>Esc/Enter:close</SheetFooter>
       </BottomSheetFrameView>
     );
   }


### PR DESCRIPTION
## Summary

- detect running agents that have no Station session, provider stop capability, or closeable terminal
- label their context-menu action **Delete Worktree…**
- open a non-confirming explanation instead of dispatching `worktree.remove`
- preserve existing removal behavior for managed sessions and agentless worktrees

## Root cause

Hook-discovered external agents appear in the dashboard but are not controlled by a Station session or terminal. The normal forced removal path attempted harness cleanup first, then surfaced `HARNESS_STOP_UNSUPPORTED` because Codex cannot stop the run.

This keeps observer cleanup semantics unchanged and handles only the unavailable action in the TUI.

## UX

Affected rows now explain that Station can observe the agent but cannot stop it, and direct the user to the original terminal or external tooling. The screen has no Yes/No controls; Escape or Enter closes it, and confirmation keys cannot dispatch removal.

Closes #93.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- focused dashboard-core transition tests: 47 passed
- focused Station context-menu/input/keymap/golden tests: 139 passed
- full Station suite: 944 passed
- isolated-HOME root unit suite: 1181 passed
- contracts: 24 passed
- integration: 302 passed, 1 skipped
- diagnostics: 34 passed
- scripted agent: 3 passed
- setup e2e: 7 passed

Local `pnpm test:all` under the developer HOME stops on an unrelated Claude doctor assertion because generated Station hooks exist while that fixture does not request hooks. The complete unit lane passes with an isolated HOME; every remaining deterministic lane passes normally.