### PR TITLE
ci(release): publish and safely install Station binaries

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,8 +1,12 @@
 name: Bump Homebrew formula
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published Station source tag to package
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,7 +20,7 @@ jobs:
           formula-name: station
           homebrew-tap: jeremy0dell/homebrew-station
           push-to: jeremy0dell/homebrew-station
-          tag-name: ${{ github.event.release.tag_name }}
+          tag-name: ${{ inputs.tag }}
           download-url: https://github.com/jeremy0dell/station.git
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,149 @@
+name: promote-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_run_id:
+        description: Successful release workflow run containing the accepted candidate artifact
+        required: true
+        type: string
+      tag:
+        description: Draft release tag to verify and publish
+        required: true
+        type: string
+      manual_acceptance:
+        description: Confirm the documented real-terminal acceptance gate passed
+        required: true
+        type: boolean
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: promote-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: inputs.manual_acceptance
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify accepted candidate and publish its draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          [[ "$RELEASE_RUN_ID" =~ ^[0-9]+$ ]]
+          node -e '
+            const tag = process.argv[1];
+            const semver = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+            if (!semver.test(tag)) throw new Error(`Invalid release tag: ${tag}`);
+          ' "$TAG"
+          version="${TAG#v}"
+
+          run_json="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID")"
+          test "$(jq -r .name <<<"$run_json")" = release
+          test "$(jq -r .event <<<"$run_json")" = push
+          test "$(jq -r .conclusion <<<"$run_json")" = success
+          workflow_id="$(jq -er .workflow_id <<<"$run_json")"
+          [[ "$workflow_id" =~ ^[0-9]+$ ]]
+          test "$(
+            gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$workflow_id" --jq .path
+          )" = .github/workflows/release.yml
+          run_attempt="$(jq -r .run_attempt <<<"$run_json")"
+          [[ "$run_attempt" =~ ^[0-9]+$ ]]
+
+          artifact="accepted-release-candidate-$version-attempt-$run_attempt"
+          mkdir candidate
+          gh run download "$RELEASE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact" \
+            --dir candidate
+
+          commit="$(jq -er .commit candidate/manifest.json)"
+          release_id="$(jq -er .releaseId candidate/manifest.json)"
+          [[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$release_id" =~ ^[0-9]+$ ]]
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$TAG" \
+            --arg commit "$commit" \
+            --argjson workflowRunId "$RELEASE_RUN_ID" \
+            --argjson workflowRunAttempt "$run_attempt" \
+            --argjson releaseId "$release_id" \
+            '.repository == $repository and
+             .tag == $tag and
+             .commit == $commit and
+             .workflowRunId == $workflowRunId and
+             .workflowRunAttempt == $workflowRunAttempt and
+             .releaseId == $releaseId and
+             (.checksumFileSha256 | test("^[0-9a-f]{64}$"))' \
+            candidate/manifest.json >/dev/null
+          test "$(jq -r .head_sha <<<"$run_json")" = "$commit"
+          comparison_status="$(
+            gh api "repos/$GITHUB_REPOSITORY/compare/$commit...main" --jq .status
+          )"
+          case "$comparison_status" in
+            ahead|identical) ;;
+            *) echo "Release commit $commit is no longer on main." >&2; exit 1 ;;
+          esac
+          test "$(sha256sum candidate/SHA256SUMS | awk '{print $1}')" = \
+            "$(jq -r .checksumFileSha256 candidate/manifest.json)"
+
+          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          test "$remote_commit" = "$commit"
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
+          test "$(jq -r .draft <<<"$release_json")" = true
+          test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
+          expected_prerelease=false
+          case "$version" in *-*) expected_prerelease=true ;; esac
+          test "$(jq -r .prerelease <<<"$release_json")" = "$expected_prerelease"
+
+          expected=(
+            SHA256SUMS
+            "stn-v$version-darwin-arm64.tar.gz"
+            "stn-v$version-darwin-x64.tar.gz"
+            "stn-v$version-linux-arm64.tar.gz"
+            "stn-v$version-linux-x64.tar.gz"
+          )
+          mapfile -t actual < <(jq -r '.assets[].name' <<<"$release_json" | sort)
+          mapfile -t wanted < <(printf '%s\n' "${expected[@]}" | sort)
+          test "${actual[*]}" = "${wanted[*]}"
+
+          current_ids="$(
+            jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$release_json"
+          )"
+          test "$current_ids" = "$(cat candidate/asset-ids.txt)"
+          mkdir downloaded
+          for name in "${expected[@]}"; do
+            asset_id="$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .id' <<<"$release_json")"
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" > "downloaded/$name"
+          done
+          cmp candidate/SHA256SUMS downloaded/SHA256SUMS
+          (cd downloaded && sha256sum -c SHA256SUMS)
+
+          final_release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
+          final_ids="$(
+            jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$final_release_json"
+          )"
+          test "$(jq -r .draft <<<"$final_release_json")" = true
+          test "$(jq -r .prerelease <<<"$final_release_json")" = "$expected_prerelease"
+          test "$final_ids" = "$current_ids"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"
+
+          gh api --method PATCH \
+            "repos/$GITHUB_REPOSITORY/releases/$release_id" \
+            -F tag_name="$TAG" \
+            -F prerelease="$expected_prerelease" \
+            -F draft=false >/dev/null
+          published_release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$release_id")"
+          test "$(jq -r .draft <<<"$published_release_json")" = false
+          test "$(jq -r .tag_name <<<"$published_release_json")" = "$TAG"
+          test "$(jq -r .prerelease <<<"$published_release_json")" = "$expected_prerelease"
+          test "$(
+            jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$published_release_json"
+          )" = "$current_ids"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,325 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    outputs:
+      prerelease: ${{ steps.release.outputs.prerelease }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Validate release tag
+        id: release
+        run: |
+          version="$(node -p 'require("./package.json").version')"
+          tag="$GITHUB_REF_NAME"
+
+          node -e '
+            const version = process.argv[1];
+            const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+            if (!semver.test(version)) {
+              throw new Error(`Release version must be SemVer without build metadata: ${version}`);
+            }
+          ' "$version"
+
+          if [[ "$tag" != "v$version" ]]; then
+            echo "Release tag $tag must exactly match package.json version v$version." >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "Release commit $GITHUB_SHA is not on origin/main." >&2
+            exit 1
+          fi
+
+          prerelease=false
+          if [[ "$version" == *-* ]]; then
+            prerelease=true
+          fi
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  standard-ci:
+    needs: validate
+    permissions:
+      contents: read
+    uses: ./.github/workflows/standard-ci.yml
+
+  release-smoke:
+    needs: validate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Release smoke
+        run: pnpm smoke:release
+
+  # Checked 2026-07-11: these hosted labels cover the four supported native targets.
+  build-native:
+    name: build (${{ matrix.target }})
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-15-intel
+            target: darwin-x64
+          - runner: macos-15
+            target: darwin-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install (pnpm)
+        run: pnpm install --frozen-lockfile
+      - name: Install (bun)
+        run: bun install --frozen-lockfile
+        working-directory: station
+      - name: Build compiled binary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: pnpm build:binary -- --version "$VERSION"
+      - name: Test compiled binary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: pnpm smoke:binary -- --expected-version "$VERSION"
+      - name: Package release archive
+        env:
+          RUNNER_LABEL: ${{ matrix.runner }}
+          TARGET: ${{ matrix.target }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          bin_dir="station/dist/bin"
+          test -x "$bin_dir/stn"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+          test -f "$bin_dir/LICENSE"
+
+          archive="stn-v$VERSION-$TARGET.tar.gz"
+          tar -C "$bin_dir" -czf "$archive" stn stn-ingress stn-tmux-popup LICENSE
+          tar -tzf "$archive" > "$RUNNER_TEMP/archive-manifest"
+          diff -u <(printf '%s\n' stn stn-ingress stn-tmux-popup LICENSE) "$RUNNER_TEMP/archive-manifest"
+
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            floor="$(getconf GNU_LIBC_VERSION)"
+          else
+            minos="$(otool -l "$bin_dir/stn" | awk '/cmd LC_BUILD_VERSION/{found=1; next} found && $1 == "minos" {print $2; exit}')"
+            test -n "$minos"
+            floor="macOS $minos"
+          fi
+
+          {
+            echo "target=$TARGET"
+            echo "runner=$RUNNER_LABEL"
+            echo "floor=$floor"
+          } > "platform-metadata-$TARGET.txt"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.target }}
+          path: |
+            stn-v${{ needs.validate.outputs.version }}-${{ matrix.target }}.tar.gz
+            platform-metadata-${{ matrix.target }}.txt
+          if-no-files-found: error
+
+  create-draft:
+    needs:
+      - validate
+      - standard-ci
+      - release-smoke
+      - build-native
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    outputs:
+      release_id: ${{ steps.release.outputs.release_id }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          path: release
+          merge-multiple: true
+      - name: Verify assets and checksums
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        working-directory: release
+        run: |
+          expected=(
+            "stn-v$VERSION-darwin-arm64.tar.gz"
+            "stn-v$VERSION-darwin-x64.tar.gz"
+            "stn-v$VERSION-linux-arm64.tar.gz"
+            "stn-v$VERSION-linux-x64.tar.gz"
+          )
+          mapfile -t actual < <(find . -maxdepth 1 -type f -name 'stn-v*.tar.gz' -printf '%f\n' | sort)
+          if [[ "${actual[*]}" != "${expected[*]}" ]]; then
+            printf 'Expected archives: %s\n' "${expected[*]}" >&2
+            printf 'Actual archives: %s\n' "${actual[*]}" >&2
+            exit 1
+          fi
+
+          : > SHA256SUMS
+          for archive in "${expected[@]}"; do
+            sha256sum "$archive" >> SHA256SUMS
+          done
+
+          mapfile -t metadata < <(find . -maxdepth 1 -type f -name 'platform-metadata-*.txt' -printf '%f\n' | sort)
+          if [[ "${#metadata[@]}" -ne 4 ]]; then
+            echo "Expected four platform metadata records; found ${#metadata[@]}." >&2
+            exit 1
+          fi
+      - name: Write release notes
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        working-directory: release
+        run: |
+          {
+            echo "Station $TAG native binaries."
+            printf 'Build commit: `%s`.\n' "$GITHUB_SHA"
+            echo
+            echo "Install through the authenticated installer documented in the repository."
+            echo
+            echo "## Native platform floors"
+            echo
+            echo '```text'
+            for metadata in platform-metadata-*.txt; do
+              cat "$metadata"
+              echo
+            done
+            echo '```'
+            echo
+            echo "The x64 builds use Bun's baseline CPU targets. Linux artifacts require glibc."
+          } > release-notes.md
+      - name: Create draft release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        working-directory: release
+        run: |
+          assets=(
+            "stn-v$VERSION-darwin-arm64.tar.gz"
+            "stn-v$VERSION-darwin-x64.tar.gz"
+            "stn-v$VERSION-linux-arm64.tar.gz"
+            "stn-v$VERSION-linux-x64.tar.gz"
+            SHA256SUMS
+          )
+          args=(
+            "$TAG"
+            "${assets[@]}"
+            --draft
+            --generate-notes
+            --notes-file release-notes.md
+            --title "Station $TAG"
+            --verify-tag
+          )
+          if [[ "$PRERELEASE" == true ]]; then
+            args+=(--prerelease)
+          fi
+          # Installer acceptance runs against this draft before a human may publish it.
+          gh release create "${args[@]}"
+
+          # GitHub's tag endpoint excludes drafts, so acceptance uses the captured release id.
+          release_ids="$(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+              --jq ".[] | select(.draft == true and .tag_name == \"$TAG\") | .id"
+          )"
+          if [[ ! "$release_ids" =~ ^[0-9]+$ ]]; then
+            echo "Expected exactly one draft release for $TAG." >&2
+            exit 1
+          fi
+          echo "release_id=$release_ids" >> "$GITHUB_OUTPUT"
+
+  install-draft:
+    name: install draft (${{ matrix.target }})
+    needs:
+      - validate
+      - create-draft
+    permissions:
+      # GitHub exposes draft releases only to tokens with push access.
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-15-intel
+            target: darwin-x64
+          - runner: macos-15
+            target: darwin-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install from draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STATION_INSTALL_RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/install-home" "$RUNNER_TEMP/install-data"
+          HOME="$RUNNER_TEMP/install-home" \
+            XDG_DATA_HOME="$RUNNER_TEMP/install-data" \
+            scripts/install.sh --version "$TAG" --install-dir "$RUNNER_TEMP/station-bin"
+      - name: Verify installed artifact
+        env:
+          EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          bin_dir="$RUNNER_TEMP/station-bin"
+          runtime_path="$RUNNER_TEMP/runtime-path"
+          mkdir -p "$runtime_path"
+          test -x "$bin_dir/stn"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+          test -f "$RUNNER_TEMP/install-data/station/LICENSE"
+
+          actual="$(env -i \
+            HOME="$RUNNER_TEMP/install-home" \
+            XDG_DATA_HOME="$RUNNER_TEMP/install-data" \
+            PATH="$bin_dir:$runtime_path" \
+            "$bin_dir/stn" --version)"
+          test "$actual" = "$EXPECTED_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     outputs:
+      commit: ${{ steps.release.outputs.commit }}
       prerelease: ${{ steps.release.outputs.prerelease }}
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
@@ -23,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -45,6 +47,12 @@ jobs:
             exit 1
           fi
 
+          tag_commit="$(git rev-parse "$tag^{commit}")"
+          if [[ "$tag_commit" != "$GITHUB_SHA" ]]; then
+            echo "Release tag $tag resolves to $tag_commit, not workflow commit $GITHUB_SHA." >&2
+            exit 1
+          fi
+
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "Release commit $GITHUB_SHA is not on origin/main." >&2
@@ -56,6 +64,7 @@ jobs:
             prerelease=true
           fi
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "commit=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
@@ -70,6 +79,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -101,6 +113,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -108,7 +123,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@11.0.0 --activate
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install (pnpm)
@@ -226,11 +241,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ needs.validate.outputs.commit }}
           PRERELEASE: ${{ needs.validate.outputs.prerelease }}
           TAG: ${{ needs.validate.outputs.tag }}
           VERSION: ${{ needs.validate.outputs.version }}
         working-directory: release
         run: |
+          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          if [[ "$remote_commit" != "$COMMIT" ]]; then
+            echo "Release tag $TAG moved from validated commit $COMMIT to $remote_commit." >&2
+            exit 1
+          fi
+
           assets=(
             "stn-v$VERSION-darwin-arm64.tar.gz"
             "stn-v$VERSION-darwin-x64.tar.gz"
@@ -264,14 +286,41 @@ jobs:
           fi
           echo "release_id=$release_ids" >> "$GITHUB_OUTPUT"
 
+          mkdir candidate
+          cp SHA256SUMS candidate/SHA256SUMS
+          checksum_file_sha="$(sha256sum SHA256SUMS | awk '{print $1}')"
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$TAG" \
+            --arg commit "$COMMIT" \
+            --arg checksumFileSha256 "$checksum_file_sha" \
+            --argjson workflowRunId "$GITHUB_RUN_ID" \
+            --argjson workflowRunAttempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson releaseId "$release_ids" \
+            '{
+              repository: $repository,
+              workflowRunId: $workflowRunId,
+              workflowRunAttempt: $workflowRunAttempt,
+              commit: $commit,
+              tag: $tag,
+              releaseId: $releaseId,
+              checksumFileSha256: $checksumFileSha256
+            }' > candidate/manifest.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
+          path: release/candidate
+          if-no-files-found: error
+          retention-days: 90
+
   install-draft:
     name: install draft (${{ matrix.target }})
     needs:
       - validate
       - create-draft
     permissions:
-      # GitHub exposes draft releases only to tokens with push access.
-      contents: write
+      # Draft list/get and asset downloads require only read permission.
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -287,15 +336,24 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
       - name: Fetch tagged installer
         env:
           GH_HOST: github.com
           GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ needs.validate.outputs.commit }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
+          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          if [[ "$remote_commit" != "$COMMIT" ]]; then
+            echo "Release tag $TAG moved from validated commit $COMMIT to $remote_commit." >&2
+            exit 1
+          fi
           installer="$RUNNER_TEMP/station-install.sh"
           gh api --method GET \
-            -f ref="$TAG" \
+            -f ref="$COMMIT" \
             -H "Accept: application/vnd.github.raw+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "repos/$GITHUB_REPOSITORY/contents/scripts/install.sh" > "$installer"
@@ -437,3 +495,83 @@ jobs:
             PATH="$bin_dir:$RUNNER_TEMP/runtime-path" \
             stn --version)"
           test "$actual" = "$EXPECTED_VERSION"
+
+  record-accepted-candidate:
+    needs:
+      - validate
+      - create-draft
+      - install-draft
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
+          path: candidate
+      - name: Bind accepted draft assets to the workflow run
+        env:
+          COMMIT: ${{ needs.validate.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          expected=(
+            SHA256SUMS
+            "stn-v$VERSION-darwin-arm64.tar.gz"
+            "stn-v$VERSION-darwin-x64.tar.gz"
+            "stn-v$VERSION-linux-arm64.tar.gz"
+            "stn-v$VERSION-linux-x64.tar.gz"
+          )
+
+          jq -e \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg tag "$TAG" \
+            --arg commit "$COMMIT" \
+            --argjson workflowRunId "$GITHUB_RUN_ID" \
+            --argjson workflowRunAttempt "$GITHUB_RUN_ATTEMPT" \
+            --argjson releaseId "$RELEASE_ID" \
+            '.repository == $repository and
+             .tag == $tag and
+             .commit == $commit and
+             .workflowRunId == $workflowRunId and
+             .workflowRunAttempt == $workflowRunAttempt and
+             .releaseId == $releaseId and
+             (.checksumFileSha256 | test("^[0-9a-f]{64}$"))' \
+            candidate/manifest.json >/dev/null
+          test "$(sha256sum candidate/SHA256SUMS | awk '{print $1}')" = \
+            "$(jq -r .checksumFileSha256 candidate/manifest.json)"
+
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          test "$(jq -r .draft <<<"$release_json")" = true
+          test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
+          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
+          test "$remote_commit" = "$COMMIT"
+
+          mapfile -t actual < <(jq -r '.assets[].name' <<<"$release_json" | sort)
+          mapfile -t wanted < <(printf '%s\n' "${expected[@]}" | sort)
+          if [[ "${actual[*]}" != "${wanted[*]}" ]]; then
+            printf 'Expected draft assets: %s\n' "${wanted[*]}" >&2
+            printf 'Actual draft assets: %s\n' "${actual[*]}" >&2
+            exit 1
+          fi
+
+          mkdir downloaded
+          : > candidate/asset-ids.txt
+          for name in "${expected[@]}"; do
+            asset_id="$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .id' <<<"$release_json")"
+            [[ "$asset_id" =~ ^[0-9]+$ ]]
+            printf '%s=%s\n' "$name" "$asset_id" >> candidate/asset-ids.txt
+            gh api -H 'Accept: application/octet-stream' \
+              "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id" > "downloaded/$name"
+          done
+          cmp candidate/SHA256SUMS downloaded/SHA256SUMS
+          (cd downloaded && sha256sum -c SHA256SUMS)
+      - uses: actions/upload-artifact@v4
+        with:
+          name: accepted-release-candidate-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
+          path: candidate
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,15 +131,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           bin_dir="station/dist/bin"
-          test -x "$bin_dir/stn"
-          test "$(readlink "$bin_dir/stn-ingress")" = stn
-          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
-          test -f "$bin_dir/LICENSE"
-
-          archive="stn-v$VERSION-$TARGET.tar.gz"
-          tar -C "$bin_dir" -czf "$archive" stn stn-ingress stn-tmux-popup LICENSE
-          tar -tzf "$archive" > "$RUNNER_TEMP/archive-manifest"
-          diff -u <(printf '%s\n' stn stn-ingress stn-tmux-popup LICENSE) "$RUNNER_TEMP/archive-manifest"
+          scripts/release/package-archive.sh "$VERSION" "$TARGET"
 
           if [[ "$RUNNER_OS" == Linux ]]; then
             floor="$(getconf GNU_LIBC_VERSION)"
@@ -295,6 +287,21 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - name: Fetch tagged installer
+        env:
+          GH_HOST: github.com
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          installer="$RUNNER_TEMP/station-install.sh"
+          gh api --method GET \
+            -f ref="$TAG" \
+            -H "Accept: application/vnd.github.raw+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/contents/scripts/install.sh" > "$installer"
+          test -s "$installer"
+          /bin/sh -n "$installer"
+          chmod 0700 "$installer"
       - name: Seed existing installation
         run: |
           install_home="$RUNNER_TEMP/install-home"
@@ -329,7 +336,7 @@ jobs:
           umask 0777
           HOME="$install_home" \
             XDG_DATA_HOME="$data_home" \
-            scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
+            /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
       - name: Verify installed artifact
         env:
           EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
@@ -396,7 +403,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
           ) > "$RUNNER_TEMP/locked-install.stdout" 2> "$lock_stderr"; then
             echo "Installer unexpectedly succeeded while $lock_dir was owned." >&2
             exit 1
@@ -418,7 +425,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
           )
 
           test ! -e "$lock_dir"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,31 +295,138 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - name: Seed existing installation
+        run: |
+          install_home="$RUNNER_TEMP/install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          license_dir="$data_home/station"
+          mkdir -p "$bin_dir" "$license_dir"
+
+          cat > "$bin_dir/stn" <<'EOF'
+          #!/bin/sh
+          printf '%s\n' 0.0.0-old-fixture
+          EOF
+          chmod 0755 "$bin_dir/stn"
+          ln -s stn "$bin_dir/stn-ingress"
+          ln -s stn "$bin_dir/stn-tmux-popup"
+          printf '%s\n' 'old Station license fixture' > "$license_dir/LICENSE"
+          chmod 0644 "$license_dir/LICENSE"
+          cp "$bin_dir/stn" "$RUNNER_TEMP/old-stn-fixture"
+
+          test "$("$bin_dir/stn" --version)" = 0.0.0-old-fixture
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
       - name: Install from draft release
         env:
           GH_TOKEN: ${{ github.token }}
           STATION_INSTALL_RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          mkdir -p "$RUNNER_TEMP/install-home" "$RUNNER_TEMP/install-data"
-          HOME="$RUNNER_TEMP/install-home" \
-            XDG_DATA_HOME="$RUNNER_TEMP/install-data" \
-            scripts/install.sh --version "$TAG" --install-dir "$RUNNER_TEMP/station-bin"
+          install_home="$RUNNER_TEMP/install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          umask 0777
+          HOME="$install_home" \
+            XDG_DATA_HOME="$data_home" \
+            scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
       - name: Verify installed artifact
         env:
           EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          bin_dir="$RUNNER_TEMP/station-bin"
+          install_home="$RUNNER_TEMP/install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          license_path="$data_home/station/LICENSE"
           runtime_path="$RUNNER_TEMP/runtime-path"
           mkdir -p "$runtime_path"
+
+          mode() {
+            if [[ "$RUNNER_OS" == Linux ]]; then
+              stat -c '%a' "$1"
+            else
+              stat -f '%Lp' "$1"
+            fi
+          }
+
           test -x "$bin_dir/stn"
           test "$(readlink "$bin_dir/stn-ingress")" = stn
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
-          test -f "$RUNNER_TEMP/install-data/station/LICENSE"
+          test -f "$license_path"
+          test ! -L "$license_path"
+          test "$(mode "$bin_dir/stn")" = 755
+          test "$(mode "$license_path")" = 644
+          ! cmp -s "$RUNNER_TEMP/old-stn-fixture" "$bin_dir/stn"
+          cmp -s LICENSE "$license_path"
 
           actual="$(env -i \
-            HOME="$RUNNER_TEMP/install-home" \
-            XDG_DATA_HOME="$RUNNER_TEMP/install-data" \
+            HOME="$install_home" \
+            XDG_DATA_HOME="$data_home" \
             PATH="$bin_dir:$runtime_path" \
-            "$bin_dir/stn" --version)"
+            stn --version)"
+          test "$actual" = "$EXPECTED_VERSION"
+      - name: Verify lock refusal and same-version retry
+        env:
+          EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+          STATION_INSTALL_RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          install_home="$RUNNER_TEMP/install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          license_path="$data_home/station/LICENSE"
+          lock_dir="$bin_dir/.station-install.lock"
+          lock_stderr="$RUNNER_TEMP/locked-install.stderr"
+
+          mkdir "$lock_dir"
+          chmod 0700 "$lock_dir"
+          (
+            umask 077
+            {
+              printf 'pid=%s\n' "$$"
+              printf 'requested=%s\n' "$TAG"
+            } > "$lock_dir/owner"
+          )
+
+          before_binary="$(cksum < "$bin_dir/stn")"
+          before_license="$(cksum < "$license_path")"
+          before_entries="$(ls -ldi "$bin_dir/stn" "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$license_path")"
+          if (
+            umask 0777
+            HOME="$install_home" \
+              XDG_DATA_HOME="$data_home" \
+              scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
+          ) > "$RUNNER_TEMP/locked-install.stdout" 2> "$lock_stderr"; then
+            echo "Installer unexpectedly succeeded while $lock_dir was owned." >&2
+            exit 1
+          fi
+
+          grep -F "$lock_dir" "$lock_stderr"
+          grep -F "$$" "$lock_stderr"
+          grep -Eiq 'existing Station( installation)? was unchanged' "$lock_stderr"
+          grep -Eiq 'wait' "$lock_stderr"
+          test -d "$lock_dir"
+          test "$(cksum < "$bin_dir/stn")" = "$before_binary"
+          test "$(cksum < "$license_path")" = "$before_license"
+          test "$(ls -ldi "$bin_dir/stn" "$bin_dir/stn-ingress" "$bin_dir/stn-tmux-popup" "$license_path")" = "$before_entries"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+
+          rm -rf "$lock_dir"
+          (
+            umask 0777
+            HOME="$install_home" \
+              XDG_DATA_HOME="$data_home" \
+              scripts/install.sh --version "$TAG" --install-dir "$bin_dir"
+          )
+
+          test ! -e "$lock_dir"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+          actual="$(env -i \
+            HOME="$install_home" \
+            XDG_DATA_HOME="$data_home" \
+            PATH="$bin_dir:$RUNNER_TEMP/runtime-path" \
+            stn --version)"
           test "$actual" = "$EXPECTED_VERSION"

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -55,6 +57,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -71,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -83,7 +89,7 @@ jobs:
       # The link script symlinks built @station dist into the bun workspace.
       - name: Build @station packages
         run: pnpm build
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Test cross-runtime SQLite compatibility
@@ -117,6 +123,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -124,7 +132,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@11.0.0 --activate
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install (pnpm)
@@ -291,6 +299,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
@@ -298,7 +308,7 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@11.0.0 --activate
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
       - name: Install (pnpm)

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -43,6 +43,25 @@ jobs:
         run: pnpm test:agent:scripted
       - name: Setup e2e tests
         run: pnpm test:e2e:setup
+
+  installer-smoke:
+    name: installer smoke (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - ubuntu-24.04
+          - macos-15
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
       - name: Installer smoke
         run: pnpm smoke:install
 
@@ -125,6 +144,148 @@ jobs:
         run: pnpm smoke:binary -- --expected-version 0.0.0-ci
         env:
           STATION_BINARY_SMOKE_PTY_ONLY: "1"
+      - name: Package release archive
+        run: scripts/release/package-archive.sh 0.0.0-ci "${{ matrix.target }}"
+      - name: Install packaged binary without Node or Bun
+        env:
+          TARGET: ${{ matrix.target }}
+          VERSION: 0.0.0-ci
+        shell: bash
+        run: |
+          archive_name="stn-v$VERSION-$TARGET.tar.gz"
+          archive_path="$GITHUB_WORKSPACE/$archive_name"
+          checksums_path="$RUNNER_TEMP/SHA256SUMS"
+          fake_bin="$RUNNER_TEMP/fake-gh-bin"
+          fake_state="$RUNNER_TEMP/fake-gh-state"
+          install_home="$RUNNER_TEMP/install-home"
+          install_bin="$install_home/.local/bin"
+          native_bin="$RUNNER_TEMP/native-bin"
+          runtime_path="$install_bin:$fake_bin:$native_bin"
+
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            archive_hash="$(sha256sum "$archive_path" | awk '{print $1}')"
+          else
+            archive_hash="$(shasum -a 256 "$archive_path" | awk '{print $1}')"
+          fi
+          printf '%s  %s\n' "$archive_hash" "$archive_name" > "$checksums_path"
+          mkdir -p "$fake_bin" "$install_home" "$native_bin"
+          printf '0\n' > "$fake_state"
+
+          for source_dir in /usr/bin /bin; do
+            for tool in "$source_dir"/*; do
+              name=${tool##*/}
+              case "$name" in
+                gh|node|nodejs|npm|npx|corepack|pnpm|bun|bunx) continue ;;
+              esac
+              [[ -e "$native_bin/$name" || -L "$native_bin/$name" ]] || \
+                ln -s "$tool" "$native_bin/$name"
+            done
+          done
+
+          cat > "$fake_bin/gh" <<'FAKE_GH'
+          #!/bin/sh
+          set -eu
+
+          fail() {
+            printf 'strict fake gh: %s\n' "$1" >&2
+            exit 97
+          }
+
+          [ "${GH_HOST:-}" = github.com ] || fail "GH_HOST must be github.com"
+          [ "${GH_REPO:-}" = jeremy0dell/station ] || fail "GH_REPO must be jeremy0dell/station"
+          state=$(cat "$FAKE_GH_STATE")
+          release_endpoint="repos/jeremy0dell/station/releases/tags/$FAKE_GH_TAG"
+
+          case "$state" in
+            0)
+              [ "$#" -eq 4 ] && [ "$1" = auth ] && [ "$2" = status ] && \
+                [ "$3" = --hostname ] && [ "$4" = github.com ] || \
+                fail "expected authenticated github.com status check first"
+              printf '1\n' > "$FAKE_GH_STATE"
+              ;;
+            1)
+              expected_jq=".assets[] | select(.name == \"$FAKE_GH_ARCHIVE_NAME\") | .id"
+              [ "$#" -eq 4 ] && [ "$1" = api ] && [ "$2" = "$release_endpoint" ] && \
+                [ "$3" = --jq ] && [ "$4" = "$expected_jq" ] || \
+                fail "expected exact archive asset lookup second"
+              printf '2\n' > "$FAKE_GH_STATE"
+              printf '9101\n'
+              ;;
+            2)
+              expected_jq='.assets[] | select(.name == "SHA256SUMS") | .id'
+              [ "$#" -eq 4 ] && [ "$1" = api ] && [ "$2" = "$release_endpoint" ] && \
+                [ "$3" = --jq ] && [ "$4" = "$expected_jq" ] || \
+                fail "expected exact checksum asset lookup third"
+              printf '3\n' > "$FAKE_GH_STATE"
+              printf '9102\n'
+              ;;
+            3)
+              [ "$#" -eq 4 ] && [ "$1" = api ] && [ "$2" = -H ] && \
+                [ "$3" = 'Accept: application/octet-stream' ] && \
+                [ "$4" = repos/jeremy0dell/station/releases/assets/9101 ] || \
+                fail "expected authenticated archive download fourth"
+              printf '4\n' > "$FAKE_GH_STATE"
+              cat "$FAKE_GH_ARCHIVE"
+              ;;
+            4)
+              [ "$#" -eq 4 ] && [ "$1" = api ] && [ "$2" = -H ] && \
+                [ "$3" = 'Accept: application/octet-stream' ] && \
+                [ "$4" = repos/jeremy0dell/station/releases/assets/9102 ] || \
+                fail "expected authenticated checksum download fifth"
+              printf '5\n' > "$FAKE_GH_STATE"
+              cat "$FAKE_GH_CHECKSUMS"
+              ;;
+            *)
+              fail "unexpected extra gh invocation after state $state"
+              ;;
+          esac
+          FAKE_GH
+          chmod 0755 "$fake_bin/gh"
+
+          if PATH="$runtime_path" command -v node >/dev/null 2>&1 || \
+            PATH="$runtime_path" command -v bun >/dev/null 2>&1; then
+            echo "Native install runtime PATH unexpectedly contains Node or Bun." >&2
+            exit 1
+          fi
+
+          env -u XDG_DATA_HOME \
+            HOME="$install_home" \
+            PATH="$runtime_path" \
+            GH_HOST=github.com \
+            GH_REPO=jeremy0dell/station \
+            FAKE_GH_ARCHIVE="$archive_path" \
+            FAKE_GH_ARCHIVE_NAME="$archive_name" \
+            FAKE_GH_CHECKSUMS="$checksums_path" \
+            FAKE_GH_STATE="$fake_state" \
+            FAKE_GH_TAG="v$VERSION" \
+            /bin/sh scripts/install.sh --version "v$VERSION"
+
+          test "$(cat "$fake_state")" = 5
+          test -x "$install_bin/stn"
+          test "$(readlink "$install_bin/stn-ingress")" = stn
+          test "$(readlink "$install_bin/stn-tmux-popup")" = stn
+          test -f "$install_home/.local/share/station/LICENSE"
+          test ! -L "$install_home/.local/share/station/LICENSE"
+
+          if [[ "$RUNNER_OS" == Linux ]]; then
+            test "$(stat -c '%a' "$install_bin/stn")" = 755
+            test "$(stat -c '%a' "$install_home/.local/share/station/LICENSE")" = 644
+          else
+            test "$(stat -f '%Lp' "$install_bin/stn")" = 755
+            test "$(stat -f '%Lp' "$install_home/.local/share/station/LICENSE")" = 644
+          fi
+          cmp -s LICENSE "$install_home/.local/share/station/LICENSE"
+
+          test "$(env -u XDG_DATA_HOME HOME="$install_home" PATH="$runtime_path" stn --version)" = "$VERSION"
+          env -u XDG_DATA_HOME HOME="$install_home" PATH="$runtime_path" \
+            stn-tmux-popup --help > "$RUNNER_TEMP/popup-help"
+          grep -F 'stn popup' "$RUNNER_TEMP/popup-help"
+          if env -u XDG_DATA_HOME HOME="$install_home" PATH="$runtime_path" \
+            stn-ingress </dev/null > "$RUNNER_TEMP/ingress.stdout" 2> "$RUNNER_TEMP/ingress.stderr"; then
+            echo "stn-ingress unexpectedly accepted an empty invocation." >&2
+            exit 1
+          fi
+          grep -F 'Usage: stn-ingress' "$RUNNER_TEMP/ingress.stderr"
 
   binary-smoke:
     runs-on: ubuntu-24.04

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_call:
 
 concurrency:
   group: standard-ci-${{ github.event.pull_request.number || github.ref }}
@@ -42,6 +43,8 @@ jobs:
         run: pnpm test:agent:scripted
       - name: Setup e2e tests
         run: pnpm test:e2e:setup
+      - name: Installer smoke
+        run: pnpm smoke:install
 
   # Station is the sole UI (Ink retired), so the Bun lane is mandatory: it
   # typechecks and tests the OpenTUI dashboard renderer and its view goldens.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The authenticated private binary is the user install path. Authenticate the GitH
 gh auth login --hostname github.com
 (
   set -e
-  tag=v0.1.1-rc.1
+  tag=v0.7.0
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
   GH_HOST=github.com gh api --method GET \
@@ -69,17 +69,20 @@ stn
 
 The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. Git, Worktrunk (`wt`), tmux, diffnav/git-delta, GitHub integration, and agent CLIs remain feature-gated external tools; `stn setup` and `stn doctor` say which workflow capabilities are ready.
 
-The explicit RC is the first supported private-binary baseline. The installer
-code and artifacts always come from the same immutable tag. Once `v0.1.1` is
-published, the latest-install recipe first resolves that stable tag and then
-fetches and invokes its installer. See [Install](docs/install.md) for that
-recipe, version pinning, rollback, PATH recovery, custom install directories,
-and the supported-platform contract.
+`v0.7.0` is the first supported private-binary baseline. The installer code
+and artifacts always come from the same immutable tag. The latest-install
+recipe resolves the current stable tag before fetching and invoking its
+installer. Immutable rollback begins with the second binary release because
+`v0.7.0` has no earlier binary artifact. See [Install](docs/install.md) for the
+recipe, version pinning, PATH recovery, custom install directories, and the
+supported-platform contract.
 
 Installs serialize commands and license data with
 `<install-dir>/.station-install.lock` and
-`<data-home>/station/.station-install.lock`; inspect each lock's `owner`,
-confirm its PID is not alive, and remove it manually only for abandoned work.
+`<data-home>/station/.station-install.lock`; each owner records a PID, request,
+and unique token so cleanup cannot remove a replacement lock. Inspect the
+lock's sole `owner-*` file (or legacy `owner`), confirm its PID is not alive,
+and remove it manually only for abandoned work.
 Compatibility diagnostics are sanitized and bounded to 4096 bytes. If final
 activation is ambiguous, follow the printed absolute `stn --version` inspection
 command rather than assuming the previous install is unchanged. After success,

--- a/README.md
+++ b/README.md
@@ -42,11 +42,37 @@ station keeps track of everything that's running and makes it visible:
 
 ## Getting started
 
-**Requirements:** Node.js 24.2+ (and below 25), pnpm 11, and Bun (Bun renders the terminal UI). A `.node-version` / `.nvmrc` selects the current Node 24 release for fnm/nvm (asdf needs `legacy_version_file = yes`). External tools (Worktrunk `wt`, tmux, agent CLIs) are optional and checked by `stn doctor`.
+The authenticated private binary is the user install path. Authenticate the GitHub CLI for the private repository, fetch the installer, then run setup:
 
-### macOS: one command
+```sh
+gh auth login --hostname github.com
+(
+  set -e
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  test -s "$installer"
+  sh "$installer" --version v0.1.1-rc.1
+)
+```
 
-From a fresh clone, one script installs the system dependencies via Homebrew, builds **both** lanes (the pnpm/Node CLI + observer *and* the Bun terminal UI), and links all three checkout launchers:
+After the checked installer exits successfully:
+
+```sh
+stn setup
+stn
+```
+
+The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. Git, Worktrunk (`wt`), tmux, diffnav/git-delta, GitHub integration, and agent CLIs remain feature-gated external tools; `stn setup` and `stn doctor` say which workflow capabilities are ready.
+
+The explicit RC is the A5 validation baseline. Once `v0.1.1` is published, omit `--version` to select the latest stable release. See [Install](docs/install.md) for version pinning, rollback, custom install directories, and the supported-platform contract.
+
+### Development checkout
+
+Source development still requires Node.js 24.2+ (and below 25), pnpm 11, and Bun 1.3.14. A `.node-version` / `.nvmrc` selects the current Node 24 release for fnm/nvm (asdf needs `legacy_version_file = yes`).
+
+On macOS, a fresh checkout can install the development dependencies, build both source lanes, and link `stn`:
 
 ```sh
 ./scripts/setup/bootstrap.sh
@@ -54,7 +80,7 @@ stn setup     # required tools, an agent CLI, and your first project
 stn           # launch the workspace
 ```
 
-### Manual / non-macOS
+For manual or non-macOS development, install and verify both source lanes:
 
 station has two lanes and both must be installed: the **CLI + observer** on pnpm/Node, and the **terminal UI** on Bun (a separate workspace, *not* a pnpm-workspace member, so `pnpm install` does not touch it).
 
@@ -157,7 +183,8 @@ pnpm test:contracts     # contract tests
 pnpm test:integration   # integration tests
 pnpm test:diagnostics   # diagnostics tests
 pnpm test:agent:scripted  # scripted-agent lane (no real harness needed)
-pnpm test:all           # full gate: build + typecheck + lint + all test suites
+pnpm smoke:install      # isolated authenticated-installer contract
+pnpm test:all           # full gate: build + typecheck + lint + tests + installer smoke
 ```
 
 ---
@@ -173,8 +200,8 @@ station is under active development. The current build supports local setup, dia
 | Doc | What it covers |
 |-----|---------------|
 | [Overview](docs/overview.md) | What station is, why it exists, and the mental model behind it |
-| [Install](docs/install.md) | Full checkout setup, smoke options, local CLI linking |
-| [Homebrew packaging](docs/homebrew.md) | Draft tap formula path and release checklist |
+| [Install](docs/install.md) | Private binary install, rollback, and development checkout setup |
+| [Homebrew packaging](docs/homebrew.md) | Separate source formula and manual tap workflow |
 | [Architecture](docs/architecture.md) | Repository-wide system and boundary map |
 | [Observer architecture](docs/observer-architecture.md) | Canonical Observer boundaries, flows, state lifetimes, and active deviations |
 | [Architecture documentation](docs/architecture-documentation.md) | Controlled JSDoc roles for Observer architectural seams |

--- a/README.md
+++ b/README.md
@@ -48,12 +48,15 @@ The authenticated private binary is the user install path. Authenticate the GitH
 gh auth login --hostname github.com
 (
   set -e
+  tag=v0.1.1-rc.1
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  GH_HOST=github.com gh api --method GET \
+    repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" \
+    -f ref="$tag" > "$installer"
   test -s "$installer"
-  sh "$installer" --version v0.1.1-rc.1
+  sh "$installer" --version "$tag"
 )
 ```
 
@@ -66,7 +69,25 @@ stn
 
 The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. Git, Worktrunk (`wt`), tmux, diffnav/git-delta, GitHub integration, and agent CLIs remain feature-gated external tools; `stn setup` and `stn doctor` say which workflow capabilities are ready.
 
-The explicit RC is the A5 validation baseline. Once `v0.1.1` is published, omit `--version` to select the latest stable release. See [Install](docs/install.md) for version pinning, rollback, custom install directories, and the supported-platform contract.
+The explicit RC is the first supported private-binary baseline. The installer
+code and artifacts always come from the same immutable tag. Once `v0.1.1` is
+published, the latest-install recipe first resolves that stable tag and then
+fetches and invokes its installer. See [Install](docs/install.md) for that
+recipe, version pinning, rollback, PATH recovery, custom install directories,
+and the supported-platform contract.
+
+Installs serialize commands and license data with
+`<install-dir>/.station-install.lock` and
+`<data-home>/station/.station-install.lock`; inspect each lock's `owner`,
+confirm its PID is not alive, and remove it manually only for abandoned work.
+Compatibility diagnostics are sanitized and bounded to 4096 bytes. If final
+activation is ambiguous, follow the printed absolute `stn --version` inspection
+command rather than assuming the previous install is unchanged. After success,
+the installer checks all three bare launchers and prints a current-shell PATH
+block for anything missing or shadowed without editing a profile. SIGKILL can
+leave recoverable locks/stages; atomic rename gives coherent process-level
+visibility, but without file/directory fsync there is no post-power-loss
+durability guarantee.
 
 ### Development checkout
 

--- a/apps/cli/test/unit/entrypoints.test.ts
+++ b/apps/cli/test/unit/entrypoints.test.ts
@@ -23,5 +23,5 @@ describe("process entrypoints", () => {
     expect(process.listenerCount("SIGTERM")).toBe(signalListeners.sigterm);
 
     await expect(cli.runCli(["--help"])).resolves.toMatchObject({ code: 0 });
-  });
+  }, 30_000);
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,12 @@ pnpm test:sqlite:bun
 pnpm test:diagnostics
 pnpm test:agent:scripted
 pnpm smoke:release
+pnpm smoke:install
 ```
+
+`pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
+authenticated GitHub responses and temporary homes, so it is deterministic and
+does not download a real release.
 
 Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
 creates observer databases under Node and Bun, then reopens each database under
@@ -136,7 +141,7 @@ The isolated or configured `logs/station-host.jsonl` should record
 `ptyImplementation` as `bun`.
 
 To verify binary host upgrades, build two copies with distinct prerelease
-versions (for example `0.1.0-host-a` and `0.1.0-host-b`) and use an isolated
+versions (for example `0.1.1-host-a` and `0.1.1-host-b`) and use an isolated
 config with `station_persistent_agents = true`. Start A, open a hosted terminal,
 print a recognizable marker, leave a long command running, and exit the UI so
 the host survives. Because Observer version eviction is separate B3 work,
@@ -150,6 +155,73 @@ replaced on demand. The next `host.start` record in `logs/station-host.jsonl`
 must show B's build and protocol versions. Legacy or different-protocol hosts
 refuse automatic replacement and must be stopped explicitly only after their
 sessions are accounted for.
+
+## Private Binary Release
+
+Before tagging, an administrator must enable GitHub immutable releases; the
+workflow token cannot read that administration setting. The workflow validates
+that release tags use supported release SemVer without `+` build metadata,
+exactly equal `v${package.json.version}`, come from a commit on `origin/main`,
+and have no existing GitHub release. Pushing a `v*` tag runs the callable
+standard CI workflow, `pnpm smoke:release`, native binary build and smoke jobs
+for all four supported targets, archive/checksum assembly, and an authenticated
+installer smoke against the resulting GitHub release draft. The workflow never
+publishes the draft automatically.
+
+The initial immutable baseline is `v0.1.1-rc.1`:
+
+1. Enable GitHub immutable releases, merge the A5 implementation with
+   `package.json` at `0.1.1-rc.1`, then create and push `v0.1.1-rc.1`.
+2. Confirm the draft contains exactly four native archives plus
+   `SHA256SUMS`, and that every native build and installer job passed. Immediately
+   before publishing, fetch the remote tag and verify its peeled commit
+   (`git rev-parse "v0.1.1-rc.1^{commit}"`) still equals the successful release
+   workflow SHA recorded in the draft notes; drafts do not receive immutable
+   tag protection until publication.
+3. Install the explicit RC on clean native machines for `darwin-arm64`,
+   `darwin-x64`, `linux-arm64`, and `linux-x64`; complete the manual UX gate
+   below, then publish it as a prerelease.
+4. Merge only the version change to `0.1.1`, create and push `v0.1.1`, and
+   repeat the automated and manual gates against the stable draft.
+5. Prove RC-to-stable upgrade and explicit RC rollback before manually
+   publishing `v0.1.1` as latest. Repeat the remote-tag/workflow-SHA comparison
+   and five-asset inventory immediately before publishing the stable draft.
+
+Published tags and assets are immutable. Recovery may explicitly reinstall a
+prior version, but the release line moves forward with a superseding patch; it
+never deletes, retags, or overwrites a published release. The source Homebrew
+formula is a separate manually dispatched workflow and is not part of this
+binary release gate.
+
+If a transient workflow failure leaves an unpublished draft, delete only that
+draft and rerun the unchanged tag workflow. If the source needs a fix, leave
+the pushed tag alone and use the next prerelease tag. Never delete or mutate a
+published release.
+
+For each target, install through the authenticated script into a clean home and
+manually verify the actual user experience, not a dashboard override:
+
+1. With the installed binary's runtime `PATH` containing neither Node nor Bun,
+   run bare `stn` outside tmux. Confirm the real OpenTUI first-run screen draws
+   and connects to a healthy Observer.
+2. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
+3. Run `stn setup` to add a project. Confirm the open TUI reconnects and shows
+   it after activation on the same Observer socket.
+4. Run bare `stn` inside tmux and confirm `stn-tmux-popup` opens the popup.
+5. Deliver a provider event through `stn-ingress` and confirm it appears in
+   Station.
+6. Leave a hosted PTY alive under the RC, run
+   `scripts/install.sh --version v0.1.1`, and confirm launch reports
+   `HOST_UPGRADE_BLOCKED` without losing the terminal or scrollback. Reinstall
+   the RC to reattach and close every hosted terminal; reinstall `v0.1.1` and
+   confirm the idle host is replaced.
+7. Run `scripts/install.sh --version v0.1.1-rc.1`, confirm the version changed,
+   then reinstall `v0.1.1`.
+
+Record the oldest supported macOS version or built-against glibc version in the
+release notes. Signing and notarization are not part of A5; integrity is the
+authenticated GitHub asset plus `SHA256SUMS` verification and immutable
+publication.
 
 For CI install parity, use:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,11 @@ pnpm smoke:install
 
 `pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
 authenticated GitHub responses and temporary homes, so it is deterministic and
-does not download a real release.
+does not download a real release. CI runs it once in a dedicated
+`ubuntu-24.04`/`macos-15` matrix; the heavier Ubuntu gate does not duplicate it.
+The four-target native PTY matrix also packages the local binary through the
+release helper and installs it with real platform utilities and no Node or Bun
+on the runtime `PATH`.
 
 Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
 creates observer databases under Node and Bun, then reopens each database under
@@ -165,8 +169,11 @@ exactly equal `v${package.json.version}`, come from a commit on `origin/main`,
 and have no existing GitHub release. Pushing a `v*` tag runs the callable
 standard CI workflow, `pnpm smoke:release`, native binary build and smoke jobs
 for all four supported targets, archive/checksum assembly, and an authenticated
-installer smoke against the resulting GitHub release draft. The workflow never
-publishes the draft automatically.
+installer smoke against the resulting GitHub release draft. PR and release
+jobs use the same archive-packaging helper. Draft acceptance fetches
+`scripts/install.sh` from the tag through the authenticated Contents API, then
+passes that same tag with `--version`; it never substitutes checkout-local or
+`main` installer code. The workflow never publishes the draft automatically.
 
 The initial immutable baseline is `v0.1.1-rc.1`:
 
@@ -198,57 +205,82 @@ draft and rerun the unchanged tag workflow. If the source needs a fix, leave
 the pushed tag alone and use the next prerelease tag. Never delete or mutate a
 published release.
 
-Installer acceptance uses the destination lock
-`<install-dir>/.station-install.lock`, acquired before release lookup or
-download; `<install-dir>/.station-install.lock/owner` records the PID and
-requested tag or `latest`. A lock refusal must name the lock path and recorded
-owner PID when readable, state that the existing Station installation was
-unchanged, and tell the user to wait and retry. The installer never auto-removes
-an uncertain lock: after confirming that no installer with the recorded PID is
-alive, the operator removes the lock directory manually and retries.
+Installer acceptance uses both `<install-dir>/.station-install.lock` and
+`<data-home>/station/.station-install.lock`. Their corresponding
+`<install-dir>/.station-install.lock/owner` and
+`<data-home>/station/.station-install.lock/owner` files record the PID and
+requested tag or `latest`. The command lock is acquired first and the license
+lock second, with the duplicate path skipped, and they are released in reverse
+order. Either refusal must name the lock and readable owner PID, state that the
+existing Station installation was unchanged, and tell the user to wait and
+retry; a license-lock refusal also releases the command lock without making a
+release API request. The installer never auto-removes an uncertain lock. Only
+after confirming that no installer with the recorded PID is alive may an
+operator remove the affected lock directory manually and retry.
 
-The staged binary's `--version` probe must finish within 10 seconds. A timeout
-terminates and reaps the probe and preserves the existing install. HUP, INT,
-and TERM use the rollback/cleanup path and exit 129, 130, and 143 respectively.
-The verified `stn` rename is the sole runtime commit point: aliases already
-resolve to `stn`, and pre-commit caught failures restore the old license and
-remove aliases created by that attempt. SIGKILL and power loss cannot clean up;
-they may leave a stale lock, stage, or old/new `LICENSE` metadata when the data
-and install directories are on different filesystems, but pre-existing runtime
-entrypoints must still resolve coherently to the complete old or new binary.
+The staged binary's `--version` probe must finish within 10 seconds. Its
+watchdog returns 124 for timeout and 125 for timer failure, bounds output at the
+filesystem level, TERM/KILLs and reaps the probe, and shows at most 4096
+sanitized bytes of compatibility stderr. Every potentially blocking `gh`
+operation is a tracked file-backed child; HUP, INT, and TERM forward to that
+child, use the same TERM/KILL/reap cleanup, and exit 129, 130, and 143.
+
+The verified `stn` rename is the sole runtime commit point. Immediately before
+it, both aliases must still be exact symlinks to `stn` and binary/license
+destinations must retain accepted types. A failure with the staged `stn` still
+present restores the old license and removes only aliases this attempt created.
+If the staged `stn` disappeared, activation is ambiguous: preserve the new
+license and aliases, exit nonzero, and print the absolute `stn --version`
+inspection command without claiming the previous installation was unchanged.
+
+SIGKILL cannot clean up and may leave either lock or a stage behind. Atomic
+rename makes process-level readers observe a coherent complete old or new
+binary. Power loss is different: because the installer does not fsync the file
+or containing directories, it makes no post-power-loss durability guarantee;
+old/new cross-filesystem `LICENSE` metadata may also remain.
 
 For each target, install through the authenticated script into a clean home and
 manually verify the actual user experience, not a dashboard override:
 
-1. With the installed binary's runtime `PATH` containing neither Node nor Bun,
+1. Install into a clean default `HOME` with `XDG_DATA_HOME` unset and an install
+   directory absent from `PATH`. Confirm all three missing launchers are named,
+   the printed current-shell block prepends the safely quoted directory and
+   runs `hash -r` plus `stn setup`, and the absolute `stn` fallback works.
+2. Repeat with an older `stn` shadowing the install and then with one shadowed
+   sibling launcher. Confirm each mismatch is named and no shell profile is
+   edited. With all three launchers resolving physically to the install
+   directory, confirm the short `Next: run stn setup` success message.
+3. With the installed binary's runtime `PATH` containing neither Node nor Bun,
    run bare `stn` outside tmux. Confirm the real OpenTUI first-run screen draws
    and connects to a healthy Observer.
-2. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
-3. Run `stn setup` to add a project. Confirm the open TUI reconnects and shows
+4. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
+5. Run `stn setup` to add a project. Confirm the open TUI reconnects and shows
    it after activation on the same Observer socket.
-4. Run bare `stn` inside tmux and confirm `stn-tmux-popup` opens the popup.
-5. Deliver a provider event through `stn-ingress` and confirm it appears in
+6. Run bare `stn` inside tmux and confirm `stn-tmux-popup` opens the popup.
+7. Deliver a provider event through `stn-ingress` and confirm it appears in
    Station.
-6. Leave a hosted PTY alive under the RC, run
-   `scripts/install.sh --version v0.1.1`, and confirm launch reports
+8. Leave a hosted PTY alive under the RC, fetch the `v0.1.1` installer by tag,
+   run it with `--version v0.1.1`, and confirm launch reports
    `HOST_UPGRADE_BLOCKED` without losing the terminal or scrollback. Reinstall
    the RC to reattach and close every hosted terminal; reinstall `v0.1.1` and
    confirm the idle host is replaced.
-7. In terminal A, continuously run the installed `stn --version`. In terminal
+9. In terminal A, continuously run the installed `stn --version`. In terminal
    B, install RC → stable → RC. Terminal A may print only complete old or
    new versions: never command-not-found or malformed output. After each
    transition, confirm `stn-ingress` and `stn-tmux-popup` still link to `stn`,
    so the runtime never has mixed entrypoints.
-8. In an isolated install directory, create an abandoned
-   `.station-install.lock` with representative owner metadata. Run the
-   installer and follow its printed inspection, manual removal, and retry
-   instructions exactly; do not remove the lock until no owner process is
-   alive.
-9. Interrupt a real authenticated upgrade with Ctrl-C. Confirm the prior TUI
+10. In an isolated home, test abandoned locks separately at
+    `<install-dir>/.station-install.lock` and
+    `<data-home>/station/.station-install.lock` with representative owner
+    metadata. Follow each printed inspection, dead-PID confirmation, manual
+    removal, and retry instruction exactly; never remove a lock while its owner
+    may be alive.
+11. Interrupt a real authenticated upgrade with Ctrl-C. Confirm the prior TUI
    still opens, the installer exits with status 130 and leaves no owned lock or
    stage, then retry successfully.
-10. Run `scripts/install.sh --version v0.1.1-rc.1`, confirm the version changed,
-    then reinstall `v0.1.1` to complete the explicit rollback check.
+12. Fetch and run the tagged `v0.1.1-rc.1` installer, confirm the version
+    changed, then fetch and reinstall `v0.1.1` to complete the explicit rollback
+    check.
 
 Record the oldest supported macOS version or built-against glibc version in the
 release notes. Signing and notarization are not part of A5; integrity is the

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,6 +81,9 @@ pnpm smoke:install
 authenticated GitHub responses and temporary homes, so it is deterministic and
 does not download a real release. CI runs it once in a dedicated
 `ubuntu-24.04`/`macos-15` matrix; the heavier Ubuntu gate does not duplicate it.
+On a heavily contended local host, run
+`STATION_INSTALL_SMOKE_TIMEOUT_SCALE=4 pnpm smoke:install` to scale only the
+harness deadlines; the default and hosted gate remain strict.
 The four-target native PTY matrix also packages the local binary through the
 release helper and installs it with real platform utilities and no Node or Bun
 on the runtime `PATH`.
@@ -145,7 +148,7 @@ The isolated or configured `logs/station-host.jsonl` should record
 `ptyImplementation` as `bun`.
 
 To verify binary host upgrades, build two copies with distinct prerelease
-versions (for example `0.1.1-host-a` and `0.1.1-host-b`) and use an isolated
+versions (for example `0.7.0-host-a` and `0.7.0-host-b`) and use an isolated
 config with `station_persistent_agents = true`. Start A, open a hosted terminal,
 print a recognizable marker, leave a long command running, and exit the UI so
 the host survives. Because Observer version eviction is separate B3 work,
@@ -170,35 +173,36 @@ and have no existing GitHub release. Pushing a `v*` tag runs the callable
 standard CI workflow, `pnpm smoke:release`, native binary build and smoke jobs
 for all four supported targets, archive/checksum assembly, and an authenticated
 installer smoke against the resulting GitHub release draft. PR and release
-jobs use the same archive-packaging helper. Draft acceptance fetches
-`scripts/install.sh` from the tag through the authenticated Contents API, then
-passes that same tag with `--version`; it never substitutes checkout-local or
-`main` installer code. The workflow never publishes the draft automatically.
+jobs use the same archive-packaging helper. Draft acceptance revalidates the tag
+but fetches `scripts/install.sh` by the validated commit SHA, then passes the tag
+with `--version`; a moved tag cannot substitute different installer code. After
+all four native installs pass, the workflow re-downloads the five draft assets,
+verifies them against the build checksum, and uploads an immutable
+`accepted-release-candidate-*` Actions artifact containing the commit, release
+ID, asset IDs, and checksums. Draft install and candidate-recording jobs have
+read-only contents permission; only draft creation and manual promotion can
+write releases. The tag workflow never publishes the draft automatically.
 
-The initial immutable baseline is `v0.1.1-rc.1`:
+The initial immutable binary baseline is `v0.7.0`:
 
-1. Enable GitHub immutable releases, merge the A5 implementation with
-   `package.json` at `0.1.1-rc.1`, then create and push `v0.1.1-rc.1`.
-2. Confirm the draft contains exactly four native archives plus
-   `SHA256SUMS`, and that every native build and installer job passed. Immediately
-   before publishing, fetch the remote tag and verify its peeled commit
-   (`git rev-parse "v0.1.1-rc.1^{commit}"`) still equals the successful release
-   workflow SHA recorded in the draft notes; drafts do not receive immutable
-   tag protection until publication.
-3. Install the explicit RC on clean native machines for `darwin-arm64`,
-   `darwin-x64`, `linux-arm64`, and `linux-x64`; complete the manual UX gate
-   below, then publish it as a prerelease.
-4. Merge only the version change to `0.1.1`, create and push `v0.1.1`, and
-   repeat the automated and manual gates against the stable draft.
-5. Prove RC-to-stable upgrade and explicit RC rollback before manually
-   publishing `v0.1.1` as latest. Repeat the remote-tag/workflow-SHA comparison
-   and five-asset inventory immediately before publishing the stable draft.
+1. Enable GitHub immutable releases, merge A5 with `package.json` and source
+   runtime reporting at `0.7.0`, then create and push `v0.7.0`.
+2. Confirm every release job passed and the successful run contains exactly one
+   `accepted-release-candidate-0.7.0-attempt-*` artifact.
+3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
+   `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
+4. Dispatch `promote-release.yml` with the successful release run ID, tag
+   `v0.7.0`, and the manual-acceptance confirmation. It rechecks the successful
+   run SHA, immutable candidate manifest, tag commit, release ID, asset IDs, and
+   all archive hashes immediately before publishing that exact draft.
+5. Treat cross-version immutable rollback as a gate for the second binary
+   release. `v0.7.0` has no prior binary artifact to reinstall.
 
-Published tags and assets are immutable. Recovery may explicitly reinstall a
-prior version, but the release line moves forward with a superseding patch; it
-never deletes, retags, or overwrites a published release. The source Homebrew
-formula is a separate manually dispatched workflow and is not part of this
-binary release gate.
+Published tags and assets are immutable. Once two binary releases exist,
+recovery may explicitly reinstall the prior version, but the release line moves
+forward with a superseding patch; it never deletes, retags, or overwrites a
+published release. The source Homebrew formula is a separate manually
+dispatched workflow and is not part of this binary release gate.
 
 If a transient workflow failure leaves an unpublished draft, delete only that
 draft and rerun the unchanged tag workflow. If the source needs a fix, leave
@@ -206,21 +210,25 @@ the pushed tag alone and use the next prerelease tag. Never delete or mutate a
 published release.
 
 Installer acceptance uses both `<install-dir>/.station-install.lock` and
-`<data-home>/station/.station-install.lock`. Their corresponding
-`<install-dir>/.station-install.lock/owner` and
-`<data-home>/station/.station-install.lock/owner` files record the PID and
-requested tag or `latest`. The command lock is acquired first and the license
-lock second, with the duplicate path skipped, and they are released in reverse
-order. Either refusal must name the lock and readable owner PID, state that the
-existing Station installation was unchanged, and tell the user to wait and
-retry; a license-lock refusal also releases the command lock without making a
-release API request. The installer never auto-removes an uncertain lock. Only
-after confirming that no installer with the recorded PID is alive may an
-operator remove the affected lock directory manually and retry.
+`<data-home>/station/.station-install.lock`. Their sole corresponding
+`<install-dir>/.station-install.lock/owner-*` and
+`<data-home>/station/.station-install.lock/owner-*` files record the PID,
+requested tag or `latest`, and the token embedded in each filename. The command
+lock is acquired first and the license lock second, with the duplicate path
+skipped, and they are released in reverse order. Cleanup removes only its
+token-specific owner file and revalidates the directory inode so it cannot
+remove a replacement owner's lock. Either refusal must name the lock and
+readable owner PID, state that the existing
+Station installation was unchanged, and tell the user to wait and retry; a
+license-lock refusal also releases the command lock without making a release
+API request. The installer never auto-removes an uncertain lock. Only after
+confirming that no installer with the recorded PID is alive may an operator
+remove the affected lock directory manually and retry.
 
 The staged binary's `--version` probe must finish within 10 seconds. Its
 watchdog returns 124 for timeout and 125 for timer failure, bounds output at the
-filesystem level, TERM/KILLs and reaps the probe, and shows at most 4096
+filesystem level, TERM/KILLs and reaps the probe, removes common GitHub and
+Actions token variables from the child environment, and shows at most 4096
 sanitized bytes of compatibility stderr. Every potentially blocking `gh`
 operation is a tracked file-backed child; HUP, INT, and TERM forward to that
 child, use the same TERM/KILL/reap cleanup, and exit 129, 130, and 143.
@@ -259,16 +267,15 @@ manually verify the actual user experience, not a dashboard override:
 6. Run bare `stn` inside tmux and confirm `stn-tmux-popup` opens the popup.
 7. Deliver a provider event through `stn-ingress` and confirm it appears in
    Station.
-8. Leave a hosted PTY alive under the RC, fetch the `v0.1.1` installer by tag,
-   run it with `--version v0.1.1`, and confirm launch reports
-   `HOST_UPGRADE_BLOCKED` without losing the terminal or scrollback. Reinstall
-   the RC to reattach and close every hosted terminal; reinstall `v0.1.1` and
-   confirm the idle host is replaced.
+8. Complete the local `0.7.0-host-a` → `0.7.0-host-b` procedure above with a
+   live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
+   scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, install RC → stable → RC. Terminal A may print only complete old or
-   new versions: never command-not-found or malformed output. After each
-   transition, confirm `stn-ingress` and `stn-tmux-popup` still link to `stn`,
-   so the runtime never has mixed entrypoints.
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.0`: never
+   command-not-found or malformed output. After each transition, confirm
+   `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
+   has mixed entrypoints. Repeat this with two versions when preparing the
+   second binary release.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner
@@ -278,9 +285,10 @@ manually verify the actual user experience, not a dashboard override:
 11. Interrupt a real authenticated upgrade with Ctrl-C. Confirm the prior TUI
    still opens, the installer exits with status 130 and leaves no owned lock or
    stage, then retry successfully.
-12. Fetch and run the tagged `v0.1.1-rc.1` installer, confirm the version
-    changed, then fetch and reinstall `v0.1.1` to complete the explicit rollback
-    check.
+12. Run `promote-release.yml` only after steps 1-11 pass. Confirm it selects the
+    successful release run's `accepted-release-candidate-*` artifact, verifies
+    the exact draft asset IDs and hashes, and publishes that draft without
+    replacing any asset.
 
 Record the oldest supported macOS version or built-against glibc version in the
 release notes. Signing and notarization are not part of A5; integrity is the

--- a/docs/development.md
+++ b/docs/development.md
@@ -198,6 +198,25 @@ draft and rerun the unchanged tag workflow. If the source needs a fix, leave
 the pushed tag alone and use the next prerelease tag. Never delete or mutate a
 published release.
 
+Installer acceptance uses the destination lock
+`<install-dir>/.station-install.lock`, acquired before release lookup or
+download; `<install-dir>/.station-install.lock/owner` records the PID and
+requested tag or `latest`. A lock refusal must name the lock path and recorded
+owner PID when readable, state that the existing Station installation was
+unchanged, and tell the user to wait and retry. The installer never auto-removes
+an uncertain lock: after confirming that no installer with the recorded PID is
+alive, the operator removes the lock directory manually and retries.
+
+The staged binary's `--version` probe must finish within 10 seconds. A timeout
+terminates and reaps the probe and preserves the existing install. HUP, INT,
+and TERM use the rollback/cleanup path and exit 129, 130, and 143 respectively.
+The verified `stn` rename is the sole runtime commit point: aliases already
+resolve to `stn`, and pre-commit caught failures restore the old license and
+remove aliases created by that attempt. SIGKILL and power loss cannot clean up;
+they may leave a stale lock, stage, or old/new `LICENSE` metadata when the data
+and install directories are on different filesystems, but pre-existing runtime
+entrypoints must still resolve coherently to the complete old or new binary.
+
 For each target, install through the authenticated script into a clean home and
 manually verify the actual user experience, not a dashboard override:
 
@@ -215,8 +234,21 @@ manually verify the actual user experience, not a dashboard override:
    `HOST_UPGRADE_BLOCKED` without losing the terminal or scrollback. Reinstall
    the RC to reattach and close every hosted terminal; reinstall `v0.1.1` and
    confirm the idle host is replaced.
-7. Run `scripts/install.sh --version v0.1.1-rc.1`, confirm the version changed,
-   then reinstall `v0.1.1`.
+7. In terminal A, continuously run the installed `stn --version`. In terminal
+   B, install RC → stable → RC. Terminal A may print only complete old or
+   new versions: never command-not-found or malformed output. After each
+   transition, confirm `stn-ingress` and `stn-tmux-popup` still link to `stn`,
+   so the runtime never has mixed entrypoints.
+8. In an isolated install directory, create an abandoned
+   `.station-install.lock` with representative owner metadata. Run the
+   installer and follow its printed inspection, manual removal, and retry
+   instructions exactly; do not remove the lock until no owner process is
+   alive.
+9. Interrupt a real authenticated upgrade with Ctrl-C. Confirm the prior TUI
+   still opens, the installer exits with status 130 and leaves no owned lock or
+   stage, then retry successfully.
+10. Run `scripts/install.sh --version v0.1.1-rc.1`, confirm the version changed,
+    then reinstall `v0.1.1` to complete the explicit rollback check.
 
 Record the oldest supported macOS version or built-against glibc version in the
 release notes. Signing and notarization are not part of A5; integrity is the

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,10 +1,16 @@
 # Homebrew Packaging
 
-Status: live, internal/team tap at
+Status: live, internal/team **source formula** at
 [`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station).
 Station is not ready for `homebrew/core` yet: the `station` repo itself is
 private, uses Node.js 24.2+ (and below 25) plus a separate Bun workspace, and requires explicit
-first-run setup. v0.1.0 is the first tagged release.
+first-run setup. v0.1.0 is the first source-formula baseline.
+
+The authenticated compiled binary is the primary private user channel. The tap
+remains a separate source-build option for development and internal packaging
+validation; it does not consume A5 binary archives and is not updated when a
+binary release is published. A binary Homebrew formula remains deferred until
+private release-asset downloads have a tested Homebrew authentication strategy.
 
 Because `jeremy0dell/station` is a private GitHub repo, this tap is for
 internal/team use, not public onboarding. There is no built-in Homebrew
@@ -16,7 +22,7 @@ for github.com (SSH key, or `gh auth login`'s git credential helper) -- no
 extra token/env var needed at install time. Revisit this once `station` goes
 public.
 
-## Target user flow
+## Source-formula user flow
 
 ```bash
 brew tap jeremy0dell/station
@@ -66,22 +72,26 @@ Runtime launchers should wrap the installed tree and prepend Homebrew's
 
 ## Release checklist
 
-1. Bump `version` in root `package.json`, commit, tag (`git tag vX.Y.Z`), push
-   the commit and tag.
-2. `gh release create vX.Y.Z --generate-notes`.
-3. `.github/workflows/homebrew-bump.yml` runs on `release: published` and
-   updates `Formula/station.rb`'s `tag`/`revision` in the tap automatically,
-   committing directly to the tap's default branch (no PR, single maintainer).
-   It needs a `COMMITTER_TOKEN` repo secret on `jeremy0dell/station`: a PAT
-   (fine-grained, `contents: write` on `jeremy0dell/homebrew-station`, or
-   classic with `repo` scope) -- create one and run
-   `gh secret set COMMITTER_TOKEN -R jeremy0dell/station`. Without it the
-   workflow fails to push to the tap (cross-repo push needs an explicit
-   token; the default `GITHUB_TOKEN` only has access to the repo the
-   workflow runs in).
-4. If the bump workflow isn't set up yet, update `Formula/station.rb`'s `tag`
-   and `revision` by hand (`git rev-parse vX.Y.Z` for the revision).
-5. Test locally:
+Binary publication never updates the source formula. When a published Station
+source tag should be packaged separately:
+
+1. Confirm the tag contains the source checkout version intended for the
+   formula and that its normal CI is green.
+2. Manually dispatch the source-formula workflow with the exact published tag:
+
+   ```bash
+   gh workflow run homebrew-bump.yml -f tag=vX.Y.Z
+   ```
+
+   `.github/workflows/homebrew-bump.yml` is `workflow_dispatch` only; it does
+   not listen to `release: published`. The workflow updates
+   `Formula/station.rb`'s `tag` and revision in the tap and commits directly to
+   the tap's default branch.
+3. `COMMITTER_TOKEN` remains intentionally unconfigured for A5. A future
+   source-formula dispatch needs a PAT with cross-repository contents write
+   access on `jeremy0dell/homebrew-station`; the default `GITHUB_TOKEN` cannot
+   push to that repository. Until then, update the tap formula manually.
+4. Test locally:
 
    ```bash
    brew untap jeremy0dell/station; brew tap jeremy0dell/station
@@ -94,7 +104,7 @@ Runtime launchers should wrap the installed tree and prepend Homebrew's
    stn
    ```
 
-6. Publish bottles from the tap once the formula is reviewed and the tap CI is
+5. Publish bottles from the tap once the formula is reviewed and the tap CI is
    green.
 
 ## Known issues

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,67 @@
 # Install
 
-This setup path is for a local development checkout. station remains a private workspace package for this milestone; there is no public npm package or publish flow yet.
+Station is distributed internally as authenticated private GitHub release assets. There is no public package or public download channel.
 
-## Quick start (macOS)
+## Private Binary
 
-From a fresh clone, one script installs the system dependencies via Homebrew, builds the workspace, and links all three checkout launchers onto `PATH`:
+Authenticate `gh` for `jeremy0dell/station`, then run the installer directly from the private repository:
+
+```bash
+gh auth login --hostname github.com
+(
+  set -e
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  test -s "$installer"
+  sh "$installer" --version v0.1.1-rc.1
+)
+```
+
+Only after that block succeeds:
+
+```bash
+stn setup
+stn
+```
+
+The explicit RC is the A5 validation baseline. Once `v0.1.1` is published, omitting `--version` selects the latest stable release:
+
+```bash
+(
+  set -e
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  test -s "$installer"
+  sh "$installer"
+)
+```
+
+Use `--version` whenever an exact install or rollback is required.
+
+Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
+
+The installer:
+
+- accepts only `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`;
+- downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` through authenticated `gh api` calls (`{version}` excludes the tag's leading `v`);
+- verifies the matching SHA-256 before extraction and rejects an unexpected archive manifest;
+- stages the verified binary on the destination filesystem and requires its `--version` to match, so an incompatible OS/libc/CPU artifact or version mismatch fails before replacing an existing command;
+- replaces the compiled `stn`, `stn-ingress`, and `stn-tmux-popup` paths by atomic rename, preserving an existing install on any pre-install failure;
+- installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`;
+- removes `com.apple.quarantine` from the verified binary defensively on macOS; and
+- prints `stn setup` plus a PATH hint only when the selected bin directory is not already on `PATH`.
+
+The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
+
+Rollback is the same authenticated explicit-version install. Published tags and assets are immutable; do not delete, move, or overwrite them. If a stable release is bad, reinstall the prior tag for recovery and publish a higher patch release containing the revert or fix.
+
+## Development Checkout
+
+The source checkout remains the development path. On macOS, one script installs the development dependencies via Homebrew, builds the workspace, and links the source `stn` command:
 
 ```bash
 ./scripts/setup/bootstrap.sh
@@ -14,14 +71,14 @@ stn
 
 `bootstrap.sh` runs `brew bundle` (Node 24, Bun, Worktrunk, tmux, diffnav, git-delta), then `pnpm install`, `pnpm build`, the Bun UI install (`cd station && bun install && bun run link:station && bun run repair:node-pty`), and `pnpm station:link`. That final command uses pnpm 11's supported global-add path to expose `stn`, `stn-ingress`, and `stn-tmux-popup` while keeping them bound to the checkout. The Bun step matters: `station/` is a separate Bun workspace, not a pnpm-workspace member, so `pnpm install` never installs it — skip it and bare `stn` refuses to launch with an install hint (the underlying failure is "@opentui not found"). If you manage your own runtimes, the manual steps below are equivalent. A single prebuilt binary is the post-alpha goal — the design and phased roadmap live in [Single-binary Station](single-binary.md); until then, the draft Homebrew tap path is documented in [Homebrew packaging](homebrew.md).
 
-## Requirements
+## Development Requirements
 
-`stn setup check` blocks (exit 1) until these required tools are present:
+For a complete source-development workflow, `stn setup check` exits 1 until these tools are present. A compiled binary can still launch when a feature-gated tool is missing:
 
 - Git, run from inside the git repository you want to manage (macOS: the Command Line Tools)
 - Worktrunk `wt` for core worktree setup
 - tmux for the reference terminal provider and popup path
-- Bun — bare `stn` renders the TUI through `bun run` (not required when `STATION_DASHBOARD_COMMAND` overrides the renderer)
+- Bun — source-checkout `stn` renders the TUI through `bun run`; compiled `stn` embeds the renderer
 - diffnav and git-delta for the "See diff (split right)" automation
 - One agent CLI: Claude Code, Codex, Cursor, OpenCode, or Pi
 
@@ -29,7 +86,7 @@ stn
 
 Node.js 24.2+ (and below 25) and pnpm 11 are dev/build prerequisites for this checkout, validated by `stn setup system --check` (not `stn setup check`); setup does not install or change them (use corepack for pnpm, and a Node version manager or `brew node@24` for Node). The repo selects the current Node 24 release with `.node-version` and `.nvmrc` (`24`), so fnm/nvm use the supported release in the checkout instead of falling back to your global default (asdf reads these only with `legacy_version_file = yes` in `~/.asdfrc`).
 
-## Fresh Checkout
+## Fresh Development Checkout
 
 From the repository root:
 
@@ -39,6 +96,7 @@ pnpm build
 cd station && bun install && cd ..   # Bun UI lane (separate workspace; pnpm does not install it)
 pnpm stn setup
 pnpm smoke:release
+pnpm smoke:install
 ```
 
 `cd station && bun install` is required for the terminal UI: bare `stn` renders it by shelling into `bun run` against `station/`, so without the install `stn` refuses to launch and prints the install hint (historically a raw "@opentui not found" error) even though the Bun binary is healthy. `stn doctor` reports this lane explicitly (a `renderer-runtime` warning with code `STATION_UI_NOT_INSTALLED`).
@@ -56,6 +114,8 @@ Optional integrations can be added later.
 ```
 
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
+
+`pnpm smoke:install` exercises latest and explicit-version selection, all four platform mappings, checksums, archive safety, atomic replacement, rollback, symlinks, license placement, authentication failure, and PATH hints against local fake release assets. It does not contact GitHub or modify the real home directory.
 
 Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. When bare `stn` launchers are not on `PATH`, setup uses launcher paths from the current checkout for generated tmux and hook commands and offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,11 +49,46 @@ The installer:
 - accepts only `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`;
 - downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` through authenticated `gh api` calls (`{version}` excludes the tag's leading `v`);
 - verifies the matching SHA-256 before extraction and rejects an unexpected archive manifest;
-- stages the verified binary on the destination filesystem and requires its `--version` to match, so an incompatible OS/libc/CPU artifact or version mismatch fails before replacing an existing command;
-- replaces the compiled `stn`, `stn-ingress`, and `stn-tmux-popup` paths by atomic rename, preserving an existing install on any pre-install failure;
-- installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`;
+- stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command;
+- keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
 - removes `com.apple.quarantine` from the verified binary defensively on macOS; and
 - prints `stn setup` plus a PATH hint only when the selected bin directory is not already on `PATH`.
+
+### Concurrent and interrupted installs
+
+Each destination has one installer lock at
+`<install-dir>/.station-install.lock` (by default
+`~/.local/bin/.station-install.lock`); its `owner` file records the installer
+PID and requested tag or `latest`. The installer acquires the lock before
+release lookup or download and holds it through cleanup. If the lock already
+exists, the installer does not contact the release API or mutate the
+destination. It prints the lock path and the owner PID when readable, says that
+the existing Station installation was unchanged, and instructs the user to
+wait for the other installer to finish before retrying.
+
+The installer never guesses that a lock is stale. For an abandoned lock, read
+`<install-dir>/.station-install.lock/owner` and confirm that no installer
+process with the recorded PID is alive. Only then remove
+`<install-dir>/.station-install.lock` manually and retry the same install. Do
+not remove a lock while its owner may still be running.
+
+The staged `stn --version` probe has a 10-second deadline. On timeout the
+installer terminates and reaps the probe, reports that the artifact did not
+respond in time, and leaves the existing Station installation unchanged.
+HUP, INT, and TERM run the same rollback/cleanup path and exit with the
+signal-appropriate status (129, 130, and 143 respectively), so Ctrl-C does not
+return to an interrupted install. Before the final `stn` rename, caught
+failures restore the prior license and remove only aliases created by that
+attempt. After the rename, every runtime entrypoint resolves through the new
+binary and cleanup failures are warnings rather than a failed install.
+
+SIGKILL and power loss cannot run shell cleanup. They may leave the lock or a
+staging path behind, and because `LICENSE` may live on another filesystem they
+may leave license metadata from the old or new release. During an upgrade, the
+pre-existing command entrypoints still resolve coherently to the complete old
+or new runtime; exact cross-filesystem license consistency is not claimed.
+Recover an abandoned lock only with the inspection-and-manual-removal procedure
+above.
 
 The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ Authenticate `gh` for `jeremy0dell/station`, then run the installer directly fro
 gh auth login --hostname github.com
 (
   set -e
-  tag=v0.1.1-rc.1
+  tag=v0.7.0
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
   GH_HOST=github.com gh api --method GET \
@@ -29,9 +29,8 @@ stn setup
 stn
 ```
 
-`v0.1.1-rc.1` is the first supported private-binary baseline. Once `v0.1.1`
-is published, resolve the latest stable tag first, then fetch and invoke that
-tag's installer:
+`v0.7.0` is the first supported private-binary baseline. Resolve the latest
+stable tag first, then fetch and invoke that tag's installer:
 
 ```bash
 (
@@ -52,9 +51,10 @@ tag's installer:
 )
 ```
 
-Use the explicit form with the desired `tag` for every exact install or
-rollback. Both forms pair installer code and artifacts from one immutable tag;
-they never fall back to `main`.
+Use the explicit form with the desired `tag` for every exact install. Both
+forms pair installer code and artifacts from one immutable tag; they never
+fall back to `main`. Because `v0.7.0` is the first binary release, immutable
+rollback to a prior binary becomes available only after the next binary release.
 
 Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
 
@@ -77,25 +77,30 @@ Every install serializes both mutated resources with these locks:
 - `<data-home>/station/.station-install.lock` (by default
   `~/.local/share/station/.station-install.lock`) for `LICENSE`.
 
-Each lock's `owner` file records the installer PID and requested tag or
-`latest`. The installer acquires the command lock first and the license lock
-second, skips the second acquisition if both paths coincide, and releases them
-in reverse order. A refusal happens before release lookup or download, names
+Each lock's sole `owner-*` file records the installer PID, requested tag or
+`latest`, and the unique ownership token embedded in its filename. Cleanup
+removes only that token-specific file and revalidates the lock inode, so an
+earlier installer cannot remove a replacement lock. The installer acquires
+the command lock first and the license lock second, skips the second acquisition
+if both paths coincide, and releases them in reverse order. A refusal happens
+before release lookup or download, names
 the lock and readable owner PID, states that the existing Station installation
 was unchanged, and tells the user to wait and retry. A license-lock refusal
 releases the command lock and performs no release API request.
 
 The installer never guesses that either lock is stale. For an abandoned lock,
-read its `owner` file—`<install-dir>/.station-install.lock/owner` or
-`<data-home>/station/.station-install.lock/owner`—and confirm that no installer
-process with the recorded PID is alive. Only then remove that lock directory
-manually and retry the same install. Do not remove a lock while its owner may
-still be running.
+read its sole `<install-dir>/.station-install.lock/owner-*` or
+`<data-home>/station/.station-install.lock/owner-*` file and confirm that no
+installer process with the recorded PID is alive. Only then remove that lock
+directory manually and retry the same install. Do not remove a lock while its
+owner may still be running. Legacy locks with a single `owner` file remain
+readable for safe refusal and manual recovery.
 
 The staged `stn --version` probe has a 10-second supervised deadline and a
 bounded output file. Timeout status 124 means the watchdog terminated, killed
 if necessary, and reaped the probe; status 125 means the timer machinery
-failed. A loader or compatibility failure prints no more than 4096 sanitized
+failed. Common GitHub and Actions token variables are removed from the probe's
+environment. A loader or compatibility failure prints no more than 4096 sanitized
 bytes of probe stderr. HUP, INT, and TERM forward to the active child, run the
 same TERM/KILL/reap and rollback path, and exit with status 129, 130, and 143
 respectively, so Ctrl-C does not return to an interrupted install.
@@ -122,7 +127,10 @@ retrying after a machine loss.
 
 The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
 
-Rollback is the same authenticated explicit-version install. Published tags and assets are immutable; do not delete, move, or overwrite them. If a stable release is bad, reinstall the prior tag for recovery and publish a higher patch release containing the revert or fix.
+After a second binary version exists, rollback is the same authenticated
+explicit-version install. Published tags and assets are immutable; do not
+delete, move, or overwrite them. If `v0.7.0` itself is bad, publish a higher
+version containing the revert or fix because there is no earlier binary tag.
 
 ## Development Checkout
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,12 +10,15 @@ Authenticate `gh` for `jeremy0dell/station`, then run the installer directly fro
 gh auth login --hostname github.com
 (
   set -e
+  tag=v0.1.1-rc.1
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  GH_HOST=github.com gh api --method GET \
+    repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" \
+    -f ref="$tag" > "$installer"
   test -s "$installer"
-  sh "$installer" --version v0.1.1-rc.1
+  sh "$installer" --version "$tag"
 )
 ```
 
@@ -26,21 +29,32 @@ stn setup
 stn
 ```
 
-The explicit RC is the A5 validation baseline. Once `v0.1.1` is published, omitting `--version` selects the latest stable release:
+`v0.1.1-rc.1` is the first supported private-binary baseline. Once `v0.1.1`
+is published, resolve the latest stable tag first, then fetch and invoke that
+tag's installer:
 
 ```bash
 (
   set -e
+  tag="$(
+    GH_HOST=github.com gh api --method GET \
+      repos/jeremy0dell/station/releases/latest --jq '.tag_name'
+  )"
+  test -n "$tag"
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" > "$installer"
+  GH_HOST=github.com gh api --method GET \
+    repos/jeremy0dell/station/contents/scripts/install.sh \
+    -H "Accept: application/vnd.github.raw+json" \
+    -f ref="$tag" > "$installer"
   test -s "$installer"
-  sh "$installer"
+  sh "$installer" --version "$tag"
 )
 ```
 
-Use `--version` whenever an exact install or rollback is required.
+Use the explicit form with the desired `tag` for every exact install or
+rollback. Both forms pair installer code and artifacts from one immutable tag;
+they never fall back to `main`.
 
 Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
 
@@ -49,46 +63,62 @@ The installer:
 - accepts only `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`;
 - downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` through authenticated `gh api` calls (`{version}` excludes the tag's leading `v`);
 - verifies the matching SHA-256 before extraction and rejects an unexpected archive manifest;
-- stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command;
+- stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command; compatibility failures include at most 4096 sanitized bytes of probe stderr;
 - keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
 - removes `com.apple.quarantine` from the verified binary defensively on macOS; and
-- prints `stn setup` plus a PATH hint only when the selected bin directory is not already on `PATH`.
+- resolves all three bare launchers after installation. If any is missing or shadowed, it names every mismatch, prints a safely quoted current-shell block that prepends the install directory, runs `hash -r`, and starts `stn setup`, and also prints the absolute installed `stn` path. It never edits a shell profile.
 
 ### Concurrent and interrupted installs
 
-Each destination has one installer lock at
-`<install-dir>/.station-install.lock` (by default
-`~/.local/bin/.station-install.lock`); its `owner` file records the installer
-PID and requested tag or `latest`. The installer acquires the lock before
-release lookup or download and holds it through cleanup. If the lock already
-exists, the installer does not contact the release API or mutate the
-destination. It prints the lock path and the owner PID when readable, says that
-the existing Station installation was unchanged, and instructs the user to
-wait for the other installer to finish before retrying.
+Every install serializes both mutated resources with these locks:
 
-The installer never guesses that a lock is stale. For an abandoned lock, read
-`<install-dir>/.station-install.lock/owner` and confirm that no installer
-process with the recorded PID is alive. Only then remove
-`<install-dir>/.station-install.lock` manually and retry the same install. Do
-not remove a lock while its owner may still be running.
+- `<install-dir>/.station-install.lock` (by default
+  `~/.local/bin/.station-install.lock`) for the commands; and
+- `<data-home>/station/.station-install.lock` (by default
+  `~/.local/share/station/.station-install.lock`) for `LICENSE`.
 
-The staged `stn --version` probe has a 10-second deadline. On timeout the
-installer terminates and reaps the probe, reports that the artifact did not
-respond in time, and leaves the existing Station installation unchanged.
-HUP, INT, and TERM run the same rollback/cleanup path and exit with the
-signal-appropriate status (129, 130, and 143 respectively), so Ctrl-C does not
-return to an interrupted install. Before the final `stn` rename, caught
-failures restore the prior license and remove only aliases created by that
-attempt. After the rename, every runtime entrypoint resolves through the new
-binary and cleanup failures are warnings rather than a failed install.
+Each lock's `owner` file records the installer PID and requested tag or
+`latest`. The installer acquires the command lock first and the license lock
+second, skips the second acquisition if both paths coincide, and releases them
+in reverse order. A refusal happens before release lookup or download, names
+the lock and readable owner PID, states that the existing Station installation
+was unchanged, and tells the user to wait and retry. A license-lock refusal
+releases the command lock and performs no release API request.
 
-SIGKILL and power loss cannot run shell cleanup. They may leave the lock or a
-staging path behind, and because `LICENSE` may live on another filesystem they
-may leave license metadata from the old or new release. During an upgrade, the
-pre-existing command entrypoints still resolve coherently to the complete old
-or new runtime; exact cross-filesystem license consistency is not claimed.
-Recover an abandoned lock only with the inspection-and-manual-removal procedure
-above.
+The installer never guesses that either lock is stale. For an abandoned lock,
+read its `owner` file—`<install-dir>/.station-install.lock/owner` or
+`<data-home>/station/.station-install.lock/owner`—and confirm that no installer
+process with the recorded PID is alive. Only then remove that lock directory
+manually and retry the same install. Do not remove a lock while its owner may
+still be running.
+
+The staged `stn --version` probe has a 10-second supervised deadline and a
+bounded output file. Timeout status 124 means the watchdog terminated, killed
+if necessary, and reaped the probe; status 125 means the timer machinery
+failed. A loader or compatibility failure prints no more than 4096 sanitized
+bytes of probe stderr. HUP, INT, and TERM forward to the active child, run the
+same TERM/KILL/reap and rollback path, and exit with status 129, 130, and 143
+respectively, so Ctrl-C does not return to an interrupted install.
+
+Immediately before commit, the installer revalidates both aliases as exact
+symlinks to `stn` and the accepted binary and license destination types. Before
+the final rename, a caught failure restores the prior license and removes only
+an alias that this attempt successfully created and that still matches it. If
+a failed final `mv` leaves the staged `stn` present, rollback restores the
+previous state and the installer reports it unchanged. If the staged `stn`
+disappeared, activation may have committed: the installer preserves the new
+license and aliases, exits nonzero, and prints an absolute
+`<install-dir>/stn --version` inspection command. It does not claim that the previous installation
+was unchanged in that ambiguous case. Post-commit cleanup failures are warnings.
+
+SIGKILL cannot run shell cleanup, so it can leave a stale lock or staging path;
+recover a lock only with the inspection-and-manual-removal procedure above.
+Atomic rename gives coherent process-level visibility—continuous readers see a
+complete old or new runtime—but this installer does not fsync the files or
+containing directories. It therefore makes no post-power-loss durability
+guarantee, and power loss can also leave old/new cross-filesystem `LICENSE`
+metadata. Inspect the absolute installed `stn --version` and both locks before
+retrying after a machine loss.
 
 The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
 
@@ -104,7 +134,7 @@ stn setup
 stn
 ```
 
-`bootstrap.sh` runs `brew bundle` (Node 24, Bun, Worktrunk, tmux, diffnav, git-delta), then `pnpm install`, `pnpm build`, the Bun UI install (`cd station && bun install && bun run link:station && bun run repair:node-pty`), and `pnpm station:link`. That final command uses pnpm 11's supported global-add path to expose `stn`, `stn-ingress`, and `stn-tmux-popup` while keeping them bound to the checkout. The Bun step matters: `station/` is a separate Bun workspace, not a pnpm-workspace member, so `pnpm install` never installs it — skip it and bare `stn` refuses to launch with an install hint (the underlying failure is "@opentui not found"). If you manage your own runtimes, the manual steps below are equivalent. A single prebuilt binary is the post-alpha goal — the design and phased roadmap live in [Single-binary Station](single-binary.md); until then, the draft Homebrew tap path is documented in [Homebrew packaging](homebrew.md).
+`bootstrap.sh` runs `brew bundle` (Node 24, Bun, Worktrunk, tmux, diffnav, git-delta), then `pnpm install`, `pnpm build`, the Bun UI install (`cd station && bun install && bun run link:station && bun run repair:node-pty`), and `pnpm station:link`. That final command uses pnpm 11's supported global-add path to expose `stn`, `stn-ingress`, and `stn-tmux-popup` while keeping them bound to the checkout. The Bun step matters: `station/` is a separate Bun workspace, not a pnpm-workspace member, so `pnpm install` never installs it — skip it and bare `stn` refuses to launch with an install hint (the underlying failure is "@opentui not found"). If you manage your own runtimes, the manual steps below are equivalent. The compiled release design and phased roadmap live in [Single-binary Station](single-binary.md); the separate source-package path is documented in [Homebrew packaging](homebrew.md).
 
 ## Development Requirements
 
@@ -150,7 +180,13 @@ Optional integrations can be added later.
 
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
-`pnpm smoke:install` exercises latest and explicit-version selection, all four platform mappings, checksums, archive safety, atomic replacement, rollback, symlinks, license placement, authentication failure, and PATH hints against local fake release assets. It does not contact GitHub or modify the real home directory.
+`pnpm smoke:install` exercises latest, explicit, and draft selection; strict
+authenticated API arguments; all four platform mappings; default-home and PATH
+shadow behavior; checksum/archive/probe failures; dual-lock concurrency and
+stale recovery; rollback and ambiguous commit points; continuous readers;
+HUP/INT/TERM/SIGKILL; and runner self-interruption against local fake release
+assets. Every child and the overall runner have deadlines. It does not contact
+GitHub or modify the real home directory.
 
 Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. When bare `stn` launchers are not on `PATH`, setup uses launcher paths from the current checkout for generated tmux and hook commands and offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -356,22 +356,32 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.1.1-rc.1-darwin-arm64.tar.gz`.
+example `stn-v0.7.0-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
 duplicate targets, emits a stably sorted `SHA256SUMS`, and creates a GitHub
 release **draft** without clobbering an existing release. A second native
-matrix fetches the installer from the release tag through the authenticated
-Contents API, invokes it with the same explicit tag against that real draft,
-and verifies the binary version, both argv0 aliases, license, and launch without
-Node or Bun on the runtime PATH. The PR matrix and release matrix use one
+matrix revalidates the tag, fetches the installer by the validated commit SHA
+through the authenticated Contents API, invokes it with the explicit tag against
+that real draft, and verifies the binary version, both argv0 aliases, license,
+and launch without Node or Bun on the runtime PATH. The PR matrix and release
+matrix use one
 archive-packaging helper, so their manifests cannot drift. Publication remains
 a manual decision after the real-TTY acceptance below. GitHub's tag endpoint
 exposes published releases only, so the workflow captures the new draft's
 numeric release ID from the authenticated release list and passes it only to
 these acceptance jobs; normal installs keep using the latest/published-tag
 endpoints.
+
+After all native acceptance jobs pass, the release workflow re-downloads the
+five draft assets, checks them against the build-generated `SHA256SUMS`, and
+uploads an immutable `accepted-release-candidate-*` Actions artifact containing
+the validated commit, workflow run/attempt, release ID, asset IDs, and checksums.
+The manually dispatched `promote-release.yml` downloads that exact artifact,
+rechecks the successful run, tag commit, draft identity, asset IDs, and hashes,
+then publishes the unchanged draft. Draft assets cannot drift between acceptance
+and promotion without failing that workflow.
 
 `SHA256SUMS` is unsigned in A5 because no signing-key infrastructure exists;
 the trust chain is authenticated GitHub access plus immutable release assets.
@@ -380,12 +390,13 @@ claim bit-for-bit reproducible Bun executables or archives.
 
 `scripts/install.sh` supports latest stable, explicit `--version`, and
 `--install-dir` (default `~/.local/bin`). The supported binary-install baseline
-starts at `v0.1.1-rc.1`. Explicit install and rollback set a tag, fetch
+starts at `v0.7.0`. Explicit installs set a tag, fetch
 `scripts/install.sh` from that tag through the authenticated Contents API, and
 invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
-always paired.
+always paired. Immutable rollback becomes available with the second binary
+release because `v0.7.0` has no earlier binary artifact.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -397,22 +408,27 @@ The staged binary's `--version` probe has a 10-second supervised deadline and
 a POSIX file-size limit on stdout/stderr. Watchdog exit 124 reports timeout;
 125 reports timer machinery failure. Cleanup sends TERM, waits one second,
 sends KILL if needed, and reaps the probe without depending on a marker file.
-Compatibility failures show at most 4096 sanitized bytes of stderr, and the
-existing Station installation was unchanged before activation.
+Compatibility failures show at most 4096 sanitized bytes of stderr. Common
+GitHub and Actions token variables are removed from the probe environment, and
+the existing Station installation was unchanged before activation.
 
 The command lock is `<install-dir>/.station-install.lock`; the license lock is
-`<data-home>/station/.station-install.lock`. Their owner files—
-`<install-dir>/.station-install.lock/owner` and
-`<data-home>/station/.station-install.lock/owner`—record the PID and requested
-tag or `latest`. The installer acquires the command lock first and the license
-lock second, skips a duplicate path, and releases in reverse order. An existing
+`<data-home>/station/.station-install.lock`. Their sole owner files—
+`<install-dir>/.station-install.lock/owner-*` and
+`<data-home>/station/.station-install.lock/owner-*`—record the PID, requested
+tag or `latest`, and the token embedded in each filename. Cleanup removes only
+its token-specific owner file and revalidates the lock-directory inode so it
+cannot remove a replacement owner's lock. The installer acquires the
+command lock first and the license lock second, skips a duplicate path, and
+releases in reverse order. An existing
 lock causes a fail-fast refusal before release requests; a license-lock refusal
 releases the command lock and performs no release API request. The message
 names the lock and readable owner PID, states that the existing Station
 installation was unchanged, and tells the user to wait before retrying. The
 installer never auto-reclaims a possibly active lock. An operator may remove
-either abandoned lock manually only after reading its owner file and confirming
-that no installer process with the recorded PID is alive, then retry.
+either abandoned lock manually only after reading its sole owner file and
+confirming that no installer process with the recorded PID is alive, then
+retry. A legacy lock with one `owner` file remains readable for refusal.
 
 Existing exact `stn-ingress` and `stn-tmux-popup` symlinks remain stable; a
 missing alias is considered created only after `ln` succeeds and cleanup
@@ -446,18 +462,17 @@ prints a safely shell-quoted current-shell block that prepends the directory,
 runs `hash -r`, and invokes `stn setup`, plus the absolute installed `stn`
 fallback. It never edits a shell profile.
 
-The release starts with immutable `v0.1.1-rc.1`, promotes only after all four
-native targets pass automated and manual acceptance, then repeats the gates for
-`v0.1.1`. Explicit installation of the RC proves rollback before stable
-publication. Published tags and assets are never deleted, moved, or overwritten:
-users may explicitly reinstall the prior good version for recovery, while the
-release line rolls forward with a superseding patch containing the revert or
-fix.
+The first binary release is immutable `v0.7.0` and promotes only after all four
+native targets pass automated and manual acceptance. Published tags and assets
+are never deleted, moved, or overwritten. Cross-version rollback is intentionally
+deferred until a second binary version exists; a bad `v0.7.0` rolls forward to a
+higher version containing the revert or fix.
 
-Drafts are still mutable. Release notes record the workflow commit, and the
-manual promotion gate re-fetches the remote tag, compares its peeled commit to
-that SHA, and rechecks the exact five-asset inventory immediately before
-publication; GitHub immutability begins only when the draft is published.
+Drafts are still mutable. Release notes record the workflow commit, while the
+accepted-candidate artifact immutably records that commit plus the draft release
+and asset identities. The manual promotion workflow re-fetches every asset,
+compares its ID and digest to the accepted artifact, and publishes only that
+unchanged draft; GitHub release immutability begins at publication.
 An unpublished draft left by a transient workflow failure may be deleted and
 the unchanged tag workflow rerun; a source fix uses a new prerelease tag, while
 published releases are never deleted or mutated.
@@ -638,17 +653,20 @@ flow:
    reconnects without a manual restart.
 5. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
 6. `stn-ingress` symlink delivers a provider hook event end to end.
-7. Upgrade the binary while **live host PTYs** exist → the new build reports
+7. Use local `0.7.0-host-a` and `0.7.0-host-b` builds while **live host PTYs**
+   exist → the new build reports
    `HOST_UPGRADE_BLOCKED`; the old host and sessions remain reattachable with
    the old build. After every hosted terminal closes, retry → the idle host is
    stopped; open a hosted terminal → the replacement health reports the new
    build (B-host).
-8. Tagged rollback → the tagged installer returns to the prior immutable
-   version, then the stable tagged installer restores the upgrade.
+8. Manual promotion selects the successful run's immutable
+   `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
+   asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   installs RC → stable → RC → only complete old or new versions appear,
-   never command-not-found or malformed output; both aliases remain links to
-   `stn`, so entrypoints never mix.
+   repeatedly installs the draft → only complete `0.7.0` output appears, never
+   command-not-found or malformed output; both aliases remain links to `stn`,
+   so entrypoints never mix. Repeat with two immutable versions when preparing
+   the second binary release and first rollback gate.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.
@@ -684,7 +702,8 @@ Against `e0d4307`, reproduced this session (bun 1.3.14, darwin-arm64):
 8. **Artifact inventory incomplete** — `stn-tmux-popup`, Pi extension file,
    LICENSE. New manifest + extraction policy.
 9. **Release not shippable** — runner label, OS/CPU/glibc floors, gate
-   bypass, checksums, license, real rollback. Fixed in A5 + platform table.
+   bypass, checksums, license, and recovery policy. Fixed in A5 + platform table;
+   immutable rollback starts with the second binary release.
    (Sub-claim "`macos-13` retired": consistent with GitHub's Intel-macOS
    deprecation; **not independently verified from this environment** — pin
    available labels at implementation time rather than trust the name.)

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -362,13 +362,16 @@ Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
 duplicate targets, emits a stably sorted `SHA256SUMS`, and creates a GitHub
 release **draft** without clobbering an existing release. A second native
-matrix uses the authenticated installer against that real draft and verifies
-the binary version, both argv0 aliases, license, and launch without Node or Bun
-on the runtime PATH. Publication remains a manual decision after the real-TTY
-acceptance below. GitHub's tag endpoint exposes published releases only, so the
-workflow captures the new draft's numeric release ID from the authenticated
-release list and passes it only to these acceptance jobs; normal installs keep
-using the latest/published-tag endpoints.
+matrix fetches the installer from the release tag through the authenticated
+Contents API, invokes it with the same explicit tag against that real draft,
+and verifies the binary version, both argv0 aliases, license, and launch without
+Node or Bun on the runtime PATH. The PR matrix and release matrix use one
+archive-packaging helper, so their manifests cannot drift. Publication remains
+a manual decision after the real-TTY acceptance below. GitHub's tag endpoint
+exposes published releases only, so the workflow captures the new draft's
+numeric release ID from the authenticated release list and passes it only to
+these acceptance jobs; normal installs keep using the latest/published-tag
+endpoints.
 
 `SHA256SUMS` is unsigned in A5 because no signing-key infrastructure exists;
 the trust chain is authenticated GitHub access plus immutable release assets.
@@ -376,37 +379,72 @@ The pipeline pins inputs, gates, targets, names, and manifest, but does not
 claim bit-for-bit reproducible Bun executables or archives.
 
 `scripts/install.sh` supports latest stable, explicit `--version`, and
-`--install-dir` (default `~/.local/bin`). It uses authenticated `gh api`
-release endpoints, accepts only the four supported targets, verifies the one
-matching `SHA256SUMS` entry and exhaustive archive manifest before touching an
-existing install, and stages replacement on the destination filesystem. The
-staged binary's `--version` probe has a 10-second deadline; timeout terminates
-and reaps it, reports that the artifact did not respond in time, and leaves the
-existing Station installation unchanged.
+`--install-dir` (default `~/.local/bin`). The supported binary-install baseline
+starts at `v0.1.1-rc.1`. Explicit install and rollback set a tag, fetch
+`scripts/install.sh` from that tag through the authenticated Contents API, and
+invoke it with `--version` set to the same tag. Latest install first resolves
+the latest stable tag, then performs the same tagged fetch and explicit invoke.
+There is no silent `main` fallback, so installer code and release artifacts are
+always paired.
 
-The destination-scoped lock is `<install-dir>/.station-install.lock`. It is
-held from before release lookup/download through cleanup, and its `owner` file
-records the PID and requested tag or `latest`. An existing lock causes a
-fail-fast refusal with no release request or destination mutation; the message
+The installer uses authenticated `gh api` release endpoints, accepts only the
+four supported targets, verifies the one matching `SHA256SUMS` entry and exact
+archive manifest before touching an existing install, and stages replacement
+on each destination filesystem. Every potentially blocking `gh` operation is a
+tracked file-backed child rather than a command substitution.
+
+The staged binary's `--version` probe has a 10-second supervised deadline and
+a POSIX file-size limit on stdout/stderr. Watchdog exit 124 reports timeout;
+125 reports timer machinery failure. Cleanup sends TERM, waits one second,
+sends KILL if needed, and reaps the probe without depending on a marker file.
+Compatibility failures show at most 4096 sanitized bytes of stderr, and the
+existing Station installation was unchanged before activation.
+
+The command lock is `<install-dir>/.station-install.lock`; the license lock is
+`<data-home>/station/.station-install.lock`. Their owner files—
+`<install-dir>/.station-install.lock/owner` and
+`<data-home>/station/.station-install.lock/owner`—record the PID and requested
+tag or `latest`. The installer acquires the command lock first and the license
+lock second, skips a duplicate path, and releases in reverse order. An existing
+lock causes a fail-fast refusal before release requests; a license-lock refusal
+releases the command lock and performs no release API request. The message
 names the lock and readable owner PID, states that the existing Station
 installation was unchanged, and tells the user to wait before retrying. The
 installer never auto-reclaims a possibly active lock. An operator may remove
-an abandoned lock manually only after reading
-`<install-dir>/.station-install.lock/owner` and confirming that no installer
-process with the recorded PID is alive, then retry.
+either abandoned lock manually only after reading its owner file and confirming
+that no installer process with the recorded PID is alive, then retry.
 
-Existing exact `stn-ingress` and `stn-tmux-popup` symlinks remain stable; any
-missing aliases are created before activation. The previous license is backed
-up, the new `LICENSE` is installed, and the verified staged `stn` is atomically
-renamed last as the sole runtime commit point. A caught HUP, INT, or TERM runs
-rollback/cleanup and exits 129, 130, or 143 rather than resuming the interrupted
-operation. Before commit, caught failures restore the license and remove only
-new aliases. After commit, cleanup failures are warnings. SIGKILL and power
-loss cannot run cleanup, so a stale lock/stage or old/new cross-filesystem
-`LICENSE` metadata may remain; exact license consistency is not claimed, but
-pre-existing command entrypoints resolve to one complete old or new runtime.
-The deterministic `smoke:install` suite exercises this boundary with fake
-authenticated release assets and is part of `test:all`.
+Existing exact `stn-ingress` and `stn-tmux-popup` symlinks remain stable; a
+missing alias is considered created only after `ln` succeeds and cleanup
+removes it only while it still exactly matches this attempt. Immediately before
+commit, both aliases are revalidated as symlinks to `stn` and binary/license
+destinations are revalidated against their accepted types. The previous license
+is backed up, the new `LICENSE` is installed, and the verified staged `stn` is
+atomically renamed last as the sole runtime commit point.
+
+A caught HUP, INT, or TERM forwards to the active child, runs bounded
+TERM/KILL/reap cleanup, and exits 129, 130, or 143. If a failed final rename
+leaves staged `stn`, pre-commit rollback restores the license and matching new
+aliases and reports the install unchanged. If staged `stn` disappeared,
+activation may be committed: preserve the new license and aliases, exit
+nonzero, print an absolute `stn --version` inspection command, and do not claim
+the previous installation was unchanged. After commit, cleanup failures are
+warnings.
+
+SIGKILL cannot run cleanup and may leave either lock or a stage. Atomic rename
+still gives coherent process-level visibility to continuous readers. Power loss
+is not equivalent: the installer does not fsync files or containing directories
+and therefore makes no post-power-loss durability guarantee; old/new
+cross-filesystem `LICENSE` metadata may also remain. The deterministic
+`smoke:install` suite exercises this boundary with fake authenticated release
+assets and is part of `test:all`.
+
+After success, all three bare launchers are resolved physically. If every one
+points into the new install directory, the installer prints
+`Next: run stn setup`. Otherwise it names every missing or shadowed launcher,
+prints a safely shell-quoted current-shell block that prepends the directory,
+runs `hash -r`, and invokes `stn setup`, plus the absolute installed `stn`
+fallback. It never edits a shell profile.
 
 The release starts with immutable `v0.1.1-rc.1`, promotes only after all four
 native targets pass automated and manual acceptance, then repeats the gates for
@@ -587,30 +625,36 @@ COMMAND=true` and `HOME=$(mktemp -d)` do **not** count — and note
 must scrub `XDG_RUNTIME_DIR`/`XDG_STATE_HOME` too. The manual/automated
 flow:
 
-1. Launch bare `stn` outside tmux in a sanitized, isolated env → real
+1. Install in a clean default home with the directory missing from `PATH`,
+   then with an older `stn` and one sibling launcher shadowing it → every
+   mismatch is named, the current-shell recovery block works, and no profile is
+   edited. With all three physical resolutions correct, the short setup next
+   step is printed.
+2. Launch bare `stn` outside tmux in a sanitized, isolated env → real
    OpenTUI renderer draws, observer connects, first-run screen shows.
-2. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
-3. Run `stn setup` adding a project → the observer restarts on the **same
+3. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
+4. Run `stn setup` adding a project → the observer restarts on the **same
    socket** and reflects the new project immediately (B-config); an open TUI
    reconnects without a manual restart.
-4. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
-5. `stn-ingress` symlink delivers a provider hook event end to end.
-6. Upgrade the binary while **live host PTYs** exist → the new build reports
+5. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
+6. `stn-ingress` symlink delivers a provider hook event end to end.
+7. Upgrade the binary while **live host PTYs** exist → the new build reports
    `HOST_UPGRADE_BLOCKED`; the old host and sessions remain reattachable with
    the old build. After every hosted terminal closes, retry → the idle host is
    stopped; open a hosted terminal → the replacement health reports the new
    build (B-host).
-7. Rollback → install script returns to the prior good version (immutable).
-8. With terminal A continuously running installed `stn --version`, terminal B
+8. Tagged rollback → the tagged installer returns to the prior immutable
+   version, then the stable tagged installer restores the upgrade.
+9. With terminal A continuously running installed `stn --version`, terminal B
    installs RC → stable → RC → only complete old or new versions appear,
    never command-not-found or malformed output; both aliases remain links to
    `stn`, so entrypoints never mix.
-9. An abandoned `.station-install.lock` in an isolated destination refuses the
-   install until its recorded PID is confirmed dead, the lock is manually
-   removed, and the same install is retried successfully.
-10. Ctrl-C during a real authenticated upgrade exits 130, preserves the prior
-    launchable TUI, cleans its owned stage and lock, and permits a successful
-    retry.
+10. Abandoned command and license `.station-install.lock` directories each
+    refuse the install until their recorded PID is confirmed dead, the lock is
+    manually removed, and the same install is retried successfully.
+11. Ctrl-C during a real authenticated upgrade exits 130, preserves the prior
+    launchable TUI, cleans its owned stages and both locks, and permits a
+    successful retry.
 
 ## Audit findings (all confirmed)
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -379,14 +379,34 @@ claim bit-for-bit reproducible Bun executables or archives.
 `--install-dir` (default `~/.local/bin`). It uses authenticated `gh api`
 release endpoints, accepts only the four supported targets, verifies the one
 matching `SHA256SUMS` entry and exhaustive archive manifest before touching an
-existing install, and stages replacement on the destination filesystem. It
-then strips `com.apple.quarantine` on macOS and runs the staged binary's
-`--version`, refusing incompatible OS/libc/CPU artifacts or an embedded-version
-mismatch before any existing command is replaced. Successful installs replace
-`stn` and both symlinks by atomic rename, retain `LICENSE` under the Station
-data directory, and print a PATH hint only when needed. The deterministic
-`smoke:install` suite exercises this boundary with fake authenticated release
-assets and is part of `test:all`.
+existing install, and stages replacement on the destination filesystem. The
+staged binary's `--version` probe has a 10-second deadline; timeout terminates
+and reaps it, reports that the artifact did not respond in time, and leaves the
+existing Station installation unchanged.
+
+The destination-scoped lock is `<install-dir>/.station-install.lock`. It is
+held from before release lookup/download through cleanup, and its `owner` file
+records the PID and requested tag or `latest`. An existing lock causes a
+fail-fast refusal with no release request or destination mutation; the message
+names the lock and readable owner PID, states that the existing Station
+installation was unchanged, and tells the user to wait before retrying. The
+installer never auto-reclaims a possibly active lock. An operator may remove
+an abandoned lock manually only after reading
+`<install-dir>/.station-install.lock/owner` and confirming that no installer
+process with the recorded PID is alive, then retry.
+
+Existing exact `stn-ingress` and `stn-tmux-popup` symlinks remain stable; any
+missing aliases are created before activation. The previous license is backed
+up, the new `LICENSE` is installed, and the verified staged `stn` is atomically
+renamed last as the sole runtime commit point. A caught HUP, INT, or TERM runs
+rollback/cleanup and exits 129, 130, or 143 rather than resuming the interrupted
+operation. Before commit, caught failures restore the license and remove only
+new aliases. After commit, cleanup failures are warnings. SIGKILL and power
+loss cannot run cleanup, so a stale lock/stage or old/new cross-filesystem
+`LICENSE` metadata may remain; exact license consistency is not claimed, but
+pre-existing command entrypoints resolve to one complete old or new runtime.
+The deterministic `smoke:install` suite exercises this boundary with fake
+authenticated release assets and is part of `test:all`.
 
 The release starts with immutable `v0.1.1-rc.1`, promotes only after all four
 native targets pass automated and manual acceptance, then repeats the gates for
@@ -581,6 +601,16 @@ flow:
    stopped; open a hosted terminal → the replacement health reports the new
    build (B-host).
 7. Rollback → install script returns to the prior good version (immutable).
+8. With terminal A continuously running installed `stn --version`, terminal B
+   installs RC → stable → RC → only complete old or new versions appear,
+   never command-not-found or malformed output; both aliases remain links to
+   `stn`, so entrypoints never mix.
+9. An abandoned `.station-install.lock` in an isolated destination refuses the
+   install until its recorded PID is confirmed dead, the lock is manually
+   removed, and the same install is retried successfully.
+10. Ctrl-C during a real authenticated upgrade exits 130, preserves the prior
+    launchable TUI, cleans its owned stage and lock, and permits a successful
+    retry.
 
 ## Audit findings (all confirmed)
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -337,28 +337,89 @@ reaper recognize the exact compiled process shapes.
 
 ### A5 — release pipeline (private, deterministic, verifiable)
 
-`.github/workflows/release.yml` on `v*` tags, native-runner matrix
-(labels resolved at build time per the platform table — not `macos-13`).
-Requirements v1 omitted:
+**Status: implemented.** `.github/workflows/release.yml` runs on `v*` tags.
+It requires release SemVer without `+` build metadata, exact agreement between
+the tag and root package version, ancestry from `origin/main`, and a tag with no
+existing GitHub release. An administrator must enable GitHub immutable releases
+before tagging; `GITHUB_TOKEN` cannot read that administration setting, so the
+workflow cannot enforce the precondition itself. It then reuses the callable
+`standard-ci` gate, runs
+`pnpm smoke:release`, and builds natively on the four dated runner labels
+checked on 2026-07-11: `ubuntu-24.04`, `ubuntu-24.04-arm`,
+`macos-15-intel`, and `macos-15`.
 
-- **Reuse the existing gate**: tag builds must run the same deterministic
-  checks as hosted `standard-ci` + `pnpm smoke:release`, not bypass them.
-- **Checksums**: emit `SHA256SUMS`, sign or at least publish it; the
-  install script verifies each artifact against it before extraction.
-- **License**: include `LICENSE` in every archive (F9 / LICENSE:67).
-- **Homebrew (F10)**: a release created with the default `GITHUB_TOKEN`
-  **does not** trigger the existing `release: published` bump workflow
-  (`homebrew-bump.yml`). Either fold the tap update into `release.yml` (with
-  a PAT / `COMMITTER_TOKEN`) or dispatch it explicitly. **Until a tested
-  private-asset download strategy exists, defer the binary formula** and
-  ship only the authenticated install script.
-- **Rollback**: deleting a published tag is **not** rollback. Define
-  immutable rollback = publish a superseding patch release pointing the
-  install script / `latest` at the prior good version; never mutate or
-  delete a published artifact.
-- `scripts/install.sh`: authenticated `gh api` download → checksum verify →
-  `xattr -d com.apple.quarantine` (defensive; gh/curl set none per S3) →
-  install to `~/.local/bin` with the `stn-ingress` symlink → PATH hint.
+Each native job runs the full binary smoke and uploads one archive:
+
+- `stn-v{version}-linux-x64.tar.gz`
+- `stn-v{version}-linux-arm64.tar.gz`
+- `stn-v{version}-darwin-x64.tar.gz`
+- `stn-v{version}-darwin-arm64.tar.gz`
+
+Here `{version}` is the package version without the tag's leading `v`, for
+example `stn-v0.1.1-rc.1-darwin-arm64.tar.gz`.
+
+Every archive contains exactly `stn`, the `stn-ingress` and
+`stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
+duplicate targets, emits a stably sorted `SHA256SUMS`, and creates a GitHub
+release **draft** without clobbering an existing release. A second native
+matrix uses the authenticated installer against that real draft and verifies
+the binary version, both argv0 aliases, license, and launch without Node or Bun
+on the runtime PATH. Publication remains a manual decision after the real-TTY
+acceptance below. GitHub's tag endpoint exposes published releases only, so the
+workflow captures the new draft's numeric release ID from the authenticated
+release list and passes it only to these acceptance jobs; normal installs keep
+using the latest/published-tag endpoints.
+
+`SHA256SUMS` is unsigned in A5 because no signing-key infrastructure exists;
+the trust chain is authenticated GitHub access plus immutable release assets.
+The pipeline pins inputs, gates, targets, names, and manifest, but does not
+claim bit-for-bit reproducible Bun executables or archives.
+
+`scripts/install.sh` supports latest stable, explicit `--version`, and
+`--install-dir` (default `~/.local/bin`). It uses authenticated `gh api`
+release endpoints, accepts only the four supported targets, verifies the one
+matching `SHA256SUMS` entry and exhaustive archive manifest before touching an
+existing install, and stages replacement on the destination filesystem. It
+then strips `com.apple.quarantine` on macOS and runs the staged binary's
+`--version`, refusing incompatible OS/libc/CPU artifacts or an embedded-version
+mismatch before any existing command is replaced. Successful installs replace
+`stn` and both symlinks by atomic rename, retain `LICENSE` under the Station
+data directory, and print a PATH hint only when needed. The deterministic
+`smoke:install` suite exercises this boundary with fake authenticated release
+assets and is part of `test:all`.
+
+The release starts with immutable `v0.1.1-rc.1`, promotes only after all four
+native targets pass automated and manual acceptance, then repeats the gates for
+`v0.1.1`. Explicit installation of the RC proves rollback before stable
+publication. Published tags and assets are never deleted, moved, or overwritten:
+users may explicitly reinstall the prior good version for recovery, while the
+release line rolls forward with a superseding patch containing the revert or
+fix.
+
+Drafts are still mutable. Release notes record the workflow commit, and the
+manual promotion gate re-fetches the remote tag, compares its peeled commit to
+that SHA, and rechecks the exact five-asset inventory immediately before
+publication; GitHub immutability begins only when the draft is published.
+An unpublished draft left by a transient workflow failure may be deleted and
+the unchanged tag workflow rerun; a source fix uses a new prerelease tag, while
+published releases are never deleted or mutated.
+
+The source-based Homebrew formula remains separate and manually dispatched.
+The default release `GITHUB_TOKEN` cannot trigger another workflow, and the tap
+`COMMITTER_TOKEN` is intentionally not configured for A5; no binary Homebrew
+formula is claimed until private asset authentication is proven there.
+
+Implementation sources: the target and manifest policy above; the existing
+[`build:binary` staging](../scripts/build-binary.mjs),
+[`standard-ci` gates](../.github/workflows/standard-ci.yml), and
+[`smoke:release`](../scripts/test-runners/run-release-smoke.mjs); the
+redistribution requirement in [`LICENSE`](../LICENSE); B-host's shipped live
+PTY refusal policy; and GitHub's official documentation for
+[hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-private-repositories),
+[reusable workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows),
+[`GITHUB_TOKEN` permissions](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token),
+[release API draft visibility](https://docs.github.com/en/rest/releases/releases#list-releases),
+and [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
 
 ### A6 — cleanup (after one release on the ctty PTY path)
 

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -1,6 +1,6 @@
 # System Dependencies
 
-station ships Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, and OpenCode as external provider integrations. They are not npm packages bundled into the workspace. The primary first-run path is:
+Station integrates with Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, and OpenCode as external programs. They are not bundled into the compiled binary. Bare compiled `stn` can launch the first-run TUI without them; configure the full local workflow with:
 
 ```bash
 stn setup
@@ -8,7 +8,7 @@ stn setup
 
 This configures the core local workflow: the required tools, an agent CLI, and your first project. Optional integrations can be added later.
 
-The local checkout also expects Node.js 24.2+ (and below 25) and pnpm 11 for development. Real-provider test lanes remain opt-in.
+The compiled `stn` launches its TUI and Observer without Node.js, pnpm, or Bun. A local source checkout expects Node.js 24.2+ (and below 25), pnpm 11, and Bun 1.3.14 for development. Real-provider test lanes remain opt-in.
 `stn setup system --check` reports those versions, but it does not change the active Node or pnpm
 installation automatically.
 
@@ -36,11 +36,14 @@ Exit codes:
 
 ## Dependency Tiers
 
-Required for the default useful workflow:
+The binary itself is sufficient for `launchReady`: it can start the TUI and a
+healthy Observer with a writable state directory. These external tools gate the
+corresponding `workflowReady` features and are required for the default useful
+workflow, not for launch:
 
 - Worktrunk / `wt`
 - tmux
-- Bun — bare `stn` renders the terminal UI by shelling out to `bun run` against the station workspace, so the dashboard cannot launch without it
+- Bun — only a source-checkout launcher shells out to `bun run`; the compiled binary embeds the renderer
 - diffnav and git-delta (`delta`) — diffnav powers the "See diff (split right)" automation and renders through delta, so the two are required together
 - git (the binary) and a git repository for the first project
 - one supported agent CLI: Claude Code, Codex, Cursor Agent, OpenCode, or Pi
@@ -157,7 +160,11 @@ diagnostics.installHint
 
 The same provider-health evidence is included in `stn debug bundle`, so a failed `session.create` can be tied back to the missing external binary. Failed Worktrunk commands can also surface redacted command diagnostics through `stn command get <commandId>` and `stn debug trace <traceOrCommandId>`.
 
-`stn doctor` also runs a CLI-side `renderer-runtime` check: when Bun is not on PATH it reports a `warn` (degraded) finding with code `BUN_RUNTIME_MISSING`, because bare `stn` cannot render the TUI without `bun run` even when the observer is healthy. This catches an already-set-up machine that later loses Bun.
+In a source development checkout, `stn doctor` also runs a CLI-side
+`renderer-runtime` check. When Bun is not on PATH it reports a `warn` finding
+with code `BUN_RUNTIME_MISSING`, because the source launcher cannot render the
+TUI without `bun run` even when the Observer is healthy. Compiled mode embeds
+the renderer and does not require that runtime.
 
 ## Hooks
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
+    "smoke:install": "node scripts/test-runners/run-install-smoke.mjs",
     "typecheck": "turbo run typecheck",
     "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs",
     "format": "biome format --write .",
@@ -60,7 +61,7 @@
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
-    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup",
+    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup && pnpm smoke:install",
     "test:pre-push": "pnpm test:all && pnpm test:sqlite:bun && pnpm --dir station typecheck && pnpm --dir station test && pnpm --dir station test:pty:bun && pnpm build:binary -- --version 0.0.0-local && pnpm smoke:binary -- --expected-version 0.0.0-local"
   },
   "devDependencies": {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,20 +18,30 @@ license_path=""
 license_backup=""
 license_displaced=0
 license_installed=0
-lock_dir=""
-lock_owned=0
+command_lock_dir=""
+license_lock_dir=""
+command_lock_owned=0
+license_lock_owned=0
 lock_acquiring=0
 pending_signal_name=""
 pending_signal_status=0
 child_starting=0
+tracked_child_pid=""
 probe_pid=""
 watchdog_pid=""
 commit_started=0
 runtime_committed=0
+activation_ambiguity_reported=0
+activation_failed_precommit=0
+rollback_failed=0
 created_ingress=0
 created_popup=0
+created_ingress_inode=""
+created_popup_inode=""
+preserve_install_stage=0
 line_feed='
 '
+tab='	'
 
 usage() {
   cat <<'EOF'
@@ -55,6 +65,24 @@ warn() {
   printf 'Station install warning: %s\n' "$1" >&2 || true
 }
 
+print_shell_word() {
+  quote_value=$1
+  printf "'"
+  while :; do
+    case "$quote_value" in
+      *"'"*)
+        quote_prefix=${quote_value%%"'"*}
+        printf "%s'\\\\''" "$quote_prefix"
+        quote_value=${quote_value#*"'"}
+        ;;
+      *)
+        printf "%s'" "$quote_value"
+        return 0
+        ;;
+    esac
+  done
+}
+
 readlink_target() {
   if ! raw_link=$(
     readlink -n "$1"
@@ -65,6 +93,17 @@ readlink_target() {
     return 1
   fi
   link_target=${raw_link%x}
+}
+
+alias_inode() {
+  if ! raw_inode=$(LC_ALL=C ls -di "$1" 2>/dev/null); then
+    return 1
+  fi
+  set -- $raw_inode
+  case "${1:-}" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  alias_inode_result=$1
 }
 
 remove_tree() {
@@ -79,60 +118,124 @@ remove_tree() {
 remove_created_alias() {
   path=$1
   created=$2
+  expected_inode=$3
+  quarantine=$4
   [ "$created" -eq 1 ] || return 0
-  if [ -L "$path" ] && readlink_target "$path" 2>/dev/null && [ "$link_target" = stn ]; then
-    rm -f "$path" 2>/dev/null || warn "could not remove residual alias '$path'; remove it manually."
-  elif [ -e "$path" ] || [ -L "$path" ]; then
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    return 0
+  fi
+  if ! alias_inode "$path" || [ -z "$expected_inode" ] || [ "$alias_inode_result" != "$expected_inode" ]; then
+    rollback_failed=1
     warn "created alias '$path' changed during cleanup; inspect it manually."
+    return 0
+  fi
+  if ! mv "$path" "$quarantine" 2>/dev/null; then
+    rollback_failed=1
+    warn "could not quarantine created alias '$path' for safe cleanup; inspect it manually."
+    return 0
+  fi
+  if alias_inode "$quarantine" && [ "$alias_inode_result" = "$expected_inode" ] && [ -L "$quarantine" ] && readlink_target "$quarantine" 2>/dev/null && [ "$link_target" = stn ]; then
+    if ! rm -f "$quarantine" 2>/dev/null; then
+      rollback_failed=1
+      preserve_install_stage=1
+      warn "could not remove residual alias '$quarantine'; remove it manually."
+    fi
+    return 0
+  fi
+
+  rollback_failed=1
+  if { [ ! -e "$path" ] && [ ! -L "$path" ]; } && mv "$quarantine" "$path" 2>/dev/null; then
+    warn "created alias '$path' changed during cleanup; the changed path was restored for manual inspection."
+  else
+    preserve_install_stage=1
+    warn "created alias '$path' changed during cleanup; inspect '$quarantine' and '$path' manually."
+  fi
+}
+
+report_activation_ambiguity() {
+  [ "$activation_ambiguity_reported" -eq 0 ] || return 0
+  activation_ambiguity_reported=1
+  printf 'Station install failed: the staged binary disappeared during final activation; Station may have been updated.\n' >&2
+  printf 'Inspect the installed runtime with: ' >&2
+  print_shell_word "$binary_path" >&2
+  printf ' --version\n' >&2
+}
+
+stop_children() {
+  children_present=0
+  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+    [ -n "$child_pid" ] || continue
+    children_present=1
+    kill -TERM "$child_pid" 2>/dev/null || true
+  done
+  if [ "$children_present" -eq 1 ]; then
+    sleep 1 2>/dev/null || true
+  fi
+  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+    [ -n "$child_pid" ] || continue
+    kill -KILL "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
+  done
+  tracked_child_pid=""
+  watchdog_pid=""
+  probe_pid=""
+}
+
+release_lock() {
+  release_path=$1
+  rm -f "$release_path/owner" 2>/dev/null || warn "could not remove lock owner '$release_path/owner'."
+  if ! rmdir "$release_path" 2>/dev/null; then
+    warn "could not remove install lock '$release_path'; inspect and remove it manually before retrying."
   fi
 }
 
 cleanup() {
   status=$?
-  trap - EXIT HUP INT TERM
+  trap - EXIT
+  trap '' HUP INT TERM
   set +e
 
-  if [ -n "$watchdog_pid" ]; then
-    kill -TERM "$watchdog_pid" 2>/dev/null || true
-    wait "$watchdog_pid" 2>/dev/null || true
-    watchdog_pid=""
-  fi
-  if [ -n "$probe_pid" ]; then
-    kill -TERM "$probe_pid" 2>/dev/null || true
-    kill -KILL "$probe_pid" 2>/dev/null || true
-    wait "$probe_pid" 2>/dev/null || true
-    probe_pid=""
-  fi
+  stop_children
 
   if [ "$license_displaced" -eq 0 ] && [ -n "$license_backup" ] && [ -e "$license_backup" ]; then
     license_displaced=1
   fi
-  if [ "$commit_started" -eq 1 ] && [ -n "$install_stage" ] && [ ! -e "$install_stage/stn" ]; then
+  if [ "$runtime_committed" -eq 0 ] && [ "$commit_started" -eq 1 ] && [ -n "$install_stage" ] && [ ! -e "$install_stage/stn" ] && [ ! -L "$install_stage/stn" ]; then
     runtime_committed=1
+    report_activation_ambiguity
   fi
 
   if [ "$runtime_committed" -eq 0 ]; then
     if [ "$license_displaced" -eq 1 ]; then
       if ! mv -f "$license_backup" "$license_path" 2>/dev/null; then
+        rollback_failed=1
         warn "could not restore the previous license from '$license_backup' to '$license_path'."
         license_stage=""
       fi
     elif [ "$license_installed" -eq 1 ]; then
-      rm -f "$license_path" 2>/dev/null || warn "could not remove the new license '$license_path'."
+      if ! rm -f "$license_path" 2>/dev/null; then
+        rollback_failed=1
+        warn "could not remove the new license '$license_path'."
+      fi
     fi
-    remove_created_alias "$install_dir/stn-ingress" "$created_ingress"
-    remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup"
+    remove_created_alias "$install_dir/stn-ingress" "$created_ingress" "$created_ingress_inode" "$install_stage/stn-ingress.rollback"
+    remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup" "$created_popup_inode" "$install_stage/stn-tmux-popup.rollback"
+    if [ "$activation_failed_precommit" -eq 1 ] && [ "$rollback_failed" -eq 0 ]; then
+      printf 'The existing Station installation was unchanged.\n' >&2
+    fi
   fi
 
   remove_tree "$temp_dir"
-  remove_tree "$install_stage"
+  if [ "$preserve_install_stage" -eq 0 ]; then
+    remove_tree "$install_stage"
+  fi
   remove_tree "$license_stage"
 
-  if [ "$lock_owned" -eq 1 ]; then
-    rm -f "$lock_dir/owner" 2>/dev/null || warn "could not remove lock owner '$lock_dir/owner'."
-    if ! rmdir "$lock_dir" 2>/dev/null; then
-      warn "could not remove install lock '$lock_dir'; inspect and remove it manually before retrying."
-    fi
+  if [ "$license_lock_owned" -eq 1 ]; then
+    release_lock "$license_lock_dir"
+  fi
+  if [ "$command_lock_owned" -eq 1 ]; then
+    release_lock "$command_lock_dir"
   fi
 
   exit "$status"
@@ -149,11 +252,92 @@ on_signal() {
     return 0
   fi
   printf 'Station install interrupted by %s; cleaning up.\n' "$signal" >&2 || true
+  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+    [ -n "$child_pid" ] || continue
+    kill -"$signal" "$child_pid" 2>/dev/null || true
+  done
   exit "$status"
 }
 
 finish_pending_signal() {
   [ "$pending_signal_status" -eq 0 ] || on_signal "$pending_signal_name" "$pending_signal_status"
+}
+
+run_gh() {
+  gh_output=$1
+  gh_error=$2
+  shift 2
+  child_starting=1
+  gh "$@" > "$gh_output" 2> "$gh_error" &
+  tracked_child_pid=$!
+  child_starting=0
+  finish_pending_signal
+  if wait "$tracked_child_pid"; then
+    tracked_status=0
+  else
+    tracked_status=$?
+  fi
+  tracked_child_pid=""
+  return "$tracked_status"
+}
+
+read_file_value() {
+  value_file=$1
+  if ! file_value=$(
+    cat "$value_file"
+    cat_status=$?
+    printf x
+    exit "$cat_status"
+  ); then
+    return 1
+  fi
+  file_value=${file_value%x}
+  case "$file_value" in
+    *"$line_feed") file_value=${file_value%"$line_feed"} ;;
+  esac
+}
+
+acquire_lock() {
+  acquire_path=$1
+  acquire_kind=$2
+  lock_acquiring=1
+  # Ignore signals only across atomic mkdir so cleanup never guesses whether this process owns the lock.
+  if (
+    trap '' HUP INT TERM
+    mkdir "$acquire_path" 2>/dev/null
+  ); then
+    case "$acquire_kind" in
+      command) command_lock_owned=1 ;;
+      license) license_lock_owned=1 ;;
+    esac
+    if ! printf 'pid=%s\nrequested=%s\n' "$$" "$owner_request" > "$acquire_path/owner"; then
+      fail "could not write install lock owner '$acquire_path/owner'."
+    fi
+    lock_acquiring=0
+    finish_pending_signal
+    return 0
+  fi
+
+  lock_acquiring=0
+  finish_pending_signal
+  if [ ! -e "$acquire_path" ] && [ ! -L "$acquire_path" ]; then
+    fail "could not acquire install lock '$acquire_path'; check the destination permissions."
+  fi
+  owner_pid=""
+  if [ -f "$acquire_path/owner" ] && [ ! -L "$acquire_path/owner" ] && [ -r "$acquire_path/owner" ]; then
+    while IFS='=' read -r owner_key owner_value; do
+      if [ "$owner_key" = pid ]; then
+        case "$owner_value" in
+          ''|*[!0-9]*) ;;
+          *) owner_pid=$owner_value ;;
+        esac
+      fi
+    done < "$acquire_path/owner"
+  fi
+  if [ -n "$owner_pid" ]; then
+    fail "another Station installer owns '$acquire_path' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$acquire_path' and retry."
+  fi
+  fail "another Station installer owns '$acquire_path' (owner PID unavailable). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process is alive, then manually remove '$acquire_path' and retry."
 }
 
 trap cleanup EXIT
@@ -273,52 +457,25 @@ case "$(uname -s 2>/dev/null || true):$(uname -m 2>/dev/null || true)" in
 esac
 
 command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
-if ! gh auth status --hostname "$github_host" >/dev/null 2>&1; then
+temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
+if ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
   fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
 fi
 
 mkdir -p "$install_dir" || fail "could not create Station install directory '$install_dir'."
-lock_dir=$install_dir/.station-install.lock
-lock_acquiring=1
-# The mkdir child ignores signals so cleanup learns whether this process owns the atomic lock.
-if (
-  trap '' HUP INT TERM
-  mkdir "$lock_dir" 2>/dev/null
-); then
-  lock_owned=1
-  lock_acquiring=0
-  finish_pending_signal
-  if [ "$requested_version_set" -eq 1 ]; then
-    owner_request=$requested_version
-  else
-    owner_request=latest
-  fi
-  if ! printf 'pid=%s\nrequested=%s\n' "$$" "$owner_request" > "$lock_dir/owner"; then
-    fail "could not write install lock owner '$lock_dir/owner'."
-  fi
+if [ "$requested_version_set" -eq 1 ]; then
+  owner_request=$requested_version
 else
-  lock_acquiring=0
-  finish_pending_signal
-  if [ ! -e "$lock_dir" ] && [ ! -L "$lock_dir" ]; then
-    fail "could not acquire install lock '$lock_dir'; check the destination permissions."
-  fi
-  owner_pid=""
-  if [ -f "$lock_dir/owner" ] && [ ! -L "$lock_dir/owner" ] && [ -r "$lock_dir/owner" ]; then
-    while IFS='=' read -r owner_key owner_value; do
-      if [ "$owner_key" = pid ]; then
-        case "$owner_value" in
-          ''|*[!0-9]*) ;;
-          *) owner_pid=$owner_value ;;
-        esac
-      fi
-    done < "$lock_dir/owner"
-  fi
-  if [ -n "$owner_pid" ]; then
-    fail "another Station installer owns '$lock_dir' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$lock_dir' and retry."
-  fi
-  fail "another Station installer owns '$lock_dir' (owner PID unavailable). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process is alive, then manually remove '$lock_dir' and retry."
+  owner_request=latest
 fi
+command_lock_dir=$install_dir/.station-install.lock
+acquire_lock "$command_lock_dir" command
+
 mkdir -p "$license_dir" || fail "could not create Station data directory '$license_dir'."
+license_lock_dir=$license_dir/.station-install.lock
+if [ "$license_lock_dir" != "$command_lock_dir" ] && ! [ "$license_dir" -ef "$install_dir" ]; then
+  acquire_lock "$license_lock_dir" license
+fi
 
 binary_path=$install_dir/stn
 ingress_path=$install_dir/stn-ingress
@@ -348,6 +505,16 @@ require_single_numeric_id() {
   esac
 }
 
+read_numeric_result() {
+  numeric_file=$1
+  numeric_error=$2
+  if ! read_file_value "$numeric_file"; then
+    fail "could not read the GitHub CLI response from '$numeric_file'."
+  fi
+  require_single_numeric_id "$file_value" "$numeric_error"
+  numeric_result=$file_value
+}
+
 if [ -n "$release_id" ]; then
   tag=$requested_version
   version=${tag#v}
@@ -355,40 +522,37 @@ if [ -n "$release_id" ]; then
   # GitHub tag endpoints exclude drafts; the authenticated release list is draft-visible.
   draft_endpoint="repos/$repository/releases?per_page=100"
   draft_match=".[] | select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
-  if ! draft_ids=$(gh api --paginate "$draft_endpoint" --jq "$draft_match | .id"); then
+  if ! run_gh "$temp_dir/draft-release.stdout" "$temp_dir/draft-release.stderr" api --paginate "$draft_endpoint" --jq "$draft_match | .id"; then
     fail "could not list draft releases; check your authentication and repository access."
   fi
-  require_single_numeric_id "$draft_ids" "no single draft matched ID $release_id and requested version '$tag'."
+  read_numeric_result "$temp_dir/draft-release.stdout" "no single draft matched ID $release_id and requested version '$tag'."
 
-  draft_asset_id() {
+  lookup_draft_asset() {
     asset_name=$1
+    asset_slug=$2
     filter="$draft_match | .assets[] | select(.name == \"$asset_name\") | .id"
-    if ! ids=$(gh api --paginate "$draft_endpoint" --jq "$filter"); then
+    if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api --paginate "$draft_endpoint" --jq "$filter"; then
       fail "could not read assets for draft release $tag."
     fi
-    require_single_numeric_id "$ids" "release $tag must contain exactly one '$asset_name' asset."
-    printf '%s\n' "$ids"
+    read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
+    asset_result=$numeric_result
   }
 
-  archive_id=$(draft_asset_id "$archive_name")
-  checksums_id=$(draft_asset_id "SHA256SUMS")
+  lookup_draft_asset "$archive_name" draft-archive
+  archive_id=$asset_result
+  lookup_draft_asset SHA256SUMS draft-checksums
+  checksums_id=$asset_result
 elif [ "$requested_version_set" -eq 1 ]; then
   tag=$requested_version
   release_endpoint="repos/$repository/releases/tags/$tag"
 else
-  if ! raw_tag=$(
-    gh api "repos/$repository/releases/latest" --jq '.tag_name'
-    gh_status=$?
-    printf x
-    exit "$gh_status"
-  ); then
+  if ! run_gh "$temp_dir/latest.stdout" "$temp_dir/latest.stderr" api "repos/$repository/releases/latest" --jq '.tag_name'; then
     fail "could not resolve the latest stable Station release; check 'gh auth status' and repository access."
   fi
-  raw_tag=${raw_tag%x}
-  case "$raw_tag" in
-    *"$line_feed") tag=${raw_tag%"$line_feed"} ;;
-    *) tag=$raw_tag ;;
-  esac
+  if ! read_file_value "$temp_dir/latest.stdout"; then
+    fail "could not read the latest stable Station release tag."
+  fi
+  tag=$file_value
   if ! valid_version "$tag"; then
     fail "the latest Station release returned an invalid tag."
   fi
@@ -400,27 +564,29 @@ if [ -z "$release_id" ]; then
   archive_name="stn-v${version}-${target}.tar.gz"
 fi
 
-asset_id() {
+lookup_asset() {
   asset_name=$1
-  if ! ids=$(gh api "$release_endpoint" --jq ".assets[] | select(.name == \"$asset_name\") | .id"); then
+  asset_slug=$2
+  if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api "$release_endpoint" --jq ".assets[] | select(.name == \"$asset_name\") | .id"; then
     fail "could not read release $tag; check that the release exists and your account can access it."
   fi
-  require_single_numeric_id "$ids" "release $tag must contain exactly one '$asset_name' asset."
-  printf '%s\n' "$ids"
+  read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
+  asset_result=$numeric_result
 }
 
 if [ -z "$release_id" ]; then
-  archive_id=$(asset_id "$archive_name")
-  checksums_id=$(asset_id "SHA256SUMS")
+  lookup_asset "$archive_name" release-archive
+  archive_id=$asset_result
+  lookup_asset SHA256SUMS release-checksums
+  checksums_id=$asset_result
 fi
-temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
 archive_path=$temp_dir/$archive_name
 checksums_path=$temp_dir/SHA256SUMS
 
-if ! gh api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id" > "$archive_path"; then
+if ! run_gh "$archive_path" "$temp_dir/archive-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id"; then
   fail "could not download $archive_name from release $tag."
 fi
-if ! gh api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id" > "$checksums_path"; then
+if ! run_gh "$checksums_path" "$temp_dir/checksums-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id"; then
   fail "could not download SHA256SUMS from release $tag."
 fi
 
@@ -454,6 +620,17 @@ expected_manifest=$(printf '%s\n' LICENSE stn stn-ingress stn-tmux-popup | LC_AL
 if [ "$actual_manifest" != "$expected_manifest" ]; then
   fail "$archive_name does not contain the exact Station release manifest; nothing was installed."
 fi
+verbose_manifest_path=$temp_dir/manifest.verbose
+manifest_types_path=$temp_dir/manifest.types
+if ! tar -tvzf "$archive_path" > "$verbose_manifest_path"; then
+  fail "$archive_name does not expose readable Station member types."
+fi
+awk '{ print substr($1, 1, 1) }' "$verbose_manifest_path" > "$manifest_types_path"
+actual_typed_manifest=$(LC_ALL=C paste "$manifest_path" "$manifest_types_path" | LC_ALL=C sort)
+expected_typed_manifest=$(printf 'LICENSE\t-\nstn\t-\nstn-ingress\tl\nstn-tmux-popup\tl\n' | LC_ALL=C sort)
+if [ "$actual_typed_manifest" != "$expected_typed_manifest" ]; then
+  fail "$archive_name does not contain the required Station member types; nothing was installed."
+fi
 
 extracted_dir=$temp_dir/extracted
 mkdir "$extracted_dir"
@@ -486,48 +663,62 @@ fi
 
 probe_output=$temp_dir/probe.stdout
 probe_error=$temp_dir/probe.stderr
-probe_timeout_marker=$temp_dir/probe-timeout
 child_starting=1
-"$install_stage/stn" --version > "$probe_output" 2> "$probe_error" &
+(
+  if ! ulimit -f 8; then
+    exit 125
+  fi
+  exec "$install_stage/stn" --version
+) > "$probe_output" 2> "$probe_error" &
 probe_pid=$!
 child_starting=0
 finish_pending_signal
 child_starting=1
 (
   watchdog_timer=""
-  watchdog_cancelled=0
+  watchdog_result=0
+
   stop_watchdog() {
-    watchdog_cancelled=1
     if [ -n "$watchdog_timer" ]; then
       kill -TERM "$watchdog_timer" 2>/dev/null || true
+      kill -KILL "$watchdog_timer" 2>/dev/null || true
       wait "$watchdog_timer" 2>/dev/null || true
-      exit 0
     fi
+    exit "$watchdog_result"
+  }
+
+  stop_probe() {
+    watchdog_result=$1
+    kill -TERM "$probe_pid" 2>/dev/null || true
+    if ! sleep 1; then
+      watchdog_result=125
+      kill -KILL "$probe_pid" 2>/dev/null || true
+      exit "$watchdog_result"
+    fi
+    kill -KILL "$probe_pid" 2>/dev/null || true
+    exit "$watchdog_result"
   }
   trap stop_watchdog HUP INT TERM
 
   sleep 10 &
   watchdog_timer=$!
-  if [ "$watchdog_cancelled" -eq 1 ]; then
-    stop_watchdog
-  fi
-  if ! wait "$watchdog_timer"; then
+  if wait "$watchdog_timer"; then
+    watchdog_timer=""
+    if kill -0 "$probe_pid" 2>/dev/null; then
+      stop_probe 124
+    fi
     exit 0
+  else
+    timer_status=$?
+    watchdog_result=125
   fi
   watchdog_timer=""
+
   if kill -0 "$probe_pid" 2>/dev/null; then
-    : > "$probe_timeout_marker"
-    kill -TERM "$probe_pid" 2>/dev/null || true
-    sleep 1 &
-    watchdog_timer=$!
-    if [ "$watchdog_cancelled" -eq 1 ]; then
-      stop_watchdog
-    fi
-    if wait "$watchdog_timer"; then
-      watchdog_timer=""
-      kill -KILL "$probe_pid" 2>/dev/null || true
-    fi
+    stop_probe 125
   fi
+  [ "$timer_status" -eq 0 ] || exit 125
+  exit 0
 ) &
 watchdog_pid=$!
 child_starting=0
@@ -540,39 +731,134 @@ else
   probe_status=$?
 fi
 probe_pid=""
-# Cancellation is latched before timer cleanup so each watchdog child is recorded and reaped.
-kill -TERM "$watchdog_pid" 2>/dev/null || true
-wait "$watchdog_pid" 2>/dev/null || true
+watchdog_cancelled=0
+if kill -TERM "$watchdog_pid" 2>/dev/null; then
+  watchdog_cancelled=1
+fi
+if wait "$watchdog_pid"; then
+  watchdog_status=0
+else
+  watchdog_status=$?
+fi
 watchdog_pid=""
+if [ "$watchdog_cancelled" -eq 1 ] && [ "$watchdog_status" -eq 143 ]; then
+  # A fast probe can finish before the watchdog installs its TERM cleanup trap.
+  watchdog_status=0
+fi
 
-if [ -f "$probe_timeout_marker" ]; then
+print_probe_diagnostics() {
+  [ -s "$probe_error" ] || return 0
+  printf 'Compatibility probe stderr (up to 4096 sanitized bytes):\n' >&2
+  dd if="$probe_error" bs=4096 count=1 2>/dev/null | LC_ALL=C tr -cd "[:print:]$tab$line_feed" >&2
+  printf '\n' >&2
+}
+
+if [ "$watchdog_status" -eq 124 ]; then
+  print_probe_diagnostics
   fail "the verified Station binary did not respond to '--version' within 10 seconds; the existing Station installation was unchanged."
 fi
+if [ "$watchdog_status" -eq 125 ]; then
+  print_probe_diagnostics
+  fail "the compatibility probe timer failed; the existing Station installation was unchanged."
+fi
+if [ "$watchdog_status" -ne 0 ]; then
+  print_probe_diagnostics
+  fail "the compatibility probe supervisor failed; the existing Station installation was unchanged."
+fi
 if [ "$probe_status" -ne 0 ]; then
+  print_probe_diagnostics
   fail "the verified Station binary cannot run on this system; the existing installation was not changed."
 fi
 if ! probed_version=$(cat "$probe_output"); then
   fail "could not read the verified Station binary version; the existing installation was not changed."
 fi
 if [ "$probed_version" != "$version" ]; then
-  fail "the verified Station binary reports version '$probed_version', expected '$version'; the existing installation was not changed."
+  fail "the verified Station binary reports an unexpected version; expected '$version'. The existing installation was not changed."
 fi
 
+create_alias() {
+  alias_path=$1
+  alias_kind=$2
+  alias_name=${alias_path##*/}
+  alias_source_dir=$install_stage/$alias_kind.alias-source
+  alias_source=$alias_source_dir/$alias_name
+  alias_owner=$install_stage/$alias_kind.alias-inode
+  child_starting=1
+  # Publish the recorded symlink inode atomically so cleanup never adopts an external replacement.
+  if (
+    trap '' HUP INT TERM
+    mkdir "$alias_source_dir" || exit
+    ln -s stn "$alias_source" || exit
+    alias_inode "$alias_source" || exit
+    printf '%s\n' "$alias_inode_result" > "$alias_owner" || exit
+    alias_status=0
+    ln -P "$alias_source" "$install_dir" || alias_status=$?
+    rm -rf "$alias_source_dir"
+    exit "$alias_status"
+  ); then
+    if ! read_file_value "$alias_owner"; then
+      child_starting=0
+      finish_pending_signal
+      fail "created Station launcher '$alias_path' but could not read its ownership record; inspect it manually."
+    fi
+    case "$file_value" in
+      ''|*[!0-9]*)
+        child_starting=0
+        finish_pending_signal
+        fail "created Station launcher '$alias_path' with an invalid ownership record; inspect it manually."
+        ;;
+    esac
+    case "$alias_kind" in
+      ingress)
+        created_ingress=1
+        created_ingress_inode=$file_value
+        ;;
+      popup)
+        created_popup=1
+        created_popup_inode=$file_value
+        ;;
+    esac
+    child_starting=0
+    finish_pending_signal
+    return 0
+  fi
+  child_starting=0
+  finish_pending_signal
+  fail "could not create Station launcher '$alias_path'."
+}
+
 if [ ! -L "$ingress_path" ]; then
-  created_ingress=1
-  ln -s stn "$ingress_path" || fail "could not create Station launcher '$ingress_path'."
+  create_alias "$ingress_path" ingress
 fi
 if [ ! -L "$popup_path" ]; then
-  created_popup=1
-  ln -s stn "$popup_path" || fail "could not create Station launcher '$popup_path'."
+  create_alias "$popup_path" popup
 fi
+
+revalidate_managed_paths() {
+  if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+    if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
+      fail "Station binary destination '$binary_path' changed during installation; it must remain absent or a regular non-symlink file."
+    fi
+  fi
+  for managed_launcher in "$ingress_path" "$popup_path"; do
+    if [ ! -L "$managed_launcher" ] || ! readlink_target "$managed_launcher" 2>/dev/null || [ "$link_target" != stn ]; then
+      fail "Station launcher '$managed_launcher' changed during installation; it must remain a symlink exactly targeting 'stn'."
+    fi
+  done
+  if [ -e "$license_path" ] || [ -L "$license_path" ]; then
+    if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
+      fail "Station license destination '$license_path' changed during installation; it must remain absent or a regular non-symlink file."
+    fi
+  fi
+}
 
 new_license=$license_stage/LICENSE.new
 if ! cp "$extracted_dir/LICENSE" "$new_license"; then
   fail "could not stage the Station license in $license_dir."
 fi
 chmod 0644 "$new_license" || fail "could not set permissions on the staged Station license."
-if [ -e "$license_path" ]; then
+revalidate_managed_paths
+if [ -e "$license_path" ] || [ -L "$license_path" ]; then
   license_backup=$license_stage/LICENSE.previous
   if ! mv "$license_path" "$license_backup"; then
     fail "could not back up the existing Station license '$license_path'."
@@ -585,17 +871,70 @@ if ! mv "$new_license" "$license_path"; then
 fi
 
 # Renaming the verified binary is the sole runtime commit point; aliases already resolve through stn.
+revalidate_managed_paths
 commit_started=1
-if ! mv -f "$install_stage/stn" "$binary_path"; then
-  fail "could not activate the verified Station binary; the existing Station installation was unchanged."
+if mv -f "$install_stage/stn" "$binary_path"; then
+  runtime_committed=1
+elif [ -e "$install_stage/stn" ] || [ -L "$install_stage/stn" ]; then
+  activation_failed_precommit=1
+  fail "could not activate the verified Station binary; restoring the previous installation."
+else
+  runtime_committed=1
+  report_activation_ambiguity
+  exit 1
 fi
-runtime_committed=1
 
 set +e
-printf 'Installed Station %s to %s/stn\n' "$tag" "$install_dir"
-printf 'Next: run stn setup\n'
-case ":${PATH:-}:" in
-  *":$install_dir:"*) ;;
-  *) printf 'Add %s to PATH to run stn from any directory.\n' "$install_dir" ;;
-esac
+printf 'Installed Station %s to ' "$tag"
+print_shell_word "$binary_path"
+printf '\n'
+
+path_mismatch=0
+check_launcher_resolution() {
+  launcher_name=$1
+  expected_launcher=$2
+  if ! raw_resolved=$(
+    command -v "$launcher_name" 2>/dev/null
+    resolve_status=$?
+    printf x
+    exit "$resolve_status"
+  ); then
+    printf 'PATH mismatch: %s is not available in the current shell.\n' "$launcher_name"
+    path_mismatch=1
+    return 0
+  fi
+  raw_resolved=${raw_resolved%x}
+  case "$raw_resolved" in
+    *"$line_feed") resolved_launcher=${raw_resolved%"$line_feed"} ;;
+    *) resolved_launcher=$raw_resolved ;;
+  esac
+  if { [ -e "$resolved_launcher" ] || [ -L "$resolved_launcher" ]; } && [ "$resolved_launcher" -ef "$expected_launcher" ]; then
+    return 0
+  fi
+  printf 'PATH mismatch: %s resolves to ' "$launcher_name"
+  print_shell_word "$resolved_launcher"
+  printf ', not the newly installed launcher '
+  print_shell_word "$expected_launcher"
+  printf '.\n'
+  path_mismatch=1
+}
+
+check_launcher_resolution stn "$binary_path"
+check_launcher_resolution stn-ingress "$ingress_path"
+check_launcher_resolution stn-tmux-popup "$popup_path"
+
+if [ "$path_mismatch" -eq 0 ]; then
+  printf 'Next: run stn setup\n'
+else
+  printf 'Run this block in the current shell, then continue setup:\n'
+  printf '  PATH='
+  print_shell_word "$install_dir"
+  printf '${PATH:+":$PATH"}\n'
+  printf '  export PATH\n'
+  printf '  hash -r\n'
+  printf '  stn setup\n'
+  printf 'Absolute fallback: '
+  print_shell_word "$binary_path"
+  printf ' setup\n'
+fi
 exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,274 @@
+#!/bin/sh
+
+set -eu
+
+repository="jeremy0dell/station"
+github_host="github.com"
+export GH_HOST=$github_host
+requested_version=""
+install_dir=""
+release_id=${STATION_INSTALL_RELEASE_ID:-}
+temp_dir=""
+install_stage=""
+license_stage=""
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH]
+
+Install the latest stable private Station release, or an explicit version.
+
+Options:
+  --version VERSION   Install an immutable v-prefixed release version.
+  --install-dir PATH  Install commands here (default: ~/.local/bin).
+  -h, --help          Show this help.
+EOF
+}
+
+fail() {
+  printf 'Station install failed: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  [ -z "$temp_dir" ] || rm -rf "$temp_dir"
+  [ -z "$install_stage" ] || rm -rf "$install_stage"
+  [ -z "$license_stage" ] || rm -rf "$license_stage"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+valid_version() {
+  version=$1
+  if ! printf '%s\n' "$version" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+    return 1
+  fi
+
+  case "$version" in
+    *-*) prerelease=${version#*-} ;;
+    *) return 0 ;;
+  esac
+
+  old_ifs=$IFS
+  IFS=.
+  set -- $prerelease
+  IFS=$old_ifs
+  for identifier do
+    case "$identifier" in
+      *[!0-9]*) ;;
+      0) ;;
+      0*) return 1 ;;
+    esac
+  done
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || fail "--version requires a value."
+      [ -z "$requested_version" ] || fail "--version may be specified only once."
+      requested_version=$2
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || fail "--install-dir requires a path."
+      [ -z "$install_dir" ] || fail "--install-dir may be specified only once."
+      [ -n "$2" ] || fail "--install-dir requires a non-empty path."
+      install_dir=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option '$1'; run with --help for usage."
+      ;;
+  esac
+done
+
+if [ -n "$requested_version" ] && ! valid_version "$requested_version"; then
+  fail "version must be valid v-prefixed SemVer, for example v0.1.1 or v0.1.1-rc.1."
+fi
+if [ -n "$release_id" ]; then
+  case "$release_id" in
+    *[!0-9]*) fail "STATION_INSTALL_RELEASE_ID must be a numeric GitHub release ID." ;;
+  esac
+  [ -n "$requested_version" ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
+fi
+
+if [ -z "$install_dir" ]; then
+  [ -n "${HOME:-}" ] || fail "HOME is unset; pass --install-dir explicitly."
+  install_dir=$HOME/.local/bin
+fi
+
+case "$(uname -s 2>/dev/null || true):$(uname -m 2>/dev/null || true)" in
+  Darwin:arm64|Darwin:aarch64) target=darwin-arm64 ;;
+  Darwin:x86_64|Darwin:amd64) target=darwin-x64 ;;
+  Linux:arm64|Linux:aarch64) target=linux-arm64 ;;
+  Linux:x86_64|Linux:amd64) target=linux-x64 ;;
+  *) fail "unsupported platform; Station binaries support macOS and glibc Linux on arm64 or x64." ;;
+esac
+
+command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
+if ! gh auth status --hostname "$github_host" >/dev/null 2>&1; then
+  fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
+fi
+
+require_single_numeric_id() {
+  case "$1" in
+    ''|*[!0-9]*) fail "$2" ;;
+  esac
+}
+
+if [ -n "$release_id" ]; then
+  tag=$requested_version
+  version=${tag#v}
+  archive_name="stn-v${version}-${target}.tar.gz"
+  # GitHub tag endpoints exclude drafts; the authenticated release list is draft-visible.
+  draft_endpoint="repos/$repository/releases?per_page=100"
+  draft_match=".[] | select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
+  if ! draft_ids=$(gh api --paginate "$draft_endpoint" --jq "$draft_match | .id"); then
+    fail "could not list draft releases; check your authentication and repository access."
+  fi
+  require_single_numeric_id "$draft_ids" "no single draft matched ID $release_id and requested version '$tag'."
+
+  draft_asset_id() {
+    asset_name=$1
+    filter="$draft_match | .assets[] | select(.name == \"$asset_name\") | .id"
+    if ! ids=$(gh api --paginate "$draft_endpoint" --jq "$filter"); then
+      fail "could not read assets for draft release $tag."
+    fi
+    require_single_numeric_id "$ids" "release $tag must contain exactly one '$asset_name' asset."
+    printf '%s\n' "$ids"
+  }
+
+  archive_id=$(draft_asset_id "$archive_name")
+  checksums_id=$(draft_asset_id "SHA256SUMS")
+elif [ -n "$requested_version" ]; then
+  tag=$requested_version
+  release_endpoint="repos/$repository/releases/tags/$tag"
+else
+  if ! tag=$(gh api "repos/$repository/releases/latest" --jq '.tag_name'); then
+    fail "could not resolve the latest stable Station release; check 'gh auth status' and repository access."
+  fi
+  if ! valid_version "$tag"; then
+    fail "the latest Station release returned an invalid tag."
+  fi
+  release_endpoint="repos/$repository/releases/tags/$tag"
+fi
+
+if [ -z "$release_id" ]; then
+  version=${tag#v}
+  archive_name="stn-v${version}-${target}.tar.gz"
+fi
+
+asset_id() {
+  asset_name=$1
+  if ! ids=$(gh api "$release_endpoint" --jq ".assets[] | select(.name == \"$asset_name\") | .id"); then
+    fail "could not read release $tag; check that the release exists and your account can access it."
+  fi
+  require_single_numeric_id "$ids" "release $tag must contain exactly one '$asset_name' asset."
+  printf '%s\n' "$ids"
+}
+
+if [ -z "$release_id" ]; then
+  archive_id=$(asset_id "$archive_name")
+  checksums_id=$(asset_id "SHA256SUMS")
+fi
+temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/station-install.XXXXXX") || fail "could not create a temporary directory."
+archive_path=$temp_dir/$archive_name
+checksums_path=$temp_dir/SHA256SUMS
+
+if ! gh api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id" > "$archive_path"; then
+  fail "could not download $archive_name from release $tag."
+fi
+if ! gh api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id" > "$checksums_path"; then
+  fail "could not download SHA256SUMS from release $tag."
+fi
+
+expected_hashes=$(awk -v name="$archive_name" '$2 == name || $2 == "*" name { print $1 }' "$checksums_path")
+case "$expected_hashes" in
+  ''|*'
+'*) fail "SHA256SUMS must contain exactly one checksum for $archive_name." ;;
+esac
+if ! printf '%s\n' "$expected_hashes" | grep -Eq '^[0-9A-Fa-f]{64}$'; then
+  fail "SHA256SUMS contains an invalid checksum for $archive_name."
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | sha256sum -c - >/dev/null 2>&1); then
+    fail "checksum verification failed for $archive_name; the existing installation was not changed."
+  fi
+elif command -v shasum >/dev/null 2>&1; then
+  if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | shasum -a 256 -c - >/dev/null 2>&1); then
+    fail "checksum verification failed for $archive_name; the existing installation was not changed."
+  fi
+else
+  fail "sha256sum or shasum is required to verify the release archive."
+fi
+
+manifest_path=$temp_dir/manifest
+if ! tar -tzf "$archive_path" > "$manifest_path"; then
+  fail "$archive_name is not a readable gzip-compressed tar archive."
+fi
+actual_manifest=$(LC_ALL=C sort "$manifest_path")
+expected_manifest=$(printf '%s\n' LICENSE stn stn-ingress stn-tmux-popup | LC_ALL=C sort)
+if [ "$actual_manifest" != "$expected_manifest" ]; then
+  fail "$archive_name does not contain the exact Station release manifest; nothing was installed."
+fi
+
+extracted_dir=$temp_dir/extracted
+mkdir "$extracted_dir"
+# Extract only the approved names so an archive cannot write outside the staging directory.
+if ! tar -xzf "$archive_path" -C "$extracted_dir" stn stn-ingress stn-tmux-popup LICENSE; then
+  fail "could not extract the verified Station release archive."
+fi
+if [ ! -f "$extracted_dir/stn" ] || [ -L "$extracted_dir/stn" ]; then
+  fail "the Station release manifest must contain a regular 'stn' binary."
+fi
+if [ ! -f "$extracted_dir/LICENSE" ] || [ -L "$extracted_dir/LICENSE" ]; then
+  fail "the Station release manifest must contain a regular 'LICENSE' file."
+fi
+for launcher in stn-ingress stn-tmux-popup; do
+  if [ ! -L "$extracted_dir/$launcher" ] || [ "$(readlink "$extracted_dir/$launcher")" != "stn" ]; then
+    fail "the Station release manifest must contain '$launcher' as a symlink to 'stn'."
+  fi
+done
+
+[ -n "${HOME:-}" ] || fail "HOME is unset; it is required to install the Station license."
+license_dir=${XDG_DATA_HOME:-$HOME/.local/share}/station
+mkdir -p "$install_dir" "$license_dir"
+for destination in "$install_dir/stn" "$install_dir/stn-ingress" "$install_dir/stn-tmux-popup" "$license_dir/LICENSE"; do
+  [ ! -d "$destination" ] || fail "cannot replace directory '$destination'."
+done
+
+# Stage on each destination filesystem so every final rename is atomic.
+install_stage=$(mktemp -d "$install_dir/.station-install.XXXXXX") || fail "cannot stage files in $install_dir."
+license_stage=$(mktemp -d "$license_dir/.station-install.XXXXXX") || fail "cannot stage the license in $license_dir."
+cp "$extracted_dir/stn" "$install_stage/stn"
+chmod 755 "$install_stage/stn"
+if { [ "$target" = darwin-arm64 ] || [ "$target" = darwin-x64 ]; } && command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$install_stage/stn" 2>/dev/null || true
+fi
+if ! probed_version=$("$install_stage/stn" --version 2>/dev/null); then
+  fail "the verified Station binary cannot run on this system; the existing installation was not changed."
+fi
+if [ "$probed_version" != "$version" ]; then
+  fail "the verified Station binary reports version '$probed_version', expected '$version'; the existing installation was not changed."
+fi
+ln -s stn "$install_stage/stn-ingress"
+ln -s stn "$install_stage/stn-tmux-popup"
+cp "$extracted_dir/LICENSE" "$license_stage/LICENSE"
+
+mv -f "$license_stage/LICENSE" "$license_dir/LICENSE"
+mv -f "$install_stage/stn" "$install_dir/stn"
+mv -f "$install_stage/stn-ingress" "$install_dir/stn-ingress"
+mv -f "$install_stage/stn-tmux-popup" "$install_dir/stn-tmux-popup"
+
+printf 'Installed Station %s to %s/stn\n' "$tag" "$install_dir"
+printf 'Next: run stn setup\n'
+case ":${PATH:-}:" in
+  *":$install_dir:"*) ;;
+  *) printf 'Add %s to PATH to run stn from any directory.\n' "$install_dir" ;;
+esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,16 +1,37 @@
 #!/bin/sh
 
 set -eu
+umask 077
 
 repository="jeremy0dell/station"
 github_host="github.com"
 export GH_HOST=$github_host
 requested_version=""
+requested_version_set=0
 install_dir=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
 install_stage=""
 license_stage=""
+license_dir=""
+license_path=""
+license_backup=""
+license_displaced=0
+license_installed=0
+lock_dir=""
+lock_owned=0
+lock_acquiring=0
+pending_signal_name=""
+pending_signal_status=0
+child_starting=0
+probe_pid=""
+watchdog_pid=""
+commit_started=0
+runtime_committed=0
+created_ingress=0
+created_popup=0
+line_feed='
+'
 
 usage() {
   cat <<'EOF'
@@ -30,17 +51,129 @@ fail() {
   exit 1
 }
 
-cleanup() {
-  [ -z "$temp_dir" ] || rm -rf "$temp_dir"
-  [ -z "$install_stage" ] || rm -rf "$install_stage"
-  [ -z "$license_stage" ] || rm -rf "$license_stage"
+warn() {
+  printf 'Station install warning: %s\n' "$1" >&2 || true
 }
 
-trap cleanup EXIT HUP INT TERM
+readlink_target() {
+  if ! raw_link=$(
+    readlink -n "$1"
+    readlink_status=$?
+    printf x
+    exit "$readlink_status"
+  ); then
+    return 1
+  fi
+  link_target=${raw_link%x}
+}
+
+remove_tree() {
+  path=$1
+  [ -n "$path" ] || return 0
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    return 0
+  fi
+  rm -rf "$path" 2>/dev/null || warn "could not remove residual path '$path'; remove it manually."
+}
+
+remove_created_alias() {
+  path=$1
+  created=$2
+  [ "$created" -eq 1 ] || return 0
+  if [ -L "$path" ] && readlink_target "$path" 2>/dev/null && [ "$link_target" = stn ]; then
+    rm -f "$path" 2>/dev/null || warn "could not remove residual alias '$path'; remove it manually."
+  elif [ -e "$path" ] || [ -L "$path" ]; then
+    warn "created alias '$path' changed during cleanup; inspect it manually."
+  fi
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  set +e
+
+  if [ -n "$watchdog_pid" ]; then
+    kill -TERM "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+    watchdog_pid=""
+  fi
+  if [ -n "$probe_pid" ]; then
+    kill -TERM "$probe_pid" 2>/dev/null || true
+    kill -KILL "$probe_pid" 2>/dev/null || true
+    wait "$probe_pid" 2>/dev/null || true
+    probe_pid=""
+  fi
+
+  if [ "$license_displaced" -eq 0 ] && [ -n "$license_backup" ] && [ -e "$license_backup" ]; then
+    license_displaced=1
+  fi
+  if [ "$commit_started" -eq 1 ] && [ -n "$install_stage" ] && [ ! -e "$install_stage/stn" ]; then
+    runtime_committed=1
+  fi
+
+  if [ "$runtime_committed" -eq 0 ]; then
+    if [ "$license_displaced" -eq 1 ]; then
+      if ! mv -f "$license_backup" "$license_path" 2>/dev/null; then
+        warn "could not restore the previous license from '$license_backup' to '$license_path'."
+        license_stage=""
+      fi
+    elif [ "$license_installed" -eq 1 ]; then
+      rm -f "$license_path" 2>/dev/null || warn "could not remove the new license '$license_path'."
+    fi
+    remove_created_alias "$install_dir/stn-ingress" "$created_ingress"
+    remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup"
+  fi
+
+  remove_tree "$temp_dir"
+  remove_tree "$install_stage"
+  remove_tree "$license_stage"
+
+  if [ "$lock_owned" -eq 1 ]; then
+    rm -f "$lock_dir/owner" 2>/dev/null || warn "could not remove lock owner '$lock_dir/owner'."
+    if ! rmdir "$lock_dir" 2>/dev/null; then
+      warn "could not remove install lock '$lock_dir'; inspect and remove it manually before retrying."
+    fi
+  fi
+
+  exit "$status"
+}
+
+on_signal() {
+  signal=$1
+  status=$2
+  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ]; then
+    if [ "$pending_signal_status" -eq 0 ]; then
+      pending_signal_name=$signal
+      pending_signal_status=$status
+    fi
+    return 0
+  fi
+  printf 'Station install interrupted by %s; cleaning up.\n' "$signal" >&2 || true
+  exit "$status"
+}
+
+finish_pending_signal() {
+  [ "$pending_signal_status" -eq 0 ] || on_signal "$pending_signal_name" "$pending_signal_status"
+}
+
+trap cleanup EXIT
+trap 'on_signal HUP 129' HUP
+trap 'on_signal INT 130' INT
+trap 'on_signal TERM 143' TERM
+
+absolute_path() {
+  case "$1" in
+    /*) absolute_result=$1 ;;
+    *) absolute_result=$current_dir/$1 ;;
+  esac
+}
 
 valid_version() {
   version=$1
-  if ! printf '%s\n' "$version" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+  case "$version" in
+    ''|*[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.+-]*) return 1 ;;
+  esac
+  if ! printf '%s\n' "$version" | LC_ALL=C grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
     return 1
   fi
 
@@ -66,8 +199,9 @@ while [ "$#" -gt 0 ]; do
   case "$1" in
     --version)
       [ "$#" -ge 2 ] || fail "--version requires a value."
-      [ -z "$requested_version" ] || fail "--version may be specified only once."
+      [ "$requested_version_set" -eq 0 ] || fail "--version may be specified only once."
       requested_version=$2
+      requested_version_set=1
       shift 2
       ;;
     --install-dir)
@@ -87,20 +221,48 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ -n "$requested_version" ] && ! valid_version "$requested_version"; then
+if [ "$requested_version_set" -eq 1 ] && ! valid_version "$requested_version"; then
   fail "version must be valid v-prefixed SemVer, for example v0.1.1 or v0.1.1-rc.1."
 fi
 if [ -n "$release_id" ]; then
   case "$release_id" in
     *[!0-9]*) fail "STATION_INSTALL_RELEASE_ID must be a numeric GitHub release ID." ;;
   esac
-  [ -n "$requested_version" ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
+  [ "$requested_version_set" -eq 1 ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
 fi
 
+if ! raw_current_dir=$(
+  pwd -P
+  pwd_status=$?
+  printf x
+  exit "$pwd_status"
+); then
+  fail "could not resolve the current directory."
+fi
+raw_current_dir=${raw_current_dir%x}
+case "$raw_current_dir" in
+  *"$line_feed") current_dir=${raw_current_dir%"$line_feed"} ;;
+  *) current_dir=$raw_current_dir ;;
+esac
 if [ -z "$install_dir" ]; then
   [ -n "${HOME:-}" ] || fail "HOME is unset; pass --install-dir explicitly."
   install_dir=$HOME/.local/bin
 fi
+absolute_path "$install_dir"
+install_dir=$absolute_result
+
+if [ -n "${XDG_DATA_HOME:-}" ]; then
+  absolute_path "$XDG_DATA_HOME"
+  data_home=$absolute_result
+else
+  [ -n "${HOME:-}" ] || fail "HOME is unset; set an absolute XDG_DATA_HOME for the Station license."
+  absolute_path "$HOME/.local/share"
+  data_home=$absolute_result
+fi
+license_dir=$data_home/station
+license_path=$license_dir/LICENSE
+absolute_path "${TMPDIR:-/tmp}"
+tmp_base=$absolute_result
 
 case "$(uname -s 2>/dev/null || true):$(uname -m 2>/dev/null || true)" in
   Darwin:arm64|Darwin:aarch64) target=darwin-arm64 ;;
@@ -113,6 +275,71 @@ esac
 command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
 if ! gh auth status --hostname "$github_host" >/dev/null 2>&1; then
   fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
+fi
+
+mkdir -p "$install_dir" || fail "could not create Station install directory '$install_dir'."
+lock_dir=$install_dir/.station-install.lock
+lock_acquiring=1
+# The mkdir child ignores signals so cleanup learns whether this process owns the atomic lock.
+if (
+  trap '' HUP INT TERM
+  mkdir "$lock_dir" 2>/dev/null
+); then
+  lock_owned=1
+  lock_acquiring=0
+  finish_pending_signal
+  if [ "$requested_version_set" -eq 1 ]; then
+    owner_request=$requested_version
+  else
+    owner_request=latest
+  fi
+  if ! printf 'pid=%s\nrequested=%s\n' "$$" "$owner_request" > "$lock_dir/owner"; then
+    fail "could not write install lock owner '$lock_dir/owner'."
+  fi
+else
+  lock_acquiring=0
+  finish_pending_signal
+  if [ ! -e "$lock_dir" ] && [ ! -L "$lock_dir" ]; then
+    fail "could not acquire install lock '$lock_dir'; check the destination permissions."
+  fi
+  owner_pid=""
+  if [ -f "$lock_dir/owner" ] && [ ! -L "$lock_dir/owner" ] && [ -r "$lock_dir/owner" ]; then
+    while IFS='=' read -r owner_key owner_value; do
+      if [ "$owner_key" = pid ]; then
+        case "$owner_value" in
+          ''|*[!0-9]*) ;;
+          *) owner_pid=$owner_value ;;
+        esac
+      fi
+    done < "$lock_dir/owner"
+  fi
+  if [ -n "$owner_pid" ]; then
+    fail "another Station installer owns '$lock_dir' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$lock_dir' and retry."
+  fi
+  fail "another Station installer owns '$lock_dir' (owner PID unavailable). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process is alive, then manually remove '$lock_dir' and retry."
+fi
+mkdir -p "$license_dir" || fail "could not create Station data directory '$license_dir'."
+
+binary_path=$install_dir/stn
+ingress_path=$install_dir/stn-ingress
+popup_path=$install_dir/stn-tmux-popup
+
+if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+  if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
+    fail "existing Station binary '$binary_path' must be a regular non-symlink file."
+  fi
+fi
+for launcher_path in "$ingress_path" "$popup_path"; do
+  if [ -e "$launcher_path" ] || [ -L "$launcher_path" ]; then
+    if [ ! -L "$launcher_path" ] || ! readlink_target "$launcher_path" 2>/dev/null || [ "$link_target" != stn ]; then
+      fail "existing launcher '$launcher_path' must be absent or a symlink to 'stn'; it was not changed."
+    fi
+  fi
+done
+if [ -e "$license_path" ] || [ -L "$license_path" ]; then
+  if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
+    fail "existing Station license '$license_path' must be a regular non-symlink file."
+  fi
 fi
 
 require_single_numeric_id() {
@@ -145,13 +372,23 @@ if [ -n "$release_id" ]; then
 
   archive_id=$(draft_asset_id "$archive_name")
   checksums_id=$(draft_asset_id "SHA256SUMS")
-elif [ -n "$requested_version" ]; then
+elif [ "$requested_version_set" -eq 1 ]; then
   tag=$requested_version
   release_endpoint="repos/$repository/releases/tags/$tag"
 else
-  if ! tag=$(gh api "repos/$repository/releases/latest" --jq '.tag_name'); then
+  if ! raw_tag=$(
+    gh api "repos/$repository/releases/latest" --jq '.tag_name'
+    gh_status=$?
+    printf x
+    exit "$gh_status"
+  ); then
     fail "could not resolve the latest stable Station release; check 'gh auth status' and repository access."
   fi
+  raw_tag=${raw_tag%x}
+  case "$raw_tag" in
+    *"$line_feed") tag=${raw_tag%"$line_feed"} ;;
+    *) tag=$raw_tag ;;
+  esac
   if ! valid_version "$tag"; then
     fail "the latest Station release returned an invalid tag."
   fi
@@ -176,7 +413,7 @@ if [ -z "$release_id" ]; then
   archive_id=$(asset_id "$archive_name")
   checksums_id=$(asset_id "SHA256SUMS")
 fi
-temp_dir=$(mktemp -d "${TMPDIR:-/tmp}/station-install.XXXXXX") || fail "could not create a temporary directory."
+temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
 archive_path=$temp_dir/$archive_name
 checksums_path=$temp_dir/SHA256SUMS
 
@@ -231,44 +468,134 @@ if [ ! -f "$extracted_dir/LICENSE" ] || [ -L "$extracted_dir/LICENSE" ]; then
   fail "the Station release manifest must contain a regular 'LICENSE' file."
 fi
 for launcher in stn-ingress stn-tmux-popup; do
-  if [ ! -L "$extracted_dir/$launcher" ] || [ "$(readlink "$extracted_dir/$launcher")" != "stn" ]; then
+  if [ ! -L "$extracted_dir/$launcher" ] || ! readlink_target "$extracted_dir/$launcher" || [ "$link_target" != stn ]; then
     fail "the Station release manifest must contain '$launcher' as a symlink to 'stn'."
   fi
-done
-
-[ -n "${HOME:-}" ] || fail "HOME is unset; it is required to install the Station license."
-license_dir=${XDG_DATA_HOME:-$HOME/.local/share}/station
-mkdir -p "$install_dir" "$license_dir"
-for destination in "$install_dir/stn" "$install_dir/stn-ingress" "$install_dir/stn-tmux-popup" "$license_dir/LICENSE"; do
-  [ ! -d "$destination" ] || fail "cannot replace directory '$destination'."
 done
 
 # Stage on each destination filesystem so every final rename is atomic.
 install_stage=$(mktemp -d "$install_dir/.station-install.XXXXXX") || fail "cannot stage files in $install_dir."
 license_stage=$(mktemp -d "$license_dir/.station-install.XXXXXX") || fail "cannot stage the license in $license_dir."
-cp "$extracted_dir/stn" "$install_stage/stn"
-chmod 755 "$install_stage/stn"
+if ! cp "$extracted_dir/stn" "$install_stage/stn"; then
+  fail "could not stage the Station binary in $install_dir."
+fi
+chmod 0755 "$install_stage/stn" || fail "could not set executable permissions on the staged Station binary."
 if { [ "$target" = darwin-arm64 ] || [ "$target" = darwin-x64 ]; } && command -v xattr >/dev/null 2>&1; then
   xattr -d com.apple.quarantine "$install_stage/stn" 2>/dev/null || true
 fi
-if ! probed_version=$("$install_stage/stn" --version 2>/dev/null); then
+
+probe_output=$temp_dir/probe.stdout
+probe_error=$temp_dir/probe.stderr
+probe_timeout_marker=$temp_dir/probe-timeout
+child_starting=1
+"$install_stage/stn" --version > "$probe_output" 2> "$probe_error" &
+probe_pid=$!
+child_starting=0
+finish_pending_signal
+child_starting=1
+(
+  watchdog_timer=""
+  watchdog_cancelled=0
+  stop_watchdog() {
+    watchdog_cancelled=1
+    if [ -n "$watchdog_timer" ]; then
+      kill -TERM "$watchdog_timer" 2>/dev/null || true
+      wait "$watchdog_timer" 2>/dev/null || true
+      exit 0
+    fi
+  }
+  trap stop_watchdog HUP INT TERM
+
+  sleep 10 &
+  watchdog_timer=$!
+  if [ "$watchdog_cancelled" -eq 1 ]; then
+    stop_watchdog
+  fi
+  if ! wait "$watchdog_timer"; then
+    exit 0
+  fi
+  watchdog_timer=""
+  if kill -0 "$probe_pid" 2>/dev/null; then
+    : > "$probe_timeout_marker"
+    kill -TERM "$probe_pid" 2>/dev/null || true
+    sleep 1 &
+    watchdog_timer=$!
+    if [ "$watchdog_cancelled" -eq 1 ]; then
+      stop_watchdog
+    fi
+    if wait "$watchdog_timer"; then
+      watchdog_timer=""
+      kill -KILL "$probe_pid" 2>/dev/null || true
+    fi
+  fi
+) &
+watchdog_pid=$!
+child_starting=0
+finish_pending_signal
+
+probe_status=0
+if wait "$probe_pid"; then
+  probe_status=0
+else
+  probe_status=$?
+fi
+probe_pid=""
+# Cancellation is latched before timer cleanup so each watchdog child is recorded and reaped.
+kill -TERM "$watchdog_pid" 2>/dev/null || true
+wait "$watchdog_pid" 2>/dev/null || true
+watchdog_pid=""
+
+if [ -f "$probe_timeout_marker" ]; then
+  fail "the verified Station binary did not respond to '--version' within 10 seconds; the existing Station installation was unchanged."
+fi
+if [ "$probe_status" -ne 0 ]; then
   fail "the verified Station binary cannot run on this system; the existing installation was not changed."
+fi
+if ! probed_version=$(cat "$probe_output"); then
+  fail "could not read the verified Station binary version; the existing installation was not changed."
 fi
 if [ "$probed_version" != "$version" ]; then
   fail "the verified Station binary reports version '$probed_version', expected '$version'; the existing installation was not changed."
 fi
-ln -s stn "$install_stage/stn-ingress"
-ln -s stn "$install_stage/stn-tmux-popup"
-cp "$extracted_dir/LICENSE" "$license_stage/LICENSE"
 
-mv -f "$license_stage/LICENSE" "$license_dir/LICENSE"
-mv -f "$install_stage/stn" "$install_dir/stn"
-mv -f "$install_stage/stn-ingress" "$install_dir/stn-ingress"
-mv -f "$install_stage/stn-tmux-popup" "$install_dir/stn-tmux-popup"
+if [ ! -L "$ingress_path" ]; then
+  created_ingress=1
+  ln -s stn "$ingress_path" || fail "could not create Station launcher '$ingress_path'."
+fi
+if [ ! -L "$popup_path" ]; then
+  created_popup=1
+  ln -s stn "$popup_path" || fail "could not create Station launcher '$popup_path'."
+fi
 
+new_license=$license_stage/LICENSE.new
+if ! cp "$extracted_dir/LICENSE" "$new_license"; then
+  fail "could not stage the Station license in $license_dir."
+fi
+chmod 0644 "$new_license" || fail "could not set permissions on the staged Station license."
+if [ -e "$license_path" ]; then
+  license_backup=$license_stage/LICENSE.previous
+  if ! mv "$license_path" "$license_backup"; then
+    fail "could not back up the existing Station license '$license_path'."
+  fi
+  license_displaced=1
+fi
+license_installed=1
+if ! mv "$new_license" "$license_path"; then
+  fail "could not install the Station license '$license_path'."
+fi
+
+# Renaming the verified binary is the sole runtime commit point; aliases already resolve through stn.
+commit_started=1
+if ! mv -f "$install_stage/stn" "$binary_path"; then
+  fail "could not activate the verified Station binary; the existing Station installation was unchanged."
+fi
+runtime_committed=1
+
+set +e
 printf 'Installed Station %s to %s/stn\n' "$tag" "$install_dir"
 printf 'Next: run stn setup\n'
 case ":${PATH:-}:" in
   *":$install_dir:"*) ;;
   *) printf 'Add %s to PATH to run stn from any directory.\n' "$install_dir" ;;
 esac
+exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,11 @@ command_lock_dir=""
 license_lock_dir=""
 command_lock_owned=0
 license_lock_owned=0
+command_lock_token=""
+license_lock_token=""
+command_lock_inode=""
+license_lock_inode=""
+install_lock_token=""
 lock_acquiring=0
 pending_signal_name=""
 pending_signal_status=0
@@ -183,7 +188,35 @@ stop_children() {
 
 release_lock() {
   release_path=$1
-  rm -f "$release_path/owner" 2>/dev/null || warn "could not remove lock owner '$release_path/owner'."
+  release_token=$2
+  release_inode=$3
+  release_owner=$release_path/owner-$release_token
+  if [ ! -e "$release_path" ] && [ ! -L "$release_path" ]; then
+    return 0
+  fi
+  if ! alias_inode "$release_path" || [ -z "$release_inode" ] || [ "$alias_inode_result" != "$release_inode" ]; then
+    warn "install lock '$release_path' changed ownership; it was not removed."
+    return 0
+  fi
+  lock_token_result=""
+  lock_token_count=0
+  if [ -f "$release_owner" ] && [ ! -L "$release_owner" ] && [ -r "$release_owner" ]; then
+    while IFS='=' read -r owner_key owner_value; do
+      if [ "$owner_key" = token ]; then
+        lock_token_count=$((lock_token_count + 1))
+        lock_token_result=$owner_value
+      fi
+    done < "$release_owner"
+  fi
+  if [ "$lock_token_count" -ne 1 ] || [ -z "$release_token" ] || [ "$lock_token_result" != "$release_token" ]; then
+    warn "install lock '$release_path' changed ownership; it was not removed."
+    return 0
+  fi
+  rm -f "$release_owner" 2>/dev/null || warn "could not remove lock owner '$release_owner'."
+  if ! alias_inode "$release_path" || [ "$alias_inode_result" != "$release_inode" ]; then
+    warn "install lock '$release_path' changed ownership; it was not removed."
+    return 0
+  fi
   if ! rmdir "$release_path" 2>/dev/null; then
     warn "could not remove install lock '$release_path'; inspect and remove it manually before retrying."
   fi
@@ -232,10 +265,10 @@ cleanup() {
   remove_tree "$license_stage"
 
   if [ "$license_lock_owned" -eq 1 ]; then
-    release_lock "$license_lock_dir"
+    release_lock "$license_lock_dir" "$license_lock_token" "$license_lock_inode"
   fi
   if [ "$command_lock_owned" -eq 1 ]; then
-    release_lock "$command_lock_dir"
+    release_lock "$command_lock_dir" "$command_lock_token" "$command_lock_inode"
   fi
 
   exit "$status"
@@ -306,12 +339,26 @@ acquire_lock() {
     trap '' HUP INT TERM
     mkdir "$acquire_path" 2>/dev/null
   ); then
+    if ! alias_inode "$acquire_path"; then
+      fail "could not identify acquired install lock '$acquire_path'."
+    fi
+    acquire_inode=$alias_inode_result
+    acquire_token=$install_lock_token-$acquire_kind
     case "$acquire_kind" in
-      command) command_lock_owned=1 ;;
-      license) license_lock_owned=1 ;;
+      command)
+        command_lock_owned=1
+        command_lock_token=$acquire_token
+        command_lock_inode=$acquire_inode
+        ;;
+      license)
+        license_lock_owned=1
+        license_lock_token=$acquire_token
+        license_lock_inode=$acquire_inode
+        ;;
     esac
-    if ! printf 'pid=%s\nrequested=%s\n' "$$" "$owner_request" > "$acquire_path/owner"; then
-      fail "could not write install lock owner '$acquire_path/owner'."
+    acquire_owner=$acquire_path/owner-$acquire_token
+    if ! printf 'pid=%s\nrequested=%s\ntoken=%s\n' "$$" "$owner_request" "$acquire_token" > "$acquire_owner"; then
+      fail "could not write install lock owner '$acquire_owner'."
     fi
     lock_acquiring=0
     finish_pending_signal
@@ -324,7 +371,16 @@ acquire_lock() {
     fail "could not acquire install lock '$acquire_path'; check the destination permissions."
   fi
   owner_pid=""
-  if [ -f "$acquire_path/owner" ] && [ ! -L "$acquire_path/owner" ] && [ -r "$acquire_path/owner" ]; then
+  owner_file=""
+  owner_file_count=0
+  for owner_candidate in "$acquire_path/owner" "$acquire_path"/owner-*; do
+    if [ ! -e "$owner_candidate" ] && [ ! -L "$owner_candidate" ]; then
+      continue
+    fi
+    owner_file_count=$((owner_file_count + 1))
+    owner_file=$owner_candidate
+  done
+  if [ "$owner_file_count" -eq 1 ] && [ -f "$owner_file" ] && [ ! -L "$owner_file" ] && [ -r "$owner_file" ]; then
     while IFS='=' read -r owner_key owner_value; do
       if [ "$owner_key" = pid ]; then
         case "$owner_value" in
@@ -332,7 +388,7 @@ acquire_lock() {
           *) owner_pid=$owner_value ;;
         esac
       fi
-    done < "$acquire_path/owner"
+    done < "$owner_file"
   fi
   if [ -n "$owner_pid" ]; then
     fail "another Station installer owns '$acquire_path' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$acquire_path' and retry."
@@ -406,7 +462,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$requested_version_set" -eq 1 ] && ! valid_version "$requested_version"; then
-  fail "version must be valid v-prefixed SemVer, for example v0.1.1 or v0.1.1-rc.1."
+  fail "version must be valid v-prefixed SemVer, for example v0.7.0 or v0.7.1-rc.1."
 fi
 if [ -n "$release_id" ]; then
   case "$release_id" in
@@ -458,6 +514,7 @@ esac
 
 command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
 temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
+install_lock_token=$$-${temp_dir##*/}
 if ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
   fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
 fi
@@ -668,6 +725,9 @@ child_starting=1
   if ! ulimit -f 8; then
     exit 125
   fi
+  # The untrusted compatibility probe must not inherit download or CI credentials.
+  unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
+  unset ACTIONS_RUNTIME_TOKEN ACTIONS_ID_TOKEN_REQUEST_TOKEN STATION_INSTALL_RELEASE_ID
   exec "$install_stage/stn" --version
 ) > "$probe_output" 2> "$probe_error" &
 probe_pid=$!

--- a/scripts/release/package-archive.sh
+++ b/scripts/release/package-archive.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  printf 'Usage: package-archive.sh <version> <target>\n' >&2
+  exit 2
+fi
+
+version=$1
+target=$2
+
+case "$version" in
+  ''|*[!0-9A-Za-z.+-]*)
+    printf 'Invalid release version: %s\n' "$version" >&2
+    exit 2
+    ;;
+esac
+
+case "$target" in
+  darwin-arm64|darwin-x64|linux-arm64|linux-x64) ;;
+  *)
+    printf 'Unsupported release target: %s\n' "$target" >&2
+    exit 2
+    ;;
+esac
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+repo_root=$(CDPATH= cd "$script_dir/../.." && pwd -P)
+bin_dir=$repo_root/station/dist/bin
+archive=$repo_root/stn-v$version-$target.tar.gz
+
+[ -x "$bin_dir/stn" ] && [ ! -L "$bin_dir/stn" ] || {
+  printf 'Expected an executable Station binary at %s/stn.\n' "$bin_dir" >&2
+  exit 1
+}
+[ "$(readlink "$bin_dir/stn-ingress" 2>/dev/null || true)" = stn ] || {
+  printf 'Expected stn-ingress to be a symlink to stn.\n' >&2
+  exit 1
+}
+[ "$(readlink "$bin_dir/stn-tmux-popup" 2>/dev/null || true)" = stn ] || {
+  printf 'Expected stn-tmux-popup to be a symlink to stn.\n' >&2
+  exit 1
+}
+[ -f "$bin_dir/LICENSE" ] && [ ! -L "$bin_dir/LICENSE" ] || {
+  printf 'Expected a regular LICENSE file at %s/LICENSE.\n' "$bin_dir" >&2
+  exit 1
+}
+
+tar -C "$bin_dir" -czf "$archive" stn stn-ingress stn-tmux-popup LICENSE
+actual_manifest=$(tar -tzf "$archive")
+expected_manifest=$(printf '%s\n' stn stn-ingress stn-tmux-popup LICENSE)
+if [ "$actual_manifest" != "$expected_manifest" ]; then
+  printf 'Release archive manifest does not match the installer contract.\n' >&2
+  rm -f "$archive"
+  exit 1
+fi
+
+printf '%s\n' "$archive"

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -188,7 +188,7 @@ try {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.1.0-dev";
+    return "0.7.0";
   }
   if (
     normalized.length === 2 &&

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -1,0 +1,445 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const installer = join(repoRoot, "scripts", "install.sh");
+const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
+const releasesDir = join(root, "releases");
+const fakeBinDir = join(root, "bin");
+const homeDir = join(root, "home");
+const dataDir = join(root, "data");
+const stableTag = "v1.2.3";
+const rollbackTag = "v1.2.3-rc.1";
+
+const platforms = [
+  { system: "Darwin", machine: "arm64", target: "darwin-arm64" },
+  { system: "Darwin", machine: "x86_64", target: "darwin-x64" },
+  { system: "Linux", machine: "aarch64", target: "linux-arm64" },
+  { system: "Linux", machine: "x86_64", target: "linux-x64" },
+];
+
+try {
+  mkdirSync(releasesDir, { recursive: true });
+  mkdirSync(fakeBinDir, { recursive: true });
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(root, "tmp"), { recursive: true });
+  writeFakeCommands();
+
+  createRelease(
+    stableTag,
+    platforms.map(({ target }) => target),
+  );
+  createRelease(rollbackTag, ["linux-x64"]);
+  createRelease("v1.2.4", ["linux-x64"], { corruptChecksum: true });
+  createRelease("v1.2.5", ["linux-x64"], { extraMember: "postinstall" });
+  createRelease("v1.2.6", ["linux-x64"], { probeFailure: true });
+
+  for (const platform of platforms) {
+    const installDir = join(root, `install-${platform.target}`);
+    const result = runInstaller({ installDir, platform });
+    assertSuccess(result, `${platform.target} latest install`);
+    assertInstalled({ installDir, tag: stableTag, target: platform.target });
+    assertIncludes(result.stdout, `Add ${installDir} to PATH`, `${platform.target} PATH hint`);
+  }
+
+  const rollbackDir = join(root, "rollback-bin");
+  assertSuccess(
+    runInstaller({
+      installDir: rollbackDir,
+      platform: linuxX64(),
+      version: stableTag,
+      includeInstallDirOnPath: true,
+    }),
+    "explicit stable install",
+  );
+  const rollback = runInstaller({
+    installDir: rollbackDir,
+    platform: linuxX64(),
+    version: rollbackTag,
+    includeInstallDirOnPath: true,
+  });
+  assertSuccess(rollback, "explicit prerelease rollback");
+  assertInstalled({ installDir: rollbackDir, tag: rollbackTag, target: "linux-x64" });
+  assertNotIncludes(rollback.stdout, "Add ", "PATH hint when install directory is already present");
+
+  const draftDir = join(root, "draft-bin");
+  const draft = runInstaller({
+    installDir: draftDir,
+    platform: linuxX64(),
+    version: rollbackTag,
+    releaseId: "42",
+  });
+  assertSuccess(draft, "draft release ID install");
+  assertInstalled({ installDir: draftDir, tag: rollbackTag, target: "linux-x64" });
+
+  const preservedDir = join(root, "preserved-bin");
+  mkdirSync(preservedDir, { recursive: true });
+  const preservedBinary = join(preservedDir, "stn");
+  writeFileSync(preservedBinary, "existing installation\n", { mode: 0o755 });
+
+  const badChecksum = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: "v1.2.4",
+  });
+  assertFailure(badChecksum, "checksum verification failed", "checksum rejection");
+  assertEqual(
+    readFileSync(preservedBinary, "utf8"),
+    "existing installation\n",
+    "checksum preservation",
+  );
+
+  const malicious = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: "v1.2.5",
+  });
+  assertFailure(malicious, "exact Station release manifest", "unexpected archive member");
+  assertEqual(
+    readFileSync(preservedBinary, "utf8"),
+    "existing installation\n",
+    "manifest preservation",
+  );
+
+  const incompatible = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: "v1.2.6",
+  });
+  assertFailure(incompatible, "cannot run on this system", "binary compatibility probe");
+  assertEqual(
+    readFileSync(preservedBinary, "utf8"),
+    "existing installation\n",
+    "probe preservation",
+  );
+
+  const duplicateAsset = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    duplicateArchiveAsset: true,
+  });
+  assertFailure(duplicateAsset, "exactly one", "duplicate asset rejection");
+
+  const duplicateDraftAsset = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    releaseId: "42",
+    duplicateArchiveAsset: true,
+  });
+  assertFailure(duplicateDraftAsset, "exactly one", "duplicate draft asset rejection");
+
+  const duplicateDraftRelease = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    releaseId: "42",
+    duplicateDraftRelease: true,
+  });
+  assertFailure(duplicateDraftRelease, "no single draft matched", "duplicate draft release");
+
+  const mismatchedDraft = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    releaseId: "42",
+    releaseIdTag: rollbackTag,
+  });
+  assertFailure(mismatchedDraft, "no single draft matched", "draft tag mismatch");
+
+  const publishedRelease = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    releaseId: "42",
+    releaseDraft: false,
+  });
+  assertFailure(publishedRelease, "no single draft matched", "published release ID refusal");
+
+  const invalidDraftId = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: stableTag,
+    releaseId: "draft-42",
+  });
+  assertFailure(invalidDraftId, "must be a numeric", "invalid draft release ID");
+
+  const unauthenticated = runInstaller({
+    auth: false,
+    installDir: preservedDir,
+    platform: linuxX64(),
+  });
+  assertFailure(unauthenticated, "gh auth login", "authentication failure");
+  assertEqual(
+    readFileSync(preservedBinary, "utf8"),
+    "existing installation\n",
+    "auth preservation",
+  );
+
+  const unsupported = runInstaller({
+    installDir: preservedDir,
+    platform: { system: "FreeBSD", machine: "x86_64", target: "unsupported" },
+  });
+  assertFailure(unsupported, "unsupported platform", "unsupported platform");
+
+  const invalidVersion = runInstaller({
+    installDir: preservedDir,
+    platform: linuxX64(),
+    version: "1.2.3",
+  });
+  assertFailure(invalidVersion, "v-prefixed SemVer", "invalid version");
+
+  const help = spawnSync("/bin/sh", [installer, "--help"], { encoding: "utf8" });
+  assertSuccess(help, "installer help");
+  assertIncludes(help.stdout, "--install-dir", "installer help options");
+
+  process.stdout.write("install smoke passed\n");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function linuxX64() {
+  return platforms.find(({ target }) => target === "linux-x64");
+}
+
+function createRelease(tag, targets, options = {}) {
+  const releaseDir = join(releasesDir, tag);
+  mkdirSync(releaseDir, { recursive: true });
+  const checksums = [];
+
+  for (const target of targets) {
+    const version = tag.slice(1);
+    const archiveName = `stn-v${version}-${target}.tar.gz`;
+    const archivePath = join(releaseDir, archiveName);
+    const payloadDir = join(root, `payload-${version}-${target}`);
+    mkdirSync(payloadDir, { recursive: true });
+    const binarySource = options.probeFailure
+      ? "#!/bin/sh\nexit 126\n"
+      : `#!/bin/sh
+if [ "\${1:-}" = --version ]; then
+  printf '%s\\n' '${version}'
+else
+  printf '%s\\n' 'Station ${tag} ${target}'
+fi
+`;
+    writeFileSync(join(payloadDir, "stn"), binarySource, { mode: 0o755 });
+    symlinkSync("stn", join(payloadDir, "stn-ingress"));
+    symlinkSync("stn", join(payloadDir, "stn-tmux-popup"));
+    writeFileSync(join(payloadDir, "LICENSE"), `Station fixture license ${tag}\n`);
+
+    const members = ["stn", "stn-ingress", "stn-tmux-popup", "LICENSE"];
+    if (options.extraMember !== undefined) {
+      writeFileSync(join(payloadDir, options.extraMember), "unapproved archive payload\n", {
+        mode: 0o755,
+      });
+      members.push(options.extraMember);
+    }
+    spawnChecked("tar", ["-czf", archivePath, "-C", payloadDir, ...members], "fixture archive");
+    const hash = options.corruptChecksum
+      ? "0".repeat(64)
+      : createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+    checksums.push(`${hash}  ${archiveName}`);
+  }
+
+  writeFileSync(join(releaseDir, "SHA256SUMS"), `${checksums.sort().join("\n")}\n`);
+}
+
+function writeFakeCommands() {
+  writeExecutable(
+    join(fakeBinDir, "uname"),
+    [
+      "#!/bin/sh",
+      `case "\${1:-}" in`,
+      "  -s) printf '%s\\n' \"$FAKE_UNAME_S\" ;;",
+      "  -m) printf '%s\\n' \"$FAKE_UNAME_M\" ;;",
+      "  *) exit 2 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  writeExecutable(
+    join(fakeBinDir, "gh"),
+    [
+      "#!/bin/sh",
+      "set -eu",
+      '[ "$GH_HOST" = github.com ] || exit 3',
+      `if [ "\${1:-}" = auth ]; then`,
+      `  [ "\${FAKE_GH_AUTH:-1}" = 1 ]`,
+      "  exit",
+      "fi",
+      `[ "\${1:-}" = api ] || exit 2`,
+      "shift",
+      'endpoint=""',
+      'jq_filter=""',
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      "    -H) shift 2 ;;",
+      "    --paginate) shift ;;",
+      "    --jq) jq_filter=$2; shift 2 ;;",
+      "    *) endpoint=$1; shift ;;",
+      "  esac",
+      "done",
+      'case "$endpoint" in',
+      "  */releases/latest)",
+      '    [ "$jq_filter" = .tag_name ] || exit 2',
+      "    printf '%s\\n' \"$FAKE_LATEST_TAG\"",
+      "    ;;",
+      "  */releases/tags/*)",
+      `    [ "\${endpoint##*/}" = "$FAKE_TAG" ] || exit 1`,
+      '    case "$jq_filter" in',
+      "      *SHA256SUMS*) printf '2\\n' ;;",
+      '      *"$FAKE_ARCHIVE"*)',
+      `        if [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 1 ]; then`,
+      "          printf '1\\n3\\n'",
+      "        else",
+      "          printf '1\\n'",
+      "        fi",
+      "        ;;",
+      "    esac",
+      "    ;;",
+      "  */releases?per_page=100)",
+      '    case "$jq_filter" in *".draft == true"*) ;; *) exit 2 ;; esac',
+      `    [ "\${FAKE_RELEASE_DRAFT:-1}" = 1 ] || exit 0`,
+      '    [ "$FAKE_RELEASE_ID_TAG" = "$FAKE_TAG" ] || exit 0',
+      '    case "$jq_filter" in',
+      '      *"$FAKE_ARCHIVE"*)',
+      `        if [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 1 ]; then printf '1\\n3\\n'; else printf '1\\n'; fi`,
+      "        ;;",
+      "      *SHA256SUMS*) printf '2\\n' ;;",
+      "      *)",
+      "        printf '%s\\n' \"$FAKE_RELEASE_ID\"",
+      `        if [ "\${FAKE_DUPLICATE_RELEASE:-0}" = 1 ]; then printf '%s\\n' "$FAKE_RELEASE_ID"; fi`,
+      "        ;;",
+      "    esac",
+      "    ;;",
+      '  */releases/assets/1) cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE" ;;',
+      '  */releases/assets/2) cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS" ;;',
+      "  *) exit 2 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeExecutable(path, source) {
+  writeFileSync(path, source, { mode: 0o755 });
+  chmodSync(path, 0o755);
+}
+
+function runInstaller({
+  installDir,
+  platform,
+  version,
+  auth = true,
+  duplicateArchiveAsset = false,
+  duplicateDraftRelease = false,
+  includeInstallDirOnPath = false,
+  releaseId,
+  releaseDraft = true,
+  releaseIdTag,
+}) {
+  const tag = version ?? stableTag;
+  const archive = `stn-${tag}-${platform.target}.tar.gz`;
+  const path = [fakeBinDir, "/usr/bin", "/bin"];
+  if (includeInstallDirOnPath) path.push(installDir);
+  const args = [];
+  if (version !== undefined) args.push("--version", version);
+  args.push("--install-dir", installDir);
+  const env = {
+    HOME: homeDir,
+    GH_HOST: "untrusted.example",
+    PATH: path.join(":"),
+    TMPDIR: join(root, "tmp"),
+    XDG_DATA_HOME: dataDir,
+    FAKE_ARCHIVE: archive,
+    FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
+    FAKE_DUPLICATE_RELEASE: duplicateDraftRelease ? "1" : "0",
+    FAKE_GH_AUTH: auth ? "1" : "0",
+    FAKE_LATEST_TAG: stableTag,
+    FAKE_RELEASE_ID: releaseId ?? "42",
+    FAKE_RELEASE_DRAFT: releaseDraft ? "1" : "0",
+    FAKE_RELEASE_ID_TAG: releaseIdTag ?? tag,
+    FAKE_RELEASES: releasesDir,
+    FAKE_TAG: tag,
+    FAKE_UNAME_M: platform.machine,
+    FAKE_UNAME_S: platform.system,
+  };
+  if (releaseId !== undefined) env.STATION_INSTALL_RELEASE_ID = releaseId;
+  return spawnSync("/bin/sh", [installer, ...args], { encoding: "utf8", env });
+}
+
+function assertInstalled({ installDir, tag, target }) {
+  const binary = join(installDir, "stn");
+  const result = spawnSync(binary, [], { encoding: "utf8", env: { PATH: "/usr/bin:/bin" } });
+  assertSuccess(result, `${target} installed binary`);
+  assertEqual(result.stdout, `Station ${tag} ${target}\n`, `${target} installed version`);
+  assertEqual(readlinkSync(join(installDir, "stn-ingress")), "stn", `${target} ingress link`);
+  assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", `${target} popup link`);
+  assertEqual(
+    readFileSync(join(dataDir, "station", "LICENSE"), "utf8"),
+    `Station fixture license ${tag}\n`,
+    `${target} installed license`,
+  );
+  const access = spawnSync("/bin/sh", ["-c", 'test -x "$1"', "sh", binary]);
+  assertEqual(access.status, 0, `${target} executable mode`);
+}
+
+function spawnChecked(command, args, label) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  assertSuccess(result, label);
+  return result;
+}
+
+function assertSuccess(result, label) {
+  if (result.error !== undefined) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${label} failed (${result.status})\n${result.stdout}\n${result.stderr}`);
+  }
+}
+
+function assertFailure(result, expected, label) {
+  if (result.error !== undefined) throw result.error;
+  if (result.status === 0) throw new Error(`${label} unexpectedly passed`);
+  assertIncludes(result.stderr, expected, label);
+}
+
+function assertIncludes(value, expected, label) {
+  if (!value.includes(expected)) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(value)} to include ${JSON.stringify(expected)}`,
+    );
+  }
+}
+
+function assertNotIncludes(value, expected, label) {
+  if (value.includes(expected)) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(value)} not to include ${JSON.stringify(expected)}`,
+    );
+  }
+}
+
+function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(
+      `${label}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
+    );
+  }
+}

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -13,13 +14,16 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
 
 const inheritedUmask = process.umask(0o077);
+const runner = fileURLToPath(import.meta.url);
 const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const installer = join(repoRoot, "scripts", "install.sh");
 const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
@@ -32,7 +36,15 @@ const ghLogsDir = join(root, "gh-logs");
 const stableTag = "v1.2.3";
 const rollbackTag = "v1.2.3-rc.1";
 const activeChildren = new Set();
+const childTimeoutMs = 15_000;
+const markerTimeoutMs = 10_000;
+const overallTimeoutMs = 240_000;
+const startedAt = Date.now();
+const selfInterruptChild = process.argv.includes("--self-interrupt-child");
 let invocationCount = 0;
+let cleanupPromise;
+let overallTimer;
+let signalCleanupStarted = false;
 
 const platforms = [
   { system: "Darwin", machine: "arm64", target: "darwin-arm64" },
@@ -41,27 +53,62 @@ const platforms = [
   { system: "Linux", machine: "x86_64", target: "linux-x64" },
 ];
 
+for (const [signal, status] of [
+  ["SIGHUP", 129],
+  ["SIGINT", 130],
+  ["SIGTERM", 143],
+]) {
+  process.once(signal, () => {
+    if (signalCleanupStarted) return;
+    signalCleanupStarted = true;
+    void cleanupHarness().finally(() => process.exit(status));
+  });
+}
+
+overallTimer = setTimeout(() => {
+  dumpHarnessState(`overall deadline exceeded after ${overallTimeoutMs}ms`);
+  void cleanupHarness().finally(() => process.exit(1));
+}, overallTimeoutMs);
+
 try {
-  prepareFixtures();
-  await scenarioPlatformInstalls();
-  await scenarioExplicitRollbackAndDraft();
-  await scenarioAuthenticatedReleaseValidation();
-  await scenarioStrictVersionValidation();
-  await scenarioHostileUmaskModes();
-  await scenarioPathResolutionAndFilesystemFailures();
-  await scenarioProbeDeadline();
-  await scenarioDestinationLock();
-  await scenarioCommitFailures();
-  await scenarioCaughtSignals();
-  await scenarioSignalDuringLockAcquisition();
-  await scenarioSigkillLeavesActionableLock();
-  scenarioHelp();
-  process.stdout.write("install smoke passed\n");
+  if (selfInterruptChild) {
+    await runSelfInterruptChild();
+  } else {
+    prepareFixtures();
+    await scenarioPlatformInstalls();
+    await scenarioDefaultHomeAndPathResolution();
+    await scenarioExplicitRollbackAndDraft();
+    await scenarioStrictGhFlows();
+    await scenarioAuthenticatedReleaseValidation();
+    await scenarioGhFailuresAndRetries();
+    await scenarioArtifactValidation();
+    await scenarioStrictVersionValidation();
+    await scenarioCliParsing();
+    await scenarioHostileUmaskModes();
+    await scenarioPathResolutionAndFilesystemFailures();
+    await scenarioProbeDeadline();
+    await scenarioProbeDiagnostics();
+    await scenarioDestinationLock();
+    await scenarioSharedLicenseLock();
+    await scenarioCommitFailures();
+    await scenarioAmbiguousRuntimeCommit();
+    await scenarioManagedPathReplacement();
+    await scenarioContinuousReaders();
+    await scenarioCaughtSignals();
+    await scenarioGhSignalSupervision();
+    await scenarioRepeatedSignalCleanup();
+    await scenarioAliasCreationSignal();
+    await scenarioSignalDuringLockAcquisition();
+    await scenarioSigkillLeavesActionableLocks();
+    await scenarioSelfInterruption();
+    scenarioHelp();
+    process.stdout.write("install smoke passed\n");
+  }
+} catch (error) {
+  dumpHarnessState(error instanceof Error ? error.message : String(error));
+  throw error;
 } finally {
-  await stopActiveChildren();
-  chmodSync(root, 0o700);
-  rmSync(root, { recursive: true, force: true });
-  process.umask(inheritedUmask);
+  await cleanupHarness();
 }
 
 function prepareFixtures() {
@@ -80,6 +127,55 @@ function prepareFixtures() {
   createRelease("v1.2.6", ["linux-x64"], { probeMode: "fail" });
   createRelease("v1.2.7", ["linux-x64"], { probeMode: "hang" });
   createRelease("v1.2.8", ["linux-x64"], { probeMode: "gate" });
+  createRelease("v1.2.9", ["linux-x64"], { reportedVersion: "9.9.9" });
+  createRelease("v1.2.10", ["linux-x64"], { probeMode: "flood" });
+  createRelease("v1.2.11", ["linux-x64"], { probeMode: "diagnostic" });
+  createRelease("v1.2.12", ["linux-x64"], { omitMember: "LICENSE" });
+  createRelease("v1.2.13", ["linux-x64"], { duplicateMember: "stn" });
+  createManualRelease("v1.2.14", "linux-x64", [
+    tarFile("../stn", "untrusted traversal payload\n", 0o755),
+    tarFile("LICENSE", "Station fixture license v1.2.14\n", 0o644),
+    tarSymlink("stn-ingress", "stn"),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
+  createManualRelease("v1.2.15", "linux-x64", [
+    tarSymlink("stn", "missing-runtime"),
+    tarFile("LICENSE", "Station fixture license v1.2.15\n", 0o644),
+    tarSymlink("stn-ingress", "stn"),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
+  createManualRelease("v1.2.16", "linux-x64", [
+    tarFile("stn", releaseBinarySource("v1.2.16", "linux-x64"), 0o755),
+    tarSymlink("LICENSE", "stn"),
+    tarSymlink("stn-ingress", "stn"),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
+  createRelease("v1.2.17", ["linux-x64"], { ingressTarget: "../stn" });
+  createRelease("v1.2.18", ["linux-x64"], { unreadableArchive: true });
+  createRelease("v1.2.19", ["linux-x64"], { checksumMode: "missing" });
+  createRelease("v1.2.20", ["linux-x64"], { checksumMode: "duplicate" });
+  createRelease("v1.2.21", ["linux-x64"], { checksumMode: "malformed" });
+  createRelease("v1.2.22", ["linux-x64"], { probeMode: "hang" });
+  createRelease("v1.2.23", ["linux-x64"], { popupTarget: "../stn" });
+  createManualRelease("v1.2.24", "linux-x64", [
+    tarFile("stn", releaseBinarySource("v1.2.24", "linux-x64"), 0o755),
+    tarFile("LICENSE", "Station fixture license v1.2.24\n", 0o644),
+    tarFile("stn-ingress", "not a symlink\n", 0o755),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
+  createRelease("v1.2.25", ["linux-x64"], { probeMode: "stdout-flood" });
+  createManualRelease("v1.2.26", "linux-x64", [
+    tarFile("LICENSE", "Station fixture license v1.2.26\n", 0o644),
+    tarHardlink("stn", "LICENSE"),
+    tarSymlink("stn-ingress", "stn"),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
+  createManualRelease("v1.2.27", "linux-x64", [
+    tarFile("stn", releaseBinarySource("v1.2.27", "linux-x64"), 0o755),
+    tarHardlink("LICENSE", "stn"),
+    tarSymlink("stn-ingress", "stn"),
+    tarSymlink("stn-tmux-popup", "stn"),
+  ]);
 }
 
 function scenarioPlatformInstalls() {
@@ -88,9 +184,86 @@ function scenarioPlatformInstalls() {
     const result = runInstaller({ installDir, platform });
     assertSuccess(result, `${platform.target} latest install`);
     assertInstalled({ installDir, tag: stableTag, target: platform.target });
-    assertIncludes(result.stdout, `Add ${installDir} to PATH`, `${platform.target} PATH hint`);
+    assertPathRecovery(result, installDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
     assertNoInstallerResidue(installDir, dataDir);
   }
+}
+
+function scenarioDefaultHomeAndPathResolution() {
+  const cleanHome = join(root, "default-home");
+  makeDirectory(cleanHome);
+  const defaultInstallDir = join(cleanHome, ".local", "bin");
+  const defaultDataHome = join(cleanHome, ".local", "share");
+  const defaultInstall = runInstaller({
+    platform: linuxX64(),
+    home: cleanHome,
+    unsetXdgDataHome: true,
+    omitInstallDir: true,
+  });
+  assertSuccess(defaultInstall, "default clean-home install");
+  assertInstalled({
+    installDir: defaultInstallDir,
+    dataHome: defaultDataHome,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+  assertPathRecovery(defaultInstall, defaultInstallDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
+  for (const profile of [".profile", ".bashrc", ".zshrc"]) {
+    assert(!existsSync(join(cleanHome, profile)), `installer leaves ${profile} absent`);
+  }
+
+  const shadowedStnDir = join(root, "shadowed-stn-path");
+  const shadowedStnInstall = join(root, "shadowed-stn-bin");
+  makeDirectory(shadowedStnDir);
+  writeExecutable(join(shadowedStnDir, "stn"), "#!/bin/sh\nprintf '%s\\n' '0.0.1'\n");
+  const shadowedStn = runInstaller({
+    installDir: shadowedStnInstall,
+    platform: linuxX64(),
+    pathEntries: [shadowedStnDir, shadowedStnInstall, fakeBinDir, "/usr/bin", "/bin"],
+  });
+  assertSuccess(shadowedStn, "older stn shadowing");
+  assertPathRecovery(
+    shadowedStn,
+    shadowedStnInstall,
+    ["stn"],
+    [shadowedStnDir, shadowedStnInstall, fakeBinDir, "/usr/bin", "/bin"],
+  );
+  assertIncludes(shadowedStn.stdout, join(shadowedStnDir, "stn"), "shadowed stn diagnosis");
+
+  const shadowedSiblingDir = join(root, "shadowed-sibling-path");
+  const shadowedSiblingInstall = join(root, "shadowed-sibling-bin");
+  makeDirectory(shadowedSiblingDir);
+  writeExecutable(
+    join(shadowedSiblingDir, "stn-ingress"),
+    "#!/bin/sh\nprintf '%s\\n' 'shadow ingress'\n",
+  );
+  const shadowedSibling = runInstaller({
+    installDir: shadowedSiblingInstall,
+    platform: linuxX64(),
+    pathEntries: [shadowedSiblingDir, shadowedSiblingInstall, fakeBinDir, "/usr/bin", "/bin"],
+  });
+  assertSuccess(shadowedSibling, "one shadowed sibling launcher");
+  assertPathRecovery(
+    shadowedSibling,
+    shadowedSiblingInstall,
+    ["stn-ingress"],
+    [shadowedSiblingDir, shadowedSiblingInstall, fakeBinDir, "/usr/bin", "/bin"],
+  );
+  assertIncludes(
+    shadowedSibling.stdout,
+    join(shadowedSiblingDir, "stn-ingress"),
+    "shadowed sibling diagnosis",
+  );
+
+  const correctInstallDir = join(root, "correct-path-bin");
+  const correctPath = runInstaller({
+    installDir: correctInstallDir,
+    platform: linuxX64(),
+    pathEntries: [correctInstallDir, fakeBinDir, "/usr/bin", "/bin"],
+  });
+  assertSuccess(correctPath, "all launchers on correct PATH");
+  assertIncludes(correctPath.stdout, "Next: run stn setup", "correct PATH next step");
+  assertNotIncludes(correctPath.stdout, "hash -r", "correct PATH omits recovery block");
 }
 
 function scenarioExplicitRollbackAndDraft() {
@@ -112,7 +285,8 @@ function scenarioExplicitRollbackAndDraft() {
   });
   assertSuccess(rollback, "explicit prerelease rollback");
   assertInstalled({ installDir: rollbackDir, tag: rollbackTag, target: "linux-x64" });
-  assertNotIncludes(rollback.stdout, "Add ", "PATH hint when install directory is present");
+  assertIncludes(rollback.stdout, "Next: run stn setup", "rollback PATH next step");
+  assertNotIncludes(rollback.stdout, "hash -r", "rollback PATH recovery omission");
 
   const draftDir = join(root, "draft-bin");
   const draft = runInstaller({
@@ -123,6 +297,32 @@ function scenarioExplicitRollbackAndDraft() {
   });
   assertSuccess(draft, "draft release ID install");
   assertInstalled({ installDir: draftDir, tag: rollbackTag, target: "linux-x64" });
+}
+
+function scenarioStrictGhFlows() {
+  const latest = runInstaller({
+    installDir: join(root, "strict-gh-latest-bin"),
+    platform: linuxX64(),
+  });
+  assertSuccess(latest, "strict gh latest flow");
+  assertStrictGhFlow(latest, { tag: stableTag, target: "linux-x64", latest: true });
+
+  const explicit = runInstaller({
+    installDir: join(root, "strict-gh-explicit-bin"),
+    platform: linuxX64(),
+    version: rollbackTag,
+  });
+  assertSuccess(explicit, "strict gh explicit flow");
+  assertStrictGhFlow(explicit, { tag: rollbackTag, target: "linux-x64" });
+
+  const draft = runInstaller({
+    installDir: join(root, "strict-gh-draft-bin"),
+    platform: linuxX64(),
+    version: rollbackTag,
+    releaseId: "42",
+  });
+  assertSuccess(draft, "strict gh draft flow");
+  assertStrictGhFlow(draft, { draftId: "42", tag: rollbackTag, target: "linux-x64" });
 }
 
 function scenarioAuthenticatedReleaseValidation() {
@@ -203,6 +403,114 @@ function scenarioAuthenticatedReleaseValidation() {
   }
 }
 
+function scenarioGhFailuresAndRetries() {
+  const noGhBin = join(root, "no-gh-bin");
+  makeDirectory(noGhBin);
+  symlinkSync(join(fakeBinDir, "uname"), join(noGhBin, "uname"));
+  const missingGh = runInstaller({
+    installDir: join(root, "missing-gh-install"),
+    platform: linuxX64(),
+    pathEntries: [noGhBin],
+  });
+  assertFailure(missingGh, "GitHub CLI is required", "missing gh");
+  assertEqual(ghCalls(missingGh), [], "missing gh makes no gh calls");
+
+  const installDir = join(root, "gh-failure-bin");
+  const dataHome = join(root, "gh-failure-data");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const failures = [
+    ["latest", {}, "latest release API failure"],
+    ["release", { version: stableTag }, "release asset API failure"],
+    ["archive-download", { version: stableTag }, "archive download failure"],
+    ["checksums-download", { version: stableTag }, "checksum download failure"],
+    ["partial-archive", { version: stableTag }, "partial archive download"],
+    ["partial-checksums", { version: stableTag }, "partial checksum download"],
+  ];
+
+  for (const [phase, options, label] of failures) {
+    const result = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      dataHome,
+      ...options,
+      environment: { FAKE_GH_FAIL_PHASE: phase },
+    });
+    assertNonzero(result, label);
+    assertRuntimeVersion(installDir, "v0.9.0", `${label} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${label} license preservation`);
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+
+  for (const [environment, expected, label] of [
+    [{ FAKE_ARCHIVE_ASSET_COUNT: "0" }, "exactly one", "missing archive asset"],
+    [{ FAKE_ARCHIVE_ASSET_COUNT: "2" }, "exactly one", "duplicate archive asset"],
+    [{ FAKE_CHECKSUM_ASSET_COUNT: "0" }, "exactly one", "missing checksum asset"],
+    [{ FAKE_CHECKSUM_ASSET_COUNT: "2" }, "exactly one", "duplicate checksum asset"],
+  ]) {
+    const result = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: stableTag,
+      dataHome,
+      environment,
+    });
+    assertFailure(result, expected, label);
+    assertRuntimeVersion(installDir, "v0.9.0", `${label} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${label} license preservation`);
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+
+  const retry = runInstaller({ installDir, platform: linuxX64(), version: stableTag, dataHome });
+  assertSuccess(retry, "retry after gh failures");
+  assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+}
+
+function scenarioArtifactValidation() {
+  const installDir = join(root, "artifact-validation-bin");
+  const dataHome = join(root, "artifact-validation-data");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const failures = [
+    ["v1.2.4", "checksum verification failed", "mismatched checksum"],
+    ["v1.2.19", "exactly one checksum", "missing checksum"],
+    ["v1.2.20", "exactly one checksum", "duplicate checksum"],
+    ["v1.2.21", "invalid checksum", "malformed checksum"],
+    ["v1.2.18", "not a readable gzip", "unreadable gzip"],
+    ["v1.2.12", "exact Station release manifest", "missing archive member"],
+    ["v1.2.5", "exact Station release manifest", "extra archive member"],
+    ["v1.2.13", "exact Station release manifest", "duplicate archive member"],
+    ["v1.2.14", "exact Station release manifest", "traversal-like archive member"],
+    ["v1.2.15", "required Station member types", "wrong binary archive type"],
+    ["v1.2.16", "required Station member types", "wrong license archive type"],
+    ["v1.2.17", "symlink to 'stn'", "wrong launcher archive target"],
+    ["v1.2.23", "symlink to 'stn'", "wrong popup launcher archive target"],
+    ["v1.2.24", "required Station member types", "regular-file launcher archive type"],
+    ["v1.2.26", "required Station member types", "hardlinked binary archive type"],
+    ["v1.2.27", "required Station member types", "hardlinked license archive type"],
+    ["v1.2.9", "reports an unexpected version", "wrong embedded version"],
+  ];
+
+  for (const [version, expected, label] of failures) {
+    const result = runInstaller({ installDir, platform: linuxX64(), version, dataHome });
+    assertFailure(result, expected, label);
+    assertRuntimeVersion(installDir, "v0.9.0", `${label} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${label} license preservation`);
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+
+  const noChecksumBin = makeNoChecksumBin();
+  const noChecksum = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    pathEntries: [noChecksumBin],
+  });
+  assertFailure(noChecksum, "sha256sum or shasum is required", "no checksum utility");
+  assertRuntimeVersion(installDir, "v0.9.0", "no checksum utility runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "no checksum utility license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
 function scenarioStrictVersionValidation() {
   const installDir = join(root, "invalid-versions-bin");
   const invalidVersions = [
@@ -242,6 +550,36 @@ function scenarioStrictVersionValidation() {
       1,
       `invalid latest API tag ${JSON.stringify(apiTag)} stops after lookup`,
     );
+  }
+}
+
+function scenarioCliParsing() {
+  const installDir = join(root, "cli-parsing-bin");
+  const cases = [
+    [["--version"], "--version requires a value", "missing version value"],
+    [["--install-dir"], "--install-dir requires a path", "missing install-dir value"],
+    [
+      ["--version", stableTag, "--version", rollbackTag],
+      "--version may be specified only once",
+      "duplicate version flag",
+    ],
+    [
+      ["--install-dir", installDir, "--install-dir", join(root, "other-bin")],
+      "--install-dir may be specified only once",
+      "duplicate install-dir flag",
+    ],
+    [["--install-dir", ""], "non-empty path", "empty install-dir path"],
+    [["--unknown"], "unknown option", "unknown option"],
+  ];
+
+  for (const [argumentsOverride, expected, label] of cases) {
+    const result = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      argumentsOverride,
+    });
+    assertFailure(result, expected, label);
+    assertEqual(ghCalls(result), [], `${label} makes no gh calls`);
   }
 }
 
@@ -298,7 +636,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
     target: "linux-x64",
   });
 
-  const unusualCwd = join(root, "path with spaces\nand newline");
+  const unusualCwd = join(root, "path with spaces'quote\nand newline");
   makeDirectory(unusualCwd);
   const unusualInstall = join(unusualCwd, "station bin\ncommands\n");
   const unusualData = join(unusualCwd, "station data\nfiles\n");
@@ -316,6 +654,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
     tag: stableTag,
     target: "linux-x64",
   });
+  assertPathRecovery(unusual, unusualInstall, ["stn", "stn-ingress", "stn-tmux-popup"]);
 
   const newlineLinkDir = join(root, "newline-link-bin");
   const newlineLinkData = join(root, "newline-link-data");
@@ -338,9 +677,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
     "stn\n",
     "newline launcher target remains untouched",
   );
-  const newlineLinkRuntime = spawnSync(join(newlineLinkDir, "stn"), ["--version"], {
-    encoding: "utf8",
-  });
+  const newlineLinkRuntime = spawnSync(join(newlineLinkDir, "stn"), ["--version"], syncOptions());
   assertSuccess(newlineLinkRuntime, "newline launcher runtime preservation");
   assertEqual(newlineLinkRuntime.stdout, "0.9.0\n", "newline launcher runtime version");
   assertLicense(newlineLinkData, "v0.9.0", "newline launcher license preservation");
@@ -404,6 +741,126 @@ async function scenarioProbeDeadline() {
   assertNoInstallerResidue(installDir, dataHome);
 }
 
+async function scenarioProbeDiagnostics() {
+  const installDir = join(root, "probe-diagnostics-bin");
+  const dataHome = join(root, "probe-diagnostics-data");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+
+  const flood = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.10",
+    dataHome,
+  });
+  assertNonzero(flood, "probe output flood");
+  assertIncludes(flood.stderr, "loader diagnostic", "probe output flood diagnostic");
+  const diagnosticPrefix = "Compatibility probe stderr (up to 4096 sanitized bytes):\n";
+  const diagnosticStart = flood.stderr.indexOf(diagnosticPrefix);
+  const diagnosticEnd = flood.stderr.indexOf("\nStation install failed:", diagnosticStart);
+  assert(diagnosticStart >= 0 && diagnosticEnd > diagnosticStart, "probe diagnostic boundaries");
+  const diagnosticPayload = flood.stderr.slice(
+    diagnosticStart + diagnosticPrefix.length,
+    diagnosticEnd,
+  );
+  assert(
+    Buffer.byteLength(diagnosticPayload) <= 4_096,
+    `probe diagnostic payload was not bounded: ${Buffer.byteLength(diagnosticPayload)} bytes`,
+  );
+  assertRuntimeVersion(installDir, "v0.9.0", "probe flood runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "probe flood license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const stdoutFlood = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.25",
+    dataHome,
+  });
+  assertNonzero(stdoutFlood, "probe stdout flood");
+  assert(
+    stdoutFlood.error?.code !== "ETIMEDOUT",
+    "probe stdout flood is stopped by the file limit",
+  );
+  assertRuntimeVersion(installDir, "v0.9.0", "probe stdout flood runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "probe stdout flood license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const diagnostic = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.11",
+    dataHome,
+  });
+  assertNonzero(diagnostic, "sanitized loader diagnostic");
+  assertIncludes(diagnostic.stderr, "loader", "sanitized loader diagnostic content");
+  for (const control of ["\u001b", "\u0007", "\r"]) {
+    assertNotIncludes(diagnostic.stderr, control, "sanitized loader diagnostic controls");
+  }
+  assertRuntimeVersion(installDir, "v0.9.0", "diagnostic runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "diagnostic license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const timerBin = join(root, "failed-watchdog-timer-bin");
+  const probePid = join(root, "failed-watchdog-probe.pid");
+  makeDirectory(timerBin);
+  writeExecutable(
+    join(timerBin, "sleep"),
+    `#!/bin/sh
+if [ "\${1:-}" = 10 ]; then
+  while [ ! -e "$FAKE_PROBE_PID_FILE" ]; do /bin/sleep 0.01; done
+  exit 71
+fi
+exec /bin/sleep "$@"
+`,
+  );
+  const timerFailure = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.22",
+    dataHome,
+    commandBinDirs: [timerBin],
+    environment: { FAKE_PROBE_PID_FILE: probePid },
+    asynchronous: true,
+  });
+  await waitForPath(probePid, "timer-failure probe");
+  const timerResult = await settleWithin(timerFailure, 5_000, "watchdog timer failure");
+  assertNonzero(timerResult, "watchdog timer failure");
+  assertIncludes(timerResult.stderr, "timer", "watchdog timer failure diagnosis");
+  assertRuntimeVersion(installDir, "v0.9.0", "timer failure runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "timer failure license preservation");
+  assertProcessGone(Number(readFileSync(probePid, "utf8")), "timer-failure probe child");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const markerlessClockBin = join(root, "markerless-watchdog-clock-bin");
+  makeDirectory(markerlessClockBin);
+  writeExecutable(
+    join(markerlessClockBin, "sleep"),
+    `#!/bin/sh
+case "\${1:-}" in
+  10|1) exec /bin/sleep 0.05 ;;
+  *) exec /bin/sleep "$@" ;;
+esac
+`,
+  );
+  const markerlessTimeout = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.7",
+    dataHome,
+    asynchronous: true,
+    commandBinDirs: [markerlessClockBin],
+  });
+  const markerlessResult = await settleWithin(
+    markerlessTimeout,
+    5_000,
+    "markerless compatibility timeout",
+  );
+  assertFailure(markerlessResult, "did not respond", "markerless compatibility timeout");
+  assertRuntimeVersion(installDir, "v0.9.0", "markerless timeout runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "markerless timeout license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
 async function scenarioDestinationLock() {
   const installDir = join(root, "concurrent-bin");
   const dataHome = join(root, "concurrent-data");
@@ -424,11 +881,18 @@ async function scenarioDestinationLock() {
   });
   await waitForPath(probePid, "first installer probe");
   const lockPath = join(installDir, ".station-install.lock");
+  const licenseLockPath = join(dataHome, "station", ".station-install.lock");
   await waitForPath(lockPath, "destination lock");
+  await waitForPath(licenseLockPath, "license lock");
   assertEqual(
     readFileSync(join(lockPath, "owner"), "utf8"),
     `pid=${first.child.pid}\nrequested=v1.2.8\n`,
     "destination lock owner",
+  );
+  assertEqual(
+    readFileSync(join(licenseLockPath, "owner"), "utf8"),
+    `pid=${first.child.pid}\nrequested=v1.2.8\n`,
+    "license lock owner",
   );
 
   const second = runInstaller({ installDir, platform: linuxX64(), dataHome });
@@ -452,6 +916,113 @@ async function scenarioDestinationLock() {
   assertSuccess(retry, "retry after concurrent install");
   assertInstalled({ installDir, dataHome, tag: rollbackTag, target: "linux-x64" });
   assertNoInstallerResidue(installDir, dataHome);
+}
+
+async function scenarioSharedLicenseLock() {
+  const dataHome = join(root, "shared-license-data");
+  const firstInstallDir = join(root, "shared-license-first-bin");
+  const secondInstallDir = join(root, "shared-license-second-bin");
+  const probePid = join(root, "shared-license-probe.pid");
+  const releaseFile = join(root, "shared-license-probe.release");
+  seedInstallation({ installDir: firstInstallDir, dataHome, tag: "v0.9.0" });
+  seedInstallation({ installDir: secondInstallDir, dataHome, tag: "v0.9.0" });
+
+  const first = runInstaller({
+    installDir: firstInstallDir,
+    platform: linuxX64(),
+    version: "v1.2.8",
+    dataHome,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
+    asynchronous: true,
+  });
+  const commandLock = join(firstInstallDir, ".station-install.lock");
+  const licenseLock = join(dataHome, "station", ".station-install.lock");
+  await waitForPath(probePid, "shared-license first probe");
+  await waitForPath(commandLock, "shared-license command lock");
+  await waitForPath(licenseLock, "shared-license license lock");
+
+  const second = runInstaller({
+    installDir: secondInstallDir,
+    platform: linuxX64(),
+    dataHome,
+  });
+  assertFailure(second, licenseLock, "shared-license lock refusal");
+  assertIncludes(second.stderr, String(first.child.pid), "shared-license lock owner PID");
+  assert(
+    !existsSync(join(secondInstallDir, ".station-install.lock")),
+    "license refusal releases command lock",
+  );
+  assertNoGhApiCalls(second, "shared-license lock refusal");
+  assertRuntimeVersion(secondInstallDir, "v0.9.0", "shared-license refused runtime");
+
+  writeText(releaseFile, "release\n", 0o600);
+  assertSuccess(
+    await settleWithin(first, 5_000, "shared-license first installer"),
+    "shared-license first",
+  );
+  assertInstalled({ installDir: firstInstallDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+
+  const retry = runInstaller({
+    installDir: secondInstallDir,
+    platform: linuxX64(),
+    version: rollbackTag,
+    dataHome,
+  });
+  assertSuccess(retry, "shared-license retry");
+  assertInstalled({
+    installDir: secondInstallDir,
+    dataHome,
+    tag: rollbackTag,
+    target: "linux-x64",
+  });
+
+  const coincidentDataHome = join(root, "coincident-lock-data");
+  const coincidentInstallDir = join(coincidentDataHome, "station");
+  const coincident = runInstaller({
+    installDir: coincidentInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: coincidentDataHome,
+  });
+  assertSuccess(coincident, "coincident command and license lock");
+  assertInstalled({
+    installDir: coincidentInstallDir,
+    dataHome: coincidentDataHome,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+  assertNoInstallerResidue(coincidentInstallDir, coincidentDataHome);
+
+  const orderInstallDir = join(root, "lock-order-bin");
+  const orderDataHome = join(root, "lock-order-data");
+  const orderLog = join(root, "lock-order.log");
+  const orderShim = makeMkdirLoggingShim(orderLog);
+  const ordered = runInstaller({
+    installDir: orderInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: orderDataHome,
+    commandBinDirs: [orderShim.directory],
+    environment: orderShim.environment,
+  });
+  assertSuccess(ordered, "lock acquisition order");
+  const lockOperations = readFileSync(orderLog, "utf8")
+    .trimEnd()
+    .split("\n")
+    .filter((entry) => entry.endsWith("/.station-install.lock"));
+  assertEqual(
+    lockOperations,
+    [
+      `mkdir ${join(orderInstallDir, ".station-install.lock")}`,
+      `mkdir ${join(orderDataHome, "station", ".station-install.lock")}`,
+      `rmdir ${join(orderDataHome, "station", ".station-install.lock")}`,
+      `rmdir ${join(orderInstallDir, ".station-install.lock")}`,
+    ],
+    "locks are acquired command-first and released license-first",
+  );
 }
 
 function scenarioCommitFailures() {
@@ -483,6 +1054,9 @@ function scenarioCommitFailures() {
       environment: shim.environment,
     });
     assertNonzero(failed, `${testCase.label} failure injection`);
+    if (testCase.label === "runtime commit") {
+      assertIncludes(failed.stderr, "was unchanged", "failed activation rollback report");
+    }
     assertRuntimeVersion(installDir, "v0.9.0", `${testCase.label} runtime rollback`, {
       aliases: withAliases,
     });
@@ -498,27 +1072,486 @@ function scenarioCommitFailures() {
     assertSuccess(retry, `${testCase.label} retry`);
     assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
   }
+
+  for (const testCase of cases) {
+    const slug = `first-install-${testCase.label.replaceAll(" ", "-")}`;
+    const installDir = join(root, `${slug}-bin`);
+    const dataHome = join(root, `${slug}-data`);
+    const destination =
+      testCase.destination === "LICENSE"
+        ? join(dataHome, "station", "LICENSE")
+        : join(installDir, testCase.destination);
+    const shim = makeFailOnceShim(testCase.command, destination, slug);
+    const failed = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: stableTag,
+      dataHome,
+      commandBinDirs: [shim.directory],
+      environment: shim.environment,
+    });
+    assertNonzero(failed, `${testCase.label} first-install failure injection`);
+    for (const entrypoint of ["stn", "stn-ingress", "stn-tmux-popup"]) {
+      assert(
+        !existsSync(join(installDir, entrypoint)) && !isSymlink(join(installDir, entrypoint)),
+        `${testCase.label} first-install leaves ${entrypoint} absent`,
+      );
+    }
+    assert(
+      !existsSync(join(dataHome, "station", "LICENSE")),
+      `${testCase.label} first-install leaves license absent`,
+    );
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+}
+
+function scenarioAmbiguousRuntimeCommit() {
+  const installDir = join(root, "ambiguous-runtime-bin");
+  const dataHome = join(root, "ambiguous-runtime-data");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const shim = makeMoveThenFailShim(join(installDir, "stn"));
+  const ambiguous = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    commandBinDirs: [shim.directory],
+    environment: shim.environment,
+  });
+  assertNonzero(ambiguous, "rename-performed-then-error");
+  assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+  assertIncludes(ambiguous.stderr, join(installDir, "stn"), "ambiguous activation inspection path");
+  assertIncludes(ambiguous.stderr, "--version", "ambiguous activation inspection command");
+  assertNotIncludes(ambiguous.stderr, "was unchanged", "ambiguous activation truthfulness");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const aliasInstallDir = join(root, "ambiguous-alias-bin");
+  const aliasDataHome = join(root, "ambiguous-alias-data");
+  const aliasShim = makeLinkThenFailShim(join(aliasInstallDir, "stn-ingress"));
+  const aliasFailure = runInstaller({
+    installDir: aliasInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: aliasDataHome,
+    commandBinDirs: [aliasShim.directory],
+    environment: aliasShim.environment,
+  });
+  assertNonzero(aliasFailure, "link-performed-then-error");
+  assertEqual(
+    readlinkSync(join(aliasInstallDir, "stn-ingress")),
+    "stn",
+    "unconfirmed alias is not removed",
+  );
+  assert(!existsSync(join(aliasInstallDir, "stn")), "link ambiguity leaves runtime absent");
+  assert(
+    !existsSync(join(aliasDataHome, "station", "LICENSE")),
+    "link ambiguity leaves license absent",
+  );
+  assertNoInstallerResidue(aliasInstallDir, aliasDataHome);
+
+  const warningInstallDir = join(root, "cleanup-warning-bin");
+  const warningDataHome = join(root, "cleanup-warning-data");
+  const warningShim = makeCleanupWarningShim(tempDir);
+  const warning = runInstaller({
+    installDir: warningInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: warningDataHome,
+    commandBinDirs: [warningShim.directory],
+    environment: warningShim.environment,
+  });
+  assertSuccess(warning, "post-commit cleanup warning");
+  assertIncludes(warning.stderr, "warning", "post-commit cleanup warning output");
+  assertInstalled({
+    installDir: warningInstallDir,
+    dataHome: warningDataHome,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+  for (const name of readdirSync(tempDir)) {
+    if (name.startsWith("station-install."))
+      rmSync(join(tempDir, name), { recursive: true, force: true });
+  }
+}
+
+async function scenarioManagedPathReplacement() {
+  const installDir = join(root, "revalidated-launcher-bin");
+  const dataHome = join(root, "revalidated-launcher-data");
+  const marker = join(root, "revalidated-launcher.ready");
+  const releaseFile = join(root, "revalidated-launcher.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    asynchronous: true,
+    environment: {
+      FAKE_GH_BLOCK_DOWNLOAD: "1",
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_BLOCK_RELEASE: releaseFile,
+    },
+  });
+  await waitForPath(marker, "managed-path revalidation point");
+  unlinkSync(join(installDir, "stn-ingress"));
+  symlinkSync("external-stn", join(installDir, "stn-ingress"));
+  writeText(releaseFile, "release\n", 0o600);
+  const result = await settleWithin(running, 5_000, "managed-path revalidation");
+  assertFailure(result, "launcher", "managed-path revalidation");
+  assertEqual(
+    readlinkSync(join(installDir, "stn-ingress")),
+    "external-stn",
+    "externally replaced launcher remains untouched",
+  );
+  assertRuntimeVersion(installDir, "v0.9.0", "managed-path runtime preservation", {
+    aliases: false,
+    assertAliasesAbsent: false,
+  });
+  assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", "unmodified popup remains");
+  assertLicense(dataHome, "v0.9.0", "managed-path license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+
+  for (const resource of ["popup", "binary", "license"]) {
+    const replacementInstallDir = join(root, `revalidated-${resource}-bin`);
+    const replacementDataHome = join(root, `revalidated-${resource}-data`);
+    const replacementMarker = join(root, `revalidated-${resource}.ready`);
+    const replacementRelease = join(root, `revalidated-${resource}.release`);
+    seedInstallation({
+      installDir: replacementInstallDir,
+      dataHome: replacementDataHome,
+      tag: "v0.9.0",
+    });
+    const replacementRunning = runInstaller({
+      installDir: replacementInstallDir,
+      platform: linuxX64(),
+      version: stableTag,
+      dataHome: replacementDataHome,
+      asynchronous: true,
+      environment: {
+        FAKE_GH_BLOCK_PHASE: "archive-download",
+        FAKE_BLOCK_MARKER: replacementMarker,
+        FAKE_BLOCK_RELEASE: replacementRelease,
+      },
+    });
+    await waitForPath(replacementMarker, `${resource} revalidation point`);
+    const replacementPath =
+      resource === "popup"
+        ? join(replacementInstallDir, "stn-tmux-popup")
+        : resource === "binary"
+          ? join(replacementInstallDir, "stn")
+          : join(replacementDataHome, "station", "LICENSE");
+    rmSync(replacementPath, { recursive: true, force: true });
+    if (resource === "popup") symlinkSync("external-stn", replacementPath);
+    else makeDirectory(replacementPath);
+    writeText(replacementRelease, "release\n", 0o600);
+    const replacementResult = await settleWithin(
+      replacementRunning,
+      5_000,
+      `${resource} managed-path revalidation`,
+    );
+    assertFailure(
+      replacementResult,
+      resource === "popup" ? "launcher" : resource,
+      `${resource} revalidation`,
+    );
+    if (resource === "popup") {
+      assertEqual(
+        readlinkSync(replacementPath),
+        "external-stn",
+        "external popup remains untouched",
+      );
+      assertRuntimeVersion(
+        replacementInstallDir,
+        "v0.9.0",
+        "popup replacement runtime preservation",
+        { aliases: false, assertAliasesAbsent: false },
+      );
+      assertEqual(
+        readlinkSync(join(replacementInstallDir, "stn-ingress")),
+        "stn",
+        "popup replacement leaves ingress",
+      );
+      assertLicense(replacementDataHome, "v0.9.0", "popup replacement license preservation");
+    } else if (resource === "binary") {
+      assert(
+        statSync(replacementPath).isDirectory(),
+        "external binary directory remains untouched",
+      );
+      assertLicense(replacementDataHome, "v0.9.0", "binary replacement license preservation");
+    } else {
+      assert(
+        statSync(replacementPath).isDirectory(),
+        "external license directory remains untouched",
+      );
+      assertRuntimeVersion(
+        replacementInstallDir,
+        "v0.9.0",
+        "license replacement runtime preservation",
+      );
+    }
+    assertNoInstallerResidue(replacementInstallDir, replacementDataHome);
+  }
+
+  const cleanupInstallDir = join(root, "cleanup-replaced-launcher-bin");
+  const cleanupDataHome = join(root, "cleanup-replaced-launcher-data");
+  const cleanupMarker = join(root, "cleanup-replaced-launcher.ready");
+  seedInstallation({
+    installDir: cleanupInstallDir,
+    dataHome: cleanupDataHome,
+    tag: "v0.9.0",
+    withAliases: false,
+  });
+  const blocking = makeBlockingShim("mv", join(cleanupInstallDir, "stn"), cleanupMarker);
+  const cleanupRunning = runInstaller({
+    installDir: cleanupInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: cleanupDataHome,
+    asynchronous: true,
+    commandBinDirs: [blocking.directory],
+    environment: blocking.environment,
+  });
+  await waitForPath(cleanupMarker, "external replacement cleanup point");
+  unlinkSync(join(cleanupInstallDir, "stn-ingress"));
+  writeText(join(cleanupInstallDir, "stn-ingress"), "external replacement\n", 0o600);
+  signalProcessGroup(cleanupRunning.child, "SIGTERM");
+  const cleanupResult = await settleWithin(cleanupRunning, 5_000, "external replacement cleanup");
+  assertExactStatus(cleanupResult, 143, "external replacement cleanup");
+  assertEqual(
+    readFileSync(join(cleanupInstallDir, "stn-ingress"), "utf8"),
+    "external replacement\n",
+    "cleanup preserves externally replaced launcher",
+  );
+  assert(
+    !existsSync(join(cleanupInstallDir, "stn-tmux-popup")),
+    "cleanup removes owned popup alias",
+  );
+  assertRuntimeVersion(cleanupInstallDir, "v0.9.0", "cleanup replacement runtime", {
+    aliases: false,
+    assertAliasesAbsent: false,
+  });
+  assertLicense(cleanupDataHome, "v0.9.0", "cleanup replacement license rollback");
+  assertIncludes(cleanupResult.stderr, "changed during cleanup", "cleanup replacement warning");
+  assertNoInstallerResidue(cleanupInstallDir, cleanupDataHome);
+}
+
+async function scenarioContinuousReaders() {
+  const installDir = join(root, "continuous-readers-bin");
+  const dataHome = join(root, "continuous-readers-data");
+  const probePid = join(root, "continuous-readers-probe.pid");
+  const releaseFile = join(root, "continuous-readers-probe.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.8",
+    dataHome,
+    asynchronous: true,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
+  });
+  await waitForPath(probePid, "continuous reader probe");
+  const reader = startVersionReaders(installDir);
+  await reader.waitForVersion("0.9.0");
+  writeText(releaseFile, "release\n", 0o600);
+  assertSuccess(
+    await settleWithin(running, 5_000, "continuous reader installer"),
+    "continuous reader install",
+  );
+  await reader.waitForVersion("1.2.8");
+  const observations = await reader.stop();
+  for (const entrypoint of ["stn", "stn-ingress", "stn-tmux-popup"]) {
+    const versions = observations.get(entrypoint);
+    assert(versions.includes("0.9.0"), `${entrypoint} readers observed the old version`);
+    assert(versions.includes("1.2.8"), `${entrypoint} readers observed the new version`);
+    assertEqual(
+      [...new Set(versions)].sort(),
+      ["0.9.0", "1.2.8"],
+      `${entrypoint} readers observed only complete versions`,
+    );
+  }
+  assertInstalled({ installDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+  assertNoInstallerResidue(installDir, dataHome);
 }
 
 async function scenarioCaughtSignals() {
-  const phases = ["download", "probe", "finalization"];
   const signals = [
+    { name: "SIGHUP", status: 129 },
     { name: "SIGINT", status: 130 },
     { name: "SIGTERM", status: 143 },
   ];
 
-  for (const phase of phases) {
+  for (const delivery of ["group", "parent"]) {
     for (const signal of signals) {
-      await runSignalScenario(phase, signal);
+      await runSignalScenario("download", signal, delivery);
+    }
+  }
+  for (const phase of ["probe", "finalization"]) {
+    for (const signal of signals) {
+      await runSignalScenario(phase, signal, "group");
     }
   }
 }
 
-async function runSignalScenario(phase, signal) {
-  const slug = `${phase}-${signal.name.toLowerCase()}`;
+async function scenarioGhSignalSupervision() {
+  const phases = [
+    { name: "auth", version: stableTag },
+    { name: "latest" },
+    { name: "published-archive-asset", version: stableTag },
+    { name: "published-checksum-asset", version: stableTag },
+    { name: "archive-download", version: stableTag },
+    { name: "checksum-download", version: stableTag },
+    { draft: true, name: "draft-release", version: rollbackTag },
+    { draft: true, name: "draft-archive-asset", version: rollbackTag },
+    { draft: true, name: "draft-checksum-asset", version: rollbackTag },
+  ];
+
+  for (const phase of phases) {
+    const installDir = join(root, `gh-${phase.name}-signal-bin`);
+    const dataHome = join(root, `gh-${phase.name}-signal-data`);
+    const marker = join(root, `gh-${phase.name}-signal.ready`);
+    const childPidFile = join(root, `gh-${phase.name}-signal.pid`);
+    const releaseFile = join(root, `gh-${phase.name}-signal.release`);
+    seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+    const running = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: phase.version,
+      releaseId: phase.draft ? "42" : undefined,
+      dataHome,
+      asynchronous: true,
+      environment: {
+        FAKE_GH_BLOCK_PHASE: phase.name,
+        FAKE_BLOCK_MARKER: marker,
+        FAKE_BLOCK_PID_FILE: childPidFile,
+        FAKE_BLOCK_RELEASE: releaseFile,
+      },
+    });
+    await waitForPath(marker, `${phase.name} signal injection point`);
+    await waitForPath(childPidFile, `${phase.name} child PID`);
+    running.child.kill("SIGTERM");
+    const result = await settleWithin(running, 5_000, `${phase.name} signal cleanup`);
+    assertExactStatus(result, 143, `${phase.name} parent-only SIGTERM`);
+    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${phase.name} gh child`);
+    assertRuntimeVersion(installDir, "v0.9.0", `${phase.name} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${phase.name} license preservation`);
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+}
+
+async function scenarioRepeatedSignalCleanup() {
+  const installDir = join(root, "repeated-signal-bin");
+  const dataHome = join(root, "repeated-signal-data");
+  const marker = join(root, "repeated-signal.ready");
+  const childPidFile = join(root, "repeated-signal.pid");
+  const releaseFile = join(root, "repeated-signal.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    asynchronous: true,
+    environment: {
+      FAKE_GH_BLOCK_PHASE: "archive-download",
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_BLOCK_PID_FILE: childPidFile,
+      FAKE_BLOCK_RELEASE: releaseFile,
+    },
+  });
+  await waitForPath(marker, "repeated signal injection point");
+  await waitForPath(childPidFile, "repeated signal child PID");
+  running.child.kill("SIGTERM");
+  await delay(25);
+  if (!running.settled) running.child.kill("SIGINT");
+  const result = await settleWithin(running, 5_000, "repeated signal cleanup");
+  assertExactStatus(result, 143, "first signal controls cleanup status");
+  assertProcessGone(Number(readFileSync(childPidFile, "utf8")), "repeated signal gh child");
+  assertRuntimeVersion(installDir, "v0.9.0", "repeated signal runtime preservation");
+  assertLicense(dataHome, "v0.9.0", "repeated signal license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
+async function scenarioAliasCreationSignal() {
+  const installDir = join(root, "alias-signal-bin");
+  const dataHome = join(root, "alias-signal-data");
+  const marker = join(root, "alias-signal.ready");
+  const releaseFile = join(root, "alias-signal.release");
+  const shim = makeLinkThenBlockShim(join(installDir, "stn-ingress"), marker, releaseFile);
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    asynchronous: true,
+    commandBinDirs: [shim.directory],
+    environment: shim.environment,
+  });
+  await waitForPath(marker, "alias creation signal point");
+  signalProcessGroup(running.child, "SIGTERM");
+  writeText(releaseFile, "release\n", 0o600);
+  const result = await settleWithin(running, 5_000, "alias creation signal cleanup");
+  assertExactStatus(result, 143, "alias creation signal status");
+  for (const path of [
+    join(installDir, "stn"),
+    join(installDir, "stn-ingress"),
+    join(installDir, "stn-tmux-popup"),
+    join(dataHome, "station", "LICENSE"),
+  ]) {
+    assert(!existsSync(path), `alias signal cleanup removes ${path}`);
+  }
+  assertNoInstallerResidue(installDir, dataHome);
+
+  const replacedInstallDir = join(root, "alias-signal-replaced-bin");
+  const replacedDataHome = join(root, "alias-signal-replaced-data");
+  const replacedMarker = join(root, "alias-signal-replaced.ready");
+  const replacedRelease = join(root, "alias-signal-replaced.release");
+  const replacedPath = join(replacedInstallDir, "stn-ingress");
+  const replacedShim = makeLinkThenBlockShim(replacedPath, replacedMarker, replacedRelease);
+  const replacedRunning = runInstaller({
+    installDir: replacedInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: replacedDataHome,
+    asynchronous: true,
+    commandBinDirs: [replacedShim.directory],
+    environment: replacedShim.environment,
+  });
+  await waitForPath(replacedMarker, "same-target alias replacement point");
+  unlinkSync(replacedPath);
+  symlinkSync("stn", replacedPath);
+  signalProcessGroup(replacedRunning.child, "SIGTERM");
+  writeText(replacedRelease, "release\n", 0o600);
+  const replacedResult = await settleWithin(
+    replacedRunning,
+    5_000,
+    "same-target alias replacement cleanup",
+  );
+  assertExactStatus(replacedResult, 143, "same-target alias replacement signal status");
+  assertEqual(readlinkSync(replacedPath), "stn", "same-target external alias remains untouched");
+  assertIncludes(
+    replacedResult.stderr,
+    "changed during cleanup",
+    "same-target external alias warning",
+  );
+  for (const path of [
+    join(replacedInstallDir, "stn"),
+    join(replacedInstallDir, "stn-tmux-popup"),
+    join(replacedDataHome, "station", "LICENSE"),
+  ]) {
+    assert(!existsSync(path), `same-target alias cleanup leaves ${path} absent`);
+  }
+  assertNoInstallerResidue(replacedInstallDir, replacedDataHome);
+}
+
+async function runSignalScenario(phase, signal, delivery) {
+  const slug = `${phase}-${delivery}-${signal.name.toLowerCase()}`;
   const installDir = join(root, `${slug}-bin`);
   const dataHome = join(root, `${slug}-data`);
   const marker = join(root, `${slug}.ready`);
+  const childPidFile = join(root, `${slug}.child-pid`);
   const releaseFile = join(root, `${slug}.release`);
   const options = {
     installDir,
@@ -536,6 +1569,7 @@ async function runSignalScenario(phase, signal) {
       FAKE_GH_BLOCK_DOWNLOAD: "1",
       FAKE_BLOCK_MARKER: marker,
       FAKE_BLOCK_RELEASE: releaseFile,
+      FAKE_BLOCK_PID_FILE: childPidFile,
     };
   } else if (phase === "probe") {
     options.version = "v1.2.8";
@@ -551,11 +1585,18 @@ async function runSignalScenario(phase, signal) {
 
   const running = runInstaller(options);
   await waitForPath(marker, `${phase} ${signal.name} injection point`);
-  signalProcessGroup(running.child, signal.name);
+  if (phase === "download") {
+    await waitForPath(childPidFile, `${phase} ${signal.name} child PID`);
+  }
+  if (delivery === "group") signalProcessGroup(running.child, signal.name);
+  else running.child.kill(signal.name);
   const result = await settleWithin(running, 5_000, `${phase} ${signal.name}`);
-  assertSignalStatus(result, signal, `${phase} ${signal.name}`);
+  assertExactStatus(result, signal.status, `${phase} ${delivery} ${signal.name}`);
   assertRuntimeVersion(installDir, "v0.9.0", `${phase} ${signal.name} runtime coherence`);
   assertLicense(dataHome, "v0.9.0", `${phase} ${signal.name} license rollback`);
+  if (phase === "download") {
+    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${phase} ${delivery} gh child`);
+  }
   assertNoInstallerResidue(installDir, dataHome);
 }
 
@@ -584,13 +1625,13 @@ async function scenarioSignalDuringLockAcquisition() {
   running.child.kill("SIGTERM");
   writeText(releaseFile, "release\n", 0o600);
   const result = await settleWithin(running, 5_000, "signal during lock acquisition");
-  assertSignalStatus(result, { name: "SIGTERM", status: 143 }, "signal during lock acquisition");
+  assertExactStatus(result, 143, "signal during lock acquisition");
   assertRuntimeVersion(installDir, "v0.9.0", "lock acquisition signal runtime coherence");
   assertLicense(dataHome, "v0.9.0", "lock acquisition signal license preservation");
   assertNoInstallerResidue(installDir, dataHome);
 }
 
-async function scenarioSigkillLeavesActionableLock() {
+async function scenarioSigkillLeavesActionableLocks() {
   const installDir = join(root, "sigkill-bin");
   const dataHome = join(root, "sigkill-data");
   const probePid = join(root, "sigkill-probe.pid");
@@ -610,21 +1651,38 @@ async function scenarioSigkillLeavesActionableLock() {
   });
   await waitForPath(probePid, "SIGKILL probe");
   const lockPath = join(installDir, ".station-install.lock");
+  const licenseLockPath = join(dataHome, "station", ".station-install.lock");
   await waitForPath(lockPath, "SIGKILL-owned lock");
+  await waitForPath(licenseLockPath, "SIGKILL-owned license lock");
   signalProcessGroup(killed.child, "SIGKILL");
   const killedResult = await settleWithin(killed, 5_000, "SIGKILL installer");
   assertEqual(killedResult.signal, "SIGKILL", "SIGKILL installer signal");
   assert(existsSync(lockPath), "SIGKILL leaves the owned destination lock");
+  assert(existsSync(licenseLockPath), "SIGKILL leaves the owned license lock");
   assertRuntimeVersion(installDir, "v0.9.0", "SIGKILL runtime coherence");
+  assertProcessGone(Number(readFileSync(probePid, "utf8")), "SIGKILL probe child");
 
   const refused = runInstaller({ installDir, platform: linuxX64(), dataHome });
   assertFailure(refused, lockPath, "stale lock refusal");
   assertIncludes(refused.stderr, String(killed.child.pid), "stale lock owner PID");
+  assertIncludes(refused.stderr, "alive", "stale lock dead-PID inspection UX");
+  assertIncludes(refused.stderr, "Wait", "stale lock wait UX");
   assertIncludes(refused.stderr, "manually", "stale lock manual recovery UX");
   assertIncludes(refused.stderr, "retry", "stale lock retry UX");
   assertNoGhApiCalls(refused, "stale lock refusal");
 
   rmSync(lockPath, { recursive: true });
+  const licenseRefused = runInstaller({ installDir, platform: linuxX64(), dataHome });
+  assertFailure(licenseRefused, licenseLockPath, "stale license lock refusal");
+  assertIncludes(licenseRefused.stderr, String(killed.child.pid), "stale license lock owner PID");
+  assertIncludes(licenseRefused.stderr, "alive", "stale license lock dead-PID inspection UX");
+  assertIncludes(licenseRefused.stderr, "Wait", "stale license lock wait UX");
+  assertIncludes(licenseRefused.stderr, "manually", "stale license lock manual recovery UX");
+  assertIncludes(licenseRefused.stderr, "retry", "stale license lock retry UX");
+  assert(!existsSync(lockPath), "stale license refusal releases newly acquired command lock");
+  assertNoGhApiCalls(licenseRefused, "stale license lock refusal");
+
+  rmSync(licenseLockPath, { recursive: true });
   writeText(releaseFile, "release\n", 0o600);
   const retry = runInstaller({
     installDir,
@@ -638,10 +1696,137 @@ async function scenarioSigkillLeavesActionableLock() {
   });
   assertSuccess(retry, "manual stale-lock removal retry");
   assertInstalled({ installDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+
+  const committedInstallDir = join(root, "sigkill-after-commit-bin");
+  const committedDataHome = join(root, "sigkill-after-commit-data");
+  const committedMarker = join(root, "sigkill-after-commit.ready");
+  seedInstallation({ installDir: committedInstallDir, dataHome: committedDataHome, tag: "v0.9.0" });
+  const committedShim = makeMoveThenBlockShim(join(committedInstallDir, "stn"), committedMarker);
+  const committed = runInstaller({
+    installDir: committedInstallDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome: committedDataHome,
+    asynchronous: true,
+    commandBinDirs: [committedShim.directory],
+    environment: committedShim.environment,
+  });
+  const committedLock = join(committedInstallDir, ".station-install.lock");
+  const committedLicenseLock = join(committedDataHome, "station", ".station-install.lock");
+  await waitForPath(committedMarker, "SIGKILL after runtime commit");
+  await waitForPath(committedLock, "SIGKILL after-commit command lock");
+  await waitForPath(committedLicenseLock, "SIGKILL after-commit license lock");
+  signalProcessGroup(committed.child, "SIGKILL");
+  const committedResult = await settleWithin(committed, 5_000, "SIGKILL after runtime commit");
+  assertEqual(committedResult.signal, "SIGKILL", "SIGKILL after-commit installer signal");
+  assertInstalled({
+    installDir: committedInstallDir,
+    dataHome: committedDataHome,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+  assert(existsSync(committedLock), "SIGKILL after commit leaves command lock");
+  assert(existsSync(committedLicenseLock), "SIGKILL after commit leaves license lock");
+
+  const committedRefused = runInstaller({
+    installDir: committedInstallDir,
+    platform: linuxX64(),
+    dataHome: committedDataHome,
+  });
+  assertFailure(committedRefused, committedLock, "after-commit stale command lock refusal");
+  rmSync(committedLock, { recursive: true });
+  const committedLicenseRefused = runInstaller({
+    installDir: committedInstallDir,
+    platform: linuxX64(),
+    dataHome: committedDataHome,
+  });
+  assertFailure(
+    committedLicenseRefused,
+    committedLicenseLock,
+    "after-commit stale license lock refusal",
+  );
+  assert(!existsSync(committedLock), "after-commit license refusal releases command lock");
+  rmSync(committedLicenseLock, { recursive: true });
+  const committedRetry = runInstaller({
+    installDir: committedInstallDir,
+    platform: linuxX64(),
+    version: rollbackTag,
+    dataHome: committedDataHome,
+  });
+  assertSuccess(committedRetry, "after-commit stale-lock recovery retry");
+  assertInstalled({
+    installDir: committedInstallDir,
+    dataHome: committedDataHome,
+    tag: rollbackTag,
+    target: "linux-x64",
+  });
+}
+
+async function runSelfInterruptChild() {
+  const rootFile = process.env.STATION_SMOKE_SELF_ROOT_FILE;
+  const readyFile = process.env.STATION_SMOKE_SELF_READY_FILE;
+  const installerPidFile = process.env.STATION_SMOKE_SELF_INSTALLER_PID_FILE;
+  const probePidCopy = process.env.STATION_SMOKE_SELF_PROBE_PID_FILE;
+  if (!rootFile || !readyFile || !installerPidFile || !probePidCopy) {
+    throw new Error("self-interruption child requires marker paths");
+  }
+  writeText(rootFile, `${root}\n`, 0o600);
+  prepareFixtures();
+  const installDir = join(root, "self-interruption-bin");
+  const dataHome = join(root, "self-interruption-data");
+  const probePid = join(root, "self-interruption-probe.pid");
+  const releaseFile = join(root, "self-interruption-probe.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.8",
+    dataHome,
+    asynchronous: true,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
+  });
+  await waitForPath(probePid, "self-interruption probe");
+  writeText(installerPidFile, `${running.child.pid}\n`, 0o600);
+  writeText(probePidCopy, readFileSync(probePid, "utf8"), 0o600);
+  writeText(readyFile, "ready\n", 0o600);
+  await new Promise(() => {});
+}
+
+async function scenarioSelfInterruption() {
+  const childRootFile = join(root, "self-interruption-child-root");
+  const readyFile = join(root, "self-interruption-child.ready");
+  const installerPidFile = join(root, "self-interruption-installer.pid");
+  const probePidFile = join(root, "self-interruption-probe.pid");
+  const child = spawn(process.execPath, [runner, "--self-interrupt-child"], {
+    detached: true,
+    env: {
+      ...process.env,
+      STATION_SMOKE_SELF_ROOT_FILE: childRootFile,
+      STATION_SMOKE_SELF_READY_FILE: readyFile,
+      STATION_SMOKE_SELF_INSTALLER_PID_FILE: installerPidFile,
+      STATION_SMOKE_SELF_PROBE_PID_FILE: probePidFile,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const running = trackChild(child, { label: "self-interruption runner" });
+  await waitForPath(readyFile, "self-interruption child readiness", markerTimeoutMs);
+  const childRoot = readFileSync(childRootFile, "utf8").trim();
+  const installerPid = Number(readFileSync(installerPidFile, "utf8"));
+  const probePid = Number(readFileSync(probePidFile, "utf8"));
+  assert(existsSync(childRoot), "self-interruption child temp root exists before signal");
+  child.kill("SIGTERM");
+  const result = await settleWithin(running, 10_000, "self-interruption runner");
+  assertExactStatus(result, 143, "self-interruption runner status");
+  assert(!existsSync(childRoot), "self-interruption removes the child temp root");
+  assertProcessGone(installerPid, "self-interruption installer child");
+  assertProcessGone(probePid, "self-interruption probe child");
 }
 
 function scenarioHelp() {
-  const help = spawnSync("/bin/sh", [installer, "--help"], { encoding: "utf8" });
+  const help = spawnSync("/bin/sh", [installer, "--help"], syncOptions());
   assertSuccess(help, "installer help");
   assertIncludes(help.stdout, "--install-dir", "installer help options");
 }
@@ -662,29 +1847,112 @@ function createRelease(tag, targets, options = {}) {
     const payloadDir = join(root, `payload-${version}-${target}`);
     rmSync(payloadDir, { recursive: true, force: true });
     makeDirectory(payloadDir);
-    writeReleaseBinary(join(payloadDir, "stn"), { tag, target, mode: options.probeMode });
-    symlinkSync("stn", join(payloadDir, "stn-ingress"));
-    symlinkSync("stn", join(payloadDir, "stn-tmux-popup"));
+    writeReleaseBinary(join(payloadDir, "stn"), {
+      tag,
+      target,
+      mode: options.probeMode,
+      reportedVersion: options.reportedVersion,
+    });
+    symlinkSync(options.ingressTarget ?? "stn", join(payloadDir, "stn-ingress"));
+    symlinkSync(options.popupTarget ?? "stn", join(payloadDir, "stn-tmux-popup"));
     writeText(join(payloadDir, "LICENSE"), `Station fixture license ${tag}\n`, 0o644);
 
-    const members = ["stn", "stn-ingress", "stn-tmux-popup", "LICENSE"];
+    const members = ["stn", "stn-ingress", "stn-tmux-popup", "LICENSE"].filter(
+      (member) => member !== options.omitMember,
+    );
     if (options.extraMember !== undefined) {
       writeText(join(payloadDir, options.extraMember), "unapproved archive payload\n", 0o755);
       members.push(options.extraMember);
     }
-    spawnChecked("tar", ["-czf", archivePath, "-C", payloadDir, ...members], "fixture archive");
+    if (options.duplicateMember !== undefined) members.push(options.duplicateMember);
+    if (options.unreadableArchive) {
+      writeText(archivePath, "not a gzip-compressed tar archive\n", 0o600);
+    } else {
+      spawnChecked("tar", ["-czf", archivePath, "-C", payloadDir, ...members], "fixture archive");
+    }
     chmodSync(archivePath, 0o600);
     const hash = options.corruptChecksum
       ? "0".repeat(64)
       : createHash("sha256").update(readFileSync(archivePath)).digest("hex");
-    checksums.push(`${hash}  ${archiveName}`);
+    if (options.checksumMode !== "missing") {
+      checksums.push(
+        options.checksumMode === "malformed"
+          ? `not-a-sha256  ${archiveName}`
+          : `${hash}  ${archiveName}`,
+      );
+    }
+    if (options.checksumMode === "duplicate") checksums.push(`${hash} *${archiveName}`);
   }
 
   writeText(join(releaseDir, "SHA256SUMS"), `${checksums.sort().join("\n")}\n`, 0o600);
 }
 
-function writeReleaseBinary(path, { mode, tag, target }) {
-  const version = tag.slice(1);
+function createManualRelease(tag, target, entries) {
+  const releaseDir = join(releasesDir, tag);
+  makeDirectory(releaseDir);
+  const archiveName = `stn-${tag}-${target}.tar.gz`;
+  const archivePath = join(releaseDir, archiveName);
+  writeFileSync(archivePath, gzipSync(writeTar(entries)), { mode: 0o600 });
+  const hash = createHash("sha256").update(readFileSync(archivePath)).digest("hex");
+  writeText(join(releaseDir, "SHA256SUMS"), `${hash}  ${archiveName}\n`, 0o600);
+}
+
+function tarFile(name, content, mode) {
+  return { content: Buffer.from(content), mode, name, type: "0" };
+}
+
+function tarSymlink(name, target) {
+  return { content: Buffer.alloc(0), mode: 0o777, name, target, type: "2" };
+}
+
+function tarHardlink(name, target) {
+  return { content: Buffer.alloc(0), mode: 0o644, name, target, type: "1" };
+}
+
+function writeTar(entries) {
+  const blocks = [];
+  for (const entry of entries) {
+    const header = Buffer.alloc(512);
+    writeTarString(header, 0, 100, entry.name);
+    writeTarOctal(header, 100, 8, entry.mode);
+    writeTarOctal(header, 108, 8, 0);
+    writeTarOctal(header, 116, 8, 0);
+    writeTarOctal(header, 124, 12, entry.type === "0" ? entry.content.length : 0);
+    writeTarOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header.write(entry.type, 156, 1, "ascii");
+    if (entry.target !== undefined) writeTarString(header, 157, 100, entry.target);
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    header.write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8, "ascii");
+    blocks.push(header);
+    if (entry.type === "0") {
+      blocks.push(entry.content);
+      const remainder = entry.content.length % 512;
+      if (remainder !== 0) blocks.push(Buffer.alloc(512 - remainder));
+    }
+  }
+  blocks.push(Buffer.alloc(1024));
+  return Buffer.concat(blocks);
+}
+
+function writeTarString(buffer, offset, length, value) {
+  const encoded = Buffer.from(value);
+  assert(encoded.length < length, `tar field ${value} fits in ${length} bytes`);
+  encoded.copy(buffer, offset);
+}
+
+function writeTarOctal(buffer, offset, length, value) {
+  buffer.write(`${value.toString(8).padStart(length - 1, "0")}\0`, offset, length, "ascii");
+}
+
+function writeReleaseBinary(path, options) {
+  writeExecutable(path, releaseBinarySource(options.tag, options.target, options));
+}
+
+function releaseBinarySource(tag, target, { mode, reportedVersion } = {}) {
+  const version = reportedVersion ?? tag.slice(1);
   let versionBody = `printf '%s\\n' '${version}'`;
   if (mode === "fail") versionBody = "exit 126";
   if (mode === "hang") {
@@ -708,17 +1976,31 @@ function writeReleaseBinary(path, { mode, tag, target }) {
       `printf '%s\\n' '${version}'`,
     ].join("\n  ");
   }
+  if (mode === "flood") {
+    versionBody = [
+      "i=0",
+      'while [ "$i" -lt 20000 ]; do',
+      "  printf 'loader diagnostic \\033[31munsafe\\007\\r\\n' >&2",
+      "  printf 'untrusted stdout flood payload\\n'",
+      "  i=$((i + 1))",
+      "done",
+      "exit 126",
+    ].join("\n  ");
+  }
+  if (mode === "stdout-flood") {
+    versionBody = "while :; do printf 'untrusted stdout flood payload\\n'; done";
+  }
+  if (mode === "diagnostic") {
+    versionBody = "printf 'loader \\033[31mdiagnostic\\007\\r\\n' >&2; exit 126";
+  }
 
-  writeExecutable(
-    path,
-    `#!/bin/sh
+  return `#!/bin/sh
 if [ "\${1:-}" = --version ]; then
   ${versionBody}
 else
   printf '%s\\n' 'Station ${tag} ${target}'
 fi
-`,
-  );
+`;
 }
 
 function writeFakeCommands() {
@@ -740,9 +2022,34 @@ function writeFakeCommands() {
       "#!/bin/sh",
       "set -eu",
       'printf \'%s\\n\' "$*" >> "$FAKE_GH_LOG"',
+      "{",
+      "  printf 'CALL\\n'",
+      "  for argument do printf 'ARG=%s\\n' \"$argument\"; done",
+      "  printf 'END\\n'",
+      '} >> "$FAKE_GH_ARGV_LOG"',
       'chmod 600 "$FAKE_GH_LOG"',
+      'chmod 600 "$FAKE_GH_ARGV_LOG"',
       '[ "$GH_HOST" = github.com ] || exit 3',
+      "block_phase() {",
+      "  phase=$1",
+      `  if [ "\${FAKE_GH_BLOCK_PHASE:-}" != "$phase" ]; then`,
+      `    if [ "$phase" != archive-download ] || [ "\${FAKE_GH_BLOCK_DOWNLOAD:-0}" != 1 ]; then return 0; fi`,
+      "  fi",
+      '  : > "$FAKE_BLOCK_MARKER"',
+      '  chmod 600 "$FAKE_BLOCK_MARKER"',
+      `  if [ -n "\${FAKE_BLOCK_PID_FILE:-}" ]; then printf "%s\\n" "$$" > "$FAKE_BLOCK_PID_FILE"; chmod 600 "$FAKE_BLOCK_PID_FILE"; fi`,
+      "  trap 'exit 129' HUP",
+      "  trap 'exit 130' INT",
+      "  trap 'exit 143' TERM",
+      '  while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done',
+      "}",
       `if [ "\${1:-}" = auth ]; then`,
+      '  [ "$#" -eq 4 ]',
+      '  [ "$1" = auth ]',
+      '  [ "$2" = status ]',
+      '  [ "$3" = --hostname ]',
+      '  [ "$4" = github.com ]',
+      "  block_phase auth",
       `  [ "\${FAKE_GH_AUTH:-1}" = 1 ]`,
       "  exit",
       "fi",
@@ -750,59 +2057,86 @@ function writeFakeCommands() {
       "shift",
       'endpoint=""',
       'jq_filter=""',
+      'accept_header=""',
+      "paginate=0",
       'while [ "$#" -gt 0 ]; do',
       '  case "$1" in',
-      "    -H) shift 2 ;;",
-      "    --paginate) shift ;;",
-      "    --jq) jq_filter=$2; shift 2 ;;",
-      "    *) endpoint=$1; shift ;;",
+      '    -H) [ "$#" -ge 2 ]; accept_header=$2; shift 2 ;;',
+      "    --paginate) paginate=1; shift ;;",
+      '    --jq) [ "$#" -ge 2 ]; jq_filter=$2; shift 2 ;;',
+      "    -*) exit 2 ;;",
+      '    *) [ -z "$endpoint" ]; endpoint=$1; shift ;;',
       "  esac",
       "done",
       'case "$endpoint" in',
-      "  */releases/latest)",
+      '  "repos/jeremy0dell/station/releases/latest")',
+      '    [ "$paginate" -eq 0 ] && [ -z "$accept_header" ]',
       '    [ "$jq_filter" = .tag_name ] || exit 2',
+      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != latest ] || exit 74`,
+      "    block_phase latest",
       "    printf '%s\\n' \"$FAKE_LATEST_TAG\"",
       "    ;;",
-      "  */releases/tags/*)",
-      `    [ "\${endpoint##*/}" = "$FAKE_TAG" ] || exit 1`,
-      '    case "$jq_filter" in',
-      "      *SHA256SUMS*) printf '2\\n' ;;",
-      '      *"$FAKE_ARCHIVE"*)',
-      `        if [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 1 ]; then`,
-      "          printf '1\\n3\\n'",
-      "        else",
-      "          printf '1\\n'",
-      "        fi",
-      "        ;;",
-      "    esac",
+      '  "repos/jeremy0dell/station/releases/tags/$FAKE_TAG")',
+      '    [ "$paginate" -eq 0 ] && [ -z "$accept_header" ]',
+      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != release ] || exit 74`,
+      '    archive_filter=".assets[] | select(.name == \\"$FAKE_ARCHIVE\\") | .id"',
+      '    checksum_filter=".assets[] | select(.name == \\"SHA256SUMS\\") | .id"',
+      '    if [ "$jq_filter" = "$archive_filter" ]; then',
+      "      block_phase published-archive-asset",
+      `      count=\${FAKE_ARCHIVE_ASSET_COUNT:-1}`,
+      `      [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 0 ] || count=2`,
+      '      case "$count" in 0) ;; 1) printf "1\\n" ;; 2) printf "1\\n3\\n" ;; *) exit 2 ;; esac',
+      '    elif [ "$jq_filter" = "$checksum_filter" ]; then',
+      "      block_phase published-checksum-asset",
+      `      count=\${FAKE_CHECKSUM_ASSET_COUNT:-1}`,
+      '      case "$count" in 0) ;; 1) printf "2\\n" ;; 2) printf "2\\n4\\n" ;; *) exit 2 ;; esac',
+      "    else",
+      "      exit 2",
+      "    fi",
       "    ;;",
-      "  */releases?per_page=100)",
-      '    case "$jq_filter" in *".draft == true"*) ;; *) exit 2 ;; esac',
+      '  "repos/jeremy0dell/station/releases?per_page=100")',
+      '    [ "$paginate" -eq 1 ] && [ -z "$accept_header" ]',
+      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != release ] || exit 74`,
       `    [ "\${FAKE_RELEASE_DRAFT:-1}" = 1 ] || exit 0`,
       '    [ "$FAKE_RELEASE_ID_TAG" = "$FAKE_TAG" ] || exit 0',
-      '    case "$jq_filter" in',
-      '      *"$FAKE_ARCHIVE"*)',
-      `        if [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 1 ]; then printf '1\\n3\\n'; else printf '1\\n'; fi`,
-      "        ;;",
-      "      *SHA256SUMS*) printf '2\\n' ;;",
-      "      *)",
+      '    draft_match=".[] | select(.draft == true and .id == $FAKE_RELEASE_ID and .tag_name == \\"$FAKE_TAG\\")"',
+      '    if [ "$jq_filter" = "$draft_match | .id" ]; then',
+      "        block_phase draft-release",
       "        printf '%s\\n' \"$FAKE_RELEASE_ID\"",
       `        if [ "\${FAKE_DUPLICATE_RELEASE:-0}" = 1 ]; then printf '%s\\n' "$FAKE_RELEASE_ID"; fi`,
-      "        ;;",
-      "    esac",
-      "    ;;",
-      "  */releases/assets/1)",
-      `    if [ "\${FAKE_GH_BLOCK_DOWNLOAD:-0}" = 1 ]; then`,
-      '      : > "$FAKE_BLOCK_MARKER"',
-      '      chmod 600 "$FAKE_BLOCK_MARKER"',
-      "      trap 'exit 129' HUP",
-      "      trap 'exit 130' INT",
-      "      trap 'exit 143' TERM",
-      '      while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done',
+      '    elif [ "$jq_filter" = "$draft_match | .assets[] | select(.name == \\"$FAKE_ARCHIVE\\") | .id" ]; then',
+      "      block_phase draft-archive-asset",
+      `      count=\${FAKE_ARCHIVE_ASSET_COUNT:-1}`,
+      `      [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 0 ] || count=2`,
+      '      case "$count" in 0) ;; 1) printf "1\\n" ;; 2) printf "1\\n3\\n" ;; *) exit 2 ;; esac',
+      '    elif [ "$jq_filter" = "$draft_match | .assets[] | select(.name == \\"SHA256SUMS\\") | .id" ]; then',
+      "      block_phase draft-checksum-asset",
+      `      count=\${FAKE_CHECKSUM_ASSET_COUNT:-1}`,
+      '      case "$count" in 0) ;; 1) printf "2\\n" ;; 2) printf "2\\n4\\n" ;; *) exit 2 ;; esac',
+      "    else",
+      "      exit 2",
       "    fi",
+      "    ;;",
+      '  "repos/jeremy0dell/station/releases/assets/1")',
+      '    [ "$paginate" -eq 0 ] && [ -z "$jq_filter" ]',
+      '    [ "$accept_header" = "Accept: application/octet-stream" ]',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      archive-download) exit 74 ;;",
+      "      partial-archive) printf 'partial archive'; exit 74 ;;",
+      "    esac",
+      "    block_phase archive-download",
       '    cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE"',
       "    ;;",
-      '  */releases/assets/2) cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS" ;;',
+      '  "repos/jeremy0dell/station/releases/assets/2")',
+      '    [ "$paginate" -eq 0 ] && [ -z "$jq_filter" ]',
+      '    [ "$accept_header" = "Accept: application/octet-stream" ]',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      checksums-download) exit 74 ;;",
+      "      partial-checksums) printf 'partial checksum'; exit 74 ;;",
+      "    esac",
+      "    block_phase checksum-download",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS"',
+      "    ;;",
       "  *) exit 2 ;;",
       "esac",
       "",
@@ -824,32 +2158,41 @@ function runInstaller({
   childShell = "/bin/sh",
   cwd = repoRoot,
   dataHome = dataDir,
+  home = homeDir,
+  unsetXdgDataHome = false,
+  omitInstallDir = false,
   environment = {},
   umask,
   asynchronous = false,
   commandBinDirs = [],
+  pathEntries,
   extraArguments = [],
+  argumentsOverride,
 }) {
   const tag = version ?? stableTag;
   const archive = `stn-${tag}-${platform.target}.tar.gz`;
-  const commandPath = [...commandBinDirs, fakeBinDir, "/usr/bin", "/bin"];
+  const commandPath = pathEntries ?? [...commandBinDirs, fakeBinDir, "/usr/bin", "/bin"];
   if (includeInstallDirOnPath) commandPath.push(absolutePath(installDir, cwd));
-  const args = [];
-  if (version !== undefined) args.push("--version", version);
-  args.push(...extraArguments);
-  args.push("--install-dir", installDir);
+  const args = argumentsOverride === undefined ? [] : [...argumentsOverride];
+  if (argumentsOverride === undefined) {
+    if (version !== undefined) args.push("--version", version);
+    args.push(...extraArguments);
+    if (!omitInstallDir) args.push("--install-dir", installDir);
+  }
   const ghLog = join(ghLogsDir, `${++invocationCount}.log`);
+  const ghArgvLog = join(ghLogsDir, `${invocationCount}.argv.log`);
   const env = applyEnvironmentOverrides(
     {
-      HOME: homeDir,
+      HOME: home,
       GH_HOST: "untrusted.example",
       PATH: commandPath.join(":"),
       TMPDIR: tempDir,
-      XDG_DATA_HOME: dataHome,
+      XDG_DATA_HOME: unsetXdgDataHome ? undefined : dataHome,
       FAKE_ARCHIVE: archive,
       FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
       FAKE_DUPLICATE_RELEASE: duplicateDraftRelease ? "1" : "0",
       FAKE_GH_AUTH: auth ? "1" : "0",
+      FAKE_GH_ARGV_LOG: ghArgvLog,
       FAKE_GH_LOG: ghLog,
       FAKE_LATEST_TAG: stableTag,
       FAKE_RELEASE_ID: releaseId ?? "42",
@@ -864,10 +2207,41 @@ function runInstaller({
   );
   if (releaseId !== undefined) env.STATION_INSTALL_RELEASE_ID = releaseId;
   const invocation = buildShellInvocation(childShell, args, umask);
-  const options = { cwd, encoding: "utf8", env };
+  const options = { cwd, env };
 
   if (!asynchronous) {
-    return { ...spawnSync(invocation.command, invocation.args, options), ghLog };
+    const supervisorPidFile = join(tempDir, `sync-installer-${invocationCount}.pid`);
+    const stdoutFile = join(tempDir, `sync-installer-${invocationCount}.stdout`);
+    const stderrFile = join(tempDir, `sync-installer-${invocationCount}.stderr`);
+    const result = spawnSync(
+      "/bin/sh",
+      [
+        "-c",
+        'printf "%s\\n" "$$" > "$1"; exec > "$2" 2> "$3"; shift 3; exec "$@"',
+        "station-install-supervisor",
+        supervisorPidFile,
+        stdoutFile,
+        stderrFile,
+        invocation.command,
+        ...invocation.args,
+      ],
+      syncOptions({ ...options, detached: true }),
+    );
+    if (result.error?.code === "ETIMEDOUT") {
+      dumpHarnessState(`installer child timed out after ${childTimeoutMs}ms`);
+      if (existsSync(supervisorPidFile)) {
+        const supervisorPid = Number(readFileSync(supervisorPidFile, "utf8"));
+        if (Number.isInteger(supervisorPid)) {
+          try {
+            process.kill(-supervisorPid, "SIGKILL");
+          } catch {}
+        }
+      }
+    }
+    const stdout = existsSync(stdoutFile) ? readFileSync(stdoutFile, "utf8") : "";
+    const stderr = existsSync(stderrFile) ? readFileSync(stderrFile, "utf8") : "";
+    for (const path of [supervisorPidFile, stdoutFile, stderrFile]) rmSync(path, { force: true });
+    return { ...result, ghArgvLog, ghLog, stderr, stdout };
   }
 
   const child = spawn(invocation.command, invocation.args, {
@@ -875,30 +2249,73 @@ function runInstaller({
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
   });
+  return trackChild(child, { ghArgvLog, ghLog, label: `installer ${tag}` });
+}
+
+function trackChild(child, { ghArgvLog, ghLog, label }) {
   activeChildren.add(child);
   let stdout = "";
   let stderr = "";
   let spawnError;
-  child.stdout.setEncoding("utf8");
-  child.stderr.setEncoding("utf8");
-  child.stdout.on("data", (chunk) => {
-    stdout += chunk;
+  let timedOut = false;
+  const appendBounded = (current, chunk) => `${current}${chunk}`.slice(-1_000_000);
+  child.stdout?.setEncoding("utf8");
+  child.stderr?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk) => {
+    stdout = appendBounded(stdout, chunk);
   });
-  child.stderr.on("data", (chunk) => {
-    stderr += chunk;
+  child.stderr?.on("data", (chunk) => {
+    stderr = appendBounded(stderr, chunk);
   });
   child.on("error", (error) => {
     spawnError = error;
   });
-  const running = { child, ghLog, settled: false };
+  const timeoutMs = Math.min(childTimeoutMs, remainingOverallTime());
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    dumpHarnessState(`${label} exceeded ${timeoutMs}ms`);
+    signalProcessGroup(child, "SIGKILL");
+  }, timeoutMs);
+  const running = { child, ghArgvLog, ghLog, label, settled: false };
   running.completion = new Promise((resolveCompletion) => {
     child.on("close", (status, signal) => {
+      clearTimeout(timeout);
       activeChildren.delete(child);
       running.settled = true;
-      resolveCompletion({ error: spawnError, ghLog, signal, status, stderr, stdout });
+      if (timedOut && spawnError === undefined) {
+        spawnError = Object.assign(new Error(`${label} timed out after ${timeoutMs}ms`), {
+          code: "ETIMEDOUT",
+        });
+      }
+      resolveCompletion({
+        error: spawnError,
+        ghArgvLog,
+        ghLog,
+        signal,
+        status,
+        stderr,
+        stdout,
+      });
     });
   });
   return running;
+}
+
+function syncOptions(overrides = {}) {
+  const requestedTimeout = overrides.timeout ?? childTimeoutMs;
+  return {
+    encoding: "utf8",
+    killSignal: "SIGKILL",
+    maxBuffer: 2 * 1024 * 1024,
+    ...overrides,
+    timeout: Math.max(1, Math.min(requestedTimeout, remainingOverallTime())),
+  };
+}
+
+function remainingOverallTime() {
+  const remaining = overallTimeoutMs - (Date.now() - startedAt);
+  if (remaining <= 0) throw new Error(`install smoke exceeded ${overallTimeoutMs}ms overall`);
+  return remaining;
 }
 
 function buildShellInvocation(childShell, installerArgs, umask) {
@@ -920,7 +2337,10 @@ function buildShellInvocation(childShell, installerArgs, umask) {
 }
 
 function applyEnvironmentOverrides(base, overrides) {
-  const result = { ...base };
+  const result = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (value !== undefined) result[key] = value;
+  }
   for (const [key, value] of Object.entries(overrides)) {
     if (value === undefined) delete result[key];
     else result[key] = value;
@@ -936,8 +2356,40 @@ function makeFailOnceShim(command, destination, slug) {
     join(shimDir, command),
     `#!/bin/sh
 last=''
+source=''
+for argument do source=$last; last=$argument; done
+destination=$last
+if [ "$FAKE_COMMAND" = ln ] && [ -d "$last" ]; then destination=$last/\${source##*/}; fi
+if [ "$destination" = "$FAKE_FAIL_DESTINATION" ] && [ ! -e "$FAKE_SHIM_STATE" ]; then
+  : > "$FAKE_SHIM_STATE"
+  chmod 600 "$FAKE_SHIM_STATE"
+  exit 71
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_COMMAND: command,
+      FAKE_FAIL_DESTINATION: destination,
+      FAKE_REAL_COMMAND: resolveCommand(command),
+      FAKE_SHIM_STATE: state,
+    },
+  };
+}
+
+function makeMoveThenFailShim(destination) {
+  const shimDir = join(root, "move-then-fail-shim");
+  const state = join(root, "move-then-fail.state");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "mv"),
+    `#!/bin/sh
+last=''
 for argument do last=$argument; done
 if [ "$last" = "$FAKE_FAIL_DESTINATION" ] && [ ! -e "$FAKE_SHIM_STATE" ]; then
+  "$FAKE_REAL_COMMAND" "$@" || exit
   : > "$FAKE_SHIM_STATE"
   chmod 600 "$FAKE_SHIM_STATE"
   exit 71
@@ -949,10 +2401,180 @@ exec "$FAKE_REAL_COMMAND" "$@"
     directory: shimDir,
     environment: {
       FAKE_FAIL_DESTINATION: destination,
-      FAKE_REAL_COMMAND: resolveCommand(command),
+      FAKE_REAL_COMMAND: resolveCommand("mv"),
       FAKE_SHIM_STATE: state,
     },
   };
+}
+
+function makeLinkThenFailShim(destination) {
+  const shimDir = join(root, "link-then-fail-shim");
+  const state = join(root, "link-then-fail.state");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "ln"),
+    `#!/bin/sh
+last=''
+source=''
+for argument do source=$last; last=$argument; done
+destination=$last
+if [ -d "$last" ]; then destination=$last/\${source##*/}; fi
+if [ "$destination" = "$FAKE_FAIL_DESTINATION" ] && [ ! -e "$FAKE_SHIM_STATE" ]; then
+  "$FAKE_REAL_COMMAND" "$@" || exit
+  : > "$FAKE_SHIM_STATE"
+  chmod 600 "$FAKE_SHIM_STATE"
+  exit 71
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_FAIL_DESTINATION: destination,
+      FAKE_REAL_COMMAND: resolveCommand("ln"),
+      FAKE_SHIM_STATE: state,
+    },
+  };
+}
+
+function makeLinkThenBlockShim(destination, marker, releaseFile) {
+  const shimDir = join(root, "link-then-block-shim");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "ln"),
+    `#!/bin/sh
+last=''
+source=''
+for argument do source=$last; last=$argument; done
+destination=$last
+if [ -d "$last" ]; then destination=$last/\${source##*/}; fi
+if [ "$destination" = "$FAKE_BLOCK_DESTINATION" ]; then
+  "$FAKE_REAL_COMMAND" "$@" || exit
+  : > "$FAKE_BLOCK_MARKER"
+  chmod 600 "$FAKE_BLOCK_MARKER"
+  while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done
+  exit 0
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_BLOCK_DESTINATION: destination,
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_BLOCK_RELEASE: releaseFile,
+      FAKE_REAL_COMMAND: resolveCommand("ln"),
+    },
+  };
+}
+
+function makeCleanupWarningShim(prefix) {
+  const shimDir = join(root, "cleanup-warning-shim");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "rm"),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+case "$last" in
+  "$FAKE_FAIL_PREFIX"/station-install.*) exit 71 ;;
+esac
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_FAIL_PREFIX: prefix,
+      FAKE_REAL_COMMAND: resolveCommand("rm"),
+    },
+  };
+}
+
+function makeMoveThenBlockShim(destination, marker) {
+  const shimDir = join(root, "move-then-block-shim");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "mv"),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+if [ "$last" = "$FAKE_BLOCK_DESTINATION" ]; then
+  "$FAKE_REAL_COMMAND" "$@" || exit
+  : > "$FAKE_BLOCK_MARKER"
+  chmod 600 "$FAKE_BLOCK_MARKER"
+  trap '' HUP INT TERM
+  while :; do /bin/sleep 0.02; done
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_BLOCK_DESTINATION: destination,
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_REAL_COMMAND: resolveCommand("mv"),
+    },
+  };
+}
+
+function makeMkdirLoggingShim(logPath) {
+  const shimDir = join(root, "mkdir-logging-shim");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "mkdir"),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+printf 'mkdir %s\n' "$last" >> "$FAKE_LOCK_LOG"
+exec "$FAKE_REAL_MKDIR" "$@"
+`,
+  );
+  writeExecutable(
+    join(shimDir, "rmdir"),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+printf 'rmdir %s\n' "$last" >> "$FAKE_LOCK_LOG"
+exec "$FAKE_REAL_RMDIR" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_LOCK_LOG: logPath,
+      FAKE_REAL_MKDIR: resolveCommand("mkdir"),
+      FAKE_REAL_RMDIR: resolveCommand("rmdir"),
+    },
+  };
+}
+
+function makeNoChecksumBin() {
+  const directory = join(root, "no-checksum-bin");
+  makeDirectory(directory);
+  for (const command of [
+    "awk",
+    "cat",
+    "chmod",
+    "cp",
+    "grep",
+    "mkdir",
+    "mktemp",
+    "mv",
+    "readlink",
+    "rm",
+    "rmdir",
+    "sort",
+    "tar",
+  ]) {
+    symlinkSync(resolveCommand(command), join(directory, command));
+  }
+  symlinkSync(join(fakeBinDir, "gh"), join(directory, "gh"));
+  symlinkSync(join(fakeBinDir, "uname"), join(directory, "uname"));
+  return directory;
 }
 
 function makeBlockingShim(command, destination, marker) {
@@ -1014,7 +2636,7 @@ exec "$FAKE_REAL_MKDIR" "$@"
 }
 
 function resolveCommand(command) {
-  const result = spawnSync("/bin/sh", ["-c", `command -v ${command}`], { encoding: "utf8" });
+  const result = spawnSync("/bin/sh", ["-c", `command -v ${command}`], syncOptions());
   assertSuccess(result, `resolve ${command}`);
   return result.stdout.trim();
 }
@@ -1039,7 +2661,7 @@ if [ "\${1:-}" = --version ]; then printf '%s\\n' '${version}'; else printf '%s\
 
 function assertInstalled({ installDir, dataHome = dataDir, tag, target }) {
   const binary = join(installDir, "stn");
-  const result = spawnSync(binary, [], { encoding: "utf8", env: { PATH: "/usr/bin:/bin" } });
+  const result = spawnSync(binary, [], syncOptions({ env: { PATH: "/usr/bin:/bin" } }));
   assertSuccess(result, `${target} installed binary`);
   assertEqual(result.stdout, `Station ${tag} ${target}\n`, `${target} installed version`);
   assertRuntimeVersion(installDir, tag, `${target} installed entrypoints`);
@@ -1047,24 +2669,122 @@ function assertInstalled({ installDir, dataHome = dataDir, tag, target }) {
   assertMode(binary, 0o755, `${target} executable mode`);
 }
 
-function assertRuntimeVersion(installDir, tag, label, { aliases = true } = {}) {
+function assertRuntimeVersion(
+  installDir,
+  tag,
+  label,
+  { aliases = true, assertAliasesAbsent = !aliases } = {},
+) {
   const entrypoints = aliases ? ["stn", "stn-ingress", "stn-tmux-popup"] : ["stn"];
   for (const entrypoint of entrypoints) {
     const path = join(installDir, entrypoint);
-    const result = spawnSync(path, ["--version"], {
-      encoding: "utf8",
-      env: { PATH: "/usr/bin:/bin" },
-    });
+    const result = spawnSync(path, ["--version"], syncOptions({ env: { PATH: "/usr/bin:/bin" } }));
     assertSuccess(result, `${label} ${entrypoint}`);
     assertEqual(result.stdout, `${tag.slice(1)}\n`, `${label} ${entrypoint} version`);
   }
   if (aliases) {
     assertEqual(readlinkSync(join(installDir, "stn-ingress")), "stn", `${label} ingress link`);
     assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", `${label} popup link`);
-  } else {
+  } else if (assertAliasesAbsent) {
     assert(!existsSync(join(installDir, "stn-ingress")), `${label} leaves ingress absent`);
     assert(!existsSync(join(installDir, "stn-tmux-popup")), `${label} leaves popup absent`);
   }
+}
+
+function assertPathRecovery(
+  result,
+  installDir,
+  mismatches,
+  initialPath = [fakeBinDir, "/usr/bin", "/bin"],
+) {
+  for (const launcher of mismatches) {
+    assertIncludes(result.stdout, `PATH mismatch: ${launcher} `, `${launcher} PATH mismatch`);
+  }
+  for (const launcher of ["stn", "stn-ingress", "stn-tmux-popup"]) {
+    if (!mismatches.includes(launcher)) {
+      assertNotIncludes(result.stdout, `PATH mismatch: ${launcher} `, `${launcher} PATH match`);
+    }
+  }
+  assertIncludes(result.stdout, "export PATH", "PATH recovery export");
+  assertIncludes(result.stdout, "hash -r", "PATH recovery command cache reset");
+  assertIncludes(result.stdout, "stn setup", "PATH recovery setup command");
+  assertIncludes(result.stdout, "Absolute fallback:", "PATH recovery absolute fallback");
+
+  const blockStart = result.stdout.indexOf("  PATH=");
+  const blockEnd = result.stdout.indexOf("Absolute fallback:", blockStart);
+  assert(blockStart >= 0 && blockEnd > blockStart, "PATH recovery block boundaries");
+  const recoveryBlock = result.stdout
+    .slice(blockStart + 2, blockEnd)
+    .replace(/\n {2}(export PATH|hash -r|stn setup)\n/g, "\n$1\n");
+  const reportDir = join(root, `path-recovery-${++invocationCount}`);
+  makeDirectory(reportDir);
+  const verification = spawnSync(
+    "/bin/sh",
+    [
+      "-c",
+      `${recoveryBlock}\nfor command in stn stn-ingress stn-tmux-popup; do command -v "$command" > "$PATH_REPORT_DIR/$command" || exit; done`,
+    ],
+    syncOptions({
+      env: {
+        HOME: homeDir,
+        PATH: initialPath.join(":"),
+        PATH_REPORT_DIR: reportDir,
+      },
+    }),
+  );
+  assertSuccess(verification, "PATH recovery block execution");
+  for (const launcher of ["stn", "stn-ingress", "stn-tmux-popup"]) {
+    assertEqual(
+      readFileSync(join(reportDir, launcher), "utf8"),
+      `${join(installDir, launcher)}\n`,
+      `${launcher} recovery block resolution`,
+    );
+  }
+
+  const fallbackCommand = result.stdout.slice(blockEnd + "Absolute fallback:".length).trim();
+  const fallback = spawnSync(
+    "/bin/sh",
+    ["-c", fallbackCommand],
+    syncOptions({ env: { HOME: homeDir, PATH: initialPath.join(":") } }),
+  );
+  assertSuccess(fallback, "absolute PATH fallback execution");
+}
+
+function startVersionReaders(installDir) {
+  const observations = new Map(
+    ["stn", "stn-ingress", "stn-tmux-popup"].map((entrypoint) => [entrypoint, []]),
+  );
+  let stopping = false;
+  const loop = (async () => {
+    while (!stopping) {
+      for (const [entrypoint, versions] of observations) {
+        const result = spawnSync(
+          join(installDir, entrypoint),
+          ["--version"],
+          syncOptions({ env: { PATH: "/usr/bin:/bin" }, timeout: 2_000 }),
+        );
+        versions.push(
+          result.status === 0 ? result.stdout.trim() : `failure:${result.status}:${result.signal}`,
+        );
+      }
+      await delay(5);
+    }
+  })();
+  return {
+    async waitForVersion(version) {
+      const deadline = Date.now() + markerTimeoutMs;
+      while (Date.now() < deadline) {
+        if ([...observations.values()].every((versions) => versions.includes(version))) return;
+        await delay(5);
+      }
+      throw new Error(`continuous readers did not all observe ${version}`);
+    },
+    async stop() {
+      stopping = true;
+      await loop;
+      return observations;
+    },
+  };
 }
 
 function assertLicense(dataHome, tag, label) {
@@ -1099,6 +2819,74 @@ function ghCalls(result) {
   return readFileSync(result.ghLog, "utf8").trimEnd().split("\n");
 }
 
+function ghInvocations(result) {
+  if (!result.ghArgvLog || !existsSync(result.ghArgvLog)) return [];
+  const invocations = [];
+  let current;
+  for (const line of readFileSync(result.ghArgvLog, "utf8").trimEnd().split("\n")) {
+    if (line === "CALL") {
+      assert(current === undefined, "fake gh argv log does not nest calls");
+      current = [];
+    } else if (line === "END") {
+      assert(current !== undefined, "fake gh argv log ends a call after CALL");
+      invocations.push(current);
+      current = undefined;
+    } else if (line.startsWith("ARG=")) {
+      assert(current !== undefined, "fake gh argv log records arguments inside a call");
+      current.push(line.slice(4));
+    } else if (line !== "") {
+      throw new Error(`unexpected fake gh argv log line: ${line}`);
+    }
+  }
+  assert(current === undefined, "fake gh argv log closes every call");
+  return invocations;
+}
+
+function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
+  const repository = "repos/jeremy0dell/station";
+  const archiveName = `stn-${tag}-${target}.tar.gz`;
+  const tagEndpoint = `${repository}/releases/tags/${tag}`;
+  const archiveFilter = `.assets[] | select(.name == "${archiveName}") | .id`;
+  const checksumFilter = '.assets[] | select(.name == "SHA256SUMS") | .id';
+  const expected = [["auth", "status", "--hostname", "github.com"]];
+  if (latest) expected.push(["api", `${repository}/releases/latest`, "--jq", ".tag_name"]);
+  if (draftId === undefined) {
+    expected.push(["api", tagEndpoint, "--jq", archiveFilter]);
+    expected.push(["api", tagEndpoint, "--jq", checksumFilter]);
+  } else {
+    const endpoint = `${repository}/releases?per_page=100`;
+    const match = `.[] | select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
+    expected.push(["api", "--paginate", endpoint, "--jq", `${match} | .id`]);
+    expected.push([
+      "api",
+      "--paginate",
+      endpoint,
+      "--jq",
+      `${match} | .assets[] | select(.name == "${archiveName}") | .id`,
+    ]);
+    expected.push([
+      "api",
+      "--paginate",
+      endpoint,
+      "--jq",
+      `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`,
+    ]);
+  }
+  expected.push([
+    "api",
+    "-H",
+    "Accept: application/octet-stream",
+    `${repository}/releases/assets/1`,
+  ]);
+  expected.push([
+    "api",
+    "-H",
+    "Accept: application/octet-stream",
+    `${repository}/releases/assets/2`,
+  ]);
+  assertEqual(ghInvocations(result), expected, `${tag} strict gh argv flow`);
+}
+
 function assertNoGhApiCalls(result, label) {
   assertEqual(
     ghCalls(result).filter((call) => call.startsWith("api ")),
@@ -1108,7 +2896,7 @@ function assertNoGhApiCalls(result, label) {
 }
 
 function spawnChecked(command, args, label) {
-  const result = spawnSync(command, args, { encoding: "utf8" });
+  const result = spawnSync(command, args, syncOptions());
   assertSuccess(result, label);
   return result;
 }
@@ -1131,12 +2919,21 @@ function absolutePath(path, cwd) {
   return isAbsolute(path) ? path : resolve(cwd, path);
 }
 
-async function waitForPath(path, label, timeoutMs = 5_000) {
+function isSymlink(path) {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPath(path, label, timeoutMs = markerTimeoutMs) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (existsSync(path)) return;
     await delay(20);
   }
+  dumpHarnessState(`${label} marker timeout`);
   throw new Error(`${label}: ${path} did not appear within ${timeoutMs}ms`);
 }
 
@@ -1144,6 +2941,7 @@ async function settleWithin(running, timeoutMs, label) {
   const timeout = Symbol("timeout");
   const result = await Promise.race([running.completion, delay(timeoutMs).then(() => timeout)]);
   if (result !== timeout) return result;
+  dumpHarnessState(`${label} settlement timeout`);
   signalProcessGroup(running.child, "SIGKILL");
   await running.completion;
   throw new Error(`${label} did not finish within ${timeoutMs}ms`);
@@ -1159,15 +2957,62 @@ function signalProcessGroup(child, signal) {
 
 async function stopActiveChildren() {
   const children = [...activeChildren];
-  for (const child of children) signalProcessGroup(child, "SIGKILL");
-  await Promise.all(
-    children.map(
-      (child) =>
-        new Promise((resolveExit) => {
-          if (child.exitCode !== null || child.signalCode !== null) resolveExit();
-          else child.once("close", resolveExit);
-        }),
-    ),
+  const exits = children.map(
+    (child) =>
+      new Promise((resolveExit) => {
+        if (child.exitCode !== null || child.signalCode !== null) resolveExit();
+        else child.once("close", resolveExit);
+      }),
+  );
+  for (const child of children) signalProcessGroup(child, "SIGTERM");
+  await Promise.race([Promise.all(exits), delay(1_000)]);
+  for (const child of children) {
+    if (child.exitCode === null && child.signalCode === null) signalProcessGroup(child, "SIGKILL");
+  }
+  await Promise.all(exits);
+}
+
+function cleanupHarness() {
+  if (cleanupPromise !== undefined) return cleanupPromise;
+  cleanupPromise = (async () => {
+    if (overallTimer !== undefined) clearTimeout(overallTimer);
+    await stopActiveChildren();
+    if (existsSync(root)) {
+      try {
+        chmodSync(root, 0o700);
+      } catch {}
+      rmSync(root, { recursive: true, force: true });
+    }
+    process.umask(inheritedUmask);
+  })();
+  return cleanupPromise;
+}
+
+function dumpHarnessState(reason) {
+  const paths = [];
+  const visit = (directory, depth) => {
+    if (depth > 3 || paths.length >= 120 || !existsSync(directory)) return;
+    let entries;
+    try {
+      entries = readdirSync(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      paths.push(path.slice(root.length + 1));
+      if (entry.isDirectory()) visit(path, depth + 1);
+      if (paths.length >= 120) return;
+    }
+  };
+  visit(root, 0);
+  const children = [...activeChildren].map((child) => ({
+    exitCode: child.exitCode,
+    pid: child.pid,
+    signalCode: child.signalCode,
+  }));
+  process.stderr.write(
+    `\ninstall smoke diagnostic: ${reason}\nelapsed_ms=${Date.now() - startedAt}\nroot=${root}\nchildren=${JSON.stringify(children)}\npaths=${JSON.stringify(paths)}\n`,
   );
 }
 
@@ -1180,10 +3025,10 @@ function assertProcessGone(pid, label) {
   throw new Error(`${label}: process ${pid} is still alive`);
 }
 
-function assertSignalStatus(result, signal, label) {
-  if (result.status === signal.status || result.signal === signal.name) return;
+function assertExactStatus(result, status, label) {
+  if (result.status === status && result.signal === null) return;
   throw new Error(
-    `${label}: expected status ${signal.status} or signal ${signal.name}, received ${result.status}/${result.signal}`,
+    `${label}: expected status ${status} and no signal, received ${result.status}/${result.signal}`,
   );
 }
 

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -26,6 +26,11 @@ const inheritedUmask = process.umask(0o077);
 const runner = fileURLToPath(import.meta.url);
 const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const installer = join(repoRoot, "scripts", "install.sh");
+const timeoutScaleText = process.env.STATION_INSTALL_SMOKE_TIMEOUT_SCALE ?? "1";
+if (!/^(?:[1-9]|10)$/.test(timeoutScaleText)) {
+  throw new Error("STATION_INSTALL_SMOKE_TIMEOUT_SCALE must be an integer from 1 through 10");
+}
+const timeoutScale = Number(timeoutScaleText);
 const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
 const releasesDir = join(root, "releases");
 const fakeBinDir = join(root, "bin");
@@ -36,9 +41,9 @@ const ghLogsDir = join(root, "gh-logs");
 const stableTag = "v1.2.3";
 const rollbackTag = "v1.2.3-rc.1";
 const activeChildren = new Set();
-const childTimeoutMs = 15_000;
-const markerTimeoutMs = 10_000;
-const overallTimeoutMs = 240_000;
+const childTimeoutMs = 30_000 * timeoutScale;
+const markerTimeoutMs = 10_000 * timeoutScale;
+const overallTimeoutMs = 240_000 * timeoutScale;
 const startedAt = Date.now();
 const selfInterruptChild = process.argv.includes("--self-interrupt-child");
 let invocationCount = 0;
@@ -88,8 +93,10 @@ try {
     await scenarioPathResolutionAndFilesystemFailures();
     await scenarioProbeDeadline();
     await scenarioProbeDiagnostics();
+    scenarioProbeSecretIsolation();
     await scenarioDestinationLock();
     await scenarioSharedLicenseLock();
+    await scenarioReplacedLockOwnership();
     await scenarioCommitFailures();
     await scenarioAmbiguousRuntimeCommit();
     await scenarioManagedPathReplacement();
@@ -176,6 +183,7 @@ function prepareFixtures() {
     tarSymlink("stn-ingress", "stn"),
     tarSymlink("stn-tmux-popup", "stn"),
   ]);
+  createRelease("v1.2.28", ["linux-x64"], { probeMode: "secret-check" });
 }
 
 function scenarioPlatformInstalls() {
@@ -861,6 +869,29 @@ esac
   assertNoInstallerResidue(installDir, dataHome);
 }
 
+function scenarioProbeSecretIsolation() {
+  const installDir = join(root, "probe-secret-bin");
+  const dataHome = join(root, "probe-secret-data");
+  const result = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.28",
+    releaseId: "42",
+    dataHome,
+    environment: {
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: "secret-actions-id",
+      ACTIONS_RUNTIME_TOKEN: "secret-actions-runtime",
+      GH_ENTERPRISE_TOKEN: "secret-gh-enterprise",
+      GH_TOKEN: "secret-gh",
+      GITHUB_ENTERPRISE_TOKEN: "secret-github-enterprise",
+      GITHUB_TOKEN: "secret-github",
+    },
+  });
+  assertSuccess(result, "probe credential isolation");
+  assertInstalled({ installDir, dataHome, tag: "v1.2.28", target: "linux-x64" });
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
 async function scenarioDestinationLock() {
   const installDir = join(root, "concurrent-bin");
   const dataHome = join(root, "concurrent-data");
@@ -884,16 +915,15 @@ async function scenarioDestinationLock() {
   const licenseLockPath = join(dataHome, "station", ".station-install.lock");
   await waitForPath(lockPath, "destination lock");
   await waitForPath(licenseLockPath, "license lock");
-  assertEqual(
-    readFileSync(join(lockPath, "owner"), "utf8"),
-    `pid=${first.child.pid}\nrequested=v1.2.8\n`,
-    "destination lock owner",
-  );
-  assertEqual(
-    readFileSync(join(licenseLockPath, "owner"), "utf8"),
-    `pid=${first.child.pid}\nrequested=v1.2.8\n`,
-    "license lock owner",
-  );
+  const commandOwner = onlyLockOwner(lockPath, "destination lock owner").content;
+  const licenseOwner = onlyLockOwner(licenseLockPath, "license lock owner").content;
+  assertIncludes(commandOwner, `pid=${first.child.pid}\n`, "destination lock owner PID");
+  assertIncludes(commandOwner, "requested=v1.2.8\n", "destination lock owner request");
+  assertIncludes(commandOwner, "token=", "destination lock owner token");
+  assertIncludes(licenseOwner, `pid=${first.child.pid}\n`, "license lock owner PID");
+  assertIncludes(licenseOwner, "requested=v1.2.8\n", "license lock owner request");
+  assertIncludes(licenseOwner, "token=", "license lock owner token");
+  assert(commandOwner !== licenseOwner, "command and license locks use distinct ownership tokens");
 
   const second = runInstaller({ installDir, platform: linuxX64(), dataHome });
   assertFailure(second, lockPath, "concurrent installer lock refusal");
@@ -1023,6 +1053,95 @@ async function scenarioSharedLicenseLock() {
     ],
     "locks are acquired command-first and released license-first",
   );
+}
+
+async function scenarioReplacedLockOwnership() {
+  for (const kind of ["command", "license"]) {
+    const installDir = join(root, `replaced-${kind}-lock-bin`);
+    const contenderInstallDir =
+      kind === "command" ? installDir : join(root, "replaced-license-lock-contender-bin");
+    const dataHome = join(root, `replaced-${kind}-lock-data`);
+    const probePid = join(root, `replaced-${kind}-lock-probe.pid`);
+    const probeRelease = join(root, `replaced-${kind}-lock-probe.release`);
+    const removeMarker = join(root, `replaced-${kind}-lock-remove.ready`);
+    const removeRelease = join(root, `replaced-${kind}-lock-remove.release`);
+    const removeShim = join(root, `replaced-${kind}-lock-remove-shim`);
+    makeDirectory(removeShim);
+    writeExecutable(
+      join(removeShim, "rm"),
+      `#!/bin/sh
+case "\${2:-}" in
+  */.station-install.lock/owner-*-${kind})
+    : > "$FAKE_RM_BLOCK_MARKER"
+    chmod 600 "$FAKE_RM_BLOCK_MARKER"
+    while [ ! -e "$FAKE_RM_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done
+    ;;
+esac
+exec /bin/rm "$@"
+`,
+    );
+    seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+    if (contenderInstallDir !== installDir) {
+      seedInstallation({ installDir: contenderInstallDir, dataHome, tag: "v0.9.0" });
+    }
+
+    const first = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: "v1.2.8",
+      dataHome,
+      commandBinDirs: [removeShim],
+      environment: {
+        FAKE_PROBE_PID_FILE: probePid,
+        FAKE_PROBE_RELEASE_FILE: probeRelease,
+        FAKE_RM_BLOCK_MARKER: removeMarker,
+        FAKE_RM_BLOCK_RELEASE: removeRelease,
+      },
+      asynchronous: true,
+    });
+    const commandLock = join(installDir, ".station-install.lock");
+    const licenseLock = join(dataHome, "station", ".station-install.lock");
+    await waitForPath(probePid, `${kind} replacement probe`);
+    await waitForPath(commandLock, `${kind} replacement command lock`);
+    await waitForPath(licenseLock, `${kind} replacement license lock`);
+
+    const replacedLock = kind === "command" ? commandLock : licenseLock;
+    const replacementOwner = `pid=424242\nrequested=v9.9.9\ntoken=replacement-${kind}\n`;
+    const replacementOwnerPath = join(replacedLock, `owner-replacement-${kind}`);
+
+    writeText(probeRelease, "release\n", 0o600);
+    await waitForPath(removeMarker, `${kind} owner removal`);
+    rmSync(replacedLock, { recursive: true });
+    mkdirSync(replacedLock, { mode: 0o700 });
+    writeText(replacementOwnerPath, replacementOwner, 0o600);
+
+    writeText(removeRelease, "release\n", 0o600);
+    const firstResult = await settleWithin(first, 5_000, `${kind} replacement owner`);
+    assertSuccess(firstResult, `${kind} replacement owner install`);
+    assertIncludes(firstResult.stderr, "changed ownership", `${kind} replacement warning`);
+    assertEqual(
+      readFileSync(replacementOwnerPath, "utf8"),
+      replacementOwner,
+      `${kind} replacement lock survives prior owner cleanup`,
+    );
+
+    const contender = runInstaller({
+      installDir: contenderInstallDir,
+      platform: linuxX64(),
+      version: rollbackTag,
+      dataHome,
+    });
+    assertFailure(contender, replacedLock, `${kind} replacement lock refusal`);
+    assertIncludes(contender.stderr, "424242", `${kind} replacement owner PID`);
+    assertNoGhApiCalls(contender, `${kind} replacement lock refusal`);
+
+    rmSync(replacedLock, { recursive: true });
+    assertInstalled({ installDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+    assertNoInstallerResidue(installDir, dataHome);
+    if (contenderInstallDir !== installDir) {
+      assertNoInstallerResidue(contenderInstallDir, dataHome);
+    }
+  }
 }
 
 function scenarioCommitFailures() {
@@ -1993,6 +2112,13 @@ function releaseBinarySource(tag, target, { mode, reportedVersion } = {}) {
   if (mode === "diagnostic") {
     versionBody = "printf 'loader \\033[31mdiagnostic\\007\\r\\n' >&2; exit 126";
   }
+  if (mode === "secret-check") {
+    versionBody = [
+      `test -z "\${GH_TOKEN:-}\${GITHUB_TOKEN:-}\${GH_ENTERPRISE_TOKEN:-}\${GITHUB_ENTERPRISE_TOKEN:-}"`,
+      `test -z "\${ACTIONS_RUNTIME_TOKEN:-}\${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}\${STATION_INSTALL_RELEASE_ID:-}"`,
+      `printf '%s\\n' '${version}'`,
+    ].join("\n  ");
+  }
 
   return `#!/bin/sh
 if [ "\${1:-}" = --version ]; then
@@ -2240,6 +2366,13 @@ function runInstaller({
     }
     const stdout = existsSync(stdoutFile) ? readFileSync(stdoutFile, "utf8") : "";
     const stderr = existsSync(stderrFile) ? readFileSync(stderrFile, "utf8") : "";
+    if (result.error?.code === "ETIMEDOUT") {
+      process.stderr.write(
+        `timed_out_phase=${env.FAKE_GH_FAIL_PHASE ?? "none"}\n` +
+          `timed_out_stdout=${JSON.stringify(stdout.slice(-4096))}\n` +
+          `timed_out_stderr=${JSON.stringify(stderr.slice(-4096))}\n`,
+      );
+    }
     for (const path of [supervisorPidFile, stdoutFile, stderrFile]) rmSync(path, { force: true });
     return { ...result, ghArgvLog, ghLog, stderr, stdout };
   }
@@ -2561,6 +2694,7 @@ function makeNoChecksumBin() {
     "chmod",
     "cp",
     "grep",
+    "ls",
     "mkdir",
     "mktemp",
     "mv",
@@ -2808,6 +2942,15 @@ function assertNoInstallerResidue(installDir, dataHome) {
     );
     assertEqual(residue, [], `installer residue in ${directory}`);
   }
+}
+
+function onlyLockOwner(lockPath, label) {
+  const owners = readdirSync(lockPath).filter(
+    (name) => name === "owner" || name.startsWith("owner-"),
+  );
+  assertEqual(owners.length, 1, `${label} count`);
+  const path = join(lockPath, owners[0]);
+  return { content: readFileSync(path, "utf8"), path };
 }
 
 function assertMode(path, expected, label) {

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -1,21 +1,25 @@
 #!/usr/bin/env node
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   readlinkSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const inheritedUmask = process.umask(0o077);
 const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const installer = join(repoRoot, "scripts", "install.sh");
 const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
@@ -23,8 +27,12 @@ const releasesDir = join(root, "releases");
 const fakeBinDir = join(root, "bin");
 const homeDir = join(root, "home");
 const dataDir = join(root, "data");
+const tempDir = join(root, "tmp");
+const ghLogsDir = join(root, "gh-logs");
 const stableTag = "v1.2.3";
 const rollbackTag = "v1.2.3-rc.1";
+const activeChildren = new Set();
+let invocationCount = 0;
 
 const platforms = [
   { system: "Darwin", machine: "arm64", target: "darwin-arm64" },
@@ -34,11 +42,32 @@ const platforms = [
 ];
 
 try {
-  mkdirSync(releasesDir, { recursive: true });
-  mkdirSync(fakeBinDir, { recursive: true });
-  mkdirSync(homeDir, { recursive: true });
-  mkdirSync(dataDir, { recursive: true });
-  mkdirSync(join(root, "tmp"), { recursive: true });
+  prepareFixtures();
+  await scenarioPlatformInstalls();
+  await scenarioExplicitRollbackAndDraft();
+  await scenarioAuthenticatedReleaseValidation();
+  await scenarioStrictVersionValidation();
+  await scenarioHostileUmaskModes();
+  await scenarioPathResolutionAndFilesystemFailures();
+  await scenarioProbeDeadline();
+  await scenarioDestinationLock();
+  await scenarioCommitFailures();
+  await scenarioCaughtSignals();
+  await scenarioSignalDuringLockAcquisition();
+  await scenarioSigkillLeavesActionableLock();
+  scenarioHelp();
+  process.stdout.write("install smoke passed\n");
+} finally {
+  await stopActiveChildren();
+  chmodSync(root, 0o700);
+  rmSync(root, { recursive: true, force: true });
+  process.umask(inheritedUmask);
+}
+
+function prepareFixtures() {
+  for (const path of [releasesDir, fakeBinDir, homeDir, dataDir, tempDir, ghLogsDir]) {
+    makeDirectory(path);
+  }
   writeFakeCommands();
 
   createRelease(
@@ -48,16 +77,23 @@ try {
   createRelease(rollbackTag, ["linux-x64"]);
   createRelease("v1.2.4", ["linux-x64"], { corruptChecksum: true });
   createRelease("v1.2.5", ["linux-x64"], { extraMember: "postinstall" });
-  createRelease("v1.2.6", ["linux-x64"], { probeFailure: true });
+  createRelease("v1.2.6", ["linux-x64"], { probeMode: "fail" });
+  createRelease("v1.2.7", ["linux-x64"], { probeMode: "hang" });
+  createRelease("v1.2.8", ["linux-x64"], { probeMode: "gate" });
+}
 
+function scenarioPlatformInstalls() {
   for (const platform of platforms) {
     const installDir = join(root, `install-${platform.target}`);
     const result = runInstaller({ installDir, platform });
     assertSuccess(result, `${platform.target} latest install`);
     assertInstalled({ installDir, tag: stableTag, target: platform.target });
     assertIncludes(result.stdout, `Add ${installDir} to PATH`, `${platform.target} PATH hint`);
+    assertNoInstallerResidue(installDir, dataDir);
   }
+}
 
+function scenarioExplicitRollbackAndDraft() {
   const rollbackDir = join(root, "rollback-bin");
   assertSuccess(
     runInstaller({
@@ -76,7 +112,7 @@ try {
   });
   assertSuccess(rollback, "explicit prerelease rollback");
   assertInstalled({ installDir: rollbackDir, tag: rollbackTag, target: "linux-x64" });
-  assertNotIncludes(rollback.stdout, "Add ", "PATH hint when install directory is already present");
+  assertNotIncludes(rollback.stdout, "Add ", "PATH hint when install directory is present");
 
   const draftDir = join(root, "draft-bin");
   const draft = runInstaller({
@@ -87,132 +123,527 @@ try {
   });
   assertSuccess(draft, "draft release ID install");
   assertInstalled({ installDir: draftDir, tag: rollbackTag, target: "linux-x64" });
+}
 
-  const preservedDir = join(root, "preserved-bin");
-  mkdirSync(preservedDir, { recursive: true });
-  const preservedBinary = join(preservedDir, "stn");
-  writeFileSync(preservedBinary, "existing installation\n", { mode: 0o755 });
+function scenarioAuthenticatedReleaseValidation() {
+  const installDir = join(root, "preserved-bin");
+  makeDirectory(installDir);
+  const binary = join(installDir, "stn");
+  writeText(binary, "existing installation\n", 0o755);
 
-  const badChecksum = runInstaller({
-    installDir: preservedDir,
+  const failures = [
+    {
+      label: "checksum rejection",
+      expected: "checksum verification failed",
+      options: { version: "v1.2.4" },
+    },
+    {
+      label: "unexpected archive member",
+      expected: "exact Station release manifest",
+      options: { version: "v1.2.5" },
+    },
+    {
+      label: "binary compatibility probe",
+      expected: "cannot run on this system",
+      options: { version: "v1.2.6" },
+    },
+    {
+      label: "duplicate asset rejection",
+      expected: "exactly one",
+      options: { version: stableTag, duplicateArchiveAsset: true },
+    },
+    {
+      label: "duplicate draft asset rejection",
+      expected: "exactly one",
+      options: {
+        version: stableTag,
+        releaseId: "42",
+        duplicateArchiveAsset: true,
+      },
+    },
+    {
+      label: "duplicate draft release",
+      expected: "no single draft matched",
+      options: { version: stableTag, releaseId: "42", duplicateDraftRelease: true },
+    },
+    {
+      label: "draft tag mismatch",
+      expected: "no single draft matched",
+      options: { version: stableTag, releaseId: "42", releaseIdTag: rollbackTag },
+    },
+    {
+      label: "published release ID refusal",
+      expected: "no single draft matched",
+      options: { version: stableTag, releaseId: "42", releaseDraft: false },
+    },
+    {
+      label: "invalid draft release ID",
+      expected: "must be a numeric",
+      options: { version: stableTag, releaseId: "draft-42" },
+    },
+    {
+      label: "authentication failure",
+      expected: "gh auth login",
+      options: { auth: false },
+    },
+    {
+      label: "unsupported platform",
+      expected: "unsupported platform",
+      options: {
+        platform: { system: "FreeBSD", machine: "x86_64", target: "unsupported" },
+      },
+    },
+  ];
+
+  for (const { expected, label, options } of failures) {
+    const result = runInstaller({ installDir, platform: linuxX64(), ...options });
+    assertFailure(result, expected, label);
+    assertEqual(readFileSync(binary, "utf8"), "existing installation\n", `${label} preservation`);
+    assertNoInstallerResidue(installDir, dataDir);
+  }
+}
+
+function scenarioStrictVersionValidation() {
+  const installDir = join(root, "invalid-versions-bin");
+  const invalidVersions = [
+    "",
+    "1.2.3",
+    "v01.2.3",
+    "v1.2.3+build.1",
+    "v1.2.3 ",
+    "v1.2.3\r",
+    "v1.2.3\nv9.9.9",
+  ];
+
+  for (const version of invalidVersions) {
+    const result = runInstaller({ installDir, platform: linuxX64(), version });
+    assertFailure(result, "v-prefixed SemVer", `invalid version ${JSON.stringify(version)}`);
+    assertEqual(ghCalls(result).length, 0, `invalid version ${JSON.stringify(version)} gh calls`);
+  }
+
+  const duplicateEmpty = runInstaller({
+    installDir,
     platform: linuxX64(),
-    version: "v1.2.4",
+    version: "",
+    extraArguments: ["--version", stableTag],
   });
-  assertFailure(badChecksum, "checksum verification failed", "checksum rejection");
+  assertFailure(duplicateEmpty, "only once", "duplicate version after empty value");
+  assertEqual(ghCalls(duplicateEmpty).length, 0, "duplicate version after empty value gh calls");
+
+  for (const apiTag of ["v1.2.3\nv9.9.9", "v1.2.3\n"]) {
+    const apiResult = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      environment: { FAKE_LATEST_TAG: apiTag },
+    });
+    assertFailure(apiResult, "invalid tag", `invalid latest API tag ${JSON.stringify(apiTag)}`);
+    assertEqual(
+      ghCalls(apiResult).filter((call) => call.startsWith("api ")).length,
+      1,
+      `invalid latest API tag ${JSON.stringify(apiTag)} stops after lookup`,
+    );
+  }
+}
+
+function scenarioHostileUmaskModes() {
+  const installDir = join(root, "hostile-umask-bin");
+  const dataHome = join(root, "hostile-umask-data");
+  for (const version of [stableTag, rollbackTag]) {
+    const result = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version,
+      dataHome,
+      umask: "0777",
+    });
+    assertSuccess(result, `${version} install under umask 0777`);
+    assertInstalled({ installDir, dataHome, tag: version, target: "linux-x64" });
+    assertMode(join(installDir, "stn"), 0o755, `${version} binary mode`);
+    assertMode(join(dataHome, "station", "LICENSE"), 0o644, `${version} license mode`);
+    assertNoInstallerResidue(installDir, dataHome);
+  }
+}
+
+function scenarioPathResolutionAndFilesystemFailures() {
+  const noHomeBin = join(root, "no-home-bin");
+  const noHomeData = join(root, "no-home-data");
+  const noHome = runInstaller({
+    installDir: noHomeBin,
+    platform: linuxX64(),
+    dataHome: noHomeData,
+    environment: { HOME: undefined },
+  });
+  assertSuccess(noHome, "explicit install and XDG paths without HOME");
+  assertInstalled({
+    installDir: noHomeBin,
+    dataHome: noHomeData,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+
+  const relativeCwd = join(root, "relative-path-cwd");
+  makeDirectory(relativeCwd);
+  const relative = runInstaller({
+    installDir: "-station-bin",
+    platform: linuxX64(),
+    cwd: relativeCwd,
+    dataHome: "-station-data",
+    environment: { HOME: undefined },
+  });
+  assertSuccess(relative, "relative leading-dash paths");
+  assertInstalled({
+    installDir: join(relativeCwd, "-station-bin"),
+    dataHome: join(relativeCwd, "-station-data"),
+    tag: stableTag,
+    target: "linux-x64",
+  });
+
+  const unusualCwd = join(root, "path with spaces\nand newline");
+  makeDirectory(unusualCwd);
+  const unusualInstall = join(unusualCwd, "station bin\ncommands\n");
+  const unusualData = join(unusualCwd, "station data\nfiles\n");
+  const unusual = runInstaller({
+    installDir: unusualInstall,
+    platform: linuxX64(),
+    cwd: unusualCwd,
+    dataHome: unusualData,
+    environment: { HOME: undefined },
+  });
+  assertSuccess(unusual, "paths containing spaces and newlines");
+  assertInstalled({
+    installDir: unusualInstall,
+    dataHome: unusualData,
+    tag: stableTag,
+    target: "linux-x64",
+  });
+
+  const newlineLinkDir = join(root, "newline-link-bin");
+  const newlineLinkData = join(root, "newline-link-data");
+  seedInstallation({
+    installDir: newlineLinkDir,
+    dataHome: newlineLinkData,
+    tag: "v0.9.0",
+    withAliases: false,
+  });
+  symlinkSync("stn\n", join(newlineLinkDir, "stn-ingress"));
+  const newlineLink = runInstaller({
+    installDir: newlineLinkDir,
+    platform: linuxX64(),
+    dataHome: newlineLinkData,
+  });
+  assertFailure(newlineLink, "existing launcher", "newline launcher target");
+  assertNoGhApiCalls(newlineLink, "newline launcher target");
   assertEqual(
-    readFileSync(preservedBinary, "utf8"),
-    "existing installation\n",
-    "checksum preservation",
+    readlinkSync(join(newlineLinkDir, "stn-ingress")),
+    "stn\n",
+    "newline launcher target remains untouched",
+  );
+  const newlineLinkRuntime = spawnSync(join(newlineLinkDir, "stn"), ["--version"], {
+    encoding: "utf8",
+  });
+  assertSuccess(newlineLinkRuntime, "newline launcher runtime preservation");
+  assertEqual(newlineLinkRuntime.stdout, "0.9.0\n", "newline launcher runtime version");
+  assertLicense(newlineLinkData, "v0.9.0", "newline launcher license preservation");
+  assertNoInstallerResidue(newlineLinkDir, newlineLinkData);
+
+  const readOnlyDir = join(root, "read-only-bin");
+  const readOnlyData = join(root, "read-only-data");
+  seedInstallation({ installDir: readOnlyDir, dataHome: readOnlyData, tag: "v0.9.0" });
+  chmodSync(readOnlyDir, 0o500);
+  try {
+    const readOnly = runInstaller({
+      installDir: readOnlyDir,
+      platform: linuxX64(),
+      dataHome: readOnlyData,
+    });
+    assertFailure(readOnly, "lock", "read-only destination");
+    assertRuntimeVersion(readOnlyDir, "v0.9.0", "read-only destination preservation");
+  } finally {
+    chmodSync(readOnlyDir, 0o700);
+  }
+}
+
+async function scenarioProbeDeadline() {
+  const installDir = join(root, "probe-timeout-bin");
+  const dataHome = join(root, "probe-timeout-data");
+  const pidFile = join(root, "probe-timeout.pid");
+  const clockBin = join(root, "watchdog-clock-bin");
+  makeDirectory(clockBin);
+  writeExecutable(
+    join(clockBin, "sleep"),
+    [
+      "#!/bin/sh",
+      `case "\${1:-}" in`,
+      '  10) while [ ! -e "$FAKE_PROBE_PID_FILE" ]; do /bin/sleep 0.01; done; exec /bin/sleep 0.05 ;;',
+      "  1) exec /bin/sleep 0.05 ;;",
+      '  *) exec /bin/sleep "$@" ;;',
+      "esac",
+      "",
+    ].join("\n"),
+  );
+  seedInstallation({ installDir, dataHome, tag: stableTag });
+
+  const startedAt = Date.now();
+  const running = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.7",
+    dataHome,
+    commandBinDirs: [clockBin],
+    environment: { FAKE_PROBE_PID_FILE: pidFile },
+    asynchronous: true,
+  });
+  const result = await settleWithin(running, 5_000, "hanging compatibility probe");
+  assertFailure(result, "did not respond", "hanging compatibility probe");
+  assertIncludes(result.stderr, "10 seconds", "probe timeout duration");
+  assertIncludes(result.stderr, "unchanged", "probe timeout preservation UX");
+  assert(Date.now() - startedAt < 5_000, "probe timeout was bounded by the clock shim");
+  assertRuntimeVersion(installDir, stableTag, "probe timeout runtime preservation");
+  assertLicense(dataHome, stableTag, "probe timeout license preservation");
+  assertProcessGone(Number(readFileSync(pidFile, "utf8")), "timed-out probe child");
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
+async function scenarioDestinationLock() {
+  const installDir = join(root, "concurrent-bin");
+  const dataHome = join(root, "concurrent-data");
+  const probePid = join(root, "concurrent-probe.pid");
+  const releaseFile = join(root, "concurrent-probe.release");
+  seedInstallation({ installDir, dataHome, tag: stableTag });
+
+  const first = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    version: "v1.2.8",
+    dataHome,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
+    asynchronous: true,
+  });
+  await waitForPath(probePid, "first installer probe");
+  const lockPath = join(installDir, ".station-install.lock");
+  await waitForPath(lockPath, "destination lock");
+  assertEqual(
+    readFileSync(join(lockPath, "owner"), "utf8"),
+    `pid=${first.child.pid}\nrequested=v1.2.8\n`,
+    "destination lock owner",
   );
 
-  const malicious = runInstaller({
-    installDir: preservedDir,
+  const second = runInstaller({ installDir, platform: linuxX64(), dataHome });
+  assertFailure(second, lockPath, "concurrent installer lock refusal");
+  assertIncludes(second.stderr, String(first.child.pid), "concurrent lock owner PID");
+  assertIncludes(second.stderr, "unchanged", "concurrent lock preservation UX");
+  assertNoGhApiCalls(second, "concurrent installer lock refusal");
+  assertRuntimeVersion(installDir, stableTag, "runtime while installer is locked");
+
+  writeText(releaseFile, "release\n", 0o600);
+  const firstResult = await settleWithin(first, 5_000, "first concurrent installer");
+  assertSuccess(firstResult, "first concurrent installer");
+  assertInstalled({ installDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+
+  const retry = runInstaller({
+    installDir,
     platform: linuxX64(),
-    version: "v1.2.5",
+    version: rollbackTag,
+    dataHome,
   });
-  assertFailure(malicious, "exact Station release manifest", "unexpected archive member");
-  assertEqual(
-    readFileSync(preservedBinary, "utf8"),
-    "existing installation\n",
-    "manifest preservation",
+  assertSuccess(retry, "retry after concurrent install");
+  assertInstalled({ installDir, dataHome, tag: rollbackTag, target: "linux-x64" });
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
+function scenarioCommitFailures() {
+  const cases = [
+    { command: "ln", destination: "stn-ingress", label: "ingress alias commit" },
+    { command: "ln", destination: "stn-tmux-popup", label: "popup alias commit" },
+    { command: "mv", destination: "LICENSE", label: "license commit" },
+    { command: "mv", destination: "stn", label: "runtime commit" },
+  ];
+
+  for (const testCase of cases) {
+    const slug = testCase.label.replaceAll(" ", "-");
+    const installDir = join(root, `${slug}-bin`);
+    const dataHome = join(root, `${slug}-data`);
+    const withAliases = testCase.command !== "ln";
+    seedInstallation({ installDir, dataHome, tag: "v0.9.0", withAliases });
+    const destination =
+      testCase.destination === "LICENSE"
+        ? join(dataHome, "station", "LICENSE")
+        : join(installDir, testCase.destination);
+    const shim = makeFailOnceShim(testCase.command, destination, slug);
+
+    const failed = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: stableTag,
+      dataHome,
+      commandBinDirs: [shim.directory],
+      environment: shim.environment,
+    });
+    assertNonzero(failed, `${testCase.label} failure injection`);
+    assertRuntimeVersion(installDir, "v0.9.0", `${testCase.label} runtime rollback`, {
+      aliases: withAliases,
+    });
+    assertLicense(dataHome, "v0.9.0", `${testCase.label} license rollback`);
+    assertNoInstallerResidue(installDir, dataHome);
+
+    const retry = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      version: stableTag,
+      dataHome,
+    });
+    assertSuccess(retry, `${testCase.label} retry`);
+    assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+  }
+}
+
+async function scenarioCaughtSignals() {
+  const phases = ["download", "probe", "finalization"];
+  const signals = [
+    { name: "SIGINT", status: 130 },
+    { name: "SIGTERM", status: 143 },
+  ];
+
+  for (const phase of phases) {
+    for (const signal of signals) {
+      await runSignalScenario(phase, signal);
+    }
+  }
+}
+
+async function runSignalScenario(phase, signal) {
+  const slug = `${phase}-${signal.name.toLowerCase()}`;
+  const installDir = join(root, `${slug}-bin`);
+  const dataHome = join(root, `${slug}-data`);
+  const marker = join(root, `${slug}.ready`);
+  const releaseFile = join(root, `${slug}.release`);
+  const options = {
+    installDir,
+    platform: linuxX64(),
+    version: stableTag,
+    dataHome,
+    asynchronous: true,
+    environment: {},
+    commandBinDirs: [],
+  };
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+
+  if (phase === "download") {
+    options.environment = {
+      FAKE_GH_BLOCK_DOWNLOAD: "1",
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_BLOCK_RELEASE: releaseFile,
+    };
+  } else if (phase === "probe") {
+    options.version = "v1.2.8";
+    options.environment = {
+      FAKE_PROBE_PID_FILE: marker,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    };
+  } else {
+    const shim = makeBlockingShim("mv", join(installDir, "stn"), marker);
+    options.commandBinDirs = [shim.directory];
+    options.environment = shim.environment;
+  }
+
+  const running = runInstaller(options);
+  await waitForPath(marker, `${phase} ${signal.name} injection point`);
+  signalProcessGroup(running.child, signal.name);
+  const result = await settleWithin(running, 5_000, `${phase} ${signal.name}`);
+  assertSignalStatus(result, signal, `${phase} ${signal.name}`);
+  assertRuntimeVersion(installDir, "v0.9.0", `${phase} ${signal.name} runtime coherence`);
+  assertLicense(dataHome, "v0.9.0", `${phase} ${signal.name} license rollback`);
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
+async function scenarioSignalDuringLockAcquisition() {
+  const installDir = join(root, "lock-signal-bin");
+  const dataHome = join(root, "lock-signal-data");
+  const marker = join(root, "lock-signal.ready");
+  const releaseFile = join(root, "lock-signal.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+  const shim = makeLockAcquisitionShim(
+    join(installDir, ".station-install.lock"),
+    marker,
+    releaseFile,
   );
-
-  const incompatible = runInstaller({
-    installDir: preservedDir,
-    platform: linuxX64(),
-    version: "v1.2.6",
-  });
-  assertFailure(incompatible, "cannot run on this system", "binary compatibility probe");
-  assertEqual(
-    readFileSync(preservedBinary, "utf8"),
-    "existing installation\n",
-    "probe preservation",
-  );
-
-  const duplicateAsset = runInstaller({
-    installDir: preservedDir,
+  const running = runInstaller({
+    installDir,
     platform: linuxX64(),
     version: stableTag,
-    duplicateArchiveAsset: true,
+    dataHome,
+    asynchronous: true,
+    commandBinDirs: [shim.directory],
+    environment: shim.environment,
   });
-  assertFailure(duplicateAsset, "exactly one", "duplicate asset rejection");
 
-  const duplicateDraftAsset = runInstaller({
-    installDir: preservedDir,
+  await waitForPath(marker, "signal during lock acquisition");
+  running.child.kill("SIGTERM");
+  writeText(releaseFile, "release\n", 0o600);
+  const result = await settleWithin(running, 5_000, "signal during lock acquisition");
+  assertSignalStatus(result, { name: "SIGTERM", status: 143 }, "signal during lock acquisition");
+  assertRuntimeVersion(installDir, "v0.9.0", "lock acquisition signal runtime coherence");
+  assertLicense(dataHome, "v0.9.0", "lock acquisition signal license preservation");
+  assertNoInstallerResidue(installDir, dataHome);
+}
+
+async function scenarioSigkillLeavesActionableLock() {
+  const installDir = join(root, "sigkill-bin");
+  const dataHome = join(root, "sigkill-data");
+  const probePid = join(root, "sigkill-probe.pid");
+  const releaseFile = join(root, "sigkill-probe.release");
+  seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
+
+  const killed = runInstaller({
+    installDir,
     platform: linuxX64(),
-    version: stableTag,
-    releaseId: "42",
-    duplicateArchiveAsset: true,
+    version: "v1.2.8",
+    dataHome,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
+    asynchronous: true,
   });
-  assertFailure(duplicateDraftAsset, "exactly one", "duplicate draft asset rejection");
+  await waitForPath(probePid, "SIGKILL probe");
+  const lockPath = join(installDir, ".station-install.lock");
+  await waitForPath(lockPath, "SIGKILL-owned lock");
+  signalProcessGroup(killed.child, "SIGKILL");
+  const killedResult = await settleWithin(killed, 5_000, "SIGKILL installer");
+  assertEqual(killedResult.signal, "SIGKILL", "SIGKILL installer signal");
+  assert(existsSync(lockPath), "SIGKILL leaves the owned destination lock");
+  assertRuntimeVersion(installDir, "v0.9.0", "SIGKILL runtime coherence");
 
-  const duplicateDraftRelease = runInstaller({
-    installDir: preservedDir,
+  const refused = runInstaller({ installDir, platform: linuxX64(), dataHome });
+  assertFailure(refused, lockPath, "stale lock refusal");
+  assertIncludes(refused.stderr, String(killed.child.pid), "stale lock owner PID");
+  assertIncludes(refused.stderr, "manually", "stale lock manual recovery UX");
+  assertIncludes(refused.stderr, "retry", "stale lock retry UX");
+  assertNoGhApiCalls(refused, "stale lock refusal");
+
+  rmSync(lockPath, { recursive: true });
+  writeText(releaseFile, "release\n", 0o600);
+  const retry = runInstaller({
+    installDir,
     platform: linuxX64(),
-    version: stableTag,
-    releaseId: "42",
-    duplicateDraftRelease: true,
+    version: "v1.2.8",
+    dataHome,
+    environment: {
+      FAKE_PROBE_PID_FILE: probePid,
+      FAKE_PROBE_RELEASE_FILE: releaseFile,
+    },
   });
-  assertFailure(duplicateDraftRelease, "no single draft matched", "duplicate draft release");
+  assertSuccess(retry, "manual stale-lock removal retry");
+  assertInstalled({ installDir, dataHome, tag: "v1.2.8", target: "linux-x64" });
+}
 
-  const mismatchedDraft = runInstaller({
-    installDir: preservedDir,
-    platform: linuxX64(),
-    version: stableTag,
-    releaseId: "42",
-    releaseIdTag: rollbackTag,
-  });
-  assertFailure(mismatchedDraft, "no single draft matched", "draft tag mismatch");
-
-  const publishedRelease = runInstaller({
-    installDir: preservedDir,
-    platform: linuxX64(),
-    version: stableTag,
-    releaseId: "42",
-    releaseDraft: false,
-  });
-  assertFailure(publishedRelease, "no single draft matched", "published release ID refusal");
-
-  const invalidDraftId = runInstaller({
-    installDir: preservedDir,
-    platform: linuxX64(),
-    version: stableTag,
-    releaseId: "draft-42",
-  });
-  assertFailure(invalidDraftId, "must be a numeric", "invalid draft release ID");
-
-  const unauthenticated = runInstaller({
-    auth: false,
-    installDir: preservedDir,
-    platform: linuxX64(),
-  });
-  assertFailure(unauthenticated, "gh auth login", "authentication failure");
-  assertEqual(
-    readFileSync(preservedBinary, "utf8"),
-    "existing installation\n",
-    "auth preservation",
-  );
-
-  const unsupported = runInstaller({
-    installDir: preservedDir,
-    platform: { system: "FreeBSD", machine: "x86_64", target: "unsupported" },
-  });
-  assertFailure(unsupported, "unsupported platform", "unsupported platform");
-
-  const invalidVersion = runInstaller({
-    installDir: preservedDir,
-    platform: linuxX64(),
-    version: "1.2.3",
-  });
-  assertFailure(invalidVersion, "v-prefixed SemVer", "invalid version");
-
+function scenarioHelp() {
   const help = spawnSync("/bin/sh", [installer, "--help"], { encoding: "utf8" });
   assertSuccess(help, "installer help");
   assertIncludes(help.stdout, "--install-dir", "installer help options");
-
-  process.stdout.write("install smoke passed\n");
-} finally {
-  rmSync(root, { recursive: true, force: true });
 }
 
 function linuxX64() {
@@ -221,7 +652,7 @@ function linuxX64() {
 
 function createRelease(tag, targets, options = {}) {
   const releaseDir = join(releasesDir, tag);
-  mkdirSync(releaseDir, { recursive: true });
+  makeDirectory(releaseDir);
   const checksums = [];
 
   for (const target of targets) {
@@ -229,36 +660,65 @@ function createRelease(tag, targets, options = {}) {
     const archiveName = `stn-v${version}-${target}.tar.gz`;
     const archivePath = join(releaseDir, archiveName);
     const payloadDir = join(root, `payload-${version}-${target}`);
-    mkdirSync(payloadDir, { recursive: true });
-    const binarySource = options.probeFailure
-      ? "#!/bin/sh\nexit 126\n"
-      : `#!/bin/sh
-if [ "\${1:-}" = --version ]; then
-  printf '%s\\n' '${version}'
-else
-  printf '%s\\n' 'Station ${tag} ${target}'
-fi
-`;
-    writeFileSync(join(payloadDir, "stn"), binarySource, { mode: 0o755 });
+    rmSync(payloadDir, { recursive: true, force: true });
+    makeDirectory(payloadDir);
+    writeReleaseBinary(join(payloadDir, "stn"), { tag, target, mode: options.probeMode });
     symlinkSync("stn", join(payloadDir, "stn-ingress"));
     symlinkSync("stn", join(payloadDir, "stn-tmux-popup"));
-    writeFileSync(join(payloadDir, "LICENSE"), `Station fixture license ${tag}\n`);
+    writeText(join(payloadDir, "LICENSE"), `Station fixture license ${tag}\n`, 0o644);
 
     const members = ["stn", "stn-ingress", "stn-tmux-popup", "LICENSE"];
     if (options.extraMember !== undefined) {
-      writeFileSync(join(payloadDir, options.extraMember), "unapproved archive payload\n", {
-        mode: 0o755,
-      });
+      writeText(join(payloadDir, options.extraMember), "unapproved archive payload\n", 0o755);
       members.push(options.extraMember);
     }
     spawnChecked("tar", ["-czf", archivePath, "-C", payloadDir, ...members], "fixture archive");
+    chmodSync(archivePath, 0o600);
     const hash = options.corruptChecksum
       ? "0".repeat(64)
       : createHash("sha256").update(readFileSync(archivePath)).digest("hex");
     checksums.push(`${hash}  ${archiveName}`);
   }
 
-  writeFileSync(join(releaseDir, "SHA256SUMS"), `${checksums.sort().join("\n")}\n`);
+  writeText(join(releaseDir, "SHA256SUMS"), `${checksums.sort().join("\n")}\n`, 0o600);
+}
+
+function writeReleaseBinary(path, { mode, tag, target }) {
+  const version = tag.slice(1);
+  let versionBody = `printf '%s\\n' '${version}'`;
+  if (mode === "fail") versionBody = "exit 126";
+  if (mode === "hang") {
+    versionBody = [
+      'printf \'%s\\n\' "$$" > "$FAKE_PROBE_PID_FILE"',
+      'chmod 600 "$FAKE_PROBE_PID_FILE"',
+      "trap '' HUP INT TERM",
+      "while :; do /bin/sleep 0.02; done",
+    ].join("\n  ");
+  }
+  if (mode === "gate") {
+    versionBody = [
+      `if [ -n "\${FAKE_PROBE_RELEASE_FILE:-}" ]; then`,
+      '  printf \'%s\\n\' "$$" > "$FAKE_PROBE_PID_FILE"',
+      '  chmod 600 "$FAKE_PROBE_PID_FILE"',
+      "  trap 'exit 129' HUP",
+      "  trap 'exit 130' INT",
+      "  trap 'exit 143' TERM",
+      '  while [ ! -e "$FAKE_PROBE_RELEASE_FILE" ]; do /bin/sleep 0.02; done',
+      "fi",
+      `printf '%s\\n' '${version}'`,
+    ].join("\n  ");
+  }
+
+  writeExecutable(
+    path,
+    `#!/bin/sh
+if [ "\${1:-}" = --version ]; then
+  ${versionBody}
+else
+  printf '%s\\n' 'Station ${tag} ${target}'
+fi
+`,
+  );
 }
 
 function writeFakeCommands() {
@@ -279,6 +739,8 @@ function writeFakeCommands() {
     [
       "#!/bin/sh",
       "set -eu",
+      'printf \'%s\\n\' "$*" >> "$FAKE_GH_LOG"',
+      'chmod 600 "$FAKE_GH_LOG"',
       '[ "$GH_HOST" = github.com ] || exit 3',
       `if [ "\${1:-}" = auth ]; then`,
       `  [ "\${FAKE_GH_AUTH:-1}" = 1 ]`,
@@ -329,18 +791,23 @@ function writeFakeCommands() {
       "        ;;",
       "    esac",
       "    ;;",
-      '  */releases/assets/1) cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE" ;;',
+      "  */releases/assets/1)",
+      `    if [ "\${FAKE_GH_BLOCK_DOWNLOAD:-0}" = 1 ]; then`,
+      '      : > "$FAKE_BLOCK_MARKER"',
+      '      chmod 600 "$FAKE_BLOCK_MARKER"',
+      "      trap 'exit 129' HUP",
+      "      trap 'exit 130' INT",
+      "      trap 'exit 143' TERM",
+      '      while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done',
+      "    fi",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE"',
+      "    ;;",
       '  */releases/assets/2) cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS" ;;',
       "  *) exit 2 ;;",
       "esac",
       "",
     ].join("\n"),
   );
-}
-
-function writeExecutable(path, source) {
-  writeFileSync(path, source, { mode: 0o755 });
-  chmodSync(path, 0o755);
 }
 
 function runInstaller({
@@ -354,57 +821,370 @@ function runInstaller({
   releaseId,
   releaseDraft = true,
   releaseIdTag,
+  childShell = "/bin/sh",
+  cwd = repoRoot,
+  dataHome = dataDir,
+  environment = {},
+  umask,
+  asynchronous = false,
+  commandBinDirs = [],
+  extraArguments = [],
 }) {
   const tag = version ?? stableTag;
   const archive = `stn-${tag}-${platform.target}.tar.gz`;
-  const path = [fakeBinDir, "/usr/bin", "/bin"];
-  if (includeInstallDirOnPath) path.push(installDir);
+  const commandPath = [...commandBinDirs, fakeBinDir, "/usr/bin", "/bin"];
+  if (includeInstallDirOnPath) commandPath.push(absolutePath(installDir, cwd));
   const args = [];
   if (version !== undefined) args.push("--version", version);
+  args.push(...extraArguments);
   args.push("--install-dir", installDir);
-  const env = {
-    HOME: homeDir,
-    GH_HOST: "untrusted.example",
-    PATH: path.join(":"),
-    TMPDIR: join(root, "tmp"),
-    XDG_DATA_HOME: dataDir,
-    FAKE_ARCHIVE: archive,
-    FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
-    FAKE_DUPLICATE_RELEASE: duplicateDraftRelease ? "1" : "0",
-    FAKE_GH_AUTH: auth ? "1" : "0",
-    FAKE_LATEST_TAG: stableTag,
-    FAKE_RELEASE_ID: releaseId ?? "42",
-    FAKE_RELEASE_DRAFT: releaseDraft ? "1" : "0",
-    FAKE_RELEASE_ID_TAG: releaseIdTag ?? tag,
-    FAKE_RELEASES: releasesDir,
-    FAKE_TAG: tag,
-    FAKE_UNAME_M: platform.machine,
-    FAKE_UNAME_S: platform.system,
-  };
+  const ghLog = join(ghLogsDir, `${++invocationCount}.log`);
+  const env = applyEnvironmentOverrides(
+    {
+      HOME: homeDir,
+      GH_HOST: "untrusted.example",
+      PATH: commandPath.join(":"),
+      TMPDIR: tempDir,
+      XDG_DATA_HOME: dataHome,
+      FAKE_ARCHIVE: archive,
+      FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
+      FAKE_DUPLICATE_RELEASE: duplicateDraftRelease ? "1" : "0",
+      FAKE_GH_AUTH: auth ? "1" : "0",
+      FAKE_GH_LOG: ghLog,
+      FAKE_LATEST_TAG: stableTag,
+      FAKE_RELEASE_ID: releaseId ?? "42",
+      FAKE_RELEASE_DRAFT: releaseDraft ? "1" : "0",
+      FAKE_RELEASE_ID_TAG: releaseIdTag ?? tag,
+      FAKE_RELEASES: releasesDir,
+      FAKE_TAG: tag,
+      FAKE_UNAME_M: platform.machine,
+      FAKE_UNAME_S: platform.system,
+    },
+    environment,
+  );
   if (releaseId !== undefined) env.STATION_INSTALL_RELEASE_ID = releaseId;
-  return spawnSync("/bin/sh", [installer, ...args], { encoding: "utf8", env });
+  const invocation = buildShellInvocation(childShell, args, umask);
+  const options = { cwd, encoding: "utf8", env };
+
+  if (!asynchronous) {
+    return { ...spawnSync(invocation.command, invocation.args, options), ghLog };
+  }
+
+  const child = spawn(invocation.command, invocation.args, {
+    ...options,
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  activeChildren.add(child);
+  let stdout = "";
+  let stderr = "";
+  let spawnError;
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  child.on("error", (error) => {
+    spawnError = error;
+  });
+  const running = { child, ghLog, settled: false };
+  running.completion = new Promise((resolveCompletion) => {
+    child.on("close", (status, signal) => {
+      activeChildren.delete(child);
+      running.settled = true;
+      resolveCompletion({ error: spawnError, ghLog, signal, status, stderr, stdout });
+    });
+  });
+  return running;
 }
 
-function assertInstalled({ installDir, tag, target }) {
+function buildShellInvocation(childShell, installerArgs, umask) {
+  if (umask === undefined) {
+    return { command: childShell, args: [installer, ...installerArgs] };
+  }
+  return {
+    command: childShell,
+    args: [
+      "-c",
+      'umask "$1"; shift; exec "$@"',
+      "station-install",
+      umask,
+      childShell,
+      installer,
+      ...installerArgs,
+    ],
+  };
+}
+
+function applyEnvironmentOverrides(base, overrides) {
+  const result = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete result[key];
+    else result[key] = value;
+  }
+  return result;
+}
+
+function makeFailOnceShim(command, destination, slug) {
+  const shimDir = join(root, `${slug}-shim`);
+  const state = join(root, `${slug}-failed-once`);
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, command),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+if [ "$last" = "$FAKE_FAIL_DESTINATION" ] && [ ! -e "$FAKE_SHIM_STATE" ]; then
+  : > "$FAKE_SHIM_STATE"
+  chmod 600 "$FAKE_SHIM_STATE"
+  exit 71
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_FAIL_DESTINATION: destination,
+      FAKE_REAL_COMMAND: resolveCommand(command),
+      FAKE_SHIM_STATE: state,
+    },
+  };
+}
+
+function makeBlockingShim(command, destination, marker) {
+  const shimDir = join(root, `${invocationCount + 1}-blocking-${command}`);
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, command),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+if [ "$last" = "$FAKE_BLOCK_DESTINATION" ]; then
+  : > "$FAKE_BLOCK_MARKER"
+  chmod 600 "$FAKE_BLOCK_MARKER"
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  while :; do /bin/sleep 0.02; done
+fi
+exec "$FAKE_REAL_COMMAND" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_BLOCK_DESTINATION: destination,
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_REAL_COMMAND: resolveCommand(command),
+    },
+  };
+}
+
+function makeLockAcquisitionShim(destination, marker, releaseFile) {
+  const shimDir = join(root, "lock-acquisition-shim");
+  makeDirectory(shimDir);
+  writeExecutable(
+    join(shimDir, "mkdir"),
+    `#!/bin/sh
+last=''
+for argument do last=$argument; done
+if [ "$last" = "$FAKE_LOCK_DESTINATION" ]; then
+  "$FAKE_REAL_MKDIR" "$@" || exit
+  : > "$FAKE_BLOCK_MARKER"
+  chmod 600 "$FAKE_BLOCK_MARKER"
+  while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done
+  exit 0
+fi
+exec "$FAKE_REAL_MKDIR" "$@"
+`,
+  );
+  return {
+    directory: shimDir,
+    environment: {
+      FAKE_BLOCK_MARKER: marker,
+      FAKE_BLOCK_RELEASE: releaseFile,
+      FAKE_LOCK_DESTINATION: destination,
+      FAKE_REAL_MKDIR: resolveCommand("mkdir"),
+    },
+  };
+}
+
+function resolveCommand(command) {
+  const result = spawnSync("/bin/sh", ["-c", `command -v ${command}`], { encoding: "utf8" });
+  assertSuccess(result, `resolve ${command}`);
+  return result.stdout.trim();
+}
+
+function seedInstallation({ installDir, dataHome, tag, withAliases = true }) {
+  makeDirectory(installDir);
+  const version = tag.slice(1);
+  writeExecutable(
+    join(installDir, "stn"),
+    `#!/bin/sh
+if [ "\${1:-}" = --version ]; then printf '%s\\n' '${version}'; else printf '%s\\n' 'Station ${tag} linux-x64'; fi
+`,
+  );
+  if (withAliases) {
+    symlinkSync("stn", join(installDir, "stn-ingress"));
+    symlinkSync("stn", join(installDir, "stn-tmux-popup"));
+  }
+  const licenseDir = join(dataHome, "station");
+  makeDirectory(licenseDir);
+  writeText(join(licenseDir, "LICENSE"), `Station fixture license ${tag}\n`, 0o644);
+}
+
+function assertInstalled({ installDir, dataHome = dataDir, tag, target }) {
   const binary = join(installDir, "stn");
   const result = spawnSync(binary, [], { encoding: "utf8", env: { PATH: "/usr/bin:/bin" } });
   assertSuccess(result, `${target} installed binary`);
   assertEqual(result.stdout, `Station ${tag} ${target}\n`, `${target} installed version`);
-  assertEqual(readlinkSync(join(installDir, "stn-ingress")), "stn", `${target} ingress link`);
-  assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", `${target} popup link`);
+  assertRuntimeVersion(installDir, tag, `${target} installed entrypoints`);
+  assertLicense(dataHome, tag, `${target} installed license`);
+  assertMode(binary, 0o755, `${target} executable mode`);
+}
+
+function assertRuntimeVersion(installDir, tag, label, { aliases = true } = {}) {
+  const entrypoints = aliases ? ["stn", "stn-ingress", "stn-tmux-popup"] : ["stn"];
+  for (const entrypoint of entrypoints) {
+    const path = join(installDir, entrypoint);
+    const result = spawnSync(path, ["--version"], {
+      encoding: "utf8",
+      env: { PATH: "/usr/bin:/bin" },
+    });
+    assertSuccess(result, `${label} ${entrypoint}`);
+    assertEqual(result.stdout, `${tag.slice(1)}\n`, `${label} ${entrypoint} version`);
+  }
+  if (aliases) {
+    assertEqual(readlinkSync(join(installDir, "stn-ingress")), "stn", `${label} ingress link`);
+    assertEqual(readlinkSync(join(installDir, "stn-tmux-popup")), "stn", `${label} popup link`);
+  } else {
+    assert(!existsSync(join(installDir, "stn-ingress")), `${label} leaves ingress absent`);
+    assert(!existsSync(join(installDir, "stn-tmux-popup")), `${label} leaves popup absent`);
+  }
+}
+
+function assertLicense(dataHome, tag, label) {
   assertEqual(
-    readFileSync(join(dataDir, "station", "LICENSE"), "utf8"),
+    readFileSync(join(dataHome, "station", "LICENSE"), "utf8"),
     `Station fixture license ${tag}\n`,
-    `${target} installed license`,
+    label,
   );
-  const access = spawnSync("/bin/sh", ["-c", 'test -x "$1"', "sh", binary]);
-  assertEqual(access.status, 0, `${target} executable mode`);
+}
+
+function assertNoInstallerResidue(installDir, dataHome) {
+  const directories = [
+    absolutePath(installDir, repoRoot),
+    join(absolutePath(dataHome, repoRoot), "station"),
+    tempDir,
+  ];
+  for (const directory of directories) {
+    if (!existsSync(directory)) continue;
+    const residue = readdirSync(directory).filter(
+      (name) => name.startsWith(".station-install") || name.startsWith("station-install."),
+    );
+    assertEqual(residue, [], `installer residue in ${directory}`);
+  }
+}
+
+function assertMode(path, expected, label) {
+  assertEqual(statSync(path).mode & 0o777, expected, label);
+}
+
+function ghCalls(result) {
+  if (!existsSync(result.ghLog)) return [];
+  return readFileSync(result.ghLog, "utf8").trimEnd().split("\n");
+}
+
+function assertNoGhApiCalls(result, label) {
+  assertEqual(
+    ghCalls(result).filter((call) => call.startsWith("api ")),
+    [],
+    `${label} release API calls`,
+  );
 }
 
 function spawnChecked(command, args, label) {
   const result = spawnSync(command, args, { encoding: "utf8" });
   assertSuccess(result, label);
   return result;
+}
+
+function makeDirectory(path) {
+  mkdirSync(path, { recursive: true, mode: 0o700 });
+  chmodSync(path, 0o700);
+}
+
+function writeText(path, source, mode) {
+  writeFileSync(path, source, { mode });
+  chmodSync(path, mode);
+}
+
+function writeExecutable(path, source) {
+  writeText(path, source, 0o755);
+}
+
+function absolutePath(path, cwd) {
+  return isAbsolute(path) ? path : resolve(cwd, path);
+}
+
+async function waitForPath(path, label, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return;
+    await delay(20);
+  }
+  throw new Error(`${label}: ${path} did not appear within ${timeoutMs}ms`);
+}
+
+async function settleWithin(running, timeoutMs, label) {
+  const timeout = Symbol("timeout");
+  const result = await Promise.race([running.completion, delay(timeoutMs).then(() => timeout)]);
+  if (result !== timeout) return result;
+  signalProcessGroup(running.child, "SIGKILL");
+  await running.completion;
+  throw new Error(`${label} did not finish within ${timeoutMs}ms`);
+}
+
+function signalProcessGroup(child, signal) {
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    child.kill(signal);
+  }
+}
+
+async function stopActiveChildren() {
+  const children = [...activeChildren];
+  for (const child of children) signalProcessGroup(child, "SIGKILL");
+  await Promise.all(
+    children.map(
+      (child) =>
+        new Promise((resolveExit) => {
+          if (child.exitCode !== null || child.signalCode !== null) resolveExit();
+          else child.once("close", resolveExit);
+        }),
+    ),
+  );
+}
+
+function assertProcessGone(pid, label) {
+  try {
+    process.kill(pid, 0);
+  } catch {
+    return;
+  }
+  throw new Error(`${label}: process ${pid} is still alive`);
+}
+
+function assertSignalStatus(result, signal, label) {
+  if (result.status === signal.status || result.signal === signal.name) return;
+  throw new Error(
+    `${label}: expected status ${signal.status} or signal ${signal.name}, received ${result.status}/${result.signal}`,
+  );
 }
 
 function assertSuccess(result, label) {
@@ -414,9 +1194,13 @@ function assertSuccess(result, label) {
   }
 }
 
-function assertFailure(result, expected, label) {
+function assertNonzero(result, label) {
   if (result.error !== undefined) throw result.error;
   if (result.status === 0) throw new Error(`${label} unexpectedly passed`);
+}
+
+function assertFailure(result, expected, label) {
+  assertNonzero(result, label);
   assertIncludes(result.stderr, expected, label);
 }
 
@@ -437,9 +1221,17 @@ function assertNotIncludes(value, expected, label) {
 }
 
 function assertEqual(actual, expected, label) {
-  if (actual !== expected) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     throw new Error(
       `${label}: expected ${JSON.stringify(expected)}, received ${JSON.stringify(actual)}`,
     );
   }
+}
+
+function assert(condition, label) {
+  if (!condition) throw new Error(label);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds));
 }

--- a/scripts/test-runners/run-release-smoke.mjs
+++ b/scripts/test-runners/run-release-smoke.mjs
@@ -157,6 +157,11 @@ if (args.includes("--version")) {
   process.exit(0);
 }
 
+if (args.includes("--help")) {
+  console.log("Options: --no-hooks --yes");
+  process.exit(0);
+}
+
 function current() {
   try {
     return JSON.parse(readFileSync(stateFile, "utf8"));

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -82,6 +82,46 @@ describe("release readiness docs", () => {
     expect(packageJson.scripts["test:all"]).toContain("pnpm smoke:install");
   });
 
+  it("keeps installer continuity and interrupted-upgrade recovery documented", async () => {
+    const documents = await Promise.all(
+      ["docs/install.md", "docs/development.md", "docs/single-binary.md"].map(
+        async (path) => [path, await read(path)] as const,
+      ),
+    );
+
+    for (const [path, document] of documents) {
+      expect(document, path).toContain("<install-dir>/.station-install.lock");
+      expect(document, path).toContain("<install-dir>/.station-install.lock/owner");
+      expect(document, path).toContain("requested tag or `latest`");
+      expect(document, path).toMatch(/10(?:-second| seconds)/);
+      expect(document, path).toMatch(/existing\s+Station\s+installation\s+was\s+unchanged/);
+      expect(document, path).toContain("sole runtime commit point");
+      expect(document, path).toMatch(/129, 130, (?:and|or) 143/);
+      expect(document, path).toContain("SIGKILL");
+      expect(document, path).toMatch(/power\s+loss/);
+      expect(document, path).toContain("manually");
+      expect(document, path).toContain("alive");
+    }
+
+    const development = await read("docs/development.md");
+    const normalizedDevelopment = development.replace(/\s+/g, " ");
+    for (const acceptance of [
+      "terminal A",
+      "terminal B",
+      "RC → stable → RC",
+      "command-not-found",
+      "Ctrl-C",
+      "Ctrl-Z",
+      "stn-tmux-popup",
+      "stn-ingress",
+      "HOST_UPGRADE_BLOCKED",
+      "same Observer socket",
+      "explicit rollback check",
+    ]) {
+      expect(normalizedDevelopment).toContain(acceptance);
+    }
+  });
+
   it("does not advertise removed Crush harness surfaces", async () => {
     const files = ["README.md", "AGENTS.md", ...(await markdownFiles("docs"))];
 

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -60,8 +60,12 @@ describe("release readiness docs", () => {
 
     expect(readme).toContain("authenticated private binary");
     expect(readme).toContain("without Node.js, pnpm, Bun");
-    expect(install).toContain("latest stable release");
-    expect(install).toContain("--version v0.1.1-rc.1");
+    expect(install).toContain("latest stable tag");
+    expect(install).toContain("tag=v0.1.1-rc.1");
+    expect(install).toContain('-f ref="$tag"');
+    expect(install).toContain('sh "$installer" --version "$tag"');
+    expect(readme).toContain('-f ref="$tag"');
+    expect(readme.replace(/\s+/g, " ")).toContain("installer code and artifacts");
     expect(install).toContain("SHA256SUMS");
     expect(install).toContain("stn-tmux-popup");
     for (const target of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]) {
@@ -90,15 +94,23 @@ describe("release readiness docs", () => {
     );
 
     for (const [path, document] of documents) {
+      const normalized = document.replace(/\s+/g, " ");
       expect(document, path).toContain("<install-dir>/.station-install.lock");
       expect(document, path).toContain("<install-dir>/.station-install.lock/owner");
-      expect(document, path).toContain("requested tag or `latest`");
+      expect(document, path).toContain("<data-home>/station/.station-install.lock");
+      expect(document, path).toContain("<data-home>/station/.station-install.lock/owner");
+      expect(normalized, path).toContain("requested tag or `latest`");
       expect(document, path).toMatch(/10(?:-second| seconds)/);
       expect(document, path).toMatch(/existing\s+Station\s+installation\s+was\s+unchanged/);
       expect(document, path).toContain("sole runtime commit point");
       expect(document, path).toMatch(/129, 130, (?:and|or) 143/);
+      expect(document, path).toContain("4096");
+      expect(document, path).toContain("124");
+      expect(document, path).toContain("125");
       expect(document, path).toContain("SIGKILL");
-      expect(document, path).toMatch(/power\s+loss/);
+      expect(document, path).toMatch(/power\s+loss/i);
+      expect(normalized, path).toMatch(/no post-power-loss durability guarantee/);
+      expect(document, path).toContain("fsync");
       expect(document, path).toContain("manually");
       expect(document, path).toContain("alive");
     }

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -46,6 +46,42 @@ describe("release readiness docs", () => {
     expect(JSON.parse(await read("package.json")).engines.node).toBe(">=24.2 <25");
   });
 
+  it("documents the authenticated private binary release contract", async () => {
+    const [readme, install, development, singleBinary, homebrew] = await Promise.all(
+      [
+        "README.md",
+        "docs/install.md",
+        "docs/development.md",
+        "docs/single-binary.md",
+        "docs/homebrew.md",
+      ].map(read),
+    );
+    const packageJson = JSON.parse(await read("package.json"));
+
+    expect(readme).toContain("authenticated private binary");
+    expect(readme).toContain("without Node.js, pnpm, Bun");
+    expect(install).toContain("latest stable release");
+    expect(install).toContain("--version v0.1.1-rc.1");
+    expect(install).toContain("SHA256SUMS");
+    expect(install).toContain("stn-tmux-popup");
+    for (const target of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]) {
+      expect(singleBinary).toContain(target);
+    }
+    expect(singleBinary).toContain("**Status: implemented.**");
+    expect(singleBinary).toContain("release **draft**");
+    expect(singleBinary).toContain("GitHub immutable");
+    expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
+    expect(singleBinary).toContain("without `+` build metadata");
+    expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
+    expect(development).toContain("HOST_UPGRADE_BLOCKED");
+    expect(homebrew).toContain("`workflow_dispatch` only");
+    expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");
+    expect(packageJson.scripts["smoke:install"]).toBe(
+      "node scripts/test-runners/run-install-smoke.mjs",
+    );
+    expect(packageJson.scripts["test:all"]).toContain("pnpm smoke:install");
+  });
+
   it("does not advertise removed Crush harness surfaces", async () => {
     const files = ["README.md", "AGENTS.md", ...(await markdownFiles("docs"))];
 

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -47,21 +47,24 @@ describe("release readiness docs", () => {
   });
 
   it("documents the authenticated private binary release contract", async () => {
-    const [readme, install, development, singleBinary, homebrew] = await Promise.all(
-      [
-        "README.md",
-        "docs/install.md",
-        "docs/development.md",
-        "docs/single-binary.md",
-        "docs/homebrew.md",
-      ].map(read),
-    );
+    const [readme, install, development, singleBinary, homebrew, release, promote] =
+      await Promise.all(
+        [
+          "README.md",
+          "docs/install.md",
+          "docs/development.md",
+          "docs/single-binary.md",
+          "docs/homebrew.md",
+          ".github/workflows/release.yml",
+          ".github/workflows/promote-release.yml",
+        ].map(read),
+      );
     const packageJson = JSON.parse(await read("package.json"));
 
     expect(readme).toContain("authenticated private binary");
     expect(readme).toContain("without Node.js, pnpm, Bun");
-    expect(install).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.1.1-rc.1");
+    expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
+    expect(install).toContain("tag=v0.7.0");
     expect(install).toContain('-f ref="$tag"');
     expect(install).toContain('sh "$installer" --version "$tag"');
     expect(readme).toContain('-f ref="$tag"');
@@ -77,6 +80,26 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
+    expect(development).toContain("accepted-release-candidate-0.7.0");
+    expect(release).toContain('-f ref="$COMMIT"');
+    expect(release).toContain("persist-credentials: false");
+    expect(release).toContain("accepted-release-candidate-");
+    const installDraft = release.slice(
+      release.indexOf("  install-draft:"),
+      release.indexOf("  record-accepted-candidate:"),
+    );
+    const recordCandidate = release.slice(release.indexOf("  record-accepted-candidate:"));
+    for (const job of [installDraft, recordCandidate]) {
+      expect(job).toContain("contents: read");
+      expect(job).not.toContain("contents: write");
+    }
+    expect(promote).toContain("workflow_dispatch");
+    expect(promote).toContain("manual_acceptance");
+    expect(promote).toContain("asset-ids.txt");
+    expect(promote).toContain("actions/workflows/$workflow_id");
+    expect(promote).toContain("compare/$commit...main");
+    expect(promote).toContain('prerelease="$expected_prerelease"');
+    expect(packageJson.version).toBe("0.7.0");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");
@@ -96,10 +119,11 @@ describe("release readiness docs", () => {
     for (const [path, document] of documents) {
       const normalized = document.replace(/\s+/g, " ");
       expect(document, path).toContain("<install-dir>/.station-install.lock");
-      expect(document, path).toContain("<install-dir>/.station-install.lock/owner");
+      expect(document, path).toContain("<install-dir>/.station-install.lock/owner-*");
       expect(document, path).toContain("<data-home>/station/.station-install.lock");
-      expect(document, path).toContain("<data-home>/station/.station-install.lock/owner");
+      expect(document, path).toContain("<data-home>/station/.station-install.lock/owner-*");
       expect(normalized, path).toContain("requested tag or `latest`");
+      expect(document, path).toContain("token");
       expect(document, path).toMatch(/10(?:-second| seconds)/);
       expect(document, path).toMatch(/existing\s+Station\s+installation\s+was\s+unchanged/);
       expect(document, path).toContain("sole runtime commit point");
@@ -120,7 +144,7 @@ describe("release readiness docs", () => {
     for (const acceptance of [
       "terminal A",
       "terminal B",
-      "RC → stable → RC",
+      "accepted-release-candidate",
       "command-not-found",
       "Ctrl-C",
       "Ctrl-Z",
@@ -128,7 +152,7 @@ describe("release readiness docs", () => {
       "stn-ingress",
       "HOST_UPGRADE_BLOCKED",
       "same Observer socket",
-      "explicit rollback check",
+      "second binary release",
     ]) {
       expect(normalizedDevelopment).toContain(acceptance);
     }

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -90,6 +90,7 @@ describe("setup core flow e2e", () => {
         ...process.env,
         HOME: home,
         PNPM_HOME: pnpmHome,
+        XDG_RUNTIME_DIR: runtimeDir,
         XDG_CONFIG_HOME: join(root, "xdg-config"),
         XDG_DATA_HOME: join(root, "xdg-data"),
         XDG_CACHE_HOME: join(root, "xdg-cache"),

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -90,7 +90,6 @@ describe("setup core flow e2e", () => {
         ...process.env,
         HOME: home,
         PNPM_HOME: pnpmHome,
-        XDG_RUNTIME_DIR: runtimeDir,
         XDG_CONFIG_HOME: join(root, "xdg-config"),
         XDG_DATA_HOME: join(root, "xdg-data"),
         XDG_CACHE_HOME: join(root, "xdg-cache"),


### PR DESCRIPTION
## Summary

- add the authenticated private installer for `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`
- package and verify native archives plus `SHA256SUMS`, exercise draft assets through the real installer, and keep the source/runtime baseline at `v0.7.0`
- add manual promotion that binds the accepted candidate to the canonical release workflow, workflow run and head SHA, current-main ancestry, tag commit, draft release ID, asset IDs, hashes, and prerelease semantics
- expand standard CI with native binary, installer, Station Bun, and PTY lanes
- harden upgrade continuity, interruption recovery, lock ownership, archive validation, and rollback behavior

## Review fixes

- lock ownership uses a unique `owner-*` pathname and inode checks before cleanup, so an old process cannot remove a replacement owner's lock
- uncertain or abandoned locks remain fail-safe and require explicit inspection/removal
- read-only draft inspection/install jobs use `contents: read`; write permission is limited to draft creation and promotion
- promotion resolves the canonical workflow ID/path and rechecks release/tag/prerelease state after publication
- draft installation fetches the installer at the validated commit SHA and does not persist checkout credentials
- the first binary release remains `v0.7.0`; rollback-to-an-earlier-binary claims are intentionally deferred until a second binary release exists
- no tag or release is created by merging this PR

## Local validation

- complete pre-push-equivalent gate: build, typecheck, lint, 1,327 unit tests, contract tests, 407 integration tests, 41 diagnostics tests, scripted-agent tests, setup E2E, installer smoke, Node/Bun SQLite compatibility, 990 Station tests, 26 PTY tests, native build, and binary smoke
- `pnpm smoke:release`
- installer syntax under `/bin/sh` and `dash`
- workflow YAML parse, release-readiness documentation tests, and `git diff --check`
- independent release/security review: no remaining P0-P2 findings

The local unit files were serialized and the installer harness watchdog was scaled to 10x because this shared host was scheduling-starved; every test remained enabled and the production/default hosted deadlines remain strict.

The fresh hosted run for `8beb2abb7a983651cbb12cfeea434bcc64352b6b` failed all nine jobs in 2-6 seconds with zero steps. GitHub annotated the jobs: “The job was not started because recent account payments have failed or your spending limit needs to be increased.” This is account infrastructure, not a test failure.

## UX / manual verification

Install `v0.7.0` into an isolated HOME, run `stn`, `stn-ingress`, and `stn-tmux-popup`, then retry concurrent and interrupted installs. Verify callers observe only a complete old or new runtime, replacement lock owners survive cleanup, and the real TUI reconnects after an idle upgrade. Promotion remains a separate manual workflow after real-terminal acceptance.

## Deferred

A later binary release can add real previous-version rollback acceptance. Signing/notarization, binary Homebrew distribution, and automatic release promotion remain out of scope.