### PR TITLE
fix(release): wait for draft visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,16 +280,21 @@ jobs:
           # Installer acceptance runs against this draft before a human may publish it.
           gh release create "${args[@]}"
 
-          # GitHub's tag endpoint excludes drafts, so acceptance uses the captured release id.
-          release_ids="$(
-            gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
-              --jq ".[] | select(.draft == true and .tag_name == \"$TAG\") | .id"
-          )"
-          if [[ ! "$release_ids" =~ ^[0-9]+$ ]]; then
-            echo "Expected exactly one draft release for $TAG." >&2
+          # Draft visibility can lag creation; gh release view uses GitHub's draft-aware tag lookup.
+          release_id=""
+          for _ in {1..12}; do
+            release_id="$(
+              gh release view "$TAG" --json databaseId,isDraft \
+                --jq 'select(.isDraft == true) | .databaseId' 2>/dev/null || true
+            )"
+            [[ "$release_id" =~ ^[0-9]+$ ]] && break
+            sleep 5
+          done
+          if [[ ! "$release_id" =~ ^[0-9]+$ ]]; then
+            echo "Expected the draft release for $TAG to become readable." >&2
             exit 1
           fi
-          echo "release_id=$release_ids" >> "$GITHUB_OUTPUT"
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
 
           mkdir candidate
           cp SHA256SUMS candidate/SHA256SUMS
@@ -301,7 +306,7 @@ jobs:
             --arg checksumFileSha256 "$checksum_file_sha" \
             --argjson workflowRunId "$GITHUB_RUN_ID" \
             --argjson workflowRunAttempt "$GITHUB_RUN_ATTEMPT" \
-            --argjson releaseId "$release_ids" \
+            --argjson releaseId "$release_id" \
             '{
               repository: $repository,
               workflowRunId: $workflowRunId,

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -153,6 +153,17 @@ describe("release readiness docs", () => {
     expect(validateRelease).toContain("compare/$GITHUB_SHA...main");
     expect(validateRelease).toContain("ahead|identical");
     expect(validateRelease).not.toContain("git fetch --no-tags origin");
+    const createDraftStart = release.indexOf("      - name: Create draft release");
+    const createDraft = release.slice(
+      createDraftStart,
+      release.indexOf("      - uses: actions/upload-artifact@v4", createDraftStart),
+    );
+    expect(createDraft).toContain("for _ in {1..12}");
+    expect(createDraft).toContain('gh release view "$TAG" --json databaseId,isDraft');
+    expect(createDraft).toContain("'select(.isDraft == true) | .databaseId'");
+    expect(createDraft).toContain('[[ "$release_id" =~ ^[0-9]+$ ]] && break');
+    expect(createDraft).not.toContain("releases?per_page=100");
+    expect(createDraft).toContain('--argjson releaseId "$release_id"');
     expect(release).toContain("accepted-release-candidate-");
     const installDraft = release.slice(
       release.indexOf("  install-draft:"),


### PR DESCRIPTION
## Summary

- poll GitHub's draft-aware tag lookup after `gh release create`
- capture one numeric draft release ID for installer acceptance and the candidate manifest
- lock the release-workflow contract into the existing diagnostics test

## Why

Release run `29303970091` passed validation, standard CI, release smoke, and all four native builds. It then created draft release `353558289` with all five expected assets, but the immediate REST collection lookup returned no draft about 236 ms later. That collection response is cacheable for 60 seconds.

The bounded `gh release view` lookup uses GitHub CLI's draft-aware tag resolution and fails closed if a numeric draft ID does not become readable. The existing draft and assets are intentionally untouched by this PR.

## Validation

- isolated `pnpm test:pre-push` passed
- isolated pre-push hook passed again during push
- diagnostics: 18 files / 43 tests passed
- lint passed
- workflow YAML parsed successfully
- `git diff --check` passed
- live read-only lookup returned draft release ID `353558289`

This PR does not publish or promote a release.