### PR TITLE
fix(observer): correlate Stop events by native execution

### DIFF
--- a/apps/observer/src/harnessExecutionIdentity.ts
+++ b/apps/observer/src/harnessExecutionIdentity.ts
@@ -130,7 +130,10 @@ export function sessionHarnessExecutionEvidenceFromObservation(
 /**
  * POLICY
  *
- * Advances one Station session's provider-native execution binding from non-stale evidence.
+ * Authorizes state derivation for the bound provider-native execution and advances that binding
+ * only from non-stale lifecycle evidence.
+ *
+ * Completion cannot establish a binding, and a mismatch cannot replace an active binding.
  */
 export function decideSessionHarnessExecution(input: {
   current: PersistedSessionHarnessExecution | undefined;
@@ -202,7 +205,7 @@ export function decideSessionHarnessExecution(input: {
 /**
  * POLICY
  *
- * Applies durable native identity only to the matching provider-owned Station session run.
+ * Applies each durable native binding to the provider run associated with the same Station session.
  */
 export function bindHarnessRunsToSessionExecutions(input: {
   runs: readonly HarnessRunObservation[];

--- a/apps/observer/src/harnessExecutionIdentity.ts
+++ b/apps/observer/src/harnessExecutionIdentity.ts
@@ -1,0 +1,296 @@
+import type {
+  AgentState,
+  HarnessEventObservation,
+  HarnessEventReport,
+  HarnessRunObservation,
+  ObservedStatus,
+} from "@station/contracts";
+import type {
+  PersistedSessionHarnessExecution,
+  SessionHarnessExecutionEvidence,
+} from "./persistence/types.js";
+
+type HarnessExecutionCorrelatedBy = "harnessRunId" | "nativeSessionId" | "sessionId" | "worktreeId";
+
+type HarnessExecutionEvidence = {
+  provider: string;
+  harnessRunId?: string | undefined;
+  sessionId?: string | undefined;
+  worktreeId?: string | undefined;
+  terminalTargetId?: string | undefined;
+  nativeSessionId?: string | undefined;
+  status?: ObservedStatus | undefined;
+};
+
+type HarnessExecutionMatch = {
+  run: HarnessRunObservation;
+  correlatedBy: HarnessExecutionCorrelatedBy;
+};
+
+const ACTIVE_EXECUTION_STATES = new Set<AgentState>(["starting", "working", "needs_attention"]);
+const REPLACEABLE_EXECUTION_STATES = new Set<AgentState>(["idle", "exited"]);
+
+export type SessionHarnessExecutionDecision = {
+  mayDeriveState: boolean;
+  binding?: PersistedSessionHarnessExecution;
+};
+
+/**
+ * POLICY
+ *
+ * Correlates harness evidence to one run while preventing weaker Station labels from crossing native executions.
+ */
+export function correlateHarnessExecution(input: {
+  evidence: HarnessExecutionEvidence;
+  runs: readonly HarnessRunObservation[];
+  allowNativeBinding?: boolean;
+}): HarnessExecutionMatch | undefined {
+  const providerRuns = input.runs.filter((run) => run.provider === input.evidence.provider);
+  const harnessRunId = input.evidence.harnessRunId;
+  if (harnessRunId !== undefined) {
+    return singleExecutionMatch(
+      providerRuns.filter((run) => run.id === harnessRunId),
+      "harnessRunId",
+      input.evidence,
+      input.allowNativeBinding ?? true,
+    );
+  }
+
+  const nativeSessionId = input.evidence.nativeSessionId;
+  if (nativeSessionId !== undefined) {
+    const nativeMatches = providerRuns.filter((run) => run.nativeSessionId === nativeSessionId);
+    if (nativeMatches.length > 0) {
+      return singleExecutionMatch(
+        nativeMatches,
+        "nativeSessionId",
+        input.evidence,
+        input.allowNativeBinding ?? true,
+      );
+    }
+    // Worktree-only evidence describes an external provider session. It may
+    // match only the external run synthesized for that exact native identity.
+    if (!hasStationExecutionIdentity(input.evidence)) return undefined;
+  }
+
+  const sessionId = input.evidence.sessionId;
+  if (sessionId !== undefined) {
+    return singleExecutionMatch(
+      providerRuns.filter((run) => run.sessionId === sessionId),
+      "sessionId",
+      input.evidence,
+      input.allowNativeBinding ?? true,
+    );
+  }
+
+  if (input.evidence.terminalTargetId !== undefined) return undefined;
+
+  const worktreeId = input.evidence.worktreeId;
+  if (worktreeId !== undefined) {
+    return singleExecutionMatch(
+      providerRuns.filter((run) => run.worktreeId === worktreeId),
+      "worktreeId",
+      input.evidence,
+      input.allowNativeBinding ?? true,
+    );
+  }
+
+  return undefined;
+}
+
+export function sessionHarnessExecutionEvidenceFromReport(
+  report: HarnessEventReport,
+): SessionHarnessExecutionEvidence {
+  const evidence: SessionHarnessExecutionEvidence = {
+    provider: report.provider,
+  };
+  if (report.correlation?.sessionId !== undefined) {
+    evidence.sessionId = report.correlation.sessionId;
+  }
+  if (report.correlation?.nativeSessionId !== undefined) {
+    evidence.nativeSessionId = report.correlation.nativeSessionId;
+  }
+  if (report.status !== undefined) evidence.status = report.status;
+  return evidence;
+}
+
+export function sessionHarnessExecutionEvidenceFromObservation(
+  observation: HarnessEventObservation,
+): SessionHarnessExecutionEvidence {
+  const evidence: SessionHarnessExecutionEvidence = {
+    provider: observation.provider,
+  };
+  if (observation.sessionId !== undefined) evidence.sessionId = observation.sessionId;
+  if (observation.nativeSessionId !== undefined) {
+    evidence.nativeSessionId = observation.nativeSessionId;
+  }
+  if (observation.status !== undefined) evidence.status = observation.status;
+  return evidence;
+}
+
+/**
+ * POLICY
+ *
+ * Advances one Station session's provider-native execution binding from non-stale evidence.
+ */
+export function decideSessionHarnessExecution(input: {
+  current: PersistedSessionHarnessExecution | undefined;
+  evidence: SessionHarnessExecutionEvidence;
+}): SessionHarnessExecutionDecision {
+  const sessionId = input.evidence.sessionId;
+  if (sessionId === undefined) return { mayDeriveState: true };
+
+  const nativeSessionId = input.evidence.nativeSessionId;
+  const status = input.evidence.status;
+  const current = input.current;
+  if (current === undefined) {
+    if (
+      nativeSessionId === undefined ||
+      status === undefined ||
+      !ACTIVE_EXECUTION_STATES.has(status.value)
+    ) {
+      return { mayDeriveState: nativeSessionId === undefined };
+    }
+    return {
+      mayDeriveState: true,
+      binding: bindingFromEvidence({
+        evidence: input.evidence,
+        sessionId,
+        nativeSessionId,
+        status,
+      }),
+    };
+  }
+
+  if (nativeSessionId === undefined) return { mayDeriveState: false };
+  if (current.nativeSessionId !== nativeSessionId) {
+    if (
+      status === undefined ||
+      !ACTIVE_EXECUTION_STATES.has(status.value) ||
+      !REPLACEABLE_EXECUTION_STATES.has(current.state) ||
+      Date.parse(status.updatedAt) < Date.parse(current.statusUpdatedAt)
+    ) {
+      return { mayDeriveState: false };
+    }
+    return {
+      mayDeriveState: true,
+      binding: bindingFromEvidence({
+        evidence: input.evidence,
+        sessionId,
+        nativeSessionId,
+        status,
+      }),
+    };
+  }
+
+  if (
+    status !== undefined &&
+    status.value !== "unknown" &&
+    Date.parse(status.updatedAt) < Date.parse(current.statusUpdatedAt)
+  ) {
+    return { mayDeriveState: false };
+  }
+
+  if (status === undefined || status.value === "unknown") {
+    return { mayDeriveState: true };
+  }
+  const binding: PersistedSessionHarnessExecution = { ...current };
+  binding.state = status.value;
+  binding.statusUpdatedAt = status.updatedAt;
+  return { mayDeriveState: true, binding };
+}
+
+/**
+ * POLICY
+ *
+ * Applies durable native identity only to the matching provider-owned Station session run.
+ */
+export function bindHarnessRunsToSessionExecutions(input: {
+  runs: readonly HarnessRunObservation[];
+  bindings: readonly PersistedSessionHarnessExecution[];
+}): HarnessRunObservation[] {
+  const bindings = new Map(
+    input.bindings.map((binding) => [
+      sessionHarnessExecutionKey(binding.provider, binding.sessionId),
+      binding,
+    ]),
+  );
+  return input.runs.map((run) => {
+    if (run.sessionId === undefined) return run;
+    const binding = bindings.get(sessionHarnessExecutionKey(run.provider, run.sessionId));
+    if (binding === undefined || run.nativeSessionId === binding.nativeSessionId) return run;
+    return { ...run, nativeSessionId: binding.nativeSessionId };
+  });
+}
+
+function singleExecutionMatch(
+  matches: readonly HarnessRunObservation[],
+  correlatedBy: HarnessExecutionCorrelatedBy,
+  evidence: HarnessExecutionEvidence,
+  allowNativeBinding: boolean,
+): HarnessExecutionMatch | undefined {
+  const run = matches[0];
+  if (matches.length !== 1 || run === undefined) return undefined;
+
+  const decision = nativeExecutionDecision({
+    currentNativeSessionId: run.nativeSessionId,
+    evidenceNativeSessionId: evidence.nativeSessionId,
+    evidenceStatus: evidence.status,
+  });
+  if (decision === "reject") return undefined;
+  if (decision === "bind" && evidence.nativeSessionId !== undefined && allowNativeBinding) {
+    return {
+      run: { ...run, nativeSessionId: evidence.nativeSessionId },
+      correlatedBy,
+    };
+  }
+  if (decision === "bind") return undefined;
+  return { run, correlatedBy };
+}
+
+function nativeExecutionDecision(input: {
+  currentNativeSessionId: string | undefined;
+  evidenceNativeSessionId: string | undefined;
+  evidenceStatus: ObservedStatus | undefined;
+}): "accept" | "bind" | "reject" {
+  if (input.currentNativeSessionId === input.evidenceNativeSessionId) {
+    return "accept";
+  }
+  if (
+    input.evidenceNativeSessionId !== undefined &&
+    input.evidenceStatus !== undefined &&
+    ACTIVE_EXECUTION_STATES.has(input.evidenceStatus.value) &&
+    input.currentNativeSessionId === undefined
+  ) {
+    return "bind";
+  }
+  return "reject";
+}
+
+function hasStationExecutionIdentity(
+  event: Pick<HarnessExecutionEvidence, "harnessRunId" | "sessionId" | "terminalTargetId">,
+): boolean {
+  return (
+    event.harnessRunId !== undefined ||
+    event.sessionId !== undefined ||
+    event.terminalTargetId !== undefined
+  );
+}
+
+function bindingFromEvidence(input: {
+  evidence: SessionHarnessExecutionEvidence;
+  sessionId: string;
+  nativeSessionId: string;
+  status: ObservedStatus;
+}): PersistedSessionHarnessExecution {
+  return {
+    provider: input.evidence.provider,
+    sessionId: input.sessionId,
+    nativeSessionId: input.nativeSessionId,
+    state: input.status.value,
+    statusUpdatedAt: input.status.updatedAt,
+  };
+}
+
+function sessionHarnessExecutionKey(provider: string, sessionId: string): string {
+  return `${provider}\u0000${sessionId}`;
+}

--- a/apps/observer/src/hooks/harnessIngressQueue.ts
+++ b/apps/observer/src/hooks/harnessIngressQueue.ts
@@ -490,6 +490,7 @@ function rejectedReceipt(
 function coalesceKey(report: HarnessEventReport): string {
   const correlation = report.correlation;
   const stableAgentKey =
+    correlation?.nativeSessionId ??
     correlation?.harnessRunId ??
     correlation?.sessionId ??
     correlation?.worktreeId ??

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -26,6 +26,7 @@ import {
   systemClock,
   toIsoTimestamp,
 } from "@station/runtime";
+import { sessionHarnessExecutionEvidenceFromReport } from "../harnessExecutionIdentity.js";
 import type { IngressJournal, ObservationStore, SessionStore } from "../persistence/index.js";
 import {
   providerObservationExpiresAt,
@@ -34,7 +35,7 @@ import {
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
 import { ingestProviderHookEvent } from "./providerHookIngress.js";
-import { persistTurnReadinessFromHarnessObservation } from "./turnReadiness.js";
+import { sessionTurnReadinessMutationFromHarnessObservation } from "./turnReadiness.js";
 
 export type ProviderHookIngress = {
   ingest(
@@ -72,7 +73,7 @@ export type CreateProviderHookIngressOptions = {
 };
 
 export type CreateHarnessEventReportIngestionOptions = {
-  persistence: IngressJournal & SessionStore;
+  persistence: IngressJournal;
   eventBus?: ObserverEventBus;
   clock?: RuntimeClock;
   requestReconcile?: (reason: string) => void;
@@ -150,7 +151,25 @@ export function createProviderHookIngress(
       const adapter =
         event.kind === "harness" ? options.providers?.hookAdapters.get(event.provider) : undefined;
       const reportHarnessEvent = ingestOptions.reportHarnessEvent ?? options.reportHarnessEvent;
-      if (adapter?.toHarnessEventReport !== undefined && reportHarnessEvent !== undefined) {
+      if (adapter?.toHarnessEventReport !== undefined) {
+        // Adapter-normalized harness hooks must pass the native-execution gate on the report path.
+        if (reportHarnessEvent === undefined) {
+          return ProviderHookReceiptSchema.parse({
+            schemaVersion: STATION_SCHEMA_VERSION,
+            hookId: id,
+            provider: event.provider,
+            event: event.event,
+            accepted: false,
+            status: "rejected",
+            receivedAt: event.receivedAt,
+            error: {
+              tag: "HookIngestionError",
+              code: "HARNESS_REPORT_INGRESS_UNAVAILABLE",
+              message: "Harness hook normalization requires the report ingress handoff.",
+              provider: event.provider,
+            },
+          });
+        }
         return ingestViaHookAdapter({
           event,
           adapter,
@@ -295,7 +314,7 @@ async function ingestViaHookAdapter(
 /**
  * USE CASE
  *
- * Persists a normalized harness report once and repairs its recovery and readiness projections on every retry.
+ * Persists normalized harness evidence and its accepted native-execution effects atomically.
  */
 export function createHarnessEventReportIngestion(
   options: CreateHarnessEventReportIngestionOptions,
@@ -329,6 +348,16 @@ export function createHarnessEventReportIngestion(
           },
         },
         async () => {
+          const recoveryHandle = sessionRecoveryHandleFromReport(report);
+          const turnReadiness = sessionTurnReadinessMutationFromHarnessObservation({
+            observation,
+            updatedAt: receivedAt,
+          });
+          const harnessExecution = {
+            evidence: sessionHarnessExecutionEvidenceFromReport(report),
+            ...(recoveryHandle === undefined ? {} : { recoveryHandle }),
+            ...(turnReadiness === undefined ? {} : { turnReadiness }),
+          };
           const result =
             await options.persistence.recordEventAndProviderObservationWithIngressDedupe({
               event: reportedEvent,
@@ -346,17 +375,8 @@ export function createHarnessEventReportIngestion(
                 observedAt: report.observedAt,
                 expiresAt: providerObservationExpiresAt(report.observedAt, retentionDays),
               },
+              harnessExecution,
             });
-          // Primary dedupe is acceptance evidence, not proof that later idempotent repairs finished.
-          const recoveryHandle = sessionRecoveryHandleFromReport(report);
-          if (recoveryHandle !== undefined) {
-            await options.persistence.upsertSessionRecoveryHandle(recoveryHandle);
-          }
-          await persistTurnReadinessFromHarnessObservation({
-            persistence: options.persistence,
-            observation,
-            updatedAt: receivedAt,
-          });
           if (!result.deduped) {
             options.eventBus?.publish(reportedEvent);
           }

--- a/apps/observer/src/hooks/ingestion.ts
+++ b/apps/observer/src/hooks/ingestion.ts
@@ -314,7 +314,8 @@ async function ingestViaHookAdapter(
 /**
  * USE CASE
  *
- * Persists normalized harness evidence and its accepted native-execution effects atomically.
+ * Persists each normalized report and its authorized native binding, recovery, and readiness
+ * effects in one deduplicated transaction.
  */
 export function createHarnessEventReportIngestion(
   options: CreateHarnessEventReportIngestionOptions,

--- a/apps/observer/src/hooks/providerHookIngress.ts
+++ b/apps/observer/src/hooks/providerHookIngress.ts
@@ -13,6 +13,7 @@ import {
   systemClock,
   toIsoTimestamp,
 } from "@station/runtime";
+import { sessionHarnessExecutionEvidenceFromObservation } from "../harnessExecutionIdentity.js";
 import type {
   IngressJournal,
   ObservationStore,
@@ -90,7 +91,7 @@ export async function ingestProviderHookEvent(
     expiresAt: providerObservationExpiresAt(observation.observedAt, retentionDays),
   }));
   const updatedAt = toIsoTimestamp(clock.now());
-  const turnReadiness = observations.flatMap((observation) => {
+  const harnessExecutions = observations.flatMap((observation) => {
     const harnessEvent = harnessEventObservationFromRecord(observation);
     if (harnessEvent === undefined) {
       return [];
@@ -99,12 +100,17 @@ export async function ingestProviderHookEvent(
       observation: harnessEvent,
       updatedAt,
     });
-    return mutation === undefined ? [] : [mutation];
+    return [
+      {
+        evidence: sessionHarnessExecutionEvidenceFromObservation(harnessEvent),
+        ...(mutation === undefined ? {} : { turnReadiness: mutation }),
+      },
+    ];
   });
   // Readiness shares the processing claim transaction so retries cannot apply a new correlation context.
   const processing = await options.persistence.recordProviderObservationsWithIngressDedupe({
     observations,
-    turnReadiness,
+    harnessExecutions,
     dedupe: {
       kind: "hook_processing",
       id:

--- a/apps/observer/src/hooks/providerHookIngress.ts
+++ b/apps/observer/src/hooks/providerHookIngress.ts
@@ -50,7 +50,8 @@ type ObservationRecord = RecordProviderObservationInput & {
 /**
  * USE CASE
  *
- * Normalizes provider hook evidence and atomically records all derived observations before marking that hook processing complete.
+ * Normalizes provider hook evidence and atomically records its observations and authorized
+ * native-execution effects before completing hook processing.
  */
 export async function ingestProviderHookEvent(
   options: IngestProviderHookEventOptions,
@@ -107,7 +108,8 @@ export async function ingestProviderHookEvent(
       },
     ];
   });
-  // Readiness shares the processing claim transaction so retries cannot apply a new correlation context.
+  // Native binding and readiness share the processing-claim transaction so retries
+  // cannot apply a new correlation context.
   const processing = await options.persistence.recordProviderObservationsWithIngressDedupe({
     observations,
     harnessExecutions,

--- a/apps/observer/src/hooks/turnReadiness.ts
+++ b/apps/observer/src/hooks/turnReadiness.ts
@@ -1,5 +1,5 @@
 import type { HarnessEventObservation } from "@station/contracts";
-import type { SessionStore, SessionTurnReadinessMutation } from "../persistence/index.js";
+import type { SessionTurnReadinessMutation } from "../persistence/index.js";
 
 /**
  * POLICY
@@ -41,26 +41,4 @@ export function sessionTurnReadinessMutationFromHarnessObservation(input: {
     return { action: "delete", sessionId: observation.sessionId };
   }
   return undefined;
-}
-
-export async function persistTurnReadinessFromHarnessObservation(input: {
-  persistence: SessionStore;
-  observation: HarnessEventObservation;
-  updatedAt: string;
-}): Promise<boolean> {
-  const mutation = sessionTurnReadinessMutationFromHarnessObservation(input);
-  if (mutation === undefined) {
-    return false;
-  }
-  if (mutation.action === "upsert") {
-    await input.persistence.upsertSessionTurnReadiness(mutation.value);
-    return true;
-  }
-
-  // Readiness is an interval: a session that is active again (new turn, or a
-  // request for the user mid-turn) makes ready_to_read stale. Without this
-  // closing edge the badge survives on a working agent, and it cannot be
-  // acknowledged because snapshots only expose readiness on idle agents.
-  await input.persistence.deleteSessionTurnReadiness({ sessionId: mutation.sessionId });
-  return false;
 }

--- a/apps/observer/src/migrations/013_session_harness_executions.ts
+++ b/apps/observer/src/migrations/013_session_harness_executions.ts
@@ -3,8 +3,8 @@ import type { ObserverSqliteMigration } from "./index.js";
 export const sessionHarnessExecutionsMigration: ObserverSqliteMigration = {
   version: 13,
   name: "session_harness_executions",
-  // Hook ingress can bind before reconcile reconstructs the sessions table,
-  // so provider plus Station session is authoritative without a foreign key.
+  // Hook ingress can bind before reconcile reconstructs the session row, so this
+  // table deliberately has no sessions foreign key.
   sql: `
     CREATE TABLE IF NOT EXISTS session_harness_executions (
       provider TEXT NOT NULL,

--- a/apps/observer/src/migrations/013_session_harness_executions.ts
+++ b/apps/observer/src/migrations/013_session_harness_executions.ts
@@ -1,0 +1,18 @@
+import type { ObserverSqliteMigration } from "./index.js";
+
+export const sessionHarnessExecutionsMigration: ObserverSqliteMigration = {
+  version: 13,
+  name: "session_harness_executions",
+  // Hook ingress can bind before reconcile reconstructs the sessions table,
+  // so provider plus Station session is authoritative without a foreign key.
+  sql: `
+    CREATE TABLE IF NOT EXISTS session_harness_executions (
+      provider TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      native_session_id TEXT NOT NULL,
+      state TEXT NOT NULL,
+      status_updated_at TEXT NOT NULL,
+      PRIMARY KEY (provider, session_id)
+    );
+  `,
+};

--- a/apps/observer/src/migrations/014_native_binding_ingress_claims.ts
+++ b/apps/observer/src/migrations/014_native_binding_ingress_claims.ts
@@ -1,0 +1,11 @@
+import type { ObserverSqliteMigration } from "./index.js";
+
+export const nativeBindingIngressClaimsMigration: ObserverSqliteMigration = {
+  version: 14,
+  name: "native_binding_ingress_claims",
+  sql: `
+    -- Earlier claims did not cover native binding or derived state; replay them once.
+    DELETE FROM hook_ingress_dedupe
+    WHERE kind IN ('harness_report', 'hook_processing');
+  `,
+};

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -11,6 +11,7 @@ import { sessionRecoveryHandlesMigration } from "./010_session_recovery_handles.
 import { sessionTurnReadinessMigration } from "./011_session_turn_readiness.js";
 import { sessionLifecycleMigration } from "./012_session_lifecycle.js";
 import { sessionHarnessExecutionsMigration } from "./013_session_harness_executions.js";
+import { nativeBindingIngressClaimsMigration } from "./014_native_binding_ingress_claims.js";
 
 export type ObserverSqliteMigration = {
   version: number;
@@ -32,6 +33,7 @@ export const migrations = [
   sessionTurnReadinessMigration,
   sessionLifecycleMigration,
   sessionHarnessExecutionsMigration,
+  nativeBindingIngressClaimsMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -10,6 +10,7 @@ import { sessionTitleMigration } from "./009_session_title.js";
 import { sessionRecoveryHandlesMigration } from "./010_session_recovery_handles.js";
 import { sessionTurnReadinessMigration } from "./011_session_turn_readiness.js";
 import { sessionLifecycleMigration } from "./012_session_lifecycle.js";
+import { sessionHarnessExecutionsMigration } from "./013_session_harness_executions.js";
 
 export type ObserverSqliteMigration = {
   version: number;
@@ -30,6 +31,7 @@ export const migrations = [
   sessionRecoveryHandlesMigration,
   sessionTurnReadinessMigration,
   sessionLifecycleMigration,
+  sessionHarnessExecutionsMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -13,6 +13,7 @@ import type {
   EventAndObservationIngressDedupeResult,
   EventIngressDedupeResult,
   EventRecordOptions,
+  HarnessExecutionIngress,
   IngressDedupeKey,
   ListSessionRecoveryHandlesOptions,
   PersistedCommand,
@@ -20,6 +21,7 @@ import type {
   PersistedEvent,
   PersistedProviderObservation,
   PersistedSession,
+  PersistedSessionHarnessExecution,
   PersistedSessionTurnReadiness,
   PersistedWorktreeMetadataCurrent,
   PersistReconcileResultInput,
@@ -73,7 +75,7 @@ export interface EventJournal {
 /**
  * DRIVEN PORT
  *
- * Atomically records primary ingress acceptance and downstream observation and readiness completion under separate dedupe keys.
+ * Atomically records ingress acceptance, observations, native execution binding, recovery, and readiness under dedupe keys.
  */
 export interface IngressJournal {
   recordEventWithIngressDedupe(
@@ -86,10 +88,12 @@ export interface IngressJournal {
     event: StationEvent;
     eventOptions: EventRecordOptions;
     observation: RecordProviderObservationInput;
+    harnessExecution?: HarnessExecutionIngress;
     dedupe: IngressDedupeKey;
   }): Promise<EventAndObservationIngressDedupeResult>;
   recordProviderObservationsWithIngressDedupe(input: {
     observations: RecordProviderObservationInput[];
+    harnessExecutions?: HarnessExecutionIngress[];
     turnReadiness?: SessionTurnReadinessMutation[];
     dedupe: IngressDedupeKey;
     createdAt?: string;
@@ -131,10 +135,15 @@ export interface ReconcileStore {
 /**
  * DRIVEN PORT
  *
- * Maintains Observer-owned session lifecycle, titles, remembered harness selection, recovery handles, and turn readiness.
+ * Maintains Observer-owned session lifecycle, native harness executions, titles, remembered harness selection, recovery handles, and turn readiness.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;
+  getSessionHarnessExecution(input: {
+    provider: ProviderId;
+    sessionId: string;
+  }): Promise<PersistedSessionHarnessExecution | undefined>;
+  listSessionHarnessExecutions(): Promise<PersistedSessionHarnessExecution[]>;
   findRememberedHarnessProviderForWorktree(input: {
     projectId: string;
     worktreeId: string;

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -135,7 +135,8 @@ export interface ReconcileStore {
 /**
  * DRIVEN PORT
  *
- * Maintains Observer-owned session lifecycle, native harness executions, titles, remembered harness selection, recovery handles, and turn readiness.
+ * Maintains Observer-owned session lifecycle, provider-native execution bindings, titles,
+ * remembered harness selection, recovery handles, and turn readiness.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;

--- a/apps/observer/src/persistence/sessionHarnessExecutions.ts
+++ b/apps/observer/src/persistence/sessionHarnessExecutions.ts
@@ -1,0 +1,85 @@
+import { AgentStateSchema } from "@station/contracts";
+import { decideSessionHarnessExecution } from "../harnessExecutionIdentity.js";
+import type { SqlDatabase } from "../sqlite/driver.js";
+import type { PersistedSessionHarnessExecution, SessionHarnessExecutionEvidence } from "./types.js";
+
+type SqliteSessionHarnessExecutionRow = {
+  provider: string;
+  session_id: string;
+  native_session_id: string;
+  state: string;
+  status_updated_at: string;
+};
+
+export function applySessionHarnessExecutionEvidence(
+  database: SqlDatabase,
+  evidence: SessionHarnessExecutionEvidence,
+): boolean {
+  const current =
+    evidence.sessionId === undefined
+      ? undefined
+      : getSessionHarnessExecution(database, {
+          provider: evidence.provider,
+          sessionId: evidence.sessionId,
+        });
+  const decision = decideSessionHarnessExecution({ current, evidence });
+  if (decision.binding !== undefined) upsertSessionHarnessExecution(database, decision.binding);
+  return decision.mayDeriveState;
+}
+
+export function getSessionHarnessExecution(
+  database: SqlDatabase,
+  input: { provider: string; sessionId: string },
+): PersistedSessionHarnessExecution | undefined {
+  const row = database
+    .prepare("SELECT * FROM session_harness_executions WHERE provider = ? AND session_id = ?")
+    .get(input.provider, input.sessionId) as SqliteSessionHarnessExecutionRow | undefined;
+  return row === undefined ? undefined : sessionHarnessExecutionFromRow(row);
+}
+
+export function listSessionHarnessExecutions(
+  database: SqlDatabase,
+): PersistedSessionHarnessExecution[] {
+  return (
+    database
+      .prepare("SELECT * FROM session_harness_executions ORDER BY provider, session_id")
+      .all() as SqliteSessionHarnessExecutionRow[]
+  ).map(sessionHarnessExecutionFromRow);
+}
+
+function upsertSessionHarnessExecution(
+  database: SqlDatabase,
+  binding: PersistedSessionHarnessExecution,
+): void {
+  database
+    .prepare(
+      `
+        INSERT INTO session_harness_executions
+          (provider, session_id, native_session_id, state, status_updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(provider, session_id) DO UPDATE SET
+          native_session_id = excluded.native_session_id,
+          state = excluded.state,
+          status_updated_at = excluded.status_updated_at
+      `,
+    )
+    .run(
+      binding.provider,
+      binding.sessionId,
+      binding.nativeSessionId,
+      binding.state,
+      binding.statusUpdatedAt,
+    );
+}
+
+function sessionHarnessExecutionFromRow(
+  row: SqliteSessionHarnessExecutionRow,
+): PersistedSessionHarnessExecution {
+  return {
+    provider: row.provider,
+    sessionId: row.session_id,
+    nativeSessionId: row.native_session_id,
+    state: AgentStateSchema.parse(row.state),
+    statusUpdatedAt: row.status_updated_at,
+  };
+}

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -15,9 +15,14 @@ import {
 } from "./observations.js";
 import type { ObserverPersistenceBundle, PersistenceHealthSource } from "./ports.js";
 import { providerObservationRetentionDays } from "./retention.js";
+import * as sessionHarnessExecutionStore from "./sessionHarnessExecutions.js";
 import * as sessionRecoveryHandleStore from "./sessionRecoveryHandles.js";
 import * as sessionTurnReadinessStore from "./sessionTurnReadiness.js";
-import type { ObserverIdFactory } from "./types.js";
+import type {
+  HarnessExecutionIngress,
+  ObserverIdFactory,
+  SessionTurnReadinessMutation,
+} from "./types.js";
 import * as worktreeMetadataCurrentStore from "./worktreeMetadataCurrent.js";
 
 export type CreateSqliteObserverPersistenceOptions = {
@@ -149,6 +154,10 @@ export function createSqliteObserverPersistence(
           id: idFactory.observationId(),
           observedAt: input.observation.observedAt ?? now(),
         });
+        const harnessExecution = input.harnessExecution;
+        if (harnessExecution !== undefined) {
+          applyHarnessExecutionIngress(database, harnessExecution, now());
+        }
         return {
           deduped: false,
           event,
@@ -174,17 +183,11 @@ export function createSqliteObserverPersistence(
             observedAt: observation.observedAt ?? now(),
           }),
         );
+        for (const harnessExecution of input.harnessExecutions ?? []) {
+          applyHarnessExecutionIngress(database, harnessExecution, now());
+        }
         for (const mutation of input.turnReadiness ?? []) {
-          if (mutation.action === "upsert") {
-            sessionTurnReadinessStore.upsertSessionTurnReadiness(database, {
-              ...mutation.value,
-              createdAt: now(),
-            });
-          } else {
-            sessionTurnReadinessStore.deleteSessionTurnReadiness(database, {
-              sessionId: mutation.sessionId,
-            });
-          }
+          applySessionTurnReadinessMutation(database, mutation, now());
         }
         return { deduped: false, observations };
       }),
@@ -267,6 +270,14 @@ export function createSqliteObserverPersistence(
 
     listSessions: () => transaction(correlationStore.listSessions),
 
+    getSessionHarnessExecution: (input) =>
+      transaction((database) =>
+        sessionHarnessExecutionStore.getSessionHarnessExecution(database, input),
+      ),
+
+    listSessionHarnessExecutions: () =>
+      transaction(sessionHarnessExecutionStore.listSessionHarnessExecutions),
+
     findRememberedHarnessProviderForWorktree: (input) =>
       transaction((database) =>
         correlationStore.findRememberedHarnessProviderForWorktree(database, input),
@@ -320,4 +331,45 @@ export function createSqliteObserverPersistence(
         sessionTurnReadinessStore.deleteSessionTurnReadiness(database, input),
       ),
   };
+}
+
+function applyHarnessExecutionIngress(
+  database: SqlDatabase,
+  harnessExecution: HarnessExecutionIngress,
+  createdAt: string,
+): void {
+  if (
+    !sessionHarnessExecutionStore.applySessionHarnessExecutionEvidence(
+      database,
+      harnessExecution.evidence,
+    )
+  ) {
+    return;
+  }
+  if (harnessExecution.recoveryHandle !== undefined) {
+    sessionRecoveryHandleStore.upsertSessionRecoveryHandle(
+      database,
+      harnessExecution.recoveryHandle,
+    );
+  }
+  if (harnessExecution.turnReadiness !== undefined) {
+    applySessionTurnReadinessMutation(database, harnessExecution.turnReadiness, createdAt);
+  }
+}
+
+function applySessionTurnReadinessMutation(
+  database: SqlDatabase,
+  mutation: SessionTurnReadinessMutation,
+  createdAt: string,
+): void {
+  if (mutation.action === "upsert") {
+    sessionTurnReadinessStore.upsertSessionTurnReadiness(database, {
+      ...mutation.value,
+      createdAt,
+    });
+    return;
+  }
+  sessionTurnReadinessStore.deleteSessionTurnReadiness(database, {
+    sessionId: mutation.sessionId,
+  });
 }

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -1,13 +1,16 @@
 import type {
+  AgentState,
   CommandId,
   DiagnosticDetail,
   ErrorEnvelope,
   HarnessEventObservation,
   HarnessRunObservation,
+  ObservedStatus,
   ProviderHealth,
   ProviderId,
   ProviderProjectConfig,
   SafeError,
+  SessionRecoveryHandle,
   StationCommand,
   StationEvent,
   TerminalTargetObservation,
@@ -159,6 +162,27 @@ export type SessionTurnReadinessMutation =
       action: "delete";
       sessionId: string;
     };
+
+export type SessionHarnessExecutionEvidence = {
+  provider: ProviderId;
+  sessionId?: string;
+  nativeSessionId?: string;
+  status?: ObservedStatus;
+};
+
+export type PersistedSessionHarnessExecution = {
+  provider: ProviderId;
+  sessionId: string;
+  nativeSessionId: string;
+  state: AgentState;
+  statusUpdatedAt: string;
+};
+
+export type HarnessExecutionIngress = {
+  evidence: SessionHarnessExecutionEvidence;
+  recoveryHandle?: SessionRecoveryHandle;
+  turnReadiness?: SessionTurnReadinessMutation;
+};
 
 export type PersistedWorktreeMetadataCurrent<
   TKind extends WorktreeMetadataCurrentKind = WorktreeMetadataCurrentKind,

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -11,6 +11,10 @@ import type {
 import { ProviderProjectConfigSchema } from "@station/contracts";
 import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
 import type { FeatureFlagEvaluator } from "../features/evaluator.js";
+import {
+  decideSessionHarnessExecution,
+  sessionHarnessExecutionEvidenceFromReport,
+} from "../harnessExecutionIdentity.js";
 import type {
   EventJournal,
   ObservationStore,
@@ -140,10 +144,31 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
       return execution;
     },
     projectHarnessEventStatus: async (report) => {
+      const projectedAt = toIsoTimestamp(clock.now());
+      const sessionId = report.correlation?.sessionId;
+      if (
+        report.correlation?.nativeSessionId !== undefined &&
+        (input.persistence === undefined || sessionId === undefined)
+      ) {
+        return { projected: false, snapshot, events: [] };
+      }
+      if (input.persistence !== undefined && sessionId !== undefined) {
+        const binding = await input.persistence.getSessionHarnessExecution({
+          provider: report.provider,
+          sessionId,
+        });
+        const decision = decideSessionHarnessExecution({
+          current: binding,
+          evidence: sessionHarnessExecutionEvidenceFromReport(report),
+        });
+        if (!decision.mayDeriveState) {
+          return { projected: false, snapshot, events: [] };
+        }
+      }
       const result = projectHarnessEventReportOntoSnapshot({
         snapshot,
         report,
-        projectedAt: toIsoTimestamp(clock.now()),
+        projectedAt,
       });
       if (!result.projected) {
         return result;
@@ -235,8 +260,8 @@ async function persistTurnReadinessForReport(input: {
   // for the user mid-turn) makes ready_to_read stale. Without this closing
   // edge the badge survives on a working agent and cannot be acknowledged,
   // because snapshots only expose readiness on idle agents. Status drives the
-  // clear regardless of turn.kind so this writer agrees with
-  // persistTurnReadinessFromHarnessObservation for identical input.
+  // clear regardless of turn.kind so this writer agrees with the ingress
+  // readiness policy for identical input.
   const status = input.report.status?.value;
   if (status === "working" || status === "starting" || status === "needs_attention") {
     if (input.result.sessionId !== undefined) {

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -176,6 +176,10 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
           report,
           projectedAt: toIsoTimestamp(clock.now()),
         });
+        // Durable session authorization must match the canonical session selected by projection.
+        if (sessionId !== undefined && projection.sessionId !== sessionId) {
+          return { projected: false, snapshot, events: [] };
+        }
         if (projection.projected) {
           snapshot = projection.snapshot;
         }

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -93,7 +93,9 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
   const providerReadRetries = input.providerReadRetries ?? 1;
   let config = input.config;
   let projects = providerProjectsFromConfig(config);
-  let reconcileChain: Promise<void> = Promise.resolve();
+  // Binding authorization and base projection share ordering with reconciles so
+  // an awaited authority read cannot commit through a superseding snapshot.
+  let snapshotWriterChain: Promise<void> = Promise.resolve();
   let providerHealth: Record<string, ProviderHealth> = {};
   let lastReconcile: ReconcileTiming | undefined;
   let snapshot = buildInitialSnapshot({
@@ -114,6 +116,11 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
     ...(input.logger === undefined ? {} : { logger: input.logger }),
   };
   const observer = { pid, startedAt, version };
+  const enqueueSnapshotWrite = <T>(write: () => Promise<T>): Promise<T> => {
+    const execution = snapshotWriterChain.then(write);
+    snapshotWriterChain = execution.catch(() => undefined).then(() => undefined);
+    return execution;
+  };
 
   return {
     reconcile: async (reason = "manual") => {
@@ -138,46 +145,45 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
         return snapshot;
       };
 
-      const previous = reconcileChain;
-      const execution = previous.then(run);
-      reconcileChain = execution.catch(() => undefined).then(() => undefined);
-      return execution;
+      return enqueueSnapshotWrite(run);
     },
     projectHarnessEventStatus: async (report) => {
-      const projectedAt = toIsoTimestamp(clock.now());
-      const sessionId = report.correlation?.sessionId;
-      // Native reports remain diagnostic-only until a durable Station-session
-      // binding can authorize their projection.
-      if (
-        report.correlation?.nativeSessionId !== undefined &&
-        (input.persistence === undefined || sessionId === undefined)
-      ) {
-        return { projected: false, snapshot, events: [] };
-      }
-      if (input.persistence !== undefined && sessionId !== undefined) {
-        const binding = await input.persistence.getSessionHarnessExecution({
-          provider: report.provider,
-          sessionId,
-        });
-        const decision = decideSessionHarnessExecution({
-          current: binding,
-          evidence: sessionHarnessExecutionEvidenceFromReport(report),
-        });
-        if (!decision.mayDeriveState) {
+      const result = await enqueueSnapshotWrite(async (): Promise<StatusProjectionResult> => {
+        const sessionId = report.correlation?.sessionId;
+        // Native reports remain diagnostic-only until a durable Station-session
+        // binding can authorize their projection.
+        if (
+          report.correlation?.nativeSessionId !== undefined &&
+          (input.persistence === undefined || sessionId === undefined)
+        ) {
           return { projected: false, snapshot, events: [] };
         }
-      }
-      const result = projectHarnessEventReportOntoSnapshot({
-        snapshot,
-        report,
-        projectedAt,
+        if (input.persistence !== undefined && sessionId !== undefined) {
+          const binding = await input.persistence.getSessionHarnessExecution({
+            provider: report.provider,
+            sessionId,
+          });
+          const decision = decideSessionHarnessExecution({
+            current: binding,
+            evidence: sessionHarnessExecutionEvidenceFromReport(report),
+          });
+          if (!decision.mayDeriveState) {
+            return { projected: false, snapshot, events: [] };
+          }
+        }
+        const projection = projectHarnessEventReportOntoSnapshot({
+          snapshot,
+          report,
+          projectedAt: toIsoTimestamp(clock.now()),
+        });
+        if (projection.projected) {
+          snapshot = projection.snapshot;
+        }
+        return projection;
       });
       if (!result.projected) {
         return result;
       }
-      // Commit the base projection synchronously so a concurrent reconcile or
-      // acknowledgeTurn cannot be clobbered by a stale post-await write.
-      snapshot = result.snapshot;
       if (input.persistence === undefined) {
         return result;
       }
@@ -189,6 +195,10 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
       });
       if (persisted === undefined) {
         return result;
+      }
+      // A newer completion can win the readiness conflict while this write is pending.
+      if (persisted.token !== report.reportId) {
+        return { projected: false, snapshot, events: [] };
       }
       // Re-resolve against the live snapshot, which may have changed during the
       // upsert await, then apply the readiness marker synchronously.

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -146,6 +146,8 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
     projectHarnessEventStatus: async (report) => {
       const projectedAt = toIsoTimestamp(clock.now());
       const sessionId = report.correlation?.sessionId;
+      // Native reports remain diagnostic-only until a durable Station-session
+      // binding can authorize their projection.
       if (
         report.correlation?.nativeSessionId !== undefined &&
         (input.persistence === undefined || sessionId === undefined)

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -194,7 +194,13 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
       // upsert await, then apply the readiness marker synchronously.
       const applied = applyTurnReadinessToSnapshot(snapshot, persisted);
       if (applied === undefined) {
-        return result;
+        // The live graph superseded this completion during the write; remove only
+        // its marker and suppress the stale idle events that would notify hooks.
+        await input.persistence.deleteSessionTurnReadiness({
+          sessionId: persisted.sessionId,
+          token: report.reportId,
+        });
+        return { projected: false, snapshot, events: [] };
       }
       snapshot = applied.snapshot;
       return {

--- a/apps/observer/src/reconcile/harnessEventStatus.ts
+++ b/apps/observer/src/reconcile/harnessEventStatus.ts
@@ -3,6 +3,7 @@ import type {
   HarnessRunObservation,
   ObservedStatus,
 } from "@station/contracts";
+import { correlateHarnessExecution } from "../harnessExecutionIdentity.js";
 import type { PersistedProviderObservation } from "../persistence/index.js";
 
 export type ObserverHarnessRun = {
@@ -10,12 +11,8 @@ export type ObserverHarnessRun = {
   status: ObservedStatus;
 };
 
-type CorrelatedBy = "harnessRunId" | "sessionId" | "worktreeId";
-
 type StatusOverlay = {
   status: ObservedStatus;
-  rawEventType?: string;
-  correlatedBy: CorrelatedBy;
   observedAt: string;
   observationId: string;
 };
@@ -119,6 +116,7 @@ export function synthesizeExternalHarnessRuns(input: {
         id,
         provider: event.provider,
         worktreeId,
+        nativeSessionId,
         state: status.value,
         confidence: status.confidence,
         reason: status.reason,
@@ -182,40 +180,33 @@ export function applyHarnessEventStatusOverlays(input: {
     }
 
     const event = observation.payload;
-    if (event.provider !== observation.provider) {
-      continue;
-    }
-    if (event.status === undefined || event.status.value === "unknown") {
-      continue;
-    }
+    if (event.provider !== observation.provider) continue;
+    if (event.status === undefined || event.status.value === "unknown") continue;
 
-    const match = correlateHarnessEvent(event, input.runs);
-    if (match === undefined || shouldPreserveLiveStatus(match.run, event.status)) {
-      continue;
-    }
+    const match = correlateHarnessExecution({
+      evidence: event,
+      runs: input.runs.map((run) => run.run),
+      allowNativeBinding: false,
+    });
+    if (match === undefined) continue;
+
+    const currentRun = input.runs.find((run) => run.run.id === match.run.id);
+    if (currentRun === undefined || shouldPreserveLiveStatus(currentRun, event.status)) continue;
 
     const overlay: StatusOverlay = {
       status: event.status,
-      correlatedBy: match.correlatedBy,
       observedAt: observation.observedAt,
       observationId: observation.id,
     };
-    if (event.rawEventType !== undefined) {
-      overlay.rawEventType = event.rawEventType;
-    }
-
-    const previous = latestByRunId.get(match.run.run.id);
+    const previous = latestByRunId.get(match.run.id);
     if (previous === undefined || compareOverlays(overlay, previous) >= 0) {
-      latestByRunId.set(match.run.run.id, overlay);
+      latestByRunId.set(match.run.id, overlay);
     }
   }
 
   return input.runs.map((run) => {
     const overlay = latestByRunId.get(run.run.id);
-    if (overlay === undefined) {
-      return run;
-    }
-    return applyStatusOverlay(run, overlay);
+    return overlay === undefined ? run : applyStatusOverlay(run, overlay);
   });
 }
 
@@ -226,41 +217,6 @@ function eventOrdinal(event: HarnessEventObservation): number {
   const updated = event.status === undefined ? 0 : Date.parse(event.status.updatedAt);
   const observed = Date.parse(event.observedAt);
   return Math.max(Number.isFinite(updated) ? updated : 0, Number.isFinite(observed) ? observed : 0);
-}
-
-function correlateHarnessEvent(
-  event: HarnessEventObservation,
-  runs: ObserverHarnessRun[],
-): { run: ObserverHarnessRun; correlatedBy: CorrelatedBy } | undefined {
-  const providerRuns = runs.filter((run) => run.run.provider === event.provider);
-
-  if (event.harnessRunId !== undefined) {
-    const matches = providerRuns.filter((run) => run.run.id === event.harnessRunId);
-    return singleCorrelation(matches, "harnessRunId");
-  }
-
-  if (event.sessionId !== undefined) {
-    const matches = providerRuns.filter((run) => run.run.sessionId === event.sessionId);
-    return singleCorrelation(matches, "sessionId");
-  }
-
-  if (event.worktreeId !== undefined) {
-    const matches = providerRuns.filter((run) => run.run.worktreeId === event.worktreeId);
-    return singleCorrelation(matches, "worktreeId");
-  }
-
-  return undefined;
-}
-
-function singleCorrelation(
-  matches: ObserverHarnessRun[],
-  correlatedBy: CorrelatedBy,
-): { run: ObserverHarnessRun; correlatedBy: CorrelatedBy } | undefined {
-  const run = matches[0];
-  if (matches.length !== 1 || run === undefined) {
-    return undefined;
-  }
-  return { run, correlatedBy };
 }
 
 function shouldPreserveLiveStatus(run: ObserverHarnessRun, status: ObservedStatus): boolean {
@@ -293,6 +249,7 @@ function runObservationWithStatus(
   if (run.projectId !== undefined) nextRun.projectId = run.projectId;
   if (run.worktreeId !== undefined) nextRun.worktreeId = run.worktreeId;
   if (run.sessionId !== undefined) nextRun.sessionId = run.sessionId;
+  if (run.nativeSessionId !== undefined) nextRun.nativeSessionId = run.nativeSessionId;
   if (run.pid !== undefined) nextRun.pid = run.pid;
   if (run.cwd !== undefined) nextRun.cwd = run.cwd;
   if (run.providerData !== undefined) nextRun.providerData = run.providerData;

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -110,7 +110,7 @@ export function buildInitialSnapshot(input: {
 /**
  * USE CASE
  *
- * Rebuilds the Observer graph and retains provider-native harness identity for live ingress correlation.
+ * Rebuilds the Observer graph from provider reads and accepted durable evidence.
  */
 export async function runReconcileOnce(input: ReconcileOnceInput): Promise<ReconcileOnceResult> {
   const started = toIsoTimestamp(input.read.clock.now());

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -22,6 +22,7 @@ import {
   safeErrorFromUnknown,
   toIsoTimestamp,
 } from "@station/runtime";
+import { bindHarnessRunsToSessionExecutions } from "../harnessExecutionIdentity.js";
 import { staleChangeSummary, staleChecks, stalePullRequest } from "../metadata/stalePayloads.js";
 import type {
   EventJournal,
@@ -106,6 +107,11 @@ export function buildInitialSnapshot(input: {
   });
 }
 
+/**
+ * USE CASE
+ *
+ * Rebuilds the Observer graph and retains provider-native harness identity for live ingress correlation.
+ */
 export async function runReconcileOnce(input: ReconcileOnceInput): Promise<ReconcileOnceResult> {
   const started = toIsoTimestamp(input.read.clock.now());
   const retentionDays =
@@ -154,7 +160,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
 
   const finishedAt = toIsoTimestamp(input.read.clock.now());
   const harnessStatusInput: {
-    persistence?: ObservationStore;
+    persistence?: ObservationStore & SessionStore;
     harnessRuns: ObserverHarnessRun[];
     now: string;
   } = {
@@ -686,7 +692,7 @@ async function classifyHarnessRuns(input: {
 }
 
 async function harnessRunsWithPersistedEventStatus(input: {
-  persistence?: ObservationStore;
+  persistence?: ObservationStore & SessionStore;
   harnessRuns: ObserverHarnessRun[];
   now: string;
 }): Promise<ObserverHarnessRun[]> {
@@ -694,12 +700,23 @@ async function harnessRunsWithPersistedEventStatus(input: {
     return input.harnessRuns;
   }
 
-  const observations = await input.persistence.listProviderObservations({
-    entityKind: "harness_event",
-    now: input.now,
+  const [observations, bindings] = await Promise.all([
+    input.persistence.listProviderObservations({
+      entityKind: "harness_event",
+      now: input.now,
+    }),
+    input.persistence.listSessionHarnessExecutions(),
+  ]);
+  const boundRuns = bindHarnessRunsToSessionExecutions({
+    runs: input.harnessRuns.map((run) => run.run),
+    bindings,
   });
+  const runsWithBindings = input.harnessRuns.map((run, index) => ({
+    ...run,
+    run: boundRuns[index] ?? run.run,
+  }));
   return applyHarnessEventStatusOverlays({
-    runs: synthesizeExternalHarnessRuns({ runs: input.harnessRuns, observations }),
+    runs: synthesizeExternalHarnessRuns({ runs: runsWithBindings, observations }),
     observations,
   });
 }
@@ -933,6 +950,7 @@ function runWithStatus(
   if (projectId !== undefined) nextRun.projectId = projectId;
   if (worktreeId !== undefined) nextRun.worktreeId = worktreeId;
   if (sessionId !== undefined) nextRun.sessionId = sessionId;
+  if (run.nativeSessionId !== undefined) nextRun.nativeSessionId = run.nativeSessionId;
   if (run.pid !== undefined) nextRun.pid = run.pid;
   if (run.cwd !== undefined) nextRun.cwd = run.cwd;
   if (providerData !== undefined) nextRun.providerData = providerData;

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -86,9 +86,17 @@ export function withSessionCorrelationFromSnapshot(
   });
   const match = matches[0];
   if (matches.length !== 1 || match?.agent?.sessionId === undefined) return report;
+  const session = snapshot.sessions.find(
+    (candidate) =>
+      candidate.origin === "station" &&
+      candidate.id === match.agent?.sessionId &&
+      candidate.projectId === match.projectId &&
+      candidate.worktreeId === match.id,
+  );
+  if (session === undefined) return report;
   return {
     ...report,
-    correlation: { ...correlation, sessionId: match.agent.sessionId },
+    correlation: { ...correlation, sessionId: session.id },
   };
 }
 

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -1,11 +1,12 @@
-import type {
-  HarnessEventReport,
-  ObservedStatus,
-  ProjectView,
-  SessionView,
-  StationEvent,
-  StationSnapshot,
-  WorktreeRow,
+import {
+  type HarnessEventReport,
+  harnessRunIdForTerminalTarget,
+  type ObservedStatus,
+  type ProjectView,
+  type SessionView,
+  type StationEvent,
+  type StationSnapshot,
+  type WorktreeRow,
 } from "@station/contracts";
 import { pathIsSameOrInside } from "@station/runtime";
 import { countsForSnapshot, statusPolicy } from "./statusPolicy.js";
@@ -54,6 +55,43 @@ export function withWorktreeCorrelationFromCwd(
   return { ...report, correlation: { ...correlation, worktreeId } };
 }
 
+/**
+ * POLICY
+ *
+ * Resolves Station-owned run or terminal evidence to the unique current Station session.
+ */
+export function withSessionCorrelationFromSnapshot(
+  report: HarnessEventReport,
+  snapshot: StationSnapshot,
+): HarnessEventReport {
+  const correlation = report.correlation;
+  if (
+    correlation === undefined ||
+    correlation.sessionId !== undefined ||
+    (correlation.harnessRunId === undefined && correlation.terminalTargetId === undefined)
+  ) {
+    return report;
+  }
+
+  const harnessRunId =
+    correlation.harnessRunId ??
+    (correlation.terminalTargetId === undefined
+      ? undefined
+      : harnessRunIdForTerminalTarget(report.provider, correlation.terminalTargetId));
+  if (harnessRunId === undefined) return report;
+
+  const matches = snapshot.rows.filter((row) => {
+    if (row.agent?.harness !== report.provider || row.agent.sessionId === undefined) return false;
+    return row.agent.runId === harnessRunId;
+  });
+  const match = matches[0];
+  if (matches.length !== 1 || match?.agent?.sessionId === undefined) return report;
+  return {
+    ...report,
+    correlation: { ...correlation, sessionId: match.agent.sessionId },
+  };
+}
+
 // Deepest containing worktree wins; a tie at the same depth is ambiguous and
 // resolves to nothing (mirrors resolveWorktreeByProjectPath in run.ts).
 function rowIdForCwd(rows: readonly WorktreeRow[], cwd: string): string | undefined {
@@ -76,6 +114,11 @@ function rowIdForCwd(rows: readonly WorktreeRow[], cwd: string): string | undefi
   return match.id;
 }
 
+/**
+ * POLICY
+ *
+ * Projects pre-correlated harness status onto one current row and session.
+ */
 export function projectHarnessEventReportOntoSnapshot(input: {
   snapshot: StationSnapshot;
   report: HarnessEventReport;

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -117,7 +117,7 @@ function rowIdForCwd(rows: readonly WorktreeRow[], cwd: string): string | undefi
 /**
  * POLICY
  *
- * Projects pre-correlated harness status onto one current row and session.
+ * Projects native-authorized harness status onto one current row and session.
  */
 export function projectHarnessEventReportOntoSnapshot(input: {
   snapshot: StationSnapshot;

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -43,7 +43,8 @@ function reportDecisionFields(report: HarnessEventReport): Record<string, unknow
 /**
  * USE CASE
  *
- * Accepts normalized harness evidence, projects accepted status, and schedules fresh graph truth.
+ * Persists one normalized report, projects authorized live status, publishes derived events, and
+ * returns the required reconcile reason.
  */
 export async function processHarnessIngressReport(
   deps: HarnessReportProcessorDeps,

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -3,7 +3,10 @@ import { HarnessEventReportReceiptSchema } from "@station/contracts";
 import { type RuntimeClock, runRuntimeBoundary } from "@station/runtime";
 import type { HarnessEventReportIngestion } from "../hooks/ingestion.js";
 import type { ObserverCore } from "../reconcile/core.js";
-import { withWorktreeCorrelationFromCwd } from "../reconcile/statusProjection.js";
+import {
+  withSessionCorrelationFromSnapshot,
+  withWorktreeCorrelationFromCwd,
+} from "../reconcile/statusProjection.js";
 import type { StationLogger } from "../stationLogger.js";
 import type { ObserverEventBus } from "./eventBus.js";
 
@@ -29,6 +32,7 @@ function reportDecisionFields(report: HarnessEventReport): Record<string, unknow
     attention: report.status?.attention,
     correlation: {
       harnessRunId: report.correlation?.harnessRunId,
+      nativeSessionId: report.correlation?.nativeSessionId,
       sessionId: report.correlation?.sessionId,
       worktreeId: report.correlation?.worktreeId,
       cwd: report.correlation?.cwd,
@@ -36,13 +40,22 @@ function reportDecisionFields(report: HarnessEventReport): Record<string, unknow
   };
 }
 
+/**
+ * USE CASE
+ *
+ * Accepts normalized harness evidence, projects accepted status, and schedules fresh graph truth.
+ */
 export async function processHarnessIngressReport(
   deps: HarnessReportProcessorDeps,
   rawReport: HarnessEventReport,
 ): Promise<HarnessReportProcessResult> {
   // Resolve cwd-only correlation before ingest so the persisted observation
   // carries the worktreeId too, not just this projection pass.
-  const report = withWorktreeCorrelationFromCwd(rawReport, deps.core.getSnapshot());
+  const snapshot = deps.core.getSnapshot();
+  const report = withSessionCorrelationFromSnapshot(
+    withWorktreeCorrelationFromCwd(rawReport, snapshot),
+    snapshot,
+  );
   const receipt = await deps.harnessEventReportIngestion.ingest(report, {
     triggerReconcile: false,
   });

--- a/apps/observer/src/sqlite.ts
+++ b/apps/observer/src/sqlite.ts
@@ -142,6 +142,15 @@ function applyMigrations(database: SqlDatabase, clock: RuntimeClock): void {
     );
   `);
 
+  // Requeue the two unpublished migration numbers after main assigned version 12 elsewhere.
+  database
+    .prepare(`
+      DELETE FROM observer_migrations
+      WHERE (version = 12 AND name = 'session_harness_executions')
+         OR (version = 13 AND name = 'native_binding_ingress_claims')
+    `)
+    .run();
+
   const appliedVersions = new Set(
     readAppliedMigrations(database).map((migration) => migration.version),
   );

--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -193,7 +193,13 @@ describe("observer provider hook ingress", () => {
       harnesses: [new FakeHarnessProvider({ now })],
       hookAdapters: [adapter],
     });
-    const { sqlite, persistence, api } = createTestObserver({ config, providers, clock });
+    const { sqlite, persistence, eventBus, api } = createTestObserver({
+      config,
+      providers,
+      clock,
+    });
+    const reports = eventBus.subscribe({ type: "harness.eventReported" })[Symbol.asyncIterator]();
+    const persisted = reports.next();
 
     const receipt = await api.ingestProviderHookEvent({
       schemaVersion: STATION_SCHEMA_VERSION,
@@ -205,6 +211,9 @@ describe("observer provider hook ingress", () => {
       payload: { owned: true },
     });
     expect(receipt).toMatchObject({ accepted: true, status: "ingested" });
+    await expect(persisted).resolves.toMatchObject({
+      value: { type: "harness.eventReported", reportId: "fake:hook_adapter_1" },
+    });
 
     await expect(persistence.listProviderObservations()).resolves.toEqual(
       expect.arrayContaining([
@@ -234,6 +243,47 @@ describe("observer provider hook ingress", () => {
     });
     expect(ignored).toMatchObject({ accepted: false, status: "ignored" });
 
+    await reports.return?.();
+    sqlite.close();
+  });
+
+  it("rejects adapter-backed harness hooks when the normalized report handoff is absent", async () => {
+    const clock = { now: () => new Date(now) };
+    const harness = new RecordingHarnessProvider({ now });
+    const adapter: ProviderHookAdapter = {
+      provider: "fake-harness",
+      kind: "harness",
+      toHarnessEventReport: () => {
+        throw new Error("adapter must not run without a report handoff");
+      },
+    };
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [harness],
+      hookAdapters: [adapter],
+    });
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    const ingress = createProviderHookIngress({ persistence, providers, clock });
+
+    await expect(
+      ingress.ingest({
+        schemaVersion: STATION_SCHEMA_VERSION,
+        hookId: "hook_missing_report_handoff",
+        provider: "fake-harness",
+        kind: "harness",
+        event: "Stop",
+        receivedAt: now,
+      }),
+    ).resolves.toMatchObject({
+      accepted: false,
+      status: "rejected",
+      error: { code: "HARNESS_REPORT_INGRESS_UNAVAILABLE" },
+    });
+    expect(harness.ingestCalls).toBe(0);
+    await expect(persistence.listProviderObservations()).resolves.toEqual([]);
+    await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
     sqlite.close();
   });
 
@@ -467,21 +517,78 @@ describe("observer provider hook ingress", () => {
     sqlite.close();
   });
 
-  it("repairs recovery and readiness after primary harness report persistence was already committed", async () => {
+  it("gates legacy harness readiness by the bound native execution", async () => {
+    const clock = { now: () => new Date(now) };
+    const harness = new NativeExecutionHarnessProvider({ now });
+    const providers = new ProviderRegistry({
+      worktree: new FakeWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [harness],
+    });
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    const ingress = createProviderHookIngress({ persistence, providers, clock });
+
+    await ingress.ingest(harnessProviderHook("hook_native_a_working", now));
+    harness.nativeSessionId = "native_b";
+    harness.state = "idle";
+    harness.observedAt = "2026-05-20T12:00:01.000Z";
+    await ingress.ingest(harnessProviderHook("hook_native_b_stop", harness.observedAt));
+
+    await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+      expect.objectContaining({ nativeSessionId: "native_a", state: "working" }),
+    ]);
+    await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+
+    harness.nativeSessionId = "native_a";
+    harness.observedAt = "2026-05-20T12:00:02.000Z";
+    await ingress.ingest(harnessProviderHook("hook_native_a_stop", harness.observedAt));
+    await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+      expect.objectContaining({
+        sessionId: "ses_native_execution",
+        token: "hook_native_a_stop",
+      }),
+    ]);
+    sqlite.close();
+  });
+
+  it("retries the atomic harness report transaction after persistence rejects it", async () => {
     const clock = { now: () => new Date(now) };
     const sqlite = openObserverSqlite({ clock });
     const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
-    let rejectRecoveryOnce = true;
+    const bindingIngestion = createHarnessEventReportIngestion({ persistence, clock });
+    await expect(
+      bindingIngestion.ingest(
+        {
+          ...harnessReport("report_binding_1"),
+          status: {
+            value: "working",
+            confidence: "medium",
+            reason: "Codex is active.",
+            source: "harness_event",
+            updatedAt: now,
+          },
+          correlation: {
+            projectId: "web",
+            worktreeId: "wt_web_task",
+            sessionId: "ses_web_task",
+            nativeSessionId: "native_codex_1",
+          },
+        },
+        { triggerReconcile: false },
+      ),
+    ).resolves.toMatchObject({ accepted: true });
+    let rejectReportOnce = true;
     const retryingPersistence = {
       ...persistence,
-      upsertSessionRecoveryHandle: async (
-        input: Parameters<typeof persistence.upsertSessionRecoveryHandle>[0],
+      recordEventAndProviderObservationWithIngressDedupe: async (
+        input: Parameters<typeof persistence.recordEventAndProviderObservationWithIngressDedupe>[0],
       ) => {
-        if (rejectRecoveryOnce) {
-          rejectRecoveryOnce = false;
-          throw new Error("forced recovery failure");
+        if (rejectReportOnce) {
+          rejectReportOnce = false;
+          throw new Error("forced report transaction failure");
         }
-        return persistence.upsertSessionRecoveryHandle(input);
+        return persistence.recordEventAndProviderObservationWithIngressDedupe(input);
       },
     };
     const ingestion = createHarnessEventReportIngestion({
@@ -512,7 +619,7 @@ describe("observer provider hook ingress", () => {
     });
     await expect(ingestion.ingest(report, { triggerReconcile: false })).resolves.toMatchObject({
       accepted: true,
-      deduped: true,
+      deduped: false,
     });
     await expect(persistence.listSessionRecoveryHandles()).resolves.toHaveLength(1);
     await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
@@ -721,6 +828,17 @@ function harnessReport(reportId: string) {
   };
 }
 
+function harnessProviderHook(hookId: string, receivedAt: string) {
+  return {
+    schemaVersion: STATION_SCHEMA_VERSION,
+    hookId,
+    provider: "fake-harness",
+    kind: "harness" as const,
+    event: "run.updated",
+    receivedAt,
+  };
+}
+
 function acceptedReportReceipt(
   reportId: string,
   provider: string,
@@ -830,6 +948,34 @@ class ContextChangingReadinessHarnessProvider extends FakeHarnessProvider {
           updatedAt: now,
         },
         observedAt: now,
+      },
+    ];
+  }
+}
+
+class NativeExecutionHarnessProvider extends FakeHarnessProvider {
+  nativeSessionId = "native_a";
+  state: "working" | "idle" = "working";
+  observedAt = now;
+
+  override async ingestEvent() {
+    return [
+      {
+        provider: this.id,
+        projectId: "web",
+        worktreeId: "wt_native_execution",
+        sessionId: "ses_native_execution",
+        nativeSessionId: this.nativeSessionId,
+        rawEventType: this.state === "idle" ? "Stop" : "PreToolUse",
+        ...(this.state === "idle" ? { turn: { kind: "turn_completed" as const } } : {}),
+        status: {
+          value: this.state,
+          confidence: "high" as const,
+          reason: `Native execution is ${this.state}.`,
+          source: "harness_event" as const,
+          updatedAt: this.observedAt,
+        },
+        observedAt: this.observedAt,
       },
     ];
   }

--- a/apps/observer/test/integration/persistence.test.ts
+++ b/apps/observer/test/integration/persistence.test.ts
@@ -278,6 +278,76 @@ describe("observer persistence", () => {
     sqlite.close();
   });
 
+  it("reloads native harness execution bindings without a reconstructed session row", async () => {
+    const dbPath = await tempDbPath();
+    const sqlite = openObserverSqlite({ path: dbPath, clock: { now: () => new Date(now) } });
+    const persistence = createSqliteObserverPersistence({
+      sqlite,
+      clock: { now: () => new Date(now) },
+      idFactory: ids(),
+    });
+    const status = {
+      value: "working" as const,
+      confidence: "medium" as const,
+      reason: "Codex subagent stopped.",
+      source: "harness_event" as const,
+      updatedAt: now,
+    };
+
+    await persistence.recordEventAndProviderObservationWithIngressDedupe({
+      event: {
+        type: "harness.eventReported",
+        at: now,
+        reportId: "report_native_a",
+        provider: "codex",
+        eventType: "SubagentStop",
+      },
+      eventOptions: { source: "hook", createdAt: now },
+      observation: {
+        provider: "codex",
+        providerType: "harness",
+        entityKind: "harness_event",
+        entityKey: "native_a",
+        payload: {
+          provider: "codex",
+          reportId: "report_native_a",
+          eventType: "SubagentStop",
+          sessionId: "ses_native",
+          nativeSessionId: "native_a",
+          status,
+          observedAt: now,
+        },
+        observedAt: now,
+      },
+      harnessExecution: {
+        evidence: {
+          provider: "codex",
+          sessionId: "ses_native",
+          nativeSessionId: "native_a",
+          status,
+        },
+      },
+      dedupe: { kind: "harness_report", id: "report_native_a" },
+    });
+    sqlite.close();
+
+    const reopened = openObserverSqlite({ path: dbPath, clock: { now: () => new Date(later) } });
+    const reloaded = createSqliteObserverPersistence({
+      sqlite: reopened,
+      clock: { now: () => new Date(later) },
+      idFactory: ids(),
+    });
+    await expect(
+      reloaded.getSessionHarnessExecution({ provider: "codex", sessionId: "ses_native" }),
+    ).resolves.toMatchObject({
+      nativeSessionId: "native_a",
+      state: "working",
+      statusUpdatedAt: now,
+    });
+    await expect(reloaded.listSessions()).resolves.toEqual([]);
+    reopened.close();
+  });
+
   it("skips retired command rows without requiring a migration", async () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     const persistence = createSqliteObserverPersistence({

--- a/apps/observer/test/integration/persistence.test.ts
+++ b/apps/observer/test/integration/persistence.test.ts
@@ -348,6 +348,32 @@ describe("observer persistence", () => {
     reopened.close();
   });
 
+  it("invalidates legacy ingress claims after the native binding schema is applied", async () => {
+    const dbPath = await tempDbPath();
+    const legacy = openObserverSqlite({ path: dbPath, clock: { now: () => new Date(now) } });
+    const insertClaim = legacy.database.prepare(`
+      INSERT INTO hook_ingress_dedupe (kind, dedupe_id, event_id, created_at)
+      VALUES (?, ?, ?, ?)
+    `);
+    insertClaim.run("harness_report", "legacy_report", "evt_legacy_report", now);
+    insertClaim.run("hook_processing", "legacy_processing", "evt_legacy_processing", now);
+    insertClaim.run("hook", "legacy_hook", "evt_legacy_hook", now);
+    legacy.database.exec(`
+      DELETE FROM observer_migrations WHERE version = 14;
+      UPDATE observer_meta SET value = '13' WHERE key = 'schema_version';
+    `);
+    legacy.close();
+
+    const upgraded = openObserverSqlite({ path: dbPath, clock: { now: () => new Date(later) } });
+
+    expect(
+      upgraded.database
+        .prepare("SELECT kind, dedupe_id FROM hook_ingress_dedupe ORDER BY kind, dedupe_id")
+        .all(),
+    ).toEqual([{ kind: "hook", dedupe_id: "legacy_hook" }]);
+    upgraded.close();
+  });
+
   it("skips retired command rows without requiring a migration", async () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     const persistence = createSqliteObserverPersistence({

--- a/apps/observer/test/integration/reconcile-codex-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-codex-harness.test.ts
@@ -366,16 +366,13 @@ describe("observer reconcile with Codex harness", () => {
       await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
       expect(notificationCalls).toHaveLength(0);
 
-      await reportAndReconcile(
-        api,
-        eventBus,
-        codexLifecycleReport({
-          reportId: "report_native_a_stop",
-          nativeSessionId: "native_a",
-          event: "Stop",
-          observedAt: "2026-05-21T12:00:04.000Z",
-        }),
-      );
+      const legitimateStop = codexLifecycleReport({
+        reportId: "report_native_a_stop",
+        nativeSessionId: "native_a",
+        event: "Stop",
+        observedAt: "2026-05-21T12:00:04.000Z",
+      });
+      await reportAndReconcile(api, eventBus, legitimateStop);
       await waitFor(() => reconcileProbeCalls.length === 4);
       await waitFor(() => notificationCalls.length === 1);
       expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
@@ -386,6 +383,19 @@ describe("observer reconcile with Codex harness", () => {
         },
       });
       expect(parseNotificationReportId(notificationCalls[0]?.stdin)).toBe("report_native_a_stop");
+
+      await expect(api.reportHarnessEvent(legitimateStop)).resolves.toMatchObject({
+        accepted: true,
+        deduped: true,
+        projected: false,
+        scheduledReconcile: false,
+      });
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+        expect.objectContaining({ token: "report_native_a_stop" }),
+      ]);
+      expect(notificationCalls.map((call) => parseNotificationReportId(call.stdin))).toEqual([
+        "report_native_a_stop",
+      ]);
 
       await reportAndReconcile(
         api,
@@ -424,6 +434,7 @@ describe("observer reconcile with Codex harness", () => {
         updatedAt: "2026-05-21T12:00:06.000Z",
       });
       expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
       await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
         expect.objectContaining({ nativeSessionId: "native_a", state: "working" }),
       ]);

--- a/apps/observer/test/integration/reconcile-codex-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-codex-harness.test.ts
@@ -4,6 +4,8 @@ import {
   createCodexHarnessProvider,
 } from "@station/codex";
 import type { StationConfig } from "@station/config";
+import { ObserverEventHookInvocationSchema } from "@station/contracts";
+import { createFakeExternalCommandRunner, type ExternalCommandInput } from "@station/runtime";
 import {
   createFakeTerminalTarget,
   createFakeWorktree,
@@ -14,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   createObserverCore,
   type createObserverEventBus,
+  createObserverEventHookRuntime,
   ProviderRegistry,
 } from "../../src/internal";
 import { createTestObserver } from "../support/testObserver";
@@ -195,7 +198,7 @@ describe("observer reconcile with Codex harness", () => {
           provider: "codex",
           providerType: "harness",
           entityKind: "harness_event",
-          entityKey: "wt_web_task",
+          entityKey: "ses_web_task",
           payload: expect.objectContaining({
             provider: "codex",
             worktreeId: "wt_web_task",
@@ -209,6 +212,227 @@ describe("observer reconcile with Codex harness", () => {
     );
     sqlite.close();
   });
+
+  it("keeps cross-native Stop evidence from changing readiness or firing completion", async () => {
+    const clock = { now: () => new Date(now) };
+    const { sqlite, persistence, eventBus, core, api } = createTestObserver({
+      config,
+      providers: codexProviders(),
+      clock,
+    });
+    const notificationCalls: ExternalCommandInput[] = [];
+    const reconcileProbeCalls: ExternalCommandInput[] = [];
+    const eventHooks = createObserverEventHookRuntime({
+      hooks: [
+        {
+          id: "notify-agent-state",
+          events: ["worktree.agentStateChanged"],
+          command: "notify-bin",
+          args: ["agent-state"],
+          timeoutMs: 1000,
+          filter: {
+            agentState: "idle",
+            harness: "codex",
+          },
+        },
+        {
+          id: "reconcile-probe",
+          events: ["observer.reconciled"],
+          command: "probe-bin",
+        },
+      ],
+      eventBus,
+      commandRunner: createFakeExternalCommandRunner((input) => {
+        if (input.command === "notify-bin") {
+          notificationCalls.push(input);
+        } else {
+          reconcileProbeCalls.push(input);
+        }
+        return {
+          command: input.command,
+          args: input.args ?? [],
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    });
+
+    try {
+      await core.reconcile("initial-native-codex-context");
+
+      const subagentStop = await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_a_subagent_stop",
+          nativeSessionId: "native_a",
+          event: "SubagentStop",
+          observedAt: "2026-05-21T12:00:01.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 1);
+      expect(subagentStop.receipt).toMatchObject({ projected: false });
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "working",
+        reason: "Codex subagent reviewer stopped.",
+        updatedAt: "2026-05-21T12:00:01.000Z",
+      });
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+        expect.objectContaining({
+          provider: "codex",
+          sessionId: "ses_web_task",
+          nativeSessionId: "native_a",
+          state: "working",
+        }),
+      ]);
+
+      const foreignStop = await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_b_stop",
+          nativeSessionId: "native_b",
+          event: "Stop",
+          observedAt: "2026-05-21T12:00:02.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 2);
+      expect(foreignStop.receipt).toMatchObject({ projected: false });
+      expect(
+        foreignStop.events.filter(
+          (event) =>
+            (event.type === "worktree.agentStateChanged" && event.agent.state === "idle") ||
+            (event.type === "session.updated" && event.patch.status?.value === "idle"),
+        ),
+      ).toEqual([]);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "working",
+        reason: "Codex subagent reviewer stopped.",
+        updatedAt: "2026-05-21T12:00:01.000Z",
+      });
+      expect(core.getSnapshot().sessions[0]?.status).toMatchObject({
+        value: "working",
+        updatedAt: "2026-05-21T12:00:01.000Z",
+      });
+      expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+        expect.objectContaining({
+          nativeSessionId: "native_a",
+          state: "working",
+          statusUpdatedAt: "2026-05-21T12:00:01.000Z",
+        }),
+      ]);
+      await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([
+        expect.objectContaining({
+          sessionId: "ses_web_task",
+          target: { kind: "native-session", id: "native_a" },
+        }),
+      ]);
+      expect(notificationCalls).toHaveLength(0);
+      await expect(persistence.listProviderObservations()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            entityKind: "harness_event",
+            payload: expect.objectContaining({
+              reportId: "report_native_b_stop",
+              nativeSessionId: "native_b",
+              status: expect.objectContaining({ value: "idle" }),
+            }),
+          }),
+        ]),
+      );
+
+      const continuation = await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_a_continues",
+          nativeSessionId: "native_a",
+          event: "PreToolUse",
+          observedAt: "2026-05-21T12:00:03.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 3);
+      expect(continuation.receipt).toMatchObject({ projected: false });
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "working",
+        reason: "Codex is about to use Bash.",
+        updatedAt: "2026-05-21T12:00:03.000Z",
+      });
+      expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      expect(notificationCalls).toHaveLength(0);
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_a_stop",
+          nativeSessionId: "native_a",
+          event: "Stop",
+          observedAt: "2026-05-21T12:00:04.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 4);
+      await waitFor(() => notificationCalls.length === 1);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "idle",
+        turnReadiness: {
+          state: "ready_to_read",
+          token: "report_native_a_stop",
+        },
+      });
+      expect(parseNotificationReportId(notificationCalls[0]?.stdin)).toBe("report_native_a_stop");
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_a_new_turn",
+          nativeSessionId: "native_a",
+          event: "PreToolUse",
+          observedAt: "2026-05-21T12:00:05.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 5);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "working",
+        updatedAt: "2026-05-21T12:00:05.000Z",
+      });
+      expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      expect(notificationCalls).toHaveLength(1);
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        codexLifecycleReport({
+          reportId: "report_native_a_active_stop",
+          nativeSessionId: "native_a",
+          event: "Stop",
+          stopHookActive: true,
+          observedAt: "2026-05-21T12:00:06.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 6);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        state: "working",
+        reason: "A Stop hook kept Codex working.",
+        updatedAt: "2026-05-21T12:00:06.000Z",
+      });
+      expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+        expect.objectContaining({ nativeSessionId: "native_a", state: "working" }),
+      ]);
+      expect(notificationCalls).toHaveLength(1);
+    } finally {
+      await eventHooks.shutdown();
+      sqlite.close();
+    }
+  });
 });
 
 function nextObserverReconciled(eventBus: ReturnType<typeof createObserverEventBus>) {
@@ -219,6 +443,92 @@ function nextObserverReconciled(eventBus: ReturnType<typeof createObserverEventB
       await events.return?.();
     },
   };
+}
+
+async function reportAndReconcile(
+  api: ReturnType<typeof createTestObserver>["api"],
+  eventBus: ReturnType<typeof createObserverEventBus>,
+  report: ReturnType<typeof codexHookPayloadToHarnessEventReport>,
+) {
+  const eventIterator = eventBus.subscribe()[Symbol.asyncIterator]();
+  const receipt = await api.reportHarnessEvent(report);
+  expect(receipt).toMatchObject({ accepted: true, status: "accepted" });
+  const events = [];
+  while (true) {
+    const next = await eventIterator.next();
+    if (next.done) throw new Error("Event subscription ended before reconcile.");
+    events.push(next.value);
+    if (next.value.type === "observer.reconciled") break;
+  }
+  await eventIterator.return?.();
+  return { receipt, events };
+}
+
+function codexLifecycleReport(input: {
+  reportId: string;
+  nativeSessionId: string;
+  event: "PreToolUse" | "SubagentStop" | "Stop";
+  stopHookActive?: boolean;
+  observedAt: string;
+}) {
+  const common = {
+    session_id: input.nativeSessionId,
+    transcript_path: null,
+    cwd: "/tmp/station/web/task",
+    model: "gpt-5.4-codex",
+    permission_mode: "default",
+    turn_id: "turn_1",
+    station_project_id: "web",
+    station_worktree_id: "wt_web_task",
+    station_worktree_path: "/tmp/station/web/task",
+    station_session_id: "ses_web_task",
+    station_terminal_provider: "tmux",
+    station_terminal_target_id: "tmux:station:@1:%2",
+  };
+  const payload =
+    input.event === "PreToolUse"
+      ? {
+          ...common,
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_input: { command: "pnpm test" },
+          tool_use_id: `call_${input.reportId}`,
+        }
+      : input.event === "SubagentStop"
+        ? {
+            ...common,
+            hook_event_name: "SubagentStop",
+            agent_transcript_path: null,
+            agent_id: "agent_reviewer",
+            agent_type: "reviewer",
+            stop_hook_active: false,
+            last_assistant_message: "Reviewed.",
+          }
+        : {
+            ...common,
+            hook_event_name: "Stop",
+            stop_hook_active: input.stopHookActive ?? false,
+            last_assistant_message: "Done.",
+          };
+  return codexHookPayloadToHarnessEventReport({
+    reportId: input.reportId,
+    observedAt: input.observedAt,
+    payload,
+  });
+}
+
+function parseNotificationReportId(stdin: string | undefined): string | undefined {
+  if (stdin === undefined) throw new Error("Expected notification invocation stdin.");
+  return ObserverEventHookInvocationSchema.parse(JSON.parse(stdin)).event.reportId;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() <= deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition.");
 }
 
 function codexProviders(): ProviderRegistry {

--- a/apps/observer/test/integration/reconcile-cursor-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-cursor-harness.test.ts
@@ -1,0 +1,257 @@
+import type { StationConfig } from "@station/config";
+import { ObserverEventHookInvocationSchema } from "@station/contracts";
+import {
+  createCursorHarnessProvider,
+  cursorProviderHookPayloadToHarnessEventReport,
+} from "@station/cursor";
+import { createFakeExternalCommandRunner, type ExternalCommandInput } from "@station/runtime";
+import {
+  createFakeTerminalTarget,
+  createFakeWorktree,
+  FakeTerminalProvider,
+  FakeWorktreeProvider,
+} from "@station/testing";
+import { describe, expect, it } from "vitest";
+import { createObserverEventHookRuntime, ProviderRegistry } from "../../src/internal";
+import { createTestObserver } from "../support/testObserver";
+
+const now = "2026-07-14T12:00:00.000Z";
+
+describe("observer reconcile with Cursor harness", () => {
+  it("keeps foreign Stops diagnostic and notifies once for the bound native execution", async () => {
+    const clock = { now: () => new Date(now) };
+    const { sqlite, persistence, eventBus, core, api } = createTestObserver({
+      config,
+      providers: cursorProviders(),
+      clock,
+    });
+    const notificationCalls: ExternalCommandInput[] = [];
+    const reconcileProbeCalls: ExternalCommandInput[] = [];
+    const eventHooks = createObserverEventHookRuntime({
+      hooks: [
+        {
+          id: "notify-cursor-idle",
+          events: ["worktree.agentStateChanged"],
+          command: "notify-bin",
+          filter: { agentState: "idle", harness: "cursor" },
+        },
+        {
+          id: "reconcile-probe",
+          events: ["observer.reconciled"],
+          command: "probe-bin",
+        },
+      ],
+      eventBus,
+      commandRunner: createFakeExternalCommandRunner((input) => {
+        if (input.command === "notify-bin") notificationCalls.push(input);
+        else reconcileProbeCalls.push(input);
+        return {
+          command: input.command,
+          args: input.args ?? [],
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        };
+      }),
+    });
+
+    try {
+      await core.reconcile("initial-cursor-context");
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        cursorReport({
+          reportId: "report_cursor_a_working",
+          nativeSessionId: "cursor_a",
+          event: "preToolUse",
+          observedAt: "2026-07-14T12:00:01.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 1);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({
+        harness: "cursor",
+        state: "working",
+      });
+      await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+        expect.objectContaining({ nativeSessionId: "cursor_a", state: "working" }),
+      ]);
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        cursorReport({
+          reportId: "report_cursor_b_stop",
+          nativeSessionId: "cursor_b",
+          event: "stop",
+          observedAt: "2026-07-14T12:00:02.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 2);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "working" });
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      expect(notificationCalls).toHaveLength(0);
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        cursorReport({
+          reportId: "report_cursor_a_stop",
+          nativeSessionId: "cursor_a",
+          event: "stop",
+          observedAt: "2026-07-14T12:00:03.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 3);
+      await waitFor(() => notificationCalls.length === 1);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "idle" });
+      expect(core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
+      await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+      expect(parseNotificationReportId(notificationCalls[0]?.stdin)).toBe("report_cursor_a_stop");
+
+      await reportAndReconcile(
+        api,
+        eventBus,
+        cursorReport({
+          reportId: "report_cursor_a_new_work",
+          nativeSessionId: "cursor_a",
+          event: "preToolUse",
+          observedAt: "2026-07-14T12:00:04.000Z",
+        }),
+      );
+      await waitFor(() => reconcileProbeCalls.length === 4);
+      expect(core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "working" });
+      expect(notificationCalls).toHaveLength(1);
+    } finally {
+      await eventHooks.shutdown();
+      sqlite.close();
+    }
+  });
+});
+
+async function reportAndReconcile(
+  api: ReturnType<typeof createTestObserver>["api"],
+  eventBus: ReturnType<typeof createTestObserver>["eventBus"],
+  report: ReturnType<typeof cursorProviderHookPayloadToHarnessEventReport>,
+) {
+  const events = eventBus.subscribe()[Symbol.asyncIterator]();
+  const receipt = await api.reportHarnessEvent(report);
+  expect(receipt).toMatchObject({ accepted: true, status: "accepted" });
+  while (true) {
+    const next = await events.next();
+    if (next.done) throw new Error("Event subscription ended before reconcile.");
+    if (next.value.type === "observer.reconciled") break;
+  }
+  await events.return?.();
+}
+
+function cursorReport(input: {
+  reportId: string;
+  nativeSessionId: string;
+  event: "preToolUse" | "stop";
+  observedAt: string;
+}) {
+  const common = {
+    hook_event_name: input.event,
+    session_id: input.nativeSessionId,
+    cwd: "/tmp/station/web/task",
+    station_project_id: "web",
+    station_worktree_id: "wt_web_task",
+    station_worktree_path: "/tmp/station/web/task",
+    station_session_id: "ses_web_task",
+    station_terminal_provider: "tmux",
+    station_terminal_target_id: "tmux:station:@1:%2",
+  };
+  return cursorProviderHookPayloadToHarnessEventReport({
+    reportId: input.reportId,
+    observedAt: input.observedAt,
+    payload:
+      input.event === "stop"
+        ? { ...common, status: "completed" }
+        : { ...common, tool_name: "Bash", tool_use_id: `tool_${input.reportId}` },
+  });
+}
+
+function parseNotificationReportId(stdin: string | undefined): string | undefined {
+  if (stdin === undefined) throw new Error("Expected notification invocation stdin.");
+  return ObserverEventHookInvocationSchema.parse(JSON.parse(stdin)).event.reportId;
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() <= deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for condition.");
+}
+
+function cursorProviders(): ProviderRegistry {
+  return new ProviderRegistry({
+    worktree: new FakeWorktreeProvider({
+      now,
+      worktrees: [
+        createFakeWorktree({
+          id: "wt_web_task",
+          projectId: "web",
+          branch: "task",
+          path: "/tmp/station/web/task",
+          now,
+        }),
+      ],
+    }),
+    terminal: new FakeTerminalProvider({
+      now,
+      targets: [
+        createFakeTerminalTarget({
+          id: "tmux:station:@1:%2",
+          provider: "tmux",
+          projectId: "web",
+          worktreeId: "wt_web_task",
+          sessionId: "ses_web_task",
+          now,
+          harnessBinding: {
+            role: "main-agent",
+            harnessProvider: "cursor",
+            currentCommand: "agent",
+          },
+        }),
+      ],
+    }),
+    harnesses: [
+      createCursorHarnessProvider({
+        now: () => new Date(now),
+        runner: async (input) => ({
+          command: input.command,
+          args: input.args ?? [],
+          stdout: "2026.1.0\n",
+          stderr: "",
+          exitCode: 0,
+        }),
+      }),
+    ],
+  });
+}
+
+const config: StationConfig = {
+  schemaVersion: 1,
+  defaults: {
+    worktreeProvider: "fake-worktree",
+    terminal: "fake-terminal",
+    harness: "cursor",
+    layout: "agent-shell",
+  },
+  projects: [
+    {
+      id: "web",
+      label: "web",
+      root: "/tmp/station/web",
+      defaults: {
+        harness: "cursor",
+        terminal: "fake-terminal",
+        layout: "agent-shell",
+      },
+      worktrunk: { enabled: true },
+    },
+  ],
+};

--- a/apps/observer/test/integration/reconcile-pi-harness.test.ts
+++ b/apps/observer/test/integration/reconcile-pi-harness.test.ts
@@ -69,6 +69,7 @@ describe("observer reconcile with Pi harness", () => {
           event_type: "tool_execution_start",
           cwd: "/tmp/station/web/task",
           pi_session_id: "pi_session_123",
+          pi_session_file: "/tmp/station/pi/session.jsonl",
           tool_call_id: "toolu_1",
           tool_name: "bash",
           station_project_id: "web",
@@ -120,6 +121,7 @@ describe("observer reconcile with Pi harness", () => {
             event_type: "agent_end",
             cwd: "/tmp/station/web/task",
             pi_session_id: "pi_session_123",
+            pi_session_file: "/tmp/station/pi/session.jsonl",
             station_project_id: "web",
             station_worktree_id: "wt_web_task",
             station_session_id: "ses_web_task",
@@ -151,6 +153,7 @@ describe("observer reconcile with Pi harness", () => {
       token: "report_pi_done",
       completedAt: "2026-05-27T12:00:02.000Z",
     });
+    await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([]);
     sqlite.close();
   });
 });

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -29,7 +29,7 @@ describe("SQLite-only Observer persistence behavior", () => {
     const path = join(directory, "observer.sqlite");
     const legacyDatabase = openSqlDatabase(path);
     try {
-      for (const migration of migrations.slice(0, -1)) {
+      for (const migration of migrations.filter(({ version }) => version < 12)) {
         legacyDatabase.exec(migration.sql);
         legacyDatabase
           .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -179,6 +179,85 @@ describe("SQLite-only Observer persistence behavior", () => {
     }
   });
 
+  it("repairs the pre-merge native binding migration collision without losing bindings", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-native-binding-migration-"));
+    const path = join(directory, "observer.sqlite");
+    const legacyDatabase = openSqlDatabase(path);
+    try {
+      for (const migration of migrations.filter(({ version }) => version < 12)) {
+        legacyDatabase.exec(migration.sql);
+        legacyDatabase
+          .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")
+          .run(migration.version, migration.name, now);
+      }
+      legacyDatabase.exec(`
+        CREATE TABLE session_harness_executions (
+          provider TEXT NOT NULL,
+          session_id TEXT NOT NULL,
+          native_session_id TEXT NOT NULL,
+          state TEXT NOT NULL,
+          status_updated_at TEXT NOT NULL,
+          PRIMARY KEY (provider, session_id)
+        );
+        INSERT INTO sessions
+          (id, project_id, worktree_id, harness, created_at, ended_at, last_seen_at)
+        VALUES
+          ('ses_collision', 'web', 'wt_collision', 'codex',
+           '2026-07-14T00:00:00.000Z', '2026-07-14T01:00:00.000Z',
+           '2026-07-14T01:00:00.000Z');
+        INSERT INTO session_harness_executions
+          (provider, session_id, native_session_id, state, status_updated_at)
+        VALUES
+          ('codex', 'ses_collision', 'native_collision', 'idle',
+           '2026-07-14T01:00:00.000Z');
+        INSERT INTO observer_migrations (version, name, applied_at) VALUES
+          (12, 'session_harness_executions', '2026-07-14T00:00:00.000Z'),
+          (13, 'native_binding_ingress_claims', '2026-07-14T00:01:00.000Z');
+        INSERT OR REPLACE INTO observer_meta (key, value)
+          VALUES ('schema_version', '13');
+      `);
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const sqlite = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    try {
+      const persistence = createSqliteObserverPersistence({
+        sqlite,
+        clock: { now: () => new Date(now) },
+      });
+      expect(
+        sqlite
+          .health()
+          .migrations.filter(({ version }) => version >= 12)
+          .map(({ version, name }) => [version, name]),
+      ).toEqual([
+        [12, "session_lifecycle"],
+        [13, "session_harness_executions"],
+        [14, "native_binding_ingress_claims"],
+      ]);
+      await expect(persistence.listSessions()).resolves.toEqual([
+        expect.objectContaining({
+          id: "ses_collision",
+          lifecycle: "ended",
+          endedAt: "2026-07-14T01:00:00.000Z",
+        }),
+      ]);
+      await expect(
+        persistence.getSessionHarnessExecution({
+          provider: "codex",
+          sessionId: "ses_collision",
+        }),
+      ).resolves.toMatchObject({
+        nativeSessionId: "native_collision",
+        state: "idle",
+      });
+    } finally {
+      sqlite.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("exposes healthy SQLite status in addition to the seven application ports", () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     try {

--- a/apps/observer/test/integration/turn-readiness.test.ts
+++ b/apps/observer/test/integration/turn-readiness.test.ts
@@ -218,9 +218,144 @@ describe("observer turn readiness", () => {
       fixture.sqlite.close();
     }
   });
+
+  it("does not let a binding lookup reorder live status projections", async () => {
+    const lookupStarted = deferred<void>();
+    const continueLookup = deferred<void>();
+    let lookupCount = 0;
+    const fixture = fixtureCore({
+      harnessState: "working",
+      decoratePersistence: (persistence) => ({
+        ...persistence,
+        getSessionHarnessExecution: async () => {
+          lookupCount += 1;
+          if (lookupCount === 1) {
+            lookupStarted.resolve();
+            await continueLookup.promise;
+          }
+          return {
+            provider: "fake-harness",
+            sessionId: "ses_web_ready",
+            nativeSessionId: "native_web_ready",
+            state: "working",
+            statusUpdatedAt: now,
+          };
+        },
+      }),
+    });
+    let older: ReturnType<typeof fixture.core.projectHarnessEventStatus> | undefined;
+
+    try {
+      await fixture.core.reconcile("binding-lookup-race-initial");
+      fixture.setClockNow("2026-06-17T12:00:01.000Z");
+      older = fixture.core.projectHarnessEventStatus(
+        report({
+          reportId: "report_older_idle",
+          turnCompleted: false,
+          observedAt: "2026-06-17T12:00:01.000Z",
+          nativeSessionId: "native_web_ready",
+        }),
+      );
+      await lookupStarted.promise;
+
+      fixture.setClockNow("2026-06-17T12:00:02.000Z");
+      const newer = fixture.core.projectHarnessEventStatus(
+        workingReport("report_newer_working", "2026-06-17T12:00:02.000Z", "native_web_ready"),
+      );
+      await Promise.resolve();
+      continueLookup.resolve();
+      await Promise.all([older, newer]);
+
+      expect(fixture.core.getSnapshot()).toMatchObject({
+        generatedAt: "2026-06-17T12:00:02.000Z",
+        rows: [
+          expect.objectContaining({
+            agent: expect.objectContaining({
+              state: "working",
+              updatedAt: "2026-06-17T12:00:02.000Z",
+            }),
+          }),
+        ],
+        sessions: [
+          expect.objectContaining({
+            status: expect.objectContaining({
+              value: "working",
+              updatedAt: "2026-06-17T12:00:02.000Z",
+            }),
+          }),
+        ],
+      });
+    } finally {
+      continueLookup.resolve();
+      await older?.catch(() => undefined);
+      fixture.sqlite.close();
+    }
+  });
+
+  it("rejects a readiness marker owned by a newer completion", async () => {
+    const upsertStarted = deferred<void>();
+    const continueUpsert = deferred<void>();
+    const fixture = fixtureCore({
+      harnessState: "working",
+      decoratePersistence: (persistence) => ({
+        ...persistence,
+        upsertSessionTurnReadiness: async (input) => {
+          if (input.token === "report_older_completion") {
+            upsertStarted.resolve();
+            await continueUpsert.promise;
+          }
+          return persistence.upsertSessionTurnReadiness(input);
+        },
+      }),
+    });
+    let older: ReturnType<typeof fixture.core.projectHarnessEventStatus> | undefined;
+
+    try {
+      await fixture.core.reconcile("readiness-token-race-initial");
+      older = fixture.core.projectHarnessEventStatus(
+        report({
+          reportId: "report_older_completion",
+          turnCompleted: true,
+          observedAt: "2026-06-17T12:00:01.000Z",
+        }),
+      );
+      await upsertStarted.promise;
+
+      await fixture.core.projectHarnessEventStatus(
+        workingReport("report_newer_turn", "2026-06-17T12:00:02.000Z"),
+      );
+      const newer = await fixture.core.projectHarnessEventStatus(
+        report({
+          reportId: "report_newer_completion",
+          turnCompleted: true,
+          observedAt: "2026-06-17T12:00:03.000Z",
+        }),
+      );
+      expect(newer.snapshot.rows[0]?.agent?.turnReadiness).toMatchObject({
+        token: "report_newer_completion",
+      });
+
+      continueUpsert.resolve();
+      await expect(older).resolves.toMatchObject({ projected: false, events: [] });
+      expect(fixture.core.getSnapshot().rows[0]?.agent?.turnReadiness).toMatchObject({
+        token: "report_newer_completion",
+      });
+      await expect(fixture.persistence.listSessionTurnReadiness()).resolves.toEqual([
+        expect.objectContaining({ token: "report_newer_completion" }),
+      ]);
+    } finally {
+      continueUpsert.resolve();
+      await older?.catch(() => undefined);
+      fixture.sqlite.close();
+    }
+  });
 });
 
-function workingReport(reportId: string, observedAt = completedAt): HarnessEventReport {
+function workingReport(
+  reportId: string,
+  observedAt = completedAt,
+  nativeSessionId?: string,
+): HarnessEventReport {
   return {
     schemaVersion: STATION_SCHEMA_VERSION,
     reportId,
@@ -235,9 +370,7 @@ function workingReport(reportId: string, observedAt = completedAt): HarnessEvent
       source: "harness_event",
       updatedAt: observedAt,
     },
-    correlation: {
-      harnessRunId: "run_web_ready",
-    },
+    correlation: nativeCorrelation(nativeSessionId),
   };
 }
 
@@ -247,7 +380,8 @@ function fixtureCore(
     decoratePersistence?: (persistence: ObserverPersistenceBundle) => ObserverPersistenceBundle;
   } = {},
 ) {
-  const clock = { now: () => new Date(now) };
+  let clockNow = now;
+  const clock = { now: () => new Date(clockNow) };
   const sqlite = openObserverSqlite({ clock });
   const ids = observerIds();
   const basePersistence = createSqliteObserverPersistence({
@@ -313,7 +447,16 @@ function fixtureCore(
     eventBus,
     clock,
   });
-  return { basePersistence, core, persistence, queue, sqlite };
+  return {
+    basePersistence,
+    core,
+    persistence,
+    queue,
+    setClockNow: (value: string) => {
+      clockNow = value;
+    },
+    sqlite,
+  };
 }
 
 function deferred<T>() {
@@ -354,24 +497,28 @@ function observerIds() {
   };
 }
 
-function report(input: { reportId: string; turnCompleted: boolean }): HarnessEventReport {
+function report(input: {
+  reportId: string;
+  turnCompleted: boolean;
+  observedAt?: string;
+  nativeSessionId?: string;
+}): HarnessEventReport {
+  const observedAt = input.observedAt ?? completedAt;
   const report: HarnessEventReport = {
     schemaVersion: STATION_SCHEMA_VERSION,
     reportId: input.reportId,
     provider: "fake-harness",
     kind: "harness",
     eventType: "Stop",
-    observedAt: completedAt,
+    observedAt,
     status: {
       value: "idle",
       confidence: "high",
       reason: "Harness completed a visible turn.",
       source: "harness_event",
-      updatedAt: completedAt,
+      updatedAt: observedAt,
     },
-    correlation: {
-      harnessRunId: "run_web_ready",
-    },
+    correlation: nativeCorrelation(input.nativeSessionId),
     diagnostics: {
       rawEventType: "Stop",
     },
@@ -380,4 +527,17 @@ function report(input: { reportId: string; turnCompleted: boolean }): HarnessEve
     report.turn = { kind: "turn_completed" };
   }
   return report;
+}
+
+function nativeCorrelation(
+  nativeSessionId?: string,
+): NonNullable<HarnessEventReport["correlation"]> {
+  if (nativeSessionId === undefined) {
+    return { harnessRunId: "run_web_ready" };
+  }
+  return {
+    harnessRunId: "run_web_ready",
+    sessionId: "ses_web_ready",
+    nativeSessionId,
+  };
 }

--- a/apps/observer/test/integration/turn-readiness.test.ts
+++ b/apps/observer/test/integration/turn-readiness.test.ts
@@ -292,6 +292,43 @@ describe("observer turn readiness", () => {
     }
   });
 
+  it("keeps an authorized report diagnostic-only when its projection identities disagree", async () => {
+    const fixture = fixtureCore({
+      harnessState: "working",
+      decoratePersistence: (persistence) => ({
+        ...persistence,
+        getSessionHarnessExecution: async ({ provider, sessionId }) => ({
+          provider,
+          sessionId,
+          nativeSessionId: "native_ended_a",
+          state: "working",
+          statusUpdatedAt: now,
+        }),
+      }),
+    });
+
+    try {
+      await fixture.core.reconcile("projection-identity-mismatch");
+      const foreignCompletion = report({
+        reportId: "report_ended_a_completion",
+        turnCompleted: true,
+        nativeSessionId: "native_ended_a",
+      });
+      foreignCompletion.correlation = {
+        ...foreignCompletion.correlation,
+        sessionId: "ses_ended_a",
+      };
+
+      const result = await fixture.core.projectHarnessEventStatus(foreignCompletion);
+
+      expect(result).toMatchObject({ projected: false, events: [] });
+      expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "working" });
+      await expect(fixture.persistence.listSessionTurnReadiness()).resolves.toEqual([]);
+    } finally {
+      fixture.sqlite.close();
+    }
+  });
+
   it("rejects a readiness marker owned by a newer completion", async () => {
     const upsertStarted = deferred<void>();
     const continueUpsert = deferred<void>();

--- a/apps/observer/test/integration/turn-readiness.test.ts
+++ b/apps/observer/test/integration/turn-readiness.test.ts
@@ -1,5 +1,5 @@
 import type { StationConfig } from "@station/config";
-import type { HarnessEventReport } from "@station/contracts";
+import type { AgentState, HarnessEventReport } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
   createFakeHarnessRun,
@@ -15,6 +15,7 @@ import {
   createObserverCore,
   createObserverEventBus,
   createSqliteObserverPersistence,
+  type ObserverPersistenceBundle,
   openObserverSqlite,
   ProviderRegistry,
   registerObserverCommandHandlers,
@@ -164,22 +165,75 @@ describe("observer turn readiness", () => {
     expect(fixture.core.getSnapshot().rows[0]?.agent).not.toHaveProperty("turnReadiness");
     fixture.sqlite.close();
   });
+
+  it("drops a completion superseded while its readiness write is in flight", async () => {
+    const upsertStarted = deferred<void>();
+    const continueUpsert = deferred<void>();
+    const fixture = fixtureCore({
+      harnessState: "working",
+      decoratePersistence: (persistence) => ({
+        ...persistence,
+        upsertSessionTurnReadiness: async (input) => {
+          upsertStarted.resolve();
+          await continueUpsert.promise;
+          return persistence.upsertSessionTurnReadiness(input);
+        },
+      }),
+    });
+    let completion: ReturnType<typeof fixture.core.projectHarnessEventStatus> | undefined;
+
+    try {
+      await fixture.core.reconcile("turn-readiness-race-initial");
+      completion = fixture.core.projectHarnessEventStatus(
+        report({ reportId: "report_superseded_stop", turnCompleted: true }),
+      );
+      await upsertStarted.promise;
+
+      const working = await fixture.core.projectHarnessEventStatus(
+        workingReport("report_working_during_stop", "2026-06-17T12:00:02.000Z"),
+      );
+      expect(working.projected).toBe(true);
+      expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "working" });
+
+      await fixture.basePersistence.upsertSessionTurnReadiness({
+        sessionId: "ses_web_ready",
+        projectId: "web",
+        worktreeId: "wt_web_ready",
+        token: "report_newer_completion",
+        completedAt: "2026-06-17T12:00:03.000Z",
+        createdAt: "2026-06-17T12:00:03.000Z",
+        updatedAt: "2026-06-17T12:00:03.000Z",
+      });
+
+      continueUpsert.resolve();
+      const superseded = await completion;
+      expect(superseded).toMatchObject({ projected: false, events: [] });
+      expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "working" });
+      await expect(fixture.persistence.listSessionTurnReadiness()).resolves.toEqual([
+        expect.objectContaining({ token: "report_newer_completion" }),
+      ]);
+    } finally {
+      continueUpsert.resolve();
+      await completion?.catch(() => undefined);
+      fixture.sqlite.close();
+    }
+  });
 });
 
-function workingReport(reportId: string): HarnessEventReport {
+function workingReport(reportId: string, observedAt = completedAt): HarnessEventReport {
   return {
     schemaVersion: STATION_SCHEMA_VERSION,
     reportId,
     provider: "fake-harness",
     kind: "harness",
     eventType: "PreToolUse",
-    observedAt: completedAt,
+    observedAt,
     status: {
       value: "working",
       confidence: "medium",
       reason: "Harness is using a tool.",
       source: "harness_event",
-      updatedAt: completedAt,
+      updatedAt: observedAt,
     },
     correlation: {
       harnessRunId: "run_web_ready",
@@ -187,15 +241,21 @@ function workingReport(reportId: string): HarnessEventReport {
   };
 }
 
-function fixtureCore() {
+function fixtureCore(
+  options: {
+    harnessState?: AgentState;
+    decoratePersistence?: (persistence: ObserverPersistenceBundle) => ObserverPersistenceBundle;
+  } = {},
+) {
   const clock = { now: () => new Date(now) };
   const sqlite = openObserverSqlite({ clock });
   const ids = observerIds();
-  const persistence = createSqliteObserverPersistence({
+  const basePersistence = createSqliteObserverPersistence({
     sqlite,
     clock,
     idFactory: ids,
   });
+  const persistence = options.decoratePersistence?.(basePersistence) ?? basePersistence;
   const eventBus = createObserverEventBus();
   const queue = createCommandQueue({ persistence, clock, idFactory: ids, eventBus });
   const providers = new ProviderRegistry({
@@ -235,7 +295,7 @@ function fixtureCore() {
             projectId: "web",
             worktreeId: "wt_web_ready",
             sessionId: "ses_web_ready",
-            state: "idle",
+            state: options.harnessState ?? "idle",
             now,
           }),
         ],
@@ -253,7 +313,15 @@ function fixtureCore() {
     eventBus,
     clock,
   });
-  return { core, persistence, queue, sqlite };
+  return { basePersistence, core, persistence, queue, sqlite };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
 }
 
 function observerIds() {

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -32,6 +32,7 @@ import {
   systemClock,
   toIsoTimestamp,
 } from "@station/runtime";
+import { decideSessionHarnessExecution } from "../../src/harnessExecutionIdentity.js";
 import { defaultIdFactory } from "../../src/persistence/idFactory.js";
 import { parseJson, stringifyJson } from "../../src/persistence/json.js";
 import {
@@ -47,6 +48,7 @@ import { stripTerminalProviderData } from "../../src/persistence/terminalObserva
 import type {
   CurrentProviderObservationKind,
   EventRecordOptions,
+  HarnessExecutionIngress,
   IngressDedupeKey,
   ListSessionRecoveryHandlesOptions,
   ObserverIdFactory,
@@ -55,12 +57,14 @@ import type {
   PersistedEvent,
   PersistedProviderObservation,
   PersistedSession,
+  PersistedSessionHarnessExecution,
   PersistedSessionTurnReadiness,
   PersistedWorktreeMetadataCurrent,
   PersistReconcileResultInput,
   ProviderObservationKind,
   ProviderObservationType,
   RecordProviderObservationInput,
+  SessionHarnessExecutionEvidence,
   SessionTurnReadinessMutation,
   WorktreeMetadataCurrentKind,
   WorktreeMetadataCurrentPayloadByKind,
@@ -93,6 +97,7 @@ type InMemoryObserverPersistenceState = {
   terminalTargets: Map<string, TerminalTargetObservation>;
   harnessRuns: Map<string, HarnessRunObservation>;
   sessions: Map<string, PersistedSession>;
+  sessionHarnessExecutions: Map<string, PersistedSessionHarnessExecution>;
   recoveryHandles: Map<string, SessionRecoveryHandle>;
   turnReadiness: Map<string, PersistedSessionTurnReadiness>;
   worktreeMetadata: Map<string, PersistedWorktreeMetadataCurrent>;
@@ -251,6 +256,10 @@ export function createInMemoryObserverPersistence(
           id: idFactory.observationId(),
           observedAt: input.observation.observedAt ?? now(),
         });
+        const harnessExecution = input.harnessExecution;
+        if (harnessExecution !== undefined) {
+          applyHarnessExecutionIngress(draft, harnessExecution, now());
+        }
         return { deduped: false, event, observation };
       }),
 
@@ -266,6 +275,9 @@ export function createInMemoryObserverPersistence(
             observedAt: observation.observedAt ?? now(),
           }),
         );
+        for (const harnessExecution of input.harnessExecutions ?? []) {
+          applyHarnessExecutionIngress(draft, harnessExecution, now());
+        }
         for (const mutation of input.turnReadiness ?? []) {
           applySessionTurnReadinessMutation(draft, mutation, now());
         }
@@ -339,6 +351,18 @@ export function createInMemoryObserverPersistence(
     listSessions: () =>
       transaction((draft) =>
         [...draft.sessions.values()].sort((left, right) => compareAsc(left.id, right.id)),
+      ),
+
+    getSessionHarnessExecution: (input) =>
+      transaction((draft) => draft.sessionHarnessExecutions.get(sessionHarnessExecutionKey(input))),
+
+    listSessionHarnessExecutions: () =>
+      transaction((draft) =>
+        [...draft.sessionHarnessExecutions.values()].sort(
+          (left, right) =>
+            compareAsc(left.provider, right.provider) ||
+            compareAsc(left.sessionId, right.sessionId),
+        ),
       ),
 
     findRememberedHarnessProviderForWorktree: (input) =>
@@ -499,10 +523,43 @@ function emptyState(): InMemoryObserverPersistenceState {
     terminalTargets: new Map(),
     harnessRuns: new Map(),
     sessions: new Map(),
+    sessionHarnessExecutions: new Map(),
     recoveryHandles: new Map(),
     turnReadiness: new Map(),
     worktreeMetadata: new Map(),
   };
+}
+
+function applySessionHarnessExecutionEvidence(
+  state: InMemoryObserverPersistenceState,
+  evidence: SessionHarnessExecutionEvidence,
+): boolean {
+  const key = sessionHarnessExecutionKey(evidence);
+  const current =
+    evidence.sessionId === undefined ? undefined : state.sessionHarnessExecutions.get(key);
+  const decision = decideSessionHarnessExecution({ current, evidence });
+  if (decision.binding !== undefined) {
+    state.sessionHarnessExecutions.set(key, decision.binding);
+  }
+  return decision.mayDeriveState;
+}
+
+function applyHarnessExecutionIngress(
+  state: InMemoryObserverPersistenceState,
+  harnessExecution: HarnessExecutionIngress,
+  createdAt: string,
+): void {
+  if (!applySessionHarnessExecutionEvidence(state, harnessExecution.evidence)) return;
+  if (harnessExecution.recoveryHandle !== undefined) {
+    upsertSessionRecoveryHandle(state, harnessExecution.recoveryHandle);
+  }
+  if (harnessExecution.turnReadiness !== undefined) {
+    applySessionTurnReadinessMutation(state, harnessExecution.turnReadiness, createdAt);
+  }
+}
+
+function sessionHarnessExecutionKey(input: { provider: string; sessionId?: string }): string {
+  return `${input.provider}\u0000${input.sessionId ?? ""}`;
 }
 
 function requireCommand(

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -1,5 +1,7 @@
 import type {
+  AgentState,
   ErrorEnvelope,
+  HarnessEventObservation,
   ProviderProjectConfig,
   SafeError,
   SessionRecoveryHandle,
@@ -15,6 +17,7 @@ import {
 import { describe, expect, it } from "vitest";
 import type { ObserverPersistenceBundle } from "../../src/persistence/ports";
 import type {
+  HarnessExecutionIngress,
   ObserverIdFactory,
   RecordProviderObservationInput,
 } from "../../src/persistence/types";
@@ -1452,6 +1455,75 @@ export function observerPersistenceContract(
         });
       });
 
+      it("keeps native execution binding and derived state atomic with report dedupe", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.recordEventAndProviderObservationWithIngressDedupe(
+            harnessIngressInput({
+              reportId: "report_a_active",
+              nativeSessionId: "native_a",
+              state: "working",
+              observedAt: now,
+            }),
+          );
+          await persistence.recordEventAndProviderObservationWithIngressDedupe(
+            harnessIngressInput({
+              reportId: "report_b_active",
+              nativeSessionId: "native_b",
+              state: "working",
+              observedAt: later,
+            }),
+          );
+
+          await expect(
+            persistence.getSessionHarnessExecution({
+              provider: "codex",
+              sessionId: "ses_execution",
+            }),
+          ).resolves.toMatchObject({
+            nativeSessionId: "native_a",
+            state: "working",
+          });
+          await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([
+            expect.objectContaining({ target: { kind: "native-session", id: "native_a" } }),
+          ]);
+
+          await persistence.recordEventAndProviderObservationWithIngressDedupe(
+            harnessIngressInput({
+              reportId: "report_a_stop",
+              nativeSessionId: "native_a",
+              state: "idle",
+              observedAt: latest,
+            }),
+          );
+          await expect(persistence.listSessionTurnReadiness()).resolves.toEqual([
+            expect.objectContaining({
+              sessionId: "ses_execution",
+              token: "report_a_stop",
+            }),
+          ]);
+
+          await expect(
+            persistence.recordEventAndProviderObservationWithIngressDedupe(
+              harnessIngressInput({
+                reportId: "report_b_active",
+                nativeSessionId: "native_b",
+                state: "working",
+                observedAt: later,
+              }),
+            ),
+          ).resolves.toEqual({ deduped: true });
+          await expect(persistence.listSessionHarnessExecutions()).resolves.toEqual([
+            expect.objectContaining({
+              provider: "codex",
+              sessionId: "ses_execution",
+              nativeSessionId: "native_a",
+              state: "idle",
+            }),
+          ]);
+          await expect(persistence.listSessionTurnReadiness()).resolves.toHaveLength(1);
+        });
+      });
+
       it("orders sessions by ID and preserves seeded and renamed titles", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           await persistence.seedSessionTitle({
@@ -2385,6 +2457,87 @@ function healthObservation(status: "healthy" | "degraded"): RecordProviderObserv
       lastCheckedAt: now,
     },
     observedAt: now,
+  };
+}
+
+function harnessIngressInput(input: {
+  reportId: string;
+  nativeSessionId: string;
+  state: AgentState;
+  observedAt: string;
+}): Parameters<ObserverPersistenceBundle["recordEventAndProviderObservationWithIngressDedupe"]>[0] {
+  const eventType = input.state === "idle" ? "Stop" : "PreToolUse";
+  const payload: HarnessEventObservation = {
+    provider: "codex",
+    reportId: input.reportId,
+    eventType,
+    projectId: "web",
+    worktreeId: "wt_execution",
+    sessionId: "ses_execution",
+    nativeSessionId: input.nativeSessionId,
+    status: {
+      value: input.state,
+      confidence: "high",
+      reason: input.state,
+      source: "harness_event",
+      updatedAt: input.observedAt,
+    },
+    observedAt: input.observedAt,
+  };
+  if (input.state === "idle") payload.turn = { kind: "turn_completed" };
+
+  const recoveryHandle: SessionRecoveryHandle = {
+    id: input.reportId,
+    provider: "codex",
+    projectId: "web",
+    worktreeId: "wt_execution",
+    sessionId: "ses_execution",
+    target: { kind: "native-session", id: input.nativeSessionId },
+    observedAt: input.observedAt,
+    lastSeenAt: input.observedAt,
+  };
+  const harnessExecution: HarnessExecutionIngress = {
+    evidence: {
+      provider: "codex",
+      sessionId: "ses_execution",
+      nativeSessionId: input.nativeSessionId,
+      status: payload.status,
+    },
+    recoveryHandle,
+    turnReadiness:
+      input.state === "idle"
+        ? {
+            action: "upsert",
+            value: {
+              sessionId: "ses_execution",
+              projectId: "web",
+              worktreeId: "wt_execution",
+              token: input.reportId,
+              completedAt: input.observedAt,
+              updatedAt: input.observedAt,
+            },
+          }
+        : { action: "delete", sessionId: "ses_execution" },
+  };
+  return {
+    event: {
+      type: "harness.eventReported",
+      at: input.observedAt,
+      reportId: input.reportId,
+      provider: "codex",
+      eventType,
+    },
+    eventOptions: { source: "hook", createdAt: input.observedAt },
+    observation: {
+      provider: "codex",
+      providerType: "harness",
+      entityKind: "harness_event",
+      entityKey: input.nativeSessionId,
+      payload,
+      observedAt: input.observedAt,
+    },
+    harnessExecution,
+    dedupe: { kind: "harness_report", id: input.reportId },
   };
 }
 

--- a/apps/observer/test/unit/harnessEventStatus.test.ts
+++ b/apps/observer/test/unit/harnessEventStatus.test.ts
@@ -20,6 +20,110 @@ const runObservedAt = "2026-05-21T12:00:00.000Z";
 const eventObservedAt = "2026-05-21T12:00:01.000Z";
 
 describe("harness event status overlays", () => {
+  it("does not fall back to worktree correlation for a stale terminal target", () => {
+    const result = overlay({
+      runs: [run()],
+      observations: [
+        observation({
+          worktreeId: "wt_1",
+          terminalTargetId: "tmux:station:@old:%9",
+          nativeSessionId: "native_old",
+          status: status("working", "medium", "A stale terminal is working."),
+        }),
+      ],
+    });
+
+    expect(result[0]?.run).toMatchObject({ state: "unknown" });
+  });
+
+  it("keeps a foreign native-session Stop from completing the active Codex execution", () => {
+    const active = overlay({
+      runs: [run({ nativeSessionId: "native_a" })],
+      observations: [
+        observation({
+          sessionId: "ses_1",
+          worktreeId: "wt_1",
+          nativeSessionId: "native_a",
+          rawEventType: "SubagentStop",
+          status: status(
+            "working",
+            "medium",
+            "Codex subagent stopped.",
+            "2026-05-21T12:00:02.000Z",
+          ),
+        }),
+      ],
+    });
+    const foreignStop = overlay({
+      runs: active,
+      observations: [
+        observation({
+          sessionId: "ses_1",
+          worktreeId: "wt_1",
+          nativeSessionId: "native_b",
+          rawEventType: "Stop",
+          status: status(
+            "idle",
+            "high",
+            "A different Codex session completed.",
+            "2026-05-21T12:00:03.000Z",
+          ),
+        }),
+      ],
+    });
+
+    expect(foreignStop[0]?.run).toMatchObject({
+      nativeSessionId: "native_a",
+      state: "working",
+      reason: "Codex subagent stopped.",
+    });
+
+    const continuation = overlay({
+      runs: foreignStop,
+      observations: [
+        observation({
+          sessionId: "ses_1",
+          worktreeId: "wt_1",
+          nativeSessionId: "native_a",
+          rawEventType: "PreToolUse",
+          status: status(
+            "working",
+            "medium",
+            "The active Codex session continued.",
+            "2026-05-21T12:00:04.000Z",
+          ),
+        }),
+      ],
+    });
+    expect(continuation[0]?.run).toMatchObject({
+      nativeSessionId: "native_a",
+      state: "working",
+      reason: "The active Codex session continued.",
+    });
+
+    const completed = overlay({
+      runs: continuation,
+      observations: [
+        observation({
+          sessionId: "ses_1",
+          worktreeId: "wt_1",
+          nativeSessionId: "native_a",
+          rawEventType: "Stop",
+          status: status(
+            "idle",
+            "high",
+            "The active Codex session completed.",
+            "2026-05-21T12:00:05.000Z",
+          ),
+        }),
+      ],
+    });
+    expect(completed[0]?.run).toMatchObject({
+      nativeSessionId: "native_a",
+      state: "idle",
+    });
+  });
+
   it("promotes a correlated Codex activity event over terminal-only unknown status", () => {
     const result = overlay({
       runs: [run()],
@@ -380,6 +484,9 @@ function run(input: Partial<HarnessRunObservation> = {}): ObserverHarnessRun {
   };
   if (input.pid !== undefined) runObservation.pid = input.pid;
   if (input.cwd !== undefined) runObservation.cwd = input.cwd;
+  if (input.nativeSessionId !== undefined) {
+    runObservation.nativeSessionId = input.nativeSessionId;
+  }
   if (input.providerData !== undefined) runObservation.providerData = input.providerData;
   return observerHarnessRunFromRun(runObservation);
 }

--- a/apps/observer/test/unit/harnessExecutionIdentity.test.ts
+++ b/apps/observer/test/unit/harnessExecutionIdentity.test.ts
@@ -1,0 +1,95 @@
+import type { AgentState, ObservedStatus } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  decideSessionHarnessExecution,
+  type SessionHarnessExecutionDecision,
+} from "../../src/harnessExecutionIdentity";
+import type {
+  PersistedSessionHarnessExecution,
+  SessionHarnessExecutionEvidence,
+} from "../../src/persistence";
+
+const t1 = "2026-05-21T12:00:01.000Z";
+const t2 = "2026-05-21T12:00:02.000Z";
+const t3 = "2026-05-21T12:00:03.000Z";
+
+describe("session harness execution identity", () => {
+  it("keeps arrival-bound native A authoritative over delayed activity and completion from B", () => {
+    const bound = decide(undefined, evidence("native_a", status("working", t2)));
+    expect(bound).toMatchObject({
+      mayDeriveState: true,
+      binding: { nativeSessionId: "native_a", state: "working" },
+    });
+
+    const delayedB = decide(binding(bound), evidence("native_b", status("working", t1)));
+    expect(delayedB).toEqual({ mayDeriveState: false });
+
+    const stopB = decide(binding(bound), evidence("native_b", status("idle", t3)));
+    expect(stopB).toEqual({ mayDeriveState: false });
+  });
+
+  it("fails closed for identityless or stale evidence after a native execution is bound", () => {
+    const current = binding(decide(undefined, evidence("native_a", status("working", t2))));
+    const identityless = decide(current, {
+      provider: "codex",
+      sessionId: "ses_1",
+      status: status("idle", t3),
+    });
+    expect(identityless).toEqual({ mayDeriveState: false });
+
+    const staleA = decide(current, evidence("native_a", status("idle", t1)));
+    expect(staleA).toEqual({ mayDeriveState: false });
+  });
+
+  it("allows a new native execution only after explicit idle or exited evidence", () => {
+    const activeA = binding(decide(undefined, evidence("native_a", status("working", t1))));
+    const idleA = binding(decide(activeA, evidence("native_a", status("idle", t2))));
+    const activeB = decide(idleA, evidence("native_b", status("working", t3)));
+    expect(activeB).toMatchObject({
+      mayDeriveState: true,
+      binding: { nativeSessionId: "native_b", state: "working" },
+    });
+
+    for (const state of ["unknown", "stuck"] as const) {
+      const blocked = decide({ ...idleA, state }, evidence("native_b", status("working", t3)));
+      expect(blocked).toEqual({ mayDeriveState: false });
+    }
+
+    const delayedB = decide(idleA, evidence("native_b", status("working", t1)));
+    expect(delayedB).toEqual({ mayDeriveState: false });
+  });
+});
+
+function decide(
+  current: PersistedSessionHarnessExecution | undefined,
+  executionEvidence: SessionHarnessExecutionEvidence,
+): SessionHarnessExecutionDecision {
+  return decideSessionHarnessExecution({ current, evidence: executionEvidence });
+}
+
+function binding(decision: SessionHarnessExecutionDecision): PersistedSessionHarnessExecution {
+  if (decision.binding === undefined) throw new Error("Expected an execution binding.");
+  return decision.binding;
+}
+
+function evidence(
+  nativeSessionId: string,
+  executionStatus: ObservedStatus,
+): SessionHarnessExecutionEvidence {
+  return {
+    provider: "codex",
+    sessionId: "ses_1",
+    nativeSessionId,
+    status: executionStatus,
+  };
+}
+
+function status(value: AgentState, updatedAt: string): ObservedStatus {
+  return {
+    value,
+    confidence: "high",
+    reason: value,
+    source: "harness_event",
+    updatedAt,
+  };
+}

--- a/apps/observer/test/unit/harnessIngressQueue.test.ts
+++ b/apps/observer/test/unit/harnessIngressQueue.test.ts
@@ -84,6 +84,33 @@ describe("harness ingress queue", () => {
     });
   });
 
+  it("does not coalesce reports from different native sessions sharing Station identity", async () => {
+    const started = deferred();
+    const release = deferred();
+    const processed: string[] = [];
+    const queue = createHarnessIngressQueue({
+      clock,
+      processReport: async (report) => {
+        if (report.reportId === "report_blocker") {
+          started.resolve();
+          await release.promise;
+        }
+        processed.push(report.reportId);
+        return { receipt: acceptedReceipt(report) };
+      },
+    });
+
+    queue.enqueue(harnessReport("report_blocker", "session_blocker"));
+    await started.promise;
+    queue.enqueue(harnessReport("report_native_a", "session_shared", "native_a"));
+    queue.enqueue(harnessReport("report_native_b", "session_shared", "native_b"));
+    release.resolve();
+    await queue.drain();
+
+    expect(processed).toEqual(["report_blocker", "report_native_a", "report_native_b"]);
+    expect(queue.health()).toMatchObject({ coalesced: 0, processed: 3 });
+  });
+
   it("waits for active work during shutdown and rejects later enqueue", async () => {
     const started = deferred();
     const release = deferred();
@@ -123,7 +150,11 @@ describe("harness ingress queue", () => {
   });
 });
 
-function harnessReport(reportId: string, sessionId = "session_1"): HarnessEventReport {
+function harnessReport(
+  reportId: string,
+  sessionId = "session_1",
+  nativeSessionId?: string,
+): HarnessEventReport {
   return {
     schemaVersion: STATION_SCHEMA_VERSION,
     reportId,
@@ -140,6 +171,7 @@ function harnessReport(reportId: string, sessionId = "session_1"): HarnessEventR
     },
     correlation: {
       sessionId,
+      ...(nativeSessionId === undefined ? {} : { nativeSessionId }),
     },
     coalesceKey: "turn:turn_1:tool:Bash",
   };

--- a/apps/observer/test/unit/sessionHarnessExecutions.test.ts
+++ b/apps/observer/test/unit/sessionHarnessExecutions.test.ts
@@ -1,0 +1,153 @@
+import type { AgentState, ObservedStatus, ProviderId } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  applySessionHarnessExecutionEvidence,
+  getSessionHarnessExecution,
+  listSessionHarnessExecutions,
+} from "../../src/persistence/sessionHarnessExecutions";
+import type { SessionHarnessExecutionEvidence } from "../../src/persistence/types";
+import { openObserverSqlite } from "../../src/sqlite";
+
+describe("session harness execution store", () => {
+  it("persists only authorized native execution lifecycle advances", () => {
+    const sqlite = openObserverSqlite();
+
+    try {
+      expect(
+        applySessionHarnessExecutionEvidence(
+          sqlite.database,
+          evidence("codex", "ses_1", "native_b", "idle", "2026-07-14T12:00:00.000Z"),
+        ),
+      ).toBe(false);
+      expect(
+        applySessionHarnessExecutionEvidence(sqlite.database, {
+          provider: "codex",
+          nativeSessionId: "native_external",
+          status: status("working", "2026-07-14T12:00:00.500Z"),
+        }),
+      ).toBe(true);
+      expect(listSessionHarnessExecutions(sqlite.database)).toEqual([]);
+
+      expect(
+        applySessionHarnessExecutionEvidence(
+          sqlite.database,
+          evidence("codex", "ses_1", "native_a", "working", "2026-07-14T12:00:01.000Z"),
+        ),
+      ).toBe(true);
+      expect(
+        getSessionHarnessExecution(sqlite.database, { provider: "codex", sessionId: "ses_1" }),
+      ).toEqual({
+        provider: "codex",
+        sessionId: "ses_1",
+        nativeSessionId: "native_a",
+        state: "working",
+        statusUpdatedAt: "2026-07-14T12:00:01.000Z",
+      });
+
+      expect(
+        applySessionHarnessExecutionEvidence(
+          sqlite.database,
+          evidence("codex", "ses_1", "native_b", "idle", "2026-07-14T12:00:02.000Z"),
+        ),
+      ).toBe(false);
+      expect(
+        getSessionHarnessExecution(sqlite.database, { provider: "codex", sessionId: "ses_1" }),
+      ).toMatchObject({ nativeSessionId: "native_a", state: "working" });
+
+      expect(
+        applySessionHarnessExecutionEvidence(
+          sqlite.database,
+          evidence("codex", "ses_1", "native_a", "idle", "2026-07-14T12:00:03.000Z"),
+        ),
+      ).toBe(true);
+      expect(
+        applySessionHarnessExecutionEvidence(
+          sqlite.database,
+          evidence("codex", "ses_1", "native_b", "working", "2026-07-14T12:00:04.000Z"),
+        ),
+      ).toBe(true);
+      expect(
+        getSessionHarnessExecution(sqlite.database, { provider: "codex", sessionId: "ses_1" }),
+      ).toEqual({
+        provider: "codex",
+        sessionId: "ses_1",
+        nativeSessionId: "native_b",
+        state: "working",
+        statusUpdatedAt: "2026-07-14T12:00:04.000Z",
+      });
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("isolates bindings by provider and lists them deterministically", () => {
+    const sqlite = openObserverSqlite();
+
+    try {
+      for (const input of [
+        evidence("codex", "ses_b", "codex_b", "working", "2026-07-14T12:00:01.000Z"),
+        evidence("claude", "ses_shared", "claude_a", "working", "2026-07-14T12:00:02.000Z"),
+        evidence("codex", "ses_shared", "codex_a", "working", "2026-07-14T12:00:03.000Z"),
+      ]) {
+        expect(applySessionHarnessExecutionEvidence(sqlite.database, input)).toBe(true);
+      }
+
+      expect(
+        getSessionHarnessExecution(sqlite.database, {
+          provider: "cursor",
+          sessionId: "ses_shared",
+        }),
+      ).toBeUndefined();
+      expect(listSessionHarnessExecutions(sqlite.database)).toEqual([
+        {
+          provider: "claude",
+          sessionId: "ses_shared",
+          nativeSessionId: "claude_a",
+          state: "working",
+          statusUpdatedAt: "2026-07-14T12:00:02.000Z",
+        },
+        {
+          provider: "codex",
+          sessionId: "ses_b",
+          nativeSessionId: "codex_b",
+          state: "working",
+          statusUpdatedAt: "2026-07-14T12:00:01.000Z",
+        },
+        {
+          provider: "codex",
+          sessionId: "ses_shared",
+          nativeSessionId: "codex_a",
+          state: "working",
+          statusUpdatedAt: "2026-07-14T12:00:03.000Z",
+        },
+      ]);
+    } finally {
+      sqlite.close();
+    }
+  });
+});
+
+function evidence(
+  provider: ProviderId,
+  sessionId: string,
+  nativeSessionId: string,
+  state: AgentState,
+  updatedAt: string,
+): SessionHarnessExecutionEvidence {
+  return {
+    provider,
+    sessionId,
+    nativeSessionId,
+    status: status(state, updatedAt),
+  };
+}
+
+function status(value: AgentState, updatedAt: string): ObservedStatus {
+  return {
+    value,
+    confidence: "high",
+    reason: value,
+    source: "harness_event",
+    updatedAt,
+  };
+}

--- a/apps/observer/test/unit/statusProjection.test.ts
+++ b/apps/observer/test/unit/statusProjection.test.ts
@@ -4,7 +4,7 @@ import type {
   HarnessEventReport,
   ObservedStatus,
 } from "@station/contracts";
-import { STATION_SCHEMA_VERSION } from "@station/contracts";
+import { harnessRunIdForTerminalTarget, STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
   createFakeHarnessRun,
   createFakeTerminalTarget,
@@ -15,6 +15,7 @@ import { buildStationSnapshot } from "../../src/reconcile/graph";
 import { observerHarnessRunFromRun } from "../../src/reconcile/harnessEventStatus";
 import {
   projectHarnessEventReportOntoSnapshot,
+  withSessionCorrelationFromSnapshot,
   withWorktreeCorrelationFromCwd,
 } from "../../src/reconcile/statusProjection";
 
@@ -292,6 +293,62 @@ describe("live harness status projection", () => {
 });
 
 describe("cwd correlation resolution", () => {
+  it("adds the unique Station session only for exact Station run or terminal evidence", () => {
+    const snapshot = snapshotFor();
+    const byRun = withSessionCorrelationFromSnapshot(
+      report({
+        status: status("working", "medium", "Codex is working."),
+        correlation: {
+          worktreeId: "wt_web_task",
+          harnessRunId: "run_web_task",
+          nativeSessionId: "native_a",
+        },
+      }),
+      snapshot,
+    );
+    expect(byRun.correlation).toMatchObject({ sessionId: "ses_web_task" });
+
+    const terminalTargetId = "tmux:station:@1:%2";
+    const terminalSnapshot = {
+      ...snapshot,
+      rows: snapshot.rows.map((row) =>
+        row.agent === undefined
+          ? row
+          : {
+              ...row,
+              agent: {
+                ...row.agent,
+                runId: harnessRunIdForTerminalTarget("codex", terminalTargetId),
+              },
+            },
+      ),
+    };
+    const byTerminal = withSessionCorrelationFromSnapshot(
+      report({
+        status: status("working", "medium", "Codex is working."),
+        correlation: { worktreeId: "wt_web_task", terminalTargetId, nativeSessionId: "native_a" },
+      }),
+      terminalSnapshot,
+    );
+    expect(byTerminal.correlation).toMatchObject({ sessionId: "ses_web_task" });
+
+    const staleTerminal = report({
+      status: status("working", "medium", "Codex is working."),
+      correlation: {
+        worktreeId: "wt_web_task",
+        terminalTargetId: "tmux:station:@old:%9",
+        nativeSessionId: "native_old",
+      },
+    });
+    expect(withSessionCorrelationFromSnapshot(staleTerminal, terminalSnapshot)).toBe(staleTerminal);
+
+    const external = report({
+      status: status("working", "medium", "Codex is working."),
+      correlation: { worktreeId: "wt_web_task", nativeSessionId: "native_external" },
+    });
+    expect(withSessionCorrelationFromSnapshot(external, snapshot)).toBe(external);
+  });
+
   it("resolves a cwd-only report to the containing worktree and projects it", () => {
     const snapshot = snapshotFor();
     const enriched = withWorktreeCorrelationFromCwd(
@@ -402,20 +459,7 @@ function snapshotFor(input: { state?: AgentState; confidence?: Confidence; now?:
       now,
     }),
   ];
-  const harnessRuns = [
-    observerHarnessRunFromRun(
-      createFakeHarnessRun({
-        id: "run_web_task",
-        provider: "codex",
-        projectId: "web",
-        worktreeId: "wt_web_task",
-        sessionId: "ses_web_task",
-        state: input.state ?? "unknown",
-        confidence: input.confidence ?? "low",
-        now: input.now ?? now,
-      }),
-    ),
-  ];
+  const harnessRuns = harnessRunsFor(input);
   return buildStationSnapshot({
     generatedAt: now,
     observer: {
@@ -484,6 +528,23 @@ function externalSnapshotFor(state: AgentState) {
       ),
     ],
   });
+}
+
+function harnessRunsFor(input: { state?: AgentState; confidence?: Confidence; now?: string } = {}) {
+  return [
+    observerHarnessRunFromRun(
+      createFakeHarnessRun({
+        id: "run_web_task",
+        provider: "codex",
+        projectId: "web",
+        worktreeId: "wt_web_task",
+        sessionId: "ses_web_task",
+        state: input.state ?? "unknown",
+        confidence: input.confidence ?? "low",
+        now: input.now ?? now,
+      }),
+    ),
+  ];
 }
 
 function snapshotWithTurnReadiness(snapshot: ReturnType<typeof snapshotFor>) {

--- a/apps/observer/test/unit/statusProjection.test.ts
+++ b/apps/observer/test/unit/statusProjection.test.ts
@@ -308,6 +308,18 @@ describe("cwd correlation resolution", () => {
     );
     expect(byRun.correlation).toMatchObject({ sessionId: "ses_web_task" });
 
+    const rowOnly = report({
+      status: status("working", "medium", "Codex is working."),
+      correlation: {
+        worktreeId: "wt_web_task",
+        harnessRunId: "run_web_task",
+        nativeSessionId: "native_a",
+      },
+    });
+    expect(withSessionCorrelationFromSnapshot(rowOnly, { ...snapshot, sessions: [] })).toBe(
+      rowOnly,
+    );
+
     const terminalTargetId = "tmux:station:@1:%2";
     const terminalSnapshot = {
       ...snapshot,

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -41,9 +41,11 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
   blocking input). This is the only field core/TUI may use to classify
   attention.
 - `correlation` — identity for projection, strongest first:
-  `harnessRunId` → `sessionId` → `worktreeId` → `cwd`. Providers must attach
-  the strongest identity they have; `cwd` alone is a last resort and drops the
-  event when ambiguous.
+  `harnessRunId` → bound `nativeSessionId` → `sessionId` → `worktreeId` →
+  `cwd`. Providers must attach the strongest identity they have; `cwd` alone
+  is a last resort and drops the event when ambiguous. Station session and
+  worktree IDs route evidence to a run but do not identify the provider-native
+  execution within that run.
 - `reportId` / `coalesceKey` — dedup identity. Two transports reporting the
   same fact must derive the same identity from harness-native ids (e.g. a tool
   `call_id`) so they coalesce instead of racing.
@@ -82,6 +84,13 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
    15 minutes to `unknown` (low confidence, source `reconcile`) instead of
    trusting it forever. Attention and idle states never decay, and the next
    real event restores live status.
+8. **Native completion fails closed.** Active evidence may bind an unbound
+   provider plus Station session to one native execution; a replacement may
+   bind only after explicit `idle` or `exited` evidence. While an execution is
+   active, evidence from another native execution is diagnostic-only: it cannot
+   derive recovery, readiness, projected state changes, or completion
+   notifications. Worktree-only external sessions remain independently keyed
+   by native identity, and idle/completion evidence never establishes a binding.
 
 ## Target Taxonomy (HarnessSignal)
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -53,7 +53,7 @@ Events (`integrations/harness/codex/src/hooks/hookConstants.ts`): `SessionStart`
 
 Hooks: a dedicated `station` profile (`station.config.toml`) under `~/.codex` calls `station-codex-hook.sh`.
 
-Coverage: full. `PermissionRequest` drives **needs attention** and `Stop` drives **idle**. Codex has no session-end hook, so **exited** is inferred from process state.
+Coverage: full. `PermissionRequest` drives **needs attention**, a completed `Stop` drives **idle**, and `stop_hook_active` keeps **working**. Codex has no session-end hook, so **exited** is inferred from process state.
 
 ### Cursor (Full)
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -236,9 +236,9 @@ No single layer owns all truth.
 | --- | --- |
 | Loaded config | Authoritative for managed projects, defaults, provider choices, feature policy, and configured hooks. Durable in TOML; loaded into process memory at startup and updated through explicit config operations. |
 | Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
-| Provider-owned identity | Worktree, target, harness-run, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
+| Provider-owned identity | Worktree, target, harness-run, native execution, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
-| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
+| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, native-execution bindings, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
 | Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, version, socketPath}` identity published by the process that successfully bound the socket. It corroborates process identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
 | In-memory persistence adapter | Process-local test state that preserves the seven persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
@@ -424,12 +424,22 @@ capacity is full, and exposes health counters. The worker applies durable
 dedupe while persisting a report.
 
 Spool replay bypasses queue acceptance and invokes direct durable hook/report
-processing. A primary ingress dedupe hit suppresses duplicate event publication
-but does not skip idempotent derived-observation, recovery-handle, or readiness
-completion. The filesystem spool adapter removes a record only after that work
+processing. Report dedupe, diagnostic evidence, native-execution binding,
+recovery, and readiness commit in one transaction; a dedupe hit therefore
+suppresses all duplicate work, while a failed transaction leaves the claim
+retryable. The filesystem spool adapter removes a record only after that work
 succeeds; invalid and failed records retain attempt/error evidence for later
 diagnosis or retry. Startup reconcile waits for the single-flight spool and
 queue drain before its provider scan.
+
+Station-owned harness runs bind provider-native execution identity only from
+active evidence. The provider plus Station session selects the durable binding;
+worktree-only external sessions remain independent. Once a native execution is
+active, a mismatched native report is stored as diagnostic evidence but cannot
+mutate recovery handles, readiness, live or reconciled status, or emit derived
+state-change/completion notifications. A completion report cannot claim an
+unbound session, and a later active execution may bind only after explicit
+`idle` or `exited` evidence from the prior execution.
 
 Provider hooks are delivery hints. They may update durable observations and
 immediate projections, but scheduled reconcile remains the path to fresh
@@ -520,14 +530,15 @@ when it changes several tables:
 - `CommandJournal` owns command acceptance, transitions, lookup, history, and
   command errors.
 - `EventJournal` owns ordinary event recording and queries.
-- `IngressJournal` owns atomic dedupe plus event, atomic dedupe plus event plus
-  observation, and atomic hook-processing completion across observations and
-  turn readiness.
+- `IngressJournal` owns atomic dedupe plus event, atomic report acceptance
+  across diagnostic observation/native binding/recovery/readiness, and atomic
+  hook-processing completion across observations/native bindings/readiness.
 - `ObservationStore` owns typed provider observations, current-observation
   queries, and expiry.
 - `ReconcileStore` owns the complete atomic `persistReconcileResult` operation.
-- `SessionStore` owns explicit session lifecycle, titles, recovery handles, turn
-  readiness, and purpose-specific remembered-harness lookup.
+- `SessionStore` owns explicit session lifecycle, durable provider-native
+  execution bindings, titles, recovery handles, turn readiness, and
+  purpose-specific remembered-harness lookup.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -390,11 +390,14 @@ sessions. Terminal attachment requires matching session or run identity. Session
 and activity totals derive from canonical sessions; only worktree totals derive
 from rows.
 
-Observer core serializes full reconciles. The scheduler debounces and coalesces
-reasons while ensuring only one scheduled run is active. Startup-compatible
-requests may join the startup flight; other direct requests retain the rule that
-their scan starts at or after the request. Provider read failures degrade health
-and contribute errors without fabricating successful observations.
+Observer core serializes full reconciles and harness-report authorization plus
+base snapshot projection on one non-poisoning writer chain. Readiness persistence
+and application happen after that base commit and revalidate the live snapshot.
+The scheduler debounces and coalesces reasons while ensuring only one scheduled
+run is active. Startup-compatible requests may join the startup flight; other
+direct requests retain the rule that their scan starts at or after the request.
+Provider read failures degrade health and contribute errors without fabricating
+successful observations.
 
 ### Provider Hook And Harness Report Ingress
 
@@ -491,7 +494,7 @@ from the diagnostic use case.
 | Observer build ordering | Exact builds attach. For different valid SemVer builds, higher precedence wins; at equal precedence the lexicographically greater exact build string wins so the CLI parent and Observer child agree despite having different process identities. Missing or invalid versions refuse. Replacement requires complete corroborating identity and never uses automatic SIGKILL. |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Cancellation is cooperative; the process shutdown backstop handles ignored signals. |
-| Reconcile ordering | Core reconciles form a non-poisoning promise chain. Scheduled requests coalesce; queued work after a run receives a later flush. |
+| Snapshot writer ordering | Full reconciles and harness-report authorization plus base projection share a non-poisoning promise chain. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |
 | Provider reads | Reads are timeboxed, retried at the runtime boundary, and concurrency-limited. Failures become provider health and reconcile errors. |
 | Harness ingress | One worker processes a bounded pending map. New reports can replace pending work for the same key; a full map rejects unrelated work with a backpressure error. |
 | Spool drain | One configured drain runs at a time and processes stable filename order through direct durable ingress. Stable spool IDs survive legacy records without hook IDs; completion is idempotent after primary dedupe, and failed records remain on disk with attempt/error evidence. |

--- a/integrations/harness/codex/src/events.ts
+++ b/integrations/harness/codex/src/events.ts
@@ -286,6 +286,15 @@ export function statusFromCodexHookEvent(
     };
   }
   if (event.hook_event_name === "Stop") {
+    if (event.stop_hook_active) {
+      return {
+        value: "working",
+        confidence: "medium",
+        reason: "A Stop hook kept Codex working.",
+        source: "harness_event",
+        updatedAt: observedAt,
+      };
+    }
     return {
       value: "idle",
       confidence: "high",

--- a/integrations/harness/codex/test/unit/events.test.ts
+++ b/integrations/harness/codex/test/unit/events.test.ts
@@ -558,7 +558,7 @@ describe("Codex hook event parsing", () => {
     );
   });
 
-  it("keeps Stop status idle but does not complete the turn when stop_hook_active is true", () => {
+  it("keeps Codex working and does not complete the turn when stop_hook_active is true", () => {
     const observations = normalizeCodexRawEvent(
       {
         provider: "codex",
@@ -581,8 +581,8 @@ describe("Codex hook event parsing", () => {
     expect(observations[0]).toMatchObject({
       rawEventType: "Stop",
       status: {
-        value: "idle",
-        confidence: "high",
+        value: "working",
+        confidence: "medium",
       },
     });
     // A Stop hook forcing continuation must not mark the turn complete (no ready marker).
@@ -630,6 +630,7 @@ describe("Codex hook event parsing", () => {
       expect(report.provider).toBe("codex");
       expect(report.kind).toBe("harness");
       expect(report.status?.source).toBe("harness_event");
+      expect(report.correlation?.nativeSessionId).toBe("codex_session_123");
       expect(report.diagnostics).toMatchObject({
         rawEventType: report.eventType,
       });

--- a/packages/contracts/src/observations.ts
+++ b/packages/contracts/src/observations.ts
@@ -221,6 +221,7 @@ export const HarnessRunObservationSchema = z
     projectId: ProjectIdSchema.optional(),
     worktreeId: WorktreeIdSchema.optional(),
     sessionId: SessionIdSchema.optional(),
+    nativeSessionId: nonEmptyStringSchema.optional(),
     pid: z.number().int().positive().optional(),
     cwd: nonEmptyStringSchema.optional(),
     state: AgentStateSchema,

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -83,6 +83,21 @@ function expectFails(schema: ZodType, value: unknown, label: string) {
 }
 
 describe("contract schemas", () => {
+  it("keeps provider-native execution identity on harness run observations", () => {
+    expect(
+      HarnessRunObservationSchema.parse({
+        id: "run_codex_1",
+        provider: "codex",
+        sessionId: "ses_station_1",
+        nativeSessionId: "native_codex_1",
+        state: "working",
+        confidence: "high",
+        reason: "Codex is active.",
+        observedAt: "2026-07-14T12:00:00.000Z",
+      }),
+    ).toMatchObject({ nativeSessionId: "native_codex_1" });
+  });
+
   it("keeps id aliases distinct while preserving string wire values", () => {
     const projectId: ProjectId = "project_api";
 


### PR DESCRIPTION
Fixes #116.

## Root cause

Observer correlation stopped at Station run/session/worktree labels, so two provider-native executions sharing those labels could project one execution's `Stop` onto the other. Completion readiness and notifications inherited that mistaken projection. Two asynchronous paths could also publish stale status while binding or readiness persistence was in flight.

## Summary

- Makes provider-native execution identity explicit and durably binds it to the active Station session.
- Gates recovery, readiness, live projection, reconcile overlays, and completion notifications on that binding while retaining rejected foreign events as diagnostic evidence.
- Serializes binding authorization with snapshot projection and rejects readiness markers whose persisted token belongs to a newer completion.
- Requires the canonical projection target to be the same session whose durable native binding authorized the report.
- Backfills the latest valid active native binding during migration and invalidates only legacy ingress claims that cannot safely replay.
- Rebases onto #181's canonical session-membership model: projection enriches only from matching Station-origin sessions in `snapshot.sessions`, not stale row metadata.
- Resolves the unpublished migration-number collision as v12 session lifecycle, v13 native bindings, and v14 claim invalidation; an exact-name preflight requeues old PR audit rows while preserving existing binding data.
- Treats Codex `Stop` events with `stop_hook_active=true` as continuing work and keeps native identity in ingress coalescing.
- Leaves issue #106's missing-completion fallback unchanged.

## Reproduction and proof

Coverage verifies that a foreign native `Stop` cannot idle another execution, create readiness, overwrite recovery state, or notify; a delayed completion authorized for ended session A cannot target canonical session B through a reused or mismatched run ID; the matching execution completes once; duplicates are deduped; newer work suppresses an older completion; and an upgrade from the old unpublished v12/v13 numbering preserves lifecycle and binding data under the canonical migration history.

## Validation

- Isolated `pnpm test:pre-push` — passed end to end on final head
- Root unit — 171 files, 1,471 tests
- Contracts — 28 tests
- Integration — 52 files passed / 1 skipped; 461 tests passed / 2 skipped
- Diagnostics — 43 tests
- Setup E2E — 15 tests
- Observer lifecycle E2E — 15 tests
- Station — 105 files, 1,000 tests
- Bun PTY — 26 tests
- SQLite Node/Bun compatibility, Observer claim races, install smoke, binary build, and binary smoke — passed
