### PR TITLE
refactor(protocol): make attachment opaque and remove dead commands

### DIFF
--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -17,7 +17,6 @@ import {
   LogRecordSchema,
   SafeErrorSchema,
   SpanIdSchema,
-  StationCommandTypeSchema,
   TraceIdSchema,
 } from "@station/contracts";
 import { z } from "zod";
@@ -93,7 +92,7 @@ const DebugTraceLogAttributesSchema = z
     commandId: CommandIdSchema.optional(),
     traceId: TraceIdSchema.optional(),
     spanId: SpanIdSchema.optional(),
-    commandType: StationCommandTypeSchema.optional(),
+    commandType: z.string().min(1).optional(),
     error: z.unknown().optional(),
   })
   .passthrough();

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -218,7 +218,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -18,7 +18,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -34,7 +34,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.6.0",
+        schemaVersion: "0.7.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -129,7 +129,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -163,7 +163,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -199,7 +199,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -261,7 +261,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -301,7 +301,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -355,7 +355,7 @@ describe("CLI diagnostic commands", () => {
     });
   });
 
-  it("resolves latest debug trace failure from live logs without observer RPC", async () => {
+  it("resolves historical command types from live logs without observer RPC", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
@@ -369,7 +369,7 @@ describe("CLI diagnostic commands", () => {
           message: "Command failed.",
           attributes: {
             commandId: "cmd_old",
-            commandType: "session.create",
+            commandType: "hooks.install",
             traceId: "trc_old",
             error: { tag: "WorktreeProviderError", code: "OLD", message: "Old failure." },
           },
@@ -381,7 +381,7 @@ describe("CLI diagnostic commands", () => {
           message: "Command failed.",
           attributes: {
             commandId: "cmd_new",
-            commandType: "session.create",
+            commandType: "session.sendPrompt",
             traceId: "trc_new",
             error: {
               tag: "WorktreeProviderError",
@@ -408,6 +408,7 @@ describe("CLI diagnostic commands", () => {
         source: "log",
         command: {
           id: "cmd_new",
+          type: "session.sendPrompt",
           traceId: "trc_new",
         },
         error: {
@@ -650,12 +651,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -683,17 +684,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -56,7 +56,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -285,7 +285,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -296,7 +296,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -308,7 +308,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -265,7 +265,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -280,7 +280,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -303,7 +303,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -316,7 +316,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -390,7 +390,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -21,7 +21,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -30,7 +30,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.6.0", stopped: true, at: now };
+            return { schemaVersion: "0.7.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -66,7 +66,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -75,7 +75,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.6.0", stopped: true, at: now };
+            return { schemaVersion: "0.7.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -31,7 +31,7 @@ describe("CLI popup command", () => {
           health: async () => {
             if (!running) throw new Error("stopped");
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -103,7 +103,7 @@ describe("CLI popup command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.6.0",
+                    schemaVersion: "0.7.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -172,7 +172,7 @@ describe("CLI popup command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.6.0",
+                    schemaVersion: "0.7.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -565,7 +565,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -582,11 +582,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},
@@ -627,7 +627,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -105,7 +105,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -27,11 +27,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
       providerHealth: {},
@@ -71,7 +71,7 @@ function runningObserverDeps(
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -211,7 +211,7 @@ describe("CLI tui command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.6.0",
+                    schemaVersion: "0.7.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -276,7 +276,7 @@ describe("CLI tui command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.6.0",
+                    schemaVersion: "0.7.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -72,12 +72,12 @@ describe("provider hook ingress command", () => {
           ({
             health: async () => {
               if (!running) throw new Error("offline");
-              return { schemaVersion: "0.6.0", status: "healthy" };
+              return { schemaVersion: "0.7.0", status: "healthy" };
             },
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!running) throw new Error("offline");
               return {
-                schemaVersion: "0.6.0",
+                schemaVersion: "0.7.0",
                 hookId: event.hookId ?? "hook_final_command",
                 provider: event.provider,
                 event: event.event,
@@ -124,7 +124,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -177,7 +177,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -241,7 +241,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -304,7 +304,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -473,7 +473,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.6.0",
+              schemaVersion: "0.7.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -532,7 +532,7 @@ describe("provider hook ingress command", () => {
         clientFactory: (_socketPath, options) => {
           observedTimeoutMs = options.timeoutMs;
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => ({
-            schemaVersion: "0.6.0",
+            schemaVersion: "0.7.0",
             hookId: event.hookId ?? "hook_timeout_1",
             provider: event.provider,
             event: event.event,

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -51,7 +51,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.6.0",
+                schemaVersion: "0.7.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -95,7 +95,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.6.0",
+                schemaVersion: "0.7.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -204,7 +204,7 @@ describe("CLI observer process lifecycle", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.6.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -9,7 +9,7 @@ const now = "2026-05-20T12:00:00.000Z";
 
 const healthyObserver = (pid = 1234) =>
   ({
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     status: "healthy",
     pid,
     startedAt: now,

--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -344,7 +344,6 @@ function commandScope(command: StationCommand): string {
     case "terminal.close":
       return terminalCommandScope(command.payload);
     case "session.close":
-    case "session.sendPrompt":
     case "session.rename":
     case "session.acknowledgeTurn":
       return `session:${command.payload.sessionId}`;
@@ -361,7 +360,6 @@ function commandScope(command: StationCommand): string {
     case "project.add":
     case "project.remove":
     case "project.setDefaultHarness":
-    case "hooks.install":
       return "global";
   }
   const _exhaustive: never = command;

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -1,4 +1,4 @@
-import type { ProviderProjectConfig } from "@station/contracts";
+import type { ProviderProjectConfig, StationCommand } from "@station/contracts";
 import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import { createFeatureFlagEvaluator, type FeatureFlagEvaluator } from "../features/evaluator.js";
@@ -11,7 +11,7 @@ import {
   createProjectRemoveHandler,
   createProjectSetDefaultHarnessHandler,
 } from "./project.js";
-import type { CommandQueue } from "./queue.js";
+import type { CommandHandler, CommandQueue } from "./queue.js";
 import { createObserverReconcileHandler } from "./reconcile.js";
 import { createSessionAcknowledgeTurnHandler } from "./session/acknowledgeTurn.js";
 import { createSessionCloseHandler } from "./session/close.js";
@@ -70,38 +70,35 @@ export function registerObserverCommandHandlers(
       logger: options.logger,
       commandTimeoutMs: options.commandTimeoutMs,
     });
-  options.queue.registerHandler(
-    "observer.reconcile",
-    createObserverReconcileHandler({
+  const handlers = {
+    "worktree.create": createWorktreeCreateHandler({
+      getProjects,
+      providers: options.providers,
       core: options.core,
       eventBus: options.eventBus,
       clock: options.clock,
-    }),
-  );
-  options.queue.registerHandler(
-    "terminal.focus",
-    createTerminalFocusHandler({
-      core: options.core,
-      providers: options.providers,
-      terminalIntentRunner,
       commandTimeoutMs: options.commandTimeoutMs,
+      logger: options.logger,
     }),
-  );
-  options.queue.registerHandler(
-    "terminal.close",
-    createTerminalCloseHandler({
+    "worktree.fork": createWorktreeForkHandler({
+      getProjects,
       core: options.core,
       providers: options.providers,
+      eventBus: options.eventBus,
+      clock: options.clock,
+      commandTimeoutMs: options.commandTimeoutMs,
+      logger: options.logger,
+    }),
+    "worktree.remove": createWorktreeRemoveHandler({
+      providers: options.providers,
       terminalIntentRunner,
+      core: options.core,
       persistence: options.persistence,
       eventBus: options.eventBus,
       clock: options.clock,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.create",
-    createSessionCreateHandler({
+    "session.create": createSessionCreateHandler({
       getProjects,
       providers: options.providers,
       terminalIntentRunner,
@@ -113,10 +110,7 @@ export function registerObserverCommandHandlers(
       logger: options.logger,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.startAgent",
-    createSessionStartAgentHandler({
+    "session.startAgent": createSessionStartAgentHandler({
       getProjects,
       providers: options.providers,
       terminalIntentRunner,
@@ -128,10 +122,7 @@ export function registerObserverCommandHandlers(
       logger: options.logger,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.resumeAgent",
-    createSessionResumeAgentHandler({
+    "session.resumeAgent": createSessionResumeAgentHandler({
       getProjects,
       providers: options.providers,
       terminalIntentRunner,
@@ -143,10 +134,7 @@ export function registerObserverCommandHandlers(
       idFactory: options.idFactory,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.fork",
-    createSessionForkHandler({
+    "session.fork": createSessionForkHandler({
       getProjects,
       providers: options.providers,
       terminalIntentRunner,
@@ -158,10 +146,13 @@ export function registerObserverCommandHandlers(
       logger: options.logger,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.close",
-    createSessionCloseHandler({
+    "terminal.focus": createTerminalFocusHandler({
+      core: options.core,
+      providers: options.providers,
+      terminalIntentRunner,
+      commandTimeoutMs: options.commandTimeoutMs,
+    }),
+    "terminal.close": createTerminalCloseHandler({
       providers: options.providers,
       terminalIntentRunner,
       core: options.core,
@@ -170,51 +161,7 @@ export function registerObserverCommandHandlers(
       clock: options.clock,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "session.rename",
-    createSessionRenameHandler({
-      core: options.core,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-      clock: options.clock,
-    }),
-  );
-  options.queue.registerHandler(
-    "session.acknowledgeTurn",
-    createSessionAcknowledgeTurnHandler({
-      core: options.core,
-      persistence: options.persistence,
-      eventBus: options.eventBus,
-    }),
-  );
-  options.queue.registerHandler(
-    "worktree.create",
-    createWorktreeCreateHandler({
-      getProjects,
-      providers: options.providers,
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      commandTimeoutMs: options.commandTimeoutMs,
-      logger: options.logger,
-    }),
-  );
-  options.queue.registerHandler(
-    "worktree.fork",
-    createWorktreeForkHandler({
-      getProjects,
-      providers: options.providers,
-      core: options.core,
-      eventBus: options.eventBus,
-      clock: options.clock,
-      commandTimeoutMs: options.commandTimeoutMs,
-      logger: options.logger,
-    }),
-  );
-  options.queue.registerHandler(
-    "worktree.remove",
-    createWorktreeRemoveHandler({
+    "session.close": createSessionCloseHandler({
       providers: options.providers,
       terminalIntentRunner,
       core: options.core,
@@ -223,56 +170,51 @@ export function registerObserverCommandHandlers(
       clock: options.clock,
       commandTimeoutMs: options.commandTimeoutMs,
     }),
-  );
-  options.queue.registerHandler(
-    "project.add",
-    createProjectAddHandler({
+    "session.rename": createSessionRenameHandler({
+      core: options.core,
+      persistence: options.persistence,
+      eventBus: options.eventBus,
+      clock: options.clock,
+    }),
+    "session.acknowledgeTurn": createSessionAcknowledgeTurnHandler({
+      core: options.core,
+      persistence: options.persistence,
+      eventBus: options.eventBus,
+    }),
+    "observer.reconcile": createObserverReconcileHandler({
+      core: options.core,
+      eventBus: options.eventBus,
+      clock: options.clock,
+    }),
+    "project.add": createProjectAddHandler({
       core: options.core,
       eventBus: options.eventBus,
       clock: options.clock,
       ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
-  );
-  options.queue.registerHandler(
-    "project.remove",
-    createProjectRemoveHandler({
+    "project.remove": createProjectRemoveHandler({
       core: options.core,
       eventBus: options.eventBus,
       clock: options.clock,
       ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
-  );
-  options.queue.registerHandler(
-    "project.setDefaultHarness",
-    createProjectSetDefaultHarnessHandler({
+    "project.setDefaultHarness": createProjectSetDefaultHarnessHandler({
       core: options.core,
       eventBus: options.eventBus,
       clock: options.clock,
       ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
       ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
-  );
+  } satisfies Record<StationCommand["type"], CommandHandler>;
+
+  const commandTypes = Object.keys(handlers) as StationCommand["type"][];
+  for (const commandType of commandTypes) {
+    options.queue.registerHandler(commandType, handlers[commandType]);
+  }
 
   void options.logger?.info("Observer command handlers registered.", {
-    commandTypes: [
-      "observer.reconcile",
-      "terminal.focus",
-      "terminal.close",
-      "session.create",
-      "session.startAgent",
-      "session.resumeAgent",
-      "session.fork",
-      "session.close",
-      "session.rename",
-      "session.acknowledgeTurn",
-      "worktree.create",
-      "worktree.fork",
-      "worktree.remove",
-      "project.add",
-      "project.remove",
-      "project.setDefaultHarness",
-    ],
+    commandTypes,
   });
 }

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -1,10 +1,8 @@
 import type {
   AgentPrepareExternalLaunchParams,
   AgentPrepareExternalLaunchResult,
-  AgentReattachHandle,
   AgentReportExternalExitParams,
   AgentReportExternalExitResult,
-  ManagedTerminalLifecycle,
   SafeError,
   TerminalTargetId,
 } from "@station/contracts";
@@ -26,17 +24,6 @@ import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import { nowIso } from "../utils/time.js";
 
-async function resolveReattachHandle(
-  managedTerminal: ManagedTerminalLifecycle,
-  targetId: TerminalTargetId,
-): Promise<AgentReattachHandle | undefined> {
-  const info = await managedTerminal.reattachInfo(targetId);
-  if (info === undefined) {
-    return undefined;
-  }
-  return { ptyId: info.endpointId, terminalTargetId: targetId, hostSocketPath: info.socketPath };
-}
-
 export type ExternalLaunchDeps = {
   core: ObserverCore;
   providers: ProviderRegistry;
@@ -54,7 +41,7 @@ export type ExternalLaunchOutcome<T> = {
 /**
  * USE CASE
  *
- * Prepare Station-hosted agent identity, launch plan, and managed process handoff;
+ * Prepare Station-hosted agent identity, launch plan, and opaque managed attachment;
  * the managed target lets reconcile surface the session immediately.
  */
 export async function prepareExternalLaunch(
@@ -86,16 +73,16 @@ export async function prepareExternalLaunch(
             (target) =>
               target.worktreeId === params.worktreeId && target.sessionId === agent.sessionId,
           );
-    const reattachHandle =
+    const attachment =
       managedTerminal === undefined || managedTarget === undefined
         ? undefined
-        : await resolveReattachHandle(managedTerminal, managedTarget.id);
+        : await managedTerminal.attachmentForTarget(managedTarget.id);
     return {
       outcome: {
         kind: "existing-session",
         sessionId: agent.sessionId,
         harnessProvider: agent.harness,
-        ...(reattachHandle === undefined ? {} : { reattachHandle }),
+        ...(attachment === undefined ? {} : { attachment }),
       },
       reconcile: false,
     };
@@ -146,14 +133,14 @@ export async function prepareExternalLaunch(
         )
       : undefined;
   if (concurrentManagedTarget?.sessionId !== undefined) {
-    const reattachHandle = await resolveReattachHandle(managedTerminal, concurrentManagedTarget.id);
+    const attachment = await managedTerminal.attachmentForTarget(concurrentManagedTarget.id);
     return {
       outcome: {
         kind: "existing-session",
         sessionId: concurrentManagedTarget.sessionId,
         harnessProvider:
           concurrentManagedTarget.harnessBinding?.harnessProvider ?? harnessProviderId,
-        ...(reattachHandle === undefined ? {} : { reattachHandle }),
+        ...(attachment === undefined ? {} : { attachment }),
       },
       reconcile: false,
     };
@@ -189,12 +176,8 @@ export async function prepareExternalLaunch(
       sessionId,
     });
 
-    // Spawn the agent into the host so it outlives the UI, then hand the client a
-    // reattach handle built FROM the spawn result — so "spawned remotely" and "has
-    // a handle" never diverge (a divergence would double-spawn: host PTY + local
-    // UI PTY). `started: false` (no host / host unavailable) ⇒ no handle and the UI
-    // spawns the PTY locally from launchPlan.
-    let reattachHandle: AgentReattachHandle | undefined;
+    // The managed result requires an attachment exactly when it starts the process,
+    // so a remote spawn can never be advertised as eligible for local fallback.
     const launched = await managedTerminal.launchProcess({
       project,
       worktree,
@@ -202,13 +185,7 @@ export async function prepareExternalLaunch(
       agentEndpointId: opened.agentEndpointId,
       launchPlan,
     });
-    if (launched.started) {
-      reattachHandle = {
-        ptyId: launched.reattach.endpointId,
-        terminalTargetId: opened.target.targetId,
-        hostSocketPath: launched.reattach.socketPath,
-      };
-    }
+    const attachment = launched.started ? launched.attachment : undefined;
 
     return {
       outcome: {
@@ -216,7 +193,7 @@ export async function prepareExternalLaunch(
         sessionId,
         terminalTargetId: opened.target.targetId,
         launchPlan,
-        ...(reattachHandle === undefined ? {} : { reattachHandle }),
+        ...(attachment === undefined ? {} : { attachment }),
       },
       reconcile: true,
     };

--- a/apps/observer/test/integration/command-queue.test.ts
+++ b/apps/observer/test/integration/command-queue.test.ts
@@ -50,11 +50,11 @@ const reconcileCommand: StationCommand = {
   },
 };
 
-const sendPromptCommand: StationCommand = {
-  type: "session.sendPrompt",
+const renameSessionCommand: StationCommand = {
+  type: "session.rename",
   payload: {
     sessionId: "ses_web_main",
-    prompt: "Summarize current status.",
+    title: "Web main",
   },
 };
 
@@ -63,13 +63,6 @@ const createWorktreeCommand: StationCommand = {
   payload: {
     projectId: "web",
     branch: "feature/auth",
-  },
-};
-
-const installHooksCommand: StationCommand = {
-  type: "hooks.install",
-  payload: {
-    provider: "worktrunk",
   },
 };
 
@@ -251,17 +244,11 @@ describe("observer command queue", () => {
   it("fails accepted commands that do not have registered handlers", async () => {
     const { sqlite, persistence, queue } = createPersistenceAndQueue();
 
-    const receipts = await Promise.all([
-      queue.dispatch(createWorktreeCommand),
-      queue.dispatch(sendPromptCommand),
-      queue.dispatch(installHooksCommand),
-    ]);
+    const receipts = await Promise.all([queue.dispatch(createWorktreeCommand)]);
     await queue.drain();
 
     expect(receipts).toEqual([
       expect.objectContaining({ commandId: "cmd_1", accepted: true, status: "accepted" }),
-      expect.objectContaining({ commandId: "cmd_2", accepted: true, status: "accepted" }),
-      expect.objectContaining({ commandId: "cmd_3", accepted: true, status: "accepted" }),
     ]);
     expect(await persistence.listCommands()).toEqual([
       expect.objectContaining({
@@ -273,28 +260,6 @@ describe("observer command queue", () => {
           code: "COMMAND_HANDLER_MISSING",
           commandId: "cmd_1",
           traceId: receipts[0]?.traceId,
-        }),
-      }),
-      expect.objectContaining({
-        id: "cmd_2",
-        status: "failed",
-        traceId: receipts[1]?.traceId,
-        error: expect.objectContaining({
-          tag: "CommandRoutingError",
-          code: "COMMAND_HANDLER_MISSING",
-          commandId: "cmd_2",
-          traceId: receipts[1]?.traceId,
-        }),
-      }),
-      expect.objectContaining({
-        id: "cmd_3",
-        status: "failed",
-        traceId: receipts[2]?.traceId,
-        error: expect.objectContaining({
-          tag: "CommandRoutingError",
-          code: "COMMAND_HANDLER_MISSING",
-          commandId: "cmd_3",
-          traceId: receipts[2]?.traceId,
         }),
       }),
     ]);
@@ -323,7 +288,7 @@ describe("observer command queue", () => {
       releaseFirst = resolve;
     });
 
-    queue.registerHandler("session.sendPrompt", async ({ commandId }) => {
+    queue.registerHandler("session.rename", async ({ commandId }) => {
       starts.push(commandId);
       if (commandId === "cmd_1") {
         await firstBlocked;
@@ -331,8 +296,8 @@ describe("observer command queue", () => {
       finishes.push(commandId);
     });
 
-    const first = queue.dispatch(sendPromptCommand);
-    const second = queue.dispatch(sendPromptCommand);
+    const first = queue.dispatch(renameSessionCommand);
+    const second = queue.dispatch(renameSessionCommand);
     await Promise.all([first, second]);
     await new Promise((resolve) => setImmediate(resolve));
 

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -38,7 +38,7 @@ describe("observer diagnostics collector", () => {
     };
 
     await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       providerHealth: {
         "fake-worktree": { status: "healthy" },
       },

--- a/apps/observer/test/integration/persistence.test.ts
+++ b/apps/observer/test/integration/persistence.test.ts
@@ -280,7 +280,7 @@ describe("observer persistence", () => {
     sqlite.close();
   });
 
-  it("skips command rows that no longer match current command contracts", async () => {
+  it("skips retired command rows without requiring a migration", async () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     const persistence = createObserverPersistence({
       sqlite,
@@ -293,16 +293,28 @@ describe("observer persistence", () => {
     `);
 
     insertCommand.run(
-      "cmd_legacy_focus",
-      "terminal.focus",
+      "cmd_retired_send_prompt",
+      "session.sendPrompt",
       JSON.stringify({
-        type: "terminal.focus",
+        type: "session.sendPrompt",
         payload: {
-          targetId: "tmux:station:@83:%83",
-          origin: {
-            provider: "tmux",
-            clientId: "/dev/ttys008",
-          },
+          sessionId: "ses_web_main",
+          prompt: "Summarize current status.",
+          delivery: "harness-native",
+        },
+      }),
+      "succeeded",
+      now,
+      null,
+      null,
+    );
+    insertCommand.run(
+      "cmd_retired_hooks_install",
+      "hooks.install",
+      JSON.stringify({
+        type: "hooks.install",
+        payload: {
+          provider: "worktrunk",
         },
       }),
       "succeeded",
@@ -320,7 +332,7 @@ describe("observer persistence", () => {
     sqlite.close();
   });
 
-  it("skips event rows that no longer match current event contracts", async () => {
+  it("skips retired command events in historical diagnostic reads", async () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     const persistence = createObserverPersistence({
       sqlite,
@@ -333,19 +345,39 @@ describe("observer persistence", () => {
     `);
 
     insertEvent.run(
-      "evt_legacy_command",
+      "evt_retired_send_prompt",
       "command.accepted",
       "observer",
-      "cmd_legacy_focus",
+      "cmd_retired_send_prompt",
       null,
       null,
       JSON.stringify({
         type: "command.accepted",
-        commandId: "cmd_legacy_focus",
+        commandId: "cmd_retired_send_prompt",
         command: {
-          type: "terminal.focus",
+          type: "session.sendPrompt",
           payload: {
-            targetId: "tmux:station:@83:%83",
+            sessionId: "ses_web_main",
+            prompt: "Summarize current status.",
+          },
+        },
+      }),
+      now,
+    );
+    insertEvent.run(
+      "evt_retired_hooks_install",
+      "command.accepted",
+      "observer",
+      "cmd_retired_hooks_install",
+      null,
+      null,
+      JSON.stringify({
+        type: "command.accepted",
+        commandId: "cmd_retired_hooks_install",
+        command: {
+          type: "hooks.install",
+          payload: {
+            provider: "worktrunk",
           },
         },
       }),

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -1,6 +1,7 @@
 import type {
   AgentState,
   HarnessHooksStatus,
+  ManagedTerminalAttachment,
   ManagedTerminalLaunchProcessResult,
   ManagedTerminalLifecycle,
   OpenWorkspaceRequest,
@@ -13,7 +14,6 @@ import type {
   TerminalAttachment,
   TerminalCapabilities,
   TerminalLaunchProcessRequest,
-  TerminalReattachInfo,
   TerminalTargetId,
   TerminalTargetObservation,
   WorktreeRow,
@@ -38,7 +38,7 @@ function managedTargetId(worktreeId: string): TerminalTargetId {
 
 type FakeManagedTerminalOptions = {
   started?: boolean;
-  reattach?: TerminalReattachInfo;
+  attachment?: ManagedTerminalAttachment;
   launchFailure?: SafeError;
   releaseFailure?: SafeError;
 };
@@ -51,7 +51,7 @@ class FakeManagedTerminalLifecycle implements ManagedTerminalLifecycle {
   readonly #targets: TerminalTargetObservation[] = [];
   readonly #terminal: FakeTerminalProvider;
   readonly #started: boolean;
-  readonly #reattach: TerminalReattachInfo | undefined;
+  readonly #attachment: ManagedTerminalAttachment | undefined;
   readonly #launchFailure: SafeError | undefined;
   readonly #releaseFailure: SafeError | undefined;
 
@@ -62,7 +62,7 @@ class FakeManagedTerminalLifecycle implements ManagedTerminalLifecycle {
       targets: this.#targets,
     });
     this.#started = options.started ?? false;
-    this.#reattach = options.reattach;
+    this.#attachment = options.attachment;
     this.#launchFailure = options.launchFailure;
     this.#releaseFailure = options.releaseFailure;
   }
@@ -134,14 +134,16 @@ class FakeManagedTerminalLifecycle implements ManagedTerminalLifecycle {
     if (!this.#started) {
       return { ...result, started: false };
     }
-    if (this.#reattach === undefined) {
-      throw new Error("Fake managed terminal needs reattach info when started.");
+    if (this.#attachment === undefined) {
+      throw new Error("Fake managed terminal needs an attachment when started.");
     }
-    return { ...result, started: true, reattach: this.#reattach };
+    return { ...result, started: true, attachment: this.#attachment };
   }
 
-  async reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined> {
-    return this.#targets.some((target) => target.id === targetId) ? this.#reattach : undefined;
+  async attachmentForTarget(
+    targetId: TerminalTargetId,
+  ): Promise<ManagedTerminalAttachment | undefined> {
+    return this.#targets.some((target) => target.id === targetId) ? this.#attachment : undefined;
   }
 
   async releaseTarget(targetId: TerminalTargetId): Promise<boolean> {
@@ -383,7 +385,11 @@ describe("prepareExternalLaunch", () => {
   });
 
   it("returns the already-registered session for a concurrent prepare (snapshot lags)", async () => {
-    const station = new FakeManagedTerminalLifecycle();
+    const attachment: ManagedTerminalAttachment = {
+      kind: "managed-terminal",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+    };
+    const station = new FakeManagedTerminalLifecycle({ started: true, attachment });
     const first = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (first.outcome.kind !== "prepared") throw new Error("expected prepared");
 
@@ -396,6 +402,7 @@ describe("prepareExternalLaunch", () => {
         kind: "existing-session",
         sessionId: first.outcome.sessionId,
         harnessProvider: "fake-harness",
+        attachment,
       },
       reconcile: false,
     });
@@ -706,25 +713,27 @@ describe("prepareExternalLaunch existing-agent state matrix", () => {
   });
 });
 
-describe("prepareExternalLaunch reattachment", () => {
-  it("attaches a reattachHandle to the prepared result", async () => {
+describe("prepareExternalLaunch managed attachments", () => {
+  it("passes the adapter's opaque attachment through to the prepared result", async () => {
+    const attachment: ManagedTerminalAttachment = {
+      kind: "managed-terminal",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+    };
     const station = new FakeManagedTerminalLifecycle({
       started: true,
-      reattach: { endpointId: "endpoint-1", socketPath: "/tmp/managed-test.sock" },
+      attachment,
     });
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
-    expect(result.outcome.reattachHandle).toMatchObject({
-      ptyId: "endpoint-1",
-      terminalTargetId: managedTargetId("wt_web_feature"),
-      hostSocketPath: "/tmp/managed-test.sock",
-    });
+    expect(result.outcome.attachment).toBe(attachment);
   });
 
-  it("attaches a reattachHandle to an existing-session result", async () => {
-    const station = new FakeManagedTerminalLifecycle({
-      reattach: { endpointId: "endpoint-1", socketPath: "/tmp/managed-test.sock" },
-    });
+  it("passes the adapter's opaque attachment through to an existing-session result", async () => {
+    const attachment: ManagedTerminalAttachment = {
+      kind: "managed-terminal",
+      terminalTargetId: managedTargetId("wt_web_feature"),
+    };
+    const station = new FakeManagedTerminalLifecycle({ attachment });
     station.seedTarget({ worktreeId: "wt_web_feature", sessionId: "ses_live" });
     const result = await prepareExternalLaunch(
       deps([row({ agentSessionId: "ses_live" })], station),
@@ -734,16 +743,16 @@ describe("prepareExternalLaunch reattachment", () => {
       kind: "existing-session",
       sessionId: "ses_live",
       harnessProvider: "fake-harness",
-      reattachHandle: {
-        ptyId: "endpoint-1",
-        terminalTargetId: managedTargetId("wt_web_feature"),
-      },
+      attachment,
     });
   });
 
   it("does not attach a replacement target from a different session", async () => {
     const station = new FakeManagedTerminalLifecycle({
-      reattach: { endpointId: "endpoint-new", socketPath: "/tmp/managed-test.sock" },
+      attachment: {
+        kind: "managed-terminal",
+        terminalTargetId: managedTargetId("wt_web_feature"),
+      },
     });
     station.seedTarget({ worktreeId: "wt_web_feature", sessionId: "ses_replacement" });
 
@@ -759,10 +768,10 @@ describe("prepareExternalLaunch reattachment", () => {
     });
   });
 
-  it("omits the reattachHandle when the managed adapter does not start the process", async () => {
+  it("omits the attachment when the managed adapter does not start the process", async () => {
     const station = new FakeManagedTerminalLifecycle();
     const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
     if (result.outcome.kind !== "prepared") throw new Error("expected prepared");
-    expect(result.outcome.reattachHandle).toBeUndefined();
+    expect(result.outcome.attachment).toBeUndefined();
   });
 });

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,7 +56,8 @@ When these disagree, reconcile from config, providers, and current observer stat
 ## Boundary Rules
 
 - Provider-specific behavior stays in `integrations/...` or provider-injected capabilities. Observer/core code aggregates through contracts, registries, and provider interfaces.
-- Station-managed terminal lifecycle is supplied as an explicit application role. Observer application code may forward target IDs returned by that role, but must not select its adapter by provider ID, reconstruct provider-owned target IDs, or discover lifecycle operations through runtime method probing.
+- Station-managed terminal lifecycle is supplied as an explicit application role. Observer application code may forward opaque managed-terminal attachments returned by that role, but must not select its adapter by provider ID, reconstruct provider-owned target IDs, or expose Station Host PTY and socket mechanics.
+- Station resolves managed-terminal attachments through its own host attacher. An absent attachment permits the existing local launch; an advertised attachment that cannot resolve fails visibly and must never fall through to a local spawn.
 - The Station UI is a client. It renders snapshots/events and dispatches typed commands; it must not import providers, read SQLite, run `wt`, run `tmux`, run `git`/`gh`, or parse raw provider payloads for core behavior.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
@@ -77,6 +78,7 @@ See [Observer Architecture](observer-architecture.md).
 The Station UI in `station/` is a `@station/client` consumer plus a terminal-hosting runtime:
 
 - The `station-station-host` daemon (`packages/station-host`) owns PTYs that outlive the UI. Its socket defaults beside the observer socket at `<state_dir>/run/station-host.sock` (override `STATION_HOST_SOCKET_PATH`).
+- Observer external-launch results carry only an opaque managed-terminal target identity. Station resolves that identity to a live Station Host PTY immediately before pane creation, keeping socket paths and PTY IDs on the Station side of the boundary.
 - Pane liveness is split from pane layout. On a UI restart while the host survives, panes **warm-reattach** to live PTYs with scrollback via the host's attach call; on a cold start (reboot or host down) the saved layout spec **cold-respawns** fresh shells in their saved working directory. Layout persists to `<state_dir>/station/layout.json` (override `STATION_LAYOUT_PATH`), which deliberately does not fall back to `XDG_RUNTIME_DIR` so it survives a reboot.
 - "New Session" in Station hosts the agent in a Station pane by dispatching the observer `worktree.create` command, rather than launching an external tmux session. Liveness decisions (launch vs. focus, destructive guards) route through the shared `worktreeHasLiveAgent` contract in `packages/contracts`.
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -159,8 +159,8 @@ must not compensate for it by selecting concrete adapters at runtime.
 
 The Station terminal adapter may use Station Host when CLI composition enables
 host-backed terminals. Observer application code knows only the injected
-`ManagedTerminalLifecycle`; it must not know Station Host socket, process, or
-target-format mechanics.
+`ManagedTerminalLifecycle` and its opaque managed-terminal attachment; Station
+resolves that attachment to host socket and PTY mechanics at its own boundary.
 
 ## Port, Actor, And Adapter Map
 
@@ -170,12 +170,12 @@ ownership even where current ownership is still a deviation.
 | Conversation | Direction | Application seam | Actor or adapter | Rule and current status |
 | --- | --- | --- | --- | --- |
 | Observer operations | Driving | `ObserverApi` | NDJSON/Unix-socket server, direct tests | Conforming application-owned driving port; protocol adapts transport messages while direct tests can invoke it without transport. |
-| Recorded mutations | Driving | `StationCommand`, `dispatch`, command handlers | CLI, Station client, protocol client | Commands persist acceptance and completion; registration is not yet exhaustive (OBS-HEX-006). |
+| Recorded mutations | Driving | `StationCommand`, `dispatch`, command handlers | CLI, Station client, protocol client | Commands persist acceptance and completion; the production handler map is compile-time exhaustive over the command union. |
 | Provider hook delivery | Driving | provider hook ingress | `stn-ingress`, protocol method, offline spool, provider hook adapters | Raw input is validated once and provider vocabulary is normalized at the adapter boundary. |
 | Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
 | Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Strong purpose-owned port. |
 | Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
-| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role; the remaining response payload is host-shaped (OBS-HEX-009). |
+| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity; Station owns host attachment resolution. |
 | Harness operations | Driven | `HarnessProvider` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned port with provider-local parsing. |
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
 | Durable observer memory | Driven | current `ObserverPersistence` | SQLite persistence modules | A port exists, but it is broad and leaks SQLite representations (OBS-HEX-004 and OBS-HEX-005). |
@@ -350,9 +350,11 @@ patch.
 `prepareExternalLaunch` and `reportExternalExit` are latency-sensitive
 handshakes rather than recorded commands. Their use cases depend on the
 composition-supplied `ManagedTerminalLifecycle`, carry provider-owned target IDs
-opaquely, and request reconcile after relevant lifecycle changes. The current
-wire result still exposes host-shaped reattachment data; OBS-HEX-009 tracks its
-replacement with an opaque managed-terminal attachment.
+opaquely, and request reconcile after relevant lifecycle changes. A managed
+launch result may include an opaque attachment that Station resolves to its
+host mechanics. An absent attachment permits Station's local launch path; once
+an attachment is advertised, resolution or later attachment failure must not
+fall through to a second local spawn.
 
 ### Diagnostics
 
@@ -501,8 +503,8 @@ Current enforcement is partial. The boundary inventory catches forbidden
 package imports but cannot detect copied provider IDs, reconstructed target
 formats, or application logic that selects a concrete adapter. Marker and
 declared-seam checks begin with documented or touched seams. Complete
-conformance requires dependency-direction checks, exhaustive command
-registration, substitutable persistence/local-evidence adapters, and an
+conformance requires dependency-direction checks, substitutable
+persistence/local-evidence adapters, and an
 Observer application lane that does not require SQLite.
 
 A new architecture diagnostic must enforce declarations and dependency facts,
@@ -520,9 +522,7 @@ and exit condition here.
 | --- | --- | --- | --- |
 | `OBS-HEX-004` | `ObserverCore` accepts `ObserverSqliteHandle`, exposes SQLite health, and imports persisted representations. Storage technology crosses inward. | Keep new SQLite details out of core. Exit when core depends only on application-purpose persistence and health capabilities. | SQLite/core isolation. |
 | `OBS-HEX-005` | `ObserverPersistence` combines unrelated use cases, complete Observer tests require SQLite, and the existing fake is not a safe substitute. | Add no new generic persistence bucket. Exit when consumers use the seven purpose-owned ports, SQLite and in-memory adapters pass shared contracts, and the full application runs without SQLite. | Persistence port and substitution remediation. |
-| `OBS-HEX-006` | `StationCommand` includes `session.sendPrompt` and `hooks.install`, but the Observer router registers neither; accepted commands can fail only after queueing. | Do not add another non-executable contract member. Exit when unsupported members are removed and construction proves exhaustive registration or an explicit reviewed unsupported allowlist. | Command surface cleanup and exhaustive registration. |
 | `OBS-HEX-007` | Terminal intent orchestration now belongs to `commands/`, resolving that provider/application back-edge. Unrelated type-only ownership cycles remain, so not every major module role is yet explainable without source cycles. | A dependency diagnostic prevents `providers/**` from importing `commands/**`. Exit when the remaining major-module type cycles are removed and final dependency-direction enforcement covers every major Observer module. | Internal ownership remediation. |
-| `OBS-HEX-009` | External-launch application results still expose `AgentReattachHandle` with host PTY and socket data. A host-specific representation crosses the application API. | The managed lifecycle remains explicitly injected and application code must not construct the payload. Exit when the API returns an opaque managed-terminal attachment resolved by Station-side attachment behavior. | Managed attachment protocol cutover. |
 | `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Keep behavior behind existing narrow call sites. Exit with purpose-owned `StationLogger` and `ProjectConfigWriter` ports and adapters. | Logging and project-config edge inversion. |
 | `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Use case and local adapter mechanics are mixed. | Keep new provider-specific parsing out of metadata orchestration. Exit when `WorktreeMetadataSource` owns local Git/ref evidence. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only and paths stay composition-supplied. Exit when a `DiagnosticEvidenceSource` adapter owns local traversal and the use case runs against a fake. | Diagnostic evidence isolation. |
@@ -535,7 +535,12 @@ selected without application changes, and overlapping support fails explicitly.
 `OBS-HEX-003` is resolved: `ObserverApi` and external-launch application
 contracts are owned by `packages/contracts`, protocol retains transport mapping
 and validation, and a boundary diagnostic confines Observer protocol imports to
-the runtime server adapter.
+the runtime server adapter. `OBS-HEX-006` is resolved: the two unsupported
+command members are gone, and production registration is constructed from one
+handler map that is exhaustive over `StationCommand["type"]`. `OBS-HEX-009` is
+resolved: external launch exposes only an opaque managed-terminal attachment,
+Station owns host PTY and socket resolution, and an advertised attachment can
+never fail over to a duplicate local spawn.
 This document resolves `OBS-HEX-008`, the missing canonical Observer architecture
 contract. Resolved history belongs in its issue and pull request, not in the
 active register.

--- a/integrations/terminal/station/src/provider.ts
+++ b/integrations/terminal/station/src/provider.ts
@@ -1,4 +1,5 @@
 import type {
+  ManagedTerminalAttachment,
   ManagedTerminalLaunchProcessResult,
   ManagedTerminalLifecycle,
   OpenWorkspaceRequest,
@@ -11,7 +12,6 @@ import type {
   TerminalCapabilities,
   TerminalIdentityBinding,
   TerminalLaunchProcessRequest,
-  TerminalReattachInfo,
   TerminalTargetId,
   TerminalTargetObservation,
   WorktreeId,
@@ -40,8 +40,8 @@ export type StationTerminalProviderOptions = {
  * ADAPTER
  *
  * Station terminal provider: UI-hosted mode is a registration shim; host-backed
- * mode uses `host.list` as liveness truth so reattach/restart re-derives the
- * same session instead of minting another.
+ * mode uses `host.list` as liveness truth and exposes only opaque target identity
+ * for Station-side attachment resolution.
  */
 export class StationTerminalProvider implements ManagedTerminalLifecycle {
   readonly id: ProviderId = STATION_TERMINAL_PROVIDER_ID;
@@ -195,7 +195,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
   /**
    * Host-backed spawn ownership: spawn the agent into the host so it outlives the
    * UI. Returns `started: false` when not host-backed or the host is unavailable,
-   * so the observer falls back to the UI spawning from the launch plan.
+   * so the observer permits the UI to spawn from the launch plan.
    */
   async launchProcess(
     request: TerminalLaunchProcessRequest,
@@ -212,14 +212,15 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
       return { ...base, started: false };
     }
     try {
-      const spawned = await handle.client.spawn(buildSpawnParams(request));
+      await handle.client.spawn(buildSpawnParams(request));
       this.#hostBackedTargets.add(request.terminalTarget.targetId);
-      // Hand back the reattach info from the spawn result so the caller need not
-      // re-query host.list — and so "started" and "has a handle" never diverge.
       return {
         ...base,
         started: true,
-        reattach: { endpointId: spawned.ptyId, socketPath: this.#host.socketPath },
+        attachment: {
+          kind: "managed-terminal",
+          terminalTargetId: request.terminalTarget.targetId,
+        },
       };
     } catch (error) {
       // A rejected host spawn must not leave the provisional target visible to reconcile.
@@ -228,7 +229,9 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
     }
   }
 
-  async reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined> {
+  async attachmentForTarget(
+    targetId: TerminalTargetId,
+  ): Promise<ManagedTerminalAttachment | undefined> {
     if (this.#host === undefined) {
       return undefined;
     }
@@ -236,7 +239,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
     if (entry === undefined) {
       return undefined;
     }
-    return { endpointId: entry.ptyId, socketPath: this.#host.socketPath };
+    return { kind: "managed-terminal", terminalTargetId: targetId };
   }
 
   async focusTarget(targetId: TerminalTargetId): Promise<void> {
@@ -272,7 +275,9 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
     } catch {
       return undefined;
     }
-    return live.find((entry) => entry.terminalTargetId === targetId && entry.alive);
+    return live.find(
+      (entry) => entry.kind === "agent" && entry.terminalTargetId === targetId && entry.alive,
+    );
   }
 
   async #requirePtyId(targetId: TerminalTargetId): Promise<string> {

--- a/integrations/terminal/station/test/unit/provider.test.ts
+++ b/integrations/terminal/station/test/unit/provider.test.ts
@@ -84,7 +84,7 @@ describe("StationTerminalProvider", () => {
       },
     });
     expect(result.started).toBe(false);
-    await expect(provider.reattachInfo("native:web-feature")).resolves.toBeUndefined();
+    await expect(provider.attachmentForTarget("native:web-feature")).resolves.toBeUndefined();
   });
 
   it("reports healthy", async () => {
@@ -256,7 +256,15 @@ describe("StationTerminalProvider (host-backed)", () => {
       agentEndpointId: opened.agentEndpointId,
       launchPlan,
     });
-    expect(result.started).toBe(true);
+    expect(result).toEqual({
+      terminalTargetId: stationTargetId(worktree.id),
+      agentEndpointId: stationTargetId(worktree.id),
+      started: true,
+      attachment: {
+        kind: "managed-terminal",
+        terminalTargetId: stationTargetId(worktree.id),
+      },
+    });
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn.mock.calls[0]?.[0]).toMatchObject({
       terminalTargetId: stationTargetId(worktree.id),
@@ -396,8 +404,9 @@ describe("StationTerminalProvider (host-backed)", () => {
     const targets = await provider.listTargets();
     expect(targets).toHaveLength(1);
     expect(targets[0]?.sessionId).toBe("ses_first");
-    await expect(provider.reattachInfo(stationTargetId(worktree.id))).resolves.toMatchObject({
-      endpointId: "pty-first",
+    await expect(provider.attachmentForTarget(stationTargetId(worktree.id))).resolves.toEqual({
+      kind: "managed-terminal",
+      terminalTargetId: stationTargetId(worktree.id),
     });
   });
 
@@ -455,11 +464,33 @@ describe("StationTerminalProvider (host-backed)", () => {
     await expect(provider.listTargets()).resolves.toHaveLength(1);
   });
 
-  it("reattachInfo returns the live host PTY endpoint and socket", async () => {
+  it("attachmentForTarget returns only opaque target identity for a live host entry", async () => {
     const provider = hostBackedProvider(fakeHostClient({ list: async () => [liveEntry()] }));
-    const info = await provider.reattachInfo(stationTargetId(worktree.id));
-    expect(info).toMatchObject({ endpointId: "pty-1" });
-    expect(info?.socketPath).toContain("station-host-");
+    await expect(provider.attachmentForTarget(stationTargetId(worktree.id))).resolves.toEqual({
+      kind: "managed-terminal",
+      terminalTargetId: stationTargetId(worktree.id),
+    });
+  });
+
+  it("attachmentForTarget ignores an alive aux entry with the target id", async () => {
+    const provider = hostBackedProvider(
+      fakeHostClient({ list: async () => [liveEntry({ kind: "aux" })] }),
+    );
+    await expect(
+      provider.attachmentForTarget(stationTargetId(worktree.id)),
+    ).resolves.toBeUndefined();
+  });
+
+  it("attachmentForTarget omits missing and dead host targets", async () => {
+    const provider = hostBackedProvider(
+      fakeHostClient({ list: async () => [liveEntry({ alive: false })] }),
+    );
+    await expect(
+      provider.attachmentForTarget(stationTargetId(worktree.id)),
+    ).resolves.toBeUndefined();
+    await expect(
+      provider.attachmentForTarget(stationTargetId("wt_missing")),
+    ).resolves.toBeUndefined();
   });
 
   it("focus/close resolve the host PTY id and drive the host", async () => {

--- a/packages/client/test/integration/observerService.test.ts
+++ b/packages/client/test/integration/observerService.test.ts
@@ -76,6 +76,10 @@ describe("observer client service", () => {
               env: { STATION_SESSION_ID: "ses_external_1" },
               mode: "interactive",
             },
+            attachment: {
+              kind: "managed-terminal",
+              terminalTargetId: `native:${params.worktreeId}`,
+            },
           };
         },
         reportExternalExit: async (params) => {
@@ -93,6 +97,10 @@ describe("observer client service", () => {
       sessionId: "ses_external_1",
       terminalTargetId: "native:wt_web_feature",
       launchPlan: { provider: "claude", env: { STATION_SESSION_ID: "ses_external_1" } },
+      attachment: {
+        kind: "managed-terminal",
+        terminalTargetId: "native:wt_web_feature",
+      },
     });
     await expect(
       service.reportExternalExit({ terminalTargetId: "native:wt_web_feature" }),

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -179,16 +179,6 @@ export const CloseSessionPayloadSchema = z
 
 export type CloseSessionPayload = z.infer<typeof CloseSessionPayloadSchema>;
 
-export const SendPromptPayloadSchema = z
-  .object({
-    sessionId: SessionIdSchema,
-    prompt: nonEmptyStringSchema,
-    delivery: z.enum(["harness-native", "paste-and-focus"]).optional(),
-  })
-  .strict();
-
-export type SendPromptPayload = z.infer<typeof SendPromptPayloadSchema>;
-
 export const RenameSessionPayloadSchema = z
   .object({
     sessionId: SessionIdSchema,
@@ -243,14 +233,6 @@ export const SetProjectDefaultHarnessPayloadSchema = z
 
 export type SetProjectDefaultHarnessPayload = z.infer<typeof SetProjectDefaultHarnessPayloadSchema>;
 
-export const InstallHooksPayloadSchema = z
-  .object({
-    provider: ProviderIdSchema,
-  })
-  .strict();
-
-export type InstallHooksPayload = z.infer<typeof InstallHooksPayloadSchema>;
-
 export const StationCommandTypeSchema = z.enum([
   "worktree.create",
   "worktree.fork",
@@ -262,14 +244,12 @@ export const StationCommandTypeSchema = z.enum([
   "terminal.focus",
   "terminal.close",
   "session.close",
-  "session.sendPrompt",
   "session.rename",
   "session.acknowledgeTurn",
   "observer.reconcile",
   "project.add",
   "project.remove",
   "project.setDefaultHarness",
-  "hooks.install",
 ]);
 
 export const CreateWorktreeCommandSchema = z
@@ -312,10 +292,6 @@ export const CloseSessionCommandSchema = z
   .object({ type: z.literal("session.close"), payload: CloseSessionPayloadSchema })
   .strict();
 
-export const SendPromptCommandSchema = z
-  .object({ type: z.literal("session.sendPrompt"), payload: SendPromptPayloadSchema })
-  .strict();
-
 export const RenameSessionCommandSchema = z
   .object({ type: z.literal("session.rename"), payload: RenameSessionPayloadSchema })
   .strict();
@@ -343,10 +319,6 @@ export const SetProjectDefaultHarnessCommandSchema = z
   })
   .strict();
 
-export const InstallHooksCommandSchema = z
-  .object({ type: z.literal("hooks.install"), payload: InstallHooksPayloadSchema })
-  .strict();
-
 export const StationCommandSchema = z.discriminatedUnion("type", [
   CreateWorktreeCommandSchema,
   ForkWorktreeCommandSchema,
@@ -358,14 +330,12 @@ export const StationCommandSchema = z.discriminatedUnion("type", [
   TerminalFocusCommandSchema,
   TerminalCloseCommandSchema,
   CloseSessionCommandSchema,
-  SendPromptCommandSchema,
   RenameSessionCommandSchema,
   AcknowledgeTurnCommandSchema,
   ObserverReconcileCommandSchema,
   AddProjectCommandSchema,
   RemoveProjectCommandSchema,
   SetProjectDefaultHarnessCommandSchema,
-  InstallHooksCommandSchema,
 ]);
 
 export type StationCommand = z.infer<typeof StationCommandSchema>;

--- a/packages/contracts/src/featureFlags.ts
+++ b/packages/contracts/src/featureFlags.ts
@@ -53,8 +53,8 @@ export const FeatureFlagDefinitions = {
   stationPersistentAgents: {
     defaultValue: false,
     // Server-exposed: the observer/provider gate spawning in the host and
-    // populating the launch result's reattachHandle. The Station UI keys off
-    // that handle's presence, so it needs no client-side flag value.
+    // populating the launch result's attachment. Station keys off attachment
+    // presence, so it needs no client-side flag value.
     exposure: "server",
     owner: "observer",
     surfaces: ["config", "observer", "protocol", "provider"],

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.6.0" as const;
+export const STATION_SCHEMA_VERSION = "0.7.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -24,7 +24,11 @@ import {
   TimestampSchema,
   WorktreeIdSchema,
 } from "./ids.js";
-import { HarnessLaunchPlanSchema, ProviderHealthSchema } from "./providers.js";
+import {
+  HarnessLaunchPlanSchema,
+  ManagedTerminalAttachmentSchema,
+  ProviderHealthSchema,
+} from "./providers.js";
 import { nonEmptyStringSchema } from "./shared.js";
 import { type StationSnapshot, StationSnapshotSchema } from "./snapshot.js";
 
@@ -134,22 +138,6 @@ export type AgentPrepareExternalLaunchParams = z.infer<
   typeof AgentPrepareExternalLaunchParamsSchema
 >;
 
-/**
- * Where a reattaching Station client picks up a persistent host-owned agent: the
- * live host PTY id, its STATION target id, and the host socket to attach to. Present
- * only behind `stationPersistentAgents` when a live host PTY exists — absent ⇒
- * the UI spawns the PTY locally from `launchPlan`.
- */
-export const AgentReattachHandleSchema = z
-  .object({
-    ptyId: z.string().min(1),
-    terminalTargetId: TerminalTargetIdSchema,
-    hostSocketPath: z.string().min(1),
-  })
-  .strict();
-
-export type AgentReattachHandle = z.infer<typeof AgentReattachHandleSchema>;
-
 export const AgentPrepareExternalLaunchResultSchema = z.discriminatedUnion("kind", [
   z
     .object({
@@ -157,7 +145,7 @@ export const AgentPrepareExternalLaunchResultSchema = z.discriminatedUnion("kind
       sessionId: SessionIdSchema,
       terminalTargetId: TerminalTargetIdSchema,
       launchPlan: HarnessLaunchPlanSchema,
-      reattachHandle: AgentReattachHandleSchema.optional(),
+      attachment: ManagedTerminalAttachmentSchema.optional(),
     })
     .strict(),
   z
@@ -165,7 +153,7 @@ export const AgentPrepareExternalLaunchResultSchema = z.discriminatedUnion("kind
       kind: z.literal("existing-session"),
       sessionId: SessionIdSchema,
       harnessProvider: ProviderIdSchema,
-      reattachHandle: AgentReattachHandleSchema.optional(),
+      attachment: ManagedTerminalAttachmentSchema.optional(),
     })
     .strict(),
 ]);

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -10,7 +10,13 @@ import type {
   TerminalTargetId,
   WorktreeId,
 } from "./ids.js";
-import { ProjectIdSchema, ProviderIdSchema, TimestampSchema, WorktreeIdSchema } from "./ids.js";
+import {
+  ProjectIdSchema,
+  ProviderIdSchema,
+  TerminalTargetIdSchema,
+  TimestampSchema,
+  WorktreeIdSchema,
+} from "./ids.js";
 import type {
   HarnessEventObservation,
   HarnessRunObservation,
@@ -278,12 +284,21 @@ export type TerminalLaunchProcessRequest = {
   signal?: AbortSignal;
 };
 
+export const ManagedTerminalAttachmentSchema = z
+  .object({
+    kind: z.literal("managed-terminal"),
+    terminalTargetId: TerminalTargetIdSchema,
+  })
+  .strict();
+
+export type ManagedTerminalAttachment = z.infer<typeof ManagedTerminalAttachmentSchema>;
+
 export type TerminalLaunchProcessResult = {
   terminalTargetId: TerminalTargetId;
   agentEndpointId: string;
   started: boolean;
-  /** When `started` and the process is reattachable, where a client reattaches. */
-  reattach?: TerminalReattachInfo;
+  /** When `started` and managed, the opaque target a client may attach to. */
+  attachment?: ManagedTerminalAttachment;
   providerData?: unknown;
 };
 
@@ -391,32 +406,26 @@ export interface TerminalProvider {
   sendInput?(targetId: TerminalTargetId, input: string): Promise<void>;
 }
 
-export type TerminalReattachInfo = {
-  /** Provider-opaque id of the live process to reattach to. */
-  endpointId: string;
-  /** Endpoint a client uses to reach the process host. */
-  socketPath: string;
-};
-
 export type ManagedTerminalLaunchProcessResult =
-  | (Omit<TerminalLaunchProcessResult, "started" | "reattach"> & {
+  | (Omit<TerminalLaunchProcessResult, "started" | "attachment"> & {
       started: false;
-      reattach?: never;
+      attachment?: never;
     })
-  | (Omit<TerminalLaunchProcessResult, "started" | "reattach"> & {
+  | (Omit<TerminalLaunchProcessResult, "started" | "attachment"> & {
       started: true;
-      reattach: TerminalReattachInfo;
+      attachment: ManagedTerminalAttachment;
     });
 
 /**
  * DRIVEN PORT
  *
  * Owns the single managed terminal target used for an external Station launch.
- * Target identity is adapter-owned and at most one target may exist per worktree.
+ * Attachments expose only adapter-owned target identity, and at most one target
+ * may exist per worktree.
  */
 export interface ManagedTerminalLifecycle extends TerminalProvider {
   launchProcess(request: TerminalLaunchProcessRequest): Promise<ManagedTerminalLaunchProcessResult>;
-  reattachInfo(targetId: TerminalTargetId): Promise<TerminalReattachInfo | undefined>;
+  attachmentForTarget(targetId: TerminalTargetId): Promise<ManagedTerminalAttachment | undefined>;
   /** Forgets an abandoned or already-exited target without terminating its process. */
   releaseTarget(targetId: TerminalTargetId): Promise<boolean>;
 }

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import {
   AgentPrepareExternalLaunchParamsSchema,
   AgentPrepareExternalLaunchResultSchema,
-  AgentReattachHandleSchema,
   AgentReportExternalExitParamsSchema,
   AgentReportExternalExitResultSchema,
   CommandRecordSchema,
@@ -22,6 +21,7 @@ import {
   HarnessResumeTargetSchema,
   HarnessRunObservationSchema,
   HarnessStatusObservationSchema,
+  ManagedTerminalAttachmentSchema,
   ObservedStatusSchema,
   type ObserverApi,
   ObserverEventHookConfigSchema,
@@ -45,6 +45,7 @@ import {
   SafeErrorSchema,
   STATION_SCHEMA_VERSION,
   StationCommandSchema,
+  StationCommandTypeSchema,
   StationEventSchema,
   StationHookIdentityPayloadSchema,
   StationSnapshotSchema,
@@ -89,7 +90,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.6.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.7.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -124,12 +125,20 @@ describe("contract schemas", () => {
       "external launch params with transport detail",
     );
 
-    const reattachHandle = {
-      ptyId: "pty_api",
+    const attachment = {
+      kind: "managed-terminal",
       terminalTargetId: "native:wt_api",
-      hostSocketPath: "/tmp/station-host.sock",
-    };
-    expectParses(AgentReattachHandleSchema, reattachHandle, "agent reattach handle");
+    } as const;
+    expectParses(ManagedTerminalAttachmentSchema, attachment, "managed terminal attachment");
+    expectFails(
+      ManagedTerminalAttachmentSchema,
+      {
+        ...attachment,
+        ptyId: "pty_api",
+        hostSocketPath: "/tmp/station-host.sock",
+      },
+      "managed terminal attachment with host fields",
+    );
     expectParses(
       AgentPrepareExternalLaunchResultSchema,
       {
@@ -144,9 +153,31 @@ describe("contract schemas", () => {
           env: { STATION_SESSION_ID: "ses_api" },
           mode: "interactive",
         },
-        reattachHandle,
+        attachment,
       },
       "prepared external launch result",
+    );
+    expectFails(
+      AgentPrepareExternalLaunchResultSchema,
+      {
+        kind: "prepared",
+        sessionId: "ses_api",
+        terminalTargetId: "native:wt_api",
+        launchPlan: {
+          provider: "codex",
+          command: "codex",
+          args: ["--resume"],
+          cwd: "/tmp/worktree",
+          env: { STATION_SESSION_ID: "ses_api" },
+          mode: "interactive",
+        },
+        reattachHandle: {
+          ptyId: "pty_api",
+          terminalTargetId: "native:wt_api",
+          hostSocketPath: "/tmp/station-host.sock",
+        },
+      },
+      "prepared external launch result with legacy reattach handle",
     );
     expectParses(
       AgentPrepareExternalLaunchResultSchema,
@@ -732,25 +763,28 @@ describe("contract schemas", () => {
       .map((command) => (command as { type: string }).type)
       .sort();
 
-    expect(commandTypes).toEqual([
-      "hooks.install",
-      "observer.reconcile",
-      "project.add",
-      "project.remove",
-      "project.setDefaultHarness",
-      "session.acknowledgeTurn",
-      "session.close",
-      "session.create",
-      "session.fork",
-      "session.rename",
-      "session.resumeAgent",
-      "session.sendPrompt",
-      "session.startAgent",
-      "terminal.close",
-      "terminal.focus",
-      "worktree.create",
-      "worktree.remove",
-    ]);
+    expect(commandTypes).toEqual([...StationCommandTypeSchema.options].sort());
+
+    expectFails(
+      StationCommandSchema,
+      {
+        type: "session.sendPrompt",
+        payload: {
+          sessionId: "ses_api_cache",
+          prompt: "Summarize current status.",
+          delivery: "harness-native",
+        },
+      },
+      "retired session.sendPrompt command",
+    );
+    expectFails(
+      StationCommandSchema,
+      {
+        type: "hooks.install",
+        payload: { provider: "worktrunk" },
+      },
+      "retired hooks.install command",
+    );
 
     expectFails(
       StationCommandSchema,

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -2,7 +2,6 @@ import type {
   ProjectView,
   ProviderId,
   SessionId,
-  SessionView,
   StationCommand,
   TerminalFocusOrigin,
   WorktreeId,
@@ -243,37 +242,6 @@ export function buildReconcileCommand(reason?: string): StationCommand {
   return {
     type: "observer.reconcile",
     payload: reason === undefined ? {} : { reason },
-  };
-}
-
-export function canSendPromptToRow(row: WorktreeRow, sessions: readonly SessionView[]): boolean {
-  const sessionId = row.agent?.sessionId;
-  if (sessionId === undefined) {
-    return false;
-  }
-  const session = sessions.find((candidate) => candidate.id === sessionId);
-  return session?.harness.capabilities.canReceivePrompt === true;
-}
-
-export function buildSendPromptCommand(
-  row: WorktreeRow,
-  sessions: readonly SessionView[],
-  prompt: string,
-): StationCommand {
-  if (!canSendPromptToRow(row, sessions)) {
-    throw new Error("The target harness cannot receive prompts safely.");
-  }
-  const sessionId = row.agent?.sessionId;
-  if (sessionId === undefined) {
-    throw new Error("The target row has no session.");
-  }
-  return {
-    type: "session.sendPrompt",
-    payload: {
-      sessionId,
-      prompt,
-      delivery: "harness-native",
-    },
   };
 }
 

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -56,27 +56,6 @@ export function createCommandSnapshot(
   ]);
 }
 
-export function createPromptCapableSnapshot(): StationSnapshot {
-  const snapshot = createCommandSnapshot("idle");
-  const sessions = snapshot.sessions.map((session) => {
-    const nextSession: SessionView = {
-      ...session,
-      harness: {
-        ...session.harness,
-        capabilities: {
-          ...session.harness.capabilities,
-          canReceivePrompt: true,
-        },
-      },
-    };
-    return nextSession;
-  });
-  return {
-    ...snapshot,
-    sessions,
-  };
-}
-
 export function createExternalAgentSnapshot(): StationSnapshot {
   const snapshot = createDashboardSnapshot();
   const externalRow = snapshot.rows.find((candidate) => candidate.id === "wt_web_idle");

--- a/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
+++ b/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
@@ -4,17 +4,11 @@ import {
   buildFocusCommand,
   buildRenameSessionCommand,
   buildResumeAgentCommand,
-  buildSendPromptCommand,
   buildStartAgentCommand,
-  canSendPromptToRow,
   cleanupForceRequired,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import {
-  createCommandSnapshot,
-  createDashboardSnapshot,
-  createPromptCapableSnapshot,
-} from "../../fixtures/snapshots.js";
+import { createCommandSnapshot, createDashboardSnapshot } from "../../fixtures/snapshots.js";
 
 describe("TUI command builders", () => {
   it("maps focusable rows to terminal.focus using the agent session", () => {
@@ -147,25 +141,6 @@ describe("TUI command builders", () => {
       payload: {
         sessionId: "ses_wt_web_idle",
         title: "Readable feature task",
-      },
-    });
-  });
-
-  it("keeps idle-agent primary actions focus-only unless prompt delivery is supported", () => {
-    const snapshot = createCommandSnapshot("idle");
-    const row = snapshot.rows[0];
-
-    expect(canSendPromptToRow(row, snapshot.sessions)).toBe(false);
-
-    const promptCapable = createPromptCapableSnapshot();
-    const promptCapableRow = promptCapable.rows[0];
-    expect(canSendPromptToRow(promptCapableRow, promptCapable.sessions)).toBe(true);
-    expect(buildSendPromptCommand(promptCapableRow, promptCapable.sessions, "continue")).toEqual({
-      type: "session.sendPrompt",
-      payload: {
-        sessionId: "ses_wt_web_idle",
-        prompt: "continue",
-        delivery: "harness-native",
       },
     });
   });

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -158,17 +158,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       generatedAt: now,
       observer: {
         pid: 1234,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.6.0",
+      "schemaVersion": "0.7.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -121,6 +121,10 @@ describe("protocol client/server", () => {
           env: { STATION_SESSION_ID: "ses_round_trip" },
           mode: "interactive",
         },
+        attachment: {
+          kind: "managed-terminal",
+          terminalTargetId: `native:${params.worktreeId}`,
+        },
       }),
       reportExternalExit: async (params) => ({
         acknowledged: true,
@@ -144,6 +148,10 @@ describe("protocol client/server", () => {
           cwd: "/tmp/station/web/feature",
           env: { STATION_SESSION_ID: "ses_round_trip" },
           mode: "interactive",
+        },
+        attachment: {
+          kind: "managed-terminal",
+          terminalTargetId: "native:wt_web_feature",
         },
       });
       await expect(
@@ -276,7 +284,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.6.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.7.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.6.0",
+        schemaVersion: "0.7.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -23,6 +23,7 @@ import type { StationStore } from "../state/store.js";
 import type { PaneId } from "../state/types.js";
 import type { StationClient } from "../sources/types.js";
 import { resolveAuxShellPlacement } from "../terminal/pty/auxShellPlacement.js";
+import { createStationHostManagedTerminalAttacher } from "../terminal/pty/managedTerminalAttacher.js";
 import { createPtyRegistry, type PtyRegistry } from "../terminal/registry/ptyRegistry.js";
 import { createStationViewStore } from "../station/store/stationViewStore.js";
 import type { CreateStationOptions, Station, StationAppProps } from "./types.js";
@@ -344,6 +345,11 @@ function createInputRuntime(
     options.hostSocketPath === undefined
       ? undefined
       : resolveAuxShellPlacement(options.hostSocketPath);
+  const managedTerminalAttacher =
+    options.managedTerminalAttacher ??
+    (options.hostSocketPath === undefined
+      ? undefined
+      : createStationHostManagedTerminalAttacher(options.hostSocketPath));
   const inputOptions: Parameters<typeof createStationInputRuntime>[0] = {
     store: deps.store,
     shutdown: deps.onShutdown,
@@ -358,6 +364,9 @@ function createInputRuntime(
   }
   if (auxShellPlacement !== undefined) {
     inputOptions.resolveAuxShellPlacement = auxShellPlacement;
+  }
+  if (managedTerminalAttacher !== undefined) {
+    inputOptions.managedTerminalAttacher = managedTerminalAttacher;
   }
   return createStationInputRuntime(inputOptions);
 }

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -12,6 +12,7 @@ import type { StationInputRuntime } from "../input/stationInput.js";
 import type { StationLayoutSnapshot } from "../state/layout/layoutSnapshot.js";
 import type { StationStore } from "../state/store.js";
 import type { StationClient } from "../sources/types.js";
+import type { ManagedTerminalAttacher } from "../terminal/pty/managedTerminalAttacher.js";
 import type { PtyRegistry } from "../terminal/registry/ptyRegistry.js";
 import type {
   StationTerminalProcess,
@@ -65,6 +66,8 @@ export type CreateStationOptions = {
    * otherwise. Absent in tests/mock mode ⇒ aux shells are always local.
    */
   hostSocketPath?: string;
+  /** Test seam for resolving observer-advertised managed-terminal attachments. */
+  managedTerminalAttacher?: ManagedTerminalAttacher;
   /**
    * Persist the aux-pane layout to disk so a cold restart restores it. Absent in
    * tests/mock mode. `write` is a test seam; main supplies the state-dir path and

--- a/station/src/input/runtime/managedLaunch.ts
+++ b/station/src/input/runtime/managedLaunch.ts
@@ -1,4 +1,5 @@
-import { createHostAttachedTerminal } from "../../terminal/pty/hostAttachedTerminal.js";
+import { StationHostProviderError } from "@station/host";
+import type { ManagedTerminalAttacher } from "../../terminal/pty/managedTerminalAttacher.js";
 import type { PtyRegistry } from "../../terminal/registry/ptyRegistry.js";
 import type { StationTerminalSpawnOptions } from "../../terminal/types.js";
 import type { StoreApi } from "zustand/vanilla";
@@ -69,10 +70,11 @@ type ManagedLaunchDeps = {
   stationViewStore: StoreApi<TuiStore> | undefined;
   observerService: ObserverService | undefined;
   registry: PtyRegistry | undefined;
+  managedTerminalAttacher: ManagedTerminalAttacher | undefined;
 };
 
 export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
-  const { store, stationViewStore, observerService, registry } = deps;
+  const { store, stationViewStore, observerService, registry, managedTerminalAttacher } = deps;
   // Guards a managed launch's async window: between a click's synchronous return
   // and its `prepareExternalLaunch` resolving, no pane record exists yet, so a
   // second click would otherwise fire a second prepare for the same pane and
@@ -212,21 +214,27 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
         pushLaunchError(error);
         return;
       }
-      // A persistent host PTY backs this worktree (the observer spawned it): attach to the host
-      // instead of spawning locally. Covers both a fresh launch and a reopen onto a running agent.
-      if (prepared.reattachHandle !== undefined) {
-        const handle = prepared.reattachHandle;
-        registry?.ensure(paneId, { cwd: target.cwd }, (spawn) =>
-          createHostAttachedTerminal({
-            hostSocketPath: handle.hostSocketPath,
-            ptyId: handle.ptyId,
-            size: { cols: spawn.size?.cols ?? 80, rows: spawn.size?.rows ?? 24 },
-          }),
-        );
+      // Resolve an advertised attachment before touching the registry or store.
+      // Failure is terminal for this launch: falling through would double-spawn locally.
+      if (prepared.attachment !== undefined) {
+        if (managedTerminalAttacher === undefined) {
+          pushLaunchError(
+            new StationHostProviderError("HOST_UNREACHABLE", "Station host is not reachable."),
+          );
+          return;
+        }
+        let createTerminal: Awaited<ReturnType<ManagedTerminalAttacher["resolve"]>>;
+        try {
+          createTerminal = await managedTerminalAttacher.resolve(prepared.attachment);
+        } catch (error) {
+          pushLaunchError(error);
+          return;
+        }
+        registry?.ensure(paneId, { cwd: target.cwd }, createTerminal);
         store.actions.createPane(paneId, { role: "primary-agent" });
         const identity: AgentIdentity = {
           sessionId: prepared.sessionId,
-          terminalTargetId: handle.terminalTargetId,
+          terminalTargetId: prepared.attachment.terminalTargetId,
           harnessProvider:
             prepared.kind === "prepared" ? prepared.launchPlan.provider : prepared.harnessProvider,
         };

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -14,6 +14,10 @@ import {
 import type { Automation } from "../config/stationConfig.js";
 import { createPtyRegistry, type PtyRegistry } from "../terminal/registry/ptyRegistry.js";
 import type { StationTerminalProcess, StationTerminalSpawnOptions } from "../terminal/types.js";
+import type {
+  ManagedTerminalAttacher,
+  ManagedTerminalFactory,
+} from "../terminal/pty/managedTerminalAttacher.js";
 import { createScriptedTerminal } from "../terminal/testing/scriptedTerminal.js";
 import { waitFor } from "../terminal/testing/waitFor.js";
 import {
@@ -1134,6 +1138,7 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
   function agentHarness(
     prepared: AgentPrepareExternalLaunchResult = preparedPlan(),
     snapshot: StationSnapshot = manyProjectsSnapshot(),
+    managedTerminalAttacher?: ManagedTerminalAttacher,
   ) {
     const observerService = new FakeTuiObserverService(snapshot);
     observerService.nextPreparedLaunch = prepared;
@@ -1149,16 +1154,20 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     const base = createPtyRegistry({ createTerminal: () => scripted.terminal });
     const calls: string[] = [];
     const ensured: StationTerminalSpawnOptions[] = [];
+    const terminalFactories: ManagedTerminalFactory[] = [];
     const registry: PtyRegistry = {
       ...base,
-      ensure: (paneId, spawnOptions) => {
+      ensure: (paneId, spawnOptions, createTerminalOverride) => {
         if (spawnOptions !== undefined) {
           ensured.push(spawnOptions);
+        }
+        if (createTerminalOverride !== undefined) {
+          terminalFactories.push(createTerminalOverride);
         }
         calls.push(
           `ensure:${paneId}:${spawnOptions?.cwd ?? ""}:${spawnOptions?.command ?? ""}:${(spawnOptions?.args ?? []).join(",")}`,
         );
-        return base.ensure(paneId, spawnOptions);
+        return base.ensure(paneId, spawnOptions, createTerminalOverride);
       },
     };
     const store = createStationStore();
@@ -1178,6 +1187,7 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
       stationViewStore,
       registry,
       observerService,
+      ...(managedTerminalAttacher === undefined ? {} : { managedTerminalAttacher }),
     });
     const dispatch = (
       target: { kind: "row"; rowId: string } | { kind: "openShellForRow"; rowId: string },
@@ -1185,7 +1195,17 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     const pressKey = (sequence: string): boolean => runtime.handleSequence(sequence);
     // The launch is fire-and-forget; flush its microtask chain.
     const settle = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
-    return { store, calls, ensured, dispatch, pressKey, settle, observerService, stationViewStore };
+    return {
+      store,
+      calls,
+      ensured,
+      terminalFactories,
+      dispatch,
+      pressKey,
+      settle,
+      observerService,
+      stationViewStore,
+    };
   }
 
   // A snapshot whose ROW_ID is Station-hosted (terminal.provider "native")
@@ -1468,71 +1488,123 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     expect(selectStationOverlayVisible(store.getState())).toBe(true);
   });
 
-  it("attaches to a host-attached agent: seeds cwd only and records the handle's target", async () => {
-    // A persistent host PTY already backs this worktree, so prepare returns a
-    // reattach handle. Station attaches (no local launch command/args) and the
-    // primary-agent identity is the HANDLE's terminalTargetId, not the row's.
-    const handle = {
-      ptyId: "pty_host_1",
+  it("resolves a prepared attachment before seeding the managed pane", async () => {
+    const attachment = {
+      kind: "managed-terminal",
       terminalTargetId: `${TERMINAL_TARGET_ID}-host`,
-      hostSocketPath: "/tmp/station-station-host.sock",
-    };
+    } as const;
     const base = preparedPlan();
     if (base.kind !== "prepared") {
       throw new Error("preparedPlan must be a prepared launch");
     }
-    const { store, calls, ensured, dispatch, settle } = agentHarness({
-      ...base,
-      reattachHandle: handle,
-    });
-    store.actions.openOverlay(STATION_OVERLAY_ID);
-
-    dispatch({ kind: "row", rowId: ROW_ID });
-    await settle();
-
-    // Attach, not spawn: cwd seeded but no launch command/args.
-    expect(calls).toEqual([
-      `ensure:${AGENT_PANE_ID}:${CWD}::`,
-      `createPane:${AGENT_PANE_ID}:primary-agent`,
-      `setPrimaryAgent:${AGENT_PANE_ID}:ses_managed:${handle.terminalTargetId}`,
-    ]);
-    expect(ensured[0]).toEqual({ cwd: CWD });
-    expect(
-      store.getState().workspace.panes.find((pane) => pane.id === AGENT_PANE_ID)?.agentIdentity,
-    ).toEqual({
-      sessionId: "ses_managed",
-      terminalTargetId: handle.terminalTargetId,
-      harnessProvider: "codex",
-    });
-  });
-
-  it("records the provider when reattaching to an existing host-attached agent", async () => {
-    const handle = {
-      ptyId: "pty_host_1",
-      terminalTargetId: `${TERMINAL_TARGET_ID}-host`,
-      hostSocketPath: "/tmp/station-station-host.sock",
-    };
-    const { store, dispatch, settle } = agentHarness(
-      {
-        kind: "existing-session",
-        sessionId: "ses_live",
-        harnessProvider: "codex",
-        reattachHandle: handle,
+    const resolutions: unknown[] = [];
+    const scripted = createScriptedTerminal();
+    const factory: ManagedTerminalFactory = () => scripted.terminal;
+    const managedTerminalAttacher: ManagedTerminalAttacher = {
+      resolve: async (candidate) => {
+        resolutions.push(candidate);
+        return factory;
       },
-      stationHostedSnapshot({ focusable: true }),
+    };
+    const { store, calls, ensured, terminalFactories, dispatch, settle } = agentHarness(
+      { ...base, attachment },
+      manyProjectsSnapshot(),
+      managedTerminalAttacher,
     );
     store.actions.openOverlay(STATION_OVERLAY_ID);
 
     dispatch({ kind: "row", rowId: ROW_ID });
     await settle();
 
+    expect(resolutions).toEqual([attachment]);
+    expect(calls).toEqual([
+      `ensure:${AGENT_PANE_ID}:${CWD}::`,
+      `createPane:${AGENT_PANE_ID}:primary-agent`,
+      `setPrimaryAgent:${AGENT_PANE_ID}:ses_managed:${attachment.terminalTargetId}`,
+    ]);
+    expect(ensured[0]).toEqual({ cwd: CWD });
+    expect(terminalFactories).toEqual([factory]);
+    expect(
+      store.getState().workspace.panes.find((pane) => pane.id === AGENT_PANE_ID)?.agentIdentity,
+    ).toEqual({
+      sessionId: "ses_managed",
+      terminalTargetId: attachment.terminalTargetId,
+      harnessProvider: "codex",
+    });
+  });
+
+  it("uses the resolver and records the provider for an existing attached agent", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-host`,
+    } as const;
+    const resolutions: unknown[] = [];
+    const scripted = createScriptedTerminal();
+    const { store, dispatch, settle } = agentHarness(
+      {
+        kind: "existing-session",
+        sessionId: "ses_live",
+        harnessProvider: "codex",
+        attachment,
+      },
+      stationHostedSnapshot({ focusable: true }),
+      {
+        resolve: async (candidate) => {
+          resolutions.push(candidate);
+          return () => scripted.terminal;
+        },
+      },
+    );
+    store.actions.openOverlay(STATION_OVERLAY_ID);
+
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+
+    expect(resolutions).toEqual([attachment]);
     expect(
       store.getState().workspace.panes.find((pane) => pane.id === AGENT_PANE_ID)?.agentIdentity,
     ).toEqual({
       sessionId: "ses_live",
-      terminalTargetId: handle.terminalTargetId,
+      terminalTargetId: attachment.terminalTargetId,
       harnessProvider: "codex",
     });
+  });
+
+  it("toasts attachment resolution failures without creating or locally spawning a pane", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-gone`,
+    } as const;
+    const base = preparedPlan();
+    if (base.kind !== "prepared") {
+      throw new Error("preparedPlan must be a prepared launch");
+    }
+    const { store, calls, dispatch, settle, stationViewStore } = agentHarness(
+      { ...base, attachment },
+      manyProjectsSnapshot(),
+      {
+        resolve: async () => {
+          throw {
+            tag: "TerminalProviderError",
+            code: "HOST_ATTACH_GONE",
+            message: "The managed terminal is no longer available.",
+            provider: "native",
+          };
+        },
+      },
+    );
+    store.actions.openOverlay(STATION_OVERLAY_ID);
+
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+
+    expect(calls).toEqual([]);
+    expect(store.getState().workspace.panes.some((pane) => pane.role === "primary-agent")).toBe(false);
+    expect(stationViewStore.getState().toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: "The managed terminal is no longer available.",
+    });
+    expect(selectStationOverlayVisible(store.getState())).toBe(true);
   });
 
   it("toasts the observer's error when prepareExternalLaunch rejects", async () => {

--- a/station/src/input/stationInput.ts
+++ b/station/src/input/stationInput.ts
@@ -1,4 +1,5 @@
 import type { AuxShellPlacement } from "../terminal/pty/auxShellPlacement.js";
+import type { ManagedTerminalAttacher } from "../terminal/pty/managedTerminalAttacher.js";
 import type { PtyRegistry } from "../terminal/registry/ptyRegistry.js";
 import type { Automation } from "../config/stationConfig.js";
 import type { StoreApi } from "zustand/vanilla";
@@ -162,6 +163,8 @@ export type StationInputRuntimeOptions = {
    * Absent in tests/mock mode ⇒ aux shells are always local.
    */
   resolveAuxShellPlacement?: AuxShellPlacement;
+  /** Resolves opaque managed-agent attachments before any pane is created. */
+  managedTerminalAttacher?: ManagedTerminalAttacher;
   /** Observer service for managed primary-agent launches; absent in mock mode. */
   observerService?: ObserverService;
   openExternalUrl?: (url: string) => void;
@@ -203,6 +206,7 @@ export function createStationInputRuntime(options: StationInputRuntimeOptions): 
     stationViewStore: options.stationViewStore,
     observerService: options.observerService,
     registry,
+    managedTerminalAttacher: options.managedTerminalAttacher,
   });
 
   // Pane chords are `reserved`, so they pierce the context-menu catch-all; gate on that real modal

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.6.0",
+  schemaVersion: "0.7.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,

--- a/station/src/terminal/pty/managedTerminalAttacher.test.ts
+++ b/station/src/terminal/pty/managedTerminalAttacher.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { HostListEntry } from "@station/host";
+import { createScriptedTerminal } from "../testing/scriptedTerminal.js";
+import type { HostAttachedTerminalOptions } from "./hostAttachedTerminal.js";
+import { createStationHostManagedTerminalAttacher } from "./managedTerminalAttacher.js";
+
+const TARGET_ID = "native:wt-agent";
+const ATTACHMENT = { kind: "managed-terminal", terminalTargetId: TARGET_ID } as const;
+
+function hostEntry(overrides: Partial<HostListEntry> = {}): HostListEntry {
+  return {
+    kind: "agent",
+    terminalTargetId: TARGET_ID,
+    worktreeId: "wt-agent",
+    projectId: "station",
+    sessionId: "ses-agent",
+    worktreePath: "/work/agent",
+    harnessProvider: "codex",
+    ptyId: "pty-agent",
+    pid: 42,
+    alive: true,
+    cols: 80,
+    rows: 24,
+    ...overrides,
+  };
+}
+
+describe("createStationHostManagedTerminalAttacher", () => {
+  it("resolves the first live matching agent to a lazy host terminal factory", async () => {
+    const created: HostAttachedTerminalOptions[] = [];
+    const scripted = createScriptedTerminal();
+    const listed = [
+      hostEntry({ ptyId: "pty-dead", alive: false }),
+      hostEntry({ ptyId: "pty-aux", kind: "aux" }),
+      hostEntry({ ptyId: "pty-other", terminalTargetId: "native:other" }),
+      hostEntry({ ptyId: "pty-first" }),
+      hostEntry({ ptyId: "pty-second" }),
+    ];
+    const attacher = createStationHostManagedTerminalAttacher("/run/station-host.sock", {
+      listHost: async () => listed,
+      createTerminal: (options) => {
+        created.push(options);
+        return scripted.terminal;
+      },
+    });
+
+    const createTerminal = await attacher.resolve(ATTACHMENT);
+    expect(created).toEqual([]);
+
+    expect(createTerminal({ size: { cols: 120, rows: 40 } })).toBe(scripted.terminal);
+    expect(created).toEqual([
+      {
+        hostSocketPath: "/run/station-host.sock",
+        ptyId: "pty-first",
+        size: { cols: 120, rows: 40 },
+      },
+    ]);
+  });
+
+  it("reports HOST_UNREACHABLE when the host cannot be listed", async () => {
+    const attacher = createStationHostManagedTerminalAttacher("/missing/station-host.sock", {
+      listHost: async () => undefined,
+    });
+
+    await expect(attacher.resolve(ATTACHMENT)).rejects.toMatchObject({
+      code: "HOST_UNREACHABLE",
+    });
+  });
+
+  it("reports HOST_ATTACH_GONE when no live agent matches the attachment", async () => {
+    const attacher = createStationHostManagedTerminalAttacher("/run/station-host.sock", {
+      listHost: async () => [
+        hostEntry({ alive: false }),
+        hostEntry({ kind: "aux" }),
+        hostEntry({ terminalTargetId: "native:other" }),
+      ],
+    });
+
+    await expect(attacher.resolve(ATTACHMENT)).rejects.toMatchObject({
+      code: "HOST_ATTACH_GONE",
+    });
+  });
+});

--- a/station/src/terminal/pty/managedTerminalAttacher.ts
+++ b/station/src/terminal/pty/managedTerminalAttacher.ts
@@ -1,0 +1,68 @@
+import type { ManagedTerminalAttachment } from "@station/contracts";
+import {
+  StationHostProviderError,
+  type HostListEntry,
+} from "@station/host";
+import { listLiveHostPtys } from "../../sources/listLiveHostPtys.js";
+import type { StationTerminalProcess, StationTerminalSpawnOptions } from "../types.js";
+import {
+  createHostAttachedTerminal,
+  type HostAttachedTerminalOptions,
+} from "./hostAttachedTerminal.js";
+
+export type ManagedTerminalFactory = (
+  options: StationTerminalSpawnOptions,
+) => StationTerminalProcess;
+
+/**
+ * Resolves an advertised managed-terminal attachment to lazy pane construction.
+ *
+ * A rejection is terminal for the launch and must never permit a local spawn fallback.
+ */
+export type ManagedTerminalAttacher = {
+  resolve(attachment: ManagedTerminalAttachment): Promise<ManagedTerminalFactory>;
+};
+
+type ManagedTerminalAttacherDeps = {
+  listHost?: (socketPath: string) => Promise<readonly HostListEntry[] | undefined>;
+  createTerminal?: (options: HostAttachedTerminalOptions) => StationTerminalProcess;
+};
+
+export function createStationHostManagedTerminalAttacher(
+  hostSocketPath: string,
+  deps: ManagedTerminalAttacherDeps = {},
+): ManagedTerminalAttacher {
+  const listHost = deps.listHost ?? listLiveHostPtys;
+  const createTerminal = deps.createTerminal ?? createHostAttachedTerminal;
+
+  return {
+    async resolve(attachment) {
+      const entries = await listHost(hostSocketPath);
+      if (entries === undefined) {
+        throw new StationHostProviderError("HOST_UNREACHABLE", "Station host is not reachable.");
+      }
+      const entry = entries.find(
+        (candidate) =>
+          candidate.kind === "agent" &&
+          candidate.alive &&
+          candidate.terminalTargetId === attachment.terminalTargetId,
+      );
+      if (entry === undefined) {
+        throw new StationHostProviderError(
+          "HOST_ATTACH_GONE",
+          `No live host terminal is available for target "${attachment.terminalTargetId}".`,
+        );
+      }
+
+      return (spawnOptions) =>
+        createTerminal({
+          hostSocketPath,
+          ptyId: entry.ptyId,
+          size: {
+            cols: spawnOptions.size?.cols ?? 80,
+            rows: spawnOptions.size?.rows ?? 24,
+          },
+        });
+    },
+  };
+}

--- a/station/src/terminal/registry/ptyRegistry.test.ts
+++ b/station/src/terminal/registry/ptyRegistry.test.ts
@@ -225,6 +225,28 @@ describe("createPtyRegistry", () => {
     expect(registry.write(PANE_A, "x")).toBe(false);
   });
 
+  it("never falls back to the local terminal when a managed attach fails lazily", () => {
+    let localAttempts = 0;
+    let attachAttempts = 0;
+    const registry = createPtyRegistry({
+      createTerminal: () => {
+        localAttempts += 1;
+        return createScriptedTerminal().terminal;
+      },
+    });
+    registry.ensure(PANE_A, undefined, () => {
+      attachAttempts += 1;
+      throw new Error("host attach failed");
+    });
+
+    registry.resize(PANE_A, SIZE);
+
+    expect(attachAttempts).toBe(1);
+    expect(localAttempts).toBe(0);
+    expect(registry.get(PANE_A)?.status).toBe("failed to start shell");
+    expect(registry.get(PANE_A)?.terminal).toBeNull();
+  });
+
   it("dispose tears down the pane and removes its entry", () => {
     const { registry, scripted } = harness();
     registry.resize(PANE_A, SIZE);

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -11,6 +11,16 @@
       }
     }
   },
+  "worktreeFork": {
+    "type": "worktree.fork",
+    "payload": {
+      "projectId": "web",
+      "sourceWorktreeId": "wt_web_main",
+      "branch": "feature/auth-fork",
+      "base": "main",
+      "copyDirty": true
+    }
+  },
   "worktreeRemove": {
     "type": "worktree.remove",
     "payload": {
@@ -118,14 +128,6 @@
       "force": true
     }
   },
-  "sessionSendPrompt": {
-    "type": "session.sendPrompt",
-    "payload": {
-      "sessionId": "ses_api_cache",
-      "prompt": "Summarize current status.",
-      "delivery": "harness-native"
-    }
-  },
   "sessionRename": {
     "type": "session.rename",
     "payload": {
@@ -166,12 +168,6 @@
     "payload": {
       "projectId": "web",
       "harness": "codex"
-    }
-  },
-  "hooksInstall": {
-    "type": "hooks.install",
-    "payload": {
-      "provider": "worktrunk"
     }
   }
 }

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -24,7 +24,7 @@
     "alerts": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -109,7 +109,7 @@
     "alerts": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -158,7 +158,7 @@
     "alerts": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -228,7 +228,7 @@
     "alerts": []
   },
   "idleAgent": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -355,7 +355,7 @@
     "alerts": []
   },
   "workingAgent": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -440,7 +440,7 @@
     "alerts": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -524,7 +524,7 @@
     "alerts": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -609,7 +609,7 @@
     "alerts": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -691,7 +691,7 @@
     "alerts": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -775,7 +775,7 @@
     "alerts": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -809,7 +809,7 @@
     ]
   },
   "providerFailure": {
-    "schemaVersion": "0.6.0",
+    "schemaVersion": "0.7.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.6.0",
+          schemaVersion: "0.7.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -38,7 +38,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.6.0",
+        schemaVersion: "0.7.0",
         counts: { projects: 0 },
       });
       await expect(access(join(fixture.root, "config.toml"))).rejects.toMatchObject({
@@ -212,7 +212,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.6.0",
+        schemaVersion: "0.7.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -45,10 +45,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.6.0",
+      schemaVersion: "0.7.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -66,7 +66,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.6.0",
+    schemaVersion: "0.7.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,


### PR DESCRIPTION
## Summary

- replace host-shaped external-launch reattachment data with an opaque managed-terminal attachment that Station resolves at its own boundary
- prevent advertised attachment failures from falling through to a duplicate local spawn, including late lazy-attach failures
- delete the unsupported `session.sendPrompt` and `hooks.install` command contracts and make production handler registration compile-time exhaustive
- preserve historical command diagnostics, bump the shared schema from `0.6.0` to `0.7.0`, and resolve `OBS-HEX-006` and `OBS-HEX-009` in the living architecture

## Why

The Observer application contract exposed Station Host PTY IDs and socket paths, crossing the documented provider and UI boundary. It also advertised two commands that had no production handlers, so accepted commands could fail only after queueing.

The new contract carries only managed target identity. Station owns host lookup and attachment mechanics, while the Observer passes adapter-produced attachments through unchanged. An absent attachment retains the existing local launch; an advertised attachment is terminal for that launch path and can never fall back to a second process.

## Impact

Successful persistent-agent launches and reattachment keep the same UX. If the advertised host target is unavailable, Station now shows the existing safe-error toast, keeps the overlay open, and creates no pane, identity, registry entry, or local duplicate.

Historical command rows and log attributes for the retired command types remain readable through best-effort diagnostic paths; no database migration is required. The real `stn hooks install` CLI workflow is unchanged.

## Validation

- isolated `HOME=<temp> pnpm test:all`
  - build: 22 packages
  - typecheck: 42 tasks
  - unit: 1,261 passed
  - contracts: 25 passed
  - integration: 327 passed, 1 real-tmux test skipped
  - diagnostics: 37 passed
  - scripted agent: 3 passed
  - setup E2E: 7 passed
- Station focused attachment/input/registry tests: 116 passed
- Station typecheck: passed
- full Station suite: 965 passed, 35 snapshots
- Observer lifecycle E2E: 5 passed
- Node/Bun SQLite compatibility: passed
- real Station Host reattach demo: same PID survived client close/reopen and detached scrollback replayed
- `git diff --check`: passed
- pre-commit lint hook: passed

## UX verification

The real host demo spawned a persistent local shell, detached the first client, confirmed the process remained alive with the same PID, reattached a second client with scrollback produced while detached, and closed the PTY cleanly. Focused Station tests also prove unavailable or late-failing attachments never invoke the local terminal factory.
