### PR TITLE
refactor(repository): move remote support selection into adapters

### DIFF
--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -23,7 +23,6 @@ import type {
   HarnessProvider,
   HarnessRunObservation,
   ProviderHealth,
-  RepositoryCapabilities,
   RepositoryProvider,
   SafeError,
   TerminalCapabilities,
@@ -600,30 +599,6 @@ class UnavailableHarnessProvider implements HarnessProvider {
   }
 
   async classifyRun(): Promise<never> {
-    throw providerUnavailableError(this.id);
-  }
-}
-
-export class UnavailableRepositoryProvider implements RepositoryProvider {
-  constructor(readonly id: string) {}
-
-  capabilities(): RepositoryCapabilities {
-    return {
-      canDiscoverPullRequests: false,
-      canReadChecks: false,
-      canUseCliAuth: false,
-    };
-  }
-
-  async health(): Promise<ProviderHealth> {
-    return unavailableHealth(this.id, "repository", this.capabilities());
-  }
-
-  async discoverPullRequest(): Promise<never> {
-    throw providerUnavailableError(this.id);
-  }
-
-  async readChecks(): Promise<never> {
     throw providerUnavailableError(this.id);
   }
 }

--- a/apps/observer/src/metadata/repositoryProviderSelection.ts
+++ b/apps/observer/src/metadata/repositoryProviderSelection.ts
@@ -1,0 +1,23 @@
+import type { RepositoryProvider, RepositoryRemote, SafeError } from "@station/contracts";
+
+/**
+ * POLICY
+ *
+ * Selects the sole repository adapter that supports a remote and rejects
+ * overlapping support rules.
+ */
+export function selectRepositoryProvider(
+  remote: RepositoryRemote,
+  providers: Iterable<RepositoryProvider>,
+): RepositoryProvider | undefined {
+  const matches = Array.from(providers).filter((provider) => provider.supportsRemote(remote));
+  if (matches.length > 1) {
+    throw {
+      tag: "RepositoryProviderError",
+      code: "REPOSITORY_PROVIDER_AMBIGUOUS",
+      message: "More than one repository provider supports this remote.",
+      hint: "Ensure repository provider remote-support rules do not overlap.",
+    } satisfies SafeError;
+  }
+  return matches[0];
+}

--- a/apps/observer/src/metadata/repositoryRefresh.ts
+++ b/apps/observer/src/metadata/repositoryRefresh.ts
@@ -24,8 +24,15 @@ import {
   readRepositoryGitContext,
   repositoryMetadataCacheKey,
 } from "./repositoryGit.js";
+import { selectRepositoryProvider } from "./repositoryProviderSelection.js";
 import { staleChecks, stalePullRequest } from "./stalePayloads.js";
 
+/**
+ * USE CASE
+ *
+ * Refreshes and persists code-host metadata for snapshot worktrees through
+ * matching repository provider ports.
+ */
 export type RepositoryMetadataRefresher = {
   refresh(input: RepositoryRefreshInput): Promise<void>;
 };
@@ -73,7 +80,7 @@ export function createRepositoryMetadataRefresher(
         return;
       }
 
-      const grouped = await collectRepositoryTasks(input);
+      const grouped = collectRepositoryTasks(input);
       for (const tasks of grouped.values()) {
         if (input.signal.aborted) {
           return;
@@ -91,54 +98,50 @@ export function createRepositoryMetadataRefresher(
     },
   };
 
-  async function collectRepositoryTasks(
+  function collectRepositoryTasks(
     input: RepositoryRefreshInput,
-  ): Promise<Map<string, RepositoryRefreshTask[]>> {
+  ): Map<string, RepositoryRefreshTask[]> {
     const grouped = new Map<string, RepositoryRefreshTask[]>();
-    await forEachConcurrent(
-      input.snapshot.rows,
-      { concurrency: defaultRepositoryConcurrency },
-      async (row) => {
-        if (input.signal.aborted || !options.projectsById.has(row.projectId)) {
-          return;
-        }
+    for (const row of input.snapshot.rows) {
+      if (input.signal.aborted || !options.projectsById.has(row.projectId)) {
+        continue;
+      }
 
-        const git = readRepositoryGitContext({
-          worktree: {
-            id: row.id,
-            projectId: row.projectId,
-            path: row.path,
-            branch: row.branch,
-            state: row.worktree.state,
-            ...(row.worktree.remote !== undefined ? { remote: row.worktree.remote } : {}),
-            ...(row.worktree.headSha !== undefined ? { headSha: row.worktree.headSha } : {}),
-          },
-          clock,
-        });
-        const provider = git === undefined ? undefined : repositoryProviderFor(git);
-        if (git === undefined || provider === undefined) {
-          return;
-        }
+      const git = readRepositoryGitContext({
+        worktree: {
+          id: row.id,
+          projectId: row.projectId,
+          path: row.path,
+          branch: row.branch,
+          state: row.worktree.state,
+          ...(row.worktree.remote !== undefined ? { remote: row.worktree.remote } : {}),
+          ...(row.worktree.headSha !== undefined ? { headSha: row.worktree.headSha } : {}),
+        },
+        clock,
+      });
+      const provider = git === undefined ? undefined : repositoryProviderFor(git);
+      if (git === undefined || provider === undefined) {
+        continue;
+      }
 
-        const task: RepositoryRefreshTask = {
-          row,
-          git,
-          provider,
-        };
-        const existingPullRequest = input.pullRequestByWorktree.get(row.id);
-        const existingChecks = input.checksByWorktree.get(row.id);
-        if (existingPullRequest !== undefined) task.existingPullRequest = existingPullRequest;
-        if (existingChecks !== undefined) task.existingChecks = existingChecks;
+      const task: RepositoryRefreshTask = {
+        row,
+        git,
+        provider,
+      };
+      const existingPullRequest = input.pullRequestByWorktree.get(row.id);
+      const existingChecks = input.checksByWorktree.get(row.id);
+      if (existingPullRequest !== undefined) task.existingPullRequest = existingPullRequest;
+      if (existingChecks !== undefined) task.existingChecks = existingChecks;
 
-        const groupKey = repositoryGroupKey(git);
-        const existingGroup = grouped.get(groupKey);
-        if (existingGroup === undefined) {
-          grouped.set(groupKey, [task]);
-        } else {
-          existingGroup.push(task);
-        }
-      },
-    );
+      const groupKey = repositoryGroupKey(git);
+      const existingGroup = grouped.get(groupKey);
+      if (existingGroup === undefined) {
+        grouped.set(groupKey, [task]);
+      } else {
+        existingGroup.push(task);
+      }
+    }
     return grouped;
   }
 
@@ -405,10 +408,7 @@ export function createRepositoryMetadataRefresher(
   }
 
   function repositoryProviderFor(git: RepositoryGitContext): RepositoryProvider | undefined {
-    if (git.remote.host === "github.com" || git.remote.host.includes("github.")) {
-      return repositoryProviders.get("github");
-    }
-    return undefined;
+    return selectRepositoryProvider(git.remote, repositoryProviders.values());
   }
 }
 

--- a/apps/observer/test/integration/metadata-refresh.test.ts
+++ b/apps/observer/test/integration/metadata-refresh.test.ts
@@ -5,6 +5,7 @@ import type {
   RepositoryChecksRequest,
   RepositoryProvider,
   RepositoryPullRequestRequest,
+  RepositoryRemote,
   WorktreeChecksSummary,
   WorktreePullRequest,
 } from "@station/contracts";
@@ -358,6 +359,7 @@ describe("observer worktree metadata refresh", () => {
     const reasons: string[] = [];
     const repository = new FakeRepositoryProvider({
       clock: fixture.clock,
+      supportsRemote: supportsGithubRemote,
       pullRequest: {
         number: 77,
         url: "https://github.com/example/web/pull/77",
@@ -419,6 +421,110 @@ describe("observer worktree metadata refresh", () => {
     fixture.sqlite.close();
   });
 
+  it("refreshes repository metadata through a non-GitHub provider", async () => {
+    const fixture = createFixture({ host: "forge.example", owner: "example", repo: "web" });
+    const repository = new FakeRepositoryProvider({
+      id: "forge",
+      clock: fixture.clock,
+      supportsRemote: (remote) => remote.host === "forge.example",
+      pullRequest: {
+        number: 88,
+        url: "https://forge.example/example/web/pulls/88",
+        host: "forge.example",
+        baseRef: "main",
+        headRef: "feature",
+        checkedAt: now,
+      },
+      checks: {
+        state: "pass",
+        total: 1,
+        passed: 1,
+        source: "forge",
+        checkedAt: now,
+      },
+    });
+    const runner = gitRunner({
+      "rev-parse --verify HEAD^{commit}": headSha,
+      remote: "origin\n",
+      "rev-parse --verify refs/remotes/origin/main^{commit}": baseSha,
+      "merge-base origin/main HEAD": mergeBaseSha,
+      [`diff --numstat ${mergeBaseSha}..HEAD`]: "1\t0\tsrc/a.ts\n",
+      "remote get-url origin": "git@forge.example:example/web.git\n",
+    });
+    const service = createWorktreeMetadataRefreshService({
+      projects: providerProjectsFromConfig(config),
+      persistence: fixture.persistence,
+      requestReconcile: () => undefined,
+      clock: fixture.clock,
+      runner,
+      repositoryProviders: [repository],
+    });
+
+    const snapshot = await fixture.core.reconcile("metadata-forge-before");
+    await service.refresh(snapshot);
+
+    await expect(
+      fixture.persistence.listWorktreeMetadataCurrent({
+        kind: ["pull_request", "checks"],
+        now,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "pull_request",
+          payload: expect.objectContaining({ number: 88, host: "forge.example" }),
+        }),
+        expect.objectContaining({
+          kind: "checks",
+          payload: expect.objectContaining({ state: "pass", source: "forge" }),
+        }),
+      ]),
+    );
+    fixture.sqlite.close();
+  });
+
+  it("rejects ambiguous repository support before provider operations run", async () => {
+    const fixture = createFixture({ host: "forge.example", owner: "example", repo: "web" });
+    let operations = 0;
+    const providers = ["forge-a", "forge-b"].map(
+      (id) =>
+        new FakeRepositoryProvider({
+          id,
+          clock: fixture.clock,
+          supportsRemote: (remote) => remote.host === "forge.example",
+          discover: async () => {
+            operations += 1;
+            return null;
+          },
+        }),
+    );
+    const runner = gitRunner({
+      "rev-parse --verify HEAD^{commit}": headSha,
+      remote: "origin\n",
+      "rev-parse --verify refs/remotes/origin/main^{commit}": baseSha,
+      "merge-base origin/main HEAD": mergeBaseSha,
+      [`diff --numstat ${mergeBaseSha}..HEAD`]: "1\t0\tsrc/a.ts\n",
+      "remote get-url origin": "git@forge.example:example/web.git\n",
+    });
+    const service = createWorktreeMetadataRefreshService({
+      projects: providerProjectsFromConfig(config),
+      persistence: fixture.persistence,
+      requestReconcile: () => undefined,
+      clock: fixture.clock,
+      runner,
+      repositoryProviders: providers,
+    });
+
+    const snapshot = await fixture.core.reconcile("metadata-ambiguous-before");
+
+    await expect(service.refresh(snapshot)).rejects.toMatchObject({
+      tag: "RepositoryProviderError",
+      code: "REPOSITORY_PROVIDER_AMBIGUOUS",
+    });
+    expect(operations).toBe(0);
+    fixture.sqlite.close();
+  });
+
   it("marks existing repository metadata stale when remote refresh fails", async () => {
     const fixture = createFixture();
     await fixture.persistence.upsertWorktreeMetadataCurrent({
@@ -434,6 +540,7 @@ describe("observer worktree metadata refresh", () => {
     });
     const repository = new FakeRepositoryProvider({
       clock: fixture.clock,
+      supportsRemote: supportsGithubRemote,
       error: {
         tag: "RepositoryProviderError",
         code: "GITHUB_NETWORK_FAILED",
@@ -483,6 +590,7 @@ describe("observer worktree metadata refresh", () => {
     let aborted = false;
     const repository = new FakeRepositoryProvider({
       clock: fixture.clock,
+      supportsRemote: supportsGithubRemote,
       discover: async (request) => {
         started = true;
         await new Promise<void>((_resolve, reject) => {
@@ -522,7 +630,9 @@ describe("observer worktree metadata refresh", () => {
   });
 });
 
-function createFixture() {
+function createFixture(
+  remote: RepositoryRemote = { host: "github.com", owner: "example", repo: "web" },
+) {
   const clock = { now: () => new Date(now) };
   const providers = new ProviderRegistry({
     worktree: new FakeWorktreeProvider({
@@ -533,7 +643,7 @@ function createFixture() {
           projectId: "web",
           branch: "feature",
           path: "/tmp/station/web/feature",
-          remote: { host: "github.com", owner: "example", repo: "web" },
+          remote,
           headSha,
           now,
         }),
@@ -586,28 +696,37 @@ function ids() {
 }
 
 class FakeRepositoryProvider implements RepositoryProvider {
-  readonly id = "github";
+  readonly id: string;
 
   readonly #clock: RuntimeClock;
   readonly #pullRequest: WorktreePullRequest | null;
   readonly #checks: WorktreeChecksSummary | null;
   readonly #error: unknown;
+  readonly #supportsRemote: (remote: RepositoryRemote) => boolean;
   readonly #discover:
     | ((request: RepositoryPullRequestRequest) => Promise<WorktreePullRequest | null>)
     | undefined;
 
   constructor(input: {
+    id?: string;
     clock: RuntimeClock;
     pullRequest?: WorktreePullRequest | null;
     checks?: WorktreeChecksSummary | null;
     error?: unknown;
+    supportsRemote: (remote: RepositoryRemote) => boolean;
     discover?: (request: RepositoryPullRequestRequest) => Promise<WorktreePullRequest | null>;
   }) {
+    this.id = input.id ?? "github";
     this.#clock = input.clock;
     this.#pullRequest = input.pullRequest ?? null;
     this.#checks = input.checks ?? null;
     this.#error = input.error;
+    this.#supportsRemote = input.supportsRemote;
     this.#discover = input.discover;
+  }
+
+  supportsRemote(remote: RepositoryRemote): boolean {
+    return this.#supportsRemote(remote);
   }
 
   capabilities(): RepositoryCapabilities {
@@ -646,6 +765,10 @@ class FakeRepositoryProvider implements RepositoryProvider {
     }
     return this.#checks;
   }
+}
+
+function supportsGithubRemote(remote: RepositoryRemote): boolean {
+  return remote.host === "github.com" || remote.host.includes("github.");
 }
 
 function toIso(clock: RuntimeClock): string {

--- a/apps/observer/test/unit/repository-provider-selection.test.ts
+++ b/apps/observer/test/unit/repository-provider-selection.test.ts
@@ -1,0 +1,72 @@
+import type { RepositoryProvider, RepositoryRemote } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import { selectRepositoryProvider } from "../../src/metadata/repositoryProviderSelection";
+
+const remote: RepositoryRemote = {
+  host: "forge.example",
+  owner: "example",
+  repo: "web",
+};
+
+describe("repository provider selection", () => {
+  it("returns undefined when no provider supports the remote", () => {
+    const provider = fakeRepositoryProvider("other", () => false);
+
+    expect(selectRepositoryProvider(remote, [provider])).toBeUndefined();
+  });
+
+  it("selects a provider without relying on its ID", () => {
+    const provider = fakeRepositoryProvider("forge", (candidate) => candidate.host === remote.host);
+
+    expect(selectRepositoryProvider(remote, [provider])).toBe(provider);
+  });
+
+  it("rejects overlapping provider support", () => {
+    const providers = [
+      fakeRepositoryProvider("forge", () => true),
+      fakeRepositoryProvider("other-forge", () => true),
+    ];
+    let thrown: unknown;
+
+    try {
+      selectRepositoryProvider(remote, providers);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toEqual({
+      tag: "RepositoryProviderError",
+      code: "REPOSITORY_PROVIDER_AMBIGUOUS",
+      message: "More than one repository provider supports this remote.",
+      hint: "Ensure repository provider remote-support rules do not overlap.",
+    });
+  });
+});
+
+function fakeRepositoryProvider(
+  id: string,
+  supportsRemote: (remote: RepositoryRemote) => boolean,
+): RepositoryProvider {
+  return {
+    id,
+    supportsRemote,
+    capabilities: () => ({
+      canDiscoverPullRequests: true,
+      canReadChecks: true,
+      canUseCliAuth: false,
+    }),
+    health: async () => ({
+      providerId: id,
+      providerType: "repository",
+      status: "unknown",
+      lastCheckedAt: "2026-05-20T12:00:00.000Z",
+      capabilities: {
+        canDiscoverPullRequests: true,
+        canReadChecks: true,
+        canUseCliAuth: false,
+      },
+    }),
+    discoverPullRequest: async () => null,
+    readChecks: async () => null,
+  };
+}

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -177,7 +177,7 @@ ownership even where current ownership is still a deviation.
 | Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
 | Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role; the remaining response payload is host-shaped (OBS-HEX-009). |
 | Harness operations | Driven | `HarnessProvider` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned port with provider-local parsing. |
-| Repository metadata | Driven | `RepositoryProvider` | GitHub repository adapter | The port is generic; selection is still GitHub-specific in application code (OBS-HEX-002). |
+| Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
 | Durable observer memory | Driven | current `ObserverPersistence` | SQLite persistence modules | A port exists, but it is broad and leaks SQLite representations (OBS-HEX-004 and OBS-HEX-005). |
 | Logging and config mutation | Driven | injected logger and config path today | JSONL logger and config filesystem | These require purpose-owned application ports (OBS-HEX-010). |
 | Worktree metadata evidence | Driven | metadata refresh dependencies today | Git commands, ref watcher, repository adapter | Local Git/process/watch mechanics remain mixed into the use case (OBS-HEX-011). |
@@ -201,7 +201,7 @@ areas contain the following responsibilities:
 | `hooks/` | hook/report ingestion, dedupe, readiness, spool I/O, and ingress queue | Ingress use cases and queue orchestration separated from filesystem spool adapters. |
 | `runtime/` | API assembly, process lifecycle, scheduling, event delivery, server bridge, and external launch | Observer composition plus application operations; transport and infrastructure stay at the edge. |
 | `providers/` | provider aggregation and health cache | Provider aggregation and health only; provider modules must not own or import application orchestration. |
-| `metadata/` | metadata refresh, repository lookup, Git execution, and ref watching | Metadata use cases depend on repository and local-metadata ports (OBS-HEX-002 and OBS-HEX-011). |
+| `metadata/` | metadata refresh, repository lookup, Git execution, and ref watching | Metadata use cases select adapters through provider-neutral policy and depend on local-metadata ports (OBS-HEX-011). |
 | `persistence/`, `migrations/`, `sqlite.ts` | persistence contract, SQL translation, transactions, migrations, and rows | Application persistence ports are distinct from the SQLite adapter (OBS-HEX-004 and OBS-HEX-005). |
 | `diagnostics/` | doctor and diagnostic collection plus local evidence traversal | Diagnostic use cases depend on an evidence-source port (OBS-HEX-012). |
 | `features/` | feature-flag evaluation | Deterministic application policy. |
@@ -518,7 +518,6 @@ and exit condition here.
 
 | ID | Current evidence and risk | Containment and exit evidence | Tracking |
 | --- | --- | --- | --- |
-| `OBS-HEX-002` | Repository refresh recognizes GitHub hosts and selects provider ID `github`; another repository adapter requires application edits. | Keep repository behavior behind the existing port. Exit when adapters declare remote support and a non-GitHub fake is selected without application changes; ambiguous matches fail explicitly. | Repository adapter selection remediation. |
 | `OBS-HEX-003` | `ObserverApi` and external-launch application DTOs are owned by `packages/protocol`. The semantic boundary and one transport share an owner. | Do not add more application semantics to transport. Exit when application contracts live in `packages/contracts` and protocol owns only transport mapping and validation. | Observer application contract move. |
 | `OBS-HEX-004` | `ObserverCore` accepts `ObserverSqliteHandle`, exposes SQLite health, and imports persisted representations. Storage technology crosses inward. | Keep new SQLite details out of core. Exit when core depends only on application-purpose persistence and health capabilities. | SQLite/core isolation. |
 | `OBS-HEX-005` | `ObserverPersistence` combines unrelated use cases, complete Observer tests require SQLite, and the existing fake is not a safe substitute. | Add no new generic persistence bucket. Exit when consumers use the seven purpose-owned ports, SQLite and in-memory adapters pass shared contracts, and the full application runs without SQLite. | Persistence port and substitution remediation. |
@@ -526,15 +525,17 @@ and exit condition here.
 | `OBS-HEX-007` | Terminal intent orchestration now belongs to `commands/`, resolving that provider/application back-edge. Unrelated type-only ownership cycles remain, so not every major module role is yet explainable without source cycles. | A dependency diagnostic prevents `providers/**` from importing `commands/**`. Exit when the remaining major-module type cycles are removed and final dependency-direction enforcement covers every major Observer module. | Internal ownership remediation. |
 | `OBS-HEX-009` | External-launch application results still expose `TerminalReattachInfo` with host endpoint and socket data. A host-specific representation crosses the application API. | The managed lifecycle remains explicitly injected and application code must not construct the payload. Exit when the API returns an opaque managed-terminal attachment resolved by Station-side attachment behavior. | Managed attachment protocol cutover. |
 | `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Keep behavior behind existing narrow call sites. Exit with purpose-owned `StationLogger` and `ProjectConfigWriter` ports and adapters. | Logging and project-config edge inversion. |
-| `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers while also selecting repository behavior. Use case and local adapter mechanics are mixed. | Keep new provider-specific parsing out of metadata orchestration. Exit when `WorktreeMetadataSource` owns local Git/ref evidence and repository matching is adapter-owned. | Local metadata source isolation. |
+| `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Use case and local adapter mechanics are mixed. | Keep new provider-specific parsing out of metadata orchestration. Exit when `WorktreeMetadataSource` owns local Git/ref evidence. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only and paths stay composition-supplied. Exit when a `DiagnosticEvidenceSource` adapter owns local traversal and the use case runs against a fake. | Diagnostic evidence isolation. |
 
 The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
 resolved: application code receives `ManagedTerminalLifecycle` from composition,
 does not select the Station adapter by ID, and does not construct its target
-format. This document resolves `OBS-HEX-008`, the missing canonical Observer
-architecture contract. Resolved history belongs in its issue and pull request,
-not in the active register.
+format. `OBS-HEX-002` is resolved: a non-GitHub repository adapter can be
+selected without application changes, and overlapping support fails explicitly.
+This document resolves `OBS-HEX-008`, the missing canonical Observer architecture
+contract. Resolved history belongs in its issue and pull request, not in the
+active register.
 
 ## Related Living Documents
 

--- a/integrations/repository/github/src/provider.ts
+++ b/integrations/repository/github/src/provider.ts
@@ -80,6 +80,12 @@ const GithubChecksSchema = z.array(GithubCheckSchema);
 
 type GithubCheck = z.infer<typeof GithubCheckSchema>;
 
+/**
+ * ADAPTER
+ *
+ * Translates repository metadata operations to the GitHub CLI and owns
+ * matching GitHub remotes.
+ */
 export class GithubRepositoryProvider implements RepositoryProvider {
   readonly id = "github";
 
@@ -94,6 +100,10 @@ export class GithubRepositoryProvider implements RepositoryProvider {
     this.#timeoutMs = options.timeoutMs ?? defaultTimeoutMs;
     this.#runner = options.runner;
     this.#clock = options.clock ?? systemClock;
+  }
+
+  supportsRemote(remote: RepositoryRemote): boolean {
+    return remote.host === "github.com" || remote.host.includes("github.");
   }
 
   capabilities(): RepositoryCapabilities {

--- a/integrations/repository/github/test/unit/provider.test.ts
+++ b/integrations/repository/github/test/unit/provider.test.ts
@@ -12,6 +12,30 @@ const remote = {
 };
 
 describe("GitHub repository provider", () => {
+  it("supports github.com remotes", () => {
+    expect(new GithubRepositoryProvider().supportsRemote(remote)).toBe(true);
+  });
+
+  it("supports hosts containing github.", () => {
+    expect(
+      new GithubRepositoryProvider().supportsRemote({
+        host: "git.github.example",
+        owner: "example",
+        repo: "web",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated remotes", () => {
+    expect(
+      new GithubRepositoryProvider().supportsRemote({
+        host: "forge.example",
+        owner: "example",
+        repo: "web",
+      }),
+    ).toBe(false);
+  });
+
   it("discovers a unique pull request with gh pr list", async () => {
     const calls: string[] = [];
     const provider = providerWithResponses(calls, {

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -15,6 +15,7 @@ import type {
   HarnessEventObservation,
   HarnessRunObservation,
   HarnessStatusObservation,
+  RepositoryRemote,
   TerminalIdentityBinding,
   TerminalTargetObservation,
   WorktreeChecksSummary,
@@ -457,8 +458,15 @@ export interface HarnessProvider {
   stop?(request: HarnessStopRequest): Promise<HarnessStopResult>;
 }
 
+/**
+ * DRIVEN PORT
+ *
+ * Supplies code-host metadata and declares deterministic, I/O-free remote
+ * support so application policy can select an adapter.
+ */
 export interface RepositoryProvider {
   id: ProviderId;
+  supportsRemote(remote: RepositoryRemote): boolean;
   capabilities(): RepositoryCapabilities;
   health(): Promise<ProviderHealth>;
   doctorChecks?(context?: ProviderDoctorContext): Promise<ProviderDoctorCheck[]>;


### PR DESCRIPTION
## Summary

- add deterministic, synchronous `supportsRemote(remote)` ownership to the `RepositoryProvider` port and the GitHub adapter while preserving the exact existing case-sensitive GitHub/GitHub Enterprise predicate
- add a pure provider-neutral selection policy: unsupported remotes remain a no-op, one match is selected by identity, and overlapping support rejects with `REPOSITORY_PROVIDER_AMBIGUOUS`
- route repository metadata refresh through provider-map values, prove a non-GitHub `forge` adapter persists PR/check metadata, and delete the unused unavailable repository fake
- update the Observer port/ownership maps and record `OBS-HEX-002` as resolved while leaving `OBS-HEX-011` active

## Why

[`OBS-HEX-002`](https://github.com/jeremy0dell/station/blob/main/docs/observer-architecture.md#active-deviations) records the root cause: metadata refresh owned both the GitHub hostname predicate and the concrete provider ID lookup, so adding another repository adapter required application edits.

The adopted [repository architecture](https://github.com/jeremy0dell/station/blob/main/docs/architecture.md), [Observer architecture](https://github.com/jeremy0dell/station/blob/main/docs/observer-architecture.md), and [architecture role language](https://github.com/jeremy0dell/station/blob/main/docs/architecture-documentation.md) require provider-specific behavior at adapter boundaries and deterministic selection in application policy. The architecture research at `~/Documents/station/planning/observer-hexagonal-architecture-research.md` identifies this as `OBS-HEX-002` and delivery stage 4.

[PR #102](https://github.com/jeremy0dell/station/pull/102) is the boundary precedent: move application decisions out of provider-ID lookup/registry state and express the dependency through explicit roles. This PR applies that precedent only to repository remote support; no separate issue is introduced.

## User impact

GitHub PR/check metadata behavior is unchanged. The GitHub adapter keeps the exact existing predicate:

```ts
remote.host === "github.com" || remote.host.includes("github.")
```

Unsupported remotes remain silent no-ops. If adapter support rules overlap, background metadata refresh logs the typed failure while primary reconcile remains successful. There are no command, protocol, config, persistence, database, snapshot, or UI schema changes.

## Validation

- focused unit: 12 passed
- focused metadata integration: 11 passed
- focused boundary diagnostics: 4 passed
- `HOME=<isolated-temp> pnpm test:all`: passed on current `origin/main`
  - build: 22 packages
  - typecheck: 42 tasks
  - lint: clean
  - unit: 1,217
  - contracts: 24
  - integration: 323 passed, 1 real-tmux test skipped
  - diagnostics: 35
  - scripted agent: 3
  - setup e2e: 7
- `git diff --check`: passed

## UX verification

No visible change is intended. Against a GitHub-backed worktree, run `stn snapshot --json` and confirm its existing pull-request and check metadata still appears as before.