### PR TITLE
docs(observer): adopt architecture contract and role language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Agent Guidance
 
-For architecture or boundary decisions, read `docs/architecture.md`.
+For repository-wide architecture or boundary decisions, read `docs/architecture.md`. For
+Observer ports, adapters, use cases, policies, composition, or dependency direction, also
+read `docs/observer-architecture.md` and `docs/architecture-documentation.md`.
 
 For configuration — the runtime `config.toml` (all sections, including `[workspace]` and `[tui]`), the project-local `.station/config.toml`, and environment variables — read `docs/configuration.md`.
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ station is under active development. The current build supports local setup, dia
 | [Overview](docs/overview.md) | What station is, why it exists, and the mental model behind it |
 | [Install](docs/install.md) | Full checkout setup, smoke options, local CLI linking |
 | [Homebrew packaging](docs/homebrew.md) | Draft tap formula path and release checklist |
-| [Architecture](docs/architecture.md) | Authoritative boundary map for architecture decisions |
+| [Architecture](docs/architecture.md) | Repository-wide system and boundary map |
+| [Observer architecture](docs/observer-architecture.md) | Canonical Observer boundaries, flows, state lifetimes, and active deviations |
+| [Architecture documentation](docs/architecture-documentation.md) | Controlled JSDoc roles for Observer architectural seams |
 | [Development](docs/development.md) | Environment, test gates, data-shape conventions |
 | [TUI](docs/tui.md) | OpenTUI/React Station UI coding, terminal layout, test expectations |
 | [Debugging](docs/debugging.md) | Trace IDs, command IDs, no-action debugging, evidence lookup |

--- a/docs/architecture-documentation.md
+++ b/docs/architecture-documentation.md
@@ -1,0 +1,254 @@
+# Architecture Documentation
+
+Status: adopted living standard for Observer architectural declarations.
+
+This standard applies to `apps/observer` and to declarations in immediate
+contracts, protocol, CLI composition, and integrations when they participate in
+an Observer seam. It does not automatically classify the Station UI, client,
+host, or unrelated packages; another subsystem may adopt it through an explicit
+architecture decision.
+
+Use this document when adding or materially changing an Observer application
+port, adapter entrypoint, use case, shared policy, or composition root. It
+defines the small JSDoc language that makes those seams recognizable in source.
+
+This document does not define the Observer's boundaries, flows, or known
+deviations. See [Observer Architecture](observer-architecture.md) for those
+decisions and [Architecture](architecture.md) for the repository-wide system
+map. Ordinary code comments continue to follow the concise, load-bearing
+comment rules in `AGENTS.md`.
+
+## Controlled Roles
+
+Architectural declarations use exactly one of these first-line markers:
+
+| Marker | Meaning |
+| --- | --- |
+| `DRIVING PORT` | An application-owned contract through which an external actor requests application behavior. |
+| `DRIVEN PORT` | An application-owned capability contract that a use case calls to reach an external actor. |
+| `ADAPTER` | A boundary implementation that translates between application terms and an external actor or representation. |
+| `USE CASE` | An application operation that realizes one product intent, coordinating policies and ports as needed. |
+| `POLICY` | A reusable, deterministic, IO-free product decision. |
+| `COMPOSITION ROOT` | An entrypoint that chooses concrete adapters and owns their wiring or lifecycle. |
+
+These roles describe dependency direction, not folders or naming suffixes:
+
+```text
+external actor
+    -> driving adapter -> DRIVING PORT -> USE CASE -> POLICY
+                                               |
+                                               v
+                                          DRIVEN PORT -> ADAPTER -> external actor
+
+                     COMPOSITION ROOT wires concrete roles
+```
+
+The vocabulary is deliberately small. `Provider`, `Repository`, `Service`,
+`Model`, and `Component` are not architectural markers. They may remain useful
+domain or implementation names: `StationTerminalProvider`, for example, is an
+`ADAPTER`, while `ManagedTerminalLifecycle` is a `DRIVEN PORT`.
+
+Commands, queries, events, snapshots, entities, value objects, schemas, DTOs,
+and workers are also meaningful concepts rather than additional roles. Classify
+their architectural entrypoint with one of the six roles when applicable; leave
+ordinary declarations unmarked.
+
+## Exact JSDoc Form
+
+Put the marker on the declaration's first nonblank JSDoc line, followed by a
+blank JSDoc line and one concise application-purpose paragraph:
+
+```ts
+/**
+ * ROLE
+ *
+ * States the application purpose in plain language.
+ *
+ * Optionally records only load-bearing authority, identity, ordering,
+ * idempotency, lifecycle, cancellation, or failure semantics.
+ */
+export interface NamedArchitecturalDeclaration {
+  // ...
+}
+```
+
+The grammar is:
+
+1. Use a multiline `/** ... */` JSDoc block immediately before a named,
+   top-level exported production declaration.
+2. Make the first content line exactly one controlled marker, including case and
+   spacing. Do not write `Adapter`, `[ADAPTER]`, `ADAPTER:`, or combined roles.
+3. Put a blank JSDoc line immediately after the marker.
+4. Follow with one short paragraph that explains what the application gains
+   from the seam, rather than restating the declaration name or TypeScript type.
+5. Add further prose only when it protects a stable boundary rule. Normal
+   JSDoc tags, when needed, come after the prose.
+
+Do not add a metadata mini-language such as `Purpose:`, `Owner:`, `Direction:`,
+`Implements:`, or `Composed by:`. The prose should remain readable without a
+parser, while structured ownership and adapter mappings belong in the canonical
+architecture document.
+
+One declaration has one role. If a declaration can only be explained with two
+markers, split its responsibilities or record an explicit deviation; do not
+write `USE CASE / ADAPTER`.
+
+## Where Markers Apply
+
+Mark the exported declaration that forms a consequential architectural seam:
+
+- an application-owned driving or driven port;
+- the public class, object, or factory that implements an adapter boundary;
+- an application entrypoint that owns a complete use case;
+- a shared policy reused across use cases or clients;
+- an entrypoint that selects concrete implementations or owns their lifecycle.
+
+Do not mark:
+
+- schemas, DTOs, errors, value types, constants, or data-only records;
+- ordinary helpers, selectors, mappers, or formatters;
+- every method on a marked port or adapter;
+- adapter-private parsers, command runners, and representation types;
+- tests, fixtures, fakes, and test builders;
+- UI components or hooks merely because they are exported;
+- pure `index.ts` barrels or module-wide comments.
+
+An `index.ts` or `types.ts` filename carries no architectural meaning. A pure
+barrel stays unmarked. When an `index.ts` contains a real architectural
+entrypoint, mark its declaration; move the behavior to a purpose-named module
+only when that improves ownership or navigation.
+
+Use this quick classification check:
+
+1. Does an outside actor enter the application through this contract? `DRIVING
+   PORT`.
+2. Does application behavior call this contract to reach outward? `DRIVEN
+   PORT`.
+3. Does this implementation translate at either boundary? `ADAPTER`.
+4. Does this operation coordinate a complete application intent? `USE CASE`.
+5. Is this a reusable deterministic product decision with no IO? `POLICY`.
+6. Does this entrypoint choose concrete implementations or own their lifecycle?
+   `COMPOSITION ROOT`.
+7. If none applies, leave it unmarked.
+
+## Role Distinctions
+
+### Port versus adapter
+
+The application owns the port's vocabulary; an adapter implements or invokes
+that conversation using outside mechanics. Mark both declarations when both
+are public seams, each with its own role. Do not label an implementation as a
+port merely because it satisfies an interface.
+
+Current example:
+
+- [`ManagedTerminalLifecycle`](../packages/contracts/src/providers.ts) is a
+  `DRIVEN PORT` owned in application contracts.
+- [`StationTerminalProvider`](../integrations/terminal/station/src/provider.ts)
+  is an `ADAPTER` that implements it using Station terminal and host mechanics.
+
+### Driving port versus use case
+
+A driving port is the callable application contract. A use case is the
+operation that fulfills an intent behind that contract. One driving port may
+expose several use cases, and a use case may be called by more than one driving
+adapter.
+
+`ObserverApi` is the expected Observer `DRIVING PORT` when its application
+contract ownership is moved inward. Its current ownership by
+`packages/protocol` remains a documented deviation, so this standard does not
+silently declare that migration complete.
+
+[`prepareExternalLaunch`](../apps/observer/src/runtime/externalLaunch.ts) and
+[`reportExternalExit`](../apps/observer/src/runtime/externalLaunch.ts) are
+current `USE CASE` examples. Their callers and transport wrappers are not part
+of those use cases merely because they invoke them.
+
+### Policy versus helper or use case
+
+A policy expresses a product decision and can run without a database, socket,
+filesystem, process, provider, clock, or logger. It is marked only when the
+decision is a shared architectural seam, not merely because a helper is pure.
+
+`worktreeHasLiveAgent` is an existing policy-shaped decision reused by Observer
+commands, reconciliation, external launch, and dashboard behavior. It is a
+candidate for the first `POLICY` marker when that declaration is materially
+touched; this document does not require an unrelated backfill edit.
+
+A function that coordinates a policy with persistence or provider calls is a
+`USE CASE`, even if most of its calculations are pure.
+
+### Adapter versus composition root
+
+An adapter performs boundary translation at runtime. A composition root chooses
+which concrete adapters occupy application roles and wires their lifecycles.
+Constructors and factories are not automatically composition roots.
+
+[`createProviderRegistry`](../apps/cli/src/observerProviders.ts) is a current
+`COMPOSITION ROOT`: it chooses concrete provider integrations and supplies
+their application roles. Constructing an internal helper or returning a use
+case closure without choosing concrete boundary implementations is not
+composition.
+
+## Adoption on Touch
+
+Adopt the language seam by seam instead of performing a comment-only backfill:
+
+- New architectural seams must use the marker when introduced.
+- A materially changed existing seam gains or corrects its marker in the same
+  change. Material changes include responsibility, dependency direction,
+  application contract, external actor, authority, identity, lifecycle, or
+  failure semantics.
+- Formatting, private refactoring, and behavior fixes that do not change the
+  seam do not force a marker-only edit.
+- When a remediation stage classifies or moves a group of seams, add that group
+  to architecture diagnostics together rather than sweeping unrelated areas.
+- An unmarked legacy seam is staged migration work, not evidence that the
+  vocabulary is optional. The seam inventory tracks marker coverage; the
+  architecture deviation register is reserved for consequential boundary
+  violations.
+
+If a touched declaration does not fit one role honestly, do not choose the
+nearest-sounding word. Split mixed ownership when the change permits it, or
+record the deviation and exit condition in
+[Observer Architecture](observer-architecture.md).
+
+## Enforcement Limits
+
+Architecture diagnostics may mechanically enforce:
+
+- the closed marker vocabulary and exact first-line form;
+- attachment to named, exported production declarations;
+- agreement between controlled markers and the staged seam inventory;
+- absence of orphan markers or stale inventory entries.
+
+The staged inventory defines migration coverage; it must not claim that every
+legacy seam is already marked. Tests should derive each declaration's role from
+its JSDoc instead of repeating the role in a second hand-maintained list.
+
+Automation cannot prove that a role is truthful, a purpose paragraph is
+accurate, a policy is free of hidden IO, an adapter is substitutable, or
+application code is semantically provider-neutral. Dependency checks, pure
+policy tests, deliberately different fakes, port contract suites, adapter
+integration tests, composition tests, and review provide that evidence. Do not
+add prose lint or force ordinary exports into roles merely to make the marker
+count look complete.
+
+## Extending the Vocabulary
+
+Treat the six markers as a closed vocabulary. Add a role only when a recurring,
+consequential dependency responsibility cannot be described truthfully by an
+existing role. A domain noun, file pattern, or one-off implementation shape is
+not sufficient.
+
+The same change that adds a role must:
+
+1. define its dependency meaning and distinguish it from all existing roles;
+2. state which declarations require it and which similar declarations do not;
+3. show at least one real Station seam that needs it;
+4. update this document, the canonical subsystem architecture where relevant,
+   and the architecture diagnostic vocabulary;
+5. migrate the motivating declaration without introducing aliases for an
+   existing marker.
+
+Do not introduce a new all-caps marker in source first and document it later.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,13 @@
 # Architecture
 
-Status: current living doc for ordinary architecture and boundary decisions.
+Status: current living repository-wide system and boundary map.
 
 Use [Naming](naming.md) for provider hook, provider hook ingress, harness event report, STATION event, and observer event hook terminology.
+
+Use [Observer Architecture](observer-architecture.md) for the Observer's application model,
+dependency direction, runtime flows, state lifetimes, and active deviations. Use
+[Architecture Documentation](architecture-documentation.md) for the controlled JSDoc language
+applied to Observer architectural seams.
 
 station is a terminal-native control plane for AI-agent worktree sessions. It keeps repositories, worktrees, terminal targets, provider hooks, agent runs, commands, and diagnostics in one runtime graph.
 
@@ -28,8 +33,8 @@ The repo is organized around these boundaries:
 - `packages/protocol` owns the observer transport and validates request, response, and event messages.
 - `packages/runtime` owns shared runtime boundary helpers for timeouts, retry, cancellation, external commands, and typed error conversion.
 - `packages/client` owns the framework-neutral rich-client observer runtime: snapshot loading, the event subscription/reconnect loop, event-to-snapshot reduction, and command dispatch/completion-wait wrappers consumed by the Station UI.
-- `apps/cli/src/ingress` owns the tiny `stn-ingress` sender: raw provider hook delivery to the observer socket and offline spool writes. Normalization/compaction run observer-side via provider hook adapters.
-- `packages/station-host` owns the standalone `station-station-host` daemon contract and client: a process that owns PTYs outliving the Station UI, exposing attach/list/close over its own local socket so panes can warm-reattach with scrollback. It is consumed by Station, not by the observer.
+- `apps/cli/src/ingress` owns the tiny `stn-ingress` sender: raw provider hook delivery to the observer socket and offline spool writes. Events sent through this raw path normalize and compact observer-side via provider hook adapters; integrations that submit typed harness reports normalize in their own adapter.
+- `packages/station-host` owns the standalone `station-station-host` daemon contract and client: a process that owns PTYs outliving the Station UI, exposing attach/list/close over its own local socket so panes can warm-reattach with scrollback. Station consumes it directly; Observer application code can reach host-backed terminal behavior only through an adapter supplied by CLI composition.
 - `packages/config`, `packages/observability`, and `packages/testing` are shared support packages.
 - `integrations/...` adapt external tools: Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, OpenCode, scripted harnesses, and GitHub repository metadata.
 
@@ -60,9 +65,12 @@ When these disagree, reconcile from config, providers, and current observer stat
 - Provider hooks are ingress notifications and fast status reports. They can trigger persistence, projection, spool fallback, or scheduled reconcile, but they are not authoritative graph truth by themselves. Observer event hooks are configured commands triggered by STATION events and should not be conflated with provider hook ingress.
 - Terminal topology is provider-owned. Shared contracts and Station UI behavior should express product intent where possible, not provider target mechanics.
 
-## Module Layout
+## Station UI Module Layout
 
-When a directory outgrows a handful of files, keep its public surface and composition root at the directory root and push internal concern-clusters into lowercase subdirs — mirroring `terminal/`'s `protocol|pty|registry` and `state/`'s `reducers|reconcilers`. For example `input/` keeps the consumed hubs (`router`, `mouse`) and the `stationInput` composition root at root, with `keymap/` and `runtime/` beneath. Colocate each test beside its source and move it with the source. Add an `index.ts` barrel only when a directory's public symbols would otherwise be reached through deep subpaths; skip it when the public surface already sits at the root.
+Within `station/`, when a directory outgrows a handful of files, keep its public surface and composition root at the directory root and push internal concern-clusters into lowercase subdirs — mirroring `terminal/`'s `protocol|pty|registry` and `state/`'s `reducers|reconcilers`. For example `input/` keeps the consumed hubs (`router`, `mouse`) and the `stationInput` composition root at root, with `keymap/` and `runtime/` beneath. Colocate each test beside its source and move it with the source. Add an `index.ts` barrel only when a directory's public symbols would otherwise be reached through deep subpaths; skip it when the public surface already sits at the root.
+
+Observer layout follows ownership and dependency direction rather than this UI-specific shape.
+See [Observer Architecture](observer-architecture.md).
 
 ## Station Subsystem
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -94,6 +94,19 @@ Use `pnpm setup:system:check` before real lanes. Real lanes may require `STATION
 - Current code, tests, runtime traces, and deterministic fixtures are stronger evidence than historical plans.
 - Do not introduce production behavior through docs-only changes.
 
+## Architecture Documentation
+
+- Read [Observer Architecture](observer-architecture.md) before changing Observer boundaries,
+  composition, state authority, lifecycle, concurrency, or persistence responsibilities.
+- New or materially changed Observer ports, adapter entrypoints, use cases, shared policies,
+  and composition roots must follow
+  [Architecture Documentation](architecture-documentation.md).
+- Update the Observer architecture in the same change when a boundary, dependency rule,
+  runtime flow, state lifetime, or registered deviation changes. Ordinary helper refactors do
+  not require architecture-document churn.
+- Apply role markers to touched seams. Do not classify every exported helper or perform an
+  unrelated repository-wide marker backfill.
+
 ## TUI Work
 
 TUI work has additional OpenTUI/React and terminal-layout expectations. The terminal UI is the OpenTUI renderer in `station/` (package `@station/workspace`, built on `@opentui/core` + `@opentui/react` + `react`). Use [TUI development](tui.md) before changing `station/` components, hooks, sources, keymaps, selectors, popup behavior, or renderer tests.

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -50,9 +50,12 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
 
 ## Invariants
 
-1. **Single normalizer.** One event is normalized by exactly one code version.
-   (Today normalization runs in `stn-ingress`; it moves observer-side so a
-   stale ingress binary cannot bake stale semantics.)
+1. **Single normalizer.** One event is normalized by exactly one adapter
+   version. Raw events delivered by `stn-ingress` normalize observer-side
+   through the selected provider hook adapter, so a stale ingress binary cannot
+   bake stale semantics. Integrations such as Pi that submit an already-typed
+   `HarnessEventReport` normalize in their own adapter and are not normalized
+   again by the observer.
 2. **No provider vocabulary in core.** Observer core and the TUI must not
    match on provider prose (`reason` strings), provider event names, or
    provider keys in `providerData`. If core needs to branch on it, it becomes

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -1,0 +1,555 @@
+# Observer Architecture
+
+Status: adopted normative architecture for `apps/observer` and its immediate
+contracts, transports, integrations, and composition roots.
+
+Use [Architecture](architecture.md) for the repository-wide system map and
+[Architecture documentation](architecture-documentation.md) for the controlled
+JSDoc role language. Use [Naming](naming.md) for provider, hook, harness report,
+STATION event, and observer event hook terminology.
+
+## Scope And Authority
+
+The observer is Station's long-lived application runtime. It correlates config,
+provider observations, and durable observer memory into snapshots; executes
+commands; ingests provider and harness events; and exposes health, diagnostics,
+and lifecycle operations.
+
+This document has three kinds of statements:
+
+- **Adopted rule** defines the dependency direction and ownership new work must
+  preserve.
+- **Current behavior** describes the implementation contributors must understand
+  today.
+- **Active deviation** names current code that does not yet satisfy an adopted
+  rule and gives its exit condition.
+
+Code, tests, runtime traces, and diagnostics remain the evidence for what the
+program currently does. This document is the authority for what dependencies
+and responsibilities are allowed. A mismatch that is not an active deviation
+must be fixed or documented in the same change that discovers it.
+
+Update this document when a change adds or changes a port, adapter, use case,
+policy, composition root, external actor, durable boundary, API category,
+ingress path, background worker, authority rule, lifecycle, concurrency
+contract, replay guarantee, migration rule, or active deviation. Ordinary
+helper extraction and file-to-directory growth do not require architecture
+churn.
+
+This architecture does not require:
+
+- microservices or a dependency-injection framework;
+- global `Model`, `Service`, `Provider`, or `Repository` layers;
+- one port per function or use case;
+- identical directory skeletons;
+- a repository-wide folder move;
+- an interface around ordinary pure helpers.
+
+## Adopted Shape
+
+The observer is a use-case-oriented modular monolith with a functional policy
+core and strict ports-and-adapters boundaries around external technology and
+durable state.
+
+```mermaid
+flowchart LR
+  A[External actor] --> DA[Driving adapter]
+  DA --> DP[Driving port]
+  DP --> UC[Use case]
+  UC --> P[Policy]
+  UC --> OP[Driven port]
+  OP --> OA[Adapter]
+  OA --> E[External system or representation]
+  CR[Composition root] -. constructs and wires .-> DA
+  CR -. constructs and wires .-> UC
+  CR -. constructs and wires .-> OA
+```
+
+Dependencies point toward application semantics:
+
+- Driving adapters validate and translate outside input before invoking an
+  application-owned driving port.
+- Use cases coordinate one product intent through policies and driven ports.
+- Policies make deterministic product decisions without process, filesystem,
+  socket, database, clock, or provider setup.
+- Driven ports express capabilities the application needs from external actors.
+- Adapters implement those ports and own technology-specific translation.
+- Composition roots may know every category because their job is to choose
+  concrete implementations and own their lifecycle.
+
+Application code must not select an adapter by concrete provider ID, reconstruct
+provider-owned identity, inspect SQL rows or transport envelopes, scrape generic
+provider payloads, or reach back into composition. Ports must use
+Station-purpose language rather than SDK, command-line, SQL, filesystem-layout,
+or transport-native representations.
+
+### Architectural Roles
+
+The controlled source roles are:
+
+- **Driving port:** an application-owned contract offered to an actor invoking
+  the observer.
+- **Driven port:** an application-owned capability the observer calls outward.
+- **Adapter:** translation between a port and an external actor or
+  representation.
+- **Use case:** orchestration that realizes one application intent.
+- **Policy:** reusable deterministic decision logic with no I/O.
+- **Composition root:** construction, role assignment, and lifecycle wiring for
+  concrete implementations.
+
+These are dependency roles, not a complete glossary of backend nouns. Commands,
+queries, events, snapshots, schemas, DTOs, identities, workers, and projections
+remain meaningful concepts without becoming additional architectural roles.
+`Provider` and `Repository` can remain domain names: a provider interface is
+usually a driven port, while its concrete implementation is an adapter.
+
+High-level declarations carry their controlled role in JSDoc so a contributor
+can recognize the seam locally. The exact grammar, required scope, and examples
+live in [Architecture documentation](architecture-documentation.md); do not
+invent local variants in this document or source comments.
+
+### Application Operations
+
+Use a recorded command for a user-requested mutation that needs acceptance,
+serialization, progress, durable completion, and diagnostics. Direct Observer
+API methods are limited to:
+
+- **queries** that return current or historical application state;
+- **handshakes** whose caller needs an immediate result before continuing;
+- **ingress reports** that acknowledge external evidence delivery;
+- **maintenance operations** that refresh Observer-owned state, such as
+  startup, scheduled, or manually requested reconcile;
+- **lifecycle operations** such as health and controlled stop.
+
+A new mutation does not become a direct method merely because it is easier to
+wire. A query or latency-sensitive handshake does not become a command merely
+to make the API look uniform.
+
+## System Boundary And Composition
+
+The observer's driving actors are CLI commands, the Station client runtime and
+TUI, provider hook senders, harness integrations, protocol clients, and tests.
+Its driven actors include worktree, terminal, harness, and repository systems;
+SQLite; local Git and filesystem evidence; configured commands; the clock; and
+logging sinks.
+
+```text
+CLI / TUI / hooks / tests
+        |
+        v
+protocol validation or direct test driver
+        |
+        v
+Observer API -> use cases and policies -> application-owned ports
+                                           |
+                                           v
+                     providers / SQLite / Git / filesystem / logs / processes
+```
+
+Composition is intentionally split:
+
+1. `apps/cli/src/observerProviders.ts` constructs concrete integrations,
+   assigns provider roles, and supplies a `ProviderRegistry` factory.
+2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
+   private infrastructure: SQLite, persistence, logger, event bus, command
+   queue, core, handlers, ingress queues, schedulers, API, and protocol server.
+
+The split is allowed because both pieces are outer wiring. Application modules
+must not compensate for it by selecting concrete adapters at runtime.
+
+The Station terminal adapter may use Station Host when CLI composition enables
+host-backed terminals. Observer application code knows only the injected
+`ManagedTerminalLifecycle`; it must not know Station Host socket, process, or
+target-format mechanics.
+
+## Port, Actor, And Adapter Map
+
+This table describes the current seams. The rule column states the adopted
+ownership even where current ownership is still a deviation.
+
+| Conversation | Direction | Application seam | Actor or adapter | Rule and current status |
+| --- | --- | --- | --- | --- |
+| Observer operations | Driving | `ObserverApi` | NDJSON/Unix-socket server, direct tests | This is the current driving-port-shaped surface; it becomes a conforming application-owned driving port when OBS-HEX-003 exits. |
+| Recorded mutations | Driving | `StationCommand`, `dispatch`, command handlers | CLI, Station client, protocol client | Commands persist acceptance and completion; registration is not yet exhaustive (OBS-HEX-006). |
+| Provider hook delivery | Driving | provider hook ingress | `stn-ingress`, protocol method, offline spool, provider hook adapters | Raw input is validated once and provider vocabulary is normalized at the adapter boundary. |
+| Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
+| Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Strong purpose-owned port. |
+| Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
+| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role; the remaining response payload is host-shaped (OBS-HEX-009). |
+| Harness operations | Driven | `HarnessProvider` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned port with provider-local parsing. |
+| Repository metadata | Driven | `RepositoryProvider` | GitHub repository adapter | The port is generic; selection is still GitHub-specific in application code (OBS-HEX-002). |
+| Durable observer memory | Driven | current `ObserverPersistence` | SQLite persistence modules | A port exists, but it is broad and leaks SQLite representations (OBS-HEX-004 and OBS-HEX-005). |
+| Logging and config mutation | Driven | injected logger and config path today | JSONL logger and config filesystem | These require purpose-owned application ports (OBS-HEX-010). |
+| Worktree metadata evidence | Driven | metadata refresh dependencies today | Git commands, ref watcher, repository adapter | Local Git/process/watch mechanics remain mixed into the use case (OBS-HEX-011). |
+| Diagnostic evidence | Driven | diagnostic runtime paths today | filesystem, logs, spool, SQLite history | Local evidence traversal remains mixed into diagnostics collection (OBS-HEX-012). |
+
+`packages/contracts` owns shared Station schemas, application values, and
+provider port contracts. `packages/protocol` must own only transport envelopes,
+method mapping, validation, and client/server mechanics. An integration under
+`integrations/**` may depend inward on contracts; application code must not
+depend outward on a concrete integration.
+
+## Current Module Ownership
+
+Folders aid navigation but do not assign architectural roles. Current Observer
+areas contain the following responsibilities:
+
+| Area | Current responsibility | Adopted ownership |
+| --- | --- | --- |
+| `commands/` | command queue, routing, scopes, cancellation, and command use cases | Driving application behavior; handlers depend on driven ports and policies. |
+| `reconcile/` | provider reads, correlation, graph construction, projection, and core state | Reconcile use case plus deterministic policies; provider I/O remains at its driven edges. |
+| `hooks/` | hook/report ingestion, dedupe, readiness, spool I/O, and ingress queue | Ingress use cases and queue orchestration separated from filesystem spool adapters. |
+| `runtime/` | API assembly, process lifecycle, scheduling, event delivery, server bridge, and external launch | Observer composition plus application operations; transport and infrastructure stay at the edge. |
+| `providers/` | provider aggregation, health cache, and terminal intent execution | Registry and health composition must not own application orchestration (OBS-HEX-007). |
+| `metadata/` | metadata refresh, repository lookup, Git execution, and ref watching | Metadata use cases depend on repository and local-metadata ports (OBS-HEX-002 and OBS-HEX-011). |
+| `persistence/`, `migrations/`, `sqlite.ts` | persistence contract, SQL translation, transactions, migrations, and rows | Application persistence ports are distinct from the SQLite adapter (OBS-HEX-004 and OBS-HEX-005). |
+| `diagnostics/` | doctor and diagnostic collection plus local evidence traversal | Diagnostic use cases depend on an evidence-source port (OBS-HEX-012). |
+| `features/` | feature-flag evaluation | Deterministic application policy. |
+| `apps/cli/src/observerProviders.ts` | concrete provider construction and role assignment | Outer composition root. |
+| `integrations/**` | external-system parsing and operations | Outbound adapters. |
+
+`index.ts` and `types.ts` are filenames, not roles. A pure `index.ts` barrel may
+re-export a public surface. If a barrel accumulates behavior, give that behavior
+a purpose-named module when the area is materially changed. A file may become a
+directory when it grows; identical feature skeletons add ceremony without
+protecting dependency direction.
+
+## State, Authority, And Lifetime
+
+No single layer owns all truth.
+
+| State | Authority and lifetime |
+| --- | --- |
+| Loaded config | Authoritative for managed projects, defaults, provider choices, feature policy, and configured hooks. Durable in TOML; loaded into process memory at startup and updated through explicit config operations. |
+| Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
+| Provider-owned identity | Worktree, target, harness-run, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
+| Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
+| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
+| `StationSnapshot` | Current normalized graph held in memory. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
+| Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
+| Persisted event rows | Historical and diagnostic observer memory. They are not currently the source for live subscription replay. |
+| Hook spool | Durable delivery fallback while ingress cannot reach the observer. A queued record is pending evidence, not current graph truth. |
+| JSONL logs and debug bundles | Diagnostic evidence. They never outrank config, provider reads, current observer state, or command records. |
+
+Clients must treat a subscription gap as possible event loss. The Station client
+runtime subscribes first, loads a full snapshot while that subscription is live,
+and reloads after later gaps or events that cannot be reduced safely.
+
+## Runtime Lifecycle
+
+### Startup
+
+Current startup proceeds in this order:
+
+1. CLI composition supplies the concrete provider registry factory.
+2. Observer runtime loads config, resolves the state and socket paths, and
+   creates the state directory.
+3. SQLite opens, applies pending migrations, and constructs persistence.
+4. The runtime creates the event bus, logger, command queue, provider registry,
+   feature evaluator, Observer core, command handlers, and configured event
+   hooks.
+5. The API constructs ingress queues, reconcile scheduling, metadata refresh,
+   diagnostics dependencies, and spool draining.
+6. The protocol server binds the socket before startup reconcile. A
+   socket-ownership watch is armed so a displaced observer shuts itself down.
+7. Startup reconcile establishes the first provider-backed snapshot. Provider
+   health and harness-version probes fill caches in the background.
+
+Composition must make lifecycle ownership obvious. Anything that owns a timer,
+fiber, watcher, queue, socket, child process, or durable handle must have a
+defined startup failure path and shutdown owner.
+
+### Shutdown
+
+The current API stop path drains harness ingress and metadata watchers, then
+schedules process shutdown. Command-queue shutdown rejects new commands,
+aborts running handlers cooperatively, and waits for their per-scope chains;
+configured event hooks and the protocol server then close before SQLite. A
+bounded process backstop prevents a handler that ignores cancellation from
+keeping a displaced or stopped observer alive indefinitely.
+
+## Main Flows
+
+### Command Execution
+
+```text
+client -> transport validation -> ObserverApi.dispatch
+       -> validate command -> persist accepted -> publish accepted
+       -> serialize by command scope -> persist/publish started
+       -> handler -> policies and driven ports -> reconcile when required
+       -> persist/publish succeeded or failed -> command query/completion wait
+```
+
+Acceptance means the command has a durable ID and accepted record, not that its
+operation succeeded. Commands touching the same narrow stable scope serialize;
+unrelated scopes may run concurrently. Failure is normalized into `SafeError`,
+persisted with trace correlation, and published. A failed command does not
+poison the following command in its scope.
+
+### Reconciliation
+
+Reconcile reads worktree and terminal actors, derives the worktree context for
+harness reads, applies cached metadata and durable overlays, correlates the
+graph, persists the result, and replaces the in-memory snapshot. It then
+publishes state-change and reconcile events and schedules metadata refresh.
+
+Observer core serializes full reconciles. The scheduler debounces and coalesces
+reasons while ensuring only one scheduled run is active. Startup-compatible
+requests may join the startup flight; other direct requests retain the rule that
+their scan starts at or after the request. Provider read failures degrade health
+and contribute errors without fabricating successful observations.
+
+### Provider Hook And Harness Report Ingress
+
+```text
+raw harness hook
+    -> strict schema validation -> persist and dedupe raw hook
+    -> Observer-side provider adapter normalization ---------+
+                                                              |
+already-normalized HarnessEventReport -> strict validation ---+
+    -> bounded, coalesced in-memory queue
+    -> worker persists and durably dedupes report
+    -> project immediate status/events
+    -> schedule reconcile for fresh provider-backed graph truth
+```
+
+`stn-ingress` performs delivery and writes the offline spool when the Observer
+cannot be reached. Hooks delivered as raw `ProviderHookEvent`s are normalized
+Observer-side through injected provider hook adapters. Integrations that
+already own a typed report path, including Pi, normalize once in that adapter
+and submit a `HarnessEventReport`; the Observer does not normalize it again.
+
+The harness queue acknowledges accepted work before durable processing or
+reconcile. Queue acceptance is process-memory acceptance, not a durability
+guarantee. It remembers recent report IDs in memory, coalesces replaceable
+pending reports by correlation key, rejects new keys when its bounded pending
+capacity is full, and exposes health counters. The worker applies durable
+dedupe while persisting a report. Spool draining is single-flight; invalid or
+failed records stay available for later diagnosis or retry.
+
+Provider hooks are delivery hints. They may update durable observations and
+immediate projections, but scheduled reconcile remains the path to fresh
+provider-backed graph truth.
+
+### Snapshot And Event Delivery
+
+`getSnapshot` returns the current in-memory graph. `subscribe` registers a
+future-only filtered event stream. Publishing does not persist automatically;
+the producing use case owns whether the event is also durable and its ordering
+relative to publication. Callers must not assume persist-before-publish unless
+that use case defines the guarantee.
+
+Live events optimize freshness and incremental rendering. They are not a
+durable log, replay protocol, or substitute for resynchronization. Any future
+replay guarantee requires sequence identity, retention semantics, bounded
+subscriber behavior, and a protocol contract rather than an adapter-local
+patch.
+
+### External Launch
+
+`prepareExternalLaunch` and `reportExternalExit` are latency-sensitive
+handshakes rather than recorded commands. Their use cases depend on the
+composition-supplied `ManagedTerminalLifecycle`, carry provider-owned target IDs
+opaquely, and request reconcile after relevant lifecycle changes. The current
+wire result still exposes host-shaped reattachment data; OBS-HEX-009 tracks its
+replacement with an opaque managed-terminal attachment.
+
+### Diagnostics
+
+Doctor and diagnostic collection are direct query operations over current core
+health, durable Observer records, config diagnostics, provider checks, and
+local runtime evidence. Collection must remain read-only with respect to product
+state. OBS-HEX-012 tracks separation of filesystem, log, and spool traversal
+from the diagnostic use case.
+
+## Concurrency, Failure, And Backpressure
+
+| Concern | Current contract |
+| --- | --- |
+| Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
+| Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Cancellation is cooperative; the process shutdown backstop handles ignored signals. |
+| Reconcile ordering | Core reconciles form a non-poisoning promise chain. Scheduled requests coalesce; queued work after a run receives a later flush. |
+| Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Failures become provider health and reconcile errors. |
+| Harness ingress | One worker processes a bounded pending map. New reports can replace pending work for the same key; a full map rejects unrelated work with a backpressure error. |
+| Spool drain | One configured drain runs at a time and processes stable filename order. Failed records remain on disk with attempt/error evidence. |
+| Event delivery | Each subscriber currently has an unbounded in-memory queue. There is no replay or publisher backpressure; slow-subscriber growth is therefore a known operating characteristic. |
+| Background refresh | Provider probes and metadata refresh are best-effort and must report failure without blocking the primary reconcile result. |
+
+Retry belongs at an adapter or runtime boundary whose owner can state why the
+operation is safe to repeat. Do not retry a mutation without an idempotency key,
+dedupe rule, or actor-specific guarantee. Queue capacity and overload behavior
+must be explicit at every ingress boundary; silent loss is not acceptable.
+
+## Persistence And Migrations
+
+Persistence is a driven boundary. Application code owns purpose-specific
+conversations; the SQLite adapter owns SQL, rows, transactions, schema health,
+driver differences, and migrations.
+
+The adopted persistence ports are:
+
+- `CommandJournal`
+- `EventJournal`
+- `IngressJournal`
+- `ObservationStore`
+- `ReconcileStore`
+- `SessionStore`
+- `WorktreeMetadataStore`
+
+These are capability groupings by application purpose, not one repository per
+table. An operation that must be atomic for a use case remains one port method
+even when it changes several tables. A composition-only intersection may gather
+the ports for wiring; consumers receive only the capabilities they use.
+
+Current persistence is one broad `ObserverPersistence` built directly from an
+`ObserverSqliteHandle`, and `ObserverCore` receives SQLite health and persisted
+row concepts. OBS-HEX-004 and OBS-HEX-005 track removal of those dependencies
+and creation of an in-memory adapter capable of running the complete Observer
+application.
+
+Migration rules:
+
+- Add a new monotonically ordered migration; never rewrite an applied
+  migration.
+- Apply each known migration transactionally and fail startup when a known
+  migration cannot be applied.
+- Keep SQL and row translation inside the SQLite adapter.
+- Preserve the database format unless a migration explicitly changes it.
+- Run the normal persistence tests and the Node/Bun cross-runtime SQLite gate
+  after migration or driver changes.
+- Exercise the same application port contract against SQLite and the in-memory
+  adapter once that substitute exists.
+
+## Extension Recipes
+
+Every extension starts by naming the application conversation, not by choosing
+a folder or suffix. For a new seam:
+
+1. classify the driving actor or driven actor;
+2. define the application-owned contract in Station-purpose terms;
+3. keep deterministic decisions in policies and orchestration in a use case;
+4. translate technology and untrusted input in an adapter;
+5. select the concrete implementation only in composition;
+6. define identity, authority, failure, timeout, cancellation, idempotency,
+   ordering, and overload behavior that apply;
+7. prove policy behavior, contract substitution, and adapter translation at the
+   narrowest useful levels;
+8. apply the architectural JSDoc role and update this document or its deviation
+   register when the seam changes the map.
+
+### Add A Command
+
+Add the strict command schema, implement one command use case, register it
+exhaustively, and test acceptance through durable completion. Choose the
+narrowest stable serialization scope. A command handler may call driven ports
+and request reconcile; it must not parse transport input or select adapters.
+
+### Add A Provider Or Capability
+
+Extend or add a purpose-owned provider port in shared contracts, provide a
+reusable fake or contract suite, implement the concrete adapter under
+`integrations/**`, and bind it in CLI composition. Prove a deliberately
+different provider ID and identity shape works without application changes.
+
+### Add Persistence Behavior Or A Migration
+
+Put the operation on the narrow application-purpose port that owns its atomic
+meaning. Implement it in the SQLite adapter, add an append-only migration when
+the schema changes, and run contract and cross-runtime tests. Do not expose a
+row type or generic database handle to avoid writing a port method.
+
+### Add Provider Ingress
+
+Define one strict shared input schema, normalize provider vocabulary in the
+provider adapter, assign a stable dedupe identity, choose bounded/coalesced
+queue behavior, persist before acknowledging when durability is promised, and
+schedule reconcile when fresh provider truth is required.
+
+### Add A Protocol Operation
+
+First classify it as a command, query, handshake, ingress report, or lifecycle
+operation. Put application values and the driving port inward; keep transport
+envelopes, versioning, method mapping, and validation in protocol. Test the use
+case directly and the transport mapping separately.
+
+### Add A Background Worker
+
+Construct it in composition. Document who starts, stops, drains, cancels, and
+reports its health; bound its queue or explain its backpressure; isolate retry
+and timeout behavior; and make shutdown deterministic in tests.
+
+### Add A Shared Policy
+
+Keep the policy deterministic over application values. Test its decision table
+without providers, SQLite, filesystem, sockets, time, or process setup. If it
+must perform I/O, split the decision from the use case that calls the relevant
+port.
+
+## Enforcement And Verification
+
+Architecture is protected by several forms of evidence:
+
+- strict schemas at transport, config, hook, provider, and persisted-payload
+  boundaries;
+- provider contract tests and reusable fakes;
+- boundary diagnostics under `tests/diagnostics`;
+- controlled architectural JSDoc on declared seams;
+- focused tests for ordering, cancellation, dedupe, and substitution;
+- whole-application execution with adapters replaced at composition.
+
+Current enforcement is partial. The boundary inventory catches forbidden
+package imports but cannot detect copied provider IDs, reconstructed target
+formats, or application logic that selects a concrete adapter. Marker and
+declared-seam checks begin with documented or touched seams. Complete
+conformance requires dependency-direction checks, exhaustive command
+registration, substitutable persistence/local-evidence adapters, and an
+Observer application lane that does not require SQLite.
+
+A new architecture diagnostic must enforce declarations and dependency facts,
+not subjective prose. Human review remains responsible for whether a port names
+a purposeful conversation and whether policy belongs inside the application.
+
+## Active Deviations
+
+Active deviations are accepted migration debt, not alternative architecture.
+Each remains active until its exit evidence is in the repository. A change may
+add a deviation only when it also records the risk, containment, tracking work,
+and exit condition here.
+
+| ID | Current evidence and risk | Containment and exit evidence | Tracking |
+| --- | --- | --- | --- |
+| `OBS-HEX-002` | Repository refresh recognizes GitHub hosts and selects provider ID `github`; another repository adapter requires application edits. | Keep repository behavior behind the existing port. Exit when adapters declare remote support and a non-GitHub fake is selected without application changes; ambiguous matches fail explicitly. | Repository adapter selection remediation. |
+| `OBS-HEX-003` | `ObserverApi` and external-launch application DTOs are owned by `packages/protocol`. The semantic boundary and one transport share an owner. | Do not add more application semantics to transport. Exit when application contracts live in `packages/contracts` and protocol owns only transport mapping and validation. | Observer application contract move. |
+| `OBS-HEX-004` | `ObserverCore` accepts `ObserverSqliteHandle`, exposes SQLite health, and imports persisted representations. Storage technology crosses inward. | Keep new SQLite details out of core. Exit when core depends only on application-purpose persistence and health capabilities. | SQLite/core isolation. |
+| `OBS-HEX-005` | `ObserverPersistence` combines unrelated use cases, complete Observer tests require SQLite, and the existing fake is not a safe substitute. | Add no new generic persistence bucket. Exit when consumers use the seven purpose-owned ports, SQLite and in-memory adapters pass shared contracts, and the full application runs without SQLite. | Persistence port and substitution remediation. |
+| `OBS-HEX-006` | `StationCommand` includes `session.sendPrompt` and `hooks.install`, but the Observer router registers neither; accepted commands can fail only after queueing. | Do not add another non-executable contract member. Exit when unsupported members are removed and construction proves exhaustive registration or an explicit reviewed unsupported allowlist. | Command surface cleanup and exhaustive registration. |
+| `OBS-HEX-007` | Terminal intent application orchestration lives under `providers/`, and Observer modules retain type-level ownership cycles. Roles cannot always be explained from dependency direction. | Avoid expanding provider/application back-edges. Exit when intent orchestration belongs to command/application ownership and every major module has one explainable role without source cycles. | Internal ownership remediation. |
+| `OBS-HEX-009` | External-launch application results still expose `TerminalReattachInfo` with host endpoint and socket data. A host-specific representation crosses the application API. | The managed lifecycle remains explicitly injected and application code must not construct the payload. Exit when the API returns an opaque managed-terminal attachment resolved by Station-side attachment behavior. | Managed attachment protocol cutover. |
+| `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Keep behavior behind existing narrow call sites. Exit with purpose-owned `StationLogger` and `ProjectConfigWriter` ports and adapters. | Logging and project-config edge inversion. |
+| `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers while also selecting repository behavior. Use case and local adapter mechanics are mixed. | Keep new provider-specific parsing out of metadata orchestration. Exit when `WorktreeMetadataSource` owns local Git/ref evidence and repository matching is adapter-owned. | Local metadata source isolation. |
+| `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only and paths stay composition-supplied. Exit when a `DiagnosticEvidenceSource` adapter owns local traversal and the use case runs against a fake. | Diagnostic evidence isolation. |
+
+The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
+resolved: application code receives `ManagedTerminalLifecycle` from composition,
+does not select the Station adapter by ID, and does not construct its target
+format. This document resolves `OBS-HEX-008`, the missing canonical Observer
+architecture contract. Resolved history belongs in its issue and pull request,
+not in the active register.
+
+## Related Living Documents
+
+- [Architecture](architecture.md): repository-wide packages and system
+  boundaries.
+- [Architecture documentation](architecture-documentation.md): exact JSDoc role
+  vocabulary and source-comment rules.
+- [Configuration](configuration.md): config authority, paths, and overrides.
+- [Development](development.md): deterministic gates and documentation workflow.
+- [Harness signals](harness-signals.md): status, attention, and event semantics.
+- [Harness authoring](harness-authoring.md): provider integration requirements.
+- [Debugging](debugging.md): runtime evidence and diagnostic workflow.
+- [Observer singleton](observer-singleton.md): process ownership and takeover
+  history.
+
+For ordinary work, current code, tests, runtime evidence, and these living docs
+supersede historical planning material. When they disagree, verify the live path
+and update the code, tests, or living document that is stale.

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -1,5 +1,8 @@
 # Observer singleton & step-down
 
+Status: shipped-history and remaining singleton roadmap. For the current Observer runtime
+ownership and lifecycle contract, see [Observer Architecture](observer-architecture.md).
+
 How STATION keeps exactly one observer per state dir, why the old design let
 duplicates accumulate, what has shipped, and the remaining work. Pick up the
 unfinished phases from the "Remaining work" section — each is independently

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,8 @@
 # Overview
 
-Status: conceptual overview — the mental model behind station. For boundary and ownership rules see [Architecture](architecture.md); for setup see the [README](../README.md).
+Status: conceptual overview — the mental model behind station. For repository-wide boundaries
+see [Architecture](architecture.md), for Observer internals see
+[Observer Architecture](observer-architecture.md), and for setup see the [README](../README.md).
 
 ## What station is
 
@@ -14,7 +16,7 @@ The state that would answer those questions is real, but it's scattered across t
 
 ## The core idea
 
-One process — the **observer** — owns the live picture. Everything else either feeds it evidence or asks it questions. The observer never invents state; it correlates what real tools report into a normalized graph and publishes that graph to clients.
+One process — the **observer** — owns the live picture. Everything else either feeds it evidence or asks it questions. The observer does not invent external facts; it correlates what real tools report while minting command IDs and records, events, correlations, and durable overlays needed to operate the normalized graph.
 
 The runtime model reads top to bottom:
 
@@ -30,11 +32,11 @@ A crucial subtlety: **no single layer owns all truth.** Config is authoritative 
 
 ## How the pieces fit
 
-- **Providers** are the only code that touches the outside world. Each one adapts a specific external tool behind a boundary: *worktree* providers (Worktrunk) prove which branches and worktrees exist; *terminal* providers (tmux) own pane and window topology; *harness* providers (Claude Code, Codex, Cursor, Pi, OpenCode) report agent launches and status; *repository* providers fetch code-host metadata like PR and CI state. Provider-specific mechanics never leak past this boundary.
+- **Providers** adapt provider-facing external tools behind boundaries: *worktree* providers (Worktrunk) prove which branches and worktrees exist; *terminal* providers (tmux) own pane and window topology; *harness* providers (Claude Code, Codex, Cursor, Pi, OpenCode) report agent launches and status; *repository* providers fetch code-host metadata like PR and CI state. Other outside-world edges include SQLite, filesystem, sockets, logging, Git, and processes. The adopted Observer architecture puts those mechanics behind application-owned adapter seams and tracks current violations explicitly.
 
 - **The observer** is the long-lived background process. It runs reconciliation, routes commands, tracks provider health, persists durable memory in SQLite, ingests provider hooks, and publishes the graph. It is the one place where scattered evidence becomes a coherent picture.
 
-- **Snapshots and events** are the two ways to read the graph. A *snapshot* is the whole current graph at a moment; *events* (`StationEvent`s like `worktree.agentStateChanged` or `command.failed`) are the incremental changes clients subscribe to. A client loads a snapshot once, then keeps it fresh from the event stream.
+- **Snapshots and events** are the two ways to read the graph. A *snapshot* is the whole current graph at a moment; *events* (`StationEvent`s like `worktree.agentStateChanged` or `command.failed`) are the incremental changes clients subscribe to. A client subscribes, loads a full snapshot while the subscription is live, reduces safe events, and reloads after a gap or an event it cannot reduce safely.
 
 - **Commands** are how clients change the world. Clients never run `git`, `tmux`, or `wt` themselves — they submit a typed command (for example, "create a session for this project on this branch with this harness"), and the observer routes it to the providers that own the mechanics.
 


### PR DESCRIPTION
## Summary

- add the canonical Observer architecture with explicit current behavior, adopted rules, and active deviations
- define the controlled architectural JSDoc language for ports, adapters, use cases, policies, and composition roots
- route existing contributor docs to the new authorities and correct stale architecture claims

## Why

The Observer had a repository-level boundary summary but no canonical application architecture or shared language for recognizing high-level seams. These documents make dependency direction, state authority, lifecycle, extension rules, and known migration debt explicit without imposing folder skeletons or generic backend buckets.

## Impact

Documentation only. Runtime behavior and user-facing UI are unchanged; contributor navigation and boundary review become more explicit.

## Validation

- pre-commit lint hook passed
- no additional checks were requested before merge