### PR TITLE
feat(install): add authenticated binary installer

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,16 @@
 # Install
 
-This setup path is for a local development checkout. station remains a private workspace package for this milestone; there is no public npm package or publish flow yet.
+The source setup path is for a local development checkout. Station remains private and is not published to npm.
+
+## Authenticated Binary Install
+
+Private releases publish native macOS and Linux archives. With an authenticated GitHub CLI session, install the latest release to `~/.local/bin` with:
+
+```bash
+./scripts/install.sh
+```
+
+Use `--version vX.Y.Z` for an immutable install or rollback, and `--install-dir PATH` for a different launcher directory. The installer prefers xz when available, falls back to gzip, and verifies the published checksum and complete archive manifest before replacing an existing installation. The source bootstrap and source-based Homebrew formula remain supported and unchanged.
 
 ## Quick start (macOS)
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
     "smoke:binary-archives": "scripts/test-runners/verify-binary-archives.sh",
+    "smoke:install": "node scripts/test-runners/run-install-smoke.mjs",
     "typecheck": "turbo run typecheck",
     "lint": "biome check . && node tools/lint/check-source-order.mjs && node tools/lint/check-no-raw-hex.mjs && node tools/lint/check-no-parser-renderables.mjs",
     "format": "biome format --write .",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+set -eu
+
+repository=${STATION_INSTALL_REPOSITORY:-jeremy0dell/station}
+install_dir=${HOME:?HOME is required}/.local/bin
+version=
+
+usage() {
+  echo "Usage: install.sh [--version vX.Y.Z] [--install-dir PATH]"
+}
+
+fail() {
+  echo "station installer: $*" >&2
+  exit 1
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "$#" -ge 2 ] || fail "--version requires vX.Y.Z"
+      version=$2
+      shift 2
+      ;;
+    --install-dir)
+      [ "$#" -ge 2 ] || fail "--install-dir requires a path"
+      install_dir=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *) fail "unsupported argument: $1" ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required"
+gh auth status >/dev/null 2>&1 || fail "authenticate first with: gh auth login"
+
+if [ -z "$version" ]; then
+  version=$(gh api "repos/$repository/releases/latest" --jq .tag_name)
+fi
+printf '%s\n' "$version" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' ||
+  fail "version must be vX.Y.Z: $version"
+
+case "$(uname -s):$(uname -m)" in
+  Darwin:arm64) target=darwin-arm64 ;;
+  Darwin:x86_64) target=darwin-x64 ;;
+  Linux:aarch64|Linux:arm64) target=linux-arm64 ;;
+  Linux:x86_64) target=linux-x64 ;;
+  *) fail "unsupported platform: $(uname -s)/$(uname -m)" ;;
+esac
+
+format=gz
+if command -v xz >/dev/null 2>&1; then
+  format=xz
+fi
+archive="stn-$version-$target.tar.$format"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT HUP INT TERM
+
+gh release download "$version" --repo "$repository" --pattern "$archive" --dir "$work"
+gh release download "$version" --repo "$repository" --pattern SHA256SUMS --dir "$work"
+
+expected=$(awk -v file="$archive" '$2 == file { print $1 }' "$work/SHA256SUMS")
+[ "$(printf '%s\n' "$expected" | wc -l | tr -d ' ')" -eq 1 ] || fail "missing or duplicate checksum for $archive"
+case "$(uname -s)" in
+  Darwin) actual=$(shasum -a 256 "$work/$archive" | awk '{ print $1 }') ;;
+  *) actual=$(sha256sum "$work/$archive" | awk '{ print $1 }') ;;
+esac
+[ "$actual" = "$expected" ] || fail "checksum mismatch for $archive"
+
+mkdir "$work/extracted"
+case "$format" in
+  xz) xz -dc "$work/$archive" > "$work/archive.tar" ;;
+  gz) gzip -dc "$work/$archive" > "$work/archive.tar" ;;
+esac
+archive_manifest=$(tar -tf "$work/archive.tar" | LC_ALL=C sort)
+expected_manifest=$(printf '%s\n' LICENSE stn stn-ingress stn-tmux-popup | LC_ALL=C sort)
+[ "$archive_manifest" = "$expected_manifest" ] || fail "archive manifest is invalid"
+tar -xf "$work/archive.tar" -C "$work/extracted"
+
+actual_manifest=$(find "$work/extracted" -mindepth 1 -maxdepth 1 -exec basename {} \; | LC_ALL=C sort)
+[ "$actual_manifest" = "$expected_manifest" ] || fail "archive manifest is invalid"
+[ -f "$work/extracted/stn" ] && [ ! -L "$work/extracted/stn" ] || fail "stn is not a regular file"
+[ -x "$work/extracted/stn" ] || fail "stn is not executable"
+[ -f "$work/extracted/LICENSE" ] && [ ! -L "$work/extracted/LICENSE" ] || fail "LICENSE is not a regular file"
+[ -L "$work/extracted/stn-ingress" ] && [ "$(readlink "$work/extracted/stn-ingress")" = stn ] || fail "stn-ingress symlink is invalid"
+[ -L "$work/extracted/stn-tmux-popup" ] && [ "$(readlink "$work/extracted/stn-tmux-popup")" = stn ] || fail "stn-tmux-popup symlink is invalid"
+
+mkdir -p "$install_dir"
+stage="$install_dir/.stn-install-$$"
+cp "$work/extracted/stn" "$stage"
+chmod 0755 "$stage"
+if command -v xattr >/dev/null 2>&1; then
+  xattr -d com.apple.quarantine "$stage" 2>/dev/null || true
+fi
+ln -s stn "$stage-ingress"
+ln -s stn "$stage-tmux-popup"
+
+mv -f "$stage" "$install_dir/stn"
+mv -f "$stage-ingress" "$install_dir/stn-ingress"
+mv -f "$stage-tmux-popup" "$install_dir/stn-tmux-popup"
+
+echo "Installed Station $version to $install_dir"
+case ":$PATH:" in
+  *:"$install_dir":*) ;;
+  *) echo "Add $install_dir to PATH to run stn." ;;
+esac

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { gzipSync } from "node:zlib";
+
+const installer = resolve("scripts/install.sh");
+const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
+const releases = join(root, "releases");
+const fakeBin = join(root, "bin");
+const realXz = execFileSync("sh", ["-c", "command -v xz"], { encoding: "utf8" }).trim();
+
+try {
+  mkdirSync(releases);
+  mkdirSync(fakeBin);
+  writeFakeCommands();
+  createRelease("v1.2.3", "darwin-arm64");
+  createRelease("v1.2.3", "linux-x64");
+  createRelease("v1.2.4", "linux-x64", { extra: true });
+  createRelease("v1.2.5", "linux-x64", { truncate: true });
+  createRelease("v1.2.6", "linux-x64", { corruptChecksum: true });
+
+  symlinkSync(realXz, join(fakeBin, "xz"));
+  assertInstall({ system: "Darwin", machine: "arm64", format: "xz" });
+  assertInstall({ system: "Linux", machine: "x86_64", format: "xz" });
+  rmSync(join(fakeBin, "xz"));
+  assertInstall({ system: "Linux", machine: "x86_64", format: "gz" });
+
+  const preserved = join(root, "preserved");
+  mkdirSync(preserved);
+  writeFileSync(join(preserved, "stn"), "old runtime\n", { mode: 0o755 });
+  for (const version of ["v1.2.4", "v1.2.5", "v1.2.6"]) {
+    const result = runInstaller({
+      system: "Linux",
+      machine: "x86_64",
+      installDir: preserved,
+      version,
+    });
+    if (result.status === 0) throw new Error(`${version} unexpectedly installed`);
+    if (readFileSync(join(preserved, "stn"), "utf8") !== "old runtime\n") {
+      throw new Error(`${version} changed the existing installation`);
+    }
+  }
+  process.stdout.write("install smoke passed\n");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function writeFakeCommands() {
+  writeFileSync(
+    join(fakeBin, "gh"),
+    `#!/bin/sh
+set -eu
+if [ "$1 $2" = "auth status" ]; then exit 0; fi
+if [ "$1" = api ]; then printf '%s\\n' v1.2.3; exit 0; fi
+pattern=
+directory=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --pattern) pattern=$2; shift 2 ;;
+    --dir) directory=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+cp "$STATION_TEST_RELEASES/$pattern" "$directory/$pattern"
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    join(fakeBin, "uname"),
+    '#!/bin/sh\ncase "$1" in -s) echo "$STATION_TEST_SYSTEM";; -m) echo "$STATION_TEST_MACHINE";; esac\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(join(fakeBin, "sha256sum"), '#!/bin/sh\nshasum -a 256 "$1"\n', {
+    mode: 0o755,
+  });
+}
+
+function createRelease(version, target, options = {}) {
+  const stage = join(root, `stage-${version}-${target}`);
+  mkdirSync(stage);
+  writeFileSync(join(stage, "stn"), `#!/bin/sh\necho ${version}\n`, { mode: 0o755 });
+  writeFileSync(join(stage, "LICENSE"), "Station test license\n", { mode: 0o644 });
+  symlinkSync("stn", join(stage, "stn-ingress"));
+  symlinkSync("stn", join(stage, "stn-tmux-popup"));
+  if (options.extra) writeFileSync(join(stage, "unexpected"), "no\n");
+  const tarPath = join(root, `${version}-${target}.tar`);
+  const members = ["LICENSE", "stn", "stn-ingress", "stn-tmux-popup"];
+  if (options.extra) members.push("unexpected");
+  execFileSync("tar", ["-cf", tarPath, "-C", stage, ...members]);
+  const tarBytes = readFileSync(tarPath);
+  const base = `stn-${version}-${target}.tar`;
+  writeFileSync(join(releases, `${base}.gz`), gzipSync(tarBytes));
+  writeFileSync(join(releases, `${base}.xz`), execFileSync(realXz, ["-6", "-c", tarPath]));
+  if (options.truncate) {
+    const path = join(releases, `${base}.gz`);
+    const bytes = readFileSync(path);
+    writeFileSync(path, bytes.subarray(0, Math.floor(bytes.length / 2)));
+  }
+  const sums = ["gz", "xz"].map((format) => {
+    const name = `${base}.${format}`;
+    const hash = createHash("sha256")
+      .update(readFileSync(join(releases, name)))
+      .digest("hex");
+    return `${options.corruptChecksum ? "0".repeat(64) : hash}  ${name}`;
+  });
+  writeFileSync(join(releases, `SHA256SUMS-${version}-${target}`), `${sums.join("\n")}\n`);
+}
+
+function runInstaller({ system, machine, installDir, version = "v1.2.3" }) {
+  const target = `${system === "Darwin" ? "darwin" : "linux"}-${machine === "arm64" ? "arm64" : "x64"}`;
+  cpSync(join(releases, `SHA256SUMS-${version}-${target}`), join(releases, "SHA256SUMS"));
+  return spawnSync(installer, ["--version", version, "--install-dir", installDir], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: join(root, "home"),
+      PATH: `${fakeBin}:/usr/bin:/bin`,
+      STATION_TEST_MACHINE: machine,
+      STATION_TEST_RELEASES: releases,
+      STATION_TEST_SYSTEM: system,
+    },
+  });
+}
+
+function assertInstall({ system, machine, format }) {
+  const installDir = join(root, `install-${system}-${machine}-${format}`);
+  const result = runInstaller({ system, machine, installDir });
+  if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+  if (readlinkSync(join(installDir, "stn-ingress")) !== "stn") throw new Error("bad ingress");
+  if (readlinkSync(join(installDir, "stn-tmux-popup")) !== "stn") throw new Error("bad popup");
+  chmodSync(join(installDir, "stn"), 0o755);
+}


### PR DESCRIPTION
## What changed
- add authenticated private-release installation through the existing gh session
- prefer xz with gzip fallback and support exact version rollback/install-dir selection
- verify checksum and exact archive paths, modes, and alias targets before extraction activation
- stage on the destination filesystem and atomically replace the runtime binary
- defensively clear macOS quarantine metadata
- add macOS/Linux xz, Linux gzip, corrupt checksum, truncated archive, unexpected entry, and existing-install preservation smoke coverage

## UX
A failed download or verification leaves the current installation unchanged. Run `./scripts/install.sh --version vX.Y.Z`, then `stn --version`; rerun with an older tag to roll back.

## Verification
- `pnpm smoke:install`
- lint and diff checks

Stacked on #129.