### PR TITLE
docs(install): document authenticated curl onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,32 +42,56 @@ station keeps track of everything that's running and makes it visible:
 
 ## Getting started
 
-The authenticated private binary is the user install path. Authenticate the GitHub CLI for the private repository, fetch the installer, then run setup:
+The authenticated private binary is the user install path. Authenticate the GitHub CLI for the private repository, use `curl` to fetch the version-pinned installer, then run setup:
 
 ```sh
 gh auth login --hostname github.com
 (
   set -e
+  umask 077
   tag=v0.7.0
+  token="$(gh auth token --hostname github.com)"
+  test -n "$token"
+  headers="$(mktemp)"
   installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api --method GET \
-    repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" \
-    -f ref="$tag" > "$installer"
+  trap 'rm -f "$headers" "$installer"' EXIT
+  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
+    "$token" > "$headers"
+  unset token
+  curl --disable \
+    --proto '=https' \
+    --tlsv1.2 \
+    --fail \
+    --silent \
+    --show-error \
+    --max-redirs 0 \
+    --header "@$headers" \
+    --output "$installer" \
+    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
+  rm -f "$headers"
   test -s "$installer"
+  sh -n "$installer"
   sh "$installer" --version "$tag"
 )
 ```
 
-After the checked installer exits successfully:
+The curl block only installs the Station binaries; it does not configure a project or edit your shell profile. From the Git repository you want Station to manage, make the default install available in the current shell, run guided setup, verify it, and launch:
 
 ```sh
+cd /path/to/your/git-project
+PATH="$HOME/.local/bin${PATH:+":$PATH"}"
+export PATH
+hash -r
+
+stn --version
 stn setup
+stn doctor
 stn
 ```
 
-The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. Git, Worktrunk (`wt`), tmux, diffnav/git-delta, GitHub integration, and agent CLIs remain feature-gated external tools; `stn setup` and `stn doctor` say which workflow capabilities are ready.
+`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file for future terminals. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
+
+The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
 
 `v0.7.0` is the first supported private-binary baseline. The installer code
 and artifacts always come from the same immutable tag. The latest-install

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ station keeps track of everything that's running and makes it visible:
 
 ## Getting started
 
-The authenticated private binary is the user install path. Authenticate the GitHub CLI for the private repository, use `curl` to fetch the version-pinned installer, then run setup:
+The authenticated private binary is the user install path. Start in the Git repository you want Station to manage, authenticate the GitHub CLI for the private repository, use `curl` to fetch the version-pinned installer, then run setup:
 
 ```sh
+cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
   set -e
@@ -75,10 +76,9 @@ gh auth login --hostname github.com
 )
 ```
 
-The curl block only installs the Station binaries; it does not configure a project or edit your shell profile. From the Git repository you want Station to manage, make the default install available in the current shell, run guided setup, verify it, and launch:
+The curl block only installs the Station binaries; it does not configure the current project or edit your shell profile. From the same project shell, make the default install available, run guided setup, verify it, and launch the full workspace:
 
 ```sh
-cd /path/to/your/git-project
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
 export PATH
 hash -r
@@ -86,12 +86,14 @@ hash -r
 stn --version
 stn setup
 stn doctor
-stn
+stn tui
 ```
 
 `stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file for future terminals. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
+
+`stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
 The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ stn
 
 `stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file for future terminals. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
 
+On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
+
 The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
 
 `v0.7.0` is the first supported private-binary baseline. The installer code

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,9 +4,10 @@ Station is distributed internally as authenticated private GitHub release assets
 
 ## Private Binary
 
-Authenticate `gh` for `jeremy0dell/station`, then use `curl` to fetch the version-pinned installer from the private repository:
+Start in the Git repository you want Station to manage, authenticate `gh` for `jeremy0dell/station`, then use `curl` to fetch the version-pinned installer from the private repository:
 
 ```bash
+cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
   set -e
@@ -41,6 +42,7 @@ gh auth login --hostname github.com
 stable tag first, then fetch and invoke that tag's installer:
 
 ```bash
+cd /path/to/your/git-project
 (
   set -e
   umask 077
@@ -83,10 +85,9 @@ rollback to a prior binary becomes available only after the next binary release.
 
 ### Complete first-run setup
 
-The curl block only installs the Station binaries; it does not configure a project or edit your shell profile. `stn setup` uses the current Git repository as the first Station project, so change into that repository before running it. For the default install location, the complete handoff is:
+The curl block only installs the Station binaries; it does not configure the current project or edit your shell profile. Both recipes begin by changing into the Git repository that `stn setup` will use as the first Station project. For the default install location, the remaining handoff is:
 
 ```bash
-cd /path/to/your/git-project
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
 export PATH
 hash -r
@@ -94,14 +95,14 @@ hash -r
 stn --version
 stn setup
 stn doctor
-stn
+stn tui
 ```
 
-If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`; change into the project repository before running that block. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
+If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`. When running the installer outside these recipes, change into the project repository before using that block. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
 
 Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes `~/.config/station/config.toml` for the current repository; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
 
-The PATH assignment above affects only the current shell. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file if future terminals do not already include that directory. The installer never edits a profile. Outside tmux, `stn` launches the fullscreen workspace; inside tmux it opens the popup dashboard, and `stn tui` forces fullscreen.
+The PATH assignment above affects only the current shell. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file if future terminals do not already include that directory. The installer never edits a profile. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,29 +4,37 @@ Station is distributed internally as authenticated private GitHub release assets
 
 ## Private Binary
 
-Authenticate `gh` for `jeremy0dell/station`, then run the installer directly from the private repository:
+Authenticate `gh` for `jeremy0dell/station`, then use `curl` to fetch the version-pinned installer from the private repository:
 
 ```bash
 gh auth login --hostname github.com
 (
   set -e
+  umask 077
   tag=v0.7.0
+  token="$(gh auth token --hostname github.com)"
+  test -n "$token"
+  headers="$(mktemp)"
   installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api --method GET \
-    repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" \
-    -f ref="$tag" > "$installer"
+  trap 'rm -f "$headers" "$installer"' EXIT
+  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
+    "$token" > "$headers"
+  unset token
+  curl --disable \
+    --proto '=https' \
+    --tlsv1.2 \
+    --fail \
+    --silent \
+    --show-error \
+    --max-redirs 0 \
+    --header "@$headers" \
+    --output "$installer" \
+    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
+  rm -f "$headers"
   test -s "$installer"
+  sh -n "$installer"
   sh "$installer" --version "$tag"
 )
-```
-
-Only after that block succeeds:
-
-```bash
-stn setup
-stn
 ```
 
 `v0.7.0` is the first supported private-binary baseline. Resolve the latest
@@ -35,26 +43,65 @@ stable tag first, then fetch and invoke that tag's installer:
 ```bash
 (
   set -e
+  umask 077
   tag="$(
     GH_HOST=github.com gh api --method GET \
       repos/jeremy0dell/station/releases/latest --jq '.tag_name'
   )"
   test -n "$tag"
+  token="$(gh auth token --hostname github.com)"
+  test -n "$token"
+  headers="$(mktemp)"
   installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  GH_HOST=github.com gh api --method GET \
-    repos/jeremy0dell/station/contents/scripts/install.sh \
-    -H "Accept: application/vnd.github.raw+json" \
-    -f ref="$tag" > "$installer"
+  trap 'rm -f "$headers" "$installer"' EXIT
+  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
+    "$token" > "$headers"
+  unset token
+  curl --disable \
+    --proto '=https' \
+    --tlsv1.2 \
+    --fail \
+    --silent \
+    --show-error \
+    --max-redirs 0 \
+    --header "@$headers" \
+    --output "$installer" \
+    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
+  rm -f "$headers"
   test -s "$installer"
+  sh -n "$installer"
   sh "$installer" --version "$tag"
 )
 ```
 
 Use the explicit form with the desired `tag` for every exact install. Both
 forms pair installer code and artifacts from one immutable tag; they never
-fall back to `main`. Because `v0.7.0` is the first binary release, immutable
+fall back to `main`. `curl` only bootstraps that checked installer; the
+installer continues to use authenticated `gh` for private release discovery
+and asset downloads. Because `v0.7.0` is the first binary release, immutable
 rollback to a prior binary becomes available only after the next binary release.
+
+### Complete first-run setup
+
+The curl block only installs the Station binaries; it does not configure a project or edit your shell profile. `stn setup` uses the current Git repository as the first Station project, so change into that repository before running it. For the default install location, the complete handoff is:
+
+```bash
+cd /path/to/your/git-project
+PATH="$HOME/.local/bin${PATH:+":$PATH"}"
+export PATH
+hash -r
+
+stn --version
+stn setup
+stn doctor
+stn
+```
+
+If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`; change into the project repository before running that block. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
+
+Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes `~/.config/station/config.toml` for the current repository; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
+
+The PATH assignment above affects only the current shell. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file if future terminals do not already include that directory. The installer never edits a profile. Outside tmux, `stn` launches the fullscreen workspace; inside tmux it opens the popup dashboard, and `stn tui` forces fullscreen.
 
 Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -103,6 +103,8 @@ Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta
 
 The PATH assignment above affects only the current shell. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file if future terminals do not already include that directory. The installer never edits a profile. Outside tmux, `stn` launches the fullscreen workspace; inside tmux it opens the popup dashboard, and `stn tui` forces fullscreen.
 
+On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
+
 Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
 
 The installer:

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -65,9 +65,61 @@ describe("release readiness docs", () => {
     expect(readme).toContain("without Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
     expect(install).toContain("tag=v0.7.0");
-    expect(install).toContain('-f ref="$tag"');
-    expect(install).toContain('sh "$installer" --version "$tag"');
-    expect(readme).toContain('-f ref="$tag"');
+    for (const [path, document] of [
+      ["README.md", readme],
+      ["docs/install.md", install],
+    ] as const) {
+      expect(document, path).not.toContain("ref=main");
+      const expectedRecipeCount = path === "README.md" ? 1 : 2;
+      const contentsFetches = continuedShellCommands(document).filter((command) =>
+        command.includes("contents/scripts/install.sh"),
+      );
+      expect(contentsFetches, path).toHaveLength(expectedRecipeCount);
+      for (const command of contentsFetches) {
+        expect(command, path).toMatch(/^curl\s/);
+      }
+      const recipes = shellBlocks(document).filter((block) =>
+        block.includes(
+          "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
+        ),
+      );
+      expect(recipes, path).toHaveLength(expectedRecipeCount);
+      for (const recipe of recipes) {
+        expect(recipe, path).toContain("umask 077");
+        expect(recipe, path).toContain('token="$(gh auth token --hostname github.com)"');
+        expect(recipe, path).toContain('headers="$(mktemp)"');
+        expect(recipe, path).toContain('installer="$(mktemp)"');
+        expect(recipe, path).toContain('trap \'rm -f "$headers" "$installer"\' EXIT');
+        expect(recipe, path).toContain("Authorization: Bearer %s");
+        expect(recipe, path).toContain("Accept: application/vnd.github.raw+json");
+        expect(recipe, path).toContain("unset token");
+        expect(recipe, path).toContain('test -s "$installer"');
+        expect(recipe, path).toContain('sh -n "$installer"');
+        expect(recipe, path).toContain('sh "$installer" --version "$tag"');
+
+        const installerFetches = continuedShellCommands(recipe).filter((command) =>
+          command.includes("contents/scripts/install.sh?ref=$tag"),
+        );
+        expect(installerFetches, path).toHaveLength(1);
+        const command = installerFetches[0] ?? "";
+        expect(command, path).toContain("--disable");
+        expect(command, path).toContain("--proto '=https'");
+        expect(command, path).toContain("--tlsv1.2");
+        expect(command, path).toContain("--fail");
+        expect(command, path).toContain("--silent");
+        expect(command, path).toContain("--show-error");
+        expect(command, path).toContain("--max-redirs 0");
+        expect(command, path).toContain('--header "@$headers"');
+        expect(command, path).toContain('--output "$installer"');
+        expect(command, path).toContain(
+          "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
+        );
+        expect(command, path).toMatch(/^curl\s/);
+        expect(command, path).not.toMatch(/\b(?:Authorization|Bearer|token)\b/i);
+        expect(command, path).not.toMatch(/(?:^|\s)(?:-L|--location)(?:\s|$)/);
+        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
+      }
+    }
     expect(readme.replace(/\s+/g, " ")).toContain("installer code and artifacts");
     expect(install).toContain("SHA256SUMS");
     expect(install).toContain("stn-tmux-popup");
@@ -158,6 +210,24 @@ describe("release readiness docs", () => {
     }
   });
 
+  it("documents the complete first-run handoff after the binary install", async () => {
+    const documents = await Promise.all(
+      ["README.md", "docs/install.md"].map(async (path) => [path, await read(path)] as const),
+    );
+
+    for (const [path, document] of documents) {
+      expect(document, path).toContain("only installs the Station binaries");
+      expect(document, path).toContain("cd /path/to/your/git-project");
+      expect(document, path).toMatch(/PATH="\$HOME\/\.local\/bin\$\{PATH:\+":\$PATH"\}"/);
+      expect(document, path).toContain("hash -r");
+      expect(document, path).toContain("stn setup");
+      expect(document, path).toContain("stn doctor");
+      expect(document, path).toMatch(/\nstn\n/);
+      expect(document, path).toContain("~/.config/station/config.toml");
+      expect(document, path).toContain("shell startup file");
+    }
+  });
+
   it("does not advertise removed Crush harness surfaces", async () => {
     const files = ["README.md", "AGENTS.md", ...(await markdownFiles("docs"))];
 
@@ -170,6 +240,18 @@ describe("release readiness docs", () => {
 
 async function read(path: string): Promise<string> {
   return readFile(path, "utf8");
+}
+
+function continuedShellCommands(document: string): string[] {
+  return document
+    .replace(/\\\r?\n\s*/g, " ")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => /^(?:[A-Z_]+=[^ ]+\s+)*(?:curl|gh)\s/.test(line));
+}
+
+function shellBlocks(document: string): string[] {
+  return [...document.matchAll(/```(?:sh|bash)\r?\n([\s\S]*?)```/g)].map((match) => match[1] ?? "");
 }
 
 async function markdownFiles(root: string): Promise<string[]> {

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -71,13 +71,20 @@ describe("release readiness docs", () => {
     ] as const) {
       expect(document, path).not.toContain("ref=main");
       const expectedRecipeCount = path === "README.md" ? 1 : 2;
-      const contentsFetches = continuedShellCommands(document).filter((command) =>
+      const curlCommands = shellBlocks(document)
+        .flatMap(continuedShellCommands)
+        .filter((command) => command.startsWith("curl "));
+      expect(curlCommands, path).toHaveLength(expectedRecipeCount);
+      for (const command of curlCommands) {
+        expect(command, path).toMatch(/^curl\s+--disable(?:\s|$)/);
+        expect(command, path).not.toMatch(/\b(?:Authorization|Bearer|token)\b/i);
+        expect(command, path).not.toMatch(/(?:^|\s)(?:-L|--location)(?:\s|$)/);
+        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
+      }
+      const contentsFetches = curlCommands.filter((command) =>
         command.includes("contents/scripts/install.sh"),
       );
       expect(contentsFetches, path).toHaveLength(expectedRecipeCount);
-      for (const command of contentsFetches) {
-        expect(command, path).toMatch(/^curl\s/);
-      }
       const recipes = shellBlocks(document).filter((block) =>
         block.includes(
           "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
@@ -85,6 +92,10 @@ describe("release readiness docs", () => {
       );
       expect(recipes, path).toHaveLength(expectedRecipeCount);
       for (const recipe of recipes) {
+        expect(recipe, path).toContain("cd /path/to/your/git-project");
+        expect(recipe.indexOf("cd /path/to/your/git-project"), path).toBeLessThan(
+          recipe.indexOf("curl --disable"),
+        );
         expect(recipe, path).toContain("umask 077");
         expect(recipe, path).toContain('token="$(gh auth token --hostname github.com)"');
         expect(recipe, path).toContain('headers="$(mktemp)"');
@@ -102,7 +113,6 @@ describe("release readiness docs", () => {
         );
         expect(installerFetches, path).toHaveLength(1);
         const command = installerFetches[0] ?? "";
-        expect(command, path).toContain("--disable");
         expect(command, path).toContain("--proto '=https'");
         expect(command, path).toContain("--tlsv1.2");
         expect(command, path).toContain("--fail");
@@ -114,10 +124,6 @@ describe("release readiness docs", () => {
         expect(command, path).toContain(
           "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
         );
-        expect(command, path).toMatch(/^curl\s/);
-        expect(command, path).not.toMatch(/\b(?:Authorization|Bearer|token)\b/i);
-        expect(command, path).not.toMatch(/(?:^|\s)(?:-L|--location)(?:\s|$)/);
-        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
       }
     }
     expect(readme.replace(/\s+/g, " ")).toContain("installer code and artifacts");
@@ -222,7 +228,7 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("hash -r");
       expect(document, path).toContain("stn setup");
       expect(document, path).toContain("stn doctor");
-      expect(document, path).toMatch(/\nstn\n/);
+      expect(document, path).toContain("stn tui");
       expect(document, path).toContain("~/.config/station/config.toml");
       expect(document, path).toContain("shell startup file");
       expect(document, path).toContain("cold-boot welcome screen");

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -225,6 +225,9 @@ describe("release readiness docs", () => {
       expect(document, path).toMatch(/\nstn\n/);
       expect(document, path).toContain("~/.config/station/config.toml");
       expect(document, path).toContain("shell startup file");
+      expect(document, path).toContain("cold-boot welcome screen");
+      expect(document, path).toContain("Create Session");
+      expect(document, path).toContain("start the agent session");
     }
   });
 


### PR DESCRIPTION
## Summary

- replace the private Contents bootstrap in the README and install guide with authenticated, tag-pinned `curl`
- keep `gh` as the authenticated release-discovery and asset-download dependency inside the installer
- document the complete binary-to-session handoff, beginning in the target Git repository and ending in the full `stn tui` workspace
- enforce the transport, token-handling, temporary-file, syntax-check, version, working-directory, and first-run documentation contract

## Why

The previous recipe used `gh api` to fetch the installer and then jumped straight to `stn setup`. That left the actual first-run UX ambiguous: the installer only installs binaries, setup is current-directory-sensitive, PATH recovery is not persistent, and the selected agent may still need its own login.

Review also found two handoff traps: the installer can print a PATH block ending in `stn setup`, so the user must enter the intended repository before installation; and bare `stn` opens the read-only popup inside tmux, so deterministic first-session onboarding must use `stn tui`.

## User journey

1. Change into the Git repository Station should manage.
2. Authenticate `gh` for the private repository.
3. Run the version-pinned curl block.
4. Put the install directory on PATH for the current shell.
5. Run `stn --version`, `stn setup`, `stn doctor`, then `stn tui`.
6. Open project view and create the first agent session.

The docs also name the workflow tools guided setup requires, the optional integrations it offers, the config it writes, and the fact that the compiled binary needs neither Node nor Bun.

## Review fixes

- make the project `cd` precede the installer so its copyable setup continuation uses the correct repository
- use `stn tui` for a deterministic writable workspace inside and outside tmux
- require `curl --disable` as the first curl option
- apply token, redirect, and pipe-to-shell prohibitions to every documented curl command

## Validation

- isolated `pnpm test:pre-push` — passed on `6107773`
- focused diagnostics and Biome — passed
- documented shell recipes — syntax-clean
- disposable macOS arm64 draft build/install acceptance — passed, artifacts cleaned
- authenticated curl fetch at the pinned commit matched the Git blob SHA-256

Hosted jobs did not allocate runners because of the repository account billing/spending-limit condition; the failure annotations contain no repository-code execution.

## Scope

No production installer logic, release workflow, package version, or TypeScript API changes. The documented `v0.7.0` path becomes user-actionable when that release/tag and assets are published.