### PR TITLE
test(binary): exercise packaged Pi extension

### DIFF
--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -92,7 +92,25 @@ try {
     const piExtensionPath = await findFile(join(stateDir, "run", "assets", "pi"), (name) =>
       name.endsWith(".mjs"),
     );
-    await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
+    const piExtension = await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
+    assertEqual(typeof piExtension.default, "function", "packaged Pi default export");
+    assertEqual(
+      typeof piExtension.registerStationPiExtension,
+      "function",
+      "packaged Pi named export",
+    );
+    const piHandlers = new Map();
+    const deliveredEvents = [];
+    piExtension.registerStationPiExtension(
+      { on: (eventType, handler) => piHandlers.set(eventType, handler) },
+      {
+        env: { STATION_WORKTREE_PATH: root },
+        sendReport: async (input) => deliveredEvents.push(input),
+      },
+    );
+    assertEqual(piHandlers.size > 0, true, "packaged Pi handler registration");
+    await piHandlers.get("session_start")?.({ reason: "startup" }, { cwd: root });
+    assertEqual(deliveredEvents.length, 1, "packaged Pi injected event delivery");
 
     await observerClient.stop();
     observerClient = undefined;


### PR DESCRIPTION
## What changed

Extend the existing compiled-binary smoke to import the extracted Pi extension, assert its default and named exports, register its handlers, and deliver one injected `session_start` event through the packaged bundle.

No production build, runtime, release, or installer behavior changes.

## Why

The packaged Pi bundle was previously only imported. This proves the extracted artifact remains callable and preserves its integration surface.

## UX

No user-visible behavior changes. Manually verify with the normal compiled-binary smoke.

## Verification

- `pnpm build:binary -- --version 0.0.0-local`
- `pnpm smoke:binary -- --expected-version 0.0.0-local`