### PR TITLE
fix(codex): align app-server plan attention semantics

### DIFF
--- a/integrations/harness/codex/src/appServer/status.ts
+++ b/integrations/harness/codex/src/appServer/status.ts
@@ -11,6 +11,17 @@ export function statusFromCodexAppServerEvent(
     case "turn-completed":
       return statusFromTurnCompletion(event.turnStatus, observedAt);
     case "item-completed":
+      // Plan updates are progress; Codex reserves completed plan items for proposed plans.
+      if (event.itemType === "plan") {
+        return {
+          value: "needs_attention",
+          confidence: "high",
+          reason: "Codex proposed a plan.",
+          source: "harness_event",
+          updatedAt: observedAt,
+          attention: "plan_approval",
+        };
+      }
       return undefined;
     case "server-request":
       return statusFromServerRequest(event.method, observedAt);

--- a/integrations/harness/codex/test/unit/appServerEvents.test.ts
+++ b/integrations/harness/codex/test/unit/appServerEvents.test.ts
@@ -1,3 +1,4 @@
+import { HarnessEventObservationSchema } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import {
   codexAppServerEventToHarnessEventObservation,
@@ -9,7 +10,22 @@ import { CodexHarnessProviderError } from "../../src/errors";
 const now = "2026-06-17T12:00:00.000Z";
 
 describe("Codex app-server event parsing", () => {
-  it("ignores completed plan items because they do not directly request input", () => {
+  it("maps a completed proposed plan to plan approval attention", () => {
+    expect(
+      codexAppServerEventToHarnessEventObservation(
+        {
+          method: "item/plan/delta",
+          params: {
+            threadId: "thr_plan",
+            turnId: "turn_1",
+            itemId: "item_plan_1",
+            delta: "1. Inspect the code.",
+          },
+        },
+        context(),
+      ),
+    ).toEqual([]);
+
     const event = parseCodexAppServerEvent({
       method: "item/completed",
       params: {
@@ -28,26 +44,54 @@ describe("Codex app-server event parsing", () => {
       kind: "item-completed",
       itemType: "plan",
     });
-    expect(statusFromCodexAppServerEvent(event, now)).toBeUndefined();
+    expect(statusFromCodexAppServerEvent(event, now)).toMatchObject({
+      value: "needs_attention",
+      confidence: "high",
+      reason: "Codex proposed a plan.",
+      attention: "plan_approval",
+    });
 
-    expect(
-      codexAppServerEventToHarnessEventObservation(
-        {
-          method: "item/completed",
-          params: {
-            threadId: "thr_plan",
-            turnId: "turn_1",
-            completedAtMs: 1781712000000,
-            item: {
-              type: "plan",
-              id: "item_plan_1",
-              text: "Plan text must stay provider-local.",
-            },
+    const observations = codexAppServerEventToHarnessEventObservation(
+      {
+        method: "item/completed",
+        params: {
+          threadId: "thr_plan",
+          turnId: "turn_1",
+          completedAtMs: 1781712000000,
+          item: {
+            type: "plan",
+            id: "item_plan_1",
+            text: "Plan text must stay provider-local.",
           },
         },
-        context(),
-      ),
-    ).toEqual([]);
+      },
+      context(),
+    );
+
+    expect(observations).toHaveLength(1);
+    expect(HarnessEventObservationSchema.parse(observations[0])).toEqual(observations[0]);
+    expect(observations[0]).toMatchObject({
+      provider: "codex",
+      sessionId: "ses_web_task",
+      worktreeId: "wt_web_task",
+      harnessRunId: "codex:app-server:thr_plan",
+      nativeSessionId: "thr_plan",
+      rawEventType: "item/completed",
+      status: {
+        value: "needs_attention",
+        source: "harness_event",
+        attention: "plan_approval",
+      },
+      providerData: {
+        transport: "app-server",
+        appServerMethod: "item/completed",
+        codexThreadId: "thr_plan",
+        codexTurnId: "turn_1",
+        codexItemId: "item_plan_1",
+        itemType: "plan",
+      },
+    });
+    expect(JSON.stringify(observations[0]?.providerData)).not.toContain("Plan text");
   });
 
   it("maps thread approval and user-input flags to needs_attention", () => {

--- a/tests/agent/real/codex/codex-app-server-plan.test.ts
+++ b/tests/agent/real/codex/codex-app-server-plan.test.ts
@@ -111,6 +111,7 @@ describeRealCodex("real Codex app-server plan mode", () => {
           value: "needs_attention",
           confidence: "high",
           reason: "Codex proposed a plan.",
+          attention: "plan_approval",
         },
         providerData: {
           transport: "app-server",
@@ -159,6 +160,8 @@ function startCodexAppServer(input: {
   const planRejecters: Array<(reason: unknown) => void> = [];
   let requestId = 0;
   let closed = false;
+  let planObserved = false;
+  let turnCompletedWithoutPlanError: Error | undefined;
 
   child.stderr.setEncoding("utf8");
   child.stderr.on("data", (chunk) => {
@@ -204,10 +207,21 @@ function startCodexAppServer(input: {
           observation.status.reason === "Codex proposed a plan.",
       );
       if (planObservation !== undefined) {
+        planObserved = true;
         for (const resolve of planWaiters.splice(0)) {
           resolve(planObservation);
         }
         planRejecters.length = 0;
+      } else if (message.method === "turn/completed" && !planObserved) {
+        const summary = methods.join(", ");
+        const error = new Error(
+          `Codex turn completed without a plan observation. Methods: ${summary}.\n${stderr()}`,
+        );
+        turnCompletedWithoutPlanError = error;
+        for (const reject of planRejecters.splice(0)) {
+          reject(error);
+        }
+        planWaiters.length = 0;
       }
       return;
     }
@@ -270,6 +284,9 @@ function startCodexAppServer(input: {
     );
     if (existing !== undefined) {
       return Promise.resolve(existing);
+    }
+    if (turnCompletedWithoutPlanError !== undefined) {
+      return Promise.reject(turnCompletedWithoutPlanError);
     }
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {


### PR DESCRIPTION
## What

- map completed Codex App Server `plan` items to `needs_attention` with typed `plan_approval` attention
- keep plan deltas, turn-plan progress, and non-plan completions non-blocking
- make the real plan test fail as soon as `turn/completed` proves no plan observation will arrive

## Why

Codex 0.144.1 streams proposed-plan deltas and then completes a `ThreadItem` with `type: "plan"`. Station parsed that item but discarded it, so a plan-mode turn completed without surfacing the user's decision point. The generated App Server protocol exposes no narrower approval discriminator for completed plan items.

Refs #117.

## UX

A completed Codex plan proposal now raises Station's plan-approval attention instead of leaving the row without the expected needs-attention state.

Manual verification: run the focused real App Server plan test with `STATION_REAL_CODEX=1` and both `STATION_REAL_CLAUDE` and `STATION_CLAUDE_BIN` unset.

## Verification

- focused Codex App Server and ingest-path unit tests: 21/21
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- focused real Codex App Server plan test: 1/1 in 33.1s
- no Claude test, binary, selection, or fallback was invoked
