### PR TITLE
fix(release): authenticate private ancestry check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           node-version: 24.x
       - name: Validate release tag
         id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           version="$(node -p 'require("./package.json").version')"
           tag="$GITHUB_REF_NAME"
@@ -53,11 +55,13 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
-            echo "Release commit $GITHUB_SHA is not on origin/main." >&2
-            exit 1
-          fi
+          comparison_status="$(
+            gh api "repos/$GITHUB_REPOSITORY/compare/$GITHUB_SHA...main" --jq .status
+          )"
+          case "$comparison_status" in
+            ahead|identical) ;;
+            *) echo "Release commit $GITHUB_SHA is not on main." >&2; exit 1 ;;
+          esac
 
           prerelease=false
           if [[ "$version" == *-* ]]; then

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -145,6 +145,14 @@ describe("release readiness docs", () => {
     );
     expect(release).toContain('-f ref="$COMMIT"');
     expect(release).toContain("persist-credentials: false");
+    const validateRelease = release.slice(
+      release.indexOf("      - name: Validate release tag"),
+      release.indexOf("\n  standard-ci:"),
+    );
+    expect(validateRelease).toMatch(/GH_TOKEN: \$\{\{ github\.token \}\}/);
+    expect(validateRelease).toContain("compare/$GITHUB_SHA...main");
+    expect(validateRelease).toContain("ahead|identical");
+    expect(validateRelease).not.toContain("git fetch --no-tags origin");
     expect(release).toContain("accepted-release-candidate-");
     const installDraft = release.slice(
       release.indexOf("  install-draft:"),

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -143,6 +143,7 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
   await writeShim(bin, "diffnav", "exit 0\n");
   await writeShim(bin, "delta", "exit 0\n");
   await writeShim(bin, "bun", "exit 0\n");
+  await writeShim(bin, "npm", "echo 0.1.0\n");
   if (input.harness === "codex") {
     await writeCodexShim(bin);
   }


### PR DESCRIPTION
## Summary

- keep release checkouts free of persisted Git credentials
- validate release ancestry through the read-only GitHub compare API
- pin the validator token and accepted ancestry statuses in the release contract test
- isolate the guided setup E2E from the real npm registry probe

## Root cause

The first v0.7.0 release run failed before builds because the validator disabled persisted checkout credentials and then fetched main from the private repository.

Failed release validation: https://github.com/jeremy0dell/station/actions/runs/29299426179

The first PR run then exposed an unrelated setup-fixture race: the guided setup fixture reached real npm for the Codex version probe, which could write its temporary HOME during teardown. It now uses the same hermetic npm shim as the neighboring setup E2E.

Failed PR run: https://github.com/jeremy0dell/station/actions/runs/29299992128

No release draft or assets were created.

## Validation

- full isolated pnpm test:pre-push passed, including installer and compiled macOS binary smoke
- guided setup E2E passed 5 consecutive focused runs
- complete setup E2E passed: 9 tests
- diagnostics passed: 43 tests
- lint and YAML parse passed
- live compare API returned identical for the release SHA and diverged for a non-main branch
- independent review returned no findings after its test-scope finding was addressed

## UX

No installer or TUI behavior changes. Manual verification is the repaired v0.7.0 tag workflow reaching all four native build and draft-install jobs.