### PR TITLE
refactor(observer): invert logging and project configuration edges

### DIFF
--- a/apps/observer/src/commands/project.ts
+++ b/apps/observer/src/commands/project.ts
@@ -1,39 +1,31 @@
-import {
-  addProjectToConfig,
-  removeProjectFromConfig,
-  setProjectDefaultHarnessInConfig,
-} from "@station/config";
 import type { RuntimeClock } from "@station/runtime";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
 import { assertCommandType } from "./assertCommand.js";
+import type { ProjectConfigWriter } from "./projectConfigWriter.js";
 import type { CommandHandler } from "./queue.js";
 import { reconcileAndPublish } from "./reconcile.js";
 
 export type CreateProjectCommandHandlerOptions = {
   core: ObserverCore;
-  configPath?: string | undefined;
-  homeDir?: string | undefined;
+  projectConfigWriter: ProjectConfigWriter;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
 };
 
+/**
+ * USE CASE
+ *
+ * Adds a managed project through the configuration port, updates the live
+ * configuration, and reconciles the published graph.
+ */
 export function createProjectAddHandler(
   options: CreateProjectCommandHandlerOptions,
 ): CommandHandler {
   return async (context) => {
     assertCommandType(context, "project.add");
-    const payload = context.command.payload;
-    const result = await addProjectToConfig({
-      path: payload.path,
-      ...(payload.id === undefined ? {} : { id: payload.id }),
-      ...(payload.label === undefined ? {} : { label: payload.label }),
-      ...(payload.allowNonGit === undefined ? {} : { allowNonGit: payload.allowNonGit }),
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
-    });
-
-    options.core.updateConfig(result.config);
+    const config = await options.projectConfigWriter.addProject(context.command.payload);
+    options.core.updateConfig(config);
     await reconcileAndPublish({
       core: options.core,
       eventBus: options.eventBus,
@@ -44,18 +36,19 @@ export function createProjectAddHandler(
   };
 }
 
+/**
+ * USE CASE
+ *
+ * Removes a managed project through the configuration port, updates the live
+ * configuration, and reconciles the published graph.
+ */
 export function createProjectRemoveHandler(
   options: CreateProjectCommandHandlerOptions,
 ): CommandHandler {
   return async (context) => {
     assertCommandType(context, "project.remove");
-    const result = await removeProjectFromConfig({
-      projectId: context.command.payload.projectId,
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
-    });
-
-    options.core.updateConfig(result.config);
+    const config = await options.projectConfigWriter.removeProject(context.command.payload);
+    options.core.updateConfig(config);
     await reconcileAndPublish({
       core: options.core,
       eventBus: options.eventBus,
@@ -66,19 +59,19 @@ export function createProjectRemoveHandler(
   };
 }
 
+/**
+ * USE CASE
+ *
+ * Changes a project's default harness through the configuration port, updates
+ * the live configuration, and reconciles the published graph.
+ */
 export function createProjectSetDefaultHarnessHandler(
   options: CreateProjectCommandHandlerOptions,
 ): CommandHandler {
   return async (context) => {
     assertCommandType(context, "project.setDefaultHarness");
-    const result = await setProjectDefaultHarnessInConfig({
-      projectId: context.command.payload.projectId,
-      harness: context.command.payload.harness,
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
-    });
-
-    options.core.updateConfig(result.config);
+    const config = await options.projectConfigWriter.setDefaultHarness(context.command.payload);
+    options.core.updateConfig(config);
     await reconcileAndPublish({
       core: options.core,
       eventBus: options.eventBus,

--- a/apps/observer/src/commands/projectConfigWriter.ts
+++ b/apps/observer/src/commands/projectConfigWriter.ts
@@ -1,0 +1,18 @@
+import type { StationConfig } from "@station/config";
+import type {
+  AddProjectPayload,
+  RemoveProjectPayload,
+  SetProjectDefaultHarnessPayload,
+} from "@station/contracts";
+
+/**
+ * DRIVEN PORT
+ *
+ * Applies project-command values to the authoritative Station configuration
+ * and returns the effective configuration.
+ */
+export interface ProjectConfigWriter {
+  addProject(input: AddProjectPayload): Promise<StationConfig>;
+  removeProject(input: RemoveProjectPayload): Promise<StationConfig>;
+  setDefaultHarness(input: SetProjectDefaultHarnessPayload): Promise<StationConfig>;
+}

--- a/apps/observer/src/commands/queue.ts
+++ b/apps/observer/src/commands/queue.ts
@@ -9,10 +9,11 @@ import type {
   TraceContext,
 } from "@station/contracts";
 import { CommandReceiptSchema, StationCommandSchema } from "@station/contracts";
-import { createTraceContext, type JsonlLogger } from "@station/observability";
+import { createTraceContext } from "@station/observability";
 import { type RuntimeClock, runRuntimeBoundaryWithTimeout, systemClock } from "@station/runtime";
 import { createErrorEnvelope, toSafeError } from "../diagnostics/errors.js";
 import type { CommandJournal, EventJournal, ObserverIdFactory } from "../persistence/index.js";
+import type { StationLogger } from "../stationLogger.js";
 import { nowIso } from "../utils/time.js";
 import { commandCancellationError, linkAbortSignals, throwIfAborted } from "./cancellation.js";
 
@@ -39,7 +40,7 @@ export type CreateCommandQueueOptions = {
   clock?: RuntimeClock;
   idFactory?: Partial<Pick<ObserverIdFactory, "commandId" | "errorId">>;
   handlers?: Partial<Record<StationCommand["type"], CommandHandler>>;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   eventBus?: {
     publish(event: StationEvent): void;
   };
@@ -189,7 +190,7 @@ async function executeCommand(
     eventBus?: {
       publish(event: StationEvent): void;
     };
-    logger?: JsonlLogger;
+    logger?: StationLogger;
     signal?: AbortSignal;
     commandTimeoutMs?: number;
   },

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -1,16 +1,17 @@
 import type { ProviderProjectConfig, StationCommand } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import { createFeatureFlagEvaluator, type FeatureFlagEvaluator } from "../features/evaluator.js";
 import type { EventJournal, SessionStore } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
+import type { StationLogger } from "../stationLogger.js";
 import {
   createProjectAddHandler,
   createProjectRemoveHandler,
   createProjectSetDefaultHarnessHandler,
 } from "./project.js";
+import type { ProjectConfigWriter } from "./projectConfigWriter.js";
 import type { CommandHandler, CommandQueue } from "./queue.js";
 import { createObserverReconcileHandler } from "./reconcile.js";
 import { createSessionAcknowledgeTurnHandler } from "./session/acknowledgeTurn.js";
@@ -37,12 +38,11 @@ export type RegisterObserverCommandHandlersOptions = {
   featureFlags?: FeatureFlagEvaluator | undefined;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
   commandTimeoutMs?: number | undefined;
   terminalIntentRunner?: TerminalIntentRunner | undefined;
-  configPath?: string | undefined;
-  homeDir?: string | undefined;
+  projectConfigWriter: ProjectConfigWriter;
 };
 
 /**
@@ -51,8 +51,8 @@ export type RegisterObserverCommandHandlersOptions = {
  * Constructs process-lifetime Observer command use cases and registers their
  * handlers with the command queue.
  *
- * Terminal intent orchestration is created once here and injected directly
- * into every handler that uses it.
+ * Terminal intent orchestration and ProjectConfigWriter are prebound here;
+ * handlers never receive configuration or home paths.
  */
 export function registerObserverCommandHandlers(
   options: RegisterObserverCommandHandlersOptions,
@@ -188,24 +188,21 @@ export function registerObserverCommandHandlers(
     }),
     "project.add": createProjectAddHandler({
       core: options.core,
+      projectConfigWriter: options.projectConfigWriter,
       eventBus: options.eventBus,
       clock: options.clock,
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
     "project.remove": createProjectRemoveHandler({
       core: options.core,
+      projectConfigWriter: options.projectConfigWriter,
       eventBus: options.eventBus,
       clock: options.clock,
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
     "project.setDefaultHarness": createProjectSetDefaultHarnessHandler({
       core: options.core,
+      projectConfigWriter: options.projectConfigWriter,
       eventBus: options.eventBus,
       clock: options.clock,
-      ...(options.configPath === undefined ? {} : { configPath: options.configPath }),
-      ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
     }),
   } satisfies Record<StationCommand["type"], CommandHandler>;
 

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -1,10 +1,10 @@
 import type { ProviderProjectConfig, WorktreeObservation } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
@@ -33,7 +33,7 @@ export type CreateSessionCreateHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   commandTimeoutMs?: number | undefined;
 };
 

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -1,10 +1,10 @@
 import type { ProviderProjectConfig, WorktreeObservation } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
@@ -36,7 +36,7 @@ export type CreateSessionForkHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   commandTimeoutMs?: number | undefined;
 };
 

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -15,7 +15,6 @@ import type {
   WorktreeObservation,
   WorktreeRow,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   type RuntimeClock,
   type RuntimeSafeErrorFallback,
@@ -26,6 +25,7 @@ import {
 import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { linkAbortSignals, throwIfAborted } from "../cancellation.js";
 
 export { throwIfAborted } from "../cancellation.js";
@@ -310,7 +310,7 @@ export async function deleteSessionTitleSeedBestEffort(input: {
   persistence: SessionStore;
   sessionId: SessionId;
   context: CommandHandlerContext;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
 }): Promise<void> {
   try {
     await input.persistence.deleteSessionTitleSeed(input.sessionId);
@@ -430,7 +430,7 @@ export async function closeTerminalTargetBestEffort(input: {
   terminal: TerminalProvider;
   targetId: string;
   context: CommandHandlerContext;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
 }): Promise<void> {
@@ -467,7 +467,7 @@ export async function removeWorktreeBestEffort(input: {
   projectId: string;
   worktreeId: string;
   context: CommandHandlerContext;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
 }): Promise<void> {
@@ -510,7 +510,7 @@ export async function focusTerminalTargetBestEffort(input: {
   targetId: string;
   origin?: TerminalFocusOrigin | undefined;
   context: CommandHandlerContext;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
 }): Promise<void> {

--- a/apps/observer/src/commands/session/startAgent.ts
+++ b/apps/observer/src/commands/session/startAgent.ts
@@ -1,10 +1,10 @@
 import type { ProviderProjectConfig } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
@@ -37,7 +37,7 @@ export type CreateSessionStartAgentHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   commandTimeoutMs?: number | undefined;
 };
 

--- a/apps/observer/src/commands/terminalIntentRunner.ts
+++ b/apps/observer/src/commands/terminalIntentRunner.ts
@@ -19,9 +19,9 @@ import {
   TerminalIntentSchema,
   terminalTargetObservationFromBinding,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
 import { toSafeError } from "../diagnostics/errors.js";
+import type { StationLogger } from "../stationLogger.js";
 import { throwIfAborted } from "./cancellation.js";
 import { launchHarnessInTerminal, runProviderMutation } from "./session/shared.js";
 
@@ -55,14 +55,14 @@ export type TerminalIntentProviderAccess = {
 export type DefaultTerminalIntentRunnerOptions = {
   providers: TerminalIntentProviderAccess;
   clock?: RuntimeClock | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
   commandTimeoutMs?: number | undefined;
 };
 
 class DefaultTerminalIntentRunner implements TerminalIntentRunner {
   readonly #providers: TerminalIntentProviderAccess;
   readonly #clock: RuntimeClock;
-  readonly #logger: JsonlLogger | undefined;
+  readonly #logger: StationLogger | undefined;
   readonly #commandTimeoutMs: number | undefined;
   readonly #receipts = new Map<string, Promise<TerminalIntentReceipt>>();
 

--- a/apps/observer/src/commands/worktree/create.ts
+++ b/apps/observer/src/commands/worktree/create.ts
@@ -1,9 +1,9 @@
 import type { CreateWorktreeRequest, ProviderProjectConfig } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
@@ -16,7 +16,7 @@ export type CreateWorktreeCreateHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
 };
 
 /**

--- a/apps/observer/src/commands/worktree/fork.ts
+++ b/apps/observer/src/commands/worktree/fork.ts
@@ -1,9 +1,9 @@
 import type { CreateWorktreeRequest, ProviderProjectConfig } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
@@ -22,7 +22,7 @@ export type WorktreeForkHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
-  logger?: JsonlLogger | undefined;
+  logger?: StationLogger | undefined;
 };
 
 /**

--- a/apps/observer/src/hooks/harnessIngressQueue.ts
+++ b/apps/observer/src/hooks/harnessIngressQueue.ts
@@ -9,7 +9,6 @@ import {
   HarnessEventReportSchema,
   STATION_SCHEMA_VERSION,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   Deferred,
   Effect,
@@ -21,6 +20,7 @@ import {
   systemClock,
   toIsoTimestamp,
 } from "@station/runtime";
+import type { StationLogger } from "../stationLogger.js";
 
 export type HarnessIngressProcessResult = {
   receipt: HarnessEventReportReceipt;
@@ -39,7 +39,7 @@ export type CreateHarnessIngressQueueOptions = {
   processReport(report: HarnessEventReport): Promise<HarnessIngressProcessResult>;
   requestReconcile?: (reason: string) => void;
   clock?: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   maxPendingReports?: number;
 };
 

--- a/apps/observer/src/hooks/observerEventHooks.ts
+++ b/apps/observer/src/hooks/observerEventHooks.ts
@@ -4,7 +4,6 @@ import {
   STATION_SCHEMA_VERSION,
   stationEventMetadata,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   type ExternalCommandInput,
   type ExternalCommandRunner,
@@ -15,6 +14,7 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
+import type { StationLogger } from "../stationLogger.js";
 
 export type ObserverEventHookRuntime = {
   shutdown(): Promise<void>;
@@ -24,7 +24,7 @@ export type CreateObserverEventHookRuntimeOptions = {
   hooks: ObserverEventHookConfig[];
   eventBus: ObserverEventBus;
   clock?: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   commandRunner?: ExternalCommandRunner;
 };
 
@@ -32,7 +32,7 @@ type ObserverEventHookDispatchInput = {
   event: StationEvent;
   hooks: ObserverEventHookConfig[];
   clock: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   commandRunner?: ExternalCommandRunner;
 };
 
@@ -61,7 +61,7 @@ async function runObserverEventHook(input: {
   event: StationEvent;
   hook: ObserverEventHookConfig;
   clock: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   commandRunner?: ExternalCommandRunner;
 }): Promise<void> {
   const invocation = ObserverEventHookInvocationSchema.parse({

--- a/apps/observer/src/metadata/gitRefInvalidation.ts
+++ b/apps/observer/src/metadata/gitRefInvalidation.ts
@@ -1,7 +1,7 @@
 import { existsSync, type FSWatcher, lstatSync, readFileSync, watch } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import type { StationSnapshot, WorktreeRow } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
+import type { StationLogger } from "../stationLogger.js";
 
 // A Git ref move invalidates all metadata keyed to HEAD: local diff, PR identity, and checks.
 // This trigger only requests reconcile; observer runtime remains the only UI event publisher.
@@ -13,7 +13,7 @@ export type WorktreeGitRefInvalidationService = {
 export type CreateWorktreeGitRefInvalidationServiceOptions = {
   requestReconcile(reason: string): void;
   debounceMs?: number;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   watchDirectory?: WatchDirectory;
 };
 

--- a/apps/observer/src/metadata/refresh.ts
+++ b/apps/observer/src/metadata/refresh.ts
@@ -5,7 +5,6 @@ import type {
   WorktreeChangeSummary,
   WorktreePullRequest,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   type ExternalCommandRunner,
   forEachConcurrent,
@@ -18,6 +17,7 @@ import type {
   PersistedWorktreeMetadataCurrent,
   WorktreeMetadataStore,
 } from "../persistence/index.js";
+import type { StationLogger } from "../stationLogger.js";
 import { addMs } from "../utils/time.js";
 import {
   type CreateWorktreeGitRefInvalidationServiceOptions,
@@ -40,7 +40,7 @@ export type CreateWorktreeMetadataRefreshServiceOptions = {
   persistence: WorktreeMetadataStore;
   requestReconcile(reason: string): void;
   clock?: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   runner?: ExternalCommandRunner;
   repositoryProviders?: Iterable<RepositoryProvider> | Map<string, RepositoryProvider>;
   gitTimeoutMs?: number;

--- a/apps/observer/src/metadata/repositoryRefresh.ts
+++ b/apps/observer/src/metadata/repositoryRefresh.ts
@@ -6,7 +6,6 @@ import type {
   WorktreeChecksSummary,
   WorktreePullRequest,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   forEachConcurrent,
   type RuntimeClock,
@@ -18,6 +17,7 @@ import type {
   PersistedWorktreeMetadataCurrent,
   WorktreeMetadataStore,
 } from "../persistence/index.js";
+import type { StationLogger } from "../stationLogger.js";
 import { addMs } from "../utils/time.js";
 import {
   type RepositoryGitContext,
@@ -49,7 +49,7 @@ export type CreateRepositoryMetadataRefresherOptions = {
   persistence: WorktreeMetadataStore;
   requestReconcile(reason: string): void;
   clock?: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   repositoryProviders?: Iterable<RepositoryProvider> | Map<string, RepositoryProvider>;
   repositoryConcurrency?: number;
   negativeBackoffMs?: number;

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -9,7 +9,6 @@ import type {
   WorktreeRow,
 } from "@station/contracts";
 import { ProviderProjectConfigSchema } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
 import type { FeatureFlagEvaluator } from "../features/evaluator.js";
 import type {
@@ -22,6 +21,7 @@ import type {
 import { providerObservationRetentionDays } from "../persistence/retention.js";
 import type { PersistedSessionTurnReadiness } from "../persistence/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
+import type { StationLogger } from "../stationLogger.js";
 import {
   buildInitialSnapshot,
   harnessesFromRegistry,
@@ -72,7 +72,7 @@ export type CreateObserverCoreInput = {
     SessionStore &
     WorktreeMetadataStore &
     EventJournal;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   pid?: number;
   version?: string;
   providerTimeoutMs?: number;

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -13,7 +13,6 @@ import type {
   TerminalTargetObservation,
   WorktreeObservation,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   durationMs,
   forEachConcurrent,
@@ -33,6 +32,7 @@ import type {
 } from "../persistence/index.js";
 import { providerObservationRetentionDays } from "../persistence/retention.js";
 import type { ProviderRegistry } from "../providers/registry.js";
+import type { StationLogger } from "../stationLogger.js";
 import type { ReconcileTiming } from "./core.js";
 import { buildStationSnapshot, safeErrorToProviderHealth } from "./graph.js";
 import {
@@ -46,7 +46,7 @@ export type ProviderReadOptions = {
   clock: RuntimeClock;
   timeoutMs: number;
   retries: number;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
 };
 
 // Caps concurrent provider subprocesses (wt list / listTargets) per reconcile.
@@ -868,7 +868,7 @@ async function recordProviderReadFailure(input: {
   capabilities: Record<string, boolean>;
   providerHealth: Record<string, ProviderHealth>;
   errors: SafeError[];
-  logger: JsonlLogger | undefined;
+  logger: StationLogger | undefined;
 }): Promise<void> {
   input.errors.push(input.error);
   await input.logger?.error(input.message, {

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -19,7 +19,6 @@ import type {
   StationEvent,
 } from "@station/contracts";
 import { STARTUP_RECONCILE_REASONS, STATION_SCHEMA_VERSION } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
 import type { CommandQueue } from "../commands/queue.js";
 import { commandRecordFromPersisted } from "../commands/record.js";
@@ -50,6 +49,7 @@ import {
 import type { ObserverPersistenceBundle, PersistenceHealthSource } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import { type ObserverCore, providerProjectsFromConfig } from "../reconcile/core.js";
+import type { StationLogger } from "../stationLogger.js";
 import type { ObserverEventBus } from "./eventBus.js";
 import {
   type ExternalLaunchDeps,
@@ -82,7 +82,7 @@ export type CreateObserverApiOptions = {
   stateDir?: string;
   diagnosticsDir?: string;
   logPaths?: string[];
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   config?: StationConfig;
   configPath?: string;
   configDiagnostics?: ConfigDiagnostic[];
@@ -236,7 +236,7 @@ function reconcileAfterExternalLaunch(
   deps: ReconcileExecutorDeps,
   guard: { reconciling: boolean },
   reason: string,
-  logger?: JsonlLogger,
+  logger?: StationLogger,
 ): void {
   void runReconcile(deps, guard, reason).catch(async (error) => {
     await logger?.error("Post-external-launch reconcile failed.", { reason, error });

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -1,10 +1,10 @@
 import type { HarnessEventReport, HarnessEventReportReceipt } from "@station/contracts";
 import { HarnessEventReportReceiptSchema } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, runRuntimeBoundary } from "@station/runtime";
 import type { HarnessEventReportIngestion } from "../hooks/ingestion.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import { withWorktreeCorrelationFromCwd } from "../reconcile/statusProjection.js";
+import type { StationLogger } from "../stationLogger.js";
 import type { ObserverEventBus } from "./eventBus.js";
 
 export type HarnessReportProcessorDeps = {
@@ -12,7 +12,7 @@ export type HarnessReportProcessorDeps = {
   core: ObserverCore;
   eventBus: ObserverEventBus;
   clock: RuntimeClock;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
 };
 
 export type HarnessReportProcessResult = {

--- a/apps/observer/src/runtime/logging.ts
+++ b/apps/observer/src/runtime/logging.ts
@@ -1,13 +1,31 @@
-import { componentLogPath, createJsonlLogger, type JsonlLogger } from "@station/observability";
+import { componentLogPath, createJsonlLogger } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
+import type { StationLogger } from "../stationLogger.js";
 
+/**
+ * ADAPTER
+ *
+ * Writes Observer operational events as redacted JSONL while retaining path and
+ * record representations at the logging boundary.
+ */
 export function createObserverLogger(input: {
   stateDir: string;
   clock?: RuntimeClock;
-}): JsonlLogger {
-  return createJsonlLogger({
+}): StationLogger {
+  const logger = createJsonlLogger({
     component: "observer",
     path: componentLogPath(input.stateDir, "observer"),
     ...(input.clock === undefined ? {} : { clock: input.clock }),
   });
+  return {
+    async info(message, attributes) {
+      await logger.info(message, attributes);
+    },
+    async warn(message, attributes) {
+      await logger.warn(message, attributes);
+    },
+    async error(message, attributes) {
+      await logger.error(message, attributes);
+    },
+  };
 }

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -43,6 +43,7 @@ import {
   removeObserverProcessIdentity,
 } from "./observerPidfile.js";
 import { createLocalObserverProcessEvidence } from "./observerProcessEvidence.js";
+import { createProjectConfigWriter } from "./projectConfigWriter.js";
 import {
   createObserverLifecycleClient,
   type ObserverServer,
@@ -89,8 +90,9 @@ export type RunObserverMainDeps = {
  * COMPOSITION ROOT
  *
  * Claims boot ownership before negotiating an incumbent or constructing
- * adapters, owns socket and pidfile publication, and releases the claim before
- * publishing health for the process lifetime it composes.
+ * adapters, then constructs logging and project-config adapters once and passes
+ * only their application ports inward. It owns socket and pidfile publication
+ * and releases the boot claim before publishing health.
  */
 export async function runObserverMain(
   argv = process.argv.slice(2),
@@ -170,6 +172,7 @@ export async function runObserverMain(
       stateDir,
       socketPath,
       buildVersion,
+      homeDir,
       claim: claimResult,
       deps,
     });
@@ -184,10 +187,11 @@ async function runClaimedObserverRuntime(input: {
   stateDir: string;
   socketPath: string;
   buildVersion: string;
+  homeDir: string;
   claim: AcquiredObserverBootClaim;
   deps: RunObserverMainDeps;
 }): Promise<number> {
-  const { options, loadedConfig, stateDir, socketPath, buildVersion, claim, deps } = input;
+  const { options, loadedConfig, stateDir, socketPath, buildVersion, homeDir, claim, deps } = input;
   const config = loadedConfig.config;
   const spoolDir = providerIngressSpoolDir(stateDir);
   const providerOptions: ObserverProviderRegistryFactoryOptions = { stateDir };
@@ -203,6 +207,10 @@ async function runClaimedObserverRuntime(input: {
   const persistence = createSqliteObserverPersistence({ sqlite, clock: systemClock });
   const eventBus = createObserverEventBus();
   const logger = createObserverLogger({ stateDir, clock: systemClock });
+  const projectConfigWriter = createProjectConfigWriter({
+    homeDir,
+    ...(options.configPath === undefined ? {} : { configPath: loadedConfig.configPath }),
+  });
   const pruneAt = toIsoTimestamp(systemClock.now());
   await persistence.pruneExpiredProviderObservations(pruneAt);
   const commandQueue = createCommandQueue({ persistence, clock: systemClock, eventBus, logger });
@@ -233,7 +241,7 @@ async function runClaimedObserverRuntime(input: {
     eventBus,
     clock: systemClock,
     logger,
-    ...(options.configPath === undefined ? {} : { configPath: loadedConfig.configPath }),
+    projectConfigWriter,
   });
   const eventHooks = createConfiguredEventHooks(config, eventBus, logger);
 
@@ -330,7 +338,7 @@ async function runClaimedObserverRuntime(input: {
     socketPath,
     stateDir,
     diagnosticsDir: join(stateDir, "diagnostics"),
-    logPaths: [logger.path, componentLogPath(stateDir, "hook")],
+    logPaths: [componentLogPath(stateDir, "observer"), componentLogPath(stateDir, "hook")],
     config,
     ...(options.configPath === undefined ? {} : { configPath: loadedConfig.configPath }),
     configDiagnostics: loadedConfig.diagnostics,

--- a/apps/observer/src/runtime/projectConfigWriter.ts
+++ b/apps/observer/src/runtime/projectConfigWriter.ts
@@ -1,0 +1,44 @@
+import {
+  addProjectToConfig,
+  removeProjectFromConfig,
+  setProjectDefaultHarnessInConfig,
+} from "@station/config";
+import type { ProjectConfigWriter } from "../commands/projectConfigWriter.js";
+
+/**
+ * ADAPTER
+ *
+ * Applies Observer project mutations through `@station/config` while retaining
+ * config and home paths at the filesystem boundary.
+ */
+export function createProjectConfigWriter(input: {
+  homeDir: string;
+  configPath?: string | undefined;
+}): ProjectConfigWriter {
+  const paths = {
+    homeDir: input.homeDir,
+    ...(input.configPath === undefined ? {} : { configPath: input.configPath }),
+  };
+
+  return {
+    async addProject(payload) {
+      const mutation = {
+        path: payload.path,
+        ...paths,
+        ...(payload.id === undefined ? {} : { id: payload.id }),
+        ...(payload.label === undefined ? {} : { label: payload.label }),
+        ...(payload.allowNonGit === undefined ? {} : { allowNonGit: payload.allowNonGit }),
+      };
+      const result = await addProjectToConfig(mutation);
+      return result.config;
+    },
+    async removeProject(payload) {
+      const result = await removeProjectFromConfig({ ...payload, ...paths });
+      return result.config;
+    },
+    async setDefaultHarness(payload) {
+      const result = await setProjectDefaultHarnessInConfig({ ...payload, ...paths });
+      return result.config;
+    },
+  };
+}

--- a/apps/observer/src/runtime/reconcileExecutor.ts
+++ b/apps/observer/src/runtime/reconcileExecutor.ts
@@ -1,9 +1,9 @@
 import type { ReconcileReceipt, StationEvent } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { type RuntimeClock, runRuntimeBoundary } from "@station/runtime";
 import type { WorktreeMetadataRefreshService } from "../metadata/refresh.js";
 import type { ObserverCore } from "../reconcile/core.js";
+import type { StationLogger } from "../stationLogger.js";
 import { agentStateChangedEventsFromReconcile } from "./agentEvents.js";
 import type { ObserverEventBus } from "./eventBus.js";
 import { elapsedMs, logReconcileProfile, type ReconcileProfile } from "./reconcileProfiling.js";
@@ -14,7 +14,7 @@ export type ReconcileExecutorDeps = {
   core: ObserverCore;
   eventBus: ObserverEventBus;
   metadataRefresh?: WorktreeMetadataRefreshService;
-  logger?: JsonlLogger;
+  logger?: StationLogger;
   clock: RuntimeClock;
   drainSpoolAndQueue: () => Promise<void>;
 };

--- a/apps/observer/src/runtime/reconcileProfiling.ts
+++ b/apps/observer/src/runtime/reconcileProfiling.ts
@@ -1,4 +1,4 @@
-import type { JsonlLogger } from "@station/observability";
+import type { StationLogger } from "../stationLogger.js";
 import type { ReconcileSchedulerFlushProfile } from "./reconcileScheduler.js";
 
 export type ReconcileProfile = {
@@ -20,7 +20,7 @@ export function elapsedMs(startedAt: number): number {
 }
 
 export async function logReconcileSchedulerProfile(
-  logger: JsonlLogger | undefined,
+  logger: StationLogger | undefined,
   profile: ReconcileSchedulerFlushProfile,
 ): Promise<void> {
   if (
@@ -34,7 +34,7 @@ export async function logReconcileSchedulerProfile(
 }
 
 export async function logReconcileProfile(
-  logger: JsonlLogger | undefined,
+  logger: StationLogger | undefined,
   profile: ReconcileProfile,
 ): Promise<void> {
   if (profile.totalMs < profileSlowReconcileMs) {

--- a/apps/observer/src/stationLogger.ts
+++ b/apps/observer/src/stationLogger.ts
@@ -1,0 +1,11 @@
+/**
+ * DRIVEN PORT
+ *
+ * Records Observer operational events without exposing their storage
+ * representation or destination.
+ */
+export interface StationLogger {
+  info(message: string, attributes?: Record<string, unknown>): Promise<void>;
+  warn(message: string, attributes?: Record<string, unknown>): Promise<void>;
+  error(message: string, attributes?: Record<string, unknown>): Promise<void>;
+}

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -19,6 +19,7 @@ import {
   registerObserverCommandHandlers,
   type TerminalIntentRunner,
 } from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-05-21T12:00:00.000Z";
 
@@ -434,6 +435,7 @@ function createFixture(input: {
   });
   const core = createObserverCore({ config, providers, persistence, clock });
   registerObserverCommandHandlers({
+    projectConfigWriter: createUnexpectedProjectConfigWriter(),
     queue,
     core,
     providers,

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -17,6 +17,7 @@ import { createObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
 import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 const healthStub = {
@@ -58,6 +59,7 @@ describe("Observer API with in-memory persistence", () => {
       onStop: () => commandQueue.shutdown(),
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue: commandQueue,
       core,
       providers,

--- a/apps/observer/test/integration/project-commands.test.ts
+++ b/apps/observer/test/integration/project-commands.test.ts
@@ -1,9 +1,10 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig } from "@station/config";
+import { loadConfig, loadConfigFromToml, type StationConfig } from "@station/config";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import type { ProjectConfigWriter } from "../../src/commands/projectConfigWriter.js";
 import {
   createCommandQueue,
   createObserverCore,
@@ -13,6 +14,8 @@ import {
   ProviderRegistry,
   registerObserverCommandHandlers,
 } from "../../src/internal";
+import type { ObserverCore } from "../../src/reconcile/core.js";
+import { createProjectConfigWriter } from "../../src/runtime/projectConfigWriter.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -134,9 +137,137 @@ describe("observer project commands", () => {
 
     fixture.sqlite.close();
   });
+
+  it("passes the exact validated payload through a substitute writer before reconcile", async () => {
+    const received: unknown[] = [];
+    const fixture = await createFixture({
+      instrumentCore: true,
+      createWriter: async ({ root, configPath, calls }) => {
+        const repo = await makeRepo(root, "substituted");
+        const nextConfig = (
+          await loadConfigFromToml(configToml(repo), { configPath, homeDir: root })
+        ).config;
+        return {
+          async addProject(payload) {
+            calls.push("writer");
+            received.push(payload);
+            return nextConfig;
+          },
+          removeProject: unexpectedMutation,
+          setDefaultHarness: unexpectedMutation,
+        };
+      },
+    });
+
+    await fixture.queue.dispatch({
+      type: "project.add",
+      payload: { path: "/selected/path", label: "Selected" },
+    });
+    await fixture.queue.drain();
+
+    expect(received).toEqual([{ path: "/selected/path", label: "Selected" }]);
+    expect(fixture.calls).toEqual(["writer", "updateConfig", "reconcile"]);
+    expect(fixture.core.getSnapshot().projects).toEqual([
+      expect.objectContaining({ id: "substituted", label: "substituted" }),
+    ]);
+    fixture.sqlite.close();
+  });
+
+  it("does not update core or reconcile when the writer fails", async () => {
+    const fixture = await createFixture({
+      instrumentCore: true,
+      createWriter: async () => ({
+        async addProject() {
+          throw Object.assign(new Error("Project write failed."), {
+            name: "ProjectConfigError",
+            tag: "ProjectConfigError" as const,
+            code: "PROJECT_WRITE_FAILED",
+          });
+        },
+        removeProject: unexpectedMutation,
+        setDefaultHarness: unexpectedMutation,
+      }),
+    });
+
+    const receipt = await fixture.queue.dispatch({
+      type: "project.add",
+      payload: { path: "/selected/path" },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: { tag: "ProjectConfigError", code: "PROJECT_WRITE_FAILED" },
+    });
+    expect(fixture.calls).toEqual([]);
+    expect(fixture.core.getSnapshot().projects).toEqual([]);
+    fixture.sqlite.close();
+  });
+
+  it("still updates core and reconciles when the real writer reports an unchanged add", async () => {
+    const fixture = await createFixture({ instrumentCore: true });
+    const repo = await makeRepo(fixture.root, "unchanged");
+    await fixture.queue.dispatch({ type: "project.add", payload: { path: repo } });
+    await fixture.queue.drain();
+    fixture.calls.length = 0;
+
+    await fixture.queue.dispatch({ type: "project.add", payload: { path: repo } });
+    await fixture.queue.drain();
+
+    expect(fixture.calls).toEqual(["updateConfig", "reconcile"]);
+    expect(fixture.core.getSnapshot().projects).toHaveLength(1);
+    fixture.sqlite.close();
+  });
+
+  it("resolves the default config path from the home captured by the real adapter", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-observer-project-home-"));
+    const configPath = join(root, ".config", "station", "config.toml");
+    await mkdir(join(root, ".config", "station"), { recursive: true });
+    await writeFile(configPath, configToml(), "utf8");
+    const repo = await makeRepo(root, "home-project");
+    const writer = createProjectConfigWriter({ homeDir: root });
+
+    const config = await writer.addProject({ path: repo });
+
+    expect(config.projects).toEqual([expect.objectContaining({ id: "home-project", root: repo })]);
+    await expect(readFile(configPath, "utf8")).resolves.toContain('id = "home-project"');
+  });
+
+  it("preserves project-local harness overrides and the authoritative config on failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-observer-project-local-"));
+    const repo = await makeRepo(root, "local-project");
+    await mkdir(join(repo, ".station"), { recursive: true });
+    await writeFile(
+      join(repo, ".station", "config.toml"),
+      'schema_version = 1\n\n[defaults]\nharness = "claude"\n',
+      "utf8",
+    );
+    const configPath = join(root, "config.toml");
+    await writeFile(configPath, configTomlWithLocalProject(repo), "utf8");
+    const before = await readFile(configPath, "utf8");
+    const writer = createProjectConfigWriter({ configPath, homeDir: root });
+
+    await expect(
+      writer.setDefaultHarness({ projectId: "local-project", harness: "opencode" }),
+    ).rejects.toMatchObject({
+      tag: "ProjectConfigError",
+      code: "PROJECT_DEFAULT_HARNESS_OVERRIDDEN",
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+  });
 });
 
-async function createFixture() {
+type FixtureOptions = {
+  instrumentCore?: boolean;
+  createWriter?: (input: {
+    root: string;
+    configPath: string;
+    config: StationConfig;
+    calls: string[];
+  }) => Promise<ProjectConfigWriter>;
+};
+
+async function createFixture(options: FixtureOptions = {}) {
   const root = await mkdtemp(join(tmpdir(), "station-observer-project-"));
   const configPath = join(root, "config.toml");
   await writeFile(configPath, configToml(), "utf8");
@@ -158,19 +289,36 @@ async function createFixture() {
     persistence,
     clock,
   });
+  const calls: string[] = [];
+  const handlerCore: ObserverCore =
+    options.instrumentCore === true
+      ? {
+          ...core,
+          updateConfig(nextConfig) {
+            calls.push("updateConfig");
+            core.updateConfig(nextConfig);
+          },
+          async reconcile(reason) {
+            calls.push("reconcile");
+            return core.reconcile(reason);
+          },
+        }
+      : core;
+  const projectConfigWriter =
+    (await options.createWriter?.({ root, configPath, config, calls })) ??
+    createProjectConfigWriter({ configPath, homeDir: root });
   registerObserverCommandHandlers({
     queue,
-    core,
+    core: handlerCore,
     providers,
     projects: [],
-    getProjects: () => core.getProjects(),
+    getProjects: () => handlerCore.getProjects(),
     persistence,
     eventBus,
     clock,
-    configPath,
-    homeDir: root,
+    projectConfigWriter,
   });
-  return { root, configPath, sqlite, persistence, queue, core };
+  return { root, configPath, sqlite, persistence, queue, core, calls };
 }
 
 async function makeRepo(root: string, name: string): Promise<string> {
@@ -179,17 +327,45 @@ async function makeRepo(root: string, name: string): Promise<string> {
   return repo;
 }
 
-function configToml(): string {
+function configToml(projectRoot?: string): string {
   return `
 schema_version = 1
-projects = []
+${projectRoot === undefined ? "projects = []" : ""}
 
 [defaults]
 worktree_provider = "fake-worktree"
 terminal = "fake-terminal"
 harness = "fake-harness"
 layout = "agent-shell"
+${
+  projectRoot === undefined
+    ? ""
+    : `
+[[projects]]
+id = "substituted"
+label = "substituted"
+root = "${projectRoot}"
+`
+}
 `;
+}
+
+function configTomlWithLocalProject(projectRoot: string): string {
+  return configToml().replace(
+    "projects = []",
+    `[[projects]]
+id = "local-project"
+label = "local-project"
+root = "${projectRoot}"
+
+[projects.local_config]
+enabled = true
+path = ".station/config.toml"`,
+  );
+}
+
+async function unexpectedMutation(): Promise<never> {
+  throw new Error("Unexpected project mutation.");
 }
 
 function observerIds() {

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -26,6 +26,7 @@ import {
   runObserverMain,
   startObserverServer,
 } from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 const persistenceFailure = {
@@ -203,6 +204,7 @@ function createObserverFixture(socketPath: string) {
     socketPath,
   });
   registerObserverCommandHandlers({
+    projectConfigWriter: createUnexpectedProjectConfigWriter(),
     queue,
     core,
     providers,

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -28,6 +28,7 @@ import {
   registerObserverCommandHandlers,
   type TerminalIntentRunner,
 } from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-05-21T12:00:00.000Z";
 
@@ -1658,6 +1659,7 @@ function createFixture(
   });
   const sessionIds = [...(options.sessionIds ?? [])];
   registerObserverCommandHandlers({
+    projectConfigWriter: createUnexpectedProjectConfigWriter(),
     queue,
     core,
     providers,

--- a/apps/observer/test/integration/turn-readiness.test.ts
+++ b/apps/observer/test/integration/turn-readiness.test.ts
@@ -19,6 +19,7 @@ import {
   ProviderRegistry,
   registerObserverCommandHandlers,
 } from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-06-17T12:00:00.000Z";
 const completedAt = "2026-06-17T12:00:01.000Z";
@@ -243,6 +244,7 @@ function fixtureCore() {
   });
   const core = createObserverCore({ config, providers, persistence, clock });
   registerObserverCommandHandlers({
+    projectConfigWriter: createUnexpectedProjectConfigWriter(),
     queue,
     core,
     providers,

--- a/apps/observer/test/support/projectConfigWriter.ts
+++ b/apps/observer/test/support/projectConfigWriter.ts
@@ -1,0 +1,12 @@
+import type { ProjectConfigWriter } from "../../src/commands/projectConfigWriter.js";
+
+export function createUnexpectedProjectConfigWriter(): ProjectConfigWriter {
+  const unexpected = (): never => {
+    throw new Error("Unexpected project configuration mutation in test.");
+  };
+  return {
+    addProject: async () => unexpected(),
+    removeProject: async () => unexpected(),
+    setDefaultHarness: async () => unexpected(),
+  };
+}

--- a/apps/observer/test/unit/logging.test.ts
+++ b/apps/observer/test/unit/logging.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { componentLogPath, readJsonlLog } from "@station/observability";
+import { describe, expect, it } from "vitest";
+import { createObserverLogger } from "../../src/runtime/logging.js";
+
+describe("Observer logging adapter", () => {
+  it("exposes only application logging operations and discards JSONL records", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-log-"));
+    const logger = createObserverLogger({
+      stateDir,
+      clock: { now: () => new Date("2026-05-20T12:00:00.000Z") },
+    });
+
+    expect(Object.keys(logger).sort()).toEqual(["error", "info", "warn"]);
+    await expect(
+      logger.info("Observer ready.", { token: "sk-secret000000000000" }),
+    ).resolves.toBeUndefined();
+    await expect(logger.warn("Observer delayed.")).resolves.toBeUndefined();
+    await expect(logger.error("Observer failed.")).resolves.toBeUndefined();
+
+    await expect(readJsonlLog(componentLogPath(stateDir, "observer"))).resolves.toEqual([
+      expect.objectContaining({
+        level: "info",
+        message: "Observer ready.",
+        attributes: { token: "[REDACTED]" },
+      }),
+      expect.objectContaining({ level: "warn", message: "Observer delayed." }),
+      expect.objectContaining({ level: "error", message: "Observer failed." }),
+    ]);
+  });
+});

--- a/apps/observer/test/unit/reconcileProfiling.test.ts
+++ b/apps/observer/test/unit/reconcileProfiling.test.ts
@@ -1,9 +1,9 @@
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
+import type { StationLogger } from "../../src/stationLogger";
 import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
 import { emptyStationSnapshot, fakeObserverCommandQueue } from "../support/testObserver";
 
@@ -93,7 +93,7 @@ describe("observer reconcile profiling", () => {
 });
 
 function createProfilingApi(input: {
-  logger: JsonlLogger & { records: LogRecord[] };
+  logger: StationLogger & { records: LogRecord[] };
   reconcileDelayMs: number;
   hookReconcileDebounceMs?: number;
 }) {
@@ -153,54 +153,23 @@ type LogRecord = {
   attributes?: Record<string, unknown>;
 };
 
-function fakeLogger(): JsonlLogger & { records: LogRecord[] } {
+function fakeLogger(): StationLogger & { records: LogRecord[] } {
   const records: LogRecord[] = [];
-  return {
-    path: "memory://observer.jsonl",
-    records,
-    log: async (record) => {
-      records.push({
-        level: record.level,
-        message: record.message,
-        attributes: record.attributes,
-      });
-      return {
-        timestamp: now,
-        component: "observer",
-        level: record.level,
-        message: record.message,
-        ...(record.attributes === undefined ? {} : { attributes: record.attributes }),
-      };
-    },
-    debug: async (message, attributes) => {
-      records.push({ level: "debug", message, attributes });
-      return logReturn("debug", message, attributes);
-    },
-    info: async (message, attributes) => {
-      records.push({ level: "info", message, attributes });
-      return logReturn("info", message, attributes);
-    },
-    warn: async (message, attributes) => {
-      records.push({ level: "warn", message, attributes });
-      return logReturn("warn", message, attributes);
-    },
-    error: async (message, attributes) => {
-      records.push({ level: "error", message, attributes });
-      return logReturn("error", message, attributes);
-    },
+  const record = async (
+    level: LogRecord["level"],
+    message: string,
+    attributes?: Record<string, unknown>,
+  ): Promise<void> => {
+    records.push({
+      level,
+      message,
+      ...(attributes === undefined ? {} : { attributes }),
+    });
   };
-}
-
-function logReturn(
-  level: "debug" | "info" | "warn" | "error",
-  message: string,
-  attributes?: Record<string, unknown>,
-) {
   return {
-    timestamp: now,
-    component: "observer" as const,
-    level,
-    message,
-    ...(attributes === undefined ? {} : { attributes }),
+    records,
+    info: (message, attributes) => record("info", message, attributes),
+    warn: (message, attributes) => record("warn", message, attributes),
+    error: (message, attributes) => record("error", message, attributes),
   };
 }

--- a/apps/observer/test/unit/terminal-intent-runner.test.ts
+++ b/apps/observer/test/unit/terminal-intent-runner.test.ts
@@ -12,7 +12,6 @@ import type {
   TerminalTargetId,
   TerminalTargetObservation,
 } from "@station/contracts";
-import type { JsonlLogger } from "@station/observability";
 import {
   createFakeTerminalTarget,
   createFakeWorktree,
@@ -25,6 +24,7 @@ import {
   type TerminalIntentProviderAccess,
   type TerminalIntentRunner,
 } from "../../src/commands/terminalIntentRunner";
+import type { StationLogger } from "../../src/stationLogger.js";
 
 const now = "2026-06-04T12:00:00.000Z";
 const clock = { now: () => new Date(now) };
@@ -590,50 +590,33 @@ class CapturingHarnessProvider extends FakeHarnessProvider {
   }
 }
 
-class CapturingLogger implements JsonlLogger {
-  readonly path = "/tmp/station/test-observer.jsonl";
+class CapturingLogger implements StationLogger {
   readonly records: LogRecord[] = [];
 
-  async log(
-    record: Omit<LogRecord, "timestamp" | "component"> & { timestamp?: string },
-  ): Promise<LogRecord> {
+  async info(message: string, attributes?: Record<string, unknown>): Promise<void> {
+    this.record("info", message, attributes);
+  }
+
+  async warn(message: string, attributes?: Record<string, unknown>): Promise<void> {
+    this.record("warn", message, attributes);
+  }
+
+  async error(message: string, attributes?: Record<string, unknown>): Promise<void> {
+    this.record("error", message, attributes);
+  }
+
+  private record(
+    level: LogRecord["level"],
+    message: string,
+    attributes?: Record<string, unknown>,
+  ): void {
     const logged: LogRecord = {
       component: "observer",
-      timestamp: record.timestamp ?? now,
-      level: record.level,
-      message: record.message,
+      timestamp: now,
+      level,
+      message,
     };
-    if (record.attributes !== undefined) logged.attributes = record.attributes;
+    if (attributes !== undefined) logged.attributes = attributes;
     this.records.push(logged);
-    return logged;
   }
-
-  async debug(message: string, attributes?: Record<string, unknown>): Promise<LogRecord> {
-    return this.log(logInput("debug", message, attributes));
-  }
-
-  async info(message: string, attributes?: Record<string, unknown>): Promise<LogRecord> {
-    return this.log(logInput("info", message, attributes));
-  }
-
-  async warn(message: string, attributes?: Record<string, unknown>): Promise<LogRecord> {
-    return this.log(logInput("warn", message, attributes));
-  }
-
-  async error(message: string, attributes?: Record<string, unknown>): Promise<LogRecord> {
-    return this.log(logInput("error", message, attributes));
-  }
-}
-
-function logInput(
-  level: LogRecord["level"],
-  message: string,
-  attributes: Record<string, unknown> | undefined,
-): Omit<LogRecord, "timestamp" | "component"> {
-  const input: Omit<LogRecord, "timestamp" | "component"> = {
-    level,
-    message,
-  };
-  if (attributes !== undefined) input.attributes = attributes;
-  return input;
 }

--- a/apps/observer/tsconfig.test-support.json
+++ b/apps/observer/tsconfig.test-support.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["test/support/inMemoryObserverPersistence.ts"]
+  "include": ["test/support/inMemoryObserverPersistence.ts", "test/support/projectConfigWriter.ts"]
 }

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -157,7 +157,7 @@ Composition is intentionally split:
 1. `apps/cli/src/observerProviders.ts` constructs concrete integrations,
    assigns provider roles, and supplies a `ProviderRegistry` factory.
 2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
-   private infrastructure: SQLite, persistence, logger, event bus, command
+   private infrastructure: SQLite, persistence, logging and project-config adapters, event bus, command
    queue, core, handlers, ingress queues, schedulers, API, and protocol server.
 
 The split is allowed because both pieces are outer wiring. Application modules
@@ -186,7 +186,7 @@ ownership even where current ownership is still a deviation.
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
 | Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |
 | Persistence health | Driven | `PersistenceHealthSource` | SQLite adapter created by `createSqliteObserverPersistence` | Runtime health and diagnostics read the public SQLite health projection without receiving the concrete database handle. |
-| Logging and config mutation | Driven | target `StationLogger` and `ProjectConfigWriter` | JSONL logger and project-config adapters | Logger methods expose no path or JSONL result; project commands expose no config or home path (OBS-HEX-010). |
+| Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose only operational logging and the three project mutations; paths and representations remain adapter-owned. |
 | Worktree metadata evidence | Driven | target `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | One role reads typed change evidence; the other owns watcher replacement and shutdown (OBS-HEX-011). |
 | Diagnostic evidence | Driven | target `DiagnosticEvidenceSource` | local state, log, and hook-spool adapter | Only typed local evidence traversal crosses the port; command/event persistence, providers, core, and SQLite remain separate inputs (OBS-HEX-012). |
 | Observer incumbent lifecycle | Driven | `ObserverIncumbentLifecycle` | local protocol client adapter | Handoff may read health and request controlled stop without importing transport mechanics into policy or orchestration. |
@@ -210,6 +210,8 @@ areas contain the following responsibilities:
 | `reconcile/` | provider reads, correlation, graph construction, projection, and core state | Reconcile use case plus deterministic policies; provider I/O remains at its driven edges. |
 | `hooks/` | hook/report ingestion, dedupe, readiness, spool I/O, and ingress queue | Ingress use cases and queue orchestration separated from filesystem spool adapters. |
 | `runtime/` | API assembly, process lifecycle, scheduling, event delivery, server bridge, and external launch | Observer composition plus application operations; transport and infrastructure stay at the edge. |
+| `stationLogger.ts`, `commands/projectConfigWriter.ts` | Observer-private logging and authoritative project-configuration capabilities | Driven application ports free of JSONL records and configuration/home-path plumbing. |
+| `runtime/logging.ts`, `runtime/projectConfigWriter.ts` | Redacted JSONL writes and `@station/config` project mutation translation | Outbound adapters retaining log, config, and home paths at composition. |
 | `providers/` | provider aggregation and health cache | Provider aggregation and health only; provider modules must not own or import application orchestration. |
 | `metadata/` | metadata refresh, repository lookup, Git execution, and ref watching | Metadata use cases select adapters through provider-neutral policy and depend on local-metadata ports (OBS-HEX-011). |
 | `persistence/ports.ts`, `persistence/types.ts` | seven purpose-owned persistence ports, their seven-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
@@ -282,9 +284,10 @@ Current startup proceeds in this order:
    ports and `PersistenceHealthSource` to that handle. Runtime composition
    retains the concrete handle only for open/close lifecycle ownership and
    distributes the composition bundle into narrow application views.
-6. The runtime creates the event bus, logger, command queue, feature evaluator,
-   Observer core, command handlers, and configured event hooks around the
-   awaited provider registry.
+6. The runtime creates the event bus, `StationLogger` JSONL adapter,
+   `ProjectConfigWriter` configuration adapter, command queue, feature evaluator,
+   Observer core, command handlers, and configured event hooks around the awaited
+   provider registry. Only the two application ports pass inward.
 7. The API constructs ingress queues, reconcile scheduling, metadata refresh,
    diagnostics dependencies, and spool draining.
 8. The runtime constructs a private startup-and-health gate, then the protocol
@@ -667,7 +670,6 @@ and exit condition here.
 | ID | Current evidence and risk | Containment and exit evidence | Tracking |
 | --- | --- | --- | --- |
 | `OBS-HEX-007` | Terminal intent orchestration now belongs to `commands/`, resolving that provider/application back-edge. Unrelated type-only ownership cycles remain, so not every major module role is yet explainable without source cycles. | A dependency diagnostic prevents `providers/**` from importing `commands/**`. Exit when the remaining major-module type cycles are removed and final dependency-direction enforcement covers every major Observer module. | Internal ownership remediation. |
-| `OBS-HEX-010` | Use cases depend on concrete `JsonlLogger` and project commands receive config paths for filesystem mutation. Local representations cross inward. | Exit when `StationLogger` exposes only `info`/`warn`/`error`, `ProjectConfigWriter` exposes only the three project mutations returning updated config, and their adapters alone own log/config/home paths. | Logging and project-config edge inversion. |
 | `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Read evidence and long-lived watcher lifecycle are mixed into the use case. | Exit when `WorktreeChangeSource` owns typed Git reads, `WorktreeMetadataInvalidationSource` separately owns watched-worktree replacement and shutdown, and use cases receive neither Git runners nor filesystem paths. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only. Exit when a `DiagnosticEvidenceSource` adapter owns only local-state, recent-log, and hook-spool traversal, captures its paths, and the use case runs against a fake without absorbing persistence, providers, core, or SQLite. | Diagnostic evidence isolation. |
 
@@ -691,6 +693,9 @@ over `StationCommand["type"]`. `OBS-HEX-009` is
 resolved: external launch exposes only an opaque managed-terminal attachment,
 Station owns host PTY and socket resolution, and an advertised attachment can
 never fail over to a duplicate local spawn.
+`OBS-HEX-010` is resolved: Observer consumers depend on `StationLogger` and
+`ProjectConfigWriter`, while runtime adapters alone retain JSONL records and
+configuration/home paths; static inventory and substitution tests enforce both edges.
 `OBS-HEX-013` is resolved: normal and provider-hook clients no longer unlink
 stale sockets, the child holds the persistent SQLite boot claim through ready
 commitment, and permanent Node/Bun plus production lifecycle races cover

--- a/tests/agent/real/claude/claude-session-create.test.ts
+++ b/tests/agent/real/claude/claude-session-create.test.ts
@@ -19,6 +19,7 @@ import {
 import { FakeWorktreeProvider } from "@station/testing";
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
 
 const execFileAsync = promisify(execFile);
 const realClaudeEnabled = process.env.STATION_REAL_CLAUDE === "1";
@@ -106,6 +107,7 @@ describeRealClaude("real Claude session.create", () => {
       providerTimeoutMs: 20_000,
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/agent/real/codex/codex-session-create.test.ts
+++ b/tests/agent/real/codex/codex-session-create.test.ts
@@ -19,6 +19,7 @@ import {
 import { FakeWorktreeProvider } from "@station/testing";
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
 
 const execFileAsync = promisify(execFile);
 const realCodexEnabled = process.env.STATION_REAL_CODEX === "1";
@@ -107,6 +108,7 @@ describeRealCodex("real Codex session.create", () => {
       providerTimeoutMs: 20_000,
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/agent/real/cursor/cursor-session-create.test.ts
+++ b/tests/agent/real/cursor/cursor-session-create.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@station/testing";
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
 
 const execFileAsync = promisify(execFile);
 const realCursorEnabled = process.env.STATION_REAL_CURSOR === "1";
@@ -115,6 +116,7 @@ describeRealCursor("real Cursor session.create launch lane", () => {
       providerTimeoutMs: 20_000,
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/agent/real/opencode/opencode-session-create.test.ts
+++ b/tests/agent/real/opencode/opencode-session-create.test.ts
@@ -19,6 +19,7 @@ import { createOpenCodeHarnessProvider, installOpenCodePlugin } from "@station/o
 import { FakeWorktreeProvider } from "@station/testing";
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
 import { requireRealE2eEnvironment, requireToolPath } from "../../../support/real-station/env";
 
 const execFileAsync = promisify(execFile);
@@ -128,6 +129,7 @@ describeRealOpenCode("real OpenCode session.create", () => {
       providerTimeoutMs: 20_000,
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/agent/real/pi/pi-session-create.test.ts
+++ b/tests/agent/real/pi/pi-session-create.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@station/testing";
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
 import type { RealE2eEnvironment } from "../../../support/real-station/env";
 import { createPiLaunchLoggingWrapper, waitForPiLaunchLog } from "../../../support/real-station/pi";
 
@@ -130,6 +131,7 @@ describeRealPi("real Pi session.create launch lane", () => {
       providerTimeoutMs: 20_000,
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/agent/scripted/scripted-agent-lifecycle.test.ts
+++ b/tests/agent/scripted/scripted-agent-lifecycle.test.ts
@@ -21,6 +21,7 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 import { runScriptedAgentLaunchPlan } from "../../support/fake-agent";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -178,6 +179,7 @@ describe("scripted agent lifecycle", () => {
       clock: { now: () => new Date(now) },
     });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -194,6 +194,41 @@ describe("boundary inventory guard", () => {
     expect(violations).toEqual([]);
   });
 
+  it("keeps Observer logging and project configuration representations at runtime adapters", async () => {
+    const files = (await sourceFilesAt(join(process.cwd(), "apps/observer/src"))).filter(
+      isProductionSourceFile,
+    );
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      const path = relative(process.cwd(), file);
+      if (
+        /\b(?:JsonlLogger|createJsonlLogger)\b/.test(source) &&
+        path !== "apps/observer/src/runtime/logging.ts"
+      ) {
+        violations.push(`${path}: concrete JSONL logger`);
+      }
+      if (
+        /\b(?:addProjectToConfig|removeProjectFromConfig|setProjectDefaultHarnessInConfig)\b/.test(
+          source,
+        ) &&
+        path !== "apps/observer/src/runtime/projectConfigWriter.ts"
+      ) {
+        violations.push(`${path}: concrete project config mutation`);
+      }
+      if (
+        (path === "apps/observer/src/commands/project.ts" ||
+          path === "apps/observer/src/commands/router.ts") &&
+        /\b(?:configPath|homeDir)\b/.test(source)
+      ) {
+        violations.push(`${path}: configuration path plumbing`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
   it("keeps command orchestration out of observer provider modules", async () => {
     const commandsRoot = join(process.cwd(), "apps/observer/src/commands");
     const files = (await sourceFilesAt(join(process.cwd(), "apps/observer/src/providers"))).filter(

--- a/tests/diagnostics/debug-bundle/cleanup-command.test.ts
+++ b/tests/diagnostics/debug-bundle/cleanup-command.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
@@ -23,6 +23,7 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 
 const now = "2026-05-21T12:00:00.000Z";
 
@@ -84,6 +85,7 @@ describe("cleanup command debug bundle diagnostics", () => {
     const core = createObserverCore({ config, providers, persistence, clock, logger });
     const queue = createCommandQueue({ persistence, clock, idFactory: ids, eventBus, logger });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,
@@ -121,7 +123,7 @@ describe("cleanup command debug bundle diagnostics", () => {
         paths: {
           stateDir,
           diagnosticsDir,
-          logPaths: [logger.path],
+          logPaths: [componentLogPath(stateDir, "observer")],
         },
         clock,
       },

--- a/tests/diagnostics/debug-bundle/debug-bundle-operational.test.ts
+++ b/tests/diagnostics/debug-bundle/debug-bundle-operational.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
@@ -83,7 +83,7 @@ describe("operational debug bundle", () => {
         paths: {
           stateDir,
           diagnosticsDir,
-          logPaths: [logger.path],
+          logPaths: [componentLogPath(stateDir, "observer")],
         },
         clock,
       },

--- a/tests/diagnostics/debug-bundle/session-create-command.test.ts
+++ b/tests/diagnostics/debug-bundle/session-create-command.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
@@ -21,6 +21,7 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 
 const now = "2026-05-21T12:00:00.000Z";
 
@@ -59,6 +60,7 @@ describe("session.create debug bundle diagnostics", () => {
     const config = configFor(root, stateDir);
     const core = createObserverCore({ config, providers, persistence, clock, logger });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,
@@ -92,7 +94,7 @@ describe("session.create debug bundle diagnostics", () => {
         paths: {
           stateDir,
           diagnosticsDir,
-          logPaths: [logger.path],
+          logPaths: [componentLogPath(stateDir, "observer")],
         },
         clock,
       },
@@ -144,6 +146,7 @@ describe("session.create debug bundle diagnostics", () => {
     const config = configFor(root, stateDir);
     const core = createObserverCore({ config, providers, persistence, clock, logger });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,
@@ -177,7 +180,7 @@ describe("session.create debug bundle diagnostics", () => {
         paths: {
           stateDir,
           diagnosticsDir,
-          logPaths: [logger.path],
+          logPaths: [componentLogPath(stateDir, "observer")],
         },
         clock,
       },

--- a/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
@@ -22,6 +22,7 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 import { createTempSocketPath } from "../../support/sockets";
 
 const now = "2026-05-21T12:00:00.000Z";
@@ -72,6 +73,7 @@ describe("full session cleanup e2e", () => {
     });
     const core = createObserverCore({ config, providers, persistence, clock });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,

--- a/tests/e2e/full-session-lifecycle/session-create-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-create-scripted.test.ts
@@ -20,6 +20,7 @@ import type { ExternalCommandInput } from "@station/runtime";
 import { ScriptedAgentHarnessProvider } from "@station/scripted-harness";
 import { FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 import { runScriptedAgentLaunchPlan } from "../../support/fake-agent";
 import { createTempSocketPath } from "../../support/sockets";
 
@@ -85,6 +86,7 @@ describe("full session lifecycle e2e", () => {
     });
     const core = createObserverCore({ config, providers, persistence, clock });
     registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
       queue,
       core,
       providers,


### PR DESCRIPTION
## Summary

- add Observer-private `StationLogger` and `ProjectConfigWriter` driven ports
- retain JSONL and project-config path mechanics in runtime adapters
- require explicit project-writer composition and add throwing test substitutes
- enforce the boundaries statically and resolve `OBS-HEX-010`

## Impact

Behavior and UX are unchanged. Project mutations retain existing add, remove, default-harness, no-op, validation, and project-local override semantics. Observer logs retain their existing JSONL records and redaction behavior.

## Validation

- `pnpm test:pre-push` with isolated `HOME`
  - build, typecheck, lint, unit, contract, integration, diagnostics, scripted-agent, setup and Observer E2Es
  - install smoke
  - Node/Bun SQLite compatibility and Observer boot-claim races
  - Station typecheck and tests
  - Bun PTY tests
  - compiled binary build and smoke
