### PR TITLE
feat(station): compile standalone binary

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -95,10 +95,19 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-      - name: Install
+      - name: Install (pnpm)
+        run: pnpm install --frozen-lockfile
+      - name: Install (bun)
         run: bun install
         working-directory: station
       - name: Build controlling-terminal helper
@@ -107,3 +116,33 @@ jobs:
       - name: Test Bun PTY
         run: bun run test:pty:bun
         working-directory: station
+      - name: Build compiled binary
+        run: pnpm build:binary -- --version 0.0.0-ci
+      - name: Test compiled default PTY
+        run: pnpm smoke:binary -- --expected-version 0.0.0-ci
+        env:
+          STATION_BINARY_SMOKE_PTY_ONLY: "1"
+
+  binary-smoke:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install (pnpm)
+        run: pnpm install --frozen-lockfile
+      - name: Install (bun)
+        run: bun install
+        working-directory: station
+      - name: Build compiled binary
+        run: pnpm build:binary -- --version 0.0.0-ci
+      - name: Test compiled binary
+        run: pnpm smoke:binary -- --expected-version 0.0.0-ci

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,6 +15,22 @@
     "./ingress": {
       "types": "./dist/ingress/index.d.ts",
       "import": "./dist/ingress/index.js"
+    },
+    "./self-exec": {
+      "types": "./dist/selfExec.d.ts",
+      "import": "./dist/selfExec.js"
+    },
+    "./main": {
+      "types": "./dist/main.d.ts",
+      "import": "./dist/main.js"
+    },
+    "./observer-main": {
+      "types": "./dist/observerMain.d.ts",
+      "import": "./dist/observerMain.js"
+    },
+    "./ingress-main": {
+      "types": "./dist/ingressMain.d.ts",
+      "import": "./dist/ingressMain.js"
     }
   },
   "bin": {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -3,7 +3,11 @@ import type { StationConfig } from "@station/config";
 import type { DoctorCheck, DoctorOptions, DoctorReport } from "@station/contracts";
 import { DoctorOptionsSchema } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
-import { resolveExecutablePath, runRuntimeBoundaryWithTimeout } from "@station/runtime";
+import {
+  isCompiledBinary,
+  resolveExecutablePath,
+  runRuntimeBoundaryWithTimeout,
+} from "@station/runtime";
 import { parseRequiredOptionValue } from "../args.js";
 import {
   type ObserverProcessDeps,
@@ -81,17 +85,20 @@ export async function runDoctorCommand(
 }
 
 /**
- * Bare `stn` renders the TUI by shelling out to `bun run` against the station
- * workspace, so a missing Bun — or an installed Bun whose station/ lane was never
- * `bun install`ed — leaves the primary terminal UI silently broken even when the
- * observer is healthy. Surface either as a degraded (warn) doctor finding.
+ * Source `stn` renders the TUI through the station Bun workspace, so missing
+ * runtime dependencies surface as a degraded finding; compiled binaries carry
+ * the renderer and skip this source-only check.
  */
 export async function rendererRuntimeCheck(
   resolve: (command: string) => Promise<string | undefined> = (command) =>
     resolveExecutablePath(command),
   dashboardCommandOverride: string | undefined = process.env.STATION_DASHBOARD_COMMAND,
   uiInstalled: () => Promise<boolean> = () => isStationUiInstalled(),
+  compiled = isCompiledBinary(),
 ): Promise<DoctorCheck | undefined> {
+  if (compiled) {
+    return undefined;
+  }
   // Mirror tui.ts: STATION_DASHBOARD_COMMAND replaces `bun run` with a custom
   // renderer command, so neither Bun nor the station/ lane is required when set.
   if (dashboardCommandOverride !== undefined) {

--- a/apps/cli/src/commands/setup/checks/config.ts
+++ b/apps/cli/src/commands/setup/checks/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CONFIG_PATH, loadConfigFromToml } from "@station/config";
+import { DEFAULT_CONFIG_PATH, loadConfigFromToml, resolveObserverPaths } from "@station/config";
 import { pathIsSame, resolveLocalPath } from "@station/runtime";
 import type { CliEnv } from "../../../env.js";
 import type { SetupConfigDiagnosticFact, SetupConfigFact } from "../model.js";
@@ -54,6 +54,7 @@ export async function checkSetupConfig(
       status: "valid",
       path,
       source,
+      observerStateDir: resolveObserverPaths(loaded.config, setupHomeDir(options)).stateDir,
       hasProjectForRoot: matchedProject !== undefined,
       configuredHarnesses: Object.keys(loaded.config.harness ?? {}),
       configuredHookHarnesses: Object.entries(loaded.config.harness ?? {}).flatMap(

--- a/apps/cli/src/commands/setup/checks/stateDir.ts
+++ b/apps/cli/src/commands/setup/checks/stateDir.ts
@@ -1,0 +1,88 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import type { SetupStateDirFact } from "../model.js";
+
+type SetupStateDirFileHandle = {
+  close(): Promise<void>;
+  writeFile(data: string): Promise<void>;
+};
+
+export type SetupStateDirFileSystem = {
+  mkdir(path: string, options: { recursive: true; mode: number }): Promise<unknown>;
+  open(path: string, flags: "wx", mode: number): Promise<SetupStateDirFileHandle>;
+  unlink(path: string): Promise<void>;
+};
+
+export type CheckSetupStateDirOptions = {
+  path: string;
+  executable?: boolean;
+  execute?: (path: string) => Promise<void>;
+  fs?: SetupStateDirFileSystem;
+  probeName?: string;
+};
+
+/** Proves the writable state-directory prerequisite shared by source and compiled launch. */
+export async function checkSetupStateDir(
+  options: CheckSetupStateDirOptions,
+): Promise<SetupStateDirFact> {
+  const fs = options.fs ?? nodeStateDirFileSystem;
+  const probePath = join(
+    options.path,
+    options.probeName ?? `.station-write-probe-${process.pid}-${randomUUID()}`,
+  );
+  let handle: SetupStateDirFileHandle | undefined;
+  let executionFailed = false;
+  try {
+    await fs.mkdir(options.path, { recursive: true, mode: 0o700 });
+    handle = await fs.open(probePath, "wx", options.executable === true ? 0o700 : 0o600);
+    if (options.executable === true) {
+      await handle.writeFile("#!/bin/sh\nexit 0\n");
+    }
+    await handle.close();
+    handle = undefined;
+    if (options.executable === true) {
+      try {
+        await (options.execute ?? executeProbe)(probePath);
+      } catch (error) {
+        executionFailed = true;
+        throw error;
+      }
+    }
+    await fs.unlink(probePath);
+    return { status: "ok", path: options.path };
+  } catch {
+    await handle?.close().catch(() => undefined);
+    await fs.unlink(probePath).catch(() => undefined);
+    return {
+      status: "missing",
+      path: options.path,
+      message: executionFailed
+        ? `STATION state directory does not permit executable assets at ${options.path}.`
+        : `STATION state directory is not writable at ${options.path}.`,
+    };
+  }
+}
+
+function executeProbe(path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(path, [], { stdio: "ignore" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(
+          new Error(`Executable state-directory probe exited ${code ?? signal ?? "unknown"}.`),
+        );
+      }
+    });
+  });
+}
+
+const nodeStateDirFileSystem: SetupStateDirFileSystem = {
+  mkdir,
+  open,
+  unlink,
+};

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
-import type { ExternalCommandRunner } from "@station/runtime";
+import { resolveObserverPaths } from "@station/config";
+import { type ExternalCommandRunner, isCompiledBinary } from "@station/runtime";
 import type { CliEnv } from "../../../env.js";
 import { isStationUiInstalled } from "../../../stationWorkspace.js";
 import type { SetupDependencyFact, SetupFacts, SetupMode, SetupStationUiFact } from "../model.js";
@@ -17,6 +18,7 @@ import { type CheckGitOptions, checkSetupGit } from "./git.js";
 import { checkSetupGitDelta } from "./gitDelta.js";
 import { type CheckHarnessesOptions, checkSetupHarnesses } from "./harnesses.js";
 import { checkSetupLaunchers } from "./launchers.js";
+import { checkSetupStateDir, type SetupStateDirFileSystem } from "./stateDir.js";
 import { checkSetupTmux } from "./tmux.js";
 import { checkSetupTmuxBinding } from "./tmuxBinding.js";
 import { checkSetupWorktrunk, checkSetupWorktrunkAutomation } from "./worktrunk.js";
@@ -45,6 +47,9 @@ export type CollectSetupFactsOptions = {
   // Defaults to process.platform; injectable so machine-state tests can drive the
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
+  compiled?: boolean;
+  stateDirExecute?: (path: string) => Promise<void>;
+  stateDirFs?: SetupStateDirFileSystem;
 };
 
 export async function collectSetupFacts(options: CollectSetupFactsOptions): Promise<SetupFacts> {
@@ -52,6 +57,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   const cwd = options.cwd ?? process.cwd();
   const homeDir = options.homeDir ?? env.HOME ?? homedir();
   const generatedAt = (options.now ?? (() => new Date()))().toISOString();
+  const compiled = options.compiled ?? isCompiledBinary();
   const commandInput: {
     runner?: ExternalCommandRunner;
     env: CliEnv;
@@ -85,14 +91,18 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     await Promise.all([
       checkSetupWorktrunk(dependencyOptions),
       checkSetupTmux(dependencyOptions),
-      checkSetupBun(dependencyOptions),
+      compiled
+        ? Promise.resolve({ status: "ok" as const, command: "bun" })
+        : checkSetupBun(dependencyOptions),
       checkSetupDiffnav(dependencyOptions),
       checkSetupGitDelta(dependencyOptions),
       checkBrewDependency({
         ...commandOptions,
         ...(options.noBrew === undefined ? {} : { noBrew: options.noBrew }),
       }),
-      checkSetupXcode(xcodeOptions),
+      compiled
+        ? Promise.resolve({ status: "ok" as const, applicable: false })
+        : checkSetupXcode(xcodeOptions),
       checkSetupHarnesses(commandOptions),
       checkSetupConfig({ ...configPathOptions, configPath }),
       checkSetupLaunchers(dependencyOptions),
@@ -113,10 +123,22 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     ...(options.runner === undefined ? {} : { runner: options.runner }),
     tmuxCommand: tmux.command,
   });
-  const stationUi = await resolveStationUiFact({
-    env,
-    bunStatus: bun.status,
-    uiInstalled: options.stationUiInstalled ?? isStationUiInstalled,
+  const stationUi = compiled
+    ? ({ status: "skipped" } as const)
+    : await resolveStationUiFact({
+        env,
+        bunStatus: bun.status,
+        uiInstalled: options.stationUiInstalled ?? isStationUiInstalled,
+      });
+  const stateDirPath =
+    config.status === "valid"
+      ? config.observerStateDir
+      : resolveObserverPaths(undefined, homeDir).stateDir;
+  const stateDir = await checkSetupStateDir({
+    path: stateDirPath,
+    executable: compiled,
+    ...(options.stateDirExecute === undefined ? {} : { execute: options.stateDirExecute }),
+    ...(options.stateDirFs === undefined ? {} : { fs: options.stateDirFs }),
   });
 
   return {
@@ -124,6 +146,8 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     mode: options.mode,
     configPath,
     homeDir,
+    compiled,
+    stateDir,
     worktrunk,
     worktrunkAutomation,
     tmux,

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -36,6 +36,9 @@ export function collectForCommand(
   if (deps.fs !== undefined) collectOptions.fs = deps.fs;
   if (deps.now !== undefined) collectOptions.now = deps.now;
   if (deps.platform !== undefined) collectOptions.platform = deps.platform;
+  if (deps.compiled !== undefined) collectOptions.compiled = deps.compiled;
+  if (deps.stateDirExecute !== undefined) collectOptions.stateDirExecute = deps.stateDirExecute;
+  if (deps.stateDirFs !== undefined) collectOptions.stateDirFs = deps.stateDirFs;
   if (flags.noBrew !== undefined) collectOptions.noBrew = flags.noBrew;
   return collectSetupFacts(collectOptions);
 }
@@ -185,6 +188,7 @@ export function markRequiredIncomplete(plan: SetupPlan): SetupPlan {
     ...plan,
     summary: {
       ...plan.summary,
+      workflowReady: false,
       requiredOk: false,
       requiredMissing: Math.max(1, plan.summary.requiredMissing),
     },

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -193,7 +193,7 @@ async function runGuidedSetupWithPrompt(
   await write(
     deps,
     renderSetupApplyResult(
-      { ...plan, summary: { ...plan.summary, requiredOk: true } },
+      { ...plan, summary: { ...plan.summary, workflowReady: true, requiredOk: true } },
       renderOptions(deps),
     ),
   );

--- a/apps/cli/src/commands/setup/flows/nonInteractive.ts
+++ b/apps/cli/src/commands/setup/flows/nonInteractive.ts
@@ -73,7 +73,7 @@ export async function runNonInteractiveApply(
 
   const outputPlan = {
     ...writeResult.plan,
-    summary: { ...writeResult.plan.summary, requiredOk: true },
+    summary: { ...writeResult.plan.summary, workflowReady: true, requiredOk: true },
   };
   await write(deps, renderSetupApplyResult(outputPlan, renderOptions(deps)));
   return { code: 0 };

--- a/apps/cli/src/commands/setup/harnessInstall.ts
+++ b/apps/cli/src/commands/setup/harnessInstall.ts
@@ -71,6 +71,10 @@ export function harnessInstallPlan(facts: SetupFacts, actions: readonly SetupAct
     checks: [],
     actions: [...actions],
     summary: {
+      launchReady:
+        facts.stateDir.status === "ok" &&
+        (facts.compiled || (facts.bun.status === "ok" && facts.stationUi.status !== "missing")),
+      workflowReady: false,
       requiredOk: false,
       requiredMissing: 1,
       warnings: 0,

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -56,6 +56,8 @@ export const SetupActionSchema = z
 
 export const SetupSummarySchema = z
   .object({
+    launchReady: z.boolean(),
+    workflowReady: z.boolean(),
     requiredOk: z.boolean(),
     requiredMissing: z.number().int().nonnegative(),
     warnings: z.number().int().nonnegative(),
@@ -63,7 +65,11 @@ export const SetupSummarySchema = z
     selectedHarness: SupportedHarnessIdSchema.optional(),
     configPath: z.string(),
   })
-  .strict();
+  .strict()
+  .refine((summary) => summary.requiredOk === summary.workflowReady, {
+    message: "requiredOk must match workflowReady",
+    path: ["requiredOk"],
+  });
 
 export const SetupPlanSchema = z
   .object({
@@ -190,6 +196,7 @@ export type SetupConfigFact =
       status: "valid";
       path: string;
       source: string;
+      observerStateDir: string;
       hasProjectForRoot: boolean;
       configuredHarnesses: readonly string[];
       configuredHookHarnesses: readonly string[];
@@ -235,11 +242,24 @@ export type SetupStationUiFact = {
   status: "installed" | "missing" | "skipped";
 };
 
+export type SetupStateDirFact =
+  | {
+      status: "ok";
+      path: string;
+    }
+  | {
+      status: "missing";
+      path: string;
+      message: string;
+    };
+
 export type SetupFacts = {
   generatedAt: string;
   mode: SetupMode;
   configPath: string;
   homeDir: string;
+  compiled: boolean;
+  stateDir: SetupStateDirFact;
   worktrunk: SetupDependencyFact;
   worktrunkAutomation: SetupWorktrunkAutomationFact;
   tmux: SetupDependencyFact;

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -26,8 +26,13 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
     (check) => check.tier === "required" && check.status !== "ok",
   ).length;
   const warnings = checks.filter((check) => check.status === "warning").length;
+  const workflowReady = checks.every((check) => check.tier !== "required" || check.status === "ok");
   const summary = {
-    requiredOk: checks.every((check) => check.tier !== "required" || check.status === "ok"),
+    launchReady:
+      facts.stateDir.status === "ok" &&
+      (facts.compiled || (facts.bun.status === "ok" && facts.stationUi.status !== "missing")),
+    workflowReady,
+    requiredOk: workflowReady,
     requiredMissing,
     warnings,
     selectedActions: actions.filter((action) => action.selected).length,
@@ -50,7 +55,8 @@ function setupChecks(
   selectedHarness: SupportedHarnessId | undefined,
 ): SetupCheck[] {
   return [
-    ...xcodeChecks(facts),
+    stateDirCheck(facts),
+    ...(facts.compiled ? [] : xcodeChecks(facts)),
     dependencyCheck({
       id: "worktrunk",
       label: "Worktrunk / wt",
@@ -63,19 +69,23 @@ function setupChecks(
       missingMessage: facts.tmux.message ?? "tmux is required for the reference terminal workflow.",
       dependency: facts.tmux,
     }),
-    dependencyCheck({
-      id: "bun",
-      label: "Bun",
-      missingMessage:
-        facts.bun.message ?? "Bun is required to run the STATION terminal UI (bare stn).",
-      dependency: facts.bun,
-    }),
+    ...(facts.compiled
+      ? []
+      : [
+          dependencyCheck({
+            id: "bun",
+            label: "Bun",
+            missingMessage:
+              facts.bun.message ?? "Bun is required to run the STATION terminal UI (bare stn).",
+            dependency: facts.bun,
+          }),
+        ]),
     gitCheck(facts),
     harnessCheck(facts, selectedHarness),
     configCheck(facts),
     ...configDiagnosticsChecks(facts),
     launcherCheck(facts),
-    stationUiCheck(facts),
+    ...(facts.compiled ? [] : [stationUiCheck(facts)]),
     {
       id: "worktrunk-shell-integration",
       tier: "recommended",
@@ -116,6 +126,20 @@ function setupChecks(
       message: "Run stn doctor after setup to validate the observer runtime.",
     },
   ];
+}
+
+function stateDirCheck(facts: SetupFacts): SetupCheck {
+  return {
+    id: "state-dir",
+    tier: "required",
+    status: facts.stateDir.status === "ok" ? "ok" : "missing",
+    label: "STATION state directory",
+    message:
+      facts.stateDir.status === "ok"
+        ? "STATION state directory is writable."
+        : facts.stateDir.message,
+    details: { path: facts.stateDir.path },
+  };
 }
 
 function launcherCheck(facts: SetupFacts): SetupCheck {
@@ -589,7 +613,7 @@ function setupActions(
   if (facts.tmux.status === "missing") {
     actions.push(installAction("install-tmux", "tmux", "tmux", facts.brew));
   }
-  if (facts.bun.status === "missing") {
+  if (!facts.compiled && facts.bun.status === "missing") {
     actions.push(installAction("install-bun", "Bun", "bun", facts.brew));
   }
   if (facts.diffnav.status === "missing") {
@@ -824,6 +848,9 @@ function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
   if (requiredMissing === 0) {
     const stationCommand = quoteCommandPart(facts.launchers.station.command);
     return [`${stationCommand} doctor`, stationCommand];
+  }
+  if (facts.stateDir.status === "missing") {
+    return [facts.stateDir.message];
   }
   if (facts.xcode.status === "missing") {
     return [facts.xcode.message];

--- a/apps/cli/src/commands/setup/systemCommand.ts
+++ b/apps/cli/src/commands/setup/systemCommand.ts
@@ -1,3 +1,4 @@
+import { isCompiledBinary } from "@station/runtime";
 import { applySetupPlan } from "./apply.js";
 import { checkBrewDependency } from "./checks/brew.js";
 import { checkSetupBun } from "./checks/bun.js";
@@ -24,7 +25,9 @@ export async function runSetupSystemCommand(
     if (initial.worktrunk.status === "missing")
       actions.push(systemInstallAction("worktrunk", "worktrunk"));
     if (initial.tmux.status === "missing") actions.push(systemInstallAction("tmux", "tmux"));
-    if (initial.bun.status === "missing") actions.push(systemInstallAction("bun", "bun"));
+    if (!initial.compiled && initial.bun.status === "missing") {
+      actions.push(systemInstallAction("bun", "bun"));
+    }
     if (initial.diffnav.status === "missing")
       actions.push(systemInstallAction("diffnav", "dlvhdr/formulae/diffnav"));
     if (initial.gitDelta.status === "missing")
@@ -49,6 +52,7 @@ export async function runSetupSystemCommand(
 }
 
 type SystemFacts = {
+  compiled: boolean;
   worktrunk: Awaited<ReturnType<typeof checkSetupWorktrunk>>;
   tmux: Awaited<ReturnType<typeof checkSetupTmux>>;
   bun: Awaited<ReturnType<typeof checkSetupBun>>;
@@ -64,11 +68,14 @@ async function collectSystemFacts(
   deps: SetupCommandDeps,
 ): Promise<SystemFacts> {
   const env = deps.env ?? options.env;
+  const compiled = deps.compiled ?? isCompiledBinary();
   const dependencyOptions = dependencyOptionsForCommand(deps, env);
   const [worktrunk, tmux, bun, diffnav, gitDelta, brew, toolchain] = await Promise.all([
     checkSetupWorktrunk(dependencyOptions),
     checkSetupTmux(dependencyOptions),
-    checkSetupBun(dependencyOptions),
+    compiled
+      ? Promise.resolve({ status: "ok" as const, command: "bun" })
+      : checkSetupBun(dependencyOptions),
     checkSetupDiffnav(dependencyOptions),
     checkSetupGitDelta(dependencyOptions),
     checkBrewDependency({
@@ -83,7 +90,7 @@ async function collectSystemFacts(
       ...(deps.cwd === undefined ? {} : { cwd: deps.cwd }),
     }),
   ]);
-  return { worktrunk, tmux, bun, diffnav, gitDelta, brew, toolchain };
+  return { compiled, worktrunk, tmux, bun, diffnav, gitDelta, brew, toolchain };
 }
 
 function renderSystemStatus(title: string, facts: SystemFacts): string {
@@ -92,7 +99,7 @@ function renderSystemStatus(title: string, facts: SystemFacts): string {
     "",
     `  ${facts.worktrunk.status === "ok" ? "ok" : "missing"} Worktrunk / wt`,
     `  ${facts.tmux.status === "ok" ? "ok" : "missing"} tmux`,
-    `  ${facts.bun.status === "ok" ? "ok" : "missing"} Bun`,
+    ...(facts.compiled ? [] : [`  ${facts.bun.status === "ok" ? "ok" : "missing"} Bun`]),
     `  ${facts.diffnav.status === "ok" ? "ok" : "missing"} diffnav`,
     `  ${facts.gitDelta.status === "ok" ? "ok" : "missing"} git-delta`,
     `  ${facts.brew.status === "ok" ? "ok" : facts.brew.status} Homebrew`,
@@ -111,7 +118,7 @@ function systemReady(facts: SystemFacts): boolean {
   return (
     facts.worktrunk.status === "ok" &&
     facts.tmux.status === "ok" &&
-    facts.bun.status === "ok" &&
+    (facts.compiled || facts.bun.status === "ok") &&
     facts.diffnav.status === "ok" &&
     facts.gitDelta.status === "ok" &&
     facts.toolchain.node.status === "ok" &&
@@ -139,6 +146,8 @@ function systemPlan(actions: SetupAction[]): SetupPlan {
     checks: [],
     actions,
     summary: {
+      launchReady: true,
+      workflowReady: true,
       requiredOk: true,
       requiredMissing: 0,
       warnings: 0,

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -2,6 +2,7 @@ import type { ExternalCommandRunner } from "@station/runtime";
 import type { CliEnv } from "../../env.js";
 import type { SetupApplyFileSystem } from "./apply.js";
 import type { SetupFileSystemReader } from "./checks/config.js";
+import type { SetupStateDirFileSystem } from "./checks/stateDir.js";
 
 export type SetupPromptChoice = {
   value: string;
@@ -28,6 +29,9 @@ export type SetupCommandDeps = {
   // Defaults to process.platform; injected by machine-state tests to drive the
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
+  compiled?: boolean;
+  stateDirExecute?: (path: string) => Promise<void>;
+  stateDirFs?: SetupStateDirFileSystem;
 };
 
 export type SetupCommandOptions = {

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -1,15 +1,35 @@
 #!/usr/bin/env node
 import { runObserverMain } from "@station/observer";
-import { createProviderRegistry } from "./observerProviders.js";
+import { type CreateProviderRegistryOptions, createProviderRegistry } from "./observerProviders.js";
+
+export type RunCliObserverMainOptions = {
+  preparePiExtension?: (stateDir: string) => string | Promise<string>;
+};
 
 /**
- * Receives raw observer arguments and delegates provider composition to the
- * Observer bootstrap.
+ * ADAPTER
+ *
+ * Translates raw process arguments and optional compiled Pi asset preparation
+ * into CLI-owned Observer provider composition.
  */
 export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),
+  options: RunCliObserverMainOptions = {},
 ): Promise<number> {
-  return runObserverMain([...argv], { providerRegistryFactory: createProviderRegistry });
+  return runObserverMain([...argv], {
+    providerRegistryFactory: async (config, providerOptions) => {
+      const registryOptions: CreateProviderRegistryOptions = {};
+      if (providerOptions.configPath !== undefined) {
+        registryOptions.configPath = providerOptions.configPath;
+      }
+      if (options.preparePiExtension !== undefined) {
+        registryOptions.piExtensionPath = await options.preparePiExtension(
+          providerOptions.stateDir,
+        );
+      }
+      return createProviderRegistry(config, registryOptions);
+    },
+  });
 }
 
 async function runCliObserverProcess(): Promise<void> {

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -53,12 +53,14 @@ import { selfExecArgv } from "./selfExec.js";
 
 export type CreateProviderRegistryOptions = {
   configPath?: string | undefined;
+  piExtensionPath?: string | undefined;
 };
 
 /**
  * COMPOSITION ROOT
  *
- * Constructs concrete provider adapters and assigns their Observer roles.
+ * Constructs concrete provider adapters, including the packaged Pi extension
+ * path supplied by compiled CLI composition, and assigns their Observer roles.
  *
  * Observer application use cases are composed by the Observer runtime, not
  * stored in the provider registry.
@@ -275,6 +277,9 @@ function createHarnessProvider(
     }
     if (registryOptions.configPath !== undefined) {
       options.configPath = registryOptions.configPath;
+    }
+    if (registryOptions.piExtensionPath !== undefined) {
+      options.extensionPath = registryOptions.piExtensionPath;
     }
     applyObserverPaths(options, config, false);
     return createPiHarnessProvider(options);

--- a/apps/cli/src/observerReap.ts
+++ b/apps/cli/src/observerReap.ts
@@ -165,13 +165,14 @@ export function parseObserverPsOutput(output: string): ObserverProcessEntry[] {
     const pid = Number(pidStr);
     const startToken = tokenStr.trim();
     const argv = command.split(/\s+/).filter((token) => token.length > 0);
-    // Real observer only: argv[0] is a node binary running a …/observerMain.js
-    // script. Shell wrappers (/bin/zsh -c '…observerMain…') are excluded because
-    // their argv[0] is a shell, so grep/ps tooling never matches itself.
+    // Accept only the source Node entry or the exact compiled self-exec token;
+    // shell wrappers remain excluded so ps/grep tooling never matches itself.
     const exe = argv[0] ?? "";
     const isNode = exe === "node" || exe.endsWith("/node");
-    const runsObserver = argv.some((token) => token.endsWith("observerMain.js"));
-    if (!Number.isInteger(pid) || !isNode || !runsObserver) continue;
+    const runsSourceObserver = isNode && argv[1]?.endsWith("observerMain.js") === true;
+    const isStationBinary = exe === "stn" || exe.endsWith("/stn");
+    const runsCompiledObserver = isStationBinary && argv[1] === "__observer";
+    if (!Number.isInteger(pid) || (!runsSourceObserver && !runsCompiledObserver)) continue;
     const socketPath = resolveObserverSocketForProcessArgs(argv);
     entries.push(
       socketPath === undefined ? { pid, argv, startToken } : { pid, argv, startToken, socketPath },

--- a/apps/cli/src/selfExec.ts
+++ b/apps/cli/src/selfExec.ts
@@ -61,7 +61,7 @@ export type SelfExecRunners = {
 };
 
 /**
- * Routes argv0 ingress before consuming one exact internal first token.
+ * Routes argv0 aliases before consuming one exact internal first token.
  * Dispatch occurs before CLI parsing or stdin reads; all other argv reaches the CLI unchanged.
  */
 export async function dispatchSelfExec(
@@ -70,6 +70,10 @@ export async function dispatchSelfExec(
 ): Promise<void> {
   if (basename(input.argv0) === "stn-ingress") {
     await runners.ingress(input.argv);
+    return;
+  }
+  if (basename(input.argv0) === "stn-tmux-popup") {
+    await runners.tmuxPopup(input.argv);
     return;
   }
 

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -5,7 +5,7 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { runCli } from "@station/cli";
 import { observerRuntimeFreshnessCheck, rendererRuntimeCheck } from "@station/cli/internal";
 import type { DiagnosticEvidenceIndex, DiagnosticSnapshot, DoctorReport } from "@station/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -120,6 +120,17 @@ describe("CLI diagnostic commands", () => {
     await expect(
       rendererRuntimeCheck(async () => undefined, "my-renderer --foo"),
     ).resolves.toBeUndefined();
+  });
+
+  it("skips source renderer probes in compiled mode", async () => {
+    const resolve = vi.fn(async () => "/usr/local/bin/bun");
+    const uiInstalled = vi.fn(async () => true);
+
+    await expect(
+      rendererRuntimeCheck(resolve, undefined, uiInstalled, true),
+    ).resolves.toBeUndefined();
+    expect(resolve).not.toHaveBeenCalled();
+    expect(uiInstalled).not.toHaveBeenCalled();
   });
 
   it("collects diagnostics and writes a debug bundle", async () => {

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -52,12 +52,44 @@ describe("CLI setup command", () => {
       generatedAt: "2026-06-08T12:00:00.000Z",
       mode: "check",
       summary: {
+        workflowReady: false,
         requiredOk: false,
         selectedHarness: "codex",
         configPath: join(root, "missing.toml"),
       },
     });
     expect(calls.map((call) => call.command)).not.toContain("gh");
+  });
+
+  it("reports compiled launch readiness independently from workflow readiness", async () => {
+    const root = await tempRoot(tempRoots);
+    const result = await runCli(["setup", "check", "--json"], {
+      setupDeps: {
+        compiled: true,
+        cwd: root,
+        homeDir: join(root, "home"),
+        env: { PATH: "/empty" },
+        runner: fakeRunner([], {}),
+        access: fakeAccess([]),
+        fs: readOnlyFs({}),
+      },
+    });
+
+    expect(result.code).toBe(1);
+    const plan = result.output as {
+      summary: { launchReady: boolean; workflowReady: boolean; requiredOk: boolean };
+      checks: Array<{ id: string }>;
+      actions: Array<{ id: string }>;
+    };
+    expect(plan.summary).toMatchObject({
+      launchReady: true,
+      workflowReady: false,
+      requiredOk: false,
+    });
+    expect(plan.checks.some((check) => check.id === "bun")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "station-ui")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
+    expect(plan.actions.some((action) => action.id === "install-bun")).toBe(false);
   });
 
   it("setup plan is read-only and includes a config write action", async () => {
@@ -292,7 +324,7 @@ describe("CLI setup command", () => {
 
     expect(result.code).toBe(1);
     expect(result.output).toMatchObject({
-      summary: { requiredOk: false },
+      summary: { workflowReady: false, requiredOk: false },
     });
   });
 

--- a/apps/cli/test/unit/observer-main.test.ts
+++ b/apps/cli/test/unit/observer-main.test.ts
@@ -1,0 +1,65 @@
+import type { StationConfig } from "@station/config";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runObserverMain: vi.fn(),
+  createProviderRegistry: vi.fn(),
+}));
+
+vi.mock("@station/observer", () => ({ runObserverMain: mocks.runObserverMain }));
+vi.mock("../../src/observerProviders.js", () => ({
+  createProviderRegistry: mocks.createProviderRegistry,
+}));
+
+import { runCliObserverMain } from "../../src/observerMain.js";
+
+describe("runCliObserverMain", () => {
+  beforeEach(() => {
+    mocks.runObserverMain.mockReset();
+    mocks.createProviderRegistry.mockReset();
+    mocks.runObserverMain.mockResolvedValue(0);
+  });
+
+  it("prepares Pi from the canonical Observer state directory", async () => {
+    const preparePiExtension = vi.fn(
+      async (stateDir: string) => `${stateDir}/assets/pi/station-pi-extension.mjs`,
+    );
+
+    await expect(
+      runCliObserverMain(["--state-dir", "/custom/state"], { preparePiExtension }),
+    ).resolves.toBe(0);
+
+    const deps = mocks.runObserverMain.mock.calls[0]?.[1] as {
+      providerRegistryFactory: (
+        config: StationConfig,
+        options: { stateDir: string; configPath?: string },
+      ) => Promise<unknown>;
+    };
+    const config = {} as StationConfig;
+    await deps.providerRegistryFactory(config, {
+      stateDir: "/canonical/state",
+      configPath: "/config/station.toml",
+    });
+
+    expect(preparePiExtension).toHaveBeenCalledWith("/canonical/state");
+    expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {
+      configPath: "/config/station.toml",
+      piExtensionPath: "/canonical/state/assets/pi/station-pi-extension.mjs",
+    });
+  });
+
+  it("does not prepare or inject Pi assets in source composition", async () => {
+    await runCliObserverMain([]);
+
+    const deps = mocks.runObserverMain.mock.calls[0]?.[1] as {
+      providerRegistryFactory: (
+        config: StationConfig,
+        options: { stateDir: string },
+      ) => Promise<unknown>;
+    };
+    const config = {} as StationConfig;
+    await deps.providerRegistryFactory(config, { stateDir: "/source/state" });
+
+    expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {});
+  });
+});

--- a/apps/cli/test/unit/observer-reap.test.ts
+++ b/apps/cli/test/unit/observer-reap.test.ts
@@ -39,6 +39,19 @@ describe("parseObserverPsOutput", () => {
       "88888 Sat Jul  4 17:47:24 2026 /bin/zsh -c ps -axww | grep observerMain.js --state-dir /x";
     expect(parseObserverPsOutput(out)).toEqual([]);
   });
+
+  it("keeps only the exact compiled stn observer command shape", () => {
+    const out = [
+      " 4001 Sat Jul  4 17:45:33 2026 /opt/station/stn __observer --socket /compiled/o.sock",
+      " 4002 Sat Jul  4 17:45:34 2026 /opt/station/stn observer start --socket /wrong/o.sock",
+      " 4003 Sat Jul  4 17:45:35 2026 /opt/station/stn-copy __observer --socket /wrong/o.sock",
+      " 4004 Sat Jul  4 17:45:36 2026 /bin/zsh -c /opt/station/stn __observer --socket /wrong/o.sock",
+    ].join("\n");
+
+    expect(parseObserverPsOutput(out)).toEqual([
+      expect.objectContaining({ pid: 4001, socketPath: "/compiled/o.sock" }),
+    ]);
+  });
 });
 
 describe("selectReapPlan", () => {

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type { StationConfig } from "@station/config";
 import * as contracts from "@station/contracts";
 import { installCursorHooks } from "@station/cursor";
+import { createPiHarnessProvider } from "@station/pi";
 import { createStationHostController } from "@station/terminal";
 import { describe, expect, it, vi } from "vitest";
 import { createProviderRegistry } from "../../src/observerProviders";
@@ -13,6 +14,14 @@ vi.mock("@station/terminal", async (importOriginal) => {
   return {
     ...actual,
     createStationHostController: vi.fn(actual.createStationHostController),
+  };
+});
+
+vi.mock("@station/pi", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@station/pi")>();
+  return {
+    ...actual,
+    createPiHarnessProvider: vi.fn(actual.createPiHarnessProvider),
   };
 });
 
@@ -221,6 +230,25 @@ describe("observer providers", () => {
     });
 
     expect([...allBuiltIns.harnesses.keys()]).toEqual(["codex", "cursor", "pi", "opencode"]);
+  });
+
+  it("forwards a prepared extension path only to the Pi provider", () => {
+    vi.mocked(createPiHarnessProvider).mockClear();
+
+    createProviderRegistry(
+      {
+        ...config,
+        harness: { codex: {}, pi: {} },
+      },
+      { piExtensionPath: "/state/assets/pi/station-pi-extension.mjs" },
+    );
+
+    expect(createPiHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(createPiHarnessProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        extensionPath: "/state/assets/pi/station-pi-extension.mjs",
+      }),
+    );
   });
 
   it("passes tmux command config into the tmux terminal provider", async () => {

--- a/apps/cli/test/unit/self-exec.test.ts
+++ b/apps/cli/test/unit/self-exec.test.ts
@@ -100,6 +100,15 @@ describe("dispatchSelfExec", () => {
     expect(calls).toEqual([{ runner: "ingress", argv }]);
   });
 
+  it("gives the stn-tmux-popup argv0 route precedence over internal tokens", async () => {
+    const argv = ["__observer", "--socket", "/tmp/observer.sock"] as const;
+    const { calls, runners } = createRecordingRunners();
+
+    await dispatchSelfExec({ argv0: "/usr/local/bin/stn-tmux-popup", argv }, runners);
+
+    expect(calls).toEqual([{ runner: "tmuxPopup", argv }]);
+  });
+
   it.each(INTERNAL_ROUTES)("consumes only $token and invokes only the $runner runner", async ({
     token,
     runner,

--- a/apps/cli/test/unit/setup-apply.test.ts
+++ b/apps/cli/test/unit/setup-apply.test.ts
@@ -217,6 +217,8 @@ function plan(actions: SetupPlan["actions"]): SetupPlan {
     checks: [],
     actions,
     summary: {
+      launchReady: true,
+      workflowReady: true,
       requiredOk: true,
       requiredMissing: 0,
       warnings: 0,

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1,13 +1,14 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { checkSetupBun } from "../../src/commands/setup/checks/bun.js";
 import { setupProbeTimeoutMs } from "../../src/commands/setup/checks/constants.js";
 import { checkSetupDiffnav } from "../../src/commands/setup/checks/diffnav.js";
 import { checkSetupGit } from "../../src/commands/setup/checks/git.js";
 import { checkSetupGitDelta } from "../../src/commands/setup/checks/gitDelta.js";
+import { checkSetupStateDir } from "../../src/commands/setup/checks/stateDir.js";
 import { collectSetupFacts } from "../../src/commands/setup/checks/system.js";
 import {
   checkSetupTmuxBinding,
@@ -23,6 +24,105 @@ describe("setup dependency checks", () => {
     await Promise.all(
       tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
     );
+  });
+
+  it("creates and proves a writable private state directory", async () => {
+    const root = await tempRoot(tempRoots);
+    const path = join(root, "state");
+
+    await expect(checkSetupStateDir({ path, probeName: ".probe" })).resolves.toEqual({
+      status: "ok",
+      path,
+    });
+  });
+
+  it("executes the compiled asset probe from the state directory", async () => {
+    const root = await tempRoot(tempRoots);
+    const path = join(root, "state");
+
+    await expect(
+      checkSetupStateDir({ path, executable: true, probeName: ".probe" }),
+    ).resolves.toEqual({ status: "ok", path });
+    await expect(access(join(path, ".probe"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects and cleans up a compiled state directory that cannot execute assets", async () => {
+    const root = await tempRoot(tempRoots);
+    const path = join(root, "state");
+
+    await expect(
+      checkSetupStateDir({
+        path,
+        executable: true,
+        probeName: ".probe",
+        execute: async () => {
+          throw Object.assign(new Error("execution denied"), { code: "EACCES" });
+        },
+      }),
+    ).resolves.toEqual({
+      status: "missing",
+      path,
+      message: `STATION state directory does not permit executable assets at ${path}.`,
+    });
+    await expect(access(join(path, ".probe"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reports an actionable state-directory failure and cleans up the probe", async () => {
+    const unlinked: string[] = [];
+    const path = "/readonly/state";
+
+    await expect(
+      checkSetupStateDir({
+        path,
+        probeName: ".probe",
+        fs: {
+          async mkdir() {},
+          async open() {
+            throw Object.assign(new Error("read only"), { code: "EACCES" });
+          },
+          async unlink(probePath) {
+            unlinked.push(probePath);
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      status: "missing",
+      path,
+      message: `STATION state directory is not writable at ${path}.`,
+    });
+    expect(unlinked).toEqual([join(path, ".probe")]);
+  });
+
+  it("skips source renderer and Xcode probes in compiled setup", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const stationUiInstalled = vi.fn(async () => false);
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: join(root, "home"),
+      compiled: true,
+      platform: "darwin",
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner(calls, {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      }),
+      access: fakeAccess([]),
+      fs: readOnlyFs({}),
+      stationUiInstalled,
+    });
+    const plan = buildSetupPlan(facts);
+
+    expect(stationUiInstalled).not.toHaveBeenCalled();
+    expect(calls.some((call) => call.command === "xcode-select")).toBe(false);
+    expect(plan.summary.launchReady).toBe(true);
+    expect(plan.checks.some((check) => check.id === "bun")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "station-ui")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
   });
 
   it("collects core facts through injected effects only", async () => {

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -271,6 +271,8 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
     mode: "plan",
     configPath: "/tmp/config.toml",
     homeDir: "/tmp/home",
+    compiled: false,
+    stateDir: { status: "ok", path: "/tmp/home/.local/state/station" },
     worktrunk: { status: "ok", command: "wt" },
     worktrunkAutomation: {
       status: "ok",

--- a/apps/cli/test/unit/setup-model.test.ts
+++ b/apps/cli/test/unit/setup-model.test.ts
@@ -37,6 +37,8 @@ describe("setup model", () => {
         },
       ],
       summary: {
+        launchReady: true,
+        workflowReady: true,
         requiredOk: true,
         requiredMissing: 0,
         warnings: 0,
@@ -48,6 +50,8 @@ describe("setup model", () => {
     });
 
     expect(parsed.summary.requiredOk).toBe(true);
+    expect(parsed.summary.launchReady).toBe(true);
+    expect(parsed.summary.workflowReady).toBe(true);
   });
 
   it("rejects unexpected output fields", () => {
@@ -58,6 +62,8 @@ describe("setup model", () => {
         checks: [],
         actions: [],
         summary: {
+          launchReady: true,
+          workflowReady: true,
           requiredOk: true,
           requiredMissing: 0,
           warnings: 0,
@@ -68,5 +74,26 @@ describe("setup model", () => {
         extra: true,
       }),
     ).toThrow();
+  });
+
+  it("keeps requiredOk as a compatibility alias of workflowReady", () => {
+    expect(() =>
+      SetupPlanSchema.parse({
+        generatedAt: "2026-06-08T12:00:00.000Z",
+        mode: "check",
+        checks: [],
+        actions: [],
+        summary: {
+          launchReady: true,
+          workflowReady: false,
+          requiredOk: true,
+          requiredMissing: 1,
+          warnings: 0,
+          selectedActions: 0,
+          configPath: "/tmp/config.toml",
+        },
+        nextSteps: [],
+      }),
+    ).toThrow("requiredOk must match workflowReady");
   });
 });

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -12,12 +12,15 @@ describe("setup planner", () => {
     const plan = buildSetupPlan(facts());
 
     expect(plan.summary).toMatchObject({
+      launchReady: true,
+      workflowReady: true,
       requiredOk: true,
       requiredMissing: 0,
       selectedActions: 0,
       selectedHarness: "codex",
     });
     expect(plan.checks.map((check) => [check.id, check.status])).toEqual([
+      ["state-dir", "ok"],
       ["worktrunk", "ok"],
       ["tmux", "ok"],
       ["bun", "ok"],
@@ -80,6 +83,57 @@ describe("setup planner", () => {
       tier: "required",
       selected: true,
       command: ["brew", "install", "bun"],
+    });
+  });
+
+  it("keeps compiled launch ready without source Bun or Station UI rows", () => {
+    const plan = buildSetupPlan(
+      facts({
+        compiled: true,
+        bun: { status: "missing", command: "bun", message: "Bun missing." },
+        stationUi: { status: "missing" },
+        xcode: {
+          status: "missing",
+          applicable: true,
+          message: "Command Line Tools missing.",
+        },
+      }),
+    );
+
+    expect(plan.summary).toMatchObject({
+      launchReady: true,
+      workflowReady: true,
+      requiredOk: true,
+    });
+    expect(plan.checks.some((check) => check.id === "bun")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "station-ui")).toBe(false);
+    expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
+    expect(plan.actions.some((action) => action.id === "install-bun")).toBe(false);
+  });
+
+  it("separates launch readiness from workflow readiness", () => {
+    const workflowIncomplete = buildSetupPlan(
+      facts({ worktrunk: { status: "missing", command: "wt", message: "Missing." } }),
+    );
+    expect(workflowIncomplete.summary).toMatchObject({
+      launchReady: true,
+      workflowReady: false,
+      requiredOk: false,
+    });
+
+    const launchBlocked = buildSetupPlan(
+      facts({
+        stateDir: {
+          status: "missing",
+          path: "/readonly/state",
+          message: "State directory is not writable.",
+        },
+      }),
+    );
+    expect(launchBlocked.summary).toMatchObject({
+      launchReady: false,
+      workflowReady: false,
+      requiredOk: false,
     });
   });
 
@@ -323,6 +377,8 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
     mode: "plan",
     configPath: "/tmp/config.toml",
     homeDir: "/tmp/home",
+    compiled: false,
+    stateDir: { status: "ok", path: "/tmp/home/.local/state/station" },
     worktrunk: {
       status: "ok",
       command: "wt",
@@ -422,6 +478,7 @@ function validConfigFact(
     status: "valid",
     path: "/tmp/config.toml",
     source: "schema_version = 1\n",
+    observerStateDir: "/tmp/home/.local/state/station",
     hasProjectForRoot: true,
     configuredHarnesses: ["codex"],
     configuredHookHarnesses: [],

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -122,6 +122,8 @@ function plan(): SetupPlan {
       },
     ],
     summary: {
+      launchReady: true,
+      workflowReady: false,
       requiredOk: false,
       requiredMissing: 1,
       warnings: 0,

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -38,13 +38,14 @@ import {
 const STOP_BACKSTOP_MS = 5000;
 
 export type ObserverProviderRegistryFactoryOptions = {
+  stateDir: string;
   configPath?: string | undefined;
 };
 
 export type ObserverProviderRegistryFactory = (
   config: StationConfig,
   options: ObserverProviderRegistryFactoryOptions,
-) => ProviderRegistry;
+) => ProviderRegistry | Promise<ProviderRegistry>;
 
 export type RunObserverMainDeps = {
   providerRegistryFactory: ObserverProviderRegistryFactory;
@@ -54,7 +55,7 @@ export type RunObserverMainDeps = {
  * COMPOSITION ROOT
  *
  * Builds the process-lifetime Observer runtime around provider adapters
- * supplied by CLI composition.
+ * supplied by awaited CLI composition.
  *
  * Shutdown owns the command queue, event hook, server, and SQLite lifecycles
  * created here.
@@ -82,6 +83,11 @@ export async function runObserverMain(
   const socketPath = resolveObserverSocketPath(options.socketPath, config, stateDir, homeDir);
   const spoolDir = providerIngressSpoolDir(stateDir);
   await mkdir(stateDir, { recursive: true, mode: 0o700 });
+  const providerOptions: ObserverProviderRegistryFactoryOptions = { stateDir };
+  if (options.configPath !== undefined) {
+    providerOptions.configPath = loadedConfig.configPath;
+  }
+  const providers = await deps.providerRegistryFactory(config, providerOptions);
 
   const sqlite = openObserverSqlite({
     path: join(stateDir, "observer.sqlite"),
@@ -93,11 +99,6 @@ export async function runObserverMain(
   const pruneAt = toIsoTimestamp(systemClock.now());
   await persistence.pruneExpiredProviderObservations(pruneAt);
   const commandQueue = createCommandQueue({ persistence, clock: systemClock, eventBus, logger });
-  const providerOptions: ObserverProviderRegistryFactoryOptions = {};
-  if (options.configPath !== undefined) {
-    providerOptions.configPath = loadedConfig.configPath;
-  }
-  const providers = deps.providerRegistryFactory(config, providerOptions);
   // Fire-and-forget boot probes: snapshots read cached results and fill in as they land.
   void providers.refreshHarnessVersions();
   void providers.healthCache.refreshAll();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -432,7 +432,7 @@ Advanced development/demo overrides:
 | --- | --- | --- |
 | `STATION_SOURCE` | Native Station TUI data source | unset/empty/`observer` for live observer, `mock` for fixture data. |
 | `STATION_SCENARIO` | Native Station mock data | Fixture scenario name when `STATION_SOURCE=mock`; defaults to `baseline`. |
-| `STATION_PTY_IMPL` | Station local and persistent-host PTYs | unset, empty, or `bridge` uses the Node/node-pty bridge (default); `bun` uses `Bun.Terminal` through the controlling-terminal helper; `bun-nocctty` starts the payload directly without job-control or orphan-cleanup guarantees. |
+| `STATION_PTY_IMPL` | Station local and persistent-host PTYs | Source mode defaults to `bridge`; a compiled binary defaults to `bun`. Explicit `bun` uses `Bun.Terminal` through the controlling-terminal helper; `bun-nocctty` starts the payload directly without job-control or orphan-cleanup guarantees. `bridge` is source-only. |
 | `STATION_NODE` | Station local PTY bridge | Node executable path/name; fallback is `node`. |
 | `STATION_BUN` | Source/development Station host launches | Bun executable path/name for source/development host launches; fallback is `bun`. |
 | `STATION_HOST_ENTRY` | Source/development Station host launches | Non-standard source/development override for the host entry file. Usually leave unset. |
@@ -447,6 +447,16 @@ Source installs using `STATION_PTY_IMPL=bun` must first run
 automatically to `bun-nocctty`. Any other selector value is also an error.
 An existing station host keeps the implementation setting it inherited at
 startup, so stop and start the host when changing this variable.
+
+Compiled binaries embed the helper and materialize it under
+`<state_dir>/run/assets/ctty/` with private permissions, integrity checks, and a
+process lease so a newer TUI does not prune a helper still needed by an older
+host. The bundled Pi extension is materialized under
+`<state_dir>/run/assets/pi/` and retained because a live Pi process may reload
+its extension path. If `state_dir` is mounted `noexec`, compiled Bun PTYs fail
+with a diagnostic naming the path; move `[observer].state_dir` to an executable
+filesystem or explicitly select the degraded `bun-nocctty` mode. There is no
+automatic no-ctty fallback.
 
 Default state paths (all under `state_dir`, default `~/.local/state/station`):
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,6 +85,36 @@ preserves the existing host, so changing PTY implementations requires `stop`
 followed by `start`. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`,
 then press Ctrl-C. Finally stop the devbox and confirm no pane payload remains.
 
+For standalone-binary work, Bun 1.3.14 is required. From `station/`, install the
+native UI dependencies, return to the repository root, then build and run the
+binary smoke:
+
+```bash
+bun install
+cd ..
+pnpm build:binary -- --version 0.1.0-dev
+pnpm smoke:binary -- --expected-version 0.1.0-dev
+```
+
+The staged artifact is `station/dist/bin/stn`, with `stn-ingress` and
+`stn-tmux-popup` symlinks beside it. The build is native-only: it compiles the
+portable C controlling-terminal helper with the host `cc`, bundles the Pi
+extension, and selects the matching Bun target. Intel/x64 builds use Bun's
+baseline target for older CPU compatibility. The smoke runs the binary with a
+child `PATH` that contains neither Node nor Bun and covers Observer self-spawn,
+ingress and popup argv0 dispatch, packaged assets, hostile working-directory
+configuration, and a real host-backed Bun PTY.
+
+To inspect the UX manually after the smoke:
+
+```bash
+./station/dist/bin/stn
+```
+
+Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
+The isolated or configured `logs/station-host.jsonl` should record
+`ptyImplementation` as `bun`.
+
 For CI install parity, use:
 
 ```bash

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -241,13 +241,16 @@ and reloads after later gaps or events that cannot be reduced safely.
 
 Current startup proceeds in this order:
 
-1. CLI composition supplies the concrete provider registry factory.
-2. Observer runtime loads config, resolves the state and socket paths, and
-   creates the state directory.
+1. CLI composition supplies the concrete, optionally asynchronous provider
+   registry factory.
+2. Observer runtime loads config, resolves the canonical state and socket paths,
+   creates the state directory, and passes that resolved directory to CLI
+   composition. Compiled composition materializes the Pi extension here before
+   constructing providers; Observer code remains provider-neutral.
 3. SQLite opens, applies pending migrations, and constructs persistence.
-4. The runtime creates the event bus, logger, command queue, provider registry,
-   feature evaluator, Observer core, command handlers, and configured event
-   hooks.
+4. The runtime creates the event bus, logger, command queue, feature evaluator,
+   Observer core, command handlers, and configured event hooks around the
+   awaited provider registry.
 5. The API constructs ingress queues, reconcile scheduling, metadata refresh,
    diagnostics dependencies, and spool draining.
 6. The protocol server binds the socket before startup reconcile. A

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -53,7 +53,7 @@ Pinned so the release job, install script, and acceptance suite agree.
 | Build runners | Native per target (no cross-compile — only the host-matching `@opentui/core-*` optional dep installs). Use *currently available* GitHub-hosted labels resolved at implementation time; do **not** hard-code `macos-13` (F9 — Intel macOS labels are being retired). Pin exact labels in the workflow with a comment naming the check date. |
 | macOS floor | Match the oldest OS the chosen Intel/arm runners image supports; state it in release notes. |
 | Linux floor | glibc only for v1.1 (bun's default). Declare the built-against glibc version (the runner's) as the floor; musl is a later target, not silently implied. |
-| CPU | x64 baseline = bun's default (no AVX-512 assumption); arm64 = Apple/ARMv8. |
+| CPU | x64 uses Bun's explicit `-baseline` targets for older SSE4.2-era CPUs; arm64 = Apple/ARMv8. |
 | Artifact | `stn-v{ver}-{darwin|linux}-{arm64|x64}.tar.gz`. **Manifest below is exhaustive.** |
 
 **Artifact manifest** (every file the binary needs on disk that
@@ -61,11 +61,9 @@ Pinned so the release job, install script, and acceptance suite agree.
 
 - `stn` — the compiled binary.
 - `stn-ingress` — symlink → `stn` (argv0 dispatch).
-- `stn-tmux-popup` — the tmux popup toggle. Today a separate bin
-  (`package.json` → `integrations/terminal/tmux/bin/stn-popup`); the popup
-  keybinding and setup depend on it. Either ship it as a third symlink →
-  `stn` routed to an internal `__tmux-popup` mode, or vendor the script.
-  Decide in A4; it is **not** optional.
+- `stn-tmux-popup` — symlink → `stn`. A4 routes its argv0 identity (and the
+  reserved `__tmux-popup` token) through the existing `popup` CLI command. The
+  source POSIX fast launcher remains unchanged for development installs.
 - `LICENSE` — required. FSL-1.1 (LICENSE:67) obliges every redistributed
   copy to include the Terms or a link and keep copyright notices. The
   archive must carry it.
@@ -166,16 +164,21 @@ Rather than move required checks to `recommended` (v1's B4, which erodes
 what "required" means), split the setup summary into two truths:
 
 - `launchReady` — the binary can start the TUI + observer. Needs: the
-  binary itself, a writable state dir. Nothing else. Bare `stn` gates on
-  this.
+  binary itself and a writable state dir; compiled mode also proves that
+  extracted executable assets can run there. Nothing else. Bare `stn` gates
+  on this.
 - `workflowReady` — full worktree workflow: worktrunk, tmux, diffnav,
   git-delta, an agent CLI, git repo cwd, a project in config. `stn setup`
   reports these as unmet *capabilities*, not as "broken."
 
 Each check keeps its real status; `stn setup check --json` gains both
-booleans. `stn` launches whenever `launchReady`; the TUI surfaces unmet
-`workflowReady` capabilities inline. Bun/station-UI/`rendererRuntimeCheck`
-checks are skipped when `isCompiledBinary()`.
+booleans and retains `requiredOk` as an alias of `workflowReady`. The compiled
+launch path enforces the same writable/executable-state prerequisite without
+running the full setup suite before first paint. Bun, station-UI, Xcode
+build-tool, and `rendererRuntimeCheck` checks are skipped when
+`isCompiledBinary()`. Surfacing dynamic `workflowReady` details inside the TUI
+is deferred until those facts have a proper runtime data boundary; setup JSON
+remains their authority.
 
 ## Phases
 
@@ -245,6 +248,9 @@ target's native `cc` to write the ignored development/CI executable at
 supply `TIOCSCTTY`, so TypeScript contains no platform ioctl constants. The
 four-target `station-pty` CI matrix compiles that same source natively on
 linux-x64, linux-arm64, darwin-x64, and darwin-arm64.
+The helper stays C because it is a small direct wrapper over POSIX `setsid`,
+`ioctl`, and `execvp`; Zig or Rust would add a build toolchain without improving
+that boundary.
 
 `createLocalPtyTerminal` is now a selector: unset, empty, or `bridge` preserves
 the Node/node-pty default; `bun` uses `Bun.Terminal` through the helper; and
@@ -258,11 +264,12 @@ resumes, a `SIGKILL` of the Station owner leaves no orphaned pane child, and
 `terminal.close()` is paired with an explicit `child.kill()` (S2: close alone
 does not kill). These checks remain release-blocking after the default flip.
 
-**A2b status: pending.** The default must not flip until A4 owns the packaged
-helper lifecycle, the four-target gate is green, and A2a has been daily-driven
-for at least one week. In-field undo for binary users is
-`STATION_PTY_IMPL=bun-nocctty` plus reverting the flip — **not** the bridge
-(dev-only).
+**A2b status: implemented for compiled binaries by A4.** An unset selector in a
+compiled TUI or station-host resolves to the packaged `bun` implementation;
+source development deliberately continues to default to `bridge`. In-field
+undo for binary users is the explicit degraded `STATION_PTY_IMPL=bun-nocctty`
+mode plus reverting the compiled activation — **not** the source-only bridge.
+Bridge removal remains A6 work after a full release cycle.
 
 ### A3 — self-exec seam + raw-argv dispatch
 
@@ -288,37 +295,45 @@ commands. The host and ingress boundaries receive finalized executable tuples
 and append only their operation-specific flags. The scripted harness remains
 an on-disk development/test runner: there is no `__scripted` mode.
 
-`__tmux-popup` is reserved and dispatches only to A3's injected placeholder
-runner. A4 chooses and packages the executable popup implementation; A3 leaves
-the POSIX launcher unchanged.
+`__tmux-popup` was reserved with an injected runner. A4 now binds it, and the
+`stn-tmux-popup` argv0 alias, to the existing CLI popup command while leaving the
+source POSIX launcher unchanged.
 
 ### A4 — compile entry + build script + asset extraction + CI smoke
 
-`station/src/bin/stnMain.ts` composes `dispatchSelfExec` with lazy route imports;
-`scripts/build-binary.mjs` + `build:binary`. Compile command carries **both**
-ambient-config disable flags (F1) and the version/compiled defines.
-`link-station-packages.sh` is extended for the app links.
+**Status: implemented.** `station/src/bin/stnMain.ts` composes
+`dispatchSelfExec` with lazy route imports; `scripts/build-binary.mjs` and
+`build:binary` build one native artifact with Bun 1.3.14. The compile command
+carries **both** ambient-config disable flags (F1), version/compiled defines,
+and the native target mapping; x64 selects Bun's `-baseline` targets.
+`link-station-packages.sh` links the CLI and Observer applications.
 
 A4 owns the packaged helper lifecycle that A2a deliberately leaves out:
 
 - compile the one portable helper source natively for each target and embed the
   resulting executable alongside the Pi extension asset;
-- extract assets into a per-version, per-user cache such as
-  `<stateDir>/run/helpers/<ver>/`, set executable permissions, and verify their
-  size/hash before reuse;
+- extract the helper under `<stateDir>/run/assets/ctty/` and Pi extension under
+  `<stateDir>/run/assets/pi/`, set private permissions, and verify size plus full
+  SHA-256 before reuse;
 - make extraction atomic and lock-guarded so racing panes cannot observe a
   partial helper;
-- use an executable temporary location when the state cache is mounted `noexec`,
-  or surface a clear diagnostic without dropping to the no-ctty path; and
-- prune stale versions from the host/TUI asset-owning runtime. The observer does
-  not own helper extraction or cleanup.
+- probe the extracted helper and surface a clear configured-state-directory
+  diagnostic on `noexec`, without a temporary or no-ctty fallback;
+- lease helper versions to live TUI/host processes and prune only unleased stale
+  helper directories; and
+- retain immutable content-addressed Pi bundles because an external Pi process
+  may reload its extension path. Pi pruning waits for provider-process lifetime
+  ownership rather than risking a live session.
 
-CI `binary-smoke` (ubuntu): `--version`, `--help`, `setup check --json`
+CI `binary-smoke` (ubuntu): `--version`, `--help`, popup argv0 routing,
+`setup check --json`
 (asserting the `launchReady`/`workflowReady` split), an **observer round
 trip through the binary** in an isolated state dir, an ingress receipt via
 the `stn-ingress` symlink, the **hostile-directory RCE test** (F1), and the
-**detached self-spawn** check (folds in S5). Note: `observerReap.ts`'s
-ps-matcher must learn the compiled argv shape.
+**detached self-spawn** check (folds in S5). The four-target PTY matrix also
+builds the native binary and proves the unset compiled selector launches a
+payload through the extracted helper. `observerReap.ts` and the same-TTY UI
+reaper recognize the exact compiled process shapes.
 
 ### A5 — release pipeline (private, deterministic, verifiable)
 
@@ -433,7 +448,7 @@ driving **live PTYs**. Define:
 One graph replaces v1's two prose landing-orders.
 
 ```
-A1 ─────────────┬─► A2a ─► A3 ─► A4 ─► A2b ─► A5 ─► A6
+A1 ─────────────┬─► A2a ─► A3 ─► A4 + compiled A2b ─► A5 ─► A6
  (buildInfo,     │
   sqlite,        │
   real version)  │
@@ -443,14 +458,14 @@ B1 ─► B2 ─► B-config ─► B3
 B-host  (independent; needed before upgrade is advertised safe)
 
 A2a: opt-in PTY + native helper gate    A3: raw dispatch
-A4: packaged asset lifecycle            A2b: default flip
+A4: packaged assets + compiled default   A2b: folded into A4
 A5: release                              A6: cleanup
 
 External dependency: observer-singleton 3c/3d/3e + version order
   → required before any older-version observer handoff is claimed safe.
 ```
 
-Suggested merge order: A1 → B1 → B2 → B-config → A2a → A3 → A4 → A2b →
+Suggested merge order: A1 → B1 → B2 → B-config → A2a → A3 → A4/A2b →
 B-host → A5 → A6, with B3's version half gated on the singleton roadmap.
 
 ## Verification (F11 — prove the headline UX, not a proxy)
@@ -460,7 +475,7 @@ tests; the cross-runtime SQLite test (A1).
 
 A2a PTY CI (every PR): Bun 1.3.14 plus a native helper build and focused
 real-PTY tests on `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15-intel`, and
-`macos-15`.
+`macos-15`. A4 extends those jobs with a native compiled-default/helper smoke.
 
 CI smoke (A4): the binary end-to-end minus TTY, **including** the
 hostile-directory RCE gate and detached self-spawn.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "turbo run build",
+    "build:binary": "bun scripts/build-binary.mjs",
     "setup:system": "scripts/setup/setup-system-dependencies.sh",
     "setup:system:check": "scripts/setup/setup-system-dependencies.sh --check",
     "agent:cleanup": "node scripts/maintenance/agent-cleanup.mjs",
@@ -32,6 +33,7 @@
     "dev": "node scripts/tui-dev.mjs",
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
+    "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
     "typecheck": "turbo run typecheck",
     "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs",
     "format": "biome format --write .",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env bun
+import { cp, mkdir, rm, symlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REQUIRED_BUN_VERSION = "1.3.14";
+const SEMVER =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const stationRoot = join(repoRoot, "station");
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  let version;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--version") {
+      version = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    fail(`Unsupported build:binary argument: ${arg}`);
+  }
+  if (version === undefined || !SEMVER.test(version)) {
+    fail("build:binary requires --version <semver>.");
+  }
+  return { version };
+}
+
+function nativeTarget() {
+  // OpenTUI and the controlling-terminal helper make every artifact native-only.
+  const target = {
+    "darwin:arm64": "bun-darwin-arm64",
+    "darwin:x64": "bun-darwin-x64-baseline",
+    "linux:arm64": "bun-linux-arm64",
+    "linux:x64": "bun-linux-x64-baseline",
+  }[`${process.platform}:${process.arch}`];
+  if (target === undefined) {
+    fail(`Unsupported binary build host: ${process.platform}/${process.arch}`);
+  }
+  return target;
+}
+
+async function run(command, args, cwd) {
+  const child = Bun.spawn([command, ...args], {
+    cwd,
+    env: process.env,
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) {
+    fail(`${command} ${args.join(" ")} exited with code ${exitCode}.`);
+  }
+}
+
+async function checkedBuild(options, label) {
+  const result = await Bun.build(options);
+  if (result.success) return;
+  for (const log of result.logs) {
+    process.stderr.write(`${log}\n`);
+  }
+  fail(`${label} failed.`);
+}
+
+async function replaceSymlink(path, target) {
+  await rm(path, { force: true });
+  await symlink(target, path);
+}
+
+async function main() {
+  if (Bun.version !== REQUIRED_BUN_VERSION) {
+    fail(`build:binary requires Bun ${REQUIRED_BUN_VERSION}; found ${Bun.version}.`);
+  }
+  const { version } = parseArgs(process.argv.slice(2));
+  const outputDir = join(stationRoot, "dist", "bin");
+  const outputPath = join(outputDir, "stn");
+  const piBundlePath = join(stationRoot, "dist", "piExtension.mjs");
+
+  await run("pnpm", ["build"], repoRoot);
+  await run("bun", ["run", "link:station"], stationRoot);
+  await run("bun", ["run", "build:ctty-helper"], stationRoot);
+
+  await mkdir(dirname(piBundlePath), { recursive: true });
+  await checkedBuild(
+    {
+      entrypoints: [join(repoRoot, "integrations", "harness", "pi", "src", "piExtension.ts")],
+      outdir: dirname(piBundlePath),
+      naming: "piExtension.mjs",
+      target: "node",
+      format: "esm",
+      sourcemap: "none",
+    },
+    "Pi extension bundle",
+  );
+
+  await mkdir(outputDir, { recursive: true });
+  await rm(outputPath, { force: true });
+  await checkedBuild(
+    {
+      entrypoints: [join(stationRoot, "src", "bin", "stnMain.ts")],
+      compile: {
+        target: nativeTarget(),
+        outfile: outputPath,
+        // A compiled artifact must not execute ambient project startup configuration.
+        autoloadDotenv: false,
+        autoloadBunfig: false,
+      },
+      define: {
+        STATION_BUILD_VERSION: JSON.stringify(version),
+        STATION_BUILD_COMPILED: "true",
+      },
+    },
+    "Station binary compile",
+  );
+
+  await replaceSymlink(join(outputDir, "stn-ingress"), "stn");
+  await replaceSymlink(join(outputDir, "stn-tmux-popup"), "stn");
+  await cp(join(repoRoot, "LICENSE"), join(outputDir, "LICENSE"));
+  process.stdout.write(`Built ${outputPath} (${nativeTarget()}, ${version}).\n`);
+}
+
+await main();

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1,0 +1,424 @@
+import { spawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createObserverClient } from "../../packages/protocol/dist/index.js";
+import { createStationHostClient } from "../../packages/station-host/dist/index.js";
+
+const binaryPath = resolve(process.env.STATION_BINARY_PATH ?? "station/dist/bin/stn");
+const expectedVersion = parseExpectedVersion(process.argv.slice(2));
+const ptyOnly = process.env.STATION_BINARY_SMOKE_PTY_ONLY === "1";
+const root = await mkdtemp(join(tmpdir(), "station-binary-smoke-"));
+const homeDir = join(root, "home");
+const stateDir = join(root, "state");
+const runtimeDir = join(root, "runtime");
+const hostileDir = join(root, "hostile");
+const socketPath = join(runtimeDir, "observer.sock");
+const configPath = join(root, "config.toml");
+const markerPath = join(root, "ambient-config-pwned");
+const childEnv = isolatedBinaryEnv({ homeDir, runtimeDir });
+
+let observerClient;
+let observerPid;
+let hostClient;
+let hostProcess;
+
+try {
+  await access(binaryPath, constants.X_OK);
+  await Promise.all([
+    mkdir(homeDir, { recursive: true, mode: 0o700 }),
+    mkdir(stateDir, { recursive: true, mode: 0o700 }),
+    mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
+    mkdir(hostileDir, { recursive: true, mode: 0o700 }),
+  ]);
+  await writeSmokeConfig(configPath, stateDir, socketPath);
+  await writeHostileConfig(hostileDir, markerPath);
+
+  if (!ptyOnly) {
+    const version = await run(binaryPath, ["--version"], { env: childEnv });
+    assertEqual(version.stdout.trim(), expectedVersion, "compiled --version");
+
+    const help = await run(binaryPath, ["--help"], { env: childEnv });
+    assertIncludes(help.stdout, "Usage:", "compiled --help");
+
+    const popupHelp = await run(join(dirname(binaryPath), "stn-tmux-popup"), ["--help"], {
+      env: childEnv,
+    });
+    assertIncludes(popupHelp.stdout, "stn popup", "popup symlink dispatch");
+
+    const setup = await run(
+      binaryPath,
+      ["--config", configPath, "setup", "check", "--json", "--no-brew"],
+      { cwd: root, env: childEnv, allowedExitCodes: [1] },
+    );
+    const setupPlan = JSON.parse(setup.stdout);
+    assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
+    assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
+    assertEqual(setupPlan.summary.requiredOk, false, "compiled setup requiredOk alias");
+
+    await run(binaryPath, ["--config", configPath, "observer", "start", "--timeout-ms", "30000"], {
+      env: childEnv,
+    });
+    observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
+    const health = await observerClient.health();
+    observerPid = health.pid;
+    assertEqual(health.status, "healthy", "compiled observer health");
+    const snapshot = await observerClient.getSnapshot();
+    assertEqual(snapshot.observer.healthy, true, "compiled observer snapshot");
+
+    const ingress = await run(
+      join(dirname(binaryPath), "stn-ingress"),
+      ["--socket", socketPath, "--state-dir", stateDir, "worktrunk", "post-create"],
+      {
+        env: childEnv,
+        input: JSON.stringify({ branch: "station/binary-smoke" }),
+      },
+    );
+    assertEqual(ingress.code, 0, "ingress symlink receipt");
+    assertEqual(
+      await directoryFileCount(join(stateDir, "spool", "hooks")),
+      0,
+      "online ingress must not spool",
+    );
+    assertEqual((await observerClient.health()).status, "healthy", "observer after ingress");
+
+    const bootLog = await readFile(join(stateDir, "logs", "observer-boot.log"), "utf8");
+    const bootHeader = JSON.parse(bootLog.split(/\r?\n/, 1)[0] ?? "{}");
+    assertEqual(bootHeader.command?.[0], binaryPath, "detached observer executable");
+    assertEqual(bootHeader.command?.[1], "__observer", "detached observer internal route");
+
+    const piExtensionPath = await findFile(join(stateDir, "run", "assets", "pi"), (name) =>
+      name.endsWith(".mjs"),
+    );
+    await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
+
+    await observerClient.stop();
+    observerClient = undefined;
+    await waitForMissing(socketPath);
+  }
+
+  const hostSocketPath = join(runtimeDir, "station-host.sock");
+  hostProcess = spawn(
+    binaryPath,
+    ["__station-host", "--socket", hostSocketPath, "--state-dir", stateDir],
+    {
+      cwd: hostileDir,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const hostDiagnostics = collectOutput(hostProcess);
+  hostClient = createStationHostClient({ socketPath: hostSocketPath, timeoutMs: 1000 });
+  await waitForHost(hostClient, hostDiagnostics);
+  await access(markerPath).then(
+    () => fail("hostile .env or bunfig preload created its marker"),
+    () => undefined,
+  );
+
+  const spawned = await hostClient.spawn({
+    terminalTargetId: "native:binary-smoke",
+    worktreeId: "binary-smoke",
+    projectId: "binary-smoke",
+    sessionId: "ses_binary_smoke",
+    worktreePath: root,
+    harnessProvider: "scripted",
+    command: "/bin/sh",
+    args: ["-c", "printf STATION_BINARY_PTY_OK; sleep 1; exit 7"],
+    cwd: root,
+    cols: 80,
+    rows: 24,
+  });
+  const attachment = await hostClient.attach(spawned.ptyId);
+  const terminalResult = await collectTerminalResult(attachment, 10_000);
+  assertIncludes(terminalResult.output, "STATION_BINARY_PTY_OK", "compiled host PTY output");
+  assertEqual(terminalResult.exitCode, 7, "compiled host PTY exit code");
+
+  const hostLog = await readFile(join(stateDir, "logs", "station-host.jsonl"), "utf8");
+  assertIncludes(hostLog, '"ptyImplementation":"bun"', "compiled host PTY implementation");
+  await findFile(join(stateDir, "run", "assets", "ctty"), (name) => name === "station-ctty-helper");
+
+  process.stdout.write("binary smoke passed\n");
+} finally {
+  if (observerClient !== undefined) {
+    await observerClient.stop().catch(() => undefined);
+    await waitForMissing(socketPath).catch(() => undefined);
+  }
+  if (observerPid !== undefined) {
+    await terminateProcess(observerPid);
+  }
+  hostClient?.dispose();
+  if (hostProcess !== undefined && hostProcess.exitCode === null) {
+    hostProcess.kill("SIGTERM");
+    try {
+      await waitForExit(hostProcess, 3000);
+    } catch {
+      hostProcess.kill("SIGKILL");
+      await waitForExit(hostProcess, 3000).catch(() => undefined);
+    }
+  }
+  await rm(root, { recursive: true, force: true });
+}
+
+function parseExpectedVersion(args) {
+  const normalized = args[0] === "--" ? args.slice(1) : args;
+  if (normalized.length === 0) {
+    return "0.1.0-dev";
+  }
+  if (
+    normalized.length === 2 &&
+    normalized[0] === "--expected-version" &&
+    normalized[1]?.length > 0
+  ) {
+    return normalized[1];
+  }
+  throw new Error("Usage: run-binary-smoke.mjs --expected-version <version>");
+}
+
+function isolatedBinaryEnv({ homeDir: home, runtimeDir: runtime }) {
+  return {
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    XDG_STATE_HOME: join(home, ".local", "state"),
+    XDG_RUNTIME_DIR: runtime,
+    PATH: "/usr/bin:/bin",
+    SHELL: "/bin/sh",
+    LANG: "C",
+    TERM: "xterm-256color",
+    TMPDIR: join(home, "tmp"),
+  };
+}
+
+async function writeSmokeConfig(path, state, socket) {
+  await writeFile(
+    path,
+    [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[observer]",
+      `state_dir = ${JSON.stringify(state)}`,
+      `socket_path = ${JSON.stringify(socket)}`,
+      "",
+      "[defaults]",
+      'worktree_provider = "noop-worktree"',
+      'terminal = "noop-terminal"',
+      'harness = "noop-harness"',
+      'layout = "agent-shell"',
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+}
+
+async function writeHostileConfig(directory, marker) {
+  await writeFile(
+    join(directory, ".env"),
+    [
+      "STATION_PTY_IMPL=ambient-config-must-not-load",
+      `STATION_DASHBOARD_COMMAND=touch ${marker}`,
+    ].join("\n"),
+  );
+  await writeFile(join(directory, "bunfig.toml"), '[run]\npreload = ["./preload.mjs"]\n');
+  await writeFile(
+    join(directory, "preload.mjs"),
+    `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "pwned");\n`,
+  );
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`${command} ${args.join(" ")} timed out\n${stderr}`));
+    }, options.timeoutMs ?? 30_000);
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      const allowed = options.allowedExitCodes ?? [0];
+      if (code === null || !allowed.includes(code)) {
+        reject(
+          new Error(
+            `${command} ${args.join(" ")} exited ${code ?? signal ?? "unknown"}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolveRun({ code, stdout, stderr });
+    });
+    child.stdin.end(options.input);
+  });
+}
+
+function collectOutput(child) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => (stdout += chunk));
+  child.stderr?.on("data", (chunk) => (stderr += chunk));
+  return () => ({ stdout, stderr });
+}
+
+async function waitForHost(client, diagnostics) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await client.health();
+      return;
+    } catch {
+      await delay(50);
+    }
+  }
+  const output = diagnostics();
+  fail(`compiled station-host did not become healthy\n${output.stdout}\n${output.stderr}`);
+}
+
+async function collectTerminalResult(attachment, timeoutMs) {
+  let output = attachment.ack.scrollback.join("");
+  if (attachment.ack.exited) {
+    fail("compiled PTY exited before its exit frame could be observed");
+  }
+  const iterator = attachment.frames[Symbol.asyncIterator]();
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (Date.now() < deadline) {
+      const remaining = Math.max(1, deadline - Date.now());
+      const next = await Promise.race([
+        iterator.next(),
+        delay(remaining).then(() => ({ timeout: true })),
+      ]);
+      if (next.timeout === true) break;
+      if (next.done) break;
+      if (next.value.type === "data") output += next.value.data;
+      if (next.value.type === "exit") {
+        return { output, exitCode: next.value.exitCode };
+      }
+    }
+  } finally {
+    await iterator.return?.();
+  }
+  fail(`timed out waiting for compiled PTY exit; output=${JSON.stringify(output)}`);
+}
+
+async function findFile(directory, matches) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      try {
+        return await findFile(path, matches);
+      } catch (error) {
+        if (!(error instanceof Error) || !error.message.startsWith("No matching file")) throw error;
+      }
+    } else if (entry.isFile() && matches(entry.name)) {
+      return path;
+    }
+  }
+  throw new Error(`No matching file under ${directory}`);
+}
+
+async function directoryFileCount(directory) {
+  try {
+    return (await readdir(directory, { withFileTypes: true })).filter((entry) => entry.isFile())
+      .length;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return 0;
+    throw error;
+  }
+}
+
+async function waitForMissing(path) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await access(path);
+      await delay(25);
+    } catch {
+      return;
+    }
+  }
+  fail(`path remained present: ${path}`);
+}
+
+function waitForExit(child, timeoutMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolveWait, reject) => {
+    const timeout = setTimeout(() => reject(new Error("process did not exit")), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolveWait();
+    });
+  });
+}
+
+async function terminateProcess(pid) {
+  if (await waitForProcessExit(pid, 3000)) return;
+  if (!signalProcess(pid, "SIGTERM")) return;
+  if (await waitForProcessExit(pid, 3000)) return;
+  if (!signalProcess(pid, "SIGKILL")) return;
+  if (!(await waitForProcessExit(pid, 3000))) {
+    throw new Error(`observer process ${pid} survived SIGKILL`);
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processIsAlive(pid)) return true;
+    await delay(25);
+  }
+  return !processIsAlive(pid);
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function signalProcess(pid, signal) {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    fail(`${label}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertIncludes(value, expected, label) {
+  if (!value.includes(expected)) {
+    fail(`${label}: expected ${JSON.stringify(value)} to include ${JSON.stringify(expected)}`);
+  }
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}

--- a/station/scripts/link-station-packages.sh
+++ b/station/scripts/link-station-packages.sh
@@ -10,6 +10,7 @@ repo_root="$(cd "${station_root}/.." && pwd)"
 target_dir="${station_root}/node_modules/@station"
 
 linked_packages=(client config contracts dashboard-core runtime protocol observability station-host)
+linked_apps=(cli observer)
 
 for package in "${linked_packages[@]}"; do
   dist_entry="${repo_root}/packages/${package}/dist/index.js"
@@ -28,12 +29,32 @@ EOF
   fi
 done
 
+for app in "${linked_apps[@]}"; do
+  dist_entry="${repo_root}/apps/${app}/dist/index.js"
+  if [[ ! -f "${dist_entry}" ]]; then
+    cat >&2 <<EOF
+${dist_entry} is missing.
+
+Station consumes the built @station/${app} application package. Build the
+workspace at the repo root first:
+
+  cd ${repo_root}
+  pnpm install
+  pnpm build
+EOF
+    exit 1
+  fi
+done
+
 mkdir -p "${target_dir}"
 for package in "${linked_packages[@]}"; do
   # station-host publishes as @station/host (the redundant qualifier is dropped),
   # so the symlink name strips the leading station- while the source dir keeps it.
   link_name="${package#station-}"
   ln -sfn "../../../packages/${package}" "${target_dir}/${link_name}"
+done
+for app in "${linked_apps[@]}"; do
+  ln -sfn "../../../apps/${app}" "${target_dir}/${app}"
 done
 
 # Echo each linked dist's mtime so a stale build is visible at link time —
@@ -44,8 +65,13 @@ for package in "${linked_packages[@]}"; do
   mtime="$(date -r "${dist_entry}" "+%Y-%m-%d %H:%M" 2>/dev/null || stat -c "%y" "${dist_entry}" 2>/dev/null | cut -c1-16)"
   freshness="${freshness}${package}@${mtime}  "
 done
+for app in "${linked_apps[@]}"; do
+  dist_entry="${repo_root}/apps/${app}/dist/index.js"
+  mtime="$(date -r "${dist_entry}" "+%Y-%m-%d %H:%M" 2>/dev/null || stat -c "%y" "${dist_entry}" 2>/dev/null | cut -c1-16)"
+  freshness="${freshness}${app}@${mtime}  "
+done
 
 if [[ "${STATION_QUIET_PRELAUNCH:-}" != "1" ]]; then
-  echo "Linked @station packages (${linked_packages[*]}) into node_modules."
+  echo "Linked @station packages (${linked_packages[*]} ${linked_apps[*]}) into node_modules."
   echo "dist builds: ${freshness}"
 fi

--- a/station/src/bin/embeddedAssets.d.ts
+++ b/station/src/bin/embeddedAssets.d.ts
@@ -1,0 +1,9 @@
+declare module "*ctty-helper" {
+  const embeddedPath: string;
+  export default embeddedPath;
+}
+
+declare module "*piExtension.mjs" {
+  const embeddedPath: string;
+  export default embeddedPath;
+}

--- a/station/src/bin/packagedAssets.test.ts
+++ b/station/src/bin/packagedAssets.test.ts
@@ -1,0 +1,320 @@
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  preparePackagedPiExtension,
+  preparePackagedPtyRuntime,
+  type PackagedAssetDeps,
+  type PreparedPtyRuntime,
+} from "./packagedAssets.js";
+
+const tempDirs: string[] = [];
+const runtimes: PreparedPtyRuntime[] = [];
+
+afterEach(async () => {
+  for (const runtime of runtimes.splice(0)) {
+    runtime.dispose();
+  }
+  for (const dir of tempDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  delete process.env.STATION_PTY_IMPL;
+});
+
+async function stateDir(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "station-packaged-assets-"));
+  tempDirs.push(path);
+  return path;
+}
+
+async function assetPaths(state: string): Promise<{ helper: string; pi: string }> {
+  const sourceDir = join(state, "embedded-source");
+  const helper = join(sourceDir, "ctty-helper");
+  const pi = join(sourceDir, "piExtension.mjs");
+  await mkdir(sourceDir, { recursive: true });
+  await Promise.all([
+    writeFixture(helper, "test ctty helper bytes"),
+    writeFixture(pi, "export const stationPiTest = true;\n"),
+  ]);
+  return { helper, pi };
+}
+
+async function writeFixture(path: string, contents: string): Promise<void> {
+  try {
+    await writeFile(path, contents, { flag: "wx" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
+}
+
+async function preparePty(
+  state: string,
+  deps: PackagedAssetDeps = {},
+): Promise<PreparedPtyRuntime> {
+  const { helper } = await assetPaths(state);
+  return preparePackagedPtyRuntime(state, helper, {
+    helperExitCode: async () => 64,
+    ...deps,
+  });
+}
+
+async function preparePi(state: string, deps: PackagedAssetDeps = {}): Promise<string> {
+  const { pi } = await assetPaths(state);
+  return preparePackagedPiExtension(state, pi, deps);
+}
+
+describe("preparePackagedPtyRuntime", () => {
+  it("uses Bun by default and extracts an executable content-addressed helper", async () => {
+    const state = await stateDir();
+    const runtime = await preparePty(state);
+    runtimes.push(runtime);
+
+    expect(runtime.implementation).toBe("bun");
+    const helper = await onlyHelper(state);
+    expect((await lstat(helper)).mode & 0o777).toBe(0o700);
+    expect((await lstat(dirname(helper))).mode & 0o777).toBe(0o700);
+    expect(helper).toMatch(/\/ctty\/[^/]+-[a-f0-9]{64}\/station-ctty-helper$/);
+  });
+
+  it("repairs a corrupt regular helper without changing its identity", async () => {
+    const state = await stateDir();
+    const first = await preparePty(state);
+    runtimes.push(first);
+    const helper = await onlyHelper(state);
+    const expected = await readFile(helper);
+
+    first.dispose();
+    await writeFile(helper, "corrupt");
+    await chmod(helper, 0o600);
+    const second = await preparePty(state);
+    runtimes.push(second);
+
+    expect(await onlyHelper(state)).toBe(helper);
+    expect(await readFile(helper)).toEqual(expected);
+    expect((await lstat(helper)).mode & 0o777).toBe(0o700);
+  });
+
+  it("rejects a symlink at the immutable helper target", async () => {
+    const state = await stateDir();
+    const runtime = await preparePty(state);
+    runtimes.push(runtime);
+    const helper = await onlyHelper(state);
+    runtime.dispose();
+    await rm(helper);
+    await symlink("/bin/true", helper);
+
+    expect(await rejectionMessage(preparePty(state))).toContain(
+      "Refusing non-regular packaged asset path",
+    );
+  });
+
+  it("keeps bun-nocctty explicit and never extracts a helper", async () => {
+    process.env.STATION_PTY_IMPL = "bun-nocctty";
+    const state = await stateDir();
+    const runtime = await preparePty(state);
+    runtimes.push(runtime);
+
+    expect(runtime.implementation).toBe("bun-nocctty");
+    expect(await pathExists(join(state, "run", "assets"))).toBe(false);
+  });
+
+  it("rejects the source-only bridge instead of silently degrading", async () => {
+    process.env.STATION_PTY_IMPL = "bridge";
+    expect(await rejectionMessage(preparePty(await stateDir()))).toContain(
+      "bridge is unavailable in the compiled Station binary",
+    );
+  });
+
+  it("retains helper versions leased by live processes and prunes dead leases", async () => {
+    const state = await stateDir();
+    const ctty = join(state, "run", "assets", "ctty");
+    const live = join(ctty, "old-live");
+    const dead = join(ctty, "old-dead");
+    await mkdir(join(live, ".leases"), { recursive: true });
+    await mkdir(join(dead, ".leases"), { recursive: true });
+    await writeFile(join(live, ".leases", `${process.pid}-live`), "");
+    await writeFile(join(dead, ".leases", "2147483647-dead"), "");
+
+    const runtime = await preparePty(state);
+    runtimes.push(runtime);
+
+    expect(await pathExists(live)).toBe(true);
+    expect(await pathExists(dead)).toBe(false);
+  });
+
+  it("reclaims an extraction lock owned by a dead process", async () => {
+    const state = await stateDir();
+    const first = await preparePty(state);
+    runtimes.push(first);
+    const assetDir = dirname(await onlyHelper(state));
+    first.dispose();
+    await rm(assetDir, { recursive: true });
+    await mkdir(`${assetDir}.lock`, { recursive: true });
+    await writeFile(join(`${assetDir}.lock`, "owner-2147483647"), "");
+
+    const second = await preparePty(state);
+    runtimes.push(second);
+    expect(await pathExists(join(assetDir, "station-ctty-helper"))).toBe(true);
+    expect(await pathExists(`${assetDir}.lock`)).toBe(false);
+  });
+
+  it("times out on a live extraction owner without stealing its lock", async () => {
+    const state = await stateDir();
+    const first = await preparePty(state);
+    runtimes.push(first);
+    const assetDir = dirname(await onlyHelper(state));
+    first.dispose();
+    await rm(assetDir, { recursive: true });
+    await mkdir(`${assetDir}.lock`, { recursive: true });
+    await writeFile(join(`${assetDir}.lock`, `owner-${process.pid}`), "");
+
+    expect(
+      await rejectionMessage(
+        preparePty(state, {
+          lockTimeoutMs: 0,
+          lockWaitMs: 0,
+        }),
+      ),
+    ).toContain("Timed out waiting for packaged asset lock");
+    expect(await pathExists(`${assetDir}.lock`)).toBe(true);
+  });
+
+  it("converges concurrent extraction on one complete helper", async () => {
+    const state = await stateDir();
+    const prepared = await Promise.all(Array.from({ length: 6 }, () => preparePty(state)));
+    runtimes.push(...prepared);
+
+    const helper = await onlyHelper(state);
+    expect((await readFile(helper)).toString()).toBe("test ctty helper bytes");
+    const siblings = await readdir(dirname(helper));
+    expect(siblings.sort()).toEqual([".leases", "station-ctty-helper"]);
+  });
+
+  it("serializes first leases and pruning across helper identities", async () => {
+    const state = await stateDir();
+    const sourceDir = join(state, "identity-sources");
+    const firstHelper = join(sourceDir, "first-helper");
+    const secondHelper = join(sourceDir, "second-helper");
+    await mkdir(sourceDir, { recursive: true });
+    await Promise.all([
+      writeFile(firstHelper, "first helper bytes"),
+      writeFile(secondHelper, "second helper bytes"),
+    ]);
+
+    let releaseFirst!: () => void;
+    let markFirstProbeStarted!: () => void;
+    const firstProbeStarted = new Promise<void>((resolve) => {
+      markFirstProbeStarted = resolve;
+    });
+    const firstProbeRelease = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = preparePackagedPtyRuntime(state, firstHelper, {
+      helperExitCode: async () => {
+        markFirstProbeStarted();
+        await firstProbeRelease;
+        return 64;
+      },
+    });
+    await firstProbeStarted;
+
+    let secondSettled = false;
+    const second = preparePackagedPtyRuntime(state, secondHelper, {
+      helperExitCode: async () => 64,
+    }).finally(() => {
+      secondSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(secondSettled).toBe(false);
+
+    releaseFirst();
+    const prepared = await Promise.all([first, second]);
+    runtimes.push(...prepared);
+    const identityDirs = (await readdir(join(state, "run", "assets", "ctty"), {
+      withFileTypes: true,
+    })).filter((entry) => entry.isDirectory() && !entry.name.endsWith(".lock"));
+    expect(identityDirs).toHaveLength(2);
+    for (const entry of identityDirs) {
+      expect(
+        (await lstat(join(state, "run", "assets", "ctty", entry.name, "station-ctty-helper"))).isFile(),
+      ).toBe(true);
+    }
+  });
+
+  it("reports a noexec helper cache without falling back to bun-nocctty", async () => {
+    const state = await stateDir();
+    const denied = Object.assign(new Error("execution denied"), { code: "EACCES" });
+    const message = await rejectionMessage(
+      preparePty(state, {
+        helperExitCode: async () => Promise.reject(denied),
+      }),
+    );
+
+    expect(message).toContain("cannot execute");
+    expect(message).toContain("[observer].state_dir");
+    expect(message).not.toContain("bun-nocctty");
+  });
+});
+
+describe("preparePackagedPiExtension", () => {
+  it("extracts privately, repairs corruption, and retains older immutable bundles", async () => {
+    const state = await stateDir();
+    const first = await preparePi(state);
+    const expected = await readFile(first);
+    expect((await lstat(first)).mode & 0o777).toBe(0o600);
+
+    await writeFile(first, "corrupt");
+    const second = await preparePi(state);
+    expect(second).toBe(first);
+    expect(await readFile(second)).toEqual(expected);
+
+    const retained = join(dirname(dirname(first)), "older-build", "station-pi-extension.mjs");
+    await mkdir(dirname(retained), { recursive: true });
+    await writeFile(retained, "old");
+    await preparePi(state);
+    expect(await pathExists(retained)).toBe(true);
+  });
+});
+
+async function onlyHelper(state: string): Promise<string> {
+  const root = join(state, "run", "assets", "ctty");
+  const entries = (await readdir(root, { withFileTypes: true })).filter(
+    (entry) => entry.isDirectory() && !entry.name.endsWith(".lock"),
+  );
+  expect(entries).toHaveLength(1);
+  return join(root, entries[0]?.name ?? "missing", "station-ctty-helper");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("Expected promise to reject.");
+}

--- a/station/src/bin/packagedAssets.ts
+++ b/station/src/bin/packagedAssets.ts
@@ -1,0 +1,424 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { rmSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { stationBuildInfo } from "@station/runtime";
+import type {
+  StationTerminalProcess,
+  StationTerminalSpawnOptions,
+} from "../terminal/types.js";
+import {
+  createLocalPtyTerminal,
+  type PtyImplementation,
+  resolvePtyImplementation,
+} from "../terminal/pty/localPtyTerminal.js";
+
+const DIRECTORY_MODE = 0o700;
+const HELPER_MODE = 0o700;
+const PI_MODE = 0o600;
+const LOCK_WAIT_MS = 25;
+const LOCK_TIMEOUT_MS = 5_000;
+const OWNER_PREFIX = "owner-";
+
+type AssetKind = "ctty" | "pi";
+
+type AssetSpec = {
+  kind: AssetKind;
+  bytes: Uint8Array;
+  fileName: string;
+  mode: number;
+};
+
+/** @internal Deterministic seams for cache contention and execution-boundary tests. */
+export type PackagedAssetDeps = {
+  helperExitCode?: (path: string) => Promise<number>;
+  lockTimeoutMs?: number;
+  lockWaitMs?: number;
+};
+
+export type PreparedPtyRuntime = {
+  implementation: PtyImplementation;
+  createTerminal(options: StationTerminalSpawnOptions): StationTerminalProcess;
+  dispose(): void;
+};
+
+/**
+ * Materializes the compiled PTY helper once, verifies that its filesystem is
+ * executable, and fixes the PTY selector for the lifetime of this process.
+ */
+export async function preparePackagedPtyRuntime(
+  stateDir: string,
+  cttyHelperAssetPath: string,
+  deps: PackagedAssetDeps = {},
+): Promise<PreparedPtyRuntime> {
+  const implementation = resolvePtyImplementation(process.env.STATION_PTY_IMPL, "bun");
+  if (implementation === "bridge") {
+    throw new Error(
+      "STATION_PTY_IMPL=bridge is unavailable in the compiled Station binary because the Node/node-pty bridge is source-only. Unset STATION_PTY_IMPL or set it to bun.",
+    );
+  }
+
+  if (implementation === "bun-nocctty") {
+    return {
+      implementation,
+      createTerminal: (options) => createLocalPtyTerminal(options, { implementation }),
+      dispose: () => undefined,
+    };
+  }
+
+  const bytes = await readEmbeddedAsset(cttyHelperAssetPath);
+  const cttyDir = join(stateDir, "run", "assets", "ctty");
+  await ensureAssetDirectories(stateDir, cttyDir);
+  return withAssetLock(join(cttyDir, ".lifecycle.lock"), deps, async () => {
+    // One lifecycle lock spans identities so pruning cannot race a new helper's first lease.
+    const helperPath = await materializeAsset(
+      stateDir,
+      {
+        kind: "ctty",
+        bytes,
+        fileName: "station-ctty-helper",
+        mode: HELPER_MODE,
+      },
+      deps,
+    );
+    await probeCttyHelper(helperPath, deps.helperExitCode ?? spawnExitCode);
+    const lease = await createHelperLease(helperPath);
+    await pruneStaleHelpers(cttyDir, dirname(helperPath));
+
+    return {
+      implementation,
+      createTerminal: (options) =>
+        createLocalPtyTerminal(options, {
+          implementation,
+          cttyHelperPath: helperPath,
+        }),
+      dispose: lease.dispose,
+    };
+  });
+}
+
+/**
+ * Extracts the bundled Pi extension to an immutable content-addressed path.
+ * Pi may reload this path after launch, so A4 deliberately never prunes it.
+ */
+export async function preparePackagedPiExtension(
+  stateDir: string,
+  piExtensionAssetPath: string,
+  deps: PackagedAssetDeps = {},
+): Promise<string> {
+  return materializeAsset(
+    stateDir,
+    {
+      kind: "pi",
+      bytes: await readEmbeddedAsset(piExtensionAssetPath),
+      fileName: "station-pi-extension.mjs",
+      mode: PI_MODE,
+    },
+    deps,
+  );
+}
+
+async function readEmbeddedAsset(assetPath: string): Promise<Uint8Array> {
+  return readFile(assetPath);
+}
+
+/** Atomic extraction keeps concurrent compiled processes from observing partial assets. */
+async function materializeAsset(
+  stateDir: string,
+  spec: AssetSpec,
+  deps: PackagedAssetDeps,
+): Promise<string> {
+  const hash = sha256(spec.bytes);
+  const version = safePathComponent(stationBuildInfo().version);
+  const identity =
+    spec.kind === "ctty"
+      ? `${version}-${process.platform}-${process.arch}-${hash}`
+      : `${version}-${hash}`;
+  const kindDir = join(stateDir, "run", "assets", spec.kind);
+  const assetDir = join(kindDir, identity);
+  const targetPath = join(assetDir, spec.fileName);
+  const lockDir = `${assetDir}.lock`;
+
+  await ensureAssetDirectories(stateDir, kindDir);
+  await validateDirectoryIfPresent(assetDir);
+  if (await isValidAsset(targetPath, spec)) {
+    return targetPath;
+  }
+
+  await withAssetLock(lockDir, deps, async () => {
+    await ensurePrivateDirectory(assetDir);
+    if (await isValidAsset(targetPath, spec)) {
+      return;
+    }
+    await rejectNonRegularTarget(targetPath);
+    await writeAssetAtomically(targetPath, spec);
+    if (!(await isValidAsset(targetPath, spec))) {
+      throw new Error(`Packaged ${spec.kind} asset failed integrity verification at ${targetPath}.`);
+    }
+  });
+  return targetPath;
+}
+
+async function ensureAssetDirectories(stateDir: string, kindDir: string): Promise<void> {
+  await ensurePrivateDirectory(join(stateDir, "run"));
+  await ensurePrivateDirectory(join(stateDir, "run", "assets"));
+  await ensurePrivateDirectory(kindDir);
+}
+
+async function validateDirectoryIfPresent(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink() || !stats.isDirectory()) {
+      throw new Error(`Packaged asset directory is not a regular directory: ${path}.`);
+    }
+    await chmod(path, DIRECTORY_MODE);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function ensurePrivateDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: DIRECTORY_MODE });
+  const stats = await lstat(path);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error(`Packaged asset directory is not a regular directory: ${path}.`);
+  }
+  await chmod(path, DIRECTORY_MODE);
+}
+
+async function isValidAsset(path: string, spec: AssetSpec): Promise<boolean> {
+  let stats;
+  try {
+    stats = await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`Refusing non-regular packaged asset path: ${path}.`);
+  }
+  if (stats.size !== spec.bytes.byteLength || (stats.mode & 0o777) !== spec.mode) {
+    return false;
+  }
+  return sha256(await readFile(path)) === sha256(spec.bytes);
+}
+
+async function rejectNonRegularTarget(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSymbolicLink() || !stats.isFile()) {
+      throw new Error(`Refusing non-regular packaged asset path: ${path}.`);
+    }
+    await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function writeAssetAtomically(targetPath: string, spec: AssetSpec): Promise<void> {
+  const temporaryPath = join(
+    dirname(targetPath),
+    `.${basename(targetPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  let handle;
+  try {
+    handle = await open(temporaryPath, "wx", spec.mode);
+    await handle.writeFile(spec.bytes);
+    await handle.sync();
+    await handle.chmod(spec.mode);
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryPath, targetPath);
+  } finally {
+    await handle?.close().catch(() => undefined);
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function withAssetLock<T>(
+  lockDir: string,
+  deps: PackagedAssetDeps,
+  action: () => Promise<T>,
+): Promise<T> {
+  const lockTimeoutMs = deps.lockTimeoutMs ?? LOCK_TIMEOUT_MS;
+  const lockWaitMs = deps.lockWaitMs ?? LOCK_WAIT_MS;
+  const deadline = Date.now() + lockTimeoutMs;
+  while (true) {
+    try {
+      await mkdir(lockDir, { mode: DIRECTORY_MODE });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+      await validateDirectoryIfPresent(lockDir);
+      if (!(await lockHasLiveOwner(lockDir))) {
+        await rm(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for packaged asset lock ${lockDir}.`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, lockWaitMs));
+      continue;
+    }
+
+    await writeFile(join(lockDir, `${OWNER_PREFIX}${process.pid}`), "", {
+      flag: "wx",
+      mode: 0o600,
+    });
+    try {
+      return await action();
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  }
+}
+
+async function lockHasLiveOwner(lockDir: string): Promise<boolean> {
+  let names: string[];
+  try {
+    names = await readdir(lockDir);
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+  const owner = names.find((name) => name.startsWith(OWNER_PREFIX));
+  if (owner === undefined) {
+    // The lock owner writes its marker immediately after mkdir; let that short
+    // creation window settle, but reclaim a process that died between the two.
+    const stats = await lstat(lockDir).catch(() => undefined);
+    return stats !== undefined && Date.now() - stats.mtimeMs < LOCK_TIMEOUT_MS;
+  }
+  const pid = Number(owner.slice(OWNER_PREFIX.length));
+  return Number.isSafeInteger(pid) && pid > 0 && processIsAlive(pid);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+async function probeCttyHelper(
+  path: string,
+  helperExitCode: (path: string) => Promise<number>,
+): Promise<void> {
+  let exitCode: number;
+  try {
+    exitCode = await helperExitCode(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
+      throw new Error(
+        `The packaged controlling-terminal helper at ${path} cannot execute. Move [observer].state_dir to a filesystem mounted with execution enabled.`,
+        { cause: error },
+      );
+    }
+    throw new Error(`The packaged controlling-terminal helper at ${path} could not start.`, {
+      cause: error,
+    });
+  }
+  if (exitCode !== 64) {
+    throw new Error(
+      `The packaged controlling-terminal helper at ${path} failed its startup probe (expected exit 64, received ${exitCode}).`,
+    );
+  }
+}
+
+function spawnExitCode(command: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [], { stdio: "ignore" });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      resolve(code ?? (signal === null ? 1 : 128));
+    });
+  });
+}
+
+async function createHelperLease(helperPath: string): Promise<{ dispose(): void }> {
+  const leasesDir = join(dirname(helperPath), ".leases");
+  await ensurePrivateDirectory(leasesDir);
+  const leasePath = join(leasesDir, `${process.pid}-${randomUUID()}`);
+  await writeFile(leasePath, "", { flag: "wx", mode: 0o600 });
+  let disposed = false;
+  return {
+    dispose() {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      try {
+        rmSync(leasePath, { force: true });
+      } catch {
+        // A stale lease is safe: the next owner validates its PID before pruning.
+      }
+    },
+  };
+}
+
+async function pruneStaleHelpers(cttyDir: string, currentDir: string): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(cttyDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name.endsWith(".lock")) {
+      continue;
+    }
+    const assetDir = join(cttyDir, entry.name);
+    if (assetDir === currentDir || (await hasLiveLease(assetDir))) {
+      continue;
+    }
+    await rm(assetDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+async function hasLiveLease(assetDir: string): Promise<boolean> {
+  const leasesDir = join(assetDir, ".leases");
+  let leases: string[];
+  try {
+    leases = await readdir(leasesDir);
+  } catch {
+    return false;
+  }
+  let live = false;
+  for (const lease of leases) {
+    const match = /^(\d+)-/.exec(lease);
+    if (match === null || !processIsAlive(Number(match[1]))) {
+      await rm(join(leasesDir, lease), { force: true }).catch(() => undefined);
+    } else {
+      live = true;
+    }
+  }
+  return live;
+}
+
+function safePathComponent(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._+-]/g, "_");
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/station/src/bin/stnMain.ts
+++ b/station/src/bin/stnMain.ts
@@ -1,0 +1,61 @@
+import { dispatchSelfExec, type SelfExecRunners } from "@station/cli/self-exec";
+import cttyHelperAsset from "../../dist/ctty-helper" with { type: "file" };
+import piExtensionAsset from "../../dist/piExtension.mjs" with { type: "file" };
+import {
+  preparePackagedPiExtension,
+  preparePackagedPtyRuntime,
+} from "./packagedAssets.js";
+
+const prepareCompiledPtyRuntime = (stateDir: string) =>
+  preparePackagedPtyRuntime(stateDir, cttyHelperAsset);
+
+const prepareCompiledPiExtension = (stateDir: string) =>
+  preparePackagedPiExtension(stateDir, piExtensionAsset);
+
+function popupArgv(argv: readonly string[]): readonly string[] {
+  return argv[0] === "popup" ? argv : ["popup", ...argv];
+}
+
+function compiledRunners(): SelfExecRunners {
+  return {
+    cli: async (argv) => (await import("@station/cli/main")).runCliMain(argv),
+    observer: async (argv) => {
+      const { runCliObserverMain } = await import("@station/cli/observer-main");
+      process.exitCode = await runCliObserverMain(argv, {
+        preparePiExtension: prepareCompiledPiExtension,
+      });
+    },
+    ingress: async (argv) => (await import("@station/cli/ingress-main")).runCliIngressMain(argv),
+    tui: async () =>
+      (await import("../main.js")).runStationMain({
+        preparePtyRuntime: prepareCompiledPtyRuntime,
+      }),
+    dashboard: async () => (await import("../dashboardRenderer/main.js")).runDashboardMain(),
+    stationHost: async (argv) =>
+      (await import("../host/hostMain.js")).runStationHostMain(argv, {
+        preparePtyRuntime: prepareCompiledPtyRuntime,
+      }),
+    tmuxPopup: async (argv) =>
+      (await import("@station/cli/main")).runCliMain(popupArgv(argv)),
+  };
+}
+
+/**
+ * COMPOSITION ROOT
+ *
+ * Binds compiled raw arguments to lazy process entries and packaged runtime assets.
+ */
+export async function runStationBinaryMain(): Promise<void> {
+  await dispatchSelfExec(
+    {
+      // Bun preserves the invoked symlink in argv0 while process.argv[0] names the executable.
+      argv0: process.argv0,
+      argv: process.argv.slice(2),
+    },
+    compiledRunners(),
+  );
+}
+
+if (import.meta.main) {
+  await runStationBinaryMain();
+}

--- a/station/src/host/hostMain.ts
+++ b/station/src/host/hostMain.ts
@@ -1,4 +1,10 @@
 import { startStationHost } from "./startHost.js";
+import type { PreparedPtyRuntime } from "../bin/packagedAssets.js";
+
+export type RunStationHostMainOptions = {
+  /** Compiled entrypoint seam: prepare embedded PTY assets for the parsed state dir. */
+  preparePtyRuntime?: (stateDir: string) => Promise<PreparedPtyRuntime>;
+};
 
 function parseArgs(argv: readonly string[]): { socketPath: string; stateDir: string } {
   let socketPath: string | undefined;
@@ -22,14 +28,37 @@ function parseArgs(argv: readonly string[]): { socketPath: string; stateDir: str
 /**
  * Standalone station-station-host daemon entry, spawned detached by the
  * observer-side station provider. Parses raw --socket/--state-dir arguments and
- * shuts down cleanly on signal.
+ * shuts down cleanly on signal. Compiled startup may inject packaged PTY
+ * preparation without changing the source-host default.
  */
-export async function runStationHostMain(argv: readonly string[]): Promise<void> {
+export async function runStationHostMain(
+  argv: readonly string[],
+  options: RunStationHostMainOptions = {},
+): Promise<void> {
   const { socketPath, stateDir } = parseArgs(argv);
-  const host = await startStationHost({ socketPath, stateDir });
+  const ptyRuntime = await options.preparePtyRuntime?.(stateDir);
+  let host;
+  try {
+    host = await startStationHost({
+      socketPath,
+      stateDir,
+      ...(ptyRuntime === undefined
+        ? {}
+        : {
+            ptyImplementation: ptyRuntime.implementation,
+            ptyTableOptions: { createTerminal: ptyRuntime.createTerminal },
+          }),
+    });
+  } catch (error) {
+    ptyRuntime?.dispose();
+    throw error;
+  }
 
   const shutdown = () => {
-    void host.close().finally(() => process.exit(0));
+    void host.close().finally(() => {
+      ptyRuntime?.dispose();
+      process.exit(0);
+    });
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);

--- a/station/src/host/startHost.test.ts
+++ b/station/src/host/startHost.test.ts
@@ -52,32 +52,23 @@ describe("startStationHost", () => {
   });
 
   it("records the selected PTY implementation at startup", async () => {
-    const previous = process.env.STATION_PTY_IMPL;
-    process.env.STATION_PTY_IMPL = "bun-nocctty";
     const records: Array<{ message: string; attributes: Record<string, unknown> }> = [];
     const dir = await mkdtemp(join(tmpdir(), "station-host-log-"));
-    try {
-      host = await startStationHost({
-        socketPath: join(dir, "station-host.sock"),
-        stateDir: dir,
-        logger: {
-          log: async (record: (typeof records)[number]) => {
-            records.push(record);
-          },
-        } as never,
-      });
+    host = await startStationHost({
+      socketPath: join(dir, "station-host.sock"),
+      stateDir: dir,
+      ptyImplementation: "bun-nocctty",
+      logger: {
+        log: async (record: (typeof records)[number]) => {
+          records.push(record);
+        },
+      } as never,
+    });
 
-      expect(records[0]).toMatchObject({
-        message: "host.start",
-        attributes: { ptyImplementation: "bun-nocctty" },
-      });
-    } finally {
-      if (previous === undefined) {
-        delete process.env.STATION_PTY_IMPL;
-      } else {
-        process.env.STATION_PTY_IMPL = previous;
-      }
-    }
+    expect(records[0]).toMatchObject({
+      message: "host.start",
+      attributes: { ptyImplementation: "bun-nocctty" },
+    });
   });
 
   it("handles host.focus (best-effort) over a real unix socket", async () => {

--- a/station/src/host/startHost.ts
+++ b/station/src/host/startHost.ts
@@ -11,12 +11,18 @@ import {
   serveHostConnection,
 } from "@station/host";
 import { createPtyTable, type PtyTable, type PtyTableOptions } from "./ptyTable.js";
+import {
+  type PtyImplementation,
+  resolvePtyImplementation,
+} from "../terminal/pty/localPtyTerminal.js";
 
 export type StartStationHostOptions = {
   socketPath: string;
   stateDir: string;
   logger?: JsonlLogger;
   ptyTableOptions?: PtyTableOptions;
+  /** Prepared compiled runtimes supply the fixed selector reported at startup. */
+  ptyImplementation?: PtyImplementation;
 };
 
 export type StationHostInstance = {
@@ -32,7 +38,8 @@ export type StationHostInstance = {
 export async function startStationHost(
   options: StartStationHostOptions,
 ): Promise<StationHostInstance> {
-  const ptyImplementation = process.env.STATION_PTY_IMPL || "bridge";
+  const ptyImplementation =
+    options.ptyImplementation ?? resolvePtyImplementation(process.env.STATION_PTY_IMPL);
   const logger =
     options.logger ??
     createJsonlLogger({

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -35,6 +35,12 @@ import { resolveOpenUrlCommand } from "./openUrl.js";
 import { listLiveHostPtys } from "./sources/listLiveHostPtys.js";
 import { resolveStationHostSocketPath } from "./sources/stationHostSocketPath.js";
 import { resolveStationLayoutPath } from "./sources/stationLayoutPath.js";
+import type { PreparedPtyRuntime } from "./bin/packagedAssets.js";
+
+export type RunStationMainOptions = {
+  /** Compiled entrypoint seam: prepare embedded PTY assets after state-dir resolution. */
+  preparePtyRuntime?: (stateDir: string) => Promise<PreparedPtyRuntime>;
+};
 
 // A 1/0/true/false flag in the readSourceName style: opt in to auto-closing
 // the STATION overlay when a `[+sh]` shell pane opens. Unset/empty keeps the
@@ -87,8 +93,9 @@ function openExternalUrl(rawUrl: string): void {
 
 /**
  * Callable native OpenTUI process entry; standalone and HMR module startup invoke it once.
+ * Compiled startup may inject packaged PTY preparation without changing source defaults.
  */
-export async function runStationMain(): Promise<void> {
+export async function runStationMain(options: RunStationMainOptions = {}): Promise<void> {
   const env = process.env;
   const stationClient = createStationClient(env, {
     onAttentionNeeded: () => {
@@ -172,6 +179,7 @@ export async function runStationMain(): Promise<void> {
   if (tuiConfig.warning !== undefined) {
     console.error(`[station] ${tuiConfig.warning}`);
   }
+  const ptyRuntime = await options.preparePtyRuntime?.(stationConfig.stateDir);
 
   // Corruption telemetry sink: detectors count regardless; with this wired they
   // also log to logs/tui.jsonl and write pane evidence dumps under
@@ -230,9 +238,11 @@ export async function runStationMain(): Promise<void> {
     shellAutoCloseOverlay: readShellAutoCloseOverlay(env.STATION_SHELL_AUTOCLOSE),
     ...(hostSocketPath === undefined ? {} : { hostSocketPath }),
     ...(layoutPath === undefined ? {} : { layout: { path: layoutPath } }),
+    ...(ptyRuntime === undefined ? {} : { createTerminal: ptyRuntime.createTerminal }),
     shutdown: () => {
       rootForShutdown?.unmount();
       rendererForInput?.destroy();
+      ptyRuntime?.dispose();
       process.exit(0);
     },
   });

--- a/station/src/singleInstance.test.ts
+++ b/station/src/singleInstance.test.ts
@@ -20,10 +20,11 @@ describe("selectRivalStationUiPids", () => {
     }, // launcher: argv mentions the script but it is not the bun process
     { pid: 4242, tty: "ttys002", command: "bun --hot src/main.tsx" }, // a UI on another terminal
     { pid: 9000, tty: "ttys001", command: "bun src/host/hostMain.ts" }, // host daemon, not a UI
+    { pid: 9001, tty: "ttys001", command: "/usr/local/bin/stn __tui" }, // compiled UI
   ];
 
   it("targets only a rival UI on the same tty", () => {
-    expect(selectRivalStationUiPids(ROWS, SELF, "ttys001")).toEqual([5018]);
+    expect(selectRivalStationUiPids(ROWS, SELF, "ttys001")).toEqual([5018, 9001]);
   });
 
   it("never returns self even on a shared tty", () => {
@@ -40,6 +41,17 @@ describe("selectRivalStationUiPids", () => {
 
   it("matches a bun invoked by absolute path", () => {
     const rows = [{ pid: 1, tty: "ttys001", command: "/opt/homebrew/bin/bun --hot src/main.tsx" }];
+    expect(selectRivalStationUiPids(rows, 99, "ttys001")).toEqual([1]);
+  });
+
+  it("matches only the exact compiled stn TUI command shape", () => {
+    const rows = [
+      { pid: 1, tty: "ttys001", command: "/opt/station/stn __tui" },
+      { pid: 2, tty: "ttys001", command: "/opt/station/stn __station-host" },
+      { pid: 3, tty: "ttys001", command: "/opt/station/stn __tui extra" },
+      { pid: 4, tty: "ttys001", command: "/opt/station/stn-copy __tui" },
+      { pid: 5, tty: "ttys001", command: "/bin/sh -c /opt/station/stn __tui" },
+    ];
     expect(selectRivalStationUiPids(rows, 99, "ttys001")).toEqual([1]);
   });
 });

--- a/station/src/singleInstance.ts
+++ b/station/src/singleInstance.ts
@@ -11,6 +11,7 @@
 // terminal.
 
 import { execFileSync } from "node:child_process";
+import { basename } from "node:path";
 
 export type ProcEntry = { pid: number; tty: string; command: string };
 
@@ -19,11 +20,16 @@ function isBunExecutable(command: string): boolean {
   return exe === "bun" || exe.endsWith("/bun");
 }
 
+function isCompiledStationTui(command: string): boolean {
+  const argv = command.trim().split(/\s+/);
+  return argv.length === 2 && basename(argv[0] ?? "") === "stn" && argv[1] === "__tui";
+}
+
 /**
  * Rival Station UIs: another process (never self) on the same controlling tty
- * whose command runs the `bun` executable on `src/main.tsx`. The `bash -c`
- * launcher whose argv merely mentions `src/main.tsx` is excluded by the bun
- * check — and it exits on its own once the bun child it waits on is gone.
+ * whose command is either Bun running `src/main.tsx` or the exact compiled
+ * `stn __tui` shape. Shell launchers that merely mention either shape are
+ * excluded by the executable and argv checks.
  */
 export function selectRivalStationUiPids(
   processes: readonly ProcEntry[],
@@ -35,8 +41,8 @@ export function selectRivalStationUiPids(
       (p) =>
         p.pid !== self &&
         p.tty === myTty &&
-        isBunExecutable(p.command) &&
-        p.command.includes("src/main.tsx"),
+        ((isBunExecutable(p.command) && p.command.includes("src/main.tsx")) ||
+          isCompiledStationTui(p.command)),
     )
     .map((p) => p.pid);
 }

--- a/station/src/terminal/pty/localPtyTerminal.test.ts
+++ b/station/src/terminal/pty/localPtyTerminal.test.ts
@@ -58,6 +58,12 @@ describe("resolvePtyImplementation", () => {
     expect(resolvePtyImplementation("bridge")).toBe("bridge");
   });
 
+  it("allows compiled startup to supply Bun as the default", () => {
+    expect(resolvePtyImplementation(undefined, "bun")).toBe("bun");
+    expect(resolvePtyImplementation("", "bun")).toBe("bun");
+    expect(resolvePtyImplementation("bridge", "bun")).toBe("bridge");
+  });
+
   it("accepts the two explicit Bun modes", () => {
     expect(resolvePtyImplementation("bun")).toBe("bun");
     expect(resolvePtyImplementation("bun-nocctty")).toBe("bun-nocctty");

--- a/station/src/terminal/pty/localPtyTerminal.ts
+++ b/station/src/terminal/pty/localPtyTerminal.ts
@@ -83,6 +83,7 @@ function ensureSpawnHelperExecutable(): void {
 
 export function createLocalPtyTerminal(
   options: StationTerminalSpawnOptions = {},
+  runtime: LocalPtyTerminalRuntime = {},
 ): StationTerminalProcess {
   const size = normalizeSize(options.size);
   const env = createPtyEnv(options.env);
@@ -90,7 +91,8 @@ export function createLocalPtyTerminal(
   const args = options.args === undefined ? defaultShellArgs() : [...options.args];
   let implementation: PtyImplementation;
   try {
-    implementation = resolvePtyImplementation(process.env.STATION_PTY_IMPL);
+    implementation =
+      runtime.implementation ?? resolvePtyImplementation(process.env.STATION_PTY_IMPL);
   } catch (error) {
     const detail =
       error instanceof Error ? error.message : "STATION_PTY_IMPL selects an unsupported value.";
@@ -111,7 +113,7 @@ export function createLocalPtyTerminal(
       size,
     };
     if (implementation === "bun") {
-      bunOptions.cttyHelperPath = CTTY_HELPER_PATH;
+      bunOptions.cttyHelperPath = runtime.cttyHelperPath ?? CTTY_HELPER_PATH;
     }
     return createBunTerminalProcess(bunOptions);
   }
@@ -346,10 +348,20 @@ class LocalPtyTerminalProcess implements StationTerminalProcess {
 
 export type PtyImplementation = "bridge" | "bun" | "bun-nocctty";
 
-export function resolvePtyImplementation(value: string | undefined): PtyImplementation {
+export type LocalPtyTerminalRuntime = {
+  /** A prepared runtime fixes the selector once at process startup. */
+  implementation?: PtyImplementation;
+  cttyHelperPath?: string;
+};
+
+export function resolvePtyImplementation(
+  value: string | undefined,
+  defaultImplementation: PtyImplementation = "bridge",
+): PtyImplementation {
   switch (value) {
     case undefined:
     case "":
+      return defaultImplementation;
     case "bridge":
       return "bridge";
     case "bun":


### PR DESCRIPTION
## Summary

- compile the CLI, Observer, ingress, popup, TUI, and station-host into one native Bun executable
- embed and safely materialize the controlling-terminal helper and Pi extension under the configured state directory
- default compiled PTYs to `Bun.Terminal` while preserving the node-pty bridge for source development
- split setup launch readiness from full workflow readiness and verify compiled state directories can execute packaged assets
- add native four-target PTY/binary CI plus an isolated end-to-end binary smoke

## Why

Source installs currently depend on Node, node-pty native assets, and separate application entrypoints. This adds the packaged runtime and lifecycle needed for a standalone Station binary without changing source-development defaults.

## User impact

The compiled `stn` runs without Node or Bun on `PATH`, routes `stn-ingress` and `stn-tmux-popup` through symlink identity, uses the packaged controlling-terminal helper for shell job control, and reports `launchReady=false` when the configured state filesystem is writable but mounted `noexec`.

## Validation

- `pnpm test:all`
- Station Bun suite: 974 passed
- focused real PTY suite: 26 passed
- packaged-asset tests, including cross-version extraction concurrency
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:binary -- --version 0.1.0-dev`
- `pnpm smoke:binary -- --expected-version 0.1.0-dev`
