### PR TITLE
fix(station): restore active session row on overlay open

### DIFF
--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -1,4 +1,4 @@
-import type { WorktreeRow } from "@station/contracts";
+import type { SessionId, WorktreeRow } from "@station/contracts";
 import { clampDashboardScrollOffset, dashboardBodyRows } from "../components/Dashboard/layout.js";
 import {
   type DashboardViewportItem,
@@ -10,6 +10,33 @@ import type { TuiTransition } from "./transition.js";
 import type { TuiState } from "./types.js";
 
 type WorktreeItem = Extract<DashboardViewportItem, { type: "worktree" }>;
+
+/** Focuses the visible dashboard row for a canonical session identity. */
+export function focusDashboardSession<TState extends TuiState>(
+  state: TState,
+  sessionId: SessionId,
+): TState {
+  if (state.snapshot === undefined) {
+    return clearDashboardFocus(state);
+  }
+  // Match only canonical session identity; worktree and row ids are not session ids.
+  const session = state.snapshot.sessions.find((candidate) => candidate.id === sessionId);
+  if (session === undefined) {
+    return clearDashboardFocus(state);
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  const index = items.findIndex(
+    (item) => item.type === "worktree" && item.row.id === session.worktreeId,
+  );
+  return index === -1 ? clearDashboardFocus(state) : focusItem(state, items, index);
+}
+
+/** Removes transient dashboard row focus without disturbing other view state. */
+export function clearDashboardFocus<TState extends TuiState>(state: TState): TState {
+  const cleared = { ...state };
+  delete cleared.focusedRowId;
+  return cleared;
+}
 
 // Cursor rule (D9): the cursor is where you are — ↑↓/⇥ move it and the viewport
 // follows; jump keys and mouse clicks still teleport-and-activate directly.
@@ -110,11 +137,11 @@ function enterFocusIndex(
   return entered ?? fallback ?? 0;
 }
 
-function focusItem(
-  state: TuiState,
+function focusItem<TState extends TuiState>(
+  state: TState,
   items: readonly DashboardViewportItem[],
   index: number,
-): TuiState {
+): TState {
   const item = items[index];
   if (item === undefined || item.type !== "worktree") {
     return { ...state };

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -12,10 +12,7 @@ import type { TuiState } from "./types.js";
 type WorktreeItem = Extract<DashboardViewportItem, { type: "worktree" }>;
 
 /** Focuses the visible dashboard row for a canonical session identity. */
-export function focusDashboardSession<TState extends TuiState>(
-  state: TState,
-  sessionId: SessionId,
-): TState {
+export function focusDashboardSession(state: TuiState, sessionId: SessionId): TuiState {
   if (state.snapshot === undefined) {
     return clearDashboardFocus(state);
   }
@@ -32,7 +29,7 @@ export function focusDashboardSession<TState extends TuiState>(
 }
 
 /** Removes transient dashboard row focus without disturbing other view state. */
-export function clearDashboardFocus<TState extends TuiState>(state: TState): TState {
+export function clearDashboardFocus(state: TuiState): TuiState {
   const cleared = { ...state };
   delete cleared.focusedRowId;
   return cleared;
@@ -137,11 +134,11 @@ function enterFocusIndex(
   return entered ?? fallback ?? 0;
 }
 
-function focusItem<TState extends TuiState>(
-  state: TState,
+function focusItem(
+  state: TuiState,
   items: readonly DashboardViewportItem[],
   index: number,
-): TState {
+): TuiState {
   const item = items[index];
   if (item === undefined || item.type !== "worktree") {
     return { ...state };

--- a/packages/dashboard-core/src/state/store.ts
+++ b/packages/dashboard-core/src/state/store.ts
@@ -1,6 +1,7 @@
 import { createStationClientRuntime, type StationClientRuntime } from "@station/client";
 import type {
   CommandReceipt,
+  SessionId,
   StationCommand,
   StationSnapshot,
   TerminalFocusOrigin,
@@ -12,6 +13,10 @@ import { safeErrorToToast, toSafeError } from "../services/errors/errors.js";
 import { createNodeFolderService, type TuiFolderService } from "../services/folderService.js";
 import type { TuiObserverService, TuiToast } from "../services/types.js";
 import { buildFocusCommand } from "./commandBuilders.js";
+import {
+  clearDashboardFocus as clearDashboardFocusState,
+  focusDashboardSession as focusDashboardSessionState,
+} from "./dashboardFocus.js";
 import { clampDashboardStateScroll } from "./dashboardScroll.js";
 import type { TuiKey } from "./keys.js";
 import { bridgeOperationService, createObserverBridgeHooks } from "./observerBridge.js";
@@ -35,6 +40,10 @@ export type TuiStore = TuiState & {
   start(): () => void;
   handleKey(key: TuiKey): TuiHandleKeyResult;
   setTerminalRows(rows: number): void;
+  /** Synchronize row focus from a canonical observer session identity. */
+  focusDashboardSession(sessionId: SessionId): void;
+  /** Remove transient row focus without changing other dashboard state. */
+  clearDashboardFocus(): void;
   /** Surface a client-side toast (e.g. an unresolved-harness notice). */
   pushToast(toast: TuiToast): void;
   dismissToasts(): void;
@@ -147,6 +156,16 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
     setTerminalRows: (rows): void => {
       set(clampDashboardStateScroll({ ...get(), terminalRows: rows }));
     },
+    focusDashboardSession: (sessionId): void => {
+      set(
+        (current) =>
+          applyDashboardFocusState(current, focusDashboardSessionState(current, sessionId)),
+        true,
+      );
+    },
+    clearDashboardFocus: (): void => {
+      set((current) => applyDashboardFocusState(current, clearDashboardFocusState(current)), true);
+    },
     pushToast: (toast): void => {
       set(addTuiToast(get(), toast));
     },
@@ -162,6 +181,14 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
   }));
 
   return store;
+}
+
+function applyDashboardFocusState(current: TuiStore, next: TuiState): TuiStore {
+  // Full replacement propagates an absent optional cursor; seeding from the
+  // concrete store retains its action methods.
+  const replacement = { ...current };
+  delete replacement.focusedRowId;
+  return { ...replacement, ...next };
 }
 
 type RuntimeOptions = {

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -29,7 +29,7 @@ export type TuiViewState = {
   scrollOffset: number;
   terminalRows: number;
   localRows: TuiLocalRows;
-  /** Persistent list cursor; a stale id (row gone) is harmless and simply unfocused. */
+  /** List cursor; native overlays synchronize it once per open and clear it on close. */
   focusedRowId?: WorktreeId;
   /** Per-list cursor for screens migrated onto the shared selection engine. */
   selection: TuiSelectionState;

--- a/packages/dashboard-core/test/unit/sourceBridge.test.ts
+++ b/packages/dashboard-core/test/unit/sourceBridge.test.ts
@@ -124,6 +124,8 @@ function makeStore(): StoreApi<TuiStore> {
     start: () => () => {},
     handleKey: () => ({ dismissPopup: false }),
     setTerminalRows: () => {},
+    focusDashboardSession: () => {},
+    clearDashboardFocus: () => {},
     pushToast: () => {},
     dismissToasts: () => {},
     expireToasts: () => {},

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -1,5 +1,12 @@
+import type { StationSnapshot } from "@station/contracts";
 import type { TuiState } from "@station/dashboard-core";
-import { createInitialTuiState, handleTuiKey, selectDashboardItems } from "@station/dashboard-core";
+import {
+  clearDashboardFocus,
+  createInitialTuiState,
+  focusDashboardSession,
+  handleTuiKey,
+  selectDashboardItems,
+} from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
 
@@ -15,6 +22,88 @@ function state(options: Partial<Parameters<typeof createInitialTuiState>[0]> = {
 }
 
 describe("dashboard focus cursor", () => {
+  it("focuses the canonical session row and minimally scrolls it into view", () => {
+    const snapshot = createDashboardSnapshot();
+    snapshot.rows = snapshot.rows.map((row) =>
+      row.id === "wt_api_working" && row.agent !== undefined
+        ? { ...row, agent: { ...row.agent, sessionId: "ses_stale_row_metadata" } }
+        : row,
+    );
+    const initial = {
+      ...createInitialTuiState({ initialSnapshot: snapshot, terminalRows: 12, scrollOffset: 0 }),
+      storeAction: () => "preserved",
+    };
+    const focused = focusDashboardSession(initial, "ses_wt_api_working");
+
+    expect(focused.focusedRowId).toBe("wt_api_working");
+    expect(focused.scrollOffset).toBe(6);
+    expect(focused.storeAction()).toBe("preserved");
+  });
+
+  it.each([
+    ["non-session worktree id", (snapshot: StationSnapshot) => snapshot, "wt_api_working"],
+    [
+      "stale session row",
+      (snapshot: StationSnapshot) => ({
+        ...snapshot,
+        rows: snapshot.rows.filter((row) => row.id !== "wt_api_working"),
+      }),
+      "ses_wt_api_working",
+    ],
+  ])("clears focus for a %s without moving the viewport", (_label, updateSnapshot, sessionId) => {
+    const initial = state({ focusedRowId: "wt_web_attention", scrollOffset: 3 });
+    const snapshot = updateSnapshot(initial.snapshot as StationSnapshot);
+    const focused = focusDashboardSession({ ...initial, snapshot }, sessionId);
+
+    expect("focusedRowId" in focused).toBe(false);
+    expect(focused.scrollOffset).toBe(3);
+  });
+
+  it("clears focus when search filters out the session without changing search or scroll", () => {
+    const initial = state({
+      focusedRowId: "wt_web_attention",
+      searchQuery: "cache-refactor",
+      scrollOffset: 2,
+    });
+    const focused = focusDashboardSession(initial, "ses_wt_api_working");
+
+    expect("focusedRowId" in focused).toBe(false);
+    expect(focused.searchQuery).toBe("cache-refactor");
+    expect(focused.scrollOffset).toBe(2);
+  });
+
+  it("clears focus when the session project is collapsed without changing collapse or scroll", () => {
+    const initial = state({
+      focusedRowId: "wt_web_attention",
+      collapsedProjectIds: ["api"],
+      scrollOffset: 2,
+    });
+    const focused = focusDashboardSession(initial, "ses_wt_api_working");
+
+    expect("focusedRowId" in focused).toBe(false);
+    expect(focused.collapsedProjectIds).toEqual(new Set(["api"]));
+    expect(focused.scrollOffset).toBe(2);
+  });
+
+  it("removes transient focus while preserving extended store actions", () => {
+    const initial = {
+      ...state({ focusedRowId: "wt_web_attention", scrollOffset: 2 }),
+      storeAction: () => "preserved",
+    };
+    const cleared = clearDashboardFocus(initial);
+
+    expect("focusedRowId" in cleared).toBe(false);
+    expect(cleared.scrollOffset).toBe(2);
+    expect(cleared.storeAction()).toBe("preserved");
+  });
+
+  it("continues arrow navigation from synchronized focus", () => {
+    const focused = focusDashboardSession(state({ terminalRows: 12 }), "ses_wt_web_attention");
+    const moved = handleTuiKey(focused, DOWN).state;
+
+    expect(moved.focusedRowId).toBe("wt_web_exited");
+  });
+
   it("enters on the first visible session row and walks rows, skipping headers", () => {
     const first = handleTuiKey(state({ terminalRows: 12 }), DOWN).state;
     expect(first.focusedRowId).toBe("wt_web_working");

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -3,12 +3,14 @@ import type { TuiState } from "@station/dashboard-core";
 import {
   clearDashboardFocus,
   createInitialTuiState,
+  createTuiStore,
   focusDashboardSession,
   handleTuiKey,
   selectDashboardItems,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import { FakeTuiObserverService } from "../../support/fakeObserverService.js";
 
 const DOWN = { input: "", downArrow: true } as const;
 const UP = { input: "", upArrow: true } as const;
@@ -29,15 +31,15 @@ describe("dashboard focus cursor", () => {
         ? { ...row, agent: { ...row.agent, sessionId: "ses_stale_row_metadata" } }
         : row,
     );
-    const initial = {
-      ...createInitialTuiState({ initialSnapshot: snapshot, terminalRows: 12, scrollOffset: 0 }),
-      storeAction: () => "preserved",
-    };
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: 12,
+      scrollOffset: 0,
+    });
     const focused = focusDashboardSession(initial, "ses_wt_api_working");
 
     expect(focused.focusedRowId).toBe("wt_api_working");
     expect(focused.scrollOffset).toBe(6);
-    expect(focused.storeAction()).toBe("preserved");
   });
 
   it.each([
@@ -85,23 +87,31 @@ describe("dashboard focus cursor", () => {
     expect(focused.scrollOffset).toBe(2);
   });
 
-  it("removes transient focus while preserving extended store actions", () => {
-    const initial = {
-      ...state({ focusedRowId: "wt_web_attention", scrollOffset: 2 }),
-      storeAction: () => "preserved",
-    };
+  it("removes transient focus without changing the viewport", () => {
+    const initial = state({ focusedRowId: "wt_web_attention", scrollOffset: 2 });
     const cleared = clearDashboardFocus(initial);
 
     expect("focusedRowId" in cleared).toBe(false);
     expect(cleared.scrollOffset).toBe(2);
-    expect(cleared.storeAction()).toBe("preserved");
   });
 
-  it("continues arrow navigation from synchronized focus", () => {
-    const focused = focusDashboardSession(state({ terminalRows: 12 }), "ses_wt_web_attention");
-    const moved = handleTuiKey(focused, DOWN).state;
+  it("preserves store actions while synchronizing and clearing focus", () => {
+    const snapshot = createDashboardSnapshot();
+    const store = createTuiStore({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      initialState: { terminalRows: 12 },
+    });
 
-    expect(moved.focusedRowId).toBe("wt_web_exited");
+    store.getState().focusDashboardSession("ses_wt_web_attention");
+    store.getState().handleKey(DOWN);
+
+    expect(store.getState().focusedRowId).toBe("wt_web_exited");
+
+    store.getState().clearDashboardFocus();
+
+    expect("focusedRowId" in store.getState()).toBe(false);
+    expect(typeof store.getState().handleKey).toBe("function");
   });
 
   it("enters on the first visible session row and walks rows, skipping headers", () => {

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -97,6 +97,40 @@ describe("Station app composition", () => {
     expect(station.scripted.helpers.isDisposed()).toBe(true);
   });
 
+  it("focuses the active managed session row on each overlay open and clears it on close", async () => {
+    const station = await renderComposedStation();
+    const firstPaneId = agentWorktreePaneId("wt_station_working");
+    const secondPaneId = agentWorktreePaneId("wt_station_idle");
+
+    station.store.actions.createPane(firstPaneId, { role: "primary-agent" });
+    station.store.actions.setPrimaryAgent(firstPaneId, {
+      sessionId: "ses_wt_station_working",
+      terminalTargetId: "native:wt_station_working",
+    });
+    station.store.actions.createPane(secondPaneId, { role: "primary-agent" });
+    station.store.actions.setPrimaryAgent(secondPaneId, {
+      sessionId: "ses_wt_station_idle",
+      terminalTargetId: "native:wt_station_idle",
+    });
+
+    station.store.actions.focusPane(firstPaneId);
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(
+      () => station.composition.stationViewStore.getState().focusedRowId === "wt_station_working",
+    );
+
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(
+      () => !("focusedRowId" in station.composition.stationViewStore.getState()),
+    );
+
+    station.store.actions.focusPane(secondPaneId);
+    station.setup.mockInput.pressKey("o", { ctrl: true });
+    await waitFor(
+      () => station.composition.stationViewStore.getState().focusedRowId === "wt_station_idle",
+    );
+  });
+
   it("renders configured widgets in the Station overlay header", async () => {
     const station = await renderComposedStation({
       tuiConfig: {

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -16,6 +16,7 @@ import {
   writeLayoutSnapshotSync,
   type LayoutWriter,
 } from "../state/layout/layoutPersistence.js";
+import { createOverlayRowFocusReconciler } from "../state/reconcilers/overlayRowFocus.js";
 import { createPaneReconciler } from "../state/reconcilers/reconcilePanes.js";
 import { createSessionReaper } from "../state/reconcilers/sessionReaper.js";
 import { selectPaneRecord } from "../state/selectors.js";
@@ -211,6 +212,7 @@ function createLifecycle(deps: {
     tuiConfigPath,
   } = deps;
   let detachStationSource: (() => void) | undefined;
+  let detachOverlayRowFocus: (() => void) | undefined;
   let detachReconcile: (() => void) | undefined;
   let detachSessionReconcile: (() => void) | undefined;
   let detachLayoutWriter: (() => void) | undefined;
@@ -222,6 +224,8 @@ function createLifecycle(deps: {
       return;
     }
     disposed = true;
+    detachOverlayRowFocus?.();
+    detachOverlayRowFocus = undefined;
     detachStationSource?.();
     detachStationSource = undefined;
     detachReconcile?.();
@@ -272,6 +276,9 @@ function createLifecycle(deps: {
         detachWidgetConfigWrites = startWidgetConfigWrites(stationViewStore, tuiConfigPath);
       }
       detachStationSource = stationViewStore.getState().start();
+      // The overlay bridge may synchronize immediately, so its dashboard source
+      // subscription must already be active before the bridge starts.
+      detachOverlayRowFocus = createOverlayRowFocusReconciler(store, stationViewStore);
       stationClient.start();
     },
     disposeForShutdown: (): void => disposeInternal(true),

--- a/station/src/contextMenu/ContextMenuRoot.test.tsx
+++ b/station/src/contextMenu/ContextMenuRoot.test.tsx
@@ -80,6 +80,8 @@ function emptyStationStore(): StoreApi<TuiStore> {
     start: () => () => {},
     handleKey: () => ({ dismissPopup: false }),
     setTerminalRows: () => {},
+    focusDashboardSession: () => {},
+    clearDashboardFocus: () => {},
     pushToast: () => {},
     dismissToasts: () => {},
     expireToasts: () => {},

--- a/station/src/state/README.md
+++ b/station/src/state/README.md
@@ -24,17 +24,19 @@ registries (`terminal/`), never here.
   `selectActivePaneTree`, `paneTreeIds`). Read-surface for both the view and
   the store; stays at the root because `terminal/PaneGrid.tsx` imports it.
 
-## reconcilers/ — source → store/registry bridges
+## reconcilers/ — state/source coordination bridges
 
-Subscribed by `createStation.ts`; each watches a source and drives effects.
+Subscribed by `createStation.ts`; each watches a source or store and drives effects
+through the state/registry boundary that owns the mutation.
 
 - **`reconcilePanes.ts`** — store workspace → `PtyRegistry`: ensure a live PTY
   for every pane record, dispose entries whose pane is gone.
 - **`sessionReaper.ts`** — observer snapshot → store: when a session leaves the
   snapshot, kill and close its on-screen panes.
-- **`overlayRowFocus.ts`** — pane/overlay store → dashboard store: on each
-  STATION open, focus the visible row for the active pane tree's canonical
-  session identity once; clear transient row focus on close or no match.
+- **`overlayRowFocus.ts`** — pane/overlay store → dashboard-store actions:
+  resolve the active pane tree's explicit primary-agent session identity on
+  each STATION open, defer only until the first snapshot, and request
+  focus/clear without owning dashboard mutation.
 
 ## layout/ — persist + restore plumbing
 

--- a/station/src/state/README.md
+++ b/station/src/state/README.md
@@ -32,6 +32,9 @@ Subscribed by `createStation.ts`; each watches a source and drives effects.
   for every pane record, dispose entries whose pane is gone.
 - **`sessionReaper.ts`** — observer snapshot → store: when a session leaves the
   snapshot, kill and close its on-screen panes.
+- **`overlayRowFocus.ts`** — pane/overlay store → dashboard store: on each
+  STATION open, focus the visible row for the active pane tree's canonical
+  session identity once; clear transient row focus on close or no match.
 
 ## layout/ — persist + restore plumbing
 

--- a/station/src/state/reconcilers/overlayRowFocus.test.ts
+++ b/station/src/state/reconcilers/overlayRowFocus.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "bun:test";
+import type { StationSnapshot } from "@station/contracts";
+import { scrollDashboard, type TuiStore } from "@station/dashboard-core";
+import type { StoreApi } from "zustand/vanilla";
+import { manyProjectsSnapshot } from "../../station/fixtures/scenarios.js";
+import { makeStationTestStore } from "../../station/test/support/makeStationTestStore.js";
+import { createStationStore, type StationStore } from "../store.js";
+import {
+  agentWorktreePaneId,
+  MAIN_PANE_ID,
+  STATION_OVERLAY_ID,
+  worktreePaneId,
+} from "../types.js";
+import { createOverlayRowFocusReconciler } from "./overlayRowFocus.js";
+
+const FIRST_ROW_ID = "wt_station_working";
+const FIRST_SESSION_ID = `ses_${FIRST_ROW_ID}`;
+const SECOND_ROW_ID = "wt_obs_working";
+const SECOND_SESSION_ID = `ses_${SECOND_ROW_ID}`;
+
+describe("createOverlayRowFocusReconciler", () => {
+  it("focuses the managed session from its primary pane or an auxiliary split", () => {
+    for (const returnPane of ["primary", "auxiliary"] as const) {
+      const stationStore = createStationStore({ boot: "empty" });
+      addManagedTree(stationStore, "pane-agent", FIRST_SESSION_ID, "pane-shell");
+      stationStore.actions.focusPane(returnPane === "primary" ? "pane-agent" : "pane-shell");
+      const stationViewStore = loadedViewStore();
+      const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+      stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+
+      expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+      dispose();
+    }
+  });
+
+  const unmatchedCases: ReadonlyArray<{
+    label: string;
+    arrangePane: (store: StationStore) => void;
+  }> = [
+    {
+      label: "standalone shell",
+      arrangePane: (store) => {
+        store.actions.createPane(MAIN_PANE_ID);
+        store.actions.focusPane(MAIN_PANE_ID);
+      },
+    },
+    {
+      label: "worktree-associated shell",
+      arrangePane: (store) => {
+        const paneId = worktreePaneId(FIRST_ROW_ID);
+        store.actions.createPane(paneId);
+        store.actions.focusPane(paneId);
+      },
+    },
+    {
+      label: "stale primary-agent identity",
+      arrangePane: (store) => {
+        const paneId = agentWorktreePaneId(FIRST_ROW_ID);
+        store.actions.createPane(paneId, { role: "primary-agent" });
+        store.actions.setPrimaryAgent(paneId, {
+          sessionId: "ses_stale",
+          terminalTargetId: "target-stale",
+        });
+        store.actions.focusPane(paneId);
+      },
+    },
+  ];
+
+  for (const { label, arrangePane } of unmatchedCases) {
+    it(`does not infer a dashboard row from a ${label}`, () => {
+      const stationStore = createStationStore({ boot: "empty" });
+      arrangePane(stationStore);
+      const stationViewStore = loadedViewStore();
+      stationViewStore.setState({ focusedRowId: SECOND_ROW_ID, scrollOffset: 2 });
+      const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+      stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+
+      expect("focusedRowId" in stationViewStore.getState()).toBe(false);
+      expect(stationViewStore.getState().scrollOffset).toBe(2);
+      dispose();
+    });
+  }
+
+  it("clears focus on close and resolves the newly active pane when reopened", () => {
+    const stationStore = createStationStore({ boot: "empty" });
+    addManagedTree(stationStore, "pane-first", FIRST_SESSION_ID);
+    addManagedTree(stationStore, "pane-second", SECOND_SESSION_ID);
+    stationStore.actions.focusPane("pane-first");
+    const stationViewStore = loadedViewStore();
+    const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+    stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+
+    stationStore.actions.closeOverlay();
+    expect("focusedRowId" in stationViewStore.getState()).toBe(false);
+
+    stationStore.actions.focusPane("pane-second");
+    stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_ROW_ID);
+    dispose();
+  });
+
+  it("synchronizes a delayed first snapshot once without snapping navigation back", () => {
+    const stationStore = managedStore(FIRST_SESSION_ID);
+    const stationViewStore = unloadedViewStore();
+    const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+    stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+    expect("focusedRowId" in stationViewStore.getState()).toBe(false);
+
+    const firstSnapshot = manyProjectsSnapshot();
+    stationViewStore.setState({ snapshot: firstSnapshot, loading: false });
+    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+
+    stationViewStore.getState().handleKey({ input: "", downArrow: true });
+    const navigatedRowId = stationViewStore.getState().focusedRowId;
+    expect(navigatedRowId).not.toBe(FIRST_ROW_ID);
+
+    stationViewStore.setState(scrollDashboard(stationViewStore.getState(), 1));
+    const scrolledOffset = stationViewStore.getState().scrollOffset;
+    expect(scrolledOffset).toBeGreaterThan(0);
+
+    const laterSnapshot: StationSnapshot = {
+      ...firstSnapshot,
+      generatedAt: "2026-06-12T12:01:00.000Z",
+    };
+    stationViewStore.setState({ snapshot: laterSnapshot });
+
+    expect(stationViewStore.getState().focusedRowId).toBe(navigatedRowId);
+    expect(stationViewStore.getState().scrollOffset).toBe(scrolledOffset);
+    dispose();
+  });
+
+  it("cancels a pending first-snapshot synchronization when the overlay closes", () => {
+    const stationStore = managedStore(FIRST_SESSION_ID);
+    const stationViewStore = unloadedViewStore();
+    const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+    stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+    stationStore.actions.closeOverlay();
+    stationViewStore.setState({ snapshot: manyProjectsSnapshot(), loading: false });
+
+    expect("focusedRowId" in stationViewStore.getState()).toBe(false);
+    dispose();
+  });
+
+  it("disposes both the Station and dashboard subscriptions", () => {
+    const stationStore = managedStore(FIRST_SESSION_ID);
+    const stationViewStore = unloadedViewStore();
+    const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
+
+    stationStore.actions.openOverlay(STATION_OVERLAY_ID);
+    dispose();
+    dispose();
+
+    stationViewStore.setState({ snapshot: manyProjectsSnapshot(), loading: false });
+    expect("focusedRowId" in stationViewStore.getState()).toBe(false);
+
+    stationViewStore.setState({ focusedRowId: SECOND_ROW_ID });
+    stationStore.actions.closeOverlay();
+    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_ROW_ID);
+  });
+});
+
+function loadedViewStore(): StoreApi<TuiStore> {
+  return makeStationTestStore({ snapshot: manyProjectsSnapshot(), terminalRows: 12 }).store;
+}
+
+function unloadedViewStore(): StoreApi<TuiStore> {
+  return makeStationTestStore({ snapshot: null, terminalRows: 12 }).store;
+}
+
+function managedStore(sessionId: string): StationStore {
+  const store = createStationStore({ boot: "empty" });
+  addManagedTree(store, "pane-agent", sessionId);
+  store.actions.focusPane("pane-agent");
+  return store;
+}
+
+function addManagedTree(
+  store: StationStore,
+  primaryPaneId: string,
+  sessionId: string,
+  auxiliaryPaneId?: string,
+): void {
+  store.actions.createPane(primaryPaneId, { role: "primary-agent" });
+  store.actions.setPrimaryAgent(primaryPaneId, {
+    sessionId,
+    terminalTargetId: `target-${sessionId}`,
+  });
+  if (auxiliaryPaneId !== undefined) {
+    store.actions.createPane(auxiliaryPaneId, {
+      split: { anchorPaneId: primaryPaneId, direction: "right" },
+    });
+  }
+}

--- a/station/src/state/reconcilers/overlayRowFocus.ts
+++ b/station/src/state/reconcilers/overlayRowFocus.ts
@@ -1,8 +1,4 @@
-import {
-  clearDashboardFocus,
-  focusDashboardSession,
-  type TuiStore,
-} from "@station/dashboard-core";
+import type { TuiStore } from "@station/dashboard-core";
 import type { StoreApi } from "zustand/vanilla";
 import { paneTreeIds } from "../paneTree.js";
 import type { StationStore } from "../store.js";
@@ -17,11 +13,8 @@ export function createOverlayRowFocusReconciler(
   let pendingSessionId: string | undefined;
   let disposed = false;
 
-  const replaceDashboardState = (state: TuiStore): void => {
-    stationViewStore.setState(state, true);
-  };
   const clearFocus = (): void => {
-    replaceDashboardState(clearDashboardFocus(stationViewStore.getState()));
+    stationViewStore.getState().clearDashboardFocus();
   };
   const synchronize = (sessionId: string): void => {
     const state = stationViewStore.getState();
@@ -31,7 +24,7 @@ export function createOverlayRowFocusReconciler(
       return;
     }
     pendingSessionId = undefined;
-    replaceDashboardState(focusDashboardSession(state, sessionId));
+    state.focusDashboardSession(sessionId);
   };
 
   const detachStationStore = store.subscribe(() => {
@@ -60,11 +53,11 @@ export function createOverlayRowFocusReconciler(
     if (pendingSessionId === undefined || state.snapshot === undefined) {
       return;
     }
-    // Clear before replacing state so the replacement notification cannot
-    // resynchronize subsequent cursor or scroll changes.
+    // Clear before the dashboard action notifies subscribers so subsequent
+    // cursor or scroll changes cannot resynchronize.
     const sessionId = pendingSessionId;
     pendingSessionId = undefined;
-    replaceDashboardState(focusDashboardSession(state, sessionId));
+    state.focusDashboardSession(sessionId);
   });
 
   return () => {

--- a/station/src/state/reconcilers/overlayRowFocus.ts
+++ b/station/src/state/reconcilers/overlayRowFocus.ts
@@ -1,0 +1,91 @@
+import {
+  clearDashboardFocus,
+  focusDashboardSession,
+  type TuiStore,
+} from "@station/dashboard-core";
+import type { StoreApi } from "zustand/vanilla";
+import { paneTreeIds } from "../paneTree.js";
+import type { StationStore } from "../store.js";
+import { STATION_OVERLAY_ID } from "../types.js";
+
+/** Synchronizes native-pane identity to the dashboard cursor once per overlay open. */
+export function createOverlayRowFocusReconciler(
+  store: StationStore,
+  stationViewStore: StoreApi<TuiStore>,
+): () => void {
+  let previousOverlay = store.getState().input.activeOverlay;
+  let pendingSessionId: string | undefined;
+  let disposed = false;
+
+  const replaceDashboardState = (state: TuiStore): void => {
+    stationViewStore.setState(state, true);
+  };
+  const clearFocus = (): void => {
+    replaceDashboardState(clearDashboardFocus(stationViewStore.getState()));
+  };
+  const synchronize = (sessionId: string): void => {
+    const state = stationViewStore.getState();
+    if (state.snapshot === undefined) {
+      clearFocus();
+      pendingSessionId = sessionId;
+      return;
+    }
+    pendingSessionId = undefined;
+    replaceDashboardState(focusDashboardSession(state, sessionId));
+  };
+
+  const detachStationStore = store.subscribe(() => {
+    const activeOverlay = store.getState().input.activeOverlay;
+    const opened = previousOverlay !== STATION_OVERLAY_ID && activeOverlay === STATION_OVERLAY_ID;
+    const closed = previousOverlay === STATION_OVERLAY_ID && activeOverlay !== STATION_OVERLAY_ID;
+    previousOverlay = activeOverlay;
+
+    if (opened) {
+      pendingSessionId = undefined;
+      // Pane-tree membership finds the explicit primary agent; pane ids and paths
+      // are never treated as observer session identity.
+      const sessionId = sessionIdForOverlayReturn(store);
+      if (sessionId === undefined) {
+        clearFocus();
+      } else {
+        synchronize(sessionId);
+      }
+    } else if (closed) {
+      pendingSessionId = undefined;
+      clearFocus();
+    }
+  });
+
+  const detachDashboardStore = stationViewStore.subscribe((state) => {
+    if (pendingSessionId === undefined || state.snapshot === undefined) {
+      return;
+    }
+    // Clear before replacing state so the replacement notification cannot
+    // resynchronize subsequent cursor or scroll changes.
+    const sessionId = pendingSessionId;
+    pendingSessionId = undefined;
+    replaceDashboardState(focusDashboardSession(state, sessionId));
+  });
+
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    pendingSessionId = undefined;
+    detachStationStore();
+    detachDashboardStore();
+  };
+}
+
+function sessionIdForOverlayReturn(store: StationStore): string | undefined {
+  const state = store.getState();
+  const returnFocus = state.input.overlayReturnFocus;
+  if (returnFocus?.kind !== "pane") {
+    return undefined;
+  }
+  const treeIds = paneTreeIds(state.workspace.panes, returnFocus.paneId);
+  return state.workspace.panes.find(
+    (pane) => treeIds.has(pane.id) && pane.role === "primary-agent",
+  )?.agentIdentity?.sessionId;
+}

--- a/station/src/station/store/stationViewStore.ts
+++ b/station/src/station/store/stationViewStore.ts
@@ -1,7 +1,7 @@
 // The STATION view's store: the shared TuiState machine fed by Station's source
-// boundary. main.tsx owns the instance (view state survives overlay toggles
-// because the store outlives the overlay component). The runtime flags pin the
-// popup posture:
+// boundary. createStation.ts owns the instance, so search, collapse, and scroll
+// state survive overlay toggles; overlayRowFocus separately treats row focus as
+// transient. The runtime flags pin the popup posture:
 // in Station the STATION view is always a persistent popup whose dismiss is
 // executed by the router (overlay-close outcome) — the store-level onDismiss
 // is a recorded no-op so canDismissPopup derives true and Q/Esc produce


### PR DESCRIPTION
## Summary

- focus the dashboard row for the active managed session whenever the STATION overlay opens
- minimally scroll that row into view without changing search, collapse, modal, or unrelated dashboard state
- clear transient row focus on close or when no canonical session match exists
- preserve normal keyboard and mouse navigation after the one-shot synchronization

Closes #162.

## Root cause

The pane/overlay coordination store and dashboard cursor store had no lifecycle bridge. Dashboard row focus therefore survived overlay closes and reopening could show stale navigation instead of the session owning terminal focus.

## Changes

- add plain `TuiState → TuiState` dashboard-core helpers for exact session matching, visible-row focus, viewport following, and optional-property deletion
- keep Zustand replacement behind concrete dashboard-store focus/clear actions so action methods remain intact without subtype generics
- add a Station reconciler that owns only native overlay timing and explicit primary-agent identity resolution
- defer synchronization until the first snapshot when necessary, then synchronize only once
- wire and dispose the reconciler with Station startup, shutdown, and HMR
- document the pane/overlay-store → dashboard-store-action boundary
- add unit and composition coverage for primary and auxiliary panes, unmatched shells, stale identities, delayed snapshots, close/reopen, navigation, scrolling, action preservation, and disposal

## Validation

- `pnpm exec vitest run packages/dashboard-core/test/unit/state/dashboardFocus.test.ts packages/dashboard-core/test/unit/sourceBridge.test.ts` — 20 passed
- focused Station boundary suite — 25 passed
- `cd station && bun run typecheck` — passed
- isolated `pnpm test:pre-push` — passed, including 1,412 root unit tests, integration/E2E suites, cross-runtime SQLite/claim races, 999 Station tests, Bun PTY smoke, native binary build, and binary smoke
- pre-commit Biome/source-order/raw-hex checks — passed

## UX

Opening STATION from a managed primary pane or one of its auxiliary splits highlights and reveals that session row. Closing removes the highlight; reopening after pane focus changes follows the new session. Opening from a standalone shell leaves no row focused.

Manual follow-up: verify the open/close/reopen behavior through Ctrl-O, Escape, Q, backdrop, and header actions in a live Station session.