### PR TITLE
fix(runtime): align 0.7.0 identity and validation gates

### DIFF
--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-dev", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.0", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,6 +43,19 @@ It runs build, typecheck, lint, unit tests, contract tests, integration tests,
 diagnostics tests, the scripted-agent lane, setup E2E coverage, and a production
 Observer SQLite restart smoke. It intentionally excludes real provider lanes.
 
+After root `pnpm install`, Lefthook runs the broader local gate before pushes:
+
+```bash
+pnpm test:pre-push
+```
+
+In addition to `test:all`, it checks cross-runtime SQLite compatibility, the
+Station renderer, the native PTY implementation, and the compiled binary on
+the developer's current platform. Install both the root pnpm dependencies and
+the `station/` Bun dependencies before pushing. GitHub-hosted CI remains the
+required PR and `main` gate, including cross-platform PTY coverage; the local
+gate is supplementary and can be bypassed with `git push --no-verify`.
+
 Useful focused commands:
 
 ```bash
@@ -60,8 +73,8 @@ pnpm smoke:release
 
 Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
 creates observer databases under Node and Bun, then reopens each database under
-the other runtime to verify the shared SQLite contract and migrations. The
-mandatory `station-bun` CI job runs this gate.
+the other runtime to verify the shared SQLite contract and migrations. Both the
+local pre-push gate and the mandatory hosted `station-bun` job run this check.
 
 For focused Station PTY work, run both implementations explicitly:
 
@@ -94,8 +107,8 @@ binary smoke:
 ```bash
 bun install
 cd ..
-pnpm build:binary -- --version 0.1.0-dev
-pnpm smoke:binary -- --expected-version 0.1.0-dev
+pnpm build:binary -- --version 0.7.0
+pnpm smoke:binary -- --expected-version 0.7.0
 ```
 
 The staged artifact is `station/dist/bin/stn`, with `stn-ingress` and

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -30,8 +30,8 @@ profile { name, state: { platform, xcodeClt, git, insideRepo, brew, worktrunk,
 `apps/cli/test/integration/setup-profiles.test.ts` compiles each profile into the
 real `SetupCommandDeps` seam and runs `runCli([... "setup","check","--json"])`,
 asserting exit code + `requiredOk` + per-check status. Runs in the existing
-`pnpm test:integration` lane (so it is already in `standard-ci.yml` and
-`pnpm test:all`). This is the backbone and the canonical contract; it covers every
+`pnpm test:integration` lane (so it is already in `pnpm test:all`, the
+pre-push gate, and hosted CI). This is the backbone and the canonical contract; it covers every
 profile, including the darwin `no-xcode-clt` case via an injected `platform`.
 
 ```bash

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -134,7 +134,7 @@ stn (bun build --compile, per platform, no ambient env)
   fire.)
 - **Runtime-mode seam** `packages/runtime/src/buildInfo.ts`: build-time
   defines `STATION_BUILD_VERSION` / `STATION_BUILD_COMPILED` behind `typeof`
-  guards; dev tsc reports `{ version: "0.0.0-dev", compiled: false }`.
+  guards; dev tsc reports `{ version: "0.7.0", compiled: false }`.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -243,11 +243,11 @@ through a **ctty helper** (S2, F6): `setsid()`,
 `ioctl(STDIN_FILENO, TIOCSCTTY)`, `execvp(payload)`.
 
 A2a checks in one portable POSIX C source. `bun run build:ctty-helper` uses the
-target's native `cc` to write the ignored development/CI executable at
+target's native `cc` to write the ignored development executable at
 `station/dist/ctty-helper`; no built helper is committed. Platform headers
 supply `TIOCSCTTY`, so TypeScript contains no platform ioctl constants. The
-four-target `station-pty` CI matrix compiles that same source natively on
-linux-x64, linux-arm64, darwin-x64, and darwin-arm64.
+pre-push gate compiles and tests that source natively on the developer's current
+platform, while hosted CI covers Linux and macOS across x64 and arm64.
 The helper stays C because it is a small direct wrapper over POSIX `setsid`,
 `ioctl`, and `execvp`; Zig or Rust would add a build toolchain without improving
 that boundary.
@@ -325,14 +325,14 @@ A4 owns the packaged helper lifecycle that A2a deliberately leaves out:
   may reload its extension path. Pi pruning waits for provider-process lifetime
   ownership rather than risking a live session.
 
-CI `binary-smoke` (ubuntu): `--version`, `--help`, popup argv0 routing,
+Local pre-push and hosted `binary-smoke` checks: `--version`, `--help`, popup argv0 routing,
 `setup check --json`
 (asserting the `launchReady`/`workflowReady` split), an **observer round
 trip through the binary** in an isolated state dir, an ingress receipt via
 the `stn-ingress` symlink, the **hostile-directory RCE test** (F1), and the
-**detached self-spawn** check (folds in S5). The four-target PTY matrix also
-builds the native binary and proves the unset compiled selector launches a
-payload through the extracted helper. `observerReap.ts` and the same-TTY UI
+**detached self-spawn** check (folds in S5). The native PTY test also proves the
+unset compiled selector launches a payload through the extracted helper on the
+current platform. `observerReap.ts` and the same-TTY UI
 reaper recognize the exact compiled process shapes.
 
 ### A5 — release pipeline (private, deterministic, verifiable)
@@ -342,7 +342,7 @@ reaper recognize the exact compiled process shapes.
 Requirements v1 omitted:
 
 - **Reuse the existing gate**: tag builds must run the same deterministic
-  checks as `standard-ci` + `pnpm smoke:release`, not bypass them.
+  checks as hosted `standard-ci` + `pnpm smoke:release`, not bypass them.
 - **Checksums**: emit `SHA256SUMS`, sign or at least publish it; the
   install script verifies each artifact against it before extraction.
 - **License**: include `LICENSE` in every archive (F9 / LICENSE:67).

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,3 +2,8 @@ pre-commit:
   commands:
     biome:
       run: pnpm lint
+
+pre-push:
+  commands:
+    test:
+      run: pnpm test:pre-push

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",
@@ -15,6 +15,7 @@
     "pnpm": "11.0.0"
   },
   "scripts": {
+    "prepare": "lefthook install",
     "build": "turbo run build",
     "build:binary": "bun scripts/build-binary.mjs",
     "setup:system": "scripts/setup/setup-system-dependencies.sh",
@@ -59,7 +60,8 @@
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
-    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup"
+    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup",
+    "test:pre-push": "pnpm test:all && pnpm test:sqlite:bun && pnpm --dir station typecheck && pnpm --dir station test && pnpm --dir station test:pty:bun && pnpm build:binary -- --version 0.0.0-local && pnpm smoke:binary -- --expected-version 0.0.0-local"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -8,7 +8,7 @@ export type StationBuildInfo = {
 
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-dev" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.0" : STATION_BUILD_VERSION,
     compiled: typeof STATION_BUILD_COMPILED === "undefined" ? false : STATION_BUILD_COMPILED,
   };
 }

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -3,7 +3,7 @@ import { isCompiledBinary, stationBuildInfo } from "../../src/buildInfo.js";
 
 describe("station build info", () => {
   it("reports the source-mode defaults when compile-time defines are absent", () => {
-    expect(stationBuildInfo()).toEqual({ version: "0.0.0-dev", compiled: false });
+    expect(stationBuildInfo()).toEqual({ version: "0.7.0", compiled: false });
     expect(isCompiledBinary()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- align the root package and source-mode Station runtime identity to `0.7.0`
- retain the full Lefthook pre-push gate as a local supplement to mandatory hosted CI
- install Lefthook during root dependency preparation
- document the local/current-platform and hosted/cross-platform validation boundaries accurately

The hosted workflows are already present on current `main`; the branch was rebased and squashed so it no longer carries the stale delete/restore history.

## Validation

- isolated-HOME `pnpm test:pre-push`
  - root build, typecheck, lint, unit, contract, integration, diagnostics, scripted-agent, and setup E2E gates
  - Node/Bun SQLite compatibility
  - Station typecheck and 990 renderer tests
  - native Bun PTY tests
  - compiled binary smoke
- `git diff --check`

## UX

Source-mode `stn --version` and Observer health now report `0.7.0`. After `pnpm install`, pushes run the broader local gate; verify manually with `pnpm stn --version` and `pnpm test:pre-push`.