### PR TITLE
fix(setup): handle fresh shells without rc files

### DIFF
--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -1,3 +1,5 @@
+import { access } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { applySetupPlan } from "../apply.js";
 import { checkSetupTmuxBinding } from "../checks/tmuxBinding.js";
 import { planSetupConfigWrite } from "../configWriter.js";
@@ -170,10 +172,7 @@ async function runGuidedSetupWithPrompt(
   if (shellIntegration !== undefined) {
     const accepted = await prompt.confirm("Install Worktrunk shell integration?");
     if (accepted) {
-      await applySetupPlan(
-        { ...plan, actions: [{ ...shellIntegration, selected: true }] },
-        applyOptions(deps, { announceActions: true, showCommandOutput: true }),
-      );
+      await installWorktrunkShellIntegration(shellIntegration, plan, facts, options, deps);
     }
   }
 
@@ -237,6 +236,65 @@ async function runGuidedSetupWithPrompt(
     ),
   );
   return { code: 0 };
+}
+
+async function installWorktrunkShellIntegration(
+  action: SetupAction,
+  plan: SetupPlan,
+  facts: SetupFacts,
+  options: SetupCommandOptions,
+  deps: SetupCommandDeps,
+): Promise<void> {
+  const baseCommand = action.command;
+  if (baseCommand === undefined) return;
+
+  const shellRc = activeShellRc(facts.homeDir, (deps.env ?? options.env ?? process.env).SHELL);
+  const command = shellRc === undefined ? baseCommand : [...baseCommand, shellRc.shell];
+  if (shellRc !== undefined && !(await pathExists(shellRc.path, deps))) {
+    await write(
+      deps,
+      [
+        "Optional Worktrunk shell integration was not installed; core setup is complete.",
+        `Active ${shellRc.shell} rc file not found: ${shellRc.path}`,
+        `Run: ${formatCommand(["touch", shellRc.path])} && ${formatCommand(command)}`,
+        "",
+      ].join("\n"),
+    );
+    return;
+  }
+
+  const shellApplyOptions =
+    applyOptions(deps, { announceActions: true, showCommandOutput: true }) ?? {};
+  shellApplyOptions.onActionFailed = () => undefined;
+  const result = await applySetupPlan(
+    { ...plan, actions: [{ ...action, command, selected: true }] },
+    shellApplyOptions,
+  );
+  if (result.failedAction !== undefined) {
+    await write(
+      deps,
+      `Optional Worktrunk shell integration was not installed; core setup is complete.\nRun: ${formatCommand(command)}\n`,
+    );
+  }
+}
+
+function activeShellRc(
+  homeDir: string,
+  shellCommand: string | undefined,
+): { shell: "bash" | "zsh"; path: string } | undefined {
+  const shell = basename(shellCommand ?? "");
+  if (shell !== "bash" && shell !== "zsh") return undefined;
+  return { shell, path: join(homeDir, shell === "bash" ? ".bashrc" : ".zshrc") };
+}
+
+async function pathExists(path: string, deps: SetupCommandDeps): Promise<boolean> {
+  try {
+    await (deps.fs?.access ?? access)(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
 }
 
 function renderTmuxPopupFeedback(

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -293,7 +293,8 @@ async function pathExists(path: string, deps: SetupCommandDeps): Promise<boolean
     return true;
   } catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
-    throw error;
+    // Let Worktrunk surface other rc errors through the optional action-failure path.
+    return true;
   }
 }
 

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -184,6 +184,61 @@ describe("guided setup command", () => {
     expect(chunks.join("")).toContain("Completed: Install Worktrunk shell integration");
   });
 
+  it("keeps an unreadable shell rc probe inside the optional integration step", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const zshrc = join(homeDir, ".zshrc");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({ [zshrc]: "# existing zsh config\n" });
+    const baseAccess = fs.access.bind(fs);
+    fs.access = async (path) => {
+      if (path === zshrc) throw Object.assign(new Error("symlink loop"), { code: "ELOOP" });
+      await baseAccess(path);
+    };
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin", SHELL: "/bin/zsh" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: prompt({ confirms: [false, false, true, true, false] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(calls.find((call) => call.command === "wt" && call.args?.[0] === "-y")).toMatchObject({
+      args: ["-y", "config", "shell", "install", "zsh"],
+    });
+    expect(fs.files[zshrc]).toBe("# existing zsh config\n");
+    expect(chunks.join("")).toContain(
+      "Optional Worktrunk shell integration was not installed; core setup is complete.",
+    );
+    expect(chunks.join("")).toContain("Run: wt -y config shell install zsh");
+    expect(chunks.join("")).not.toContain("Failed: Install Worktrunk shell integration");
+  });
+
   it("declining config write produces no writes", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -138,9 +138,11 @@ describe("guided setup command", () => {
   it("runs Worktrunk shell integration non-interactively after the STATION prompt", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const zshrc = join(homeDir, ".zshrc");
     await mkdir(repo, { recursive: true });
     const calls: ExternalCommandInput[] = [];
-    const fs = fakeFs({});
+    const fs = fakeFs({ [zshrc]: "# existing zsh config\n" });
     const chunks: string[] = [];
 
     const result = await runSetupCommand(
@@ -148,15 +150,15 @@ describe("guided setup command", () => {
       {},
       {
         cwd: repo,
-        homeDir: join(root, "home"),
-        env: { PATH: "/fake/bin" },
+        homeDir,
+        env: { PATH: "/fake/bin", SHELL: "/bin/zsh" },
         runner: fakeRunner(calls, {
           "git rev-parse --show-toplevel": repo,
           "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
           "wt --version": "worktrunk 1.2.3\n",
           "tmux -V": "tmux 3.5a\n",
           "codex --version": "codex 0.1.0\n",
-          "wt -y config shell install": "",
+          "wt -y config shell install zsh": "",
         }),
         access: fakeAccess([
           "/fake/bin/wt",
@@ -174,10 +176,11 @@ describe("guided setup command", () => {
 
     expect(result.code).toBe(0);
     expect(calls.find((call) => call.command === "wt" && call.args?.[0] === "-y")).toMatchObject({
-      args: ["-y", "config", "shell", "install"],
+      args: ["-y", "config", "shell", "install", "zsh"],
       stdio: "inherit",
     });
-    expect(chunks.join("")).toContain("Running: wt -y config shell install");
+    expect(fs.files[zshrc]).toBe("# existing zsh config\n");
+    expect(chunks.join("")).toContain("Running: wt -y config shell install zsh");
     expect(chunks.join("")).toContain("Completed: Install Worktrunk shell integration");
   });
 

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -6,6 +6,10 @@ import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
 import { waitForSocketClosed } from "../support/sockets";
 
+const shellIntegrationMarker = "# Worktrunk shell integration";
+const supportedShells = ["zsh", "bash"] as const;
+type SupportedShell = (typeof supportedShells)[number];
+
 describe("setup guided feedback e2e", () => {
   it("exits instead of hanging when every agent install choice is declined", async () => {
     const fixture = await createFixture({ harness: "missing" });
@@ -47,6 +51,89 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  for (const shell of supportedShells) {
+    it(`gives one optional recovery command when the active ${shell} rc file is missing`, async () => {
+      const fixture = await createFixture({ harness: "codex", shell });
+      const rcPath = shellRcPath(fixture.home, shell);
+      try {
+        const result = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "n", "n", "y", "y", "n"],
+        });
+
+        expect(result.timedOut).toBe(false);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain(
+          "Optional Worktrunk shell integration was not installed; core setup is complete.",
+        );
+        expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
+        expect(result.stdout).toContain(
+          `Run: touch ${rcPath} && wt -y config shell install ${shell}`,
+        );
+        expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
+        expect(result.stdout).not.toContain("fake shell integration installed");
+        expect(result.stdout).toContain("Core setup complete.");
+        await expect(readFile(rcPath, "utf8")).rejects.toThrow();
+        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+
+    it(`preserves an existing ${shell} rc file and does not duplicate integration`, async () => {
+      const fixture = await createFixture({ harness: "codex", shell });
+      const rcPath = shellRcPath(fixture.home, shell);
+      const original = "# user shell config\nexport USER_SETTING=preserved\n";
+      await writeFile(rcPath, original, "utf8");
+      try {
+        const first = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "n", "n", "y", "y", "n"],
+        });
+        const second = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "y", "n"],
+        });
+
+        expect(first.exitCode).toBe(0);
+        expect(second.exitCode).toBe(0);
+        expect(first.stdout).toContain(`Running: wt -y config shell install ${shell}`);
+        expect(second.stdout).toContain(`Running: wt -y config shell install ${shell}`);
+        const contents = await readFile(rcPath, "utf8");
+        expect(contents.startsWith(original)).toBe(true);
+        expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
+        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
+
+  it("does not create or modify shell files when integration is declined", async () => {
+    const fixture = await createFixture({ harness: "codex", shell: "zsh" });
+    const bashrc = shellRcPath(fixture.home, "bash");
+    const existingBashrc = "# unrelated bash config\n";
+    await writeFile(bashrc, existingBashrc, "utf8");
+    try {
+      const result = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["n", "n", "n", "y", "n", "n"],
+      });
+
+      expect(result.exitCode).toBe(0);
+      await expect(readFile(shellRcPath(fixture.home, "zsh"), "utf8")).rejects.toThrow();
+      await expect(readFile(bashrc, "utf8")).resolves.toBe(existingBashrc);
+      expect(result.stdout).not.toContain("fake shell integration installed");
+      expect(result.stdout).not.toContain("Optional Worktrunk shell integration was not installed");
     } finally {
       await fixture.cleanup();
     }
@@ -156,6 +243,7 @@ type Fixture = {
 async function createFixture(input: {
   harness: HarnessMode;
   launchers?: "complex";
+  shell?: SupportedShell;
 }): Promise<Fixture> {
   const root = await mkdtemp(join(tmpdir(), "station-setup-guided-feedback-"));
   const runtimeDir = await mkdtemp(join(tmpdir(), "stn-setup-run-"));
@@ -192,6 +280,16 @@ async function createFixture(input: {
     [
       'if [ "$1" = "--version" ]; then echo "worktrunk 1.2.3"; exit 0; fi',
       'if [ "$1 $2 $3 $4" = "-y config shell install" ]; then',
+      '  if [ "$#" -ge 5 ]; then',
+      '    case "$5" in',
+      '      zsh) rc="$HOME/.zshrc" ;;',
+      '      bash) rc="$HOME/.bashrc" ;;',
+      '      *) echo "unexpected shell $5" >&2; exit 2 ;;',
+      "    esac",
+      '    if [ ! -f "$rc" ]; then echo "No shell config file found" >&2; exit 1; fi',
+      `    marker=${shellQuote(shellIntegrationMarker)}`,
+      '    grep -F -x "$marker" "$rc" >/dev/null 2>&1 || printf "\\n%s\\n" "$marker" >> "$rc"',
+      "  fi",
       '  echo "fake shell integration installed"',
       "  exit 0",
       "fi",
@@ -269,6 +367,7 @@ async function createFixture(input: {
     STATION_PI_BIN: "/missing/pi",
     STATION_CLAUDE_BIN: "/missing/claude",
   };
+  if (input.shell !== undefined) env.SHELL = `/bin/${input.shell}`;
 
   return {
     root,
@@ -292,6 +391,14 @@ async function createFixture(input: {
       }
     },
   };
+}
+
+function shellRcPath(home: string, shell: SupportedShell): string {
+  return join(home, shell === "zsh" ? ".zshrc" : ".bashrc");
+}
+
+function otherShellRcPath(home: string, shell: SupportedShell): string {
+  return shellRcPath(home, shell === "zsh" ? "bash" : "zsh");
 }
 
 async function stopObservers(socketPaths: readonly string[]): Promise<void> {


### PR DESCRIPTION
## Summary

- detect the active zsh or bash rc file before installing Worktrunk shell integration
- leave a missing rc file untouched and print one exact, shell-specific recovery command while clearly treating the integration as optional
- target only the active shell when an rc file exists, preserving existing contents and Worktrunk's idempotent install behavior
- keep decline behavior mutation-free

## Root cause

Guided setup accepted the optional integration prompt and immediately ran Worktrunk's all-shell installer. On a fresh account with no `.zshrc` or `.bashrc`, Worktrunk exited nonzero; setup rendered a red failure but ignored the result and offered no recovery.

## UX

A fresh zsh or bash user now sees core setup complete plus one copyable `touch <active-rc> && wt -y config shell install <shell>` recovery command. Station does not create either rc file. Existing active-shell files continue through Worktrunk installation, and declining changes no shell files.

## Scope

Installer PATH persistence and `--persist-path`, tmux popup behavior, first-project onboarding, CI, and unrelated issues are unchanged.

## Validation

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/setup-guided.test.ts apps/cli/test/unit/setup-planner.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-guided-feedback.test.ts`
- `pnpm test:e2e:setup`
- isolated `pnpm test:all`
- self-review plus independent diff review

Closes #154