### PR TITLE
build(binary): minify and guard compiled assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
     "typecheck": "turbo run typecheck",
-    "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs",
+    "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs && node tools/lint/check-no-parser-renderables.mjs",
     "format": "biome format --write .",
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",

--- a/scripts/build-binary.mjs
+++ b/scripts/build-binary.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { cp, mkdir, rm, symlink } from "node:fs/promises";
+import { cp, mkdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +8,19 @@ const SEMVER =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
 const repoRoot = fileURLToPath(new URL("../", import.meta.url));
 const stationRoot = join(repoRoot, "station");
+const excludedOpenTuiParserAssets = new Set([
+  "javascript/highlights.scm",
+  "javascript/tree-sitter-javascript.wasm",
+  "typescript/highlights.scm",
+  "typescript/tree-sitter-typescript.wasm",
+  "markdown/highlights.scm",
+  "markdown/injections.scm",
+  "markdown/tree-sitter-markdown.wasm",
+  "markdown_inline/highlights.scm",
+  "markdown_inline/tree-sitter-markdown_inline.wasm",
+  "zig/highlights.scm",
+  "zig/tree-sitter-zig.wasm",
+]);
 
 function fail(message) {
   process.stderr.write(`${message}\n`);
@@ -45,6 +58,18 @@ function nativeTarget() {
   return target;
 }
 
+function openTuiNativeAsset() {
+  const asset = {
+    "darwin:arm64": "@opentui/core-darwin-arm64/libopentui.dylib",
+    "darwin:x64": "@opentui/core-darwin-x64/libopentui.dylib",
+    "linux:arm64": "@opentui/core-linux-arm64/libopentui.so",
+    "linux:x64": "@opentui/core-linux-x64/libopentui.so",
+  }[`${process.platform}:${process.arch}`];
+  if (asset === undefined)
+    fail(`Unsupported OpenTUI build host: ${process.platform}/${process.arch}`);
+  return asset;
+}
+
 async function run(command, args, cwd) {
   const child = Bun.spawn([command, ...args], {
     cwd,
@@ -73,6 +98,34 @@ async function replaceSymlink(path, target) {
   await symlink(target, path);
 }
 
+function openTuiParserAssetPlugin() {
+  const observed = new Set();
+  return {
+    name: "exclude-unused-opentui-parser-assets",
+    setup(build) {
+      build.onResolve({ filter: /\/assets\/.*\.(?:scm|wasm)$/ }, (args) => {
+        if (!args.importer.includes("/node_modules/@opentui/core/")) return;
+        const asset = args.path.replace(/^\.\/assets\//, "");
+        if (!excludedOpenTuiParserAssets.has(asset)) {
+          throw new Error(`Unexpected OpenTUI parser asset: ${asset}`);
+        }
+        observed.add(asset);
+        return { path: asset, namespace: "excluded-opentui-parser-asset" };
+      });
+      build.onLoad({ filter: /.*/, namespace: "excluded-opentui-parser-asset" }, () => ({
+        contents: 'export default "";',
+        loader: "js",
+      }));
+    },
+    assertObserved() {
+      const missing = [...excludedOpenTuiParserAssets].filter((asset) => !observed.has(asset));
+      if (missing.length > 0 || observed.size !== excludedOpenTuiParserAssets.size) {
+        fail(`OpenTUI parser asset graph changed; missing: ${missing.join(", ") || "none"}.`);
+      }
+    },
+  };
+}
+
 async function main() {
   if (Bun.version !== REQUIRED_BUN_VERSION) {
     fail(`build:binary requires Bun ${REQUIRED_BUN_VERSION}; found ${Bun.version}.`);
@@ -81,12 +134,17 @@ async function main() {
   const outputDir = join(stationRoot, "dist", "bin");
   const outputPath = join(outputDir, "stn");
   const piBundlePath = join(stationRoot, "dist", "piExtension.mjs");
+  const openTuiAssetModulePath = join(stationRoot, "dist", "openTuiAsset.mjs");
 
   await run("pnpm", ["build"], repoRoot);
   await run("bun", ["run", "link:station"], stationRoot);
   await run("bun", ["run", "build:ctty-helper"], stationRoot);
 
   await mkdir(dirname(piBundlePath), { recursive: true });
+  await writeFile(
+    openTuiAssetModulePath,
+    `import asset from ${JSON.stringify(`../node_modules/${openTuiNativeAsset()}`)} with { type: "file" };\nexport default asset;\n`,
+  );
   await checkedBuild(
     {
       entrypoints: [join(repoRoot, "integrations", "harness", "pi", "src", "piExtension.ts")],
@@ -95,12 +153,15 @@ async function main() {
       target: "node",
       format: "esm",
       sourcemap: "none",
+      minify: true,
+      keepNames: true,
     },
     "Pi extension bundle",
   );
 
   await mkdir(outputDir, { recursive: true });
   await rm(outputPath, { force: true });
+  const parserAssetPlugin = openTuiParserAssetPlugin();
   await checkedBuild(
     {
       entrypoints: [join(stationRoot, "src", "bin", "stnMain.ts")],
@@ -114,15 +175,21 @@ async function main() {
       define: {
         STATION_BUILD_VERSION: JSON.stringify(version),
         STATION_BUILD_COMPILED: "true",
+        "process.env.NODE_ENV": JSON.stringify("production"),
       },
+      minify: true,
+      keepNames: true,
+      plugins: [parserAssetPlugin],
     },
     "Station binary compile",
   );
+  parserAssetPlugin.assertObserved();
 
   await replaceSymlink(join(outputDir, "stn-ingress"), "stn");
   await replaceSymlink(join(outputDir, "stn-tmux-popup"), "stn");
   await cp(join(repoRoot, "LICENSE"), join(outputDir, "LICENSE"));
-  process.stdout.write(`Built ${outputPath} (${nativeTarget()}, ${version}).\n`);
+  const { size } = await stat(outputPath);
+  process.stdout.write(`Built ${outputPath} (${nativeTarget()}, ${version}, ${size} bytes).\n`);
 }
 
 await main();

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -92,7 +93,27 @@ try {
     const piExtensionPath = await findFile(join(stateDir, "run", "assets", "pi"), (name) =>
       name.endsWith(".mjs"),
     );
-    await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
+    const piExtension = await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
+    assertEqual(typeof piExtension.default, "function", "minified Pi default export");
+    assertEqual(
+      typeof piExtension.registerStationPiExtension,
+      "function",
+      "minified Pi named export",
+    );
+    const piHandlers = new Map();
+    const deliveredEvents = [];
+    piExtension.registerStationPiExtension(
+      { on: (eventType, handler) => piHandlers.set(eventType, handler) },
+      {
+        env: { STATION_WORKTREE_PATH: root },
+        sendReport: async (input) => deliveredEvents.push(input),
+      },
+    );
+    assertEqual(piHandlers.size > 0, true, "minified Pi handler registration");
+    await piHandlers.get("session_start")?.({ reason: "startup" }, { cwd: root });
+    assertEqual(deliveredEvents.length, 1, "minified Pi injected event delivery");
+
+    await smokeTuiInPty(binaryPath, configPath, childEnv, root);
 
     await observerClient.stop();
     observerClient = undefined;
@@ -279,6 +300,54 @@ function collectOutput(child) {
   child.stdout?.on("data", (chunk) => (stdout += chunk));
   child.stderr?.on("data", (chunk) => (stderr += chunk));
   return () => ({ stdout, stderr });
+}
+
+async function smokeTuiInPty(command, config, env, cwd) {
+  const require = createRequire(import.meta.url);
+  await chmod(
+    resolve(
+      "station/node_modules/node-pty/prebuilds",
+      `${process.platform}-${process.arch}`,
+      "spawn-helper",
+    ),
+    0o755,
+  );
+  const pty = require(resolve("station/node_modules/node-pty"));
+  const terminal = pty.spawn(command, ["--config", config], {
+    cols: 100,
+    rows: 30,
+    cwd,
+    env,
+    name: "xterm-256color",
+  });
+  let output = "";
+  const exit = new Promise((resolveExit) => terminal.onExit(resolveExit));
+  const welcome = new Promise((resolveWelcome, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error(`compiled TUI welcome frame timed out\n${output}`)),
+      30_000,
+    );
+    terminal.onData((data) => {
+      output += data;
+      if (output.includes("Welcome to")) {
+        clearTimeout(timeout);
+        resolveWelcome();
+      }
+    });
+  });
+  try {
+    await welcome;
+    terminal.write("\x11");
+    const result = await Promise.race([
+      exit,
+      delay(10_000).then(() => {
+        throw new Error("compiled TUI did not exit after Ctrl-Q");
+      }),
+    ]);
+    assertEqual(result.exitCode, 0, "compiled TUI Ctrl-Q shutdown");
+  } finally {
+    terminal.kill();
+  }
 }
 
 async function waitForHost(client, diagnostics) {

--- a/station/src/bin/embeddedAssets.d.ts
+++ b/station/src/bin/embeddedAssets.d.ts
@@ -7,3 +7,8 @@ declare module "*piExtension.mjs" {
   const embeddedPath: string;
   export default embeddedPath;
 }
+
+declare module "*openTuiAsset.mjs" {
+  const embeddedPath: string;
+  export default embeddedPath;
+}

--- a/station/src/bin/packagedAssets.ts
+++ b/station/src/bin/packagedAssets.ts
@@ -32,7 +32,7 @@ const LOCK_WAIT_MS = 25;
 const LOCK_TIMEOUT_MS = 5_000;
 const OWNER_PREFIX = "owner-";
 
-type AssetKind = "ctty" | "pi";
+type AssetKind = "ctty" | "opentui" | "pi";
 
 type AssetSpec = {
   kind: AssetKind;
@@ -62,7 +62,22 @@ export async function preparePackagedPtyRuntime(
   stateDir: string,
   cttyHelperAssetPath: string,
   deps: PackagedAssetDeps = {},
+  openTuiAssetPath?: string,
 ): Promise<PreparedPtyRuntime> {
+  if (openTuiAssetPath !== undefined) {
+    const libraryPath = await materializeAsset(
+      stateDir,
+      {
+        kind: "opentui",
+        bytes: await readEmbeddedAsset(openTuiAssetPath),
+        fileName: process.platform === "darwin" ? "libopentui.dylib" : "libopentui.so",
+        mode: PI_MODE,
+      },
+      deps,
+    );
+    const { setRenderLibPath } = await import("@opentui/core");
+    setRenderLibPath(libraryPath);
+  }
   const implementation = resolvePtyImplementation(process.env.STATION_PTY_IMPL, "bun");
   if (implementation === "bridge") {
     throw new Error(

--- a/station/src/bin/stnMain.ts
+++ b/station/src/bin/stnMain.ts
@@ -1,5 +1,6 @@
 import { dispatchSelfExec, type SelfExecRunners } from "@station/cli/self-exec";
 import cttyHelperAsset from "../../dist/ctty-helper" with { type: "file" };
+import openTuiAsset from "../../dist/openTuiAsset.mjs";
 import piExtensionAsset from "../../dist/piExtension.mjs" with { type: "file" };
 import {
   preparePackagedPiExtension,
@@ -7,7 +8,7 @@ import {
 } from "./packagedAssets.js";
 
 const prepareCompiledPtyRuntime = (stateDir: string) =>
-  preparePackagedPtyRuntime(stateDir, cttyHelperAsset);
+  preparePackagedPtyRuntime(stateDir, cttyHelperAsset, {}, openTuiAsset);
 
 const prepareCompiledPiExtension = (stateDir: string) =>
   preparePackagedPiExtension(stateDir, piExtensionAsset);

--- a/tools/lint/check-no-parser-renderables.mjs
+++ b/tools/lint/check-no-parser-renderables.mjs
@@ -1,0 +1,23 @@
+import { glob, readFile } from "node:fs/promises";
+import { relative } from "node:path";
+
+const forbidden = [
+  /<(?:code|diff|markdown)(?:\s|>)/i,
+  /\b(?:CodeRenderable|MarkdownRenderable)\b/,
+  /tree-sitter/i,
+];
+const violations = [];
+
+for await (const path of glob("station/src/**/*.{ts,tsx}", {
+  exclude: (path) => /\.(?:test|spec)\.[^.]+$/.test(path),
+})) {
+  const source = await readFile(path, "utf8");
+  if (forbidden.some((pattern) => pattern.test(source))) violations.push(relative(".", path));
+}
+
+if (violations.length > 0) {
+  process.stderr.write(
+    `Parser-backed production UI is incompatible with the compiled asset exclusions:\n${violations.join("\n")}\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## What changed
- minify the compiled Station binary and embedded Pi extension with preserved names and production NODE_ENV
- guard the exact 11 excluded OpenTUI parser assets and reject parser-backed production UI
- materialize the embedded OpenTUI native library before renderer startup
- extend binary smoke with real-PTY welcome/shutdown and minified Pi event delivery

## UX
The standalone binary keeps DEV=true diagnostics and now launches the real TUI from a PTY. Manually run `./station/dist/bin/stn`, open a shell pane, and verify Ctrl-Z, fg, and Ctrl-C.

## Verification
- optimized build: 71,322,338 bytes on darwin-arm64
- `pnpm smoke:binary -- --expected-version 0.0.0-local`
- Station typecheck and packaged-assets tests
- full pre-push remainder passed; the complete wrapper is blocked by the existing live Claude hook-state fixture mismatch