### PR TITLE
fix(observer): serialize stale-socket boot ownership

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -45,6 +45,8 @@ jobs:
         run: pnpm test:agent:scripted
       - name: Setup e2e tests
         run: pnpm test:e2e:setup
+      - name: Observer lifecycle e2e tests
+        run: pnpm test:e2e:observer
 
   installer-smoke:
     name: installer smoke (${{ matrix.runner }})
@@ -92,7 +94,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
-      - name: Test cross-runtime SQLite compatibility
+      - name: Test cross-runtime SQLite and Observer boot claim
         run: pnpm test:sqlite:bun
       - name: Install (bun)
         run: bun install
@@ -137,6 +139,12 @@ jobs:
           bun-version: 1.3.14
       - name: Install (pnpm)
         run: pnpm install --frozen-lockfile
+      - name: Build @station packages
+        run: pnpm build
+      - name: Test Observer boot claim and lifecycle
+        run: |
+          pnpm test:observer-claim:cross-runtime -- --rounds 10
+          pnpm test:e2e:observer
       - name: Install (bun)
         run: bun install
         working-directory: station

--- a/apps/cli/src/ingress/deliveryPolicy.ts
+++ b/apps/cli/src/ingress/deliveryPolicy.ts
@@ -242,6 +242,7 @@ async function waitForContendedAutoStart(input: {
 }
 
 function autoStartLockDir(paths: ObserverPaths): string {
+  // This state-dir lock throttles hook spawns only; the child claim owns Observer boot.
   return join(paths.stateDir, "run", autoStartLockName);
 }
 
@@ -264,7 +265,7 @@ async function writeAutoStartLockOwner(
       { mode: 0o600 },
     );
   } catch {
-    // Owner metadata is diagnostic-only; the lock directory itself is the authority.
+    // Owner metadata is diagnostic-only; the directory itself gates hook rate limiting.
   }
 }
 

--- a/apps/cli/src/ingress/observerStartup.ts
+++ b/apps/cli/src/ingress/observerStartup.ts
@@ -3,7 +3,7 @@ import { mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { ObserverPaths } from "@station/config";
 import type { ObserverHealth, SafeError } from "@station/contracts";
-import { createObserverClient, isSocketStale, removeStaleSocket } from "@station/protocol";
+import { createObserverClient, isSocketStale } from "@station/protocol";
 import {
   environmentWithoutGitLocals,
   type RuntimeClock,
@@ -87,6 +87,12 @@ export async function getProviderHookObserverStatus(
   }
 }
 
+/**
+ * USE CASE
+ *
+ * Attaches provider-hook delivery to a healthy Observer or starts a child while
+ * leaving socket ownership mutation to the child's serialized boot lifecycle.
+ */
 export async function startProviderHookObserver(
   options: ProviderHookObserverStartupOptions,
   deps: ProviderHookObserverStartupDeps = {},
@@ -98,10 +104,6 @@ export async function startProviderHookObserver(
   if (existing.status === "running") {
     return existing;
   }
-  if (existing.status === "stale") {
-    await removeStaleSocket(paths.socketPath);
-  }
-
   let child: ChildProcessLike | undefined;
   const result = await runRuntimeBoundaryWithTimeout(
     {
@@ -129,7 +131,10 @@ export async function startProviderHookObserver(
       if (options.configPath !== undefined) {
         spawnInput.configPath = options.configPath;
       }
-      child = await (deps.spawnObserver ?? defaultSpawnObserver)(spawnInput);
+      child =
+        deps.spawnObserver === undefined
+          ? defaultSpawnObserver(spawnInput, timeoutMs)
+          : await deps.spawnObserver(spawnInput);
       child.unref?.();
       return waitForProviderHookObserverHealth({ paths, timeoutMs }, deps);
     },
@@ -189,7 +194,10 @@ function defaultClientFactory(socketPath: string) {
   return createObserverClient({ socketPath, timeoutMs: 500 });
 }
 
-function defaultSpawnObserver(input: SpawnProviderHookObserverInput): ChildProcessLike {
+function defaultSpawnObserver(
+  input: SpawnProviderHookObserverInput,
+  startupTimeoutMs: number,
+): ChildProcessLike {
   if (input.observerCommand === undefined) {
     throw new Error("observerCommand is required to auto-start observer from provider hooks");
   }
@@ -201,6 +209,8 @@ function defaultSpawnObserver(input: SpawnProviderHookObserverInput): ChildProce
     "--state-dir",
     input.paths.stateDir,
     ...(input.configPath === undefined ? [] : ["--config", input.configPath]),
+    "--startup-timeout-ms",
+    String(startupTimeoutMs),
   ];
   return spawn(command, args, {
     detached: true,

--- a/apps/cli/src/ingress/observerStartup.ts
+++ b/apps/cli/src/ingress/observerStartup.ts
@@ -141,6 +141,14 @@ export async function startProviderHookObserver(
   );
 
   if (result.ok) {
+    // A child queued on the boot claim must not outlive the incumbent this hook attached to.
+    if (
+      child?.pid !== undefined &&
+      result.value.pid !== undefined &&
+      child.pid !== result.value.pid
+    ) {
+      child.kill?.();
+    }
     return {
       status: "running",
       paths,

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -1,7 +1,7 @@
 import { lstat } from "node:fs/promises";
 import type { ObserverStopReceipt, SafeError } from "@station/contracts";
 import { componentLogPath, createJsonlLogger, createTraceContext } from "@station/observability";
-import { createObserverClient, isSocketStale, removeStaleSocket } from "@station/protocol";
+import { createObserverClient, isSocketStale } from "@station/protocol";
 import {
   type RuntimeClock,
   type RuntimeTraceContext,
@@ -60,6 +60,12 @@ export async function getObserverStatus(
   }
 }
 
+/**
+ * USE CASE
+ *
+ * Attaches to a healthy Observer or starts a child while leaving socket
+ * ownership mutation to the child's serialized boot lifecycle.
+ */
 export async function startObserver(
   options: ObserverProcessOptions = {},
   deps: ObserverProcessDeps = {},
@@ -71,9 +77,6 @@ export async function startObserver(
   const existing = await getObserverStatus({ ...options, paths }, deps);
   if (existing.status === "running") {
     return existing;
-  }
-  if (existing.status === "stale") {
-    await removeStaleSocket(paths.socketPath);
   }
   if (existing.status === "unhealthy") {
     return existing;

--- a/apps/cli/src/observerProcess/spawn.ts
+++ b/apps/cli/src/observerProcess/spawn.ts
@@ -6,7 +6,11 @@ import { environmentWithoutGitLocals } from "@station/runtime";
 import { selfExecArgv } from "../selfExec.js";
 import type { ChildExitResult, ChildProcessLike, SpawnObserverInput } from "./types.js";
 
-export async function defaultSpawnObserver(input: SpawnObserverInput): Promise<ChildProcessLike> {
+type DefaultSpawnObserverInput = SpawnObserverInput & { startupTimeoutMs: number };
+
+export async function defaultSpawnObserver(
+  input: DefaultSpawnObserverInput,
+): Promise<ChildProcessLike> {
   const argv = observerSpawnArgv(input);
   const bootLogPath = observerBootLogPath(input.paths);
   const pendingBootLogPath = observerPendingBootLogPath(input.paths);
@@ -45,7 +49,7 @@ export async function defaultSpawnObserver(input: SpawnObserverInput): Promise<C
   }
 }
 
-export function observerSpawnArgv(input: SpawnObserverInput): [string, ...string[]] {
+export function observerSpawnArgv(input: DefaultSpawnObserverInput): [string, ...string[]] {
   // Compiled dist/observerProcess/spawn.js must resolve ../observerMain.js; source-alias tests launch the built entry instead.
   const observerEntry = import.meta.url.endsWith(".ts")
     ? new URL("../../dist/observerMain.js", import.meta.url)
@@ -58,6 +62,8 @@ export function observerSpawnArgv(input: SpawnObserverInput): [string, ...string
     "--state-dir",
     input.paths.stateDir,
     ...(input.configPath === undefined ? [] : ["--config", input.configPath]),
+    "--startup-timeout-ms",
+    String(input.startupTimeoutMs),
   ];
 }
 

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -85,6 +85,15 @@ export async function startObserverProcess(
     },
   ).finally(() => clearObserverStartupProgress(progressTimers));
 
+  // A child queued on the boot claim must not outlive the incumbent this caller attached to.
+  if (
+    result.ok &&
+    child?.pid !== undefined &&
+    result.value.pid !== undefined &&
+    child.pid !== result.value.pid
+  ) {
+    child.kill?.();
+  }
   if (!result.ok && result.error.code !== "OBSERVER_EXITED_ON_START") {
     child?.kill?.();
   }

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -63,7 +63,10 @@ export async function startObserverProcess(
       if (input.configPath !== undefined) {
         spawnInput.configPath = input.configPath;
       }
-      child = await (deps.spawnObserver ?? defaultSpawnObserver)(spawnInput);
+      child =
+        deps.spawnObserver === undefined
+          ? await defaultSpawnObserver({ ...spawnInput, startupTimeoutMs: input.timeoutMs })
+          : await deps.spawnObserver(spawnInput);
       if (signal.aborted) {
         child.kill?.();
         throw observerHealthWaitCancelledError();

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -1,8 +1,13 @@
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ProviderHookEvent, ProviderHookReceipt } from "@station/contracts";
 import { describe, expect, it } from "vitest";
-import { listHookSpoolFiles, readHookSpoolRecord } from "../../../../tests/support/spool";
+import { createStaleSocketFile } from "../../../../tests/support/sockets";
+import {
+  fileExists,
+  listHookSpoolFiles,
+  readHookSpoolRecord,
+} from "../../../../tests/support/spool";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 import { runProviderIngressCommand } from "../../src/ingress/command.js";
 
@@ -46,7 +51,9 @@ describe("provider hook ingress command", () => {
   it("turns raw observer flags into one finalized startup command", async () => {
     const fixture = await createTempState();
     const observerEntry = join(fixture.root, "custom-observer.js");
+    await createStaleSocketFile(fixture.socketPath);
     let running = false;
+    let staleSocketPresentAtSpawn = false;
     let spawnInput:
       | Parameters<NonNullable<Parameters<typeof runProviderIngressCommand>[2]["spawnObserver"]>>[0]
       | undefined;
@@ -90,6 +97,7 @@ describe("provider hook ingress command", () => {
           }) as never,
         spawnObserver: async (input) => {
           spawnInput = input;
+          staleSocketPresentAtSpawn = await fileExists(fixture.socketPath);
           running = true;
           return { pid: 12345, unref: () => undefined };
         },
@@ -97,6 +105,7 @@ describe("provider hook ingress command", () => {
     );
 
     expect(receipt.status).toBe("ingested");
+    expect(staleSocketPresentAtSpawn).toBe(true);
     expect(spawnInput).toEqual({
       paths: expect.objectContaining({
         socketPath: fixture.socketPath,
@@ -104,6 +113,72 @@ describe("provider hook ingress command", () => {
       }),
       observerCommand: [process.execPath, observerEntry],
     });
+  });
+
+  it("passes the exact startup timeout to the production observer child", async () => {
+    const fixture = await createTempState();
+    const observerEntry = join(fixture.root, "record-observer-argv.cjs");
+    const argvPath = join(fixture.root, "observer-argv.json");
+    await writeFile(
+      observerEntry,
+      [
+        'const { writeFileSync } = require("node:fs");',
+        `writeFileSync(${JSON.stringify(argvPath)}, JSON.stringify(process.argv.slice(2)));`,
+      ].join("\n"),
+      "utf8",
+    );
+
+    const receipt = await runProviderIngressCommand(
+      [
+        "--socket",
+        fixture.socketPath,
+        "--state-dir",
+        fixture.stateDir,
+        "--observer-entry",
+        observerEntry,
+        "--startup-timeout-ms",
+        "2000",
+        "worktrunk",
+        "post-create",
+      ],
+      { stdin: JSON.stringify({ branch: "feature/child-timeout" }) },
+      {
+        clock: { now: () => new Date(now) },
+        hookId: () => "hook_child_timeout",
+        clientFactory: () =>
+          ({
+            health: async () => {
+              if (!(await fileExists(argvPath))) throw new Error("offline");
+              return { schemaVersion: "0.7.0", status: "healthy" };
+            },
+            ingestProviderHookEvent: async (event: ProviderHookEvent) => {
+              if (!(await fileExists(argvPath))) throw new Error("offline");
+              return {
+                schemaVersion: "0.7.0",
+                hookId: event.hookId ?? "hook_child_timeout",
+                provider: event.provider,
+                event: event.event,
+                accepted: true,
+                status: "ingested",
+                receivedAt: event.receivedAt,
+                reconciled: false,
+              } satisfies ProviderHookReceipt;
+            },
+          }) as never,
+      },
+    );
+
+    expect(receipt.status).toBe("ingested");
+    await expect(readFile(argvPath, "utf8")).resolves.toBe(
+      JSON.stringify([
+        "--socket",
+        fixture.socketPath,
+        "--state-dir",
+        fixture.stateDir,
+        "--startup-timeout-ms",
+        "2000",
+      ]),
+    );
   });
 
   it("delivers Worktrunk lifecycle hooks through observer.ingestProviderHookEvent", async () => {

--- a/apps/cli/test/unit/ingress-delivery-policy.test.ts
+++ b/apps/cli/test/unit/ingress-delivery-policy.test.ts
@@ -45,6 +45,39 @@ describe("provider hook delivery policy", () => {
     expect(observedCommand).toBe(observerCommand);
   });
 
+  it("cancels a queued hook-started child after attaching to an incumbent", async () => {
+    const fixture = await createTempState();
+    const state = { running: false, spawnCount: 0, spooled: 0 };
+    let childKills = 0;
+    const deps = {
+      clock: { now: () => new Date(now) },
+      clientFactory: () =>
+        ({
+          health: async (): Promise<ObserverHealth> => {
+            if (!state.running) throw new Error("observer offline");
+            return { ...healthyObserver(fixture), pid: 9876 };
+          },
+        }) as never,
+      spawnObserver: async () => {
+        state.spawnCount += 1;
+        state.running = true;
+        return {
+          pid: 12345,
+          unref: () => undefined,
+          kill: () => {
+            childKills += 1;
+            return true;
+          },
+        };
+      },
+    };
+
+    await expect(
+      deliverProviderHookWithSpooling(deliveryInput(fixture, "hook_losing_child", state, deps)),
+    ).resolves.toMatchObject({ status: "ingested" });
+    expect(childKills).toBe(1);
+  });
+
   it("serializes concurrent observer auto-start attempts across hook senders", async () => {
     const fixture = await createTempState();
     const state = { running: false, spawnCount: 0, spooled: 0 };

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -31,6 +31,7 @@ describe("CLI observer process lifecycle", () => {
     const fixture = await createTempState();
     let spawned = false;
     let healthAttempts = 0;
+    let spawnInput: unknown;
 
     const result = await startObserver(
       {
@@ -39,7 +40,8 @@ describe("CLI observer process lifecycle", () => {
       },
       {
         clock: { now: () => new Date(now) },
-        spawnObserver: async (): Promise<ChildProcessLike> => {
+        spawnObserver: async (input): Promise<ChildProcessLike> => {
+          spawnInput = input;
           spawned = true;
           return { pid: 1234, unref: () => undefined };
         },
@@ -64,6 +66,9 @@ describe("CLI observer process lifecycle", () => {
     );
 
     expect(spawned).toBe(true);
+    expect(spawnInput).toEqual({
+      paths: expect.objectContaining({ socketPath: fixture.socketPath }),
+    });
     expect(result).toMatchObject({
       status: "running",
       health: {
@@ -72,10 +77,11 @@ describe("CLI observer process lifecycle", () => {
     });
   });
 
-  it("removes a stale socket before spawning the observer", async () => {
+  it("leaves a stale socket for the spawned observer to reclaim", async () => {
     const fixture = await createTempState();
     await createStaleSocketFile(fixture.socketPath);
     let spawned = false;
+    let staleSocketPresentAtSpawn = false;
 
     const result = await startObserver(
       {
@@ -85,6 +91,7 @@ describe("CLI observer process lifecycle", () => {
       {
         clock: { now: () => new Date(now) },
         spawnObserver: async (): Promise<ChildProcessLike> => {
+          staleSocketPresentAtSpawn = await fileExists(fixture.socketPath);
           spawned = true;
           return { pid: 1234, unref: () => undefined };
         },
@@ -108,8 +115,9 @@ describe("CLI observer process lifecycle", () => {
     );
 
     expect(spawned).toBe(true);
+    expect(staleSocketPresentAtSpawn).toBe(true);
     expect(result.status).toBe("running");
-    await expect(fileExists(fixture.socketPath)).resolves.toBe(false);
+    await expect(fileExists(fixture.socketPath)).resolves.toBe(true);
   });
 
   it("returns a safe startup error when health does not arrive before timeout", async () => {

--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -15,15 +15,23 @@ describe("observer spawn argv", () => {
   it("keeps the source entry prefix and observer flag order", () => {
     const observerEntry = fileURLToPath(new URL("../../../dist/observerMain.js", import.meta.url));
 
-    expect(observerSpawnArgv({ paths })).toEqual([
+    expect(observerSpawnArgv({ paths, startupTimeoutMs: 4321 })).toEqual([
       process.execPath,
       observerEntry,
       "--socket",
       paths.socketPath,
       "--state-dir",
       paths.stateDir,
+      "--startup-timeout-ms",
+      "4321",
     ]);
-    expect(observerSpawnArgv({ paths, configPath: "/tmp/station/config.toml" })).toEqual([
+    expect(
+      observerSpawnArgv({
+        paths,
+        configPath: "/tmp/station/config.toml",
+        startupTimeoutMs: 9876,
+      }),
+    ).toEqual([
       process.execPath,
       observerEntry,
       "--socket",
@@ -32,6 +40,8 @@ describe("observer spawn argv", () => {
       paths.stateDir,
       "--config",
       "/tmp/station/config.toml",
+      "--startup-timeout-ms",
+      "9876",
     ]);
   });
 

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -162,7 +162,7 @@ describe("CLI observer process startup", () => {
     }
   });
 
-  it("attaches to a concurrent incumbent when the spawned child exits", async () => {
+  it("cancels its spawned child after attaching to a concurrent incumbent", async () => {
     const fixture = await createTempState();
     const exited = deferred<{ type: "exit"; code: number; signal: null }>();
     let healthCalls = 0;
@@ -198,7 +198,7 @@ describe("CLI observer process startup", () => {
 
     expect(result).toMatchObject({ status: "running", health: { pid: 9876 } });
     expect(healthCalls).toBe(4);
-    expect(kills).toBe(0);
+    expect(kills).toBe(1);
     expect(exitWaitDisposals).toBe(1);
   });
 

--- a/apps/observer/src/internal.ts
+++ b/apps/observer/src/internal.ts
@@ -30,6 +30,7 @@ export * from "./runtime/api.js";
 export * from "./runtime/eventBus.js";
 export * from "./runtime/logging.js";
 export * from "./runtime/main.js";
+export * from "./runtime/observerBootClaim.js";
 export * from "./runtime/reconcileScheduler.js";
 export * from "./runtime/server.js";
 export type { SqlDatabase, SqlParam, SqlRunResult, SqlStatement } from "./sqlite/driver.js";

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -28,11 +28,16 @@ import { createObserverEventBus } from "./eventBus.js";
 import { runShutdownWithBackstop } from "./gracefulExit.js";
 import { createObserverLogger } from "./logging.js";
 import {
+  type AcquiredObserverBootClaim,
+  acquireObserverBootClaim,
+  type ObserverBootClaimReleaseResult,
+} from "./observerBootClaim.js";
+import {
   createObserverProcessIdentity,
   publishObserverProcessIdentity,
   removeObserverProcessIdentity,
 } from "./observerPidfile.js";
-import { type ObserverServer, startObserverServer } from "./server.js";
+import { type ObserverServer, probeObserverSocket, startObserverServer } from "./server.js";
 import {
   readSocketIdentity,
   type SocketIdentity,
@@ -43,6 +48,7 @@ import {
 // Ceiling on a graceful stop; a wedged drain (a handler ignoring its abort)
 // force-exits at this point instead of keeping the observer alive forever.
 const STOP_BACKSTOP_MS = 5000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 10_000;
 
 export type ObserverProviderRegistryFactoryOptions = {
   stateDir: string;
@@ -61,9 +67,9 @@ export type RunObserverMainDeps = {
 /**
  * COMPOSITION ROOT
  *
- * Builds the process-lifetime Observer runtime around provider adapters
- * supplied by awaited CLI composition, including socket identity publication,
- * health readiness, and shutdown of the services created here.
+ * Claims boot ownership before constructing provider or persistence adapters,
+ * owns socket and pidfile publication, and releases the claim before publishing
+ * health for the process lifetime it composes.
  */
 export async function runObserverMain(
   argv = process.argv.slice(2),
@@ -86,8 +92,45 @@ export async function runObserverMain(
     homeDir,
   );
   const socketPath = resolveObserverSocketPath(options.socketPath, config, stateDir, homeDir);
-  const spoolDir = providerIngressSpoolDir(stateDir);
   await mkdir(stateDir, { recursive: true, mode: 0o700 });
+  const claimResult = await acquireObserverBootClaim({
+    socketPath,
+    timeoutMs: options.startupTimeoutMs,
+  });
+  if (claimResult.status !== "acquired") {
+    throw claimResult.error;
+  }
+
+  // This outer lifetime keeps the claim through any pre-ready socket and
+  // pidfile cleanup; the ready gate performs the normal early release.
+  try {
+    if ((await probeObserverSocket(socketPath)) === "listening") {
+      return 0;
+    }
+    return await runClaimedObserverRuntime({
+      options,
+      loadedConfig,
+      stateDir,
+      socketPath,
+      claim: claimResult,
+      deps,
+    });
+  } finally {
+    releaseObserverBootClaim(claimResult);
+  }
+}
+
+async function runClaimedObserverRuntime(input: {
+  options: ReturnType<typeof parseArgs>;
+  loadedConfig: LoadedStationConfig;
+  stateDir: string;
+  socketPath: string;
+  claim: AcquiredObserverBootClaim;
+  deps: RunObserverMainDeps;
+}): Promise<number> {
+  const { options, loadedConfig, stateDir, socketPath, claim, deps } = input;
+  const config = loadedConfig.config;
+  const spoolDir = providerIngressSpoolDir(stateDir);
   const providerOptions: ObserverProviderRegistryFactoryOptions = { stateDir };
   if (options.configPath !== undefined) {
     providerOptions.configPath = loadedConfig.configPath;
@@ -156,7 +199,8 @@ export async function runObserverMain(
       async () => {
         let shutdownError: unknown;
         stopReceipt ??= (async () => {
-          // Publication must settle before cleanup so a pre-ready stop cannot leave a late pidfile behind.
+          // Publication must settle before cleanup so a pre-ready stop cannot
+          // leave a late pidfile behind or release the boot claim too early.
           await startupGate.waitUntilSettled();
           return observerApi.stop();
         })();
@@ -289,7 +333,18 @@ export async function runObserverMain(
         void api.stop();
       },
     });
-    shouldReconcile = startupGate.settleReady();
+    const startupCommit = startupGate.settleReady(() => claim.release());
+    shouldReconcile = startupCommit.status === "ready";
+    if (startupCommit.status === "ready" && startupCommit.claimRelease.status === "failed") {
+      // Readiness is already committed; cleanup after a partial SQLite release
+      // could race a successor, so the live Observer remains the socket owner.
+      void logger
+        .error("Observer boot claim could not be released cleanly after startup commitment.", {
+          socketPath,
+          error: startupCommit.claimRelease.error,
+        })
+        .catch(() => undefined);
+    }
   } catch (error) {
     startupGate.settleFailed();
     shutdownExitCode = 1;
@@ -353,12 +408,14 @@ function parseArgs(argv: string[]): {
   configPath?: string;
   socketPath?: string;
   stateDir?: string;
+  startupTimeoutMs: number;
 } {
   const result: {
     configPath?: string;
     socketPath?: string;
     stateDir?: string;
-  } = {};
+    startupTimeoutMs: number;
+  } = { startupTimeoutMs: DEFAULT_STARTUP_TIMEOUT_MS };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     const value = argv[index + 1];
@@ -370,6 +427,16 @@ function parseArgs(argv: string[]): {
       index += 1;
     } else if (arg === "--state-dir" && value !== undefined) {
       result.stateDir = value;
+      index += 1;
+    } else if (arg === "--startup-timeout-ms") {
+      if (value === undefined || !/^[1-9]\d*$/u.test(value)) {
+        throw new Error("--startup-timeout-ms must be a positive integer.");
+      }
+      const timeoutMs = Number(value);
+      if (!Number.isSafeInteger(timeoutMs)) {
+        throw new Error("--startup-timeout-ms must be a positive safe integer.");
+      }
+      result.startupTimeoutMs = timeoutMs;
       index += 1;
     }
   }
@@ -402,15 +469,19 @@ function resolvePath(input: string, homeDir: string): string {
 
 type ObserverStartupGate = {
   requestStop(): void;
-  settleReady(): boolean;
+  settleReady(releaseClaim: () => ObserverBootClaimReleaseResult): ObserverStartupCommit;
   settleFailed(): void;
   waitUntilSettled(): Promise<void>;
   runHealth<T>(operation: () => Promise<T>): Promise<T>;
 };
 
+type ObserverStartupCommit =
+  | { status: "stopped" }
+  | { status: "ready"; claimRelease: ObserverBootClaimReleaseResult };
+
 export function createObserverStartupGate(): ObserverStartupGate {
   let state: "starting" | "ready" | "stopping" | "failed" = "starting";
-  let release: () => void = () => undefined;
+  let releaseHealth: () => void = () => undefined;
   let ready = pending();
   let settleStartup: () => void = () => undefined;
   const startupSettled = new Promise<void>((resolve) => {
@@ -419,7 +490,7 @@ export function createObserverStartupGate(): ObserverStartupGate {
 
   function pending(): Promise<void> {
     return new Promise((resolve) => {
-      release = resolve;
+      releaseHealth = resolve;
     });
   }
 
@@ -429,15 +500,25 @@ export function createObserverStartupGate(): ObserverStartupGate {
       if (state === "ready") ready = pending();
       state = "stopping";
     },
-    settleReady: () => {
+    settleReady: (releaseClaim) => {
       if (state !== "starting") {
         settleStartup();
-        return false;
+        return { status: "stopped" };
       }
       state = "ready";
-      release();
+      let claimRelease: ObserverBootClaimReleaseResult;
+      try {
+        // Ready is committed while the claim is held; health becomes visible
+        // only after synchronous release lets the next child probe this socket.
+        claimRelease = releaseClaim();
+      } catch (error) {
+        state = "failed";
+        settleStartup();
+        throw error;
+      }
+      releaseHealth();
       settleStartup();
-      return true;
+      return { status: "ready", claimRelease };
     },
     settleFailed: () => {
       if (state === "starting") state = "failed";
@@ -453,4 +534,11 @@ export function createObserverStartupGate(): ObserverStartupGate {
       }
     },
   };
+}
+
+function releaseObserverBootClaim(claim: AcquiredObserverBootClaim): void {
+  const released = claim.release();
+  if (released.status === "failed") {
+    throw released.error;
+  }
 }

--- a/apps/observer/src/runtime/observerBootClaim.ts
+++ b/apps/observer/src/runtime/observerBootClaim.ts
@@ -1,0 +1,250 @@
+import { chmod, lstat, mkdir, open } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import type { SafeError } from "@station/contracts";
+import { safeErrorFromUnknown } from "@station/runtime";
+import { isSqliteBusyError, openSqlDatabase, type SqlDatabase } from "../sqlite/driver.js";
+
+const claimFileName = "observer.claim.sqlite";
+const claimSidecarSuffixes = ["", "-journal", "-wal", "-shm"] as const;
+
+export type ObserverBootClaimReleaseResult =
+  | { status: "released" }
+  | { status: "failed"; error: ObserverBootClaimError };
+
+export type ObserverBootClaimError = Error & SafeError;
+
+export type AcquiredObserverBootClaim = {
+  status: "acquired";
+  path: string;
+  release(): ObserverBootClaimReleaseResult;
+};
+
+export type ObserverBootClaimResult =
+  | AcquiredObserverBootClaim
+  | { status: "contended"; path: string; error: ObserverBootClaimError }
+  | { status: "failed"; path: string; error: ObserverBootClaimError };
+
+type ObserverBootClaimDeps = {
+  openDatabase?: (path: string) => SqlDatabase;
+};
+
+export function observerBootClaimPath(socketPath: string): string {
+  return join(dirname(socketPath), claimFileName);
+}
+
+/**
+ * ADAPTER
+ *
+ * Excludes cross-runtime socket boot mutation through a SQLite transaction
+ * whose ownership comes from the OS lock, never the persistent claim file.
+ */
+export async function acquireObserverBootClaim(
+  options: { socketPath: string; timeoutMs: number },
+  deps: ObserverBootClaimDeps = {},
+): Promise<ObserverBootClaimResult> {
+  const path = observerBootClaimPath(options.socketPath);
+  if (isReservedClaimSocketPath(options.socketPath)) {
+    return failedClaim(
+      path,
+      new Error("Observer socket path collides with the reserved boot claim database."),
+    );
+  }
+  if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+    return failedClaim(path, new Error("Observer boot claim timeout must be a positive integer."));
+  }
+
+  try {
+    await prepareClaimFiles(path);
+  } catch (error) {
+    return failedClaim(path, error);
+  }
+
+  let database: SqlDatabase | undefined;
+  try {
+    // process.umask is process-global, so keep its private override inside one
+    // synchronous block where no other JavaScript work can interleave.
+    withPrivateSqliteUmask(() => {
+      database = (deps.openDatabase ?? openSqlDatabase)(path);
+      database.exec(`PRAGMA busy_timeout = ${options.timeoutMs}`);
+      database.exec("BEGIN IMMEDIATE");
+    });
+  } catch (error) {
+    const closeError = closeAfterFailedAcquire(database);
+    if (closeError !== undefined) {
+      return failedClaim(
+        path,
+        new AggregateError([error, closeError], "Observer boot claim database cleanup failed."),
+      );
+    }
+    if (isSqliteBusyError(error)) {
+      return {
+        status: "contended",
+        path,
+        error: observerBootClaimError(error, {
+          code: "OBSERVER_BOOT_CLAIM_CONTENDED",
+          message: "Observer boot ownership remained contended for the startup budget.",
+        }),
+      };
+    }
+    return failedClaim(path, error);
+  }
+
+  if (database === undefined) {
+    return failedClaim(path, new Error("Observer boot claim database did not open."));
+  }
+
+  const release = createRelease(database);
+  try {
+    await requirePrivateClaimFiles(path);
+  } catch (error) {
+    const releaseResult = release();
+    return failedClaim(
+      path,
+      releaseResult.status === "failed"
+        ? new AggregateError(
+            [error, releaseResult.error],
+            "Observer boot claim validation and cleanup failed.",
+          )
+        : error,
+    );
+  }
+
+  return { status: "acquired", path, release };
+}
+
+function isReservedClaimSocketPath(socketPath: string): boolean {
+  const socketName = basename(socketPath).toLowerCase();
+  return claimSidecarSuffixes.some((suffix) => socketName === `${claimFileName}${suffix}`);
+}
+
+async function prepareClaimFiles(path: string): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await chmod(directory, 0o700);
+
+  // The database persists across boots; existence only prepares the SQLite
+  // representation and never proves transaction ownership.
+  let created: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    created = await open(path, "wx", 0o600);
+    await created.chmod(0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  } finally {
+    await created?.close();
+  }
+
+  await requirePrivateClaimFiles(path);
+}
+
+async function requirePrivateClaimFiles(path: string): Promise<void> {
+  await Promise.all(
+    claimSidecarSuffixes.map((suffix) =>
+      requirePrivateRegularFile(`${path}${suffix}`, suffix === ""),
+    ),
+  );
+}
+
+async function requirePrivateRegularFile(path: string, required: boolean): Promise<void> {
+  let metadata: Awaited<ReturnType<typeof lstat>>;
+  try {
+    metadata = await lstat(path);
+  } catch (error) {
+    if (!required && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  if (!metadata.isFile() || metadata.isSymbolicLink()) {
+    throw new Error(`Observer boot claim path must be a regular non-symlink file: ${path}`);
+  }
+  await chmod(path, 0o600);
+}
+
+function createRelease(database: SqlDatabase): () => ObserverBootClaimReleaseResult {
+  let result: ObserverBootClaimReleaseResult | undefined;
+  return () => {
+    if (result !== undefined) {
+      return result;
+    }
+
+    const errors: unknown[] = [];
+    try {
+      withPrivateSqliteUmask(() => {
+        try {
+          database.exec("ROLLBACK");
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          database.close();
+        } catch (error) {
+          errors.push(error);
+        }
+      });
+    } catch (error) {
+      errors.push(error);
+    }
+
+    result =
+      errors.length === 0
+        ? { status: "released" }
+        : {
+            status: "failed",
+            error: observerBootClaimError(
+              new AggregateError(errors, "Observer boot claim release failed."),
+              {
+                code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED",
+                message: "Observer boot ownership could not be released cleanly.",
+              },
+            ),
+          };
+    return result;
+  };
+}
+
+function closeAfterFailedAcquire(database: SqlDatabase | undefined): unknown | undefined {
+  if (database === undefined) {
+    return undefined;
+  }
+  try {
+    withPrivateSqliteUmask(() => database.close());
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+function withPrivateSqliteUmask<T>(operation: () => T): T {
+  const previous = process.umask(0o077);
+  try {
+    return operation();
+  } finally {
+    process.umask(previous);
+  }
+}
+
+function failedClaim(path: string, error: unknown): ObserverBootClaimResult {
+  return {
+    status: "failed",
+    path,
+    error: observerBootClaimError(error, {
+      code: "OBSERVER_BOOT_CLAIM_FAILED",
+      message: "Observer boot ownership could not be acquired.",
+    }),
+  };
+}
+
+function observerBootClaimError(
+  cause: unknown,
+  fallback: { code: string; message: string },
+): ObserverBootClaimError {
+  const safeError = safeErrorFromUnknown(cause, {
+    tag: "ObserverBootClaimError",
+    code: fallback.code,
+    message: fallback.message,
+  }) as SafeError;
+  return Object.assign(new Error(safeError.message, { cause }), safeError);
+}

--- a/apps/observer/src/runtime/server.ts
+++ b/apps/observer/src/runtime/server.ts
@@ -1,5 +1,6 @@
+import { lstat } from "node:fs/promises";
 import type { ObserverApi } from "@station/contracts";
-import { startProtocolServer, type UnixSocketServer } from "@station/protocol";
+import { connectUnixSocket, startProtocolServer, type UnixSocketServer } from "@station/protocol";
 import { type RuntimeClock, runRuntimeBoundary, systemClock } from "@station/runtime";
 
 export type ObserverServer = {
@@ -13,6 +14,32 @@ export type StartObserverServerOptions = {
   clock?: RuntimeClock;
   drainOnStart?: boolean;
 };
+
+export type ObserverSocketProbe = "absent" | "stale" | "listening";
+
+/**
+ * ADAPTER
+ *
+ * Translates local Unix-socket transport evidence into the boot states used by
+ * Observer composition without exposing connection mechanics there.
+ */
+export async function probeObserverSocket(socketPath: string): Promise<ObserverSocketProbe> {
+  const initial = await socketMetadata(socketPath);
+  if (initial === undefined) {
+    return "absent";
+  }
+  if (!initial.isSocket()) {
+    return "stale";
+  }
+
+  try {
+    const connection = await connectUnixSocket(socketPath, { timeoutMs: 1000 });
+    connection.close();
+    return "listening";
+  } catch {
+    return (await socketMetadata(socketPath)) === undefined ? "absent" : "stale";
+  }
+}
 
 export async function startObserverServer(
   options: StartObserverServerOptions,
@@ -61,5 +88,18 @@ async function closeObserverServer(server: UnixSocketServer, clock: RuntimeClock
   );
   if (!closed.ok) {
     throw closed.error;
+  }
+}
+
+async function socketMetadata(
+  socketPath: string,
+): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  try {
+    return await lstat(socketPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
   }
 }

--- a/apps/observer/src/runtime/socketOwnership.ts
+++ b/apps/observer/src/runtime/socketOwnership.ts
@@ -17,9 +17,10 @@ export type WatchSocketOwnershipOptions = {
   onLost(): void;
 };
 
-// A newer observer claims the socket path by unlinking and rebinding it, which
-// gives the displaced process no signal. Watching the file's inode is the only
-// way it can learn it lost ownership and must shut down instead of lingering.
+// A legacy or otherwise uncoordinated observer can claim the socket path by
+// unlinking and rebinding it, which gives the displaced process no signal.
+// Watching the file's inode is the only way it can learn it lost ownership and
+// must shut down instead of lingering.
 // Inode number alone is ambiguous: a recreated path can reuse the just-freed
 // inode (ext4 does this routinely), so identity pairs it with the birth time.
 // Filesystems without btime report 0n for both files, degrading to inode-only.

--- a/apps/observer/src/sqlite/driver.ts
+++ b/apps/observer/src/sqlite/driver.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 export type SqlParam = string | number | bigint | Uint8Array | null;
 
 export type SqlRunResult = {
@@ -38,6 +40,11 @@ type NativeSqliteConstructor = new (path: string) => NativeSqliteDatabase;
 
 declare const Bun: object;
 
+const SqliteBusyErrorSchema = z.union([
+  z.object({ code: z.literal("ERR_SQLITE_ERROR"), errcode: z.literal(5) }),
+  z.object({ code: z.literal("SQLITE_BUSY"), errno: z.literal(5) }),
+]);
+
 // Import exactly one driver: loading node:sqlite terminates Bun before fallback is possible.
 const openSqlite =
   typeof Bun !== "undefined"
@@ -46,6 +53,10 @@ const openSqlite =
     : adaptNodeSqlite((await import("node:sqlite")).DatabaseSync);
 
 export const openSqlDatabase = (path: string): SqlDatabase => openSqlite(path);
+
+export function isSqliteBusyError(error: unknown): boolean {
+  return SqliteBusyErrorSchema.safeParse(error).success;
+}
 
 function adaptNodeSqlite(Database: NativeSqliteConstructor): (path: string) => SqlDatabase {
   return (path) => adaptDatabase(new Database(path), false);

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -1,3 +1,5 @@
+import { access } from "node:fs/promises";
+import { join } from "node:path";
 import type { StationConfig } from "@station/config";
 import { createObserverClient } from "@station/protocol";
 import {
@@ -6,8 +8,8 @@ import {
   FakeTerminalProvider,
   FakeWorktreeProvider,
 } from "@station/testing";
-import { describe, expect, it } from "vitest";
-import { createTempSocketPath } from "../../../../tests/support/sockets";
+import { describe, expect, it, vi } from "vitest";
+import { createStaleSocketFile, createTempSocketPath } from "../../../../tests/support/sockets";
 import {
   createCommandQueue,
   createObserverApi,
@@ -17,7 +19,9 @@ import {
   openObserverSqlite,
   type PersistenceHealthSource,
   ProviderRegistry,
+  probeObserverSocket,
   registerObserverCommandHandlers,
+  runObserverMain,
   startObserverServer,
 } from "../../src/internal";
 
@@ -38,6 +42,43 @@ const degradedSqliteHealth = {
 } as const;
 
 describe("observer protocol server", () => {
+  it("translates absent, stale, and listening socket transport states", async () => {
+    const { dir, socketPath } = await createTempSocketPath();
+    await expect(probeObserverSocket(socketPath)).resolves.toBe("absent");
+
+    await createStaleSocketFile(socketPath);
+    await expect(probeObserverSocket(socketPath)).resolves.toBe("stale");
+
+    const fixture = createObserverFixture(socketPath);
+    const server = await startObserverServer({
+      socketPath,
+      api: fixture.api,
+      clock: fixture.clock,
+      drainOnStart: false,
+    });
+    try {
+      await expect(probeObserverSocket(socketPath)).resolves.toBe("listening");
+      const stateDir = join(dir, "losing-state");
+      const providerRegistryFactory = vi.fn(() => {
+        throw new Error("providers must not be constructed for a listening socket");
+      });
+      await expect(
+        runObserverMain(
+          ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "100"],
+          { providerRegistryFactory },
+        ),
+      ).resolves.toBe(0);
+      expect(providerRegistryFactory).not.toHaveBeenCalled();
+      await expect(access(join(stateDir, "observer.sqlite"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(access(`${socketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await server.close();
+      fixture.sqlite.close();
+    }
+  });
+
   it("serves health, diagnostics, command dispatch, command get, and reconcile", async () => {
     const { socketPath } = await createTempSocketPath();
     const fixture = createObserverFixture(socketPath);

--- a/apps/observer/test/unit/observerBootClaim.test.ts
+++ b/apps/observer/test/unit/observerBootClaim.test.ts
@@ -1,0 +1,326 @@
+import {
+  access,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createObserverStartupGate, runObserverMain } from "../../src/runtime/main.js";
+import {
+  acquireObserverBootClaim,
+  observerBootClaimPath,
+} from "../../src/runtime/observerBootClaim.js";
+import type { SqlDatabase } from "../../src/sqlite/driver.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("observer boot claim", () => {
+  it("derives a socket-relative path with private directory and database modes", async () => {
+    const root = await tempRoot("station observer claim ");
+    const socketPath = join(root, "runtime with spaces", "custom observer.sock");
+    const path = join(dirname(socketPath), "observer.claim.sqlite");
+
+    const claim = await acquireObserverBootClaim({ socketPath, timeoutMs: 100 });
+    expect(claim.status).toBe("acquired");
+    if (claim.status !== "acquired") return;
+    try {
+      expect(observerBootClaimPath(socketPath)).toBe(path);
+      expect(claim.path).toBe(path);
+      expect((await stat(dirname(path))).mode & 0o777).toBe(0o700);
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+      expect((await lstat(path)).isFile()).toBe(true);
+    } finally {
+      expect(claim.release()).toEqual({ status: "released" });
+    }
+  });
+
+  it("bounds contention, then releases and reacquires without replacing the database", async () => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const first = await acquireObserverBootClaim({ socketPath, timeoutMs: 500 });
+    expect(first.status).toBe("acquired");
+    if (first.status !== "acquired") return;
+    const inode = (await stat(first.path)).ino;
+
+    try {
+      const startedAt = Date.now();
+      const second = await acquireObserverBootClaim({ socketPath, timeoutMs: 75 });
+      const elapsedMs = Date.now() - startedAt;
+      expect(second).toMatchObject({
+        status: "contended",
+        error: { code: "OBSERVER_BOOT_CLAIM_CONTENDED" },
+      });
+      if (second.status === "contended") {
+        expect(second.error).toBeInstanceOf(Error);
+      }
+      expect(elapsedMs).toBeGreaterThanOrEqual(40);
+      expect(elapsedMs).toBeLessThan(2_000);
+    } finally {
+      const released = first.release();
+      expect(first.release()).toBe(released);
+      expect(released).toEqual({ status: "released" });
+    }
+
+    const successor = await acquireObserverBootClaim({ socketPath, timeoutMs: 100 });
+    expect(successor.status).toBe("acquired");
+    if (successor.status !== "acquired") return;
+    expect((await stat(successor.path)).ino).toBe(inode);
+    expect(successor.release()).toEqual({ status: "released" });
+  });
+
+  it("normalizes existing database and sidecar modes without treating them as ownership", async () => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const path = observerBootClaimPath(socketPath);
+    await mkdir(dirname(path), { recursive: true, mode: 0o755 });
+    for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+      await writeFile(`${path}${suffix}`, "", { mode: 0o644 });
+    }
+    const database = fakeDatabase();
+    const originalUmask = process.umask();
+
+    const claim = await acquireObserverBootClaim(
+      { socketPath, timeoutMs: 100 },
+      { openDatabase: () => database },
+    );
+    expect(claim.status).toBe("acquired");
+    expect(process.umask()).toBe(originalUmask);
+    if (claim.status !== "acquired") return;
+    for (const suffix of ["", "-journal", "-wal", "-shm"]) {
+      expect((await stat(`${path}${suffix}`)).mode & 0o777).toBe(0o600);
+    }
+    expect(claim.release()).toEqual({ status: "released" });
+    expect(process.umask()).toBe(originalUmask);
+  });
+
+  it.each([
+    "",
+    "-journal",
+    "-wal",
+    "-shm",
+  ])("rejects a symlink at the claim%s path without replacing it", async (suffix) => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const path = observerBootClaimPath(socketPath);
+    const target = join(root, `target${suffix || "-db"}`);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(target, "target", "utf8");
+    if (suffix !== "") {
+      await writeFile(path, "", { mode: 0o600 });
+    }
+    await symlink(target, `${path}${suffix}`);
+
+    const claim = await acquireObserverBootClaim({ socketPath, timeoutMs: 50 });
+    expect(claim).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_BOOT_CLAIM_FAILED" },
+    });
+    expect((await lstat(`${path}${suffix}`)).isSymbolicLink()).toBe(true);
+    await expect(readFile(target, "utf8")).resolves.toBe("target");
+  });
+
+  it.each([
+    "",
+    "-journal",
+    "-wal",
+    "-shm",
+  ])("rejects a directory at the claim%s path", async (suffix) => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const path = observerBootClaimPath(socketPath);
+    await mkdir(dirname(path), { recursive: true });
+    if (suffix !== "") {
+      await writeFile(path, "", { mode: 0o600 });
+    }
+    await mkdir(`${path}${suffix}`);
+
+    const claim = await acquireObserverBootClaim({ socketPath, timeoutMs: 50 });
+    expect(claim).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_BOOT_CLAIM_FAILED" },
+    });
+    expect((await lstat(`${path}${suffix}`)).isDirectory()).toBe(true);
+  });
+
+  it.each([
+    "observer.claim.sqlite",
+    "observer.claim.sqlite-journal",
+    "observer.claim.sqlite-wal",
+    "observer.claim.sqlite-shm",
+    "OBSERVER.CLAIM.SQLITE",
+  ])("rejects the reserved claim socket basename %s before mutation", async (socketName) => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", socketName);
+    const path = observerBootClaimPath(socketPath);
+
+    const claim = await acquireObserverBootClaim({ socketPath, timeoutMs: 50 });
+
+    expect(claim).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_BOOT_CLAIM_FAILED" },
+    });
+    await expect(access(path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("fails on a corrupt database without replacing its inode or contents", async () => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const path = observerBootClaimPath(socketPath);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "not a sqlite database", { mode: 0o600 });
+    const inode = (await stat(path)).ino;
+
+    const claim = await acquireObserverBootClaim({ socketPath, timeoutMs: 50 });
+    expect(claim).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_BOOT_CLAIM_FAILED" },
+    });
+    expect((await stat(path)).ino).toBe(inode);
+    await expect(readFile(path, "utf8")).resolves.toBe("not a sqlite database");
+  });
+
+  it("maps permission and non-busy SQLite failures to claim failure", async () => {
+    for (const error of [
+      Object.assign(new Error("permission denied"), { code: "EACCES" }),
+      Object.assign(new Error("not busy"), { code: "ERR_SQLITE_ERROR", errcode: 11 }),
+    ]) {
+      const root = await tempRoot();
+      const socketPath = join(root, "run", "observer.sock");
+      const database = fakeDatabase({ beginError: error });
+      const claim = await acquireObserverBootClaim(
+        { socketPath, timeoutMs: 50 },
+        { openDatabase: () => database },
+      );
+      expect(claim).toMatchObject({
+        status: "failed",
+        error: { code: "OBSERVER_BOOT_CLAIM_FAILED" },
+      });
+      if (claim.status === "failed") {
+        expect(claim.error).toBeInstanceOf(Error);
+      }
+      expect(database.close).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("attempts both rollback and close, then caches a release failure", async () => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const database = fakeDatabase({
+      rollbackError: new Error("rollback failed"),
+      closeError: new Error("close failed"),
+    });
+    const claim = await acquireObserverBootClaim(
+      { socketPath, timeoutMs: 50 },
+      { openDatabase: () => database },
+    );
+    expect(claim.status).toBe("acquired");
+    if (claim.status !== "acquired") return;
+
+    const released = claim.release();
+    expect(released).toMatchObject({
+      status: "failed",
+      error: { code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED" },
+    });
+    if (released.status === "failed") {
+      expect(released.error).toBeInstanceOf(Error);
+    }
+    expect(claim.release()).toBe(released);
+    expect(database.exec).toHaveBeenCalledWith("ROLLBACK");
+    expect(database.close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps committed health available when rollback succeeds but close fails", async () => {
+    const root = await tempRoot();
+    const socketPath = join(root, "run", "observer.sock");
+    const database = fakeDatabase({ closeError: new Error("close failed") });
+    const claim = await acquireObserverBootClaim(
+      { socketPath, timeoutMs: 50 },
+      { openDatabase: () => database },
+    );
+    expect(claim.status).toBe("acquired");
+    if (claim.status !== "acquired") return;
+    const gate = createObserverStartupGate();
+    const health = vi.fn(async () => "healthy");
+    const healthResult = gate.runHealth(health);
+
+    const commit = gate.settleReady(() => claim.release());
+
+    expect(commit).toMatchObject({
+      status: "ready",
+      claimRelease: {
+        status: "failed",
+        error: { code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED" },
+      },
+    });
+    expect(database.exec).toHaveBeenCalledWith("ROLLBACK");
+    await expect(healthResult).resolves.toBe("healthy");
+    expect(health).toHaveBeenCalledOnce();
+  });
+
+  it("does not construct providers or mutate runtime ownership after claim failure", async () => {
+    const root = await tempRoot();
+    const stateDir = join(root, "state");
+    const socketPath = join(root, "run", "observer.sock");
+    const path = observerBootClaimPath(socketPath);
+    await mkdir(path, { recursive: true });
+    const providerRegistryFactory = vi.fn(() => {
+      throw new Error("providers must not be constructed");
+    });
+
+    await expect(
+      runObserverMain(
+        ["--state-dir", stateDir, "--socket", socketPath, "--startup-timeout-ms", "50"],
+        { providerRegistryFactory },
+      ),
+    ).rejects.toMatchObject({ code: "OBSERVER_BOOT_CLAIM_FAILED" });
+    expect(providerRegistryFactory).not.toHaveBeenCalled();
+    await expect(access(socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(`${socketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(access(join(stateDir, "observer.sqlite"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect((await lstat(path)).isDirectory()).toBe(true);
+  });
+});
+
+async function tempRoot(prefix = "station-observer-claim-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function fakeDatabase(
+  options: { beginError?: unknown; rollbackError?: unknown; closeError?: unknown } = {},
+): SqlDatabase & { exec: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> } {
+  const exec = vi.fn((sql: string) => {
+    if (sql === "BEGIN IMMEDIATE" && options.beginError !== undefined) {
+      throw options.beginError;
+    }
+    if (sql === "ROLLBACK" && options.rollbackError !== undefined) {
+      throw options.rollbackError;
+    }
+  });
+  const close = vi.fn(() => {
+    if (options.closeError !== undefined) {
+      throw options.closeError;
+    }
+  });
+  return {
+    exec,
+    prepare: vi.fn(() => {
+      throw new Error("prepare is not used by the boot claim");
+    }),
+    close,
+  };
+}

--- a/apps/observer/test/unit/observerStartupGate.test.ts
+++ b/apps/observer/test/unit/observerStartupGate.test.ts
@@ -13,7 +13,9 @@ describe("observer startup gate", () => {
     await Promise.resolve();
     expect(shutdownReleased).toBe(false);
 
-    expect(gate.settleReady()).toBe(false);
+    const releaseClaim = vi.fn();
+    expect(gate.settleReady(releaseClaim)).toEqual({ status: "stopped" });
+    expect(releaseClaim).not.toHaveBeenCalled();
     await gate.waitUntilSettled();
     expect(shutdownReleased).toBe(true);
   });
@@ -22,10 +24,57 @@ describe("observer startup gate", () => {
     const gate = createObserverStartupGate();
     const health = vi.fn(async () => "healthy");
     const healthResult = gate.runHealth(health);
+    const order: string[] = [];
 
     expect(health).not.toHaveBeenCalled();
-    expect(gate.settleReady()).toBe(true);
+    expect(
+      gate.settleReady(() => {
+        order.push("claim-released");
+        return { status: "released" };
+      }),
+    ).toEqual({ status: "ready", claimRelease: { status: "released" } });
 
+    await expect(
+      healthResult.then((result) => {
+        order.push("health-returned");
+        return result;
+      }),
+    ).resolves.toBe("healthy");
+    expect(health).toHaveBeenCalledOnce();
+    expect(order).toEqual(["claim-released", "health-returned"]);
+  });
+
+  it("keeps health blocked when synchronous claim release fails", async () => {
+    const gate = createObserverStartupGate();
+    const health = vi.fn(async () => "healthy");
+    void gate.runHealth(health);
+    const releaseError = new Error("release failed");
+
+    expect(() =>
+      gate.settleReady(() => {
+        throw releaseError;
+      }),
+    ).toThrow(releaseError);
+    await gate.waitUntilSettled();
+    await Promise.resolve();
+    expect(health).not.toHaveBeenCalled();
+  });
+
+  it("keeps committed health available when claim release reports a partial failure", async () => {
+    const gate = createObserverStartupGate();
+    const health = vi.fn(async () => "healthy");
+    const healthResult = gate.runHealth(health);
+    const releaseError = Object.assign(new Error("close failed"), {
+      tag: "ObserverBootClaimError",
+      code: "OBSERVER_BOOT_CLAIM_RELEASE_FAILED",
+    });
+
+    const commit = gate.settleReady(() => ({ status: "failed", error: releaseError }));
+
+    expect(commit).toEqual({
+      status: "ready",
+      claimRelease: { status: "failed", error: releaseError },
+    });
     await expect(healthResult).resolves.toBe("healthy");
     expect(health).toHaveBeenCalledOnce();
   });

--- a/apps/observer/test/unit/sqlite-driver.test.ts
+++ b/apps/observer/test/unit/sqlite-driver.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { openSqlDatabase } from "../../src/sqlite/driver";
+import { isSqliteBusyError, openSqlDatabase } from "../../src/sqlite/driver";
 
 describe("SQLite driver", () => {
   it("normalizes Node SQLite statements to the shared contract", () => {
@@ -20,5 +20,18 @@ describe("SQLite driver", () => {
     } finally {
       database.close();
     }
+  });
+
+  it.each([
+    [{ code: "ERR_SQLITE_ERROR", errcode: 5 }, true],
+    [{ code: "SQLITE_BUSY", errno: 5 }, true],
+    [{ code: "ERR_SQLITE_ERROR", errcode: 6 }, false],
+    [{ code: "SQLITE_BUSY", errno: 6 }, false],
+    [{ code: "SQLITE_BUSY", errcode: 5 }, false],
+    [{ code: "ERR_SQLITE_ERROR", errno: 5 }, false],
+    [{ code: "SQLITE_BUSY" }, false],
+    [new Error("busy"), false],
+  ])("classifies only verified native busy error shapes", (error, expected) => {
+    expect(isSqliteBusyError(error)).toBe(expected);
   });
 });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,7 @@ Not config, but adjacent:
 
 | Directory | Path (default) | Holds | Relocate with |
 | --- | --- | --- | --- |
-| **State dir** | `~/.local/state/station/` | SQLite DB, logs, diagnostics, hook spool, sockets | `observer.state_dir` in config; sockets also follow `XDG_RUNTIME_DIR` |
+| **State dir** | `~/.local/state/station/` | SQLite DB, logs, diagnostics, hook spool, and default runtime paths | `observer.state_dir`; sockets and the boot claim follow `observer.socket_path` or `XDG_RUNTIME_DIR` when set |
 
 The state dir is **not** a config file — never edit anything under
 `~/.local/state/station` by hand. See [debugging.md](./debugging.md).
@@ -463,6 +463,14 @@ Default state paths (all under `state_dir`, default `~/.local/state/station`):
 - `observer.sqlite`, `logs/`, `diagnostics/`, `spool/hooks/` follow `state_dir`.
 - `run/observer.sock` and sibling `run/station-host.sock` sit under a `run/` subdir of
   `state_dir`, **unless** `XDG_RUNTIME_DIR` is set (then `$XDG_RUNTIME_DIR/station/`).
+- `observer.claim.sqlite` sits beside the resolved Observer socket. It is a
+  persistent boot-serialization database, not Observer application state:
+  file existence is never ownership, and startup never removes or replaces it.
+  The socket directory is mode `0700`; the claim and any SQLite sidecars are
+  regular non-symlink files at mode `0600`. Different sockets in one directory
+  share startup serialization while retaining separate sockets and pidfiles.
+  A configured socket filename cannot be `observer.claim.sqlite` or one of its
+  `-journal`, `-wal`, or `-shm` sidecars.
 
 Generated launch/hook env vars are internal context, not hand-authored config:
 `STATION_PROJECT_ID`, `STATION_WORKTREE_ID`, `STATION_WORKTREE_PATH`,

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -137,6 +137,15 @@ and explicit-socket layouts where the socket directory is outside the configured
 state directory. Including the socket filename keeps identities distinct when
 multiple configured sockets share one directory.
 
+The startup claim is `dirname(resolvedSocket)/observer.claim.sqlite`. It is a
+persistent private SQLite file whose active `BEGIN IMMEDIATE` transaction, not
+its existence, identifies a boot owner. Do not delete, rename, replace, or
+"stale reclaim" it. A process exit releases the OS lock, and the next start
+reuses the same inode. The socket directory is mode `0700`; the claim and any
+`-journal`, `-wal`, or `-shm` sidecars are regular non-symlink files at mode
+`0600`. When XDG or an explicit socket moves this file outside `state_dir`, use
+the resolved health `socketPath` to locate it.
+
 Important files and directories:
 
 ```text
@@ -176,6 +185,9 @@ matches its published value.
 ## Reading Evidence
 
 - `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes the latest path and, when available, a redacted final 15-line tail captured from its own failed child.
+- `observer.claim.sqlite` is boot-exclusion evidence only. Inspect it with
+  read-only SQLite tooling after confirming no startup is in progress; never
+  infer ownership from the file or sidecars being present.
 - `diagnostic-index.json` is the fastest summary for root-cause codes and correlated evidence.
 - `commands.jsonl` is the command lifecycle record. Failed commands can include redacted provider command diagnostics when an error envelope was persisted for the command.
 - `errors.jsonl` carries safe error envelopes, diagnostic IDs, trace IDs, provider context, and redacted diagnostic details when available.

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,8 +45,9 @@ pnpm test:all
 ```
 
 It runs build, typecheck, lint, unit tests, contract tests, integration tests,
-diagnostics tests, the scripted-agent lane, setup E2E coverage, and a production
-Observer SQLite restart smoke. It intentionally excludes real provider lanes.
+diagnostics tests, the scripted-agent lane, setup and Observer lifecycle E2E
+coverage, and a production Observer SQLite restart smoke. It intentionally
+excludes real provider lanes.
 
 After root `pnpm install`, Lefthook runs the broader local gate before pushes:
 
@@ -70,6 +71,8 @@ pnpm lint
 pnpm test:unit
 pnpm test:contracts
 pnpm test:integration
+pnpm test:e2e:observer
+pnpm test:observer-claim:cross-runtime
 pnpm test:sqlite:bun
 pnpm test:diagnostics
 pnpm test:agent:scripted
@@ -90,8 +93,17 @@ on the runtime `PATH`.
 
 Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
 creates observer databases under Node and Bun, then reopens each database under
-the other runtime to verify the shared SQLite contract and migrations. Both the
-local pre-push gate and the mandatory hosted `station-bun` job run this check.
+the other runtime to verify the shared SQLite contract and migrations. It also
+runs the permanent boot-claim race: 50 alternating Node/Bun two-process rounds,
+three-contender rounds, and killed-owner recovery with stable inode and
+`integrity_check=ok`; this gate makes no fairness claim. Both the local pre-push
+gate and the mandatory hosted `station-bun` job run these checks.
+
+`pnpm test:e2e:observer` drives the built production Observer through cold and
+real stale-socket races, XDG/state divergence, explicit paths with spaces,
+claim-held no-side-effect behavior, pidfile publication, and clean restart while
+the persistent claim remains. Run it after `pnpm build` when changing startup,
+socket ownership, pidfiles, or claim lifecycle behavior.
 
 For focused Station PTY work, run both implementations explicitly:
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -235,6 +235,7 @@ No single layer owns all truth.
 | Provider-owned identity | Worktree, target, harness-run, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
 | Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
+| Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, version, socketPath}` identity published by the process that successfully bound the socket. It corroborates process identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
 | In-memory persistence adapter | Process-local test state that preserves the seven persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
 | `StationSnapshot` | Current normalized graph held in memory. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
@@ -251,45 +252,53 @@ and reloads after later gaps or events that cannot be reduced safely.
 
 ### Startup
 
-Normal CLI and provider-hook startup currently probe and may remove a stale
-socket pathname before spawning. Each spawned Observer later uses bind-first
-stale reclamation in the protocol server. Those ownership mutations are not
-serialized across processes; `OBS-HEX-013` tracks the resulting cached-stale
-race.
+Normal CLI and provider-hook startup is attach-or-spawn: clients may classify a
+stale socket, but only the spawned Observer child mutates ownership. The child
+serializes probe, stale reclaim, bind, pidfile publication, watcher setup, and
+ready-state commitment with an OS-backed SQLite transaction.
 
 Current startup proceeds in this order:
 
 1. CLI composition supplies the concrete, optionally asynchronous provider
-   registry factory.
+   registry factory. The normal and provider-hook spawners pass the caller's
+   positive startup budget as internal child argv; custom spawn callback
+   contracts remain unchanged.
 2. Observer runtime loads config, resolves the canonical state and socket paths,
-   creates the state directory, and passes that resolved directory to CLI
-   composition. Compiled composition materializes the Pi extension here before
-   constructing providers; Observer code remains provider-neutral.
-3. SQLite opens and applies pending migrations, then
+   and prepares private state and socket directories.
+3. Before provider construction or main-database access, the child opens the
+   low-level claim database beside the resolved socket and acquires `BEGIN
+   IMMEDIATE` with that startup budget. A listening probe releases the claim and
+   exits successfully so the parent attaches. An absent or stale probe keeps the
+   claim for owned startup; hard contention or claim I/O failure is fatal.
+4. CLI composition receives the resolved state directory and constructs the
+   providers. Compiled composition materializes the Pi extension here; Observer
+   code remains provider-neutral.
+5. The main Observer SQLite opens and applies pending migrations, then
    `createSqliteObserverPersistence` binds the seven application persistence
    ports and `PersistenceHealthSource` to that handle. Runtime composition
    retains the concrete handle only for open/close lifecycle ownership and
    distributes the composition bundle into narrow application views.
-4. The runtime creates the event bus, logger, command queue, feature evaluator,
+6. The runtime creates the event bus, logger, command queue, feature evaluator,
    Observer core, command handlers, and configured event hooks around the
    awaited provider registry.
-5. The API constructs ingress queues, reconcile scheduling, metadata refresh,
+7. The API constructs ingress queues, reconcile scheduling, metadata refresh,
    diagnostics dependencies, and spool draining.
-6. The runtime constructs a private startup-and-health gate, then the protocol
+8. The runtime constructs a private startup-and-health gate, then the protocol
    server binds the resolved socket before startup reconcile. Only the
    successful socket binder may publish process identity.
-7. The runtime captures the bound-socket identity, atomically publishes and
+9. The runtime captures the bound-socket identity, atomically publishes and
    fsyncs `<socketPath>.pid`, then arms the socket-ownership
    watcher from the captured identity. Identity publication or OS-start-token
    failure is fatal: health stays gated while the runtime logs the startup
    failure, tears down its services, socket, and SQLite handle, and exits
    nonzero.
-8. Health responses are enabled only after pidfile publication and watcher
-   setup complete. Startup reconcile then establishes the first provider-backed
-   snapshot; provider health and harness-version probes fill caches in the
-   background. A stop requested before readiness is terminal: shutdown waits
-   for publication to settle, health remains gated, and startup reconcile is
-   skipped.
+10. The startup gate marks the runtime ready, synchronously rolls back and closes
+    the boot claim, then unblocks health responses. Startup reconcile follows
+    outside the claim and establishes the first provider-backed snapshot;
+    provider health and harness-version probes fill caches in the background. A
+    stop requested before readiness is terminal: health remains gated, socket
+    and pidfile cleanup finish while the claim is held, and the outer lifecycle
+    `finally` releases it before exit.
 
 Composition must make lifecycle ownership obvious. Anything that owns a timer,
 fiber, watcher, queue, socket, child process, or durable handle must have a
@@ -417,7 +426,7 @@ from the diagnostic use case.
 
 | Concern | Current contract |
 | --- | --- |
-| Observer boot ownership | The resolved socket defines singleton identity, but client-side stale deletion and server-side stale reclamation are not yet serialized. Different sockets remain independent owners even when their paths share a state or runtime directory (OBS-HEX-013). |
+| Observer boot ownership | The resolved socket defines singleton identity. One persistent claim per socket directory serializes all child-side ownership mutation; different sockets in that directory wait on the same transaction but retain separate listeners and pidfiles. Claim existence is not ownership, process death releases the OS lock, and the claim path is never stale-reclaimed. |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Cancellation is cooperative; the process shutdown backstop handles ignored signals. |
 | Reconcile ordering | Core reconciles form a non-poisoning promise chain. Scheduled requests coalesce; queued work after a run receives a later flush. |
@@ -640,7 +649,6 @@ and exit condition here.
 | `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Exit when `StationLogger` exposes only `info`/`warn`/`error`, `ProjectConfigWriter` exposes only the three project mutations returning updated config, and their adapters alone own log/config/home paths. | Logging and project-config edge inversion. |
 | `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Read evidence and long-lived watcher lifecycle are mixed into the use case. | Exit when `WorktreeChangeSource` owns typed Git reads, `WorktreeMetadataInvalidationSource` separately owns watched-worktree replacement and shutdown, and use cases receive neither Git runners nor filesystem paths. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only. Exit when a `DiagnosticEvidenceSource` adapter owns only local-state, recent-log, and hook-spool traversal, captures its paths, and the use case runs against a fake without absorbing persistence, providers, core, or SQLite. | Diagnostic evidence isolation. |
-| `OBS-HEX-013` | Normal CLI and provider-hook startup may delete a socket pathname after separate stale probes, while `bindWithStaleReclaim` also probes and unlinks without a cross-process critical section. Two contenders can cache the same stale result, unlink a newly bound successor, and leave duplicate live processes for one resolved socket. | The seeded ownership watcher and `stn observer reap` contain displacement but do not prevent the race. Exit when the Observer child serializes probe, stale reclaim, bind, pidfile publication, watcher setup, and ready-state commitment with an OS-backed SQLite transaction at `dirname(resolvedSocket)/observer.claim.sqlite`; clients no longer mutate the socket; and process-level Node/Bun plus CLI/hook races prove one healthy owner. Different sockets in one directory may share the startup claim while retaining separate singleton identities. | [#135](https://github.com/jeremy0dell/station/issues/135) boot serialization. |
 
 The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
 resolved: application code receives `ManagedTerminalLifecycle` from composition,
@@ -662,6 +670,10 @@ over `StationCommand["type"]`. `OBS-HEX-009` is
 resolved: external launch exposes only an opaque managed-terminal attachment,
 Station owns host PTY and socket resolution, and an advertised attachment can
 never fail over to a duplicate local spawn.
+`OBS-HEX-013` is resolved: normal and provider-hook clients no longer unlink
+stale sockets, the child holds the persistent SQLite boot claim through ready
+commitment, and permanent Node/Bun plus production lifecycle races cover
+contention, owner death, stale reclaim, and distinct sockets sharing a claim.
 This document resolves `OBS-HEX-008`, the missing canonical Observer architecture
 contract. Resolved history belongs in its issue and pull request, not in the
 active register.

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -72,30 +72,29 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
 | #81 | WAL + `synchronous=NORMAL` sqlite; `stn observer reap` (socket-keyed candidacy, `lsof` keeper + health tiebreak, refuse-on-ambiguity, re-verify argv+start-token before every signal, SIGTERM→SIGKILL). `resolveObserverSocketForProcessArgs` in `@station/config`. |
 | #82 | Seeded socket-ownership watcher (`readSocketIdentity` + `expectedIdentity`); boot reorder — bind (`drainOnStart:false`) → arm seeded watcher → `observer.startup` reconcile, so a takeover during the scan is caught. |
 | #83 | `runShutdownWithBackstop`: `stopObserver` force-exits at a 5s ceiling so a wedged drain can't hang shutdown. Self-stop is now terminal (prerequisite for eviction). |
-| #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a remaining concurrent stale-reclaimer ABA, so this helper is safe only once boot attempts are serialized by 3d-a. |
+| #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a concurrent stale-reclaimer ABA; 3d-a now supplies the serialization required before this helper may reclaim. |
 | 3c | Durable process identity: the successful socket binder atomically publishes and fsyncs `<socketPath>.pid` with the strict `{pid, osStartTime, version, socketPath}` payload before health is enabled. The full socket filename keeps identities distinct within a shared runtime directory. Publication failure is fatal. Clean shutdown removes only its exact matching identity; `lsof` remains primary ownership evidence. |
+| 3d-a / #135 | The Observer child holds `BEGIN IMMEDIATE` on `dirname(resolvedSocket)/observer.claim.sqlite` across probe, stale reclaim, bind, pidfile publication, seeded watcher setup, and ready commitment. CLI and provider-hook clients only attach or spawn; health opens after synchronous claim release. |
 
 Together these **stop the bleeding**: `reap` clears duplicates on demand, the
 seeded watcher self-heals future displacements, and stop is terminal. Phase 3c
 also gives later handoff and reaping work a durable, socket-relative
 corroborating identity without changing current attach-or-spawn or
-duplicate-reaping behavior. Concurrent reclamation of one already-stale socket
-remains open until 3d-a serializes boot.
+duplicate-reaping behavior. Phase 3d-a now serializes stale-socket reclamation
+before either the socket path or pidfile can be mutated.
 
-## Remaining work
-
-### 3d-a — serialize stale-socket boot ownership ([#135](https://github.com/jeremy0dell/station/issues/135))
+### 3d-a boot contract
 
 Spike result: **NO-GO for both stale-path deletion designs (directory rename and
 AF_UNIX unlink/rebind); GO for a dedicated SQLite transaction claim backed by a
-permanent cross-runtime adversarial test.** The current stale-socket race is
-tracked as `OBS-HEX-013` and in #135.
+permanent cross-runtime adversarial test.** #135 shipped that narrow result;
+version-aware replacement remains separate below.
 
-Move startup ownership mutation into the observer boot (`main.ts`) under the
+Startup ownership mutation lives in observer boot (`main.ts`) under the
 OS-lock-backed claim database
-`C = dirname(resolvedSocket)/observer.claim.sqlite`. Hold one `BEGIN IMMEDIATE`
-transaction from the socket probe through ready-state commitment. Clients
-shrink to attach-or-spawn and never delete the socket path themselves.
+`C = dirname(resolvedSocket)/observer.claim.sqlite`. It holds one `BEGIN
+IMMEDIATE` transaction from the socket probe through ready-state commitment.
+Clients attach or spawn and never delete the socket path themselves.
 
 The singleton identity remains the **resolved socket**, not the state directory
 or claim path. Two different sockets in one directory intentionally share `C`
@@ -128,10 +127,12 @@ Supporting:
 - File existence is never ownership. The claim database and SQLite sidecars are
   persistent private files and are never stale-reclaimed, renamed, or replaced.
 
-Implementation starts red with deterministic two-process regressions for both
-rejected cached-stale ABA schedules. Then preserve the 50-round Node-vs-Bun
-transaction race, killed-owner recovery, production stale-socket races, and
-CLI/hook path-parity cases from the spikes as permanent coverage.
+Permanent coverage includes the 50-round Node-vs-Bun transaction race,
+three-contender rounds, killed-owner recovery, production cold and stale-socket
+races, XDG/state divergence, explicit paths with spaces, and CLI/hook timeout
+and non-mutation cases. It proves mutual exclusion, not fairness.
+
+## Remaining work
 
 ### 3d-b — version-aware incumbent replacement (deferred)
 
@@ -158,7 +159,7 @@ none belongs to #135.
 
 ### 3e — isolate hook auto-start rate limiting
 
-3d-a will route CLI and provider-hook children through the same child-owned
+3d-a routes CLI and provider-hook children through the same child-owned
 claim. Keep `hook-autostart.lock` authoritative only for hook rate limiting,
 never Observer ownership. Its state-directory location may diverge from the
 resolved socket under config and XDG overrides without weakening the 3d-a

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -36,8 +36,8 @@ Non-goals:
 - **Windows targets.**
 - **Any observer replacement / eviction in this roadmap.** Coordinated
   single-observer behavior is owned entirely by
-  [observer-singleton](observer-singleton.md). This plan *depends on* that
-  roadmap's 3c/3d-a/3d-b/3e phases; it does not add a second,
+  [observer-singleton](observer-singleton.md). This plan uses shipped 3c/3d-a
+  and defers remaining ownership policy to 3d-b/3e; it does not add a second,
   uncoordinated eviction path (v1 did — removed, see F3).
 - **Replacing the dev workflow.** Dev mode (tsc dist under Node +
   `bun --hot` TUI from source) stays byte-identical; compiled mode is new
@@ -528,11 +528,10 @@ health wait is 10 seconds; only TUI and popup launches show delayed progress.
 **Removed from v1:** the client-side unhealthy-incumbent SIGTERM eviction.
 It conflicts with [observer-singleton](observer-singleton.md), which is
 split between 3d-a's narrow boot serialization and 3d-b's deferred
-version-aware replacement. Today, CLI and provider-hook clients can delete a
-socket after their own stale probe while the server independently performs
-bind-first stale reclamation; those mutations are not serialized
-(`OBS-HEX-013`). 3d-a ([#135](https://github.com/jeremy0dell/station/issues/135))
-moves mutation into the child under
+version-aware replacement. 3d-a ([#135](https://github.com/jeremy0dell/station/issues/135))
+is implemented: CLI and provider-hook clients only attach or spawn, while the
+child serializes socket probe, stale reclamation, bind, pidfile publication,
+and ready commitment under
 `dirname(resolvedSocket)/observer.claim.sqlite`, without version comparison,
 signals, or eviction. **Dependency, not duplication:** the version-aware
 upgrade behavior this plan needs (B3) belongs to 3d-b. If that lands, B3
@@ -617,7 +616,7 @@ A2a: opt-in PTY + native helper gate    A3: raw dispatch
 A4: packaged assets + compiled default   A2b: folded into A4
 A5: release                              A6: cleanup
 
-External dependency: observer-singleton 3d-a
+Satisfied dependency: observer-singleton 3d-a
   → required for serialized concurrent stale-socket startup.
 External dependency: observer-singleton 3d-b
   → required before any older-version observer handoff is claimed safe.

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
     "test:unit": "vitest run --config config/vitest/vitest.unit.config.ts",
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",
     "test:integration": "pnpm build && vitest run --config config/vitest/vitest.integration.config.ts",
-    "test:sqlite:bun": "node scripts/test-runners/run-sqlite-cross-runtime.mjs",
+    "test:observer-claim:cross-runtime": "node scripts/test-runners/run-observer-claim-cross-runtime.mjs",
+    "test:sqlite:bun": "node scripts/test-runners/run-sqlite-cross-runtime.mjs && pnpm test:observer-claim:cross-runtime",
     "test:diagnostics": "vitest run --config config/vitest/vitest.diagnostics.config.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
+    "test:e2e:observer": "vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts",
     "test:e2e": "vitest run --config config/vitest/vitest.e2e.config.ts",
     "test:e2e:real": "vitest run --config config/vitest/vitest.real-e2e.config.ts",
     "test:e2e:real:local": "node scripts/test-runners/run-real-e2e.mjs",
@@ -61,7 +63,7 @@
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
-    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup && pnpm smoke:install",
+    "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup && pnpm test:e2e:observer && pnpm smoke:install",
     "test:pre-push": "pnpm test:all && pnpm test:sqlite:bun && pnpm --dir station typecheck && pnpm --dir station test && pnpm --dir station test:pty:bun && pnpm build:binary -- --version 0.0.0-local && pnpm smoke:binary -- --expected-version 0.0.0-local"
   },
   "devDependencies": {

--- a/packages/config/src/observerProcessArgs.ts
+++ b/packages/config/src/observerProcessArgs.ts
@@ -11,7 +11,7 @@ export type ObserverProcessArgs = {
   stateDir?: string;
 };
 
-/** Mirrors runObserverMain's parseArgs so a candidate's socket resolves identically. */
+/** Mirrors runObserverMain's path-affecting flags so a candidate's socket resolves identically. */
 export function parseObserverProcessArgs(argv: readonly string[]): ObserverProcessArgs {
   const result: ObserverProcessArgs = {};
   for (let index = 0; index < argv.length; index += 1) {

--- a/packages/protocol/src/transport.ts
+++ b/packages/protocol/src/transport.ts
@@ -91,10 +91,9 @@ export async function listenUnixSocket(
   };
 }
 
-// Claims the socket path by binding, never by pre-emptively unlinking. A stale
-// file is removed only after a bind fails AND a reconnect confirms nobody is
-// listening — so a socket that another observer is actively serving is never
-// unlinked out from under it (the check-then-unlink race this replaces).
+// Claims the socket path by binding, never by pre-emptively unlinking. The
+// reprobe protects an already-live owner, but does not serialize reclaimers
+// that cached the same stale result; Observer boot owns that exclusion.
 async function bindWithStaleReclaim(server: Server, socketPath: string): Promise<void> {
   try {
     await listenOnce(server, socketPath);

--- a/scripts/test-runners/run-observer-claim-cross-runtime.mjs
+++ b/scripts/test-runners/run-observer-claim-cross-runtime.mjs
@@ -1,0 +1,420 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const runnerPath = fileURLToPath(import.meta.url);
+const repoRoot = dirname(dirname(dirname(runnerPath)));
+const observerInternalUrl = pathToFileURL(
+  join(repoRoot, "apps", "observer", "dist", "internal.js"),
+).href;
+const contentionTimeoutMs = 100;
+const processTimeoutMs = 15_000;
+
+if (process.argv[2] === "--child") {
+  await runChild(parseFlags(process.argv.slice(3))).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+} else {
+  await runController(parseControllerArgs(process.argv.slice(2)));
+}
+
+async function runController({ rounds }) {
+  const { observerBootClaimPath } = await import(observerInternalUrl);
+  assert.equal(typeof observerBootClaimPath, "function");
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "station-observer-claim-cross-runtime-"));
+  const socketPath = join(tempRoot, "socket directory with spaces", "observer.sock");
+  const claimPath = observerBootClaimPath(socketPath);
+  assert.equal(claimPath, join(dirname(socketPath), "observer.claim.sqlite"));
+
+  let initialClaimIdentity;
+  let maximumCriticalSectionConcurrency = 0;
+  const threeContenderRounds = 10;
+
+  try {
+    for (let round = 0; round < rounds; round += 1) {
+      const runtimes = round % 2 === 0 ? ["node", "bun"] : ["bun", "node"];
+      const result = await runRace({
+        tempRoot,
+        socketPath,
+        name: `two-${round + 1}`,
+        runtimes,
+      });
+      maximumCriticalSectionConcurrency = Math.max(
+        maximumCriticalSectionConcurrency,
+        result.criticalSectionConcurrency,
+      );
+      initialClaimIdentity ??= claimIdentity(claimPath);
+      assertClaimIdentity(claimPath, initialClaimIdentity);
+    }
+
+    for (let round = 0; round < threeContenderRounds; round += 1) {
+      const runtimes = round % 2 === 0 ? ["node", "bun", "node"] : ["bun", "node", "bun"];
+      const result = await runRace({
+        tempRoot,
+        socketPath,
+        name: `three-${round + 1}`,
+        runtimes,
+      });
+      maximumCriticalSectionConcurrency = Math.max(
+        maximumCriticalSectionConcurrency,
+        result.criticalSectionConcurrency,
+      );
+      assertClaimIdentity(claimPath, initialClaimIdentity);
+    }
+
+    const recoveryResult = await runKilledOwnerRecovery({ tempRoot, socketPath });
+    maximumCriticalSectionConcurrency = Math.max(
+      maximumCriticalSectionConcurrency,
+      recoveryResult.criticalSectionConcurrency,
+    );
+    assertClaimIdentity(claimPath, initialClaimIdentity);
+    assert.equal(maximumCriticalSectionConcurrency, 1);
+    assertClaimFile(claimPath);
+    assert.equal(await readIntegrityCheck(claimPath), "ok");
+
+    console.log(
+      `Observer boot claim passed ${rounds} alternating Node/Bun races, ` +
+        `${threeContenderRounds} three-contender races, and killed-owner recovery.`,
+    );
+    console.log("Exactly one transaction entered each race; maximum critical concurrency was 1.");
+    console.log("The persistent claim inode was unchanged and integrity_check=ok.");
+    console.log("No fairness property is asserted.");
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function runRace({ tempRoot, socketPath, name, runtimes }) {
+  const raceDir = join(tempRoot, "races", name);
+  const goPath = join(raceDir, "go");
+  const releasePath = join(raceDir, "release");
+  const activePath = join(raceDir, "active");
+  mkdirSync(raceDir, { recursive: true, mode: 0o700 });
+
+  const children = runtimes.map((runtime, index) =>
+    startClaimChild({
+      runtime,
+      nonce: `${name}-${index}-${runtime}`,
+      socketPath,
+      raceDir,
+      goPath,
+      releasePath,
+      activePath,
+    }),
+  );
+
+  await waitFor(`${name} contenders to become ready`, () =>
+    children.every(({ readyPath }) => existsSync(readyPath)),
+  );
+  writeMarker(goPath);
+
+  await waitFor(`${name} claim decisions`, () => {
+    const entries = children.filter(({ entryPath }) => existsSync(entryPath));
+    const results = children.filter(({ resultPath }) => existsSync(resultPath));
+    const crashed = children.some(
+      ({ entryPath, exit, resultPath }) =>
+        exit !== undefined && !existsSync(entryPath) && !existsSync(resultPath),
+    );
+    return crashed || entries.length > 1 || entries.length + results.length === children.length;
+  });
+
+  const entriesBeforeRelease = children
+    .filter(({ entryPath }) => existsSync(entryPath))
+    .map(({ entryPath }) => readJson(entryPath));
+  writeMarker(releasePath);
+
+  const exits = await Promise.all(children.map(({ completed }) => completed));
+  for (const exit of exits) {
+    assert.equal(
+      exit.code,
+      0,
+      `${exit.runtime} child failed (${exit.signal ?? "no signal"}):\n${exit.stderr}`,
+    );
+  }
+
+  const outcomes = children.map(({ resultPath }) => readJson(resultPath));
+  const acquired = outcomes.filter(({ status }) => status === "acquired");
+  const contended = outcomes.filter(({ status }) => status === "contended");
+  assert.equal(entriesBeforeRelease.length, 1, `${name} had multiple transaction entrants.`);
+  assert.equal(entriesBeforeRelease[0].overlap, false, `${name} overlapped its critical section.`);
+  assert.equal(acquired.length, 1, `${name} did not produce exactly one acquired result.`);
+  assert.equal(acquired[0].releaseStatus, "released", `${name} did not release cleanly.`);
+  assert.equal(contended.length, runtimes.length - 1, `${name} had a non-busy losing result.`);
+  assert.equal(existsSync(activePath), false, `${name} left its critical-section marker behind.`);
+
+  return {
+    criticalSectionConcurrency: entriesBeforeRelease.length,
+    winner: entriesBeforeRelease[0],
+  };
+}
+
+async function runKilledOwnerRecovery({ tempRoot, socketPath }) {
+  const raceDir = join(tempRoot, "killed-owner");
+  const goPath = join(raceDir, "go");
+  const releasePath = join(raceDir, "release-never-written");
+  const activePath = join(raceDir, "active");
+  const nonce = `bun-owner-${process.pid}-${Date.now()}`;
+  mkdirSync(raceDir, { recursive: true, mode: 0o700 });
+
+  const owner = startClaimChild({
+    runtime: "bun",
+    nonce,
+    socketPath,
+    raceDir,
+    goPath,
+    releasePath,
+    activePath,
+  });
+  await waitFor("Bun owner to become ready", () => existsSync(owner.readyPath));
+  writeMarker(goPath);
+  await waitFor("Bun owner to enter the claim transaction", () => existsSync(owner.entryPath));
+
+  const entry = readJson(owner.entryPath);
+  assert.equal(entry.nonce, nonce);
+  assert.equal(entry.pid, owner.pid);
+  assert.equal(entry.runtime, "bun");
+  assert.equal(entry.overlap, false);
+  assert.equal(existsSync(activePath), true);
+
+  process.kill(owner.pid, "SIGKILL");
+  const ownerExit = await owner.completed;
+  assert.equal(ownerExit.code, null);
+  assert.equal(ownerExit.signal, "SIGKILL");
+  assert.equal(existsSync(owner.resultPath), false);
+  rmSync(activePath, { recursive: true, force: true });
+
+  const successor = await runRace({
+    tempRoot,
+    socketPath,
+    name: "node-successor",
+    runtimes: ["node"],
+  });
+  assert.equal(successor.winner.runtime, "node");
+  return successor;
+}
+
+function startClaimChild({ runtime, nonce, socketPath, raceDir, goPath, releasePath, activePath }) {
+  const readyPath = join(raceDir, `${nonce}.ready`);
+  const entryPath = join(raceDir, `${nonce}.entry.json`);
+  const resultPath = join(raceDir, `${nonce}.result.json`);
+  const executable = runtime === "node" ? nodeExecutable() : "bun";
+  const args = [
+    runnerPath,
+    "--child",
+    "--runtime",
+    runtime,
+    "--nonce",
+    nonce,
+    "--socket",
+    socketPath,
+    "--ready",
+    readyPath,
+    "--go",
+    goPath,
+    "--release",
+    releasePath,
+    "--active",
+    activePath,
+    "--entry",
+    entryPath,
+    "--result",
+    resultPath,
+  ];
+  const child = spawn(executable, args, {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  assert.ok(child.pid !== undefined, `Could not start ${runtime} claim child.`);
+
+  const record = {
+    pid: child.pid,
+    runtime,
+    readyPath,
+    entryPath,
+    resultPath,
+    exit: undefined,
+    completed: undefined,
+  };
+  record.completed = collectChildExit(child, runtime).then((exit) => {
+    record.exit = exit;
+    return exit;
+  });
+  return record;
+}
+
+async function runChild(flags) {
+  const runtime = requiredFlag(flags, "runtime");
+  const nonce = requiredFlag(flags, "nonce");
+  const socketPath = requiredFlag(flags, "socket");
+  const readyPath = requiredFlag(flags, "ready");
+  const goPath = requiredFlag(flags, "go");
+  const releasePath = requiredFlag(flags, "release");
+  const activePath = requiredFlag(flags, "active");
+  const entryPath = requiredFlag(flags, "entry");
+  const resultPath = requiredFlag(flags, "result");
+  const { acquireObserverBootClaim } = await import(observerInternalUrl);
+  assert.equal(typeof acquireObserverBootClaim, "function");
+
+  writeMarker(readyPath);
+  await waitFor("controller race barrier", () => existsSync(goPath));
+  const result = await acquireObserverBootClaim({
+    socketPath,
+    timeoutMs: contentionTimeoutMs,
+  });
+
+  if (result.status !== "acquired") {
+    writeJson(resultPath, { status: result.status, error: errorMessage(result.error) });
+    return;
+  }
+
+  let ownsActiveMarker = false;
+  let overlap = false;
+  let releaseResult;
+  try {
+    try {
+      mkdirSync(activePath, { mode: 0o700 });
+      ownsActiveMarker = true;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      overlap = true;
+    }
+    writeJson(entryPath, {
+      nonce,
+      pid: process.pid,
+      runtime,
+      path: result.path,
+      overlap,
+    });
+    await waitFor("controller claim release", () => existsSync(releasePath));
+  } finally {
+    if (ownsActiveMarker) rmSync(activePath, { recursive: true, force: true });
+    releaseResult = result.release();
+  }
+
+  writeJson(resultPath, {
+    status: "acquired",
+    path: result.path,
+    releaseStatus: releaseResult.status,
+    ...(releaseResult.status === "failed"
+      ? { releaseError: errorMessage(releaseResult.error) }
+      : {}),
+  });
+  if (releaseResult.status !== "released") process.exitCode = 1;
+}
+
+function parseControllerArgs(args) {
+  if (args[0] === "--") args = args.slice(1);
+  if (args.length === 0) return { rounds: 50 };
+  assert.deepEqual(args.slice(0, 1), ["--rounds"], "Usage: --rounds <positive integer>");
+  assert.equal(args.length, 2, "Usage: --rounds <positive integer>");
+  const rounds = Number(args[1]);
+  assert.ok(Number.isSafeInteger(rounds) && rounds > 0, "--rounds must be a positive integer.");
+  return { rounds };
+}
+
+function parseFlags(args) {
+  assert.equal(args.length % 2, 0, "Child flags must be key/value pairs.");
+  const flags = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    assert.ok(flag.startsWith("--"), `Expected a flag, received ${flag}.`);
+    assert.equal(flags.has(flag.slice(2)), false, `Duplicate child flag ${flag}.`);
+    flags.set(flag.slice(2), args[index + 1]);
+  }
+  return flags;
+}
+
+function requiredFlag(flags, name) {
+  const value = flags.get(name);
+  assert.ok(value !== undefined && value.length > 0, `Missing --${name}.`);
+  return value;
+}
+
+function nodeExecutable() {
+  return process.versions.bun === undefined ? process.execPath : "node";
+}
+
+function collectChildExit(child, runtime) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr, runtime }));
+  });
+}
+
+async function waitFor(description, predicate) {
+  const deadline = Date.now() + processTimeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await delay(5);
+  }
+  throw new Error(`Timed out waiting for ${description}.`);
+}
+
+function writeMarker(path) {
+  writeFileSync(path, "", { flag: "wx", mode: 0o600 });
+}
+
+function writeJson(path, value) {
+  writeFileSync(path, `${JSON.stringify(value)}\n`, { flag: "wx", mode: 0o600 });
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function claimIdentity(path) {
+  const stats = statSync(path);
+  return { device: stats.dev, inode: stats.ino };
+}
+
+function assertClaimIdentity(path, expected) {
+  assert.deepEqual(claimIdentity(path), expected, "The persistent claim database inode changed.");
+}
+
+function assertClaimFile(path) {
+  const stats = lstatSync(path);
+  assert.equal(stats.isFile(), true, "The claim database must be a regular file.");
+  assert.equal(stats.isSymbolicLink(), false, "The claim database must not be a symlink.");
+  assert.equal(stats.mode & 0o777, 0o600, "The claim database must remain mode 0600.");
+}
+
+async function readIntegrityCheck(path) {
+  const { DatabaseSync } = await import("node:sqlite");
+  const database = new DatabaseSync(path, { readOnly: true });
+  try {
+    return database.prepare("PRAGMA integrity_check").get()?.integrity_check;
+  } finally {
+    database.close();
+  }
+}
+
+function errorMessage(error) {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -1,12 +1,18 @@
+import { execFile } from "node:child_process";
 import { access, chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { promisify } from "node:util";
 import { startObserver } from "@station/cli";
 import { emptyConfig } from "@station/config";
 import { ObserverProcessIdentitySchema } from "@station/contracts";
+import { acquireObserverBootClaim, observerBootClaimPath } from "@station/observer/internal";
 import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
-import { waitForSocketClosed } from "../support/sockets";
+import { createRealStaleSocket, waitForSocketClosed } from "../support/sockets";
 import { createTempState, writeConfigToml } from "../support/temp-projects";
+
+const execFileAsync = promisify(execFile);
 
 describe("observer lifecycle e2e", () => {
   it("boots a real observer with in-memory defaults and no config file", async () => {
@@ -75,6 +81,8 @@ describe("observer lifecycle e2e", () => {
           fixture.socketPath,
           "--state-dir",
           fixture.stateDir,
+          "--startup-timeout-ms",
+          "30000",
         ],
       });
       expect((await stat(bootLogPath)).mode & 0o777).toBe(0o600);
@@ -129,6 +137,128 @@ describe("observer lifecycle e2e", () => {
     }
 
     await expect(access(pidfilePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("derives the default socket and persistent claim from state when XDG is unset", async () => {
+    const fixture = await createTempState();
+    const socketPath = join(fixture.stateDir, "run", "observer.sock");
+    const claimPath = observerBootClaimPath(socketPath);
+    const config = {
+      ...emptyConfig(),
+      observer: { stateDir: fixture.stateDir },
+    };
+    const previousRuntimeDir = process.env.XDG_RUNTIME_DIR;
+    delete process.env.XDG_RUNTIME_DIR;
+    const client = createObserverClient({ socketPath, timeoutMs: 1000 });
+    let started = false;
+
+    try {
+      const status = await startObserver({ config, timeoutMs: 30_000 });
+      expect(status).toMatchObject({ status: "running", paths: { socketPath } });
+      started = status.status === "running";
+      await expectClaimDatabase(claimPath);
+    } finally {
+      if (started) {
+        await client.stop();
+        await waitForSocketClosed(socketPath);
+      }
+      if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
+      else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
+    }
+
+    await expectClaimDatabase(claimPath);
+  });
+
+  it("keeps the claim inode stable across clean stop and restart", async () => {
+    const fixture = await createTempState();
+    const config = observerConfig(fixture.stateDir, fixture.socketPath);
+    const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    const claimPath = observerBootClaimPath(fixture.socketPath);
+
+    const first = await startObserver({ config, timeoutMs: 30_000 });
+    expect(first.status).toBe("running");
+    const firstClaim = await stat(claimPath);
+    await expectClaimDatabase(claimPath);
+    await client.stop();
+    await waitForSocketClosed(fixture.socketPath);
+
+    const second = await startObserver({ config, timeoutMs: 30_000 });
+    expect(second.status).toBe("running");
+    const secondClaim = await stat(claimPath);
+    expect(secondClaim.ino).toBe(firstClaim.ino);
+    await expectClaimDatabase(claimPath);
+    await client.stop();
+    await waitForSocketClosed(fixture.socketPath);
+
+    expect((await stat(claimPath)).ino).toBe(firstClaim.ino);
+    await expectClaimDatabase(claimPath);
+  });
+
+  it("does not construct Observer state while a production boot claim is held", async () => {
+    const fixture = await createTempState();
+    const config = observerConfig(fixture.stateDir, fixture.socketPath);
+    const claimResult = await acquireObserverBootClaim({
+      socketPath: fixture.socketPath,
+      timeoutMs: 1000,
+    });
+    expect(claimResult.status).toBe("acquired");
+    if (claimResult.status !== "acquired") {
+      throw new Error(`Could not hold Observer boot claim: ${claimResult.error.code}`);
+    }
+
+    const client = createObserverClient({ socketPath: fixture.socketPath, timeoutMs: 1000 });
+    const startup = startObserver({ config, timeoutMs: 10_000 });
+    let released = false;
+    let status: Awaited<typeof startup> | undefined;
+    try {
+      await waitFor(
+        async () => (await observerProcessesForSocket(fixture.socketPath)).length === 1,
+        3000,
+      );
+      await sleep(100);
+      await expect(access(join(fixture.stateDir, "observer.sqlite"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(access(fixture.socketPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(`${fixture.socketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
+
+      expect(claimResult.release()).toEqual({ status: "released" });
+      released = true;
+      status = await startup;
+      expect(status.status).toBe("running");
+    } finally {
+      if (!released) claimResult.release();
+      status ??= await startup;
+      if (status.status === "running") {
+        await client.stop().catch(() => undefined);
+        await waitForSocketClosed(fixture.socketPath).catch(() => undefined);
+      }
+    }
+  });
+
+  it("converges five starts from one real stale socket with spaces in its path", async () => {
+    const fixture = await createTempState();
+    const socketDir = await mkdtemp("/tmp/stn socket spaces ");
+    const socketPath = join(socketDir, "observer socket.sock");
+    const config = observerConfig(fixture.stateDir, socketPath);
+    const client = createObserverClient({ socketPath, timeoutMs: 1000 });
+    let started = false;
+
+    try {
+      await createRealStaleSocket(socketPath);
+      const statuses = await Promise.all(
+        Array.from({ length: 5 }, () => startObserver({ config, timeoutMs: 30_000 })),
+      );
+      started = statuses.some((status) => status.status === "running");
+      await expectSingleObserver(statuses, socketPath);
+      await expectClaimDatabase(observerBootClaimPath(socketPath));
+    } finally {
+      if (started) {
+        await client.stop().catch(() => undefined);
+        await waitForSocketClosed(socketPath).catch(() => undefined);
+      }
+      await rm(socketDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps identities distinct for sockets sharing one directory", async () => {
@@ -195,7 +325,7 @@ describe("observer lifecycle e2e", () => {
     await expect(access(`${secondSocketPath}.pid`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("publishes identity beside an XDG runtime socket", async () => {
+  it("converges two stale starts on the XDG socket when state and runtime diverge", async () => {
     const fixture = await createTempState();
     const runtimeDir = await mkdtemp("/tmp/stn-xdg-");
     const socketPath = join(runtimeDir, "station", "observer.sock");
@@ -210,16 +340,15 @@ describe("observer lifecycle e2e", () => {
     let started = false;
 
     try {
-      const status = await startObserver({ config, timeoutMs: 30_000 });
-      expect(status).toMatchObject({
-        status: "running",
-        paths: { socketPath },
-        health: { socketPath },
-      });
-      if (status.status !== "running") {
-        throw new Error(`Observer failed to start: ${status.status}`);
-      }
-      started = true;
+      await createRealStaleSocket(socketPath);
+      const statuses = await Promise.all([
+        startObserver({ config, timeoutMs: 30_000 }),
+        startObserver({ config, timeoutMs: 30_000 }),
+      ]);
+      started = statuses.some((status) => status.status === "running");
+      await expectSingleObserver(statuses, socketPath);
+      const status = statuses[0];
+      if (status?.status !== "running") throw new Error("Observer failed to start.");
 
       expect(
         ObserverProcessIdentitySchema.parse(JSON.parse(await readFile(pidfilePath, "utf8"))),
@@ -231,6 +360,10 @@ describe("observer lifecycle e2e", () => {
       await expect(access(join(fixture.stateDir, "observer.sock.pid"))).rejects.toMatchObject({
         code: "ENOENT",
       });
+      await expectClaimDatabase(observerBootClaimPath(socketPath));
+      await expect(
+        access(join(fixture.stateDir, "run", "observer.claim.sqlite")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       if (started) {
         await client.stop();
@@ -395,3 +528,78 @@ describe("observer lifecycle e2e", () => {
     await expect(client.health()).rejects.toBeDefined();
   });
 });
+
+function observerConfig(stateDir: string, socketPath: string) {
+  return {
+    ...emptyConfig(),
+    observer: { stateDir, socketPath },
+  };
+}
+
+async function expectClaimDatabase(path: string): Promise<void> {
+  const info = await stat(path);
+  expect(info.isFile()).toBe(true);
+  expect(info.mode & 0o777).toBe(0o600);
+  expect((await stat(dirname(path))).mode & 0o777).toBe(0o700);
+
+  const database = new DatabaseSync(path);
+  try {
+    expect(database.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+  } finally {
+    database.close();
+  }
+}
+
+async function expectSingleObserver(
+  statuses: readonly Awaited<ReturnType<typeof startObserver>>[],
+  socketPath: string,
+): Promise<void> {
+  expect(statuses.every((status) => status.status === "running")).toBe(true);
+  const pids = statuses.flatMap((status) =>
+    status.status === "running" && status.health.pid !== undefined ? [status.health.pid] : [],
+  );
+  expect(new Set(pids).size).toBe(1);
+  const pid = pids[0];
+  expect(pid).toBeTypeOf("number");
+  if (pid === undefined) throw new Error("Observer start did not report a PID.");
+
+  const identity = ObserverProcessIdentitySchema.parse(
+    JSON.parse(await readFile(`${socketPath}.pid`, "utf8")),
+  );
+  expect(identity).toMatchObject({ pid, socketPath });
+
+  await waitFor(async () => (await observerProcessesForSocket(socketPath)).length === 1, 3000);
+  expect(await observerProcessesForSocket(socketPath)).toEqual([pid]);
+
+  const { stdout } = await execFileAsync("lsof", ["-t", socketPath]);
+  const holders = new Set(
+    stdout
+      .split(/\s+/)
+      .filter((value) => value.length > 0)
+      .map(Number),
+  );
+  expect([...holders]).toEqual([pid]);
+}
+
+async function observerProcessesForSocket(socketPath: string): Promise<number[]> {
+  const { stdout } = await execFileAsync("/bin/ps", ["-axo", "pid=,command="]);
+  return stdout
+    .split(/\r?\n/)
+    .filter((line) => line.includes("observerMain.js") && line.includes(socketPath))
+    .map((line) => Number.parseInt(line.trimStart().split(/\s+/, 1)[0] ?? "", 10))
+    .filter(Number.isFinite)
+    .sort((left, right) => left - right);
+}
+
+async function waitFor(condition: () => Promise<boolean>, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (await condition()) return;
+    await sleep(25);
+  }
+  throw new Error(`Condition did not become true within ${timeoutMs}ms.`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/tests/support/sockets/index.ts
+++ b/tests/support/sockets/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { lstat, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
@@ -17,6 +18,38 @@ export async function createTempSocketPath(prefix = "station-protocol-"): Promis
 export async function createStaleSocketFile(socketPath: string): Promise<void> {
   await mkdir(dirname(socketPath), { recursive: true });
   await writeFile(socketPath, "stale", { mode: 0o600 });
+}
+
+export async function createRealStaleSocket(socketPath: string): Promise<void> {
+  await mkdir(dirname(socketPath), { recursive: true, mode: 0o700 });
+  const child = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "--eval",
+      [
+        'import { createServer } from "node:net";',
+        "const server = createServer();",
+        'server.listen(process.argv[1], () => process.stdout.write("ready\\n"));',
+      ].join(""),
+      socketPath,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+
+  try {
+    await waitForChildReady(child, socketPath);
+    child.kill("SIGKILL");
+    await waitForChildExit(child);
+    const socket = await lstat(socketPath);
+    if (!socket.isSocket()) {
+      throw new Error(`Killed socket owner did not leave an AF_UNIX pathname: ${socketPath}`);
+    }
+  } catch (error) {
+    child.kill("SIGKILL");
+    await waitForChildExit(child).catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function waitForSocketClosed(
@@ -67,4 +100,53 @@ async function socketAcceptsConnections(socketPath: string): Promise<boolean> {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function waitForChildReady(child: ReturnType<typeof spawn>, socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out creating stale socket: ${socketPath}`));
+    }, 2000);
+    let stderr = "";
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout?.off("data", onStdout);
+      child.stderr?.off("data", onStderr);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onStdout = (chunk: Buffer) => {
+      if (!chunk.toString("utf8").includes("ready")) return;
+      cleanup();
+      resolve();
+    };
+    const onStderr = (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Socket owner exited before listening (${signal ?? `exit ${String(code)}`}): ${stderr}`,
+        ),
+      );
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    child.stdout?.on("data", onStdout);
+    child.stderr?.on("data", onStderr);
+    child.once("exit", onExit);
+    child.once("error", onError);
+  });
+}
+
+function waitForChildExit(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    child.once("exit", () => resolve());
+    child.once("error", reject);
+  });
 }


### PR DESCRIPTION
## Summary

- serialize Observer socket startup through a persistent SQLite `BEGIN IMMEDIATE` claim beside the resolved socket
- move stale-socket probe/reclaim ownership into the claimed child and remove pre-spawn unlinking from CLI and provider-hook clients
- release the claim only after bind, pidfile publication, seeded ownership watching, and ready commitment, before health becomes visible
- add claim hardening, lifecycle E2E coverage, a Node/Bun race runner, native CI wiring, and living documentation

## Root cause

Concurrent starters could cache the same stale-socket result and both enter the bind/reclaim path. Bind-first reprobes protected a live owner but did not serialize those cached-stale reclaimers.

The claim database is persistent evidence only; its active OS-backed SQLite transaction is ownership. It is never unlinked, renamed, or stale-reclaimed. This PR deliberately does not compare versions or evict a listening incumbent.

## Verification

- `pnpm test:pre-push` with isolated `HOME`
  - build, typecheck, lint
  - 1,359 unit, 26 contract, 408 integration, 42 diagnostics, and scripted/setup/lifecycle tests
  - install smoke, Station Bun tests (990), Bun PTY tests (26), compiled binary smoke
  - Node/Bun SQLite compatibility and 50 two-process + 10 three-contender claim races with killed-owner recovery
- `pnpm test:e2e:observer`
- `git diff --check`
- manual isolated CLI and provider-hook verification: an exact-PID kill left a real stale socket; concurrent starts converged on one healthy PID/pidfile/`lsof` holder; the claim inode survived stop/restart with `integrity_check=ok`; provider-hook auto-start preserved the stale pathname and delivered successfully

## Hosted checks

All nine standard-ci jobs were rejected before their first step by GitHub's account-payment/spending-limit gate. No hosted job result is claimed; the platform coverage is wired for execution once runners are available.

## UX impact

Concurrent `stn observer start` and provider-hook auto-start calls now attach to one healthy Observer without client-side socket deletion. Manually verify by killing an isolated Observer, launching two starts together, and confirming one PID in health, the pidfile, and `lsof`; restart without deleting `observer.claim.sqlite`.

Closes #135

Version-aware incumbent handoff remains deferred to #137; this does not reopen or claim to fix #123.