### PR TITLE
fix(worktrunk): exclude stale sessions and isolate Git commands

### DIFF
--- a/apps/cli/src/ingress/observerStartup.ts
+++ b/apps/cli/src/ingress/observerStartup.ts
@@ -5,6 +5,7 @@ import type { ObserverPaths } from "@station/config";
 import type { ObserverHealth, SafeError } from "@station/contracts";
 import { createObserverClient, isSocketStale, removeStaleSocket } from "@station/protocol";
 import {
+  environmentWithoutGitLocals,
   type RuntimeClock,
   runRuntimeBoundaryWithRetryAndTimeout,
   runRuntimeBoundaryWithTimeout,
@@ -203,6 +204,7 @@ function defaultSpawnObserver(input: SpawnProviderHookObserverInput): ChildProce
   ];
   return spawn(command, args, {
     detached: true,
+    env: environmentWithoutGitLocals(),
     stdio: "ignore",
   });
 }

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -2,6 +2,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { type FileHandle, mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { environmentWithoutGitLocals } from "@station/runtime";
 import { selfExecArgv } from "../selfExec.js";
 import type { ChildExitResult, ChildProcessLike, SpawnObserverInput } from "./types.js";
 
@@ -24,6 +25,7 @@ export async function defaultSpawnObserver(input: SpawnObserverInput): Promise<C
     const [command, ...args] = argv;
     child = spawn(command, args, {
       detached: true,
+      env: environmentWithoutGitLocals(),
       stdio: ["ignore", bootLog.fd, bootLog.fd],
     });
     const startedChild = Object.assign(

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -354,7 +354,7 @@ describe("observer providers", () => {
       await expect(readFile(logPath, "utf8")).resolves.toBe(
         [
           "switch --no-hooks --create feature --base main --no-cd --format=json",
-          "remove --no-hooks feature --foreground --format=json",
+          `-C ${projectRoot} remove --no-hooks feature --foreground --format=json`,
           "",
         ].join("\n"),
       );

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -837,7 +837,7 @@ describe("checkSetupGit", () => {
   it("distinguishes a missing git binary from a missing repository", async () => {
     const absent = await checkSetupGit({
       env: { PATH: "/fake/bin" },
-      cwd: "/tmp/not-a-repo",
+      cwd: tmpdir(),
       runner: fakeRunner([], {}),
     });
     expect(absent).toMatchObject({ status: "missing", reason: "git-absent" });
@@ -846,7 +846,7 @@ describe("checkSetupGit", () => {
 
     const notARepo = await checkSetupGit({
       env: { PATH: "/fake/bin" },
-      cwd: "/tmp/not-a-repo",
+      cwd: tmpdir(),
       // git resolves but rev-parse fails with a non-ENOENT exit code.
       runner: async () => {
         throw Object.assign(new Error("not a git repository"), { code: 128 });

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -199,6 +199,21 @@ export async function lookupWorktree(input: {
       message: "The requested worktree is not visible to the worktree provider.",
     });
   }
+  if (worktree.projectId !== input.projectId) {
+    throw commandValidationError({
+      code: "WORKTREE_PROJECT_MISMATCH",
+      message: "The requested worktree belongs to a different configured project.",
+      projectId: input.projectId,
+      worktreeId: input.worktreeId,
+    });
+  }
+  if (worktree.state !== "exists") {
+    throw worktreeMissingError({
+      projectId: input.projectId,
+      worktreeId: input.worktreeId,
+      message: "The requested worktree no longer has a working directory.",
+    });
+  }
   return worktree;
 }
 

--- a/apps/observer/src/diagnostics/collector.ts
+++ b/apps/observer/src/diagnostics/collector.ts
@@ -149,7 +149,7 @@ export async function collectDiagnosticSnapshot(
 
 export async function runDoctor(
   deps: ObserverDiagnosticsDeps,
-  _options: DoctorOptions = {},
+  options: DoctorOptions = {},
 ): Promise<DoctorReport> {
   const clock = deps.clock ?? systemClock;
   const snapshot = await collectDiagnosticSnapshot(deps, {
@@ -162,7 +162,7 @@ export async function runDoctor(
     ...doctorSnapshot.providerHealth,
     ...providerHealth,
   };
-  const providerChecks = await collectProviderDoctorChecks(deps);
+  const providerChecks = await collectProviderDoctorChecks(deps, options);
   const sqliteCheck: DoctorCheck = {
     name: "sqlite",
     status: doctorSnapshot.observerHealth.sqlite?.status === "healthy" ? "ok" : "warn",
@@ -437,13 +437,19 @@ function missingDoctorStateError(field: string): SafeError {
 
 async function collectProviderDoctorChecks(
   deps: ObserverDiagnosticsDeps,
+  options: DoctorOptions,
 ): Promise<ProviderDoctorCheck[]> {
   if (deps.providers === undefined) {
     return [];
   }
 
   const checks: ProviderDoctorCheck[] = [];
-  const context: ProviderDoctorContext = {};
+  const context: ProviderDoctorContext = {
+    projects:
+      options?.projectId === undefined
+        ? deps.config.projects
+        : deps.config.projects.filter((project) => project.id === options.projectId),
+  };
   if (deps.configPath !== undefined) {
     context.stationConfigPath = deps.configPath;
   }
@@ -453,11 +459,12 @@ async function collectProviderDoctorChecks(
     if (provider.doctorChecks === undefined) {
       continue;
     }
+    const timeoutMs = deps.providerDoctorTimeoutMs ?? 5000;
     const result = await runRuntimeBoundaryWithTimeout(
       {
         operation: `observer.doctor.providerChecks.${provider.id}`,
         clock: deps.clock,
-        timeoutMs: deps.providerDoctorTimeoutMs ?? 5000,
+        timeoutMs,
         error: {
           tag: "ProviderDiagnosticError",
           code: "PROVIDER_DOCTOR_CHECK_FAILED",
@@ -471,7 +478,12 @@ async function collectProviderDoctorChecks(
           provider: provider.id,
         },
       },
-      async () => provider.doctorChecks?.(context) ?? [],
+      async ({ signal }) =>
+        provider.doctorChecks?.({
+          ...context,
+          signal,
+          timeoutMs,
+        }) ?? [],
     );
 
     if (result.ok) {

--- a/apps/observer/src/metadata/gitCommand.ts
+++ b/apps/observer/src/metadata/gitCommand.ts
@@ -1,4 +1,8 @@
-import { type ExternalCommandRunner, runExternalCommand } from "@station/runtime";
+import {
+  type ExternalCommandRunner,
+  gitLocalEnvironmentVariables,
+  runExternalCommand,
+} from "@station/runtime";
 
 export type GitCommandContext = {
   cwd: string;
@@ -23,6 +27,7 @@ export async function runGitCommand(
     cwd: command.cwd,
     timeoutMs: command.timeoutMs,
     maxOutputChars: options.maxOutputChars,
+    unsetEnv: gitLocalEnvironmentVariables,
   };
   if (command.signal !== undefined) input.signal = command.signal;
   const result = await runExternalCommand(input, command.runner);

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -80,8 +80,8 @@ const confidenceRank = {
 
 export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot {
   const projectsById = new Map(input.projects.map((project) => [project.id, project]));
-  const configuredWorktrees = input.worktrees.filter((worktree) =>
-    projectsById.has(worktree.projectId),
+  const configuredWorktrees = input.worktrees.filter(
+    (worktree) => projectsById.has(worktree.projectId) && worktree.state === "exists",
   );
   const worktreesById = new Map(configuredWorktrees.map((worktree) => [worktree.id, worktree]));
   const harnessRuns = input.harnessRuns;

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -894,6 +894,82 @@ describe("session command vertical slice", () => {
     fixture.sqlite.close();
   });
 
+  it("rejects session.startAgent when the provider only retains a missing worktree", async () => {
+    const missing = createFakeWorktree({
+      id: "wt_web_missing",
+      projectId: "web",
+      branch: "missing",
+      now,
+    });
+    missing.state = "missing";
+    const terminalIntentRunner = new CapturingTerminalIntentRunner();
+    const fixture = createFixture({
+      worktree: new FakeWorktreeProvider({ now, worktrees: [missing] }),
+      terminalIntentRunner,
+    });
+    await fixture.core.reconcile("missing-worktree");
+    expect(fixture.core.getSnapshot().rows).toEqual([]);
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.startAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: missing.id,
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: {
+        tag: "CommandValidationError",
+        code: "WORKTREE_NOT_FOUND",
+        worktreeId: missing.id,
+      },
+    });
+    expect(terminalIntentRunner.intents).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual([]);
+    fixture.sqlite.close();
+  });
+
+  it("rejects session.startAgent when provider lookup crosses project ownership", async () => {
+    const foreign = createFakeWorktree({
+      id: "wt_api_foreign",
+      projectId: "api",
+      branch: "foreign",
+      now,
+    });
+    const terminalIntentRunner = new CapturingTerminalIntentRunner();
+    const fixture = createFixture({
+      worktree: new FakeWorktreeProvider({ now, worktrees: [foreign] }),
+      terminalIntentRunner,
+    });
+    await fixture.core.reconcile("foreign-worktree");
+    expect(fixture.core.getSnapshot().rows).toEqual([]);
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.startAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: foreign.id,
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: {
+        tag: "CommandValidationError",
+        code: "WORKTREE_PROJECT_MISMATCH",
+        projectId: "web",
+        worktreeId: foreign.id,
+      },
+    });
+    expect(terminalIntentRunner.intents).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual([]);
+    fixture.sqlite.close();
+  });
+
   it("submits session.startAgent launch work through the terminal intent runner seam", async () => {
     const terminalIntentRunner = new CapturingTerminalIntentRunner();
     const terminal = new FakeTerminalProvider({

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -2,6 +2,8 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
+import type { ProviderProjectConfig } from "@station/contracts";
+import type { ExternalCommandInput } from "@station/runtime";
 import { FakeHarnessProvider, FakeTerminalProvider } from "@station/testing";
 import { WorktrunkProvider } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
@@ -68,9 +70,173 @@ describe("Worktrunk diagnostics", () => {
     );
     sqlite.close();
   });
+
+  it("scopes stale-registration diagnostics to the requested project", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-wt-diag-scope-"));
+    const clock = { now: () => new Date(now) };
+    const projects = [project("web"), project("api")];
+    const stationConfig = config(stateDir, projects);
+    const listCalls: ExternalCommandInput[] = [];
+    const providers = new ProviderRegistry({
+      worktree: new WorktrunkProvider({
+        command: "wt",
+        useLifecycleHooks: false,
+        clock,
+        runner: async (input) => {
+          if (input.args?.includes("list")) {
+            listCalls.push(input);
+            return {
+              command: input.command,
+              args: input.args ?? [],
+              stdout: JSON.stringify([
+                {
+                  path: `${input.cwd}/missing-feature`,
+                  branch: "missing-feature",
+                  worktree: { state: "prunable" },
+                },
+              ]),
+              stderr: "",
+              exitCode: 0,
+            };
+          }
+          return {
+            command: input.command,
+            args: input.args ?? [],
+            stdout: input.args?.includes("--version") ? "wt 0.64.0" : "--no-hooks",
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+    });
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config: stationConfig,
+      providers,
+      clock,
+      sqlitePath: join(stateDir, "observer.sqlite"),
+    });
+
+    const report = await runDoctor(
+      {
+        config: stationConfig,
+        core,
+        persistence,
+        persistenceHealth: persistence,
+        providers,
+        paths: { stateDir },
+        clock,
+      },
+      { projectId: "web" },
+    );
+
+    expect(listCalls.map((call) => call.cwd)).toEqual([projects[0]?.root]);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-web",
+          status: "warn",
+        }),
+      ]),
+    );
+    expect(report.checks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "worktrunk-stale-registrations-api" }),
+      ]),
+    );
+    sqlite.close();
+  });
+
+  it("returns partial stale evidence before the outer provider timeout", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-wt-diag-timeout-"));
+    const clock = { now: () => new Date(now) };
+    const projects = [project("web"), project("api")];
+    const stationConfig = config(stateDir, projects);
+    let slowScanAborted = false;
+    const providers = new ProviderRegistry({
+      worktree: new WorktrunkProvider({
+        command: "wt",
+        useLifecycleHooks: false,
+        clock,
+        runner: async (input) => {
+          if (input.args?.includes("list") && input.cwd === projects[1]?.root) {
+            return new Promise((_, reject) => {
+              const abort = () => {
+                slowScanAborted = true;
+                reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+              };
+              if (input.signal?.aborted === true) {
+                abort();
+              } else {
+                input.signal?.addEventListener("abort", abort, { once: true });
+              }
+            });
+          }
+          return commandResult(
+            input,
+            input.args?.includes("list")
+              ? JSON.stringify([
+                  {
+                    path: "/tmp/station/web/missing-feature",
+                    branch: "missing-feature",
+                    worktree: { state: "prunable" },
+                  },
+                ])
+              : input.args?.includes("--version")
+                ? "wt 0.64.0"
+                : "--no-hooks",
+          );
+        },
+      }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+    });
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config: stationConfig,
+      providers,
+      clock,
+      sqlitePath: join(stateDir, "observer.sqlite"),
+    });
+
+    const report = await runDoctor({
+      config: stationConfig,
+      core,
+      persistence,
+      persistenceHealth: persistence,
+      providers,
+      paths: { stateDir },
+      clock,
+      providerDoctorTimeoutMs: 250,
+    });
+
+    expect(slowScanAborted).toBe(true);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-web",
+          status: "warn",
+        }),
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-scan",
+          status: "warn",
+          message: expect.stringContaining("1 of 2 project(s)"),
+        }),
+      ]),
+    );
+    expect(report.checks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-diagnostics",
+          error: expect.objectContaining({ code: "PROVIDER_DOCTOR_CHECK_TIMEOUT" }),
+        }),
+      ]),
+    );
+    sqlite.close();
+  });
 });
 
-function config(stateDir: string): StationConfig {
+function config(stateDir: string, projects: ProviderProjectConfig[] = []): StationConfig {
   return {
     schemaVersion: 1,
     observer: {
@@ -87,6 +253,32 @@ function config(stateDir: string): StationConfig {
         configPath: join(stateDir, "worktrunk", "config.toml"),
       },
     },
-    projects: [],
+    projects,
+  };
+}
+
+function project(id: string): ProviderProjectConfig {
+  return {
+    id,
+    label: id,
+    root: `/tmp/station/${id}`,
+    defaults: {
+      harness: "fake-harness",
+      terminal: "fake-terminal",
+      layout: "agent-shell",
+    },
+    worktrunk: {
+      enabled: true,
+    },
+  };
+}
+
+function commandResult(input: ExternalCommandInput, stdout: string) {
+  return {
+    command: input.command,
+    args: input.args ?? [],
+    stdout,
+    stderr: "",
+    exitCode: 0,
   };
 }

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -180,6 +180,30 @@ describe("observer graph derivation", () => {
     expect(StationSnapshotSchema.parse(snapshot)).toEqual(snapshot);
   });
 
+  it("keeps missing and orphaned worktree evidence out of actionable sessions", () => {
+    const existing = worktree("wt_web_exists", "web", "exists");
+    const missing = worktree("wt_web_missing", "web", "missing");
+    missing.state = "missing";
+    const orphaned = worktree("wt_web_orphaned", "web", "orphaned");
+    orphaned.state = "orphaned";
+    const staleTerminal = terminal("term_missing", missing.id, "run_missing");
+    const staleRun = harness("run_missing", missing.id, "working");
+
+    const snapshot = build({
+      worktrees: [existing, missing, orphaned],
+      terminals: [staleTerminal],
+      harnessRuns: [staleRun],
+    });
+
+    expect(snapshot.rows.map((row) => row.id)).toEqual([existing.id]);
+    expect(snapshot.sessions).toEqual([]);
+    expect(snapshot.counts.worktrees).toBe(1);
+    expect(snapshot.orphans?.map((orphan) => orphan.kind).sort()).toEqual([
+      "harness_run",
+      "terminal_target",
+    ]);
+  });
+
   it("honors target-level focus and close overrides", () => {
     const target = terminal("term_idle", "wt_web_idle", "run_idle");
     target.focusable = false;

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,11 @@ CLI/package, observer, provider, protocol, and host restart boundaries.
 
 ## Deterministic Gates
 
+Git-backed fixtures and child processes must clear Git's repository-local environment variables;
+`cwd` and `git -C` do not isolate a command when variables such as `GIT_DIR` or `GIT_WORK_TREE`
+are inherited. Remove linked worktrees and other Git-created resources through Git before deleting
+their directories.
+
 The deterministic local gate is:
 
 ```bash

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -109,6 +109,20 @@ expected; explicitly disabled hooks are reported as the skip-hooks automation
 mode instead. Provider command failures from `wt` are recorded through provider
 health, command records, logs, debug traces, and debug bundle evidence.
 
+Doctor also reports Worktrunk registrations whose working directories are
+missing or prunable. `stn doctor --project <id>` limits this scan to one project;
+the unscoped command scans configured projects with bounded concurrency and
+reports if its time budget permits only partial coverage. Inspect the exact
+prune operation before changing Git metadata, then run it without `--dry-run`:
+
+```bash
+git -C '<project-root>' worktree prune --dry-run --verbose
+git -C '<project-root>' worktree prune --verbose
+```
+
+Pruning removes administrative records for worktree directories that are
+already gone; it does not delete a live worktree directory.
+
 ## Manual Smoke
 
 After building, the diagnostic surface can be checked with a throwaway fake-provider config:

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,4 +96,4 @@ mkdir -p ~/.config/station
 cp examples/local-real-config.toml ~/.config/station/config.toml
 ```
 
-Run `stn doctor` after editing the config. Doctor should report config diagnostics, Worktrunk availability, effective Worktrunk automation mode, hook setup status when hooks are expected, SQLite health, provider health, local-state retention, and debug-bundle availability.
+Run `stn doctor` after editing the config. Doctor should report config diagnostics, Worktrunk availability and stale registrations, effective Worktrunk automation mode, hook setup status when hooks are expected, SQLite health, provider health, local-state retention, and debug-bundle availability.

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -401,8 +401,11 @@ health, persistence health, durable Observer records, config diagnostics,
 provider checks, and local runtime evidence. They receive
 `PersistenceHealthSource` separately from the command and event journals, so
 neither use case needs a concrete SQLite handle. Collection must remain
-read-only with respect to product state. OBS-HEX-012 tracks separation of
-filesystem, log, and spool traversal from the diagnostic use case.
+read-only with respect to product state. Provider doctor calls receive an
+Observer-owned total timeout and cancellation signal; adapters that fan out
+checks must bound concurrency and return completed evidence before that budget
+expires. OBS-HEX-012 tracks separation of filesystem, log, and spool traversal
+from the diagnostic use case.
 
 ## Concurrency, Failure, And Backpressure
 

--- a/integrations/worktree/worktrunk/src/automation.ts
+++ b/integrations/worktree/worktrunk/src/automation.ts
@@ -1,4 +1,8 @@
-import { type ExternalCommandRunner, runExternalCommand } from "@station/runtime";
+import {
+  type ExternalCommandRunner,
+  gitLocalEnvironmentVariables,
+  runExternalCommand,
+} from "@station/runtime";
 
 export type WorktrunkAutomationFlag = "--no-hooks" | "--yes";
 export type WorktrunkAutomationModeName = "skip-hooks" | "preapprove-hooks" | "worktrunk-default";
@@ -37,6 +41,7 @@ export async function missingWorktrunkAutomationFlagSupport(input: {
   flag: WorktrunkAutomationFlag;
   timeoutMs: number;
   runner?: ExternalCommandRunner | undefined;
+  signal?: AbortSignal | undefined;
 }): Promise<string[]> {
   const subcommands = ["switch", "remove"] as const;
   const missing: string[] = [];
@@ -45,8 +50,10 @@ export async function missingWorktrunkAutomationFlagSupport(input: {
       {
         command: input.command,
         args: [subcommand, "--help"],
+        unsetEnv: gitLocalEnvironmentVariables,
         timeoutMs: input.timeoutMs,
         maxOutputChars: 64 * 1024,
+        ...(input.signal === undefined ? {} : { signal: input.signal }),
       },
       input.runner,
     );

--- a/integrations/worktree/worktrunk/src/dependency.ts
+++ b/integrations/worktree/worktrunk/src/dependency.ts
@@ -1,6 +1,7 @@
 import type { SafeError } from "@station/contracts";
 import {
   type ExternalCommandRunner,
+  gitLocalEnvironmentVariables,
   type ResolveExecutablePathOptions,
   resolveExecutablePath,
   runExternalCommand,
@@ -80,6 +81,7 @@ export async function checkWorktrunkDependency(
       {
         command: probeCommand,
         args: ["--version"],
+        unsetEnv: gitLocalEnvironmentVariables,
         ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
         maxOutputChars: 4096,
       },

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -14,6 +14,7 @@ import type {
   RawWorktreeEvent,
   RemoveWorktreeRequest,
   RemoveWorktreeResult,
+  SafeError,
   WorktreeCapabilities,
   WorktreeEventContext,
   WorktreeObservation,
@@ -22,6 +23,7 @@ import type {
 import { ExternalCommandDiagnosticDetailSchema } from "@station/contracts";
 import {
   type ExternalCommandRunner,
+  gitLocalEnvironmentVariables,
   type RuntimeClock,
   runExternalCommand,
   runRuntimeBoundaryWithRetryAndTimeout,
@@ -56,6 +58,12 @@ export type WorktrunkProviderOptions = {
   clock?: RuntimeClock;
 };
 
+type WorktrunkRunPolicy = {
+  retries?: number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
 const defaultCapabilities: WorktreeCapabilities = {
   canCreate: true,
   canRemove: true,
@@ -65,6 +73,11 @@ const defaultCapabilities: WorktreeCapabilities = {
   canSeedWorkingTree: true,
 };
 
+/**
+ * ADAPTER
+ *
+ * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
+ */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
 
@@ -75,6 +88,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
   readonly #observations = new Map<string, WorktreeObservation>();
+  readonly #projectRoots = new Map<string, string>();
 
   constructor(options: WorktrunkProviderOptions = {}) {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
@@ -120,7 +134,22 @@ export class WorktrunkProvider implements WorktreeProvider {
   }
 
   async doctorChecks(context: ProviderDoctorContext = {}): Promise<ProviderDoctorCheck[]> {
-    const checks: ProviderDoctorCheck[] = [await this.#automationCapabilityCheck()];
+    const workBudgetMs = doctorWorkBudgetMs(context.timeoutMs ?? this.#timeoutMs);
+    const budgetSignal = AbortSignal.timeout(workBudgetMs);
+    const signal =
+      context.signal === undefined ? budgetSignal : AbortSignal.any([context.signal, budgetSignal]);
+    const [automationCheck, staleChecks, hookCheck] = await Promise.all([
+      this.#automationCapabilityCheck({ signal, timeoutMs: workBudgetMs }),
+      this.#staleRegistrationChecks(context.projects ?? [], {
+        signal,
+        timeoutMs: workBudgetMs,
+      }),
+      this.#hookCheck(context),
+    ]);
+    return [automationCheck, ...staleChecks, hookCheck];
+  }
+
+  async #hookCheck(context: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
     try {
       const result = await doctorWorktrunkHooks({
         ...(this.#configPath === undefined ? {} : { worktrunkConfigPath: this.#configPath }),
@@ -142,8 +171,7 @@ export class WorktrunkProvider implements WorktreeProvider {
           provider: this.id,
         };
       }
-      checks.push(check);
-      return checks;
+      return check;
     } catch (cause) {
       const error = safeErrorFromUnknown(cause, {
         tag: "WorktrunkHookSetupError",
@@ -151,13 +179,12 @@ export class WorktrunkProvider implements WorktreeProvider {
         message: "Worktrunk hook diagnostics failed.",
         provider: this.id,
       });
-      checks.push({
+      return {
         name: "worktrunk-hooks",
         status: "error",
         message: error.message,
         error,
-      });
-      return checks;
+      };
     }
   }
 
@@ -169,9 +196,17 @@ export class WorktrunkProvider implements WorktreeProvider {
   }
 
   async listWorktrees(project: ProviderProjectConfig): Promise<WorktreeObservation[]> {
+    return this.#listWorktrees(project, { retries: 1 });
+  }
+
+  async #listWorktrees(
+    project: ProviderProjectConfig,
+    policy: WorktrunkRunPolicy,
+  ): Promise<WorktreeObservation[]> {
     if (!project.worktrunk.enabled) {
       return [];
     }
+    this.#projectRoots.set(project.id, project.root);
 
     const output = await this.#run(
       this.#args(["list", "--format=json"]),
@@ -180,7 +215,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         code: "WORKTRUNK_COMMAND_FAILED",
         message: "Worktrunk failed to list worktrees.",
       },
-      { retries: 1 },
+      policy,
     );
     const observations = parseWorktrunkListJson(output.stdout, {
       project,
@@ -202,6 +237,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   }
 
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
+    this.#projectRoots.set(request.project.id, request.project.root);
     const base = request.base ?? request.project.worktrunk.base;
     const output = await this.#run(
       this.#args([
@@ -292,6 +328,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         {
           command,
           args,
+          unsetEnv: gitLocalEnvironmentVariables,
           timeoutMs: this.#timeoutMs,
           ...(options?.env === undefined ? {} : { env: options.env }),
         },
@@ -315,9 +352,19 @@ export class WorktrunkProvider implements WorktreeProvider {
         { hint: "Run listWorktrees before removeWorktree so the provider can resolve the target." },
       );
     }
+    const projectRoot = this.#projectRoots.get(observation.projectId);
+    if (projectRoot === undefined) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_WORKTREE_NOT_FOUND",
+        "Worktrunk remove requires the repository root from a previous project listing.",
+        { hint: "Run listWorktrees for the project before removeWorktree." },
+      );
+    }
 
     await this.#run(
       this.#args([
+        "-C",
+        projectRoot,
         "remove",
         ...this.#automationHookArgs(),
         removeTarget(observation),
@@ -326,7 +373,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         "--foreground",
         "--format=json",
       ]),
-      observation.path,
+      undefined,
       {
         code: "WORKTRUNK_COMMAND_FAILED",
         message: "Worktrunk failed to remove a worktree.",
@@ -366,7 +413,10 @@ export class WorktrunkProvider implements WorktreeProvider {
     return [];
   }
 
-  async #automationCapabilityCheck(): Promise<ProviderDoctorCheck> {
+  async #automationCapabilityCheck(options: {
+    signal: AbortSignal;
+    timeoutMs: number;
+  }): Promise<ProviderDoctorCheck> {
     const mode = worktrunkAutomationMode(this.#useLifecycleHooks);
     if (mode.flag === undefined) {
       return {
@@ -382,8 +432,9 @@ export class WorktrunkProvider implements WorktreeProvider {
       missing = await missingWorktrunkAutomationFlagSupport({
         command: this.#command,
         flag: mode.flag,
-        timeoutMs: this.#timeoutMs,
+        timeoutMs: options.timeoutMs,
         runner: this.#runner,
+        signal: options.signal,
       });
     } catch (cause) {
       const fallback = safeErrorFromUnknown(cause, {
@@ -431,6 +482,81 @@ export class WorktrunkProvider implements WorktreeProvider {
     };
   }
 
+  async #staleRegistrationChecks(
+    projects: readonly ProviderProjectConfig[],
+    options: { signal: AbortSignal; timeoutMs: number },
+  ): Promise<ProviderDoctorCheck[]> {
+    const enabledProjects = projects.filter((candidate) => candidate.worktrunk.enabled);
+    const checks: Array<ProviderDoctorCheck | undefined> = enabledProjects.map(() => undefined);
+    let completed = 0;
+    for (let offset = 0; offset < enabledProjects.length; offset += 4) {
+      const batch = enabledProjects.slice(offset, offset + 4);
+      await Promise.all(
+        batch.map(async (project, batchIndex) => {
+          if (options.signal.aborted) return;
+          const index = offset + batchIndex;
+          let missing: WorktreeObservation[];
+          try {
+            missing = (
+              await this.#listWorktrees(project, {
+                retries: 0,
+                signal: options.signal,
+                timeoutMs: options.timeoutMs,
+              })
+            ).filter((observation) => observation.state !== "exists");
+            completed += 1;
+          } catch (cause) {
+            if (options.signal.aborted) return;
+            const failure = safeErrorFromUnknown(cause, {
+              tag: "WorktrunkStaleRegistrationDiagnosticError",
+              code: "WORKTRUNK_STALE_REGISTRATION_CHECK_FAILED",
+              message: `Worktrunk could not inspect stale registrations for ${project.label}.`,
+              provider: this.id,
+            });
+            const error: SafeError = {
+              tag: failure.tag,
+              code: failure.code,
+              message: failure.message,
+              projectId: project.id,
+            };
+            if (failure.hint !== undefined) error.hint = failure.hint;
+            if (failure.provider !== undefined) error.provider = failure.provider;
+            checks[index] = {
+              name: `worktrunk-stale-registrations-${project.id}`,
+              status: "warn",
+              message: error.message,
+              error,
+            };
+            return;
+          }
+          if (missing.length === 0) return;
+          const root = shellQuote(project.root);
+          checks[index] = {
+            name: `worktrunk-stale-registrations-${project.id}`,
+            status: "warn",
+            message: `Worktrunk found missing/prunable registrations for ${project.label}: ${missing
+              .map((item) => `${item.branch} (${item.path})`)
+              .join(
+                ", ",
+              )}. Inspect with git -C ${root} worktree prune --dry-run --verbose, then clean with git -C ${root} worktree prune --verbose.`,
+          };
+        }),
+      );
+      if (options.signal.aborted) break;
+    }
+    const completedChecks = checks.filter(
+      (check): check is ProviderDoctorCheck => check !== undefined,
+    );
+    if (options.signal.aborted && completed < enabledProjects.length) {
+      completedChecks.push({
+        name: "worktrunk-stale-registrations-scan",
+        status: "warn",
+        message: `Worktrunk stale-registration diagnostics reached their time budget after checking ${completed} of ${enabledProjects.length} project(s).`,
+      });
+    }
+    return completedChecks;
+  }
+
   async #run(
     args: string[],
     cwd?: string,
@@ -441,7 +567,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       code: "WORKTRUNK_UNAVAILABLE",
       message: "Worktrunk is not available.",
     },
-    policy: { retries?: number } = {},
+    policy: WorktrunkRunPolicy = {},
     env?: Record<string, string>,
   ) {
     const operation = `provider.worktrunk.${worktrunkSubcommand(args)}`;
@@ -449,7 +575,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       {
         operation,
         clock: this.#clock,
-        timeoutMs: this.#timeoutMs,
+        timeoutMs: policy.timeoutMs ?? this.#timeoutMs,
         error: {
           tag:
             fallback.code === "WORKTRUNK_UNAVAILABLE"
@@ -469,7 +595,9 @@ export class WorktrunkProvider implements WorktreeProvider {
           retries: policy.retries ?? 0,
           delayMs: 10,
           shouldRetry: (error) =>
-            error.code !== "WORKTRUNK_TIMEOUT" && error.code !== "WORKTRUNK_CANCELLED",
+            error.code !== "WORKTRUNK_TIMEOUT" &&
+            error.code !== "WORKTRUNK_CANCELLED" &&
+            error.code !== "EXTERNAL_COMMAND_ABORTED",
         },
       },
       ({ signal }) =>
@@ -477,9 +605,10 @@ export class WorktrunkProvider implements WorktreeProvider {
           {
             command: this.#command,
             args,
+            unsetEnv: gitLocalEnvironmentVariables,
             ...(cwd === undefined ? {} : { cwd }),
             ...(env === undefined ? {} : { env }),
-            signal,
+            signal: mergeAbortSignals(signal, policy.signal),
             maxOutputChars: 512 * 1024,
           },
           this.#runner,
@@ -550,6 +679,14 @@ function dependencyDiagnostics(status: WorktrunkDependencyStatus): Record<string
     if (status.rawVersion !== undefined) diagnostics.rawVersion = status.rawVersion;
   }
   return diagnostics;
+}
+
+function doctorWorkBudgetMs(timeoutMs: number): number {
+  return Math.max(1, Math.floor(timeoutMs * 0.8));
+}
+
+function mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal | undefined): AbortSignal {
+  return secondary === undefined ? primary : AbortSignal.any([primary, secondary]);
 }
 
 function worktrunkCommandDiagnostics(input: {
@@ -717,7 +854,7 @@ function worktrunkSubcommand(args: readonly string[]): string {
     if (arg === undefined) {
       continue;
     }
-    if (arg === "--config") {
+    if (arg === "--config" || arg === "-C") {
       index += 1;
       continue;
     }
@@ -835,7 +972,12 @@ function isMissingBinary(error: unknown): boolean {
     return false;
   }
   const cause = error as { code?: unknown; cause?: unknown };
+  if (cause.code === "EXTERNAL_COMMAND_CWD_NOT_FOUND") return false;
   return cause.code === "ENOENT" || isMissingBinary(cause.cause);
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function stringFieldDeep(

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -1,13 +1,14 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
-import { nodeExternalCommandRunner } from "@station/runtime";
+import { gitLocalEnvironmentVariables, nodeExternalCommandRunner } from "@station/runtime";
 import { WorktrunkProvider } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 
 const now = "2026-05-21T12:00:00.000Z";
-const project = {
+const project: ProviderProjectConfig = {
   id: "web",
   label: "web",
   root: "/tmp/station/web",
@@ -290,7 +291,16 @@ describe("WorktrunkProvider", () => {
     expect(removed).toEqual({ worktreeId: created.id, removed: true });
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
-      ["remove", "feature", "--force", "--force-delete", "--foreground", "--format=json"],
+      [
+        "-C",
+        project.root,
+        "remove",
+        "feature",
+        "--force",
+        "--force-delete",
+        "--foreground",
+        "--format=json",
+      ],
     ]);
   });
 
@@ -299,20 +309,37 @@ describe("WorktrunkProvider", () => {
     const srcPath = join(root, "source");
     const tgtPath = join(root, "feature");
     const git = (cwd: string, ...args: string[]) =>
-      nodeExternalCommandRunner({ command: "git", args, cwd });
+      nodeExternalCommandRunner({
+        command: "git",
+        args,
+        cwd,
+        unsetEnv: gitLocalEnvironmentVariables,
+      });
 
     // Real source repo: a base commit, then a dirty working tree spanning every state
     // the seed must carry (unstaged mod, staged mod, tracked deletion, untracked + nested).
     await mkdir(srcPath, { recursive: true });
     await git(srcPath, "init", "-q");
-    await git(srcPath, "config", "user.email", "t@example.com");
-    await git(srcPath, "config", "user.name", "t");
-    await git(srcPath, "config", "commit.gpgsign", "false");
+    const commonDir = (
+      await git(srcPath, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    ).stdout.trim();
+    expect(commonDir.replace(/^\/private(?=\/var\/)/, "").startsWith(root)).toBe(true);
     await writeFile(join(srcPath, "tracked.txt"), "base\n");
     await writeFile(join(srcPath, "staged.txt"), "base\n");
     await writeFile(join(srcPath, "deleteme.txt"), "bye\n");
     await git(srcPath, "add", ".");
-    await git(srcPath, "commit", "-qm", "init");
+    await git(
+      srcPath,
+      "-c",
+      "user.email=t@example.com",
+      "-c",
+      "user.name=t",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "-qm",
+      "init",
+    );
     await writeFile(join(srcPath, "tracked.txt"), "base\nunstaged\n");
     await writeFile(join(srcPath, "staged.txt"), "base\nstaged\n");
     await git(srcPath, "add", "staged.txt");
@@ -387,6 +414,7 @@ describe("WorktrunkProvider", () => {
       const switchCall = calls.find((c) => c.command === "wt" && c.args?.[0] === "switch");
       expect(switchCall?.args).toContain("source-branch");
     } finally {
+      await git(srcPath, "worktree", "remove", "--force", tgtPath).catch(() => undefined);
       await rm(root, { recursive: true, force: true });
     }
   });
@@ -417,7 +445,7 @@ describe("WorktrunkProvider", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--no-hooks", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
-      ["remove", "--no-hooks", "feature", "--foreground", "--format=json"],
+      ["-C", project.root, "remove", "--no-hooks", "feature", "--foreground", "--format=json"],
     ]);
   });
 
@@ -447,7 +475,7 @@ describe("WorktrunkProvider", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--yes", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
-      ["remove", "--yes", "feature", "--foreground", "--format=json"],
+      ["-C", project.root, "remove", "--yes", "feature", "--foreground", "--format=json"],
     ]);
   });
 
@@ -589,6 +617,145 @@ describe("WorktrunkProvider", () => {
       ["switch", "--help"],
       ["remove", "--help"],
     ]);
+  });
+
+  it("warns about missing registrations with safe prune commands", async () => {
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) =>
+        result(
+          input,
+          input.args?.includes("list")
+            ? JSON.stringify([
+                {
+                  path: "/tmp/station/web/missing feature",
+                  branch: "missing-feature",
+                  state: "prunable",
+                },
+              ])
+            : "--no-hooks",
+        ),
+    });
+
+    const checks = await provider.doctorChecks({ projects: [project] });
+
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-web",
+          status: "warn",
+          message: expect.stringContaining(
+            "git -C '/tmp/station/web' worktree prune --dry-run --verbose",
+          ),
+        }),
+      ]),
+    );
+  });
+
+  it("returns completed stale warnings and aborts slow scans before the provider deadline", async () => {
+    const slowProject: ProviderProjectConfig = {
+      ...project,
+      id: "api",
+      label: "api",
+      root: "/tmp/station/api",
+    };
+    let slowScanAborted = false;
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.args?.includes("list") && input.cwd === slowProject.root) {
+          return new Promise((_, reject) => {
+            const abort = () => {
+              slowScanAborted = true;
+              reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+            };
+            if (input.signal?.aborted === true) {
+              abort();
+            } else {
+              input.signal?.addEventListener("abort", abort, { once: true });
+            }
+          });
+        }
+        return result(
+          input,
+          input.args?.includes("list")
+            ? JSON.stringify([
+                {
+                  path: "/tmp/station/web/missing-feature",
+                  branch: "missing-feature",
+                  worktree: { state: "prunable" },
+                },
+              ])
+            : "--no-hooks",
+        );
+      },
+    });
+
+    const checks = await provider.doctorChecks({
+      projects: [project, slowProject],
+      timeoutMs: 50,
+    });
+
+    expect(slowScanAborted).toBe(true);
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-web",
+          status: "warn",
+        }),
+        expect.objectContaining({
+          name: "worktrunk-stale-registrations-scan",
+          status: "warn",
+          message: expect.stringContaining("1 of 2 project(s)"),
+        }),
+        expect.objectContaining({
+          name: "worktrunk-hooks",
+          status: "ok",
+        }),
+      ]),
+    );
+  });
+
+  it("bounds concurrent stale-registration scans", async () => {
+    const projects: ProviderProjectConfig[] = Array.from({ length: 6 }, (_, index) => ({
+      ...project,
+      id: `project-${index}`,
+      label: `project-${index}`,
+      root: `/tmp/station/project-${index}`,
+    }));
+    let activeScans = 0;
+    let maxActiveScans = 0;
+    let completedScans = 0;
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.args?.includes("list")) {
+          activeScans += 1;
+          maxActiveScans = Math.max(maxActiveScans, activeScans);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          activeScans -= 1;
+          completedScans += 1;
+          return result(input, "[]");
+        }
+        return result(input, "--no-hooks");
+      },
+    });
+
+    const checks = await provider.doctorChecks({ projects, timeoutMs: 500 });
+
+    expect(completedScans).toBe(projects.length);
+    expect(maxActiveScans).toBe(4);
+    expect(checks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "worktrunk-stale-registrations-scan" }),
+      ]),
+    );
   });
 
   it("reports unsupported configured Worktrunk automation flags in doctor checks", async () => {

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -196,6 +196,9 @@ export type ProviderDoctorCheck = {
 
 export type ProviderDoctorContext = {
   stationConfigPath?: string;
+  projects?: readonly ProviderProjectConfig[];
+  signal?: AbortSignal;
+  timeoutMs?: number;
 };
 
 /**
@@ -373,6 +376,11 @@ export type RepositoryChecksRequest = z.infer<typeof RepositoryChecksRequestSche
   signal?: AbortSignal;
 };
 
+/**
+ * DRIVEN PORT
+ *
+ * Supplies worktree lifecycle evidence and mutations without exposing provider mechanics.
+ */
 export interface WorktreeProvider {
   id: ProviderId;
   capabilities(): WorktreeCapabilities;

--- a/packages/runtime/src/externalCommand.ts
+++ b/packages/runtime/src/externalCommand.ts
@@ -36,6 +36,7 @@ export type ExternalCommandInput = {
   args?: string[];
   cwd?: string;
   env?: Record<string, string>;
+  unsetEnv?: readonly string[];
   timeoutMs?: number;
   maxOutputChars?: number;
   stdin?: string;
@@ -78,7 +79,11 @@ export async function runExternalCommand(
         if (allowedResult !== undefined) {
           return allowedResult;
         }
-        throw externalCommandErrorFromUnknown(error, input);
+        throw externalCommandErrorFromUnknown(
+          error,
+          input,
+          await missingWorkingDirectory(error, input.cwd),
+        );
       }
     } finally {
       linked.cleanup();
@@ -126,7 +131,7 @@ export async function nodeExternalCommandRunner(
   const args = input.args ?? [];
   const result = await execFileAsync(input.command, args, {
     cwd: input.cwd,
-    env: input.env === undefined ? process.env : { ...process.env, ...input.env },
+    env: externalCommandEnvironment(input),
     maxBuffer: input.maxOutputChars ?? 64 * 1024,
     signal: input.signal,
   });
@@ -149,7 +154,7 @@ async function nodeExternalCommandRunnerWithInheritedStdio(
   return new Promise((resolve, reject) => {
     const child = spawn(input.command, args, {
       cwd: input.cwd,
-      env: input.env === undefined ? process.env : { ...process.env, ...input.env },
+      env: externalCommandEnvironment(input),
       signal: input.signal,
       stdio: "inherit",
     });
@@ -212,7 +217,7 @@ async function nodeExternalCommandRunnerWithStdin(
       ],
       {
         cwd: input.cwd,
-        env: input.env === undefined ? process.env : { ...process.env, ...input.env },
+        env: externalCommandEnvironment(input),
         maxBuffer: input.maxOutputChars ?? 64 * 1024,
         signal: input.signal,
       },
@@ -262,13 +267,16 @@ export async function resolveExecutablePath(
 export function externalCommandErrorFromUnknown(
   error: unknown,
   input: Pick<ExternalCommandInput, "command" | "args" | "cwd">,
+  cwdMissing = false,
 ): ExternalCommandError {
   const fallback = externalCommandFallback("EXTERNAL_COMMAND_FAILED", "External command failed.");
   const safeError = safeErrorFromUnknown(error, fallback);
   const cause = externalCommandErrorLike(error);
   const normalized: ExternalCommandError = {
     tag: "ExternalCommandError",
-    code: externalCommandCode(error, cause, safeError),
+    code: cwdMissing
+      ? "EXTERNAL_COMMAND_CWD_NOT_FOUND"
+      : externalCommandCode(error, cause, safeError),
     message: externalCommandMessage(error, safeError),
     command: formatCommandForError(input),
   };
@@ -302,6 +310,30 @@ export function externalCommandErrorFromUnknown(
   normalized.diagnosticDetails = [externalCommandDiagnosticDetail(normalized)];
 
   return normalized;
+}
+
+function externalCommandEnvironment(input: Pick<ExternalCommandInput, "env" | "unsetEnv">) {
+  const env = { ...process.env };
+  for (const key of input.unsetEnv ?? []) {
+    delete env[key];
+  }
+  Object.assign(env, input.env);
+  return env;
+}
+
+async function missingWorkingDirectory(error: unknown, cwd: string | undefined): Promise<boolean> {
+  if (
+    cwd === undefined ||
+    externalCommandStringValue(externalCommandErrorLike(error), "code") !== "ENOENT"
+  ) {
+    return false;
+  }
+  try {
+    await defaultAccess(cwd);
+    return false;
+  } catch (cause) {
+    return externalCommandStringValue(externalCommandErrorLike(cause), "code") === "ENOENT";
+  }
 }
 
 function externalCommandFallback(code: string, message: string): RuntimeSafeErrorFallback {

--- a/packages/runtime/src/gitEnvironment.ts
+++ b/packages/runtime/src/gitEnvironment.ts
@@ -1,0 +1,25 @@
+export const gitLocalEnvironmentVariables = [
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CONFIG",
+  "GIT_CONFIG_PARAMETERS",
+  "GIT_CONFIG_COUNT",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_IMPLICIT_WORK_TREE",
+  "GIT_GRAFT_FILE",
+  "GIT_INDEX_FILE",
+  "GIT_NO_REPLACE_OBJECTS",
+  "GIT_REPLACE_REF_BASE",
+  "GIT_PREFIX",
+  "GIT_SHALLOW_FILE",
+  "GIT_COMMON_DIR",
+] as const;
+
+export function environmentWithoutGitLocals(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const sanitized = { ...env };
+  for (const key of gitLocalEnvironmentVariables) delete sanitized[key];
+  return sanitized;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,7 @@ export * from "./effect.js";
 export * from "./errors.js";
 export * from "./externalCommand.js";
 export * from "./files.js";
+export * from "./gitEnvironment.js";
 export * from "./hookSetup.js";
 export * from "./names.js";
 export * from "./objects.js";

--- a/packages/runtime/test/unit/external-command.test.ts
+++ b/packages/runtime/test/unit/external-command.test.ts
@@ -32,6 +32,39 @@ describe("runtime external command boundary", () => {
     });
   });
 
+  it("removes requested inherited environment keys without dropping unrelated values", async () => {
+    process.env.DROP_ME = "drop";
+    try {
+      const result = await runExternalCommand({
+        command: process.execPath,
+        args: [
+          "-e",
+          "process.stdout.write(JSON.stringify({drop:process.env.DROP_ME,keep:process.env.KEEP_ME}))",
+        ],
+        env: { KEEP_ME: "keep" },
+        unsetEnv: ["DROP_ME"],
+      });
+
+      expect(JSON.parse(result.stdout)).toEqual({ keep: "keep" });
+    } finally {
+      delete process.env.DROP_ME;
+    }
+  });
+
+  it("distinguishes a missing working directory from a missing executable", async () => {
+    const missingCwd = join(tmpdir(), `station-missing-cwd-${Date.now()}`);
+    await expect(
+      runExternalCommand({ command: process.execPath, cwd: missingCwd }),
+    ).rejects.toMatchObject({
+      code: "EXTERNAL_COMMAND_CWD_NOT_FOUND",
+      cwd: missingCwd,
+      command: process.execPath,
+    });
+    await expect(
+      runExternalCommand({ command: `station-missing-command-${Date.now()}`, cwd: tmpdir() }),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("redacts command output in typed failures", () => {
     const error = externalCommandErrorFromUnknown(
       {


### PR DESCRIPTION
## Summary

- isolate Git and Worktrunk subprocesses from caller-local Git environment
- exclude missing/prunable registrations from observer rows and reject stale or cross-project command targets
- scope Worktrunk doctor scans to the requested project, bound and cancel the scan work, and retain partial diagnostic evidence
- report safe dry-run/prune guidance for stale registrations
- keep provider diagnostic failures within the strict shared `SafeError` contract

## Review fixes

- made missing worktrees non-actionable even when the provider still returns a registration
- prevented project-wide doctor scans from exceeding the observer timeout
- added bounded concurrency and cancellation coverage
- fixed strict protocol validation for provider diagnostic errors

## Local CI

Passed on `95fe17eca9b13d42af904b98c78690a1790ab24c` with an isolated HOME:

- build, typecheck, lint
- 1,327 unit tests (serialized to avoid host worker starvation)
- 26 contract tests, 407 integration tests, 39 diagnostics tests
- scripted-agent and setup E2E suites
- Node/Bun SQLite compatibility
- Station typecheck, 990 Station tests, 26 Bun PTY tests
- compiled binary build and smoke

## UX

Stale Worktrunk registrations no longer appear as actionable sessions, and `stn doctor --project <id>` reports project-scoped dry-run/prune guidance.