### PR TITLE
fix(test): exercise dashboard lifecycle in real TUI control

### DIFF
--- a/apps/cli/test/unit/real-station-tmux-support.test.ts
+++ b/apps/cli/test/unit/real-station-tmux-support.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RealE2eEnvironment } from "../../../../tests/support/real-station/env.js";
+
+const execFile = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    options: unknown,
+    callback: (error: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    execFile(file, args, options);
+    callback(null, "", "");
+  },
+  spawn: vi.fn(),
+}));
+
+import { startStationTuiInTmux } from "../../../../tests/support/real-station/tmux.js";
+
+describe("real Station tmux support", () => {
+  beforeEach(() => {
+    execFile.mockClear();
+  });
+
+  it("launches the dashboard entry in the captured tmux viewport", async () => {
+    const env: RealE2eEnvironment = {
+      repoRoot: "/repo",
+      stationBin: "/repo/bin/stn",
+      stationIngressBin: "/repo/bin/stn-ingress",
+      tmuxBin: "/opt/homebrew/bin/tmux",
+    };
+
+    await startStationTuiInTmux({
+      env,
+      configPath: "/tmp/station config.toml",
+      sessionName: "station-real-tui",
+    });
+
+    expect(execFile).toHaveBeenCalledWith(
+      "/opt/homebrew/bin/tmux",
+      [
+        "new-session",
+        "-d",
+        "-s",
+        "station-real-tui",
+        "'/repo/bin/stn' --config '/tmp/station config.toml' tui --popup",
+      ],
+      { timeout: 10_000 },
+    );
+  });
+});

--- a/tests/e2e/real/real-tui-control.test.ts
+++ b/tests/e2e/real/real-tui-control.test.ts
@@ -85,7 +85,6 @@ describeReal("real TUI control", () => {
     const row = findRowByBranch(snapshot, branch);
     expect(row.agent).toMatchObject({ harness: "codex" });
 
-    await sendTmuxKeys({ env, target: tuiSession, keys: ["1"] });
     await expect(activeTmuxWindow(env, config.tmuxSession)).resolves.toBe(
       expectedWindowName(config.projectId, branch, row.id, row.path),
     );

--- a/tests/support/real-station/tmux.ts
+++ b/tests/support/real-station/tmux.ts
@@ -106,6 +106,7 @@ export async function startStationTuiInTmux(input: {
     "--config",
     shellQuote(input.configPath),
     "tui",
+    "--popup",
   ].join(" ");
   await execFileAsync(
     requireToolPath(input.env, "tmux"),


### PR DESCRIPTION
## What

- launch the real TUI control fixture with `tui --popup` so tmux captures the dashboard surface
- remove the redundant second key after popup activation has already started and focused the agent
- add a deterministic helper regression for the exact detached-tmux command

## Why

The Observer snapshot contained the expected branch and the 80-column dashboard layout rendered its full label. The test nevertheless launched bare native `tui`, whose active surface is the Station workspace welcome screen, then polled that pane for dashboard text. Once the helper opened the dashboard, the original visibility gate passed; the first numeric activation successfully ran both `session.startAgent` and `terminal.focus` and intentionally closed the popup, making the old second key target stale.

This is a test active-surface/lifecycle mismatch, not a renderer, filtering, reconcile, timeout, or data defect. The full branch assertion remains unchanged. Refs #117.

## UX

The real control lane now exercises the actual popup interaction: the reconciled worktree is visible and one numeric key starts Codex and focuses its tmux workbench.

Manual verification: launch an isolated config with `stn tui --popup`, confirm the branch row is visible, press its number once, and confirm tmux lands on the matching workbench window.

## Verification

- focused tmux/dashboard helper units: 52/52
- CLI TUI integration tests: 20/20
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- focused real TUI control: 1/1 in 3.7s
- retained diagnosis evidence: `/var/folders/2b/yvd22vqx2c95tq_lcsmf5k8w0000gn/T/station-real-e2e-PImwkA`
- retained passing evidence: `/var/folders/2b/yvd22vqx2c95tq_lcsmf5k8w0000gn/T/station-real-e2e-VXu0Cq`
- both Claude variables were unset; no Claude test, binary, selection, or fallback was invoked
