### PR TITLE
fix(onboarding): require explicit first-project selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ station keeps track of everything that's running and makes it visible:
 
 The authenticated private binary is the user install path. On a development-ready Mac, have Xcode Command Line Tools, Homebrew, GitHub CLI access to the private repository, and Codex or another supported agent CLI ready. Node.js can be present, but the compiled Station binary does not use it.
 
-Start in the Git repository you want Station to manage, authenticate `gh`, fetch the installer for the binary baseline, and run it:
+From any directory, authenticate `gh`, fetch the installer for the binary baseline, and run it:
 
 ```sh
-cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
   set -eu
@@ -66,7 +65,7 @@ gh auth login --hostname github.com
 )
 ```
 
-The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to your login-shell profile. It does not configure the current project. From the same project shell, make the default install available immediately, run guided setup, verify it, and launch the full workspace:
+The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to your login-shell profile. It does not infer a project from the install directory. In the same shell, make the default install available immediately, run guided setup, verify it, and launch the full workspace:
 
 ```sh
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -79,9 +78,9 @@ stn doctor
 stn tui
 ```
 
-`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, writes `~/.config/station/config.toml` for the current Git repository, and can add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; `--persist-path` makes the same directory available to future login shells. Omit that flag to leave profiles unchanged and receive an exact opt-in command instead. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
+`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, and writes a valid zero-project `~/.config/station/config.toml`; it never adds the current directory implicitly. It can also add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; `--persist-path` makes the same directory available to future login shells. Omit that flag to leave profiles unchanged and receive an exact opt-in command instead. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
 
-On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
+On the cold-boot welcome screen, press `Enter` or `Space` to open project view. On the empty dashboard, press `Enter` (or `A`) on **Add your first project**, choose a folder inside an existing Git repository, and confirm it. Station resolves nested selections to their Git root and will not add an ordinary non-Git folder. Then press `N`, review the project, generated session name, and agent in the **Create Session** dialog, and press `Enter` on **Create session** to start the agent session.
 
 `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
@@ -103,7 +102,7 @@ On macOS, a fresh checkout can install the development dependencies, build both 
 
 ```sh
 ./scripts/setup/bootstrap.sh
-stn setup     # required tools, an agent CLI, and your first project
+stn setup     # required tools, an agent CLI, and a zero-project config
 stn           # launch the workspace
 ```
 

--- a/apps/cli/src/commands/setup/checks/git.ts
+++ b/apps/cli/src/commands/setup/checks/git.ts
@@ -53,7 +53,7 @@ export async function checkSetupGit(options: CheckGitOptions = {}): Promise<Setu
       // so the not-a-repo wording is wrong; point at the real fix instead.
       message: isDubiousOwnershipError(error)
         ? "git refused this repository for dubious ownership (it is owned by a different user, common with mounted volumes or containers). Run: git config --global --add safe.directory <repository path>, then run stn setup."
-        : "Run stn setup from inside the git repository you want to manage.",
+        : "Git is available. Finish setup here, then choose a project explicitly in STATION.",
     };
   }
 }

--- a/apps/cli/src/commands/setup/configWriter.ts
+++ b/apps/cli/src/commands/setup/configWriter.ts
@@ -1,13 +1,5 @@
-import { basename } from "node:path";
-import { stableName } from "@station/runtime";
 import { selectSetupHarness } from "./harnessSelection.js";
-import type {
-  ConfigWritePlan,
-  SetupConfigFact,
-  SetupFacts,
-  SetupGitFact,
-  SetupHarnessFact,
-} from "./model.js";
+import type { ConfigWritePlan, SetupConfigFact, SetupFacts, SetupHarnessFact } from "./model.js";
 
 export type PlanSetupConfigWriteOptions = {
   selectedHarness?: SetupHarnessFact;
@@ -30,19 +22,11 @@ export async function planSetupConfigWrite(
       reason: "No supported harness CLI is available; config was not planned.",
     };
   }
-  if (facts.git.status !== "ok") {
-    return {
-      operation: "blocked",
-      path: facts.configPath,
-      reason: "No git repository was detected; config was not planned.",
-    };
-  }
-
   if (facts.config.status === "missing") {
     return {
       operation: "create",
       path: facts.configPath,
-      content: renderNewSetupConfig(facts.git, selectedHarness, facts, options),
+      content: renderNewSetupConfig(selectedHarness, facts, options),
     };
   }
 
@@ -54,17 +38,14 @@ export async function planSetupConfigWrite(
     };
   }
 
-  return planExistingConfigAppend(facts.config, facts.git, selectedHarness, options);
+  return planExistingConfigAppend(facts.config, selectedHarness, options);
 }
 
 export function renderNewSetupConfig(
-  git: Extract<SetupGitFact, { status: "ok" }>,
   harness: SetupHarnessFact,
   facts?: Pick<SetupFacts, "worktrunk" | "tmux">,
   options: Pick<PlanSetupConfigWriteOptions, "installWorktrunkHooks" | "installHarnessHooks"> = {},
 ): string {
-  const projectId = projectIdForGit(git);
-  const defaultBranch = git.defaultBranch;
   const worktrunkCommand =
     facts?.worktrunk === undefined ? "wt" : detectedCommand(facts.worktrunk, "wt");
   const tmuxCommand =
@@ -72,6 +53,7 @@ export function renderNewSetupConfig(
   const installWorktrunkHooks = options.installWorktrunkHooks === true;
   return [
     "schema_version = 1",
+    "projects = []",
     "",
     "[observer]",
     'state_dir = "~/.local/state/station"',
@@ -81,12 +63,10 @@ export function renderNewSetupConfig(
     'terminal = "tmux"',
     `harness = ${tomlString(harness.id)}`,
     'layout = "agent-shell"',
-    `default_branch = ${tomlString(defaultBranch)}`,
     "",
     "[worktree.worktrunk]",
     `command = ${tomlString(worktrunkCommand)}`,
     'managed_root = "~/.worktrees"',
-    `base = ${tomlString(defaultBranch)}`,
     "include_main = false",
     "include_external = false",
     `use_lifecycle_hooks = ${installWorktrunkHooks ? "true" : "false"}`,
@@ -107,11 +87,6 @@ export function renderNewSetupConfig(
       ? ["install_hooks = true"]
       : []),
     "",
-    "[[projects]]",
-    `id = ${tomlString(projectId)}`,
-    `label = ${tomlString(git.repoName)}`,
-    `root = ${tomlString(git.root)}`,
-    "",
   ].join("\n");
 }
 
@@ -122,7 +97,7 @@ function resolveConfigWriteHarness(
   if (facts.config.status !== "valid") {
     return fallback;
   }
-  const configuredHarness = facts.config.matchedProject?.harness ?? facts.config.defaults.harness;
+  const configuredHarness = facts.config.defaults.harness;
   return (
     facts.harnesses.find(
       (harness) => harness.id === configuredHarness && harness.status === "ok",
@@ -132,7 +107,6 @@ function resolveConfigWriteHarness(
 
 function planExistingConfigAppend(
   config: Extract<SetupConfigFact, { status: "valid" }>,
-  git: Extract<SetupGitFact, { status: "ok" }>,
   harness: SetupHarnessFact,
   options: Pick<PlanSetupConfigWriteOptions, "installHarnessHooks">,
 ): ConfigWritePlan {
@@ -145,16 +119,14 @@ function planExistingConfigAppend(
     };
   }
   const appendedText = renderAppendText({
-    git,
     harness,
-    addProject: !config.hasProjectForRoot,
     addHarness: !config.configuredHarnesses.includes(harness.id),
     installHarnessHooks: options.installHarnessHooks === true,
   });
   if (appendedText.length === 0) {
     return {
       operation: "none",
-      reason: "Config already includes this repository and selected harness.",
+      reason: "Config already includes the selected harness and core defaults.",
     };
   }
   return {
@@ -169,38 +141,20 @@ function existingConfigAppendCoreProblem(
   config: Extract<SetupConfigFact, { status: "valid" }>,
   harness: SetupHarnessFact,
 ): string | undefined {
-  if (config.matchedProject === undefined) {
-    if (config.defaults.worktreeProvider !== "worktrunk") {
-      return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; setup will not rewrite existing defaults.`;
-    }
-    if (config.defaults.terminal !== "tmux") {
-      return `Config defaults use terminal ${config.defaults.terminal}; setup will not rewrite existing defaults.`;
-    }
-    if (config.defaults.harness !== harness.id) {
-      return `Config defaults use harness ${config.defaults.harness}; setup will not rewrite existing defaults.`;
-    }
-    return undefined;
+  if (config.defaults.worktreeProvider !== "worktrunk") {
+    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; setup will not rewrite existing defaults.`;
   }
-
-  if (config.matchedProject.worktreeProvider !== "worktrunk") {
-    return `Project ${config.matchedProject.id} uses worktree provider ${config.matchedProject.worktreeProvider}; setup will not rewrite existing project defaults.`;
+  if (config.defaults.terminal !== "tmux") {
+    return `Config defaults use terminal ${config.defaults.terminal}; setup will not rewrite existing defaults.`;
   }
-  if (!config.matchedProject.worktrunkEnabled) {
-    return `Project ${config.matchedProject.id} disables Worktrunk; setup will not rewrite existing project defaults.`;
-  }
-  if (config.matchedProject.terminal !== "tmux") {
-    return `Project ${config.matchedProject.id} uses terminal ${config.matchedProject.terminal}; setup will not rewrite existing project defaults.`;
-  }
-  if (config.matchedProject.harness !== harness.id) {
-    return `Project ${config.matchedProject.id} uses harness ${config.matchedProject.harness}; setup will not rewrite existing project defaults.`;
+  if (config.defaults.harness !== harness.id) {
+    return `Config defaults use harness ${config.defaults.harness}; setup will not rewrite existing defaults.`;
   }
   return undefined;
 }
 
 function renderAppendText(input: {
-  git: Extract<SetupGitFact, { status: "ok" }>;
   harness: SetupHarnessFact;
-  addProject: boolean;
   addHarness: boolean;
   installHarnessHooks: boolean;
 }): string {
@@ -217,26 +171,7 @@ function renderAppendText(input: {
       ].join("\n"),
     );
   }
-  if (input.addProject) {
-    blocks.push(
-      [
-        "[[projects]]",
-        `id = ${tomlString(projectIdForGit(input.git))}`,
-        `label = ${tomlString(input.git.repoName)}`,
-        `root = ${tomlString(input.git.root)}`,
-      ].join("\n"),
-    );
-  }
   return blocks.length === 0 ? "" : `\n${blocks.join("\n\n")}\n`;
-}
-
-function projectIdForGit(git: Extract<SetupGitFact, { status: "ok" }>): string {
-  return stableName({
-    profile: "id",
-    display: [basename(git.root) || git.repoName],
-    unique: [git.root],
-    maxLength: 64,
-  });
 }
 
 function tomlString(value: string): string {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -48,7 +48,10 @@ async function runGuidedSetupWithPrompt(
   deps: SetupCommandDeps,
   prompt: SetupPromptAdapter,
 ): Promise<SetupCommandResult> {
-  await write(deps, "Core setup: required tools, one agent, and your first project.\n\n");
+  await write(
+    deps,
+    "Core setup: required tools and one agent. Add your first project in STATION.\n\n",
+  );
   let facts = await collectForCommand("apply", options, deps, {});
 
   // Bootstrap layer (macOS): Command Line Tools, then Homebrew — the prerequisites
@@ -125,7 +128,7 @@ async function runGuidedSetupWithPrompt(
   const configActions = plan.actions.filter(isConfigAction).filter((action) => action.selected);
   let writtenPlan: SetupPlan | undefined;
   if (configActions.length > 0) {
-    const accepted = await prompt.confirm("Write STATION project config?");
+    const accepted = await prompt.confirm("Write core STATION config?");
     if (!accepted) {
       await write(deps, "Config was not written.\n");
       return { code: 1 };

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -430,19 +430,29 @@ function gitCheck(facts: SetupFacts): SetupCheck {
       id: "git-project",
       tier: "required",
       status: "ok",
-      label: "Git project",
-      message: "Current directory is inside a git repository.",
+      label: "Git",
+      message: "Git is available; choose projects explicitly in STATION.",
       details: {
         root: facts.git.root,
         defaultBranch: facts.git.defaultBranch,
       },
     };
   }
+  if (facts.git.reason === "not-a-repo") {
+    return {
+      id: "git-project",
+      tier: "required",
+      status: "ok",
+      label: "Git",
+      message: "Git is available; choose a project explicitly in STATION.",
+      details: { defaultBranch: facts.git.defaultBranch },
+    };
+  }
   return {
     id: "git-project",
     tier: "required",
     status: "missing",
-    label: "Git project",
+    label: "Git",
     message: facts.git.message,
     details: {
       defaultBranch: facts.git.defaultBranch,
@@ -491,7 +501,7 @@ function configCheck(facts: SetupFacts): SetupCheck {
       id: "config",
       tier: "required",
       status: "missing",
-      label: "STATION project config",
+      label: "STATION config",
       message: facts.config.message,
       details: { path: facts.config.path },
     };
@@ -501,7 +511,7 @@ function configCheck(facts: SetupFacts): SetupCheck {
       id: "config",
       tier: "required",
       status: "missing",
-      label: "STATION project config",
+      label: "STATION config",
       message: facts.config.message,
       details: { path: facts.config.path },
     };
@@ -509,57 +519,19 @@ function configCheck(facts: SetupFacts): SetupCheck {
   const supportedHarnesses = new Set(
     facts.harnesses.filter((harness) => harness.status === "ok").map((harness) => harness.id),
   );
-  if (!facts.config.hasProjectForRoot) {
-    const defaultCoreProblem = defaultConfigCoreProblem(facts.config, supportedHarnesses);
-    if (defaultCoreProblem !== undefined) {
-      return {
-        id: "config",
-        tier: "required",
-        status: "missing",
-        label: "STATION project config",
-        message: defaultCoreProblem,
-        details: {
-          path: facts.config.path,
-          worktreeProvider: facts.config.defaults.worktreeProvider,
-          terminal: facts.config.defaults.terminal,
-          harness: facts.config.defaults.harness,
-        },
-      };
-    }
+  const defaultCoreProblem = defaultConfigCoreProblem(facts.config, supportedHarnesses);
+  if (defaultCoreProblem !== undefined) {
     return {
       id: "config",
       tier: "required",
       status: "missing",
-      label: "STATION project config",
-      message: "Config exists but does not include the current git repository.",
-      details: { path: facts.config.path },
-    };
-  }
-  const project = facts.config.matchedProject;
-  if (project === undefined) {
-    return {
-      id: "config",
-      tier: "required",
-      status: "missing",
-      label: "STATION project config",
-      message: "Config includes the current git repository, but setup could not inspect it.",
-      details: { path: facts.config.path },
-    };
-  }
-  const projectCoreProblem = projectConfigCoreProblem(project, supportedHarnesses);
-  if (projectCoreProblem !== undefined) {
-    return {
-      id: "config",
-      tier: "required",
-      status: "missing",
-      label: "STATION project config",
-      message: projectCoreProblem,
+      label: "STATION config",
+      message: defaultCoreProblem,
       details: {
         path: facts.config.path,
-        project: project.id,
-        worktreeProvider: project.worktreeProvider,
-        terminal: project.terminal,
-        harness: project.harness,
+        worktreeProvider: facts.config.defaults.worktreeProvider,
+        terminal: facts.config.defaults.terminal,
+        harness: facts.config.defaults.harness,
       },
     };
   }
@@ -567,8 +539,8 @@ function configCheck(facts: SetupFacts): SetupCheck {
     id: "config",
     tier: "required",
     status: "ok",
-    label: "STATION project config",
-    message: "Config includes the current git repository.",
+    label: "STATION config",
+    message: "Core STATION config is ready; projects are added explicitly in STATION.",
     details: { path: facts.config.path },
   };
 }
@@ -604,32 +576,13 @@ function defaultConfigCoreProblem(
   supportedHarnesses: ReadonlySet<string>,
 ): string | undefined {
   if (config.defaults.worktreeProvider !== "worktrunk") {
-    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; set defaults.worktree_provider to "worktrunk" before setup can append this project safely.`;
+    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; set defaults.worktree_provider to "worktrunk" for the setup core path.`;
   }
   if (config.defaults.terminal !== "tmux") {
-    return `Config defaults use terminal ${config.defaults.terminal}; set defaults.terminal to "tmux" before setup can append this project safely.`;
+    return `Config defaults use terminal ${config.defaults.terminal}; set defaults.terminal to "tmux" for the setup core path.`;
   }
   if (!supportedHarnesses.has(config.defaults.harness)) {
     return `Config defaults use harness ${config.defaults.harness}, but setup did not detect that supported harness CLI.`;
-  }
-  return undefined;
-}
-
-function projectConfigCoreProblem(
-  project: NonNullable<Extract<SetupFacts["config"], { status: "valid" }>["matchedProject"]>,
-  supportedHarnesses: ReadonlySet<string>,
-): string | undefined {
-  if (project.worktreeProvider !== "worktrunk") {
-    return `Project ${project.id} uses worktree provider ${project.worktreeProvider}; set the effective provider to "worktrunk" for the setup core path.`;
-  }
-  if (!project.worktrunkEnabled) {
-    return `Project ${project.id} disables Worktrunk; enable project Worktrunk config for the setup core path.`;
-  }
-  if (project.terminal !== "tmux") {
-    return `Project ${project.id} uses terminal ${project.terminal}; set the effective terminal to "tmux" for the setup core path.`;
-  }
-  if (!supportedHarnesses.has(project.harness)) {
-    return `Project ${project.id} uses harness ${project.harness}, but setup did not detect that supported harness CLI.`;
   }
   return undefined;
 }
@@ -724,7 +677,7 @@ function setupActions(
 
   actions.push(...hookSetupActions(facts, selectedHarness, options));
 
-  const configActions = configWriteActions(facts, selectedHarness, configWrite);
+  const configActions = configWriteActions(selectedHarness, configWrite);
   actions.push(...configActions);
   return actions;
 }
@@ -828,11 +781,10 @@ function installAction(
 }
 
 function configWriteActions(
-  facts: SetupFacts,
   selectedHarness: SetupHarnessFact | undefined,
   configWrite: ConfigWritePlan | undefined,
 ): SetupAction[] {
-  if (selectedHarness === undefined || facts.git.status !== "ok") {
+  if (selectedHarness === undefined) {
     return [];
   }
   if (configWrite === undefined || configWrite.operation === "none") {
@@ -868,7 +820,7 @@ function configWriteActions(
     label: configWrite.operation === "create" ? "Write STATION config" : "Append STATION config",
     message:
       configWrite.operation === "create"
-        ? "Create the core STATION config for this repository."
+        ? "Create the core STATION config; add your first project in STATION."
         : "Append safe missing setup blocks to the existing STATION config.",
     path: configWrite.path,
     data: {
@@ -901,7 +853,7 @@ function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
   if (facts.bun.status === "missing") {
     return ["Install Bun (brew install bun), then run: stn setup check"];
   }
-  if (facts.git.status === "missing") {
+  if (facts.git.status === "missing" && facts.git.reason === "git-absent") {
     return [facts.git.message];
   }
   if (facts.diffnav.status === "missing" || facts.gitDelta.status === "missing") {

--- a/apps/cli/test/integration/first-project-default-branch.test.ts
+++ b/apps/cli/test/integration/first-project-default-branch.test.ts
@@ -1,0 +1,300 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { type AddProjectToConfigResult, addProjectToConfig } from "@station/config";
+import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { environmentWithoutGitLocals } from "@station/runtime";
+import { WorktrunkProvider } from "@station/worktrunk";
+import { describe, expect, it } from "vitest";
+import { renderNewSetupConfig } from "../../src/commands/setup/configWriter.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("first-project default branch", () => {
+  it.each([
+    "master",
+    "trunk",
+  ] as const)("persists the sole committed %s branch for worktree creation", async (defaultBranch) => {
+    await withFreshConfig(`${defaultBranch}-project`, async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, defaultBranch);
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      expect(added.writtenBlock).toMatchObject({
+        defaultBranch,
+        worktrunkBase: defaultBranch,
+      });
+      expect(added.project).toMatchObject({
+        root: repo,
+        defaultBranch,
+        worktrunk: { enabled: true, base: defaultBranch },
+      });
+      const projectSource = projectBlock(await readFile(configPath, "utf8"));
+      expect(projectSource).toContain(`default_branch = "${defaultBranch}"`);
+      expect(projectSource).toContain(`[projects.worktrunk]\nbase = "${defaultBranch}"`);
+
+      const worktreePath = join(root, ".worktrees", `${defaultBranch}-project`, "feature");
+      const calls: ExternalCommandInput[] = [];
+      const provider = new WorktrunkProvider({
+        command: "wt",
+        useLifecycleHooks: false,
+        resolveRegistrationIdentity: async (path) => `git-registration:${path}`,
+        runner: async (input) => {
+          calls.push(input);
+          await mkdir(dirname(worktreePath), { recursive: true });
+          await git(repo, "worktree", "add", "-b", "feature", worktreePath, defaultBranch);
+          return result(input, JSON.stringify([{ path: worktreePath, branch: "feature" }]));
+        },
+      });
+
+      try {
+        await expect(
+          provider.createWorktree({ project: added.project, branch: "feature" }),
+        ).resolves.toMatchObject({
+          branch: "feature",
+          path: worktreePath,
+          registrationIdentity: `git-registration:${worktreePath}`,
+        });
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.args).toEqual([
+          "switch",
+          "--no-hooks",
+          "--create",
+          "feature",
+          "--base",
+          defaultBranch,
+          "--no-cd",
+          "--format=json",
+        ]);
+      } finally {
+        await git(repo, "worktree", "remove", "--force", worktreePath).catch(() => undefined);
+      }
+    });
+  });
+
+  it("never rewrites an existing project when Git evidence changes", async () => {
+    await withFreshConfig("existing-project", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await addProjectToConfig({ path: repo, configPath, homeDir: root });
+      const source = await readFile(configPath, "utf8");
+      await git(repo, "branch", "trunk");
+
+      const existing = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      expect(existing.status).toBe("unchanged");
+      expect(await readFile(configPath, "utf8")).toBe(source);
+      expect(existing.project).toMatchObject({
+        defaultBranch: "main",
+        worktrunk: { base: "main" },
+      });
+    });
+  });
+
+  it("prefers a committed origin/HEAD over multiple local branches", async () => {
+    await withFreshConfig("origin-project", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "feature");
+      await addRemote(repo, "origin");
+      await git(repo, "branch", "trunk");
+      await git(repo, "update-ref", "refs/remotes/origin/trunk", "refs/heads/trunk");
+      await git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/trunk");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      expect(added.project).toMatchObject({
+        defaultBranch: "trunk",
+        worktrunk: { base: "origin/trunk" },
+      });
+    });
+  });
+
+  it("accepts one committed upstream HEAD when configured origin has no HEAD", async () => {
+    await withFreshConfig("upstream-project", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "feature");
+      await addRemote(repo, "origin");
+      await addRemote(repo, "upstream");
+      await git(repo, "branch", "trunk");
+      await git(repo, "update-ref", "refs/remotes/upstream/trunk", "refs/heads/trunk");
+      await git(repo, "symbolic-ref", "refs/remotes/upstream/HEAD", "refs/remotes/upstream/trunk");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      expect(added.project).toMatchObject({
+        defaultBranch: "trunk",
+        worktrunk: { base: "upstream/trunk" },
+      });
+    });
+  });
+
+  it.each([
+    "outside-origin",
+    "direct-ref",
+  ] as const)("persists no default for a malformed origin/HEAD: %s", async (failure) => {
+    await withFreshConfig("malformed-origin", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await addRemote(repo, "origin");
+      await git(repo, "branch", "trunk");
+      if (failure === "outside-origin") {
+        await git(repo, "update-ref", "refs/remotes/upstream/trunk", "refs/heads/trunk");
+        await git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/upstream/trunk");
+      } else {
+        await git(repo, "update-ref", "refs/remotes/origin/HEAD", "refs/heads/main");
+      }
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default for a dangling origin/HEAD with one local branch", async () => {
+    await withFreshConfig("dangling-origin", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await addRemote(repo, "origin");
+      await git(repo, "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/missing");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default for a dangling upstream HEAD with one local branch", async () => {
+    await withFreshConfig("dangling-upstream", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await addRemote(repo, "upstream");
+      await git(
+        repo,
+        "symbolic-ref",
+        "refs/remotes/upstream/HEAD",
+        "refs/remotes/upstream/missing",
+      );
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default for conflicting non-origin remote HEADs", async () => {
+    await withFreshConfig("conflicting-remotes", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await addRemote(repo, "upstream");
+      await addRemote(repo, "fork");
+      await git(repo, "branch", "trunk");
+      await git(repo, "update-ref", "refs/remotes/upstream/trunk", "refs/heads/trunk");
+      await git(repo, "update-ref", "refs/remotes/fork/main", "refs/heads/main");
+      await git(repo, "symbolic-ref", "refs/remotes/upstream/HEAD", "refs/remotes/upstream/trunk");
+      await git(repo, "symbolic-ref", "refs/remotes/fork/HEAD", "refs/remotes/fork/main");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default for multiple committed local branches", async () => {
+    await withFreshConfig("ambiguous-local", async ({ root, configPath, repo }) => {
+      await initCommittedRepo(repo, "main");
+      await git(repo, "branch", "trunk");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default for an unborn repository", async () => {
+    await withFreshConfig("unborn", async ({ root, configPath, repo }) => {
+      await mkdir(repo, { recursive: true });
+      await git(repo, "init", "-b", "trunk");
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+
+  it("persists no default when Git evidence cannot be read", async () => {
+    await withFreshConfig("git-error", async ({ root, configPath, repo }) => {
+      await mkdir(join(repo, ".git"), { recursive: true });
+
+      const added = await addProjectToConfig({ path: repo, configPath, homeDir: root });
+
+      await expectNoDetectedDefaults(added, configPath);
+    });
+  });
+});
+
+async function withFreshConfig(
+  name: string,
+  run: (context: { root: string; configPath: string; repo: string }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), "station-first-project-"));
+  const configPath = join(root, "config.toml");
+  const repo = join(root, name);
+  try {
+    await writeFile(
+      configPath,
+      renderNewSetupConfig({
+        id: "codex",
+        label: "Codex",
+        status: "ok",
+        command: "codex",
+      }),
+      "utf8",
+    );
+    await run({ root, configPath, repo });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function initCommittedRepo(repo: string, branch: string): Promise<void> {
+  await mkdir(repo, { recursive: true });
+  await git(repo, "init", "-b", branch);
+  await git(
+    repo,
+    "-c",
+    "user.email=station@example.invalid",
+    "-c",
+    "user.name=station",
+    "commit",
+    "--allow-empty",
+    "-m",
+    "initial",
+  );
+}
+
+async function addRemote(repo: string, remote: string): Promise<void> {
+  await git(repo, "remote", "add", remote, repo);
+}
+
+async function expectNoDetectedDefaults(
+  added: AddProjectToConfigResult,
+  configPath: string,
+): Promise<void> {
+  expect(added.project.defaultBranch).toBeUndefined();
+  expect(added.project.worktrunk.base).toBeUndefined();
+  const source = projectBlock(await readFile(configPath, "utf8"));
+  expect(source).not.toContain("default_branch =");
+  expect(source).not.toContain("[projects.worktrunk]");
+}
+
+function projectBlock(source: string): string {
+  return source.slice(source.indexOf("[[projects]]"));
+}
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd, env: environmentWithoutGitLocals() });
+}
+
+function result(input: ExternalCommandInput, stdout: string): ExternalCommandResult {
+  return {
+    command: input.command,
+    args: input.args ?? [],
+    stdout,
+    stderr: "",
+    exitCode: 0,
+  };
+}

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -174,7 +174,7 @@ describe("CLI setup command", () => {
     expect(activationCount).toBe(0);
   });
 
-  it("activates an appended project with the normalized config path and setup home", async () => {
+  it("does not append or activate the current repository during setup", async () => {
     const root = await tempRoot(tempRoots);
     const home = join(root, "home");
     const repo = join(root, "repo");
@@ -182,7 +182,8 @@ describe("CLI setup command", () => {
     const configPath = join(home, "station", "config.toml");
     await mkdir(repo, { recursive: true });
     await mkdir(otherRepo, { recursive: true });
-    const fs = fakeFs({ [configPath]: setupConfigToml(otherRepo, { includeHarness: true }) });
+    const original = setupConfigToml(otherRepo, { includeHarness: true });
+    const fs = fakeFs({ [configPath]: original });
     const activations: Array<{ configPath: string; homeDir: string }> = [];
 
     const result = await runCli(["--config", "~/station/config.toml", "setup", "apply", "--yes"], {
@@ -193,16 +194,14 @@ describe("CLI setup command", () => {
         runner: readySetupRunner(repo),
         access: readySetupAccess(),
         fs,
-        activateObserverConfig: async (input) => {
-          expect(fs.files[input.configPath]).toContain(`root = ${JSON.stringify(repo)}`);
-          activations.push(input);
-        },
+        activateObserverConfig: async (input) => activations.push(input),
         writeStdout: () => undefined,
       },
     });
 
     expect(result.code).toBe(0);
-    expect(activations).toEqual([{ configPath, homeDir: home }]);
+    expect(fs.files[configPath]).toBe(original);
+    expect(activations).toEqual([]);
   });
 
   it("activates a harness-only config write", async () => {
@@ -266,7 +265,7 @@ describe("CLI setup command", () => {
 
     const output = chunks.join("");
     expect(result.code).toBe(1);
-    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(fs.files[configPath]).toContain("projects = []");
     expect(output).toContain("Config was written, but observer activation failed.");
     expect(output).toContain("Code: OBSERVER_EXITED_ON_START");
     expect(output).toContain("Hint: Inspect the observer boot log.");

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -40,12 +40,10 @@ describe("setup config writer", () => {
       worktreeProvider: "worktrunk",
       terminal: "tmux",
       harness: "codex",
-      defaultBranch: "main",
     });
-    expect(loaded.config.projects[0]).toMatchObject({
-      id: "repo",
-      root: repo,
-    });
+    expect(loaded.config.defaults.defaultBranch).toBeUndefined();
+    expect(loaded.config.worktree?.worktrunk?.base).toBeUndefined();
+    expect(loaded.config.projects).toEqual([]);
   });
 
   it("keeps generated config on the first-run observer socket", async () => {
@@ -109,7 +107,7 @@ describe("setup config writer", () => {
     expect(write.content).toContain("install_hooks = true");
   });
 
-  it("appends only missing project and harness blocks to a valid existing config", async () => {
+  it("appends only a missing harness block to a valid existing config", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     const otherRepo = join(root, "other");
@@ -141,8 +139,79 @@ describe("setup config writer", () => {
     if (write.operation !== "append") throw new Error("expected append plan");
     expect(write.content.startsWith(source.trimEnd())).toBe(true);
     expect(write.appendedText).toContain("[harness.codex]");
-    expect(write.appendedText).toContain("[[projects]]");
+    expect(write.appendedText).not.toContain("[[projects]]");
     expect(write.appendedText).not.toContain("[defaults]");
+  });
+
+  it("creates a zero-project config when setup is run outside a repository", async () => {
+    const root = await tempRoot(tempRoots);
+    const facts = setupFacts(root, {
+      git: {
+        status: "missing",
+        reason: "not-a-repo",
+        defaultBranch: "main",
+        message: "Choose a project after setup.",
+      },
+      config: {
+        status: "missing",
+        path: join(root, "config.toml"),
+        message: "missing",
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts);
+
+    expect(write.operation).toBe("create");
+    if (write.operation !== "create") throw new Error("expected create plan");
+    const loaded = await loadConfigFromToml(write.content, {
+      configPath: write.path,
+      homeDir: root,
+    });
+    expect(loaded.config.projects).toEqual([]);
+    expect(write.content).toContain("projects = []");
+    expect(write.content).not.toContain("[[projects]]");
+  });
+
+  it("keeps zero-project config independent of an ancestor repository's default branch", async () => {
+    const root = await tempRoot(tempRoots);
+    const config = {
+      status: "missing" as const,
+      path: join(root, "config.toml"),
+      message: "missing",
+    };
+    const outsideRepo = await planSetupConfigWrite(
+      setupFacts(root, {
+        git: {
+          status: "missing",
+          reason: "not-a-repo",
+          defaultBranch: "main",
+          message: "Choose a project after setup.",
+        },
+        config,
+      }),
+    );
+    const insideTrunkRepo = await planSetupConfigWrite(
+      setupFacts(join(root, "ancestor"), {
+        git: {
+          status: "ok",
+          root: join(root, "ancestor"),
+          repoName: "ancestor",
+          defaultBranch: "trunk",
+        },
+        config,
+      }),
+    );
+
+    expect(outsideRepo.operation).toBe("create");
+    expect(insideTrunkRepo.operation).toBe("create");
+    if (outsideRepo.operation !== "create" || insideTrunkRepo.operation !== "create") {
+      throw new Error("expected create plans");
+    }
+    expect(insideTrunkRepo.content).toBe(outsideRepo.content);
+    expect(insideTrunkRepo.content).not.toContain("default_branch =");
+    expect(insideTrunkRepo.content).not.toContain("base =");
+    expect(insideTrunkRepo.content).not.toContain('default_branch = "trunk"');
+    expect(insideTrunkRepo.content).not.toContain('base = "trunk"');
   });
 
   it("does not plan broad rewrites for an already-covered config", async () => {
@@ -175,7 +244,7 @@ describe("setup config writer", () => {
 
     await expect(planSetupConfigWrite(facts)).resolves.toEqual({
       operation: "none",
-      reason: "Config already includes this repository and selected harness.",
+      reason: "Config already includes the selected harness and core defaults.",
     });
   });
 
@@ -229,7 +298,7 @@ describe("setup config writer", () => {
     expect(write.content).toContain('[terminal.tmux]\ncommand = "/custom/bin/tmux"');
   });
 
-  it("blocks appending a project that would inherit non-core defaults", async () => {
+  it("blocks appending a harness when the existing defaults are outside the core path", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     const otherRepo = join(root, "other");

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -52,7 +52,7 @@ describe("guided setup command", () => {
         ]),
         fs,
         activateObserverConfig: async (input) => {
-          expect(fs.files[input.configPath]).toContain("[[projects]]");
+          expect(fs.files[input.configPath]).toContain("projects = []");
           activations.push(input);
         },
         prompt: prompt({ confirms: [false, false, true, false, false] }),
@@ -63,7 +63,7 @@ describe("guided setup command", () => {
 
     expect(result.code).toBe(0);
     const configPath = join(root, "home/.config/station/config.toml");
-    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(fs.files[configPath]).toContain("projects = []");
     expect(activations).toEqual([{ configPath, homeDir: join(root, "home") }]);
     expect(chunks.join("")).toContain(`Applying: Write STATION config (${configPath})`);
     expect(chunks.join("")).toContain("Completed: Write STATION config");
@@ -111,7 +111,7 @@ describe("guided setup command", () => {
           async confirm(message: string) {
             return (
               message.includes("Link STATION launchers") ||
-              message.includes("Write STATION project config") ||
+              message.includes("Write core STATION config") ||
               message.includes("Install or load tmux popup binding")
             );
           },
@@ -132,7 +132,7 @@ describe("guided setup command", () => {
       "STATION launcher link failed. Continuing with checkout launcher paths.",
     );
     expect(chunks.join("")).toContain(`Direct fallback: ${join(packageRoot, "bin/stn")} popup`);
-    expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain("[[projects]]");
+    expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain("projects = []");
   });
 
   it("runs Worktrunk shell integration non-interactively after the STATION prompt", async () => {
@@ -381,7 +381,7 @@ describe("guided setup command", () => {
     const output = chunks.join("");
     expect(result.code).toBe(1);
     expect(activations).toBe(1);
-    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(fs.files[configPath]).toContain("projects = []");
     expect(output).toContain("Config was written, but observer activation failed.");
     expect(output).toContain("Code: TEST_ACTIVATION_FAILED");
     expect(output).toContain("Hint: Inspect observer logs.");
@@ -737,7 +737,7 @@ describe("guided setup command", () => {
         prompt: {
           async confirm(message: string) {
             return (
-              message.includes("Install Codex?") || message.includes("Write STATION project config")
+              message.includes("Install Codex?") || message.includes("Write core STATION config")
             );
           },
           async select() {
@@ -1024,7 +1024,7 @@ describe("guided setup command", () => {
             return (
               message.includes("Install Homebrew") ||
               message.includes("Install missing required tools") ||
-              message.includes("Write STATION project config")
+              message.includes("Write core STATION config")
             );
           },
           async select() {
@@ -1043,7 +1043,7 @@ describe("guided setup command", () => {
         .filter((call) => call.command === "brew" && call.args?.[0] === "install")
         .map((call) => call.args?.[1]),
     ).toEqual(expect.arrayContaining(["worktrunk", "tmux", "bun", "diffnav", "git-delta"]));
-    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(fs.files[configPath]).toContain("projects = []");
   });
 
   it("keeps brew tools after a fresh Mac installs its first agent CLI", async () => {
@@ -1148,7 +1148,7 @@ describe("guided setup command", () => {
               message.includes("Install Homebrew") ||
               message.includes("Install missing required tools") ||
               message.includes("chatgpt.com/codex") ||
-              message.includes("Write STATION project config")
+              message.includes("Write core STATION config")
             );
           },
           async select() {
@@ -1163,7 +1163,7 @@ describe("guided setup command", () => {
     // config: the brew tools (resolvable only under /opt/homebrew/bin) re-read missing.
     expect(result.code).toBe(0);
     expect(calls.some((call) => call.command === "sh")).toBe(true);
-    expect(fs.files[configPath]).toContain("[[projects]]");
+    expect(fs.files[configPath]).toContain("projects = []");
   });
 });
 

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -234,6 +234,34 @@ describe("setup planner", () => {
     ]);
   });
 
+  it("treats Git outside a repository as ready for first-project selection", () => {
+    const config = validConfigFact({ hasProjectForRoot: false });
+    delete config.matchedProject;
+
+    const plan = buildSetupPlan(
+      facts({
+        git: {
+          status: "missing",
+          reason: "not-a-repo",
+          defaultBranch: "main",
+          message: "Choose a project after setup.",
+        },
+        config,
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "git-project")).toMatchObject({
+      status: "ok",
+      label: "Git",
+      message: expect.stringContaining("choose a project"),
+    });
+    expect(plan.checks.find((check) => check.id === "config")).toMatchObject({
+      status: "ok",
+    });
+    expect(plan.summary.requiredOk).toBe(true);
+    expect(plan.nextSteps).toEqual(["stn doctor", "stn"]);
+  });
+
   it("plans the optional tmux popup binding when it is missing", () => {
     const plan = buildSetupPlan(facts());
 
@@ -473,7 +501,7 @@ describe("setup planner", () => {
     expect(plan.nextSteps).toEqual(["stn doctor", "stn"]);
   });
 
-  it("fails readiness for existing projects outside the core setup path", () => {
+  it("checks global setup defaults without adopting the current repository", () => {
     const plan = buildSetupPlan(
       facts({
         config: validConfigFact({
@@ -488,10 +516,11 @@ describe("setup planner", () => {
       }),
     );
 
-    expect(plan.summary.requiredOk).toBe(false);
-    expect(plan.checks.find((check) => check.id === "config")?.message).toContain(
-      "uses terminal noop-terminal",
-    );
+    expect(plan.summary.requiredOk).toBe(true);
+    expect(plan.checks.find((check) => check.id === "config")).toMatchObject({
+      status: "ok",
+      message: "Core STATION config is ready; projects are added explicitly in STATION.",
+    });
   });
 });
 

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -8,7 +8,7 @@ describe("setup renderer", () => {
 
     expect(output).toContain("Core\n\n");
     expect(output).toContain("  OK        Worktrunk / wt");
-    expect(output).toContain("  MISSING   STATION project config");
+    expect(output).toContain("  MISSING   STATION config");
     expect(output).toContain("           path /tmp/station/config.toml");
     expect(output).toContain("Actions\n\n");
     expect(output).toContain("  WILL      Write STATION config");
@@ -96,7 +96,7 @@ function plan(): SetupPlan {
         id: "config",
         tier: "required",
         status: "missing",
-        label: "STATION project config",
+        label: "STATION config",
         message: "Config is missing.",
         details: { path: "/tmp/station/config.toml" },
       },

--- a/apps/observer/test/unit/cleanup-command-validation.test.ts
+++ b/apps/observer/test/unit/cleanup-command-validation.test.ts
@@ -146,6 +146,20 @@ describe("cleanup command validation", () => {
       refusalReason: "default_branch",
     });
 
+    const trunkRow = { ...row, branch: "trunk" };
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: { ...payload, expectedBranch: "trunk" },
+        snapshotRow: trunkRow,
+        project: { ...bareProject, defaultBranch: "trunk" },
+        currentWorktrees: [{ ...current, branch: "trunk" }],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_DEFAULT_BRANCH_REMOVAL_NOT_ALLOWED" },
+      refusalReason: "default_branch",
+    });
+
     const derivedDefaultProject = {
       id: project.id,
       label: project.label,
@@ -201,6 +215,25 @@ describe("cleanup command validation", () => {
         snapshotRow: row,
         project: { ...derivedDefaultProject, worktrunk: { enabled: true, base: "   " } },
         currentWorktrees: [current],
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "WORKTREE_REMOVE_PROTECTION_UNVERIFIED" },
+      refusalReason: "protection_unverified",
+    });
+
+    expect(
+      resolveWorktreeRemovalTarget({
+        payload: {
+          worktreeId: row.id,
+          projectId: row.projectId,
+          expectedPath: row.path,
+          expectedBranch: "main",
+          expectedRegistrationIdentity: "git-registration:cleanup",
+        },
+        snapshotRow: { ...row, branch: "main" },
+        project: { ...derivedDefaultProject, worktrunk: { enabled: true } },
+        currentWorktrees: [{ ...current, branch: "main" }],
       }),
     ).toMatchObject({
       ok: false,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,12 +10,25 @@ If you only ever edit one thing, it is `~/.config/station/config.toml`.
 If that default file does not exist yet, `stn` and its `tui`/`popup` launch
 routes use in-memory first-run defaults, ensure the observer, and show the
 existing empty-state UI. They do not create a config file; `stn setup` remains
-the writer. After every successful guided or non-interactive setup config write,
-setup starts or restarts the observer and waits for it to become healthy with
-the updated configuration. If activation fails, setup retains the config, exits
-nonzero, and points to `stn observer restart`. This exception applies only to the
-implicit default path: a missing explicit `--config`, an unreadable file,
-malformed TOML, or invalid config still stops launch with an error.
+the writer. Setup writes `projects = []` and never infers a project from its
+working directory; use the empty dashboard's **Add your first project** flow to
+choose an existing Git repository explicitly. After every successful guided or
+non-interactive setup config write, setup starts or restarts the observer and
+waits for it to become healthy with the updated configuration. If activation
+fails, setup retains the config, exits nonzero, and points to
+`stn observer restart`. This exception applies only to the implicit default
+path: a missing explicit `--config`, an unreadable file, malformed TOML, or
+invalid config still stops launch with an error.
+
+The generated zero-project config leaves `[defaults].default_branch` and
+`[worktree.worktrunk].base` unset because setup has no selected repository from
+which to verify them. When a Git project is explicitly added, Station persists
+both per-project values only from a committed `origin/HEAD` for a configured
+origin, the committed symbolic HEAD of exactly one other configured remote, or
+exactly one committed local branch. With ambiguous, malformed, unborn, or
+unreadable Git evidence, both remain unset; Station omits Worktrunk's `--base`,
+and destructive worktree removal fails closed until the protected default
+branch is configured.
 
 > The annotated `examples/config.toml` is the copy-paste starting point;
 > `examples/project-local-config.toml` shows the project-local file. This page is
@@ -97,7 +110,7 @@ accepted by config validation but become unavailable providers at runtime.
 | `command` | string | Worktrunk CLI, e.g. `"wt"`. Overrides `STATION_WORKTRUNK_BIN`; fallback is `wt`. |
 | `config_path` | string | Path to worktrunk's own config. `~` expands at load time. |
 | `managed_root` | string | Root for managed worktrees, e.g. `~/.worktrees`; `~` expands at load time. |
-| `base` | string | Default base branch for Worktrunk project listings and new worktrees. Project entries inherit this unless `[projects.worktrunk].base` is set. |
+| `base` | string (optional) | Default base branch for Worktrunk project listings and new worktrees. Project entries inherit this unless `[projects.worktrunk].base` is set; when neither is configured, Station omits `--base`. |
 | `include_main` | bool | Default include-main policy for Worktrunk project listings. Project entries inherit this unless overridden. |
 | `include_external` | bool | Default include-external policy for Worktrunk project listings. Project entries inherit this unless overridden. |
 | `use_lifecycle_hooks` | bool | Worktrunk automation mode. `false` makes automated mutations pass `--no-hooks`; `true` passes `--yes`; unset uses Worktrunk defaults. |

--- a/docs/development.md
+++ b/docs/development.md
@@ -272,7 +272,6 @@ downloads its candidate manifest and uses the exact draft ID and commit that
 promotion will verify:
 
 ```sh
-cd /path/to/your/git-project
 (
   set -eu
   umask 077
@@ -363,8 +362,10 @@ manually verify the actual user experience, not a dashboard override:
    run bare `stn` outside tmux. Confirm the real OpenTUI first-run screen draws
    and connects to a healthy Observer.
 4. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
-5. Run `stn setup` to add a project. Confirm the open TUI reconnects and shows
-   it after activation on the same Observer socket.
+5. Run `stn setup` from `HOME` or Desktop. Confirm it creates a zero-project
+   config without adopting that directory. In the open TUI, press `Enter` on
+   **Add your first project**, choose a Git repository, and confirm the TUI
+   reconnects and shows it after activation on the same Observer socket.
 6. Expose `stn-tmux-popup` only to the shell running `stn setup`, accept the
    popup binding, and confirm `~/.tmux.conf` contains its safely quoted absolute
    path. Start a fresh tmux server with `PATH=/usr/bin:/bin`; `Ctrl-b Space`

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -28,16 +28,19 @@ public.
 brew tap jeremy0dell/station
 brew trust jeremy0dell/station
 brew install station
-cd /path/to/first/git/project
 stn setup
 stn doctor
 stn
 ```
 
+Setup is independent of the current directory. On first launch, choose **Add
+your first project** and select an existing Git repository.
+
 Homebrew should install Station and its machine-level dependencies. It should not
 write `~/.config/station/config.toml`, install provider hooks, install the tmux
 popup binding, start the observer, or run `stn doctor` during formula install.
-Those steps are user/project aware and belong to `stn setup`.
+Those steps are user and runtime aware and belong to `stn setup`; explicit
+project selection belongs to the first-project flow in Station.
 
 ## Formula shape
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,10 +6,9 @@ Station is distributed internally as authenticated private GitHub release assets
 
 On a development-ready Mac, have Xcode Command Line Tools, Homebrew, GitHub CLI access to `jeremy0dell/station`, and Codex or another supported agent CLI ready. Node.js can be present, but the compiled Station binary does not use it.
 
-Start in the Git repository you want Station to manage, authenticate `gh`, then fetch and run the installer for the first binary baseline:
+From any directory, authenticate `gh`, then fetch and run the installer for the first binary baseline:
 
 ```bash
-cd /path/to/your/git-project
 gh auth login --hostname github.com
 (
   set -eu
@@ -38,7 +37,7 @@ The recipe never falls back to `main`. `gh` handles private-repository authentic
 
 ### Complete first-run setup
 
-The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to the supported login-shell profile. It does not configure the current project. The recipe begins by changing into the Git repository that `stn setup` will use as the first Station project. Because profile changes apply to future login shells, the remaining handoff for the current shell is:
+The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to the supported login-shell profile. It does not infer a project from the install directory. Because profile changes apply to future login shells, the remaining handoff for the current shell is:
 
 ```bash
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -51,13 +50,13 @@ stn doctor
 stn tui
 ```
 
-If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`. When running the installer outside these recipes, change into the project repository before using that block. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
+If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`. It is safe to run that block from `HOME`, Desktop, or another ordinary directory. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
 
-Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes `~/.config/station/config.toml` for the current repository; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
+Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes a valid zero-project `~/.config/station/config.toml`; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup never adopts its current directory or an ancestor repository. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
 
 The PATH assignment above affects only the current shell. `--persist-path` adds an idempotent entry to the login-shell profile selected from `SHELL` (`.zprofile` for zsh, the first existing bash login profile, or `.profile` for POSIX shells) while preserving existing content such as Homebrew setup. Omit the flag to leave profiles unchanged; unless the exact entry is already present, the installer prints the idempotent command you can run instead, even when its own shell temporarily resolves the launchers. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
-On the cold-boot welcome screen, press `Enter` or `Space` to open project view. Press `N`, review the project, generated session name, and agent in the **Create Session** dialog, then press `Enter` on **Create session** to start the agent session.
+On the cold-boot welcome screen, press `Enter` or `Space` to open project view. On the empty dashboard, press `Enter` (or `A`) on **Add your first project**, choose a folder inside an existing Git repository, and confirm it. A nested folder resolves to its Git root; an ordinary non-Git folder cannot be added from this flow. Then press `N`, review the project, generated session name, and agent in the **Create Session** dialog, and press `Enter` on **Create session** to start the agent session.
 
 Pass `--install-dir PATH` to override the default `~/.local/bin`, and combine it with `--persist-path` to persist that exact custom directory; run `scripts/install.sh --help` from a checkout for the complete command surface.
 
@@ -151,7 +150,7 @@ stn
 
 For a complete source-development workflow, `stn setup check` exits 1 until these tools are present. A compiled binary can still launch when a feature-gated tool is missing:
 
-- Git, run from inside the git repository you want to manage (macOS: the Command Line Tools)
+- Git (macOS: the Command Line Tools); choose the repository explicitly after setup
 - Worktrunk `wt` for core worktree setup
 - tmux for the reference terminal provider and popup path
 - Bun — source-checkout `stn` renders the TUI through `bun run`; compiled `stn` embeds the renderer
@@ -185,7 +184,7 @@ STATION is installed.
 Next:
   stn setup
 
-This configures the core local workflow: the required tools, an agent CLI, and your first project.
+This configures the core local workflow: the required tools, an agent CLI, and a zero-project config.
 Optional integrations can be added later.
 ```
 
@@ -200,7 +199,7 @@ and runner self-interruption against local fake release assets. Every child and
 the overall runner have deadlines. It does not contact GitHub or modify the real
 home directory.
 
-Guided setup writes a first-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. Generated tmux and hook commands persist the resolved absolute launcher paths, whether they came from an installed runtime or the current checkout, so later processes do not depend on setup's PATH. When bare `stn` launchers are not on `PATH`, setup offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
+Guided setup writes a zero-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. Add the first Git repository explicitly from Station after setup. Generated tmux and hook commands persist the resolved absolute launcher paths, whether they came from an installed runtime or the current checkout, so later processes do not depend on setup's PATH. When bare `stn` launchers are not on `PATH`, setup offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 
 Useful smoke options:
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -167,9 +167,11 @@ what "required" means), split the setup summary into two truths:
   binary itself and a writable state dir; compiled mode also proves that
   extracted executable assets can run there. Nothing else. Bare `stn` gates
   on this.
-- `workflowReady` — full worktree workflow: worktrunk, tmux, diffnav,
-  git-delta, an agent CLI, git repo cwd, a project in config. `stn setup`
-  reports these as unmet *capabilities*, not as "broken."
+- `workflowReady` — core worktree workflow prerequisites: Git, worktrunk,
+  tmux, diffnav, git-delta, an agent CLI, and valid core config. It is
+  independent of the current directory and remains true with zero projects;
+  choosing a project is the next TUI onboarding state. `stn setup` reports
+  missing prerequisites as unmet *capabilities*, not as "broken."
 
 Each check keeps its real status; `stn setup check --json` gains both
 booleans and retains `requiredOk` as an alias of `workflowReady`. The compiled
@@ -651,9 +653,10 @@ flow:
 2. Launch bare `stn` outside tmux in a sanitized, isolated env → real
    OpenTUI renderer draws, observer connects, first-run screen shows.
 3. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
-4. Run `stn setup` adding a project → the observer restarts on the **same
-   socket** and reflects the new project immediately (B-config); an open TUI
-   reconnects without a manual restart.
+4. From `HOME` or `Desktop`, run `stn setup` → zero-project config is written
+   and the observer restarts on the **same socket**. Open the TUI, explicitly
+   add an existing Git repository, and verify the observer reflects it
+   immediately (B-config); an open TUI reconnects without a manual restart.
 5. Run setup with `stn-tmux-popup` visible only on its temporary `PATH` → the
    persisted binding contains the absolute launcher, and `Ctrl-b Space` works
    in a fresh tmux server started with `PATH=/usr/bin:/bin`.

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -6,7 +6,7 @@ Station integrates with Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, and Ope
 stn setup
 ```
 
-This configures the core local workflow: the required tools, an agent CLI, and your first project. Optional integrations can be added later.
+This configures the core local workflow: the required tools, an agent CLI, and a zero-project config. Add the first project explicitly in Station. Optional integrations can be added later.
 
 The compiled `stn` launches its TUI and Observer without Node.js, pnpm, or Bun. A local source checkout expects Node.js 24.2+ (and below 25), pnpm 11, and Bun 1.3.14 for development. Real-provider test lanes remain opt-in.
 `stn setup system --check` reports those versions, but it does not change the active Node or pnpm
@@ -45,12 +45,13 @@ workflow, not for launch:
 - tmux
 - Bun — only a source-checkout launcher shells out to `bun run`; the compiled binary embeds the renderer
 - diffnav and git-delta (`delta`) — diffnav powers the "See diff (split right)" automation and renders through delta, so the two are required together
-- git (the binary) and a git repository for the first project
+- git (the binary); select an existing git repository explicitly after setup
 - one supported agent CLI: Claude Code, Codex, Cursor Agent, OpenCode, or Pi
 
 On macOS, the Command Line Tools provide git and the compilers Homebrew needs.
-`stn setup` detects a missing-git binary distinctly from "not inside a repo" and,
-on macOS, reports missing Command Line Tools with the `xcode-select --install`
+`stn setup` detects a missing-git binary distinctly from "not inside a repo". The
+latter is healthy because setup does not adopt its working directory. On macOS,
+setup reports missing Command Line Tools with the `xcode-select --install`
 remediation. `scripts/setup/bootstrap.sh` preflights both before touching Homebrew.
 
 Recommended after setup:

--- a/packages/config/src/projects/add.ts
+++ b/packages/config/src/projects/add.ts
@@ -1,6 +1,6 @@
 import { loadConfig, loadConfigFromToml } from "../load/index.js";
 import { projectConfigSafeError } from "./errors.js";
-import { findGitRoot, resolveExistingDirectory } from "./git.js";
+import { detectGitDefaultBranch, findGitRoot, resolveExistingDirectory } from "./git.js";
 import {
   labelFromRoot,
   minimalBlockFromProject,
@@ -48,6 +48,13 @@ export async function addProjectToConfig(
   const id = uniqueProjectId(requestedId, loaded.loaded.projects);
   const label = options.label ?? labelFromRoot(root);
   const block: MinimalProjectBlock = { id, label, root };
+  if (gitRoot !== undefined) {
+    const detectedDefault = await detectGitDefaultBranch(root);
+    if (detectedDefault !== undefined) {
+      block.defaultBranch = detectedDefault.defaultBranch;
+      block.worktrunkBase = detectedDefault.worktrunkBase;
+    }
+  }
   const candidateSource = appendProjectBlock(loaded.source, block);
 
   await loadConfigFromToml(candidateSource, {

--- a/packages/config/src/projects/git.ts
+++ b/packages/config/src/projects/git.ts
@@ -1,7 +1,17 @@
 import { stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { gitLocalEnvironmentVariables, runExternalCommand } from "@station/runtime";
 import { resolveConfigPath } from "../load/paths.js";
 import { isProjectSafeError, projectConfigSafeError } from "./errors.js";
+
+export type DetectedGitDefaultBranch = {
+  defaultBranch: string;
+  worktrunkBase: string;
+};
+
+type RemoteHeadInspection =
+  | { status: "valid"; value: DetectedGitDefaultBranch }
+  | { status: "absent" | "malformed" };
 
 export async function findGitRoot(startPath: string): Promise<string | undefined> {
   let current = resolve(startPath);
@@ -41,6 +51,126 @@ export async function resolveExistingDirectory(
     });
   }
   return resolvedPath;
+}
+
+/** Resolves only committed, unambiguous Git evidence suitable for project defaults. */
+export async function detectGitDefaultBranch(
+  root: string,
+): Promise<DetectedGitDefaultBranch | undefined> {
+  const remotes = await gitLines(root, ["remote"]);
+  if (remotes === undefined) {
+    return undefined;
+  }
+
+  if (remotes.includes("origin")) {
+    const origin = await inspectRemoteHead(root, "origin");
+    if (origin.status === "valid") {
+      return origin.value;
+    }
+    if (origin.status === "malformed") {
+      return undefined;
+    }
+  }
+
+  const otherRemotes = remotes.filter((remote) => remote !== "origin");
+  // Refuse ambiguous configured remotes before probing so command count stays bounded.
+  if (otherRemotes.length > 1) {
+    return undefined;
+  }
+  if (otherRemotes[0] !== undefined) {
+    const other = await inspectRemoteHead(root, otherRemotes[0]);
+    if (other.status === "valid") {
+      return other.value;
+    }
+    if (other.status === "malformed") {
+      return undefined;
+    }
+  }
+
+  const localBranches = await gitLines(root, [
+    "for-each-ref",
+    "--format=%(refname)%09%(objecttype)",
+    "refs/heads",
+  ]);
+  if (localBranches?.length !== 1) {
+    return undefined;
+  }
+  const [ref, objectType] = (localBranches[0] ?? "").split("\t");
+  const prefix = "refs/heads/";
+  if (objectType !== "commit" || ref === undefined || !ref.startsWith(prefix)) {
+    return undefined;
+  }
+  const branch = ref.slice(prefix.length);
+  if (branch.length === 0) {
+    return undefined;
+  }
+  return { defaultBranch: branch, worktrunkBase: branch };
+}
+
+async function inspectRemoteHead(root: string, remote: string): Promise<RemoteHeadInspection> {
+  const headRef = `refs/remotes/${remote}/HEAD`;
+  const symbolic = await gitResult(root, ["symbolic-ref", "--quiet", headRef], [0, 1]);
+  if (symbolic === undefined) {
+    return { status: "malformed" };
+  }
+  if (symbolic.exitCode === 0) {
+    const value = await resolveRemoteTarget(root, headRef, symbolic.stdout.trim());
+    return value === undefined ? { status: "malformed" } : { status: "valid", value };
+  }
+
+  const direct = await gitResult(root, ["rev-parse", "--verify", "--quiet", headRef], [0, 1]);
+  if (direct === undefined || direct.exitCode === 0) {
+    return { status: "malformed" };
+  }
+  return { status: "absent" };
+}
+
+async function resolveRemoteTarget(
+  root: string,
+  headRef: string,
+  target: string,
+): Promise<DetectedGitDefaultBranch | undefined> {
+  const remotePrefix = headRef.slice(0, -"HEAD".length);
+  if (!target.startsWith(remotePrefix)) {
+    return undefined;
+  }
+  const branch = target.slice(remotePrefix.length);
+  if (branch.length === 0) {
+    return undefined;
+  }
+  const commit = await gitOutput(root, ["rev-parse", "--verify", "--quiet", `${target}^{commit}`]);
+  if (commit === undefined || commit.length === 0) {
+    return undefined;
+  }
+  return {
+    defaultBranch: branch,
+    worktrunkBase: target.slice("refs/remotes/".length),
+  };
+}
+
+async function gitLines(root: string, args: string[]): Promise<string[] | undefined> {
+  const output = await gitOutput(root, args);
+  return output === undefined || output.length === 0 ? [] : output.split(/\r?\n/);
+}
+
+async function gitOutput(root: string, args: string[]): Promise<string | undefined> {
+  const result = await gitResult(root, args);
+  return result?.stdout.trim();
+}
+
+async function gitResult(root: string, args: string[], allowedExitCodes?: number[]) {
+  try {
+    return await runExternalCommand({
+      command: "git",
+      args,
+      cwd: root,
+      unsetEnv: gitLocalEnvironmentVariables,
+      timeoutMs: 5_000,
+      ...(allowedExitCodes === undefined ? {} : { allowedExitCodes }),
+    });
+  } catch {
+    return undefined;
+  }
 }
 
 async function hasGitMarker(directory: string): Promise<boolean> {

--- a/packages/config/src/projects/tomlBlocks.ts
+++ b/packages/config/src/projects/tomlBlocks.ts
@@ -176,12 +176,19 @@ function firstTableLineIndex(lines: readonly string[]): number {
 }
 
 function formatMinimalProjectBlock(block: MinimalProjectBlock): string {
-  return [
+  const lines = [
     "[[projects]]",
     `id = ${quoteTomlString(block.id)}`,
     `label = ${quoteTomlString(block.label)}`,
     `root = ${quoteTomlString(block.root)}`,
-  ].join("\n");
+  ];
+  if (block.defaultBranch !== undefined) {
+    lines.push(`default_branch = ${quoteTomlString(block.defaultBranch)}`);
+  }
+  if (block.worktrunkBase !== undefined) {
+    lines.push("", "[projects.worktrunk]", `base = ${quoteTomlString(block.worktrunkBase)}`);
+  }
+  return lines.join("\n");
 }
 
 function replaceTomlStringValue(line: string, key: string, value: string): string {

--- a/packages/config/src/projects/types.ts
+++ b/packages/config/src/projects/types.ts
@@ -5,6 +5,8 @@ export type MinimalProjectBlock = {
   id: string;
   label: string;
   root: string;
+  defaultBranch?: string;
+  worktrunkBase?: string;
 };
 
 export type AddProjectToConfigOptions = {

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -118,7 +118,7 @@ function plural(count: number, noun: string): string {
   return count === 1 ? noun : `${noun}s`;
 }
 
-export const FIRST_RUN_BODY_LABEL = "No projects configured yet.";
+export const FIRST_RUN_BODY_LABEL = "Add your first project.";
 
 export function scrollIndicatorLabel(
   direction: "above" | "below",

--- a/packages/dashboard-core/src/flows/addProject/flow.ts
+++ b/packages/dashboard-core/src/flows/addProject/flow.ts
@@ -176,7 +176,9 @@ function chooseSelected(state: AddProjectFlowState): AddProjectTransition {
 }
 
 function submitReview(state: AddProjectFlowState): AddProjectTransition {
-  if (state.mode !== "review" || state.editingId !== undefined) return { state };
+  if (state.mode !== "review" || state.editingId !== undefined || state.gitRoot === undefined) {
+    return { state };
+  }
   return {
     state: { ...state, submitting: true },
     effects: [
@@ -188,7 +190,6 @@ function submitReview(state: AddProjectFlowState): AddProjectTransition {
             path: state.selectedPath,
             id: state.id,
             label: state.label,
-            ...(state.gitRoot === undefined ? { allowNonGit: true } : {}),
           },
         },
       },

--- a/packages/dashboard-core/src/flows/addProject/state.ts
+++ b/packages/dashboard-core/src/flows/addProject/state.ts
@@ -17,6 +17,7 @@ import type {
 type AddProjectWizardFields<TMode extends AddProjectStep> = {
   mode: TMode;
   stepHistory: AddProjectFlowState["stepHistory"];
+  firstProject: boolean;
 };
 
 export function createAddProjectStartState(input: CreateAddProjectFlowInput): AddProjectStartState {
@@ -24,6 +25,7 @@ export function createAddProjectStartState(input: CreateAddProjectFlowInput): Ad
   return {
     mode: wizard.mode,
     stepHistory: wizard.stepHistory,
+    firstProject: input.firstProject === true,
     selectedIndex: 0,
     choices: startChoices(input.cwd, input.homeDir),
   };
@@ -132,12 +134,14 @@ function wizardFieldsFor<TMode extends AddProjectStep>(
     return {
       mode,
       stepHistory: state.stepHistory,
+      firstProject: state.firstProject,
     };
   }
   const next = enterWizardStep(state, mode);
   return {
     mode: next.mode,
     stepHistory: next.stepHistory,
+    firstProject: state.firstProject,
   };
 }
 

--- a/packages/dashboard-core/src/flows/addProject/types.ts
+++ b/packages/dashboard-core/src/flows/addProject/types.ts
@@ -13,7 +13,9 @@ import type { StepWizardState } from "../stepWizard.js";
 
 export type AddProjectStep = "start" | "choose" | "review" | "success" | "failed";
 
-type AddProjectBaseState = StepWizardState<AddProjectStep>;
+type AddProjectBaseState = StepWizardState<AddProjectStep> & {
+  firstProject: boolean;
+};
 
 export type AddProjectStartChoice = {
   label: string;
@@ -74,6 +76,7 @@ export type AddProjectFlowState =
 export type CreateAddProjectFlowInput = {
   cwd: string;
   homeDir: string;
+  firstProject?: boolean;
 };
 
 export type AddProjectFlowAction =

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -928,9 +928,13 @@ export function dashboardFooterLabel({
   // Spec A5 triage keybar: the visible chords are the triage loop; everything
   // else lives behind "? help".
   const full = firstRun
-    ? `A add project  ${quitHint}`
+    ? `↵ add first project  A add project  ${quitHint}`
     : `↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  ${quitHint}`;
+  const compactFirstRun = `↵ add first project  ${quitHint}`;
   const compactClose = `↵ open  N new  ⇥ next  / search  X delete  ? help  ${QUIT_HINT_CLOSE}`;
+  if (firstRun && full.length > columns) {
+    return compactFirstRun;
+  }
   return quitHint === QUIT_HINT_CLOSE && full.length > columns ? compactClose : full;
 }
 

--- a/packages/dashboard-core/src/state/screens/addProjectScreen.ts
+++ b/packages/dashboard-core/src/state/screens/addProjectScreen.ts
@@ -1,7 +1,10 @@
 import { dirname } from "node:path";
 import { editableTextInputIntentForInput } from "../../components/EditableTextInput/editing.js";
 import { createAddProjectFlow, transitionAddProjectFlow } from "../../flows/addProject/flow.js";
-import type { AddProjectFlowEffect } from "../../flows/addProject/types.js";
+import type {
+  AddProjectFlowEffect,
+  CreateAddProjectFlowInput,
+} from "../../flows/addProject/types.js";
 import { toSafeError } from "../../services/errors/errors.js";
 import type {
   TuiFolderReadResult,
@@ -13,7 +16,7 @@ import { isReturnKey } from "../keys.js";
 import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
 
-export function openAddProject(state: TuiState, input: { cwd: string; homeDir: string }): TuiState {
+export function openAddProject(state: TuiState, input: CreateAddProjectFlowInput): TuiState {
   return {
     ...state,
     screen: {

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -54,7 +54,9 @@ function handleDashboardBinding(
         state: moveDashboardFocus(state, 1),
       };
     case "tui.focus.activate":
-      return activateFocusedDashboardRow(state);
+      return hasNoProjects(state)
+        ? { state: openAddProject(state, { ...context, firstProject: true }) }
+        : activateFocusedDashboardRow(state);
     case "tui.focus.nextNeedsMe":
       return {
         state: focusNextNeedsMe(state),
@@ -109,7 +111,7 @@ function handleDashboardBinding(
       return openNewSession(state);
     case "tui.addProject.open":
       return {
-        state: openAddProject(state, context),
+        state: openAddProject(state, { ...context, firstProject: hasNoProjects(state) }),
       };
     case "tui.collapse.open":
       return openProjectSlotPicker(state, "projectCollapse");
@@ -122,6 +124,10 @@ function handleDashboardBinding(
     default:
       return assertNever(binding);
   }
+}
+
+function hasNoProjects(state: TuiState): boolean {
+  return state.snapshot?.projects.length === 0;
 }
 
 function assertNever(value: never): never {

--- a/packages/dashboard-core/test/unit/flows/addProject/flow.test.ts
+++ b/packages/dashboard-core/test/unit/flows/addProject/flow.test.ts
@@ -113,4 +113,60 @@ describe("add project flow", () => {
     expect(Object.hasOwn(failed ?? {}, "filter")).toBe(false);
     expect(Object.hasOwn(failed ?? {}, "searchEntries")).toBe(false);
   });
+
+  it("does not submit a folder until a git repository is detected", () => {
+    const started = createAddProjectFlow({
+      cwd: "/Users/example/Desktop",
+      homeDir: "/Users/example",
+      firstProject: true,
+    });
+    const reviewed = transitionAddProjectFlow(started, {
+      type: "folderReviewed",
+      review: {
+        selectedPath: "/Users/example/Desktop/notes",
+        id: "notes",
+        label: "notes",
+      },
+    }).state;
+    if (reviewed?.mode !== "review") throw new Error("expected review mode");
+
+    const submitted = transitionAddProjectFlow(reviewed, { type: "submit" });
+
+    expect(submitted.state).toEqual(reviewed);
+    expect(submitted.effects).toBeUndefined();
+    expect(reviewed.firstProject).toBe(true);
+  });
+
+  it("submits a detected git root without a non-git override", () => {
+    const started = createAddProjectFlow({
+      cwd: "/Users/example/Developer/station",
+      homeDir: "/Users/example",
+    });
+    const reviewed = transitionAddProjectFlow(started, {
+      type: "folderReviewed",
+      review: {
+        selectedPath: "/Users/example/Developer/station/packages/config",
+        gitRoot: "/Users/example/Developer/station",
+        id: "station",
+        label: "station",
+      },
+    }).state;
+    if (reviewed?.mode !== "review") throw new Error("expected review mode");
+
+    const submitted = transitionAddProjectFlow(reviewed, { type: "submit" });
+
+    expect(submitted.effects).toEqual([
+      {
+        type: "submitProject",
+        command: {
+          type: "project.add",
+          payload: {
+            path: "/Users/example/Developer/station/packages/config",
+            id: "station",
+            label: "station",
+          },
+        },
+      },
+    ]);
+  });
 });

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -1,6 +1,7 @@
 import type { TuiKey, TuiState } from "@station/dashboard-core";
 import {
   createInitialTuiState,
+  dashboardFooterLabel,
   deriveTuiInputMode,
   editableTextBindings,
   handleTuiKey,
@@ -229,6 +230,22 @@ describe("tui keymap metadata", () => {
       if (textIndex !== -1) {
         expect(`${mode}:${textIndex}`).toBe(`${mode}:${table.length - 1}`);
       }
+    }
+  });
+});
+
+describe("dashboard footer", () => {
+  it("keeps the first-project action at wide and compact widths", () => {
+    for (const columns of [120, 40]) {
+      const label = dashboardFooterLabel({
+        columns,
+        quitHint: "Q/esc:close",
+        firstRun: true,
+      });
+      expect(label).toContain("add first project");
+      expect(label).not.toContain("open");
+      expect(label).not.toContain("N new");
+      expect(label).not.toContain("delete");
     }
   });
 });

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -260,6 +260,23 @@ describe("TUI store", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
   });
 
+  it("opens the explicit first-project flow with Enter on an empty dashboard", () => {
+    const snapshot = createNoProjectsSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      folderService: fakeFolderService(),
+    });
+
+    store.getState().handleKey({ input: "\r", return: true });
+
+    expect(store.getState().screen).toMatchObject({
+      name: "addProject",
+      flow: { mode: "start", firstProject: true },
+    });
+  });
+
   it("sets a project default harness, refreshes the snapshot, and shows success", async () => {
     const snapshot = createDashboardSnapshot();
     const service = new FakeTuiObserverService(snapshot);

--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -83,7 +83,7 @@ cat <<'EOF'
 Station is installed.
 
 Next:
-  stn setup     # required tools, an agent CLI, and your first project
+  stn setup     # required tools, an agent CLI, and a zero-project config
   stn           # launch the workspace
 EOF
 

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -64,24 +64,24 @@ describe("Station app composition", () => {
     expect(station.composition.stationViewStore.getState().collapsedProjectIds.has("station")).toBe(true);
 
     station.source.setSnapshot(noProjectsSnapshot());
-    expect(await waitForFrame(station, (frame) => frame.includes("No projects configured yet."))).toContain(
-      "No projects configured yet.",
+    expect(await waitForFrame(station, (frame) => frame.includes("Add your first project."))).toContain(
+      "Add your first project.",
     );
 
     station.setup.mockInput.pressKey("c", { ctrl: true });
     await waitFor(() => !overlayVisible(station));
     station.setup.mockInput.pressKey("o", { ctrl: true });
     await waitFor(() => overlayVisible(station));
-    expect(await waitForFrame(station, (frame) => frame.includes("No projects configured yet."))).toContain(
-      "No projects configured yet.",
+    expect(await waitForFrame(station, (frame) => frame.includes("Add your first project."))).toContain(
+      "Add your first project.",
     );
 
     station.composition.stationInput.dispatchMouse({ kind: "header" }, LEFT_DOWN);
     await waitFor(() => !overlayVisible(station));
     station.composition.stationInput.dispatchMouse({ kind: "header" }, LEFT_DOWN);
     await waitFor(() => overlayVisible(station));
-    expect(await waitForFrame(station, (frame) => frame.includes("No projects configured yet."))).toContain(
-      "No projects configured yet.",
+    expect(await waitForFrame(station, (frame) => frame.includes("Add your first project."))).toContain(
+      "Add your first project.",
     );
 
     station.composition.stationInput.dispatchMouse({ kind: "header" }, LEFT_DOWN);

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`dashboard golden frames renders no-projects at 80x24 1`] = `
 "                                                                                
 ─────────────────────────────────────────────────────────────────────────────── 
                                                                                 
-No projects configured yet.                                                     
+Add your first project.                                                         
                                                                                 
                                                                                 
                                                                                 
@@ -240,7 +240,7 @@ No projects configured yet.
                                                                                 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
-A add project  Q/esc:close                                                      
+↵ add first project  A add project  Q/esc:close                                 
 "
 `;
 
@@ -248,7 +248,7 @@ exports[`dashboard golden frames renders no-projects at 120x40 1`] = `
 "                                                                                                                        
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                                                                                                                         
-No projects configured yet.                                                                                             
+Add your first project.                                                                                                 
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -284,7 +284,7 @@ No projects configured yet.
                                                                                                                         
                                                                                                                         
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
-A add project  Q/esc:close                                                                                              
+↵ add first project  A add project  Q/esc:close                                                                         
 "
 `;
 
@@ -292,7 +292,7 @@ exports[`dashboard golden frames renders no-projects at 60x16 1`] = `
 "                                                            
 ─────────────────────────────────────────────────────────── 
                                                             
-No projects configured yet.                                 
+Add your first project.                                     
                                                             
                                                             
                                                             
@@ -304,7 +304,7 @@ No projects configured yet.
                                                             
                                                             
 ─────────────────────────────────────────────────────────── 
-A add project  Q/esc:close                                  
+↵ add first project  A add project  Q/esc:close             
 "
 `;
 
@@ -312,7 +312,7 @@ exports[`dashboard golden frames renders no-projects at 40x12 1`] = `
 "                                        
 ─────────────────────────────────────── 
                                         
-No projects configured yet.             
+Add your first project.                 
                                         
                                         
                                         
@@ -320,6 +320,6 @@ No projects configured yet.
                                         
                                         
 ─────────────────────────────────────── 
-A add project  Q/esc:close              
+↵ add first project  Q/esc:close        
 "
 `;

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -84,6 +84,34 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 "
 `;
 
+exports[`modal flow golden frames renders the collapse project sheet windows a long list 1`] = `
+"┌──────────────────────────────────────────────────────────────────────────────┐
+│ Collapse Project                                                             │
+│                                                                              │
+│ 1 station healthy                                                            │
+│ 2 observer healthy                                                           │
+│ 3 scripts healthy                                                            │
+│ 4 empty-project healthy                                                      │
+│ 5 filler-0 healthy                                                           │
+│ 6 filler-1 healthy                                                           │
+│ 7 filler-2 healthy                                                           │
+│ 8 filler-3 healthy                                                           │
+│ 9 filler-4 healthy                                                           │
+│ a filler-5 healthy                                                           │
+│ b filler-6 healthy                                                           │
+│ c filler-7 healthy                                                           │
+│ d filler-8 healthy                                                           │
+│ e filler-9 healthy                                                           │
+│ f filler-10 healthy                                                          │
+│ g filler-11 healthy                                                          │
+│ h filler-12 healthy                                                          │
+│ i filler-13 healthy                                                          │
+│                                                                              │
+│ ↑↓ move   ↵ select   1-18 of 25   Esc cancel                                 │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
 exports[`modal flow golden frames renders the project settings picker sheet 1`] = `
 "
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
@@ -249,6 +277,34 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
+"
+`;
+
+exports[`modal flow golden frames renders the external agent removal information 1`] = `
+"
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
+───────────────────────────────────────────────────────────────────────────────
+       SESSION                            AGENT     STATUS            DIFF · PR
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
+ [2] - docs-cleanup                       -         no agent
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓
+ [4] + session-resume                     codex     starting
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
+
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
+ [6] x batch-export                       opencode  exited                 #8 ✓
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
+┌──────────────────────────────────────────────────────────────────┐
+│ Cannot delete worktree                                           │h] [qs] [▾]
+│ This agent was started outside Station.                          │14 -6 #5 x1
+│ Station can see its status, but cannot stop it.                  │  +3 -1 #10
+│                                                                  │
+│ Stop or remove it from its original terminal or external tooling.│
+│                                                                  │
+│ Esc/Enter:close                                                  │───────────
+└──────────────────────────────────────────────────────────────────┘/esc:close
 "
 `;
 
@@ -532,6 +588,34 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 "
 `;
 
+exports[`modal flow golden frames renders the first project sheet 1`] = `
+"                                                                                
+─────────────────────────────────────────────────────────────────────────────── 
+                                                                                
+Add your first project.                                                         
+                                                                                
+                                                                                
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Add Your First Project                                                       │
+│ Start location                                                               │
+│                                                                              │
+│ > current directory                          /Users/example/Developer/station│
+│   ~                                                                      home│
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│ Enter:open Right:open Esc:cancel                                             │
+└──────────────────────────────────────────────────────────────────────────────┘
+"
+`;
+
 exports[`modal flow golden frames renders the widget settings panel 1`] = `
 "
 FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
@@ -585,61 +669,5 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 
 ───────────────────────────────────────────────────────────────────────────────
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close
-"
-`;
-
-exports[`modal flow golden frames renders the collapse project sheet windows a long list 1`] = `
-"┌──────────────────────────────────────────────────────────────────────────────┐
-│ Collapse Project                                                             │
-│                                                                              │
-│ 1 station healthy                                                            │
-│ 2 observer healthy                                                           │
-│ 3 scripts healthy                                                            │
-│ 4 empty-project healthy                                                      │
-│ 5 filler-0 healthy                                                           │
-│ 6 filler-1 healthy                                                           │
-│ 7 filler-2 healthy                                                           │
-│ 8 filler-3 healthy                                                           │
-│ 9 filler-4 healthy                                                           │
-│ a filler-5 healthy                                                           │
-│ b filler-6 healthy                                                           │
-│ c filler-7 healthy                                                           │
-│ d filler-8 healthy                                                           │
-│ e filler-9 healthy                                                           │
-│ f filler-10 healthy                                                          │
-│ g filler-11 healthy                                                          │
-│ h filler-12 healthy                                                          │
-│ i filler-13 healthy                                                          │
-│                                                                              │
-│ ↑↓ move   ↵ select   1-18 of 25   Esc cancel                                 │
-└──────────────────────────────────────────────────────────────────────────────┘
-"
-`;
-
-exports[`modal flow golden frames renders the external agent removal information 1`] = `
-"
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle
-───────────────────────────────────────────────────────────────────────────────
-       SESSION                            AGENT     STATUS            DIFF · PR
-▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
- [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
- [3] ○ pty-buffer                         codex     idle                  #73 ✓
- [4] + session-resume                     codex     starting
- [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
-
-▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾]
- [6] x batch-export                       opencode  exited                 #8 ✓
- [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 …
- [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓
-┌──────────────────────────────────────────────────────────────────┐
-│ Cannot delete worktree                                           │h] [qs] [▾]
-│ This agent was started outside Station.                          │14 -6 #5 x1
-│ Station can see its status, but cannot stop it.                  │  +3 -1 #10
-│                                                                  │
-│ Stop or remove it from its original terminal or external tooling.│
-│                                                                  │
-│ Esc/Enter:close                                                  │───────────
-└──────────────────────────────────────────────────────────────────┘/esc:close
 "
 `;

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -9,6 +9,7 @@ import {
   attentionAndFailuresSnapshot,
   externalAgentSnapshot,
   manyProjectsSnapshot,
+  noProjectsSnapshot,
 } from "../fixtures/scenarios.js";
 import type { TuiKey } from "@station/dashboard-core";
 import type { TuiStore } from "@station/dashboard-core";
@@ -194,6 +195,12 @@ const CASES: ModalCase[] = [
     name: "add project sheet",
     keys: [{ input: "A" }],
     expect: ["Add Project", "Start location", "Enter:open Right:open Esc:cancel"],
+  },
+  {
+    name: "first project sheet",
+    keys: [{ input: "\r", return: true }],
+    snapshot: noProjectsSnapshot,
+    expect: ["Add Your First Project", "Start location", "Enter:open Right:open Esc:cancel"],
   },
   {
     name: "widget settings panel",

--- a/station/src/station/view/sheets/AddProjectSheetView.tsx
+++ b/station/src/station/view/sheets/AddProjectSheetView.tsx
@@ -209,7 +209,7 @@ function Review({
         <>
           <SheetLine width={width}> </SheetLine>
           <SheetMessageLine width={width} tone="warning">
-            This does not look like a git repository.
+            Choose a folder inside an existing Git repository.
           </SheetMessageLine>
         </>
       ) : (
@@ -298,12 +298,12 @@ function reviewFooter(state: Extract<AddProjectFlowState, { mode: "review" }>): 
     return "Enter:save id   Esc:cancel edit";
   }
   return state.gitRoot === undefined
-    ? "Enter:add anyway   N:edit id   B:choose folder   Esc:cancel"
+    ? "B:choose Git repository   Esc:cancel"
     : "Enter:add project   N:edit id   B:choose folder   Esc:cancel";
 }
 
 function titleForState(state: AddProjectFlowState): string {
-  if (state.mode === "start") return "Add Project";
+  if (state.mode === "start") return state.firstProject ? "Add Your First Project" : "Add Project";
   if (state.mode === "choose") return "Choose Project Folder";
   if (state.mode === "review") return "Add Project: Review";
   if (state.mode === "success") return "Project Added";

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -78,10 +78,7 @@ describe("release readiness docs", () => {
       );
       expect(recipes, path).toHaveLength(1);
       for (const recipe of recipes) {
-        expect(recipe, path).toContain("cd /path/to/your/git-project");
-        expect(recipe.indexOf("cd /path/to/your/git-project"), path).toBeLessThan(
-          recipe.indexOf("gh api --method GET"),
-        );
+        expect(recipe, path).not.toContain("cd /path/to/your/git-project");
         expect(recipe, path).toContain("umask 077");
         expect(recipe, path).toContain("export GH_HOST=github.com");
         expect(recipe.indexOf("export GH_HOST=github.com"), path).toBeLessThan(
@@ -248,7 +245,10 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("--persist-path");
       expect(document, path).toContain("explicit");
       expect(document, path).toContain("login-shell profile");
-      expect(document, path).toContain("cd /path/to/your/git-project");
+      expect(document, path).toContain("From any directory");
+      expect(document, path).toContain("zero-project");
+      expect(document, path).toContain("Add your first project");
+      expect(document, path).not.toContain("cd /path/to/your/git-project");
       expect(document, path).toMatch(/PATH="\$HOME\/\.local\/bin\$\{PATH:\+":\$PATH"\}"/);
       expect(document, path).toContain("hash -r");
       expect(document, path).toContain("stn setup");
@@ -256,7 +256,7 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("stn tui");
       expect(document, path).toContain("~/.config/station/config.toml");
       expect(document, path).toContain("future login shells");
-      expect(document, path).toContain("cold-boot welcome screen");
+      expect(document, path).toContain("empty dashboard");
       expect(document, path).toContain("Create Session");
       expect(document, path).toContain("start the agent session");
     }

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -120,12 +120,9 @@ describe("setup core flow e2e", () => {
       await expect(realpath(globalStation)).resolves.toBe(repoRoot);
       expect(run("stn", ["--help"], { cwd: root, env }).stdout).toContain("stn --help");
 
-      const project = join(root, "project");
       const configPath = join(home, ".config", "station", "config.toml");
-      await mkdir(project, { recursive: true });
-      run("git", ["init", "-b", "main"], { cwd: project, env });
       const setup = run("stn", ["--config", configPath, "setup", "apply", "--yes", "--no-brew"], {
-        cwd: project,
+        cwd: root,
         env,
       });
       expect(setup.stdout).toContain("Core setup complete.");
@@ -135,10 +132,8 @@ describe("setup core flow e2e", () => {
       const health = await observer.health();
       const snapshot = await observer.getSnapshot();
       expect(health.pid).toBeTypeOf("number");
-      expect(snapshot.projects).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: "project" })]),
-      );
-      expect(snapshot.counts.projects).toBe(1);
+      expect(snapshot.projects).toEqual([]);
+      expect(snapshot.counts.projects).toBe(0);
 
       const ingress = run("stn-ingress", [], { cwd: root, env, allowFailure: true });
       expect(ingress.status).toBe(1);
@@ -166,7 +161,7 @@ describe("setup core flow e2e", () => {
     }
   });
 
-  it("creates core config from a temp git repo without real external tools", async () => {
+  it("creates a zero-project config from a temp non-git directory", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-setup-e2e-"));
     const runtimeDir = await mkdtemp(join(tmpdir(), "stn-r-"));
     const observerSocket = join(runtimeDir, "station", "observer.sock");
@@ -174,11 +169,11 @@ describe("setup core flow e2e", () => {
     let passed = false;
     try {
       const home = join(root, "home");
-      const repo = join(root, "repo");
+      const setupCwd = join(root, "setup-cwd");
       const bin = join(root, "bin");
       const configPath = join(home, ".config", "station", "config.toml");
       await mkdir(home, { recursive: true });
-      await mkdir(repo, { recursive: true });
+      await mkdir(setupCwd, { recursive: true });
       await mkdir(bin, { recursive: true });
       await writeShim(
         bin,
@@ -205,8 +200,6 @@ describe("setup core flow e2e", () => {
       await writeShim(bin, "diffnav", "exit 0\n");
       await writeShim(bin, "delta", "exit 0\n");
       await writeShim(bin, "bun", "exit 0\n");
-      run("git", ["init", "-b", "main"], { cwd: repo });
-
       const env = {
         ...process.env,
         HOME: home,
@@ -216,7 +209,7 @@ describe("setup core flow e2e", () => {
         STATION_DASHBOARD_COMMAND: "true",
         STATION_FAST_POPUP_NO_FALLBACK: "1",
       };
-      const launch = runStation([], { cwd: repo, env });
+      const launch = runStation([], { cwd: setupCwd, env });
       expect(launch.status).toBe(0);
       const observer = createObserverClient({ socketPath: observerSocket, timeoutMs: 1000 });
       const beforeHealth = await observer.health();
@@ -225,7 +218,7 @@ describe("setup core flow e2e", () => {
       expect(beforeSnapshot).toMatchObject({ counts: { projects: 0 }, projects: [] });
 
       const firstCheck = runStation(["--config", configPath, "setup", "check", "--json"], {
-        cwd: repo,
+        cwd: setupCwd,
         env,
         allowFailure: true,
       });
@@ -241,7 +234,7 @@ describe("setup core flow e2e", () => {
       );
 
       const plan = runStation(["--config", configPath, "setup", "plan", "--json"], {
-        cwd: repo,
+        cwd: setupCwd,
         env,
       });
       const parsedPlan = JSON.parse(plan.stdout);
@@ -251,7 +244,7 @@ describe("setup core flow e2e", () => {
       expect(JSON.stringify(parsedPlan.actions)).not.toContain("github");
 
       const apply = runStation(["--config", configPath, "setup", "apply", "--yes"], {
-        cwd: repo,
+        cwd: setupCwd,
         env,
       });
       expect(apply.stdout).toContain("Core setup complete.");
@@ -261,19 +254,18 @@ describe("setup core flow e2e", () => {
       const afterSnapshot = await observer.getSnapshot();
       expect(afterHealth.pid).toBeTypeOf("number");
       expect(afterHealth.pid).not.toBe(beforeHealth.pid);
-      expect(afterSnapshot.projects).toEqual(
-        expect.arrayContaining([expect.objectContaining({ id: "repo" })]),
-      );
-      expect(afterSnapshot.counts.projects).toBe(1);
+      expect(afterSnapshot.projects).toEqual([]);
+      expect(afterSnapshot.counts.projects).toBe(0);
 
       const finalCheck = runStation(["--config", configPath, "setup", "check", "--json"], {
-        cwd: repo,
+        cwd: setupCwd,
         env,
       });
       const finalPlan = JSON.parse(finalCheck.stdout);
       expect(finalPlan.summary.requiredOk).toBe(true);
       await expect(loadConfig({ configPath, homeDir: home })).resolves.toMatchObject({
         config: {
+          projects: [],
           defaults: {
             harness: "codex",
             terminal: "tmux",


### PR DESCRIPTION
## Summary

- let guided setup finish from any working directory by writing a valid zero-project config instead of adopting the current directory or an ancestor repository
- give the empty dashboard an explicit **Add your first project** action and keep ordinary TUI project addition Git-backed
- persist a new project's verified default branch and Worktrunk base from unambiguous committed Git evidence, while failing closed when that evidence is absent or malformed
- update install, setup, configuration, Homebrew, and single-binary guidance to match the fresh-machine flow

This is a focused partial implementation of #156. It does **not** close that issue.

## Deferred from #156

- confirmed Git initialization and first-commit guidance for a new directory
- protected-home and broad personal-folder selection policy
- mutation-time Git readiness checks for stale configured projects
- project-scoped reconciliation when one configured project is invalid

Session-time diagnostics for an already configured unborn repository remain owned by #155.

## Validation

- isolated-state `pnpm test:pre-push` passed on `b2e8cc7a086d0c8dfffa11ee27fee74a8b79526e`
- 1,443 unit, 27 contract, 441 integration, 43 diagnostic, 1,000 Station, and 26 PTY tests passed
- setup E2E, observer lifecycle, install smoke, Node/Bun SQLite compatibility, observer-claim races, and arm64 `0.0.0-local` binary build/smoke passed
- focused real-Git default-branch coverage passed 13/13

## UX implication and manual verification

From Desktop, `$HOME`, or another arbitrary directory, run `stn setup` and confirm no project is inferred. Launch `stn`, continue through Welcome, and confirm the empty dashboard opens **Add your first project** with Enter or `A`. A non-Git folder must not be addable through the ordinary flow; selecting a committed `master` or `trunk` repository should add it and allow Worktrunk creation from that detected base.