### PR TITLE
fix(worktrees): refuse protected checkout removal

### DIFF
--- a/apps/cli/src/commands/setup/checks/git.ts
+++ b/apps/cli/src/commands/setup/checks/git.ts
@@ -62,7 +62,9 @@ function isDubiousOwnershipError(error: unknown): boolean {
   if (!isSafeError(error)) {
     return false;
   }
-  const stderr = error.diagnosticDetails?.[0]?.stderrSnippet ?? "";
+  const stderr =
+    error.diagnosticDetails?.find((detail) => detail.type === "external_command")?.stderrSnippet ??
+    "";
   return /dubious ownership|safe\.directory/i.test(stderr);
 }
 

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -355,7 +355,11 @@ describe("observer providers", () => {
         branch: "feature",
       });
       await mkdir(createdWorktreePath, { recursive: true });
-      await registry.worktree.removeWorktree({ worktreeId: created.id });
+      await registry.worktree.removeWorktree({
+        worktreeId: created.id,
+        expectedPath: created.path,
+        expectedBranch: created.branch,
+      });
 
       await expect(readFile(logPath, "utf8")).resolves.toBe(
         [

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -297,6 +297,8 @@ describe("observer providers", () => {
           "#!/bin/sh",
           `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`,
           'if [ "$1" = "switch" ]; then',
+          `  mkdir -p ${JSON.stringify(createdWorktreePath)}`,
+          `  printf '%s\n' 'gitdir: fixture' > ${JSON.stringify(join(createdWorktreePath, ".git"))}`,
           `  printf '%s' ${JSON.stringify(
             JSON.stringify([{ path: createdWorktreePath, branch: "feature" }]),
           )}`,
@@ -354,11 +356,15 @@ describe("observer providers", () => {
         project,
         branch: "feature",
       });
+      if (created.registrationIdentity === undefined) {
+        throw new Error("Expected the created worktree registration identity.");
+      }
       await mkdir(createdWorktreePath, { recursive: true });
       await registry.worktree.removeWorktree({
         worktreeId: created.id,
         expectedPath: created.path,
         expectedBranch: created.branch,
+        expectedRegistrationIdentity: created.registrationIdentity,
       });
 
       await expect(readFile(logPath, "utf8")).resolves.toBe(

--- a/apps/observer/src/commands/cleanup/guards.ts
+++ b/apps/observer/src/commands/cleanup/guards.ts
@@ -5,23 +5,18 @@ import type {
   SafeError,
   SessionView,
   WorktreeObservation,
+  WorktreeRemovalRefusalDiagnosticDetail,
+  WorktreeRemovalRefusalReason,
   WorktreeRow,
 } from "@station/contracts";
 import { isRunningAgentState, normalizeObservedPath, sameObservedPath } from "@station/contracts";
 
-export type WorktreeRemovalRefusalReason =
-  | "ambiguous_identity"
-  | "branch_changed"
-  | "default_branch"
-  | "identity_changed"
-  | "missing_target"
-  | "path_changed"
-  | "primary_checkout"
-  | "protection_unverified"
-  | "snapshot_changed";
+export type VerifiedWorktreeRemovalTarget = WorktreeObservation & {
+  registrationIdentity: string;
+};
 
 export type WorktreeRemovalTargetResolution =
-  | { ok: true; target: WorktreeObservation }
+  | { ok: true; target: VerifiedWorktreeRemovalTarget }
   | {
       ok: false;
       error: SafeError;
@@ -39,7 +34,8 @@ export function resolveWorktreeRemovalTarget(input: {
   const canonicalExpectedPath = normalizeObservedPath(input.payload.expectedPath);
   if (
     !sameObservedPath(input.snapshotRow.path, canonicalExpectedPath) ||
-    input.snapshotRow.branch !== input.payload.expectedBranch
+    input.snapshotRow.branch !== input.payload.expectedBranch ||
+    input.snapshotRow.registrationIdentity !== input.payload.expectedRegistrationIdentity
   ) {
     return staleRemovalRefusal({
       payload: input.payload,
@@ -124,6 +120,25 @@ export function resolveWorktreeRemovalTarget(input: {
       message: `The selected worktree changed from branch '${input.payload.expectedBranch}' to '${target.branch}'.`,
     });
   }
+  if (target.registrationIdentity === undefined) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "registration_unverified",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: "Station could not verify the selected checkout's Git registration.",
+    });
+  }
+  const registrationIdentity = target.registrationIdentity;
+  if (registrationIdentity !== input.payload.expectedRegistrationIdentity) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "registration_changed",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: "The selected path now belongs to a different Git checkout registration.",
+    });
+  }
 
   if (target.isPrimaryCheckout === true || sameObservedPath(target.path, input.project.root)) {
     return removalRefusal({
@@ -138,10 +153,11 @@ export function resolveWorktreeRemovalTarget(input: {
   }
 
   const configuredDefaultBranch = input.project.defaultBranch ?? input.project.worktrunk.base;
-  if (
-    configuredDefaultBranch !== undefined &&
-    branchMatchesConfiguredDefault(target.branch, configuredDefaultBranch)
-  ) {
+  const defaultBranchCandidates =
+    configuredDefaultBranch === undefined
+      ? []
+      : configuredDefaultBranchCandidates(configuredDefaultBranch);
+  if (defaultBranchCandidates.includes(target.branch)) {
     return removalRefusal({
       payload: input.payload,
       code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED",
@@ -152,7 +168,7 @@ export function resolveWorktreeRemovalTarget(input: {
       observedBranch: target.branch,
     });
   }
-  if (configuredDefaultBranch === undefined) {
+  if (defaultBranchCandidates.length === 0) {
     return removalRefusal({
       payload: input.payload,
       code: "WORKTREE_REMOVE_PROTECTION_UNVERIFIED",
@@ -164,7 +180,7 @@ export function resolveWorktreeRemovalTarget(input: {
     });
   }
 
-  return { ok: true, target };
+  return { ok: true, target: { ...target, registrationIdentity } };
 }
 
 export function assertWorktreeRemovalAllowed(
@@ -285,12 +301,23 @@ function removalRefusal(input: {
   canonicalPath: string;
   observedBranch: string;
 }): WorktreeRemovalTargetResolution {
-  const error: SafeError = {
+  const detail: WorktreeRemovalRefusalDiagnosticDetail = {
+    type: "worktree_removal_refusal",
+    worktreeId: input.payload.worktreeId,
+    canonicalPath: input.canonicalPath,
+    observedBranch: input.observedBranch,
+    refusalReason: input.refusalReason,
+  };
+  if (input.payload.projectId !== undefined) detail.projectId = input.payload.projectId;
+  const error: SafeError & {
+    diagnosticDetails: WorktreeRemovalRefusalDiagnosticDetail[];
+  } = {
     tag: "CommandValidationError",
     code: input.code,
     message: input.message,
     hint: input.hint,
     worktreeId: input.payload.worktreeId,
+    diagnosticDetails: [detail],
   };
   if (input.payload.projectId !== undefined) error.projectId = input.payload.projectId;
   return {
@@ -302,13 +329,21 @@ function removalRefusal(input: {
   };
 }
 
-function branchMatchesConfiguredDefault(observed: string, configured: string): boolean {
-  return branchName(observed) === branchName(configured);
-}
-
-function branchName(value: string): string {
-  return value
-    .replace(/^refs\/heads\//, "")
-    .replace(/^refs\/remotes\/[^/]+\//, "")
-    .replace(/^origin\//, "");
+function configuredDefaultBranchCandidates(value: string): string[] {
+  const configured = value.trim();
+  if (configured === "") {
+    return [];
+  }
+  if (configured.startsWith("refs/heads/")) {
+    return [configured.slice("refs/heads/".length)].filter(Boolean);
+  }
+  const remoteRef = configured.match(/^refs\/remotes\/[^/]+\/(.+)$/)?.[1];
+  if (remoteRef !== undefined) {
+    return [remoteRef];
+  }
+  const slash = configured.indexOf("/");
+  if (slash < 1 || slash === configured.length - 1) {
+    return [configured];
+  }
+  return [...new Set([configured, configured.slice(slash + 1)])];
 }

--- a/apps/observer/src/commands/cleanup/guards.ts
+++ b/apps/observer/src/commands/cleanup/guards.ts
@@ -1,13 +1,179 @@
-import { normalize } from "node:path";
-import type { ProjectView, SafeError, SessionView, WorktreeRow } from "@station/contracts";
-import { isRunningAgentState } from "@station/contracts";
+import type {
+  ProjectView,
+  ProviderProjectConfig,
+  RemoveWorktreePayload,
+  SafeError,
+  SessionView,
+  WorktreeObservation,
+  WorktreeRow,
+} from "@station/contracts";
+import { isRunningAgentState, normalizeObservedPath, sameObservedPath } from "@station/contracts";
+
+export type WorktreeRemovalRefusalReason =
+  | "ambiguous_identity"
+  | "branch_changed"
+  | "default_branch"
+  | "identity_changed"
+  | "missing_target"
+  | "path_changed"
+  | "primary_checkout"
+  | "protection_unverified"
+  | "snapshot_changed";
+
+export type WorktreeRemovalTargetResolution =
+  | { ok: true; target: WorktreeObservation }
+  | {
+      ok: false;
+      error: SafeError;
+      refusalReason: WorktreeRemovalRefusalReason;
+      canonicalPath: string;
+      observedBranch: string;
+    };
+
+export function resolveWorktreeRemovalTarget(input: {
+  payload: RemoveWorktreePayload;
+  snapshotRow: WorktreeRow;
+  project: ProviderProjectConfig;
+  currentWorktrees: readonly WorktreeObservation[];
+}): WorktreeRemovalTargetResolution {
+  const canonicalExpectedPath = normalizeObservedPath(input.payload.expectedPath);
+  if (
+    !sameObservedPath(input.snapshotRow.path, canonicalExpectedPath) ||
+    input.snapshotRow.branch !== input.payload.expectedBranch
+  ) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "snapshot_changed",
+      canonicalPath: normalizeObservedPath(input.snapshotRow.path),
+      observedBranch: input.snapshotRow.branch,
+      message: "The selected worktree changed in the observer snapshot before removal began.",
+    });
+  }
+
+  const projectWorktrees = input.currentWorktrees.filter(
+    (candidate) => candidate.projectId === input.project.id,
+  );
+  const identityMatches = projectWorktrees.filter(
+    (candidate) => candidate.id === input.payload.worktreeId,
+  );
+  const pathMatches = projectWorktrees.filter((candidate) =>
+    sameObservedPath(candidate.path, canonicalExpectedPath),
+  );
+
+  if (identityMatches.length > 1 || pathMatches.length > 1) {
+    return removalRefusal({
+      payload: input.payload,
+      code: "WORKTREE_REMOVE_TARGET_AMBIGUOUS",
+      message: "Station could not uniquely re-resolve the selected worktree.",
+      hint: "Refresh the dashboard and reselect the worktree; no cleanup was performed.",
+      refusalReason: "ambiguous_identity",
+      canonicalPath: canonicalExpectedPath,
+      observedBranch: input.payload.expectedBranch,
+    });
+  }
+
+  const target = identityMatches[0];
+  if (target === undefined) {
+    const pathMatch = pathMatches[0];
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: pathMatch === undefined ? "missing_target" : "identity_changed",
+      canonicalPath: normalizeObservedPath(pathMatch?.path ?? canonicalExpectedPath),
+      observedBranch: pathMatch?.branch ?? input.payload.expectedBranch,
+      message:
+        pathMatch === undefined
+          ? "The selected worktree is no longer present in current provider evidence."
+          : "The selected path now belongs to a different worktree identity.",
+    });
+  }
+
+  const canonicalCurrentPath = normalizeObservedPath(target.path);
+  if (!sameObservedPath(canonicalCurrentPath, canonicalExpectedPath)) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "path_changed",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: "The selected worktree path changed after it was selected.",
+    });
+  }
+  if (pathMatches[0]?.id !== target.id) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "identity_changed",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: "The selected path no longer resolves to the same worktree identity.",
+    });
+  }
+  if (target.state !== "exists") {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "missing_target",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: "The selected worktree is no longer an existing checkout.",
+    });
+  }
+  if (target.branch !== input.payload.expectedBranch) {
+    return staleRemovalRefusal({
+      payload: input.payload,
+      refusalReason: "branch_changed",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+      message: `The selected worktree changed from branch '${input.payload.expectedBranch}' to '${target.branch}'.`,
+    });
+  }
+
+  if (target.isPrimaryCheckout === true || sameObservedPath(target.path, input.project.root)) {
+    return removalRefusal({
+      payload: input.payload,
+      code: "WORKTREE_ROOT_REMOVAL_NOT_ALLOWED",
+      message: "The project root checkout cannot be removed as a worktree.",
+      hint: "Close the session without removing the checkout, or choose a managed worktree.",
+      refusalReason: "primary_checkout",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+    });
+  }
+
+  const configuredDefaultBranch = input.project.defaultBranch ?? input.project.worktrunk.base;
+  if (
+    configuredDefaultBranch !== undefined &&
+    branchMatchesConfiguredDefault(target.branch, configuredDefaultBranch)
+  ) {
+    return removalRefusal({
+      payload: input.payload,
+      code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED",
+      message: `The selected checkout currently owns the repository default branch '${target.branch}'.`,
+      hint: "Move the default branch back to its protected checkout, refresh, and reselect the disposable worktree.",
+      refusalReason: "default_branch",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+    });
+  }
+  if (configuredDefaultBranch === undefined) {
+    return removalRefusal({
+      payload: input.payload,
+      code: "WORKTREE_REMOVE_PROTECTION_UNVERIFIED",
+      message: "Station could not verify which checkout owns the repository default branch.",
+      hint: "Configure the project's default branch, refresh, and retry.",
+      refusalReason: "protection_unverified",
+      canonicalPath: canonicalCurrentPath,
+      observedBranch: target.branch,
+    });
+  }
+
+  return { ok: true, target };
+}
 
 export function assertWorktreeRemovalAllowed(
   row: WorktreeRow,
   force: boolean,
   project?: ProjectView | undefined,
+  current?: WorktreeObservation | undefined,
 ): void {
-  if (project !== undefined && samePath(row.path, project.root)) {
+  if (project !== undefined && sameObservedPath(current?.path ?? row.path, project.root)) {
     const error: SafeError = {
       tag: "CommandValidationError",
       code: "WORKTREE_ROOT_REMOVAL_NOT_ALLOWED",
@@ -20,7 +186,7 @@ export function assertWorktreeRemovalAllowed(
     throw error;
   }
 
-  if (row.worktree.dirty === true && !force) {
+  if ((current?.dirty ?? row.worktree.dirty) === true && !force) {
     const error: SafeError = {
       tag: "CommandValidationError",
       code: "WORKTREE_DIRTY_REQUIRES_FORCE",
@@ -96,6 +262,53 @@ function isSessionOrRowRunning(
   return isRunningAgentState(row?.agent?.state ?? session?.status.value);
 }
 
-function samePath(left: string, right: string): boolean {
-  return normalize(left) === normalize(right);
+function staleRemovalRefusal(input: {
+  payload: RemoveWorktreePayload;
+  message: string;
+  refusalReason: WorktreeRemovalRefusalReason;
+  canonicalPath: string;
+  observedBranch: string;
+}): WorktreeRemovalTargetResolution {
+  return removalRefusal({
+    ...input,
+    code: "WORKTREE_REMOVE_STALE_SELECTION",
+    hint: "Refresh the dashboard and reselect the worktree; no cleanup was performed.",
+  });
+}
+
+function removalRefusal(input: {
+  payload: RemoveWorktreePayload;
+  code: string;
+  message: string;
+  hint: string;
+  refusalReason: WorktreeRemovalRefusalReason;
+  canonicalPath: string;
+  observedBranch: string;
+}): WorktreeRemovalTargetResolution {
+  const error: SafeError = {
+    tag: "CommandValidationError",
+    code: input.code,
+    message: input.message,
+    hint: input.hint,
+    worktreeId: input.payload.worktreeId,
+  };
+  if (input.payload.projectId !== undefined) error.projectId = input.payload.projectId;
+  return {
+    ok: false,
+    error,
+    refusalReason: input.refusalReason,
+    canonicalPath: input.canonicalPath,
+    observedBranch: input.observedBranch,
+  };
+}
+
+function branchMatchesConfiguredDefault(observed: string, configured: string): boolean {
+  return branchName(observed) === branchName(configured);
+}
+
+function branchName(value: string): string {
+  return value
+    .replace(/^refs\/heads\//, "")
+    .replace(/^refs\/remotes\/[^/]+\//, "")
+    .replace(/^origin\//, "");
 }

--- a/apps/observer/src/commands/cleanup/operations.ts
+++ b/apps/observer/src/commands/cleanup/operations.ts
@@ -5,7 +5,6 @@ import type {
   SessionView,
   TerminalProvider,
   TerminalTargetId,
-  WorktreeObservation,
   WorktreeRow,
 } from "@station/contracts";
 import { isRunningAgentState, SafeErrorSchema } from "@station/contracts";
@@ -21,6 +20,7 @@ import {
   terminalCloseIntentForSession,
   terminalCloseIntentForWorktree,
 } from "../terminalIntents.js";
+import type { VerifiedWorktreeRemovalTarget } from "./guards.js";
 
 export type CleanupRuntime = {
   clock?: RuntimeClock | undefined;
@@ -179,7 +179,7 @@ export async function removeWorktreeThroughProvider(
   input: {
     providers: ProviderRegistry;
     row: WorktreeRow;
-    target: WorktreeObservation;
+    target: VerifiedWorktreeRemovalTarget;
     force: boolean;
     context: CommandHandlerContext;
   } & CleanupRuntime,
@@ -189,6 +189,7 @@ export async function removeWorktreeThroughProvider(
     projectId: input.row.projectId,
     expectedPath: input.target.path,
     expectedBranch: input.target.branch,
+    expectedRegistrationIdentity: input.target.registrationIdentity,
   };
   const providerRequest: typeof request & { force?: boolean } = { ...request };
   if (input.force) {

--- a/apps/observer/src/commands/cleanup/operations.ts
+++ b/apps/observer/src/commands/cleanup/operations.ts
@@ -5,6 +5,7 @@ import type {
   SessionView,
   TerminalProvider,
   TerminalTargetId,
+  WorktreeObservation,
   WorktreeRow,
 } from "@station/contracts";
 import { isRunningAgentState, SafeErrorSchema } from "@station/contracts";
@@ -178,6 +179,7 @@ export async function removeWorktreeThroughProvider(
   input: {
     providers: ProviderRegistry;
     row: WorktreeRow;
+    target: WorktreeObservation;
     force: boolean;
     context: CommandHandlerContext;
   } & CleanupRuntime,
@@ -185,6 +187,8 @@ export async function removeWorktreeThroughProvider(
   const request = {
     worktreeId: input.row.id,
     projectId: input.row.projectId,
+    expectedPath: input.target.path,
+    expectedBranch: input.target.branch,
   };
   const providerRequest: typeof request & { force?: boolean } = { ...request };
   if (input.force) {

--- a/apps/observer/src/commands/router.ts
+++ b/apps/observer/src/commands/router.ts
@@ -90,6 +90,7 @@ export function registerObserverCommandHandlers(
       logger: options.logger,
     }),
     "worktree.remove": createWorktreeRemoveHandler({
+      getProjects,
       providers: options.providers,
       terminalIntentRunner,
       core: options.core,
@@ -97,6 +98,7 @@ export function registerObserverCommandHandlers(
       eventBus: options.eventBus,
       clock: options.clock,
       commandTimeoutMs: options.commandTimeoutMs,
+      logger: options.logger,
     }),
     "session.create": createSessionCreateHandler({
       getProjects,

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -134,6 +134,8 @@ export function createSessionCreateHandler(
           providers: options.providers,
           projectId: project.id,
           worktreeId: createdWorktree.id,
+          expectedPath: createdWorktree.path,
+          expectedBranch: createdWorktree.branch,
           context,
           logger: options.logger,
           clock: options.clock,

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -136,6 +136,7 @@ export function createSessionCreateHandler(
           worktreeId: createdWorktree.id,
           expectedPath: createdWorktree.path,
           expectedBranch: createdWorktree.branch,
+          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
           context,
           logger: options.logger,
           clock: options.clock,

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -172,6 +172,8 @@ export function createSessionForkHandler(options: CreateSessionForkHandlerOption
           providers: options.providers,
           projectId: project.id,
           worktreeId: createdWorktree.id,
+          expectedPath: createdWorktree.path,
+          expectedBranch: createdWorktree.branch,
           context,
           logger: options.logger,
           clock: options.clock,

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -174,6 +174,7 @@ export function createSessionForkHandler(options: CreateSessionForkHandlerOption
           worktreeId: createdWorktree.id,
           expectedPath: createdWorktree.path,
           expectedBranch: createdWorktree.branch,
+          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
           context,
           logger: options.logger,
           clock: options.clock,

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -466,6 +466,8 @@ export async function removeWorktreeBestEffort(input: {
   providers: ProviderRegistry;
   projectId: string;
   worktreeId: string;
+  expectedPath: string;
+  expectedBranch: string;
   context: CommandHandlerContext;
   logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
@@ -489,6 +491,8 @@ export async function removeWorktreeBestEffort(input: {
         input.providers.worktree.removeWorktree({
           projectId: input.projectId,
           worktreeId: input.worktreeId,
+          expectedPath: input.expectedPath,
+          expectedBranch: input.expectedBranch,
           force: true,
         }),
     );

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -111,6 +111,9 @@ export function worktreeObservationFromRow(
     reason: "Resolved from the current observer snapshot.",
     observedAt,
   };
+  if (row.registrationIdentity !== undefined) {
+    observation.registrationIdentity = row.registrationIdentity;
+  }
   if (row.worktree.dirty !== undefined) observation.dirty = row.worktree.dirty;
   if (row.worktree.ahead !== undefined) observation.ahead = row.worktree.ahead;
   if (row.worktree.behind !== undefined) observation.behind = row.worktree.behind;
@@ -468,11 +471,25 @@ export async function removeWorktreeBestEffort(input: {
   worktreeId: string;
   expectedPath: string;
   expectedBranch: string;
+  expectedRegistrationIdentity: string | undefined;
   context: CommandHandlerContext;
   logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
 }): Promise<void> {
+  if (input.expectedRegistrationIdentity === undefined) {
+    await input.logger?.warn("Session cleanup skipped an unverified worktree removal.", {
+      commandId: input.context.commandId,
+      traceId: input.context.trace.traceId,
+      provider: input.providers.worktree.id,
+      operation: "removeWorktree",
+      projectId: input.projectId,
+      worktreeId: input.worktreeId,
+      refusalReason: "registration_unverified",
+    });
+    return;
+  }
+  const expectedRegistrationIdentity = input.expectedRegistrationIdentity;
   try {
     await runProviderMutation(
       {
@@ -493,6 +510,7 @@ export async function removeWorktreeBestEffort(input: {
           worktreeId: input.worktreeId,
           expectedPath: input.expectedPath,
           expectedBranch: input.expectedBranch,
+          expectedRegistrationIdentity,
           force: true,
         }),
     );

--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -1,4 +1,8 @@
-import type { ProviderProjectConfig } from "@station/contracts";
+import {
+  type ProviderProjectConfig,
+  type WorktreeRemovalRefusalDiagnosticDetail,
+  WorktreeRemovalRefusalDiagnosticDetailSchema,
+} from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
 import type { EventJournal } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
@@ -37,7 +41,8 @@ export type CreateWorktreeRemoveHandlerOptions = {
 /**
  * USE CASE
  *
- * Revalidates a selected checkout before coordinating terminal and worktree removal.
+ * Revalidates selected checkout and Git registration identity before coordinating removal.
+ * Provider-side race refusals retain command-correlated evidence for diagnostics.
  */
 export function createWorktreeRemoveHandler(
   options: CreateWorktreeRemoveHandlerOptions,
@@ -110,15 +115,32 @@ export function createWorktreeRemoveHandler(
       commandTimeoutMs: options.commandTimeoutMs,
     });
     throwIfAborted(context.signal);
-    await removeWorktreeThroughProvider({
-      providers: options.providers,
-      row,
-      target: resolution.target,
-      force,
-      context,
-      clock: options.clock,
-      commandTimeoutMs: options.commandTimeoutMs,
-    });
+    try {
+      await removeWorktreeThroughProvider({
+        providers: options.providers,
+        row,
+        target: resolution.target,
+        force,
+        context,
+        clock: options.clock,
+        commandTimeoutMs: options.commandTimeoutMs,
+      });
+    } catch (error) {
+      const refusal = worktreeRemovalRefusalDiagnostic(error);
+      if (refusal !== undefined) {
+        await options.logger?.warn("Worktree removal refused during final provider validation.", {
+          commandId: context.commandId,
+          traceId: context.trace.traceId,
+          projectId: refusal.projectId ?? row.projectId,
+          worktreeId: refusal.worktreeId,
+          canonicalPath: refusal.canonicalPath,
+          observedBranch: refusal.observedBranch,
+          refusalReason: refusal.refusalReason,
+          provider: refusal.provider ?? options.providers.worktree.id,
+        });
+      }
+      throw error;
+    }
     throwIfAborted(context.signal);
 
     const nextSnapshot = await reconcileAndPublish({
@@ -144,4 +166,23 @@ export function createWorktreeRemoveHandler(
       clock: options.clock,
     });
   };
+}
+
+function worktreeRemovalRefusalDiagnostic(
+  error: unknown,
+): WorktreeRemovalRefusalDiagnosticDetail | undefined {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const details = (error as { diagnosticDetails?: unknown }).diagnosticDetails;
+  if (!Array.isArray(details)) {
+    return undefined;
+  }
+  for (const detail of details) {
+    const parsed = WorktreeRemovalRefusalDiagnosticDetailSchema.safeParse(detail);
+    if (parsed.success) {
+      return parsed.data;
+    }
+  }
+  return undefined;
 }

--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -1,8 +1,10 @@
+import type { ProviderProjectConfig } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
 import type { EventJournal } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { assertCommandType } from "../assertCommand.js";
 import {
   assertWorktreeRemovalAllowed,
@@ -11,15 +13,17 @@ import {
   publishRemovedSessionIfAbsent,
   publishWorktreeRemoved,
   removeWorktreeThroughProvider,
+  resolveWorktreeRemovalTarget,
   resolveWorktreeRowOrThrow,
   stopHarnessForWorktree,
 } from "../cleanup/index.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
-import { throwIfAborted } from "../session/shared.js";
+import { findProjectOrThrow, runProviderMutation, throwIfAborted } from "../session/shared.js";
 import type { TerminalIntentRunner } from "../terminalIntentRunner.js";
 
 export type CreateWorktreeRemoveHandlerOptions = {
+  getProjects: () => readonly ProviderProjectConfig[];
   providers: ProviderRegistry;
   terminalIntentRunner: TerminalIntentRunner;
   core: ObserverCore;
@@ -27,8 +31,14 @@ export type CreateWorktreeRemoveHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
+  logger?: StationLogger | undefined;
 };
 
+/**
+ * USE CASE
+ *
+ * Revalidates a selected checkout before coordinating terminal and worktree removal.
+ */
 export function createWorktreeRemoveHandler(
   options: CreateWorktreeRemoveHandlerOptions,
 ): CommandHandler {
@@ -39,10 +49,46 @@ export function createWorktreeRemoveHandler(
     const payload = context.command.payload;
     const snapshot = options.core.getSnapshot();
     const row = resolveWorktreeRowOrThrow(snapshot, payload.worktreeId, payload.projectId);
-    const project = snapshot.projects.find((candidate) => candidate.id === row.projectId);
+    const projectView = snapshot.projects.find((candidate) => candidate.id === row.projectId);
+    const project = findProjectOrThrow(options.getProjects(), row.projectId);
     const previousSessionId = row.agent?.sessionId;
     const force = payload.force === true;
-    assertWorktreeRemovalAllowed(row, force, project);
+    const currentWorktrees = await runProviderMutation(
+      {
+        operation: `provider.${options.providers.worktree.id}.listWorktrees.removeRevalidation`,
+        clock: options.clock,
+        commandTimeoutMs: options.commandTimeoutMs,
+        signal: context.signal,
+        trace: context.trace,
+        fallback: {
+          tag: "WorktreeProviderError",
+          code: "WORKTREE_REMOVE_REVALIDATION_FAILED",
+          message: "Station could not refresh worktree evidence before removal.",
+          provider: options.providers.worktree.id,
+        },
+      },
+      () => options.providers.worktree.listWorktrees(project),
+    );
+    throwIfAborted(context.signal);
+    const resolution = resolveWorktreeRemovalTarget({
+      payload,
+      snapshotRow: row,
+      project,
+      currentWorktrees,
+    });
+    if (!resolution.ok) {
+      await options.logger?.warn("Worktree removal refused.", {
+        commandId: context.commandId,
+        traceId: context.trace.traceId,
+        projectId: row.projectId,
+        worktreeId: row.id,
+        canonicalPath: resolution.canonicalPath,
+        observedBranch: resolution.observedBranch,
+        refusalReason: resolution.refusalReason,
+      });
+      throw resolution.error;
+    }
+    assertWorktreeRemovalAllowed(row, force, projectView, resolution.target);
 
     await stopHarnessForWorktree({
       providers: options.providers,
@@ -67,6 +113,7 @@ export function createWorktreeRemoveHandler(
     await removeWorktreeThroughProvider({
       providers: options.providers,
       row,
+      target: resolution.target,
       force,
       context,
       clock: options.clock,

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -241,6 +241,9 @@ function buildWorktreeRow(input: BuildWorktreeRowInput): WorktreeRow {
     worktree,
     display,
   };
+  if (input.worktree.registrationIdentity !== undefined) {
+    row.registrationIdentity = input.worktree.registrationIdentity;
+  }
   if (input.terminal !== undefined)
     row.terminal = terminalAttachment(input.terminal, input.harnessRun, input.terminalCapabilities);
   if (input.harnessRun !== undefined) row.agent = rowAgent(input.harnessRun);

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -192,6 +192,8 @@ describe("cleanup command handlers", () => {
       payload: {
         worktreeId: "wt_web_cleanup",
         projectId: "web",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
       },
     });
     await fixture.queue.drain();
@@ -217,6 +219,8 @@ describe("cleanup command handlers", () => {
       payload: {
         worktreeId: "wt_web_cleanup",
         projectId: "web",
+        expectedPath: "/tmp/station/web",
+        expectedBranch: "cleanup",
         force: true,
       },
     });
@@ -234,6 +238,37 @@ describe("cleanup command handlers", () => {
     fixture.sqlite.close();
   });
 
+  it("refuses a stale feature selection that now owns the default branch before cleanup", async () => {
+    const fixture = createFixture({ state: "working" });
+    await fixture.core.reconcile("pre-cleanup");
+    fixture.worktreeObservation.branch = "main";
+
+    const receipt = await fixture.queue.dispatch({
+      type: "worktree.remove",
+      payload: {
+        worktreeId: "wt_web_cleanup",
+        projectId: "web",
+        expectedPath: fixture.worktreeObservation.path,
+        expectedBranch: "cleanup",
+        force: true,
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: {
+        tag: "CommandValidationError",
+        code: "WORKTREE_REMOVE_STALE_SELECTION",
+        worktreeId: "wt_web_cleanup",
+      },
+    });
+    expect(fixture.harness.snapshot().stopped).toEqual([]);
+    expect(fixture.terminal.snapshot().closed).toEqual([]);
+    expect(fixture.worktree.snapshot().removed).toEqual([]);
+    fixture.sqlite.close();
+  });
+
   it("force-removes an active worktree after stopping harness and closing terminal", async () => {
     const fixture = createFixture({ dirty: true, state: "working" });
     await fixture.core.reconcile("pre-cleanup");
@@ -243,6 +278,8 @@ describe("cleanup command handlers", () => {
       payload: {
         worktreeId: "wt_web_cleanup",
         projectId: "web",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
         force: true,
       },
     });
@@ -253,7 +290,13 @@ describe("cleanup command handlers", () => {
     ]);
     expect(fixture.terminal.snapshot().closed).toEqual(["term_web_cleanup"]);
     expect(fixture.worktree.snapshot().removed).toEqual([
-      { projectId: "web", worktreeId: "wt_web_cleanup", force: true },
+      {
+        projectId: "web",
+        worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     ]);
     expect(await fixture.persistence.listEvents({ commandId: receipt.commandId })).toEqual(
       expect.arrayContaining([
@@ -278,7 +321,13 @@ describe("cleanup command handlers", () => {
 
     const receipt = await fixture.queue.dispatch({
       type: "worktree.remove",
-      payload: { worktreeId: "wt_web_cleanup", projectId: "web", force: true },
+      payload: {
+        worktreeId: "wt_web_cleanup",
+        projectId: "web",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     });
     await fixture.queue.drain();
 
@@ -292,7 +341,13 @@ describe("cleanup command handlers", () => {
     ]);
     expect(fixture.terminal.snapshot().closed).toEqual([]);
     expect(fixture.worktree.snapshot().removed).toEqual([
-      { projectId: "web", worktreeId: "wt_web_cleanup", force: true },
+      {
+        projectId: "web",
+        worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     ]);
     fixture.sqlite.close();
   });
@@ -310,6 +365,8 @@ describe("cleanup command handlers", () => {
       payload: {
         worktreeId: "wt_web_cleanup",
         projectId: "web",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
         force: true,
       },
     });
@@ -323,7 +380,13 @@ describe("cleanup command handlers", () => {
     ]);
     expect(fixture.terminal.snapshot().closed).toEqual([]);
     expect(fixture.worktree.snapshot().removed).toEqual([
-      { projectId: "web", worktreeId: "wt_web_cleanup", force: true },
+      {
+        projectId: "web",
+        worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     ]);
     expect(fixture.core.getSnapshot().rows).toEqual([]);
     fixture.sqlite.close();
@@ -338,6 +401,8 @@ describe("cleanup command handlers", () => {
       payload: {
         worktreeId: "wt_web_cleanup",
         projectId: "web",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
         force: true,
       },
     });
@@ -349,7 +414,13 @@ describe("cleanup command handlers", () => {
     expect(fixture.harness.snapshot().stopped).toEqual([]);
     expect(fixture.terminal.snapshot().closed).toEqual(["term_web_cleanup"]);
     expect(fixture.worktree.snapshot().removed).toEqual([
-      { projectId: "web", worktreeId: "wt_web_cleanup", force: true },
+      {
+        projectId: "web",
+        worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     ]);
     fixture.sqlite.close();
   });
@@ -369,18 +440,17 @@ function createFixture(input: {
   const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids });
   const eventBus = createObserverEventBus();
   const queue = createCommandQueue({ persistence, clock, idFactory: ids, eventBus });
+  const worktreeObservation = createFakeWorktree({
+    id: "wt_web_cleanup",
+    projectId: "web",
+    branch: "cleanup",
+    ...(input.projectRootPath === true ? { path: config.projects[0].root } : {}),
+    dirty: input.dirty ?? false,
+    now,
+  });
   const worktree = new FakeWorktreeProvider({
     now,
-    worktrees: [
-      createFakeWorktree({
-        id: "wt_web_cleanup",
-        projectId: "web",
-        branch: "cleanup",
-        ...(input.projectRootPath === true ? { path: config.projects[0].root } : {}),
-        dirty: input.dirty ?? false,
-        now,
-      }),
-    ],
+    worktrees: [worktreeObservation],
   });
   const terminalOptions: ConstructorParameters<typeof FakeTerminalProvider>[0] = {
     now,
@@ -447,7 +517,18 @@ function createFixture(input: {
       ? {}
       : { terminalIntentRunner: input.terminalIntentRunner }),
   });
-  return { sqlite, persistence, eventBus, queue, providers, core, worktree, terminal, harness };
+  return {
+    sqlite,
+    persistence,
+    eventBus,
+    queue,
+    providers,
+    core,
+    worktree,
+    worktreeObservation,
+    terminal,
+    harness,
+  };
 }
 
 class CapturingTerminalIntentRunner implements TerminalIntentRunner {
@@ -494,6 +575,7 @@ const config: StationConfig = {
       id: "web",
       label: "web",
       root: "/tmp/station/web",
+      defaultBranch: "main",
       defaults: {
         harness: "fake-harness",
         terminal: "fake-terminal",

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -194,6 +194,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
       },
     });
     await fixture.queue.drain();
@@ -221,6 +222,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -250,6 +252,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: fixture.worktreeObservation.path,
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -280,6 +283,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -295,6 +299,7 @@ describe("cleanup command handlers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     ]);
@@ -326,6 +331,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -346,6 +352,7 @@ describe("cleanup command handlers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     ]);
@@ -367,6 +374,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -385,6 +393,7 @@ describe("cleanup command handlers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     ]);
@@ -403,6 +412,7 @@ describe("cleanup command handlers", () => {
         projectId: "web",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });
@@ -419,6 +429,7 @@ describe("cleanup command handlers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     ]);
@@ -444,6 +455,7 @@ function createFixture(input: {
     id: "wt_web_cleanup",
     projectId: "web",
     branch: "cleanup",
+    registrationIdentity: "git-registration:cleanup",
     ...(input.projectRootPath === true ? { path: config.projects[0].root } : {}),
     dirty: input.dirty ?? false,
     now,

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -593,6 +593,7 @@ describe("session command vertical slice", () => {
         worktreeId: "wt_web_cleanup_open",
         expectedPath: "/tmp/station/web/cleanup-open",
         expectedBranch: "cleanup-open",
+        expectedRegistrationIdentity: "fake-registration:web:cleanup-open:managed",
         force: true,
       },
     ]);
@@ -646,6 +647,7 @@ describe("session command vertical slice", () => {
         worktreeId: "wt_web_cleanup_build",
         expectedPath: "/tmp/station/web/cleanup-build",
         expectedBranch: "cleanup-build",
+        expectedRegistrationIdentity: "fake-registration:web:cleanup-build:managed",
         force: true,
       },
     ]);
@@ -692,6 +694,7 @@ describe("session command vertical slice", () => {
         worktreeId: "wt_web_cleanup_launch",
         expectedPath: "/tmp/station/web/cleanup-launch",
         expectedBranch: "cleanup-launch",
+        expectedRegistrationIdentity: "fake-registration:web:cleanup-launch:managed",
         force: true,
       },
     ]);
@@ -1567,6 +1570,7 @@ describe("session command vertical slice", () => {
         worktreeId: "wt_web_cleanup_failure",
         expectedPath: "/tmp/station/web/cleanup-failure",
         expectedBranch: "cleanup-failure",
+        expectedRegistrationIdentity: "fake-registration:web:cleanup-failure:managed",
         force: true,
       },
     ]);

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -591,6 +591,8 @@ describe("session command vertical slice", () => {
       {
         projectId: "web",
         worktreeId: "wt_web_cleanup_open",
+        expectedPath: "/tmp/station/web/cleanup-open",
+        expectedBranch: "cleanup-open",
         force: true,
       },
     ]);
@@ -642,6 +644,8 @@ describe("session command vertical slice", () => {
       {
         projectId: "web",
         worktreeId: "wt_web_cleanup_build",
+        expectedPath: "/tmp/station/web/cleanup-build",
+        expectedBranch: "cleanup-build",
         force: true,
       },
     ]);
@@ -686,6 +690,8 @@ describe("session command vertical slice", () => {
       {
         projectId: "web",
         worktreeId: "wt_web_cleanup_launch",
+        expectedPath: "/tmp/station/web/cleanup-launch",
+        expectedBranch: "cleanup-launch",
         force: true,
       },
     ]);
@@ -1559,6 +1565,8 @@ describe("session command vertical slice", () => {
       {
         projectId: "web",
         worktreeId: "wt_web_cleanup_failure",
+        expectedPath: "/tmp/station/web/cleanup-failure",
+        expectedBranch: "cleanup-failure",
         force: true,
       },
     ]);

--- a/apps/observer/test/integration/worktree-remove-preservation.test.ts
+++ b/apps/observer/test/integration/worktree-remove-preservation.test.ts
@@ -24,7 +24,7 @@ const execFileAsync = promisify(execFile);
 const now = "2026-07-14T20:00:00.000Z";
 
 describe("worktree removal preservation", () => {
-  it("preserves Git topology and dirty state when Worktrunk filters a selected checkout that becomes main", async () => {
+  it("protects a same-path replacement and preserves it when Worktrunk later filters it", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-remove-preservation-"));
     const repo = join(root, "repo");
     const linked = join(root, "feature");
@@ -95,8 +95,53 @@ describe("worktree removal preservation", () => {
     try {
       await core.reconcile("capture-feature-selection");
       const selected = core.getSnapshot().rows.find((row) => row.branch === "feature");
-      expect(selected).toMatchObject({ branch: "feature", path: linked });
+      expect(selected).toMatchObject({
+        branch: "feature",
+        path: linked,
+        registrationIdentity: expect.stringMatching(/^git-registration:/),
+      });
       if (selected === undefined) throw new Error("Expected the feature worktree row.");
+      if (selected.registrationIdentity === undefined) {
+        throw new Error("Expected the feature worktree registration identity.");
+      }
+
+      await git(repo, "worktree", "remove", "--force", linked);
+      await git(repo, "worktree", "add", linked, "feature");
+      const replacementReceipt = await queue.dispatch({
+        type: "worktree.remove",
+        payload: {
+          projectId: "web",
+          worktreeId: selected.id,
+          expectedPath: selected.path,
+          expectedBranch: selected.branch,
+          expectedRegistrationIdentity: selected.registrationIdentity,
+          force: true,
+        },
+      });
+      await queue.drain();
+
+      await expect(persistence.getCommand(replacementReceipt.commandId)).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "WORKTREE_REMOVE_STALE_SELECTION", worktreeId: selected.id },
+        diagnostics: [
+          expect.objectContaining({
+            type: "worktree_removal_refusal",
+            worktreeId: selected.id,
+            canonicalPath: linked,
+            observedBranch: "feature",
+            refusalReason: "registration_changed",
+          }),
+        ],
+      });
+      expect(worktrunkCalls.filter((args) => args.includes("remove"))).toEqual([]);
+      await expect(access(linked)).resolves.toBeUndefined();
+
+      await core.reconcile("capture-replacement-selection");
+      const replacement = core.getSnapshot().rows.find((row) => row.branch === "feature");
+      if (replacement?.registrationIdentity === undefined) {
+        throw new Error("Expected the replacement worktree registration identity.");
+      }
+      expect(replacement.registrationIdentity).not.toBe(selected.registrationIdentity);
 
       await git(repo, "switch", "--detach");
       await git(linked, "switch", "main");
@@ -114,9 +159,10 @@ describe("worktree removal preservation", () => {
         type: "worktree.remove",
         payload: {
           projectId: "web",
-          worktreeId: selected.id,
-          expectedPath: selected.path,
-          expectedBranch: selected.branch,
+          worktreeId: replacement.id,
+          expectedPath: replacement.path,
+          expectedBranch: replacement.branch,
+          expectedRegistrationIdentity: replacement.registrationIdentity,
           force: true,
         },
       });
@@ -126,7 +172,7 @@ describe("worktree removal preservation", () => {
         status: "failed",
         error: {
           code: "WORKTREE_REMOVE_STALE_SELECTION",
-          worktreeId: selected.id,
+          worktreeId: replacement.id,
         },
       });
       expect(worktrunkCalls.filter((args) => args.includes("remove"))).toEqual([]);
@@ -135,7 +181,7 @@ describe("worktree removal preservation", () => {
       expect(warnings).toContainEqual(
         expect.objectContaining({
           commandId: receipt.commandId,
-          worktreeId: selected.id,
+          worktreeId: replacement.id,
           canonicalPath: linked,
           observedBranch: "feature",
           refusalReason: "missing_target",
@@ -155,6 +201,125 @@ describe("worktree removal preservation", () => {
     } finally {
       await queue.shutdown();
       await git(repo, "worktree", "remove", "--force", linked).catch(() => undefined);
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records correlated refusal evidence when registration changes at final adapter validation", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-remove-final-race-"));
+    const repo = join(root, "repo");
+    const linked = join(root, "feature");
+    const stateDir = join(root, "state");
+    await mkdir(repo, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
+    const clock = { now: () => new Date(now) };
+    const sqlite = openObserverSqlite({ path: join(stateDir, "observer.sqlite"), clock });
+    const ids = observerIds();
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids });
+    const eventBus = createObserverEventBus();
+    const warnings: Record<string, unknown>[] = [];
+    const logger = {
+      async info(): Promise<void> {},
+      async warn(_message: string, attributes?: Record<string, unknown>): Promise<void> {
+        warnings.push(attributes ?? {});
+      },
+      async error(): Promise<void> {},
+    };
+    const worktrunkCalls: string[][] = [];
+    let finalRaceArmed = false;
+    let armedIdentityReads = 0;
+    const worktree = new WorktrunkProvider({
+      command: "wt",
+      clock,
+      resolveRegistrationIdentity: async () => {
+        if (!finalRaceArmed) return "git-registration:original";
+        armedIdentityReads += 1;
+        return armedIdentityReads === 1
+          ? "git-registration:original"
+          : "git-registration:replacement";
+      },
+      runner: async (input) => {
+        worktrunkCalls.push(input.args ?? []);
+        return externalResult(input, JSON.stringify([{ path: linked, branch: "feature" }]));
+      },
+    });
+    const terminal = new FakeTerminalProvider({ now });
+    const harness = new FakeHarnessProvider({ now });
+    const providers = new ProviderRegistry({ worktree, terminal, harnesses: [harness] });
+    const config = configFor(repo, stateDir);
+    const core = createObserverCore({ config, providers, persistence, clock, logger });
+    const queue = createCommandQueue({ persistence, clock, idFactory: ids, eventBus, logger });
+    registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
+      queue,
+      core,
+      providers,
+      projects: config.projects,
+      persistence,
+      eventBus,
+      clock,
+      logger,
+    });
+
+    try {
+      await core.reconcile("capture-original-registration");
+      const selected = core.getSnapshot().rows[0];
+      expect(selected).toMatchObject({
+        branch: "feature",
+        path: linked,
+        registrationIdentity: "git-registration:original",
+      });
+      if (selected?.registrationIdentity === undefined) {
+        throw new Error("Expected the original worktree registration identity.");
+      }
+      finalRaceArmed = true;
+
+      const receipt = await queue.dispatch({
+        type: "worktree.remove",
+        payload: {
+          projectId: "web",
+          worktreeId: selected.id,
+          expectedPath: selected.path,
+          expectedBranch: selected.branch,
+          expectedRegistrationIdentity: selected.registrationIdentity,
+          force: true,
+        },
+      });
+      await queue.drain();
+
+      await expect(persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+        status: "failed",
+        error: { code: "WORKTRUNK_WORKTREE_CHANGED" },
+        diagnostics: [
+          expect.objectContaining({
+            type: "worktree_removal_refusal",
+            provider: "worktrunk",
+            projectId: "web",
+            worktreeId: selected.id,
+            canonicalPath: linked,
+            observedBranch: "feature",
+            refusalReason: "registration_changed",
+          }),
+        ],
+      });
+      expect(worktrunkCalls.filter((args) => args.includes("remove"))).toEqual([]);
+      expect(terminal.snapshot().closed).toEqual([]);
+      expect(harness.snapshot().stopped).toEqual([]);
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          commandId: receipt.commandId,
+          traceId: expect.any(String),
+          provider: "worktrunk",
+          projectId: "web",
+          worktreeId: selected.id,
+          canonicalPath: linked,
+          observedBranch: "feature",
+          refusalReason: "registration_changed",
+        }),
+      );
+    } finally {
+      await queue.shutdown();
       sqlite.close();
       await rm(root, { recursive: true, force: true });
     }

--- a/apps/observer/test/integration/worktree-remove-preservation.test.ts
+++ b/apps/observer/test/integration/worktree-remove-preservation.test.ts
@@ -1,0 +1,225 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type { StationConfig } from "@station/config";
+import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { environmentWithoutGitLocals } from "@station/runtime";
+import { FakeHarnessProvider, FakeTerminalProvider } from "@station/testing";
+import { WorktrunkProvider } from "@station/worktrunk";
+import { describe, expect, it } from "vitest";
+import {
+  createCommandQueue,
+  createObserverCore,
+  createObserverEventBus,
+  createSqliteObserverPersistence,
+  openObserverSqlite,
+  ProviderRegistry,
+  registerObserverCommandHandlers,
+} from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
+
+const execFileAsync = promisify(execFile);
+const now = "2026-07-14T20:00:00.000Z";
+
+describe("worktree removal preservation", () => {
+  it("preserves Git topology and dirty state when Worktrunk filters a selected checkout that becomes main", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-remove-preservation-"));
+    const repo = join(root, "repo");
+    const linked = join(root, "feature");
+    const stateDir = join(root, "state");
+    await mkdir(repo, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.email", "station@example.invalid");
+    await git(repo, "config", "user.name", "station");
+    await writeFile(join(repo, "tracked.txt"), "base\n");
+    await git(repo, "add", "tracked.txt");
+    await git(repo, "commit", "-m", "initial");
+    await git(repo, "branch", "feature");
+    await git(repo, "worktree", "add", linked, "feature");
+
+    const clock = { now: () => new Date(now) };
+    const sqlite = openObserverSqlite({ path: join(stateDir, "observer.sqlite"), clock });
+    const ids = observerIds();
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids });
+    const eventBus = createObserverEventBus();
+    const warnings: Record<string, unknown>[] = [];
+    const logger = {
+      async info(): Promise<void> {},
+      async warn(_message: string, attributes?: Record<string, unknown>): Promise<void> {
+        warnings.push(attributes ?? {});
+      },
+      async error(): Promise<void> {},
+    };
+    const worktrunkCalls: string[][] = [];
+    const worktree = new WorktrunkProvider({
+      command: "wt",
+      clock,
+      runner: async (input) => {
+        worktrunkCalls.push(input.args ?? []);
+        const branch = await gitOutput(linked, "symbolic-ref", "--short", "HEAD");
+        const dirty = (await gitOutput(linked, "status", "--porcelain=v1")).length > 0;
+        return externalResult(
+          input,
+          JSON.stringify([
+            {
+              path: linked,
+              branch,
+              is_main: false,
+              worktree: { modified: dirty ? 1 : 0 },
+            },
+          ]),
+        );
+      },
+    });
+    const terminal = new FakeTerminalProvider({ now });
+    const harness = new FakeHarnessProvider({ now });
+    const providers = new ProviderRegistry({ worktree, terminal, harnesses: [harness] });
+    const config = configFor(repo, stateDir);
+    const core = createObserverCore({ config, providers, persistence, clock, logger });
+    const queue = createCommandQueue({ persistence, clock, idFactory: ids, eventBus, logger });
+    registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
+      queue,
+      core,
+      providers,
+      projects: config.projects,
+      persistence,
+      eventBus,
+      clock,
+      logger,
+    });
+
+    try {
+      await core.reconcile("capture-feature-selection");
+      const selected = core.getSnapshot().rows.find((row) => row.branch === "feature");
+      expect(selected).toMatchObject({ branch: "feature", path: linked });
+      if (selected === undefined) throw new Error("Expected the feature worktree row.");
+
+      await git(repo, "switch", "--detach");
+      await git(linked, "switch", "main");
+      await writeFile(join(linked, "tracked.txt"), "dirty\n");
+      await writeFile(join(linked, "staged.txt"), "staged\n");
+      await git(linked, "add", "staged.txt");
+      await writeFile(join(linked, "untracked.txt"), "untracked\n");
+
+      const statusBefore = await gitOutput(linked, "status", "--porcelain=v1");
+      const indexBefore = await gitOutput(linked, "write-tree");
+      const registrationBefore = await gitOutput(repo, "worktree", "list", "--porcelain");
+      const mainBefore = await gitOutput(repo, "rev-parse", "refs/heads/main");
+
+      const receipt = await queue.dispatch({
+        type: "worktree.remove",
+        payload: {
+          projectId: "web",
+          worktreeId: selected.id,
+          expectedPath: selected.path,
+          expectedBranch: selected.branch,
+          force: true,
+        },
+      });
+      await queue.drain();
+
+      await expect(persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+        status: "failed",
+        error: {
+          code: "WORKTREE_REMOVE_STALE_SELECTION",
+          worktreeId: selected.id,
+        },
+      });
+      expect(worktrunkCalls.filter((args) => args.includes("remove"))).toEqual([]);
+      expect(terminal.snapshot().closed).toEqual([]);
+      expect(harness.snapshot().stopped).toEqual([]);
+      expect(warnings).toContainEqual(
+        expect.objectContaining({
+          commandId: receipt.commandId,
+          worktreeId: selected.id,
+          canonicalPath: linked,
+          observedBranch: "feature",
+          refusalReason: "missing_target",
+        }),
+      );
+
+      await expect(access(linked)).resolves.toBeUndefined();
+      await expect(gitOutput(linked, "status", "--porcelain=v1")).resolves.toBe(statusBefore);
+      await expect(gitOutput(linked, "write-tree")).resolves.toBe(indexBefore);
+      await expect(gitOutput(repo, "worktree", "list", "--porcelain")).resolves.toBe(
+        registrationBefore,
+      );
+      await expect(gitOutput(repo, "rev-parse", "refs/heads/main")).resolves.toBe(mainBefore);
+      await expect(readFile(join(linked, "tracked.txt"), "utf8")).resolves.toBe("dirty\n");
+      await expect(readFile(join(linked, "staged.txt"), "utf8")).resolves.toBe("staged\n");
+      await expect(readFile(join(linked, "untracked.txt"), "utf8")).resolves.toBe("untracked\n");
+    } finally {
+      await queue.shutdown();
+      await git(repo, "worktree", "remove", "--force", linked).catch(() => undefined);
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function configFor(repo: string, stateDir: string): StationConfig {
+  return {
+    schemaVersion: 1,
+    observer: { stateDir },
+    defaults: {
+      worktreeProvider: "worktrunk",
+      terminal: "fake-terminal",
+      harness: "fake-harness",
+      layout: "agent-shell",
+      defaultBranch: "main",
+    },
+    projects: [
+      {
+        id: "web",
+        label: "web",
+        root: repo,
+        defaultBranch: "main",
+        defaults: {
+          harness: "fake-harness",
+          terminal: "fake-terminal",
+          layout: "agent-shell",
+        },
+        worktrunk: { enabled: true, base: "main", includeMain: false },
+      },
+    ],
+  };
+}
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd, env: environmentWithoutGitLocals() });
+}
+
+async function gitOutput(cwd: string, ...args: string[]): Promise<string> {
+  return (
+    await execFileAsync("git", args, { cwd, env: environmentWithoutGitLocals() })
+  ).stdout.trim();
+}
+
+function externalResult(input: ExternalCommandInput, stdout: string): ExternalCommandResult {
+  return {
+    command: input.command,
+    args: input.args ?? [],
+    stdout,
+    stderr: "",
+    exitCode: 0,
+  };
+}
+
+function observerIds() {
+  let command = 0;
+  let event = 0;
+  let error = 0;
+  let observation = 0;
+  let breadcrumb = 0;
+  return {
+    commandId: () => `cmd_${++command}`,
+    eventId: () => `evt_${++event}`,
+    errorId: () => `err_${++error}`,
+    observationId: () => `obs_${++observation}`,
+    breadcrumbId: () => `crumb_${++breadcrumb}`,
+  };
+}

--- a/apps/observer/test/unit/cleanup-command-validation.test.ts
+++ b/apps/observer/test/unit/cleanup-command-validation.test.ts
@@ -10,6 +10,7 @@ import {
   assertWorktreeRemovalAllowed,
   buildStationSnapshot,
   resolveSessionOrThrow,
+  resolveWorktreeRemovalTarget,
   resolveWorktreeRowOrThrow,
 } from "../../src/internal";
 import { observerHarnessRunFromRun } from "../../src/reconcile/harnessEventStatus";
@@ -84,6 +85,215 @@ describe("cleanup command validation", () => {
       }),
     );
   });
+
+  it("fails closed for primary and default-branch checkouts in normal and bare layouts", () => {
+    const snapshot = snapshotFor({ dirty: false, state: "none" });
+    const row = snapshot.rows[0];
+    const current = createFakeWorktree({
+      id: row.id,
+      projectId: row.projectId,
+      branch: row.branch,
+      path: row.path,
+      now,
+    });
+    const payload = {
+      worktreeId: row.id,
+      projectId: row.projectId,
+      expectedPath: row.path,
+      expectedBranch: row.branch,
+    };
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedPath: project.root },
+        snapshotRow: { ...row, path: project.root },
+        project,
+        currentWorktrees: [{ ...current, path: project.root }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_ROOT_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "primary_checkout",
+    });
+
+    const bareProject = { ...project, root: "/tmp/station/web.git" };
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project: bareProject,
+        currentWorktrees: [{ ...current, isPrimaryCheckout: true }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_ROOT_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "primary_checkout",
+    });
+
+    const mainRow = { ...row, branch: "main" };
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedBranch: "main" },
+        snapshotRow: mainRow,
+        project: bareProject,
+        currentWorktrees: [{ ...current, branch: "main" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "default_branch",
+    });
+
+    const derivedDefaultProject = {
+      id: project.id,
+      label: project.label,
+      root: bareProject.root,
+      defaults: project.defaults,
+      worktrunk: { enabled: true, base: "origin/main" },
+    };
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedBranch: "main" },
+        snapshotRow: mainRow,
+        project: derivedDefaultProject,
+        currentWorktrees: [{ ...current, branch: "main" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
+    });
+  });
+
+  it("reports changed, missing, and ambiguous removal selections as stale evidence", () => {
+    const snapshot = snapshotFor({ dirty: false, state: "none" });
+    const row = snapshot.rows[0];
+    const current = createFakeWorktree({
+      id: row.id,
+      projectId: row.projectId,
+      branch: row.branch,
+      path: row.path,
+      now,
+    });
+    const payload = {
+      worktreeId: row.id,
+      projectId: row.projectId,
+      expectedPath: row.path,
+      expectedBranch: row.branch,
+    };
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [{ ...current, branch: "main" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_STALE_SELECTION" },
+      refusalReason: "branch_changed",
+      observedBranch: "main",
+    });
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [{ ...current, path: `${row.path}-moved` }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_STALE_SELECTION" },
+      refusalReason: "path_changed",
+    });
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_STALE_SELECTION" },
+      refusalReason: "missing_target",
+    });
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [current, { ...current }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_TARGET_AMBIGUOUS" },
+      refusalReason: "ambiguous_identity",
+    });
+  });
+
+  it("resolves an unchanged disposable worktree for removal", () => {
+    const snapshot = snapshotFor({ dirty: false, state: "none" });
+    const row = snapshot.rows[0];
+    const current = createFakeWorktree({
+      id: row.id,
+      projectId: row.projectId,
+      branch: row.branch,
+      path: row.path,
+      now,
+    });
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: {
+          worktreeId: row.id,
+          projectId: row.projectId,
+          expectedPath: row.path,
+          expectedBranch: row.branch,
+        },
+        snapshotRow: row,
+        project,
+        currentWorktrees: [current],
+      }),
+    ).toEqual({ ok: true, target: current });
+  });
+
+  it("refuses removal when default-branch protection cannot be verified", () => {
+    const snapshot = snapshotFor({ dirty: false, state: "none" });
+    const row = snapshot.rows[0];
+    const current = createFakeWorktree({
+      id: row.id,
+      projectId: row.projectId,
+      branch: row.branch,
+      path: row.path,
+      now,
+    });
+    const unverifiedProject = {
+      id: project.id,
+      label: project.label,
+      root: project.root,
+      defaults: project.defaults,
+      worktrunk: { enabled: true },
+    };
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: {
+          worktreeId: row.id,
+          projectId: row.projectId,
+          expectedPath: row.path,
+          expectedBranch: row.branch,
+        },
+        snapshotRow: row,
+        project: unverifiedProject,
+        currentWorktrees: [current],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_PROTECTION_UNVERIFIED" },
+      refusalReason: "protection_unverified",
+    });
+  });
 });
 
 function snapshotFor(input: { dirty: boolean; state: "none" | "working" }) {
@@ -140,6 +350,7 @@ const project = {
   id: "web",
   label: "web",
   root: "/tmp/station/web",
+  defaultBranch: "main",
   defaults: {
     harness: "fake-harness",
     terminal: "fake-terminal",

--- a/apps/observer/test/unit/cleanup-command-validation.test.ts
+++ b/apps/observer/test/unit/cleanup-command-validation.test.ts
@@ -94,6 +94,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       branch: row.branch,
       path: row.path,
+      registrationIdentity: "git-registration:cleanup",
       now,
     });
     const payload = {
@@ -101,6 +102,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       expectedPath: row.path,
       expectedBranch: row.branch,
+      expectedRegistrationIdentity: "git-registration:cleanup",
     };
 
     expect(
@@ -162,6 +164,49 @@ describe("cleanup command validation", () => {
       ok: false,
       error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
     });
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedBranch: "main" },
+        snapshotRow: mainRow,
+        project: { ...derivedDefaultProject, worktrunk: { enabled: true, base: "upstream/main" } },
+        currentWorktrees: [{ ...current, branch: "main" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "default_branch",
+    });
+
+    const releaseRow = { ...row, branch: "release/main" };
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedBranch: "release/main" },
+        snapshotRow: releaseRow,
+        project: {
+          ...derivedDefaultProject,
+          worktrunk: { enabled: true, base: "refs/heads/release/main" },
+        },
+        currentWorktrees: [{ ...current, branch: "release/main" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "default_branch",
+    });
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project: { ...derivedDefaultProject, worktrunk: { enabled: true, base: "   " } },
+        currentWorktrees: [current],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_PROTECTION_UNVERIFIED" },
+      refusalReason: "protection_unverified",
+    });
   });
 
   it("reports changed, missing, and ambiguous removal selections as stale evidence", () => {
@@ -172,6 +217,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       branch: row.branch,
       path: row.path,
+      registrationIdentity: "git-registration:cleanup",
       now,
     });
     const payload = {
@@ -179,6 +225,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       expectedPath: row.path,
       expectedBranch: row.branch,
+      expectedRegistrationIdentity: "git-registration:cleanup",
     };
 
     expect(
@@ -230,6 +277,40 @@ describe("cleanup command validation", () => {
       error: { code: "WORKTREE_REMOVE_TARGET_AMBIGUOUS" },
       refusalReason: "ambiguous_identity",
     });
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [{ ...current, registrationIdentity: "git-registration:replacement" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: {
+        code: "WORKTREE_REMOVE_STALE_SELECTION",
+        diagnosticDetails: [
+          expect.objectContaining({
+            type: "worktree_removal_refusal",
+            refusalReason: "registration_changed",
+          }),
+        ],
+      },
+      refusalReason: "registration_changed",
+    });
+
+    const { registrationIdentity: _registrationIdentity, ...unverifiedCurrent } = current;
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload,
+        snapshotRow: row,
+        project,
+        currentWorktrees: [unverifiedCurrent],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_STALE_SELECTION" },
+      refusalReason: "registration_unverified",
+    });
   });
 
   it("resolves an unchanged disposable worktree for removal", () => {
@@ -240,6 +321,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       branch: row.branch,
       path: row.path,
+      registrationIdentity: "git-registration:cleanup",
       now,
     });
 
@@ -250,6 +332,7 @@ describe("cleanup command validation", () => {
           projectId: row.projectId,
           expectedPath: row.path,
           expectedBranch: row.branch,
+          expectedRegistrationIdentity: "git-registration:cleanup",
         },
         snapshotRow: row,
         project,
@@ -266,6 +349,7 @@ describe("cleanup command validation", () => {
       projectId: row.projectId,
       branch: row.branch,
       path: row.path,
+      registrationIdentity: "git-registration:cleanup",
       now,
     });
     const unverifiedProject = {
@@ -283,6 +367,7 @@ describe("cleanup command validation", () => {
           projectId: row.projectId,
           expectedPath: row.path,
           expectedBranch: row.branch,
+          expectedRegistrationIdentity: "git-registration:cleanup",
         },
         snapshotRow: row,
         project: unverifiedProject,
@@ -301,6 +386,7 @@ function snapshotFor(input: { dirty: boolean; state: "none" | "working" }) {
     id: "wt_web_cleanup",
     projectId: "web",
     branch: "cleanup",
+    registrationIdentity: "git-registration:cleanup",
     dirty: input.dirty,
     now,
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,7 +78,7 @@ A project omitting a field inherits the global value.
 | `terminal` | string | e.g. `"tmux"`. Free-form. |
 | `harness` | string | e.g. `"codex"`. Free-form; **not** cross-checked against `[harness.*]`. |
 | `layout` | string | e.g. `"agent-build-shell"`. Free-form. |
-| `default_branch` | string (optional) | e.g. `"main"`. |
+| `default_branch` | string (optional) | e.g. `"main"`. Destructive worktree removal fails closed when neither this value nor the Worktrunk base identifies the protected default branch. |
 | `harness_permission_mode` | `standard` \| `yolo` (optional) | **`auto` is rejected here** — it is Claude-only (see `[harness.*]`). |
 
 `worktree_provider`, `terminal`, `harness`, and `layout` are **required**. Values are

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -354,6 +354,13 @@ unrelated scopes may run concurrently. Failure is normalized into `SafeError`,
 persisted with trace correlation, and published. A failed command does not
 poison the following command in its scope.
 
+`worktree.remove` carries the selected worktree ID, canonical path, and branch.
+Its use case refreshes provider evidence and uniquely re-resolves that identity
+before terminal or worktree cleanup, refusing primary, default-branch, stale,
+missing, or ambiguous targets. The worktree adapter rechecks the same expected
+path and branch immediately before its mutation so an external checkout change
+cannot turn branch text into removal identity.
+
 ### Reconciliation
 
 Reconcile reads worktree and terminal actors, derives the worktree context for

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -354,12 +354,14 @@ unrelated scopes may run concurrently. Failure is normalized into `SafeError`,
 persisted with trace correlation, and published. A failed command does not
 poison the following command in its scope.
 
-`worktree.remove` carries the selected worktree ID, canonical path, and branch.
-Its use case refreshes provider evidence and uniquely re-resolves that identity
-before terminal or worktree cleanup, refusing primary, default-branch, stale,
-missing, or ambiguous targets. The worktree adapter rechecks the same expected
-path and branch immediately before its mutation so an external checkout change
-cannot turn branch text into removal identity.
+`worktree.remove` carries the selected worktree ID, canonical path, branch, and
+opaque Git registration identity. Its use case refreshes provider evidence and
+uniquely re-resolves that identity before terminal or worktree cleanup, refusing
+primary, default-branch, stale, missing, or ambiguous targets. The worktree
+adapter rechecks the expected registration identity, path, and branch immediately
+before mutation so an external checkout replacement cannot reuse the selected
+path and branch as removal identity. Adapter race refusals retain provider-neutral,
+trace-correlated diagnostic evidence.
 
 ### Reconciliation
 

--- a/integrations/worktree/worktrunk/src/errors.ts
+++ b/integrations/worktree/worktrunk/src/errors.ts
@@ -13,6 +13,7 @@ export type WorktrunkProviderErrorCode =
   | "WORKTRUNK_UNAVAILABLE"
   | "WORKTRUNK_UNSUPPORTED_FLAG"
   | "WORKTRUNK_WORKTREE_EXISTS"
+  | "WORKTRUNK_WORKTREE_CHANGED"
   | "WORKTRUNK_WORKTREE_NOT_FOUND";
 
 export class WorktrunkProviderError extends Error implements SafeError {

--- a/integrations/worktree/worktrunk/src/parse.ts
+++ b/integrations/worktree/worktrunk/src/parse.ts
@@ -67,6 +67,7 @@ export function parseWorktrunkListItem(
   const ahead = numberField(main, "ahead");
   const behind = numberField(main, "behind");
   const dirty = dirtyFromItem(item);
+  const isPrimaryCheckout = booleanField(item, "is_main");
   const remote = repositoryRemoteFromItem(item);
   const headSha = headShaFromItem(item);
   const observationInput: WorktreeObservation = {
@@ -85,6 +86,7 @@ export function parseWorktrunkListItem(
       ...(metadata === undefined ? {} : { metadata }),
     },
   };
+  if (isPrimaryCheckout !== undefined) observationInput.isPrimaryCheckout = isPrimaryCheckout;
   if (dirty !== undefined) observationInput.dirty = dirty;
   if (ahead !== undefined) observationInput.ahead = ahead;
   if (behind !== undefined) observationInput.behind = behind;

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { lstat, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, normalize, relative, resolve } from "node:path";
 import { stripVTControlCharacters } from "node:util";
@@ -20,6 +21,8 @@ import type {
   WorktreeEventContext,
   WorktreeObservation,
   WorktreeProvider,
+  WorktreeRemovalRefusalDiagnosticDetail,
+  WorktreeRemovalRefusalReason,
 } from "@station/contracts";
 import { ExternalCommandDiagnosticDetailSchema } from "@station/contracts";
 import {
@@ -57,6 +60,7 @@ export type WorktrunkProviderOptions = {
   timeoutMs?: number;
   runner?: ExternalCommandRunner;
   clock?: RuntimeClock;
+  resolveRegistrationIdentity?: (worktreePath: string) => Promise<string | undefined>;
 };
 
 type WorktrunkRunPolicy = {
@@ -78,7 +82,7 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Removal revalidates stable identity, path, and branch immediately before invoking Worktrunk.
+ * Removal revalidates native Git registration identity, path, and branch immediately before invoking Worktrunk.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -89,6 +93,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #timeoutMs: number;
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
+  readonly #resolveRegistrationIdentity: (worktreePath: string) => Promise<string | undefined>;
   readonly #observations = new Map<string, WorktreeObservation>();
   readonly #projects = new Map<string, ProviderProjectConfig>();
 
@@ -99,6 +104,8 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#timeoutMs = options.timeoutMs ?? 5000;
     this.#runner = options.runner;
     this.#clock = options.clock ?? systemClock;
+    this.#resolveRegistrationIdentity =
+      options.resolveRegistrationIdentity ?? nativeGitRegistrationIdentity;
   }
 
   capabilities(): WorktreeCapabilities {
@@ -238,11 +245,14 @@ export class WorktrunkProvider implements WorktreeProvider {
       },
       policy,
     );
-    return parseWorktrunkListJson(output.stdout, {
+    const observations = parseWorktrunkListJson(output.stdout, {
       project,
       providerId: this.id,
       observedAt: toIsoTimestamp(this.#clock.now()),
     });
+    return Promise.all(
+      observations.map((observation) => this.#withRegistrationIdentity(observation)),
+    );
   }
 
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
@@ -268,11 +278,16 @@ export class WorktrunkProvider implements WorktreeProvider {
       worktreePathEnv(request.project, request.branch, request.path),
     );
 
-    const observations = parseCommandObservation(output.stdout, {
+    const commandObservations = parseCommandObservation(output.stdout, {
       project: request.project,
       providerId: this.id,
       observedAt: toIsoTimestamp(this.#clock.now()),
-    }).filter((observation) => isManagedWorktreeObservation(request.project, observation));
+    });
+    const observations = (
+      await Promise.all(
+        commandObservations.map((observation) => this.#withRegistrationIdentity(observation)),
+      )
+    ).filter((observation) => isManagedWorktreeObservation(request.project, observation));
     const found =
       observations.find((observation) => observation.branch === request.branch) ??
       observations.find((observation) => observation.path === request.path) ??
@@ -283,6 +298,15 @@ export class WorktrunkProvider implements WorktreeProvider {
       throw new WorktrunkProviderError(
         "WORKTRUNK_INVALID_OUTPUT",
         "Worktrunk create did not return or list the created worktree.",
+      );
+    }
+    if (found.registrationIdentity === undefined) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_WORKTREE_CHANGED",
+        "Worktrunk created the worktree but Station could not verify its Git registration.",
+        {
+          hint: "Inspect the created worktree and refresh before trying to manage it in Station.",
+        },
       );
     }
     // Cache before seeding so the cleanup path can resolve the worktree if seeding fails.
@@ -297,6 +321,7 @@ export class WorktrunkProvider implements WorktreeProvider {
           worktreeId: found.id,
           expectedPath: found.path,
           expectedBranch: found.branch,
+          expectedRegistrationIdentity: found.registrationIdentity,
           force: true,
         }).catch(() => {});
         this.#observations.delete(found.id);
@@ -312,6 +337,16 @@ export class WorktrunkProvider implements WorktreeProvider {
       }
     }
     return found;
+  }
+
+  async #withRegistrationIdentity(observation: WorktreeObservation): Promise<WorktreeObservation> {
+    if (observation.state !== "exists") {
+      return observation;
+    }
+    const registrationIdentity = await this.#resolveRegistrationIdentity(observation.path);
+    return registrationIdentity === undefined
+      ? observation
+      : { ...observation, registrationIdentity };
   }
 
   async #seedWorkingTree(srcPath: string, tgtPath: string): Promise<void> {
@@ -361,29 +396,41 @@ export class WorktrunkProvider implements WorktreeProvider {
   async removeWorktree(request: RemoveWorktreeRequest): Promise<RemoveWorktreeResult> {
     const observation = this.#observations.get(request.worktreeId);
     if (observation === undefined) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_WORKTREE_NOT_FOUND",
-        "Worktrunk remove requires a previously observed worktree.",
-        { hint: "Run listWorktrees before removeWorktree so the provider can resolve the target." },
-      );
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_NOT_FOUND",
+        message: "Worktrunk remove requires a previously observed worktree.",
+        hint: "Run listWorktrees before removeWorktree so the provider can resolve the target.",
+        request,
+        canonicalPath: request.expectedPath,
+        observedBranch: request.expectedBranch,
+        refusalReason: "missing_target",
+      });
     }
-    if (
-      !samePath(observation.path, request.expectedPath) ||
-      observation.branch !== request.expectedBranch
-    ) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_WORKTREE_CHANGED",
-        "Worktrunk remove received stale checkout identity.",
-        { hint: "Refresh and reselect the worktree before retrying removal." },
-      );
+    const cachedRefusalReason = changedRemovalIdentityReason(observation, request);
+    if (cachedRefusalReason !== undefined) {
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_CHANGED",
+        message: "Worktrunk remove received stale checkout identity.",
+        hint: "Refresh and reselect the worktree before retrying removal.",
+        request,
+        projectId: observation.projectId,
+        canonicalPath: observation.path,
+        observedBranch: observation.branch,
+        refusalReason: cachedRefusalReason,
+      });
     }
     const project = this.#projects.get(observation.projectId);
     if (project === undefined) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_WORKTREE_NOT_FOUND",
-        "Worktrunk remove requires the repository root from a previous project listing.",
-        { hint: "Run listWorktrees for the project before removeWorktree." },
-      );
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_NOT_FOUND",
+        message: "Worktrunk remove requires the repository root from a previous project listing.",
+        hint: "Run listWorktrees for the project before removeWorktree.",
+        request,
+        projectId: observation.projectId,
+        canonicalPath: observation.path,
+        observedBranch: observation.branch,
+        refusalReason: "protection_unverified",
+      });
     }
 
     const currentWorktrees = await this.#readWorktrees(project, { retries: 1 });
@@ -394,27 +441,38 @@ export class WorktrunkProvider implements WorktreeProvider {
       samePath(worktree.path, request.expectedPath),
     );
     if (identityMatches.length === 0 && pathMatches.length === 0) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_WORKTREE_NOT_FOUND",
-        "Worktrunk remove could not confirm that the selected worktree still exists.",
-        { hint: "Run listWorktrees again before retrying removal." },
-      );
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_NOT_FOUND",
+        message: "Worktrunk remove could not confirm that the selected worktree still exists.",
+        hint: "Run listWorktrees again before retrying removal.",
+        request,
+        projectId: project.id,
+        canonicalPath: request.expectedPath,
+        observedBranch: request.expectedBranch,
+        refusalReason: "missing_target",
+      });
     }
     const selected = identityMatches[0];
-    if (
-      identityMatches.length !== 1 ||
-      pathMatches.length !== 1 ||
-      selected === undefined ||
-      selected.id !== pathMatches[0]?.id ||
-      selected.state !== "exists" ||
-      !samePath(selected.path, request.expectedPath) ||
-      selected.branch !== request.expectedBranch
-    ) {
-      throw new WorktrunkProviderError(
-        "WORKTRUNK_WORKTREE_CHANGED",
-        "The selected worktree changed before Worktrunk could remove it.",
-        { hint: "Refresh and reselect the worktree before retrying removal." },
-      );
+    const pathMatch = pathMatches[0];
+    const finalRefusalReason =
+      identityMatches.length !== 1 || pathMatches.length !== 1
+        ? "ambiguous_identity"
+        : selected === undefined || pathMatch === undefined || selected.id !== pathMatch.id
+          ? "identity_changed"
+          : selected.state !== "exists"
+            ? "missing_target"
+            : changedRemovalIdentityReason(selected, request);
+    if (finalRefusalReason !== undefined || selected === undefined || pathMatch === undefined) {
+      throw worktreeRemovalRefusalError({
+        code: "WORKTRUNK_WORKTREE_CHANGED",
+        message: "The selected worktree changed before Worktrunk could remove it.",
+        hint: "Refresh and reselect the worktree before retrying removal.",
+        request,
+        projectId: project.id,
+        canonicalPath: selected?.path ?? pathMatch?.path ?? request.expectedPath,
+        observedBranch: selected?.branch ?? pathMatch?.branch ?? request.expectedBranch,
+        refusalReason: finalRefusalReason ?? "ambiguous_identity",
+      });
     }
     const branchIsShared =
       !selected.branch.startsWith("detached:") &&
@@ -1038,6 +1096,89 @@ function isPathInside(path: string, root: string): boolean {
 
 function samePath(left: string, right: string): boolean {
   return canonicalPathForComparison(left) === canonicalPathForComparison(right);
+}
+
+function changedRemovalIdentityReason(
+  observation: WorktreeObservation,
+  request: RemoveWorktreeRequest,
+): WorktreeRemovalRefusalReason | undefined {
+  if (!samePath(observation.path, request.expectedPath)) {
+    return "path_changed";
+  }
+  if (observation.branch !== request.expectedBranch) {
+    return "branch_changed";
+  }
+  if (observation.registrationIdentity === undefined) {
+    return "registration_unverified";
+  }
+  if (observation.registrationIdentity !== request.expectedRegistrationIdentity) {
+    return "registration_changed";
+  }
+  return undefined;
+}
+
+function worktreeRemovalRefusalError(input: {
+  code: WorktrunkProviderErrorCode;
+  message: string;
+  hint: string;
+  request: RemoveWorktreeRequest;
+  projectId?: string;
+  canonicalPath: string;
+  observedBranch: string;
+  refusalReason: WorktreeRemovalRefusalReason;
+}): WorktrunkProviderError {
+  const detail: WorktreeRemovalRefusalDiagnosticDetail = {
+    type: "worktree_removal_refusal",
+    worktreeId: input.request.worktreeId,
+    canonicalPath: canonicalPathForComparison(input.canonicalPath),
+    observedBranch: input.observedBranch,
+    refusalReason: input.refusalReason,
+    provider: "worktrunk",
+  };
+  if (input.projectId !== undefined) {
+    detail.projectId = input.projectId;
+  }
+  return new WorktrunkProviderError(input.code, input.message, {
+    hint: input.hint,
+    diagnosticDetails: [detail],
+  });
+}
+
+async function nativeGitRegistrationIdentity(worktreePath: string): Promise<string | undefined> {
+  const markerPath = join(worktreePath, ".git");
+  try {
+    const before = await lstat(markerPath, { bigint: true });
+    const kind = before.isFile() ? "file" : before.isDirectory() ? "directory" : undefined;
+    if (kind === undefined || (kind === "file" && before.size > 4096n)) {
+      return undefined;
+    }
+    // Double-stat the native registration object so replacement during the read fails closed.
+    const marker = kind === "file" ? await readFile(markerPath, "utf8") : "";
+    const after = await lstat(markerPath, { bigint: true });
+    if (
+      before.dev !== after.dev ||
+      before.ino !== after.ino ||
+      before.birthtimeNs !== after.birthtimeNs ||
+      before.ctimeNs !== after.ctimeNs
+    ) {
+      return undefined;
+    }
+    const digest = createHash("sha256")
+      .update(
+        [
+          kind,
+          before.dev.toString(),
+          before.ino.toString(),
+          before.birthtimeNs.toString(),
+          before.ctimeNs.toString(),
+          marker,
+        ].join("\0"),
+      )
+      .digest("hex");
+    return `git-registration:${digest}`;
+  } catch {
+    return undefined;
+  }
 }
 
 function canonicalPathForComparison(path: string): string {

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -78,6 +78,7 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
+ * Removal revalidates stable identity, path, and branch immediately before invoking Worktrunk.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -292,7 +293,12 @@ export class WorktrunkProvider implements WorktreeProvider {
       } catch (seedError) {
         // Seeding failed after the worktree was created. Remove it so callers never
         // inherit a half-seeded worktree; best-effort, then rethrow the seed cause.
-        await this.removeWorktree({ worktreeId: found.id, force: true }).catch(() => {});
+        await this.removeWorktree({
+          worktreeId: found.id,
+          expectedPath: found.path,
+          expectedBranch: found.branch,
+          force: true,
+        }).catch(() => {});
         this.#observations.delete(found.id);
         throw seedError;
       }
@@ -361,6 +367,16 @@ export class WorktrunkProvider implements WorktreeProvider {
         { hint: "Run listWorktrees before removeWorktree so the provider can resolve the target." },
       );
     }
+    if (
+      !samePath(observation.path, request.expectedPath) ||
+      observation.branch !== request.expectedBranch
+    ) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_WORKTREE_CHANGED",
+        "Worktrunk remove received stale checkout identity.",
+        { hint: "Refresh and reselect the worktree before retrying removal." },
+      );
+    }
     const project = this.#projects.get(observation.projectId);
     if (project === undefined) {
       throw new WorktrunkProviderError(
@@ -371,12 +387,33 @@ export class WorktrunkProvider implements WorktreeProvider {
     }
 
     const currentWorktrees = await this.#readWorktrees(project, { retries: 1 });
-    const selected = currentWorktrees.find((worktree) => samePath(worktree.path, observation.path));
-    if (selected?.state !== "exists") {
+    const identityMatches = currentWorktrees.filter(
+      (worktree) => worktree.id === request.worktreeId,
+    );
+    const pathMatches = currentWorktrees.filter((worktree) =>
+      samePath(worktree.path, request.expectedPath),
+    );
+    if (identityMatches.length === 0 && pathMatches.length === 0) {
       throw new WorktrunkProviderError(
         "WORKTRUNK_WORKTREE_NOT_FOUND",
         "Worktrunk remove could not confirm that the selected worktree still exists.",
         { hint: "Run listWorktrees again before retrying removal." },
+      );
+    }
+    const selected = identityMatches[0];
+    if (
+      identityMatches.length !== 1 ||
+      pathMatches.length !== 1 ||
+      selected === undefined ||
+      selected.id !== pathMatches[0]?.id ||
+      selected.state !== "exists" ||
+      !samePath(selected.path, request.expectedPath) ||
+      selected.branch !== request.expectedBranch
+    ) {
+      throw new WorktrunkProviderError(
+        "WORKTRUNK_WORKTREE_CHANGED",
+        "The selected worktree changed before Worktrunk could remove it.",
+        { hint: "Refresh and reselect the worktree before retrying removal." },
       );
     }
     const branchIsShared =

--- a/integrations/worktree/worktrunk/test/unit/parse.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/parse.test.ts
@@ -104,6 +104,18 @@ describe("Worktrunk list parser", () => {
     expect(observations[0]).not.toHaveProperty("changeSummary");
   });
 
+  it("normalizes Worktrunk is_main as primary-checkout evidence", () => {
+    const observations = parseWorktrunkListJson(
+      JSON.stringify([
+        { branch: "main", path: project.root, is_main: true },
+        { branch: "feature", path: `${project.root}/feature`, is_main: false },
+      ]),
+      { project, observedAt: now },
+    );
+
+    expect(observations.map((observation) => observation.isPrimaryCheckout)).toEqual([true, false]);
+  });
+
   it("rejects invalid structured output with a typed provider error", async () => {
     const source = await fixture("invalid-list.json");
 

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { gitLocalEnvironmentVariables, nodeExternalCommandRunner } from "@station/runtime";
-import { WorktrunkProvider } from "@station/worktrunk";
+import { WorktrunkProvider, type WorktrunkProviderOptions } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 
 const now = "2026-05-21T12:00:00.000Z";
@@ -24,10 +24,17 @@ const project: ProviderProjectConfig = {
   },
 };
 
+function testProvider(options: WorktrunkProviderOptions): WorktrunkProvider {
+  return new WorktrunkProvider({
+    resolveRegistrationIdentity: async (path) => `git-registration:${path}`,
+    ...options,
+  });
+}
+
 describe("WorktrunkProvider", () => {
   it("lists worktrees through strict argv arrays", async () => {
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       configPath: "/tmp/wt/config.toml",
       clock: { now: () => new Date(now) },
@@ -66,7 +73,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) =>
@@ -100,7 +107,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) =>
@@ -135,7 +142,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) =>
@@ -169,7 +176,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -203,7 +210,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -237,7 +244,7 @@ describe("WorktrunkProvider", () => {
         includeExternal: false,
       },
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -264,7 +271,7 @@ describe("WorktrunkProvider", () => {
 
   it("creates and removes worktrees using Worktrunk lifecycle commands", async () => {
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -290,6 +297,7 @@ describe("WorktrunkProvider", () => {
       worktreeId: created.id,
       expectedPath: created.path,
       expectedBranch: created.branch,
+      expectedRegistrationIdentity: `git-registration:${created.path}`,
       force: true,
     });
 
@@ -309,6 +317,31 @@ describe("WorktrunkProvider", () => {
     ]);
   });
 
+  it("retains a created worktree when its Git registration cannot be verified", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      resolveRegistrationIdentity: async () => undefined,
+      runner: async (input) => {
+        calls.push(input);
+        return result(
+          input,
+          JSON.stringify([{ path: "/tmp/station/web/feature", branch: "feature" }]),
+        );
+      },
+    });
+
+    await expect(provider.createWorktree({ project, branch: "feature" })).rejects.toMatchObject({
+      code: "WORKTRUNK_WORKTREE_CHANGED",
+      message: "Worktrunk created the worktree but Station could not verify its Git registration.",
+      hint: "Inspect the created worktree and refresh before trying to manage it in Station.",
+    });
+    expect(calls.map((call) => call.args)).toEqual([
+      ["switch", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
+    ]);
+  });
+
   it("removes a selected shared-branch worktree without deleting the shared branch", async () => {
     const calls: ExternalCommandInput[] = [];
     const linkedPath = "/tmp/station/web/duplicate-linked";
@@ -320,7 +353,7 @@ describe("WorktrunkProvider", () => {
       },
     };
     let listCalls = 0;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -349,6 +382,7 @@ describe("WorktrunkProvider", () => {
       worktreeId: selected.id,
       expectedPath: selected.path,
       expectedBranch: selected.branch,
+      expectedRegistrationIdentity: `git-registration:${selected.path}`,
       force: true,
     });
 
@@ -372,7 +406,7 @@ describe("WorktrunkProvider", () => {
     const calls: ExternalCommandInput[] = [];
     const linkedPath = "/tmp/station/web/feature";
     let listCalls = 0;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -397,6 +431,7 @@ describe("WorktrunkProvider", () => {
         worktreeId: selected.id,
         expectedPath: selected.path,
         expectedBranch: selected.branch,
+        expectedRegistrationIdentity: `git-registration:${selected.path}`,
       }),
     ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_NOT_FOUND" });
     expect(calls.map((call) => call.args)).toEqual([
@@ -409,7 +444,7 @@ describe("WorktrunkProvider", () => {
     const calls: ExternalCommandInput[] = [];
     const linkedPath = "/tmp/station/web/feature";
     let listCalls = 0;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -440,6 +475,7 @@ describe("WorktrunkProvider", () => {
         worktreeId: selected.id,
         expectedPath: selected.path,
         expectedBranch: selected.branch,
+        expectedRegistrationIdentity: `git-registration:${selected.path}`,
       }),
     ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_CHANGED" });
     expect(calls.map((call) => call.args)).toEqual([
@@ -494,7 +530,7 @@ describe("WorktrunkProvider", () => {
     const srcStatusBefore = (await git(srcPath, "status", "--porcelain")).stdout;
 
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -565,7 +601,7 @@ describe("WorktrunkProvider", () => {
 
   it("skips Worktrunk hooks for automated mutations when lifecycle hooks are disabled", async () => {
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -592,6 +628,7 @@ describe("WorktrunkProvider", () => {
       worktreeId: created.id,
       expectedPath: created.path,
       expectedBranch: created.branch,
+      expectedRegistrationIdentity: `git-registration:${created.path}`,
     });
 
     expect(calls.map((call) => call.args)).toEqual([
@@ -603,7 +640,7 @@ describe("WorktrunkProvider", () => {
 
   it("pre-approves Worktrunk hook prompts for automated mutations when lifecycle hooks are enabled", async () => {
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: true,
       clock: { now: () => new Date(now) },
@@ -630,6 +667,7 @@ describe("WorktrunkProvider", () => {
       worktreeId: created.id,
       expectedPath: created.path,
       expectedBranch: created.branch,
+      expectedRegistrationIdentity: `git-registration:${created.path}`,
     });
 
     expect(calls.map((call) => call.args)).toEqual([
@@ -640,7 +678,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies duplicate branch failures and preserves external command diagnostics", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async () => {
@@ -671,7 +709,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies duplicate worktree path failures", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async () => {
@@ -690,7 +728,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies unsupported automation flag failures", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -710,7 +748,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies hook prompt approval failures", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async () => {
@@ -769,7 +807,7 @@ describe("WorktrunkProvider", () => {
       label: "healthy",
       root: healthyRoot,
     };
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {
@@ -842,7 +880,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies missing base failures", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async () => {
@@ -862,7 +900,7 @@ describe("WorktrunkProvider", () => {
 
   it("reports supported Worktrunk automation mode in doctor checks", async () => {
     const calls: ExternalCommandInput[] = [];
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -893,7 +931,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("warns about missing registrations with safe prune commands", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -935,7 +973,7 @@ describe("WorktrunkProvider", () => {
       root: "/tmp/station/api",
     };
     let slowScanAborted = false;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -1003,7 +1041,7 @@ describe("WorktrunkProvider", () => {
     let activeScans = 0;
     let maxActiveScans = 0;
     let completedScans = 0;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: false,
       clock: { now: () => new Date(now) },
@@ -1032,7 +1070,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("reports unsupported configured Worktrunk automation flags in doctor checks", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       useLifecycleHooks: true,
       clock: { now: () => new Date(now) },
@@ -1054,7 +1092,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("reports unavailable health when the wt binary is missing", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "missing-wt",
       clock: { now: () => new Date(now) },
       runner: async () => {
@@ -1078,7 +1116,7 @@ describe("WorktrunkProvider", () => {
 
   it("aborts Worktrunk subprocesses on timeout with a typed provider error", async () => {
     let aborted = false;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       timeoutMs: 5,
       clock: { now: () => new Date(now) },
@@ -1099,7 +1137,7 @@ describe("WorktrunkProvider", () => {
   });
 
   it("maps invalid create output to a WorktrunkProviderError", async () => {
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => result(input, "{not-json"),
@@ -1113,7 +1151,7 @@ describe("WorktrunkProvider", () => {
 
   it("retries safe reads but not create commands", async () => {
     let listCalls = 0;
-    const provider = new WorktrunkProvider({
+    const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
       runner: async (input) => {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -286,7 +286,12 @@ describe("WorktrunkProvider", () => {
     });
 
     const created = await provider.createWorktree({ project, branch: "feature" });
-    const removed = await provider.removeWorktree({ worktreeId: created.id, force: true });
+    const removed = await provider.removeWorktree({
+      worktreeId: created.id,
+      expectedPath: created.path,
+      expectedBranch: created.branch,
+      force: true,
+    });
 
     expect(removed).toEqual({ worktreeId: created.id, removed: true });
     expect(calls.map((call) => call.args)).toEqual([
@@ -340,7 +345,12 @@ describe("WorktrunkProvider", () => {
     expect(selected).toBeDefined();
     if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
 
-    await provider.removeWorktree({ worktreeId: selected.id, force: true });
+    await provider.removeWorktree({
+      worktreeId: selected.id,
+      expectedPath: selected.path,
+      expectedBranch: selected.branch,
+      force: true,
+    });
 
     expect(calls.map((call) => call.args)).toEqual([
       ["list", "--format=json"],
@@ -382,9 +392,56 @@ describe("WorktrunkProvider", () => {
     expect(selected).toBeDefined();
     if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
 
-    await expect(provider.removeWorktree({ worktreeId: selected.id })).rejects.toMatchObject({
-      code: "WORKTRUNK_WORKTREE_NOT_FOUND",
+    await expect(
+      provider.removeWorktree({
+        worktreeId: selected.id,
+        expectedPath: selected.path,
+        expectedBranch: selected.branch,
+      }),
+    ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_NOT_FOUND" });
+    expect(calls.map((call) => call.args)).toEqual([
+      ["list", "--format=json"],
+      ["list", "--format=json"],
+    ]);
+  });
+
+  it("does not remove a selected worktree whose branch changed before mutation", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const linkedPath = "/tmp/station/web/feature";
+    let listCalls = 0;
+    const provider = new WorktrunkProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.includes("list")) {
+          listCalls += 1;
+          return result(
+            input,
+            JSON.stringify([
+              {
+                path: linkedPath,
+                branch: listCalls === 1 ? "feature" : "main",
+                is_main: false,
+              },
+            ]),
+          );
+        }
+        return result(input, "{}");
+      },
     });
+
+    const [selected] = await provider.listWorktrees(project);
+    expect(selected).toBeDefined();
+    if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
+
+    await expect(
+      provider.removeWorktree({
+        worktreeId: selected.id,
+        expectedPath: selected.path,
+        expectedBranch: selected.branch,
+      }),
+    ).rejects.toMatchObject({ code: "WORKTRUNK_WORKTREE_CHANGED" });
     expect(calls.map((call) => call.args)).toEqual([
       ["list", "--format=json"],
       ["list", "--format=json"],
@@ -531,7 +588,11 @@ describe("WorktrunkProvider", () => {
     });
 
     const created = await provider.createWorktree({ project, branch: "feature" });
-    await provider.removeWorktree({ worktreeId: created.id });
+    await provider.removeWorktree({
+      worktreeId: created.id,
+      expectedPath: created.path,
+      expectedBranch: created.branch,
+    });
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--no-hooks", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],
@@ -565,7 +626,11 @@ describe("WorktrunkProvider", () => {
     });
 
     const created = await provider.createWorktree({ project, branch: "feature" });
-    await provider.removeWorktree({ worktreeId: created.id });
+    await provider.removeWorktree({
+      worktreeId: created.id,
+      expectedPath: created.path,
+      expectedBranch: created.branch,
+    });
 
     expect(calls.map((call) => call.args)).toEqual([
       ["switch", "--yes", "--create", "feature", "--base", "main", "--no-cd", "--format=json"],

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -35,6 +35,7 @@ export const RemoveWorktreePayloadSchema = z
     projectId: ProjectIdSchema.optional(),
     expectedPath: nonEmptyStringSchema,
     expectedBranch: nonEmptyStringSchema,
+    expectedRegistrationIdentity: nonEmptyStringSchema,
     force: z.boolean().optional(),
   })
   .strict();

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -33,6 +33,8 @@ export const RemoveWorktreePayloadSchema = z
   .object({
     worktreeId: WorktreeIdSchema,
     projectId: ProjectIdSchema.optional(),
+    expectedPath: nonEmptyStringSchema,
+    expectedBranch: nonEmptyStringSchema,
     force: z.boolean().optional(),
   })
   .strict();

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -11,6 +11,22 @@ import { nonEmptyStringSchema, safeTextSchema } from "./shared.js";
 
 export const ErrorSeveritySchema = z.enum(["debug", "info", "warn", "error", "fatal"]);
 
+export const WorktreeRemovalRefusalReasonSchema = z.enum([
+  "ambiguous_identity",
+  "branch_changed",
+  "default_branch",
+  "identity_changed",
+  "missing_target",
+  "path_changed",
+  "primary_checkout",
+  "protection_unverified",
+  "registration_changed",
+  "registration_unverified",
+  "snapshot_changed",
+]);
+
+export type WorktreeRemovalRefusalReason = z.infer<typeof WorktreeRemovalRefusalReasonSchema>;
+
 export const SafeErrorSchema = z
   .object({
     tag: nonEmptyStringSchema,
@@ -46,7 +62,26 @@ export const ExternalCommandDiagnosticDetailSchema = z
 
 export type ExternalCommandDiagnosticDetail = z.infer<typeof ExternalCommandDiagnosticDetailSchema>;
 
-export const DiagnosticDetailSchema = ExternalCommandDiagnosticDetailSchema;
+export const WorktreeRemovalRefusalDiagnosticDetailSchema = z
+  .object({
+    type: z.literal("worktree_removal_refusal"),
+    provider: ProviderIdSchema.optional(),
+    projectId: ProjectIdSchema.optional(),
+    worktreeId: WorktreeIdSchema,
+    canonicalPath: nonEmptyStringSchema,
+    observedBranch: nonEmptyStringSchema,
+    refusalReason: WorktreeRemovalRefusalReasonSchema,
+  })
+  .strict();
+
+export type WorktreeRemovalRefusalDiagnosticDetail = z.infer<
+  typeof WorktreeRemovalRefusalDiagnosticDetailSchema
+>;
+
+export const DiagnosticDetailSchema = z.discriminatedUnion("type", [
+  ExternalCommandDiagnosticDetailSchema,
+  WorktreeRemovalRefusalDiagnosticDetailSchema,
+]);
 
 export type DiagnosticDetail = z.infer<typeof DiagnosticDetailSchema>;
 

--- a/packages/contracts/src/observations.ts
+++ b/packages/contracts/src/observations.ts
@@ -171,6 +171,7 @@ export const WorktreeObservationSchema = z
     path: nonEmptyStringSchema,
     state: WorktreeStateSchema,
     source: WorktreeSourceSchema,
+    isPrimaryCheckout: z.boolean().optional(),
     dirty: z.boolean().optional(),
     ahead: z.number().int().nonnegative().optional(),
     behind: z.number().int().nonnegative().optional(),

--- a/packages/contracts/src/observations.ts
+++ b/packages/contracts/src/observations.ts
@@ -169,6 +169,7 @@ export const WorktreeObservationSchema = z
     projectId: ProjectIdSchema,
     branch: nonEmptyStringSchema,
     path: nonEmptyStringSchema,
+    registrationIdentity: nonEmptyStringSchema.optional(),
     state: WorktreeStateSchema,
     source: WorktreeSourceSchema,
     isPrimaryCheckout: z.boolean().optional(),

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -161,6 +161,8 @@ export type CreateWorktreeRequest = {
 
 export type RemoveWorktreeRequest = {
   worktreeId: WorktreeId;
+  expectedPath: string;
+  expectedBranch: string;
   projectId?: ProjectId;
   force?: boolean;
 };
@@ -380,6 +382,7 @@ export type RepositoryChecksRequest = z.infer<typeof RepositoryChecksRequestSche
  * DRIVEN PORT
  *
  * Supplies worktree lifecycle evidence and mutations without exposing provider mechanics.
+ * Removal adapters must revalidate the expected path and branch immediately before mutation.
  */
 export interface WorktreeProvider {
   id: ProviderId;

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -163,6 +163,7 @@ export type RemoveWorktreeRequest = {
   worktreeId: WorktreeId;
   expectedPath: string;
   expectedBranch: string;
+  expectedRegistrationIdentity: string;
   projectId?: ProjectId;
   force?: boolean;
 };
@@ -382,7 +383,7 @@ export type RepositoryChecksRequest = z.infer<typeof RepositoryChecksRequestSche
  * DRIVEN PORT
  *
  * Supplies worktree lifecycle evidence and mutations without exposing provider mechanics.
- * Removal adapters must revalidate the expected path and branch immediately before mutation.
+ * Removal adapters must revalidate opaque registration identity, path, and branch immediately before mutation.
  */
 export interface WorktreeProvider {
   id: ProviderId;

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -156,6 +156,7 @@ export const WorktreeRowSchema = z
     projectLabel: nonEmptyStringSchema,
     branch: nonEmptyStringSchema,
     path: nonEmptyStringSchema,
+    registrationIdentity: nonEmptyStringSchema.optional(),
     worktree: WorktreeRuntimeSchema,
     terminal: TerminalAttachmentSchema.optional(),
     agent: WorktreeAgentSchema.optional(),

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -827,7 +827,7 @@ describe("contract schemas", () => {
         type: "worktree.remove",
         payload: { projectId: "web", worktreeId: "wt_web_feature" },
       },
-      "worktree removal without selected path and branch identity",
+      "worktree removal without selected path, branch, and registration identity",
     );
 
     expectParses(

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -821,6 +821,15 @@ describe("contract schemas", () => {
       "invalid command fixture",
     );
 
+    expectFails(
+      StationCommandSchema,
+      {
+        type: "worktree.remove",
+        payload: { projectId: "web", worktreeId: "wt_web_feature" },
+      },
+      "worktree removal without selected path and branch identity",
+    );
+
     expectParses(
       StationCommandSchema,
       {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import {
   DebugBundleManifestSchema,
+  DiagnosticDetailSchema,
   DiagnosticEvidenceIndexSchema,
   DiagnosticSnapshotSchema,
   DoctorReportSchema,
@@ -133,5 +134,23 @@ describe("diagnostics schemas", () => {
       await loadJson("diagnostic-evidence-index.json"),
       "diagnostic evidence index",
     );
+  });
+
+  it("parses provider-neutral worktree removal refusal evidence strictly", () => {
+    const refusal = {
+      type: "worktree_removal_refusal",
+      provider: "worktrunk",
+      projectId: "web",
+      worktreeId: "wt_web_feature",
+      canonicalPath: "/tmp/station/web/feature",
+      observedBranch: "feature",
+      refusalReason: "registration_changed",
+    };
+
+    expect(DiagnosticDetailSchema.parse(refusal)).toEqual(refusal);
+    expect(
+      DiagnosticDetailSchema.safeParse({ ...refusal, refusalReason: "provider_private_reason" })
+        .success,
+    ).toBe(false);
   });
 });

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -1,6 +1,7 @@
 import type {
   ProjectView,
   ProviderId,
+  SafeError,
   SessionId,
   StationCommand,
   TerminalFocusOrigin,
@@ -140,11 +141,22 @@ export function buildCleanupCommand(
 }
 
 export function buildRemoveWorktreeCommand(row: WorktreeRow, force: boolean): StationCommand {
+  if (row.registrationIdentity === undefined) {
+    throw {
+      tag: "CommandValidationError",
+      code: "WORKTREE_REMOVE_REGISTRATION_UNVERIFIED",
+      message: "Station cannot verify this checkout's Git registration.",
+      hint: "Refresh the dashboard before trying to remove the checkout.",
+      projectId: row.projectId,
+      worktreeId: row.id,
+    } satisfies SafeError;
+  }
   const payload: Extract<StationCommand, { type: "worktree.remove" }>["payload"] = {
     projectId: row.projectId,
     worktreeId: row.id,
     expectedPath: normalizeObservedPath(row.path),
     expectedBranch: row.branch,
+    expectedRegistrationIdentity: row.registrationIdentity,
   };
   if (force) {
     payload.force = true;

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -7,7 +7,7 @@ import type {
   WorktreeId,
   WorktreeRow,
 } from "@station/contracts";
-import { isRunningAgentState } from "@station/contracts";
+import { isRunningAgentState, normalizeObservedPath } from "@station/contracts";
 
 type TerminalLayout = NonNullable<
   Extract<StationCommand, { type: "session.create" }>["payload"]["terminal"]["layout"]
@@ -143,6 +143,8 @@ export function buildRemoveWorktreeCommand(row: WorktreeRow, force: boolean): St
   const payload: Extract<StationCommand, { type: "worktree.remove" }>["payload"] = {
     projectId: row.projectId,
     worktreeId: row.id,
+    expectedPath: normalizeObservedPath(row.path),
+    expectedBranch: row.branch,
   };
   if (force) {
     payload.force = true;

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -1,9 +1,11 @@
 import { isRunningAgentState, type StationSnapshot, type WorktreeRow } from "@station/contracts";
 import { sessionForWorktreeRow, worktreeRowDisplayTitle } from "../../selectors/selectors.js";
+import { safeErrorToToast } from "../../services/errors/errors.js";
 import { buildRemoveWorktreeCommand, cleanupForceRequired } from "../commandBuilders.js";
 import type { TuiKey } from "../keys.js";
 import { isReturnKey } from "../keys.js";
 import { addPendingRemoveWorktreeRow } from "../localRows.js";
+import { addTuiToast } from "../toasts.js";
 import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
 import { handleDashboardRowChoiceKey } from "./rowChoose.js";
@@ -120,6 +122,24 @@ function handleConfirmKey(state: TuiState, key: TuiKey): TuiTransition {
         ...state,
         screen: { name: "dashboard" },
       },
+    };
+  }
+  if (row.registrationIdentity === undefined) {
+    return {
+      state: addTuiToast(
+        {
+          ...state,
+          screen: { name: "dashboard" },
+        },
+        safeErrorToToast({
+          tag: "CommandValidationError",
+          code: "WORKTREE_REMOVE_REGISTRATION_UNVERIFIED",
+          message: "Station cannot verify this checkout's Git registration.",
+          hint: "Refresh the dashboard before trying to remove the checkout.",
+          projectId: row.projectId,
+          worktreeId: row.id,
+        }),
+      ),
     };
   }
 

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -139,6 +139,7 @@ export function row(input: {
     projectLabel: input.projectId,
     branch: input.branch,
     path: `/tmp/station/${input.projectId}/worktrees/${input.branch.replaceAll("/", "-")}`,
+    registrationIdentity: `git-registration:${input.id}`,
     worktree: {
       state: "exists",
       source: "worktrunk",

--- a/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
+++ b/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
@@ -176,6 +176,7 @@ describe("TUI command builders", () => {
         worktreeId: "wt_web_idle",
         expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
         expectedBranch: "fix-nav-mobile",
+        expectedRegistrationIdentity: "git-registration:wt_web_idle",
       },
     });
   });
@@ -193,6 +194,7 @@ describe("TUI command builders", () => {
         worktreeId: "wt_web_idle",
         expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
         expectedBranch: "fix-nav-mobile",
+        expectedRegistrationIdentity: "git-registration:wt_web_idle",
         force: true,
       },
     });

--- a/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
+++ b/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
@@ -174,6 +174,8 @@ describe("TUI command builders", () => {
       payload: {
         projectId: "web",
         worktreeId: "wt_web_idle",
+        expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
+        expectedBranch: "fix-nav-mobile",
       },
     });
   });
@@ -189,6 +191,8 @@ describe("TUI command builders", () => {
       payload: {
         projectId: "web",
         worktreeId: "wt_web_idle",
+        expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
+        expectedBranch: "fix-nav-mobile",
         force: true,
       },
     });

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -369,11 +369,37 @@ describe("TUI screen transitions", () => {
             worktreeId: "wt_web_idle",
             expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
             expectedBranch: "fix-nav-mobile",
+            expectedRegistrationIdentity: "git-registration:wt_web_idle",
             force: true,
           },
         },
       }),
     ]);
+  });
+
+  it("refuses removal with an actionable toast when checkout registration is unverified", () => {
+    const snapshot = createDashboardSnapshot();
+    const rows = snapshot.rows.map((row) => {
+      if (row.id !== "wt_web_idle") return row;
+      const { registrationIdentity: _registrationIdentity, ...unverified } = row;
+      return unverified;
+    });
+    const state = handleTuiKey(
+      handleTuiKey(createInitialTuiState({ initialSnapshot: { ...snapshot, rows } }), {
+        input: "X",
+      }).state,
+      { input: "5" },
+    ).state;
+
+    const transition = handleTuiKey(state, { input: "y" });
+
+    expect(transition.operations).toBeUndefined();
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.state.toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: "Station cannot verify this checkout's Git registration.",
+      hint: "Refresh the dashboard before trying to remove the checkout.",
+    });
   });
 
   it("remaps remove slot choices to the visible viewport after scrolling", () => {

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -367,6 +367,8 @@ describe("TUI screen transitions", () => {
           payload: {
             projectId: "web",
             worktreeId: "wt_web_idle",
+            expectedPath: "/tmp/station/web/worktrees/fix-nav-mobile",
+            expectedBranch: "fix-nav-mobile",
             force: true,
           },
         },

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -26,7 +26,19 @@ export type RuntimeExternalCommandDiagnosticDetail = {
   durationMs?: number;
 };
 
-export type RuntimeDiagnosticDetail = RuntimeExternalCommandDiagnosticDetail;
+export type RuntimeWorktreeRemovalRefusalDiagnosticDetail = {
+  type: "worktree_removal_refusal";
+  provider?: string;
+  projectId?: string;
+  worktreeId: string;
+  canonicalPath: string;
+  observedBranch: string;
+  refusalReason: string;
+};
+
+export type RuntimeDiagnosticDetail =
+  | RuntimeExternalCommandDiagnosticDetail
+  | RuntimeWorktreeRemovalRefusalDiagnosticDetail;
 
 export type RuntimeSafeErrorFallback = {
   tag: string;
@@ -145,6 +157,18 @@ function safeErrorCause(error: unknown, seen = new Set<unknown>()): RuntimeSafeE
 }
 
 function copyDiagnosticDetail(detail: RuntimeDiagnosticDetail): RuntimeDiagnosticDetail {
+  if (detail.type === "worktree_removal_refusal") {
+    const copied: RuntimeWorktreeRemovalRefusalDiagnosticDetail = {
+      type: detail.type,
+      worktreeId: detail.worktreeId,
+      canonicalPath: detail.canonicalPath,
+      observedBranch: detail.observedBranch,
+      refusalReason: detail.refusalReason,
+    };
+    if (detail.provider !== undefined) copied.provider = detail.provider;
+    if (detail.projectId !== undefined) copied.projectId = detail.projectId;
+    return copied;
+  }
   const copied: RuntimeExternalCommandDiagnosticDetail = {
     type: "external_command",
     operation: detail.operation,

--- a/packages/runtime/test/unit/runtime-boundary.test.ts
+++ b/packages/runtime/test/unit/runtime-boundary.test.ts
@@ -1,4 +1,9 @@
-import { Effect, runRuntimeBoundary, runtimeBoundaryEffect } from "@station/runtime";
+import {
+  Effect,
+  runRuntimeBoundary,
+  runtimeBoundaryEffect,
+  safeErrorFromUnknown,
+} from "@station/runtime";
 import { describe, expect, it } from "vitest";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -54,5 +59,35 @@ describe("runtime Effect boundaries", () => {
         durationMs: 0,
       },
     });
+  });
+
+  it("copies provider-neutral worktree removal refusal diagnostics", () => {
+    const diagnosticDetails = [
+      {
+        type: "worktree_removal_refusal" as const,
+        provider: "worktrunk",
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        canonicalPath: "/tmp/station/web/feature",
+        observedBranch: "feature",
+        refusalReason: "registration_changed",
+      },
+    ];
+    const copied = safeErrorFromUnknown(
+      {
+        tag: "WorktreeProviderError",
+        code: "WORKTRUNK_WORKTREE_CHANGED",
+        message: "The Git registration changed.",
+        diagnosticDetails,
+      },
+      {
+        tag: "RuntimeError",
+        code: "RUNTIME_FAILED",
+        message: "Runtime failed.",
+      },
+    );
+
+    expect(copied.diagnosticDetails).toEqual(diagnosticDetails);
+    expect(copied.diagnosticDetails).not.toBe(diagnosticDetails);
   });
 });

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -76,6 +76,7 @@ export type CreateFakeWorktreeInput = {
   branch?: string;
   path?: string;
   now?: FakeProviderClock;
+  isPrimaryCheckout?: boolean;
   dirty?: boolean;
   ahead?: number;
   behind?: number;
@@ -233,6 +234,9 @@ export function createFakeWorktree(input: CreateFakeWorktreeInput = {}): Worktre
     path: input.path ?? `/tmp/station/${projectId}/${branch.replaceAll("/", "-")}`,
     state: "exists",
     source: "worktrunk",
+    ...(input.isPrimaryCheckout === undefined
+      ? {}
+      : { isPrimaryCheckout: input.isPrimaryCheckout }),
     dirty: input.dirty ?? false,
     ahead: input.ahead ?? 0,
     behind: input.behind ?? 0,
@@ -355,11 +359,27 @@ export class FakeWorktreeProvider implements WorktreeProvider {
     maybeThrow(this.#failures, "removeWorktree");
     const recorded: RemoveWorktreeRequest = {
       worktreeId: request.worktreeId,
+      expectedPath: request.expectedPath,
+      expectedBranch: request.expectedBranch,
     };
     if (request.projectId !== undefined) recorded.projectId = request.projectId;
     if (request.force !== undefined) recorded.force = request.force;
-    this.#removed.push(recorded);
     const index = this.#worktrees.findIndex((worktree) => worktree.id === request.worktreeId);
+    const selected = this.#worktrees[index];
+    if (
+      selected !== undefined &&
+      (selected.path !== request.expectedPath || selected.branch !== request.expectedBranch)
+    ) {
+      const error: SafeError = {
+        tag: "WorktreeProviderError",
+        code: "FAKE_WORKTREE_CHANGED",
+        message: "The fake worktree changed before removal.",
+        provider: this.id,
+        worktreeId: request.worktreeId,
+      };
+      throw error;
+    }
+    this.#removed.push(recorded);
     if (index >= 0) {
       this.#worktrees.splice(index, 1);
     }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -75,6 +75,7 @@ export type CreateFakeWorktreeInput = {
   projectId?: string;
   branch?: string;
   path?: string;
+  registrationIdentity?: string;
   now?: FakeProviderClock;
   isPrimaryCheckout?: boolean;
   dirty?: boolean;
@@ -232,6 +233,9 @@ export function createFakeWorktree(input: CreateFakeWorktreeInput = {}): Worktre
     projectId,
     branch,
     path: input.path ?? `/tmp/station/${projectId}/${branch.replaceAll("/", "-")}`,
+    ...(input.registrationIdentity === undefined
+      ? {}
+      : { registrationIdentity: input.registrationIdentity }),
     state: "exists",
     source: "worktrunk",
     ...(input.isPrimaryCheckout === undefined
@@ -308,7 +312,7 @@ export class FakeWorktreeProvider implements WorktreeProvider {
   constructor(options: FakeWorktreeProviderOptions = {}) {
     this.id = options.id ?? "fake-worktree";
     this.#now = options.now;
-    this.#worktrees = options.worktrees ?? [];
+    this.#worktrees = (options.worktrees ?? []).map(withFakeRegistrationIdentity);
     this.#createPath = options.createPath;
     this.#health = options.health;
     this.#capabilities = {
@@ -349,6 +353,7 @@ export class FakeWorktreeProvider implements WorktreeProvider {
       projectId: request.project.id,
       branch: request.branch,
       ...(path === undefined ? {} : { path }),
+      registrationIdentity: `fake-registration:${request.project.id}:${request.branch}:${path ?? "managed"}`,
       ...(this.#now === undefined ? {} : { now: this.#now }),
     });
     this.#worktrees.push(worktree);
@@ -361,6 +366,7 @@ export class FakeWorktreeProvider implements WorktreeProvider {
       worktreeId: request.worktreeId,
       expectedPath: request.expectedPath,
       expectedBranch: request.expectedBranch,
+      expectedRegistrationIdentity: request.expectedRegistrationIdentity,
     };
     if (request.projectId !== undefined) recorded.projectId = request.projectId;
     if (request.force !== undefined) recorded.force = request.force;
@@ -368,7 +374,9 @@ export class FakeWorktreeProvider implements WorktreeProvider {
     const selected = this.#worktrees[index];
     if (
       selected !== undefined &&
-      (selected.path !== request.expectedPath || selected.branch !== request.expectedBranch)
+      (selected.path !== request.expectedPath ||
+        selected.branch !== request.expectedBranch ||
+        selected.registrationIdentity !== request.expectedRegistrationIdentity)
     ) {
       const error: SafeError = {
         tag: "WorktreeProviderError",
@@ -415,6 +423,13 @@ export class FakeWorktreeProvider implements WorktreeProvider {
       created: this.#created.map((request) => ({ ...request })),
     };
   }
+}
+
+function withFakeRegistrationIdentity(worktree: WorktreeObservation): WorktreeObservation {
+  if (worktree.registrationIdentity === undefined) {
+    worktree.registrationIdentity = `fake-registration:${worktree.id}:${worktree.path}`;
+  }
+  return worktree;
 }
 
 export class FakeTerminalProvider implements TerminalProvider {

--- a/packages/testing/test/unit/fake-providers.test.ts
+++ b/packages/testing/test/unit/fake-providers.test.ts
@@ -219,6 +219,7 @@ describe("fake providers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "fake-registration:wt_web_cleanup:/tmp/station/web/cleanup",
         force: true,
       }),
     ).resolves.toEqual({ worktreeId: "wt_web_cleanup", removed: true });
@@ -240,6 +241,7 @@ describe("fake providers", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "fake-registration:wt_web_cleanup:/tmp/station/web/cleanup",
         force: true,
       },
     ]);

--- a/packages/testing/test/unit/fake-providers.test.ts
+++ b/packages/testing/test/unit/fake-providers.test.ts
@@ -217,6 +217,8 @@ describe("fake providers", () => {
       worktree.removeWorktree({
         projectId: "web",
         worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
         force: true,
       }),
     ).resolves.toEqual({ worktreeId: "wt_web_cleanup", removed: true });
@@ -233,7 +235,13 @@ describe("fake providers", () => {
     expect(terminal.snapshot().closed).toEqual(["term_web_cleanup"]);
     expect(terminal.snapshot().targets).toEqual([]);
     expect(worktree.snapshot().removed).toEqual([
-      { projectId: "web", worktreeId: "wt_web_cleanup", force: true },
+      {
+        projectId: "web",
+        worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
+        force: true,
+      },
     ]);
     expect(worktree.snapshot().worktrees).toEqual([]);
   });

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -250,6 +250,7 @@ function scenarioRow(input: ScenarioRowInput): WorktreeRow {
     projectLabel: input.project.label,
     branch: input.branch,
     path: `/Users/example/.worktrees/${input.project.id}/${input.branch.replaceAll("/", "-")}`,
+    registrationIdentity: `git-registration:${input.id}`,
     worktree: {
       state: "exists",
       source: "worktrunk",

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -26,6 +26,8 @@
     "payload": {
       "projectId": "web",
       "worktreeId": "wt_web_feature_auth",
+      "expectedPath": "/tmp/station/web/worktrees/feature-auth",
+      "expectedBranch": "feature/auth",
       "force": false
     }
   },

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -28,6 +28,7 @@
       "worktreeId": "wt_web_feature_auth",
       "expectedPath": "/tmp/station/web/worktrees/feature-auth",
       "expectedBranch": "feature/auth",
+      "expectedRegistrationIdentity": "git-registration:fixture-feature-auth",
       "force": false
     }
   },

--- a/tests/diagnostics/debug-bundle/cleanup-command.test.ts
+++ b/tests/diagnostics/debug-bundle/cleanup-command.test.ts
@@ -47,6 +47,7 @@ describe("cleanup command debug bundle diagnostics", () => {
             id: "wt_web_cleanup",
             projectId: "web",
             branch: "cleanup",
+            registrationIdentity: "git-registration:cleanup",
             dirty: true,
             now,
           }),
@@ -103,6 +104,7 @@ describe("cleanup command debug bundle diagnostics", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
       },
     });
     const succeeded = await queue.dispatch({
@@ -112,6 +114,7 @@ describe("cleanup command debug bundle diagnostics", () => {
         worktreeId: "wt_web_cleanup",
         expectedPath: "/tmp/station/web/cleanup",
         expectedBranch: "cleanup",
+        expectedRegistrationIdentity: "git-registration:cleanup",
         force: true,
       },
     });

--- a/tests/diagnostics/debug-bundle/cleanup-command.test.ts
+++ b/tests/diagnostics/debug-bundle/cleanup-command.test.ts
@@ -101,6 +101,8 @@ describe("cleanup command debug bundle diagnostics", () => {
       payload: {
         projectId: "web",
         worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
       },
     });
     const succeeded = await queue.dispatch({
@@ -108,6 +110,8 @@ describe("cleanup command debug bundle diagnostics", () => {
       payload: {
         projectId: "web",
         worktreeId: "wt_web_cleanup",
+        expectedPath: "/tmp/station/web/cleanup",
+        expectedBranch: "cleanup",
         force: true,
       },
     });
@@ -163,6 +167,7 @@ function configFor(root: string, stateDir: string): StationConfig {
         id: "web",
         label: "web",
         root,
+        defaultBranch: "main",
         defaults: {
           harness: "fake-harness",
           terminal: "fake-terminal",

--- a/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
@@ -128,6 +128,8 @@ describe("full session cleanup e2e", () => {
         payload: {
           projectId: "web",
           worktreeId: "wt_web_cleanup",
+          expectedPath: "/tmp/station/web/cleanup",
+          expectedBranch: "cleanup",
           force: true,
         },
       });
@@ -162,6 +164,7 @@ function configFor(root: string, stateDir: string, socketPath: string): StationC
         id: "web",
         label: "web",
         root,
+        defaultBranch: "main",
         defaults: {
           harness: "fake-harness",
           terminal: "fake-terminal",

--- a/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
@@ -64,6 +64,7 @@ describe("full session cleanup e2e", () => {
             id: "wt_web_cleanup",
             projectId: "web",
             branch: "cleanup",
+            registrationIdentity: "git-registration:cleanup",
             now,
           }),
         ],
@@ -130,6 +131,7 @@ describe("full session cleanup e2e", () => {
           worktreeId: "wt_web_cleanup",
           expectedPath: "/tmp/station/web/cleanup",
           expectedBranch: "cleanup",
+          expectedRegistrationIdentity: "git-registration:cleanup",
           force: true,
         },
       });

--- a/tests/e2e/real/real-session-lifecycle-claude.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-claude.test.ts
@@ -108,6 +108,9 @@ describeReal("real Claude session lifecycle", () => {
         90_000,
       );
       const row = findRowByBranch(snapshot, branch);
+      if (row.registrationIdentity === undefined) {
+        throw new Error(`Expected Git registration identity for ${branch}.`);
+      }
       await waitForClaudeSentinel(sentinel, { rootPath: row.path });
       expect(row.agent).toMatchObject({
         harness: "claude",
@@ -142,6 +145,7 @@ describeReal("real Claude session lifecycle", () => {
           projectId: row.projectId,
           expectedPath: row.path,
           expectedBranch: row.branch,
+          expectedRegistrationIdentity: row.registrationIdentity,
           force: true,
         },
       };

--- a/tests/e2e/real/real-session-lifecycle-claude.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-claude.test.ts
@@ -140,6 +140,8 @@ describeReal("real Claude session lifecycle", () => {
         payload: {
           worktreeId: row.id,
           projectId: row.projectId,
+          expectedPath: row.path,
+          expectedBranch: row.branch,
           force: true,
         },
       };

--- a/tests/e2e/real/real-session-lifecycle-codex.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-codex.test.ts
@@ -144,6 +144,8 @@ describeReal("real Codex session lifecycle", () => {
         payload: {
           worktreeId: row.id,
           projectId: row.projectId,
+          expectedPath: row.path,
+          expectedBranch: row.branch,
           force: true,
         },
       };

--- a/tests/e2e/real/real-session-lifecycle-codex.test.ts
+++ b/tests/e2e/real/real-session-lifecycle-codex.test.ts
@@ -112,6 +112,9 @@ describeReal("real Codex session lifecycle", () => {
         90_000,
       );
       const row = findRowByBranch(snapshot, branch);
+      if (row.registrationIdentity === undefined) {
+        throw new Error(`Expected Git registration identity for ${branch}.`);
+      }
       await waitForCodexSentinel(sentinel, { rootPath: row.path });
       expect(row.agent).toMatchObject({
         harness: "codex",
@@ -146,6 +149,7 @@ describeReal("real Codex session lifecycle", () => {
           projectId: row.projectId,
           expectedPath: row.path,
           expectedBranch: row.branch,
+          expectedRegistrationIdentity: row.registrationIdentity,
           force: true,
         },
       };

--- a/tests/e2e/worktrunk-real.test.ts
+++ b/tests/e2e/worktrunk-real.test.ts
@@ -74,20 +74,30 @@ describeReal("real Worktrunk provider smoke", () => {
       hookBin: stationIngressBin,
     });
 
-    let createdId: string | undefined;
+    let createdForCleanup: { id: string; path: string; branch: string } | undefined;
     try {
       await expect(provider.health()).resolves.toMatchObject({ status: "healthy" });
       await expect(provider.listWorktrees(project)).resolves.toEqual(expect.any(Array));
       const created = await provider.createWorktree({ project, branch });
-      createdId = created.id;
+      createdForCleanup = created;
       expect(created.branch).toBe(branch);
-      await expect(provider.removeWorktree({ worktreeId: created.id })).resolves.toMatchObject({
-        removed: true,
-      });
+      await expect(
+        provider.removeWorktree({
+          worktreeId: created.id,
+          expectedPath: created.path,
+          expectedBranch: created.branch,
+        }),
+      ).resolves.toMatchObject({ removed: true });
+      createdForCleanup = undefined;
     } finally {
-      if (createdId !== undefined) {
+      if (createdForCleanup !== undefined) {
         await provider
-          .removeWorktree({ worktreeId: createdId, force: true })
+          .removeWorktree({
+            worktreeId: createdForCleanup.id,
+            expectedPath: createdForCleanup.path,
+            expectedBranch: createdForCleanup.branch,
+            force: true,
+          })
           .catch(() => undefined);
       }
       await uninstallWorktrunkHooks({
@@ -147,9 +157,13 @@ describeReal("real Worktrunk provider smoke", () => {
       expect(selected).toBeDefined();
       if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
 
-      await expect(provider.removeWorktree({ worktreeId: selected.id })).resolves.toMatchObject({
-        removed: true,
-      });
+      await expect(
+        provider.removeWorktree({
+          worktreeId: selected.id,
+          expectedPath: selected.path,
+          expectedBranch: selected.branch,
+        }),
+      ).resolves.toMatchObject({ removed: true });
 
       const remaining = await git("worktree", "list", "--porcelain");
       const remainingPaths = remaining.stdout

--- a/tests/e2e/worktrunk-real.test.ts
+++ b/tests/e2e/worktrunk-real.test.ts
@@ -74,18 +74,24 @@ describeReal("real Worktrunk provider smoke", () => {
       hookBin: stationIngressBin,
     });
 
-    let createdForCleanup: { id: string; path: string; branch: string } | undefined;
+    let createdForCleanup:
+      | { id: string; path: string; branch: string; registrationIdentity: string }
+      | undefined;
     try {
       await expect(provider.health()).resolves.toMatchObject({ status: "healthy" });
       await expect(provider.listWorktrees(project)).resolves.toEqual(expect.any(Array));
       const created = await provider.createWorktree({ project, branch });
-      createdForCleanup = created;
+      if (created.registrationIdentity === undefined) {
+        throw new Error("Expected the created worktree registration identity.");
+      }
+      createdForCleanup = { ...created, registrationIdentity: created.registrationIdentity };
       expect(created.branch).toBe(branch);
       await expect(
         provider.removeWorktree({
           worktreeId: created.id,
           expectedPath: created.path,
           expectedBranch: created.branch,
+          expectedRegistrationIdentity: created.registrationIdentity,
         }),
       ).resolves.toMatchObject({ removed: true });
       createdForCleanup = undefined;
@@ -96,6 +102,7 @@ describeReal("real Worktrunk provider smoke", () => {
             worktreeId: createdForCleanup.id,
             expectedPath: createdForCleanup.path,
             expectedBranch: createdForCleanup.branch,
+            expectedRegistrationIdentity: createdForCleanup.registrationIdentity,
             force: true,
           })
           .catch(() => undefined);
@@ -156,12 +163,16 @@ describeReal("real Worktrunk provider smoke", () => {
       const selected = listed.find((worktree) => sameObservedPath(worktree.path, linked));
       expect(selected).toBeDefined();
       if (selected === undefined) throw new Error("Expected the linked worktree to be listed.");
+      if (selected.registrationIdentity === undefined) {
+        throw new Error("Expected the linked worktree registration identity.");
+      }
 
       await expect(
         provider.removeWorktree({
           worktreeId: selected.id,
           expectedPath: selected.path,
           expectedBranch: selected.branch,
+          expectedRegistrationIdentity: selected.registrationIdentity,
         }),
       ).resolves.toMatchObject({ removed: true });
 


### PR DESCRIPTION
## Summary

- bind every `worktree.remove` intent to the selected worktree ID, canonical path, branch, and opaque native Git registration identity
- refresh and uniquely re-resolve provider evidence before cleanup, then make Worktrunk revalidate registration identity/path/branch again immediately before mutation
- refuse primary, default-branch, stale, replaced, missing, ambiguous, and unverified targets with provider-neutral command/trace diagnostics
- keep legacy or otherwise unverified dashboard rows non-destructive: removal dispatch is blocked and the user gets an actionable refresh message
- document the stronger Observer/adapter identity boundary

## Root cause

The earlier guard still treated a path-derived row ID plus path/branch as sufficient identity. A checkout removed and recreated at the same path and branch could therefore look unchanged. Default-branch normalization also failed open for remote-qualified and whitespace-only configuration, and final adapter race refusals lacked correlated diagnostic evidence.

Worktrunk now derives an opaque fingerprint from native `.git` registration metadata/content and double-stats it for a stable read. Observer carries that identity through selection and preflight; Worktrunk compares it again at its final mutation boundary.

## Compatibility

`worktree.remove` now requires `expectedRegistrationIdentity`. Worktree observations and snapshot rows expose the opaque identity optionally so old/unverified evidence can still parse but cannot authorize removal. There is no database or config migration. The shared snapshot schema bump remains in #159 and must land before release.

## Validation

Final head `f8d37223d1172a6cfbd411c5fc0f131ed4b5b4ed` passed an isolated full `pnpm test:pre-push`:

- build/typecheck/lint: 22 build tasks, 42 typecheck tasks, 951 files clean
- root tests: 1,436 unit, 27 contract, 428 integration passed (2 opt-in real-tmux tests skipped), 43 diagnostics, scripted-agent/setup/Observer lifecycle E2E
- cross-runtime: Node/Bun SQLite compatibility plus 50 alternating races, 10 three-contender races, and killed-owner recovery
- Station: 999/999 renderer tests and 26/26 native PTY tests
- release surfaces: installer smoke, compiled `0.0.0-local` binary, and binary smoke
- real Git regression proves a same-path/same-branch replacement is preserved; a vertical Worktrunk-to-Observer race test proves persisted provider-neutral diagnostics and command/trace-correlated warnings

Hosted Ubuntu CI supplies the independent ext4 run for the same replacement regression.

## UX

A stale or unverified removal now stops with a refresh/reselect message and performs no worktree mutation. To verify manually: select a linked worktree, externally remove and recreate it at the same path and branch, then submit the old removal intent. Station must report `registration_changed`, preserve the replacement checkout, and record correlated refusal diagnostics.

Closes #173
