### PR TITLE
fix(worktrunk): explain unresolved worktree bases

### DIFF
--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, normalize, relative, resolve } from "node:path";
+import { stripVTControlCharacters } from "node:util";
 import type {
   CreateWorktreeRequest,
   DiagnosticDetail,
@@ -260,6 +261,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       {
         code: "WORKTRUNK_COMMAND_FAILED",
         message: "Worktrunk failed to create a worktree.",
+        ...(base === undefined ? {} : { unresolvedBase: base }),
       },
       {},
       worktreePathEnv(request.project, request.branch, request.path),
@@ -596,6 +598,7 @@ export class WorktrunkProvider implements WorktreeProvider {
     fallback: {
       code: "WORKTRUNK_COMMAND_FAILED" | "WORKTRUNK_UNAVAILABLE";
       message: string;
+      unresolvedBase?: string;
     } = {
       code: "WORKTRUNK_UNAVAILABLE",
       message: "Worktrunk is not available.",
@@ -689,14 +692,9 @@ export class WorktrunkProvider implements WorktreeProvider {
           },
         );
       }
-      throw providerErrorFromUnknown(
-        cause,
-        classifyWorktrunkFailure(cause, {
-          code: fallback.code,
-          message: fallback.message,
-        }),
-        { diagnosticDetails },
-      );
+      throw providerErrorFromUnknown(cause, classifyWorktrunkFailure(cause, fallback), {
+        diagnosticDetails,
+      });
     }
   }
 }
@@ -761,13 +759,15 @@ function classifyWorktrunkFailure(
   fallback: {
     code: "WORKTRUNK_COMMAND_FAILED" | "WORKTRUNK_UNAVAILABLE";
     message: string;
+    unresolvedBase?: string;
   },
 ): { code: WorktrunkProviderErrorCode; message: string; hint?: string } {
   if (fallback.code !== "WORKTRUNK_COMMAND_FAILED") {
     return fallback;
   }
 
-  const text = diagnosticText(error).toLowerCase();
+  const diagnostic = stripVTControlCharacters(diagnosticText(error));
+  const text = diagnostic.toLowerCase();
   if (isUnsupportedFlagText(text)) {
     return {
       code: "WORKTRUNK_UNSUPPORTED_FLAG",
@@ -798,6 +798,17 @@ function classifyWorktrunkFailure(
       code: "WORKTRUNK_WORKTREE_EXISTS",
       message: "Worktrunk could not create the worktree because the worktree path already exists.",
       hint: "Choose a different branch/path or remove the stale worktree path.",
+    };
+  }
+
+  if (
+    fallback.unresolvedBase !== undefined &&
+    unresolvedNamedReference(diagnostic) === fallback.unresolvedBase
+  ) {
+    return {
+      code: "WORKTRUNK_BASE_MISSING",
+      message: `Base \`${fallback.unresolvedBase}\` does not resolve to a commit.`,
+      hint: "Create its first commit or choose another base.",
     };
   }
 
@@ -847,6 +858,10 @@ function isDuplicateWorktreeText(text: string): boolean {
     /\bpath\b.*\balready exists/.test(text) ||
     /\bdestination\b.*\balready exists/.test(text)
   );
+}
+
+function unresolvedNamedReference(text: string): string | undefined {
+  return /no branch, tag, or commit named ['"]?([^'"\s]+)['"]?/i.exec(text)?.[1];
 }
 
 function isMissingBaseText(text: string): boolean {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -663,6 +663,119 @@ describe("WorktrunkProvider", () => {
     });
   });
 
+  it("explains an unborn main without affecting a healthy project", async () => {
+    const root = await mkdtemp(join(tmpdir(), "wt-unborn-"));
+    const unbornRoot = join(root, "unborn");
+    const healthyRoot = join(root, "healthy");
+    const healthyWorktreePath = join(healthyRoot, "feature");
+    const git = (cwd: string, ...args: string[]) =>
+      nodeExternalCommandRunner({
+        command: "git",
+        args,
+        cwd,
+        unsetEnv: gitLocalEnvironmentVariables,
+      });
+    await mkdir(unbornRoot, { recursive: true });
+    await mkdir(healthyRoot, { recursive: true });
+    await git(unbornRoot, "init", "-q", "-b", "main");
+    await git(healthyRoot, "init", "-q", "-b", "main");
+    await git(
+      healthyRoot,
+      "-c",
+      "user.email=t@example.com",
+      "-c",
+      "user.name=t",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "initial",
+    );
+    const unbornProject: ProviderProjectConfig = {
+      ...project,
+      id: "unborn",
+      label: "unborn",
+      root: unbornRoot,
+    };
+    const healthyProject: ProviderProjectConfig = {
+      ...project,
+      id: "healthy",
+      label: "healthy",
+      root: healthyRoot,
+    };
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        if (input.cwd === unbornProject.root) {
+          throw Object.assign(new Error("wt failed"), {
+            code: 1,
+            stderr: input.args?.includes("feature-color")
+              ? "\u001b[31m✗ No branch, tag, or commit named \u001b[1mmain\u001b[22m\u001b[0m"
+              : "✗ No branch, tag, or commit named main",
+          });
+        }
+        return result(
+          input,
+          JSON.stringify([{ path: healthyWorktreePath, branch: "feature", commit: "9dd15ba" }]),
+        );
+      },
+    });
+
+    try {
+      await expect(git(unbornRoot, "rev-parse", "--verify", "HEAD^{commit}")).rejects.toThrow();
+      await expect(
+        git(healthyRoot, "rev-parse", "--verify", "HEAD^{commit}"),
+      ).resolves.toMatchObject({ stdout: expect.stringMatching(/^[0-9a-f]+\n$/) });
+      await expect(git(healthyRoot, "config", "--local", "--list")).resolves.toMatchObject({
+        stdout: expect.not.stringContaining("user."),
+      });
+
+      await expect(
+        provider.createWorktree({ project: unbornProject, branch: "feature" }),
+      ).rejects.toMatchObject({
+        tag: "WorktreeProviderError",
+        code: "WORKTRUNK_BASE_MISSING",
+        message: "Base `main` does not resolve to a commit.",
+        hint: "Create its first commit or choose another base.",
+        diagnosticDetails: [
+          expect.objectContaining({
+            operation: "provider.worktrunk.switch",
+            cwd: unbornProject.root,
+            exitCode: 1,
+            stderrSnippet: "✗ No branch, tag, or commit named main",
+          }),
+        ],
+      });
+      await expect(
+        provider.createWorktree({ project: unbornProject, branch: "feature-color" }),
+      ).rejects.toMatchObject({
+        code: "WORKTRUNK_BASE_MISSING",
+        message: "Base `main` does not resolve to a commit.",
+      });
+      await expect(
+        provider.createWorktree({
+          project: unbornProject,
+          branch: "feature-release",
+          base: "release",
+        }),
+      ).rejects.toMatchObject({
+        code: "WORKTRUNK_COMMAND_FAILED",
+        message: "Worktrunk failed to create a worktree.",
+      });
+      await expect(
+        provider.createWorktree({ project: healthyProject, branch: "feature" }),
+      ).resolves.toMatchObject({
+        projectId: healthyProject.id,
+        branch: "feature",
+        path: healthyWorktreePath,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies missing base failures", async () => {
     const provider = new WorktrunkProvider({
       command: "wt",


### PR DESCRIPTION
## Summary

- classify Worktrunk's unresolved explicit base error as `WORKTRUNK_BASE_MISSING`
- name the requested base and tell the user to create its first commit or choose another base
- preserve generic handling when Worktrunk reports a different ref
- cover an unborn `main`, ANSI-colored stderr, and a healthy committed repository through the same provider instance

## Root cause

Worktrunk reports an unborn configured base as `No branch, tag, or commit named main`. Station retained the provider stderr diagnostically but surfaced the generic worktree-creation failure because its existing missing-base patterns did not recognize this form.

## Validation

- reproduced with Worktrunk v0.67.0 against `git init -b main` with no commits
- verified the reproduction did not create a commit or modify repository Git configuration
- focused Worktrunk provider tests: 28 passed
- full isolated pre-push hook: passed, including build, typecheck, lint, unit/integration/E2E, install smoke, cross-runtime, TUI/PTY, and binary smoke
- independent self-review: no remaining findings

## UX

An unborn configured `main` now surfaces:

- `Base \`main\` does not resolve to a commit.`
- `Create its first commit or choose another base.`

No onboarding or CI behavior is changed.

Closes #155