### PR TITLE
docs(observer): revise singleton claim after concurrency spikes

### DIFF
--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -251,6 +251,12 @@ and reloads after later gaps or events that cannot be reduced safely.
 
 ### Startup
 
+Normal CLI and provider-hook startup currently probe and may remove a stale
+socket pathname before spawning. Each spawned Observer later uses bind-first
+stale reclamation in the protocol server. Those ownership mutations are not
+serialized across processes; `OBS-HEX-013` tracks the resulting cached-stale
+race.
+
 Current startup proceeds in this order:
 
 1. CLI composition supplies the concrete, optionally asynchronous provider
@@ -411,6 +417,7 @@ from the diagnostic use case.
 
 | Concern | Current contract |
 | --- | --- |
+| Observer boot ownership | The resolved socket defines singleton identity, but client-side stale deletion and server-side stale reclamation are not yet serialized. Different sockets remain independent owners even when their paths share a state or runtime directory (OBS-HEX-013). |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Cancellation is cooperative; the process shutdown backstop handles ignored signals. |
 | Reconcile ordering | Core reconciles form a non-poisoning promise chain. Scheduled requests coalesce; queued work after a run receives a later flush. |
@@ -633,6 +640,7 @@ and exit condition here.
 | `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Exit when `StationLogger` exposes only `info`/`warn`/`error`, `ProjectConfigWriter` exposes only the three project mutations returning updated config, and their adapters alone own log/config/home paths. | Logging and project-config edge inversion. |
 | `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Read evidence and long-lived watcher lifecycle are mixed into the use case. | Exit when `WorktreeChangeSource` owns typed Git reads, `WorktreeMetadataInvalidationSource` separately owns watched-worktree replacement and shutdown, and use cases receive neither Git runners nor filesystem paths. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only. Exit when a `DiagnosticEvidenceSource` adapter owns only local-state, recent-log, and hook-spool traversal, captures its paths, and the use case runs against a fake without absorbing persistence, providers, core, or SQLite. | Diagnostic evidence isolation. |
+| `OBS-HEX-013` | Normal CLI and provider-hook startup may delete a socket pathname after separate stale probes, while `bindWithStaleReclaim` also probes and unlinks without a cross-process critical section. Two contenders can cache the same stale result, unlink a newly bound successor, and leave duplicate live processes for one resolved socket. | The seeded ownership watcher and `stn observer reap` contain displacement but do not prevent the race. Exit when the Observer child serializes probe, stale reclaim, bind, pidfile publication, watcher setup, and ready-state commitment with an OS-backed SQLite transaction at `dirname(resolvedSocket)/observer.claim.sqlite`; clients no longer mutate the socket; and process-level Node/Bun plus CLI/hook races prove one healthy owner. Different sockets in one directory may share the startup claim while retaining separate singleton identities. | [#135](https://github.com/jeremy0dell/station/issues/135) boot serialization. |
 
 The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
 resolved: application code receives `ManagedTerminalLifecycle` from composition,

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -3,20 +3,21 @@
 Status: shipped-history and remaining singleton roadmap. For the current Observer runtime
 ownership and lifecycle contract, see [Observer Architecture](observer-architecture.md).
 
-How STATION keeps exactly one observer per state dir, why the old design let
+How STATION keeps exactly one observer per resolved socket, why the old design let
 duplicates accumulate, what has shipped, and the remaining work. Pick up the
 unfinished phases from the "Remaining work" section — each is independently
 landable.
 
 ## Problem
 
-An observer is auto-spawned by any `stn` invocation for its state dir, but the
-default socket (`~/.local/state/station/observer.sock`) is shared across all
-worktrees. The intended model is one observer; losers of the race were meant to
-notice and exit. They didn't: displaced observers baselined ownership from their
-own first probe and never detected a takeover, so they lingered at 0% CPU
-forever — 30 processes sharing one socket, 29 of them zombies, each still
-draining spool events and firing hooks with stale logic.
+An observer is auto-spawned by any `stn` invocation for its resolved socket. With
+the default state directory and `XDG_RUNTIME_DIR` unset, that socket is
+`~/.local/state/station/run/observer.sock`; worktrees using those defaults share
+it. The intended model is one observer per resolved socket; losers of the race
+were meant to notice and exit. They didn't: displaced observers baselined
+ownership from their own first probe and never detected a takeover, so they
+lingered at 0% CPU forever — 30 processes sharing one socket, 29 of them zombies,
+each still draining spool events and firing hooks with stale logic.
 
 The fix is herdr's lesson (see `github.com/ogulcancelik/herdr`,
 `src/server/autodetect.rs` + `handoff.rs`): don't rely on passive detection —
@@ -71,7 +72,7 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
 | #81 | WAL + `synchronous=NORMAL` sqlite; `stn observer reap` (socket-keyed candidacy, `lsof` keeper + health tiebreak, refuse-on-ambiguity, re-verify argv+start-token before every signal, SIGTERM→SIGKILL). `resolveObserverSocketForProcessArgs` in `@station/config`. |
 | #82 | Seeded socket-ownership watcher (`readSocketIdentity` + `expectedIdentity`); boot reorder — bind (`drainOnStart:false`) → arm seeded watcher → `observer.startup` reconcile, so a takeover during the scan is caught. |
 | #83 | `runShutdownWithBackstop`: `stopObserver` force-exits at a 5s ceiling so a wedged drain can't hang shutdown. Self-stop is now terminal (prerequisite for eviction). |
-| #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a remaining concurrent stale-reclaimer ABA, so this helper is safe only once boot attempts are serialized by `C`. |
+| #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a remaining concurrent stale-reclaimer ABA, so this helper is safe only once boot attempts are serialized by 3d-a. |
 | 3c | Durable process identity: the successful socket binder atomically publishes and fsyncs `<socketPath>.pid` with the strict `{pid, osStartTime, version, socketPath}` payload before health is enabled. The full socket filename keeps identities distinct within a shared runtime directory. Publication failure is fatal. Clean shutdown removes only its exact matching identity; `lsof` remains primary ownership evidence. |
 
 Together these **stop the bleeding**: `reap` clears duplicates on demand, the
@@ -79,84 +80,92 @@ seeded watcher self-heals future displacements, and stop is terminal. Phase 3c
 also gives later handoff and reaping work a durable, socket-relative
 corroborating identity without changing current attach-or-spawn or
 duplicate-reaping behavior. Concurrent reclamation of one already-stale socket
-remains open until 3d serializes boot.
+remains open until 3d-a serializes boot.
 
 ## Remaining work
 
-### 3d — explicit step-down negotiation (HIGHEST RISK)
+### 3d-a — serialize stale-socket boot ownership ([#135](https://github.com/jeremy0dell/station/issues/135))
 
 Spike result: **NO-GO for both stale-path deletion designs (directory rename and
 AF_UNIX unlink/rebind); GO for a dedicated SQLite transaction claim backed by a
 permanent cross-runtime adversarial test.** The current stale-socket race is
-tracked in #135.
+tracked as `OBS-HEX-013` and in #135.
 
-Move singleton negotiation into the observer boot (`main.ts`) under **one**
-OS-lock-backed, socket-relative claim database
-`C = dirname(socketPath)/observer.claim.sqlite`. Hold one `BEGIN IMMEDIATE`
-transaction for the whole negotiation. Clients (`observerProcess.ts`) shrink
-to attach-or-spawn.
+Move startup ownership mutation into the observer boot (`main.ts`) under the
+OS-lock-backed claim database
+`C = dirname(resolvedSocket)/observer.claim.sqlite`. Hold one `BEGIN IMMEDIATE`
+transaction from the socket probe through ready-state commitment. Clients
+shrink to attach-or-spawn and never delete the socket path themselves.
+
+The singleton identity remains the **resolved socket**, not the state directory
+or claim path. Two different sockets in one directory intentionally share `C`
+and serialize startup, but retain distinct listeners and `<socketPath>.pid`
+files.
 
 Boot sequence while holding `C`:
 1. **Acquire `C`** by opening the dedicated database with private permissions
    and starting `BEGIN IMMEDIATE` with a bounded busy timeout. `SQLITE_BUSY`
-   means another boot is negotiating, so do not enter. Process death releases
+   means another boot is in progress, so do not enter. Process death releases
    the OS transaction lock; the database file persists and needs no stale-owner
    deletion. Do not revive either rejected stale-path deletion scheme.
-2. **Probe** with connect-based `isSocketStale`: no observer listener → free;
-   connect ok + incumbent version compatible-and->=mine → roll back and close
-   `C`, exit 0 (attach); connect ok + older-incompatible, or connect ok but
-   unhealthy → evict.
-3. **Resolve incumbent identity**: `lsof -t P` is primary binder evidence;
-   pidfile `F`, health PID, and `ps` argv + OS start token corroborate it. Capture
-   the exact resolved socket and refuse on missing or conflicting evidence. If
-   bound-but-unhealthy has no attributable pid, leave it to `reap --force`.
-4. **Evict + confirm by observation** (never trust the receipt — `buildStop`
-   returns before the process exits): send `observer.stop`, then poll ~25ms
-   requiring `connect(P)` fails AND `liveness(pid)==false`, where liveness =
-   `processExists(pid) AND osStartTime(pid)==token`. Budget is **adaptive**:
-   while the pid is alive but connect already fails (drain in progress), keep
-   waiting to a larger cap; escalate only on no-progress past a wedge threshold.
-   Escalate: re-verify identity → SIGTERM → poll → re-verify → SIGKILL → confirm
-   `ESRCH`. Revalidate pidfile, argv, start token, and socket ownership before
-   every signal. A token mismatch means the captured process identity is gone,
-   so do not signal it; it does **not** prove the socket is free.
-5. **Reclaim socket** via `bindWithStaleReclaim` (#84 — bind-first).
-6. **Write pidfile** `F` (3c).
-7. **Arm the seeded watcher** (#82) and reconcile.
-8. **Commit or roll back the claim transaction and close `C`.** The database
-   file remains for the next negotiation.
+2. **Probe** the resolved socket as `absent`, `stale`, or `listening`. A
+   listening socket means release `C` and exit 0; the parent's existing health
+   loop attaches or reports incompatibility. 3d-a never compares versions or
+   evicts an incumbent.
+3. For `absent` or `stale`, **bind or reclaim** through the existing claimed
+   bind path, capture socket identity, publish and fsync the socket-specific
+   pidfile, arm the seeded ownership watcher, and commit readiness.
+4. **Release `C` synchronously before health waiters are unblocked.** Startup
+   reconcile follows outside the claim. A pre-ready stop or startup failure
+   retains the claim through socket and pidfile cleanup, then releases it from
+   the outer lifecycle cleanup path.
 
 Supporting:
-- Client attach-or-spawn: spawn on `unhealthy` too; concurrent spawns are safe
-  because booted observers serialize on `C`.
-- `restartObserver` threads the held claim (no re-entrant acquire).
-- DI seams: `killProcess` / `processExists` / `osStartTime`.
-- Automatic SIGKILL is not shippable until spool consumption is idempotent by
-  event ID or atomically claimed by rename. Until then a wedged incumbent must
-  refuse or escalate only through an explicit operator path. After that
-  prerequisite, `stn observer stop` may use the same guarded SIGTERM→SIGKILL
-  escalation instead of returning with the wedged owner still alive.
+- Normal CLI and provider-hook children receive the caller's bounded startup
+  budget so SQLite contention cannot outlive the parent's health wait.
+- Claim acquisition uses the low-level cross-runtime SQLite driver, not the
+  Observer persistence database, migrations, or WAL configuration.
+- File existence is never ownership. The claim database and SQLite sidecars are
+  persistent private files and are never stale-reclaimed, renamed, or replaced.
 
 Implementation starts red with deterministic two-process regressions for both
 rejected cached-stale ABA schedules. Then preserve the 50-round Node-vs-Bun
-transaction race, killed-owner recovery, process-level eviction, and CLI/hook
-path-parity cases from the spikes as permanent coverage.
+transaction race, killed-owner recovery, production stale-socket races, and
+CLI/hook path-parity cases from the spikes as permanent coverage.
 
-### 3e — unify hook auto-start onto `C`
+### 3d-b — version-aware incumbent replacement (deferred)
 
-Route `apps/cli/src/ingress/observerStartup.ts` + `deliveryPolicy.ts` hook
-auto-start through the same spawn/claim and **retire `hook-autostart.lock`**.
-Two lock namespaces never mutually exclude under config-override/XDG divergence.
-
-### Phase 4 — version order + guarded self-heal (deferrable, needs 3d)
+Build coordinated handoff only after 3d-a establishes exclusive boot ownership.
+This phase owns version comparison, incumbent attribution, graceful stop,
+signal escalation, spool-safety prerequisites, and replacement confirmation;
+none belongs to #135.
 
 - Refine the version gate into a **total antisymmetric order** with a
-  deterministic `(version, startedAt, pid)` tiebreak so no pair both-evicts
-  (mutual-eviction livelock under crash-respawn / hook-restart).
-- Treat `undefined` health.version as UNKNOWN → conservative attach-if-
-  compatible-else-refuse, never force-replace. (The `.optional()` health fields
-  `pid`/`version`/`socketPath` may be absent on an old incumbent — the policy
-  must not depend on any being present.)
+  deterministic `(version, startedAt, pid)` tiebreak so no pair both-evicts.
+  Treat missing health version or identity fields conservatively: attach when
+  compatible, otherwise refuse rather than guessing.
+- Resolve incumbent identity with `lsof` as primary socket-owner evidence and
+  corroborate it with the pidfile, health identity, argv, and OS start token.
+  Refuse on missing or conflicting evidence and revalidate before every signal.
+- Request graceful `observer.stop`, then confirm both socket closure and exact
+  process death before binding. A stop receipt alone is not completion.
+- Do not make SIGKILL a routine terminator until spool consumption is
+  idempotent by event ID or atomically claimed. Until then a wedged incumbent
+  requires a safe refusal or an explicit operator path.
+- Preserve the process-level graceful and wedged replacement spikes as
+  permanent acceptance coverage. PTY continuity is not part of Observer
+  handoff; `station-host` owns live PTYs independently.
+
+### 3e — isolate hook auto-start rate limiting
+
+3d-a will route CLI and provider-hook children through the same child-owned
+claim. Keep `hook-autostart.lock` authoritative only for hook rate limiting,
+never Observer ownership. Its state-directory location may diverge from the
+resolved socket under config and XDG overrides without weakening the 3d-a
+claim.
+
+### Phase 4 — guarded self-heal (deferrable, needs 3d-b)
+
 - Guarded self-heal: only after own-pid is the confirmed keeper AND it owns zero
   socket fds; stays OFF until `reap --force` is field-proven.
 
@@ -174,7 +183,7 @@ Two lock namespaces never mutually exclude under config-override/XDG divergence.
 - `apps/observer/src/runtime/socketOwnership.ts` — seeded watcher (#82).
 - `apps/observer/src/runtime/gracefulExit.ts` — force-exit backstop (#83).
 - `packages/protocol/src/transport.ts` — `bindWithStaleReclaim` (#84).
-- `apps/cli/src/observerProcess.ts` — attach-or-spawn, restart lock threading.
+- `apps/cli/src/observerProcess.ts` — normal CLI attach-or-spawn.
 - `apps/cli/src/observerReap.ts` — reaper (#81).
-- `apps/cli/src/ingress/observerStartup.ts`, `deliveryPolicy.ts` — hook auto-start (3e).
+- `apps/cli/src/ingress/observerStartup.ts`, `deliveryPolicy.ts` — hook attach-or-spawn and rate limiting (3d-a/3e).
 - `packages/config/src/observerProcessArgs.ts` — socket resolution from argv (#81).

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -41,6 +41,28 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
   config `socket_path` > `XDG_RUNTIME_DIR/station/observer.sock` >
   `<state_dir>/run/observer.sock`. Candidacy must key on the **resolved socket**,
   never `--state-dir` (they diverge under XDG / explicit `socket_path`).
+- The proposed `mkdir` + unique-tombstone rename lock is **unsafe**. Two
+  contenders can cache the same stale-owner decision; after A renames and
+  recreates the lock, delayed B can rename A's new live lock and both enter.
+  The embedded `owner.json` also makes the proposed tombstone `rmdir` fail with
+  `ENOTEMPTY` until the metadata is removed.
+- Reusing the AF_UNIX bind/stale-reclaim primitive for the claim is also
+  **unsafe**. Two reclaimers can both probe the old socket as stale; after A
+  unlinks and binds, delayed B can unlink A's live pathname and bind a second
+  server. A barrier-forced process spike produced two live claim servers.
+- A separate SQLite claim database passed 50 Node-vs-Bun process races with
+  exactly one `BEGIN IMMEDIATE` transaction owner each time. Killing a Bun
+  owner released the OS lock for a Node successor without stale-path deletion,
+  and the database reopened with `integrity_check=ok`.
+- Graceful replacement returned its stop receipt before exit, then observed
+  both socket closure and exact process death before the successor bound. A
+  deliberately wedged command survived the receipt and SIGTERM, required
+  SIGKILL, left a stale socket that the successor reclaimed, and reopened the
+  database with WAL plus `integrity_check=ok`.
+- CLI and provider-hook starts resolved byte-identical proposed claim paths from
+  the effective socket with XDG unset, XDG set, and an explicit config socket
+  containing a space. The current `hook-autostart.lock` still keys off
+  `<stateDir>/run` and therefore diverges under XDG/config overrides until 3e.
 
 ## Shipped
 
@@ -49,37 +71,45 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
 | #81 | WAL + `synchronous=NORMAL` sqlite; `stn observer reap` (socket-keyed candidacy, `lsof` keeper + health tiebreak, refuse-on-ambiguity, re-verify argv+start-token before every signal, SIGTERM→SIGKILL). `resolveObserverSocketForProcessArgs` in `@station/config`. |
 | #82 | Seeded socket-ownership watcher (`readSocketIdentity` + `expectedIdentity`); boot reorder — bind (`drainOnStart:false`) → arm seeded watcher → `observer.startup` reconcile, so a takeover during the scan is caught. |
 | #83 | `runShutdownWithBackstop`: `stopObserver` force-exits at a 5s ceiling so a wedged drain can't hang shutdown. Self-stop is now terminal (prerequisite for eviction). |
-| #84 | `bindWithStaleReclaim`: bind-first, unlink+retry only after a reprobe confirms nobody's listening. A live socket is never unlinked (killed the check-then-unlink race). |
+| #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a remaining concurrent stale-reclaimer ABA, so this helper is safe only once boot attempts are serialized by `C`. |
 | 3c | Durable process identity: the successful socket binder atomically publishes and fsyncs `<socketPath>.pid` with the strict `{pid, osStartTime, version, socketPath}` payload before health is enabled. The full socket filename keeps identities distinct within a shared runtime directory. Publication failure is fatal. Clean shutdown removes only its exact matching identity; `lsof` remains primary ownership evidence. |
 
 Together these **stop the bleeding**: `reap` clears duplicates on demand, the
-seeded watcher self-heals future displacements, and stop/bind are race-safe and
-terminal. Phase 3c also gives later handoff and reaping work a durable,
-socket-relative corroborating identity without changing current attach-or-spawn
-or duplicate-reaping behavior.
+seeded watcher self-heals future displacements, and stop is terminal. Phase 3c
+also gives later handoff and reaping work a durable, socket-relative
+corroborating identity without changing current attach-or-spawn or
+duplicate-reaping behavior. Concurrent reclamation of one already-stale socket
+remains open until 3d serializes boot.
 
 ## Remaining work
 
-### 3d — explicit step-down negotiation (HIGHEST RISK — spike first)
+### 3d — explicit step-down negotiation (HIGHEST RISK)
+
+Spike result: **NO-GO for both stale-path deletion designs (directory rename and
+AF_UNIX unlink/rebind); GO for a dedicated SQLite transaction claim backed by a
+permanent cross-runtime adversarial test.** The current stale-socket race is
+tracked in #135.
 
 Move singleton negotiation into the observer boot (`main.ts`) under **one**
-socket-relative lock `L = dirname(socketPath)/observer.claim.lock`. Clients
-(`observerProcess.ts`) shrink to attach-or-spawn.
+OS-lock-backed, socket-relative claim database
+`C = dirname(socketPath)/observer.claim.sqlite`. Hold one `BEGIN IMMEDIATE`
+transaction for the whole negotiation. Clients (`observerProcess.ts`) shrink
+to attach-or-spawn.
 
-Boot sequence under `L`:
-1. **Acquire `L`** via `mkdir`. On `EEXIST`, read owner `{pid, osStartTime}`:
-   if that pid is live AND start-time matches → another boot is negotiating →
-   exit 0. If dead/mismatch → **reclaim atomically** via
-   `rename(L, L.reclaim.<nonce>)` (exactly one racer wins; the loser gets
-   `ENOENT` → backoff → reloop), winner `rmdir`s the renamed dir and re-`mkdir`s
-   `L`. **Never** blind `rmdir`+recreate (that lets two claimers occupy the
-   critical section).
-2. **Probe** under `L` with connect-based `isSocketStale`: no listener → free;
-   connect ok + incumbent version compatible-and->=mine → release `L`, exit 0
-   (attach); connect ok + older-incompatible, or connect ok but unhealthy → evict.
-3. **Resolve incumbent pid**: pidfile `F` preferred; else `lsof -t P`; else `ps`
-   argv scan matching `observerMain` + exact resolved socket. If bound-but-
-   unhealthy with no attributable pid → refuse (leave to `reap --force`).
+Boot sequence while holding `C`:
+1. **Acquire `C`** by opening the dedicated database with private permissions
+   and starting `BEGIN IMMEDIATE` with a bounded busy timeout. `SQLITE_BUSY`
+   means another boot is negotiating, so do not enter. Process death releases
+   the OS transaction lock; the database file persists and needs no stale-owner
+   deletion. Do not revive either rejected stale-path deletion scheme.
+2. **Probe** with connect-based `isSocketStale`: no observer listener → free;
+   connect ok + incumbent version compatible-and->=mine → roll back and close
+   `C`, exit 0 (attach); connect ok + older-incompatible, or connect ok but
+   unhealthy → evict.
+3. **Resolve incumbent identity**: `lsof -t P` is primary binder evidence;
+   pidfile `F`, health PID, and `ps` argv + OS start token corroborate it. Capture
+   the exact resolved socket and refuse on missing or conflicting evidence. If
+   bound-but-unhealthy has no attributable pid, leave it to `reap --force`.
 4. **Evict + confirm by observation** (never trust the receipt — `buildStop`
    returns before the process exits): send `observer.stop`, then poll ~25ms
    requiring `connect(P)` fails AND `liveness(pid)==false`, where liveness =
@@ -87,38 +117,38 @@ Boot sequence under `L`:
    while the pid is alive but connect already fails (drain in progress), keep
    waiting to a larger cap; escalate only on no-progress past a wedge threshold.
    Escalate: re-verify identity → SIGTERM → poll → re-verify → SIGKILL → confirm
-   `ESRCH`. A token/start-time mismatch at **any** step means the pid was
-   recycled → do NOT signal, treat as confirmed-gone.
+   `ESRCH`. Revalidate pidfile, argv, start token, and socket ownership before
+   every signal. A token mismatch means the captured process identity is gone,
+   so do not signal it; it does **not** prove the socket is free.
 5. **Reclaim socket** via `bindWithStaleReclaim` (#84 — bind-first).
 6. **Write pidfile** `F` (3c).
 7. **Arm the seeded watcher** (#82) and reconcile.
-8. **Release `L`.**
+8. **Commit or roll back the claim transaction and close `C`.** The database
+   file remains for the next negotiation.
 
 Supporting:
 - Client attach-or-spawn: spawn on `unhealthy` too; concurrent spawns are safe
-  because booted observers serialize on `L`.
-- `stn observer stop` escalates SIGTERM→SIGKILL client-side so a wedged owner is
-  killed, not error-returned.
-- `restartObserver` threads the held lock (no re-entrant acquire).
+  because booted observers serialize on `C`.
+- `restartObserver` threads the held claim (no re-entrant acquire).
 - DI seams: `killProcess` / `processExists` / `osStartTime`.
+- Automatic SIGKILL is not shippable until spool consumption is idempotent by
+  event ID or atomically claimed by rename. Until then a wedged incumbent must
+  refuse or escalate only through an explicit operator path. After that
+  prerequisite, `stn observer stop` may use the same guarded SIGTERM→SIGKILL
+  escalation instead of returning with the wedged owner still alive.
 
-**Spike before building** (the plan's adversarial panel flagged these; prove
-them empirically):
-- rename-steal: two processes racing to reclaim one dead-pid lockdir → exactly
-  one ends up owning `L`.
-- eviction end-to-end in an isolated state dir: spawn incumbent, evict via
-  `observer.stop`, confirm-by-observation, new one binds; wedged incumbent →
-  SIGKILL path.
-- lock path is byte-identical for hook-start vs CLI-start with `XDG_RUNTIME_DIR`
-  set AND unset.
+Implementation starts red with deterministic two-process regressions for both
+rejected cached-stale ABA schedules. Then preserve the 50-round Node-vs-Bun
+transaction race, killed-owner recovery, process-level eviction, and CLI/hook
+path-parity cases from the spikes as permanent coverage.
 
-### 3e — unify hook auto-start onto `L`
+### 3e — unify hook auto-start onto `C`
 
 Route `apps/cli/src/ingress/observerStartup.ts` + `deliveryPolicy.ts` hook
-auto-start through the same spawn/lock and **retire `hook-autostart.lock`**.
+auto-start through the same spawn/claim and **retire `hook-autostart.lock`**.
 Two lock namespaces never mutually exclude under config-override/XDG divergence.
 
-### Phase 4 — version order + spool + guarded self-heal (deferrable, needs 3d)
+### Phase 4 — version order + guarded self-heal (deferrable, needs 3d)
 
 - Refine the version gate into a **total antisymmetric order** with a
   deterministic `(version, startedAt, pid)` tiebreak so no pair both-evicts
@@ -127,8 +157,6 @@ Two lock namespaces never mutually exclude under config-override/XDG divergence.
   compatible-else-refuse, never force-replace. (The `.optional()` health fields
   `pid`/`version`/`socketPath` may be absent on an old incumbent — the policy
   must not depend on any being present.)
-- Make spool consume idempotent-by-event-id OR atomic claim-by-rename **before**
-  SIGKILL is a routine terminator (consume is read→ingest→unlink = at-least-once).
 - Guarded self-heal: only after own-pid is the confirmed keeper AND it owns zero
   socket fds; stays OFF until `reap --force` is field-proven.
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -37,7 +37,7 @@ Non-goals:
 - **Any observer replacement / eviction in this roadmap.** Coordinated
   single-observer behavior is owned entirely by
   [observer-singleton](observer-singleton.md). This plan *depends on* that
-  roadmap's 3c/3d/3e + version-order phases; it does not add a second,
+  roadmap's 3c/3d-a/3d-b/3e phases; it does not add a second,
   uncoordinated eviction path (v1 did — removed, see F3).
 - **Replacing the dev workflow.** Dev mode (tsc dist under Node +
   `bun --hot` TUI from source) stays byte-identical; compiled mode is new
@@ -527,14 +527,17 @@ health wait is 10 seconds; only TUI and popup launches show delayed progress.
 
 **Removed from v1:** the client-side unhealthy-incumbent SIGTERM eviction.
 It conflicts with [observer-singleton](observer-singleton.md), which is
-explicitly consolidating to **one** socket-relative `observer.claim.lock`
-with process-identity revalidation, total version ordering, and spool
-safety (3d/3e + Phase 4). Adding a second, uncoordinated client killer is
-exactly what that roadmap removes. **Dependency, not duplication:** the
-version-aware upgrade behavior this plan needs (B3) is delivered by the
-singleton roadmap's version-order phase. If that lands, B3 consumes it; if
-not, B3 ships **only** the same-version restart in B-config below and the
-schema-mismatch UX — never an out-of-band kill.
+split between 3d-a's narrow boot serialization and 3d-b's deferred
+version-aware replacement. Today, CLI and provider-hook clients can delete a
+socket after their own stale probe while the server independently performs
+bind-first stale reclamation; those mutations are not serialized
+(`OBS-HEX-013`). 3d-a ([#135](https://github.com/jeremy0dell/station/issues/135))
+moves mutation into the child under
+`dirname(resolvedSocket)/observer.claim.sqlite`, without version comparison,
+signals, or eviction. **Dependency, not duplication:** the version-aware
+upgrade behavior this plan needs (B3) belongs to 3d-b. If that lands, B3
+consumes it; if not, B3 ships **only** the same-version restart in B-config
+below and the schema-mismatch UX — never an out-of-band kill.
 
 ### B-config — config activation (F4 — v1 was wrong)
 
@@ -558,7 +561,7 @@ untouched.
 Same-version config activation via B-config. Renderer exit code 86 =
 "restart observer" on a `halted` + `PROTOCOL_SCHEMA_MISMATCH` state → the
 CLI parent restarts once and respawns the renderer. Older-binary-version
-auto-restart is **deferred to the singleton version-order phase**; this
+auto-restart is **deferred to singleton phase 3d-b**; this
 plan does not implement its own version eviction.
 
 ### B-host — station-host upgrade behavior (F7 — was undefined)
@@ -605,7 +608,7 @@ A1 ─────────────┬─► A2a ─► A3 ─► A4 + co
  (buildInfo,     │
   sqlite,        │
   real version)  │
-                 └─► B3 (schema/version UX) ◄── observer-singleton version-order phase
+                 └─► B3 (schema/version UX) ◄── observer-singleton 3d-b
 B1 ─► B2 ─► B-config ─► B3
               (config activation — headline UX)
 B-host  (independent; needed before upgrade is advertised safe)
@@ -614,7 +617,9 @@ A2a: opt-in PTY + native helper gate    A3: raw dispatch
 A4: packaged assets + compiled default   A2b: folded into A4
 A5: release                              A6: cleanup
 
-External dependency: observer-singleton 3c/3d/3e + version order
+External dependency: observer-singleton 3d-a
+  → required for serialized concurrent stale-socket startup.
+External dependency: observer-singleton 3d-b
   → required before any older-version observer handoff is claimed safe.
 ```
 


### PR DESCRIPTION
## Summary

- record the completed singleton 3d concurrency spikes
- reject both stale-path deletion claim designs after deterministic two-process counterexamples
- revise the remaining roadmap around a socket-relative SQLite transaction claim
- clarify incumbent identity evidence, stop confirmation, hook-path parity, and the spool-safety prerequisite
- track the current stale-socket production race in #135

No runtime code or permanent spike harness is included.

## Evidence

- directory reclaim schedule: two contenders entered before either released
- socket stale-reclaim schedule: two live servers after two reclaimers cached the stale result
- SQLite claim: 50 Node-vs-Bun process races, exactly one transaction owner every time
- owner-loss recovery: Bun owner exited unexpectedly; Node successor acquired; integrity check passed
- graceful replacement: receipt preceded socket closure and process exit; successor became sole holder
- wedged replacement: forced-stop path, stale-socket reclaim, WAL reopen, and integrity check passed
- CLI/hook future claim path: byte-identical with XDG unset, XDG set, and explicit config socket

## Verification

- `pnpm build`
- disposable three-spike E2E harness: 3/3 passed, then removed
- disposable claim redesign harness: 50/50 Node-vs-Bun races passed, then removed
- `pnpm test:diagnostics` — 18 files / 42 tests passed
- pre-commit lint passed
- `git diff --check`

Closes no issue; #135 owns implementation.