### PR TITLE
docs(release): document VirtualBuddy acceptance lane

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -278,6 +278,55 @@ binary. Power loss is different: because the installer does not fsync the file
 or containing directories, it makes no post-power-loss durability guarantee;
 old/new cross-filesystem `LICENSE` metadata may also remain.
 
+### VirtualBuddy clean-mac preparation
+
+Use a fresh VirtualBuddy guest for the primary macOS first-run lane. The guest
+covers only the native target reported by `uname -m`; it does not replace the
+other release targets. Install macOS updates, Xcode Command Line Tools,
+Homebrew, GitHub CLI, Node.js 24, and Codex or another supported agent CLI, then
+verify the development-ready baseline:
+
+```sh
+sw_vers
+uname -m
+xcode-select -p
+git --version
+brew --version
+gh --version
+node --version
+codex --version
+```
+
+Take a `dev-ready-before-station` snapshot before authenticating. Do not
+preinstall Station, Worktrunk, tmux, diffnav, or git-delta; this lane must prove
+that guided setup identifies and installs the missing Station dependencies.
+Authenticate GitHub and confirm private-repository access:
+
+```sh
+gh auth login --hostname github.com
+gh auth status --hostname github.com
+gh repo view jeremy0dell/station
+```
+
+Start the selected agent CLI once and complete its normal sign-in. Then create
+a disposable Git project for the acceptance run:
+
+```sh
+mkdir -p "$HOME/Developer/station-smoke"
+cd "$HOME/Developer/station-smoke"
+git init -b main
+printf '# Station installation smoke test\n' > README.md
+git add README.md
+git -c user.name='Station Smoke' \
+  -c user.email='station-smoke@example.invalid' \
+  commit -m 'Initial commit'
+```
+
+Before installing, `command -v stn` must print nothing and
+`~/.local/bin/stn` must not exist. Do not use the published-install recipe for
+an unpublished candidate; wait for a successful `release` workflow run and use
+its numeric run ID in the accepted-candidate recipe below.
+
 Install the accepted candidate from a successful release workflow run on each
 clean test machine. Set `release_run_id` to that run's numeric ID; the recipe
 downloads its candidate manifest and uses the exact draft ID and commit that
@@ -353,6 +402,37 @@ promotion will verify:
 
 This draft-only environment variable is for release acceptance; normal installs
 use the published-release recipe in [Install](install.md).
+
+For the primary VirtualBuddy user-flow pass, start with `XDG_DATA_HOME` unset
+and `~/.local/bin` absent from `PATH`, and retain the complete installer output.
+Follow the installer's printed current-shell block exactly; on this clean lane
+it must name all three missing launchers and end by running `stn setup`. Allow
+guided setup to install Worktrunk, tmux, diffnav, and git-delta, select the
+authenticated agent, and enable the desired provider hooks and tmux binding.
+Confirm setup writes a zero-project config without adopting the disposable
+repository, then run:
+
+```sh
+stn --version
+stn setup check --json
+stn doctor
+stn tui
+```
+
+On the welcome screen, press `Enter` or `Space`. On the empty dashboard, press
+`Enter` or `A` on **Add your first project** and select the disposable Git
+repository. Then press `N`, create a session with the authenticated agent, and
+ask it to edit the disposable README. Confirm the transcript and diff appear,
+then quit and reopen `stn tui` and confirm the session remains.
+
+If the compiled tmux binding was enabled, use `tmux prefix + Space` for the cold
+open, close the popup with the same chord, and use it again for a warm reopen.
+Confirm both opens are silent in the calling pane and the warm open reuses the
+existing `_station-ui` session. Finally confirm the installer did not edit a
+shell profile, run the exact idempotent future-shell PATH opt-in command it
+printed, open a new login shell, and verify `stn --version` still resolves.
+Preserve the exact command and output at the first failure; for a runtime
+failure with no known trace ID, start with `stn debug trace --latest-failure`.
 
 For each target, install through the authenticated script into a clean home and
 manually verify the actual user experience, not a dashboard override:

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -262,6 +262,26 @@ describe("release readiness docs", () => {
     }
   });
 
+  it("keeps the VirtualBuddy lane aligned with zero-project onboarding", async () => {
+    const development = await read("docs/development.md");
+    const start = development.indexOf("### VirtualBuddy clean-mac preparation");
+    const end = development.indexOf("\nFor each target", start);
+    const virtualBuddy = development.slice(start, end);
+    const normalizedVirtualBuddy = virtualBuddy.replace(/\s+/g, " ");
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+    expect(normalizedVirtualBuddy).toContain("zero-project config");
+    expect(virtualBuddy).toContain("**Add your first project**");
+    expect(virtualBuddy.indexOf("**Add your first project**")).toBeLessThan(
+      virtualBuddy.indexOf("press `N`"),
+    );
+    expect(normalizedVirtualBuddy).toContain("exact idempotent future-shell PATH opt-in command");
+    expect(normalizedVirtualBuddy).toContain("`tmux prefix + Space`");
+    expect(normalizedVirtualBuddy).toContain("cold open");
+    expect(normalizedVirtualBuddy).toContain("warm reopen");
+  });
+
   it("does not advertise removed Crush harness surfaces", async () => {
     const files = ["README.md", "AGENTS.md", ...(await markdownFiles("docs"))];
 


### PR DESCRIPTION
## Summary

- document the primary VirtualBuddy clean-mac preparation lane
- align first-install acceptance with zero-project onboarding and explicit first-project selection
- verify the compiled tmux binding on cold and warm opens, plus the installer's exact PATH opt-in

## Why

The private-binary release checklist covered platform-level acceptance but did not preserve the reproducible guest preparation and current user-flow pass used for the fresh-mac test.

## Validation

- `pnpm exec vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/release-readiness-docs.test.ts` — 7 passed
- isolated `pnpm test:pre-push` — passed, including Station tests, native PTY, installer smoke, compiled binary build, and binary smoke
- `git diff --check` — clean

## UX implication

A tester on a fresh VirtualBuddy macOS guest now follows one current path from a dev-ready baseline through authenticated candidate install, zero-project setup, explicit first project, first session, persistence, compiled tmux cold/warm opens, and login-shell PATH verification.

## Manual verification

Follow **VirtualBuddy clean-mac preparation** and the immediately following user-flow pass in `docs/development.md` on a fresh guest, retaining the first failing command and output if any step diverges.
