### PR TITLE
fix(observer): harden replay and version handoff

### DIFF
--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -74,6 +74,10 @@ export async function runObserverCommand(
   }
 }
 
+export function parseObserverCommandAction(args: string[]): string {
+  return parseObserverArgs(args, undefined).action;
+}
+
 function parseObserverArgs(
   args: string[],
   timeoutMs: number | undefined,

--- a/apps/cli/src/commands/registry/observer.ts
+++ b/apps/cli/src/commands/registry/observer.ts
@@ -1,6 +1,10 @@
 import { loadedCommandOptions } from "../cliCommand/helpers.js";
 import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
-import { observerCommandSummary, runObserverCommand } from "../observer.js";
+import {
+  observerCommandSummary,
+  parseObserverCommandAction,
+  runObserverCommand,
+} from "../observer.js";
 
 export const observerCliCommand: CliCommandNode = {
   name: "observer",
@@ -57,7 +61,7 @@ async function runObserverCliCommand(context: CliCommandRunContext) {
     loadedCommandOptions(context),
     context.options.observerDeps,
   );
-  const action = context.args[0] ?? "status";
+  const action = parseObserverCommandAction(context.args);
   const failedStart =
     (action === "start" || action === "restart") &&
     "status" in result &&

--- a/apps/cli/src/ingress/deliveryPolicy.ts
+++ b/apps/cli/src/ingress/deliveryPolicy.ts
@@ -52,7 +52,8 @@ export async function deliverProviderHookWithSpooling(input: {
   spoolReceipt: (error: SafeError | undefined) => Promise<ProviderHookReceipt>;
   recordReceipt?: ReceiptRecorder;
 }): Promise<ProviderHookReceipt> {
-  const readiness = await prepareObserverForDelivery(input);
+  const startupDeadlineMs = Date.now() + input.startupTimeoutMs;
+  const readiness = await prepareObserverForDelivery(input, startupDeadlineMs);
   if (!readiness.ok) {
     return recordReceipt(input, await input.spoolReceipt(readiness.error));
   }
@@ -65,7 +66,7 @@ export async function deliverProviderHookWithSpooling(input: {
   if (input.autoStart) {
     const startupInput: Parameters<typeof maybeStartObserver>[0] = {
       paths: input.paths,
-      timeoutMs: input.startupTimeoutMs,
+      startupDeadlineMs,
       rateLimitMs: input.rateLimitMs,
       deps: input.deps,
     };
@@ -89,18 +90,23 @@ export async function deliverProviderHookWithSpooling(input: {
   return recordReceipt(input, await input.spoolReceipt(firstDelivery.error));
 }
 
-async function prepareObserverForDelivery(input: {
-  paths: ObserverPaths;
-  autoStart: boolean;
-  startupTimeoutMs: number;
-  rateLimitMs: number;
-  configPath?: string;
-  observerCommand?: ProviderHookObserverCommand;
-  deps: ProviderHookObserverStartupDeps;
-}): Promise<{ ok: true } | { ok: false; error: SafeError }> {
+async function prepareObserverForDelivery(
+  input: {
+    paths: ObserverPaths;
+    autoStart: boolean;
+    startupTimeoutMs: number;
+    rateLimitMs: number;
+    configPath?: string;
+    observerCommand?: ProviderHookObserverCommand;
+    deps: ProviderHookObserverStartupDeps;
+  },
+  startupDeadlineMs: number,
+): Promise<{ ok: true } | { ok: false; error: SafeError }> {
+  const statusTimeoutMs = remainingStartupBudgetMs(startupDeadlineMs);
+  if (statusTimeoutMs === undefined) return providerHookStartupTimedOut();
   const statusOptions: Parameters<typeof getProviderHookObserverStatus>[0] = {
     paths: input.paths,
-    timeoutMs: input.startupTimeoutMs,
+    timeoutMs: statusTimeoutMs,
   };
   if (input.configPath !== undefined) statusOptions.configPath = input.configPath;
   if (input.observerCommand !== undefined) {
@@ -140,7 +146,7 @@ async function prepareObserverForDelivery(input: {
 
   const startupInput: Parameters<typeof maybeStartObserver>[0] = {
     paths: input.paths,
-    timeoutMs: input.startupTimeoutMs,
+    startupDeadlineMs,
     rateLimitMs: input.rateLimitMs,
     deps: input.deps,
   };
@@ -175,20 +181,24 @@ async function maybeStartObserver(input: {
   paths: ObserverPaths;
   configPath?: string;
   observerCommand?: ProviderHookObserverCommand;
-  timeoutMs: number;
+  startupDeadlineMs: number;
   rateLimitMs: number;
   deps: ProviderHookObserverStartupDeps;
 }) {
+  const timeoutMs = remainingStartupBudgetMs(input.startupDeadlineMs);
+  if (timeoutMs === undefined) return providerHookStartupTimedOut();
   const lock = await acquireAutoStartLock({
     paths: input.paths,
-    staleMs: Math.max(input.rateLimitMs, input.timeoutMs, minimumAutoStartLockStaleMs),
+    staleMs: Math.max(input.rateLimitMs, timeoutMs, minimumAutoStartLockStaleMs),
     deps: input.deps,
   });
 
   if (lock.status === "contended") {
+    const contendedTimeoutMs = remainingStartupBudgetMs(input.startupDeadlineMs);
+    if (contendedTimeoutMs === undefined) return providerHookStartupTimedOut();
     return waitForContendedAutoStart({
       paths: input.paths,
-      timeoutMs: input.timeoutMs,
+      timeoutMs: contendedTimeoutMs,
       deps: input.deps,
     });
   }
@@ -197,9 +207,12 @@ async function maybeStartObserver(input: {
   }
 
   try {
+    const startupTimeoutMs = remainingStartupBudgetMs(input.startupDeadlineMs);
+    if (startupTimeoutMs === undefined) return providerHookStartupTimedOut();
     const startupOptions: Parameters<typeof startProviderHookObserver>[0] = {
       paths: input.paths,
-      timeoutMs: input.timeoutMs,
+      timeoutMs: startupTimeoutMs,
+      startupDeadlineMs: input.startupDeadlineMs,
     };
     if (input.configPath !== undefined) {
       startupOptions.configPath = input.configPath;
@@ -224,6 +237,22 @@ async function maybeStartObserver(input: {
   } finally {
     await lock.release();
   }
+}
+
+function remainingStartupBudgetMs(deadlineMs: number): number | undefined {
+  const remainingMs = Math.floor(deadlineMs - Date.now());
+  return remainingMs > 0 ? remainingMs : undefined;
+}
+
+function providerHookStartupTimedOut(): { ok: false; error: SafeError } {
+  return {
+    ok: false,
+    error: {
+      tag: "ObserverStartupError",
+      code: "OBSERVER_START_FAILED",
+      message: "Observer did not become healthy before the startup timeout.",
+    },
+  };
 }
 
 type AutoStartLock =

--- a/apps/cli/src/ingress/observerStartup.ts
+++ b/apps/cli/src/ingress/observerStartup.ts
@@ -72,6 +72,8 @@ export type ProviderHookObserverStartupOptions = {
   observerCommand?: ProviderHookObserverCommand;
   paths: ObserverPaths;
   timeoutMs?: number;
+  /** Absolute startup deadline shared across provider-hook readiness phases. */
+  startupDeadlineMs?: number;
 };
 
 export async function getProviderHookObserverStatus(
@@ -121,9 +123,15 @@ export async function startProviderHookObserver(
 ): Promise<ProviderHookObserverStatus> {
   const paths = options.paths;
   const timeoutMs = options.timeoutMs ?? 30_000;
+  const startupDeadlineMs = options.startupDeadlineMs ?? Date.now() + timeoutMs;
   const clock = deps.clock ?? systemClock;
   const buildVersion = deps.buildVersion ?? stationBuildInfo().version;
-  const existing = await getProviderHookObserverStatus({ ...options, paths }, deps);
+  const statusTimeoutMs = remainingStartupBudgetMs(startupDeadlineMs);
+  if (statusTimeoutMs === undefined) return startupTimedOutStatus(paths);
+  const existing = await getProviderHookObserverStatus(
+    { ...options, paths, timeoutMs: statusTimeoutMs },
+    deps,
+  );
   if (existing.status === "running") {
     const classification = classifyObserverHealth(existing.health, buildVersion);
     if (classification.action === "attach") {
@@ -139,12 +147,14 @@ export async function startProviderHookObserver(
   } else if (existing.error?.code === "PROTOCOL_SCHEMA_MISMATCH") {
     return { status: "unhealthy", paths, error: existing.error };
   }
+  const startTimeoutMs = remainingStartupBudgetMs(startupDeadlineMs);
+  if (startTimeoutMs === undefined) return startupTimedOutStatus(paths);
   let child: ChildProcessLike | undefined;
   const result = await runRuntimeBoundaryWithTimeout(
     {
       operation: "providerHooks.observer.start",
       clock,
-      timeoutMs,
+      timeoutMs: startTimeoutMs,
       error: {
         tag: "ObserverStartupError",
         code: "OBSERVER_START_FAILED",
@@ -166,12 +176,23 @@ export async function startProviderHookObserver(
       if (options.configPath !== undefined) {
         spawnInput.configPath = options.configPath;
       }
+      const childStartupTimeoutMs = remainingStartupBudgetMs(startupDeadlineMs);
+      if (childStartupTimeoutMs === undefined) throw providerHookStartupTimeoutError();
       child =
         deps.spawnObserver === undefined
-          ? defaultSpawnObserver(spawnInput, timeoutMs)
+          ? defaultSpawnObserver(spawnInput, childStartupTimeoutMs)
           : await deps.spawnObserver(spawnInput);
+      if (signal.aborted) {
+        child.kill?.();
+        throw observerHealthWaitCancelledError();
+      }
       child.unref?.();
-      return waitForProviderHookObserverHealth({ paths, timeoutMs, buildVersion, signal }, deps);
+      const healthTimeoutMs = remainingStartupBudgetMs(startupDeadlineMs);
+      if (healthTimeoutMs === undefined) throw providerHookStartupTimeoutError();
+      return waitForProviderHookObserverHealth(
+        { paths, timeoutMs: healthTimeoutMs, buildVersion, signal },
+        deps,
+      );
     },
   );
 
@@ -288,6 +309,23 @@ function defaultClientFactory(socketPath: string, options?: { timeoutMs: number 
     socketPath,
     timeoutMs: options?.timeoutMs ?? defaultProviderHookClientTimeoutMs,
   });
+}
+
+function remainingStartupBudgetMs(deadlineMs: number): number | undefined {
+  const remainingMs = Math.floor(deadlineMs - Date.now());
+  return remainingMs > 0 ? remainingMs : undefined;
+}
+
+function providerHookStartupTimeoutError(): SafeError {
+  return {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_START_FAILED",
+    message: "Observer did not become healthy before the startup timeout.",
+  };
+}
+
+function startupTimedOutStatus(paths: ObserverPaths): ProviderHookObserverStatus {
+  return { status: "unhealthy", paths, error: providerHookStartupTimeoutError() };
 }
 
 function defaultSpawnObserver(

--- a/apps/cli/src/observerProcess.ts
+++ b/apps/cli/src/observerProcess.ts
@@ -182,7 +182,29 @@ export async function restartObserver(
 ): Promise<ObserverStatus> {
   const status = await getObserverStatus(options, deps);
   if (status.status === "running") {
-    await stopObserver({ ...options, paths: status.paths }, deps);
+    const buildVersion = deps.buildVersion ?? stationBuildInfo().version;
+    const classification = classifyObserverHealth(status.health, buildVersion);
+    if (classification.action === "attach" && classification.reason === "incumbent-wins") {
+      return {
+        status: "unhealthy",
+        paths: status.paths,
+        error: observerHandoffRefusedError(
+          status.health,
+          buildVersion,
+          "A lower-build caller cannot restart a newer Observer or activate configuration in it.",
+        ),
+      };
+    }
+    if (classification.action === "refuse") {
+      return {
+        status: "unhealthy",
+        paths: status.paths,
+        error: observerHandoffRefusedError(status.health, buildVersion, classification.reason),
+      };
+    }
+    if (classification.reason === "exact-build") {
+      await stopObserver({ ...options, paths: status.paths }, deps);
+    }
   }
   return startObserver({ ...options, paths: status.paths }, deps);
 }

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -158,6 +158,18 @@ describe("CLI observer commands", () => {
     });
 
     await expect(
+      runCli(["--config", configPath, "observer", "--timeout-ms", "100", "start"], {
+        observerDeps,
+      }),
+    ).resolves.toMatchObject({
+      code: 1,
+      output: {
+        status: "unhealthy",
+        error: { code: "OBSERVER_HANDOFF_REFUSED" },
+      },
+    });
+
+    await expect(
       runCli(["--config", configPath, "observer", "status"], { observerDeps }),
     ).resolves.toMatchObject({ code: 0, output: { status: "running" } });
   });

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -115,7 +115,7 @@ describe("provider hook ingress command", () => {
     });
   });
 
-  it("passes the exact startup timeout to the production observer child", async () => {
+  it("passes the remaining startup budget to the production observer child", async () => {
     const fixture = await createTempState();
     const observerEntry = join(fixture.root, "record-observer-argv.cjs");
     const argvPath = join(fixture.root, "observer-argv.json");
@@ -169,16 +169,17 @@ describe("provider hook ingress command", () => {
     );
 
     expect(receipt.status).toBe("ingested");
-    await expect(readFile(argvPath, "utf8")).resolves.toBe(
-      JSON.stringify([
-        "--socket",
-        fixture.socketPath,
-        "--state-dir",
-        fixture.stateDir,
-        "--startup-timeout-ms",
-        "2000",
-      ]),
-    );
+    const childArgv = JSON.parse(await readFile(argvPath, "utf8")) as string[];
+    expect(childArgv.slice(0, -1)).toEqual([
+      "--socket",
+      fixture.socketPath,
+      "--state-dir",
+      fixture.stateDir,
+      "--startup-timeout-ms",
+    ]);
+    const childTimeoutMs = Number(childArgv.at(-1));
+    expect(childTimeoutMs).toBeGreaterThan(0);
+    expect(childTimeoutMs).toBeLessThanOrEqual(2000);
   });
 
   it("delivers Worktrunk lifecycle hooks through observer.ingestProviderHookEvent", async () => {

--- a/apps/cli/test/unit/ingress-delivery-policy.test.ts
+++ b/apps/cli/test/unit/ingress-delivery-policy.test.ts
@@ -222,16 +222,21 @@ describe("provider hook delivery policy", () => {
     expect(state.spooled).toBe(1);
   });
 
-  it("stops health retries after the total startup deadline", async () => {
+  it("shares one startup deadline across preflight, repeated status, and convergence", async () => {
     const fixture = await createTempState();
     const state = { running: false, spawnCount: 0, spooled: 0 };
     let healthCalls = 0;
+    const requestTimeouts: number[] = [];
+    const startupTimeoutMs = 80;
     const deps = {
       buildVersion,
-      clientFactory: () =>
+      clientFactory: (_socketPath: string, options?: { timeoutMs: number }) =>
         ({
           health: async () => {
             healthCalls += 1;
+            const requestTimeoutMs = options?.timeoutMs ?? startupTimeoutMs;
+            requestTimeouts.push(requestTimeoutMs);
+            await new Promise((resolve) => setTimeout(resolve, Math.min(50, requestTimeoutMs)));
             throw new Error("observer offline");
           },
         }) as never,
@@ -241,14 +246,20 @@ describe("provider hook delivery policy", () => {
       },
     };
 
+    const startedAt = Date.now();
     await expect(
       deliverProviderHookWithSpooling(
-        deliveryInput(fixture, "hook_total_deadline", state, deps, { startupTimeoutMs: 50 }),
+        deliveryInput(fixture, "hook_total_deadline", state, deps, { startupTimeoutMs }),
       ),
     ).resolves.toMatchObject({ status: "spooled" });
+    const elapsedMs = Date.now() - startedAt;
     const callsAtTimeout = healthCalls;
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(healthCalls).toBe(callsAtTimeout);
+    expect(healthCalls).toBe(2);
+    expect(requestTimeouts[1]).toBeLessThan(requestTimeouts[0] ?? 0);
+    expect(state.spawnCount).toBe(0);
+    expect(elapsedMs).toBeLessThan(startupTimeoutMs * 2);
   });
 
   it("does not deliver to a lower build until its replacement is healthy", async () => {

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { getObserverStatus, startObserver } from "@station/cli";
+import { getObserverStatus, restartObserver, startObserver } from "@station/cli";
 import type { ChildProcessLike } from "@station/cli/internal";
 import { listenUnixSocket } from "@station/protocol";
 import { describe, expect, it } from "vitest";
@@ -267,6 +267,127 @@ describe("CLI observer process lifecycle", () => {
       expect(result).toMatchObject({ status: "running", health: { version, pid: 1234 } });
     }
     expect(spawned).toBe(false);
+  });
+
+  it("refuses to restart a newer incumbent from a lower build", async () => {
+    const fixture = await createTempState();
+    let stops = 0;
+    let spawns = 0;
+    const result = await restartObserver(
+      { config: fixture.config },
+      {
+        buildVersion: "1.0.0",
+        spawnObserver: async () => {
+          spawns += 1;
+          return { pid: 5678, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => ({
+              schemaVersion: "0.7.0",
+              status: "healthy",
+              pid: 1234,
+              startedAt: now,
+              version: "2.0.0",
+              socketPath: fixture.socketPath,
+            }),
+            stop: async () => {
+              stops += 1;
+              return { schemaVersion: "0.7.0", stopped: true, at: now };
+            },
+          }) as never,
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "unhealthy",
+      error: {
+        code: "OBSERVER_HANDOFF_REFUSED",
+        hint: expect.stringContaining("cannot restart a newer Observer"),
+      },
+    });
+    expect(stops).toBe(0);
+    expect(spawns).toBe(0);
+  });
+
+  it("restarts an exact build through the explicit stop path", async () => {
+    const fixture = await createTempState();
+    let running = true;
+    let stops = 0;
+    let spawns = 0;
+    const result = await restartObserver(
+      { config: fixture.config, timeoutMs: 500 },
+      {
+        buildVersion: "1.0.0",
+        spawnObserver: async () => {
+          spawns += 1;
+          running = true;
+          return { pid: 1234, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => {
+              if (!running) throw new Error("stopped");
+              return {
+                schemaVersion: "0.7.0",
+                status: "healthy",
+                pid: 1234,
+                startedAt: now,
+                version: "1.0.0",
+                socketPath: fixture.socketPath,
+              };
+            },
+            stop: async () => {
+              stops += 1;
+              running = false;
+              return { schemaVersion: "0.7.0", stopped: true, at: now };
+            },
+          }) as never,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "running", health: { version: "1.0.0" } });
+    expect(stops).toBe(1);
+    expect(spawns).toBe(1);
+  });
+
+  it("routes a higher-build restart through child handoff without a parent stop", async () => {
+    const fixture = await createTempState();
+    let version = "1.0.0";
+    let pid = 1234;
+    let stops = 0;
+    let spawns = 0;
+    const result = await restartObserver(
+      { config: fixture.config, timeoutMs: 500 },
+      {
+        buildVersion: "2.0.0",
+        spawnObserver: async () => {
+          spawns += 1;
+          version = "2.0.0";
+          pid = 5678;
+          return { pid, unref: () => undefined };
+        },
+        clientFactory: () =>
+          ({
+            health: async () => ({
+              schemaVersion: "0.7.0",
+              status: "healthy",
+              pid,
+              startedAt: now,
+              version,
+              socketPath: fixture.socketPath,
+            }),
+            stop: async () => {
+              stops += 1;
+              return { schemaVersion: "0.7.0", stopped: true, at: now };
+            },
+          }) as never,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "running", health: { pid: 5678, version: "2.0.0" } });
+    expect(stops).toBe(0);
+    expect(spawns).toBe(1);
   });
 
   it("spawns a higher build and ignores the lower incumbent until its child is healthy", async () => {

--- a/apps/observer/src/hooks/providerHookIngress.ts
+++ b/apps/observer/src/hooks/providerHookIngress.ts
@@ -24,7 +24,7 @@ import {
   providerObservationRetentionDays,
 } from "../persistence/retention.js";
 import type { ProviderRegistry } from "../providers/registry.js";
-import { persistTurnReadinessFromHarnessObservation } from "./turnReadiness.js";
+import { sessionTurnReadinessMutationFromHarnessObservation } from "./turnReadiness.js";
 
 export type ProviderHookIngestResult = {
   observations: number;
@@ -89,8 +89,22 @@ export async function ingestProviderHookEvent(
     ...observation,
     expiresAt: providerObservationExpiresAt(observation.observedAt, retentionDays),
   }));
+  const updatedAt = toIsoTimestamp(clock.now());
+  const turnReadiness = observations.flatMap((observation) => {
+    const harnessEvent = harnessEventObservationFromRecord(observation);
+    if (harnessEvent === undefined) {
+      return [];
+    }
+    const mutation = sessionTurnReadinessMutationFromHarnessObservation({
+      observation: harnessEvent,
+      updatedAt,
+    });
+    return mutation === undefined ? [] : [mutation];
+  });
+  // Readiness shares the processing claim transaction so retries cannot apply a new correlation context.
   const processing = await options.persistence.recordProviderObservationsWithIngressDedupe({
     observations,
+    turnReadiness,
     dedupe: {
       kind: "hook_processing",
       id:
@@ -99,18 +113,6 @@ export async function ingestProviderHookEvent(
     },
     createdAt: options.event.receivedAt,
   });
-
-  // Completion dedupe never suppresses idempotent readiness repair after a partial prior attempt.
-  for (const observation of observations) {
-    const harnessEvent = harnessEventObservationFromRecord(observation);
-    if (harnessEvent !== undefined) {
-      await persistTurnReadinessFromHarnessObservation({
-        persistence: options.persistence,
-        observation: harnessEvent,
-        updatedAt: toIsoTimestamp(clock.now()),
-      });
-    }
-  }
 
   return {
     observations: observations.length,

--- a/apps/observer/src/hooks/spool.ts
+++ b/apps/observer/src/hooks/spool.ts
@@ -139,7 +139,8 @@ async function drainSpoolRecord(
       hookId: record.event.hookId ?? record.spoolId,
     });
     const receipt = await options.ingest(event);
-    return receipt.status === "ingested" && receipt.error === undefined
+    return (receipt.status === "ingested" || receipt.status === "ignored") &&
+      receipt.error === undefined
       ? { status: "drained" }
       : { status: "failed", error: receipt.error };
   }

--- a/apps/observer/src/hooks/turnReadiness.ts
+++ b/apps/observer/src/hooks/turnReadiness.ts
@@ -1,14 +1,18 @@
 import type { HarnessEventObservation } from "@station/contracts";
-import type { SessionStore } from "../persistence/index.js";
+import type { SessionStore, SessionTurnReadinessMutation } from "../persistence/index.js";
 
-export async function persistTurnReadinessFromHarnessObservation(input: {
-  persistence: SessionStore;
+/**
+ * POLICY
+ *
+ * Converts normalized harness status into the durable readiness mutation owned by ingress completion.
+ */
+export function sessionTurnReadinessMutationFromHarnessObservation(input: {
   observation: HarnessEventObservation;
   updatedAt: string;
-}): Promise<boolean> {
+}): SessionTurnReadinessMutation | undefined {
   const { observation } = input;
   if (observation.sessionId === undefined) {
-    return false;
+    return undefined;
   }
 
   if (observation.turn?.kind === "turn_completed" && observation.status?.value === "idle") {
@@ -17,16 +21,39 @@ export async function persistTurnReadinessFromHarnessObservation(input: {
       observation.projectId === undefined ||
       observation.worktreeId === undefined
     ) {
-      return false;
+      return undefined;
     }
-    await input.persistence.upsertSessionTurnReadiness({
-      sessionId: observation.sessionId,
-      projectId: observation.projectId,
-      worktreeId: observation.worktreeId,
-      token: observation.reportId,
-      completedAt: observation.status.updatedAt,
-      updatedAt: input.updatedAt,
-    });
+    return {
+      action: "upsert",
+      value: {
+        sessionId: observation.sessionId,
+        projectId: observation.projectId,
+        worktreeId: observation.worktreeId,
+        token: observation.reportId,
+        completedAt: observation.status.updatedAt,
+        updatedAt: input.updatedAt,
+      },
+    };
+  }
+
+  const status = observation.status?.value;
+  if (status === "working" || status === "starting" || status === "needs_attention") {
+    return { action: "delete", sessionId: observation.sessionId };
+  }
+  return undefined;
+}
+
+export async function persistTurnReadinessFromHarnessObservation(input: {
+  persistence: SessionStore;
+  observation: HarnessEventObservation;
+  updatedAt: string;
+}): Promise<boolean> {
+  const mutation = sessionTurnReadinessMutationFromHarnessObservation(input);
+  if (mutation === undefined) {
+    return false;
+  }
+  if (mutation.action === "upsert") {
+    await input.persistence.upsertSessionTurnReadiness(mutation.value);
     return true;
   }
 
@@ -34,9 +61,6 @@ export async function persistTurnReadinessFromHarnessObservation(input: {
   // request for the user mid-turn) makes ready_to_read stale. Without this
   // closing edge the badge survives on a working agent, and it cannot be
   // acknowledged because snapshots only expose readiness on idle agents.
-  const status = observation.status?.value;
-  if (status === "working" || status === "starting" || status === "needs_attention") {
-    await input.persistence.deleteSessionTurnReadiness({ sessionId: observation.sessionId });
-  }
+  await input.persistence.deleteSessionTurnReadiness({ sessionId: mutation.sessionId });
   return false;
 }

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -26,6 +26,7 @@ import type {
   ProviderObservationKind,
   ProviderObservationsIngressDedupeResult,
   RecordProviderObservationInput,
+  SessionTurnReadinessMutation,
   WorktreeMetadataCurrentKind,
   WorktreeMetadataCurrentPayloadByKind,
 } from "./types.js";
@@ -72,7 +73,7 @@ export interface EventJournal {
 /**
  * DRIVEN PORT
  *
- * Atomically records primary ingress acceptance and downstream observation completion under separate dedupe keys.
+ * Atomically records primary ingress acceptance and downstream observation and readiness completion under separate dedupe keys.
  */
 export interface IngressJournal {
   recordEventWithIngressDedupe(
@@ -89,6 +90,7 @@ export interface IngressJournal {
   }): Promise<EventAndObservationIngressDedupeResult>;
   recordProviderObservationsWithIngressDedupe(input: {
     observations: RecordProviderObservationInput[];
+    turnReadiness?: SessionTurnReadinessMutation[];
     dedupe: IngressDedupeKey;
     createdAt?: string;
   }): Promise<ProviderObservationsIngressDedupeResult>;

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -174,6 +174,18 @@ export function createSqliteObserverPersistence(
             observedAt: observation.observedAt ?? now(),
           }),
         );
+        for (const mutation of input.turnReadiness ?? []) {
+          if (mutation.action === "upsert") {
+            sessionTurnReadinessStore.upsertSessionTurnReadiness(database, {
+              ...mutation.value,
+              createdAt: now(),
+            });
+          } else {
+            sessionTurnReadinessStore.deleteSessionTurnReadiness(database, {
+              sessionId: mutation.sessionId,
+            });
+          }
+        }
         return { deduped: false, observations };
       }),
 

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -143,6 +143,23 @@ export type ProviderObservationsIngressDedupeResult = {
   observations?: PersistedProviderObservation[];
 };
 
+export type SessionTurnReadinessMutation =
+  | {
+      action: "upsert";
+      value: {
+        sessionId: string;
+        projectId: string;
+        worktreeId: string;
+        token: string;
+        completedAt: string;
+        updatedAt: string;
+      };
+    }
+  | {
+      action: "delete";
+      sessionId: string;
+    };
+
 export type PersistedWorktreeMetadataCurrent<
   TKind extends WorktreeMetadataCurrentKind = WorktreeMetadataCurrentKind,
 > = {

--- a/apps/observer/src/runtime/observerPidfile.ts
+++ b/apps/observer/src/runtime/observerPidfile.ts
@@ -14,6 +14,7 @@ function readOsStartTime(pid: number): string {
   const psPath = process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps";
   const osStartTime = execFileSync(psPath, ["-ww", "-p", String(pid), "-o", "lstart="], {
     encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
   }).trim();
   if (osStartTime.length === 0) {
     throw new Error(`Could not determine the OS start time for process ${pid}.`);

--- a/apps/observer/src/runtime/observerProcessEvidence.ts
+++ b/apps/observer/src/runtime/observerProcessEvidence.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { resolveObserverSocketForProcessArgs } from "@station/config";
 import { z } from "zod";
 import type {
@@ -54,7 +55,7 @@ export function parseObserverProcessList(output: string): ObserverProcessEntry[]
     const command = match[3];
     if (!pid.success || startToken === undefined || command === undefined) continue;
     const argv = command.split(/\s+/u).filter((token) => token.length > 0);
-    if (!isObserverArgv(argv)) continue;
+    if (!isObserverArgv(argv) && !isSpacedCompiledObserverCommand(command)) continue;
     // ps flattens argv boundaries, so recover an explicit socket from the raw
     // command before whitespace splitting can corrupt paths containing spaces.
     const explicitSocketPath = rawObserverFlagValue(command, "socket");
@@ -67,6 +68,26 @@ export function parseObserverProcessList(output: string): ObserverProcessEntry[]
     entries.push(entry);
   }
   return entries;
+}
+
+function isSpacedCompiledObserverCommand(command: string): boolean {
+  // The exact executable path check preserves shell-wrapper exclusion after ps flattens argv boundaries.
+  const marker = " __observer";
+  let markerIndex = command.indexOf(marker);
+  while (markerIndex !== -1) {
+    const tokenEnd = markerIndex + marker.length;
+    const executable = command.slice(0, markerIndex).trim();
+    if (
+      /\s/u.test(executable) &&
+      executable.endsWith("/stn") &&
+      (command[tokenEnd] === undefined || /\s/u.test(command[tokenEnd])) &&
+      existsSync(executable)
+    ) {
+      return true;
+    }
+    markerIndex = command.indexOf(marker, markerIndex + marker.length);
+  }
+  return false;
 }
 
 function processListArgs(): string[] {
@@ -143,6 +164,7 @@ function signalProcess(
 function defaultExecFile(file: string, args: readonly string[]): string {
   return execFileSync(file, [...args], {
     encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
     maxBuffer: processListingMaxBufferBytes,
   });
 }

--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -16,6 +16,7 @@ import {
   createObserverApi,
   createObserverCore,
   createObserverEventBus,
+  createProviderHookIngress,
   createSqliteObserverPersistence,
   openObserverSqlite,
   ProviderRegistry,
@@ -419,6 +420,53 @@ describe("observer provider hook ingress", () => {
     sqlite.close();
   });
 
+  it("keeps duplicate hook readiness aligned with the originally committed normalization", async () => {
+    const clock = { now: () => new Date(now) };
+    const harness = new ContextChangingReadinessHarnessProvider({ now });
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [harness],
+    });
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    const ingress = createProviderHookIngress({ persistence, providers, clock });
+    const event = {
+      schemaVersion: STATION_SCHEMA_VERSION,
+      hookId: "hook_context_retry",
+      provider: "fake-harness",
+      kind: "harness" as const,
+      event: "turn.completed",
+      receivedAt: now,
+    };
+
+    await expect(ingress.ingest(event, { triggerReconcile: false })).resolves.toMatchObject({
+      deduped: false,
+    });
+    harness.sessionId = "ses_fresh_context";
+    harness.worktreeId = "wt_fresh_context";
+    await expect(ingress.ingest(event, { triggerReconcile: false })).resolves.toMatchObject({
+      deduped: true,
+    });
+
+    await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: "ses_original",
+        worktreeId: "wt_original",
+        token: "hook_context_retry",
+      }),
+    ]);
+    await expect(persistence.listProviderObservations()).resolves.toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          sessionId: "ses_original",
+          worktreeId: "wt_original",
+        }),
+      }),
+    ]);
+    sqlite.close();
+  });
+
   it("repairs recovery and readiness after primary harness report persistence was already committed", async () => {
     const clock = { now: () => new Date(now) };
     const sqlite = openObserverSqlite({ clock });
@@ -759,5 +807,30 @@ class ContextRecordingHarnessProvider extends FakeHarnessProvider {
   ) {
     this.lastContext = context;
     return super.ingestEvent(event, context);
+  }
+}
+
+class ContextChangingReadinessHarnessProvider extends FakeHarnessProvider {
+  sessionId = "ses_original";
+  worktreeId = "wt_original";
+
+  override async ingestEvent() {
+    return [
+      {
+        provider: this.id,
+        projectId: "web",
+        worktreeId: this.worktreeId,
+        sessionId: this.sessionId,
+        turn: { kind: "turn_completed" as const },
+        status: {
+          value: "idle" as const,
+          confidence: "high" as const,
+          reason: "Fake harness hook completed its turn.",
+          source: "harness_event" as const,
+          updatedAt: now,
+        },
+        observedAt: now,
+      },
+    ];
   }
 }

--- a/apps/observer/test/integration/hook-spool-drain.test.ts
+++ b/apps/observer/test/integration/hook-spool-drain.test.ts
@@ -144,6 +144,32 @@ describe("observer hook spool drain", () => {
     fixture.sqlite.close();
   });
 
+  it("removes spool records that are terminally ignored", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-state-"));
+    const spoolDir = providerIngressSpoolDir(stateDir);
+    const spoolPath = await writeHookSpoolRecordFixture({
+      spoolDir,
+      spoolId: "spool_ignored",
+    });
+
+    await expect(
+      drainProviderIngressSpool({
+        store: createFilesystemProviderIngressSpoolStore(spoolDir),
+        clock: { now: () => new Date(now) },
+        ingest: async (event) => ({
+          schemaVersion: STATION_SCHEMA_VERSION,
+          hookId: event.hookId ?? "spool_ignored",
+          provider: event.provider,
+          event: event.event,
+          accepted: false,
+          status: "ignored",
+          receivedAt: event.receivedAt,
+        }),
+      }),
+    ).resolves.toEqual({ scanned: 1, drained: 1, failed: 0 });
+    await expect(fileExists(spoolPath)).resolves.toBe(false);
+  });
+
   it("retries downstream processing after primary hook dedupe and unlinks only after completion", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-observer-state-"));
     const spoolDir = providerIngressSpoolDir(stateDir);

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -61,6 +61,7 @@ import type {
   ProviderObservationKind,
   ProviderObservationType,
   RecordProviderObservationInput,
+  SessionTurnReadinessMutation,
   WorktreeMetadataCurrentKind,
   WorktreeMetadataCurrentPayloadByKind,
 } from "../../src/persistence/types.js";
@@ -261,6 +262,9 @@ export function createInMemoryObserverPersistence(
             observedAt: observation.observedAt ?? now(),
           }),
         );
+        for (const mutation of input.turnReadiness ?? []) {
+          applySessionTurnReadinessMutation(draft, mutation, now());
+        }
         return { deduped: false, observations };
       }),
 
@@ -386,31 +390,12 @@ export function createInMemoryObserverPersistence(
       ),
 
     upsertSessionTurnReadiness: (input) =>
-      transaction((draft) => {
-        const createdAt = input.createdAt ?? now();
-        const readiness: PersistedSessionTurnReadiness = {
-          sessionId: input.sessionId,
-          projectId: input.projectId,
-          worktreeId: input.worktreeId,
-          token: input.token,
-          completedAt: input.completedAt,
-          createdAt,
-          updatedAt: input.updatedAt ?? createdAt,
-        };
-        const existing = draft.turnReadiness.get(input.sessionId);
-        if (existing === undefined) {
-          draft.turnReadiness.set(input.sessionId, readiness);
-          return readiness;
-        }
-        if (existing.completedAt < readiness.completedAt) {
-          existing.projectId = readiness.projectId;
-          existing.worktreeId = readiness.worktreeId;
-          existing.token = readiness.token;
-          existing.completedAt = readiness.completedAt;
-          existing.updatedAt = readiness.updatedAt;
-        }
-        return existing;
-      }),
+      transaction((draft) =>
+        upsertSessionTurnReadiness(draft, {
+          ...input,
+          createdAt: input.createdAt ?? now(),
+        }),
+      ),
 
     listSessionTurnReadiness: () =>
       transaction((draft) =>
@@ -422,14 +407,7 @@ export function createInMemoryObserverPersistence(
       ),
 
     deleteSessionTurnReadiness: (input) =>
-      transaction((draft) => {
-        const current = draft.turnReadiness.get(input.sessionId);
-        if (current === undefined || (input.token !== undefined && input.token !== current.token)) {
-          return 0;
-        }
-        draft.turnReadiness.delete(input.sessionId);
-        return 1;
-      }),
+      transaction((draft) => deleteSessionTurnReadiness(draft, input)),
 
     upsertWorktreeMetadataCurrent: (input) =>
       transaction((draft) => {
@@ -1024,6 +1002,66 @@ function matchesRecoveryHandleOptions(
     (options.worktreeId !== undefined && handle.worktreeId !== options.worktreeId) ||
     (options.provider !== undefined && handle.provider !== options.provider)
   );
+}
+
+function applySessionTurnReadinessMutation(
+  state: InMemoryObserverPersistenceState,
+  mutation: SessionTurnReadinessMutation,
+  createdAt: string,
+): void {
+  if (mutation.action === "upsert") {
+    upsertSessionTurnReadiness(state, { ...mutation.value, createdAt });
+    return;
+  }
+  deleteSessionTurnReadiness(state, { sessionId: mutation.sessionId });
+}
+
+function upsertSessionTurnReadiness(
+  state: InMemoryObserverPersistenceState,
+  input: {
+    sessionId: string;
+    projectId: string;
+    worktreeId: string;
+    token: string;
+    completedAt: string;
+    createdAt: string;
+    updatedAt?: string;
+  },
+): PersistedSessionTurnReadiness {
+  const readiness: PersistedSessionTurnReadiness = {
+    sessionId: input.sessionId,
+    projectId: input.projectId,
+    worktreeId: input.worktreeId,
+    token: input.token,
+    completedAt: input.completedAt,
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt ?? input.createdAt,
+  };
+  const existing = state.turnReadiness.get(input.sessionId);
+  if (existing === undefined) {
+    state.turnReadiness.set(input.sessionId, readiness);
+    return readiness;
+  }
+  if (existing.completedAt < readiness.completedAt) {
+    existing.projectId = readiness.projectId;
+    existing.worktreeId = readiness.worktreeId;
+    existing.token = readiness.token;
+    existing.completedAt = readiness.completedAt;
+    existing.updatedAt = readiness.updatedAt;
+  }
+  return existing;
+}
+
+function deleteSessionTurnReadiness(
+  state: InMemoryObserverPersistenceState,
+  input: { sessionId: string; token?: string },
+): number {
+  const current = state.turnReadiness.get(input.sessionId);
+  if (current === undefined || (input.token !== undefined && input.token !== current.token)) {
+    return 0;
+  }
+  state.turnReadiness.delete(input.sessionId);
+  return 1;
 }
 
 function recoveryHandleId(handle: SessionRecoveryHandle): string {

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -536,6 +536,63 @@ export function observerPersistenceContract(
         });
       });
 
+      it("does not apply readiness derived from a duplicate hook normalization", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          const dedupe = { kind: "hook_processing" as const, id: "hook_context_retry" };
+          const first = await persistence.recordProviderObservationsWithIngressDedupe({
+            observations: [healthObservation("healthy")],
+            turnReadiness: [
+              {
+                action: "upsert",
+                value: {
+                  sessionId: "ses_original",
+                  projectId: "web",
+                  worktreeId: "wt_original",
+                  token: "hook_context_retry",
+                  completedAt: earlier,
+                  updatedAt: now,
+                },
+              },
+            ],
+            dedupe,
+            createdAt: now,
+          });
+          const duplicate = await persistence.recordProviderObservationsWithIngressDedupe({
+            observations: [
+              { ...healthObservation("degraded"), entityKey: "fresh-context-observation" },
+            ],
+            turnReadiness: [
+              {
+                action: "upsert",
+                value: {
+                  sessionId: "ses_fresh_context",
+                  projectId: "web",
+                  worktreeId: "wt_fresh_context",
+                  token: "hook_context_retry",
+                  completedAt: later,
+                  updatedAt: latest,
+                },
+              },
+            ],
+            dedupe,
+            createdAt: later,
+          });
+
+          expect(first).toMatchObject({ deduped: false });
+          expect(duplicate).toEqual({ deduped: true });
+          await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+            expect.objectContaining({
+              sessionId: "ses_original",
+              worktreeId: "wt_original",
+              token: "hook_context_retry",
+            }),
+          ]);
+          await expect(
+            persistence.listProviderObservations({ includeExpired: true, now: latest }),
+          ).resolves.toEqual([expect.objectContaining({ entityKey: "fake-harness" })]);
+        });
+      });
+
       it("rolls back a downstream processing claim when any observation is invalid", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           const invalid = {

--- a/apps/observer/test/unit/observerPidfile.test.ts
+++ b/apps/observer/test/unit/observerPidfile.test.ts
@@ -34,9 +34,9 @@ describe("observer pidfile", () => {
   it("builds identity with the trimmed OS start-time token", () => {
     const socketPath = "/tmp/station/observer.sock";
     const expectedStartTime = execFileSync(
-      "ps",
+      process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps",
       ["-ww", "-p", String(process.pid), "-o", "lstart="],
-      { encoding: "utf8" },
+      { encoding: "utf8", env: { ...process.env, LC_ALL: "C" } },
     ).trim();
 
     expect(

--- a/apps/observer/test/unit/observerProcessEvidence.test.ts
+++ b/apps/observer/test/unit/observerProcessEvidence.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   createLocalObserverProcessEvidence,
@@ -22,6 +25,28 @@ describe("local Observer process evidence", () => {
         socketPath: "/tmp/socket with spaces/observer.sock",
       }),
     ]);
+  });
+
+  it("recognizes a compiled Observer executable path containing spaces", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "stn-process-evidence-"));
+    const executable = join(dir, "Station App", "stn");
+    await mkdir(dirname(executable), { recursive: true });
+    await writeFile(executable, "");
+    try {
+      const output = [
+        ` 4006 Sat Jul  4 17:45:37 2026 ${executable} __observer --socket /tmp/observer.sock`,
+        ` 4007 Sat Jul  4 17:45:38 2026 /bin/sh -c ${executable} __observer --socket /tmp/observer.sock`,
+      ].join("\n");
+
+      expect(parseObserverProcessList(output)).toEqual([
+        expect.objectContaining({
+          pid: 4006,
+          socketPath: "/tmp/observer.sock",
+        }),
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("normalizes lsof, start-token, absence, and refusal results", () => {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -491,8 +491,9 @@ when it changes several tables:
 - `CommandJournal` owns command acceptance, transitions, lookup, history, and
   command errors.
 - `EventJournal` owns ordinary event recording and queries.
-- `IngressJournal` owns atomic dedupe plus event, and atomic dedupe plus event
-  plus observation.
+- `IngressJournal` owns atomic dedupe plus event, atomic dedupe plus event plus
+  observation, and atomic hook-processing completion across observations and
+  turn readiness.
 - `ObservationStore` owns typed provider observations, current-observation
   queries, and expiry.
 - `ReconcileStore` owns the complete atomic `persistReconcileResult` operation.

--- a/docs/observer-singleton.md
+++ b/docs/observer-singleton.md
@@ -87,12 +87,12 @@ corroborating identity without changing current attach-or-spawn or
 duplicate-reaping behavior. Phase 3d-a now serializes stale-socket reclamation
 before either the socket path or pidfile can be mutated.
 
-### 3d-a boot contract
+### 3d-a/3d-b boot contract
 
 Spike result: **NO-GO for both stale-path deletion designs (directory rename and
 AF_UNIX unlink/rebind); GO for a dedicated SQLite transaction claim backed by a
 permanent cross-runtime adversarial test.** #135 shipped that narrow result;
-version-aware replacement remains separate below.
+#137 extends its claimed listening-socket branch with version-aware replacement.
 
 Startup ownership mutation lives in observer boot (`main.ts`) under the
 OS-lock-backed claim database
@@ -111,10 +111,13 @@ Boot sequence while holding `C`:
    means another boot is in progress, so do not enter. Process death releases
    the OS transaction lock; the database file persists and needs no stale-owner
    deletion. Do not revive either rejected stale-path deletion scheme.
-2. **Probe** the resolved socket as `absent`, `stale`, or `listening`. A
-   listening socket means release `C` and exit 0; the parent's existing health
-   loop attaches or reports incompatibility. 3d-a never compares versions or
-   evicts an incumbent.
+2. **Probe and negotiate** the resolved socket as `absent`, `stale`, or
+   `listening`. For a listening socket, compare strict SemVer health while still
+   holding `C`: exact or higher incumbents attach and the child exits 0; a
+   winning higher candidate replaces a lower incumbent only through verified
+   graceful handoff; incomplete, conflicting, or wedged evidence refuses. The
+   original 3d-a contract stopped at attach, while 3d-b extends this branch
+   without adding client-side ownership mutation.
 3. For `absent` or `stale`, **bind or reclaim** through the existing claimed
    bind path, capture socket identity, publish and fsync the socket-specific
    pidfile, arm the seeded ownership watcher, and commit readiness.

--- a/tests/support/observerMain.js
+++ b/tests/support/observerMain.js
@@ -98,5 +98,6 @@ function readOsStartTime(pid) {
   const psPath = process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps";
   return execFileSync(psPath, ["-ww", "-p", String(pid), "-o", "lstart="], {
     encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
   }).trim();
 }


### PR DESCRIPTION
## Summary

- commit provider-hook observations and turn readiness atomically, and terminally drain ignored records
- make Observer process evidence locale-stable and recognize compiled binaries in paths containing spaces
- enforce version ordering for restart, route upgrades through verified child handoff, and share one provider-hook startup deadline
- use parsed observer actions for exit codes and align the canonical singleton documents with shipped 3d-b behavior

## Root cause

Follow-up review of #141 and #142 found completion replay could apply newly normalized topology after dedupe, lifecycle callers could bypass version ordering, and process attribution depended on locale and flattened executable paths.

## UX

Readiness cannot move between sessions during replay, ignored spool records clear, localized and spaced-path upgrades work, older setup commands cannot replace newer Observers, and hook fallback respects its advertised startup budget.

## Validation

- `HOME=$(mktemp -d) pnpm test:pre-push`
- `LC_ALL=fr_FR.UTF-8 pnpm test:e2e:observer` (15/15)
- focused regression suites (125/125)
- `git diff --check origin/main...HEAD`