### PR TITLE
refactor(metadata): isolate local Git and ref invalidation adapters

### DIFF
--- a/apps/observer/src/internal.ts
+++ b/apps/observer/src/internal.ts
@@ -17,6 +17,7 @@ export * from "./hooks/providerHookIngress.js";
 export * from "./hooks/spool.js";
 export * from "./metadata/gitRefInvalidation.js";
 export * from "./metadata/localGitChangeSummary.js";
+export * from "./metadata/ports.js";
 export * from "./metadata/refresh.js";
 export * from "./metadata/repositoryGit.js";
 export * from "./migrations/index.js";

--- a/apps/observer/src/metadata/gitRefInvalidation.ts
+++ b/apps/observer/src/metadata/gitRefInvalidation.ts
@@ -1,16 +1,11 @@
 import { existsSync, type FSWatcher, lstatSync, readFileSync, watch } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
-import type { StationSnapshot, WorktreeRow } from "@station/contracts";
 import type { StationLogger } from "../stationLogger.js";
+import type { WorktreeMetadataInvalidationSource } from "./ports.js";
 
 // A Git ref move invalidates all metadata keyed to HEAD: local diff, PR identity, and checks.
 // This trigger only requests reconcile; observer runtime remains the only UI event publisher.
-export type WorktreeGitRefInvalidationService = {
-  update(snapshot: StationSnapshot): void;
-  shutdown(): void;
-};
-
-export type CreateWorktreeGitRefInvalidationServiceOptions = {
+export type CreateLocalGitWorktreeMetadataInvalidationSourceOptions = {
   requestReconcile(reason: string): void;
   debounceMs?: number;
   logger?: StationLogger;
@@ -32,28 +27,32 @@ type WatchDirectory = (
 
 const defaultDebounceMs = 100;
 
-export function createWorktreeGitRefInvalidationService(
-  options: CreateWorktreeGitRefInvalidationServiceOptions,
-): WorktreeGitRefInvalidationService {
+/**
+ * ADAPTER
+ *
+ * Watches local Git refs and requests metadata reconciliation while owning watcher replacement and shutdown.
+ */
+export function createLocalGitWorktreeMetadataInvalidationSource(
+  options: CreateLocalGitWorktreeMetadataInvalidationSourceOptions,
+): WorktreeMetadataInvalidationSource {
   const debounceMs = options.debounceMs ?? defaultDebounceMs;
   const watchers = new Map<string, DirectoryWatcher>();
   const timers = new Map<string, ReturnType<typeof setTimeout>>();
   const watchDirectory = options.watchDirectory ?? defaultWatchDirectory;
+  let stopped = false;
 
   return {
-    update: (snapshot) => {
+    replaceWatchedWorktrees: (targets) => {
+      if (stopped) return;
       const nextKeys = new Set<string>();
-      for (const row of snapshot.rows) {
-        if (row.worktree.state !== "exists") {
-          continue;
-        }
-        for (const target of gitRefInvalidationTargetsForRow(row)) {
-          const key = watcherKey(row.id, target.path);
+      for (const target of targets) {
+        for (const targetPath of gitRefInvalidationTargetsForWorktree(target.path, target.branch)) {
+          const key = watcherKey(target.worktreeId, targetPath.path);
           nextKeys.add(key);
           if (watchers.has(key)) {
             continue;
           }
-          const watcher = watchTarget(row.id, target);
+          const watcher = watchTarget(target.worktreeId, targetPath);
           if (watcher !== undefined) {
             watchers.set(key, watcher);
           }
@@ -69,6 +68,8 @@ export function createWorktreeGitRefInvalidationService(
       }
     },
     shutdown: () => {
+      if (stopped) return;
+      stopped = true;
       for (const timer of timers.values()) {
         clearTimeout(timer);
       }
@@ -116,6 +117,7 @@ export function createWorktreeGitRefInvalidationService(
   }
 
   function scheduleReconcile(worktreeId: string): void {
+    if (stopped) return;
     const existing = timers.get(worktreeId);
     if (existing !== undefined) {
       clearTimeout(existing);
@@ -123,14 +125,11 @@ export function createWorktreeGitRefInvalidationService(
 
     const timer = setTimeout(() => {
       timers.delete(worktreeId);
+      if (stopped) return;
       options.requestReconcile(`metadata:git-ref:${worktreeId}`);
     }, debounceMs);
     timers.set(worktreeId, timer);
   }
-}
-
-export function gitRefInvalidationTargetsForRow(row: WorktreeRow): GitRefInvalidationTarget[] {
-  return gitRefInvalidationTargetsForWorktree(row.path, row.branch);
 }
 
 export function gitRefInvalidationTargetsForWorktree(

--- a/apps/observer/src/metadata/localGitChangeSummary.ts
+++ b/apps/observer/src/metadata/localGitChangeSummary.ts
@@ -13,29 +13,22 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { type GitCommandContext, runGitCommand, runOptionalGitCommand } from "./gitCommand.js";
+import type {
+  WorktreeChangeEvidence,
+  WorktreeChangeReadInput,
+  WorktreeChangeSource,
+} from "./ports.js";
 
-export type LocalGitWorktree = {
-  id: string;
-  projectId: string;
-  path: string;
-  branch: string;
-  state?: string;
-  pr?: WorktreePullRequest;
-};
-
-export type LocalGitChangeSummaryInput = {
-  project: ProviderProjectConfig;
-  worktree: LocalGitWorktree;
-  cachedPullRequest?: WorktreePullRequest;
+type LocalGitChangeSummaryInput = WorktreeChangeReadInput & {
   timeoutMs?: number;
   clock?: RuntimeClock;
   runner?: ExternalCommandRunner;
-  signal?: AbortSignal;
 };
 
-export type LocalGitChangeSummaryResult = {
-  summary: WorktreeChangeSummary;
-  cacheKey: string;
+export type CreateLocalGitWorktreeChangeSourceOptions = {
+  clock?: RuntimeClock;
+  runner?: ExternalCommandRunner;
+  timeoutMs?: number;
 };
 
 export type ParsedGitNumstat = {
@@ -52,13 +45,28 @@ type ResolvedBase = {
 
 const defaultGitTimeoutMs = 200;
 
-export async function readLocalGitChangeSummary(
-  input: LocalGitChangeSummaryInput,
-): Promise<LocalGitChangeSummaryResult | undefined> {
-  if (input.worktree.state !== undefined && input.worktree.state !== "exists") {
-    return undefined;
-  }
+/**
+ * ADAPTER
+ *
+ * Reads worktree change evidence through local Git while retaining command, timeout, and parsing mechanics.
+ */
+export function createLocalGitWorktreeChangeSource(
+  options: CreateLocalGitWorktreeChangeSourceOptions = {},
+): WorktreeChangeSource {
+  return {
+    read: (input) =>
+      readLocalGitChangeSummary({
+        ...input,
+        ...(options.clock === undefined ? {} : { clock: options.clock }),
+        ...(options.runner === undefined ? {} : { runner: options.runner }),
+        ...(options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs }),
+      }),
+  };
+}
 
+async function readLocalGitChangeSummary(
+  input: LocalGitChangeSummaryInput,
+): Promise<WorktreeChangeEvidence | undefined> {
   const clock = input.clock ?? systemClock;
   const checkedAt = toIsoTimestamp(clock.now());
   const command: GitCommandContext = {
@@ -66,14 +74,14 @@ export async function readLocalGitChangeSummary(
     timeoutMs: input.timeoutMs ?? defaultGitTimeoutMs,
   };
   if (input.runner !== undefined) command.runner = input.runner;
-  if (input.signal !== undefined) command.signal = input.signal;
+  command.signal = input.signal;
 
   const headSha = await resolveRequiredRef(command, "HEAD", "HEAD");
   const remotes = await listRemotes(command);
   const baseInput: {
     command: GitCommandContext;
     project: ProviderProjectConfig;
-    worktree: LocalGitWorktree;
+    worktree: WorktreeChangeReadInput["worktree"];
     cachedPullRequest?: WorktreePullRequest;
     remotes: string[];
   } = {
@@ -204,12 +212,12 @@ export function changeSummaryCacheKey(input: {
 async function resolveBase(input: {
   command: GitCommandContext;
   project: ProviderProjectConfig;
-  worktree: LocalGitWorktree;
+  worktree: WorktreeChangeReadInput["worktree"];
   cachedPullRequest?: WorktreePullRequest;
   remotes: string[];
 }): Promise<ResolvedBase | undefined> {
   const configuredBases = [
-    input.cachedPullRequest?.baseRef ?? input.worktree.pr?.baseRef,
+    input.cachedPullRequest?.baseRef ?? input.worktree.pullRequest?.baseRef,
     input.project.defaultBranch,
     input.project.worktrunk.base,
   ];

--- a/apps/observer/src/metadata/ports.ts
+++ b/apps/observer/src/metadata/ports.ts
@@ -1,0 +1,48 @@
+import type {
+  ProviderProjectConfig,
+  WorktreeChangeSummary,
+  WorktreePullRequest,
+} from "@station/contracts";
+
+export type WorktreeChangeReadInput = {
+  project: ProviderProjectConfig;
+  worktree: {
+    id: string;
+    projectId: string;
+    path: string;
+    branch: string;
+    pullRequest?: WorktreePullRequest;
+  };
+  cachedPullRequest?: WorktreePullRequest;
+  signal: AbortSignal;
+};
+
+export type WorktreeChangeEvidence = {
+  summary: WorktreeChangeSummary;
+  cacheKey: string;
+};
+
+/**
+ * DRIVEN PORT
+ *
+ * Reads typed branch-diff evidence for a worktree without exposing Git command execution.
+ */
+export interface WorktreeChangeSource {
+  read(input: WorktreeChangeReadInput): Promise<WorktreeChangeEvidence | undefined>;
+}
+
+export type WorktreeMetadataWatchTarget = {
+  worktreeId: string;
+  path: string;
+  branch: string;
+};
+
+/**
+ * DRIVEN PORT
+ *
+ * Tracks worktrees whose local metadata must be invalidated without exposing filesystem watcher mechanics.
+ */
+export interface WorktreeMetadataInvalidationSource {
+  replaceWatchedWorktrees(targets: readonly WorktreeMetadataWatchTarget[]): void;
+  shutdown(): void;
+}

--- a/apps/observer/src/metadata/refresh.ts
+++ b/apps/observer/src/metadata/refresh.ts
@@ -6,7 +6,6 @@ import type {
   WorktreePullRequest,
 } from "@station/contracts";
 import {
-  type ExternalCommandRunner,
   forEachConcurrent,
   type RuntimeClock,
   systemClock,
@@ -19,20 +18,25 @@ import type {
 } from "../persistence/index.js";
 import type { StationLogger } from "../stationLogger.js";
 import { addMs } from "../utils/time.js";
-import {
-  type CreateWorktreeGitRefInvalidationServiceOptions,
-  createWorktreeGitRefInvalidationService,
-} from "./gitRefInvalidation.js";
-import { type LocalGitWorktree, readLocalGitChangeSummary } from "./localGitChangeSummary.js";
+import type {
+  WorktreeChangeReadInput,
+  WorktreeChangeSource,
+  WorktreeMetadataInvalidationSource,
+} from "./ports.js";
 import {
   type CreateRepositoryMetadataRefresherOptions,
   createRepositoryMetadataRefresher,
 } from "./repositoryRefresh.js";
 import { staleChangeSummary } from "./stalePayloads.js";
 
+/**
+ * USE CASE
+ *
+ * Refreshes and persists local-change and code-host metadata for snapshot worktrees through application-owned sources.
+ */
 export type WorktreeMetadataRefreshService = {
   refresh(snapshot: StationSnapshot): Promise<void>;
-  shutdown?(): Promise<void>;
+  shutdown(): Promise<void>;
 };
 
 export type CreateWorktreeMetadataRefreshServiceOptions = {
@@ -41,17 +45,15 @@ export type CreateWorktreeMetadataRefreshServiceOptions = {
   requestReconcile(reason: string): void;
   clock?: RuntimeClock;
   logger?: StationLogger;
-  runner?: ExternalCommandRunner;
+  worktreeChangeSource: WorktreeChangeSource;
+  worktreeMetadataInvalidationSource: WorktreeMetadataInvalidationSource;
   repositoryProviders?: Iterable<RepositoryProvider> | Map<string, RepositoryProvider>;
-  gitTimeoutMs?: number;
   ttlMs?: number;
   concurrency?: number;
   repositoryConcurrency?: number;
   repositoryNegativeBackoffMs?: number;
-  watchGitRefs?: boolean;
 };
 
-const defaultGitTimeoutMs = 200;
 const defaultTtlMs = 5 * 60 * 1000;
 const defaultConcurrency = 2;
 
@@ -78,14 +80,6 @@ export function createWorktreeMetadataRefreshService(
     repositoryOptions.negativeBackoffMs = options.repositoryNegativeBackoffMs;
   }
   const repositoryRefresher = createRepositoryMetadataRefresher(repositoryOptions);
-  const gitRefInvalidationOptions: CreateWorktreeGitRefInvalidationServiceOptions = {
-    requestReconcile: options.requestReconcile,
-  };
-  if (options.logger !== undefined) gitRefInvalidationOptions.logger = options.logger;
-  const gitRefInvalidation =
-    options.watchGitRefs === true
-      ? createWorktreeGitRefInvalidationService(gitRefInvalidationOptions)
-      : undefined;
   let pendingSnapshot: StationSnapshot | undefined;
   let running: Promise<void> | undefined;
   let shutdownRequested = false;
@@ -111,10 +105,11 @@ export function createWorktreeMetadataRefreshService(
       await running;
     },
     shutdown: async () => {
+      if (shutdownRequested) return;
       shutdownRequested = true;
       pendingSnapshot = undefined;
       controller?.abort();
-      gitRefInvalidation?.shutdown();
+      options.worktreeMetadataInvalidationSource.shutdown();
       await running?.catch(() => undefined);
     },
   };
@@ -128,7 +123,11 @@ export function createWorktreeMetadataRefreshService(
   }
 
   async function refreshSnapshot(snapshot: StationSnapshot, signal: AbortSignal): Promise<void> {
-    gitRefInvalidation?.update(snapshot);
+    options.worktreeMetadataInvalidationSource.replaceWatchedWorktrees(
+      snapshot.rows
+        .filter((row) => row.worktree.state === "exists")
+        .map((row) => ({ worktreeId: row.id, path: row.path, branch: row.branch })),
+    );
 
     const referenceTime = toIsoTimestamp(clock.now());
     const [changeRows, pullRequestRows, checksRows] = await Promise.all([
@@ -197,33 +196,32 @@ export function createWorktreeMetadataRefreshService(
     if (shouldBackOffFailedRefresh(input.existing)) {
       return;
     }
+    if (input.row.worktree.state !== "exists") {
+      await deleteExistingChangeSummary(input.row.id, input.existing);
+      return;
+    }
 
     try {
-      const worktree: LocalGitWorktree = {
+      const worktree: WorktreeChangeReadInput["worktree"] = {
         id: input.row.id,
         projectId: input.row.projectId,
         path: input.row.path,
         branch: input.row.branch,
-        state: input.row.worktree.state,
       };
       if (input.row.worktree.pr !== undefined) {
-        worktree.pr = input.row.worktree.pr;
+        worktree.pullRequest = input.row.worktree.pr;
       }
 
-      const summaryInput: Parameters<typeof readLocalGitChangeSummary>[0] = {
+      const summaryInput: WorktreeChangeReadInput = {
         project: input.project,
         worktree,
-        timeoutMs: options.gitTimeoutMs ?? defaultGitTimeoutMs,
-        clock,
         signal: input.signal,
       };
       if (input.cachedPullRequest !== undefined) {
         summaryInput.cachedPullRequest = input.cachedPullRequest;
       }
-      if (options.runner !== undefined) {
-        summaryInput.runner = options.runner;
-      }
-      const result = await readLocalGitChangeSummary(summaryInput);
+      const result = await options.worktreeChangeSource.read(summaryInput);
+      if (input.signal.aborted) return;
 
       if (result === undefined) {
         await deleteExistingChangeSummary(input.row.id, input.existing);

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -42,6 +42,8 @@ import {
   createFilesystemProviderIngressSpoolStore,
   providerIngressSpoolDepth,
 } from "../hooks/spool.js";
+import { createLocalGitWorktreeMetadataInvalidationSource } from "../metadata/gitRefInvalidation.js";
+import { createLocalGitWorktreeChangeSource } from "../metadata/localGitChangeSummary.js";
 import {
   createWorktreeMetadataRefreshService,
   type WorktreeMetadataRefreshService,
@@ -311,7 +313,11 @@ function buildMetadataRefresh(
     persistence: options.persistence,
     requestReconcile: scheduler.request,
     clock,
-    watchGitRefs: true,
+    worktreeChangeSource: createLocalGitWorktreeChangeSource({ clock }),
+    worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+      requestReconcile: scheduler.request,
+      ...(options.logger === undefined ? {} : { logger: options.logger }),
+    }),
   };
   if (options.logger !== undefined) {
     metadataRefreshOptions.logger = options.logger;
@@ -415,7 +421,7 @@ async function buildStop(
   clock: RuntimeClock,
 ): Promise<ObserverStopReceipt> {
   await harnessIngressQueue.shutdown();
-  await metadataRefresh?.shutdown?.();
+  await metadataRefresh?.shutdown();
   await options.onStop?.();
   return {
     schemaVersion: STATION_SCHEMA_VERSION,

--- a/apps/observer/test/integration/metadata-refresh.test.ts
+++ b/apps/observer/test/integration/metadata-refresh.test.ts
@@ -20,6 +20,8 @@ import {
 import { describe, expect, it } from "vitest";
 import {
   createCommandQueue,
+  createLocalGitWorktreeChangeSource,
+  createLocalGitWorktreeMetadataInvalidationSource,
   createObserverApi,
   createObserverEventBus,
   createWorktreeMetadataRefreshService,
@@ -119,7 +121,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: (reason) => reasons.push(reason),
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
     });
 
     const snapshot = await fixture.core.reconcile("metadata-refresh-before");
@@ -169,7 +174,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: (reason) => reasons.push(reason),
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
     });
 
     const snapshotBefore = await fixture.core.reconcile("metadata-default-branch-before");
@@ -236,7 +244,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: (reason) => reasons.push(reason),
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
     });
 
     const snapshot = await fixture.core.reconcile("metadata-refresh-failure-before");
@@ -291,7 +302,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: (reason) => reasons.push(reason),
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
     });
 
     const snapshot = await fixture.core.reconcile("metadata-refresh-failure-loop-before");
@@ -390,7 +404,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: (reason) => reasons.push(reason),
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
       repositoryProviders: [repository],
     });
 
@@ -457,7 +474,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: () => undefined,
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
       repositoryProviders: [repository],
     });
 
@@ -512,7 +532,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: () => undefined,
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
       repositoryProviders: providers,
     });
 
@@ -562,7 +585,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: () => undefined,
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
       repositoryProviders: [repository],
     });
 
@@ -616,7 +642,10 @@ describe("observer worktree metadata refresh", () => {
       persistence: fixture.persistence,
       requestReconcile: () => undefined,
       clock: fixture.clock,
-      runner,
+      worktreeChangeSource: createLocalGitWorktreeChangeSource({ runner }),
+      worktreeMetadataInvalidationSource: createLocalGitWorktreeMetadataInvalidationSource({
+        requestReconcile: (reason) => reasons.push(reason),
+      }),
       repositoryProviders: [repository],
     });
 

--- a/apps/observer/test/unit/git-ref-invalidation.test.ts
+++ b/apps/observer/test/unit/git-ref-invalidation.test.ts
@@ -1,10 +1,9 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationSnapshot } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import {
-  createWorktreeGitRefInvalidationService,
+  createLocalGitWorktreeMetadataInvalidationSource,
   gitRefInvalidationTargetsForWorktree,
 } from "../../src/metadata/gitRefInvalidation.js";
 
@@ -41,7 +40,7 @@ describe("worktree git ref invalidation", () => {
       directory: string;
       listener: (changedFile: string | undefined) => void;
     }> = [];
-    const watcher = createWorktreeGitRefInvalidationService({
+    const watcher = createLocalGitWorktreeMetadataInvalidationSource({
       debounceMs: 10,
       requestReconcile: (reason) => {
         reasons.push(reason);
@@ -59,16 +58,7 @@ describe("worktree git ref invalidation", () => {
       await writeFile(join(worktree, ".git", "HEAD"), "ref: refs/heads/main\n");
       await writeFile(join(refDir, "main"), "one\n");
 
-      watcher.update({
-        rows: [
-          {
-            id: "wt_1",
-            path: worktree,
-            branch: "main",
-            worktree: { state: "exists" },
-          },
-        ],
-      } as StationSnapshot);
+      watcher.replaceWatchedWorktrees([{ worktreeId: "wt_1", path: worktree, branch: "main" }]);
 
       const refWatch = directoryWatches.find((entry) => entry.directory === refDir);
       expect(refWatch).toBeDefined();
@@ -76,6 +66,43 @@ describe("worktree git ref invalidation", () => {
       await waitFor(() => reasons.includes("metadata:git-ref:wt_1"));
     } finally {
       watcher.shutdown();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("closes replaced watchers and ignores pending or late events after shutdown", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "station-git-ref-invalidation-"));
+    const reasons: string[] = [];
+    const listeners: Array<(changedFile: string | undefined) => void> = [];
+    let closed = 0;
+    const source = createLocalGitWorktreeMetadataInvalidationSource({
+      debounceMs: 10,
+      requestReconcile: (reason) => reasons.push(reason),
+      watchDirectory: (_directory, listener) => {
+        listeners.push(listener);
+        return { close: () => (closed += 1) };
+      },
+    });
+
+    try {
+      const worktree = join(tempDir, "worktree");
+      const refDir = join(worktree, ".git", "refs", "heads");
+      await mkdir(refDir, { recursive: true });
+      await writeFile(join(worktree, ".git", "HEAD"), "ref: refs/heads/main\n");
+      await writeFile(join(refDir, "main"), "one\n");
+
+      source.replaceWatchedWorktrees([{ worktreeId: "wt_1", path: worktree, branch: "main" }]);
+      listeners.at(-1)?.("main");
+      source.shutdown();
+      source.shutdown();
+      source.replaceWatchedWorktrees([{ worktreeId: "wt_1", path: worktree, branch: "main" }]);
+      listeners.at(-1)?.("main");
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(closed).toBeGreaterThan(0);
+      expect(reasons).toEqual([]);
+    } finally {
+      source.shutdown();
       await rm(tempDir, { recursive: true, force: true });
     }
   });

--- a/apps/observer/test/unit/localGitChangeSummary.test.ts
+++ b/apps/observer/test/unit/localGitChangeSummary.test.ts
@@ -1,10 +1,9 @@
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { createFakeExternalCommandRunner } from "@station/runtime";
 import { describe, expect, it } from "vitest";
-import type { LocalGitChangeSummaryInput } from "../../src/metadata/localGitChangeSummary";
 import {
+  createLocalGitWorktreeChangeSource,
   parseGitNumstat,
-  readLocalGitChangeSummary,
 } from "../../src/metadata/localGitChangeSummary";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -13,7 +12,7 @@ const baseSha = "1111111111111111111111111111111111111111";
 const mergeBaseSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const oldLocalMainSha = "3333333333333333333333333333333333333333";
 
-const baseInput: Omit<LocalGitChangeSummaryInput, "runner"> = {
+const baseInput = {
   project: {
     id: "web",
     label: "web",
@@ -78,13 +77,12 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "5\t1\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
         defaultBranch: "main",
       },
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -115,13 +113,12 @@ describe("local git change summary", () => {
       [`diff --numstat ${oldLocalMainSha}..HEAD`]: "51\t15\tsrc/stale.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
         defaultBranch: "main",
       },
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -146,13 +143,12 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "6\t4\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
         defaultBranch: "origin/main",
       },
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -179,13 +175,12 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "1\t2\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
         defaultBranch: "origin/main",
       },
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -209,7 +204,7 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "2\t3\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
@@ -218,7 +213,6 @@ describe("local git change summary", () => {
           base: "develop",
         },
       },
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -242,9 +236,8 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "1\t1\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
-      runner,
     });
 
     expect(result?.summary.baseRef).toBe("origin/trunk");
@@ -261,9 +254,8 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
-      runner,
     });
 
     expect(result?.summary).toMatchObject({
@@ -285,7 +277,7 @@ describe("local git change summary", () => {
       [`diff --numstat ${mergeBaseSha}..HEAD`]: "1\t0\tsrc/a.ts\n",
     });
 
-    const result = await readLocalGitChangeSummary({
+    const result = await createLocalGitWorktreeChangeSource({ runner }).read({
       ...baseInput,
       project: {
         ...baseInput.project,
@@ -296,7 +288,6 @@ describe("local git change summary", () => {
         baseRef: "release",
         checkedAt: now,
       },
-      runner,
     });
 
     expect(result?.summary.baseRef).toBe("origin/release");
@@ -311,9 +302,8 @@ describe("local git change summary", () => {
     });
 
     await expect(
-      readLocalGitChangeSummary({
+      createLocalGitWorktreeChangeSource({ runner }).read({
         ...baseInput,
-        runner,
       }),
     ).resolves.toBeUndefined();
   });
@@ -329,9 +319,8 @@ describe("local git change summary", () => {
     });
 
     await expect(
-      readLocalGitChangeSummary({
+      createLocalGitWorktreeChangeSource({ runner }).read({
         ...baseInput,
-        runner,
       }),
     ).rejects.toMatchObject({
       tag: "LocalGitMetadataError",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -187,7 +187,7 @@ ownership even where current ownership is still a deviation.
 | Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |
 | Persistence health | Driven | `PersistenceHealthSource` | SQLite adapter created by `createSqliteObserverPersistence` | Runtime health and diagnostics read the public SQLite health projection without receiving the concrete database handle. |
 | Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose only operational logging and the three project mutations; paths and representations remain adapter-owned. |
-| Worktree metadata evidence | Driven | target `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | One role reads typed change evidence; the other owns watcher replacement and shutdown (OBS-HEX-011). |
+| Worktree metadata evidence | Driven | `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | Conforming Observer-private ports: refresh receives typed branch evidence and watched-worktree replacement while adapters retain Git and filesystem mechanics. |
 | Diagnostic evidence | Driven | target `DiagnosticEvidenceSource` | local state, log, and hook-spool adapter | Only typed local evidence traversal crosses the port; command/event persistence, providers, core, and SQLite remain separate inputs (OBS-HEX-012). |
 | Observer incumbent lifecycle | Driven | `ObserverIncumbentLifecycle` | local protocol client adapter | Handoff may read health and request controlled stop without importing transport mechanics into policy or orchestration. |
 | Observer process evidence | Driven | `ObserverProcessEvidenceSource` | local `lsof`/`ps`/pidfile/signal adapter | `lsof` is primary socket ownership; health, strict pidfile, argv, and OS start token must corroborate before replacement or signaling. |
@@ -213,7 +213,7 @@ areas contain the following responsibilities:
 | `stationLogger.ts`, `commands/projectConfigWriter.ts` | Observer-private logging and authoritative project-configuration capabilities | Driven application ports free of JSONL records and configuration/home-path plumbing. |
 | `runtime/logging.ts`, `runtime/projectConfigWriter.ts` | Redacted JSONL writes and `@station/config` project mutation translation | Outbound adapters retaining log, config, and home paths at composition. |
 | `providers/` | provider aggregation and health cache | Provider aggregation and health only; provider modules must not own or import application orchestration. |
-| `metadata/` | metadata refresh, repository lookup, Git execution, and ref watching | Metadata use cases select adapters through provider-neutral policy and depend on local-metadata ports (OBS-HEX-011). |
+| `metadata/` | metadata refresh, repository lookup, local Git evidence, and ref watching | Refresh is the use case; local Git and ref watcher adapters implement separate Observer-private ports selected by runtime composition. |
 | `persistence/ports.ts`, `persistence/types.ts` | seven purpose-owned persistence ports, their seven-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
 | `persistence/sqliteAdapter.ts`, SQLite implementation modules, `migrations/`, `sqlite.ts` | SQL and row translation, transactions, migrations, driver compatibility, health, and durable-handle mechanics | Production outbound adapter edge selected and lifecycle-managed by runtime composition. |
 | `test/support/inMemoryObserverPersistence.ts`, `persistence/observationParser.ts` | Process-local persistence test support plus representation-neutral observation parsing and coalescing | Test-only storage substitute and shared boundary translation used to prove substitution; production source and runtime remain SQLite-only. |
@@ -321,7 +321,7 @@ defined startup failure path and shutdown owner.
 
 ### Shutdown
 
-The current API stop path drains harness ingress and metadata watchers, then
+The current API stop path drains harness ingress, stops metadata invalidation, and waits for metadata reads to settle, then
 schedules process shutdown. Process shutdown disables health responses first.
 If the process still owns the socket, it conditionally removes only an exact
 matching process identity and syncs the socket directory before the protocol
@@ -670,7 +670,6 @@ and exit condition here.
 | ID | Current evidence and risk | Containment and exit evidence | Tracking |
 | --- | --- | --- | --- |
 | `OBS-HEX-007` | Terminal intent orchestration now belongs to `commands/`, resolving that provider/application back-edge. Unrelated type-only ownership cycles remain, so not every major module role is yet explainable without source cycles. | A dependency diagnostic prevents `providers/**` from importing `commands/**`. Exit when the remaining major-module type cycles are removed and final dependency-direction enforcement covers every major Observer module. | Internal ownership remediation. |
-| `OBS-HEX-011` | Metadata refresh directly owns Git command execution and ref filesystem watchers. Read evidence and long-lived watcher lifecycle are mixed into the use case. | Exit when `WorktreeChangeSource` owns typed Git reads, `WorktreeMetadataInvalidationSource` separately owns watched-worktree replacement and shutdown, and use cases receive neither Git runners nor filesystem paths. | Local metadata source isolation. |
 | `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only. Exit when a `DiagnosticEvidenceSource` adapter owns only local-state, recent-log, and hook-spool traversal, captures its paths, and the use case runs against a fake without absorbing persistence, providers, core, or SQLite. | Diagnostic evidence isolation. |
 
 The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
@@ -696,6 +695,7 @@ never fail over to a duplicate local spawn.
 `OBS-HEX-010` is resolved: Observer consumers depend on `StationLogger` and
 `ProjectConfigWriter`, while runtime adapters alone retain JSONL records and
 configuration/home paths; static inventory and substitution tests enforce both edges.
+`OBS-HEX-011` is resolved: metadata refresh depends on separately injected typed Git evidence and ref-invalidation ports, while runtime composition selects the local Git and filesystem watcher adapters.
 `OBS-HEX-013` is resolved: normal and provider-hook clients no longer unlink
 stale sockets, the child holds the persistent SQLite boot claim through ready
 commitment, and permanent Node/Bun plus production lifecycle races cover

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -175,6 +175,23 @@ describe("boundary inventory guard", () => {
     expect(violations).toEqual([]);
   });
 
+  it("keeps local Git and ref invalidation mechanics out of metadata refresh", async () => {
+    const path = "apps/observer/src/metadata/refresh.ts";
+    const source = await readFile(join(process.cwd(), path), "utf8");
+    const forbidden = [
+      "./gitCommand.js",
+      "./localGitChangeSummary.js",
+      "./gitRefInvalidation.js",
+      "node:fs",
+      "FSWatcher",
+      "ExternalCommandRunner",
+      "watchGitRefs",
+      "gitTimeoutMs",
+    ];
+
+    expect(forbidden.filter((marker) => source.includes(marker))).toEqual([]);
+  });
+
   it("keeps protocol imports at the observer runtime server adapter", async () => {
     const files = (await sourceFilesAt(join(process.cwd(), "apps/observer/src"))).filter(
       isProductionSourceFile,


### PR DESCRIPTION
## Summary

- inject Observer-private local Git evidence and ref-invalidation ports into metadata refresh
- move concrete Git and filesystem watcher ownership to runtime composition
- make metadata shutdown terminal and enforce the boundary with focused tests and diagnostics

## Why

Metadata refresh previously mixed Git command execution and filesystem watcher lifecycle into the use case. This separates those local adapters while preserving refresh behavior.

## UX

No intended visible change. Managed-worktree change summaries and repository metadata continue to refresh after commits or branch changes without restarting Station.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- focused metadata unit, integration, and boundary-inventory suites
- isolated `HOME=$(mktemp -d) pnpm test:pre-push`

The normal push hook was bypassed only after it failed on pre-existing real-home Claude hook configuration; the isolated gate passed.