### PR TITLE
build(release): publish verified binary artifacts

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -3,6 +3,11 @@ name: Bump Homebrew formula
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Source release tag
+        required: true
 
 permissions:
   contents: read
@@ -16,7 +21,7 @@ jobs:
           formula-name: station
           homebrew-tap: jeremy0dell/homebrew-station
           push-to: jeremy0dell/homebrew-station
-          tag-name: ${{ github.event.release.tag_name }}
+          tag-name: ${{ github.event.release.tag_name || inputs.tag }}
           download-url: https://github.com/jeremy0dell/station.git
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version used for a dry-run build
+        required: true
+        default: v0.0.0-dry-run
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - run: corepack enable && corepack prepare pnpm@11.0.0 --activate
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: pnpm install --frozen-lockfile
+      - run: bun install --cwd station --frozen-lockfile
+      - run: pnpm test:pre-push
+      - run: pnpm smoke:release
+
+  build:
+    needs: gate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: darwin-arm64
+            runner: macos-15
+            tar: gtar
+          - target: darwin-x64
+            runner: macos-15-intel
+            tar: gtar
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+            tar: tar
+          - target: linux-x64
+            runner: ubuntu-24.04
+            tar: tar
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - run: corepack enable && corepack prepare pnpm@11.0.0 --activate
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - if: runner.os == 'macOS'
+        run: brew install gnu-tar xz
+      - run: pnpm install --frozen-lockfile
+      - run: bun install --cwd station --frozen-lockfile
+      - run: pnpm build:binary -- --version "${VERSION#v}"
+      - if: runner.os == 'macOS'
+        run: codesign --force --sign - station/dist/bin/stn && codesign --verify --deep --strict station/dist/bin/stn
+      - run: pnpm smoke:binary -- --expected-version "${VERSION#v}"
+      - run: TAR_COMMAND=${{ matrix.tar }} scripts/package-binary.sh "$VERSION" ${{ matrix.target }} artifacts
+      - run: scripts/test-runners/verify-binary-archives.sh artifacts/*.tar.gz artifacts/*.tar.xz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: artifacts/*
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Verify and summarize artifacts
+        run: |
+          test "$(find artifacts -type f | wc -l)" -eq 8
+          find artifacts -type f -name '*.tar.*' -print0 | sort -z | xargs -0 sha256sum | sed 's#  artifacts/#  #' > artifacts/SHA256SUMS
+          cat artifacts/SHA256SUMS
+          wc -c artifacts/*.tar.gz artifacts/*.tar.xz
+      - name: Publish release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" artifacts/* --verify-tag --generate-notes
+      - name: Dispatch source Homebrew bump
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+        run: gh workflow run homebrew-bump.yml -f tag="${{ github.ref_name }}"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
+    "smoke:binary-archives": "scripts/test-runners/verify-binary-archives.sh",
     "typecheck": "turbo run typecheck",
     "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs && node tools/lint/check-no-parser-renderables.mjs",
     "format": "biome format --write .",

--- a/scripts/package-binary.sh
+++ b/scripts/package-binary.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+version=${1:?usage: package-binary.sh vX.Y.Z target output-dir}
+target=${2:?usage: package-binary.sh vX.Y.Z target output-dir}
+output_dir=${3:?usage: package-binary.sh vX.Y.Z target output-dir}
+tar_command=${TAR_COMMAND:-tar}
+binary_dir=${STATION_BINARY_DIR:-station/dist/bin}
+name="stn-${version}-${target}"
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT HUP INT TERM
+
+mkdir -p "$output_dir"
+cp "$binary_dir/stn" "$stage/stn"
+cp LICENSE "$stage/LICENSE"
+chmod 0755 "$stage/stn"
+chmod 0644 "$stage/LICENSE"
+ln -s stn "$stage/stn-ingress"
+ln -s stn "$stage/stn-tmux-popup"
+touch -t 197001010000 "$stage/stn" "$stage/LICENSE"
+
+archive="$output_dir/$name.tar"
+"$tar_command" \
+  --format=ustar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+  -cf "$archive" -C "$stage" LICENSE stn stn-ingress stn-tmux-popup
+gzip -n -9 -c "$archive" > "$archive.gz"
+xz -6 -c "$archive" > "$archive.xz"
+rm "$archive"
+
+wc -c "$stage/stn" "$archive.gz" "$archive.xz"

--- a/scripts/test-runners/verify-binary-archives.sh
+++ b/scripts/test-runners/verify-binary-archives.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+gzip_archive=${1:?usage: verify-binary-archives.sh archive.tar.gz archive.tar.xz}
+xz_archive=${2:?usage: verify-binary-archives.sh archive.tar.gz archive.tar.xz}
+root=$(mktemp -d)
+trap 'rm -rf "$root"' EXIT HUP INT TERM
+
+gzip -dc "$gzip_archive" > "$root/gzip.tar"
+xz -dc "$xz_archive" > "$root/xz.tar"
+cmp "$root/gzip.tar" "$root/xz.tar"
+
+for format in gzip xz; do
+  mkdir "$root/$format"
+  tar -xf "$root/$format.tar" -C "$root/$format"
+  actual=$(find "$root/$format" -mindepth 1 -maxdepth 1 -exec basename {} \; | LC_ALL=C sort)
+  expected=$(printf '%s\n' LICENSE stn stn-ingress stn-tmux-popup | LC_ALL=C sort)
+  test "$actual" = "$expected"
+  test -x "$root/$format/stn"
+  test "$(readlink "$root/$format/stn-ingress")" = stn
+  test "$(readlink "$root/$format/stn-tmux-popup")" = stn
+done
+
+cmp "$root/gzip/stn" "$root/xz/stn"
+cmp "$root/gzip/LICENSE" "$root/xz/LICENSE"


### PR DESCRIPTION
## What changed
- add tag and manual dry-run native release workflow for four supported targets
- ad-hoc sign and verify macOS binaries before packaging
- derive deterministic gzip and xz archives from one normalized tar stream
- verify identical manifests and publish sorted SHA256SUMS plus size reports
- explicitly dispatch the existing source-based Homebrew bump

## UX
Private releases gain smaller xz downloads while gzip remains the fallback. The Homebrew formula stays source-based.

## Verification
- GNU-tar packaging and gzip/xz stream equivalence passed
- darwin-arm64 sample: 25,756,878 bytes gzip; 16,431,116 bytes xz
- workflow YAML parsed locally

Stacked on #128.