### PR TITLE
feat(demo): restore isolated multi-repository showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,17 @@ pnpm smoke:install      # isolated authenticated-installer contract
 pnpm test:all           # full gate: build + typecheck + lint + tests + installer smoke
 ```
 
+### Demo workspace
+
+To explore the full TUI without exposing normal projects, stage the isolated demo and launch its generated runner:
+
+```sh
+scripts/demo/stage.sh
+~/.station-demo/run.sh
+```
+
+It creates five projects and 17 real branch worktrees, including shallow Linux, Ghostty, Svelte, and is-even clones materialized through two directory levels. See the [demo runbook](scripts/demo/RUNBOOK.md) for prerequisites, harness assignments, capture flows, and safe reset.
+
 ---
 
 ## Status
@@ -233,6 +244,7 @@ station is under active development. The current build supports local setup, dia
 | [Observer architecture](docs/observer-architecture.md) | Canonical Observer boundaries, flows, state lifetimes, and active deviations |
 | [Architecture documentation](docs/architecture-documentation.md) | Controlled JSDoc roles for Observer architectural seams |
 | [Development](docs/development.md) | Environment, test gates, data-shape conventions |
+| [Demo runbook](scripts/demo/RUNBOOK.md) | Static showcase and isolated five-project live workspace |
 | [TUI](docs/tui.md) | OpenTUI/React Station UI coding, terminal layout, test expectations |
 | [Debugging](docs/debugging.md) | Trace IDs, command IDs, no-action debugging, evidence lookup |
 | [Diagnostics](docs/diagnostics.md) | `stn doctor`, debug bundles, log retention, hook setup |

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ scripts/demo/stage.sh
 ~/.station-demo/run.sh
 ```
 
-It creates five projects and 17 real branch worktrees, including shallow Linux, Ghostty, Svelte, and is-even clones materialized through two directory levels. See the [demo runbook](scripts/demo/RUNBOOK.md) for prerequisites, harness assignments, capture flows, and safe reset.
+It creates five projects and 17 real branch worktrees, including shallow Linux, Ghostty, Svelte, and is-even clones materialized through three directory levels. See the [demo runbook](scripts/demo/RUNBOOK.md) for prerequisites, harness assignments, capture flows, and safe reset.
 
 ---
 

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -122,6 +122,11 @@ function resolveStationHostCommand() {
 function createWorktreeProvider(config: StationConfig): WorktreeProvider {
   if (config.defaults.worktreeProvider === "worktrunk") {
     const options: ConstructorParameters<typeof WorktrunkProvider>[0] = {};
+    const observerPaths = resolveObserverPaths(config);
+    options.observerSocketPath = observerPaths.socketPath;
+    options.stateDir = observerPaths.stateDir;
+    options.hookSpoolDir = observerPaths.hookSpoolDir;
+    options.autoStartFromHooks = config.observer?.autoStartFromHooks !== false;
     if (config.worktree?.worktrunk?.command !== undefined) {
       options.command = config.worktree.worktrunk.command;
     }

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -6,6 +6,7 @@ import * as contracts from "@station/contracts";
 import { installCursorHooks } from "@station/cursor";
 import { createPiHarnessProvider } from "@station/pi";
 import { createStationHostController } from "@station/terminal";
+import { installWorktrunkHooks } from "@station/worktrunk";
 import { describe, expect, it, vi } from "vitest";
 import { createProviderRegistry } from "../../src/observerProviders";
 
@@ -370,6 +371,59 @@ describe("observer providers", () => {
     }
   });
 
+  it("passes observer routing into Worktrunk hook doctor checks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-worktrunk-hooks-factory-"));
+    try {
+      const command = join(root, "wt");
+      const configPath = join(root, "station.config.toml");
+      const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+      const stateDir = join(root, "state");
+      const observerSocketPath = join(root, "run", "observer.sock");
+      const hookSpoolDir = join(stateDir, "spool", "hooks");
+      await writeFile(command, "#!/bin/sh\nprintf '%s\\n' --yes\n", "utf8");
+      await chmod(command, 0o700);
+      await installWorktrunkHooks({
+        worktrunkConfigPath,
+        stationConfigPath: configPath,
+        observerSocketPath,
+        stateDir,
+        hookSpoolDir,
+        autoStartFromHooks: false,
+        hookBin: join(root, "checkout with space", "bin", "stn-ingress"),
+      });
+
+      const registry = createProviderRegistry({
+        ...config,
+        observer: {
+          stateDir,
+          socketPath: observerSocketPath,
+          autoStartFromHooks: false,
+        },
+        defaults: {
+          ...config.defaults,
+          worktreeProvider: "worktrunk",
+        },
+        worktree: {
+          worktrunk: {
+            command,
+            configPath: worktrunkConfigPath,
+            useLifecycleHooks: true,
+          },
+        },
+      });
+
+      await expect(
+        registry.worktree.doctorChecks?.({ stationConfigPath: configPath, projects: [] }),
+      ).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "worktrunk-hooks", status: "ok" }),
+        ]),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("passes Cursor command config into the Cursor harness provider", async () => {
     const registry = createProviderRegistry({
       ...config,
@@ -519,6 +573,8 @@ describe("observer providers", () => {
         "/tmp/station/web/task",
         "--profile",
         "station",
+        "--enable",
+        "hooks",
         "--sandbox",
         "workspace-write",
         "--ask-for-approval",

--- a/config/vitest/vitest.setup-e2e.config.ts
+++ b/config/vitest/vitest.setup-e2e.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     ...commonTestConfig,
     include: [
+      "tests/e2e/demo-stage.test.ts",
       "tests/e2e/observer-sqlite-smoke.test.ts",
       "tests/e2e/setup-core-flow.test.ts",
       "tests/e2e/setup-guided-feedback.test.ts",

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -6,6 +6,7 @@ import {
   expectedProviderHookScript,
   installConfigScriptHook,
   type ProviderHookScriptOptions,
+  providerHookInvocationMatchesIgnoringBin,
   providerHookScriptOptions,
 } from "@station/runtime";
 import { CLAUDE_HOOK_EVENT_NAMES, type ClaudeHookEventName } from "./hooks/hookConstants.js";
@@ -351,7 +352,13 @@ export async function doctorClaudeHooks(
     };
   }
 
-  const installed = !plan.settingsChanged && !plan.scriptChanged && !plan.artifactInvalid;
+  const scriptBefore = await fileOps.readOptionalFile(plan.hookScriptPath);
+  const scriptInstalled = providerHookInvocationMatchesIgnoringBin(
+    scriptBefore,
+    expectedClaudeHookScript(providerHookScriptOptions(plan.hookScriptPath, options)),
+    "claude",
+  );
+  const installed = !plan.settingsChanged && scriptInstalled && !plan.artifactInvalid;
   return {
     provider: "claude",
     settingsPath: plan.settingsPath,
@@ -367,7 +374,7 @@ export async function doctorClaudeHooks(
       artifactInvalid: plan.artifactInvalid,
       staleUserEntries,
       missing: plan.missing,
-      scriptChanged: plan.scriptChanged,
+      scriptChanged: !scriptInstalled,
     }),
   };
 }

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -75,7 +75,7 @@ describe("Claude hook setup", () => {
     const claudeConfigDir = join(root, "claude-home");
     const settingsPath = join(root, "state", "hooks", "station-claude-settings.json");
     const hookScriptPath = join(root, "state", "hooks", "station-claude-hook.sh");
-    const options = {
+    const runtimeOptions = {
       claudeSettingsPath: settingsPath,
       claudeConfigDir,
       hookScriptPath,
@@ -86,8 +86,14 @@ describe("Claude hook setup", () => {
       env: {},
     };
 
-    const first = await installClaudeHooks(options);
-    const second = await installClaudeHooks(options);
+    const first = await installClaudeHooks({
+      ...runtimeOptions,
+      hookBin: "/tmp/checkout/bin/stn-ingress",
+    });
+    const second = await installClaudeHooks({
+      ...runtimeOptions,
+      hookBin: "/tmp/checkout/bin/stn-ingress",
+    });
     const script = await readFile(hookScriptPath, "utf8");
     const scriptMode = (await stat(hookScriptPath)).mode & 0o777;
     const settings = JSON.parse(await readFile(settingsPath, "utf8")) as {
@@ -105,7 +111,7 @@ describe("Claude hook setup", () => {
     expect(script).toContain("claude > /dev/null");
     expect(script).not.toContain("payload_file=");
     expect(scriptMode).toBe(0o700);
-    await expect(doctorClaudeHooks({ ...options, enabled: true })).resolves.toMatchObject({
+    await expect(doctorClaudeHooks({ ...runtimeOptions, enabled: true })).resolves.toMatchObject({
       status: "ok",
       installed: true,
       settingsPath,

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -8,6 +8,7 @@ import {
   installConfigScriptHook,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
+  providerHookInvocationMatchesIgnoringBin,
   providerHookScriptOptions,
   uninstallConfigScriptHook,
 } from "@station/runtime";
@@ -279,7 +280,13 @@ export async function doctorCodexHooks(
     };
   }
 
-  const installed = plan.missing.length === 0 && !plan.scriptChanged;
+  const scriptBefore = await fileOps.readOptionalFile(plan.hookScriptPath);
+  const scriptInstalled = providerHookInvocationMatchesIgnoringBin(
+    scriptBefore,
+    expectedCodexHookScript(providerHookScriptOptions(plan.hookScriptPath, options)),
+    "codex",
+  );
+  const installed = plan.missing.length === 0 && scriptInstalled;
   return {
     provider: "codex",
     configPath: plan.configPath,
@@ -292,7 +299,11 @@ export async function doctorCodexHooks(
     missing: plan.missing,
     commands: plan.commands,
     generatedGlobalCleanup: plan.generatedGlobalCleanup,
-    message: doctorMessage({ installed, generatedGlobalInstalled, plan }),
+    message: doctorMessage({
+      installed,
+      generatedGlobalInstalled,
+      plan: { ...plan, scriptChanged: !scriptInstalled },
+    }),
   };
 }
 

--- a/integrations/harness/codex/src/launch.ts
+++ b/integrations/harness/codex/src/launch.ts
@@ -47,6 +47,7 @@ export function buildCodexLaunchPlan(
   const args = mode === "exec" ? execArgs(request) : interactiveArgs(request);
   appendCodexOptions(args, {
     profile,
+    enableHooks: hookProfile !== undefined,
     permissionMode: providerPermissionMode,
     approvalPolicy: yolo || mode === "exec" ? undefined : approvalPolicy,
     sandboxMode: yolo ? undefined : sandboxMode,
@@ -118,7 +119,7 @@ function buildCodexResumeLaunchPlan(
   const hookProfile = options.defaultHookProfile;
   const profile = hookProfile ?? configuredProfile;
   const args = ["resume", "--cd", request.worktree.path];
-  appendCodexOptions(args, { profile });
+  appendCodexOptions(args, { profile, enableHooks: hookProfile !== undefined });
   args.push(request.resume.target.id);
   if (request.initialPrompt !== undefined) {
     args.push(request.initialPrompt);
@@ -159,6 +160,7 @@ function appendCodexOptions(
   args: string[],
   options: {
     profile?: string | undefined;
+    enableHooks?: boolean | undefined;
     permissionMode?: HarnessPermissionMode | undefined;
     approvalPolicy?: string | undefined;
     sandboxMode?: string | undefined;
@@ -167,6 +169,10 @@ function appendCodexOptions(
 ): void {
   if (options.profile !== undefined) {
     args.push("--profile", options.profile);
+  }
+  if (options.enableHooks === true) {
+    // A base Codex config may disable hooks even when Station's hook profile is selected.
+    args.push("--enable", "hooks");
   }
   if (options.permissionMode === "yolo") {
     args.push(CODEX_YOLO_FLAG);

--- a/integrations/harness/codex/test/unit/hooks.test.ts
+++ b/integrations/harness/codex/test/unit/hooks.test.ts
@@ -70,6 +70,7 @@ describe("Codex hook setup", () => {
       observerSocketPath: "/tmp/station/run/observer.sock",
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
+      hookBin: "/tmp/checkout/bin/stn-ingress",
       env,
     });
     const second = await installCodexHooks({
@@ -78,6 +79,7 @@ describe("Codex hook setup", () => {
       observerSocketPath: "/tmp/station/run/observer.sock",
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
+      hookBin: "/tmp/checkout/bin/stn-ingress",
       env,
     });
     const config = await readFile(configPath, "utf8");

--- a/integrations/harness/codex/test/unit/launch.test.ts
+++ b/integrations/harness/codex/test/unit/launch.test.ts
@@ -142,7 +142,7 @@ describe("buildCodexLaunchPlan", () => {
     expect(plan.args).not.toContain("--ask-for-approval");
   });
 
-  it("uses the station profile with the current Codex profile flag", () => {
+  it("uses the station profile and enables hooks for the launch", () => {
     const plan = buildCodexLaunchPlan(request(), {
       defaultProfile: "team-default",
       defaultHookProfile: "station",
@@ -153,6 +153,8 @@ describe("buildCodexLaunchPlan", () => {
       "/tmp/station/web/task",
       "--profile",
       "station",
+      "--enable",
+      "hooks",
       "Review the task.",
     ]);
     expect(plan.providerData).toMatchObject({
@@ -287,6 +289,8 @@ describe("buildCodexLaunchPlan", () => {
       "/tmp/station/web/task",
       "--profile",
       "station",
+      "--enable",
+      "hooks",
       "codex_session_123",
       "Review the task.",
     ]);

--- a/integrations/harness/codex/test/unit/provider.test.ts
+++ b/integrations/harness/codex/test/unit/provider.test.ts
@@ -109,6 +109,8 @@ describe("CodexHarnessProvider", () => {
         "/tmp/station/web/task",
         "--profile",
         "station",
+        "--enable",
+        "hooks",
         "--sandbox",
         "workspace-write",
         "--ask-for-approval",

--- a/integrations/worktree/worktrunk/src/hooks.ts
+++ b/integrations/worktree/worktrunk/src/hooks.ts
@@ -1,6 +1,10 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { createHookSetupFileOps, providerHookCommandLine } from "@station/runtime";
+import {
+  createHookSetupFileOps,
+  providerHookCommandLine,
+  providerHookInvocationMatchesIgnoringBin,
+} from "@station/runtime";
 import { parse, stringify } from "smol-toml";
 
 export const WORKTRUNK_HOOK_NAMES = [
@@ -197,17 +201,24 @@ export async function doctorWorktrunkHooks(
     };
   }
 
-  const installed = plan.missing.length === 0;
+  const document = parseTomlDocument(plan.before);
+  const missing = WORKTRUNK_HOOK_NAMES.filter(
+    (hookName) =>
+      !hookContainsCommand(document, hookName, plan.commands[hookName], (actual, expected) =>
+        providerHookInvocationMatchesIgnoringBin(actual, expected, "worktrunk"),
+      ),
+  );
+  const installed = missing.length === 0;
   return {
     provider: "worktrunk",
     configPath: plan.configPath,
     status: installed ? "ok" : "warn",
     installed,
-    missing: plan.missing,
+    missing,
     commands: plan.commands,
     message: installed
       ? "Worktrunk lifecycle hooks are installed."
-      : `Worktrunk lifecycle hooks are missing: ${plan.missing.join(", ")}.`,
+      : `Worktrunk lifecycle hooks are missing: ${missing.join(", ")}.`,
   };
 }
 
@@ -320,25 +331,31 @@ function hookContainsCommand(
   document: Record<string, unknown>,
   hookName: WorktrunkHookName,
   command: string,
+  matches: (actual: string, expected: string) => boolean = (actual, expected) =>
+    actual === expected,
 ): boolean {
   const value = document[hookName];
   if (typeof value === "string") {
-    return value === command;
+    return matches(value, command);
   }
   if (Array.isArray(value)) {
-    return value.some((entry) => commandInHookValue(entry, command));
+    return value.some((entry) => commandInHookValue(entry, command, matches));
   }
-  return commandInHookValue(value, command);
+  return commandInHookValue(value, command, matches);
 }
 
-function commandInHookValue(value: unknown, command: string): boolean {
+function commandInHookValue(
+  value: unknown,
+  command: string,
+  matches: (actual: string, expected: string) => boolean,
+): boolean {
   if (typeof value === "string") {
-    return value === command;
+    return matches(value, command);
   }
   if (!isRecord(value)) {
     return false;
   }
-  return Object.values(value).some((child) => child === command);
+  return Object.values(value).some((child) => typeof child === "string" && matches(child, command));
 }
 
 function parseTomlDocument(source: string): Record<string, unknown> {

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -54,6 +54,10 @@ export type WorktrunkProviderOptions = {
   command?: string;
   configPath?: string;
   useLifecycleHooks?: boolean;
+  observerSocketPath?: string;
+  stateDir?: string;
+  hookSpoolDir?: string;
+  autoStartFromHooks?: boolean;
   timeoutMs?: number;
   runner?: ExternalCommandRunner;
   clock?: RuntimeClock;
@@ -85,6 +89,10 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #command: string;
   readonly #configPath: string | undefined;
   readonly #useLifecycleHooks: boolean | undefined;
+  readonly #observerSocketPath: string | undefined;
+  readonly #stateDir: string | undefined;
+  readonly #hookSpoolDir: string | undefined;
+  readonly #autoStartFromHooks: boolean | undefined;
   readonly #timeoutMs: number;
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
@@ -95,6 +103,10 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
     this.#configPath = options.configPath;
     this.#useLifecycleHooks = options.useLifecycleHooks;
+    this.#observerSocketPath = options.observerSocketPath;
+    this.#stateDir = options.stateDir;
+    this.#hookSpoolDir = options.hookSpoolDir;
+    this.#autoStartFromHooks = options.autoStartFromHooks;
     this.#timeoutMs = options.timeoutMs ?? 5000;
     this.#runner = options.runner;
     this.#clock = options.clock ?? systemClock;
@@ -154,6 +166,14 @@ export class WorktrunkProvider implements WorktreeProvider {
     try {
       const result = await doctorWorktrunkHooks({
         ...(this.#configPath === undefined ? {} : { worktrunkConfigPath: this.#configPath }),
+        ...(this.#observerSocketPath === undefined
+          ? {}
+          : { observerSocketPath: this.#observerSocketPath }),
+        ...(this.#stateDir === undefined ? {} : { stateDir: this.#stateDir }),
+        ...(this.#hookSpoolDir === undefined ? {} : { hookSpoolDir: this.#hookSpoolDir }),
+        ...(this.#autoStartFromHooks === undefined
+          ? {}
+          : { autoStartFromHooks: this.#autoStartFromHooks }),
         ...(context.stationConfigPath === undefined
           ? {}
           : { stationConfigPath: context.stationConfigPath }),

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -46,6 +46,7 @@ describe("Worktrunk hook setup", () => {
       observerSocketPath: "/tmp/station/run/observer.sock",
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
+      hookBin: "/tmp/checkout/bin/stn-ingress",
     });
     const second = await installWorktrunkHooks({
       worktrunkConfigPath: configPath,
@@ -53,6 +54,7 @@ describe("Worktrunk hook setup", () => {
       observerSocketPath: "/tmp/station/run/observer.sock",
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
+      hookBin: "/tmp/checkout/bin/stn-ingress",
     });
     const contents = await readFile(configPath, "utf8");
 

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -274,6 +274,56 @@ export function providerHookScriptRoutesByStationEnv(script: string, provider: s
   );
 }
 
+export function providerHookInvocationMatchesIgnoringBin(
+  actual: string,
+  expected: string,
+  provider: string,
+): boolean {
+  if (actual === expected) {
+    return true;
+  }
+  const actualNormalized = withoutProviderHookBin(actual, provider);
+  const expectedNormalized = withoutProviderHookBin(expected, provider);
+  return actualNormalized !== undefined && actualNormalized === expectedNormalized;
+}
+
+function withoutProviderHookBin(source: string, provider: string): string | undefined {
+  const markers = [
+    ` ${guardedArrayExpansion("SOCKET_ARG")} `,
+    " --socket ",
+    " --state-dir ",
+    " --spool-dir ",
+    " --config ",
+    " --no-auto-start ",
+    ` ${shellQuote(provider)}`,
+  ];
+  for (const marker of markers) {
+    let offset = 0;
+    for (;;) {
+      const boundary = source.indexOf(marker, offset);
+      if (boundary < 0) {
+        break;
+      }
+      const lineStart = source.lastIndexOf("\n", boundary) + 1;
+      const hookBin = source.slice(lineStart, boundary);
+      if (isProviderHookBinWord(hookBin)) {
+        return `${source.slice(0, lineStart)}<provider-hook-bin>${source.slice(boundary)}`;
+      }
+      offset = boundary + marker.length;
+    }
+  }
+  return undefined;
+}
+
+function isProviderHookBinWord(value: string): boolean {
+  const hookBin = shellSafeTokenPattern.test(value)
+    ? value
+    : /^'[^']*'(?:\\''[^']*')*$/.test(value)
+      ? value.slice(1, -1).replaceAll("'\\''", "'")
+      : undefined;
+  return hookBin === "stn-ingress" || hookBin?.endsWith("/stn-ingress") === true;
+}
+
 export function hookCommandsForEvents<EventName extends string>(
   eventNames: readonly EventName[],
   hookScriptPath: string,
@@ -402,5 +452,7 @@ export function commandLine(args: readonly string[]): string {
 }
 
 export function shellQuote(value: string): string {
-  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+  return shellSafeTokenPattern.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }
+
+const shellSafeTokenPattern = /^[A-Za-z0-9_./:=@+-]+$/;

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -12,6 +12,7 @@ import {
   planConfigScriptHook,
   providerHookCommandArgs,
   providerHookCommandLine,
+  providerHookInvocationMatchesIgnoringBin,
   providerHookScriptOptions,
   providerHookScriptRoutesByStationEnv,
   shellQuote,
@@ -195,6 +196,45 @@ describe("runtime hookSetup", () => {
         providerHookScriptRoutesByStationEnv(
           script.replaceAll("STATION_CONFIG_PATH", "STATION_OLD_CONFIG_PATH"),
           "cursor",
+        ),
+      ).toBe(false);
+    });
+
+    it("matches checkout-local and PATH hook binaries without hiding other drift", () => {
+      const expectedScript = expectedProviderHookScript({
+        provider: "codex",
+        options: { stationConfigPath: "/tmp/station/config.toml" },
+      });
+      const checkoutScript = expectedProviderHookScript({
+        provider: "codex",
+        options: {
+          stationConfigPath: "/tmp/station/config.toml",
+          hookBin: "/tmp/checkout with space/bin/stn-ingress",
+        },
+      });
+
+      expect(
+        providerHookInvocationMatchesIgnoringBin(checkoutScript, expectedScript, "codex"),
+      ).toBe(true);
+      expect(
+        providerHookInvocationMatchesIgnoringBin(
+          checkoutScript,
+          expectedScript.replace("/tmp/station/config.toml", "/tmp/other/config.toml"),
+          "codex",
+        ),
+      ).toBe(false);
+      expect(
+        providerHookInvocationMatchesIgnoringBin(
+          "/tmp/checkout/bin/stn-ingress --config /tmp/station/config.toml worktrunk post-create",
+          "stn-ingress --config /tmp/station/config.toml worktrunk post-create",
+          "worktrunk",
+        ),
+      ).toBe(true);
+      expect(
+        providerHookInvocationMatchesIgnoringBin(
+          "malicious --config /tmp/station/config.toml worktrunk post-create",
+          "stn-ingress --config /tmp/station/config.toml worktrunk post-create",
+          "worktrunk",
         ),
       ).toBe(false);
     });

--- a/scripts/demo/RUNBOOK.md
+++ b/scripts/demo/RUNBOOK.md
@@ -30,7 +30,7 @@ scripts/demo/stage.sh
 ~/.station-demo/run.sh
 ```
 
-Staging performs network clones. Linux is still a sizable checkout even though it is shallow and sparse, because the demo intentionally materializes code through three directory levels.
+Staging performs network clones. Linux is still a sizable checkout even though it is shallow and sparse, because the demo intentionally materializes code through three directory levels. The clones download all blobs for their single shallow commit so expanding Linux does not depend on a very large promisor fetch; expect the complete demo to use several gigabytes of disk.
 
 The generated `run.sh` forces the full Station workspace even when invoked from tmux. It exports isolated Station and provider paths before launching the TUI.
 

--- a/scripts/demo/RUNBOOK.md
+++ b/scripts/demo/RUNBOOK.md
@@ -30,7 +30,7 @@ scripts/demo/stage.sh
 ~/.station-demo/run.sh
 ```
 
-Staging performs network clones. Linux is still a sizable checkout even though it is shallow and sparse, because the demo intentionally materializes code through two directory levels.
+Staging performs network clones. Linux is still a sizable checkout even though it is shallow and sparse, because the demo intentionally materializes code through three directory levels.
 
 The generated `run.sh` forces the full Station workspace even when invoked from tmux. It exports isolated Station and provider paths before launching the TUI.
 
@@ -50,14 +50,14 @@ The public clones retain their real `origin` URLs, while GitHub metadata polling
 
 ### Sparse depth
 
-The four public clones include root files and files nested one or two directories below the repository root. Directories below that boundary remain excluded. Linked worktrees inherit the same sparse definition.
+The four public clones include root files and files nested one, two, or three directories below the repository root. Directories below that boundary remain excluded. Linked worktrees inherit the same sparse definition.
 
 For example:
 
 ```sh
 cd ~/.station-demo/repos/linux
 git sparse-checkout list
-find . -maxdepth 3 -type f | head -80
+find . -maxdepth 4 -type f | head -80
 ```
 
 Inside Station, open a Linux row with `[+sh]` and run the same `find` command to show that the workspace contains meaningful source structure rather than only root-level files.
@@ -110,7 +110,7 @@ Use a fixed terminal size such as 120x34, a clean high-contrast theme, and a Ner
 | Live fleet | Stage the workspace, launch `~/.station-demo/run.sh`, and show all five projects and 17 rows. |
 | Default launch | Open one blank row from each project to show its project harness assignment. |
 | Explicit launch | Press `N`, choose the T3 project and a non-Cursor harness, then create the session. |
-| Browse code | Open a Linux shell and run `find . -maxdepth 3 -type f \| head -80`. |
+| Browse code | Open a Linux shell and run `find . -maxdepth 4 -type f \| head -80`. |
 | Add project | Press `A` and select `~/.station-demo/repos/web`. |
 | Run checks | Open the added `web` project, split with `Ctrl-\`, then run `./check.sh`. |
 | See diff | Focus `web`, then use **See diff (split right)** to render its planted change. |

--- a/scripts/demo/RUNBOOK.md
+++ b/scripts/demo/RUNBOOK.md
@@ -68,7 +68,9 @@ Staging does not silently start 17 agents or terminal processes. Rows initially 
 
 Current config supports a default per project, not a declarative default per branch. The historical mixed T3 branch assignments therefore become one supported project default, Cursor. Select a different harness in **New Session** when demonstrating a mixed T3 fleet.
 
-Hooks are installed only for CLIs found on the machine. Missing harness CLIs do not prevent staging, but their assigned rows cannot launch until those CLIs are installed and signed in. Hook install and doctor output is recorded in `~/.station-demo/hooks.txt`.
+Hooks are installed only for CLIs found on the machine. Every installed hook is then checked the same way the observer checks it at launch; staging stops instead of claiming success when that runtime check fails. Missing harness CLIs do not prevent staging, but their assigned rows cannot launch until those CLIs are installed and signed in. Hook install and doctor output is recorded in `~/.station-demo/hooks.txt`.
+
+Codex launches explicitly enable the Station hook profile even when the copied base Codex config disables hooks. Codex still requires the normal one-time review for non-managed hooks: open `/hooks` in the first isolated Codex session and trust the generated Station hooks before expecting live status events.
 
 ### Isolation and reset
 

--- a/scripts/demo/RUNBOOK.md
+++ b/scripts/demo/RUNBOOK.md
@@ -1,67 +1,125 @@
-# Demo & screenshot runbook
+# Demo and screenshot runbook
 
-Goal: capture clean images/GIFs for the README without leaking your real
-projects or local data into the screenshots. Two acts — a deterministic mock
-overview, and the live interactions staged by `scripts/demo/stage.sh`.
+Station has two complementary demo modes:
 
-## Setup
+- The static showcase is instant and deterministic. It renders convincing mock data but does not create repositories or launch sessions.
+- The staged workspace is live. It creates isolated repositories, real Git worktrees, current harness defaults, local hooks, observer state, and a dedicated `stationdemo` tmux session. Its files live under `~/.station-demo`.
 
-- **Act 1 (mock):** nothing to stage.
-- **Act 2 (live):** `scripts/demo/stage.sh` → launch `stn --config ~/.station-demo/config.toml` → tear down with `scripts/demo/reset.sh`.
+Neither mode reads projects from your normal Station config.
 
-Everything in Act 2 is isolated under `~/.station-demo`; it never touches your real `~/.config/station` or observer state.
+## Static showcase
 
-## Terminal setup for clean captures
+From the repository root:
 
-- Fixed window size — **120×34** is a good default (structure shows, text stays legible).
-- A clean dark, high-contrast theme; a Nerd Font so the glyphs (⌘, braille throbbers) render.
-- Fresh window, full-screen, no prompt clutter behind the popup.
-
-## The shots → README placement
-
-| # | Shot | How | README spot |
-|---|------|-----|-------------|
-| 1 | **Hero — overview** | `cd station && STATION_SOURCE=mock STATION_SCENARIO=showcase bun run station` → wait for first frame (throbber shows `⠋`) → capture → `Ctrl-Q` | top, under the tagline |
-| 2 | **New session (any harness)** | `N` → name → project → **pick agent: claude / codex** → agent launches into a pane | "What it does" |
-| 3 | **Add project** | `A` → folder picker → `~/.station-demo/repos/web` → review → success → `N` to start a session there | "What it does" |
-| 4 | **Split + run a command** | open `is-even` (`[+sh]` or a session) → split (`Ctrl-\`) → run `./check.sh` | optional |
-| 5 | **Split + see diff** | focus the `is-even` worktree → right-click → **See diff (split right)** → `diffnav` renders the planted O(n)→O(1) diff | the automations money shot |
-
-Shot 1 is the reliable hero — zero setup, no real data. The others are live.
-
-## Stills vs GIFs
-
-- Hero + any single-state shot → **PNG**.
-- Interactions (new session, add project, see-diff) → **GIF** — they prove it actually works.
-
-## Reproducible GIFs with VHS (recommended)
-
-`brew install vhs`. VHS scripts keystrokes in a `.tape` file and records a clean GIF at a fixed size/theme — no fumbling, no personal data. Skeleton:
-
-```tape
-Output docs/images/see-diff.gif
-Set FontSize 16
-Set Width 1200
-Set Height 720
-Set Shell bash
-Type "stn --config ~/.station-demo/config.toml" Enter
-Sleep 4s
-# …drive the keys for the flow here (Type/Enter/Ctrl+… /Sleep)…
-Sleep 2s
+```sh
+cd station
+STATION_SOURCE=mock STATION_SCENARIO=showcase bun run station
 ```
 
-VHS runs Station in its own PTY; the dual-runtime renderer usually records fine, but if a flow misbehaves under VHS, fall back to a screen recording → GIF (`gifski`/QuickTime).
+Use this for a zero-setup overview or as a fallback during a recording.
 
-## Putting the images in the README
+## Live multi-repository workspace
 
-- Commit to `docs/images/` and embed: `![Station — live worktree dashboard](docs/images/overview.png)`. Works in private and public; GitHub serves them.
-- Keep GIFs lean (<~5 MB) or upload to a GitHub release/issue to get a CDN URL and avoid repo bloat.
-- **No-real-data guarantee:** Act 1 is mock (famous repos, no real data); Act 2 uses the isolated `is-even`/`web` repos. Never capture against your real observer.
-- Suggested layout: hero PNG at the top, one "it works" GIF (see-diff or new session) in "What it does".
+The source checkout must be built, both dependency lanes must be installed, and the normal development tools from `Brewfile` must be available:
 
-## Optional: make the command split a one-tap automation
+```sh
+pnpm install
+pnpm build
+(cd station && bun install)
+scripts/demo/stage.sh
+~/.station-demo/run.sh
+```
 
-The **See diff** automation ships by default. To also expose "Run checks (split below)", add a `[workspace]` automation list to `~/.config/station/config.toml` — note that providing `automations` **replaces** the default list, so include both:
+Staging performs network clones. Linux is still a sizable checkout even though it is shallow and sparse, because the demo intentionally materializes code through two directory levels.
+
+The generated `run.sh` forces the full Station workspace even when invoked from tmux. It exports isolated Station and provider paths before launching the TUI.
+
+### What gets staged
+
+| Project | Source | Branch worktrees | Default harness |
+| --- | --- | ---: | --- |
+| linux | shallow public clone, `master` | 3 | Claude |
+| ghostty | shallow public clone, `main` | 2 | Codex |
+| svelte | shallow public clone, `main` | 1 | OpenCode |
+| is-even | shallow public clone, `master` | 1 | Pi |
+| t3-code | generated local monorepo, `main` | 10 | Cursor |
+
+That is five configured projects and 17 non-main worktree rows. A sixth local repository, `~/.station-demo/repos/web`, is deliberately omitted so the **Add Project** flow has something safe to add.
+
+The public clones retain their real `origin` URLs, while GitHub metadata polling is disabled in the demo config. The generated `t3-code` fixture is a full local repository rather than a sparse clone.
+
+### Sparse depth
+
+The four public clones include root files and files nested one or two directories below the repository root. Directories below that boundary remain excluded. Linked worktrees inherit the same sparse definition.
+
+For example:
+
+```sh
+cd ~/.station-demo/repos/linux
+git sparse-checkout list
+find . -maxdepth 3 -type f | head -80
+```
+
+Inside Station, open a Linux row with `[+sh]` and run the same `find` command to show that the workspace contains meaningful source structure rather than only root-level files.
+
+### Harness and terminal behavior
+
+Staging does not silently start 17 agents or terminal processes. Rows initially show no agent. Opening a blank row launches the project's configured default harness in the isolated workspace; **New Session** lets you select any configured harness explicitly.
+
+Current config supports a default per project, not a declarative default per branch. The historical mixed T3 branch assignments therefore become one supported project default, Cursor. Select a different harness in **New Session** when demonstrating a mixed T3 fleet.
+
+Hooks are installed only for CLIs found on the machine. Missing harness CLIs do not prevent staging, but their assigned rows cannot launch until those CLIs are installed and signed in. Hook install and doctor output is recorded in `~/.station-demo/hooks.txt`.
+
+### Isolation and reset
+
+The live demo keeps these paths under `~/.station-demo`:
+
+- Station config, observer database/logs, sockets, and native layout
+- Worktrunk config and managed worktrees
+- Codex, Claude, Cursor, and OpenCode config homes
+- the generated launcher and hook report
+
+Codex authentication and Cursor's Git/SSH configuration are linked into their isolated homes when present, so real harnesses can still authenticate. Staging and reset do not rewrite the source checkout or normal Station config.
+
+Reset with:
+
+```sh
+scripts/demo/reset.sh
+```
+
+Reset gracefully stops the isolated observer, checks the demo observer and persistent-host socket owners, stops the `stationdemo` tmux session, and then removes the demo root. A non-empty root must carry the marker created by `stage.sh` or match the prior demo config signature; reset refuses an unrecognized directory.
+
+To use a different location for both commands:
+
+```sh
+export STATION_DEMO_ROOT=/path/to/station-demo
+scripts/demo/stage.sh
+"$STATION_DEMO_ROOT/run.sh"
+scripts/demo/reset.sh
+```
+
+Custom roots may contain spaces, but must not contain `.` or `..` path components, quotes, backslashes, or newlines; staging rejects values that cannot be represented safely in the generated TOML.
+
+## Suggested captures
+
+Use a fixed terminal size such as 120x34, a clean high-contrast theme, and a Nerd Font.
+
+| Shot | How |
+| --- | --- |
+| Overview | Use the static showcase, wait for the first settled frame, then capture. |
+| Live fleet | Stage the workspace, launch `~/.station-demo/run.sh`, and show all five projects and 17 rows. |
+| Default launch | Open one blank row from each project to show its project harness assignment. |
+| Explicit launch | Press `N`, choose the T3 project and a non-Cursor harness, then create the session. |
+| Browse code | Open a Linux shell and run `find . -maxdepth 3 -type f \| head -80`. |
+| Add project | Press `A` and select `~/.station-demo/repos/web`. |
+| Run checks | Open the added `web` project, split with `Ctrl-\`, then run `./check.sh`. |
+| See diff | Focus `web`, then use **See diff (split right)** to render its planted change. |
+
+Use PNG for stable overview frames and GIF/video for interactions. Never record against your normal observer when the demo can provide equivalent data.
+
+## Optional check automation
+
+The **See diff** automation is built in. To add a split-pane check command for the staged demo, append this to `~/.station-demo/config.toml` after staging. Providing `automations` replaces the defaults, so both entries are included:
 
 ```toml
 [workspace]
@@ -86,14 +144,4 @@ run = "execute"
 focus = true
 ```
 
-For the demo you can skip this and just split + type `./check.sh`.
-
-## Live-demo talking points
-
-- "One dashboard for every agent across every repo — see who's working, idle, or stuck at a glance."
-- New session: "Pick a project and a harness; Station creates the worktree and drops the agent into a pane."
-- See diff: "Right-click → See diff splits a pane and renders the change — that's the automations primitive; you can wire any command to a pane layout."
-
-## Fallback
-
-If a live agent hangs or errors mid-demo, `Ctrl-Q` and cut to the mock overview (Act 1) — it's deterministic. Keep `STATION_SCENARIO=showcase` running in a second tab as your safety net.
+Rerunning `stage.sh` regenerates the config and removes this manual addition.

--- a/scripts/demo/common.sh
+++ b/scripts/demo/common.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+canonicalize_demo_root() {
+  local path="$1" suffix="" leaf
+  case "/$path/" in
+    */./*|*/../*)
+      echo "Demo root must not contain '.' or '..' path components: $path" >&2
+      return 1
+      ;;
+  esac
+  case "$path" in
+    /*) ;;
+    *) path="$PWD/$path" ;;
+  esac
+  while [ ! -e "$path" ]; do
+    leaf="$(basename "$path")"
+    suffix="/$leaf$suffix"
+    path="$(dirname "$path")"
+  done
+  if [ -d "$path" ]; then
+    path="$(cd "$path" && pwd -P)"
+  else
+    path="$(cd "$(dirname "$path")" && pwd -P)/$(basename "$path")"
+  fi
+  printf '%s%s\n' "$path" "$suffix"
+}
+
+require_toml_safe_value() {
+  local label="$1" value="$2"
+  case "$value" in
+    *\\*|*\"*|*$'\n'*|*$'\r'*)
+      echo "$label contains a quote, backslash, or newline that cannot be written safely to demo config." >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/demo/reset.sh
+++ b/scripts/demo/reset.sh
@@ -1,13 +1,223 @@
 #!/usr/bin/env bash
-# Tear down the demo staged by scripts/demo/stage.sh.
+# Tear down the isolated workspace staged by scripts/demo/stage.sh.
 set -euo pipefail
 
-DEMO_ROOT="${STATION_DEMO_ROOT:-$HOME/.station-demo}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEMO_ROOT_INPUT="${STATION_DEMO_ROOT:-$HOME/.station-demo}"
+STN="${STATION_DEMO_STN:-$ROOT/bin/stn}"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+DEMO_ROOT="$(canonicalize_demo_root "$DEMO_ROOT_INPUT")"
+HOME_ROOT="$(canonicalize_demo_root "$HOME")"
+CHECKOUT_ROOT="$(canonicalize_demo_root "$ROOT")"
 CONFIG="$DEMO_ROOT/config.toml"
+STATE="$DEMO_ROOT/state"
+MARKER="$DEMO_ROOT/.station-demo-root"
 
-if [ -f "$CONFIG" ] && command -v stn >/dev/null 2>&1; then
-  stn --config "$CONFIG" observer stop >/dev/null 2>&1 || true
+case "$DEMO_ROOT" in
+  ""|/|"$HOME_ROOT"|"$CHECKOUT_ROOT")
+    echo "Refusing to remove unsafe demo root: $DEMO_ROOT" >&2
+    exit 1
+    ;;
+esac
+case "$HOME_ROOT/" in
+  "$DEMO_ROOT/"*)
+    echo "Refusing to remove a parent of HOME: $DEMO_ROOT" >&2
+    exit 1
+    ;;
+esac
+case "$CHECKOUT_ROOT/" in
+  "$DEMO_ROOT/"*)
+    echo "Refusing to remove a parent of this checkout: $DEMO_ROOT" >&2
+    exit 1
+    ;;
+esac
+case "$DEMO_ROOT/" in
+  "$CHECKOUT_ROOT/"*)
+    echo "Refusing to stage demo data inside this checkout: $DEMO_ROOT" >&2
+    exit 1
+    ;;
+esac
+
+if [ -e "$DEMO_ROOT" ] && [ ! -d "$DEMO_ROOT" ]; then
+  echo "Refusing to replace non-directory demo root: $DEMO_ROOT" >&2
+  exit 1
 fi
-tmux kill-session -t stationdemo >/dev/null 2>&1 || true
+legacy_demo_root() {
+  [ -f "$CONFIG" ] && [ ! -L "$CONFIG" ] &&
+    grep -Fq "state_dir = \"$STATE\"" "$CONFIG" &&
+    grep -Fq 'workbench_session = "stationdemo"' "$CONFIG"
+}
+
+valid_demo_marker() {
+  [ -f "$MARKER" ] && [ ! -L "$MARKER" ] && [ "$(cat "$MARKER")" = "station-demo-v1" ]
+}
+
+if [ -d "$DEMO_ROOT" ] && ! valid_demo_marker && ! legacy_demo_root; then
+  if [ -n "$(find "$DEMO_ROOT" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]; then
+    echo "Refusing to remove an unrecognized demo root: $DEMO_ROOT" >&2
+    echo "Choose an empty STATION_DEMO_ROOT or remove it manually after reviewing its contents." >&2
+    exit 1
+  fi
+fi
+
+stn_demo() {
+  PATH="$ROOT/bin:$PATH" \
+    STATION_CONFIG_PATH="$CONFIG" \
+    STATION_OBSERVER_SOCKET_PATH="$STATE/run/observer.sock" \
+    STATION_LAYOUT_PATH="$STATE/station/layout.json" \
+    CODEX_HOME="$DEMO_ROOT/codex-home" \
+    CLAUDE_CONFIG_DIR="$DEMO_ROOT/claude-home" \
+    STATION_CURSOR_HOME="$DEMO_ROOT/cursor-home" \
+    OPENCODE_CONFIG_DIR="$DEMO_ROOT/opencode-home" \
+    "$STN" --config "$CONFIG" "$@"
+}
+
+socket_pids() {
+  lsof -n -t "$1" 2>/dev/null | awk '/^[0-9]+$/ { print }' | sort -u || true
+}
+
+process_command() {
+  ps -ww -p "$1" -o command= 2>/dev/null || true
+}
+
+owner_matches_demo_runtime() {
+  local socket="$1" pid="$2" command
+  command="$(process_command "$pid")"
+  case "$command" in
+    *"--socket $socket"*"--state-dir $STATE"*) ;;
+    *) return 1 ;;
+  esac
+  case "$socket" in
+    */observer.sock)
+      case "$command" in
+        *observerMain.js*|*__observer*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    */station-host.sock)
+      case "$command" in
+        *hostMain.ts*|*__station-host*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+  esac
+  return 1
+}
+
+capture_socket_owners() {
+  local socket="$1" pids pid
+  if [ -L "$socket" ]; then
+    echo "Refusing to follow a symlink at demo socket path: $socket" >&2
+    return 1
+  fi
+  [ -S "$socket" ] || return 0
+  if ! command -v lsof >/dev/null 2>&1; then
+    echo "Refusing to remove $DEMO_ROOT while socket ownership cannot be checked: $socket" >&2
+    return 1
+  fi
+  pids="$(socket_pids "$socket")"
+  [ -n "$pids" ] || return 0
+  for pid in $pids; do
+    if ! owner_matches_demo_runtime "$socket" "$pid"; then
+      echo "Refusing to signal unverified process $pid at $socket: $(process_command "$pid")" >&2
+      return 1
+    fi
+  done
+  printf '%s\n' "$pids"
+}
+
+live_pids() {
+  local pid
+  for pid in $1; do
+    kill -0 "$pid" >/dev/null 2>&1 && printf '%s\n' "$pid"
+  done
+}
+
+wait_for_pids() {
+  local pids="$1" attempts="$2" remaining="$1" next pid attempt
+  for ((attempt = 0; attempt < attempts; attempt += 1)); do
+    next="$(live_pids "$remaining")"
+    [ -z "$next" ] && return 0
+    remaining="$next"
+    sleep 0.1
+  done
+  printf '%s\n' "$remaining"
+  return 1
+}
+
+stop_captured_owners() {
+  local socket="$1" pids="$2" remaining pid
+  remaining="$(live_pids "$pids")"
+  [ -n "$remaining" ] || return 0
+  for pid in $remaining; do
+    if ! owner_matches_demo_runtime "$socket" "$pid"; then
+      echo "Refusing to signal changed or unverified process $pid at $socket." >&2
+      return 1
+    fi
+    kill "$pid" >/dev/null 2>&1 || true
+  done
+  if remaining="$(wait_for_pids "$remaining" 50)"; then
+    return 0
+  fi
+  for pid in $remaining; do
+    if ! owner_matches_demo_runtime "$socket" "$pid"; then
+      echo "Refusing to force-kill changed or unverified process $pid at $socket." >&2
+      return 1
+    fi
+    kill -KILL "$pid" >/dev/null 2>&1 || true
+  done
+  if remaining="$(wait_for_pids "$remaining" 10)"; then
+    return 0
+  fi
+  echo "Refusing to remove $DEMO_ROOT; a validated process did not exit: $remaining" >&2
+  return 1
+}
+
+verify_socket_unowned() {
+  local socket="$1" pids
+  if [ -L "$socket" ]; then
+    echo "Refusing to follow a symlink at demo socket path: $socket" >&2
+    return 1
+  fi
+  [ -S "$socket" ] || return 0
+  if ! command -v lsof >/dev/null 2>&1; then
+    echo "Refusing to verify $socket because lsof is unavailable." >&2
+    return 1
+  fi
+  pids="$(socket_pids "$socket")"
+  [ -z "$pids" ] && return 0
+  echo "Refusing to remove $DEMO_ROOT; a new process owns $socket: $pids" >&2
+  return 1
+}
+
+if [ -L "$STATE" ] || [ -L "$STATE/run" ]; then
+  echo "Refusing to follow a symlink in the demo socket directory: $STATE/run" >&2
+  exit 1
+fi
+
+observer_pids="$(capture_socket_owners "$STATE/run/observer.sock")"
+host_pids="$(capture_socket_owners "$STATE/run/station-host.sock")"
+legacy_observer_pids="$(capture_socket_owners "$STATE/observer.sock")"
+legacy_host_pids="$(capture_socket_owners "$STATE/station-host.sock")"
+
+if [ -f "$CONFIG" ] && [ -x "$STN" ]; then
+  stn_demo observer stop --timeout-ms 8000 >/dev/null 2>&1 || true
+fi
+
+# Captured identities remain the authority even if graceful shutdown unlinks a socket first.
+stop_captured_owners "$STATE/run/observer.sock" "$observer_pids"
+stop_captured_owners "$STATE/observer.sock" "$legacy_observer_pids"
+stop_captured_owners "$STATE/run/station-host.sock" "$host_pids"
+stop_captured_owners "$STATE/station-host.sock" "$legacy_host_pids"
+verify_socket_unowned "$STATE/run/observer.sock"
+verify_socket_unowned "$STATE/observer.sock"
+verify_socket_unowned "$STATE/run/station-host.sock"
+verify_socket_unowned "$STATE/station-host.sock"
+
+if command -v tmux >/dev/null 2>&1; then
+  tmux kill-session -t stationdemo >/dev/null 2>&1 || true
+fi
 rm -rf "$DEMO_ROOT"
-echo "Removed $DEMO_ROOT (stopped the demo observer + tmux session if present)."
+echo "Removed $DEMO_ROOT (stopped the isolated observer, host, and tmux session if present)."

--- a/scripts/demo/stage.sh
+++ b/scripts/demo/stage.sh
@@ -374,23 +374,30 @@ chmod +x "$RUNNER"
 
 install_hook() {
   local target="$1" command="$2"
-  shift 2
   if ! have_tool "$command"; then
     printf '%s: skipped (%s not found)\n' "$target" "$command" >>"$HOOKS_REPORT"
     return 0
   fi
-  if stn_demo hooks install "$target" --yes "$@" >>"$HOOKS_REPORT" 2>&1; then
-    stn_demo hooks doctor "$target" "$@" >>"$HOOKS_REPORT" 2>&1 || true
-    printf '%s: installed\n' "$target" >>"$HOOKS_REPORT"
-  else
-    printf '%s: install failed; see output above\n' "$target" >>"$HOOKS_REPORT"
+  if [ "$target" = "opencode" ]; then
+    stn_demo hooks install "$target" --yes >>"$HOOKS_REPORT" 2>&1 || {
+      echo "$target hook installation failed; see $HOOKS_REPORT." >&2
+      return 1
+    }
+  elif ! stn_demo hooks install "$target" --yes --hook-bin "$HOOK_BIN" >>"$HOOKS_REPORT" 2>&1; then
+    echo "$target hook installation failed; see $HOOKS_REPORT." >&2
+    return 1
   fi
+  if ! stn_demo hooks doctor "$target" >>"$HOOKS_REPORT" 2>&1; then
+    echo "$target hook doctor failed; see $HOOKS_REPORT." >&2
+    return 1
+  fi
+  printf '%s: installed and runtime-verified\n' "$target" >>"$HOOKS_REPORT"
 }
 
 install_required_hook() {
   local target="$1"
   shift
-  if ! stn_demo hooks install "$target" --yes "$@" >>"$HOOKS_REPORT" 2>&1; then
+  if ! stn_demo hooks install "$target" --yes --hook-bin "$HOOK_BIN" "$@" >>"$HOOKS_REPORT" 2>&1; then
     echo "Required $target hook installation failed; see $HOOKS_REPORT." >&2
     return 1
   fi
@@ -403,10 +410,10 @@ install_required_hook() {
 
 step "Installing isolated provider hooks"
 : >"$HOOKS_REPORT"
-install_required_hook worktrunk --hook-bin "$HOOK_BIN" --worktrunk-config "$WORKTRUNK_CONFIG"
-install_hook claude "$CLAUDE_CMD" --hook-bin "$HOOK_BIN"
-install_hook codex "$CODEX_CMD" --hook-bin "$HOOK_BIN"
-install_hook cursor "$CURSOR_CMD" --hook-bin "$HOOK_BIN"
+install_required_hook worktrunk --worktrunk-config "$WORKTRUNK_CONFIG"
+install_hook claude "$CLAUDE_CMD"
+install_hook codex "$CODEX_CMD"
+install_hook cursor "$CURSOR_CMD"
 # OpenCode generates a plugin and does not accept --hook-bin; Pi has no hooks CLI target.
 install_hook opencode "$OPENCODE_CMD"
 sed 's/^/  /' "$HOOKS_REPORT"

--- a/scripts/demo/stage.sh
+++ b/scripts/demo/stage.sh
@@ -91,12 +91,11 @@ printf 'station-demo-v1\n' >"$DEMO_ROOT/.station-demo-root"
 
 clone_showcase_repo() {
   local name="$1" url="$2" branch="$3" dir="$REPOS/$1"
-  git clone --quiet --depth 1 --filter=blob:none --sparse --branch "$branch" "$url" "$dir"
+  git clone --quiet --depth 1 --sparse --branch "$branch" "$url" "$dir"
   # This non-cone boundary keeps a/b/c/file while pruning a/b/c/d/file.
   git -C "$dir" sparse-checkout set --no-cone '/*' '!/*/*/*/*/'
   git -C "$dir" config user.email "demo@station.local"
   git -C "$dir" config user.name "Station Demo"
-  # Keep the partial clone's promisor fetchable if a demo later expands the sparse boundary.
   git -C "$dir" remote set-url origin "$url"
   echo "  $dir (shallow clone through three directory levels, branch $branch)"
 }

--- a/scripts/demo/stage.sh
+++ b/scripts/demo/stage.sh
@@ -92,13 +92,13 @@ printf 'station-demo-v1\n' >"$DEMO_ROOT/.station-demo-root"
 clone_showcase_repo() {
   local name="$1" url="$2" branch="$3" dir="$REPOS/$1"
   git clone --quiet --depth 1 --filter=blob:none --sparse --branch "$branch" "$url" "$dir"
-  # This non-cone boundary keeps a/b/file while pruning a/b/c/file.
-  git -C "$dir" sparse-checkout set --no-cone '/*' '!/*/*/*/'
+  # This non-cone boundary keeps a/b/c/file while pruning a/b/c/d/file.
+  git -C "$dir" sparse-checkout set --no-cone '/*' '!/*/*/*/*/'
   git -C "$dir" config user.email "demo@station.local"
   git -C "$dir" config user.name "Station Demo"
   # Keep the partial clone's promisor fetchable if a demo later expands the sparse boundary.
   git -C "$dir" remote set-url origin "$url"
-  echo "  $dir (shallow clone through two directory levels, branch $branch)"
+  echo "  $dir (shallow clone through three directory levels, branch $branch)"
 }
 
 add_worktree_from_repo() {
@@ -426,7 +426,7 @@ Launch the full isolated workspace:
 
 What is staged:
   • 5 projects and 17 branch worktrees
-  • linux, ghostty, svelte, and is-even are shallow clones materialized through two directory levels
+  • linux, ghostty, svelte, and is-even are shallow clones materialized through three directory levels
   • project defaults: linux=claude, ghostty=codex, svelte=opencode, is-even=pi, t3-code=cursor
   • rows remain agent-free until you open one; New Session can explicitly choose any configured harness
   • $REPOS/web is intentionally unconfigured for the Add Project flow

--- a/scripts/demo/stage.sh
+++ b/scripts/demo/stage.sh
@@ -1,43 +1,123 @@
 #!/usr/bin/env bash
-# Stage a self-contained Station demo for screenshots / recordings.
-#
-# Creates example repos with a planted diff + a runnable task, writes an
-# ISOLATED observer config, and checks demo dependencies. Everything lives under
-# $STATION_DEMO_ROOT (default ~/.station-demo) and never touches your real
-# ~/.config/station or ~/.local/state/station. Launch with:
-#
-#   stn --config "$STATION_DEMO_ROOT/config.toml"
-#
-# Tear it all down with scripts/demo/reset.sh.
+# Stage the isolated multi-repository Station demo used for screenshots and tours.
 set -euo pipefail
 
-DEMO_ROOT="${STATION_DEMO_ROOT:-$HOME/.station-demo}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+DEMO_ROOT="$(canonicalize_demo_root "${STATION_DEMO_ROOT:-$HOME/.station-demo}")"
 REPOS="$DEMO_ROOT/repos"
 WORKTREES="$DEMO_ROOT/worktrees"
 STATE="$DEMO_ROOT/state"
 CONFIG="$DEMO_ROOT/config.toml"
+RUNNER="$DEMO_ROOT/run.sh"
+HOOKS_REPORT="$DEMO_ROOT/hooks.txt"
+WORKTRUNK_CONFIG="$DEMO_ROOT/worktrunk/config.toml"
+CODEX_DEMO_HOME="$DEMO_ROOT/codex-home"
+CLAUDE_DEMO_HOME="$DEMO_ROOT/claude-home"
+CURSOR_DEMO_HOME="$DEMO_ROOT/cursor-home"
+OPENCODE_DEMO_HOME="$DEMO_ROOT/opencode-home"
+STN="${STATION_DEMO_STN:-$ROOT/bin/stn}"
+HOOK_BIN="${STATION_DEMO_HOOK_BIN:-$ROOT/bin/stn-ingress}"
+
+CLAUDE_CMD="${STATION_CLAUDE_BIN:-claude}"
+CODEX_CMD="${STATION_CODEX_BIN:-codex}"
+CURSOR_CMD="${STATION_CURSOR_AGENT_BIN:-agent}"
+OPENCODE_CMD="${STATION_OPENCODE_BIN:-opencode}"
+PI_CMD="${STATION_PI_BIN:-pi}"
+
+require_toml_safe_value "Demo root" "$DEMO_ROOT"
+require_toml_safe_value "Claude command" "$CLAUDE_CMD"
+require_toml_safe_value "Codex command" "$CODEX_CMD"
+require_toml_safe_value "Cursor command" "$CURSOR_CMD"
+require_toml_safe_value "OpenCode command" "$OPENCODE_CMD"
+require_toml_safe_value "Pi command" "$PI_CMD"
 
 step() { printf '\n==> %s\n' "$1"; }
 
+have_tool() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+stn_demo() {
+  PATH="$ROOT/bin:$PATH" \
+    STATION_CONFIG_PATH="$CONFIG" \
+    STATION_OBSERVER_SOCKET_PATH="$STATE/run/observer.sock" \
+    STATION_LAYOUT_PATH="$STATE/station/layout.json" \
+    CODEX_HOME="$CODEX_DEMO_HOME" \
+    CLAUDE_CONFIG_DIR="$CLAUDE_DEMO_HOME" \
+    STATION_CURSOR_HOME="$CURSOR_DEMO_HOME" \
+    OPENCODE_CONFIG_DIR="$OPENCODE_DEMO_HOME" \
+    "$STN" --config "$CONFIG" "$@"
+}
+
 step "Checking demo dependencies"
 missing=()
-for tool in stn git wt tmux diffnav delta; do
-  command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+for tool in git node wt tmux diffnav delta lsof; do
+  have_tool "$tool" || missing+=("$tool")
 done
+[ -x "$STN" ] || missing+=("$STN")
+[ -x "$HOOK_BIN" ] || missing+=("$HOOK_BIN")
+if [ -z "${STATION_DEMO_STN:-}" ]; then
+  [ -f "$ROOT/apps/cli/dist/main.js" ] || missing+=("apps/cli/dist/main.js")
+  [ -f "$ROOT/apps/cli/dist/ingressMain.js" ] || missing+=("apps/cli/dist/ingressMain.js")
+  have_tool bun || missing+=("bun")
+  [ -d "$ROOT/station/node_modules" ] || missing+=("station/node_modules")
+fi
+if [ "${#missing[@]}" -ne 0 ]; then
+  printf 'Missing demo dependencies:\n' >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  echo "Run pnpm build, (cd station && bun install), and install the tools in Brewfile." >&2
+  exit 1
+fi
+echo "  core tools: ok"
+
 harness_missing=()
-for tool in claude codex; do
-  command -v "$tool" >/dev/null 2>&1 || harness_missing+=("$tool")
+for tool in "$CLAUDE_CMD" "$CODEX_CMD" "$CURSOR_CMD" "$OPENCODE_CMD" "$PI_CMD"; do
+  have_tool "$tool" || harness_missing+=("$tool")
 done
-[ "${#missing[@]}" -eq 0 ] && echo "  core tools: ok" || echo "  MISSING core tools: ${missing[*]}  (run: brew bundle --file Brewfile)"
-[ "${#harness_missing[@]}" -eq 0 ] && echo "  harnesses: claude, codex present" || echo "  harnesses not found: ${harness_missing[*]}  (the new-session flow needs at least one installed + logged in)"
+if [ "${#harness_missing[@]}" -eq 0 ]; then
+  echo "  harnesses: claude, codex, cursor, opencode, pi present"
+else
+  echo "  harnesses not found: ${harness_missing[*]}"
+  echo "  staging will continue; install and sign in before launching those assignments"
+fi
 
 step "Resetting demo root: $DEMO_ROOT"
-rm -rf "$DEMO_ROOT"
-mkdir -p "$REPOS" "$WORKTREES" "$STATE"
+STATION_DEMO_ROOT="$DEMO_ROOT" STATION_DEMO_STN="$STN" "$SCRIPT_DIR/reset.sh" >/dev/null
+mkdir -p "$REPOS" "$WORKTREES" "$STATE/run" "$STATE/station" "$(dirname "$WORKTRUNK_CONFIG")"
+printf 'station-demo-v1\n' >"$DEMO_ROOT/.station-demo-root"
 
-# A git repo with main committed, then a planted uncommitted diff + untracked
-# file so the default "See diff" automation has something to render, plus an
-# executable check.sh for the "split a pane to run a command" flow.
+clone_showcase_repo() {
+  local name="$1" url="$2" branch="$3" dir="$REPOS/$1"
+  git clone --quiet --depth 1 --filter=blob:none --sparse --branch "$branch" "$url" "$dir"
+  # This non-cone boundary keeps a/b/file while pruning a/b/c/file.
+  git -C "$dir" sparse-checkout set --no-cone '/*' '!/*/*/*/'
+  git -C "$dir" config user.email "demo@station.local"
+  git -C "$dir" config user.name "Station Demo"
+  # Keep the partial clone's promisor fetchable if a demo later expands the sparse boundary.
+  git -C "$dir" remote set-url origin "$url"
+  echo "  $dir (shallow clone through two directory levels, branch $branch)"
+}
+
+add_worktree_from_repo() {
+  local repo_dir="$1" group="$2" branch="$3" base="$4" demo_file="$5" note="$6"
+  local path="$WORKTREES/$group/${branch//\//-}"
+  mkdir -p "$(dirname "$path")"
+  git -C "$repo_dir" worktree add --quiet -b "$branch" "$path" "$base"
+  if [ -f "$path/$demo_file" ]; then
+    printf '\n<!-- Station demo: %s -->\n' "$note" >>"$path/$demo_file"
+  fi
+  printf '# Station demo notes\n\n%s\n' "$note" >"$path/STATION_DEMO_NOTES.md"
+  echo "  $path ($branch)"
+}
+
+add_showcase_worktree() {
+  local repo="$1" branch="$2" base="$3" demo_file="$4" note="$5"
+  add_worktree_from_repo "$REPOS/$repo" "$repo" "$branch" "$base" "$demo_file" "$note"
+}
+
 seed_repo() {
   local name="$1" file="$2" original="$3" edited="$4" untracked_name="$5" untracked_body="$6"
   local dir="$REPOS/$name"
@@ -52,55 +132,147 @@ seed_repo() {
 #!/usr/bin/env bash
 set -e
 echo "running checks…"
-node -e "const isEven=require('./is-even.js'); console.log('is-even(4)=', isEven(4), '| is-even(7)=', isEven(7));" 2>/dev/null || true
+node -e "const isEven=require('./is-even.js'); console.log('is-even(4)=', isEven(4), '| is-even(7)=', isEven(7));"
 echo "ok ✓"
 CHECK
     chmod +x check.sh
     printf '# %s\n\nDemo project for Station.\n' "$name" >README.md
     git add -A
     git commit -q -m "init $name"
-    # Plant the working-tree diff (shown by See diff) — keep it small + readable.
     printf '%s\n' "$edited" >"$file"
     printf '%s\n' "$untracked_body" >"$untracked_name"
   )
-  echo "  $dir (planted diff in $file + untracked $untracked_name)"
+  echo "  $dir (planted diff in $file and untracked $untracked_name)"
 }
 
-step "Creating example repos under $REPOS"
-# is-even: configured below, and on-brand with the mock showcase. The diff is the
-# joke — an O(n) loop collapsing to a one-liner.
-seed_repo "is-even" "is-even.js" \
-  "module.exports = function isEven(n) {
-  // O(n): toggle a flag n times. do not ship this.
-  let even = true;
-  for (let i = 0; i < Math.abs(n); i++) even = !even;
-  return even;
-};" \
-  "module.exports = function isEven(n) {
-  // O(1).
-  return n % 2 === 0;
-};" \
-  "BENCHMARK.md" "# Benchmark
+t3_project_path() {
+  case "$1" in
+    web) printf 'apps/web' ;;
+    api) printf 'apps/api' ;;
+    auth) printf 'packages/auth' ;;
+    db) printf 'packages/db' ;;
+    billing) printf 'packages/billing' ;;
+    ai) printf 'packages/ai' ;;
+    mobile) printf 'apps/mobile' ;;
+    admin) printf 'apps/admin' ;;
+    worker) printf 'packages/worker' ;;
+    docs) printf 'apps/docs' ;;
+    *) return 1 ;;
+  esac
+}
 
-Before: O(n) — ~3 evens/sec at n=1e9.
-After:  O(1) — yes."
+seed_t3_project_files() {
+  local name="$1" harness="$2" title="$3" dir
+  dir="$REPOS/t3-code/$(t3_project_path "$name")"
+  mkdir -p "$dir/scripts" "$dir/src"
+  printf '{"name":"@t3-code/%s","private":true,"type":"module","scripts":{"check":"node scripts/check.mjs"}}\n' "$name" >"$dir/package.json"
+  printf 'console.log("checking @t3-code/%s");\nconsole.log("suggested harness: %s");\n' "$name" "$harness" >"$dir/scripts/check.mjs"
+  cat >"$dir/src/index.ts" <<TS
+export const service = "$name";
+export const suggestedHarness = "$harness";
 
-# web: intentionally NOT added to the config, so you can demo "Add project".
-seed_repo "web" "is-even.js" \
+export function describe() {
+  return "$title";
+}
+TS
+  printf '# t3-code/%s\n\n%s\n' "$name" "$title" >"$dir/README.md"
+}
+
+seed_t3_repo() {
+  local dir="$REPOS/t3-code"
+  mkdir -p "$dir"
+  (
+    cd "$dir"
+    git init -q -b main
+    git config user.email "demo@station.local"
+    git config user.name "Station Demo"
+    printf '{"name":"t3-code","private":true,"type":"module","workspaces":["apps/*","packages/*"]}\n' >package.json
+    printf 'packages:\n  - "apps/*"\n  - "packages/*"\n' >pnpm-workspace.yaml
+    printf '# t3-code\n\nDemo monorepo with app and package projects.\n' >README.md
+  )
+  seed_t3_project_files web claude "Next.js app shell for the T3 code workspace."
+  seed_t3_project_files api codex "Typed RPC API boundary for the T3 code workspace."
+  seed_t3_project_files auth opencode "OAuth and session handling for the T3 code workspace."
+  seed_t3_project_files db pi "Drizzle schema and migration package for the T3 code workspace."
+  seed_t3_project_files billing claude "Stripe usage metering service for the T3 code workspace."
+  seed_t3_project_files ai codex "AI interaction package for the T3 code workspace."
+  seed_t3_project_files mobile opencode "Mobile companion app for the T3 code workspace."
+  seed_t3_project_files admin pi "Admin console for the T3 code workspace."
+  seed_t3_project_files worker cursor "Background worker package for the T3 code workspace."
+  seed_t3_project_files docs cursor "Documentation site for the T3 code workspace."
+  git -C "$dir" add -A
+  git -C "$dir" commit -q -m "init t3-code monorepo"
+}
+
+add_t3_worktree() {
+  local project="$1" branch="$2" note="$3" subdir
+  subdir="$(t3_project_path "$project")"
+  add_worktree_from_repo "$REPOS/t3-code" t3-code "$branch" main "$subdir/README.md" "$note"
+}
+
+append_project_config() {
+  local id="$1" label="$2" root="$3" default_branch="$4" harness="$5"
+  cat >>"$CONFIG" <<TOML
+
+[[projects]]
+id = "$id"
+label = "$label"
+root = "$root"
+default_branch = "$default_branch"
+
+[projects.defaults]
+harness = "$harness"
+terminal = "tmux"
+layout = "agent-shell"
+
+[projects.worktrunk]
+base = "$default_branch"
+TOML
+}
+
+step "Cloning showcase repositories under $REPOS"
+clone_showcase_repo linux https://github.com/torvalds/linux.git master
+clone_showcase_repo ghostty https://github.com/ghostty-org/ghostty.git main
+clone_showcase_repo svelte https://github.com/sveltejs/svelte.git main
+clone_showcase_repo is-even https://github.com/jonschlinkert/is-even.git master
+
+step "Creating seven showcase worktrees under $WORKTREES"
+add_showcase_worktree linux sched/eevdf-latency master README "Experiment with scheduler latency accounting for interactive workloads."
+add_showcase_worktree linux fix/cifs-null-deref master README "Tighten CIFS mount teardown around a nullable server response."
+add_showcase_worktree linux mm/folio-reclaim-trace master README "Trace folio reclaim pressure around interactive filesystem workloads."
+add_showcase_worktree ghostty feat/kitty-graphics main README.md "Prototype broader kitty graphics protocol coverage in the renderer."
+add_showcase_worktree ghostty perf/glyph-atlas-cache main README.md "Tune glyph atlas cache reuse for dense terminal redraws."
+add_showcase_worktree svelte compiler/ssr-hydration main README.md "Exercise SSR hydration mismatch diagnostics in the compiler."
+add_showcase_worktree is-even perf/constant-time-evenness master README.md "Replace iterative evenness checks with a constant-time implementation note."
+
+step "Creating t3-code and ten branch worktrees"
+seed_t3_repo
+add_t3_worktree web feat-server-actions "Wire server actions through the dashboard entry flow."
+add_t3_worktree api perf-router-cache "Tune router-level caching for repeated list queries."
+add_t3_worktree auth fix-oauth-refresh "Patch token refresh behavior after provider reconnects."
+add_t3_worktree db chore-drizzle-indexes "Add indexes around the newest activity queries."
+add_t3_worktree billing feat-usage-metering "Prototype usage rollups for metered workspaces."
+add_t3_worktree ai experiment-streaming-ui "Exercise streaming response state across route transitions."
+add_t3_worktree mobile feat-offline-sync "Stage offline sync recovery for background edits."
+add_t3_worktree admin polish-audit-log "Improve audit-log scanability for support workflows."
+add_t3_worktree docs a11y/playbook-refresh "Refresh onboarding playbooks around environment setup."
+add_t3_worktree worker async/queue-retry-backoff "Harden queue retry backoff for flaky webhook deliveries."
+
+step "Creating the add-project fixture under $REPOS/web"
+seed_repo web is-even.js \
   "module.exports = function isEven(n) { return !(n & 1); };" \
   "module.exports = function isEven(n) { return n % 2 === 0; };" \
-  "TODO.md" "# TODO
+  TODO.md "# TODO
 - [ ] wire up the dashboard
 - [ ] dark mode"
-echo "  note: 'web' is staged but left OUT of the config — use it for the Add-Project demo."
 
-step "Writing isolated config: $CONFIG"
+step "Writing isolated Station config: $CONFIG"
 cat >"$CONFIG" <<TOML
 schema_version = 1
 
 [observer]
 auto_start = true
-socket_path = "$STATE/observer.sock"
+socket_path = "$STATE/run/observer.sock"
 state_dir = "$STATE"
 
 [defaults]
@@ -109,15 +281,19 @@ terminal = "tmux"
 harness = "codex"
 layout = "agent-shell"
 default_branch = "main"
-harness_permission_mode = "yolo"
+harness_permission_mode = "standard"
+
+[feature_flags]
+station_persistent_agents = true
 
 [worktree.worktrunk]
 command = "wt"
+config_path = "$WORKTRUNK_CONFIG"
 managed_root = "$WORKTREES"
 base = "main"
-include_main = true
+include_main = false
 include_external = false
-use_lifecycle_hooks = false
+use_lifecycle_hooks = true
 
 [terminal.tmux]
 session_prefix = "stationdemo"
@@ -126,38 +302,137 @@ workbench_session = "stationdemo"
 
 [harness.claude]
 enabled = true
-command = "claude"
+command = "$CLAUDE_CMD"
 install_hooks = true
 
 [harness.codex]
 enabled = true
-command = "codex"
+command = "$CODEX_CMD"
 install_hooks = true
 
-[[projects]]
-id = "is-even"
-label = "is-even"
-root = "$REPOS/is-even"
+[harness.cursor]
+enabled = true
+command = "$CURSOR_CMD"
+install_hooks = true
 
-[projects.commands]
-test = "./check.sh"
+[harness.opencode]
+enabled = true
+command = "$OPENCODE_CMD"
+install_hooks = true
+
+[harness.pi]
+enabled = true
+command = "$PI_CMD"
+
+[repository.github]
+enabled = false
 TOML
+
+append_project_config linux linux "$REPOS/linux" master claude
+append_project_config ghostty ghostty "$REPOS/ghostty" main codex
+append_project_config svelte svelte "$REPOS/svelte" main opencode
+append_project_config is-even is-even "$REPOS/is-even" master pi
+append_project_config t3-code t3-code "$REPOS/t3-code" main cursor
+
+step "Preparing isolated provider homes"
+mkdir -p "$CODEX_DEMO_HOME" "$CLAUDE_DEMO_HOME" "$CURSOR_DEMO_HOME" "$OPENCODE_DEMO_HOME"
+[ -e "$HOME/.codex/auth.json" ] && ln -s "$HOME/.codex/auth.json" "$CODEX_DEMO_HOME/auth.json"
+[ -e "$HOME/.codex/config.toml" ] && cp "$HOME/.codex/config.toml" "$CODEX_DEMO_HOME/config.toml"
+
+seed_cursor_link() {
+  [ -e "$1" ] || return 0
+  mkdir -p "$(dirname "$2")"
+  ln -s "$1" "$2"
+}
+seed_cursor_link "$HOME/.gitconfig" "$CURSOR_DEMO_HOME/.gitconfig"
+seed_cursor_link "$HOME/.git-credentials" "$CURSOR_DEMO_HOME/.git-credentials"
+seed_cursor_link "$HOME/.ssh" "$CURSOR_DEMO_HOME/.ssh"
+seed_cursor_link "$HOME/.config/git" "$CURSOR_DEMO_HOME/.config/git"
+
+printf -v path_bin '%q' "$ROOT/bin"
+printf -v path_config '%q' "$CONFIG"
+printf -v path_socket '%q' "$STATE/run/observer.sock"
+printf -v path_layout '%q' "$STATE/station/layout.json"
+printf -v path_codex '%q' "$CODEX_DEMO_HOME"
+printf -v path_claude '%q' "$CLAUDE_DEMO_HOME"
+printf -v path_cursor '%q' "$CURSOR_DEMO_HOME"
+printf -v path_opencode '%q' "$OPENCODE_DEMO_HOME"
+printf -v path_stn '%q' "$STN"
+cat >"$RUNNER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export PATH=$path_bin:\$PATH
+export STATION_CONFIG_PATH=$path_config
+export STATION_OBSERVER_SOCKET_PATH=$path_socket
+export STATION_LAYOUT_PATH=$path_layout
+export CODEX_HOME=$path_codex
+export CLAUDE_CONFIG_DIR=$path_claude
+export STATION_CURSOR_HOME=$path_cursor
+export OPENCODE_CONFIG_DIR=$path_opencode
+exec $path_stn --config $path_config tui "\$@"
+EOF
+chmod +x "$RUNNER"
+
+install_hook() {
+  local target="$1" command="$2"
+  shift 2
+  if ! have_tool "$command"; then
+    printf '%s: skipped (%s not found)\n' "$target" "$command" >>"$HOOKS_REPORT"
+    return 0
+  fi
+  if stn_demo hooks install "$target" --yes "$@" >>"$HOOKS_REPORT" 2>&1; then
+    stn_demo hooks doctor "$target" "$@" >>"$HOOKS_REPORT" 2>&1 || true
+    printf '%s: installed\n' "$target" >>"$HOOKS_REPORT"
+  else
+    printf '%s: install failed; see output above\n' "$target" >>"$HOOKS_REPORT"
+  fi
+}
+
+install_required_hook() {
+  local target="$1"
+  shift
+  if ! stn_demo hooks install "$target" --yes "$@" >>"$HOOKS_REPORT" 2>&1; then
+    echo "Required $target hook installation failed; see $HOOKS_REPORT." >&2
+    return 1
+  fi
+  if ! stn_demo hooks doctor "$target" "$@" >>"$HOOKS_REPORT" 2>&1; then
+    echo "Required $target hook doctor failed; see $HOOKS_REPORT." >&2
+    return 1
+  fi
+  printf '%s: installed and verified\n' "$target" >>"$HOOKS_REPORT"
+}
+
+step "Installing isolated provider hooks"
+: >"$HOOKS_REPORT"
+install_required_hook worktrunk --hook-bin "$HOOK_BIN" --worktrunk-config "$WORKTRUNK_CONFIG"
+install_hook claude "$CLAUDE_CMD" --hook-bin "$HOOK_BIN"
+install_hook codex "$CODEX_CMD" --hook-bin "$HOOK_BIN"
+install_hook cursor "$CURSOR_CMD" --hook-bin "$HOOK_BIN"
+# OpenCode generates a plugin and does not accept --hook-bin; Pi has no hooks CLI target.
+install_hook opencode "$OPENCODE_CMD"
+sed 's/^/  /' "$HOOKS_REPORT"
+
+step "Starting isolated observer"
+stn_demo observer start >/dev/null
+stn_demo snapshot --json >/dev/null
 
 cat <<EOF
 
 ────────────────────────────────────────
 Demo staged under $DEMO_ROOT
 
-Launch (isolated — does not touch your real config/state):
-  stn --config "$CONFIG"
+Launch the full isolated workspace:
+  "$RUNNER"
 
-In the dashboard:
-  • is-even shows its main worktree with a planted diff
-  • 'web' is on disk at $REPOS/web — add it live with the Add-Project flow
+What is staged:
+  • 5 projects and 17 branch worktrees
+  • linux, ghostty, svelte, and is-even are shallow clones materialized through two directory levels
+  • project defaults: linux=claude, ghostty=codex, svelte=opencode, is-even=pi, t3-code=cursor
+  • rows remain agent-free until you open one; New Session can explicitly choose any configured harness
+  • $REPOS/web is intentionally unconfigured for the Add Project flow
 
-Hooks for live agent status (optional, needs logged-in harnesses):
-  stn --config "$CONFIG" hooks install claude
-  stn --config "$CONFIG" hooks install codex
+Hook report:
+  $HOOKS_REPORT
 
 Reset everything:
   scripts/demo/reset.sh

--- a/tests/e2e/demo-stage.test.ts
+++ b/tests/e2e/demo-stage.test.ts
@@ -1,0 +1,454 @@
+import { spawnSync } from "node:child_process";
+import {
+  access,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { loadConfig } from "@station/config";
+import { describe, expect, it } from "vitest";
+
+const showcaseRemotes = [
+  { name: "linux", branch: "master", url: "https://github.com/torvalds/linux.git" },
+  { name: "ghostty", branch: "main", url: "https://github.com/ghostty-org/ghostty.git" },
+  { name: "svelte", branch: "main", url: "https://github.com/sveltejs/svelte.git" },
+  { name: "is-even", branch: "master", url: "https://github.com/jonschlinkert/is-even.git" },
+] as const;
+
+describe("demo staging e2e", () => {
+  it("stages the rich demo at bounded depth without touching user state", async () => {
+    const root = await realpath(await mkdtemp("/tmp/stn-demo-e2e-"));
+    const home = join(root, "home");
+    const bin = join(root, "bin");
+    const remotes = join(root, "remotes");
+    const demoRoot = join(root, "demo root");
+    const gitConfig = join(root, "gitconfig");
+    const stnLog = join(root, "stn.log");
+    const lsofPidFile = join(root, "lsof.pid");
+    const ownerHelper = join(root, "socket-owner.mjs");
+    const repoRoot = process.cwd();
+    let ownerPid: number | undefined;
+    let passed = false;
+
+    try {
+      await Promise.all([
+        mkdir(join(home, ".codex"), { recursive: true }),
+        mkdir(join(root, "xdg-config"), { recursive: true }),
+        mkdir(join(root, "xdg-state"), { recursive: true }),
+        mkdir(bin, { recursive: true }),
+        mkdir(remotes, { recursive: true }),
+      ]);
+      await writeFile(join(home, ".codex", "config.toml"), "# user codex config\n", "utf8");
+      await writeFile(join(home, ".gitconfig"), "# user git config\n", "utf8");
+      await writeFile(join(root, "xdg-config", "canary"), "config\n", "utf8");
+      await writeFile(join(root, "xdg-state", "canary"), "state\n", "utf8");
+      await writeFile(gitConfig, "", "utf8");
+
+      for (const remote of showcaseRemotes) {
+        const path = join(remotes, remote.name);
+        await createShowcaseRemote(path, remote.branch);
+        run("git", ["config", "--file", gitConfig, `url.file://${path}.insteadOf`, remote.url], {
+          cwd: root,
+        });
+      }
+
+      for (const name of [
+        "wt",
+        "tmux",
+        "diffnav",
+        "delta",
+        "bun",
+        "claude",
+        "codex",
+        "opencode",
+        "pi",
+        "agent",
+      ]) {
+        await writeShim(bin, name, "exit 0\n");
+      }
+      await writeShim(
+        bin,
+        "lsof",
+        [
+          'pid_file="$STATION_DEMO_LSOF_PID_FILE"',
+          '[ -f "$pid_file" ] || exit 0',
+          'socket=""',
+          'for arg in "$@"; do socket="$arg"; done',
+          '[ -S "$socket" ] || exit 0',
+          'pid=$(cat "$pid_file")',
+          'kill -0 "$pid" >/dev/null 2>&1 || exit 0',
+          "printf '%s\\n' \"$pid\"",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(
+        ownerHelper,
+        [
+          'import { unlinkSync, writeFileSync } from "node:fs";',
+          'import { createServer } from "node:net";',
+          "const arg = (name) => process.argv[process.argv.indexOf(name) + 1];",
+          'const socketPath = arg("--socket");',
+          'const readyPath = arg("--ready");',
+          'const exitedPath = arg("--exited");',
+          "const server = createServer(() => undefined);",
+          "let stopping = false;",
+          "const stop = () => {",
+          "  if (stopping) return;",
+          "  stopping = true;",
+          "  server.close();",
+          "  try { unlinkSync(socketPath); } catch {}",
+          '  setTimeout(() => { writeFileSync(exitedPath, "exited\\n"); process.exit(0); }, 500);',
+          "};",
+          'server.listen(socketPath, () => writeFileSync(readyPath, "ready\\n"));',
+          'process.on("SIGTERM", stop);',
+          'process.on("SIGINT", stop);',
+          "setInterval(() => undefined, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      const fakeStn = await writeShim(
+        bin,
+        "demo-stn",
+        [
+          'log="$STATION_DEMO_STN_LOG"',
+          "{",
+          "  printf 'args=%s\\n' \"$*\"",
+          "  printf 'config=%s\\n' \"$STATION_CONFIG_PATH\"",
+          "  printf 'socket=%s\\n' \"$STATION_OBSERVER_SOCKET_PATH\"",
+          "  printf 'layout=%s\\n' \"$STATION_LAYOUT_PATH\"",
+          "  printf 'codex=%s\\n' \"$CODEX_HOME\"",
+          "  printf 'claude=%s\\n' \"$CLAUDE_CONFIG_DIR\"",
+          "  printf 'cursor=%s\\n' \"$STATION_CURSOR_HOME\"",
+          "  printf 'opencode=%s\\n' \"$OPENCODE_CONFIG_DIR\"",
+          '} >> "$log"',
+          'if [ "$STATION_DEMO_FAIL_WORKTRUNK" = "1" ]; then',
+          '  case "$*" in *"hooks install worktrunk"*) exit 42 ;; esac',
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
+      );
+      const fakeIngress = await writeShim(bin, "demo-stn-ingress", "exit 0\n");
+
+      const env = cleanGitEnvironment({
+        ...process.env,
+        HOME: home,
+        XDG_CONFIG_HOME: join(root, "xdg-config"),
+        XDG_STATE_HOME: join(root, "xdg-state"),
+        GIT_CONFIG_GLOBAL: gitConfig,
+        GIT_CONFIG_NOSYSTEM: "1",
+        PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+        STATION_DEMO_ROOT: demoRoot,
+        STATION_DEMO_STN: fakeStn,
+        STATION_DEMO_HOOK_BIN: fakeIngress,
+        STATION_DEMO_STN_LOG: stnLog,
+        STATION_DEMO_LSOF_PID_FILE: lsofPidFile,
+      });
+
+      run(join(repoRoot, "scripts/demo/stage.sh"), [], { cwd: repoRoot, env });
+
+      for (const relativePath of ["root.txt", "one/one.txt", "one/two/two.txt"]) {
+        await expect(
+          access(join(demoRoot, "repos", "linux", relativePath)),
+        ).resolves.toBeUndefined();
+        await expect(
+          access(join(demoRoot, "worktrees", "linux", "sched-eevdf-latency", relativePath)),
+        ).resolves.toBeUndefined();
+      }
+      await expect(
+        access(join(demoRoot, "repos", "linux", "one/two/three/three.txt")),
+      ).rejects.toThrow();
+      await expect(
+        access(
+          join(demoRoot, "worktrees", "linux", "sched-eevdf-latency", "one/two/three/three.txt"),
+        ),
+      ).rejects.toThrow();
+      expect(
+        run("git", ["rev-parse", "--is-shallow-repository"], {
+          cwd: join(demoRoot, "repos", "linux"),
+          env,
+        }).stdout.trim(),
+      ).toBe("true");
+      expect(
+        run("git", ["config", "--local", "--get", "remote.origin.url"], {
+          cwd: join(demoRoot, "repos", "linux"),
+          env,
+        }).stdout.trim(),
+      ).toBe(showcaseRemotes[0].url);
+      const worktreeCounts = await Promise.all(
+        ["linux", "ghostty", "svelte", "is-even", "t3-code"].map(async (project) =>
+          (await readdir(join(demoRoot, "worktrees", project), { withFileTypes: true })).filter(
+            (entry) => entry.isDirectory(),
+          ),
+        ),
+      );
+      expect(worktreeCounts.map((entries) => entries.length)).toEqual([3, 2, 1, 1, 10]);
+
+      const configPath = join(demoRoot, "config.toml");
+      const source = await readFile(configPath, "utf8");
+      const loaded = await loadConfig({ configPath, homeDir: home });
+      expect(loaded.config.observer).toMatchObject({
+        socketPath: join(demoRoot, "state", "run", "observer.sock"),
+        stateDir: join(demoRoot, "state"),
+      });
+      expect(loaded.config.worktree?.worktrunk?.managedRoot).toBe(join(demoRoot, "worktrees"));
+      expect(loaded.config.repository?.github?.enabled).toBe(false);
+      expect(loaded.config.featureFlags?.stationPersistentAgents).toBe(true);
+      expect(
+        Object.fromEntries(
+          loaded.config.projects.map((project) => [project.id, project.defaults.harness]),
+        ),
+      ).toEqual({
+        linux: "claude",
+        ghostty: "codex",
+        svelte: "opencode",
+        "is-even": "pi",
+        "t3-code": "cursor",
+      });
+      expect(
+        Object.fromEntries(
+          loaded.config.projects.map((project) => [project.id, project.worktrunk?.base]),
+        ),
+      ).toEqual({
+        linux: "master",
+        ghostty: "main",
+        svelte: "main",
+        "is-even": "master",
+        "t3-code": "main",
+      });
+      expect(loaded.config.projects.every((project) => project.root.startsWith(demoRoot))).toBe(
+        true,
+      );
+      expect(source).not.toContain("worktree_launches");
+      expect(source).not.toContain("harness.crush");
+      await expect(
+        access(join(demoRoot, "repos", "t3-code", "apps/web/src/index.ts")),
+      ).resolves.toBeUndefined();
+
+      run(join(demoRoot, "run.sh"), [], { cwd: root, env });
+      const stnCalls = await readFile(stnLog, "utf8");
+      expect(stnCalls).toContain(`args=--config ${configPath} tui`);
+      expect(stnCalls).toContain(`config=${configPath}`);
+      expect(stnCalls).toContain(`socket=${join(demoRoot, "state", "run", "observer.sock")}`);
+      expect(stnCalls).toContain(`layout=${join(demoRoot, "state", "station", "layout.json")}`);
+      expect(stnCalls).toContain(`codex=${join(demoRoot, "codex-home")}`);
+      expect(stnCalls).toContain(`claude=${join(demoRoot, "claude-home")}`);
+      expect(stnCalls).toContain(`cursor=${join(demoRoot, "cursor-home")}`);
+      expect(stnCalls).toContain(`opencode=${join(demoRoot, "opencode-home")}`);
+      expect(stnCalls).toContain(
+        `args=--config ${configPath} hooks install worktrunk --yes --hook-bin ${fakeIngress} --worktrunk-config ${join(demoRoot, "worktrunk", "config.toml")}`,
+      );
+      expect(stnCalls).toContain(
+        `args=--config ${configPath} hooks doctor worktrunk --hook-bin ${fakeIngress} --worktrunk-config ${join(demoRoot, "worktrunk", "config.toml")}`,
+      );
+      expect(stnCalls).toContain(`args=--config ${configPath} hooks install opencode --yes\n`);
+
+      const ownerReady = join(root, "owner.ready");
+      const ownerExited = join(root, "owner.exited");
+      const ownerSocket = join(demoRoot, "state", "run", "observer.sock");
+      ownerPid = Number(
+        run(
+          "/bin/sh",
+          [
+            "-c",
+            'exec "$@" >/dev/null 2>&1 & echo $!',
+            "station-demo-owner",
+            process.execPath,
+            ownerHelper,
+            "__observer",
+            "--socket",
+            ownerSocket,
+            "--state-dir",
+            join(demoRoot, "state"),
+            "--ready",
+            ownerReady,
+            "--exited",
+            ownerExited,
+          ],
+          { cwd: root, env },
+        ).stdout.trim(),
+      );
+      expect(Number.isInteger(ownerPid)).toBe(true);
+      await writeFile(lsofPidFile, `${ownerPid}\n`, "utf8");
+      await waitForFile(ownerReady);
+
+      run(join(repoRoot, "scripts/demo/reset.sh"), [], { cwd: repoRoot, env });
+      await expect(readFile(ownerExited, "utf8")).resolves.toBe("exited\n");
+      ownerPid = undefined;
+      await expect(access(demoRoot)).rejects.toThrow();
+      await expect(readFile(join(home, ".codex", "config.toml"), "utf8")).resolves.toBe(
+        "# user codex config\n",
+      );
+      await expect(readFile(join(home, ".gitconfig"), "utf8")).resolves.toBe("# user git config\n");
+      await expect(readFile(join(root, "xdg-config", "canary"), "utf8")).resolves.toBe("config\n");
+      await expect(readFile(join(root, "xdg-state", "canary"), "utf8")).resolves.toBe("state\n");
+
+      const unmarkedRoot = join(root, "unmarked-custom-root");
+      await mkdir(unmarkedRoot);
+      await writeFile(join(unmarkedRoot, "canary"), "keep\n", "utf8");
+      const refusedReset = run(join(repoRoot, "scripts/demo/reset.sh"), [], {
+        cwd: repoRoot,
+        env: { ...env, STATION_DEMO_ROOT: unmarkedRoot },
+        allowFailure: true,
+      });
+      expect(refusedReset.status).not.toBe(0);
+      await expect(readFile(join(unmarkedRoot, "canary"), "utf8")).resolves.toBe("keep\n");
+
+      const forgedRoot = join(root, "forged-socket-root");
+      const externalTarget = join(root, "external-socket-target");
+      await mkdir(join(forgedRoot, "state", "run"), { recursive: true });
+      await writeFile(join(forgedRoot, ".station-demo-root"), "station-demo-v1\n", "utf8");
+      await writeFile(externalTarget, "external\n", "utf8");
+      await symlink(externalTarget, join(forgedRoot, "state", "run", "observer.sock"));
+      const refusedSymlink = run(join(repoRoot, "scripts/demo/reset.sh"), [], {
+        cwd: repoRoot,
+        env: { ...env, STATION_DEMO_ROOT: forgedRoot },
+        allowFailure: true,
+      });
+      expect(refusedSymlink.status).not.toBe(0);
+      await expect(readFile(externalTarget, "utf8")).resolves.toBe("external\n");
+      await expect(access(forgedRoot)).resolves.toBeUndefined();
+
+      const victimRoot = join(root, "victim");
+      await mkdir(victimRoot);
+      await writeFile(join(victimRoot, "canary"), "victim\n", "utf8");
+      const refusedTraversal = run(join(repoRoot, "scripts/demo/reset.sh"), [], {
+        cwd: repoRoot,
+        env: { ...env, STATION_DEMO_ROOT: `${root}/missing/../victim` },
+        allowFailure: true,
+      });
+      expect(refusedTraversal.status).not.toBe(0);
+      await expect(readFile(join(victimRoot, "canary"), "utf8")).resolves.toBe("victim\n");
+
+      const unsafeTomlRoot = `${root}/unsafe"root`;
+      const refusedUnsafeToml = run(join(repoRoot, "scripts/demo/stage.sh"), [], {
+        cwd: repoRoot,
+        env: { ...env, STATION_DEMO_ROOT: unsafeTomlRoot },
+        allowFailure: true,
+      });
+      expect(refusedUnsafeToml.status).not.toBe(0);
+      await expect(access(unsafeTomlRoot)).rejects.toThrow();
+
+      const failedHookRoot = join(root, "failed-worktrunk-hook");
+      const failedHookLog = join(root, "failed-worktrunk-hook.log");
+      const failedHookStage = run(join(repoRoot, "scripts/demo/stage.sh"), [], {
+        cwd: repoRoot,
+        env: {
+          ...env,
+          STATION_DEMO_ROOT: failedHookRoot,
+          STATION_DEMO_STN_LOG: failedHookLog,
+          STATION_DEMO_FAIL_WORKTRUNK: "1",
+        },
+        allowFailure: true,
+      });
+      expect(failedHookStage.status).not.toBe(0);
+      expect(await readFile(failedHookLog, "utf8")).not.toContain("observer start");
+      passed = true;
+    } finally {
+      if (ownerPid !== undefined) {
+        try {
+          process.kill(ownerPid, "SIGKILL");
+        } catch {}
+      }
+      if (passed || process.env.STATION_KEEP_DEMO_E2E_TEMP !== "1") {
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+});
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    try {
+      await access(path);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+  }
+  throw new Error(`Timed out waiting for ${path}`);
+}
+
+async function createShowcaseRemote(path: string, branch: string): Promise<void> {
+  await Promise.all([
+    mkdir(join(path, "one", "two", "three"), { recursive: true }),
+    mkdir(join(path, "other"), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(path, "README"), "Fixture repository.\n", "utf8"),
+    writeFile(join(path, "README.md"), "# Fixture repository\n", "utf8"),
+    writeFile(join(path, "root.txt"), "root\n", "utf8"),
+    writeFile(join(path, "one", "one.txt"), "one\n", "utf8"),
+    writeFile(join(path, "one", "two", "two.txt"), "two\n", "utf8"),
+    writeFile(join(path, "one", "two", "three", "three.txt"), "three\n", "utf8"),
+    writeFile(join(path, "other", "other.txt"), "other\n", "utf8"),
+  ]);
+  run("git", ["init", "-q", "-b", branch], { cwd: path });
+  run("git", ["add", "-A"], { cwd: path });
+  run(
+    "git",
+    ["-c", "user.name=Demo", "-c", "user.email=demo@example.com", "commit", "-qm", "initial"],
+    { cwd: path },
+  );
+  await writeFile(join(path, "root.txt"), "root second commit\n", "utf8");
+  run("git", ["add", "root.txt"], { cwd: path });
+  run(
+    "git",
+    ["-c", "user.name=Demo", "-c", "user.email=demo@example.com", "commit", "-qm", "second"],
+    { cwd: path },
+  );
+  run("git", ["config", "uploadpack.allowFilter", "true"], { cwd: path });
+}
+
+async function writeShim(bin: string, name: string, body: string): Promise<string> {
+  const path = join(bin, name);
+  await writeFile(path, `#!/bin/sh\n${body}`, "utf8");
+  await chmod(path, 0o700);
+  return path;
+}
+
+function cleanGitEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result = { ...env };
+  for (const name of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  ]) {
+    delete result[name];
+  }
+  return result;
+}
+
+function run(
+  command: string,
+  args: string[],
+  options: { cwd: string; env?: NodeJS.ProcessEnv; allowFailure?: boolean },
+): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  if (options.allowFailure !== true && result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with ${result.status}\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+  return {
+    stdout: result.stdout,
+    stderr: result.stderr,
+    status: result.status,
+  };
+}

--- a/tests/e2e/demo-stage.test.ts
+++ b/tests/e2e/demo-stage.test.ts
@@ -129,8 +129,8 @@ describe("demo staging e2e", () => {
           "  printf 'cursor=%s\\n' \"$STATION_CURSOR_HOME\"",
           "  printf 'opencode=%s\\n' \"$OPENCODE_CONFIG_DIR\"",
           '} >> "$log"',
-          'if [ "$STATION_DEMO_FAIL_WORKTRUNK" = "1" ]; then',
-          '  case "$*" in *"hooks install worktrunk"*) exit 42 ;; esac',
+          `if [ -n "\${STATION_DEMO_FAIL_HOOK_TARGET:-}" ]; then`,
+          '  case "$*" in *"hooks doctor $STATION_DEMO_FAIL_HOOK_TARGET"*) exit 42 ;; esac',
           "fi",
           "exit 0",
           "",
@@ -265,9 +265,16 @@ describe("demo staging e2e", () => {
         `args=--config ${configPath} hooks install worktrunk --yes --hook-bin ${fakeIngress} --worktrunk-config ${join(demoRoot, "worktrunk", "config.toml")}`,
       );
       expect(stnCalls).toContain(
-        `args=--config ${configPath} hooks doctor worktrunk --hook-bin ${fakeIngress} --worktrunk-config ${join(demoRoot, "worktrunk", "config.toml")}`,
+        `args=--config ${configPath} hooks doctor worktrunk --worktrunk-config ${join(demoRoot, "worktrunk", "config.toml")}`,
       );
+      expect(stnCalls).toContain(
+        `args=--config ${configPath} hooks install codex --yes --hook-bin ${fakeIngress}`,
+      );
+      expect(stnCalls).toContain(`args=--config ${configPath} hooks doctor codex\n`);
       expect(stnCalls).toContain(`args=--config ${configPath} hooks install opencode --yes\n`);
+      await expect(readFile(join(demoRoot, "hooks.txt"), "utf8")).resolves.toContain(
+        "codex: installed and runtime-verified",
+      );
 
       const ownerReady = join(root, "owner.ready");
       const ownerExited = join(root, "owner.exited");
@@ -355,15 +362,15 @@ describe("demo staging e2e", () => {
       expect(refusedUnsafeToml.status).not.toBe(0);
       await expect(access(unsafeTomlRoot)).rejects.toThrow();
 
-      const failedHookRoot = join(root, "failed-worktrunk-hook");
-      const failedHookLog = join(root, "failed-worktrunk-hook.log");
+      const failedHookRoot = join(root, "failed-provider-hook");
+      const failedHookLog = join(root, "failed-provider-hook.log");
       const failedHookStage = run(join(repoRoot, "scripts/demo/stage.sh"), [], {
         cwd: repoRoot,
         env: {
           ...env,
           STATION_DEMO_ROOT: failedHookRoot,
           STATION_DEMO_STN_LOG: failedHookLog,
-          STATION_DEMO_FAIL_WORKTRUNK: "1",
+          STATION_DEMO_FAIL_HOOK_TARGET: "codex",
         },
         allowFailure: true,
       });

--- a/tests/e2e/demo-stage.test.ts
+++ b/tests/e2e/demo-stage.test.ts
@@ -189,6 +189,13 @@ describe("demo staging e2e", () => {
         }).stdout.trim(),
       ).toBe("true");
       expect(
+        run("git", ["config", "--local", "--get", "remote.origin.promisor"], {
+          cwd: join(demoRoot, "repos", "linux"),
+          env,
+          allowFailure: true,
+        }).status,
+      ).not.toBe(0);
+      expect(
         run("git", ["config", "--local", "--get", "remote.origin.url"], {
           cwd: join(demoRoot, "repos", "linux"),
           env,

--- a/tests/e2e/demo-stage.test.ts
+++ b/tests/e2e/demo-stage.test.ts
@@ -155,7 +155,12 @@ describe("demo staging e2e", () => {
 
       run(join(repoRoot, "scripts/demo/stage.sh"), [], { cwd: repoRoot, env });
 
-      for (const relativePath of ["root.txt", "one/one.txt", "one/two/two.txt"]) {
+      for (const relativePath of [
+        "root.txt",
+        "one/one.txt",
+        "one/two/two.txt",
+        "one/two/three/three.txt",
+      ]) {
         await expect(
           access(join(demoRoot, "repos", "linux", relativePath)),
         ).resolves.toBeUndefined();
@@ -164,11 +169,17 @@ describe("demo staging e2e", () => {
         ).resolves.toBeUndefined();
       }
       await expect(
-        access(join(demoRoot, "repos", "linux", "one/two/three/three.txt")),
+        access(join(demoRoot, "repos", "linux", "one/two/three/four/four.txt")),
       ).rejects.toThrow();
       await expect(
         access(
-          join(demoRoot, "worktrees", "linux", "sched-eevdf-latency", "one/two/three/three.txt"),
+          join(
+            demoRoot,
+            "worktrees",
+            "linux",
+            "sched-eevdf-latency",
+            "one/two/three/four/four.txt",
+          ),
         ),
       ).rejects.toThrow();
       expect(
@@ -379,7 +390,7 @@ async function waitForFile(path: string): Promise<void> {
 
 async function createShowcaseRemote(path: string, branch: string): Promise<void> {
   await Promise.all([
-    mkdir(join(path, "one", "two", "three"), { recursive: true }),
+    mkdir(join(path, "one", "two", "three", "four"), { recursive: true }),
     mkdir(join(path, "other"), { recursive: true }),
   ]);
   await Promise.all([
@@ -389,6 +400,7 @@ async function createShowcaseRemote(path: string, branch: string): Promise<void>
     writeFile(join(path, "one", "one.txt"), "one\n", "utf8"),
     writeFile(join(path, "one", "two", "two.txt"), "two\n", "utf8"),
     writeFile(join(path, "one", "two", "three", "three.txt"), "three\n", "utf8"),
+    writeFile(join(path, "one", "two", "three", "four", "four.txt"), "four\n", "utf8"),
     writeFile(join(path, "other", "other.txt"), "other\n", "utf8"),
   ]);
   run("git", ["init", "-q", "-b", branch], { cwd: path });


### PR DESCRIPTION
## Summary

- restore the live five-project demo with 17 real branch worktrees and current project-level harness defaults
- shallow-clone Linux, Ghostty, Svelte, and is-even with source materialized through three directory levels
- download each complete single-commit snapshot before sparse expansion to avoid oversized GitHub promisor fetches
- install checkout-local provider hooks, verify them through the same runtime doctor path used at launch, and stop staging on any available-provider hook failure
- force-enable Codex hooks for Station launches even when the copied base Codex config disables the feature
- isolate Station and provider state, harden reset safety, and document both static and live walkthroughs

## Why

The historical demo had drifted from Station's current config, harness, hook, and runtime contracts. Its sparse clones also exposed mostly root-level files, which did not show enough real code structure during a walkthrough.

A blobless Linux clone made the depth-three expansion request roughly 44,000 missing blobs from GitHub in one promisor fetch, which GitHub rejected with HTTP 400. Keeping history shallow while downloading the complete HEAD snapshot makes sparse materialization local and deterministic.

The bootstrap installed an absolute checkout-local `stn-ingress`, but runtime doctors rebuilt the expected command with bare `stn-ingress`. That made valid Claude, Codex, and Worktrunk installs look stale and blocked launches. Runtime checks now allow only that executable-path difference while keeping routing and provider arguments exact; Worktrunk doctor also receives the same socket, state, spool, config, and auto-start values used at installation.

## UX

Run `scripts/demo/stage.sh`, then `~/.station-demo/run.sh`. The dashboard shows five projects and 17 rows; opening a blank row launches that project's configured harness. Public clone worktrees contain files through three nested directory levels.

The stage report records every hook as `installed and runtime-verified`. In the first isolated Codex session, open `/hooks` and trust the generated Station hooks; Codex intentionally retains its one-time trust review for non-managed hooks. Reset with `scripts/demo/reset.sh`.

The deeper Linux checkout and linked worktrees require several gigabytes of disk.

## Validation

- live isolated demo: observer healthy; Worktrunk, Claude, Codex, Cursor, and OpenCode hook doctors all `ok`
- live Codex feature proof: copied base config reports hooks disabled; Station launch override reports hooks enabled
- `pnpm test:pre-push` with isolated HOME, XDG, Claude, and Codex paths
- unit: 169 files / 1,428 tests
- contracts: 3 files / 26 tests
- integration: 49 passed, 1 skipped / 425 passed, 1 skipped
- diagnostics: 18 files / 43 tests
- setup/demo E2E: 4 files / 11 tests; observer lifecycle: 15 tests
- Station Bun suite: 999 tests; Bun PTY smoke: 26 tests
- binary build and smoke
