### PR TITLE
fix(setup): restore launcher and observer activation gates

### DIFF
--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -102,6 +102,7 @@ describe("guided setup command", () => {
           join(packageRoot, "integrations/terminal/tmux/bin/stn-popup"),
         ]),
         fs,
+        activateObserverConfig: noopActivateObserverConfig,
         prompt: {
           async confirm(message: string) {
             return (

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -19,9 +19,13 @@ import { waitForSocketClosed } from "../support/sockets";
 describe("setup core flow e2e", () => {
   it("bootstraps setup and runs all checkout launchers with the pinned pnpm", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-launcher-install-e2e-"));
+    const home = join(root, "home");
+    const runtimeDir = await mkdtemp(join(tmpdir(), "stn-r-"));
+    const observerSocket = join(runtimeDir, "station", "observer.sock");
+    const fallbackObserverSocket = join(home, ".local/state/station/run/observer.sock");
+    let passed = false;
     try {
       const repoRoot = process.cwd();
-      const home = join(root, "home");
       const pnpmHome = join(root, "pnpm-home");
       const bin = join(root, "bin");
       const pnpmBin = run("/bin/sh", ["-c", "command -v pnpm"], {
@@ -90,6 +94,7 @@ describe("setup core flow e2e", () => {
         XDG_DATA_HOME: join(root, "xdg-data"),
         XDG_CACHE_HOME: join(root, "xdg-cache"),
         XDG_STATE_HOME: join(root, "xdg-state"),
+        XDG_RUNTIME_DIR: runtimeDir,
         COREPACK_HOME: join(root, "corepack"),
         PATH: `${join(pnpmHome, "bin")}:${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
         NO_COLOR: "1",
@@ -125,6 +130,15 @@ describe("setup core flow e2e", () => {
       expect(setup.stdout).toContain("Core setup complete.");
       await expect(readFile(configPath, "utf8")).resolves.toContain("[harness.codex]");
 
+      const observer = createObserverClient({ socketPath: observerSocket, timeoutMs: 1000 });
+      const health = await observer.health();
+      const snapshot = await observer.getSnapshot();
+      expect(health.pid).toBeTypeOf("number");
+      expect(snapshot.projects).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: "project" })]),
+      );
+      expect(snapshot.counts.projects).toBe(1);
+
       const ingress = run("stn-ingress", [], { cwd: root, env, allowFailure: true });
       expect(ingress.status).toBe(1);
       expect(ingress.stderr).toContain("Usage: stn-ingress [options] <provider> [event]");
@@ -139,8 +153,15 @@ describe("setup core flow e2e", () => {
         },
       });
       expect(popup.stdout.trim()).toBe("stn-tmux-popup ok");
+      passed = true;
     } finally {
-      await rm(root, { recursive: true, force: true });
+      await stopObserverCandidates([observerSocket, fallbackObserverSocket]);
+      if (passed || process.env.STATION_KEEP_SETUP_E2E_TEMP !== "1") {
+        await Promise.all([
+          rm(root, { recursive: true, force: true }),
+          rm(runtimeDir, { recursive: true, force: true }),
+        ]);
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- restore the guided launcher-fallback regression fixture without weakening mandatory Observer activation
- give the launcher-install E2E a short isolated runtime socket
- verify the activated production Observer serves health and snapshot requests, then stop and clean it

## Root cause

PR #95 and PR #96 were sibling changes that were merged without adapting the new launcher fixtures to mandatory post-write activation.

- The guided unit fixture writes through a fake filesystem, but omitted the injected activation adapter. Production already prints `STATION launcher link failed. Continuing with checkout launcher paths.` and continues; the test failed only when real config loading could not see its fake write.
- The launcher E2E omitted `XDG_RUNTIME_DIR`. Its isolated HOME produced a 128-byte Darwin Unix socket path, so the compiled Observer reached SQLite initialization and handler registration, then failed protocol-server bind. The installed package and all three launcher shims resolved to this checkout.

## UX

A failed global launcher install remains nonfatal, while a completed config write still requires successful Observer activation. The launcher-install E2E now proves `stn`, `stn-ingress`, and `stn-tmux-popup` plus Observer health and snapshot behavior.

Manual check: run setup with isolated `HOME`, `PNPM_HOME`, and a short `XDG_RUNTIME_DIR`; `stn doctor` should report `SQLite is healthy.` and `stn snapshot --json` should return the configured project.

## Validation

- both focused red-first reproductions
- full `apps/cli/test/unit/setup-guided.test.ts`
- `pnpm test:e2e:setup` (including production SQLite restart smoke)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- isolated-home `pnpm test:all` with Vitest workers capped at 4 for local CPU contention
- isolated `HOME`/`PNPM_HOME` bootstrap, all three launchers, setup activation, SQLite doctor check, snapshot, stop, and cleanup
- `git diff --check`

Binary build/smoke was not required because launcher wrappers and binary resolution did not change.

## External blocker

GitHub Actions billing is an external account issue and is intentionally not addressed by this code change. Local code validation is green.