### PR TITLE
fix(release): grant draft readers push access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,8 +329,8 @@ jobs:
       - validate
       - create-draft
     permissions:
-      # Draft list/get and asset downloads require only read permission.
-      contents: read
+      # GitHub exposes draft releases only to identities with push access.
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -514,7 +514,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       actions: read
-      contents: read
+      # GitHub exposes draft releases only to identities with push access.
+      contents: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -194,9 +194,11 @@ with `--version`; a moved tag cannot substitute different installer code. After
 all four native installs pass, the workflow re-downloads the five draft assets,
 verifies them against the build checksum, and uploads an immutable
 `accepted-release-candidate-*` Actions artifact containing the commit, release
-ID, asset IDs, and checksums. Draft install and candidate-recording jobs have
-read-only contents permission; only draft creation and manual promotion can
-write releases. The tag workflow never publishes the draft automatically.
+ID, asset IDs, and checksums. Draft install and candidate-recording jobs use
+contents write permission because GitHub exposes draft releases only to
+identities with push access, but their steps only read release metadata and
+assets. Only draft creation and manual promotion mutate releases. The tag
+workflow never publishes the draft automatically.
 
 The initial immutable binary baseline is `v0.7.0`:
 

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -171,8 +171,8 @@ describe("release readiness docs", () => {
     );
     const recordCandidate = release.slice(release.indexOf("  record-accepted-candidate:"));
     for (const job of [installDraft, recordCandidate]) {
-      expect(job).toContain("contents: read");
-      expect(job).not.toContain("contents: write");
+      expect(job).toContain("contents: write");
+      expect(job).not.toContain("contents: read");
     }
     expect(promote).toContain("workflow_dispatch");
     expect(promote).toContain("manual_acceptance");


### PR DESCRIPTION
## Summary

- give the two jobs that read an unpublished draft the push-level repository access GitHub requires
- keep every draft-consumer step read-only; only draft creation and manual promotion mutate releases
- update the release-readiness assertion and development documentation to preserve the permission boundary

## Why

Release run `29307877937` created draft `353582171`, but all four native install jobs failed immediately at the direct release-by-ID request. Their job logs show `Contents: read`; GitHub only exposes draft releases to identities with push access. The candidate-recording job uses a fresh per-job token and reads/downloads the same draft, so it needs the same visibility.

No accepted candidate was recorded and the draft remains unpublished.

## Validation

- regression assertion failed red against the old workflow, then passed green
- full diagnostics suite: 43 tests passed
- `pnpm smoke:release`
- `pnpm lint`
- release workflow YAML parse
- `git diff --check`
- full isolated `pnpm test:pre-push`: unit, integration, diagnostics, setup/Observer E2E, installer smoke, cross-runtime races, renderer, PTY, compiled binary build/smoke
- independent security review found no remaining issues

This changes no job count or runner selection. Routine CI remains one Ubuntu job; the release matrix is unchanged.