### PR TITLE
fix(test): target real Codex sentinel to active worktree

### DIFF
--- a/apps/cli/test/unit/real-station-codex-support.test.ts
+++ b/apps/cli/test/unit/real-station-codex-support.test.ts
@@ -1,0 +1,24 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createCodexSentinel } from "../../../../tests/support/real-station/codex.js";
+import type { RealTempRepo } from "../../../../tests/support/real-station/repo.js";
+
+describe("real Station Codex support", () => {
+  it("targets an explicit worktree in the prompt and sentinel path", () => {
+    const repo: RealTempRepo = {
+      root: "/tmp/station-real-e2e",
+      repoPath: "/tmp/station-real-e2e/repo",
+      realE2eDir: "/tmp/station-real-e2e/repo/.station-real-e2e",
+      baseBranch: "main",
+      cleanup: async () => undefined,
+    };
+    const targetRoot = "/tmp/station-real-e2e/worktrees/existing";
+
+    const sentinel = createCodexSentinel(repo, "start-agent", targetRoot);
+
+    expect(sentinel.absolutePath).toBe(join(targetRoot, sentinel.relativePath));
+    expect(sentinel.prompt.split("\n")).toContain(
+      `Create or overwrite only ${sentinel.absolutePath}.`,
+    );
+  });
+});

--- a/tests/e2e/real/real-existing-worktree-start-agent.test.ts
+++ b/tests/e2e/real/real-existing-worktree-start-agent.test.ts
@@ -74,7 +74,7 @@ describeReal("real existing Worktrunk worktree start-agent", () => {
     const row = findRowByBranch(before, branch);
     expect(row.agent).toBeUndefined();
 
-    const sentinel = createCodexSentinel(repo, "start-agent");
+    const sentinel = createCodexSentinel(repo, "start-agent", row.path);
     const command: StationCommand = {
       type: "session.startAgent",
       payload: {

--- a/tests/support/real-station/codex.ts
+++ b/tests/support/real-station/codex.ts
@@ -26,15 +26,19 @@ export type CodexHookFixture = {
   cleanup: () => Promise<void>;
 };
 
-export function createCodexSentinel(repo: RealTempRepo, label: string): CodexSentinel {
+export function createCodexSentinel(
+  repo: RealTempRepo,
+  label: string,
+  targetRoot?: string,
+): CodexSentinel {
   const token = `station-real-${label}-${process.pid}-${Date.now()}`;
   const relativePath = `.station-real-e2e/sentinels/${sanitize(label)}-${Date.now()}.txt`;
-  const absolutePath = join(repo.repoPath, relativePath);
+  const absolutePath = join(targetRoot ?? repo.repoPath, relativePath);
   return {
     relativePath,
     absolutePath,
     token,
-    prompt: boundedCodexPrompt(relativePath, token),
+    prompt: boundedCodexPrompt(targetRoot === undefined ? relativePath : absolutePath, token),
   };
 }
 


### PR DESCRIPTION
## What

- Let the real Codex sentinel helper target an explicit worktree with an absolute prompt path.
- Use that target for the existing-Worktrunk start-agent lane without weakening the worktree-local assertion.
- Add a narrow deterministic regression test for the helper contract.

## Why

The final #117 acceptance run on current origin/main exposed a new test-path drift after selecting the compatible Codex 0.144.1 binary: Codex completed successfully but placed the relative sentinel under the clone root, while the test correctly waited under the active Worktrunk worktree. An explicit target removes model path interpretation from this infrastructure assertion.

Refs #117.

## Verification

- Focused unit regression: 1/1
- Focused real existing-worktree start-agent test: 1/1 in 10.3 seconds
- pnpm build
- pnpm typecheck
- pnpm lint
- git diff --check
- STATION_REAL_CLAUDE and STATION_CLAUDE_BIN explicitly unset; no Claude test or binary selected

## UX

Starting Codex in an existing Worktrunk worktree is verified against that exact worktree. Manually verify by running only real-existing-worktree-start-agent.test.ts and confirming the sentinel is created beneath the observed row path.