### PR TITLE
fix(setup): simplify private binary onboarding

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,7 +3,6 @@ brew "node@24"
 brew "bun"
 
 # External tools
-tap "dlvhdr/formulae"
 brew "worktrunk"
 brew "tmux"
 # diffnav powers the station "See diff (split right)" automation; it renders via delta.

--- a/README.md
+++ b/README.md
@@ -42,41 +42,31 @@ station keeps track of everything that's running and makes it visible:
 
 ## Getting started
 
-The authenticated private binary is the user install path. Start in the Git repository you want Station to manage, authenticate the GitHub CLI for the private repository, use `curl` to fetch the version-pinned installer, then run setup:
+The authenticated private binary is the user install path. On a development-ready Mac, have Xcode Command Line Tools, Homebrew, GitHub CLI access to the private repository, and Codex or another supported agent CLI ready. Node.js can be present, but the compiled Station binary does not use it.
+
+Start in the Git repository you want Station to manage, authenticate `gh`, fetch the installer for the binary baseline, and run it:
 
 ```sh
 cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
-  set -e
+  set -eu
   umask 077
+  export GH_HOST=github.com
   tag=v0.7.0
-  token="$(gh auth token --hostname github.com)"
-  test -n "$token"
-  headers="$(mktemp)"
   installer="$(mktemp)"
-  trap 'rm -f "$headers" "$installer"' EXIT
-  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
-    "$token" > "$headers"
-  unset token
-  curl --disable \
-    --proto '=https' \
-    --tlsv1.2 \
-    --fail \
-    --silent \
-    --show-error \
-    --max-redirs 0 \
-    --header "@$headers" \
-    --output "$installer" \
-    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
-  rm -f "$headers"
+  trap 'rm -f "$installer"' EXIT
+  gh api --method GET \
+    -H 'Accept: application/vnd.github.raw+json' \
+    -f ref="$tag" \
+    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
   sh "$installer" --version "$tag"
 )
 ```
 
-The curl block only installs the Station binaries; it does not configure the current project or edit your shell profile. From the same project shell, make the default install available, run guided setup, verify it, and launch the full workspace:
+The installer block only installs the Station binaries; it does not configure the current project or edit your shell profile. From the same project shell, make the default install available, run guided setup, verify it, and launch the full workspace:
 
 ```sh
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -103,22 +93,7 @@ recipe resolves the current stable tag before fetching and invoking its
 installer. Immutable rollback begins with the second binary release because
 `v0.7.0` has no earlier binary artifact. See [Install](docs/install.md) for the
 recipe, version pinning, PATH recovery, custom install directories, and the
-supported-platform contract.
-
-Installs serialize commands and license data with
-`<install-dir>/.station-install.lock` and
-`<data-home>/station/.station-install.lock`; each owner records a PID, request,
-and unique token so cleanup cannot remove a replacement lock. Inspect the
-lock's sole `owner-*` file (or legacy `owner`), confirm its PID is not alive,
-and remove it manually only for abandoned work.
-Compatibility diagnostics are sanitized and bounded to 4096 bytes. If final
-activation is ambiguous, follow the printed absolute `stn --version` inspection
-command rather than assuming the previous install is unchanged. After success,
-the installer checks all three bare launchers and prints a current-shell PATH
-block for anything missing or shadowed without editing a profile. SIGKILL can
-leave recoverable locks/stages; atomic rename gives coherent process-level
-visibility, but without file/directory fsync there is no post-power-loss
-durability guarantee.
+supported-platform and recovery contracts.
 
 ### Development checkout
 

--- a/apps/cli/src/commands/setup/checks/diffnav.ts
+++ b/apps/cli/src/commands/setup/checks/diffnav.ts
@@ -7,7 +7,7 @@ export const defaultDiffnavCommand = "diffnav";
 
 export function diffnavInstallHint(command = defaultDiffnavCommand): string {
   return [
-    "Install diffnav with brew install dlvhdr/formulae/diffnav for the STATION 'See diff' automation.",
+    "Install diffnav with brew install diffnav for the STATION 'See diff' automation.",
     `stn tried ${command}.`,
   ].join(" ");
 }

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -617,9 +617,7 @@ function setupActions(
     actions.push(installAction("install-bun", "Bun", "bun", facts.brew));
   }
   if (facts.diffnav.status === "missing") {
-    actions.push(
-      installAction("install-diffnav", "diffnav", "dlvhdr/formulae/diffnav", facts.brew),
-    );
+    actions.push(installAction("install-diffnav", "diffnav", "diffnav", facts.brew));
   }
   // delta is diffnav's renderer, not standalone-useful here; install it alongside
   // so a required diffnav never yields a diffnav that errors for a missing delta.
@@ -869,7 +867,7 @@ function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
   }
   if (facts.diffnav.status === "missing" || facts.gitDelta.status === "missing") {
     return [
-      "Install diffnav and git-delta (brew install dlvhdr/formulae/diffnav git-delta), then run: stn setup check",
+      "Install diffnav and git-delta (brew install diffnav git-delta), then run: stn setup check",
     ];
   }
   return ["Resolve the missing required setup items, then run: stn setup check"];

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -101,7 +101,7 @@ export function renderSetupApplyResult(plan: SetupPlan, options: SetupRenderOpti
   if (missing?.id === "diffnav") {
     return missingResult(
       "diffnav is still missing.",
-      "Install it (brew install dlvhdr/formulae/diffnav), then run:",
+      "Install it (brew install diffnav), then run:",
       theme,
     );
   }

--- a/apps/cli/src/commands/setup/systemCommand.ts
+++ b/apps/cli/src/commands/setup/systemCommand.ts
@@ -29,7 +29,7 @@ export async function runSetupSystemCommand(
       actions.push(systemInstallAction("bun", "bun"));
     }
     if (initial.diffnav.status === "missing")
-      actions.push(systemInstallAction("diffnav", "dlvhdr/formulae/diffnav"));
+      actions.push(systemInstallAction("diffnav", "diffnav"));
     if (initial.gitDelta.status === "missing")
       actions.push(systemInstallAction("git-delta", "git-delta"));
     const result = await applySetupPlan(

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -403,7 +403,7 @@ describe("CLI setup command", () => {
             available.add("/fake/bin/bun");
             return commandResult(input, "");
           }
-          if (key === "brew install dlvhdr/formulae/diffnav") {
+          if (key === "brew install diffnav") {
             available.add("/fake/bin/diffnav");
             return commandResult(input, "");
           }

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -735,7 +735,7 @@ describe("checkSetupDiffnav", () => {
       access: fakeAccess([]),
     });
     expect(fact.status).toBe("missing");
-    expect(fact.message).toContain("diffnav");
+    expect(fact.message).toContain("brew install diffnav");
   });
 
   it("probes the literal diffnav the automation runs, ignoring any binary override", async () => {

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -792,7 +792,7 @@ describe("guided setup command", () => {
       worktrunk: "wt",
       tmux: "tmux",
       bun: "bun",
-      "dlvhdr/formulae/diffnav": "diffnav",
+      diffnav: "diffnav",
       "git-delta": "delta",
     };
     const hasBrewPrefix = (input: ExternalCommandInput) =>
@@ -896,9 +896,7 @@ describe("guided setup command", () => {
       calls
         .filter((call) => call.command === "brew" && call.args?.[0] === "install")
         .map((call) => call.args?.[1]),
-    ).toEqual(
-      expect.arrayContaining(["worktrunk", "tmux", "bun", "dlvhdr/formulae/diffnav", "git-delta"]),
-    );
+    ).toEqual(expect.arrayContaining(["worktrunk", "tmux", "bun", "diffnav", "git-delta"]));
     expect(fs.files[configPath]).toContain("[[projects]]");
   });
 
@@ -921,7 +919,7 @@ describe("guided setup command", () => {
       worktrunk: "wt",
       tmux: "tmux",
       bun: "bun",
-      "dlvhdr/formulae/diffnav": "diffnav",
+      diffnav: "diffnav",
       "git-delta": "delta",
     };
     const hasBrewPrefix = (input: ExternalCommandInput) =>

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -159,7 +159,7 @@ describe("setup planner", () => {
       kind: "brew-install",
       tier: "required",
       selected: true,
-      command: ["brew", "install", "dlvhdr/formulae/diffnav"],
+      command: ["brew", "install", "diffnav"],
     });
     expect(plan.actions.find((action) => action.id === "install-git-delta")).toMatchObject({
       kind: "brew-install",

--- a/docs/development.md
+++ b/docs/development.md
@@ -201,8 +201,9 @@ write releases. The tag workflow never publishes the draft automatically.
 
 The initial immutable binary baseline is `v0.7.0`:
 
-1. Enable GitHub immutable releases, merge A5 with `package.json` and source
-   runtime reporting at `0.7.0`, then create and push `v0.7.0`.
+1. Enable GitHub immutable releases, confirm the release commit is on `main`
+   with `package.json` and runtime reporting at `0.7.0`, then create and push
+   `v0.7.0`.
 2. Confirm every release job passed and the successful run contains exactly one
    `accepted-release-candidate-0.7.0-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
@@ -263,6 +264,83 @@ binary. Power loss is different: because the installer does not fsync the file
 or containing directories, it makes no post-power-loss durability guarantee;
 old/new cross-filesystem `LICENSE` metadata may also remain.
 
+Install the accepted candidate from a successful release workflow run on each
+clean test machine. Set `release_run_id` to that run's numeric ID; the recipe
+downloads its candidate manifest and uses the exact draft ID and commit that
+promotion will verify:
+
+```sh
+cd /path/to/your/git-project
+(
+  set -eu
+  umask 077
+  export GH_HOST=github.com
+  tag=v0.7.0
+  version=${tag#v}
+  release_run_id=123456789
+  case "$release_run_id" in
+    ''|*[!0-9]*) echo "release_run_id must be numeric" >&2; exit 1 ;;
+  esac
+  test "$(
+    gh run view "$release_run_id" --repo jeremy0dell/station \
+      --json conclusion --jq '.conclusion'
+  )" = success
+  test "$(
+    gh run view "$release_run_id" --repo jeremy0dell/station \
+      --json workflowName --jq '.workflowName'
+  )" = release
+  run_attempt="$(
+    gh run view "$release_run_id" --repo jeremy0dell/station \
+      --json attempt --jq '.attempt'
+  )"
+  case "$run_attempt" in
+    ''|*[!0-9]*) echo "release run attempt must be numeric" >&2; exit 1 ;;
+  esac
+  candidate_dir="$(mktemp -d)"
+  installer="$(mktemp)"
+  trap 'rm -rf "$candidate_dir"; rm -f "$installer"' EXIT
+  gh run download "$release_run_id" \
+    --repo jeremy0dell/station \
+    --name "accepted-release-candidate-$version-attempt-$run_attempt" \
+    --dir "$candidate_dir"
+  manifest="$candidate_dir/manifest.json"
+  test -f "$manifest"
+  manifest_field() {
+    node -e '
+      const { readFileSync } = require("node:fs");
+      const value = JSON.parse(readFileSync(process.argv[1], "utf8"))[process.argv[2]];
+      if (typeof value !== "string" && typeof value !== "number") process.exit(1);
+      process.stdout.write(String(value));
+    ' "$manifest" "$1"
+  }
+  manifest_tag="$(manifest_field tag)"
+  manifest_repository="$(manifest_field repository)"
+  manifest_run_id="$(manifest_field workflowRunId)"
+  manifest_run_attempt="$(manifest_field workflowRunAttempt)"
+  commit="$(manifest_field commit)"
+  release_id="$(manifest_field releaseId)"
+  test "$manifest_tag" = "$tag"
+  test "$manifest_repository" = jeremy0dell/station
+  test "$manifest_run_id" = "$release_run_id"
+  test "$manifest_run_attempt" = "$run_attempt"
+  printf '%s\n' "$commit" | grep -Eq '^[0-9a-f]{40}$'
+  case "$release_id" in
+    ''|*[!0-9]*) echo "candidate release ID must be numeric" >&2; exit 1 ;;
+  esac
+  test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq '.sha')" = "$commit"
+  gh api --method GET \
+    -H 'Accept: application/vnd.github.raw+json' \
+    -f ref="$commit" \
+    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
+  test -s "$installer"
+  sh -n "$installer"
+  STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer" --version "$tag"
+)
+```
+
+This draft-only environment variable is for release acceptance; normal installs
+use the published-release recipe in [Install](install.md).
+
 For each target, install through the authenticated script into a clean home and
 manually verify the actual user experience, not a dashboard override:
 
@@ -307,9 +385,9 @@ manually verify the actual user experience, not a dashboard override:
     replacing any asset.
 
 Record the oldest supported macOS version or built-against glibc version in the
-release notes. Signing and notarization are not part of A5; integrity is the
-authenticated GitHub asset plus `SHA256SUMS` verification and immutable
-publication.
+release notes. Signing and notarization are not part of the initial private
+binary release; integrity is the authenticated GitHub asset plus `SHA256SUMS`
+verification and immutable publication.
 
 For CI install parity, use:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,88 +4,41 @@ Station is distributed internally as authenticated private GitHub release assets
 
 ## Private Binary
 
-Start in the Git repository you want Station to manage, authenticate `gh` for `jeremy0dell/station`, then use `curl` to fetch the version-pinned installer from the private repository:
+On a development-ready Mac, have Xcode Command Line Tools, Homebrew, GitHub CLI access to `jeremy0dell/station`, and Codex or another supported agent CLI ready. Node.js can be present, but the compiled Station binary does not use it.
+
+Start in the Git repository you want Station to manage, authenticate `gh`, then fetch and run the installer for the first binary baseline:
 
 ```bash
 cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
-  set -e
+  set -eu
   umask 077
+  export GH_HOST=github.com
   tag=v0.7.0
-  token="$(gh auth token --hostname github.com)"
-  test -n "$token"
-  headers="$(mktemp)"
   installer="$(mktemp)"
-  trap 'rm -f "$headers" "$installer"' EXIT
-  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
-    "$token" > "$headers"
-  unset token
-  curl --disable \
-    --proto '=https' \
-    --tlsv1.2 \
-    --fail \
-    --silent \
-    --show-error \
-    --max-redirs 0 \
-    --header "@$headers" \
-    --output "$installer" \
-    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
-  rm -f "$headers"
+  trap 'rm -f "$installer"' EXIT
+  gh api --method GET \
+    -H 'Accept: application/vnd.github.raw+json' \
+    -f ref="$tag" \
+    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
   sh "$installer" --version "$tag"
 )
 ```
 
-`v0.7.0` is the first supported private-binary baseline. Resolve the latest
-stable tag first, then fetch and invoke that tag's installer:
+Keep `tag=v0.7.0` for an exact install. After `v0.7.0` is published, replace that assignment with the following to resolve the latest stable tag while still fetching installer code and artifacts from that same tag:
 
 ```bash
-cd /path/to/your/git-project
-(
-  set -e
-  umask 077
-  tag="$(
-    GH_HOST=github.com gh api --method GET \
-      repos/jeremy0dell/station/releases/latest --jq '.tag_name'
-  )"
-  test -n "$tag"
-  token="$(gh auth token --hostname github.com)"
-  test -n "$token"
-  headers="$(mktemp)"
-  installer="$(mktemp)"
-  trap 'rm -f "$headers" "$installer"' EXIT
-  printf 'Authorization: Bearer %s\nAccept: application/vnd.github.raw+json\nX-GitHub-Api-Version: 2022-11-28\n' \
-    "$token" > "$headers"
-  unset token
-  curl --disable \
-    --proto '=https' \
-    --tlsv1.2 \
-    --fail \
-    --silent \
-    --show-error \
-    --max-redirs 0 \
-    --header "@$headers" \
-    --output "$installer" \
-    "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag"
-  rm -f "$headers"
-  test -s "$installer"
-  sh -n "$installer"
-  sh "$installer" --version "$tag"
-)
+tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
 ```
 
-Use the explicit form with the desired `tag` for every exact install. Both
-forms pair installer code and artifacts from one immutable tag; they never
-fall back to `main`. `curl` only bootstraps that checked installer; the
-installer continues to use authenticated `gh` for private release discovery
-and asset downloads. Because `v0.7.0` is the first binary release, immutable
-rollback to a prior binary becomes available only after the next binary release.
+The recipe never falls back to `main`. `gh` handles private-repository authentication for both the bootstrap and the installer's release discovery and asset downloads. Because `v0.7.0` is the first binary release, immutable rollback to a prior binary becomes available only after the next binary release.
 
 ### Complete first-run setup
 
-The curl block only installs the Station binaries; it does not configure the current project or edit your shell profile. Both recipes begin by changing into the Git repository that `stn setup` will use as the first Station project. For the default install location, the remaining handoff is:
+The installer block only installs the Station binaries; it does not configure the current project or edit your shell profile. The recipe begins by changing into the Git repository that `stn setup` will use as the first Station project. For the default install location, the remaining handoff is:
 
 ```bash
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -70,62 +70,46 @@ describe("release readiness docs", () => {
       ["docs/install.md", install],
     ] as const) {
       expect(document, path).not.toContain("ref=main");
-      const expectedRecipeCount = path === "README.md" ? 1 : 2;
-      const curlCommands = shellBlocks(document)
-        .flatMap(continuedShellCommands)
-        .filter((command) => command.startsWith("curl "));
-      expect(curlCommands, path).toHaveLength(expectedRecipeCount);
-      for (const command of curlCommands) {
-        expect(command, path).toMatch(/^curl\s+--disable(?:\s|$)/);
-        expect(command, path).not.toMatch(/\b(?:Authorization|Bearer|token)\b/i);
-        expect(command, path).not.toMatch(/(?:^|\s)(?:-L|--location)(?:\s|$)/);
-        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
-      }
-      const contentsFetches = curlCommands.filter((command) =>
-        command.includes("contents/scripts/install.sh"),
-      );
-      expect(contentsFetches, path).toHaveLength(expectedRecipeCount);
+      expect(document, path).not.toContain("gh auth token");
+      expect(document, path).not.toContain("Authorization: Bearer");
+      expect(document, path).not.toContain("curl");
       const recipes = shellBlocks(document).filter((block) =>
-        block.includes(
-          "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
-        ),
+        block.includes("repos/jeremy0dell/station/contents/scripts/install.sh"),
       );
-      expect(recipes, path).toHaveLength(expectedRecipeCount);
+      expect(recipes, path).toHaveLength(1);
       for (const recipe of recipes) {
         expect(recipe, path).toContain("cd /path/to/your/git-project");
         expect(recipe.indexOf("cd /path/to/your/git-project"), path).toBeLessThan(
-          recipe.indexOf("curl --disable"),
+          recipe.indexOf("gh api --method GET"),
         );
         expect(recipe, path).toContain("umask 077");
-        expect(recipe, path).toContain('token="$(gh auth token --hostname github.com)"');
-        expect(recipe, path).toContain('headers="$(mktemp)"');
+        expect(recipe, path).toContain("export GH_HOST=github.com");
+        expect(recipe.indexOf("export GH_HOST=github.com"), path).toBeLessThan(
+          recipe.indexOf("gh api --method GET"),
+        );
         expect(recipe, path).toContain('installer="$(mktemp)"');
-        expect(recipe, path).toContain('trap \'rm -f "$headers" "$installer"\' EXIT');
-        expect(recipe, path).toContain("Authorization: Bearer %s");
-        expect(recipe, path).toContain("Accept: application/vnd.github.raw+json");
-        expect(recipe, path).toContain("unset token");
+        expect(recipe, path).toContain("trap 'rm -f \"$installer\"' EXIT");
         expect(recipe, path).toContain('test -s "$installer"');
         expect(recipe, path).toContain('sh -n "$installer"');
         expect(recipe, path).toContain('sh "$installer" --version "$tag"');
 
         const installerFetches = continuedShellCommands(recipe).filter((command) =>
-          command.includes("contents/scripts/install.sh?ref=$tag"),
+          command.includes("contents/scripts/install.sh"),
         );
         expect(installerFetches, path).toHaveLength(1);
         const command = installerFetches[0] ?? "";
-        expect(command, path).toContain("--proto '=https'");
-        expect(command, path).toContain("--tlsv1.2");
-        expect(command, path).toContain("--fail");
-        expect(command, path).toContain("--silent");
-        expect(command, path).toContain("--show-error");
-        expect(command, path).toContain("--max-redirs 0");
-        expect(command, path).toContain('--header "@$headers"');
-        expect(command, path).toContain('--output "$installer"');
+        expect(command, path).toContain("gh api --method GET");
+        expect(command, path).toContain("Accept: application/vnd.github.raw+json");
+        expect(command, path).toContain('-f ref="$tag"');
         expect(command, path).toContain(
-          "https://api.github.com/repos/jeremy0dell/station/contents/scripts/install.sh?ref=$tag",
+          'repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"',
         );
+        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
       }
     }
+    expect(install).toContain(
+      'tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest',
+    );
     expect(readme.replace(/\s+/g, " ")).toContain("installer code and artifacts");
     expect(install).toContain("SHA256SUMS");
     expect(install).toContain("stn-tmux-popup");
@@ -139,6 +123,26 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
     expect(development).toContain("accepted-release-candidate-0.7.0");
+    const acceptanceRecipes = shellBlocks(development).filter((block) =>
+      block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
+    );
+    expect(acceptanceRecipes).toHaveLength(1);
+    const acceptanceRecipe = acceptanceRecipes[0] ?? "";
+    expect(acceptanceRecipe).toContain("export GH_HOST=github.com");
+    expect(acceptanceRecipe).toContain("release_run_id=123456789");
+    expect(acceptanceRecipe).toContain("--json workflowName --jq '.workflowName'");
+    expect(acceptanceRecipe).toContain("accepted-release-candidate-$version-attempt-$run_attempt");
+    expect(acceptanceRecipe).toContain("manifest_field workflowRunId");
+    expect(acceptanceRecipe).toContain("manifest_field workflowRunAttempt");
+    expect(acceptanceRecipe).toContain('commit="$(manifest_field commit)"');
+    expect(acceptanceRecipe).toContain('release_id="$(manifest_field releaseId)"');
+    expect(acceptanceRecipe).toContain(
+      'test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq \'.sha\')" = "$commit"',
+    );
+    expect(acceptanceRecipe).toContain('-f ref="$commit"');
+    expect(acceptanceRecipe).not.toContain(
+      'commit="$(gh api "repos/jeremy0dell/station/commits/$tag"',
+    );
     expect(release).toContain('-f ref="$COMMIT"');
     expect(release).toContain("persist-credentials: false");
     expect(release).toContain("accepted-release-candidate-");

--- a/tests/env/macos/station-happy.pkr.hcl
+++ b/tests/env/macos/station-happy.pkr.hcl
@@ -45,7 +45,7 @@ build {
       "set -euo pipefail",
       "brew update",
       "brew install node@24 bun tmux git-delta",
-      "brew install dlvhdr/formulae/diffnav",
+      "brew install diffnav",
       "brew install worktrunk",
     ]
   }


### PR DESCRIPTION
## What

- replace the private-install token and `curl` ceremony with a `github.com`-pinned authenticated `gh api` bootstrap
- bind manual draft acceptance to the successful release workflow's accepted-candidate manifest
- install `diffnav` from Homebrew core throughout setup, tests, the Brewfile, and the macOS fixture
- update release-readiness documentation and its executable diagnostics checks

## Why

The current README makes an already-authenticated developer repeat GitHub credential plumbing, and setup still points at an obsolete external tap. The draft-acceptance instructions also need to identify the exact successful workflow candidate instead of trusting mutable release state.

## UX impact

On a dev-ready Mac, private installation is now one copy/paste bootstrap followed by `stn setup`; setup uses the current Homebrew core `diffnav` formula.

## Validation

- `CI=true pnpm install --frozen-lockfile --ignore-scripts`
- `(cd station && bun install --frozen-lockfile)`
- complete `pnpm test:pre-push` under isolated `HOME` and XDG directories
  - 1,403 unit tests
  - 425 integration tests passed, 1 skipped
  - diagnostics, setup E2E, observer lifecycle E2E, install smoke, SQLite Node/Bun compatibility, Station Bun and PTY suites
  - compiled-binary build and smoke
- commit-pinned `gh api` bootstrap fetched bytes identical to `scripts/install.sh`; `sh -n` passed
- `git diff --check`
- independent release/docs and setup reviews approved after remediation

## Test note

The duplicate pre-push hook under the real user home sees existing generated Station hooks in `~/.claude/settings.json` and fails one unrelated Claude provider fixture. The complete gate passes in an isolated home. Packer/Tart is unavailable locally, so the macOS fixture was covered by source/test review rather than a VM build.