### PR TITLE
fix(installer): fetch draft release by id

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -576,11 +576,11 @@ if [ -n "$release_id" ]; then
   tag=$requested_version
   version=${tag#v}
   archive_name="stn-v${version}-${target}.tar.gz"
-  # GitHub tag endpoints exclude drafts; the authenticated release list is draft-visible.
-  draft_endpoint="repos/$repository/releases?per_page=100"
-  draft_match=".[] | select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
-  if ! run_gh "$temp_dir/draft-release.stdout" "$temp_dir/draft-release.stderr" api --paginate "$draft_endpoint" --jq "$draft_match | .id"; then
-    fail "could not list draft releases; check your authentication and repository access."
+  # Draft release lists can lag creation, so acceptance addresses the captured release ID directly.
+  draft_endpoint="repos/$repository/releases/$release_id"
+  draft_match="select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
+  if ! run_gh "$temp_dir/draft-release.stdout" "$temp_dir/draft-release.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$draft_match | .id"; then
+    fail "could not read draft release $release_id; check your authentication and repository access."
   fi
   read_numeric_result "$temp_dir/draft-release.stdout" "no single draft matched ID $release_id and requested version '$tag'."
 
@@ -588,7 +588,7 @@ if [ -n "$release_id" ]; then
     asset_name=$1
     asset_slug=$2
     filter="$draft_match | .assets[] | select(.name == \"$asset_name\") | .id"
-    if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api --paginate "$draft_endpoint" --jq "$filter"; then
+    if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$filter"; then
       fail "could not read assets for draft release $tag."
     fi
     read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -370,11 +370,6 @@ function scenarioAuthenticatedReleaseValidation() {
       },
     },
     {
-      label: "duplicate draft release",
-      expected: "no single draft matched",
-      options: { version: stableTag, releaseId: "42", duplicateDraftRelease: true },
-    },
-    {
       label: "draft tag mismatch",
       expected: "no single draft matched",
       options: { version: stableTag, releaseId: "42", releaseIdTag: rollbackTag },
@@ -429,6 +424,7 @@ function scenarioGhFailuresAndRetries() {
   const failures = [
     ["latest", {}, "latest release API failure"],
     ["release", { version: stableTag }, "release asset API failure"],
+    ["release", { version: stableTag, releaseId: "42" }, "draft release API failure"],
     ["archive-download", { version: stableTag }, "archive download failure"],
     ["checksums-download", { version: stableTag }, "checksum download failure"],
     ["partial-archive", { version: stableTag }, "partial archive download"],
@@ -2220,16 +2216,16 @@ function writeFakeCommands() {
       "      exit 2",
       "    fi",
       "    ;;",
-      '  "repos/jeremy0dell/station/releases?per_page=100")',
-      '    [ "$paginate" -eq 1 ] && [ -z "$accept_header" ]',
+      '  "repos/jeremy0dell/station/releases/$FAKE_RELEASE_ID")',
+      '    [ "$paginate" -eq 0 ]',
+      '    [ "$accept_header" = "X-GitHub-Api-Version: 2022-11-28" ]',
       `    [ "\${FAKE_GH_FAIL_PHASE:-}" != release ] || exit 74`,
       `    [ "\${FAKE_RELEASE_DRAFT:-1}" = 1 ] || exit 0`,
       '    [ "$FAKE_RELEASE_ID_TAG" = "$FAKE_TAG" ] || exit 0',
-      '    draft_match=".[] | select(.draft == true and .id == $FAKE_RELEASE_ID and .tag_name == \\"$FAKE_TAG\\")"',
+      '    draft_match="select(.draft == true and .id == $FAKE_RELEASE_ID and .tag_name == \\"$FAKE_TAG\\")"',
       '    if [ "$jq_filter" = "$draft_match | .id" ]; then',
       "        block_phase draft-release",
       "        printf '%s\\n' \"$FAKE_RELEASE_ID\"",
-      `        if [ "\${FAKE_DUPLICATE_RELEASE:-0}" = 1 ]; then printf '%s\\n' "$FAKE_RELEASE_ID"; fi`,
       '    elif [ "$jq_filter" = "$draft_match | .assets[] | select(.name == \\"$FAKE_ARCHIVE\\") | .id" ]; then',
       "      block_phase draft-archive-asset",
       `      count=\${FAKE_ARCHIVE_ASSET_COUNT:-1}`,
@@ -2276,7 +2272,6 @@ function runInstaller({
   version,
   auth = true,
   duplicateArchiveAsset = false,
-  duplicateDraftRelease = false,
   includeInstallDirOnPath = false,
   releaseId,
   releaseDraft = true,
@@ -2316,7 +2311,6 @@ function runInstaller({
       XDG_DATA_HOME: unsetXdgDataHome ? undefined : dataHome,
       FAKE_ARCHIVE: archive,
       FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
-      FAKE_DUPLICATE_RELEASE: duplicateDraftRelease ? "1" : "0",
       FAKE_GH_AUTH: auth ? "1" : "0",
       FAKE_GH_ARGV_LOG: ghArgvLog,
       FAKE_GH_LOG: ghLog,
@@ -2997,23 +2991,12 @@ function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
     expected.push(["api", tagEndpoint, "--jq", archiveFilter]);
     expected.push(["api", tagEndpoint, "--jq", checksumFilter]);
   } else {
-    const endpoint = `${repository}/releases?per_page=100`;
-    const match = `.[] | select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
-    expected.push(["api", "--paginate", endpoint, "--jq", `${match} | .id`]);
-    expected.push([
-      "api",
-      "--paginate",
-      endpoint,
-      "--jq",
-      `${match} | .assets[] | select(.name == "${archiveName}") | .id`,
-    ]);
-    expected.push([
-      "api",
-      "--paginate",
-      endpoint,
-      "--jq",
-      `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`,
-    ]);
+    const endpoint = `${repository}/releases/${draftId}`;
+    const match = `select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
+    const prefix = ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--jq"];
+    expected.push([...prefix, `${match} | .id`]);
+    expected.push([...prefix, `${match} | .assets[] | select(.name == "${archiveName}") | .id`]);
+    expected.push([...prefix, `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`]);
   }
   expected.push([
     "api",


### PR DESCRIPTION
## Summary

- fetch a draft release through GitHub's direct release-by-ID endpoint
- keep the installer fail-closed on draft status, numeric ID, exact tag, and unique assets
- harden the smoke harness against regressions to the eventually consistent release-list endpoint

## Why

Release run `29305934568` created draft release `353569948`, then all four native install jobs failed 3–17 seconds later because `scripts/install.sh` searched the cached `releases?per_page=100` collection. The direct `repos/jeremy0dell/station/releases/353569948` endpoint already returned the draft at that point.

This change addresses the workflow-captured release ID directly. It adds no retry, list scan, or fallback.

## Validation

- red/green `pnpm smoke:install`
- `sh -n scripts/install.sh`
- `pnpm lint`
- `git diff --check`
- authenticated install from live private draft `353569948` into isolated HOME/data/install directories; exact `0.7.0`, helper symlinks, license, and cleanup verified
- full isolated `pnpm test:pre-push` passed locally
- the enabled pre-push hook repeated the full isolated gate successfully
- independent read-only review found no functional or blocking findings

The existing draft remains unpublished. Run `29305934568` has no accepted candidate.