### PR TITLE
feat(observer): publish durable singleton identity

### DIFF
--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -8,6 +8,7 @@ import {
   loadConfig,
   type StationConfig,
 } from "@station/config";
+import type { ObserverApi, ObserverProcessIdentity, ObserverStopReceipt } from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { stationBuildInfo, systemClock, toIsoTimestamp } from "@station/runtime";
 import { createCommandQueue } from "../commands/queue.js";
@@ -26,9 +27,15 @@ import { createObserverApi } from "./api.js";
 import { createObserverEventBus } from "./eventBus.js";
 import { runShutdownWithBackstop } from "./gracefulExit.js";
 import { createObserverLogger } from "./logging.js";
+import {
+  createObserverProcessIdentity,
+  publishObserverProcessIdentity,
+  removeObserverProcessIdentity,
+} from "./observerPidfile.js";
 import { type ObserverServer, startObserverServer } from "./server.js";
 import {
   readSocketIdentity,
+  type SocketIdentity,
   type SocketOwnershipWatch,
   watchSocketOwnership,
 } from "./socketOwnership.js";
@@ -55,10 +62,8 @@ export type RunObserverMainDeps = {
  * COMPOSITION ROOT
  *
  * Builds the process-lifetime Observer runtime around provider adapters
- * supplied by awaited CLI composition.
- *
- * Shutdown owns the command queue, event hook, server, and SQLite lifecycles
- * created here.
+ * supplied by awaited CLI composition, including socket identity publication,
+ * health readiness, and shutdown of the services created here.
  */
 export async function runObserverMain(
   argv = process.argv.slice(2),
@@ -96,6 +101,7 @@ export async function runObserverMain(
   const persistence = createSqliteObserverPersistence({ sqlite, clock: systemClock });
   const eventBus = createObserverEventBus();
   const logger = createObserverLogger({ stateDir, clock: systemClock });
+  const buildVersion = stationBuildInfo().version;
   const pruneAt = toIsoTimestamp(systemClock.now());
   await persistence.pruneExpiredProviderObservations(pruneAt);
   const commandQueue = createCommandQueue({ persistence, clock: systemClock, eventBus, logger });
@@ -113,7 +119,7 @@ export async function runObserverMain(
     clock: systemClock,
     logger,
     featureFlags,
-    version: stationBuildInfo().version,
+    version: buildVersion,
   });
   registerObserverCommandHandlers({
     queue: commandQueue,
@@ -132,30 +138,86 @@ export async function runObserverMain(
 
   let server: ObserverServer | undefined;
   let ownership: SocketOwnershipWatch | undefined;
+  let ownsSocket = false;
+  let boundSocketIdentity: SocketIdentity | undefined;
+  let processIdentity: ObserverProcessIdentity | undefined;
+  const startupGate = createObserverStartupGate();
   let stopResolve: () => void = () => undefined;
   const stopped = new Promise<void>((resolve) => {
     stopResolve = resolve;
   });
   let stopping: Promise<void> | undefined;
-  const stopObserver = async () => {
+  let stopReceipt: Promise<ObserverStopReceipt> | undefined;
+  let observerApi: ObserverApi;
+  let shutdownExitCode = 0;
+  const stopObserver = async (exitCode = 0) => {
+    shutdownExitCode = Math.max(shutdownExitCode, exitCode);
     stopping ??= runShutdownWithBackstop(
       async () => {
+        let shutdownError: unknown;
+        stopReceipt ??= (async () => {
+          // Publication must settle before cleanup so a pre-ready stop cannot leave a late pidfile behind.
+          await startupGate.waitUntilSettled();
+          return observerApi.stop();
+        })();
+        try {
+          await stopReceipt;
+        } catch (error) {
+          shutdownError = error;
+        }
+        try {
+          await commandQueue.shutdown();
+        } catch (error) {
+          shutdownError ??= error;
+        }
+        try {
+          await eventHooks?.shutdown();
+        } catch (error) {
+          shutdownError ??= error;
+        }
+        // Cleanup is ownership-checked so a displaced Observer cannot delete its successor's pidfile.
+        const currentSocketIdentity = await readSocketIdentity(socketPath);
+        const stillOwnsSocket =
+          ownsSocket &&
+          boundSocketIdentity !== undefined &&
+          currentSocketIdentity?.ino === boundSocketIdentity.ino &&
+          currentSocketIdentity.birthtimeNs === boundSocketIdentity.birthtimeNs;
+        ownsSocket = stillOwnsSocket;
+        if (stillOwnsSocket && processIdentity !== undefined) {
+          try {
+            await removeObserverProcessIdentity(processIdentity);
+          } catch (error) {
+            await logger
+              .warn("Observer process identity could not be removed during shutdown.", {
+                socketPath,
+                pid: processIdentity.pid,
+                error,
+              })
+              .catch(() => undefined);
+          }
+        }
         ownership?.stop();
-        await commandQueue.shutdown();
-        await eventHooks?.shutdown();
-        await server?.close();
+        try {
+          await server?.close();
+        } catch (error) {
+          shutdownError ??= error;
+        }
+        ownsSocket = false;
         stopResolve();
+        if (shutdownError !== undefined) {
+          throw shutdownError;
+        }
       },
       STOP_BACKSTOP_MS,
       {
-        exit: (code) => process.exit(code),
+        exit: () => process.exit(shutdownExitCode),
         setTimer: (fn, ms) => setTimeout(fn, ms),
         clearTimer: (timer) => clearTimeout(timer as NodeJS.Timeout),
       },
     );
     await stopping;
   };
-  const api = createObserverApi({
+  observerApi = createObserverApi({
     core,
     providers,
     persistence,
@@ -172,60 +234,94 @@ export async function runObserverMain(
     configDiagnostics: loadedConfig.diagnostics,
     clock: systemClock,
     logger,
-    onStop: () => {
-      setTimeout(() => {
-        void stopObserver();
-      }, 0);
-    },
   });
+  const api: ObserverApi = {
+    ...observerApi,
+    health: () => startupGate.runHealth(observerApi.health),
+    stop: async () => {
+      startupGate.requestStop();
+      const shutdown = stopObserver();
+      void shutdown.catch((error) =>
+        logger.error("Observer shutdown failed.", { socketPath, error }).catch(() => undefined),
+      );
+      if (stopReceipt === undefined) {
+        throw new Error("Observer shutdown did not initialize.");
+      }
+      return stopReceipt;
+    },
+  };
 
+  let shouldReconcile = false;
   try {
-    // Bind only; the startup reconcile runs below, after the ownership watch is
-    // armed, so a takeover during that ~1s scan is detected rather than missed.
+    // Only the successful socket binder may publish identity, and publication must finish before health responds.
     server = await startObserverServer({
       socketPath,
       api,
       clock: systemClock,
       drainOnStart: false,
     });
+    ownsSocket = true;
+    const boundIdentity = await readSocketIdentity(socketPath);
+    if (boundIdentity === undefined) {
+      throw new Error(`Could not capture the bound Observer socket identity at ${socketPath}.`);
+    }
+    boundSocketIdentity = boundIdentity;
+    processIdentity = createObserverProcessIdentity({
+      pid: process.pid,
+      version: buildVersion,
+      socketPath,
+    });
+    await publishObserverProcessIdentity(processIdentity);
+    // Seed the watcher with the just-bound socket identity so it never adopts a
+    // rival's socket as its baseline (the failure that let displaced observers linger).
+    ownership = watchSocketOwnership({
+      socketPath,
+      expectedIdentity: boundIdentity,
+      onLost: () => {
+        ownsSocket = false;
+        void logger.warn("Observer socket was taken over by another process; shutting down.", {
+          socketPath,
+          pid: process.pid,
+        });
+        // A displaced observer must not linger: its loops would keep draining
+        // spool events and firing hooks for a state dir it no longer serves.
+        // stopObserver's backstop guarantees the exit even if the drain hangs.
+        void api.stop();
+      },
+    });
+    shouldReconcile = startupGate.settleReady();
   } catch (error) {
-    await logger.error("Observer server could not start; shutting down runtime services.", {
+    startupGate.settleFailed();
+    shutdownExitCode = 1;
+    await logger.error("Observer startup failed; shutting down runtime services.", {
       socketPath,
       error,
     });
-    // Services started before the bind (command queue, event hooks) hold live
-    // timers; without teardown + forced exit a failed-bind observer lingers as
-    // a spool-stealing zombie that never owned the socket.
-    await stopObserver();
-    sqlite.close();
+    try {
+      await stopObserver(1);
+    } catch (shutdownError) {
+      await logger
+        .warn("Observer startup cleanup could not close every runtime service.", {
+          socketPath,
+          error: shutdownError,
+        })
+        .catch(() => undefined);
+    } finally {
+      sqlite.close();
+    }
     setTimeout(() => process.exit(1), 2000).unref();
     return 1;
   }
-  // Seed the watcher with the just-bound socket identity so it never adopts a
-  // rival's socket as its baseline (the failure that let displaced observers linger).
-  const boundIdentity = await readSocketIdentity(socketPath);
-  ownership = watchSocketOwnership({
-    socketPath,
-    ...(boundIdentity === undefined ? {} : { expectedIdentity: boundIdentity }),
-    onLost: () => {
-      void logger.warn("Observer socket was taken over by another process; shutting down.", {
-        socketPath,
-        pid: process.pid,
-      });
-      // A displaced observer must not linger: its loops would keep draining
-      // spool events and firing hooks for a state dir it no longer serves.
-      // stopObserver's backstop guarantees the exit even if the drain hangs.
+  if (shouldReconcile) {
+    const stopFromSignal = () => {
       void api.stop();
-    },
-  });
-  const stopFromSignal = () => {
-    void api.stop();
-  };
-  process.once("SIGINT", stopFromSignal);
-  process.once("SIGTERM", stopFromSignal);
+    };
+    process.once("SIGINT", stopFromSignal);
+    process.once("SIGTERM", stopFromSignal);
 
-  // Startup reconcile now that the ownership watch is live.
-  await api.reconcile("observer.startup");
+    // Startup reconcile now that the ownership watch is live.
+    await api.reconcile("observer.startup");
+  }
 
   await stopped;
   sqlite.close();
@@ -302,4 +398,59 @@ function resolvePath(input: string, homeDir: string): string {
   const expanded =
     input === "~" ? homeDir : input.startsWith("~/") ? join(homeDir, input.slice(2)) : input;
   return isAbsolute(expanded) ? resolve(expanded) : resolve(process.cwd(), expanded);
+}
+
+type ObserverStartupGate = {
+  requestStop(): void;
+  settleReady(): boolean;
+  settleFailed(): void;
+  waitUntilSettled(): Promise<void>;
+  runHealth<T>(operation: () => Promise<T>): Promise<T>;
+};
+
+export function createObserverStartupGate(): ObserverStartupGate {
+  let state: "starting" | "ready" | "stopping" | "failed" = "starting";
+  let release: () => void = () => undefined;
+  let ready = pending();
+  let settleStartup: () => void = () => undefined;
+  const startupSettled = new Promise<void>((resolve) => {
+    settleStartup = resolve;
+  });
+
+  function pending(): Promise<void> {
+    return new Promise((resolve) => {
+      release = resolve;
+    });
+  }
+
+  return {
+    requestStop: () => {
+      if (state === "stopping" || state === "failed") return;
+      if (state === "ready") ready = pending();
+      state = "stopping";
+    },
+    settleReady: () => {
+      if (state !== "starting") {
+        settleStartup();
+        return false;
+      }
+      state = "ready";
+      release();
+      settleStartup();
+      return true;
+    },
+    settleFailed: () => {
+      if (state === "starting") state = "failed";
+      settleStartup();
+    },
+    waitUntilSettled: () => startupSettled,
+    runHealth: async <T>(operation: () => Promise<T>): Promise<T> => {
+      for (;;) {
+        await ready;
+        if (state !== "ready") continue;
+        const result = await operation();
+        if (state === "ready") return result;
+      }
+    },
+  };
 }

--- a/apps/observer/src/runtime/observerPidfile.ts
+++ b/apps/observer/src/runtime/observerPidfile.ts
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { type FileHandle, link, open, readFile, rename, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { type ObserverProcessIdentity, ObserverProcessIdentitySchema } from "@station/contracts";
+
+export type CreateObserverProcessIdentityOptions = {
+  pid: number;
+  version: string;
+  socketPath: string;
+};
+
+function readOsStartTime(pid: number): string {
+  const psPath = process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps";
+  const osStartTime = execFileSync(psPath, ["-ww", "-p", String(pid), "-o", "lstart="], {
+    encoding: "utf8",
+  }).trim();
+  if (osStartTime.length === 0) {
+    throw new Error(`Could not determine the OS start time for process ${pid}.`);
+  }
+  return osStartTime;
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const directory = await open(path, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+function identitiesMatch(
+  actual: ObserverProcessIdentity,
+  expected: ObserverProcessIdentity,
+): boolean {
+  return (
+    actual.pid === expected.pid &&
+    actual.osStartTime === expected.osStartTime &&
+    actual.version === expected.version &&
+    actual.socketPath === expected.socketPath
+  );
+}
+
+function isMissingFile(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null | undefined)?.code === "ENOENT";
+}
+
+function isExistingFile(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null | undefined)?.code === "EEXIST";
+}
+
+async function restoreClaimedIdentity(claimedPath: string, path: string): Promise<void> {
+  try {
+    await link(claimedPath, path);
+  } catch (error) {
+    if (!isExistingFile(error)) {
+      throw error;
+    }
+  }
+  await unlink(claimedPath);
+  await syncDirectory(dirname(path));
+}
+
+export function observerPidfilePath(socketPath: string): string {
+  return `${socketPath}.pid`;
+}
+
+export function createObserverProcessIdentity(
+  options: CreateObserverProcessIdentityOptions,
+): ObserverProcessIdentity {
+  return ObserverProcessIdentitySchema.parse({
+    pid: options.pid,
+    osStartTime: readOsStartTime(options.pid),
+    version: options.version,
+    socketPath: options.socketPath,
+  });
+}
+
+export async function publishObserverProcessIdentity(
+  identity: ObserverProcessIdentity,
+): Promise<void> {
+  const parsedIdentity = ObserverProcessIdentitySchema.parse(identity);
+  const path = observerPidfilePath(parsedIdentity.socketPath);
+  const directory = dirname(path);
+  const temporaryPath = join(directory, `.observer.pid.${process.pid}.${randomUUID()}.tmp`);
+  let temporaryFile: FileHandle | undefined;
+  try {
+    temporaryFile = await open(temporaryPath, "wx", 0o600);
+    await temporaryFile.chmod(0o600);
+    await temporaryFile.writeFile(`${JSON.stringify(parsedIdentity)}\n`, "utf8");
+    await temporaryFile.sync();
+    await temporaryFile.close();
+    temporaryFile = undefined;
+    await rename(temporaryPath, path);
+    await syncDirectory(directory);
+  } catch (error) {
+    await temporaryFile?.close().catch(() => undefined);
+    await unlink(temporaryPath).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function readObserverProcessIdentity(
+  socketPath: string,
+): Promise<ObserverProcessIdentity | undefined> {
+  try {
+    const serialized = await readFile(observerPidfilePath(socketPath), "utf8");
+    return ObserverProcessIdentitySchema.parse(JSON.parse(serialized));
+  } catch (error) {
+    if (isMissingFile(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+export async function removeObserverProcessIdentity(
+  expectedIdentity: ObserverProcessIdentity,
+): Promise<boolean> {
+  const path = observerPidfilePath(expectedIdentity.socketPath);
+  const claimedPath = join(dirname(path), `.observer.pid.${process.pid}.${randomUUID()}.remove`);
+  try {
+    await rename(path, claimedPath);
+  } catch (error) {
+    if (isMissingFile(error)) {
+      return false;
+    }
+    throw error;
+  }
+
+  let currentIdentity: ObserverProcessIdentity;
+  try {
+    currentIdentity = ObserverProcessIdentitySchema.parse(
+      JSON.parse(await readFile(claimedPath, "utf8")),
+    );
+  } catch (error) {
+    try {
+      await restoreClaimedIdentity(claimedPath, path);
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        "Observer process identity could not be parsed or restored.",
+      );
+    }
+    throw error;
+  }
+
+  if (!identitiesMatch(currentIdentity, expectedIdentity)) {
+    await restoreClaimedIdentity(claimedPath, path);
+    return false;
+  }
+
+  try {
+    await unlink(claimedPath);
+  } catch (error) {
+    await restoreClaimedIdentity(claimedPath, path).catch(() => undefined);
+    throw error;
+  }
+  await syncDirectory(dirname(path));
+  return true;
+}

--- a/apps/observer/test/unit/observerPidfile.test.ts
+++ b/apps/observer/test/unit/observerPidfile.test.ts
@@ -1,0 +1,186 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import type { ObserverProcessIdentity } from "@station/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createObserverProcessIdentity,
+  observerPidfilePath,
+  publishObserverProcessIdentity,
+  readObserverProcessIdentity,
+  removeObserverProcessIdentity,
+} from "../../src/runtime/observerPidfile.js";
+
+describe("observer pidfile", () => {
+  let dir: string | undefined;
+
+  afterEach(async () => {
+    if (dir !== undefined) {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives a socket-specific pidfile beside the socket", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "runtime", "observer.sock");
+
+    expect(observerPidfilePath(socketPath)).toBe(`${socketPath}.pid`);
+    expect(observerPidfilePath(join(dir, "runtime", "alternate.sock"))).not.toBe(
+      observerPidfilePath(socketPath),
+    );
+  });
+
+  it("builds identity with the trimmed OS start-time token", () => {
+    const socketPath = "/tmp/station/observer.sock";
+    const expectedStartTime = execFileSync(
+      "ps",
+      ["-ww", "-p", String(process.pid), "-o", "lstart="],
+      { encoding: "utf8" },
+    ).trim();
+
+    expect(
+      createObserverProcessIdentity({
+        pid: process.pid,
+        version: "1.2.3",
+        socketPath,
+      }),
+    ).toEqual({
+      pid: process.pid,
+      osStartTime: expectedStartTime,
+      version: "1.2.3",
+      socketPath,
+    });
+  });
+
+  it("reads the OS start-time token without relying on PATH", () => {
+    const savedPath = process.env.PATH;
+    process.env.PATH = "";
+    try {
+      expect(
+        createObserverProcessIdentity({
+          pid: process.pid,
+          version: "1.2.3",
+          socketPath: "/tmp/station/observer.sock",
+        }).osStartTime,
+      ).not.toBe("");
+    } finally {
+      if (savedPath === undefined) delete process.env.PATH;
+      else process.env.PATH = savedPath;
+    }
+  });
+
+  it("atomically publishes a private strict identity beside the socket", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketDir = join(dir, "runtime");
+    const socketPath = join(socketDir, "custom.sock");
+    const identity = processIdentity(socketPath);
+    await mkdir(socketDir);
+    await writeFile(observerPidfilePath(socketPath), "{}\n", { mode: 0o644 });
+
+    await publishObserverProcessIdentity(identity);
+
+    const path = observerPidfilePath(socketPath);
+    expect(await readObserverProcessIdentity(socketPath)).toEqual(identity);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual(identity);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(await readdir(socketDir)).toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+
+  it("removes its temporary file when publication fails", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const path = observerPidfilePath(socketPath);
+    await mkdir(path);
+
+    await expect(publishObserverProcessIdentity(processIdentity(socketPath))).rejects.toThrow();
+
+    expect(await readdir(dir)).toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+
+  it("strictly parses the published identity", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const path = observerPidfilePath(socketPath);
+    const identity = processIdentity(socketPath);
+    await writeFile(path, JSON.stringify({ ...identity, unexpected: true }), { mode: 0o600 });
+
+    await expect(readObserverProcessIdentity(socketPath)).rejects.toThrow();
+  });
+
+  it("returns undefined when no identity has been published", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+
+    await expect(readObserverProcessIdentity(socketPath)).resolves.toBeUndefined();
+  });
+
+  it("removes the pidfile only when every identity field matches", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const identity = processIdentity(socketPath);
+    await publishObserverProcessIdentity(identity);
+
+    await expect(removeObserverProcessIdentity(identity)).resolves.toBe(true);
+    await expect(readObserverProcessIdentity(socketPath)).resolves.toBeUndefined();
+  });
+
+  it("never removes a successor identity published during cleanup", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const identity = processIdentity(socketPath);
+    const successor: ObserverProcessIdentity = {
+      ...identity,
+      pid: identity.pid + 1,
+      osStartTime: "Sat Jul 11 12:35:56 2026",
+    };
+    await publishObserverProcessIdentity(identity);
+
+    await Promise.all([
+      removeObserverProcessIdentity(identity),
+      publishObserverProcessIdentity(successor),
+    ]);
+
+    await expect(readObserverProcessIdentity(socketPath)).resolves.toEqual(successor);
+    await expect(readdir(dir)).resolves.toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+
+  it.each([
+    ["pid", { pid: process.pid + 1 }],
+    ["osStartTime", { osStartTime: "Mon Jan  1 00:00:00 2001" }],
+    ["version", { version: "9.9.9" }],
+    ["socketPath", { socketPath: "/tmp/other/observer.sock" }],
+  ] as const)("leaves the pidfile when %s does not match", async (_field, replacement) => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const expected = processIdentity(socketPath);
+    const current = { ...expected, ...replacement } as ObserverProcessIdentity;
+    await writeFile(observerPidfilePath(socketPath), `${JSON.stringify(current)}\n`, {
+      mode: 0o600,
+    });
+
+    await expect(removeObserverProcessIdentity(expected)).resolves.toBe(false);
+    await expect(readObserverProcessIdentity(socketPath)).resolves.toEqual(current);
+    await expect(readdir(dir)).resolves.toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+
+  it("leaves malformed identity files untouched", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const path = observerPidfilePath(socketPath);
+    await writeFile(path, "{}\n", { mode: 0o600 });
+
+    await expect(removeObserverProcessIdentity(processIdentity(socketPath))).rejects.toThrow();
+    await expect(readFile(path, "utf8")).resolves.toBe("{}\n");
+    await expect(readdir(dir)).resolves.toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+});
+
+function processIdentity(socketPath: string): ObserverProcessIdentity {
+  return {
+    pid: process.pid,
+    osStartTime: "Sat Jul 11 12:34:56 2026",
+    version: "1.2.3",
+    socketPath,
+  };
+}

--- a/apps/observer/test/unit/observerStartupGate.test.ts
+++ b/apps/observer/test/unit/observerStartupGate.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { createObserverStartupGate } from "../../src/runtime/main.js";
+
+describe("observer startup gate", () => {
+  it("keeps a pre-ready stop terminal while allowing shutdown to await startup settlement", async () => {
+    const gate = createObserverStartupGate();
+    let shutdownReleased = false;
+    void gate.waitUntilSettled().then(() => {
+      shutdownReleased = true;
+    });
+
+    gate.requestStop();
+    await Promise.resolve();
+    expect(shutdownReleased).toBe(false);
+
+    expect(gate.settleReady()).toBe(false);
+    await gate.waitUntilSettled();
+    expect(shutdownReleased).toBe(true);
+  });
+
+  it("releases health only when startup becomes ready", async () => {
+    const gate = createObserverStartupGate();
+    const health = vi.fn(async () => "healthy");
+    const healthResult = gate.runHealth(health);
+
+    expect(health).not.toHaveBeenCalled();
+    expect(gate.settleReady()).toBe(true);
+
+    await expect(healthResult).resolves.toBe("healthy");
+    expect(health).toHaveBeenCalledOnce();
+  });
+});

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -131,6 +131,12 @@ The default observer state directory is:
 
 It can be changed through config or observer startup options. The resolver also uses `$XDG_RUNTIME_DIR/station/observer.sock` for the socket when that environment variable is present.
 
+The Observer process-identity file follows the resolved socket rather than the
+state directory. Its path is always `<resolved socketPath>.pid`, including XDG
+and explicit-socket layouts where the socket directory is outside the configured
+state directory. Including the socket filename keeps identities distinct when
+multiple configured sockets share one directory.
+
 Important files and directories:
 
 ```text
@@ -147,6 +153,25 @@ diagnostics/*/logs/observer.jsonl
 diagnostics/panes/
 spool/hooks/
 ```
+
+`observer.sock.pid` is mode `0600` for the default socket and contains exactly:
+
+```json
+{
+  "pid": 12345,
+  "osStartTime": "Sat Jul 11 10:42:03 2026",
+  "version": "0.7.0",
+  "socketPath": "/resolved/socket/directory/observer.sock"
+}
+```
+
+Use this file only to corroborate the identity of the process associated with
+the socket. `lsof -t <resolved-socket-path>` remains the primary process-
+ownership evidence, and a connect or health probe establishes liveness. A
+crash or cleanup failure can leave a stale identity file, so do not signal a
+process or unlink a socket from this file alone. Clean shutdown removes the
+file only when the Observer still owns the socket and every identity field
+matches its published value.
 
 ## Reading Evidence
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -235,6 +235,7 @@ No single layer owns all truth.
 | Provider-owned identity | Worktree, target, harness-run, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
 | Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
+| Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, version, socketPath}` identity published by the process that successfully bound the socket. It corroborates process identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
 | In-memory persistence adapter | Process-local test state that preserves the seven persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
 | `StationSnapshot` | Current normalized graph held in memory. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
 | Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
@@ -268,10 +269,21 @@ Current startup proceeds in this order:
    awaited provider registry.
 5. The API constructs ingress queues, reconcile scheduling, metadata refresh,
    diagnostics dependencies, and spool draining.
-6. The protocol server binds the socket before startup reconcile. A
-   socket-ownership watch is armed so a displaced observer shuts itself down.
-7. Startup reconcile establishes the first provider-backed snapshot. Provider
-   health and harness-version probes fill caches in the background.
+6. The runtime constructs a private startup-and-health gate, then the protocol
+   server binds the resolved socket before startup reconcile. Only the
+   successful socket binder may publish process identity.
+7. The runtime captures the bound-socket identity, atomically publishes and
+   fsyncs `<socketPath>.pid`, then arms the socket-ownership
+   watcher from the captured identity. Identity publication or OS-start-token
+   failure is fatal: health stays gated while the runtime logs the startup
+   failure, tears down its services, socket, and SQLite handle, and exits
+   nonzero.
+8. Health responses are enabled only after pidfile publication and watcher
+   setup complete. Startup reconcile then establishes the first provider-backed
+   snapshot; provider health and harness-version probes fill caches in the
+   background. A stop requested before readiness is terminal: shutdown waits
+   for publication to settle, health remains gated, and startup reconcile is
+   skipped.
 
 Composition must make lifecycle ownership obvious. Anything that owns a timer,
 fiber, watcher, queue, socket, child process, or durable handle must have a
@@ -280,11 +292,19 @@ defined startup failure path and shutdown owner.
 ### Shutdown
 
 The current API stop path drains harness ingress and metadata watchers, then
-schedules process shutdown. Command-queue shutdown rejects new commands,
-aborts running handlers cooperatively, and waits for their per-scope chains;
-configured event hooks and the protocol server then close before SQLite. A
-bounded process backstop prevents a handler that ignores cancellation from
-keeping a displaced or stopped observer alive indefinitely.
+schedules process shutdown. Process shutdown disables health responses first.
+If the process still owns the socket, it conditionally removes only an exact
+matching process identity and syncs the socket directory before the protocol
+server releases the socket. A displaced process marks ownership lost before
+shutdown and leaves a successor's pidfile untouched. Pidfile cleanup failure is
+warned and shutdown continues because a stale corroborating file is safer than
+deleting another process's identity or hanging shutdown.
+
+Command-queue shutdown rejects new commands, aborts running handlers
+cooperatively, and waits for their per-scope chains; configured event hooks and
+the protocol server then close before SQLite. A bounded process backstop
+prevents a handler that ignores cancellation from keeping a displaced or
+stopped observer alive indefinitely.
 
 ## Main Flows
 

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -44,25 +44,21 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
 
 ## Shipped
 
-| PR | What |
-|----|------|
+| Change | What |
+|--------|------|
 | #81 | WAL + `synchronous=NORMAL` sqlite; `stn observer reap` (socket-keyed candidacy, `lsof` keeper + health tiebreak, refuse-on-ambiguity, re-verify argv+start-token before every signal, SIGTERM→SIGKILL). `resolveObserverSocketForProcessArgs` in `@station/config`. |
 | #82 | Seeded socket-ownership watcher (`readSocketIdentity` + `expectedIdentity`); boot reorder — bind (`drainOnStart:false`) → arm seeded watcher → `observer.startup` reconcile, so a takeover during the scan is caught. |
 | #83 | `runShutdownWithBackstop`: `stopObserver` force-exits at a 5s ceiling so a wedged drain can't hang shutdown. Self-stop is now terminal (prerequisite for eviction). |
 | #84 | `bindWithStaleReclaim`: bind-first, unlink+retry only after a reprobe confirms nobody's listening. A live socket is never unlinked (killed the check-then-unlink race). |
+| 3c | Durable process identity: the successful socket binder atomically publishes and fsyncs `<socketPath>.pid` with the strict `{pid, osStartTime, version, socketPath}` payload before health is enabled. The full socket filename keeps identities distinct within a shared runtime directory. Publication failure is fatal. Clean shutdown removes only its exact matching identity; `lsof` remains primary ownership evidence. |
 
 Together these **stop the bleeding**: `reap` clears duplicates on demand, the
 seeded watcher self-heals future displacements, and stop/bind are race-safe and
-terminal.
+terminal. Phase 3c also gives later handoff and reaping work a durable,
+socket-relative corroborating identity without changing current attach-or-spawn
+or duplicate-reaping behavior.
 
 ## Remaining work
-
-### 3c — pidfile (small, safe)
-
-Write+fsync `<socketDir>/observer.pid` = `{pid, osStartTime, version, socketPath}`
-**before the first health is answered**; remove on clean stop. Gives the reaper
-and the evictor a corroborating identity source (lsof stays primary). No
-health-ready-without-pidfile window.
 
 ### 3d — explicit step-down negotiation (HIGHEST RISK — spike first)
 

--- a/packages/contracts/src/observer.ts
+++ b/packages/contracts/src/observer.ts
@@ -34,6 +34,17 @@ import { type StationSnapshot, StationSnapshotSchema } from "./snapshot.js";
 
 export const ObserverHealthStatusSchema = z.enum(["healthy", "degraded", "unavailable"]);
 
+export const ObserverProcessIdentitySchema = z
+  .object({
+    pid: z.number().int().positive(),
+    osStartTime: nonEmptyStringSchema,
+    version: nonEmptyStringSchema,
+    socketPath: nonEmptyStringSchema,
+  })
+  .strict();
+
+export type ObserverProcessIdentity = z.infer<typeof ObserverProcessIdentitySchema>;
+
 export const ObserverSqliteHealthSummarySchema = z
   .object({
     path: nonEmptyStringSchema,

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -27,6 +27,8 @@ import {
   ObserverEventHookConfigSchema,
   ObserverEventHookInvocationSchema,
   ObserverHealthSchema,
+  type ObserverProcessIdentity,
+  ObserverProcessIdentitySchema,
   ObserverStopReceiptSchema,
   type ProjectId,
   ProjectIdSchema,
@@ -100,6 +102,33 @@ describe("contract schemas", () => {
     for (const [name, snapshot] of Object.entries(snapshots)) {
       expect(snapshot.schemaVersion, name).toBe(STATION_SCHEMA_VERSION);
     }
+  });
+
+  it("requires a strict observer process identity", () => {
+    const identity: ObserverProcessIdentity = {
+      pid: 1234,
+      osStartTime: "Sat Jul 11 12:34:56 2026",
+      version: "0.1.1-dev",
+      socketPath: "/tmp/station/observer.sock",
+    };
+
+    expect(ObserverProcessIdentitySchema.parse(identity)).toEqual(identity);
+
+    for (const field of ["pid", "osStartTime", "version", "socketPath"] as const) {
+      const incompleteIdentity: Partial<ObserverProcessIdentity> = { ...identity };
+      delete incompleteIdentity[field];
+      expectFails(
+        ObserverProcessIdentitySchema,
+        incompleteIdentity,
+        `observer process identity without ${field}`,
+      );
+    }
+
+    expectFails(
+      ObserverProcessIdentitySchema,
+      { ...identity, stateDir: "/tmp/station/state" },
+      "observer process identity with unknown field",
+    );
   });
 
   it("owns the observer application port and external-launch contracts", () => {

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -58,7 +58,7 @@ const tmuxImplementationMarkers = [
 const setTimeoutAllowlist = new Map([
   [
     "apps/observer/src/runtime/main.ts",
-    "One-tick deferral lets observer.stop flush its protocol response before shutdown closes the server.",
+    "Shutdown backstop and final exit timers keep a stopped Observer process from lingering.",
   ],
   [
     "packages/dashboard-core/src/state/operations/localOperationRunner.ts",

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1,7 +1,8 @@
-import { access, chmod, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { startObserver } from "@station/cli";
 import { emptyConfig } from "@station/config";
+import { ObserverProcessIdentitySchema } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
 import { waitForSocketClosed } from "../support/sockets";
@@ -22,6 +23,7 @@ describe("observer lifecycle e2e", () => {
       },
     };
     const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    const pidfilePath = `${fixture.socketPath}.pid`;
     let started = false;
 
     try {
@@ -30,12 +32,29 @@ describe("observer lifecycle e2e", () => {
         status: "running",
         paths: { socketPath: fixture.socketPath },
       });
+      if (status.status !== "running") {
+        throw new Error(`Observer failed to start: ${status.status}`);
+      }
       started = true;
 
-      await expect(client.health()).resolves.toMatchObject({
+      expect(status.health).toMatchObject({
         status: "healthy",
         socketPath: fixture.socketPath,
         stateDir: fixture.stateDir,
+      });
+      const identity = ObserverProcessIdentitySchema.parse(
+        JSON.parse(await readFile(pidfilePath, "utf8")),
+      );
+      expect(Object.keys(identity).sort()).toEqual(["osStartTime", "pid", "socketPath", "version"]);
+      expect(identity).toMatchObject({
+        pid: status.health.pid,
+        version: status.health.version,
+        socketPath: status.health.socketPath,
+      });
+      expect(identity.osStartTime).toBe(identity.osStartTime.trim());
+      expect((await stat(pidfilePath)).mode & 0o777).toBe(0o600);
+      await expect(access(join(fixture.stateDir, "observer.sock.pid"))).rejects.toMatchObject({
+        code: "ENOENT",
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
         schemaVersion: "0.7.0",
@@ -65,6 +84,8 @@ describe("observer lifecycle e2e", () => {
         await waitForSocketClosed(fixture.socketPath);
       }
     }
+
+    await expect(access(pidfilePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("converges concurrent cold starts on one healthy observer", async () => {
@@ -77,6 +98,7 @@ describe("observer lifecycle e2e", () => {
       },
     };
     const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    const pidfilePath = `${fixture.socketPath}.pid`;
     let started = false;
 
     try {
@@ -91,12 +113,160 @@ describe("observer lifecycle e2e", () => {
       );
       expect(new Set(pids).size).toBe(1);
       expect(pids[0]).toBeTypeOf("number");
+      const identity = ObserverProcessIdentitySchema.parse(
+        JSON.parse(await readFile(pidfilePath, "utf8")),
+      );
+      expect(identity).toMatchObject({
+        pid: pids[0],
+        version: statuses[0]?.status === "running" ? statuses[0].health.version : undefined,
+        socketPath: fixture.socketPath,
+      });
     } finally {
       if (started) {
         await client.stop();
         await waitForSocketClosed(fixture.socketPath);
       }
     }
+
+    await expect(access(pidfilePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("keeps identities distinct for sockets sharing one directory", async () => {
+    const first = await createTempState();
+    const second = await createTempState();
+    const socketDir = join(first.root, "shared-run");
+    const firstSocketPath = join(socketDir, "first.sock");
+    const secondSocketPath = join(socketDir, "second.sock");
+    const firstClient = createObserverClient({ socketPath: firstSocketPath, timeoutMs: 1000 });
+    const secondClient = createObserverClient({ socketPath: secondSocketPath, timeoutMs: 1000 });
+    let firstStarted = false;
+    let secondStarted = false;
+
+    try {
+      const [firstStatus, secondStatus] = await Promise.all([
+        startObserver({
+          config: {
+            ...emptyConfig(),
+            observer: { stateDir: first.stateDir, socketPath: firstSocketPath },
+          },
+          timeoutMs: 30_000,
+        }),
+        startObserver({
+          config: {
+            ...emptyConfig(),
+            observer: { stateDir: second.stateDir, socketPath: secondSocketPath },
+          },
+          timeoutMs: 30_000,
+        }),
+      ]);
+      firstStarted = firstStatus.status === "running";
+      secondStarted = secondStatus.status === "running";
+      expect(firstStatus.status).toBe("running");
+      expect(secondStatus.status).toBe("running");
+
+      expect(
+        ObserverProcessIdentitySchema.parse(
+          JSON.parse(await readFile(`${firstSocketPath}.pid`, "utf8")),
+        ).socketPath,
+      ).toBe(firstSocketPath);
+      expect(
+        ObserverProcessIdentitySchema.parse(
+          JSON.parse(await readFile(`${secondSocketPath}.pid`, "utf8")),
+        ).socketPath,
+      ).toBe(secondSocketPath);
+
+      await secondClient.stop();
+      await waitForSocketClosed(secondSocketPath);
+      secondStarted = false;
+      await expect(firstClient.health()).resolves.toMatchObject({ socketPath: firstSocketPath });
+      await expect(access(`${firstSocketPath}.pid`)).resolves.toBeUndefined();
+    } finally {
+      if (secondStarted) {
+        await secondClient.stop().catch(() => undefined);
+        await waitForSocketClosed(secondSocketPath).catch(() => undefined);
+      }
+      if (firstStarted) {
+        await firstClient.stop().catch(() => undefined);
+        await waitForSocketClosed(firstSocketPath).catch(() => undefined);
+      }
+    }
+
+    await expect(access(`${firstSocketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(`${secondSocketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("publishes identity beside an XDG runtime socket", async () => {
+    const fixture = await createTempState();
+    const runtimeDir = await mkdtemp("/tmp/stn-xdg-");
+    const socketPath = join(runtimeDir, "station", "observer.sock");
+    const pidfilePath = `${socketPath}.pid`;
+    const config = {
+      ...emptyConfig(),
+      observer: { stateDir: fixture.stateDir },
+    };
+    const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = runtimeDir;
+    const client = createObserverClient({ socketPath, timeoutMs: 1000 });
+    let started = false;
+
+    try {
+      const status = await startObserver({ config, timeoutMs: 30_000 });
+      expect(status).toMatchObject({
+        status: "running",
+        paths: { socketPath },
+        health: { socketPath },
+      });
+      if (status.status !== "running") {
+        throw new Error(`Observer failed to start: ${status.status}`);
+      }
+      started = true;
+
+      expect(
+        ObserverProcessIdentitySchema.parse(JSON.parse(await readFile(pidfilePath, "utf8"))),
+      ).toMatchObject({
+        pid: status.health.pid,
+        version: status.health.version,
+        socketPath,
+      });
+      await expect(access(join(fixture.stateDir, "observer.sock.pid"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      if (started) {
+        await client.stop();
+        await waitForSocketClosed(socketPath);
+        await expect(access(pidfilePath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
+      await rm(runtimeDir, { recursive: true, force: true });
+    }
+  });
+
+  it("exits nonzero without serving health when identity publication fails", async () => {
+    const fixture = await createTempState();
+    const pidfilePath = `${fixture.socketPath}.pid`;
+    await mkdir(pidfilePath, { recursive: true });
+    const config = {
+      ...emptyConfig(),
+      observer: {
+        stateDir: fixture.stateDir,
+        socketPath: fixture.socketPath,
+      },
+    };
+    const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 250 });
+
+    const status = await startObserver({ config, timeoutMs: 30_000 });
+
+    expect(status).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_EXITED_ON_START",
+        message: expect.stringContaining("exit code 1"),
+      },
+    });
+    await expect(client.health()).rejects.toBeDefined();
+    await expect(access(fixture.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("reports a malformed-config child exit without waiting for the startup timeout", async () => {


### PR DESCRIPTION
## Summary

- publish a strict `{ pid, osStartTime, version, socketPath }` Observer identity at `<socketPath>.pid`
- fsync an atomic `0600` pidfile and remove it only through socket-ownership and full-identity checks
- keep identities independent when multiple Observer sockets share one runtime directory
- make pre-ready stop terminal: publication settles before teardown, health stays gated, and startup reconcile is skipped

## Review fixes

- replaced the directory-wide `observer.pid` path that let sibling sockets overwrite one another
- serialized shutdown behind identity publication so a protocol stop cannot leave a late pidfile or re-enable health
- corrected the stale timer-allowlist rationale

## Validation

- isolated-HOME `pnpm test:pre-push`
  - 1,321 unit tests
  - contract, integration, diagnostics, scripted-agent, and setup E2E suites
  - Node/Bun SQLite compatibility
  - 990 Station tests
  - native Bun PTY tests
  - compiled binary smoke
- focused Observer lifecycle E2E: 8 passed, including two live sockets in one directory
- `git diff --check`

## UX

A healthy Observer now owns `<resolved socketPath>.pid`; stopping one custom Observer cannot remove a sibling's identity. Manually verify by starting isolated observers at `first.sock` and `second.sock`, confirming both `.pid` files exist, then stopping each independently.