### PR TITLE
fix(observer): make hook spool replay completion-safe

### DIFF
--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -52,6 +52,7 @@ export type HarnessEventReportIngestion = {
 
 export type ProviderHookIngressOptions = {
   triggerReconcile?: boolean;
+  reportHarnessEvent?: (report: HarnessEventReport) => Promise<HarnessEventReportReceipt>;
 };
 
 export type CreateProviderHookIngressOptions = {
@@ -80,6 +81,11 @@ export type CreateHarnessEventReportIngestionOptions = {
 
 const defaultHookId = () => `hook_${randomUUID()}`;
 
+/**
+ * USE CASE
+ *
+ * Accepts raw provider hook evidence once while allowing retries to finish durable downstream processing.
+ */
 export function createProviderHookIngress(
   options: CreateProviderHookIngressOptions,
 ): ProviderHookIngress {
@@ -141,27 +147,14 @@ export function createProviderHookIngress(
         return ProviderHookReceiptSchema.parse(receipt);
       }
 
-      if (persistResult.value.deduped) {
-        return ProviderHookReceiptSchema.parse({
-          schemaVersion: STATION_SCHEMA_VERSION,
-          hookId: id,
-          provider: event.provider,
-          event: event.event,
-          accepted: true,
-          status: "ingested",
-          receivedAt: event.receivedAt,
-          reconciled: false,
-          deduped: true,
-        });
-      }
-
       const adapter =
         event.kind === "harness" ? options.providers?.hookAdapters.get(event.provider) : undefined;
-      if (adapter?.toHarnessEventReport !== undefined && options.reportHarnessEvent !== undefined) {
+      const reportHarnessEvent = ingestOptions.reportHarnessEvent ?? options.reportHarnessEvent;
+      if (adapter?.toHarnessEventReport !== undefined && reportHarnessEvent !== undefined) {
         return ingestViaHookAdapter({
           event,
           adapter,
-          reportHarnessEvent: options.reportHarnessEvent,
+          reportHarnessEvent,
         });
       }
 
@@ -178,7 +171,8 @@ export function createProviderHookIngress(
             });
 
       const shouldReconcile = ingestOptions.triggerReconcile ?? true;
-      if (shouldReconcile && options.requestReconcile !== undefined) {
+      const downstreamDeduped = providerIngestResult?.deduped ?? persistResult.value.deduped;
+      if (shouldReconcile && !downstreamDeduped && options.requestReconcile !== undefined) {
         options.requestReconcile(`hook:${event.provider}:${event.event}`);
       }
 
@@ -191,7 +185,7 @@ export function createProviderHookIngress(
         status: "ingested",
         receivedAt: event.receivedAt,
         reconciled: false,
-        deduped: false,
+        deduped: persistResult.value.deduped,
       };
       if (providerIngestResult?.error !== undefined) {
         receipt.error = providerIngestResult.error;
@@ -298,6 +292,11 @@ async function ingestViaHookAdapter(
   return ProviderHookReceiptSchema.parse(hookReceipt);
 }
 
+/**
+ * USE CASE
+ *
+ * Persists a normalized harness report once and repairs its recovery and readiness projections on every retry.
+ */
 export function createHarnessEventReportIngestion(
   options: CreateHarnessEventReportIngestionOptions,
 ): HarnessEventReportIngestion {
@@ -348,9 +347,7 @@ export function createHarnessEventReportIngestion(
                 expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
               },
             });
-          if (result.deduped) {
-            return { deduped: true };
-          }
+          // Primary dedupe is acceptance evidence, not proof that later idempotent repairs finished.
           const recoveryHandle = sessionRecoveryHandleFromReport(report);
           if (recoveryHandle !== undefined) {
             await options.persistence.upsertSessionRecoveryHandle(recoveryHandle);
@@ -360,8 +357,10 @@ export function createHarnessEventReportIngestion(
             observation,
             updatedAt: receivedAt,
           });
-          options.eventBus?.publish(reportedEvent);
-          return { deduped: false };
+          if (!result.deduped) {
+            options.eventBus?.publish(reportedEvent);
+          }
+          return { deduped: result.deduped };
         },
       );
 

--- a/apps/observer/src/hooks/providerHookIngress.ts
+++ b/apps/observer/src/hooks/providerHookIngress.ts
@@ -14,6 +14,7 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import type {
+  IngressJournal,
   ObservationStore,
   RecordProviderObservationInput,
   SessionStore,
@@ -27,6 +28,7 @@ import { persistTurnReadinessFromHarnessObservation } from "./turnReadiness.js";
 
 export type ProviderHookIngestResult = {
   observations: number;
+  deduped: boolean;
   error?: SafeError;
 };
 
@@ -34,7 +36,7 @@ export type IngestProviderHookEventOptions = {
   event: ProviderHookEvent;
   providers: ProviderRegistry;
   projects: ProviderProjectConfig[];
-  persistence: ObservationStore & SessionStore;
+  persistence: IngressJournal & ObservationStore & SessionStore;
   clock?: RuntimeClock;
   timeoutMs?: number;
   retention?: ObservabilityRetentionConfig;
@@ -44,6 +46,11 @@ type ObservationRecord = RecordProviderObservationInput & {
   observedAt: string;
 };
 
+/**
+ * USE CASE
+ *
+ * Normalizes provider hook evidence and atomically records all derived observations before marking that hook processing complete.
+ */
 export async function ingestProviderHookEvent(
   options: IngestProviderHookEventOptions,
 ): Promise<ProviderHookIngestResult> {
@@ -72,16 +79,29 @@ export async function ingestProviderHookEvent(
   if (!result.ok) {
     return {
       observations: 0,
+      deduped: false,
       error: result.error,
     };
   }
 
   const retentionDays = providerObservationRetentionDays(options.retention);
-  for (const observation of result.value) {
-    await options.persistence.recordProviderObservation({
-      ...observation,
-      expiresAt: providerObservationExpiresAt(observation.observedAt, retentionDays),
-    });
+  const observations = result.value.map((observation) => ({
+    ...observation,
+    expiresAt: providerObservationExpiresAt(observation.observedAt, retentionDays),
+  }));
+  const processing = await options.persistence.recordProviderObservationsWithIngressDedupe({
+    observations,
+    dedupe: {
+      kind: "hook_processing",
+      id:
+        options.event.hookId ??
+        `${options.event.provider}:${options.event.receivedAt}:${options.event.event}`,
+    },
+    createdAt: options.event.receivedAt,
+  });
+
+  // Completion dedupe never suppresses idempotent readiness repair after a partial prior attempt.
+  for (const observation of observations) {
     const harnessEvent = harnessEventObservationFromRecord(observation);
     if (harnessEvent !== undefined) {
       await persistTurnReadinessFromHarnessObservation({
@@ -93,7 +113,8 @@ export async function ingestProviderHookEvent(
   }
 
   return {
-    observations: result.value.length,
+    observations: observations.length,
+    deduped: processing.deduped,
   };
 }
 

--- a/apps/observer/src/hooks/spool.ts
+++ b/apps/observer/src/hooks/spool.ts
@@ -1,4 +1,3 @@
-import { readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
   HarnessEventReport,
@@ -9,10 +8,7 @@ import type {
   ProviderHookSpoolRecord,
   StationEvent,
 } from "@station/contracts";
-import {
-  HarnessEventReportSpoolRecordSchema,
-  ProviderHookSpoolRecordSchema,
-} from "@station/contracts";
+import { ProviderHookEventSchema } from "@station/contracts";
 import {
   type RuntimeClock,
   safeErrorFromUnknown,
@@ -21,6 +17,18 @@ import {
 } from "@station/runtime";
 import type { EventJournal } from "../persistence/index.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
+import {
+  createFilesystemProviderIngressSpoolStore,
+  type ParsedProviderIngressSpoolRecord,
+  type ProviderIngressSpoolEntry,
+  type ProviderIngressSpoolStore,
+} from "./spoolStore.js";
+
+export {
+  createFilesystemProviderIngressSpoolStore,
+  type ProviderIngressSpoolStore,
+  providerIngressSpoolDir,
+} from "./spoolStore.js";
 
 export type ProviderIngressSpoolDrainResult = {
   scanned: number;
@@ -29,7 +37,7 @@ export type ProviderIngressSpoolDrainResult = {
 };
 
 export type DrainProviderIngressSpoolOptions = {
-  spoolDir: string;
+  store: ProviderIngressSpoolStore;
   ingest(event: ProviderHookEvent): Promise<ProviderHookReceipt>;
   report?(report: HarnessEventReport): Promise<HarnessEventReportReceipt>;
   persistence?: EventJournal;
@@ -37,101 +45,52 @@ export type DrainProviderIngressSpoolOptions = {
   clock?: RuntimeClock;
 };
 
-type ParsedSpoolRecord =
-  | {
-      kind: "hook";
-      record: ProviderHookSpoolRecord;
-    }
-  | {
-      kind: "report";
-      record: HarnessEventReportSpoolRecord;
-    };
-
-export function providerIngressSpoolDir(stateDir: string): string {
-  return join(stateDir, "spool", "hooks");
-}
-
 export async function listProviderIngressSpoolRecords(spoolDir: string): Promise<
   Array<{
     path: string;
     record: ProviderHookSpoolRecord | HarnessEventReportSpoolRecord;
   }>
 > {
-  let entries: string[];
-  try {
-    entries = await readdir(spoolDir);
-  } catch {
-    return [];
-  }
-
-  const records: Array<{
-    path: string;
-    record: ProviderHookSpoolRecord | HarnessEventReportSpoolRecord;
-  }> = [];
-  for (const entry of entries.filter((name) => name.endsWith(".json")).sort()) {
-    const path = join(spoolDir, entry);
-    try {
-      const raw = JSON.parse(await readFile(path, "utf8"));
-      const parsed = parseSpoolRecord(raw);
-      records.push({
-        path,
-        record: parsed.record,
-      });
-    } catch {
-      // Invalid spool files are left in place for later diagnostics.
-    }
-  }
-  return records;
+  const entries = await createFilesystemProviderIngressSpoolStore(spoolDir).list();
+  return entries.flatMap((entry) =>
+    entry.parsed === undefined
+      ? []
+      : [{ path: join(spoolDir, entry.id), record: entry.parsed.record }],
+  );
 }
 
-export async function providerIngressSpoolDepth(spoolDir: string): Promise<number> {
-  try {
-    return (await readdir(spoolDir)).filter((name) => name.endsWith(".json")).length;
-  } catch {
-    return 0;
-  }
+export function providerIngressSpoolDepth(spoolDir: string): Promise<number> {
+  return createFilesystemProviderIngressSpoolStore(spoolDir).depth();
 }
 
 export async function drainProviderIngressSpool(
   options: DrainProviderIngressSpoolOptions,
 ): Promise<ProviderIngressSpoolDrainResult> {
   const clock = options.clock ?? systemClock;
-  let entries: string[];
-  try {
-    entries = await readdir(options.spoolDir);
-  } catch {
-    entries = [];
-  }
-  const paths = entries
-    .filter((name) => name.endsWith(".json"))
-    .sort()
-    .map((entry) => join(options.spoolDir, entry));
+  const entries = await options.store.list();
   let drained = 0;
   let failed = 0;
 
-  for (const path of paths) {
-    let parsed: ParsedSpoolRecord;
-    try {
-      const raw = JSON.parse(await readFile(path, "utf8"));
-      parsed = parseSpoolRecord(raw);
-    } catch {
+  for (const entry of entries) {
+    const parsed = entry.parsed;
+    if (parsed === undefined) {
       failed += 1;
       continue;
     }
-
+    const validEntry = { ...entry, parsed };
     try {
-      const receipt = await drainSpoolRecord(parsed, options);
+      const receipt = await drainSpoolRecord(validEntry, options);
       if (receipt.status === "drained") {
-        await unlink(path);
+        // Removal is the durable acknowledgement that every direct processing step completed.
+        await options.store.remove(entry.id);
         drained += 1;
       } else {
-        await updateFailedSpoolRecord(path, parsed, receipt.error);
+        await options.store.recordFailure(validEntry, receipt.error);
         failed += 1;
       }
     } catch (error) {
-      await updateFailedSpoolRecord(
-        path,
-        parsed,
+      await options.store.recordFailure(
+        validEntry,
         safeErrorFromUnknown(error, {
           tag: "HookIngestionError",
           code: "HOOK_SPOOL_DRAIN_FAILED",
@@ -143,7 +102,7 @@ export async function drainProviderIngressSpool(
     }
   }
 
-  if (paths.length > 0) {
+  if (entries.length > 0) {
     const event: StationEvent = {
       type: "providerHook.spoolDrained",
       at: toIsoTimestamp(clock.now()),
@@ -157,20 +116,14 @@ export async function drainProviderIngressSpool(
     options.eventBus?.publish(event);
   }
 
-  return {
-    scanned: paths.length,
-    drained,
-    failed,
-  };
+  return { scanned: entries.length, drained, failed };
 }
 
 async function drainSpoolRecord(
-  parsed: ParsedSpoolRecord,
+  entry: ProviderIngressSpoolEntry & { parsed: ParsedProviderIngressSpoolRecord },
   options: DrainProviderIngressSpoolOptions,
 ): Promise<
-  | {
-      status: "drained";
-    }
+  | { status: "drained" }
   | {
       status: "failed";
       error:
@@ -179,9 +132,14 @@ async function drainSpoolRecord(
         | undefined;
     }
 > {
-  if (parsed.kind === "hook") {
-    const receipt = await options.ingest(parsed.record.event);
-    return receipt.status === "ingested"
+  if (entry.parsed.kind === "hook") {
+    const record = entry.parsed.record;
+    const event = ProviderHookEventSchema.parse({
+      ...record.event,
+      hookId: record.event.hookId ?? record.spoolId,
+    });
+    const receipt = await options.ingest(event);
+    return receipt.status === "ingested" && receipt.error === undefined
       ? { status: "drained" }
       : { status: "failed", error: receipt.error };
   }
@@ -193,47 +151,17 @@ async function drainSpoolRecord(
         tag: "HookIngestionError",
         code: "HOOK_REPORT_SPOOL_UNSUPPORTED",
         message: "Harness event report spool records are not supported by this drain path.",
-        provider: parsed.record.report.provider,
+        provider: entry.parsed.record.report.provider,
       }),
     };
   }
 
-  const receipt = await options.report(parsed.record.report);
-  return receipt.status === "accepted"
+  const receipt = await options.report(entry.parsed.record.report);
+  return receipt.status === "accepted" && receipt.error === undefined
     ? { status: "drained" }
     : { status: "failed", error: receipt.error };
 }
 
-function parseSpoolRecord(input: unknown): ParsedSpoolRecord {
-  const hook = ProviderHookSpoolRecordSchema.safeParse(input);
-  if (hook.success) {
-    return { kind: "hook", record: hook.data };
-  }
-  return { kind: "report", record: HarnessEventReportSpoolRecordSchema.parse(input) };
-}
-
-async function updateFailedSpoolRecord(
-  path: string,
-  parsed: ParsedSpoolRecord,
-  error:
-    | ProviderHookSpoolRecord["lastError"]
-    | HarnessEventReportSpoolRecord["lastError"]
-    | undefined,
-): Promise<void> {
-  const updated = {
-    ...parsed.record,
-    attempts: parsed.record.attempts + 1,
-  };
-  if (error !== undefined) {
-    updated.lastError = error;
-  }
-  const schema =
-    parsed.kind === "hook" ? ProviderHookSpoolRecordSchema : HarnessEventReportSpoolRecordSchema;
-  await writeFile(path, JSON.stringify(schema.parse(updated), null, 2), {
-    mode: 0o600,
-  });
-}
-
-function spoolRecordProvider(parsed: ParsedSpoolRecord): string {
+function spoolRecordProvider(parsed: ParsedProviderIngressSpoolRecord): string {
   return parsed.kind === "hook" ? parsed.record.event.provider : parsed.record.report.provider;
 }

--- a/apps/observer/src/hooks/spoolStore.ts
+++ b/apps/observer/src/hooks/spoolStore.ts
@@ -1,0 +1,101 @@
+import { readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type {
+  HarnessEventReportSpoolRecord,
+  ProviderHookSpoolRecord,
+  SafeError,
+} from "@station/contracts";
+import {
+  HarnessEventReportSpoolRecordSchema,
+  ProviderHookSpoolRecordSchema,
+} from "@station/contracts";
+
+export type ParsedProviderIngressSpoolRecord =
+  | { kind: "hook"; record: ProviderHookSpoolRecord }
+  | { kind: "report"; record: HarnessEventReportSpoolRecord };
+
+export type ProviderIngressSpoolEntry = {
+  id: string;
+  parsed?: ParsedProviderIngressSpoolRecord;
+};
+
+/**
+ * DRIVEN PORT
+ *
+ * Supplies validated pending ingress records and commits their retry or removal state without exposing filesystem mechanics.
+ */
+export interface ProviderIngressSpoolStore {
+  list(): Promise<ProviderIngressSpoolEntry[]>;
+  depth(): Promise<number>;
+  remove(id: string): Promise<void>;
+  recordFailure(
+    entry: ProviderIngressSpoolEntry & { parsed: ParsedProviderIngressSpoolRecord },
+    error?: SafeError,
+  ): Promise<void>;
+}
+
+/**
+ * ADAPTER
+ *
+ * Stores provider ingress fallback records as strict JSON files and leaves malformed evidence in place for diagnostics.
+ */
+export function createFilesystemProviderIngressSpoolStore(
+  spoolDir: string,
+): ProviderIngressSpoolStore {
+  return {
+    list: async () => {
+      let names: string[];
+      try {
+        names = await readdir(spoolDir);
+      } catch {
+        return [];
+      }
+      const entries: ProviderIngressSpoolEntry[] = [];
+      for (const id of names.filter((name) => name.endsWith(".json")).sort()) {
+        try {
+          const raw: unknown = JSON.parse(await readFile(join(spoolDir, id), "utf8"));
+          entries.push({ id, parsed: parseSpoolRecord(raw) });
+        } catch {
+          entries.push({ id });
+        }
+      }
+      return entries;
+    },
+    depth: async () => {
+      try {
+        return (await readdir(spoolDir)).filter((name) => name.endsWith(".json")).length;
+      } catch {
+        return 0;
+      }
+    },
+    remove: (id) => unlink(join(spoolDir, id)),
+    recordFailure: async (entry, error) => {
+      const updated = {
+        ...entry.parsed.record,
+        attempts: entry.parsed.record.attempts + 1,
+      };
+      if (error !== undefined) {
+        updated.lastError = error;
+      }
+      const schema =
+        entry.parsed.kind === "hook"
+          ? ProviderHookSpoolRecordSchema
+          : HarnessEventReportSpoolRecordSchema;
+      await writeFile(join(spoolDir, entry.id), JSON.stringify(schema.parse(updated), null, 2), {
+        mode: 0o600,
+      });
+    },
+  };
+}
+
+export function providerIngressSpoolDir(stateDir: string): string {
+  return join(stateDir, "spool", "hooks");
+}
+
+function parseSpoolRecord(input: unknown): ParsedProviderIngressSpoolRecord {
+  const hook = ProviderHookSpoolRecordSchema.safeParse(input);
+  if (hook.success) {
+    return { kind: "hook", record: hook.data };
+  }
+  return { kind: "report", record: HarnessEventReportSpoolRecordSchema.parse(input) };
+}

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -24,6 +24,7 @@ import type {
   PersistedWorktreeMetadataCurrent,
   PersistReconcileResultInput,
   ProviderObservationKind,
+  ProviderObservationsIngressDedupeResult,
   RecordProviderObservationInput,
   WorktreeMetadataCurrentKind,
   WorktreeMetadataCurrentPayloadByKind,
@@ -71,7 +72,7 @@ export interface EventJournal {
 /**
  * DRIVEN PORT
  *
- * Atomically deduplicates accepted ingress with its durable event and observation evidence.
+ * Atomically records primary ingress acceptance and downstream observation completion under separate dedupe keys.
  */
 export interface IngressJournal {
   recordEventWithIngressDedupe(
@@ -86,6 +87,11 @@ export interface IngressJournal {
     observation: RecordProviderObservationInput;
     dedupe: IngressDedupeKey;
   }): Promise<EventAndObservationIngressDedupeResult>;
+  recordProviderObservationsWithIngressDedupe(input: {
+    observations: RecordProviderObservationInput[];
+    dedupe: IngressDedupeKey;
+    createdAt?: string;
+  }): Promise<ProviderObservationsIngressDedupeResult>;
 }
 
 /**

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -156,6 +156,27 @@ export function createSqliteObserverPersistence(
         };
       }),
 
+    recordProviderObservationsWithIngressDedupe: (input) =>
+      transaction((database) => {
+        const createdAt = input.createdAt ?? now();
+        const claimed = ingressDedupeStore.claimIngressDedupeKey(database, {
+          ...input.dedupe,
+          eventId: input.dedupe.id,
+          createdAt,
+        });
+        if (!claimed) {
+          return { deduped: true };
+        }
+        const observations = input.observations.map((observation) =>
+          insertProviderObservation(database, {
+            ...observation,
+            id: idFactory.observationId(),
+            observedAt: observation.observedAt ?? now(),
+          }),
+        );
+        return { deduped: false, observations };
+      }),
+
     listEvents: (filter = {}) => transaction((database) => listEvents(database, filter)),
 
     recordProviderObservation: (input) =>

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -51,7 +51,7 @@ export type PersistedEvent = {
   spanId?: string;
 };
 
-export type IngressDedupeKind = "hook" | "harness_report";
+export type IngressDedupeKind = "hook" | "hook_processing" | "harness_report";
 
 export type IngressDedupeKey = {
   kind: IngressDedupeKind;
@@ -136,6 +136,11 @@ export type EventIngressDedupeResult = {
 
 export type EventAndObservationIngressDedupeResult = EventIngressDedupeResult & {
   observation?: PersistedProviderObservation;
+};
+
+export type ProviderObservationsIngressDedupeResult = {
+  deduped: boolean;
+  observations?: PersistedProviderObservation[];
 };
 
 export type PersistedWorktreeMetadataCurrent<

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -39,7 +39,10 @@ import {
   type HarnessEventReportIngestion,
   type ProviderHookIngress,
 } from "../hooks/ingestion.js";
-import { providerIngressSpoolDepth } from "../hooks/spool.js";
+import {
+  createFilesystemProviderIngressSpoolStore,
+  providerIngressSpoolDepth,
+} from "../hooks/spool.js";
 import {
   createWorktreeMetadataRefreshService,
   type WorktreeMetadataRefreshService,
@@ -88,6 +91,11 @@ export type CreateObserverApiOptions = {
   hookReconcileDebounceMs?: number;
 };
 
+/**
+ * COMPOSITION ROOT
+ *
+ * Wires Observer use cases, durable adapters, ingress workers, scheduling, and lifecycle operations behind the application API.
+ */
 export function createObserverApi(options: CreateObserverApiOptions): ObserverApi {
   const clock = options.clock ?? systemClock;
   const reconciling = { reconciling: false };
@@ -156,7 +164,9 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     harnessIngressQueue,
     harnessReportDeps,
     reconcileScheduler,
-    ...(options.hookSpoolDir === undefined ? {} : { hookSpoolDir: options.hookSpoolDir }),
+    ...(options.hookSpoolDir === undefined
+      ? {}
+      : { spoolStore: createFilesystemProviderIngressSpoolStore(options.hookSpoolDir) }),
   };
   const { drainConfiguredSpoolAndQueue } = createSpoolDrainer(spoolDrainDeps);
 

--- a/apps/observer/src/runtime/reconcileExecutor.ts
+++ b/apps/observer/src/runtime/reconcileExecutor.ts
@@ -19,6 +19,11 @@ export type ReconcileExecutorDeps = {
   drainSpoolAndQueue: () => Promise<void>;
 };
 
+/**
+ * USE CASE
+ *
+ * Replays pending ingress before scanning providers and then publishes the resulting Observer projection.
+ */
 export async function runReconcile(
   deps: ReconcileExecutorDeps,
   guard: ReconcileGuard,
@@ -30,19 +35,14 @@ export async function runReconcile(
   let publishMs = 0;
   let metadataRefreshScheduled = false;
   if (!guard.reconciling) {
-    if (reason === "observer.startup") {
-      void deps.drainSpoolAndQueue().catch(async (error: unknown) => {
-        await deps.logger?.error("Startup hook spool drain failed.", { error });
-      });
-    } else {
-      guard.reconciling = true;
-      const drainStartedAt = Date.now();
-      try {
-        await deps.drainSpoolAndQueue();
-      } finally {
-        drainMs = elapsedMs(drainStartedAt);
-        guard.reconciling = false;
-      }
+    guard.reconciling = true;
+    const drainStartedAt = Date.now();
+    try {
+      // The provider scan must observe every durable replay completed by this reconcile.
+      await deps.drainSpoolAndQueue();
+    } finally {
+      drainMs = elapsedMs(drainStartedAt);
+      guard.reconciling = false;
     }
   }
 

--- a/apps/observer/src/runtime/spoolDrain.ts
+++ b/apps/observer/src/runtime/spoolDrain.ts
@@ -1,8 +1,13 @@
+import type { HarnessEventReport } from "@station/contracts";
 import type { RuntimeBoundaryResult, RuntimeClock } from "@station/runtime";
 import { runRuntimeBoundary } from "@station/runtime";
 import type { HarnessIngressQueue } from "../hooks/harnessIngressQueue.js";
 import type { ProviderHookIngress } from "../hooks/ingestion.js";
-import { drainProviderIngressSpool, type ProviderIngressSpoolDrainResult } from "../hooks/spool.js";
+import {
+  drainProviderIngressSpool,
+  type ProviderIngressSpoolDrainResult,
+  type ProviderIngressSpoolStore,
+} from "../hooks/spool.js";
 import type { EventJournal } from "../persistence/index.js";
 import type { ObserverEventBus } from "./eventBus.js";
 import type { HarnessReportProcessorDeps } from "./harnessReportProcessor.js";
@@ -10,7 +15,7 @@ import { processHarnessIngressReport } from "./harnessReportProcessor.js";
 import type { ReconcileScheduler } from "./reconcileScheduler.js";
 
 export type SpoolDrainDeps = {
-  hookSpoolDir?: string;
+  spoolStore?: ProviderIngressSpoolStore;
   persistence: EventJournal;
   eventBus: ObserverEventBus;
   clock: RuntimeClock;
@@ -20,18 +25,31 @@ export type SpoolDrainDeps = {
   reconcileScheduler: ReconcileScheduler;
 };
 
+/**
+ * USE CASE
+ *
+ * Replays durable provider ingress directly to completion before acknowledging spool records or queued reports.
+ */
 export function createSpoolDrainer(deps: SpoolDrainDeps) {
   let configuredSpoolDrain: Promise<void> | undefined;
 
   const drainConfiguredSpool = async (): Promise<void> => {
-    if (deps.hookSpoolDir === undefined) {
+    if (deps.spoolStore === undefined) {
       return;
     }
     if (configuredSpoolDrain !== undefined) {
       await configuredSpoolDrain;
       return;
     }
-    const spoolDir = deps.hookSpoolDir;
+    const spoolStore = deps.spoolStore;
+
+    const processReport = async (report: HarnessEventReport) => {
+      const result = await processHarnessIngressReport(deps.harnessReportDeps, report);
+      if (result.reconcileReason !== undefined) {
+        deps.reconcileScheduler.request(result.reconcileReason);
+      }
+      return result.receipt;
+    };
 
     configuredSpoolDrain = runRuntimeBoundary(
       {
@@ -45,18 +63,16 @@ export function createSpoolDrainer(deps: SpoolDrainDeps) {
       },
       () =>
         drainProviderIngressSpool({
-          spoolDir,
+          store: spoolStore,
           persistence: deps.persistence,
           eventBus: deps.eventBus,
           clock: deps.clock,
-          ingest: (event) => deps.providerHookIngress.ingest(event, { triggerReconcile: false }),
-          report: async (report) => {
-            const result = await processHarnessIngressReport(deps.harnessReportDeps, report);
-            if (result.reconcileReason !== undefined) {
-              deps.reconcileScheduler.request(result.reconcileReason);
-            }
-            return result.receipt;
-          },
+          ingest: (event) =>
+            deps.providerHookIngress.ingest(event, {
+              triggerReconcile: false,
+              reportHarnessEvent: processReport,
+            }),
+          report: processReport,
         }),
     )
       .then((result: RuntimeBoundaryResult<ProviderIngressSpoolDrainResult>) => {

--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -355,7 +355,7 @@ describe("observer provider hook ingress", () => {
     sqlite.close();
   });
 
-  it("deduplicates hook ids before provider dispatch and persistence", async () => {
+  it("deduplicates hook persistence without skipping retryable provider processing", async () => {
     const clock = { now: () => new Date(now) };
     const harness = new RecordingHarnessProvider({ now });
     const providers = new ProviderRegistry({
@@ -384,7 +384,7 @@ describe("observer provider hook ingress", () => {
       value: { type: "observer.reconciled" },
     });
     await reconciled.close();
-    expect(harness.ingestCalls).toBe(1);
+    expect(harness.ingestCalls).toBe(2);
     expect(
       (await persistence.listEvents({ type: "providerHook.ingested" })).map((event) => event.event),
     ).toHaveLength(1);
@@ -416,6 +416,65 @@ describe("observer provider hook ingress", () => {
       (await persistence.listEvents({ type: "harness.eventReported" })).map((event) => event.event),
     ).toHaveLength(1);
     await expect(persistence.listProviderObservations()).resolves.toHaveLength(1);
+    sqlite.close();
+  });
+
+  it("repairs recovery and readiness after primary harness report persistence was already committed", async () => {
+    const clock = { now: () => new Date(now) };
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    let rejectRecoveryOnce = true;
+    const retryingPersistence = {
+      ...persistence,
+      upsertSessionRecoveryHandle: async (
+        input: Parameters<typeof persistence.upsertSessionRecoveryHandle>[0],
+      ) => {
+        if (rejectRecoveryOnce) {
+          rejectRecoveryOnce = false;
+          throw new Error("forced recovery failure");
+        }
+        return persistence.upsertSessionRecoveryHandle(input);
+      },
+    };
+    const ingestion = createHarnessEventReportIngestion({
+      persistence: retryingPersistence,
+      clock,
+    });
+    const report = {
+      ...harnessReport("report_repair_1"),
+      status: {
+        value: "idle" as const,
+        confidence: "high" as const,
+        reason: "Codex completed its turn.",
+        source: "harness_event" as const,
+        updatedAt: now,
+      },
+      turn: { kind: "turn_completed" as const },
+      correlation: {
+        projectId: "web",
+        worktreeId: "wt_web_task",
+        sessionId: "ses_web_task",
+        nativeSessionId: "native_codex_1",
+      },
+    };
+
+    await expect(ingestion.ingest(report, { triggerReconcile: false })).resolves.toMatchObject({
+      accepted: false,
+      status: "rejected",
+    });
+    await expect(ingestion.ingest(report, { triggerReconcile: false })).resolves.toMatchObject({
+      accepted: true,
+      deduped: true,
+    });
+    await expect(persistence.listSessionRecoveryHandles()).resolves.toHaveLength(1);
+    await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: "ses_web_task",
+        projectId: "web",
+        worktreeId: "wt_web_task",
+        token: "report_repair_1",
+      }),
+    ]);
     sqlite.close();
   });
 

--- a/apps/observer/test/integration/hook-spool-drain.test.ts
+++ b/apps/observer/test/integration/hook-spool-drain.test.ts
@@ -18,15 +18,18 @@ import {
 } from "../../../../tests/support/spool";
 import {
   createCommandQueue,
+  createFilesystemProviderIngressSpoolStore,
   createObserverApi,
   createObserverCore,
   createObserverEventBus,
+  createProviderHookIngress,
   createSqliteObserverPersistence,
   drainProviderIngressSpool,
   type HarnessEventReportIngestion,
   openObserverSqlite,
   type ProviderHookIngress,
   ProviderRegistry,
+  probeObserverSocket,
   providerIngressSpoolDir,
   startObserverServer,
 } from "../../src/internal";
@@ -43,11 +46,13 @@ describe("observer hook spool drain", () => {
     await fixture.api.reconcile("manual");
 
     await expect(stat(join(spoolDir, "spool_1.json"))).rejects.toMatchObject({ code: "ENOENT" });
-    expect((await fixture.persistence.listEvents()).map((event) => event.type)).toEqual([
+    const events = await fixture.persistence.listEvents();
+    expect(events.map((event) => event.type)).toEqual([
       "providerHook.ingested",
       "providerHook.spoolDrained",
       "observer.reconciled",
     ]);
+    expect(events[0]?.event).toMatchObject({ hookId: "spool_1" });
     fixture.sqlite.close();
   });
 
@@ -93,7 +98,7 @@ describe("observer hook spool drain", () => {
     const nextDrainEvent = drainEvents.next();
 
     const result = await drainProviderIngressSpool({
-      spoolDir,
+      store: createFilesystemProviderIngressSpoolStore(spoolDir),
       persistence: fixture.persistence,
       eventBus: fixture.eventBus,
       clock: fixture.clock,
@@ -139,7 +144,70 @@ describe("observer hook spool drain", () => {
     fixture.sqlite.close();
   });
 
-  it("starts the observer server without waiting for spool drain work to finish", async () => {
+  it("retries downstream processing after primary hook dedupe and unlinks only after completion", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-state-"));
+    const spoolDir = providerIngressSpoolDir(stateDir);
+    const spoolPath = await writeHookSpoolRecordFixture({
+      spoolDir,
+      spoolId: "spool_retry_processing",
+      event: {
+        provider: "fake-harness",
+        kind: "harness",
+        event: "run.updated",
+        payload: { state: "idle" },
+      },
+    });
+    const clock = { now: () => new Date(now) };
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    let failProcessingOnce = true;
+    const retryingPersistence = {
+      ...persistence,
+      recordProviderObservationsWithIngressDedupe: async (
+        input: Parameters<typeof persistence.recordProviderObservationsWithIngressDedupe>[0],
+      ) => {
+        if (failProcessingOnce) {
+          failProcessingOnce = false;
+          throw new Error("forced downstream processing failure");
+        }
+        return persistence.recordProviderObservationsWithIngressDedupe(input);
+      },
+    };
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new ReplayHarnessProvider({ now })],
+    });
+    const ingress = createProviderHookIngress({
+      persistence: retryingPersistence,
+      providers,
+      clock,
+    });
+    const store = createFilesystemProviderIngressSpoolStore(spoolDir);
+
+    await expect(
+      drainProviderIngressSpool({ store, ingest: (event) => ingress.ingest(event), clock }),
+    ).resolves.toEqual({ scanned: 1, drained: 0, failed: 1 });
+    await expect(fileExists(spoolPath)).resolves.toBe(true);
+    await expect(persistence.listEvents({ type: "providerHook.ingested" })).resolves.toHaveLength(
+      1,
+    );
+    await expect(persistence.listProviderObservations()).resolves.toEqual([]);
+
+    await expect(
+      drainProviderIngressSpool({ store, ingest: (event) => ingress.ingest(event), clock }),
+    ).resolves.toEqual({ scanned: 1, drained: 1, failed: 0 });
+    await expect(fileExists(spoolPath)).resolves.toBe(false);
+    await expect(persistence.listEvents({ type: "providerHook.ingested" })).resolves.toHaveLength(
+      1,
+    );
+    await expect(persistence.listProviderObservations()).resolves.toEqual([
+      expect.objectContaining({ entityKey: "run_spool_retry" }),
+    ]);
+    sqlite.close();
+  });
+
+  it("opens health while making startup completion wait for spool and queue work", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-observer-state-"));
     const spoolDir = providerIngressSpoolDir(stateDir);
     const spoolPath = await writeHookSpoolRecordFixture({ spoolDir, spoolId: "spool_startup" });
@@ -163,15 +231,17 @@ describe("observer hook spool drain", () => {
     });
     const { socketPath } = await createTempSocketPath();
 
-    const server = await startObserverServer({
+    const serverPromise = startObserverServer({
       socketPath,
       api: fixture.api,
       clock: fixture.clock,
     });
 
+    await waitFor(async () => (await probeObserverSocket(socketPath)) === "listening");
     await expect(fileExists(spoolPath)).resolves.toBe(true);
     gate.resolve();
-    await waitFor(async () => !(await fileExists(spoolPath)));
+    const server = await serverPromise;
+    await expect(fileExists(spoolPath)).resolves.toBe(false);
     await server.close();
     fixture.sqlite.close();
   });
@@ -198,7 +268,7 @@ describe("observer hook spool drain", () => {
     });
     const { socketPath } = await createTempSocketPath();
 
-    const server = await startObserverServer({
+    const serverPromise = startObserverServer({
       socketPath,
       api: fixture.api,
       clock: fixture.clock,
@@ -207,7 +277,8 @@ describe("observer hook spool drain", () => {
     await waitFor(async () => processingStarted);
     await expect(fileExists(spoolPath)).resolves.toBe(true);
     gate.resolve();
-    await waitFor(async () => !(await fileExists(spoolPath)));
+    const server = await serverPromise;
+    await expect(fileExists(spoolPath)).resolves.toBe(false);
     await server.close();
     fixture.sqlite.close();
   });
@@ -458,4 +529,25 @@ async function waitFor(predicate: () => Promise<boolean>, timeoutMs = 1000): Pro
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error("Timed out waiting for condition.");
+}
+
+class ReplayHarnessProvider extends FakeHarnessProvider {
+  override async ingestEvent() {
+    return [
+      {
+        provider: this.id,
+        harnessRunId: "run_spool_retry",
+        worktreeId: "wt_spool_retry",
+        sessionId: "ses_spool_retry",
+        status: {
+          value: "idle" as const,
+          confidence: "high" as const,
+          reason: "Replay harness reported idle.",
+          source: "harness_event" as const,
+          updatedAt: now,
+        },
+        observedAt: now,
+      },
+    ];
+  }
 }

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -109,6 +109,65 @@ describe("SQLite-only Observer persistence behavior", () => {
       sqlite.close();
     }
   });
+
+  it("rolls back a trigger-rejected processing batch before permitting the same key to retry", async () => {
+    const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
+    try {
+      const persistence = createSqliteObserverPersistence({
+        sqlite,
+        clock: { now: () => new Date(now) },
+        idFactory: ids(),
+      });
+      const observation = {
+        provider: "fake-harness",
+        providerType: "harness" as const,
+        entityKind: "provider_health" as const,
+        entityKey: "reject-processing-once",
+        payload: {
+          providerId: "fake-harness",
+          providerType: "harness" as const,
+          status: "healthy" as const,
+          lastCheckedAt: now,
+        },
+        observedAt: now,
+      };
+      const input: Parameters<IngressJournal["recordProviderObservationsWithIngressDedupe"]>[0] = {
+        observations: [observation],
+        dedupe: { kind: "hook_processing", id: "hook_processing_atomic" },
+        createdAt: now,
+      };
+      sqlite.database.exec(`
+        CREATE TRIGGER reject_processing_observation
+        BEFORE INSERT ON provider_observations
+        WHEN NEW.entity_key = 'reject-processing-once'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced processing failure');
+        END;
+      `);
+
+      await expect(persistence.recordProviderObservationsWithIngressDedupe(input)).rejects.toThrow(
+        "PERSISTENCE_TRANSACTION_FAILED",
+      );
+      expect(
+        sqlite.database
+          .prepare("SELECT COUNT(*) AS count FROM hook_ingress_dedupe WHERE kind = ?")
+          .get("hook_processing"),
+      ).toMatchObject({ count: 0 });
+      sqlite.database.exec("DROP TRIGGER reject_processing_observation");
+
+      await expect(
+        persistence.recordProviderObservationsWithIngressDedupe(input),
+      ).resolves.toMatchObject({
+        deduped: false,
+        observations: [{ entityKey: "reject-processing-once" }],
+      });
+      await expect(persistence.recordProviderObservationsWithIngressDedupe(input)).resolves.toEqual(
+        { deduped: true },
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
 });
 
 function ids() {

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -249,6 +249,21 @@ export function createInMemoryObserverPersistence(
         return { deduped: false, event, observation };
       }),
 
+    recordProviderObservationsWithIngressDedupe: (input) =>
+      transaction((draft) => {
+        if (!claimIngressDedupeKey(draft, input.dedupe)) {
+          return { deduped: true };
+        }
+        const observations = input.observations.map((observation) =>
+          insertProviderObservation(draft, {
+            ...observation,
+            id: idFactory.observationId(),
+            observedAt: observation.observedAt ?? now(),
+          }),
+        );
+        return { deduped: false, observations };
+      }),
+
     listEvents: (filter = {}) =>
       transaction((draft) =>
         [...draft.events.values()]

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -507,6 +507,62 @@ export function observerPersistenceContract(
           ).resolves.toEqual({ deduped: true });
         });
       });
+
+      it("atomically records every downstream observation before claiming processing complete", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          const observations = [
+            healthObservation("healthy"),
+            { ...healthObservation("degraded"), entityKey: "fake-harness-secondary" },
+          ];
+          const first = await persistence.recordProviderObservationsWithIngressDedupe({
+            observations,
+            dedupe: { kind: "hook_processing", id: "hook_batch" },
+            createdAt: now,
+          });
+          const duplicate = await persistence.recordProviderObservationsWithIngressDedupe({
+            observations,
+            dedupe: { kind: "hook_processing", id: "hook_batch" },
+            createdAt: now,
+          });
+
+          expect(first).toMatchObject({
+            deduped: false,
+            observations: [{ id: "contract_obs_1" }, { id: "contract_obs_2" }],
+          });
+          expect(duplicate).toEqual({ deduped: true });
+          await expect(
+            persistence.listProviderObservations({ includeExpired: true, now }),
+          ).resolves.toHaveLength(2);
+        });
+      });
+
+      it("rolls back a downstream processing claim when any observation is invalid", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          const invalid = {
+            ...healthObservation("degraded"),
+            payload: { status: "degraded" },
+          } as unknown as RecordProviderObservationInput;
+          const dedupe = { kind: "hook_processing" as const, id: "hook_batch_retry" };
+
+          await expectPersistenceFailure(
+            persistence.recordProviderObservationsWithIngressDedupe({
+              observations: [healthObservation("healthy"), invalid],
+              dedupe,
+              createdAt: now,
+            }),
+          );
+          await expect(
+            persistence.listProviderObservations({ includeExpired: true, now }),
+          ).resolves.toEqual([]);
+          await expect(
+            persistence.recordProviderObservationsWithIngressDedupe({
+              observations: [healthObservation("healthy")],
+              dedupe,
+              createdAt: now,
+            }),
+          ).resolves.toMatchObject({ deduped: false, observations: [{ id: "contract_obs_3" }] });
+        });
+      });
     });
 
     describe("ObservationStore", () => {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -241,7 +241,7 @@ No single layer owns all truth.
 | `StationSnapshot` | Current normalized graph held in memory. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
 | Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
 | Persisted event rows | Historical and diagnostic observer memory. They are not currently the source for live subscription replay. |
-| Hook spool | Durable delivery fallback while ingress cannot reach the observer. A queued record is pending evidence, not current graph truth. |
+| Hook spool | Durable delivery fallback while ingress cannot reach the observer. A queued record is pending evidence, not current graph truth. Its stable spool identity drives replay completion after primary dedupe, and the filesystem record remains until all derived durable work finishes. |
 | JSONL logs and debug bundles | Diagnostic evidence. They never outrank config, provider reads, current observer state, or command records. |
 
 Clients must treat a subscription gap as possible event loss. The Station client
@@ -372,13 +372,20 @@ Observer-side through injected provider hook adapters. Integrations that
 already own a typed report path, including Pi, normalize once in that adapter
 and submit a `HarnessEventReport`; the Observer does not normalize it again.
 
-The harness queue acknowledges accepted work before durable processing or
-reconcile. Queue acceptance is process-memory acceptance, not a durability
+The harness queue acknowledges accepted online work before durable processing
+or reconcile. Queue acceptance is process-memory acceptance, not a durability
 guarantee. It remembers recent report IDs in memory, coalesces replaceable
 pending reports by correlation key, rejects new keys when its bounded pending
 capacity is full, and exposes health counters. The worker applies durable
-dedupe while persisting a report. Spool draining is single-flight; invalid or
-failed records stay available for later diagnosis or retry.
+dedupe while persisting a report.
+
+Spool replay bypasses queue acceptance and invokes direct durable hook/report
+processing. A primary ingress dedupe hit suppresses duplicate event publication
+but does not skip idempotent derived-observation, recovery-handle, or readiness
+completion. The filesystem spool adapter removes a record only after that work
+succeeds; invalid and failed records retain attempt/error evidence for later
+diagnosis or retry. Startup reconcile waits for the single-flight spool and
+queue drain before its provider scan.
 
 Provider hooks are delivery hints. They may update durable observations and
 immediate projections, but scheduled reconcile remains the path to fresh
@@ -432,7 +439,8 @@ from the diagnostic use case.
 | Reconcile ordering | Core reconciles form a non-poisoning promise chain. Scheduled requests coalesce; queued work after a run receives a later flush. |
 | Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Failures become provider health and reconcile errors. |
 | Harness ingress | One worker processes a bounded pending map. New reports can replace pending work for the same key; a full map rejects unrelated work with a backpressure error. |
-| Spool drain | One configured drain runs at a time and processes stable filename order. Failed records remain on disk with attempt/error evidence. |
+| Spool drain | One configured drain runs at a time and processes stable filename order through direct durable ingress. Stable spool IDs survive legacy records without hook IDs; completion is idempotent after primary dedupe, and failed records remain on disk with attempt/error evidence. |
+| Hook auto-start throttle | `hook-autostart.lock` limits provider-hook spawn attempts only. It is never Observer ownership; each child still enters the socket-relative SQLite boot claim. |
 | Event delivery | Each subscriber currently has an unbounded in-memory queue. There is no replay or publisher backpressure; slow-subscriber growth is therefore a known operating characteristic. |
 | Background refresh | Provider probes and metadata refresh are best-effort and must report failure without blocking the primary reconcile result. |
 

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -62,8 +62,9 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
   database with WAL plus `integrity_check=ok`.
 - CLI and provider-hook starts resolved byte-identical proposed claim paths from
   the effective socket with XDG unset, XDG set, and an explicit config socket
-  containing a space. The current `hook-autostart.lock` still keys off
-  `<stateDir>/run` and therefore diverges under XDG/config overrides until 3e.
+  containing a space. `hook-autostart.lock` still keys off `<stateDir>/run`, but
+  it throttles hook spawns only; socket ownership remains exclusively governed
+  by the child-held claim beside the resolved socket.
 
 ## Shipped
 
@@ -75,6 +76,8 @@ Measured against a real observer in an isolated `/private/tmp` state dir:
 | #84 | `bindWithStaleReclaim`: bind-first and reprobe protect an owner that was already live at the first bind. The 3d spike found a concurrent stale-reclaimer ABA; 3d-a now supplies the serialization required before this helper may reclaim. |
 | 3c | Durable process identity: the successful socket binder atomically publishes and fsyncs `<socketPath>.pid` with the strict `{pid, osStartTime, version, socketPath}` payload before health is enabled. The full socket filename keeps identities distinct within a shared runtime directory. Publication failure is fatal. Clean shutdown removes only its exact matching identity; `lsof` remains primary ownership evidence. |
 | 3d-a / #135 | The Observer child holds `BEGIN IMMEDIATE` on `dirname(resolvedSocket)/observer.claim.sqlite` across probe, stale reclaim, bind, pidfile publication, seeded watcher setup, and ready commitment. CLI and provider-hook clients only attach or spawn; health opens after synchronous claim release. |
+| 3d-b prerequisite | Hook spool replay uses stable ingress identity, completes derived observations and report recovery state idempotently after primary dedupe, and unlinks records only after direct durable processing. Automatic handoff may now request graceful shutdown without turning process-memory queue acceptance into data loss. |
+| 3e | `hook-autostart.lock` remains a state-directory rate limiter for provider-hook spawn attempts only. Every spawned child still enters the socket-relative 3d-a claim, so lock-path divergence under XDG or explicit socket configuration cannot create a second ownership authority. |
 
 Together these **stop the bleeding**: `reap` clears duplicates on demand, the
 seeded watcher self-heals future displacements, and stop is terminal. Phase 3c
@@ -138,8 +141,8 @@ and non-mutation cases. It proves mutual exclusion, not fairness.
 
 Build coordinated handoff only after 3d-a establishes exclusive boot ownership.
 This phase owns version comparison, incumbent attribution, graceful stop,
-signal escalation, spool-safety prerequisites, and replacement confirmation;
-none belongs to #135.
+bounded signal escalation, and replacement confirmation; its replay-safe spool
+prerequisite is shipped above, and none of the handoff policy belongs to #135.
 
 - Refine the version gate into a **total antisymmetric order** with a
   deterministic `(version, startedAt, pid)` tiebreak so no pair both-evicts.
@@ -150,20 +153,12 @@ none belongs to #135.
   Refuse on missing or conflicting evidence and revalidate before every signal.
 - Request graceful `observer.stop`, then confirm both socket closure and exact
   process death before binding. A stop receipt alone is not completion.
-- Do not make SIGKILL a routine terminator until spool consumption is
-  idempotent by event ID or atomically claimed. Until then a wedged incumbent
-  requires a safe refusal or an explicit operator path.
+- Automatic handoff must never use SIGKILL. A wedged incumbent that survives
+  graceful stop and the bounded, identity-revalidated signal path requires a
+  safe refusal; forced termination remains an explicit operator action.
 - Preserve the process-level graceful and wedged replacement spikes as
   permanent acceptance coverage. PTY continuity is not part of Observer
   handoff; `station-host` owns live PTYs independently.
-
-### 3e — isolate hook auto-start rate limiting
-
-3d-a routes CLI and provider-hook children through the same child-owned
-claim. Keep `hook-autostart.lock` authoritative only for hook rate limiting,
-never Observer ownership. Its state-directory location may diverge from the
-resolved socket under config and XDG overrides without weakening the 3d-a
-claim.
 
 ### Phase 4 — guarded self-heal (deferrable, needs 3d-b)
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -36,8 +36,8 @@ Non-goals:
 - **Windows targets.**
 - **Any observer replacement / eviction in this roadmap.** Coordinated
   single-observer behavior is owned entirely by
-  [observer-singleton](observer-singleton.md). This plan uses shipped 3c/3d-a
-  and defers remaining ownership policy to 3d-b/3e; it does not add a second,
+  [observer-singleton](observer-singleton.md). This plan uses shipped 3c/3d-a/3e
+  and defers remaining ownership policy to 3d-b; it does not add a second,
   uncoordinated eviction path (v1 did — removed, see F3).
 - **Replacing the dev workflow.** Dev mode (tsc dist under Node +
   `bun --hot` TUI from source) stays byte-identical; compiled mode is new


### PR DESCRIPTION
## Summary

- make hook replay completion atomic across primary ingress and downstream observation work
- keep spool records until all durable processing succeeds, with a stable replay identity
- drain spool and ingress queues before startup reconciliation

## Why

A retry after primary dedupe could skip unfinished downstream work and unlink the spool file. Replay now resumes idempotently until the complete hook-processing batch is durable.

## Verification

- isolated `pnpm test:pre-push` passed on the stacked head
- 137 focused Observer persistence, ingress, spool, API, and reconcile tests passed
- Observer and root typechecks passed

## UX

Queued provider evidence stays pending through transient processing failures and is removed only after derived state is durable.