### PR TITLE
fix(test): use production observer entry for offline hooks

### DIFF
--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { observerSpawnArgv } from "../../../src/observerProcess/spawn.js";
@@ -40,5 +42,14 @@ describe("observer spawn argv", () => {
         execPath: "/opt/station/stn",
       }),
     ).toEqual(["/opt/station/stn", "__observer"]);
+  });
+
+  it("keeps real Worktrunk hook auto-start on the CLI observer entry", async () => {
+    const source = await readFile(
+      resolve(process.cwd(), "tests/e2e/real/real-worktrunk-hooks.test.ts"),
+      "utf8",
+    );
+
+    expect(source).toContain('join(env.repoRoot, "apps", "cli", "dist", "observerMain.js")');
   });
 });

--- a/tests/e2e/real/real-worktrunk-hooks.test.ts
+++ b/tests/e2e/real/real-worktrunk-hooks.test.ts
@@ -166,7 +166,7 @@ async function runWorktrunkIngress(
     ],
     {
       stdin: input.stdin,
-      observerEntryPath: join(env.repoRoot, "apps", "observer", "dist", "runtime", "main.js"),
+      observerEntryPath: join(env.repoRoot, "apps", "cli", "dist", "observerMain.js"),
     },
   );
   return {


### PR DESCRIPTION
## What

- point the real Worktrunk offline-hook fixture at the production CLI Observer entrypoint
- add a deterministic guard that keeps the real helper on `apps/cli/dist/observerMain.js`

## Why

The real test overrode ingress auto-start with `apps/observer/dist/runtime/main.js`. That module deliberately exits when executed directly and directs callers to the CLI composition entrypoint, so online delivery passed while offline auto-start failed health and spooled the hook. The production ingress launcher was already correct.

This is independent of the Step 1 setup-gate restoration in #118. Refs #117.

## UX

No production behavior changes. The real lane now verifies the intended user contract: with hook auto-start enabled, an offline Worktrunk event starts the Observer and returns `ingested` rather than `spooled`.

Manual verification: in an isolated config, stop the Observer, deliver a Worktrunk provider hook with auto-start enabled, then confirm the receipt is `ingested` and `stn doctor` reports a healthy Observer.

## Verification

- deterministic Observer entry/startup units: 22/22
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- focused real Worktrunk offline delivery: 1/1 in 3.7s
- retained failing evidence: `/private/var/folders/2b/yvd22vqx2c95tq_lcsmf5k8w0000gn/T/station-real-e2e-0PWJ4x`
- retained passing evidence: `/private/var/folders/2b/yvd22vqx2c95tq_lcsmf5k8w0000gn/T/station-real-e2e-TSDw8Z` and `.../station-real-e2e-Fsx8uz`
- both Claude variables were unset; no Claude test, binary, selection, or fallback was invoked
