### PR TITLE
fix(worktrunk): remove the selected duplicate-branch worktree

### DIFF
--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -302,6 +302,12 @@ describe("observer providers", () => {
           )}`,
           "  exit 0",
           "fi",
+          'if [ "$1" = "list" ]; then',
+          `  printf '%s' ${JSON.stringify(
+            JSON.stringify([{ path: createdWorktreePath, branch: "feature" }]),
+          )}`,
+          "  exit 0",
+          "fi",
           'if [ "$1" = "remove" ]; then',
           "  printf '{}'",
           "  exit 0",
@@ -354,7 +360,8 @@ describe("observer providers", () => {
       await expect(readFile(logPath, "utf8")).resolves.toBe(
         [
           "switch --no-hooks --create feature --base main --no-cd --format=json",
-          `-C ${projectRoot} remove --no-hooks feature --foreground --format=json`,
+          "list --format=json",
+          `-C ${createdWorktreePath} remove --no-hooks --foreground --format=json`,
           "",
         ].join("\n"),
       );

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -88,7 +88,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
   readonly #observations = new Map<string, WorktreeObservation>();
-  readonly #projectRoots = new Map<string, string>();
+  readonly #projects = new Map<string, ProviderProjectConfig>();
 
   constructor(options: WorktrunkProviderOptions = {}) {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
@@ -206,22 +206,9 @@ export class WorktrunkProvider implements WorktreeProvider {
     if (!project.worktrunk.enabled) {
       return [];
     }
-    this.#projectRoots.set(project.id, project.root);
+    this.#projects.set(project.id, project);
 
-    const output = await this.#run(
-      this.#args(["list", "--format=json"]),
-      project.root,
-      {
-        code: "WORKTRUNK_COMMAND_FAILED",
-        message: "Worktrunk failed to list worktrees.",
-      },
-      policy,
-    );
-    const observations = parseWorktrunkListJson(output.stdout, {
-      project,
-      providerId: this.id,
-      observedAt: toIsoTimestamp(this.#clock.now()),
-    });
+    const observations = await this.#readWorktrees(project, policy);
     const managedObservations = observations.filter((observation) =>
       isManagedWorktreeObservation(project, observation),
     );
@@ -236,8 +223,28 @@ export class WorktrunkProvider implements WorktreeProvider {
     return withBreadcrumbs;
   }
 
+  async #readWorktrees(
+    project: ProviderProjectConfig,
+    policy: WorktrunkRunPolicy,
+  ): Promise<WorktreeObservation[]> {
+    const output = await this.#run(
+      this.#args(["list", "--format=json"]),
+      project.root,
+      {
+        code: "WORKTRUNK_COMMAND_FAILED",
+        message: "Worktrunk failed to list worktrees.",
+      },
+      policy,
+    );
+    return parseWorktrunkListJson(output.stdout, {
+      project,
+      providerId: this.id,
+      observedAt: toIsoTimestamp(this.#clock.now()),
+    });
+  }
+
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
-    this.#projectRoots.set(request.project.id, request.project.root);
+    this.#projects.set(request.project.id, request.project);
     const base = request.base ?? request.project.worktrunk.base;
     const output = await this.#run(
       this.#args([
@@ -352,8 +359,8 @@ export class WorktrunkProvider implements WorktreeProvider {
         { hint: "Run listWorktrees before removeWorktree so the provider can resolve the target." },
       );
     }
-    const projectRoot = this.#projectRoots.get(observation.projectId);
-    if (projectRoot === undefined) {
+    const project = this.#projects.get(observation.projectId);
+    if (project === undefined) {
       throw new WorktrunkProviderError(
         "WORKTRUNK_WORKTREE_NOT_FOUND",
         "Worktrunk remove requires the repository root from a previous project listing.",
@@ -361,15 +368,37 @@ export class WorktrunkProvider implements WorktreeProvider {
       );
     }
 
+    const currentWorktrees = await this.#readWorktrees(project, { retries: 1 });
+    const selected = currentWorktrees.find((worktree) => samePath(worktree.path, observation.path));
+    if (selected?.state !== "exists") {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_WORKTREE_NOT_FOUND",
+        "Worktrunk remove could not confirm that the selected worktree still exists.",
+        { hint: "Run listWorktrees again before retrying removal." },
+      );
+    }
+    const branchIsShared =
+      !selected.branch.startsWith("detached:") &&
+      currentWorktrees.some(
+        (worktree) =>
+          worktree.state === "exists" &&
+          worktree.branch === selected.branch &&
+          !samePath(worktree.path, selected.path),
+      );
+
+    // Worktrunk 0.64 needs selected-checkout context and cannot delete a branch shared elsewhere.
     await this.#run(
       this.#args([
         "-C",
-        projectRoot,
+        selected.path,
         "remove",
         ...this.#automationHookArgs(),
-        removeTarget(observation),
         ...(request.force === true ? ["--force"] : []),
-        ...(request.force === true ? ["--force-delete"] : []),
+        ...(branchIsShared
+          ? ["--no-delete-branch"]
+          : request.force === true
+            ? ["--force-delete"]
+            : []),
         "--foreground",
         "--format=json",
       ]),
@@ -890,10 +919,6 @@ function parseCommandObservation(
       );
     }
   }
-}
-
-function removeTarget(observation: WorktreeObservation): string {
-  return observation.branch.startsWith("detached:") ? observation.path : observation.branch;
 }
 
 function isManagedWorktreeObservation(

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -385,6 +385,15 @@ export class WorktrunkProvider implements WorktreeProvider {
           worktree.branch === selected.branch &&
           !samePath(worktree.path, selected.path),
       );
+    const removalFlags: string[] = [];
+    if (request.force === true) {
+      removalFlags.push("--force");
+    }
+    if (branchIsShared) {
+      removalFlags.push("--no-delete-branch");
+    } else if (request.force === true) {
+      removalFlags.push("--force-delete");
+    }
 
     // Worktrunk 0.64 needs selected-checkout context and cannot delete a branch shared elsewhere.
     await this.#run(
@@ -393,12 +402,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         selected.path,
         "remove",
         ...this.#automationHookArgs(),
-        ...(request.force === true ? ["--force"] : []),
-        ...(branchIsShared
-          ? ["--no-delete-branch"]
-          : request.force === true
-            ? ["--force-delete"]
-            : []),
+        ...removalFlags,
         "--foreground",
         "--format=json",
       ]),

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -291,16 +291,103 @@ describe("WorktrunkProvider", () => {
     expect(removed).toEqual({ worktreeId: created.id, removed: true });
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
+      ["list", "--format=json"],
       [
         "-C",
-        project.root,
+        "/tmp/station/web/feature",
         "remove",
-        "feature",
         "--force",
         "--force-delete",
         "--foreground",
         "--format=json",
       ],
+    ]);
+  });
+
+  it("removes a selected shared-branch worktree without deleting the shared branch", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const linkedPath = "/tmp/station/web/duplicate-linked";
+    const sharedProject = {
+      ...project,
+      worktrunk: {
+        ...project.worktrunk,
+        includeMain: false,
+      },
+    };
+    let listCalls = 0;
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      useLifecycleHooks: false,
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.includes("list")) {
+          listCalls += 1;
+          return result(
+            input,
+            JSON.stringify([
+              { path: project.root, branch: listCalls === 1 ? "main" : "duplicate" },
+              { path: linkedPath, branch: "duplicate" },
+            ]),
+          );
+        }
+        return result(input, "{}");
+      },
+    });
+
+    const worktrees = await provider.listWorktrees(sharedProject);
+    const selected = worktrees.find((worktree) => worktree.path === linkedPath);
+    expect(selected).toBeDefined();
+    if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
+
+    await provider.removeWorktree({ worktreeId: selected.id, force: true });
+
+    expect(calls.map((call) => call.args)).toEqual([
+      ["list", "--format=json"],
+      ["list", "--format=json"],
+      [
+        "-C",
+        linkedPath,
+        "remove",
+        "--no-hooks",
+        "--force",
+        "--no-delete-branch",
+        "--foreground",
+        "--format=json",
+      ],
+    ]);
+  });
+
+  it("does not remove a worktree missing from the refreshed list", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const linkedPath = "/tmp/station/web/feature";
+    let listCalls = 0;
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.includes("list")) {
+          listCalls += 1;
+          return result(
+            input,
+            listCalls === 1 ? JSON.stringify([{ path: linkedPath, branch: "feature" }]) : "[]",
+          );
+        }
+        return result(input, "{}");
+      },
+    });
+
+    const [selected] = await provider.listWorktrees(project);
+    expect(selected).toBeDefined();
+    if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
+
+    await expect(provider.removeWorktree({ worktreeId: selected.id })).rejects.toMatchObject({
+      code: "WORKTRUNK_WORKTREE_NOT_FOUND",
+    });
+    expect(calls.map((call) => call.args)).toEqual([
+      ["list", "--format=json"],
+      ["list", "--format=json"],
     ]);
   });
 
@@ -436,7 +523,10 @@ describe("WorktrunkProvider", () => {
         if (input.args?.[0] === "remove") {
           return result(input, "{}");
         }
-        return result(input, "[]");
+        return result(
+          input,
+          JSON.stringify([{ path: "/tmp/station/web/feature", branch: "feature" }]),
+        );
       },
     });
 
@@ -445,7 +535,8 @@ describe("WorktrunkProvider", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--no-hooks", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
-      ["-C", project.root, "remove", "--no-hooks", "feature", "--foreground", "--format=json"],
+      ["list", "--format=json"],
+      ["-C", "/tmp/station/web/feature", "remove", "--no-hooks", "--foreground", "--format=json"],
     ]);
   });
 
@@ -466,7 +557,10 @@ describe("WorktrunkProvider", () => {
         if (input.args?.[0] === "remove") {
           return result(input, "{}");
         }
-        return result(input, "[]");
+        return result(
+          input,
+          JSON.stringify([{ path: "/tmp/station/web/feature", branch: "feature" }]),
+        );
       },
     });
 
@@ -475,7 +569,8 @@ describe("WorktrunkProvider", () => {
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--yes", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
-      ["-C", project.root, "remove", "--yes", "feature", "--foreground", "--format=json"],
+      ["list", "--format=json"],
+      ["-C", "/tmp/station/web/feature", "remove", "--yes", "--foreground", "--format=json"],
     ]);
   });
 

--- a/tests/e2e/worktrunk-real.test.ts
+++ b/tests/e2e/worktrunk-real.test.ts
@@ -1,8 +1,10 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp } from "node:fs/promises";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { sameObservedPath } from "@station/contracts";
+import { environmentWithoutGitLocals } from "@station/runtime";
 import {
   installWorktrunkHooks,
   uninstallWorktrunkHooks,
@@ -95,4 +97,78 @@ describeReal("real Worktrunk provider smoke", () => {
       }).catch(() => undefined);
     }
   });
+
+  it("removes only the selected linked checkout when the root shares its branch", async () => {
+    const wt = process.env.STATION_WORKTRUNK_BIN ?? "wt";
+    await execFileAsync(wt, ["--version"]);
+
+    const root = await mkdtemp(join(tmpdir(), "station-real-wt-duplicate-"));
+    const repo = join(root, "repo");
+    const linked = join(root, "linked");
+    const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+    const git = (...args: string[]) =>
+      execFileAsync("git", args, { cwd: repo, env: environmentWithoutGitLocals() });
+
+    try {
+      await mkdir(repo, { recursive: true });
+      await mkdir(join(root, "worktrunk"), { recursive: true });
+      await writeFile(worktrunkConfigPath, "");
+      await git("init", "-b", "main");
+      await git("config", "user.email", "station@example.invalid");
+      await git("config", "user.name", "station");
+      await git("commit", "--allow-empty", "-m", "initial");
+      await git("branch", "duplicate");
+      await git("worktree", "add", linked, "duplicate");
+      await git("switch", "--ignore-other-worktrees", "duplicate");
+
+      const provider = new WorktrunkProvider({
+        command: wt,
+        configPath: worktrunkConfigPath,
+        useLifecycleHooks: false,
+        timeoutMs: 15000,
+      });
+      const project = {
+        id: "duplicate",
+        label: "duplicate",
+        root: repo,
+        defaults: {
+          harness: "codex" as const,
+          terminal: "tmux" as const,
+          layout: "agent-shell" as const,
+        },
+        worktrunk: {
+          enabled: true,
+          base: "main",
+        },
+      };
+
+      const listed = await provider.listWorktrees(project);
+      const selected = listed.find((worktree) => sameObservedPath(worktree.path, linked));
+      expect(selected).toBeDefined();
+      if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
+
+      await expect(provider.removeWorktree({ worktreeId: selected.id })).resolves.toMatchObject({
+        removed: true,
+      });
+
+      const remaining = await git("worktree", "list", "--porcelain");
+      const remainingPaths = remaining.stdout
+        .split("\n")
+        .filter((line) => line.startsWith("worktree "))
+        .map((line) => line.slice("worktree ".length));
+      expect(remainingPaths).toHaveLength(1);
+      expect(remainingPaths.some((path) => sameObservedPath(path, repo))).toBe(true);
+      expect(remainingPaths.some((path) => sameObservedPath(path, linked))).toBe(false);
+      await expect(access(linked)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(git("branch", "--show-current")).resolves.toMatchObject({
+        stdout: "duplicate\n",
+      });
+      await expect(git("show-ref", "--verify", "refs/heads/duplicate")).resolves.toMatchObject({
+        stdout: expect.stringContaining("refs/heads/duplicate"),
+      });
+    } finally {
+      await git("worktree", "remove", "--force", linked).catch(() => undefined);
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

- refresh the raw Worktrunk list immediately before removal and fail closed when the selected checkout is no longer present
- remove from the selected checkout context without a positional selector
- preserve a branch shared by another checkout with `--no-delete-branch`, while retaining existing unique-branch deletion behavior
- cover the argv policy with provider and composition tests plus a bounded real Worktrunk reproduction

## Root cause

Worktrunk 0.64 resolves a branch or path selector to the repository root first when the root and a linked checkout share a branch. Station therefore attempted to remove the root instead of the selected linked checkout.

## Verification

- `STATION_REAL_WORKTRUNK=1 STATION_WORKTRUNK_BIN="$(command -v wt)" pnpm test:e2e:worktrunk:real`
- isolated full unit lane: 1,405 tests passed
- `pnpm test:pre-push` (full repository gate, including cross-runtime SQLite, Station renderer and Bun PTY tests, compiled binary build, and binary smoke)

## UX

Removing the selected linked checkout now succeeds even when the root uses the same branch; the root checkout and shared branch remain intact. Manually verify by putting the root and one linked checkout on the same branch, removing the linked checkout through Station, and confirming only the linked path disappears.

Closes #139