### PR TITLE
fix(setup): make persisted launchers PATH-independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ gh auth login --hostname github.com
     repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  sh "$installer" --version "$tag"
+  sh "$installer" --version "$tag" --persist-path
 )
 ```
 
-The installer block only installs the Station binaries; it does not configure the current project or edit your shell profile. From the same project shell, make the default install available, run guided setup, verify it, and launch the full workspace:
+The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to your login-shell profile. It does not configure the current project. From the same project shell, make the default install available immediately, run guided setup, verify it, and launch the full workspace:
 
 ```sh
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -79,7 +79,7 @@ stn doctor
 stn tui
 ```
 
-`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file for future terminals. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
+`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; `--persist-path` makes the same directory available to future login shells. Omit that flag to leave profiles unchanged and receive an exact opt-in command instead. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
 

--- a/apps/cli/src/commands/setup/checks/launchers.ts
+++ b/apps/cli/src/commands/setup/checks/launchers.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { access as nodeAccess } from "node:fs/promises";
+import { access as nodeAccess, stat as nodeStat } from "node:fs/promises";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CliEnv } from "../../../env.js";
@@ -115,5 +115,8 @@ async function resolveOnPath(
 }
 
 async function executableAccess(path: string): Promise<void> {
+  if (!(await nodeStat(path)).isFile()) {
+    throw new Error(`${path} is not a regular file.`);
+  }
   await nodeAccess(path, fsConstants.X_OK);
 }

--- a/apps/cli/src/commands/setup/checks/launchers.ts
+++ b/apps/cli/src/commands/setup/checks/launchers.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import { access as nodeAccess } from "node:fs/promises";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,7 +31,7 @@ export async function checkSetupLaunchers(
 ): Promise<SetupLaunchersFact> {
   const env = options.env ?? process.env;
   const packageRoot = options.packageRoot ?? setupPackageRoot();
-  const access = options.access ?? nodeAccess;
+  const access = options.access ?? executableAccess;
   const [station, ingress, tmuxPopup] = await Promise.all([
     checkLauncher(launcherDefinitions.station, { access, env, packageRoot }),
     checkLauncher(launcherDefinitions.ingress, { access, env, packageRoot }),
@@ -42,6 +43,10 @@ export async function checkSetupLaunchers(
     ingress,
     tmuxPopup,
   };
+}
+
+export function setupLauncherExecutable(launcher: SetupLauncherFact): string {
+  return launcher.resolvedPath ?? launcher.command;
 }
 
 export function setupPackageRoot(): string {
@@ -98,7 +103,7 @@ async function resolveOnPath(
   }
   for (const pathEntry of pathEnv.split(delimiter)) {
     if (pathEntry.length === 0) continue;
-    const candidate = join(pathEntry, command);
+    const candidate = resolve(pathEntry, command);
     try {
       await access(candidate);
       return candidate;
@@ -107,4 +112,8 @@ async function resolveOnPath(
     }
   }
   return undefined;
+}
+
+async function executableAccess(path: string): Promise<void> {
+  await nodeAccess(path, fsConstants.X_OK);
 }

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -17,7 +17,7 @@ import { setupEnv } from "./env.js";
 import { type CheckGitOptions, checkSetupGit } from "./git.js";
 import { checkSetupGitDelta } from "./gitDelta.js";
 import { type CheckHarnessesOptions, checkSetupHarnesses } from "./harnesses.js";
-import { checkSetupLaunchers } from "./launchers.js";
+import { checkSetupLaunchers, setupLauncherExecutable } from "./launchers.js";
 import { checkSetupStateDir, type SetupStateDirFileSystem } from "./stateDir.js";
 import { checkSetupTmux } from "./tmux.js";
 import { checkSetupTmuxBinding } from "./tmuxBinding.js";
@@ -119,7 +119,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     homeDir,
     env,
     ...(options.fs === undefined ? {} : { fs: options.fs }),
-    launcherCommand: launchers.tmuxPopup.command,
+    launcherCommand: setupLauncherExecutable(launchers.tmuxPopup),
     ...(options.runner === undefined ? {} : { runner: options.runner }),
     tmuxCommand: tmux.command,
   });

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -83,7 +83,7 @@ export function tmuxPopupBindingLine(launcherCommand = "stn-tmux-popup"): string
 }
 
 export function tmuxPopupRunShellCommand(launcherCommand = "stn-tmux-popup"): string {
-  return `env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} ${quoteShellValue(launcherCommand)}`;
+  return `env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} ${quoteShellValue(escapeTmuxFormat(launcherCommand))}`;
 }
 
 function missingTmuxBinding(input: {
@@ -131,26 +131,32 @@ async function checkLiveTmuxBinding(input: {
     if (!hasLiveTmuxBinding(listed.stdout, input.runShellCommand)) {
       return "missing";
     }
-    const executable = await runExternalCommand(
+    const startup = await runExternalCommand(
       {
         command: input.tmuxCommand ?? "tmux",
-        args: ["run-shell", `test -x ${quoteShellValue(input.launcherCommand)}`],
-        allowedExitCodes: [0, 1],
+        args: [
+          "run-shell",
+          `env STATION_SETUP_LAUNCHER_PROBE=1 ${quoteShellValue(escapeTmuxFormat(input.launcherCommand))} --help >/dev/null 2>&1`,
+        ],
+        allowedExitCodes: [0, 1, 126, 127],
         timeoutMs: setupProbeTimeoutMs,
         maxOutputChars: 4096,
         ...(input.env === undefined ? {} : { env: envForExternalCommand(input.env) }),
       },
       input.runner,
     );
-    return executable.exitCode === 0 ? "loaded" : "missing";
+    return startup.exitCode === 0 ? "loaded" : "missing";
   } catch {
     return "unknown";
   }
 }
 
 function hasLiveTmuxBinding(source: string, runShellCommand: string): boolean {
-  // tmux serializes a run-shell argument inside double quotes and doubles its backslashes.
-  const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  // tmux serializes a run-shell argument inside double quotes and escapes shell expansion.
+  const serialized = runShellCommand
+    .replaceAll("\\", "\\\\")
+    .replaceAll("$", "\\$")
+    .replaceAll('"', '\\"');
   return source
     .split(/\r?\n/)
     .some(
@@ -158,6 +164,10 @@ function hasLiveTmuxBinding(source: string, runShellCommand: string): boolean {
         /(?:^|\s)-T\s+prefix\s+Space\s+run-shell\s+-b\s+/.test(line) &&
         line.endsWith(`"${serialized}"`),
     );
+}
+
+function escapeTmuxFormat(value: string): string {
+  return value.replaceAll("#", "##");
 }
 
 function quoteShellValue(value: string): string {

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -29,10 +29,12 @@ export async function checkSetupTmuxBinding(
   const fs = options.fs ?? nodeFsReader();
   const launcherCommand = options.launcherCommand ?? "stn-tmux-popup";
   const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+  const bindingBlock = tmuxPopupBindingBlock(launcherCommand).trimEnd();
   const insideTmux = (options.env ?? process.env).TMUX !== undefined;
   const liveInput: Parameters<typeof checkLiveTmuxBinding>[0] = {
     insideTmux,
     launcherCommand,
+    runShellCommand,
   };
   if (options.env !== undefined) liveInput.env = options.env;
   if (options.runner !== undefined) liveInput.runner = options.runner;
@@ -41,25 +43,14 @@ export async function checkSetupTmuxBinding(
   try {
     const source = await fs.readFile(path);
     if (source.includes(tmuxPopupBindingMarker) || source.includes("stn-tmux-popup")) {
-      if (!source.includes(launcherCommand)) {
+      if (!source.includes(bindingBlock)) {
         return missingTmuxBinding({
           path,
           launcherCommand,
           runShellCommand,
           insideTmux,
           liveStatus,
-          message: "tmux popup binding is installed but uses an outdated STATION launcher command.",
-        });
-      }
-      if (insideTmux && liveStatus === "missing") {
-        return missingTmuxBinding({
-          path,
-          launcherCommand,
-          runShellCommand,
-          insideTmux,
-          liveStatus,
-          message:
-            "tmux popup binding is installed in ~/.tmux.conf but is not loaded in the current tmux server.",
+          message: `tmux popup binding uses a different launcher; rerun stn setup to replace it with ${launcherCommand}.`,
         });
       }
       return {
@@ -119,6 +110,7 @@ async function checkLiveTmuxBinding(input: {
   env?: NodeJS.ProcessEnv;
   insideTmux: boolean;
   launcherCommand: string;
+  runShellCommand: string;
   runner?: ExternalCommandRunner;
   tmuxCommand?: string;
 }): Promise<"loaded" | "missing" | "unknown"> {
@@ -126,20 +118,46 @@ async function checkLiveTmuxBinding(input: {
     return "unknown";
   }
   try {
-    const result = await runExternalCommand(
+    const listed = await runExternalCommand(
       {
         command: input.tmuxCommand ?? "tmux",
-        args: ["list-keys", "-T", "prefix", "Space"],
+        args: ["list-keys", "-T", "prefix"],
+        timeoutMs: setupProbeTimeoutMs,
+        maxOutputChars: 32_768,
+        ...(input.env === undefined ? {} : { env: envForExternalCommand(input.env) }),
+      },
+      input.runner,
+    );
+    if (!hasLiveTmuxBinding(listed.stdout, input.runShellCommand)) {
+      return "missing";
+    }
+    const executable = await runExternalCommand(
+      {
+        command: input.tmuxCommand ?? "tmux",
+        args: ["run-shell", `test -x ${quoteShellValue(input.launcherCommand)}`],
+        allowedExitCodes: [0, 1],
         timeoutMs: setupProbeTimeoutMs,
         maxOutputChars: 4096,
         ...(input.env === undefined ? {} : { env: envForExternalCommand(input.env) }),
       },
       input.runner,
     );
-    return result.stdout.includes(input.launcherCommand) ? "loaded" : "missing";
+    return executable.exitCode === 0 ? "loaded" : "missing";
   } catch {
     return "unknown";
   }
+}
+
+function hasLiveTmuxBinding(source: string, runShellCommand: string): boolean {
+  // tmux serializes a run-shell argument inside double quotes and doubles its backslashes.
+  const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return source
+    .split(/\r?\n/)
+    .some(
+      (line) =>
+        /(?:^|\s)-T\s+prefix\s+Space\s+run-shell\s+-b\s+/.test(line) &&
+        line.endsWith(`"${serialized}"`),
+    );
 }
 
 function quoteShellValue(value: string): string {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -177,17 +177,40 @@ async function runGuidedSetupWithPrompt(
   }
 
   const tmuxPopupBindingActions = plan.actions.filter(isTmuxPopupBindingAction);
+  let tmuxPopupFeedback =
+    facts.tmuxBinding.status === "ok"
+      ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded")
+      : undefined;
   if (tmuxPopupBindingActions.length > 0) {
     const accepted = await prompt.confirm("Install or load tmux popup binding?");
     if (accepted) {
-      await applySetupPlan(
+      const bindingResult = await applySetupPlan(
         {
           ...plan,
           actions: tmuxPopupBindingActions.map((action) => ({ ...action, selected: true })),
         },
         applyOptions(deps, { announceActions: true, showCommandOutput: true }),
       );
+      const completed = new Set(
+        bindingResult.plan.actions
+          .filter((action) => action.status === "completed")
+          .map((action) => action.id),
+      );
+      tmuxPopupFeedback = renderTmuxPopupFeedback(
+        facts.tmuxBinding.status === "ok" || completed.has("tmux-popup-binding"),
+        facts.tmuxBinding.liveStatus === "loaded" || completed.has("tmux-live-popup-binding"),
+        bindingResult.failedAction !== undefined,
+      );
+    } else {
+      tmuxPopupFeedback =
+        facts.tmuxBinding.status === "ok"
+          ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded")
+          : "Tmux popup binding was not changed. Direct fallback: stn popup\n";
     }
+  }
+
+  if (tmuxPopupFeedback !== undefined) {
+    await write(deps, tmuxPopupFeedback);
   }
 
   await write(
@@ -198,6 +221,27 @@ async function runGuidedSetupWithPrompt(
     ),
   );
   return { code: 0 };
+}
+
+function renderTmuxPopupFeedback(
+  persisted: boolean,
+  liveLoaded: boolean,
+  repairIncomplete = false,
+): string {
+  const lines = persisted
+    ? [
+        `Tmux popup binding: Ctrl-b Space is ${
+          liveLoaded
+            ? "persisted and loaded in the current tmux server"
+            : "persisted for future tmux servers; no current server was live-loaded"
+        }.`,
+      ]
+    : ["Tmux popup binding was not persisted. Run stn setup to retry."];
+  if (repairIncomplete) {
+    lines.push("Tmux popup binding repair was incomplete; run stn setup to retry.");
+  }
+  lines.push("Direct fallback: stn popup");
+  return `${lines.join("\n")}\n`;
 }
 
 type HookPreferences = {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -1,4 +1,5 @@
 import { applySetupPlan } from "../apply.js";
+import { checkSetupTmuxBinding } from "../checks/tmuxBinding.js";
 import { planSetupConfigWrite } from "../configWriter.js";
 import {
   activateCompletedConfigWrite,
@@ -177,9 +178,10 @@ async function runGuidedSetupWithPrompt(
   }
 
   const tmuxPopupBindingActions = plan.actions.filter(isTmuxPopupBindingAction);
+  const popupCommand = formatCommand([facts.launchers.station.command, "popup"]);
   let tmuxPopupFeedback =
     facts.tmuxBinding.status === "ok"
-      ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded")
+      ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded", popupCommand)
       : undefined;
   if (tmuxPopupBindingActions.length > 0) {
     const accepted = await prompt.confirm("Install or load tmux popup binding?");
@@ -196,16 +198,30 @@ async function runGuidedSetupWithPrompt(
           .filter((action) => action.status === "completed")
           .map((action) => action.id),
       );
+      let liveLoaded = facts.tmuxBinding.liveStatus === "loaded";
+      if (completed.has("tmux-live-popup-binding")) {
+        const recheckOptions: Parameters<typeof checkSetupTmuxBinding>[0] = {
+          homeDir: facts.homeDir,
+          launcherCommand: facts.tmuxBinding.launcherCommand,
+          tmuxCommand: facts.tmux.command,
+        };
+        const env = deps.env ?? options.env;
+        if (env !== undefined) recheckOptions.env = env;
+        if (deps.fs !== undefined) recheckOptions.fs = deps.fs;
+        if (deps.runner !== undefined) recheckOptions.runner = deps.runner;
+        liveLoaded = (await checkSetupTmuxBinding(recheckOptions)).liveStatus === "loaded";
+      }
       tmuxPopupFeedback = renderTmuxPopupFeedback(
         facts.tmuxBinding.status === "ok" || completed.has("tmux-popup-binding"),
-        facts.tmuxBinding.liveStatus === "loaded" || completed.has("tmux-live-popup-binding"),
+        liveLoaded,
+        popupCommand,
         bindingResult.failedAction !== undefined,
       );
     } else {
       tmuxPopupFeedback =
         facts.tmuxBinding.status === "ok"
-          ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded")
-          : "Tmux popup binding was not changed. Direct fallback: stn popup\n";
+          ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded", popupCommand)
+          : `Tmux popup binding was not changed. Direct fallback: ${popupCommand}\n`;
     }
   }
 
@@ -226,6 +242,7 @@ async function runGuidedSetupWithPrompt(
 function renderTmuxPopupFeedback(
   persisted: boolean,
   liveLoaded: boolean,
+  popupCommand: string,
   repairIncomplete = false,
 ): string {
   const lines = persisted
@@ -240,7 +257,7 @@ function renderTmuxPopupFeedback(
   if (repairIncomplete) {
     lines.push("Tmux popup binding repair was incomplete; run stn setup to retry.");
   }
-  lines.push("Direct fallback: stn popup");
+  lines.push(`Direct fallback: ${popupCommand}`);
   return `${lines.join("\n")}\n`;
 }
 

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,4 +1,5 @@
 import { stationUiInstallHint } from "../../stationWorkspace.js";
+import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
 import { selectSetupHarness } from "./harnessSelection.js";
 import type {
@@ -96,24 +97,7 @@ function setupChecks(
           ? "Recommended after core setup: wt config shell install."
           : "Skipped until Worktrunk is available.",
     },
-    {
-      id: "tmux-popup-binding",
-      tier: "recommended",
-      status:
-        facts.tmux.status === "ok"
-          ? facts.tmuxBinding.status === "ok"
-            ? "ok"
-            : "warning"
-          : "skipped",
-      label: "tmux popup binding",
-      message:
-        facts.tmux.status === "ok"
-          ? facts.tmuxBinding.status === "ok"
-            ? "tmux popup binding is installed."
-            : "Recommended: add Ctrl-b Space binding for the STATION popup dashboard."
-          : "Skipped until tmux is available.",
-      details: { path: facts.tmuxBinding.path },
-    },
+    tmuxPopupBindingCheck(facts),
     worktrunkHooksCheck(facts),
     harnessHooksCheck(facts, selectedHarness),
     diffnavCheck(facts),
@@ -126,6 +110,56 @@ function setupChecks(
       message: "Run stn doctor after setup to validate the observer runtime.",
     },
   ];
+}
+
+function tmuxPopupBindingCheck(facts: SetupFacts): SetupCheck {
+  const base = {
+    id: "tmux-popup-binding",
+    tier: "recommended",
+    label: "tmux popup binding",
+    details: {
+      path: facts.tmuxBinding.path,
+      launcherCommand: facts.tmuxBinding.launcherCommand,
+      liveStatus: facts.tmuxBinding.liveStatus,
+    },
+  } as const;
+  if (facts.tmux.status !== "ok") {
+    return {
+      ...base,
+      status: "skipped",
+      message: "Skipped until tmux is available.",
+    };
+  }
+  if (facts.launchers.tmuxPopup.status !== "ok") {
+    return {
+      ...base,
+      status: "warning",
+      message: "Resolve the stn-tmux-popup launcher, then rerun stn setup to install the binding.",
+    };
+  }
+  if (facts.tmuxBinding.status === "missing") {
+    return {
+      ...base,
+      status: "warning",
+      message: facts.tmuxBinding.message,
+    };
+  }
+  if (facts.tmuxBinding.insideTmux && facts.tmuxBinding.liveStatus !== "loaded") {
+    const liveMessage =
+      facts.tmuxBinding.liveStatus === "missing"
+        ? "is not loaded with that executable launcher"
+        : "could not be verified in the current tmux server";
+    return {
+      ...base,
+      status: "warning",
+      message: `tmux popup binding is persisted but ${liveMessage}; rerun stn setup to repair it.`,
+    };
+  }
+  return {
+    ...base,
+    status: "ok",
+    message: "tmux popup binding is installed.",
+  };
 }
 
 function stateDirCheck(facts: SetupFacts): SetupCheck {
@@ -147,9 +181,9 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
   const missing = launchers.filter((launcher) => launcher.status === "missing");
   const checkout = launchers.filter((launcher) => launcher.source === "checkout");
   const details = {
-    station: facts.launchers.station.command,
-    ingress: facts.launchers.ingress.command,
-    tmuxPopup: facts.launchers.tmuxPopup.command,
+    station: setupLauncherExecutable(facts.launchers.station),
+    ingress: setupLauncherExecutable(facts.launchers.ingress),
+    tmuxPopup: setupLauncherExecutable(facts.launchers.tmuxPopup),
   };
   if (missing.length > 0) {
     return {
@@ -644,7 +678,11 @@ function setupActions(
     message: "Run wt config shell install after core setup if you want Worktrunk shell helpers.",
     command: [facts.worktrunk.command, "-y", "config", "shell", "install"],
   });
-  if (facts.tmux.status === "ok" && facts.tmuxBinding.status === "missing") {
+  if (
+    facts.tmux.status === "ok" &&
+    facts.launchers.tmuxPopup.status === "ok" &&
+    facts.tmuxBinding.status === "missing"
+  ) {
     actions.push({
       id: "tmux-popup-binding",
       kind: "append-file",
@@ -662,6 +700,7 @@ function setupActions(
   }
   if (
     facts.tmux.status === "ok" &&
+    facts.launchers.tmuxPopup.status === "ok" &&
     facts.tmuxBinding.insideTmux &&
     facts.tmuxBinding.liveStatus !== "loaded"
   ) {
@@ -714,7 +753,7 @@ function hookSetupActions(
       label: "Install Worktrunk hooks",
       message: "Install Worktrunk lifecycle hooks that report worktree changes to STATION.",
       command: [
-        facts.launchers.station.command,
+        setupLauncherExecutable(facts.launchers.station),
         "--config",
         facts.configPath,
         "hooks",
@@ -722,7 +761,7 @@ function hookSetupActions(
         "worktrunk",
         "--yes",
         "--hook-bin",
-        facts.launchers.ingress.command,
+        setupLauncherExecutable(facts.launchers.ingress),
       ],
       data: { setupRole: "hook" },
     });
@@ -744,7 +783,7 @@ function hookSetupActions(
 
 function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {
   const command = [
-    facts.launchers.station.command,
+    setupLauncherExecutable(facts.launchers.station),
     "--config",
     facts.configPath,
     "hooks",
@@ -753,7 +792,7 @@ function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessI
     "--yes",
   ];
   if (harness === "claude" || harness === "codex" || harness === "cursor") {
-    command.push("--hook-bin", facts.launchers.ingress.command);
+    command.push("--hook-bin", setupLauncherExecutable(facts.launchers.ingress));
   }
   return command;
 }

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -187,6 +187,8 @@ function detailLines(details: SetupCheck["details"], theme: SetupTheme): string[
     "ingress",
     "tmuxPopup",
     "resolvedPath",
+    "launcherCommand",
+    "liveStatus",
   ];
   const lines: string[] = [];
   for (const key of orderedKeys) {

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
@@ -8,11 +8,13 @@ import { setupProbeTimeoutMs } from "../../src/commands/setup/checks/constants.j
 import { checkSetupDiffnav } from "../../src/commands/setup/checks/diffnav.js";
 import { checkSetupGit } from "../../src/commands/setup/checks/git.js";
 import { checkSetupGitDelta } from "../../src/commands/setup/checks/gitDelta.js";
+import { checkSetupLaunchers } from "../../src/commands/setup/checks/launchers.js";
 import { checkSetupStateDir } from "../../src/commands/setup/checks/stateDir.js";
 import { collectSetupFacts } from "../../src/commands/setup/checks/system.js";
 import {
   checkSetupTmuxBinding,
   tmuxPopupBindingBlock,
+  tmuxPopupRunShellCommand,
 } from "../../src/commands/setup/checks/tmuxBinding.js";
 import { checkSetupXcode } from "../../src/commands/setup/checks/xcode.js";
 import { buildSetupPlan } from "../../src/commands/setup/planner.js";
@@ -698,6 +700,161 @@ scroll_on_output = "teleport"
     }
   });
 
+  it("requires executable launchers and resolves PATH entries to absolute paths", async () => {
+    const root = await tempRoot(tempRoots);
+    const binDir = join(root, "launcher bin");
+    await mkdir(binDir, { recursive: true });
+    await Promise.all(
+      ["stn", "stn-ingress", "stn-tmux-popup"].map((command) =>
+        writeFile(join(binDir, command), "#!/bin/sh\n"),
+      ),
+    );
+    await chmod(join(binDir, "stn"), 0o755);
+    await chmod(join(binDir, "stn-ingress"), 0o644);
+    await chmod(join(binDir, "stn-tmux-popup"), 0o755);
+
+    const launchers = await checkSetupLaunchers({
+      env: { PATH: binDir },
+      packageRoot: join(root, "empty-checkout"),
+    });
+
+    expect(launchers.station).toMatchObject({
+      status: "ok",
+      source: "path",
+      resolvedPath: join(binDir, "stn"),
+    });
+    expect(launchers.ingress).toMatchObject({ status: "missing" });
+    expect(launchers.tmuxPopup).toMatchObject({
+      status: "ok",
+      source: "path",
+      resolvedPath: join(binDir, "stn-tmux-popup"),
+    });
+  });
+
+  it("recognizes an exact absolute tmux binding with quoted path characters", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/station install's/bin/stn-tmux-popup";
+
+    await expect(
+      checkSetupTmuxBinding({
+        homeDir,
+        launcherCommand,
+        fs: readOnlyFs({
+          [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      launcherCommand,
+      liveStatus: "unknown",
+    });
+  });
+
+  it("checks the exact live binding and launcher executable in the tmux server", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/station install's/bin/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    const calls: ExternalCommandInput[] = [];
+    const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
+      calls.push(input);
+      const listKeys = input.args?.[0] === "list-keys";
+      return {
+        command: input.command,
+        args: input.args ?? [],
+        stdout: listKeys ? `bind-key -T prefix Space run-shell -b "${serialized}"\n` : "",
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+
+    await expect(
+      checkSetupTmuxBinding({
+        homeDir,
+        env: { TMUX: "/tmp/tmux.sock,1,0" },
+        launcherCommand,
+        runner,
+        fs: readOnlyFs({
+          [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+        }),
+      }),
+    ).resolves.toMatchObject({ status: "ok", liveStatus: "loaded" });
+    expect(calls).toEqual([
+      expect.objectContaining({ args: ["list-keys", "-T", "prefix"] }),
+      expect.objectContaining({
+        args: ["run-shell", "test -x '/tmp/station install'\\''s/bin/stn-tmux-popup'"],
+      }),
+    ]);
+  });
+
+  it("does not accept live bindings whose executable probe fails or exits 127", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/bin/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+
+    for (const exitCode of [1, 127]) {
+      const binding = await checkSetupTmuxBinding({
+        homeDir,
+        env: { TMUX: "/tmp/tmux.sock,1,0" },
+        launcherCommand,
+        runner: async (input) => ({
+          command: input.command,
+          args: input.args ?? [],
+          stdout:
+            input.args?.[0] === "list-keys"
+              ? `bind-key -T prefix Space run-shell -b "${serialized}"\n`
+              : "",
+          stderr: "",
+          exitCode: input.args?.[0] === "run-shell" ? exitCode : 0,
+        }),
+        fs: readOnlyFs({
+          [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+        }),
+      });
+
+      expect(binding).toMatchObject({
+        status: "ok",
+        liveStatus: "missing",
+        launcherCommand,
+      });
+    }
+  });
+
+  it("treats a legacy live bare binding that would exit 127 as not loaded", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/bin/stn-tmux-popup";
+    const bareRunShellCommand = tmuxPopupRunShellCommand("stn-tmux-popup");
+    const serialized = bareRunShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    const calls: ExternalCommandInput[] = [];
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runner: async (input) => {
+        calls.push(input);
+        return {
+          command: input.command,
+          args: input.args ?? [],
+          stdout: `bind-key -T prefix Space run-shell -b "${serialized}"\n`,
+          stderr: "",
+          exitCode: 0,
+        };
+      },
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+      }),
+    });
+
+    expect(binding).toMatchObject({ status: "ok", liveStatus: "missing" });
+    expect(calls).toHaveLength(1);
+  });
+
   it("reports old tmux popup bindings as missing when setup resolved a checkout launcher", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
@@ -705,13 +862,18 @@ scroll_on_output = "teleport"
       homeDir,
       launcherCommand: "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
       fs: readOnlyFs({
-        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(),
+        [join(homeDir, ".tmux.conf")]: `${tmuxPopupBindingBlock()}\n${tmuxPopupBindingBlock(
+          "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
+        )
+          .split("\n")
+          .at(1)}\n`,
       }),
     });
 
     expect(binding).toMatchObject({
       status: "missing",
-      message: "tmux popup binding is installed but uses an outdated STATION launcher command.",
+      message:
+        "tmux popup binding uses a different launcher; rerun stn setup to replace it with /tmp/station/integrations/terminal/tmux/bin/stn-popup.",
     });
   });
 });

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1,6 +1,6 @@
 import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, delimiter, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { checkSetupBun } from "../../src/commands/setup/checks/bun.js";
@@ -700,6 +700,49 @@ scroll_on_output = "teleport"
     }
   });
 
+  it("escapes tmux formats in absolute launcher paths", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/station-#{session_name}/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    const calls: ExternalCommandInput[] = [];
+
+    expect(runShellCommand).toBe(
+      "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/station-##{session_name}/stn-tmux-popup'",
+    );
+    expect(tmuxPopupBindingBlock(launcherCommand)).toContain(
+      "STATION_FOCUS_CLIENT_ID=#{q:client_name}",
+    );
+
+    await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runner: async (input) => {
+        calls.push(input);
+        return {
+          command: input.command,
+          args: input.args ?? [],
+          stdout:
+            input.args?.[0] === "list-keys"
+              ? `bind-key -T prefix Space run-shell -b "${serialized}"\n`
+              : "",
+          stderr: "",
+          exitCode: 0,
+        };
+      },
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+      }),
+    });
+
+    expect(calls.at(1)?.args).toEqual([
+      "run-shell",
+      "env STATION_SETUP_LAUNCHER_PROBE=1 '/tmp/station-##{session_name}/stn-tmux-popup' --help >/dev/null 2>&1",
+    ]);
+  });
+
   it("requires executable launchers and resolves PATH entries to absolute paths", async () => {
     const root = await tempRoot(tempRoots);
     const binDir = join(root, "launcher bin");
@@ -731,6 +774,33 @@ scroll_on_output = "teleport"
     });
   });
 
+  it("skips executable directories that shadow launcher names on PATH", async () => {
+    const root = await tempRoot(tempRoots);
+    const shadowDir = join(root, "shadow");
+    const binDir = join(root, "bin");
+    const commands = ["stn", "stn-ingress", "stn-tmux-popup"];
+    await Promise.all(
+      commands.map((command) => mkdir(join(shadowDir, command), { recursive: true })),
+    );
+    await mkdir(binDir, { recursive: true });
+    await Promise.all(
+      commands.map(async (command) => {
+        const path = join(binDir, command);
+        await writeFile(path, "#!/bin/sh\n");
+        await chmod(path, 0o755);
+      }),
+    );
+
+    const launchers = await checkSetupLaunchers({
+      env: { PATH: `${shadowDir}${delimiter}${binDir}` },
+      packageRoot: join(root, "empty-checkout"),
+    });
+
+    expect(launchers.station.resolvedPath).toBe(join(binDir, "stn"));
+    expect(launchers.ingress.resolvedPath).toBe(join(binDir, "stn-ingress"));
+    expect(launchers.tmuxPopup.resolvedPath).toBe(join(binDir, "stn-tmux-popup"));
+  });
+
   it("recognizes an exact absolute tmux binding with quoted path characters", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
@@ -751,7 +821,7 @@ scroll_on_output = "teleport"
     });
   });
 
-  it("checks the exact live binding and launcher executable in the tmux server", async () => {
+  it("checks the exact live binding and launcher startup in the tmux server", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
     const launcherCommand = "/tmp/station install's/bin/stn-tmux-popup";
@@ -784,12 +854,82 @@ scroll_on_output = "teleport"
     expect(calls).toEqual([
       expect.objectContaining({ args: ["list-keys", "-T", "prefix"] }),
       expect.objectContaining({
-        args: ["run-shell", "test -x '/tmp/station install'\\''s/bin/stn-tmux-popup'"],
+        args: [
+          "run-shell",
+          "env STATION_SETUP_LAUNCHER_PROBE=1 '/tmp/station install'\\''s/bin/stn-tmux-popup' --help >/dev/null 2>&1",
+        ],
       }),
     ]);
   });
 
-  it("does not accept live bindings whose executable probe fails or exits 127", async () => {
+  it("probes whether the live launcher can start instead of only checking its mode", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/bin/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    const calls: ExternalCommandInput[] = [];
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runner: async (input) => {
+        calls.push(input);
+        const listKeys = input.args?.[0] === "list-keys";
+        return {
+          command: input.command,
+          args: input.args ?? [],
+          stdout: listKeys ? `bind-key -T prefix Space run-shell -b "${serialized}"\n` : "",
+          stderr: "",
+          exitCode: listKeys || input.args?.[1]?.startsWith("test -x ") === true ? 0 : 1,
+        };
+      },
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+      }),
+    });
+
+    expect(binding).toMatchObject({ status: "ok", liveStatus: "missing" });
+    expect(calls.at(1)?.args).toEqual([
+      "run-shell",
+      "env STATION_SETUP_LAUNCHER_PROBE=1 '/tmp/bin/stn-tmux-popup' --help >/dev/null 2>&1",
+    ]);
+  });
+
+  it("recognizes tmux's serialized dollar escaping in launcher paths", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/station $checkout/bin/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand
+      .replaceAll("\\", "\\\\")
+      .replaceAll("$", "\\$")
+      .replaceAll('"', '\\"');
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runner: async (input) => ({
+        command: input.command,
+        args: input.args ?? [],
+        stdout:
+          input.args?.[0] === "list-keys"
+            ? `bind-key -T prefix Space run-shell -b "${serialized}"\n`
+            : "",
+        stderr: "",
+        exitCode: 0,
+      }),
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+      }),
+    });
+
+    expect(binding).toMatchObject({ status: "ok", liveStatus: "loaded" });
+  });
+
+  it("does not accept live bindings whose startup probe fails or exits 127", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
     const launcherCommand = "/tmp/bin/stn-tmux-popup";

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -370,6 +370,7 @@ describe("guided setup command", () => {
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
     const fs = fakeFs({});
+    const chunks: string[] = [];
 
     const result = await runSetupCommand(
       [],
@@ -391,16 +392,23 @@ describe("guided setup command", () => {
           "/fake/bin/bun",
           "/fake/bin/diffnav",
           "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
         ]),
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, true] }),
-        writeStdout: () => undefined,
+        writeStdout: (chunk) => chunks.push(chunk),
       },
     );
 
     expect(result.code).toBe(0);
-    expect(fs.files[join(root, "home/.tmux.conf")]).toContain("stn-tmux-popup");
+    expect(fs.files[join(root, "home/.tmux.conf")]).toContain("'/fake/bin/stn-tmux-popup'");
+    expect(chunks.join("")).toContain(
+      "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers",
+    );
+    expect(chunks.join("")).toContain("Direct fallback: stn popup");
   });
 
   it("installs accepted Worktrunk and agent hooks with resolved ingress launcher", async () => {
@@ -417,8 +425,9 @@ describe("guided setup command", () => {
       "wt --version": "worktrunk 1.2.3\n",
       "tmux -V": "tmux 3.5a\n",
       "codex --version": "codex 0.1.0\n",
-      [`stn --config ${configPath} hooks install worktrunk --yes --hook-bin stn-ingress`]: "",
-      [`stn --config ${configPath} hooks install codex --yes --hook-bin stn-ingress`]: "",
+      [`stn --config ${configPath} hooks install worktrunk --yes --hook-bin /fake/bin/stn-ingress`]:
+        "",
+      [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]: "",
     });
 
     const result = await runSetupCommand(
@@ -430,7 +439,7 @@ describe("guided setup command", () => {
         env: { PATH: "/fake/bin" },
         runner: async (input) => {
           const result = await runner(input);
-          if (input.command === "stn" && input.args?.[2] === "hooks") {
+          if (input.command === "/fake/bin/stn" && input.args?.[2] === "hooks") {
             order.push(`hook:${input.args[4]}`);
           }
           return result;
@@ -461,7 +470,7 @@ describe("guided setup command", () => {
     expect(calls).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          command: "stn",
+          command: "/fake/bin/stn",
           args: [
             "--config",
             configPath,
@@ -470,12 +479,12 @@ describe("guided setup command", () => {
             "worktrunk",
             "--yes",
             "--hook-bin",
-            "stn-ingress",
+            "/fake/bin/stn-ingress",
           ],
           stdio: "inherit",
         }),
         expect.objectContaining({
-          command: "stn",
+          command: "/fake/bin/stn",
           args: [
             "--config",
             configPath,
@@ -484,7 +493,7 @@ describe("guided setup command", () => {
             "codex",
             "--yes",
             "--hook-bin",
-            "stn-ingress",
+            "/fake/bin/stn-ingress",
           ],
           stdio: "inherit",
         }),

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -4,6 +4,10 @@ import { basename, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import { setupPackageRoot } from "../../src/commands/setup/checks/launchers.js";
+import {
+  tmuxPopupBindingBlock,
+  tmuxPopupRunShellCommand,
+} from "../../src/commands/setup/checks/tmuxBinding.js";
 import { runSetupCommand, type SetupPromptAdapter } from "../../src/commands/setup/index.js";
 
 describe("guided setup command", () => {
@@ -67,7 +71,7 @@ describe("guided setup command", () => {
     expect(chunks.join("")).toContain("Core setup complete.");
   });
 
-  it("continues with all three checkout launchers when global installation fails", async () => {
+  it("continues with checkout launchers and prints a usable popup fallback when linking fails", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
@@ -107,7 +111,8 @@ describe("guided setup command", () => {
           async confirm(message: string) {
             return (
               message.includes("Link STATION launchers") ||
-              message.includes("Write STATION project config")
+              message.includes("Write STATION project config") ||
+              message.includes("Install or load tmux popup binding")
             );
           },
           async select() {
@@ -126,6 +131,7 @@ describe("guided setup command", () => {
     expect(chunks.join("")).toContain(
       "STATION launcher link failed. Continuing with checkout launcher paths.",
     );
+    expect(chunks.join("")).toContain(`Direct fallback: ${join(packageRoot, "bin/stn")} popup`);
     expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain("[[projects]]");
   });
 
@@ -409,6 +415,79 @@ describe("guided setup command", () => {
       "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers",
     );
     expect(chunks.join("")).toContain("Direct fallback: stn popup");
+  });
+
+  it("does not report a rebound tmux launcher as loaded when startup still fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const launcherCommand = "/fake/bin/stn-tmux-popup";
+    const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({
+      [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
+    });
+    const calls: ExternalCommandInput[] = [];
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin", TMUX: "/tmp/tmux.sock,1,0" },
+        runner: async (input) => {
+          calls.push(input);
+          const command = basename(input.command);
+          const key = `${command} ${(input.args ?? []).join(" ")}`;
+          if (key === "tmux list-keys -T prefix") {
+            return commandResult(input, `bind-key -T prefix Space run-shell -b "${serialized}"\n`);
+          }
+          if (command === "tmux" && input.args?.[0] === "run-shell") {
+            return { ...commandResult(input, ""), exitCode: 127 };
+          }
+          const outputs: Record<string, string> = {
+            "git rev-parse --show-toplevel": repo,
+            "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+            "wt --version": "worktrunk 1.2.3\n",
+            "tmux -V": "tmux 3.5a\n",
+            "codex --version": "codex 0.1.0\n",
+          };
+          const stdout = outputs[key] ?? defaultProbeOutput(key);
+          if (stdout !== undefined) return commandResult(input, stdout);
+          if (command === "tmux" && input.args?.[0] === "bind-key") {
+            return commandResult(input, "");
+          }
+          throw Object.assign(new Error(`missing fake command: ${key}`), { code: "ENOENT" });
+        },
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          launcherCommand,
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: prompt({ confirms: [false, false, true, false, true] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    const output = chunks.join("");
+    expect(result.code).toBe(0);
+    expect(output).toContain(
+      "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers; no current server was live-loaded.",
+    );
+    expect(output).not.toContain("persisted and loaded in the current tmux server");
+    expect(
+      calls.filter((call) => basename(call.command) === "tmux" && call.args?.[0] === "run-shell"),
+    ).toHaveLength(2);
   });
 
   it("installs accepted Worktrunk and agent hooks with resolved ingress launcher", async () => {

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -244,8 +244,89 @@ describe("setup planner", () => {
       path: "/tmp/home/.tmux.conf",
       data: {
         marker: "# >>> station popup binding >>>",
+        appendedText: expect.stringContaining("'/tmp/bin/stn-tmux-popup'"),
       },
     });
+    expect(plan.actions.find((action) => action.id === "worktrunk-hooks")?.command).toEqual([
+      "/tmp/bin/stn",
+      "--config",
+      "/tmp/config.toml",
+      "hooks",
+      "install",
+      "worktrunk",
+      "--yes",
+      "--hook-bin",
+      "/tmp/bin/stn-ingress",
+    ]);
+    expect(plan.actions.find((action) => action.id === "codex-hooks")?.command).toEqual([
+      "/tmp/bin/stn",
+      "--config",
+      "/tmp/config.toml",
+      "hooks",
+      "install",
+      "codex",
+      "--yes",
+      "--hook-bin",
+      "/tmp/bin/stn-ingress",
+    ]);
+  });
+
+  it("plans the absolute popup command for a reachable tmux server", () => {
+    const plan = buildSetupPlan(
+      facts({
+        tmuxBinding: {
+          status: "ok",
+          path: "/tmp/home/.tmux.conf",
+          marker: "# >>> station popup binding >>>",
+          launcherCommand: "/tmp/bin/stn-tmux-popup",
+          runShellCommand:
+            "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
+          insideTmux: true,
+          liveStatus: "missing",
+        },
+      }),
+    );
+
+    expect(plan.actions.find((action) => action.id === "tmux-live-popup-binding")).toMatchObject({
+      command: [
+        "tmux",
+        "bind-key",
+        "Space",
+        "run-shell",
+        "-b",
+        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
+      ],
+    });
+    expect(plan.actions.some((action) => action.id === "tmux-popup-binding")).toBe(false);
+    expect(plan.checks.find((check) => check.id === "tmux-popup-binding")).toMatchObject({
+      status: "warning",
+      message: expect.stringContaining("persisted"),
+    });
+  });
+
+  it("does not plan popup bindings until the launcher is usable", () => {
+    const base = facts();
+    const plan = buildSetupPlan(
+      facts({
+        launchers: {
+          ...base.launchers,
+          tmuxPopup: {
+            status: "missing",
+            source: "missing",
+            command: "stn-tmux-popup",
+            checkoutPath: "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
+            message: "missing",
+          },
+        },
+        tmuxBinding: { ...base.tmuxBinding, insideTmux: true, liveStatus: "missing" },
+      }),
+    );
+
+    expect(
+      plan.actions.some(
+        (action) => action.id === "tmux-popup-binding" || action.id === "tmux-live-popup-binding",
+      ),
+    ).toBe(false);
   });
 
   it("plans Worktrunk shell integration with Worktrunk's approval prompt disabled", () => {
@@ -267,19 +348,22 @@ describe("setup planner", () => {
         launchers: {
           ...base.launchers,
           station: {
-            ...base.launchers.station,
+            status: "ok",
             source: "checkout",
             command: base.launchers.station.checkoutPath,
+            checkoutPath: base.launchers.station.checkoutPath,
           },
           ingress: {
-            ...base.launchers.ingress,
+            status: "ok",
             source: "checkout",
             command: base.launchers.ingress.checkoutPath,
+            checkoutPath: base.launchers.ingress.checkoutPath,
           },
           tmuxPopup: {
-            ...base.launchers.tmuxPopup,
+            status: "ok",
             source: "checkout",
             command: base.launchers.tmuxPopup.checkoutPath,
+            checkoutPath: base.launchers.tmuxPopup.checkoutPath,
           },
         },
       }),
@@ -500,9 +584,9 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
       status: "missing",
       path: "/tmp/home/.tmux.conf",
       marker: "# >>> station popup binding >>>",
-      launcherCommand: "stn-tmux-popup",
+      launcherCommand: "/tmp/bin/stn-tmux-popup",
       runShellCommand:
-        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} 'stn-tmux-popup'",
+        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
       insideTmux: false,
       liveStatus: "unknown",
       message: "Optional tmux popup binding is not installed.",

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,9 +81,10 @@ pnpm smoke:install
 ```
 
 `pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
-authenticated GitHub responses and temporary homes, so it is deterministic and
-does not download a real release. The single Ubuntu CI gate runs it once. On a
-heavily contended local host, run
+authenticated GitHub responses and temporary homes, including isolated zsh
+login-profile and minimal-PATH fresh-shell coverage, so it is deterministic and
+does not download a real release or modify the real profile. The single Ubuntu
+CI gate runs it once. On a heavily contended local host, run
 `STATION_INSTALL_SMOKE_TIMEOUT_SCALE=4 pnpm smoke:install` to scale only the
 harness deadlines; the default and hosted gate remain strict.
 The release workflow builds and smokes the compiled binary on all four native
@@ -347,19 +348,28 @@ manually verify the actual user experience, not a dashboard override:
 
 1. Install into a clean default `HOME` with `XDG_DATA_HOME` unset and an install
    directory absent from `PATH`. Confirm all three missing launchers are named,
-   the printed current-shell block prepends the safely quoted directory and
-   runs `hash -r` plus `stn setup`, and the absolute `stn` fallback works.
-2. Repeat with an older `stn` shadowing the install and then with one shadowed
-   sibling launcher. Confirm each mismatch is named and no shell profile is
-   edited. With all three launchers resolving physically to the install
-   directory, confirm the short `Next: run stn setup` success message.
+   the profile is unchanged without `--persist-path`, the printed exact opt-in
+   command is idempotent, the current-shell block prepends the safely quoted
+   directory and runs `hash -r` plus `stn setup`, and the absolute `stn`
+   fallback works.
+2. Repeat with `--persist-path`, an existing zsh `.zprofile` containing only
+   Homebrew setup, and an older launcher shadowing the install. Confirm the
+   profile content and mode are preserved, one entry prepends the exact install
+   directory, a new login shell resolves all three launchers there, and a
+   second install adds no duplicate entry. With all three launchers already
+   resolving physically to the install directory, confirm the short
+   `Next: run stn setup` success message.
 3. With the installed binary's runtime `PATH` containing neither Node nor Bun,
    run bare `stn` outside tmux. Confirm the real OpenTUI first-run screen draws
    and connects to a healthy Observer.
 4. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
 5. Run `stn setup` to add a project. Confirm the open TUI reconnects and shows
    it after activation on the same Observer socket.
-6. Run bare `stn` inside tmux and confirm `stn-tmux-popup` opens the popup.
+6. Expose `stn-tmux-popup` only to the shell running `stn setup`, accept the
+   popup binding, and confirm `~/.tmux.conf` contains its safely quoted absolute
+   path. Start a fresh tmux server with `PATH=/usr/bin:/bin`; `Ctrl-b Space`
+   must open the popup without a restart or tmux PATH mutation. Also confirm
+   `stn popup` remains the direct fallback.
 7. Deliver a provider event through `stn-ingress` and confirm it appears in
    Station.
 8. Complete the local `0.7.0-host-a` → `0.7.0-host-b` procedure above with a

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ gh auth login --hostname github.com
     repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  sh "$installer" --version "$tag"
+  sh "$installer" --version "$tag" --persist-path
 )
 ```
 
@@ -38,7 +38,7 @@ The recipe never falls back to `main`. `gh` handles private-repository authentic
 
 ### Complete first-run setup
 
-The installer block only installs the Station binaries; it does not configure the current project or edit your shell profile. The recipe begins by changing into the Git repository that `stn setup` will use as the first Station project. For the default install location, the remaining handoff is:
+The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to the supported login-shell profile. It does not configure the current project. The recipe begins by changing into the Git repository that `stn setup` will use as the first Station project. Because profile changes apply to future login shells, the remaining handoff for the current shell is:
 
 ```bash
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -55,11 +55,11 @@ If the installer reported a PATH mismatch, its printed current-shell block is th
 
 Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes `~/.config/station/config.toml` for the current repository; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
 
-The PATH assignment above affects only the current shell. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell startup file if future terminals do not already include that directory. The installer never edits a profile. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
+The PATH assignment above affects only the current shell. `--persist-path` adds an idempotent entry to the login-shell profile selected from `SHELL` (`.zprofile` for zsh, the first existing bash login profile, or `.profile` for POSIX shells) while preserving existing content such as Homebrew setup. Omit the flag to leave profiles unchanged; unless the exact entry is already present, the installer prints the idempotent command you can run instead, even when its own shell temporarily resolves the launchers. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
 
-Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface.
+Pass `--install-dir PATH` to override the default `~/.local/bin`, and combine it with `--persist-path` to persist that exact custom directory; run `scripts/install.sh --help` from a checkout for the complete command surface.
 
 The installer:
 
@@ -69,7 +69,7 @@ The installer:
 - stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command; compatibility failures include at most 4096 sanitized bytes of probe stderr;
 - keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
 - removes `com.apple.quarantine` from the verified binary defensively on macOS; and
-- resolves all three bare launchers after installation. If any is missing or shadowed, it names every mismatch, prints a safely quoted current-shell block that prepends the install directory, runs `hash -r`, and starts `stn setup`, and also prints the absolute installed `stn` path. It never edits a shell profile.
+- resolves all three bare launchers after installation. If any is missing or shadowed, it names every mismatch, prints a safely quoted current-shell block that prepends the install directory, runs `hash -r`, and starts `stn setup`, and also prints the absolute installed `stn` path. Profile persistence occurs only with `--persist-path`; otherwise it prints an exact opt-in command and leaves the profile unchanged.
 
 ### Concurrent and interrupted installs
 
@@ -192,14 +192,15 @@ Optional integrations can be added later.
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
 `pnpm smoke:install` exercises latest, explicit, and draft selection; strict
-authenticated API arguments; all four platform mappings; default-home and PATH
-shadow behavior; checksum/archive/probe failures; dual-lock concurrency and
-stale recovery; rollback and ambiguous commit points; continuous readers;
-HUP/INT/TERM/SIGKILL; and runner self-interruption against local fake release
-assets. Every child and the overall runner have deadlines. It does not contact
-GitHub or modify the real home directory.
+authenticated API arguments; all four platform mappings; isolated-home login
+profile persistence, minimal-PATH fresh shells, PATH shadow behavior;
+checksum/archive/probe failures; dual-lock concurrency and stale recovery;
+rollback and ambiguous commit points; continuous readers; HUP/INT/TERM/SIGKILL;
+and runner self-interruption against local fake release assets. Every child and
+the overall runner have deadlines. It does not contact GitHub or modify the real
+home directory.
 
-Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. When bare `stn` launchers are not on `PATH`, setup uses launcher paths from the current checkout for generated tmux and hook commands and offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
+Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. Generated tmux and hook commands persist the resolved absolute launcher paths, whether they came from an installed runtime or the current checkout, so later processes do not depend on setup's PATH. When bare `stn` launchers are not on `PATH`, setup offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 
 Useful smoke options:
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -460,7 +460,9 @@ points into the new install directory, the installer prints
 `Next: run stn setup`. Otherwise it names every missing or shadowed launcher,
 prints a safely shell-quoted current-shell block that prepends the directory,
 runs `hash -r`, and invokes `stn setup`, plus the absolute installed `stn`
-fallback. It never edits a shell profile.
+fallback. Profile persistence is explicit: `--persist-path` appends one
+idempotent login-profile entry, while an install without the flag leaves the
+profile unchanged and prints an exact opt-in command.
 
 The first binary release is immutable `v0.7.0` and promotes only after all four
 native targets pass automated and manual acceptance. Published tags and assets
@@ -641,16 +643,20 @@ flow:
 
 1. Install in a clean default home with the directory missing from `PATH`,
    then with an older `stn` and one sibling launcher shadowing it → every
-   mismatch is named, the current-shell recovery block works, and no profile is
-   edited. With all three physical resolutions correct, the short setup next
-   step is printed.
+   mismatch is named, the current-shell recovery block works, and an install
+   without `--persist-path` leaves the profile unchanged. Repeat with explicit
+   persistence into a Homebrew-only `.zprofile`; a fresh shell must resolve all
+   three launchers, and a second install must not duplicate the entry. With all
+   three physical resolutions correct, the short setup next step is printed.
 2. Launch bare `stn` outside tmux in a sanitized, isolated env → real
    OpenTUI renderer draws, observer connects, first-run screen shows.
 3. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
 4. Run `stn setup` adding a project → the observer restarts on the **same
    socket** and reflects the new project immediately (B-config); an open TUI
    reconnects without a manual restart.
-5. Bare `stn` inside tmux → popup path via `stn-tmux-popup`.
+5. Run setup with `stn-tmux-popup` visible only on its temporary `PATH` → the
+   persisted binding contains the absolute launcher, and `Ctrl-b Space` works
+   in a fresh tmux server started with `PATH=/usr/bin:/bin`.
 6. `stn-ingress` symlink delivers a provider hook event end to end.
 7. Use local `0.7.0-host-a` and `0.7.0-host-b` builds while **live host PTYs**
    exist → the new build reports

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -81,7 +81,7 @@ The tmux provider shells out to `tmux` for the workbench and popup local-use pat
 recommended popup binding step. Inside tmux, setup can also load that binding into the current
 tmux server so a restart or manual `tmux source-file ~/.tmux.conf` is not required.
 
-The generated binding uses a resolved `stn-tmux-popup` launcher. In a development checkout this
+The generated binding uses the resolved absolute `stn-tmux-popup` launcher. In a development checkout this
 may be the checkout's `integrations/terminal/tmux/bin/stn-popup` path rather than a bare command.
 Run `pnpm station:link` only when you want bare `stn`, `stn-ingress`, and `stn-tmux-popup` commands
 available globally.

--- a/integrations/terminal/tmux/bin/stn-popup
+++ b/integrations/terminal/tmux/bin/stn-popup
@@ -19,6 +19,12 @@ done
 # pnpm's global shim enters through a symlinked package directory, so resolve the checkout itself.
 root=$(CDPATH= cd -- "$(dirname -- "$script")/../../../.." 2>/dev/null && pwd -P || true)
 
+if [ "${STATION_SETUP_LAUNCHER_PROBE:-}" = 1 ] && [ "$#" -eq 1 ] && [ "$1" = "--help" ]; then
+  entry=$root/apps/cli/dist/main.js
+  [ -f "$entry" ] || exit 1
+  exec node "$entry" popup --help
+fi
+
 clear_popup_client_if_current() {
   tmux_bin=$1
   client_id=$2

--- a/integrations/terminal/tmux/test/unit/popup-launcher.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-launcher.test.ts
@@ -112,6 +112,24 @@ describe("tmux popup launcher", () => {
     await expect(readLog(fixture.logPath)).resolves.toEqual([]);
   });
 
+  it("routes --help through the checkout Node entrypoint without opening tmux", async () => {
+    const binDir = await mkdtemp(join(tmpdir(), "stn-tmux-popup-help-"));
+    const nodePath = join(binDir, "node");
+    await writeFile(nodePath, "#!/bin/sh\nprintf '%s\\n' \"$*\"\n");
+    await chmod(nodePath, 0o700);
+
+    const result = await runLauncher(["--help"], {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      STATION_SETUP_LAUNCHER_PROBE: "1",
+    });
+
+    expect(result).toMatchObject({
+      code: 0,
+      stdout: expect.stringMatching(/apps\/cli\/dist\/main\.js popup --help\n$/),
+      stderr: "",
+    });
+  });
+
   it("closes the current client popup when toggled from the same client", async () => {
     const fixture = await createFakeTmux();
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,9 @@ export GH_HOST=$github_host
 requested_version=""
 requested_version_set=0
 install_dir=""
+persist_path=0
+path_profile=""
+path_profile_entry=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
 install_stage=""
@@ -39,6 +42,7 @@ runtime_committed=0
 activation_ambiguity_reported=0
 activation_failed_precommit=0
 rollback_failed=0
+profile_update_failed=0
 created_ingress=0
 created_popup=0
 created_ingress_inode=""
@@ -47,16 +51,18 @@ preserve_install_stage=0
 line_feed='
 '
 tab='	'
+carriage_return=$(printf '\r')
 
 usage() {
   cat <<'EOF'
-Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH]
+Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH] [--persist-path]
 
 Install the latest stable private Station release, or an explicit version.
 
 Options:
   --version VERSION   Install an immutable v-prefixed release version.
   --install-dir PATH  Install commands here (default: ~/.local/bin).
+  --persist-path      Add the install directory to the login-shell profile.
   -h, --help          Show this help.
 EOF
 }
@@ -86,6 +92,100 @@ print_shell_word() {
         ;;
     esac
   done
+}
+
+select_path_profile() {
+  path_profile=""
+  path_profile_shell=""
+  [ -n "${HOME:-}" ] || return 1
+  case "${SHELL##*/}" in
+    zsh)
+      path_profile=${ZDOTDIR:-$HOME}/.zprofile
+      path_profile_shell=zsh
+      ;;
+    bash)
+      path_profile_shell=bash
+      for profile_candidate in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
+        if [ -e "$profile_candidate" ] || [ -L "$profile_candidate" ]; then
+          path_profile=$profile_candidate
+          break
+        fi
+      done
+      [ -n "$path_profile" ] || path_profile=$HOME/.bash_profile
+      ;;
+    sh|dash|ksh)
+      path_profile=$HOME/.profile
+      path_profile_shell=${SHELL##*/}
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+prepare_path_profile() {
+  select_path_profile || return 1
+  case "$install_dir" in
+    *"$line_feed"*|*"$carriage_return"*) return 1 ;;
+  esac
+  path_profile_entry=$(
+    printf 'export PATH='
+    print_shell_word "$install_dir"
+    printf '%s' '${PATH:+":$PATH"}'
+  )
+}
+
+validate_path_profile() {
+  path_profile_parent=${path_profile%/*}
+  if [ -e "$path_profile" ] || [ -L "$path_profile" ]; then
+    [ -f "$path_profile" ] || fail "--persist-path requires '$path_profile' to be a regular file."
+    [ -r "$path_profile" ] && [ -w "$path_profile" ] || fail "--persist-path requires '$path_profile' to be readable and writable."
+    return 0
+  fi
+  [ -d "$path_profile_parent" ] && [ -w "$path_profile_parent" ] || fail "--persist-path cannot create '$path_profile'; its parent directory must be writable."
+}
+
+path_profile_entry_present() {
+  [ -f "$path_profile" ] || return 1
+  grep -F -x -q "$path_profile_entry" "$path_profile" 2>/dev/null
+}
+
+print_path_persistence_command() {
+  printf 'Future-shell PATH was not changed. To persist Station for %s login shells in ' "$path_profile_shell"
+  print_shell_word "$path_profile"
+  printf ', run:\n  if ! grep -F -x -q '
+  print_shell_word "$path_profile_entry"
+  printf ' '
+  print_shell_word "$path_profile"
+  printf ' 2>/dev/null; then if [ -s '
+  print_shell_word "$path_profile"
+  printf ' ]; then printf '
+  print_shell_word '\n%s\n'
+  printf ' '
+  print_shell_word "$path_profile_entry"
+  printf '; else printf '
+  print_shell_word '%s\n'
+  printf ' '
+  print_shell_word "$path_profile_entry"
+  printf '; fi >> '
+  print_shell_word "$path_profile"
+  printf '; fi\n'
+}
+
+persist_path_profile() {
+  if path_profile_entry_present; then
+    printf 'Future-shell PATH is already configured in '
+    print_shell_word "$path_profile"
+    printf '.\n'
+    return 0
+  fi
+  # Append in place so an existing profile keeps its ownership, mode, and symlink target.
+  if [ -s "$path_profile" ]; then
+    printf '\n%s\n' "$path_profile_entry" >> "$path_profile" || return 1
+  else
+    printf '%s\n' "$path_profile_entry" >> "$path_profile" || return 1
+  fi
+  printf 'Added Station to future %s login shells in ' "$path_profile_shell"
+  print_shell_word "$path_profile"
+  printf '.\n'
 }
 
 readlink_target() {
@@ -451,6 +551,11 @@ while [ "$#" -gt 0 ]; do
       install_dir=$2
       shift 2
       ;;
+    --persist-path)
+      [ "$persist_path" -eq 0 ] || fail "--persist-path may be specified only once."
+      persist_path=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -490,6 +595,10 @@ if [ -z "$install_dir" ]; then
 fi
 absolute_path "$install_dir"
 install_dir=$absolute_result
+if [ "$persist_path" -eq 1 ]; then
+  prepare_path_profile || fail "--persist-path requires a supported login shell (zsh, bash, sh, dash, or ksh) and an install directory without line breaks."
+  validate_path_profile
+fi
 
 if [ -n "${XDG_DATA_HOME:-}" ]; then
   absolute_path "$XDG_DATA_HOME"
@@ -998,6 +1107,30 @@ check_launcher_resolution stn "$binary_path"
 check_launcher_resolution stn-ingress "$ingress_path"
 check_launcher_resolution stn-tmux-popup "$popup_path"
 
+if [ "$persist_path" -eq 1 ]; then
+  if ! persist_path_profile; then
+    warn "Station was installed, but '$path_profile' could not be updated for future shells."
+    print_path_persistence_command
+    profile_update_failed=1
+  fi
+else
+  if prepare_path_profile; then
+    if path_profile_entry_present; then
+      printf 'Future-shell PATH is already configured in '
+      print_shell_word "$path_profile"
+      printf '.\n'
+    else
+      print_path_persistence_command
+    fi
+  else
+    printf 'Future-shell PATH was not changed. Add '
+    print_shell_word "$install_dir"
+    printf ' ahead of PATH in the startup file for login shell '
+    print_shell_word "${SHELL:-unknown}"
+    printf '.\n'
+  fi
+fi
+
 if [ "$path_mismatch" -eq 0 ]; then
   printf 'Next: run stn setup\n'
 else
@@ -1012,4 +1145,4 @@ else
   print_shell_word "$binary_path"
   printf ' setup\n'
 fi
-exit 0
+exit "$profile_update_failed"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,9 +96,10 @@ print_shell_word() {
 
 select_path_profile() {
   path_profile=""
-  path_profile_shell=""
+  path_profile_shell=${SHELL:-}
+  path_profile_shell=${path_profile_shell##*/}
   [ -n "${HOME:-}" ] || return 1
-  case "${SHELL##*/}" in
+  case "$path_profile_shell" in
     zsh)
       path_profile=${ZDOTDIR:-$HOME}/.zprofile
       path_profile_shell=zsh
@@ -115,7 +116,6 @@ select_path_profile() {
       ;;
     sh|dash|ksh)
       path_profile=$HOME/.profile
-      path_profile_shell=${SHELL##*/}
       ;;
     *) return 1 ;;
   esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@ install_dir=""
 persist_path=0
 path_profile=""
 path_profile_entry=""
+path_profile_error=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
 install_stage=""
@@ -43,11 +44,13 @@ activation_ambiguity_reported=0
 activation_failed_precommit=0
 rollback_failed=0
 profile_update_failed=0
+profile_updating=0
 created_ingress=0
 created_popup=0
 created_ingress_inode=""
 created_popup_inode=""
 preserve_install_stage=0
+preserve_temp_dir=0
 line_feed='
 '
 tab='	'
@@ -96,11 +99,25 @@ print_shell_word() {
 
 select_path_profile() {
   path_profile=""
+  path_profile_error=""
   path_profile_shell=${SHELL:-}
   path_profile_shell=${path_profile_shell##*/}
   [ -n "${HOME:-}" ] || return 1
   case "$path_profile_shell" in
     zsh)
+      if [ "${ZDOTDIR+x}" != x ]; then
+        if "$SHELL" -l -c 'if [ "${ZDOTDIR+x}" = x ]; then exit 42; fi; exit 0' </dev/null >/dev/null 2>&1; then
+          :
+        else
+          zsh_probe_status=$?
+          if [ "$zsh_probe_status" -eq 42 ]; then
+            path_profile_error="zsh has a non-exported ZDOTDIR; export ZDOTDIR before using --persist-path."
+          else
+            path_profile_error="could not determine zsh's profile directory; export ZDOTDIR before using --persist-path."
+          fi
+          return 1
+        fi
+      fi
       path_profile=${ZDOTDIR:-$HOME}/.zprofile
       path_profile_shell=zsh
       ;;
@@ -124,7 +141,7 @@ select_path_profile() {
 prepare_path_profile() {
   select_path_profile || return 1
   case "$install_dir" in
-    *"$line_feed"*|*"$carriage_return"*) return 1 ;;
+    *:*|*"$line_feed"*|*"$carriage_return"*) return 1 ;;
   esac
   path_profile_entry=$(
     printf 'export PATH='
@@ -145,7 +162,11 @@ validate_path_profile() {
 
 path_profile_entry_present() {
   [ -f "$path_profile" ] || return 1
-  grep -F -x -q "$path_profile_entry" "$path_profile" 2>/dev/null
+  if grep -F -x -q "$path_profile_entry" "$path_profile" 2>/dev/null; then
+    return 0
+  fi
+  [ "$install_dir" = "$HOME/.local/bin" ] || return 1
+  grep -F -x -q 'export PATH="$HOME/.local/bin:$PATH"' "$path_profile" 2>/dev/null
 }
 
 print_path_persistence_command() {
@@ -177,12 +198,36 @@ persist_path_profile() {
     printf '.\n'
     return 0
   fi
+  profile_existed=0
+  profile_backup=$temp_dir/path-profile.previous
+  if [ -e "$path_profile" ] || [ -L "$path_profile" ]; then
+    cp "$path_profile" "$profile_backup" || return 1
+    profile_existed=1
+  fi
+  # Defer caught signals until a failed in-place append can restore the original profile bytes.
+  profile_updating=1
+  profile_append_status=0
   # Append in place so an existing profile keeps its ownership, mode, and symlink target.
   if [ -s "$path_profile" ]; then
-    printf '\n%s\n' "$path_profile_entry" >> "$path_profile" || return 1
+    printf '\n%s\n' "$path_profile_entry" >> "$path_profile" || profile_append_status=$?
   else
-    printf '%s\n' "$path_profile_entry" >> "$path_profile" || return 1
+    printf '%s\n' "$path_profile_entry" >> "$path_profile" || profile_append_status=$?
   fi
+  if [ "$profile_append_status" -ne 0 ] || [ "$pending_signal_status" -ne 0 ]; then
+    if [ "$profile_existed" -eq 1 ]; then
+      if ! cat "$profile_backup" > "$path_profile"; then
+        preserve_temp_dir=1
+        warn "could not restore '$path_profile'; its original bytes remain at '$profile_backup'."
+      fi
+    elif ! rm -f "$path_profile"; then
+      warn "could not remove the partial profile '$path_profile'."
+    fi
+    profile_updating=0
+    finish_pending_signal
+    return 1
+  fi
+  profile_updating=0
+  finish_pending_signal
   printf 'Added Station to future %s login shells in ' "$path_profile_shell"
   print_shell_word "$path_profile"
   printf '.\n'
@@ -358,7 +403,9 @@ cleanup() {
     fi
   fi
 
-  remove_tree "$temp_dir"
+  if [ "$preserve_temp_dir" -eq 0 ]; then
+    remove_tree "$temp_dir"
+  fi
   if [ "$preserve_install_stage" -eq 0 ]; then
     remove_tree "$install_stage"
   fi
@@ -377,7 +424,7 @@ cleanup() {
 on_signal() {
   signal=$1
   status=$2
-  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ]; then
+  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ] || [ "$profile_updating" -eq 1 ]; then
     if [ "$pending_signal_status" -eq 0 ]; then
       pending_signal_name=$signal
       pending_signal_status=$status
@@ -596,7 +643,10 @@ fi
 absolute_path "$install_dir"
 install_dir=$absolute_result
 if [ "$persist_path" -eq 1 ]; then
-  prepare_path_profile || fail "--persist-path requires a supported login shell (zsh, bash, sh, dash, or ksh) and an install directory without line breaks."
+  if ! prepare_path_profile; then
+    [ -z "$path_profile_error" ] || fail "$path_profile_error"
+    fail "--persist-path requires a supported login shell (zsh, bash, sh, dash, or ksh) and an install directory without colons or line breaks."
+  fi
   validate_path_profile
 fi
 

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -188,9 +188,18 @@ function prepareFixtures() {
 }
 
 function scenarioPlatformInstalls() {
-  for (const platform of platforms) {
+  const shellWithoutShell = join(root, "shell-without-shell");
+  writeExecutable(
+    shellWithoutShell,
+    '#!/bin/sh\ninstaller=$1\nshift\nunset SHELL\n. "$installer"\n',
+  );
+  for (const [index, platform] of platforms.entries()) {
     const installDir = join(root, `install-${platform.target}`);
-    const result = runInstaller({ installDir, platform });
+    const result = runInstaller({
+      installDir,
+      platform,
+      childShell: index === 0 ? shellWithoutShell : "/bin/sh",
+    });
     assertSuccess(result, `${platform.target} latest install`);
     assertInstalled({ installDir, tag: stableTag, target: platform.target });
     assertPathRecovery(result, installDir, ["stn", "stn-ingress", "stn-tmux-popup"]);

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -296,6 +296,7 @@ function scenarioDefaultHomeAndPathResolution() {
 
 function scenarioFutureShellPathPersistence() {
   const installDir = join(root, "Station's custom bin");
+  const zsh = join(fakeBinDir, "zsh");
   const shadowDir = join(root, "future-shell-shadow-bin");
   const currentPath = [shadowDir, fakeBinDir, "/usr/bin", "/bin"];
   const homebrewProfile = [
@@ -320,7 +321,7 @@ function scenarioFutureShellPathPersistence() {
     home: consentHome,
     pathEntries: currentPath,
     extraArguments: ["--persist-path"],
-    environment: { SHELL: "/bin/zsh" },
+    environment: { SHELL: zsh },
   });
   assertSuccess(consent, "explicit future-shell PATH persistence");
   assertIncludes(
@@ -355,7 +356,7 @@ function scenarioFutureShellPathPersistence() {
     home: consentHome,
     pathEntries: currentPath,
     extraArguments: ["--persist-path"],
-    environment: { SHELL: "/bin/zsh" },
+    environment: { SHELL: zsh },
   });
   assertSuccess(idempotent, "idempotent future-shell PATH persistence");
   assertIncludes(
@@ -378,7 +379,7 @@ function scenarioFutureShellPathPersistence() {
     platform: linuxX64(),
     home: noConsentHome,
     pathEntries: currentPath,
-    environment: { SHELL: "/bin/zsh" },
+    environment: { SHELL: zsh },
   });
   assertSuccess(noConsent, "future-shell PATH without consent");
   assertEqual(
@@ -414,7 +415,7 @@ function scenarioFutureShellPathPersistence() {
     platform: linuxX64(),
     home: missingProfileHome,
     extraArguments: ["--persist-path"],
-    environment: { SHELL: "/bin/zsh" },
+    environment: { SHELL: zsh },
   });
   assertSuccess(created, "future-shell PATH creates a missing zprofile");
   assertEqual(
@@ -423,6 +424,128 @@ function scenarioFutureShellPathPersistence() {
     "new zprofile contains only the exact PATH entry",
   );
   assertMode(missingProfile, 0o600, "new zprofile mode");
+
+  const partialAppendShell = join(root, "partial-profile-append-shell");
+  writeExecutable(
+    partialAppendShell,
+    `#!/bin/sh
+printf() {
+  if [ "\${FAKE_PROFILE_APPEND_MODE:-}" != '' ] && [ "\${2-}" = "$FAKE_PROFILE_ENTRY" ]; then
+    command printf '\\n%.20s' "$2"
+    if [ "$FAKE_PROFILE_APPEND_MODE" = signal ]; then
+      kill -TERM "$$"
+      return 0
+    fi
+    return 1
+  fi
+  command printf "$@"
+}
+installer=$1
+shift
+. "$installer"
+`,
+  );
+  for (const [mode, expectedStatus] of [
+    ["failure", 1],
+    ["signal", 143],
+  ]) {
+    const partialHome = join(root, `future-shell-partial-${mode}-home`);
+    const partialProfile = join(partialHome, ".zprofile");
+    const originalProfile = `# profile before ${mode}\n`;
+    makeDirectory(partialHome);
+    writeText(partialProfile, originalProfile, 0o640);
+    const partial = runInstaller({
+      installDir,
+      platform: linuxX64(),
+      home: partialHome,
+      childShell: partialAppendShell,
+      extraArguments: ["--persist-path"],
+      environment: {
+        FAKE_PROFILE_APPEND_MODE: mode,
+        FAKE_PROFILE_ENTRY: expectedEntry,
+        SHELL: zsh,
+      },
+    });
+    assertExactStatus(partial, expectedStatus, `partial profile ${mode}`);
+    assertEqual(
+      readFileSync(partialProfile, "utf8"),
+      originalProfile,
+      `partial profile ${mode} restores the original bytes`,
+    );
+  }
+
+  const customZdotHome = join(root, "future-shell-custom-zdot-home");
+  const customZdotDir = join(customZdotHome, "custom-zdotdir");
+  const customZdotProfile = join(customZdotDir, ".zprofile");
+  makeDirectory(customZdotDir);
+  writeText(
+    join(customZdotHome, ".zshenv"),
+    `[ "\${FAKE_ZSH_LOGIN:-}" != 1 ] || ZDOTDIR="$HOME/custom-zdotdir"\n`,
+    0o600,
+  );
+  writeText(customZdotProfile, "# custom zprofile\n", 0o600);
+  const customZdot = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    home: customZdotHome,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: zsh },
+  });
+  assertFailure(customZdot, "non-exported ZDOTDIR", "non-exported zsh ZDOTDIR");
+  assertEqual(ghCalls(customZdot), [], "non-exported zsh ZDOTDIR makes no gh calls");
+  assert(
+    !existsSync(join(customZdotHome, ".zprofile")),
+    "non-exported ZDOTDIR leaves HOME profile absent",
+  );
+  assertEqual(
+    readFileSync(customZdotProfile, "utf8"),
+    "# custom zprofile\n",
+    "non-exported ZDOTDIR leaves the effective profile unchanged",
+  );
+
+  const colonHome = join(root, "future-shell-colon-home");
+  const colonProfile = join(colonHome, ".zprofile");
+  const colonProfileBefore = "# colon profile\n";
+  makeDirectory(colonHome);
+  writeText(colonProfile, colonProfileBefore, 0o600);
+  const colon = runInstaller({
+    installDir: join(root, "future-shell:colon-bin"),
+    platform: linuxX64(),
+    home: colonHome,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: zsh },
+  });
+  assertFailure(colon, "without colons or line breaks", "colon in persisted install directory");
+  assertEqual(ghCalls(colon), [], "colon in persisted install directory makes no gh calls");
+  assertEqual(
+    readFileSync(colonProfile, "utf8"),
+    colonProfileBefore,
+    "colon in persisted install directory leaves the profile unchanged",
+  );
+
+  const legacyHome = join(root, "future-shell-legacy-home");
+  const legacyProfile = join(legacyHome, ".zprofile");
+  const legacyEntry = 'export PATH="$HOME/.local/bin:$PATH"\n';
+  makeDirectory(legacyHome);
+  writeText(legacyProfile, legacyEntry, 0o600);
+  const legacy = runInstaller({
+    platform: linuxX64(),
+    home: legacyHome,
+    omitInstallDir: true,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: zsh },
+  });
+  assertSuccess(legacy, "legacy documented PATH persistence");
+  assertIncludes(
+    legacy.stdout,
+    "Future-shell PATH is already configured",
+    "legacy documented PATH recognition",
+  );
+  assertEqual(
+    readFileSync(legacyProfile, "utf8"),
+    legacyEntry,
+    "legacy documented PATH entry remains byte-identical",
+  );
 }
 
 function shellWord(value) {
@@ -2324,6 +2447,19 @@ fi
 }
 
 function writeFakeCommands() {
+  writeExecutable(
+    join(fakeBinDir, "zsh"),
+    `#!/bin/sh
+set -eu
+[ "\${1:-}" = -l ] || exit 2
+FAKE_ZSH_LOGIN=1
+shift
+[ "\${1:-}" = -c ] || exit 2
+[ ! -f "$HOME/.zshenv" ] || . "$HOME/.zshenv"
+shift
+eval "$1"
+`,
+  );
   writeExecutable(
     join(fakeBinDir, "uname"),
     [

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -82,6 +82,7 @@ try {
     prepareFixtures();
     await scenarioPlatformInstalls();
     await scenarioDefaultHomeAndPathResolution();
+    await scenarioFutureShellPathPersistence();
     await scenarioExplicitRollbackAndDraft();
     await scenarioStrictGhFlows();
     await scenarioAuthenticatedReleaseValidation();
@@ -216,7 +217,7 @@ function scenarioDefaultHomeAndPathResolution() {
     target: "linux-x64",
   });
   assertPathRecovery(defaultInstall, defaultInstallDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
-  for (const profile of [".profile", ".bashrc", ".zshrc"]) {
+  for (const profile of [".profile", ".bashrc", ".zprofile", ".zshrc"]) {
     assert(!existsSync(join(cleanHome, profile)), `installer leaves ${profile} absent`);
   }
 
@@ -264,14 +265,196 @@ function scenarioDefaultHomeAndPathResolution() {
   );
 
   const correctInstallDir = join(root, "correct-path-bin");
+  const correctPathHome = join(root, "correct-path-home");
+  makeDirectory(correctPathHome);
   const correctPath = runInstaller({
     installDir: correctInstallDir,
     platform: linuxX64(),
+    home: correctPathHome,
     pathEntries: [correctInstallDir, fakeBinDir, "/usr/bin", "/bin"],
+    environment: { SHELL: "/bin/zsh" },
   });
   assertSuccess(correctPath, "all launchers on correct PATH");
   assertIncludes(correctPath.stdout, "Next: run stn setup", "correct PATH next step");
   assertNotIncludes(correctPath.stdout, "hash -r", "correct PATH omits recovery block");
+  assertIncludes(
+    correctPath.stdout,
+    "Future-shell PATH was not changed",
+    "temporary correct PATH still receives future-shell guidance",
+  );
+  assert(!existsSync(join(correctPathHome, ".zprofile")), "correct PATH leaves profile absent");
+}
+
+function scenarioFutureShellPathPersistence() {
+  const installDir = join(root, "Station's custom bin");
+  const shadowDir = join(root, "future-shell-shadow-bin");
+  const currentPath = [shadowDir, fakeBinDir, "/usr/bin", "/bin"];
+  const homebrewProfile = [
+    "# Homebrew shell environment",
+    'export HOMEBREW_PREFIX="/opt/homebrew"',
+    "",
+  ].join("\n");
+  const expectedEntry = `export PATH=${shellWord(installDir)}\${PATH:+":$PATH"}`;
+  makeDirectory(shadowDir);
+  for (const launcher of ["stn", "stn-ingress", "stn-tmux-popup"]) {
+    writeExecutable(join(shadowDir, launcher), "#!/bin/sh\nexit 99\n");
+  }
+
+  const consentHome = join(root, "future-shell-consent-home");
+  const consentProfile = join(consentHome, ".zprofile");
+  makeDirectory(consentHome);
+  writeText(consentProfile, homebrewProfile, 0o640);
+  const profileBefore = statSync(consentProfile);
+  const consent = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    home: consentHome,
+    pathEntries: currentPath,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: "/bin/zsh" },
+  });
+  assertSuccess(consent, "explicit future-shell PATH persistence");
+  assertIncludes(
+    consent.stdout,
+    "Added Station to future zsh login shells",
+    "explicit persistence confirmation",
+  );
+  const persistedProfile = readFileSync(consentProfile, "utf8");
+  assert(persistedProfile.startsWith(homebrewProfile), "persistence preserves Homebrew setup");
+  assertEqual(
+    countExactLines(persistedProfile, expectedEntry),
+    1,
+    "explicit persistence adds one exact PATH entry",
+  );
+  const profileAfter = statSync(consentProfile);
+  assertEqual(profileAfter.ino, profileBefore.ino, "persistence appends to the existing profile");
+  assertEqual(
+    profileAfter.mode & 0o777,
+    profileBefore.mode & 0o777,
+    "persistence preserves profile mode",
+  );
+  assertFutureShellLauncherResolution({
+    home: consentHome,
+    installDir,
+    profile: consentProfile,
+    shadowDir,
+  });
+
+  const idempotent = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    home: consentHome,
+    pathEntries: currentPath,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: "/bin/zsh" },
+  });
+  assertSuccess(idempotent, "idempotent future-shell PATH persistence");
+  assertIncludes(
+    idempotent.stdout,
+    "Future-shell PATH is already configured",
+    "idempotent persistence confirmation",
+  );
+  assertEqual(
+    readFileSync(consentProfile, "utf8"),
+    persistedProfile,
+    "repeated persistence leaves profile byte-identical",
+  );
+
+  const noConsentHome = join(root, "future-shell-no-consent-home");
+  const noConsentProfile = join(noConsentHome, ".zprofile");
+  makeDirectory(noConsentHome);
+  writeText(noConsentProfile, homebrewProfile, 0o600);
+  const noConsent = runInstaller({
+    installDir,
+    platform: linuxX64(),
+    home: noConsentHome,
+    pathEntries: currentPath,
+    environment: { SHELL: "/bin/zsh" },
+  });
+  assertSuccess(noConsent, "future-shell PATH without consent");
+  assertEqual(
+    readFileSync(noConsentProfile, "utf8"),
+    homebrewProfile,
+    "no-flag install leaves profile unchanged",
+  );
+  const persistenceCommand = extractPathPersistenceCommand(noConsent.stdout);
+  const commandResult = spawnSync(
+    "/bin/sh",
+    ["-c", persistenceCommand],
+    syncOptions({ env: { HOME: noConsentHome, PATH: "/usr/bin:/bin" } }),
+  );
+  assertSuccess(commandResult, "printed future-shell PATH command");
+  assertEqual(
+    countExactLines(readFileSync(noConsentProfile, "utf8"), expectedEntry),
+    1,
+    "printed command adds one exact PATH entry",
+  );
+  assertFutureShellLauncherResolution({
+    home: noConsentHome,
+    installDir,
+    profile: noConsentProfile,
+    shadowDir,
+  });
+
+  const missingProfileHome = join(root, "future-shell-missing-profile-home");
+  const missingProfile = join(missingProfileHome, ".zprofile");
+  const missingProfileInstall = join(root, "future-shell-missing-profile-bin");
+  makeDirectory(missingProfileHome);
+  const created = runInstaller({
+    installDir: missingProfileInstall,
+    platform: linuxX64(),
+    home: missingProfileHome,
+    extraArguments: ["--persist-path"],
+    environment: { SHELL: "/bin/zsh" },
+  });
+  assertSuccess(created, "future-shell PATH creates a missing zprofile");
+  assertEqual(
+    readFileSync(missingProfile, "utf8"),
+    `export PATH=${shellWord(missingProfileInstall)}\${PATH:+":$PATH"}\n`,
+    "new zprofile contains only the exact PATH entry",
+  );
+  assertMode(missingProfile, 0o600, "new zprofile mode");
+}
+
+function shellWord(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function countExactLines(value, expected) {
+  return value.split("\n").filter((line) => line === expected).length;
+}
+
+function extractPathPersistenceCommand(stdout) {
+  const marker = ", run:\n  ";
+  const commandStart = stdout.indexOf(marker);
+  assert(commandStart >= 0, "no-flag install prints a future-shell PATH command");
+  const lineStart = commandStart + marker.length;
+  const lineEnd = stdout.indexOf("\n", lineStart);
+  assert(lineEnd > lineStart, "future-shell PATH command occupies one line");
+  const command = stdout.slice(lineStart, lineEnd);
+  assert(command.startsWith("if ! grep -F -x -q "), "future-shell PATH command is idempotent");
+  return command;
+}
+
+function assertFutureShellLauncherResolution({ home, installDir, profile, shadowDir }) {
+  const result = spawnSync(
+    "/bin/sh",
+    [
+      "-c",
+      '. "$1"; for launcher in stn stn-ingress stn-tmux-popup; do command -v "$launcher" || exit; done',
+      "station-future-shell",
+      profile,
+    ],
+    syncOptions({ env: { HOME: home, PATH: `${shadowDir}:/usr/bin:/bin` } }),
+  );
+  assertSuccess(result, "minimal-PATH future shell launcher resolution");
+  assertEqual(
+    result.stdout,
+    `${["stn", "stn-ingress", "stn-tmux-popup"]
+      .map((launcher) => join(installDir, launcher))
+      .join("\n")}\n`,
+    "future shell prepends installed launchers ahead of shadows",
+  );
 }
 
 function scenarioExplicitRollbackAndDraft() {
@@ -571,6 +754,11 @@ function scenarioCliParsing() {
       ["--install-dir", installDir, "--install-dir", join(root, "other-bin")],
       "--install-dir may be specified only once",
       "duplicate install-dir flag",
+    ],
+    [
+      ["--persist-path", "--persist-path"],
+      "--persist-path may be specified only once",
+      "duplicate persist-path flag",
     ],
     [["--install-dir", ""], "non-empty path", "empty install-dir path"],
     [["--unknown"], "unknown option", "unknown option"],
@@ -1944,6 +2132,7 @@ function scenarioHelp() {
   const help = spawnSync("/bin/sh", [installer, "--help"], syncOptions());
   assertSuccess(help, "installer help");
   assertIncludes(help.stdout, "--install-dir", "installer help options");
+  assertIncludes(help.stdout, "--persist-path", "installer persistence help option");
 }
 
 function linuxX64() {

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -245,7 +245,9 @@ describe("release readiness docs", () => {
     );
 
     for (const [path, document] of documents) {
-      expect(document, path).toContain("only installs the Station binaries");
+      expect(document, path).toContain("--persist-path");
+      expect(document, path).toContain("explicit");
+      expect(document, path).toContain("login-shell profile");
       expect(document, path).toContain("cd /path/to/your/git-project");
       expect(document, path).toMatch(/PATH="\$HOME\/\.local\/bin\$\{PATH:\+":\$PATH"\}"/);
       expect(document, path).toContain("hash -r");
@@ -253,7 +255,7 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("stn doctor");
       expect(document, path).toContain("stn tui");
       expect(document, path).toContain("~/.config/station/config.toml");
-      expect(document, path).toContain("shell startup file");
+      expect(document, path).toContain("future login shells");
       expect(document, path).toContain("cold-boot welcome screen");
       expect(document, path).toContain("Create Session");
       expect(document, path).toContain("start the agent session");

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -78,6 +78,66 @@ describe("setup guided feedback e2e", () => {
       await fixture.cleanup();
     }
   });
+
+  it("runs the persisted absolute popup launcher in a fresh minimal-PATH tmux context", async () => {
+    const fixture = await createFixture({ harness: "codex", launchers: "complex" });
+    try {
+      const result = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        // Decline Worktrunk and Codex hooks, write config, decline shell integration,
+        // then accept the popup binding.
+        answers: ["n", "n", "y", "n", "y"],
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers; no current server was live-loaded.",
+      );
+      expect(result.stdout).toContain("Direct fallback: stn popup");
+
+      const tmuxConfigPath = join(fixture.home, ".tmux.conf");
+      const tmuxConfig = await readFile(tmuxConfigPath, "utf8");
+      expect(tmuxConfig).toContain("bind-key Space run-shell -b");
+      expect(tmuxConfig).not.toContain("STATION_FOCUS_CLIENT_ID=#{q:client_name} stn-tmux-popup");
+
+      const freshTmux = spawnSync(
+        "/bin/sh",
+        [
+          "-c",
+          [
+            "set -eu",
+            "bind_key() {",
+            '  [ "$#" -eq 4 ]',
+            '  [ "$1 $2 $3" = "Space run-shell -b" ]',
+            '  PATH=/usr/bin:/bin /bin/sh -c "$4"',
+            "}",
+            "alias bind-key=bind_key",
+            '. "$1"',
+          ].join("\n"),
+          "fresh-tmux",
+          tmuxConfigPath,
+        ],
+        {
+          cwd: fixture.repo,
+          encoding: "utf8",
+          env: {
+            HOME: fixture.home,
+            PATH: "/usr/bin:/bin",
+            STATION_POPUP_TEST_MARKER: fixture.popupMarker,
+          },
+        },
+      );
+
+      expect(freshTmux.status, freshTmux.stderr).toBe(0);
+      expect(await readFile(fixture.popupMarker, "utf8")).toBe(
+        "/usr/bin:/bin\ntmux\n#{q:client_name}\n",
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });
 
 type HarnessMode = "codex" | "installable-codex" | "missing";
@@ -88,20 +148,27 @@ type Fixture = {
   repo: string;
   bin: string;
   configPath: string;
+  popupMarker: string;
   env: NodeJS.ProcessEnv;
   cleanup(): Promise<void>;
 };
 
-async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> {
+async function createFixture(input: {
+  harness: HarnessMode;
+  launchers?: "complex";
+}): Promise<Fixture> {
   const root = await mkdtemp(join(tmpdir(), "station-setup-guided-feedback-"));
   const runtimeDir = await mkdtemp(join(tmpdir(), "stn-setup-run-"));
   const home = join(root, "home");
   const repo = join(root, "repo");
   const bin = join(root, "bin");
+  const launcherBin = input.launchers === "complex" ? join(root, "installed path's bin") : bin;
+  const popupMarker = join(root, "popup-ran.txt");
   const configPath = join(home, ".config", "station", "config.toml");
   await mkdir(home, { recursive: true });
   await mkdir(repo, { recursive: true });
   await mkdir(bin, { recursive: true });
+  await mkdir(launcherBin, { recursive: true });
   await writeShim(
     bin,
     "git",
@@ -147,6 +214,21 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
   if (input.harness === "codex") {
     await writeCodexShim(bin);
   }
+  if (input.launchers === "complex") {
+    await writeShim(launcherBin, "stn", "exit 0\n");
+    await writeShim(launcherBin, "stn-ingress", "exit 0\n");
+    await writeShim(
+      launcherBin,
+      "stn-tmux-popup",
+      [
+        'test -n "$STATION_POPUP_TEST_MARKER"',
+        'printf "%s\\n" "$PATH" > "$STATION_POPUP_TEST_MARKER"',
+        'printf "%s\\n" "$STATION_FOCUS_PROVIDER" >> "$STATION_POPUP_TEST_MARKER"',
+        'printf "%s\\n" "$STATION_FOCUS_CLIENT_ID" >> "$STATION_POPUP_TEST_MARKER"',
+        "",
+      ].join("\n"),
+    );
+  }
   if (input.harness === "installable-codex") {
     await writeShim(bin, "stn", "exit 0\n");
     await writeShim(bin, "stn-ingress", "exit 0\n");
@@ -175,7 +257,7 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
   const env: NodeJS.ProcessEnv = {
     HOME: home,
     XDG_RUNTIME_DIR: runtimeDir,
-    PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+    PATH: `${launcherBin}:${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
     NO_COLOR: "1",
     STATION_WORKTRUNK_BIN: "wt",
     STATION_TMUX_BIN: "tmux",
@@ -194,6 +276,7 @@ async function createFixture(input: { harness: HarnessMode }): Promise<Fixture> 
     repo,
     bin,
     configPath,
+    popupMarker,
     env,
     async cleanup() {
       try {


### PR DESCRIPTION
## Summary

- add explicit, idempotent `--persist-path` support for login-shell profiles while preserving the current-shell and absolute-path handoff
- persist resolved absolute Station launcher paths in tmux bindings and generated Worktrunk/provider hook commands
- distinguish persisted tmux state from live-server readiness and report the `Ctrl-b Space` chord plus `stn popup` fallback
- add isolated-home installer coverage and a fresh minimal-PATH fake-tmux execution test

## Validation

- `pnpm test:all` with isolated `HOME` and `XDG_*` directories
- focused setup unit tests: 84 passed
- setup command integration tests: 12 passed
- setup E2E: 10 passed
- `pnpm smoke:install`
- `pnpm typecheck`
- `pnpm lint`

Closes #157
Closes #158
