### PR TITLE
fix(tmux): restore the compiled popup fast path

### DIFF
--- a/apps/cli/src/commands/registry/popup.ts
+++ b/apps/cli/src/commands/registry/popup.ts
@@ -1,4 +1,5 @@
-import { dirname, join } from "node:path";
+import { realpathSync } from "node:fs";
+import { dirname, join, normalize, parse } from "node:path";
 import { emptyConfig } from "@station/config";
 import type { CliEnv } from "../../env.js";
 import { selfExecArgv } from "../../selfExec.js";
@@ -59,6 +60,7 @@ async function runPopupCliCommand(context: CliCommandRunContext, firstRun = fals
   if (context.options.popupDeps !== undefined) {
     Object.assign(popupDeps, context.options.popupDeps);
   }
+  delete popupDeps.checkoutRoot;
   if (context.options.observerDeps !== undefined) {
     popupDeps.observer = context.options.observerDeps;
   }
@@ -74,7 +76,13 @@ async function runPopupCliCommand(context: CliCommandRunContext, firstRun = fals
   if (uiSessionName !== undefined) {
     popupOptions.uiSessionName = uiSessionName;
   }
-  popupOptions.checkoutRoot = repoRootFromCliModule(context.cliEntryPath);
+  const checkoutRoot = popupOwnerRoot(
+    context.cliEntryPath,
+    context.options.popupDeps?.checkoutRoot,
+  );
+  if (checkoutRoot !== undefined) {
+    popupOptions.checkoutRoot = checkoutRoot;
+  }
   const result = await runPopupCommand(context.args, popupOptions, popupDeps);
   return { code: "code" in result ? result.code : 0, output: result };
 }
@@ -111,6 +119,11 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
-function repoRootFromCliModule(cliEntryPath: string): string {
-  return join(dirname(cliEntryPath), "../../..");
+function popupOwnerRoot(
+  cliEntryPath: string,
+  installedRoot: string | undefined,
+): string | undefined {
+  const root = installedRoot ?? realpathSync(join(dirname(cliEntryPath), "../../.."));
+  const normalizedRoot = normalize(root);
+  return normalizedRoot === parse(normalizedRoot).root ? undefined : root;
 }

--- a/apps/cli/src/commands/setup/checks/config.ts
+++ b/apps/cli/src/commands/setup/checks/config.ts
@@ -66,6 +66,9 @@ export async function checkSetupConfig(
         harness: loaded.config.defaults.harness,
       },
     };
+    if (loaded.config.terminal?.tmux !== undefined) {
+      fact.tmux = loaded.config.terminal.tmux;
+    }
     // Surface load diagnostics that loadConfigFromToml records but does not
     // throw on (broken project-local file, bad [tui]/[workspace]), so `stn
     // setup check` does not report a config with hidden problems as cleanly valid.

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -1,6 +1,10 @@
+import { constants as fsConstants } from "node:fs";
+import { access as nodeAccess } from "node:fs/promises";
 import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
 import { resolveObserverPaths } from "@station/config";
 import { type ExternalCommandRunner, isCompiledBinary } from "@station/runtime";
+import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import type { CliEnv } from "../../../env.js";
 import { isStationUiInstalled } from "../../../stationWorkspace.js";
 import type { SetupDependencyFact, SetupFacts, SetupMode, SetupStationUiFact } from "../model.js";
@@ -48,6 +52,7 @@ export type CollectSetupFactsOptions = {
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
   compiled?: boolean;
+  tmuxPopupOwnerRoot?: string;
   stateDirExecute?: (path: string) => Promise<void>;
   stateDirFs?: SetupStateDirFileSystem;
 };
@@ -115,14 +120,49 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
       : {}),
     ...(options.runner === undefined ? {} : { runner: options.runner }),
   });
-  const tmuxBinding = await checkSetupTmuxBinding({
+  const launcherCommand =
+    options.tmuxPopupOwnerRoot === undefined
+      ? setupLauncherExecutable(launchers.tmuxPopup)
+      : join(options.tmuxPopupOwnerRoot, "stn-tmux-popup");
+  const resolvedLaunchers =
+    options.tmuxPopupOwnerRoot === undefined
+      ? launchers
+      : {
+          ...launchers,
+          tmuxPopup: (await canExecute(launcherCommand, options.access))
+            ? {
+                status: "ok" as const,
+                source: "installed" as const,
+                command: launchers.tmuxPopup.command,
+                resolvedPath: launcherCommand,
+                checkoutPath: launchers.tmuxPopup.checkoutPath,
+              }
+            : {
+                status: "missing" as const,
+                source: "missing" as const,
+                command: launchers.tmuxPopup.command,
+                checkoutPath: launchers.tmuxPopup.checkoutPath,
+                message: `The installed stn-tmux-popup alias is missing or not executable at ${launcherCommand}.`,
+              },
+        };
+  const tmuxBindingOptions: Parameters<typeof checkSetupTmuxBinding>[0] = {
     homeDir,
     env,
     ...(options.fs === undefined ? {} : { fs: options.fs }),
-    launcherCommand: setupLauncherExecutable(launchers.tmuxPopup),
+    launcherCommand,
     ...(options.runner === undefined ? {} : { runner: options.runner }),
-    tmuxCommand: tmux.command,
-  });
+    tmuxCommand: tmux.resolvedPath ?? tmux.command,
+  };
+  const resolvedTmuxCommand =
+    tmux.resolvedPath ?? (isAbsolute(tmux.command) ? tmux.command : undefined);
+  if (options.tmuxPopupOwnerRoot !== undefined && resolvedTmuxCommand !== undefined) {
+    tmuxBindingOptions.runShellCommand = buildManagedFastPopupRunShellCommand({
+      installedRoot: options.tmuxPopupOwnerRoot,
+      fallbackAlias: launcherCommand,
+      tmuxCommand: resolvedTmuxCommand,
+    });
+  }
+  const tmuxBinding = await checkSetupTmuxBinding(tmuxBindingOptions);
   const stationUi = compiled
     ? ({ status: "skipped" } as const)
     : await resolveStationUiFact({
@@ -157,12 +197,28 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     gitDelta,
     brew,
     xcode,
-    launchers,
+    launchers: resolvedLaunchers,
     git,
     harnesses,
     config,
     tmuxBinding,
   };
+}
+
+async function canExecute(
+  path: string,
+  injectedAccess: ((path: string) => Promise<void>) | undefined,
+): Promise<boolean> {
+  try {
+    if (injectedAccess === undefined) {
+      await nodeAccess(path, fsConstants.X_OK);
+    } else {
+      await injectedAccess(path);
+    }
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // Mirrors doctor's rendererRuntimeCheck: the station/ Bun lane only matters when Bun

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -4,10 +4,20 @@ import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
 import { resolveObserverPaths } from "@station/config";
 import { type ExternalCommandRunner, isCompiledBinary } from "@station/runtime";
-import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
+import {
+  buildManagedFastPopupRunShellCommand,
+  defaultTmuxWorkbenchConfig,
+  resolveTmuxWorkbenchConfig,
+} from "@station/tmux";
 import type { CliEnv } from "../../../env.js";
 import { isStationUiInstalled } from "../../../stationWorkspace.js";
-import type { SetupDependencyFact, SetupFacts, SetupMode, SetupStationUiFact } from "../model.js";
+import type {
+  SetupConfigFact,
+  SetupDependencyFact,
+  SetupFacts,
+  SetupMode,
+  SetupStationUiFact,
+} from "../model.js";
 import { checkBrewDependency } from "./brew.js";
 import { checkSetupBun } from "./bun.js";
 import {
@@ -24,7 +34,7 @@ import { type CheckHarnessesOptions, checkSetupHarnesses } from "./harnesses.js"
 import { checkSetupLaunchers, setupLauncherExecutable } from "./launchers.js";
 import { checkSetupStateDir, type SetupStateDirFileSystem } from "./stateDir.js";
 import { checkSetupTmux } from "./tmux.js";
-import { checkSetupTmuxBinding } from "./tmuxBinding.js";
+import { checkSetupTmuxBinding, tmuxPopupRunShellCommand } from "./tmuxBinding.js";
 import { checkSetupWorktrunk, checkSetupWorktrunkAutomation } from "./worktrunk.js";
 import { type CheckXcodeOptions, checkSetupXcode } from "./xcode.js";
 
@@ -155,12 +165,20 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   };
   const resolvedTmuxCommand =
     tmux.resolvedPath ?? (isAbsolute(tmux.command) ? tmux.command : undefined);
-  if (options.tmuxPopupOwnerRoot !== undefined && resolvedTmuxCommand !== undefined) {
-    tmuxBindingOptions.runShellCommand = buildManagedFastPopupRunShellCommand({
+  const defaultPopupGeometry = usesDefaultPopupGeometry(config);
+  const configAwarePopup = options.configPath !== undefined || !defaultPopupGeometry;
+  if (options.tmuxPopupOwnerRoot !== undefined && configAwarePopup) {
+    tmuxBindingOptions.runShellCommand = tmuxPopupRunShellCommand(launcherCommand, config.path);
+  } else if (options.tmuxPopupOwnerRoot !== undefined && resolvedTmuxCommand !== undefined) {
+    const fastBindingOptions: Parameters<typeof buildManagedFastPopupRunShellCommand>[0] = {
       installedRoot: options.tmuxPopupOwnerRoot,
       fallbackAlias: launcherCommand,
       tmuxCommand: resolvedTmuxCommand,
-    });
+    };
+    if (config.status === "valid") {
+      fastBindingOptions.configPath = config.path;
+    }
+    tmuxBindingOptions.runShellCommand = buildManagedFastPopupRunShellCommand(fastBindingOptions);
   }
   const tmuxBinding = await checkSetupTmuxBinding(tmuxBindingOptions);
   const stationUi = compiled
@@ -203,6 +221,17 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     config,
     tmuxBinding,
   };
+}
+
+function usesDefaultPopupGeometry(config: SetupConfigFact): boolean {
+  if (config.status === "missing") return true;
+  if (config.status !== "valid") return false;
+  const tmux = resolveTmuxWorkbenchConfig(config.tmux);
+  return (
+    tmux.popupWidth === defaultTmuxWorkbenchConfig.popupWidth &&
+    tmux.popupHeight === defaultTmuxWorkbenchConfig.popupHeight &&
+    tmux.popupPosition === defaultTmuxWorkbenchConfig.popupPosition
+  );
 }
 
 async function canExecute(

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -7,13 +7,25 @@ import { setupProbeTimeoutMs } from "./constants.js";
 export const tmuxPopupBindingMarker = "# >>> station popup binding >>>";
 export const tmuxPopupBindingEndMarker = "# <<< station popup binding <<<";
 
+const defaultBindingKey = "Space";
+const bindingEditComment = "# Change Space to any tmux key; stn setup preserves it.";
+const supportedBindingKeyPattern =
+  /^(?:[A-Za-z0-9]|Space|F(?:[1-9]|1[0-2])|[CM]-(?:[A-Za-z0-9]|Space|F(?:[1-9]|1[0-2])))$/;
+const quotedShellValuePattern = /^'[^']*'(?:\\''[^']*')*$/;
+
 export type CheckSetupTmuxBindingOptions = {
   homeDir: string;
   env?: NodeJS.ProcessEnv;
   fs?: SetupFileSystemReader;
   launcherCommand?: string;
+  runShellCommand?: string;
   runner?: ExternalCommandRunner;
   tmuxCommand?: string;
+};
+
+export type TmuxPopupBindingBlockOptions = {
+  bindingKey?: string;
+  runShellCommand?: string;
 };
 
 export function setupTmuxConfigPath(
@@ -28,11 +40,27 @@ export async function checkSetupTmuxBinding(
   const path = setupTmuxConfigPath(options);
   const fs = options.fs ?? nodeFsReader();
   const launcherCommand = options.launcherCommand ?? "stn-tmux-popup";
-  const runShellCommand = tmuxPopupRunShellCommand(launcherCommand);
-  const bindingBlock = tmuxPopupBindingBlock(launcherCommand).trimEnd();
+  const runShellCommand = options.runShellCommand ?? tmuxPopupRunShellCommand(launcherCommand);
   const insideTmux = (options.env ?? process.env).TMUX !== undefined;
+  const persisted = parseOwnedBindingBlock(await readTmuxConfig(fs, path));
+
+  if (persisted.status === "conflict") {
+    return {
+      status: "conflict",
+      path,
+      marker: tmuxPopupBindingMarker,
+      launcherCommand,
+      runShellCommand,
+      insideTmux,
+      liveStatus: "unknown",
+      message: persisted.message,
+    };
+  }
+
+  const bindingKey = persisted.bindingKey;
   const liveInput: Parameters<typeof checkLiveTmuxBinding>[0] = {
     insideTmux,
+    bindingKey,
     launcherCommand,
     runShellCommand,
   };
@@ -40,46 +68,61 @@ export async function checkSetupTmuxBinding(
   if (options.runner !== undefined) liveInput.runner = options.runner;
   if (options.tmuxCommand !== undefined) liveInput.tmuxCommand = options.tmuxCommand;
   const liveStatus = await checkLiveTmuxBinding(liveInput);
-  try {
-    const source = await fs.readFile(path);
-    if (source.includes(tmuxPopupBindingMarker) || source.includes("stn-tmux-popup")) {
-      if (!source.includes(bindingBlock)) {
-        return missingTmuxBinding({
-          path,
-          launcherCommand,
-          runShellCommand,
-          insideTmux,
-          liveStatus,
-          message: `tmux popup binding uses a different launcher; rerun stn setup to replace it with ${launcherCommand}.`,
-        });
-      }
-      return {
-        status: "ok",
-        path,
-        marker: tmuxPopupBindingMarker,
-        launcherCommand,
-        runShellCommand,
-        insideTmux,
-        liveStatus,
-      };
-    }
-  } catch {
-    return missingTmuxBinding({ path, launcherCommand, runShellCommand, insideTmux, liveStatus });
+
+  if (
+    persisted.status === "binding" &&
+    persisted.quotedRunShellCommand === quoteShellValue(runShellCommand)
+  ) {
+    return {
+      status: "ok",
+      path,
+      marker: tmuxPopupBindingMarker,
+      launcherCommand,
+      runShellCommand,
+      bindingKey,
+      insideTmux,
+      liveStatus,
+    };
   }
-  return missingTmuxBinding({ path, launcherCommand, runShellCommand, insideTmux, liveStatus });
+
+  return missingTmuxBinding({
+    path,
+    launcherCommand,
+    runShellCommand,
+    bindingKey,
+    insideTmux,
+    liveStatus,
+    ...(persisted.status === "binding"
+      ? {
+          message: `tmux popup binding command is stale; rerun stn setup to update it while preserving ${bindingKey}.`,
+        }
+      : {}),
+  });
 }
 
-export function tmuxPopupBindingBlock(launcherCommand = "stn-tmux-popup"): string {
+export function tmuxPopupBindingBlock(
+  launcherCommand = "stn-tmux-popup",
+  options: TmuxPopupBindingBlockOptions = {},
+): string {
   return [
     tmuxPopupBindingMarker,
-    tmuxPopupBindingLine(launcherCommand),
+    bindingEditComment,
+    tmuxPopupBindingLine(launcherCommand, options),
     tmuxPopupBindingEndMarker,
     "",
   ].join("\n");
 }
 
-export function tmuxPopupBindingLine(launcherCommand = "stn-tmux-popup"): string {
-  return `bind-key Space run-shell -b ${quoteShellValue(tmuxPopupRunShellCommand(launcherCommand))}`;
+export function tmuxPopupBindingLine(
+  launcherCommand = "stn-tmux-popup",
+  options: TmuxPopupBindingBlockOptions = {},
+): string {
+  const bindingKey = options.bindingKey ?? defaultBindingKey;
+  if (!isSupportedBindingKey(bindingKey)) {
+    throw new Error(`Unsupported tmux popup binding key: ${bindingKey}`);
+  }
+  const runShellCommand = options.runShellCommand ?? tmuxPopupRunShellCommand(launcherCommand);
+  return `bind-key ${bindingKey} run-shell -b ${quoteShellValue(runShellCommand)}`;
 }
 
 export function tmuxPopupRunShellCommand(launcherCommand = "stn-tmux-popup"): string {
@@ -90,6 +133,7 @@ function missingTmuxBinding(input: {
   path: string;
   launcherCommand: string;
   runShellCommand: string;
+  bindingKey: string;
   insideTmux: boolean;
   liveStatus: "loaded" | "missing" | "unknown";
   message?: string;
@@ -100,15 +144,117 @@ function missingTmuxBinding(input: {
     marker: tmuxPopupBindingMarker,
     launcherCommand: input.launcherCommand,
     runShellCommand: input.runShellCommand,
+    bindingKey: input.bindingKey,
     insideTmux: input.insideTmux,
     liveStatus: input.liveStatus,
     message: input.message ?? "Optional tmux popup binding is not installed.",
   };
 }
 
+type ParsedOwnedBindingBlock =
+  | { status: "absent"; bindingKey: typeof defaultBindingKey }
+  | { status: "binding"; bindingKey: string; quotedRunShellCommand: string }
+  | { status: "conflict"; message: string };
+
+function parseOwnedBindingBlock(source: string | undefined): ParsedOwnedBindingBlock {
+  if (source === undefined) {
+    return { status: "absent", bindingKey: defaultBindingKey };
+  }
+
+  const lines = source.split(/\r?\n/);
+  const startLines = markerLineIndexes(lines, tmuxPopupBindingMarker);
+  const endLines = markerLineIndexes(lines, tmuxPopupBindingEndMarker);
+  if (startLines.length === 0 && endLines.length === 0) {
+    return { status: "absent", bindingKey: defaultBindingKey };
+  }
+  if (
+    startLines.length !== 1 ||
+    endLines.length !== 1 ||
+    startLines[0]?.exact !== true ||
+    endLines[0]?.exact !== true ||
+    (startLines[0]?.index ?? -1) >= (endLines[0]?.index ?? -1)
+  ) {
+    return bindingConflict(
+      "tmux popup binding markers are duplicated or malformed; edit ~/.tmux.conf manually before rerunning stn setup.",
+    );
+  }
+
+  const start = startLines[0].index;
+  const end = endLines[0].index;
+  const activeLines = lines
+    .slice(start + 1, end)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+  if (activeLines.length === 0) {
+    return { status: "absent", bindingKey: defaultBindingKey };
+  }
+  if (activeLines.length !== 1) {
+    return bindingConflict(
+      "tmux popup binding block contains multiple active lines; edit ~/.tmux.conf manually before rerunning stn setup.",
+    );
+  }
+
+  const activeLine = activeLines[0];
+  if (activeLine === undefined) {
+    return { status: "absent", bindingKey: defaultBindingKey };
+  }
+  const parsed = /^bind-key(?:\s+-T\s+(\S+))?\s+(\S+)\s+run-shell\s+-b\s+(.+)$/.exec(activeLine);
+  if (parsed === null) {
+    return bindingConflict(
+      "tmux popup binding block has an unsupported selector; edit ~/.tmux.conf manually before rerunning stn setup.",
+    );
+  }
+  const [, table, bindingKey, quotedRunShellCommand] = parsed;
+  if (
+    (table !== undefined && table !== "prefix") ||
+    bindingKey === undefined ||
+    !isSupportedBindingKey(bindingKey) ||
+    quotedRunShellCommand === undefined ||
+    !quotedShellValuePattern.test(quotedRunShellCommand)
+  ) {
+    return bindingConflict(
+      "tmux popup binding block has an unsupported selector; edit ~/.tmux.conf manually before rerunning stn setup.",
+    );
+  }
+  return { status: "binding", bindingKey, quotedRunShellCommand };
+}
+
+function markerLineIndexes(
+  lines: readonly string[],
+  marker: string,
+): Array<{ index: number; exact: boolean }> {
+  const result: Array<{ index: number; exact: boolean }> = [];
+  for (const [index, line] of lines.entries()) {
+    if (line.includes(marker)) {
+      result.push({ index, exact: line.trim() === marker });
+    }
+  }
+  return result;
+}
+
+function bindingConflict(message: string): ParsedOwnedBindingBlock {
+  return { status: "conflict", message };
+}
+
+function isSupportedBindingKey(value: string): boolean {
+  return supportedBindingKeyPattern.test(value);
+}
+
+async function readTmuxConfig(
+  fs: SetupFileSystemReader,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    return await fs.readFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
 async function checkLiveTmuxBinding(input: {
   env?: NodeJS.ProcessEnv;
   insideTmux: boolean;
+  bindingKey: string;
   launcherCommand: string;
   runShellCommand: string;
   runner?: ExternalCommandRunner;
@@ -128,7 +274,7 @@ async function checkLiveTmuxBinding(input: {
       },
       input.runner,
     );
-    if (!hasLiveTmuxBinding(listed.stdout, input.runShellCommand)) {
+    if (!hasLiveTmuxBinding(listed.stdout, input.bindingKey, input.runShellCommand)) {
       return "missing";
     }
     const startup = await runExternalCommand(
@@ -151,19 +297,32 @@ async function checkLiveTmuxBinding(input: {
   }
 }
 
-function hasLiveTmuxBinding(source: string, runShellCommand: string): boolean {
-  // tmux serializes a run-shell argument inside double quotes and escapes shell expansion.
-  const serialized = runShellCommand
-    .replaceAll("\\", "\\\\")
-    .replaceAll("$", "\\$")
-    .replaceAll('"', '\\"');
-  return source
-    .split(/\r?\n/)
-    .some(
-      (line) =>
-        /(?:^|\s)-T\s+prefix\s+Space\s+run-shell\s+-b\s+/.test(line) &&
-        line.endsWith(`"${serialized}"`),
-    );
+function hasLiveTmuxBinding(source: string, bindingKey: string, runShellCommand: string): boolean {
+  return source.split(/\r?\n/).some((line) => {
+    const match = /^bind-key\s+-T\s+prefix\s+(\S+)\s+(.*)$/.exec(line.trim());
+    return match?.[1] === bindingKey && parseListedRunShellCommand(match[2]) === runShellCommand;
+  });
+}
+
+function parseListedRunShellCommand(value: string | undefined): string | undefined {
+  const prefix = 'run-shell -b "';
+  if (value === undefined || !value.startsWith(prefix) || !value.endsWith('"')) {
+    return undefined;
+  }
+  const serialized = value.slice(prefix.length, -1);
+  let command = "";
+  for (let index = 0; index < serialized.length; index += 1) {
+    const character = serialized[index];
+    if (character !== "\\") {
+      command += character;
+      continue;
+    }
+    index += 1;
+    const escaped = serialized[index];
+    if (escaped !== "\\" && escaped !== '"' && escaped !== "$") return undefined;
+    command += escaped;
+  }
+  return command;
 }
 
 function escapeTmuxFormat(value: string): string {

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -125,8 +125,33 @@ export function tmuxPopupBindingLine(
   return `bind-key ${bindingKey} run-shell -b ${quoteShellValue(runShellCommand)}`;
 }
 
-export function tmuxPopupRunShellCommand(launcherCommand = "stn-tmux-popup"): string {
-  return `env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} ${quoteShellValue(escapeTmuxFormat(launcherCommand))}`;
+export function tmuxPopupRunShellCommand(
+  launcherCommand = "stn-tmux-popup",
+  configPath?: string,
+): string {
+  if (containsUnsafeShellValue(launcherCommand)) {
+    throw new Error("tmux popup launcher contains an unsupported control character.");
+  }
+  if (configPath !== undefined && containsUnsafeShellValue(configPath)) {
+    throw new Error("tmux popup config path contains an unsupported control character.");
+  }
+  const command = ["env"];
+  if (configPath !== undefined) {
+    command.push(`STATION_CONFIG_PATH=${quoteShellValue(escapeTmuxFormat(configPath))}`);
+  }
+  command.push(
+    "STATION_FOCUS_PROVIDER=tmux",
+    "STATION_FOCUS_CLIENT_ID=#{q:client_name}",
+    quoteShellValue(escapeTmuxFormat(launcherCommand)),
+  );
+  if (configPath !== undefined) {
+    command.push("--config", quoteShellValue(escapeTmuxFormat(configPath)));
+  }
+  return command.join(" ");
+}
+
+function containsUnsafeShellValue(value: string): boolean {
+  return value.includes("\0") || value.includes("\r") || value.includes("\n");
 }
 
 function missingTmuxBinding(input: {

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -37,6 +37,9 @@ export function collectForCommand(
   if (deps.now !== undefined) collectOptions.now = deps.now;
   if (deps.platform !== undefined) collectOptions.platform = deps.platform;
   if (deps.compiled !== undefined) collectOptions.compiled = deps.compiled;
+  if (deps.tmuxPopupOwnerRoot !== undefined) {
+    collectOptions.tmuxPopupOwnerRoot = deps.tmuxPopupOwnerRoot;
+  }
   if (deps.stateDirExecute !== undefined) collectOptions.stateDirExecute = deps.stateDirExecute;
   if (deps.stateDirFs !== undefined) collectOptions.stateDirFs = deps.stateDirFs;
   if (flags.noBrew !== undefined) collectOptions.noBrew = flags.noBrew;

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -181,11 +181,18 @@ async function runGuidedSetupWithPrompt(
 
   const tmuxPopupBindingActions = plan.actions.filter(isTmuxPopupBindingAction);
   const popupCommand = formatCommand([facts.launchers.station.command, "popup"]);
+  const bindingKey =
+    facts.tmuxBinding.status === "conflict" ? undefined : facts.tmuxBinding.bindingKey;
   let tmuxPopupFeedback =
     facts.tmuxBinding.status === "ok"
-      ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded", popupCommand)
+      ? renderTmuxPopupFeedback(
+          true,
+          facts.tmuxBinding.liveStatus === "loaded",
+          facts.tmuxBinding.bindingKey,
+          popupCommand,
+        )
       : undefined;
-  if (tmuxPopupBindingActions.length > 0) {
+  if (tmuxPopupBindingActions.length > 0 && bindingKey !== undefined) {
     const accepted = await prompt.confirm("Install or load tmux popup binding?");
     if (accepted) {
       const bindingResult = await applySetupPlan(
@@ -205,7 +212,8 @@ async function runGuidedSetupWithPrompt(
         const recheckOptions: Parameters<typeof checkSetupTmuxBinding>[0] = {
           homeDir: facts.homeDir,
           launcherCommand: facts.tmuxBinding.launcherCommand,
-          tmuxCommand: facts.tmux.command,
+          runShellCommand: facts.tmuxBinding.runShellCommand,
+          tmuxCommand: facts.tmux.resolvedPath ?? facts.tmux.command,
         };
         const env = deps.env ?? options.env;
         if (env !== undefined) recheckOptions.env = env;
@@ -216,13 +224,19 @@ async function runGuidedSetupWithPrompt(
       tmuxPopupFeedback = renderTmuxPopupFeedback(
         facts.tmuxBinding.status === "ok" || completed.has("tmux-popup-binding"),
         liveLoaded,
+        bindingKey,
         popupCommand,
         bindingResult.failedAction !== undefined,
       );
     } else {
       tmuxPopupFeedback =
         facts.tmuxBinding.status === "ok"
-          ? renderTmuxPopupFeedback(true, facts.tmuxBinding.liveStatus === "loaded", popupCommand)
+          ? renderTmuxPopupFeedback(
+              true,
+              facts.tmuxBinding.liveStatus === "loaded",
+              facts.tmuxBinding.bindingKey,
+              popupCommand,
+            )
           : `Tmux popup binding was not changed. Direct fallback: ${popupCommand}\n`;
     }
   }
@@ -304,12 +318,13 @@ async function pathExists(path: string, deps: SetupCommandDeps): Promise<boolean
 function renderTmuxPopupFeedback(
   persisted: boolean,
   liveLoaded: boolean,
+  bindingKey: string,
   popupCommand: string,
   repairIncomplete = false,
 ): string {
   const lines = persisted
     ? [
-        `Tmux popup binding: Ctrl-b Space is ${
+        `Tmux popup binding: tmux prefix + ${bindingKey} is ${
           liveLoaded
             ? "persisted and loaded in the current tmux server"
             : "persisted for future tmux servers; no current server was live-loaded"

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -169,6 +169,13 @@ async function runGuidedSetupWithPrompt(
     return { code: 1 };
   }
 
+  let tmuxPopupFacts = facts;
+  let tmuxPopupPlan = plan;
+  if (writtenPlan !== undefined) {
+    tmuxPopupFacts = await collectForCommand("apply", options, depsWithBrewBinPath(deps), {});
+    tmuxPopupPlan = buildSetupPlan(tmuxPopupFacts);
+  }
+
   const shellIntegration = plan.actions.find(
     (action) => action.id === "worktrunk-shell-integration",
   );
@@ -179,16 +186,18 @@ async function runGuidedSetupWithPrompt(
     }
   }
 
-  const tmuxPopupBindingActions = plan.actions.filter(isTmuxPopupBindingAction);
-  const popupCommand = formatCommand([facts.launchers.station.command, "popup"]);
+  const tmuxPopupBindingActions = tmuxPopupPlan.actions.filter(isTmuxPopupBindingAction);
+  const popupCommand = formatCommand([tmuxPopupFacts.launchers.station.command, "popup"]);
   const bindingKey =
-    facts.tmuxBinding.status === "conflict" ? undefined : facts.tmuxBinding.bindingKey;
+    tmuxPopupFacts.tmuxBinding.status === "conflict"
+      ? undefined
+      : tmuxPopupFacts.tmuxBinding.bindingKey;
   let tmuxPopupFeedback =
-    facts.tmuxBinding.status === "ok"
+    tmuxPopupFacts.tmuxBinding.status === "ok"
       ? renderTmuxPopupFeedback(
           true,
-          facts.tmuxBinding.liveStatus === "loaded",
-          facts.tmuxBinding.bindingKey,
+          tmuxPopupFacts.tmuxBinding.liveStatus === "loaded",
+          tmuxPopupFacts.tmuxBinding.bindingKey,
           popupCommand,
         )
       : undefined;
@@ -197,7 +206,7 @@ async function runGuidedSetupWithPrompt(
     if (accepted) {
       const bindingResult = await applySetupPlan(
         {
-          ...plan,
+          ...tmuxPopupPlan,
           actions: tmuxPopupBindingActions.map((action) => ({ ...action, selected: true })),
         },
         applyOptions(deps, { announceActions: true, showCommandOutput: true }),
@@ -207,13 +216,13 @@ async function runGuidedSetupWithPrompt(
           .filter((action) => action.status === "completed")
           .map((action) => action.id),
       );
-      let liveLoaded = facts.tmuxBinding.liveStatus === "loaded";
+      let liveLoaded = tmuxPopupFacts.tmuxBinding.liveStatus === "loaded";
       if (completed.has("tmux-live-popup-binding")) {
         const recheckOptions: Parameters<typeof checkSetupTmuxBinding>[0] = {
-          homeDir: facts.homeDir,
-          launcherCommand: facts.tmuxBinding.launcherCommand,
-          runShellCommand: facts.tmuxBinding.runShellCommand,
-          tmuxCommand: facts.tmux.resolvedPath ?? facts.tmux.command,
+          homeDir: tmuxPopupFacts.homeDir,
+          launcherCommand: tmuxPopupFacts.tmuxBinding.launcherCommand,
+          runShellCommand: tmuxPopupFacts.tmuxBinding.runShellCommand,
+          tmuxCommand: tmuxPopupFacts.tmux.resolvedPath ?? tmuxPopupFacts.tmux.command,
         };
         const env = deps.env ?? options.env;
         if (env !== undefined) recheckOptions.env = env;
@@ -222,7 +231,7 @@ async function runGuidedSetupWithPrompt(
         liveLoaded = (await checkSetupTmuxBinding(recheckOptions)).liveStatus === "loaded";
       }
       tmuxPopupFeedback = renderTmuxPopupFeedback(
-        facts.tmuxBinding.status === "ok" || completed.has("tmux-popup-binding"),
+        tmuxPopupFacts.tmuxBinding.status === "ok" || completed.has("tmux-popup-binding"),
         liveLoaded,
         bindingKey,
         popupCommand,
@@ -230,11 +239,11 @@ async function runGuidedSetupWithPrompt(
       );
     } else {
       tmuxPopupFeedback =
-        facts.tmuxBinding.status === "ok"
+        tmuxPopupFacts.tmuxBinding.status === "ok"
           ? renderTmuxPopupFeedback(
               true,
-              facts.tmuxBinding.liveStatus === "loaded",
-              facts.tmuxBinding.bindingKey,
+              tmuxPopupFacts.tmuxBinding.liveStatus === "loaded",
+              tmuxPopupFacts.tmuxBinding.bindingKey,
               popupCommand,
             )
           : `Tmux popup binding was not changed. Direct fallback: ${popupCommand}\n`;

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -166,7 +166,7 @@ export type SetupConfigDefaultsFact = {
 
 export type SetupLauncherFact = {
   status: "ok" | "missing";
-  source: "path" | "checkout" | "missing";
+  source: "path" | "installed" | "checkout" | "missing";
   command: string;
   checkoutPath: string;
   resolvedPath?: string;
@@ -221,6 +221,7 @@ export type SetupTmuxBindingFact =
       marker: string;
       launcherCommand: string;
       runShellCommand: string;
+      bindingKey: string;
       insideTmux: boolean;
       liveStatus: "loaded" | "missing" | "unknown";
     }
@@ -230,8 +231,19 @@ export type SetupTmuxBindingFact =
       marker: string;
       launcherCommand: string;
       runShellCommand: string;
+      bindingKey: string;
       insideTmux: boolean;
       liveStatus: "loaded" | "missing" | "unknown";
+      message: string;
+    }
+  | {
+      status: "conflict";
+      path: string;
+      marker: string;
+      launcherCommand: string;
+      runShellCommand: string;
+      insideTmux: boolean;
+      liveStatus: "unknown";
       message: string;
     };
 

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -1,3 +1,4 @@
+import type { TmuxConfig } from "@station/config";
 import { z } from "zod";
 
 export const setupTiers = ["required", "recommended", "optional"] as const;
@@ -201,6 +202,7 @@ export type SetupConfigFact =
       configuredHarnesses: readonly string[];
       configuredHookHarnesses: readonly string[];
       defaults: SetupConfigDefaultsFact;
+      tmux?: TmuxConfig;
       worktrunkUseLifecycleHooks?: boolean;
       matchedProject?: SetupConfigProjectFact;
       // Non-fatal load diagnostics (broken project-local file, bad

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -121,8 +121,18 @@ function tmuxPopupBindingCheck(facts: SetupFacts): SetupCheck {
       path: facts.tmuxBinding.path,
       launcherCommand: facts.tmuxBinding.launcherCommand,
       liveStatus: facts.tmuxBinding.liveStatus,
+      ...(facts.tmuxBinding.status === "conflict"
+        ? {}
+        : { bindingKey: facts.tmuxBinding.bindingKey }),
     },
   } as const;
+  if (facts.tmuxBinding.status === "conflict") {
+    return {
+      ...base,
+      status: "warning",
+      message: facts.tmuxBinding.message,
+    };
+  }
   if (facts.tmux.status !== "ok") {
     return {
       ...base,
@@ -180,6 +190,7 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
   const launchers = [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup];
   const missing = launchers.filter((launcher) => launcher.status === "missing");
   const checkout = launchers.filter((launcher) => launcher.source === "checkout");
+  const installed = launchers.filter((launcher) => launcher.source === "installed");
   const details = {
     station: setupLauncherExecutable(facts.launchers.station),
     ingress: setupLauncherExecutable(facts.launchers.ingress),
@@ -203,6 +214,16 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
       label: "STATION launchers",
       message:
         "Bare station launchers are not on PATH; setup will use current-checkout launcher paths.",
+      details,
+    };
+  }
+  if (installed.length > 0) {
+    return {
+      id: "station-launchers",
+      tier: "recommended",
+      status: "ok",
+      label: "STATION launchers",
+      message: "STATION launchers are available from PATH or the installed artifact.",
       details,
     };
   }
@@ -642,18 +663,22 @@ function setupActions(
       tier: "recommended",
       selected: false,
       label: "Install tmux popup binding",
-      message: "Append a Ctrl-b Space binding for the STATION popup dashboard to ~/.tmux.conf.",
+      message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} binding for the STATION popup dashboard in ~/.tmux.conf.`,
       path: facts.tmuxBinding.path,
       data: {
         marker: facts.tmuxBinding.marker,
         endMarker: tmuxPopupBindingEndMarker,
-        appendedText: tmuxPopupBindingBlock(facts.tmuxBinding.launcherCommand),
+        appendedText: tmuxPopupBindingBlock(facts.tmuxBinding.launcherCommand, {
+          bindingKey: facts.tmuxBinding.bindingKey,
+          runShellCommand: facts.tmuxBinding.runShellCommand,
+        }),
       },
     });
   }
   if (
     facts.tmux.status === "ok" &&
     facts.launchers.tmuxPopup.status === "ok" &&
+    facts.tmuxBinding.status !== "conflict" &&
     facts.tmuxBinding.insideTmux &&
     facts.tmuxBinding.liveStatus !== "loaded"
   ) {
@@ -663,11 +688,11 @@ function setupActions(
       tier: "recommended",
       selected: false,
       label: "Load tmux popup binding",
-      message: "Install the Ctrl-b Space STATION popup binding in the current tmux server.",
+      message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} STATION popup binding in the current tmux server.`,
       command: [
-        facts.tmux.command,
+        facts.tmux.resolvedPath ?? facts.tmux.command,
         "bind-key",
-        "Space",
+        facts.tmuxBinding.bindingKey,
         "run-shell",
         "-b",
         facts.tmuxBinding.runShellCommand,
@@ -684,7 +709,7 @@ function setupActions(
 
 function stationLaunchersNeedLink(facts: SetupFacts): boolean {
   return [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup].some(
-    (launcher) => launcher.source !== "path",
+    (launcher) => launcher.source !== "path" && launcher.source !== "installed",
   );
 }
 

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -30,6 +30,7 @@ export type SetupCommandDeps = {
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
   compiled?: boolean;
+  tmuxPopupOwnerRoot?: string;
   stateDirExecute?: (path: string) => Promise<void>;
   stateDirFs?: SetupStateDirFileSystem;
 };

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,7 +13,10 @@ import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
-const repoRoot = fileURLToPath(new URL("../../../../", import.meta.url)).replace(/\/$/, "");
+const repoRoot = realpathSync(fileURLToPath(new URL("../../../../", import.meta.url))).replace(
+  /\/$/,
+  "",
+);
 
 describe("CLI popup command", () => {
   it("ensures the observer before opening a config-less first-run popup", async () => {
@@ -398,6 +402,66 @@ describe("CLI popup command", () => {
         "--persistent",
       ].join(" "),
     );
+  });
+
+  it("prefers an injected installed popup owner over the source checkout", async () => {
+    const fixture = await createTempState();
+    fixture.config.defaults.terminal = "tmux";
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const calls: TmuxPopupOptions[] = [];
+
+    await expect(
+      runCli(["--config", configPath, "popup"], {
+        observerDeps: runningObserverDeps([]),
+        popupDeps: {
+          checkoutRoot: "/opt/station/current",
+          env: {
+            TMUX: "/tmp/tmux-501/default,123,0",
+          },
+          openTmuxPopup: async (options) => {
+            calls.push(options);
+            return { opened: true };
+          },
+          preferRegisteredDevPopup: false,
+        },
+      }),
+    ).resolves.toEqual({
+      code: 0,
+      output: { opened: true },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.checkoutRoot).toBe("/opt/station/current");
+    expect(calls[0]?.preferRegisteredDevPopup).toBe(false);
+  });
+
+  it("omits an unsafe filesystem-root popup owner", async () => {
+    const fixture = await createTempState();
+    fixture.config.defaults.terminal = "tmux";
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const calls: TmuxPopupOptions[] = [];
+
+    await expect(
+      runCli(["--config", configPath, "popup"], {
+        observerDeps: runningObserverDeps([]),
+        popupDeps: {
+          checkoutRoot: "/",
+          env: {
+            TMUX: "/tmp/tmux-501/default,123,0",
+          },
+          openTmuxPopup: async (options) => {
+            calls.push(options);
+            return { opened: true };
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      code: 0,
+      output: { opened: true },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).not.toHaveProperty("checkoutRoot");
   });
 
   it("defaults bare station to the popup command when invoked from tmux", async () => {

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { runCli } from "@station/cli";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
 
 describe("CLI setup command", () => {
@@ -90,6 +91,72 @@ describe("CLI setup command", () => {
     expect(plan.checks.some((check) => check.id === "station-ui")).toBe(false);
     expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
     expect(plan.actions.some((action) => action.id === "install-bun")).toBe(false);
+  });
+
+  it("generates the compiled binding from installed ownership while preserving its key", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const installedRoot = join(root, "installed");
+    const popupAlias = join(installedRoot, "stn-tmux-popup");
+    const tmuxCommand = "/fake/bin/tmux";
+    const tmuxConfigPath = join(home, ".tmux.conf");
+    await mkdir(repo, { recursive: true });
+    const fs = readOnlyFs({
+      [tmuxConfigPath]: [
+        "# >>> station popup binding >>>",
+        "# Change Space to any tmux key; stn setup preserves it.",
+        "bind-key C-s run-shell -b 'old-command'",
+        "# <<< station popup binding <<<",
+        "",
+      ].join("\n"),
+    });
+
+    const result = await runCli(["setup", "plan", "--json"], {
+      setupDeps: {
+        compiled: true,
+        tmuxPopupOwnerRoot: installedRoot,
+        cwd: repo,
+        homeDir: home,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          tmuxCommand,
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          popupAlias,
+        ]),
+        fs,
+      },
+    });
+
+    expect(result.code).toBe(0);
+    const plan = result.output as {
+      actions: Array<{ id: string; data?: { appendedText?: string } }>;
+      checks: Array<{ id: string; details?: Record<string, string> }>;
+    };
+    const runShellCommand = buildManagedFastPopupRunShellCommand({
+      installedRoot,
+      fallbackAlias: popupAlias,
+      tmuxCommand,
+    });
+    expect(plan.checks.find((check) => check.id === "tmux-popup-binding")?.details).toMatchObject({
+      bindingKey: "C-s",
+    });
+    const bindingAction = plan.actions.find((action) => action.id === "tmux-popup-binding");
+    expect(bindingAction?.data?.appendedText).toContain("bind-key C-s run-shell -b");
+    expect(bindingAction?.data?.appendedText).toContain(
+      `'${runShellCommand.replaceAll("'", "'\\''")}'`,
+    );
   });
 
   it("setup plan is read-only and includes a config write action", async () => {

--- a/apps/cli/test/unit/setup-apply.test.ts
+++ b/apps/cli/test/unit/setup-apply.test.ts
@@ -139,7 +139,7 @@ describe("setup apply engine", () => {
             marker: "# >>> station popup binding >>>",
             endMarker: "# <<< station popup binding <<<",
             appendedText:
-              "# >>> station popup binding >>>\nbind-key Space run-shell -b 'stn-tmux-popup'\n# <<< station popup binding <<<\n",
+              "# >>> station popup binding >>>\n# Change Space to any tmux key; stn setup preserves it.\nbind-key Space run-shell -b 'stn-tmux-popup'\n# <<< station popup binding <<<\n",
           },
         },
       ]),
@@ -168,7 +168,8 @@ describe("setup apply engine", () => {
         "set -g mouse on",
         "",
         "# >>> station popup binding >>>",
-        "bind-key Space run-shell -b 'stn-tmux-popup'",
+        "# Change Space to any tmux key; stn setup preserves it.",
+        "bind-key C-s run-shell -b 'old-command'",
         "# <<< station popup binding <<<",
         "",
         "set -g status on",
@@ -190,7 +191,7 @@ describe("setup apply engine", () => {
             marker: "# >>> station popup binding >>>",
             endMarker: "# <<< station popup binding <<<",
             appendedText:
-              "# >>> station popup binding >>>\nbind-key Space run-shell -b '/tmp/station/integrations/terminal/tmux/bin/stn-popup'\n# <<< station popup binding <<<\n",
+              "# >>> station popup binding >>>\n# Change Space to any tmux key; stn setup preserves it.\nbind-key C-s run-shell -b 'managed-fast-command'\n# <<< station popup binding <<<\n",
           },
         },
       ]),
@@ -204,9 +205,9 @@ describe("setup apply engine", () => {
     expect(fs.writes["/tmp/home/.tmux.conf"]).toContain("set -g mouse on");
     expect(fs.writes["/tmp/home/.tmux.conf"]).toContain("set -g status on");
     expect(fs.writes["/tmp/home/.tmux.conf"]).toContain(
-      "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
+      "bind-key C-s run-shell -b 'managed-fast-command'",
     );
-    expect(fs.writes["/tmp/home/.tmux.conf"]).not.toContain("'stn-tmux-popup'");
+    expect(fs.writes["/tmp/home/.tmux.conf"]).not.toContain("'old-command'");
   });
 });
 

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1,7 +1,12 @@
 import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, delimiter, join } from "node:path";
-import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import type {
+  ExternalCommandInput,
+  ExternalCommandResult,
+  ExternalCommandRunner,
+} from "@station/runtime";
+import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { checkSetupBun } from "../../src/commands/setup/checks/bun.js";
 import { setupProbeTimeoutMs } from "../../src/commands/setup/checks/constants.js";
@@ -125,6 +130,89 @@ describe("setup dependency checks", () => {
     expect(plan.checks.some((check) => check.id === "bun")).toBe(false);
     expect(plan.checks.some((check) => check.id === "station-ui")).toBe(false);
     expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
+  });
+
+  it("uses the installed popup sibling and resolved tmux path for compiled bindings", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const installedRoot = join(root, "installed");
+    const popupAlias = join(installedRoot, "stn-tmux-popup");
+    await mkdir(repo, { recursive: true });
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: join(root, "home"),
+      compiled: true,
+      tmuxPopupOwnerRoot: installedRoot,
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner([], {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+        "wt --version": "worktrunk 1.2.3\n",
+        "tmux -V": "tmux 3.5a\n",
+        "codex --version": "codex 0.1.0\n",
+      }),
+      access: fakeAccess([
+        "/fake/bin/wt",
+        "/fake/bin/tmux",
+        "/fake/bin/diffnav",
+        "/fake/bin/delta",
+        "/fake/bin/stn",
+        "/fake/bin/stn-ingress",
+        popupAlias,
+      ]),
+      fs: readOnlyFs({}),
+    });
+    const plan = buildSetupPlan(facts);
+
+    expect(facts.launchers.tmuxPopup).toMatchObject({
+      status: "ok",
+      source: "installed",
+      resolvedPath: popupAlias,
+    });
+    expect(facts.tmuxBinding).toMatchObject({
+      status: "missing",
+      launcherCommand: popupAlias,
+      bindingKey: "Space",
+    });
+    expect(facts.tmuxBinding.runShellCommand).toBe(
+      buildManagedFastPopupRunShellCommand({
+        installedRoot,
+        fallbackAlias: popupAlias,
+        tmuxCommand: "/fake/bin/tmux",
+      }),
+    );
+    expect(plan.actions.some((action) => action.id === "tmux-popup-binding")).toBe(true);
+  });
+
+  it("reports missing tmux without trying to generate a compiled fast binding", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const installedRoot = join(root, "installed");
+    const popupAlias = join(installedRoot, "stn-tmux-popup");
+    await mkdir(repo, { recursive: true });
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: join(root, "home"),
+      compiled: true,
+      tmuxPopupOwnerRoot: installedRoot,
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner([], {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      }),
+      access: fakeAccess([popupAlias]),
+      fs: readOnlyFs({}),
+    });
+
+    expect(facts.tmux.status).toBe("missing");
+    expect(facts.tmuxBinding.runShellCommand).toBe(tmuxPopupRunShellCommand(popupAlias));
+    expect(buildSetupPlan(facts).actions.some((action) => action.id === "tmux-popup-binding")).toBe(
+      false,
+    );
   });
 
   it("collects core facts through injected effects only", async () => {
@@ -700,6 +788,213 @@ scroll_on_output = "teleport"
     }
   });
 
+  it("persists an exact generated command and defaults a fresh block to Space", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/opt/station/stn-tmux-popup";
+    const runShellCommand = "managed-fast-command --exact '#{q:client_name}'";
+
+    const missing = await checkSetupTmuxBinding({
+      homeDir,
+      launcherCommand,
+      runShellCommand,
+      fs: readOnlyFs({}),
+    });
+
+    expect(missing).toMatchObject({
+      status: "missing",
+      bindingKey: "Space",
+      launcherCommand,
+      runShellCommand,
+    });
+    const quotedCommand = `'${runShellCommand.replaceAll("'", "'\\''")}'`;
+    expect(tmuxPopupBindingBlock(launcherCommand, { runShellCommand })).toContain(
+      `bind-key Space run-shell -b ${quotedCommand}`,
+    );
+  });
+
+  it("round-trips the physical one-line compiled command through the owned block", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const installedRoot = "/opt/station/bin";
+    const launcherCommand = `${installedRoot}/stn-tmux-popup`;
+    const runShellCommand = buildManagedFastPopupRunShellCommand({
+      installedRoot,
+      fallbackAlias: launcherCommand,
+      tmuxCommand: "/usr/bin/tmux",
+    });
+
+    expect(runShellCommand).not.toMatch(/[\r\n]/);
+    await expect(
+      checkSetupTmuxBinding({
+        homeDir,
+        launcherCommand,
+        runShellCommand,
+        fs: readOnlyFs({
+          [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand, {
+            runShellCommand,
+          }),
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      bindingKey: "Space",
+      runShellCommand,
+    });
+  });
+
+  it.each([
+    "p",
+    "Space",
+    "F12",
+    "C-Space",
+    "M-p",
+    "C-s",
+  ])("preserves the supported customized key %s while upgrading Station's command", async (bindingKey) => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/opt/station/stn-tmux-popup";
+    const runShellCommand = "managed-fast-command";
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      launcherCommand,
+      runShellCommand,
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock("old-popup", {
+          bindingKey,
+        }),
+      }),
+    });
+
+    expect(binding).toMatchObject({
+      status: "missing",
+      bindingKey,
+      runShellCommand,
+      message: expect.stringContaining(`preserving ${bindingKey}`),
+    });
+  });
+
+  it("accepts an explicit prefix table and matches the preserved live key exactly", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/opt/station/stn-tmux-popup";
+    const runShellCommand = "managed-fast-command";
+    const quotedCommand = `'${runShellCommand}'`;
+    const serialized = runShellCommand.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runShellCommand,
+      runner: async (input) => ({
+        command: input.command,
+        args: input.args ?? [],
+        stdout:
+          input.args?.[0] === "list-keys"
+            ? `bind-key -T prefix C-Space run-shell -b "${serialized}"\n`
+            : "",
+        stderr: "",
+        exitCode: 0,
+      }),
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: [
+          "# >>> station popup binding >>>",
+          `bind-key -T prefix C-Space run-shell -b ${quotedCommand}`,
+          "# <<< station popup binding <<<",
+          "",
+        ].join("\n"),
+      }),
+    });
+
+    expect(binding).toMatchObject({ status: "ok", bindingKey: "C-Space", liveStatus: "loaded" });
+  });
+
+  it("treats deleted, commented, and unmarked bindings as absent without inferring a key", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const markedComment = [
+      "# >>> station popup binding >>>",
+      "# bind-key C-s run-shell -b 'old-popup'",
+      "# <<< station popup binding <<<",
+      "",
+    ].join("\n");
+    const unmarked = "bind-key M-p run-shell -b 'stn-tmux-popup'\n";
+
+    for (const source of [markedComment, unmarked]) {
+      await expect(
+        checkSetupTmuxBinding({
+          homeDir,
+          runShellCommand: "managed-fast-command",
+          fs: readOnlyFs({ [join(homeDir, ".tmux.conf")]: source }),
+        }),
+      ).resolves.toMatchObject({ status: "missing", bindingKey: "Space" });
+    }
+  });
+
+  it.each([
+    {
+      name: "duplicate markers",
+      source: `${tmuxPopupBindingBlock()}${tmuxPopupBindingBlock()}`,
+    },
+    {
+      name: "a malformed marker",
+      source: [
+        "# >>> station popup binding >>> trailing",
+        "bind-key Space run-shell -b 'stn-tmux-popup'",
+        "# <<< station popup binding <<<",
+      ].join("\n"),
+    },
+    {
+      name: "multiple active lines",
+      source: [
+        "# >>> station popup binding >>>",
+        "bind-key Space run-shell -b 'stn-tmux-popup'",
+        "bind-key p run-shell -b 'stn-tmux-popup'",
+        "# <<< station popup binding <<<",
+      ].join("\n"),
+    },
+    {
+      name: "multiple commands on one active line",
+      source: [
+        "# >>> station popup binding >>>",
+        "bind-key C-s run-shell -b 'old-popup' ; bind-key M-p display-message hi",
+        "# <<< station popup binding <<<",
+      ].join("\n"),
+    },
+    {
+      name: "a non-prefix selector",
+      source: [
+        "# >>> station popup binding >>>",
+        "bind-key -T root p run-shell -b 'stn-tmux-popup'",
+        "# <<< station popup binding <<<",
+      ].join("\n"),
+    },
+    {
+      name: "an unsupported key",
+      source: [
+        "# >>> station popup binding >>>",
+        "bind-key MouseDown1 run-shell -b 'stn-tmux-popup'",
+        "# <<< station popup binding <<<",
+      ].join("\n"),
+    },
+  ])("reports $name as a conflict without probing live tmux", async ({ source }) => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const runner = vi.fn<ExternalCommandRunner>();
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      runner,
+      fs: readOnlyFs({ [join(homeDir, ".tmux.conf")]: source }),
+    });
+
+    expect(binding).toMatchObject({ status: "conflict", liveStatus: "unknown" });
+    expect(runner).not.toHaveBeenCalled();
+  });
+
   it("escapes tmux formats in absolute launcher paths", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
@@ -834,7 +1129,7 @@ scroll_on_output = "teleport"
       return {
         command: input.command,
         args: input.args ?? [],
-        stdout: listKeys ? `bind-key -T prefix Space run-shell -b "${serialized}"\n` : "",
+        stdout: listKeys ? `bind-key    -T prefix Space   run-shell -b "${serialized}"\n` : "",
         stderr: "",
         exitCode: 0,
       };
@@ -860,6 +1155,40 @@ scroll_on_output = "teleport"
         ],
       }),
     ]);
+  });
+
+  it("decodes tmux's context-sensitive command serialization for a customized key", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const launcherCommand = "/tmp/bin/stn-tmux-popup";
+    const runShellCommand = 'encoded_script=$1; probe="$quoted"; result="$(subshell)"';
+    const listedBinding = String.raw`bind-key    -T prefix C-s     run-shell -b "encoded_script=$1; probe=\"\$quoted\"; result=\"$(subshell)\""`;
+
+    const binding = await checkSetupTmuxBinding({
+      homeDir,
+      env: { TMUX: "/tmp/tmux.sock,1,0" },
+      launcherCommand,
+      runShellCommand,
+      runner: async (input) => ({
+        command: input.command,
+        args: input.args ?? [],
+        stdout: input.args?.[0] === "list-keys" ? `${listedBinding}\n` : "",
+        stderr: "",
+        exitCode: 0,
+      }),
+      fs: readOnlyFs({
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand, {
+          bindingKey: "C-s",
+          runShellCommand,
+        }),
+      }),
+    });
+
+    expect(binding).toMatchObject({
+      status: "ok",
+      bindingKey: "C-s",
+      liveStatus: "loaded",
+    });
   });
 
   it("probes whether the live launcher can start instead of only checking its mode", async () => {
@@ -995,25 +1324,22 @@ scroll_on_output = "teleport"
     expect(calls).toHaveLength(1);
   });
 
-  it("reports old tmux popup bindings as missing when setup resolved a checkout launcher", async () => {
+  it("reports an owned old popup command as stale for a checkout launcher", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
     const binding = await checkSetupTmuxBinding({
       homeDir,
       launcherCommand: "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
       fs: readOnlyFs({
-        [join(homeDir, ".tmux.conf")]: `${tmuxPopupBindingBlock()}\n${tmuxPopupBindingBlock(
-          "/tmp/station/integrations/terminal/tmux/bin/stn-popup",
-        )
-          .split("\n")
-          .at(1)}\n`,
+        [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(),
       }),
     });
 
     expect(binding).toMatchObject({
       status: "missing",
+      bindingKey: "Space",
       message:
-        "tmux popup binding uses a different launcher; rerun stn setup to replace it with /tmp/station/integrations/terminal/tmux/bin/stn-popup.",
+        "tmux popup binding command is stale; rerun stn setup to update it while preserving Space.",
     });
   });
 });

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -132,17 +132,21 @@ describe("setup dependency checks", () => {
     expect(plan.checks.some((check) => check.id === "command-line-tools")).toBe(false);
   });
 
-  it("uses the installed popup sibling and resolved tmux path for compiled bindings", async () => {
+  it("uses the fast compiled binding for default geometry without losing explicit config identity", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
+    const home = join(root, "home");
+    const defaultConfigPath = join(home, ".config/station/config.toml");
+    const explicitConfigPath = join(root, "explicit-default.toml");
+    const invalidConfigPath = join(root, "invalid.toml");
+    const missingConfigPath = join(root, "missing.toml");
     const installedRoot = join(root, "installed");
     const popupAlias = join(installedRoot, "stn-tmux-popup");
     await mkdir(repo, { recursive: true });
 
-    const facts = await collectSetupFacts({
-      mode: "check",
+    const baseOptions = {
+      mode: "check" as const,
       cwd: repo,
-      homeDir: join(root, "home"),
       compiled: true,
       tmuxPopupOwnerRoot: installedRoot,
       env: { PATH: "/fake/bin" },
@@ -162,9 +166,40 @@ describe("setup dependency checks", () => {
         "/fake/bin/stn-ingress",
         popupAlias,
       ]),
-      fs: readOnlyFs({}),
+      fs: readOnlyFs({
+        [defaultConfigPath]: configToml(repo, {
+          popupWidth: "50%",
+          popupHeight: "50%",
+          popupPosition: "C",
+        }),
+        [explicitConfigPath]: configToml(repo, {
+          popupWidth: "50%",
+          popupHeight: "50%",
+          popupPosition: "C",
+        }),
+        [invalidConfigPath]: 'schema_version = "invalid"\n',
+      }),
+    };
+    const facts = await collectSetupFacts({ ...baseOptions, homeDir: home });
+    const explicit = await collectSetupFacts({
+      ...baseOptions,
+      configPath: explicitConfigPath,
+      homeDir: home,
     });
-    const plan = buildSetupPlan(facts);
+    const explicitMissing = await collectSetupFacts({
+      ...baseOptions,
+      configPath: missingConfigPath,
+      homeDir: home,
+    });
+    const invalid = await collectSetupFacts({
+      ...baseOptions,
+      configPath: invalidConfigPath,
+      homeDir: home,
+    });
+    const implicitMissing = await collectSetupFacts({
+      ...baseOptions,
+      homeDir: join(root, "empty-home"),
+    });
 
     expect(facts.launchers.tmuxPopup).toMatchObject({
       status: "ok",
@@ -178,12 +213,83 @@ describe("setup dependency checks", () => {
     });
     expect(facts.tmuxBinding.runShellCommand).toBe(
       buildManagedFastPopupRunShellCommand({
+        configPath: defaultConfigPath,
         installedRoot,
         fallbackAlias: popupAlias,
         tmuxCommand: "/fake/bin/tmux",
       }),
     );
-    expect(plan.actions.some((action) => action.id === "tmux-popup-binding")).toBe(true);
+    expect(explicit.tmuxBinding.runShellCommand).toBe(
+      tmuxPopupRunShellCommand(popupAlias, explicitConfigPath),
+    );
+    expect(explicitMissing.config.status).toBe("missing");
+    expect(explicitMissing.tmuxBinding.runShellCommand).toBe(
+      tmuxPopupRunShellCommand(popupAlias, missingConfigPath),
+    );
+    expect(invalid.config.status).toBe("invalid");
+    expect(invalid.tmuxBinding.runShellCommand).toBe(
+      tmuxPopupRunShellCommand(popupAlias, invalidConfigPath),
+    );
+    expect(implicitMissing.config.status).toBe("missing");
+    expect(implicitMissing.tmuxBinding.runShellCommand).toBe(
+      buildManagedFastPopupRunShellCommand({
+        installedRoot,
+        fallbackAlias: popupAlias,
+        tmuxCommand: "/fake/bin/tmux",
+      }),
+    );
+    expect(buildSetupPlan(facts).actions.some((action) => action.id === "tmux-popup-binding")).toBe(
+      true,
+    );
+  });
+
+  it("uses the config-aware popup alias for compiled bindings with custom geometry", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const configPath = join(root, "custom-config.toml");
+    const installedRoot = join(root, "installed");
+    const popupAlias = join(installedRoot, "stn-tmux-popup");
+    await mkdir(repo, { recursive: true });
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      configPath,
+      cwd: repo,
+      homeDir: home,
+      compiled: true,
+      tmuxPopupOwnerRoot: installedRoot,
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner([], {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+        "wt --version": "worktrunk 1.2.3\n",
+        "tmux -V": "tmux 3.5a\n",
+        "codex --version": "codex 0.1.0\n",
+      }),
+      access: fakeAccess([
+        "/fake/bin/wt",
+        "/fake/bin/tmux",
+        "/fake/bin/diffnav",
+        "/fake/bin/delta",
+        "/fake/bin/stn",
+        "/fake/bin/stn-ingress",
+        popupAlias,
+      ]),
+      fs: readOnlyFs({
+        [configPath]: configToml(repo, {
+          popupWidth: "80",
+          popupHeight: "24",
+          popupPosition: "C",
+        }),
+      }),
+    });
+
+    expect(facts.tmuxBinding.runShellCommand).toBe(
+      tmuxPopupRunShellCommand(popupAlias, configPath),
+    );
+    expect(facts.tmuxBinding.runShellCommand).toContain("STATION_CONFIG_PATH=");
+    expect(facts.tmuxBinding.runShellCommand).not.toContain("station-popup-binding");
   });
 
   it("reports missing tmux without trying to generate a compiled fast binding", async () => {
@@ -788,6 +894,29 @@ scroll_on_output = "teleport"
     }
   });
 
+  it("carries an explicit config through the popup alias environment and arguments", () => {
+    const command = tmuxPopupRunShellCommand(
+      "/opt/station/stn-tmux-popup",
+      "/tmp/station-#{session_name}/config.toml",
+    );
+
+    expect(command).toContain("STATION_CONFIG_PATH='/tmp/station-##{session_name}/config.toml'");
+    expect(command).toContain("--config '/tmp/station-##{session_name}/config.toml'");
+  });
+
+  it.each([
+    "\0",
+    "\r",
+    "\n",
+  ])("rejects %j in managed popup launcher and config values", (control) => {
+    expect(() => tmuxPopupRunShellCommand(`/opt/station/stn${control}-tmux-popup`)).toThrow(
+      "unsupported control character",
+    );
+    expect(() =>
+      tmuxPopupRunShellCommand("/opt/station/stn-tmux-popup", `/tmp/station${control}/config.toml`),
+    ).toThrow("unsupported control character");
+  });
+
   it("persists an exact generated command and defaults a fresh block to Space", async () => {
     const root = await tempRoot(tempRoots);
     const homeDir = join(root, "home");
@@ -811,6 +940,38 @@ scroll_on_output = "teleport"
     expect(tmuxPopupBindingBlock(launcherCommand, { runShellCommand })).toContain(
       `bind-key Space run-shell -b ${quotedCommand}`,
     );
+  });
+
+  it("marks a binding stale when an explicit config path is added", async () => {
+    const root = await tempRoot(tempRoots);
+    const homeDir = join(root, "home");
+    const installedRoot = "/opt/station";
+    const launcherCommand = `${installedRoot}/stn-tmux-popup`;
+    const base = {
+      fallbackAlias: launcherCommand,
+      installedRoot,
+      tmuxCommand: "/opt/homebrew/bin/tmux",
+    };
+    const previous = buildManagedFastPopupRunShellCommand(base);
+    const current = tmuxPopupRunShellCommand(launcherCommand, "/tmp/station/config.toml");
+
+    await expect(
+      checkSetupTmuxBinding({
+        homeDir,
+        launcherCommand,
+        runShellCommand: current,
+        fs: readOnlyFs({
+          [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand, {
+            bindingKey: "M-p",
+            runShellCommand: previous,
+          }),
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "missing",
+      bindingKey: "M-p",
+      message: expect.stringContaining("stale"),
+    });
   });
 
   it("round-trips the physical one-line compiled command through the owned block", async () => {
@@ -1575,6 +1736,9 @@ function configToml(
     terminal?: string;
     harness?: string;
     useLifecycleHooks?: boolean;
+    popupWidth?: string;
+    popupHeight?: string;
+    popupPosition?: string;
   } = {},
 ): string {
   const lines = [
@@ -1602,6 +1766,23 @@ function configToml(
       `use_lifecycle_hooks = ${options.useLifecycleHooks ? "true" : "false"}`,
       "",
     );
+  }
+  if (
+    options.popupWidth !== undefined ||
+    options.popupHeight !== undefined ||
+    options.popupPosition !== undefined
+  ) {
+    lines.push("[terminal.tmux]");
+    if (options.popupWidth !== undefined) {
+      lines.push(`popup_width = ${JSON.stringify(options.popupWidth)}`);
+    }
+    if (options.popupHeight !== undefined) {
+      lines.push(`popup_height = ${JSON.stringify(options.popupHeight)}`);
+    }
+    if (options.popupPosition !== undefined) {
+      lines.push(`popup_position = ${JSON.stringify(options.popupPosition)}`);
+    }
+    lines.push("");
   }
   return lines.join("\n");
 }

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -405,6 +405,7 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
       launcherCommand: "stn-tmux-popup",
       runShellCommand:
         "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} 'stn-tmux-popup'",
+      bindingKey: "Space",
       insideTmux: false,
       liveStatus: "unknown",
       message: "Optional tmux popup binding is not installed.",

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
 import { setupPackageRoot } from "../../src/commands/setup/checks/launchers.js";
 import {
@@ -432,6 +433,7 @@ describe("guided setup command", () => {
   it("installs the optional tmux popup binding when accepted", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
+    const configPath = join(root, "home/.config/station/config.toml");
     await mkdir(repo, { recursive: true });
     const fs = fakeFs({});
     const chunks: string[] = [];
@@ -443,6 +445,8 @@ describe("guided setup command", () => {
         cwd: repo,
         homeDir: join(root, "home"),
         env: { PATH: "/fake/bin" },
+        compiled: true,
+        tmuxPopupOwnerRoot: "/fake/bin",
         runner: fakeRunner([], {
           "git rev-parse --show-toplevel": repo,
           "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
@@ -468,9 +472,16 @@ describe("guided setup command", () => {
     );
 
     expect(result.code).toBe(0);
-    expect(fs.files[join(root, "home/.tmux.conf")]).toContain("'/fake/bin/stn-tmux-popup'");
-    expect(fs.files[join(root, "home/.tmux.conf")]).toContain(
-      "# Change Space to any tmux key; stn setup preserves it.",
+    const tmuxConfig = fs.files[join(root, "home/.tmux.conf")];
+    expect(tmuxConfig).toContain(
+      tmuxPopupBindingBlock("/fake/bin/stn-tmux-popup", {
+        runShellCommand: buildManagedFastPopupRunShellCommand({
+          installedRoot: "/fake/bin",
+          fallbackAlias: "/fake/bin/stn-tmux-popup",
+          tmuxCommand: "/fake/bin/tmux",
+          configPath,
+        }),
+      }),
     );
     expect(chunks.join("")).toContain(
       "Tmux popup binding: tmux prefix + Space is persisted for future tmux servers",
@@ -599,7 +610,7 @@ describe("guided setup command", () => {
     expect(output).not.toContain("persisted and loaded in the current tmux server");
     expect(
       calls.filter((call) => basename(call.command) === "tmux" && call.args?.[0] === "run-shell"),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
   });
 
   it("installs accepted Worktrunk and agent hooks with resolved ingress launcher", async () => {

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -469,10 +469,64 @@ describe("guided setup command", () => {
 
     expect(result.code).toBe(0);
     expect(fs.files[join(root, "home/.tmux.conf")]).toContain("'/fake/bin/stn-tmux-popup'");
+    expect(fs.files[join(root, "home/.tmux.conf")]).toContain(
+      "# Change Space to any tmux key; stn setup preserves it.",
+    );
     expect(chunks.join("")).toContain(
-      "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers",
+      "Tmux popup binding: tmux prefix + Space is persisted for future tmux servers",
     );
     expect(chunks.join("")).toContain("Direct fallback: stn popup");
+  });
+
+  it("preserves a customized tmux key while replacing Station's command", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({
+      [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock("/old/stn-tmux-popup", {
+        bindingKey: "C-s",
+      }),
+    });
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: prompt({ confirms: [false, false, true, false, true] }),
+        writeStdout: (chunk) => chunks.push(chunk),
+      },
+    );
+
+    const tmuxConfig = fs.files[join(homeDir, ".tmux.conf")];
+    expect(result.code).toBe(0);
+    expect(tmuxConfig).toContain("bind-key C-s run-shell -b");
+    expect(tmuxConfig).toContain("'/fake/bin/stn-tmux-popup'");
+    expect(tmuxConfig).not.toContain("/old/stn-tmux-popup");
+    expect(chunks.join("")).toContain("Tmux popup binding: tmux prefix + C-s is persisted");
   });
 
   it("does not report a rebound tmux launcher as loaded when startup still fails", async () => {
@@ -540,7 +594,7 @@ describe("guided setup command", () => {
     const output = chunks.join("");
     expect(result.code).toBe(0);
     expect(output).toContain(
-      "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers; no current server was live-loaded.",
+      "Tmux popup binding: tmux prefix + Space is persisted for future tmux servers; no current server was live-loaded.",
     );
     expect(output).not.toContain("persisted and loaded in the current tmux server");
     expect(

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -262,8 +262,17 @@ describe("setup planner", () => {
     expect(plan.nextSteps).toEqual(["stn doctor", "stn"]);
   });
 
-  it("plans the optional tmux popup binding when it is missing", () => {
-    const plan = buildSetupPlan(facts());
+  it("plans the optional tmux popup binding with the preserved key and exact command", () => {
+    const base = facts();
+    const plan = buildSetupPlan(
+      facts({
+        tmuxBinding: {
+          ...base.tmuxBinding,
+          bindingKey: "C-s",
+          runShellCommand: "managed-fast-command",
+        },
+      }),
+    );
 
     expect(plan.actions.find((action) => action.id === "tmux-popup-binding")).toMatchObject({
       kind: "append-file",
@@ -272,7 +281,9 @@ describe("setup planner", () => {
       path: "/tmp/home/.tmux.conf",
       data: {
         marker: "# >>> station popup binding >>>",
-        appendedText: expect.stringContaining("'/tmp/bin/stn-tmux-popup'"),
+        appendedText: expect.stringContaining(
+          "# Change Space to any tmux key; stn setup preserves it.\nbind-key C-s run-shell -b 'managed-fast-command'",
+        ),
       },
     });
     expect(plan.actions.find((action) => action.id === "worktrunk-hooks")?.command).toEqual([
@@ -299,7 +310,7 @@ describe("setup planner", () => {
     ]);
   });
 
-  it("plans the absolute popup command for a reachable tmux server", () => {
+  it("plans the exact popup command and preserved key for a reachable tmux server", () => {
     const plan = buildSetupPlan(
       facts({
         tmuxBinding: {
@@ -307,8 +318,8 @@ describe("setup planner", () => {
           path: "/tmp/home/.tmux.conf",
           marker: "# >>> station popup binding >>>",
           launcherCommand: "/tmp/bin/stn-tmux-popup",
-          runShellCommand:
-            "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
+          runShellCommand: "managed-fast-command",
+          bindingKey: "M-p",
           insideTmux: true,
           liveStatus: "missing",
         },
@@ -316,20 +327,41 @@ describe("setup planner", () => {
     );
 
     expect(plan.actions.find((action) => action.id === "tmux-live-popup-binding")).toMatchObject({
-      command: [
-        "tmux",
-        "bind-key",
-        "Space",
-        "run-shell",
-        "-b",
-        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
-      ],
+      command: ["tmux", "bind-key", "M-p", "run-shell", "-b", "managed-fast-command"],
     });
     expect(plan.actions.some((action) => action.id === "tmux-popup-binding")).toBe(false);
     expect(plan.checks.find((check) => check.id === "tmux-popup-binding")).toMatchObject({
       status: "warning",
       message: expect.stringContaining("persisted"),
     });
+  });
+
+  it("warns on an owned-block conflict without planning persisted or live actions", () => {
+    const plan = buildSetupPlan(
+      facts({
+        tmux: { status: "missing", command: "tmux", message: "tmux missing." },
+        tmuxBinding: {
+          status: "conflict",
+          path: "/tmp/home/.tmux.conf",
+          marker: "# >>> station popup binding >>>",
+          launcherCommand: "/tmp/bin/stn-tmux-popup",
+          runShellCommand: "managed-fast-command",
+          insideTmux: true,
+          liveStatus: "unknown",
+          message: "tmux popup binding markers are duplicated.",
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "tmux-popup-binding")).toMatchObject({
+      status: "warning",
+      message: "tmux popup binding markers are duplicated.",
+    });
+    expect(
+      plan.actions.some(
+        (action) => action.id === "tmux-popup-binding" || action.id === "tmux-live-popup-binding",
+      ),
+    ).toBe(false);
   });
 
   it("does not plan popup bindings until the launcher is usable", () => {
@@ -616,6 +648,7 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
       launcherCommand: "/tmp/bin/stn-tmux-popup",
       runShellCommand:
         "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
+      bindingKey: "Space",
       insideTmux: false,
       liveStatus: "unknown",
       message: "Optional tmux popup binding is not installed.",

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,7 +24,16 @@ CLI/package, observer, provider, protocol, and host restart boundaries.
 
 - `pnpm stn` opens the normal station popup from the current checkout's built CLI when run inside tmux.
 - `pnpm stn tui` opens the normal station TUI fullscreen from the current checkout's built CLI.
-- Normal tmux popup fast-path registrations are scoped to the checkout root that created them. A popup launcher from another checkout ignores and clears stale normal popup metadata before falling back to that checkout's CLI.
+- Source popup registrations are scoped to the canonical checkout root that
+  created them. Compiled registrations are scoped to the canonical installed
+  binary directory instead; neither path may register filesystem root `/`.
+- The optional binding installed by a compiled `stn setup` uses the generated
+  direct tmux fast path. Its first use can enter the exact sibling
+  `stn-tmux-popup` alias, while a valid warm use attaches, toggles, or transfers
+  the existing `_station-ui` session without Bun, config loading, or Observer
+  startup. Build the binary with `pnpm build:binary -- --version <version>` when
+  validating this path; a source `pnpm build` does not create the installed
+  artifact ownership used by the binding.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
 - `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
 - `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.
@@ -366,11 +375,13 @@ manually verify the actual user experience, not a dashboard override:
    config without adopting that directory. In the open TUI, press `Enter` on
    **Add your first project**, choose a Git repository, and confirm the TUI
    reconnects and shows it after activation on the same Observer socket.
-6. Expose `stn-tmux-popup` only to the shell running `stn setup`, accept the
-   popup binding, and confirm `~/.tmux.conf` contains its safely quoted absolute
-   path. Start a fresh tmux server with `PATH=/usr/bin:/bin`; `Ctrl-b Space`
-   must open the popup without a restart or tmux PATH mutation. Also confirm
-   `stn popup` remains the direct fallback.
+6. Accept the compiled install's optional popup binding and confirm
+   `~/.tmux.conf` contains the marked generated command and exact sibling
+   `stn-tmux-popup` fallback. Start a fresh tmux server with
+   `PATH=/usr/bin:/bin`; `tmux prefix + Space` must open the popup without a
+   restart or tmux PATH mutation. Change the marked key, source the file, rerun
+   setup, and confirm the custom key is preserved. Also confirm `stn popup`
+   remains the direct diagnostic path.
 7. Deliver a provider event through `stn-ingress` and confirm it appears in
    Station.
 8. Complete the local `0.7.0-host-a` → `0.7.0-host-b` procedure above with a
@@ -427,14 +438,26 @@ pnpm test:e2e:real:codex-hooks
 ```
 
 The real tmux popup lane requires the root pnpm dependencies and the `station/`
-Bun dependencies, Bun 1.3.14, Python 3, tmux, and a prior `pnpm build`. Set
-`STATION_TMUX_BIN` when the tmux executable is not available as `tmux`. The lane
+Bun dependencies, Bun 1.3.14, Python 3, tmux, and these prerequisite builds:
+
+```bash
+pnpm build
+pnpm build:binary -- --version 0.0.0-local
+```
+
+Set `STATION_TMUX_BIN` when the tmux executable is not available as `tmux`. The lane
 creates a disposable Git project and isolates `HOME`, the XDG directories,
 config, Observer and Host sockets, state, layout, and the Codex, Claude, Cursor,
 and OpenCode homes. It addresses tmux only through a private
 `tmux -L <unique-label> -f /dev/null` server. It aggregates cleanup failures,
 verifies that its recorded processes and temporary root are gone, and remains
 excluded from ordinary PR and `main` CI.
+
+The lane also exercises the compiled generated binding. Warm reopen must retain
+the hidden session, renderer, and Observer PIDs even with an invalid config.
+Fast-path and fallback failures must produce no pane output, leave
+`#{pane_in_mode}` at `0`, and return control without an Escape dismissal. Use
+direct `stn popup` when detailed failure output is needed.
 
 Use `pnpm setup:system:check` before real lanes. Real lanes may require `STATION_REAL_*` flags, installed provider CLIs, credentials, tmux, model access, and isolated temporary projects. They must not become required for ordinary PR or `main` CI.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -27,13 +27,16 @@ CLI/package, observer, provider, protocol, and host restart boundaries.
 - Source popup registrations are scoped to the canonical checkout root that
   created them. Compiled registrations are scoped to the canonical installed
   binary directory instead; neither path may register filesystem root `/`.
-- The optional binding installed by a compiled `stn setup` uses the generated
-  direct tmux fast path. Its first use can enter the exact sibling
-  `stn-tmux-popup` alias, while a valid warm use attaches, toggles, or transfers
-  the existing `_station-ui` session without Bun, config loading, or Observer
-  startup. Build the binary with `pnpm build:binary -- --version <version>` when
-  validating this path; a source `pnpm build` does not create the installed
-  artifact ownership used by the binding.
+- With default popup geometry, the optional binding installed by a compiled
+  `stn setup` uses the generated direct tmux fast path. Custom geometry uses the
+  config-aware exact sibling `stn-tmux-popup` alias instead, as does setup run
+  with an explicit `--config` path. The fast path's
+  first use can enter that alias, while a valid warm use attaches, toggles, or
+  transfers the existing `_station-ui` session without Bun, config loading, or
+  Observer startup. Build the binary with
+  `pnpm build:binary -- --version <version>` when validating this path; a source
+  `pnpm build` does not create the installed artifact ownership used by the
+  binding.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
 - `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
 - `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -63,9 +63,10 @@ Pinned so the release job, install script, and acceptance suite agree.
 - `stn-ingress` — symlink → `stn` (argv0 dispatch).
 - `stn-tmux-popup` — symlink → `stn`. Its argv0 identity (and the reserved
   `__tmux-popup` token) remains the complete CLI fallback. The optional binding
-  written by compiled `stn setup` owns the warm direct-attach path; first use or
-  invalid fast state invokes this exact sibling alias. The source POSIX launcher
-  remains unchanged for development installs.
+  written by compiled `stn setup` owns the warm direct-attach path for default
+  popup geometry; custom geometry and explicit `--config` setup use this exact
+  config-aware sibling alias. First use or invalid fast state also invokes the
+  alias. The source POSIX launcher remains unchanged for development installs.
 - `LICENSE` — required. FSL-1.1 (LICENSE:67) obliges every redistributed
   copy to include the Terms or a link and keep copyright notices. The
   archive must carry it.
@@ -112,7 +113,7 @@ stn (bun build --compile, per platform, no ambient env)
 ├── __tui / __dashboard     → TUI renderer (re-exec self: spawn(execPath, ["__tui"]))
 ├── __station-host          → persistent-PTY host
 ├── __tmux-popup            → full popup CLI fallback for the stn-tmux-popup alias
-├── setup-managed binding   → direct warm tmux attach/toggle, then the alias fallback
+├── default setup binding   → direct warm tmux attach/toggle, then the alias fallback
 └── else                    → runCli (commands, setup, doctor, …)
        └── auto-start observer: spawn(process.execPath, ["__observer", …], detached)
 ```
@@ -669,12 +670,13 @@ flow:
    and the observer restarts on the **same socket**. Open the TUI, explicitly
    add an existing Git repository, and verify the observer reflects it
    immediately (B-config); an open TUI reconnects without a manual restart.
-5. Build and install the compiled artifact, then accept setup's optional popup
-   binding. The marked block contains the installed-root fast command and exact
-   sibling `stn-tmux-popup` fallback, and `tmux prefix + Space` works in a fresh
-   server started with `PATH=/usr/bin:/bin`. After one cold open, warm close and
-   reopen reuse the same hidden session, renderer, and Observer PIDs without
-    loading config. Editing the marked key is preserved by later setup runs.
+5. Build and install the compiled artifact with default popup geometry, then
+   accept setup's optional popup binding. The marked block contains the
+   installed-root fast command and exact sibling `stn-tmux-popup` fallback, and
+   `tmux prefix + Space` works in a fresh server started with
+   `PATH=/usr/bin:/bin`. After one cold open, warm close and reopen reuse the
+   same hidden session, renderer, and Observer PIDs without loading config.
+   Editing the marked key is preserved by later setup runs.
 6. `stn-ingress` symlink delivers a provider hook event end to end.
 7. Use local `0.7.0-host-a` and `0.7.0-host-b` builds while **live host PTYs**
    exist → the new build reports

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -61,9 +61,11 @@ Pinned so the release job, install script, and acceptance suite agree.
 
 - `stn` — the compiled binary.
 - `stn-ingress` — symlink → `stn` (argv0 dispatch).
-- `stn-tmux-popup` — symlink → `stn`. A4 routes its argv0 identity (and the
-  reserved `__tmux-popup` token) through the existing `popup` CLI command. The
-  source POSIX fast launcher remains unchanged for development installs.
+- `stn-tmux-popup` — symlink → `stn`. Its argv0 identity (and the reserved
+  `__tmux-popup` token) remains the complete CLI fallback. The optional binding
+  written by compiled `stn setup` owns the warm direct-attach path; first use or
+  invalid fast state invokes this exact sibling alias. The source POSIX launcher
+  remains unchanged for development installs.
 - `LICENSE` — required. FSL-1.1 (LICENSE:67) obliges every redistributed
   copy to include the Terms or a link and keep copyright notices. The
   archive must carry it.
@@ -109,7 +111,8 @@ stn (bun build --compile, per platform, no ambient env)
 ├── __ingress               → ingress main (owns raw stdin)
 ├── __tui / __dashboard     → TUI renderer (re-exec self: spawn(execPath, ["__tui"]))
 ├── __station-host          → persistent-PTY host
-├── __tmux-popup            → popup toggle (replaces stn-tmux-popup bin)
+├── __tmux-popup            → full popup CLI fallback for the stn-tmux-popup alias
+├── setup-managed binding   → direct warm tmux attach/toggle, then the alias fallback
 └── else                    → runCli (commands, setup, doctor, …)
        └── auto-start observer: spawn(process.execPath, ["__observer", …], detached)
 ```
@@ -132,6 +135,12 @@ stn (bun build --compile, per platform, no ambient env)
   and `apps/observer` → `@station/observer`. (S1 confirmed the bundler
   resolves through `exports` and the feared `.d.ts` `paths` hazard does not
   fire.)
+- **Installed popup ownership** is the canonical directory containing the
+  running compiled executable. The composition root resolves it once and wires
+  it into both popup registration and setup binding generation. Source launches
+  instead derive a canonical checkout root from the real CLI module path; a
+  virtual compiled module path and filesystem root `/` are never accepted as
+  popup ownership.
 - **Runtime-mode seam** `packages/runtime/src/buildInfo.ts`: build-time
   defines `STATION_BUILD_VERSION` / `STATION_BUILD_COMPILED` behind `typeof`
   guards; dev tsc reports `{ version: "0.7.0", compiled: false }`.
@@ -328,11 +337,14 @@ A4 owns the packaged helper lifecycle that A2a deliberately leaves out:
   ownership rather than risking a live session.
 
 Local pre-push and hosted `standard-ci` binary smoke checks: `--version`,
-`--help`, popup argv0 routing, `setup check --json`
+`--help`, exact popup alias symlinks, popup argv0 fallback routing, compiled
+setup binding generation, and `setup check --json`
 (asserting the `launchReady`/`workflowReady` split), an **observer round
 trip through the binary** in an isolated state dir, an ingress receipt via
 the `stn-ingress` symlink, the **hostile-directory RCE test** (F1), and the
-**detached self-spawn** check (folds in S5). The native PTY test also proves the
+**detached self-spawn** check (folds in S5). A stateful fake tmux proves that a
+warm binding bypasses malformed config while keeping renderer and Observer PIDs
+stable, and that a failed fallback is silent and returns zero. The native PTY test also proves the
 unset compiled selector launches a payload through the extracted helper on the
 current platform. `observerReap.ts` and the same-TTY UI
 reaper recognize the exact compiled process shapes.
@@ -657,9 +669,12 @@ flow:
    and the observer restarts on the **same socket**. Open the TUI, explicitly
    add an existing Git repository, and verify the observer reflects it
    immediately (B-config); an open TUI reconnects without a manual restart.
-5. Run setup with `stn-tmux-popup` visible only on its temporary `PATH` → the
-   persisted binding contains the absolute launcher, and `Ctrl-b Space` works
-   in a fresh tmux server started with `PATH=/usr/bin:/bin`.
+5. Build and install the compiled artifact, then accept setup's optional popup
+   binding. The marked block contains the installed-root fast command and exact
+   sibling `stn-tmux-popup` fallback, and `tmux prefix + Space` works in a fresh
+   server started with `PATH=/usr/bin:/bin`. After one cold open, warm close and
+   reopen reuse the same hidden session, renderer, and Observer PIDs without
+    loading config. Editing the marked key is preserved by later setup runs.
 6. `stn-ingress` symlink delivers a provider hook event end to end.
 7. Use local `0.7.0-host-a` and `0.7.0-host-b` builds while **live host PTYs**
    exist → the new build reports

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -56,7 +56,7 @@ remediation. `scripts/setup/bootstrap.sh` preflights both before touching Homebr
 
 Recommended after setup:
 
-- tmux popup binding (`Ctrl-b Space`) for opening and closing the dashboard overlay
+- tmux popup binding (`tmux prefix + Space` by default) for opening and closing the dashboard overlay
 - Worktrunk shell integration
 - `stn doctor`
 
@@ -78,12 +78,44 @@ worktree_provider = "worktrunk"
 ```
 
 The tmux provider shells out to `tmux` for the workbench and popup local-use path. Guided
-`stn setup` can append a marked `Ctrl-b Space` binding to `~/.tmux.conf` when you accept the
-recommended popup binding step. Inside tmux, setup can also load that binding into the current
-tmux server so a restart or manual `tmux source-file ~/.tmux.conf` is not required.
+`stn setup` offers an optional recommended binding in a marked block in `~/.tmux.conf`; it is
+never selected without consent. A new block defaults to `tmux prefix + Space`:
 
-The generated binding uses the resolved absolute `stn-tmux-popup` launcher. In a development checkout this
-may be the checkout's `integrations/terminal/tmux/bin/stn-popup` path rather than a bare command.
+```tmux
+# >>> station popup binding >>>
+# Change Space to any tmux key; stn setup preserves it.
+bind-key Space run-shell -b '<Station-generated fast command>'
+# <<< station popup binding <<<
+```
+
+The key belongs to the user. Change `Space` on the marked `bind-key` line to a
+supported prefix-table key such as `p`, `F12`, `C-s`, `C-Space`, or `M-p`, then load it:
+
+```bash
+tmux source-file ~/.tmux.conf
+```
+
+Later setup runs preserve that valid key while updating Station's generated
+command. A deleted or commented binding is treated as absent and only offered
+for installation again. Duplicate or malformed markers, multiple binding lines,
+and unsupported selectors are reported as conflicts and are never rewritten or
+loaded. Unmarked custom bindings are never inferred or changed.
+
+Inside tmux, setup can load the exact marked key and command into the current
+server. Reloading after a key change can leave the old key active until
+`tmux unbind-key <old-key>` or a server restart; Station does not unbind a key
+whose ownership it cannot prove.
+
+For a compiled install, the generated command uses the canonical installed
+directory, the exact sibling `stn-tmux-popup` alias, and the resolved tmux
+executable. First use can invoke that full CLI fallback to initialize the hidden
+UI; a valid warm use directly attaches or toggles it without loading config or
+starting Bun or the Observer. Controlled binding failures are silent, return
+success to tmux, and show at most a temporary status-line message. Run
+`stn popup` directly for ordinary diagnostic output.
+
+In a development checkout, the popup launcher may instead be the checkout's
+`integrations/terminal/tmux/bin/stn-popup` path.
 Run `pnpm station:link` only when you want bare `stn`, `stn-ingress`, and `stn-tmux-popup` commands
 available globally.
 

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -84,7 +84,7 @@ never selected without consent. A new block defaults to `tmux prefix + Space`:
 ```tmux
 # >>> station popup binding >>>
 # Change Space to any tmux key; stn setup preserves it.
-bind-key Space run-shell -b '<Station-generated fast command>'
+bind-key Space run-shell -b '<Station-managed popup command>'
 # <<< station popup binding <<<
 ```
 
@@ -106,13 +106,17 @@ server. Reloading after a key change can leave the old key active until
 `tmux unbind-key <old-key>` or a server restart; Station does not unbind a key
 whose ownership it cannot prove.
 
-For a compiled install, the generated command uses the canonical installed
-directory, the exact sibling `stn-tmux-popup` alias, and the resolved tmux
-executable. First use can invoke that full CLI fallback to initialize the hidden
-UI; a valid warm use directly attaches or toggles it without loading config or
-starting Bun or the Observer. Controlled binding failures are silent, return
-success to tmux, and show at most a temporary status-line message. Run
-`stn popup` directly for ordinary diagnostic output.
+For a compiled install with default popup geometry, the generated fast command
+uses the canonical installed directory, the exact sibling `stn-tmux-popup`
+alias, and the resolved tmux executable. First use can invoke that full CLI
+fallback to initialize the hidden UI; a valid warm use directly attaches or
+toggles it without loading config or starting Bun or the Observer. Configured
+custom geometry uses the config-aware sibling alias instead so every open reads
+the requested size and position; setup with an explicit `--config` path also
+uses that alias so an existing hidden UI cannot mask a config change. Controlled
+binding failures are silent, return success to tmux, and show at most a
+temporary status-line message. Run `stn popup` directly for ordinary diagnostic
+output.
 
 In a development checkout, the popup launcher may instead be the checkout's
 `integrations/terminal/tmux/bin/stn-popup` path.

--- a/integrations/terminal/tmux/src/popup/args.ts
+++ b/integrations/terminal/tmux/src/popup/args.ts
@@ -32,6 +32,26 @@ function buildPopupCleanupScript(options: TmuxPopupState): string {
   const focusOptionName =
     options.focusOptionName === undefined ? undefined : shellQuote(options.focusOptionName);
   const clientId = shellQuote(options.clientId);
+  if (options.claim !== undefined && options.claimOptionName !== undefined) {
+    const claimOptionName = options.claimOptionName;
+    const clearCommands = [
+      `set-option -gq -u ${claimOptionName}`,
+      `if-shell -F "#{==:#{${options.optionName}},${options.clientId}}" "set-option -gq -u ${options.optionName}"`,
+      ...(options.focusOptionName === undefined
+        ? []
+        : [
+            `if-shell -F "#{==:#{${options.focusOptionName}},${options.clientId}}" "set-option -gq -u ${options.focusOptionName}"`,
+          ]),
+    ].join(" ; ");
+    return [
+      tmuxCommand,
+      "if-shell",
+      "-F",
+      shellQuote(`#{==:#{${claimOptionName}},${options.claim}}`),
+      shellQuote(clearCommands),
+      ">/dev/null 2>&1 || true",
+    ].join(" ");
+  }
   const commands = [
     `if [ "$(${tmuxCommand} show-options -gqv ${optionName} 2>/dev/null)" = ${clientId} ]; then`,
     `${tmuxCommand} set-option -gq -u ${optionName};`,

--- a/integrations/terminal/tmux/src/popup/command.ts
+++ b/integrations/terminal/tmux/src/popup/command.ts
@@ -1,7 +1,12 @@
 import type { SafeError } from "@station/contracts";
 import { runTmuxCommand, type TmuxCommandInput, tryRunTmuxCommand } from "../command.js";
 import { tmuxProviderErrorFromUnknown } from "../errors.js";
-import type { TmuxCurrentClientInput, TmuxPopupCommandInputOptions } from "./types.js";
+import { isSafePopupClientName } from "./fastProtocol.js";
+import type {
+  TmuxClientIdentity,
+  TmuxCurrentClientInput,
+  TmuxPopupCommandInputOptions,
+} from "./types.js";
 
 type TmuxPopupCommandMessages = {
   operation?: string;
@@ -31,6 +36,25 @@ function popupTimeoutError(message: string): SafeError {
     message,
     provider: "tmux",
   };
+}
+
+function parseTmuxClientIdentity(value: string): TmuxClientIdentity | undefined {
+  const [pidText, name, sessionName, ...rest] = value.trim().split("\t");
+  if (
+    rest.length > 0 ||
+    pidText === undefined ||
+    name === undefined ||
+    sessionName === undefined ||
+    !/^[1-9][0-9]{0,9}$/.test(pidText) ||
+    !isSafePopupClientName(name)
+  ) {
+    return undefined;
+  }
+  const pid = Number(pidText);
+  if (!Number.isInteger(pid) || pid > 2_147_483_647 || sessionName.length === 0) {
+    return undefined;
+  }
+  return { name, pid, sessionName };
 }
 
 export function popupCommandInput(
@@ -164,4 +188,19 @@ export async function resolveCurrentTmuxClientId(
     message: "tmux failed to resolve the current client for the station popup.",
     timeoutMessage: "tmux current client lookup timed out.",
   });
+}
+
+export async function resolveCurrentTmuxClient(
+  input: TmuxCurrentClientInput,
+): Promise<TmuxClientIdentity | undefined> {
+  if (input.env.TMUX === undefined || input.env.TMUX.length === 0) {
+    return undefined;
+  }
+  const value = await resolveTmuxOption(input, {
+    args: ["display-message", "-p", "#{client_pid}\t#{client_name}\t#{client_session}"],
+    operation: "provider.tmux.popup.currentClientIdentity",
+    message: "tmux failed to resolve the current client identity for the station popup.",
+    timeoutMessage: "tmux current client identity lookup timed out.",
+  });
+  return value === undefined ? undefined : parseTmuxClientIdentity(value);
 }

--- a/integrations/terminal/tmux/src/popup/constants.ts
+++ b/integrations/terminal/tmux/src/popup/constants.ts
@@ -1,5 +1,8 @@
 export const activePopupClientOption = "@station_popup_client";
+export const activePopupClaimOption = "@station_popup_active_claim";
 export const focusPopupClientOption = "@station_popup_focus_client";
+export const persistentUiLeaseOption = "@station_popup_ui_lease";
+export const persistentUiRouteOption = "@station_popup_ui_route";
 export const persistentUiSignatureOption = "@station_popup_ui_signature";
 export const registeredPopupExpectedSignatureOption = "@station_popup_ui_expected_signature";
 export const registeredPopupRootOption = "@station_popup_ui_root";

--- a/integrations/terminal/tmux/src/popup/fastBinding.ts
+++ b/integrations/terminal/tmux/src/popup/fastBinding.ts
@@ -1,0 +1,362 @@
+import { isAbsolute, join } from "node:path";
+import { shellQuote } from "../shell.js";
+import {
+  activePopupClaimOption,
+  activePopupClientOption,
+  defaultPersistentPopupSessionName,
+  focusPopupClientOption,
+  persistentUiLeaseOption,
+  persistentUiRouteOption,
+  persistentUiSignatureOption,
+  registeredDevPopupCommandOption,
+  registeredDevPopupOwnerOption,
+  registeredDevPopupRootOption,
+  registeredDevPopupSessionNameOption,
+  registeredPopupExpectedSignatureOption,
+  registeredPopupRootOption,
+  registeredPopupSessionNameOption,
+} from "./constants.js";
+import { popupProtocolSha256 } from "./fastProtocol.js";
+
+export type BuildManagedFastPopupRunShellCommandOptions = {
+  fallbackAlias: string;
+  installedRoot: string;
+  tmuxCommand: string;
+};
+
+function containsUnsafeShellValue(value: string): boolean {
+  return (
+    value.includes("\0") || value.includes("\r") || value.includes("\n") || value.includes("\u001f")
+  );
+}
+
+function validateManagedBindingOptions(options: BuildManagedFastPopupRunShellCommandOptions): void {
+  if (
+    !isAbsolute(options.installedRoot) ||
+    options.installedRoot === "/" ||
+    containsUnsafeShellValue(options.installedRoot)
+  ) {
+    throw new Error("Station popup ownership requires a safe canonical installed root.");
+  }
+  if (
+    options.fallbackAlias !== join(options.installedRoot, "stn-tmux-popup") ||
+    containsUnsafeShellValue(options.fallbackAlias)
+  ) {
+    throw new Error("Station popup fallback must be the installed stn-tmux-popup sibling alias.");
+  }
+  if (!isAbsolute(options.tmuxCommand) || containsUnsafeShellValue(options.tmuxCommand)) {
+    throw new Error("Station popup binding requires a safe resolved tmux executable.");
+  }
+}
+
+function snapshotFormat(): string {
+  const fields = [
+    persistentUiRouteOption,
+    persistentUiLeaseOption,
+    activePopupClaimOption,
+    persistentUiSignatureOption,
+    registeredPopupSessionNameOption,
+    registeredPopupExpectedSignatureOption,
+    registeredPopupRootOption,
+    activePopupClientOption,
+    focusPopupClientOption,
+    registeredDevPopupSessionNameOption,
+    registeredDevPopupCommandOption,
+    registeredDevPopupOwnerOption,
+    registeredDevPopupRootOption,
+  ].map((name) => `\${fmt}{${name}}`);
+  fields.push("v1");
+  return fields.join(`\${sep}`);
+}
+
+function encodePrintfScript(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("\n", "\\n");
+}
+
+function escapeTmuxFormat(value: string): string {
+  return value.replaceAll("#", "##");
+}
+
+/**
+ * ADAPTER
+ *
+ * Translates an installed popup owner into a silent tmux warm-path command that falls back to
+ * the exact compiled alias whenever its versioned route cannot be acted on safely.
+ */
+export function buildManagedFastPopupRunShellCommand(
+  options: BuildManagedFastPopupRunShellCommandOptions,
+): string {
+  validateManagedBindingOptions(options);
+
+  const sessionName = defaultPersistentPopupSessionName;
+  const expectedRootSha256 = popupProtocolSha256(options.installedRoot);
+  const expectedSessionSha256 = popupProtocolSha256(sessionName);
+  const installedRoot = escapeTmuxFormat(options.installedRoot);
+  const fallbackAlias = escapeTmuxFormat(options.fallbackAlias);
+  const tmuxCommand = escapeTmuxFormat(options.tmuxCommand);
+  const nestedTmuxCommand = escapeTmuxFormat(tmuxCommand);
+  const attachCommand = [
+    "env -u TMUX",
+    shellQuote(nestedTmuxCommand),
+    "-T hyperlinks attach-session -t",
+    shellQuote(sessionName),
+  ].join(" ");
+
+  const script = `
+set +e
+set -f
+binding_client_name=$1
+binding_client_pid=$2
+binding_client_session=$3
+tmux_bin=${shellQuote(tmuxCommand)}
+fallback_alias=${shellQuote(fallbackAlias)}
+installed_root=${shellQuote(installedRoot)}
+session_name=${shellQuote(sessionName)}
+expected_root_sha=${shellQuote(expectedRootSha256)}
+expected_session_sha=${shellQuote(expectedSessionSha256)}
+attach_arg=${shellQuote(shellQuote(attachCommand))}
+fmt='#'
+sep=$(printf '\\037')
+trap 'exit 0' HUP INT TERM
+
+fallback_popup() {
+  fallback_client_name=\${client_name:-$binding_client_name}
+  if valid_client_name "$fallback_client_name"; then
+    STATION_FOCUS_CLIENT_ID=$fallback_client_name "$fallback_alias" >/dev/null 2>&1
+  else
+    "$fallback_alias" >/dev/null 2>&1
+  fi
+  fallback_status=$?
+  case "$fallback_status" in
+    0|129) return 0 ;;
+  esac
+  "$tmux_bin" display-message -d 3000 'Station popup failed; run stn popup for details' >/dev/null 2>&1 || :
+  return 0
+}
+
+valid_nonce() {
+  [ "\${#1}" -eq 32 ] || return 1
+  case "$1" in *[!0-9a-f]*) return 1 ;; esac
+  return 0
+}
+
+valid_client_pid() {
+  case "$1" in ''|*[!0-9]*) return 1 ;; esac
+  [ "\${#1}" -le 10 ] || return 1
+  case "$1" in 0*) return 1 ;; esac
+  [ "$1" -gt 0 ] 2>/dev/null || return 1
+  [ "$1" -le 2147483647 ] 2>/dev/null || return 1
+  return 0
+}
+
+valid_client_name() {
+  [ -n "$1" ] && [ "\${#1}" -le 128 ] || return 1
+  case "$1" in *[!A-Za-z0-9_/@%+=:-]*) return 1 ;; esac
+  return 0
+}
+
+sha256_value() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$1" | sha256sum 2>/dev/null) || return 1
+  elif command -v shasum >/dev/null 2>&1; then
+    digest=$(printf '%s' "$1" | shasum -a 256 2>/dev/null) || return 1
+  else
+    return 1
+  fi
+  set -- $digest
+  [ "\${#1}" -eq 64 ] || return 1
+  case "$1" in *[!0-9a-f]*) return 1 ;; esac
+  printf '%s' "$1"
+}
+
+dev_registration_is_live() {
+  [ -n "$dev_session$dev_command$dev_owner$dev_root" ] || return 1
+  owner_pid=\${dev_owner%%:*}
+  case "$owner_pid" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$owner_pid" -gt 0 ] 2>/dev/null || return 0
+  if kill -0 "$owner_pid" 2>/dev/null; then
+    return 0
+  fi
+  # A denied signal probe is inconclusive; only a working process table may prove absence.
+  command -v ps >/dev/null 2>&1 || return 0
+  ps -p "$$" -o pid= >/dev/null 2>&1 || return 0
+  ps -p "$owner_pid" -o pid= >/dev/null 2>&1
+}
+
+parse_route() {
+  old_ifs=$IFS
+  IFS=.
+  set -- $route
+  IFS=$old_ifs
+  [ "$#" -eq 6 ] || return 1
+  [ "$1" = v1 ] && [ "$2" = n ] || return 1
+  [ "$3" = "$expected_root_sha" ] || return 1
+  [ "$4" = "$expected_session_sha" ] || return 1
+  [ "$5" = "$registered_signature_sha" ] || return 1
+  valid_nonce "$6" || return 1
+  registration_nonce=$6
+  return 0
+}
+
+parse_claim() {
+  claim_state=
+  claim_registration_nonce=
+  claim_action_nonce=
+  claim_client_pid=
+  claim_client_name=
+  [ -n "$claim" ] || return 0
+  old_ifs=$IFS
+  IFS=.
+  set -- $claim
+  IFS=$old_ifs
+  [ "$#" -eq 6 ] || return 1
+  [ "$1" = v1 ] || return 1
+  case "$2" in open|closing) claim_state=$2 ;; *) return 1 ;; esac
+  valid_nonce "$3" || return 1
+  valid_nonce "$4" || return 1
+  valid_client_pid "$5" || return 1
+  valid_client_name "$6" || return 1
+  claim_registration_nonce=$3
+  claim_action_nonce=$4
+  claim_client_pid=$5
+  claim_client_name=$6
+  return 0
+}
+
+clear_exact_claim() {
+  exact_claim=$1
+  exact_client=$2
+  clear_condition="\${fmt}{==:\${fmt}{${activePopupClaimOption}},$exact_claim}"
+  clear_commands="set-option -gq -u ${activePopupClaimOption} ; if-shell -F \\"\${fmt}{==:\${fmt}{${activePopupClientOption}},$exact_client}\\" \\"set-option -gq -u ${activePopupClientOption}\\" ; if-shell -F \\"\${fmt}{==:\${fmt}{${focusPopupClientOption}},$exact_client}\\" \\"set-option -gq -u ${focusPopupClientOption}\\""
+  "$tmux_bin" if-shell -F -t "$session_name:" "$clear_condition" "$clear_commands" >/dev/null 2>&1 || :
+}
+
+run_action() {
+  expected_claim=$1
+  new_claim=$2
+  action_kind=$3
+  previous_client=$4
+  action_condition="\${fmt}{&&:\${fmt}{==:\${fmt}{${persistentUiRouteOption}},$route},\${fmt}{&&:\${fmt}{==:\${fmt}{${persistentUiLeaseOption}},$route},\${fmt}{==:\${fmt}{${activePopupClaimOption}},$expected_claim}}}"
+  clear_condition="\${fmt}{==:\${fmt}{${activePopupClaimOption}},$new_claim}"
+  clear_commands="set-option -gq -u ${activePopupClaimOption} ; if-shell -F \\"\${fmt}{==:\${fmt}{${activePopupClientOption}},$claim_target_client}\\" \\"set-option -gq -u ${activePopupClientOption}\\" ; if-shell -F \\"\${fmt}{==:\${fmt}{${focusPopupClientOption}},$claim_target_client}\\" \\"set-option -gq -u ${focusPopupClientOption}\\""
+  finish="if-shell -F '$clear_condition' '$clear_commands'"
+  prefix="set-option -gq ${activePopupClaimOption} $new_claim ; set-option -gq ${activePopupClientOption} $claim_target_client ; set-option -gq ${focusPopupClientOption} $claim_target_client"
+  case "$action_kind" in
+    open)
+      action="$prefix ; set-option -t $session_name mouse on ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      ;;
+    replace)
+      action="$prefix ; display-popup -c $previous_client -C ; set-option -t $session_name mouse on ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      ;;
+    close)
+      action="$prefix ; display-popup -c $previous_client -C ; $finish"
+      ;;
+    *) return 1 ;;
+  esac
+  action_output=$("$tmux_bin" if-shell -F -t "$session_name:" "$action_condition" "$action" 'display-message -p STATION_POPUP_CAS_MISS' 2>/dev/null)
+  action_status=$?
+  if [ "$action_output" = STATION_POPUP_CAS_MISS ]; then
+    return 2
+  fi
+  case "$action_status" in
+    0|129) return 0 ;;
+  esac
+  clear_exact_claim "$new_claim" "$claim_target_client"
+  return 1
+}
+
+try_fast_popup() {
+  valid_client_name "$binding_client_name" || return 1
+  valid_client_pid "$binding_client_pid" || return 1
+  [ -n "$binding_client_session" ] && [ "\${#binding_client_session}" -le 256 ] || return 1
+  snapshot_format="${snapshotFormat()}"
+  snapshot=$("$tmux_bin" display-message -p -t "$session_name:" "$snapshot_format" 2>/dev/null) || return 1
+  old_ifs=$IFS
+  IFS="$sep"
+  set -- $snapshot
+  IFS=$old_ifs
+  [ "$#" -eq 14 ] || return 1
+  route=$1
+  lease=$2
+  claim=$3
+  session_signature=$4
+  registered_session=$5
+  registered_signature=$6
+  registered_root=$7
+  active_client=$8
+  focus_client=$9
+  shift 9
+  dev_session=$1
+  dev_command=$2
+  dev_owner=$3
+  dev_root=$4
+  snapshot_version=$5
+  [ "$snapshot_version" = v1 ] || return 1
+  client_pid=$binding_client_pid
+  client_name=$binding_client_name
+  client_session=$binding_client_session
+
+  if dev_registration_is_live; then
+    return 1
+  fi
+  [ -n "$route" ] && [ "$lease" = "$route" ] || return 1
+  [ "$session_signature" = "$registered_signature" ] || return 1
+  [ "\${#registered_signature}" -le 4096 ] || return 1
+  case "$registered_signature" in v1:*) ;; *) return 1 ;; esac
+  registered_signature_sha=$(sha256_value "$registered_signature") || return 1
+  parse_route || return 1
+  [ "$registered_session" = "$session_name" ] || return 1
+  [ "$registered_root" = "$installed_root" ] || return 1
+  parse_claim || return 1
+
+  if [ -z "$claim" ]; then
+    [ -z "$active_client$focus_client" ] || return 1
+  else
+    [ "$claim_registration_nonce" = "$registration_nonce" ] || return 1
+    [ "$active_client" = "$claim_client_name" ] || return 1
+    [ "$focus_client" = "$claim_client_name" ] || return 1
+    [ "$claim_state" = open ] || return 2
+  fi
+
+  action_nonce=$(od -An -N16 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n')
+  valid_nonce "$action_nonce" || return 1
+
+  if [ -n "$claim" ] && { [ "$claim_client_pid" = "$client_pid" ] && [ "$claim_client_name" = "$client_name" ]; }; then
+    claim_target_client=$claim_client_name
+    next_claim="v1.closing.$registration_nonce.$action_nonce.$claim_client_pid.$claim_client_name"
+    run_action "$claim" "$next_claim" close "$claim_client_name"
+    return $?
+  fi
+  if [ -n "$claim" ] && [ "$client_session" = "$session_name" ]; then
+    claim_target_client=$claim_client_name
+    next_claim="v1.closing.$registration_nonce.$action_nonce.$claim_client_pid.$claim_client_name"
+    run_action "$claim" "$next_claim" close "$claim_client_name"
+    return $?
+  fi
+
+  claim_target_client=$client_name
+  next_claim="v1.open.$registration_nonce.$action_nonce.$client_pid.$client_name"
+  if [ -n "$claim" ]; then
+    run_action "$claim" "$next_claim" replace "$claim_client_name"
+  else
+    run_action '' "$next_claim" open ''
+  fi
+}
+
+attempt=1
+while [ "$attempt" -le 2 ]; do
+  try_fast_popup
+  fast_status=$?
+  case "$fast_status" in
+    0) exit 0 ;;
+    2) attempt=$((attempt + 1)); continue ;;
+    *) break ;;
+  esac
+done
+fallback_popup
+exit 0
+`.trim();
+
+  const loader = `trap 'exit 0' HUP INT TERM; encoded_script=$1; shift; eval "$(printf '%b' "$encoded_script")"; exit 0`;
+  return `sh -c ${shellQuote(loader)} station-popup-binding ${shellQuote(encodePrintfScript(script))} #{q:client_name} #{client_pid} #{q:client_session} >/dev/null 2>&1`;
+}

--- a/integrations/terminal/tmux/src/popup/fastBinding.ts
+++ b/integrations/terminal/tmux/src/popup/fastBinding.ts
@@ -19,6 +19,7 @@ import {
 import { popupProtocolSha256 } from "./fastProtocol.js";
 
 export type BuildManagedFastPopupRunShellCommandOptions = {
+  configPath?: string;
   fallbackAlias: string;
   installedRoot: string;
   tmuxCommand: string;
@@ -46,6 +47,12 @@ function validateManagedBindingOptions(options: BuildManagedFastPopupRunShellCom
   }
   if (!isAbsolute(options.tmuxCommand) || containsUnsafeShellValue(options.tmuxCommand)) {
     throw new Error("Station popup binding requires a safe resolved tmux executable.");
+  }
+  if (
+    options.configPath !== undefined &&
+    (!isAbsolute(options.configPath) || containsUnsafeShellValue(options.configPath))
+  ) {
+    throw new Error("Station popup binding requires a safe absolute config path.");
   }
 }
 
@@ -77,6 +84,20 @@ function escapeTmuxFormat(value: string): string {
   return value.replaceAll("#", "##");
 }
 
+function expectedPersistentPopupSignature(options: {
+  configPath?: string;
+  installedRoot: string;
+}): string {
+  const command = [
+    shellQuote(join(options.installedRoot, "stn")),
+    ...(options.configPath === undefined ? [] : ["--config", shellQuote(options.configPath)]),
+    "tui",
+    "--popup",
+    "--persistent",
+  ].join(" ");
+  return `v1:${command}`;
+}
+
 /**
  * ADAPTER
  *
@@ -91,8 +112,10 @@ export function buildManagedFastPopupRunShellCommand(
   const sessionName = defaultPersistentPopupSessionName;
   const expectedRootSha256 = popupProtocolSha256(options.installedRoot);
   const expectedSessionSha256 = popupProtocolSha256(sessionName);
+  const expectedSignatureSha256 = popupProtocolSha256(expectedPersistentPopupSignature(options));
   const installedRoot = escapeTmuxFormat(options.installedRoot);
   const fallbackAlias = escapeTmuxFormat(options.fallbackAlias);
+  const configPath = escapeTmuxFormat(options.configPath ?? "");
   const tmuxCommand = escapeTmuxFormat(options.tmuxCommand);
   const nestedTmuxCommand = escapeTmuxFormat(tmuxCommand);
   const attachCommand = [
@@ -110,10 +133,12 @@ binding_client_pid=$2
 binding_client_session=$3
 tmux_bin=${shellQuote(tmuxCommand)}
 fallback_alias=${shellQuote(fallbackAlias)}
+config_path=${shellQuote(configPath)}
 installed_root=${shellQuote(installedRoot)}
 session_name=${shellQuote(sessionName)}
 expected_root_sha=${shellQuote(expectedRootSha256)}
 expected_session_sha=${shellQuote(expectedSessionSha256)}
+expected_signature_sha=${shellQuote(expectedSignatureSha256)}
 attach_arg=${shellQuote(shellQuote(attachCommand))}
 fmt='#'
 sep=$(printf '\\037')
@@ -121,7 +146,13 @@ trap 'exit 0' HUP INT TERM
 
 fallback_popup() {
   fallback_client_name=\${client_name:-$binding_client_name}
-  if valid_client_name "$fallback_client_name"; then
+  if [ -n "$config_path" ]; then
+    if valid_client_name "$fallback_client_name"; then
+      STATION_CONFIG_PATH=$config_path STATION_FOCUS_CLIENT_ID=$fallback_client_name "$fallback_alias" --config "$config_path" >/dev/null 2>&1
+    else
+      STATION_CONFIG_PATH=$config_path "$fallback_alias" --config "$config_path" >/dev/null 2>&1
+    fi
+  elif valid_client_name "$fallback_client_name"; then
     STATION_FOCUS_CLIENT_ID=$fallback_client_name "$fallback_alias" >/dev/null 2>&1
   else
     "$fallback_alias" >/dev/null 2>&1
@@ -304,6 +335,7 @@ try_fast_popup() {
   [ "\${#registered_signature}" -le 4096 ] || return 1
   case "$registered_signature" in v1:*) ;; *) return 1 ;; esac
   registered_signature_sha=$(sha256_value "$registered_signature") || return 1
+  [ "$registered_signature_sha" = "$expected_signature_sha" ] || return 1
   parse_route || return 1
   [ "$registered_session" = "$session_name" ] || return 1
   [ "$registered_root" = "$installed_root" ] || return 1

--- a/integrations/terminal/tmux/src/popup/fastProtocol.ts
+++ b/integrations/terminal/tmux/src/popup/fastProtocol.ts
@@ -1,0 +1,151 @@
+import { createHash, randomBytes } from "node:crypto";
+
+export type NormalPopupRoute = {
+  kind: "normal";
+  registrationNonce: string;
+  rootSha256: string;
+  sessionSha256: string;
+  signatureSha256: string;
+};
+
+export type PopupActiveClaim = {
+  actionNonce: string;
+  clientName: string;
+  clientPid: number;
+  registrationNonce: string;
+  state: "open" | "closing";
+};
+
+const sha256Pattern = /^[0-9a-f]{64}$/;
+const noncePattern = /^[0-9a-f]{32}$/;
+const clientNamePattern = /^[A-Za-z0-9_/@%+=:-]{1,128}$/;
+const routePattern = /^v1\.n\.([0-9a-f]{64})\.([0-9a-f]{64})\.([0-9a-f]{64})\.([0-9a-f]{32})$/;
+const activeClaimPattern =
+  /^v1\.(open|closing)\.([0-9a-f]{32})\.([0-9a-f]{32})\.([1-9][0-9]{0,9})\.([A-Za-z0-9_/@%+=:-]{1,128})$/;
+const maximumClientPid = 2_147_483_647;
+
+export function popupProtocolSha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function createPopupProtocolNonce(): string {
+  return randomBytes(16).toString("hex");
+}
+
+export function buildNormalPopupRoute(options: {
+  registrationNonce?: string;
+  root: string;
+  sessionName: string;
+  signature: string;
+}): string {
+  const registrationNonce = options.registrationNonce ?? createPopupProtocolNonce();
+  if (!noncePattern.test(registrationNonce)) {
+    throw new Error("Station popup registration nonce must be 128-bit lowercase hexadecimal.");
+  }
+  return [
+    "v1",
+    "n",
+    popupProtocolSha256(options.root),
+    popupProtocolSha256(options.sessionName),
+    popupProtocolSha256(options.signature),
+    registrationNonce,
+  ].join(".");
+}
+
+export function parseNormalPopupRoute(value: string): NormalPopupRoute | undefined {
+  const match = routePattern.exec(value);
+  if (match === null) {
+    return undefined;
+  }
+  const [, rootSha256, sessionSha256, signatureSha256, registrationNonce] = match;
+  if (
+    rootSha256 === undefined ||
+    sessionSha256 === undefined ||
+    signatureSha256 === undefined ||
+    registrationNonce === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "normal",
+    registrationNonce,
+    rootSha256,
+    sessionSha256,
+    signatureSha256,
+  };
+}
+
+export function normalPopupRouteMatches(
+  route: NormalPopupRoute,
+  options: { root: string; sessionName: string; signature: string },
+): boolean {
+  return (
+    sha256Pattern.test(route.rootSha256) &&
+    route.rootSha256 === popupProtocolSha256(options.root) &&
+    route.sessionSha256 === popupProtocolSha256(options.sessionName) &&
+    route.signatureSha256 === popupProtocolSha256(options.signature)
+  );
+}
+
+export function buildPopupActiveClaim(options: {
+  actionNonce?: string;
+  clientName: string;
+  clientPid: number;
+  registrationNonce: string;
+  state: "open" | "closing";
+}): string {
+  const actionNonce = options.actionNonce ?? createPopupProtocolNonce();
+  if (!noncePattern.test(options.registrationNonce) || !noncePattern.test(actionNonce)) {
+    throw new Error("Station popup claim nonces must be 128-bit lowercase hexadecimal.");
+  }
+  if (
+    !Number.isInteger(options.clientPid) ||
+    options.clientPid <= 0 ||
+    options.clientPid > maximumClientPid
+  ) {
+    throw new Error("Station popup client PID is outside the supported range.");
+  }
+  if (!clientNamePattern.test(options.clientName)) {
+    throw new Error("Station popup client name contains unsupported characters.");
+  }
+  return [
+    "v1",
+    options.state,
+    options.registrationNonce,
+    actionNonce,
+    String(options.clientPid),
+    options.clientName,
+  ].join(".");
+}
+
+export function parsePopupActiveClaim(value: string): PopupActiveClaim | undefined {
+  const match = activeClaimPattern.exec(value);
+  if (match === null) {
+    return undefined;
+  }
+  const [, state, registrationNonce, actionNonce, clientPidText, clientName] = match;
+  if (
+    (state !== "open" && state !== "closing") ||
+    registrationNonce === undefined ||
+    actionNonce === undefined ||
+    clientPidText === undefined ||
+    clientName === undefined
+  ) {
+    return undefined;
+  }
+  const clientPid = Number(clientPidText);
+  if (!Number.isInteger(clientPid) || clientPid <= 0 || clientPid > maximumClientPid) {
+    return undefined;
+  }
+  return {
+    actionNonce,
+    clientName,
+    clientPid,
+    registrationNonce,
+    state,
+  };
+}
+
+export function isSafePopupClientName(value: string): boolean {
+  return clientNamePattern.test(value);
+}

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -8,24 +8,39 @@ import {
 import type { TmuxCommandInput } from "../command.js";
 import { tmuxProviderErrorFromUnknown } from "../errors.js";
 import { buildTmuxPopupArgs } from "./args.js";
-import { closeTmuxPopup, popupCommandInput, resolveCurrentTmuxClientId } from "./command.js";
-import { activePopupClientOption, focusPopupClientOption } from "./constants.js";
+import {
+  closeTmuxPopup,
+  popupCommandInput,
+  resolveCurrentTmuxClient,
+  resolveCurrentTmuxClientId,
+} from "./command.js";
+import {
+  activePopupClaimOption,
+  activePopupClientOption,
+  focusPopupClientOption,
+} from "./constants.js";
+import { buildPopupActiveClaim, createPopupProtocolNonce } from "./fastProtocol.js";
 import {
   ensurePersistentPopupSession,
   registerFastPopupUi,
   resolvePersistentPopupUi,
 } from "./persistentUi.js";
 import {
-  clearActivePopupClient,
-  clearFocusPopupClient,
+  clearActivePopupClaimIfCurrent,
+  clearLegacyFocusIfUnclaimed,
+  clearLegacyPopupStateIfUnclaimed,
+  compareAndSetActivePopupClaim,
+  dismissLegacyPopupIfUnclaimed,
+  replaceLegacyPopupIfUnclaimed,
+  resolveActivePopupClaimState,
   resolveActivePopupClient,
   resolveFocusPopupClient,
-  setActivePopupClient,
-  setFocusPopupClient,
+  setPopupClaimMirrors,
 } from "./state.js";
 import type {
   BuildTmuxPopupArgsOptions,
   PopupWorkbenchFocusInput,
+  TmuxClientIdentity,
   TmuxCurrentClientInput,
   TmuxPersistentPopupSessionOptions,
   TmuxPersistentPopupUi,
@@ -39,6 +54,8 @@ import type {
 import { enterWorkbenchForPopup } from "./workbenchFocus.js";
 
 export { buildTmuxPopupArgs } from "./args.js";
+export type { BuildManagedFastPopupRunShellCommandOptions } from "./fastBinding.js";
+export { buildManagedFastPopupRunShellCommand } from "./fastBinding.js";
 export { ensurePersistentPopupSession, resolveRegisteredDevPopupUi } from "./persistentUi.js";
 export type {
   TmuxPersistentPopupSessionResult,
@@ -57,6 +74,7 @@ type PopupDisplayInput = {
 };
 
 type PopupArgsInput = {
+  claim?: string;
   command: string;
   config?: TmuxConfig;
   focusClientId?: string;
@@ -135,13 +153,18 @@ function persistentSessionOptions(
   return input;
 }
 
-function popupState(command: string, clientId: string): TmuxPopupState {
-  return {
+function popupState(command: string, clientId: string, claim: string | undefined): TmuxPopupState {
+  const state: TmuxPopupState = {
     clientId,
     optionName: activePopupClientOption,
     focusOptionName: focusPopupClientOption,
     tmuxCommand: command,
   };
+  if (claim !== undefined) {
+    state.claim = claim;
+    state.claimOptionName = activePopupClaimOption;
+  }
+  return state;
 }
 
 function popupArgsOptions(options: PopupArgsInput): BuildTmuxPopupArgsOptions {
@@ -154,7 +177,7 @@ function popupArgsOptions(options: PopupArgsInput): BuildTmuxPopupArgsOptions {
   }
   if (options.focusClientId !== undefined) {
     input.focusClientId = options.focusClientId;
-    input.popupState = popupState(options.command, options.focusClientId);
+    input.popupState = popupState(options.command, options.focusClientId, options.claim);
   }
   if (options.persistentUi !== undefined) {
     input.tuiCommand = options.persistentUi.command;
@@ -173,11 +196,15 @@ function popupArgsInput(
   focusClientId: string | undefined,
   persistent: boolean,
   persistentUi: TmuxPersistentPopupUi | undefined,
+  claim: string | undefined,
 ): PopupArgsInput {
   const input: PopupArgsInput = {
     command,
     persistent,
   };
+  if (claim !== undefined) {
+    input.claim = claim;
+  }
   if (options.config !== undefined) {
     input.config = options.config;
   }
@@ -200,8 +227,7 @@ async function clearPopupState(
   if (clientId === undefined || clientId.length === 0) {
     return;
   }
-  await clearActivePopupClient(input).catch(() => undefined);
-  await clearFocusPopupClient(input).catch(() => undefined);
+  await clearLegacyPopupStateIfUnclaimed({ ...input, clientId }).catch(() => undefined);
 }
 
 async function runPopupDisplay(input: PopupDisplayInput): Promise<PopupDisplayResult> {
@@ -245,6 +271,7 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
   const command = defaultTmuxCommand(options.command ?? options.config?.command);
   const persistent = options.persistent !== false;
   const clientInput = currentClientInput(options, command);
+  const currentClient = await resolveCurrentTmuxClient(clientInput);
   const requestedFocusClientId =
     options.focusClientId !== undefined && options.focusClientId.length > 0
       ? options.focusClientId
@@ -255,48 +282,188 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
       ? clientInput.env.STATION_FOCUS_CLIENT_ID
       : undefined;
   const focusClientId =
-    requestedFocusClientId ?? envFocusClientId ?? (await resolveCurrentTmuxClientId(clientInput));
+    requestedFocusClientId ??
+    envFocusClientId ??
+    currentClient?.name ??
+    (await resolveCurrentTmuxClientId(clientInput));
   const tmuxCommand = popupCommandInput(options, command);
-  if (focusClientId !== undefined && focusClientId.length > 0) {
+
+  const persistentUi = persistent
+    ? await resolvePersistentPopupUi(options, tmuxCommand)
+    : undefined;
+  let registeredRoute: Awaited<ReturnType<typeof registerFastPopupUi>> | undefined;
+
+  if (persistentUi !== undefined) {
+    await ensurePersistentPopupSession(persistentSessionOptions(options, command, persistentUi));
+    if (persistentUi.registerFastPopup) {
+      registeredRoute = await registerFastPopupUi(tmuxCommand, persistentUi).catch(() => undefined);
+    }
+  }
+
+  let activeClaim: string | undefined;
+  if (focusClientId !== undefined && focusClientId.length > 0 && currentClient !== undefined) {
+    const claimClient: TmuxClientIdentity = {
+      ...currentClient,
+      name: focusClientId,
+    };
+    const fallbackRegistrationNonce = createPopupProtocolNonce();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const claimState = await resolveActivePopupClaimState(tmuxCommand);
+      if (claimState.kind === "malformed" && claimState.raw.length > 4096) {
+        break;
+      }
+
+      if (claimState.kind === "valid") {
+        const sameClient =
+          claimState.claim.clientName === focusClientId &&
+          claimState.claim.clientPid === claimClient.pid;
+        const nestedClient =
+          persistentUi !== undefined && claimClient.sessionName === persistentUi.sessionName;
+        if (sameClient || nestedClient) {
+          const closingClaim = buildPopupActiveClaim({
+            clientName: claimState.claim.clientName,
+            clientPid: claimState.claim.clientPid,
+            registrationNonce: claimState.claim.registrationNonce,
+            state: "closing",
+          });
+          if (
+            !(await compareAndSetActivePopupClaim(tmuxCommand, {
+              expected: claimState.raw,
+              replacement: closingClaim,
+            }))
+          ) {
+            continue;
+          }
+          await setPopupClaimMirrors({
+            ...tmuxCommand,
+            clientId: claimState.claim.clientName,
+          });
+          try {
+            await closeTmuxPopup({
+              ...tmuxCommand,
+              clientId: claimState.claim.clientName,
+            });
+          } finally {
+            await clearActivePopupClaimIfCurrent(tmuxCommand, {
+              claim: closingClaim,
+              clientId: claimState.claim.clientName,
+            }).catch(() => undefined);
+          }
+          return { opened: false, closed: true };
+        }
+      }
+
+      const activeClientId = await resolveActivePopupClient(tmuxCommand);
+      if (claimState.kind === "absent" && activeClientId === focusClientId) {
+        const closingClaim = buildPopupActiveClaim({
+          clientName: claimClient.name,
+          clientPid: claimClient.pid,
+          registrationNonce: registeredRoute?.registrationNonce ?? fallbackRegistrationNonce,
+          state: "closing",
+        });
+        if (
+          !(await compareAndSetActivePopupClaim(tmuxCommand, {
+            replacement: closingClaim,
+          }))
+        ) {
+          continue;
+        }
+        await setPopupClaimMirrors({ ...tmuxCommand, clientId: focusClientId });
+        try {
+          await closeTmuxPopup({ ...tmuxCommand, clientId: focusClientId });
+        } finally {
+          await clearActivePopupClaimIfCurrent(tmuxCommand, {
+            claim: closingClaim,
+            clientId: focusClientId,
+          }).catch(() => undefined);
+        }
+        return { opened: false, closed: true };
+      }
+
+      const registrationNonce =
+        registeredRoute?.registrationNonce ??
+        (claimState.kind === "valid"
+          ? claimState.claim.registrationNonce
+          : fallbackRegistrationNonce);
+      const nextClaim = buildPopupActiveClaim({
+        clientName: claimClient.name,
+        clientPid: claimClient.pid,
+        registrationNonce,
+        state: "open",
+      });
+      const replaced = await compareAndSetActivePopupClaim(tmuxCommand, {
+        ...(claimState.kind === "absent" ? {} : { expected: claimState.raw }),
+        replacement: nextClaim,
+      });
+      if (!replaced) {
+        continue;
+      }
+      activeClaim = nextClaim;
+      try {
+        await setPopupClaimMirrors({ ...tmuxCommand, clientId: focusClientId });
+        const previousClient =
+          claimState.kind === "valid" ? claimState.claim.clientName : activeClientId;
+        if (previousClient !== undefined && previousClient !== focusClientId) {
+          await closeTmuxPopup({ ...tmuxCommand, clientId: previousClient });
+        }
+        if (options.enterWorkbench === true) {
+          await enterWorkbenchForPopup(
+            enterWorkbenchInput(tmuxCommand, focusClientId, options.config),
+          );
+        }
+      } catch (error) {
+        await clearActivePopupClaimIfCurrent(tmuxCommand, {
+          claim: nextClaim,
+          clientId: focusClientId,
+        }).catch(() => undefined);
+        throw error;
+      }
+      break;
+    }
+    if (activeClaim === undefined) {
+      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+        code: "TERMINAL_OPEN_FAILED",
+        message: "tmux failed to claim the station popup.",
+      });
+    }
+  } else if (focusClientId !== undefined && focusClientId.length > 0) {
+    const claimState = await resolveActivePopupClaimState(tmuxCommand);
+    if (claimState.kind !== "absent") {
+      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+        code: "TERMINAL_OPEN_FAILED",
+        message: "tmux failed to claim the station popup.",
+      });
+    }
     const activeClientId = await resolveActivePopupClient(tmuxCommand);
     if (activeClientId === focusClientId) {
       await dismissTmuxPopup(dismissOptions(options, command, focusClientId));
       return { opened: false, closed: true };
     }
-    if (activeClientId !== undefined) {
-      await closeTmuxPopup({
-        ...tmuxCommand,
-        clientId: activeClientId,
+    const replaced = await replaceLegacyPopupIfUnclaimed({
+      ...tmuxCommand,
+      clientId: focusClientId,
+      ...(activeClientId === undefined ? {} : { previousClientId: activeClientId }),
+    });
+    if (!replaced) {
+      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+        code: "TERMINAL_OPEN_FAILED",
+        message: "tmux failed to claim the station popup.",
       });
     }
-    await setActivePopupClient({
-      ...tmuxCommand,
-      clientId: focusClientId,
-    });
-    await setFocusPopupClient({
-      ...tmuxCommand,
-      clientId: focusClientId,
-    });
-    if (options.enterWorkbench === true) {
-      await enterWorkbenchForPopup(enterWorkbenchInput(tmuxCommand, focusClientId, options.config));
-    }
   } else {
-    await clearFocusPopupClient(tmuxCommand);
-  }
-
-  const persistentUi = persistent
-    ? await resolvePersistentPopupUi(options, tmuxCommand)
-    : undefined;
-
-  if (persistentUi !== undefined) {
-    await ensurePersistentPopupSession(persistentSessionOptions(options, command, persistentUi));
-    if (persistentUi.registerFastPopup) {
-      await registerFastPopupUi(tmuxCommand, persistentUi).catch(() => undefined);
+    const legacyFocusClientId = await resolveFocusPopupClient(tmuxCommand);
+    if (legacyFocusClientId !== undefined) {
+      await clearLegacyFocusIfUnclaimed({
+        ...tmuxCommand,
+        clientId: legacyFocusClientId,
+      }).catch(() => undefined);
     }
   }
 
   const args = buildTmuxPopupArgs(
-    popupArgsOptions(popupArgsInput(options, command, focusClientId, persistent, persistentUi)),
+    popupArgsOptions(
+      popupArgsInput(options, command, focusClientId, persistent, persistentUi, activeClaim),
+    ),
   );
 
   const displayInput: PopupDisplayInput = {
@@ -311,11 +478,25 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
   try {
     displayResult = await runPopupDisplay(displayInput);
   } catch (error) {
-    await clearPopupState(tmuxCommand, focusClientId);
+    if (activeClaim !== undefined && focusClientId !== undefined) {
+      await clearActivePopupClaimIfCurrent(tmuxCommand, {
+        claim: activeClaim,
+        clientId: focusClientId,
+      }).catch(() => undefined);
+    } else {
+      await clearPopupState(tmuxCommand, focusClientId);
+    }
     throw error;
   }
   if (displayResult === "dismissed") {
-    await clearPopupState(tmuxCommand, focusClientId);
+    if (activeClaim !== undefined && focusClientId !== undefined) {
+      await clearActivePopupClaimIfCurrent(tmuxCommand, {
+        claim: activeClaim,
+        clientId: focusClientId,
+      }).catch(() => undefined);
+    } else {
+      await clearPopupState(tmuxCommand, focusClientId);
+    }
   }
 
   return { opened: true };
@@ -334,10 +515,13 @@ export async function resolveTmuxPopupFocusOrigin(
     env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
       ? env.STATION_FOCUS_CLIENT_ID
       : undefined;
+  const input = popupCommandInput(options, command);
+  const claimState = await resolveActivePopupClaimState(input);
   const clientId =
     requestedFocusClientId ??
     envFocusClientId ??
-    (await resolveFocusPopupClient(popupCommandInput(options, command)));
+    (claimState.kind === "valid" ? claimState.claim.clientName : undefined) ??
+    (await resolveFocusPopupClient(input));
   if (clientId === undefined) {
     return undefined;
   }
@@ -361,21 +545,51 @@ export async function dismissTmuxPopup(
     env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
       ? env.STATION_FOCUS_CLIENT_ID
       : undefined;
+  let claimContended = false;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const claimState = await resolveActivePopupClaimState(input);
+    if (claimState.kind === "malformed") {
+      return { dismissed: false };
+    }
+    if (claimState.kind === "absent") {
+      break;
+    }
+    const closingClaim = buildPopupActiveClaim({
+      clientName: claimState.claim.clientName,
+      clientPid: claimState.claim.clientPid,
+      registrationNonce: claimState.claim.registrationNonce,
+      state: "closing",
+    });
+    if (
+      !(await compareAndSetActivePopupClaim(input, {
+        expected: claimState.raw,
+        replacement: closingClaim,
+      }))
+    ) {
+      claimContended = true;
+      continue;
+    }
+    await setPopupClaimMirrors({ ...input, clientId: claimState.claim.clientName });
+    try {
+      await closeTmuxPopup({ ...input, clientId: claimState.claim.clientName });
+    } finally {
+      await clearActivePopupClaimIfCurrent(input, {
+        claim: closingClaim,
+        clientId: claimState.claim.clientName,
+      }).catch(() => undefined);
+    }
+    return { dismissed: true };
+  }
+  if (claimContended) {
+    return { dismissed: false };
+  }
   const clientId =
     requestedFocusClientId ??
     envFocusClientId ??
     (await resolveFocusPopupClient(input)) ??
     (await resolveActivePopupClient(input));
   if (clientId === undefined) {
-    await clearActivePopupClient(input).catch(() => undefined);
-    await clearFocusPopupClient(input).catch(() => undefined);
     return { dismissed: false };
   }
-  await closeTmuxPopup({
-    ...input,
-    clientId,
-  });
-  await clearActivePopupClient(input);
-  await clearFocusPopupClient(input);
-  return { dismissed: true };
+  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
 }

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -7,9 +7,9 @@ import {
 } from "@station/runtime";
 import type { TmuxCommandInput } from "../command.js";
 import { tmuxProviderErrorFromUnknown } from "../errors.js";
+import { shellQuote } from "../shell.js";
 import { buildTmuxPopupArgs } from "./args.js";
 import {
-  closeTmuxPopup,
   popupCommandInput,
   resolveCurrentTmuxClient,
   resolveCurrentTmuxClientId,
@@ -19,7 +19,11 @@ import {
   activePopupClientOption,
   focusPopupClientOption,
 } from "./constants.js";
-import { buildPopupActiveClaim, createPopupProtocolNonce } from "./fastProtocol.js";
+import {
+  buildPopupActiveClaim,
+  createPopupProtocolNonce,
+  isSafePopupClientName,
+} from "./fastProtocol.js";
 import {
   ensurePersistentPopupSession,
   registerFastPopupUi,
@@ -31,11 +35,9 @@ import {
   clearLegacyPopupStateIfUnclaimed,
   compareAndSetActivePopupClaim,
   dismissLegacyPopupIfUnclaimed,
-  replaceLegacyPopupIfUnclaimed,
   resolveActivePopupClaimState,
   resolveActivePopupClient,
   resolveFocusPopupClient,
-  setPopupClaimMirrors,
 } from "./state.js";
 import type {
   BuildTmuxPopupArgsOptions,
@@ -66,11 +68,24 @@ export type {
 } from "./types.js";
 
 type PopupDisplayResult = "opened" | "dismissed";
+type ClaimedPopupActionResult = PopupDisplayResult | "contended";
 
 type PopupDisplayInput = {
   args: string[];
   command: string;
   runner?: ExternalCommandRunner;
+};
+
+type ClaimedPopupActionInput = PopupDisplayInput & {
+  claim: string;
+  clientId: string;
+  previousClientId?: string;
+};
+
+type GuardedPopupActionInput = PopupDisplayInput & {
+  clientId: string;
+  condition: string;
+  previousClientId?: string;
 };
 
 type PopupArgsInput = {
@@ -82,6 +97,9 @@ type PopupArgsInput = {
   persistentUi?: TmuxPersistentPopupUi;
   tuiCommand?: string;
 };
+
+const popupCasMiss = "STATION_POPUP_CAS_MISS";
+const safeTmuxCommandTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;
 
 function defaultTmuxCommand(command: string | undefined): string {
   return command ?? process.env.STATION_TMUX_BIN ?? "tmux";
@@ -267,6 +285,90 @@ async function runPopupDisplay(input: PopupDisplayInput): Promise<PopupDisplayRe
   return result.value.exitCode === 129 ? "dismissed" : "opened";
 }
 
+function tmuxFormatLiteral(value: string): string {
+  return value.replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
+}
+
+function nestedTmuxCommand(args: readonly string[]): string {
+  return args
+    .map((arg) => {
+      const escaped = arg.replaceAll("#", "##");
+      return safeTmuxCommandTokenPattern.test(escaped) ? escaped : shellQuote(escaped);
+    })
+    .join(" ");
+}
+
+async function runGuardedPopupAction(
+  input: GuardedPopupActionInput,
+): Promise<ClaimedPopupActionResult> {
+  if (
+    !isSafePopupClientName(input.clientId) ||
+    (input.previousClientId !== undefined && !isSafePopupClientName(input.previousClientId))
+  ) {
+    throw tmuxProviderErrorFromUnknown(new Error("unsafe tmux popup client"), {
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to open the station popup.",
+    });
+  }
+  const action = [
+    nestedTmuxCommand(["set-option", "-gq", activePopupClientOption, input.clientId]),
+    nestedTmuxCommand(["set-option", "-gq", focusPopupClientOption, input.clientId]),
+    ...(input.previousClientId === undefined || input.previousClientId === input.clientId
+      ? []
+      : [nestedTmuxCommand(["display-popup", "-c", input.previousClientId, "-C"])]),
+    nestedTmuxCommand(input.args),
+  ].join(" ; ");
+  const result = await runRuntimeBoundaryWithRetry(
+    {
+      operation: "provider.tmux.popup.guardedAction",
+      error: {
+        tag: "TerminalProviderError",
+        code: "TERMINAL_POPUP_FAILED",
+        message: "tmux failed to open the station popup.",
+        provider: "tmux",
+      },
+      retry: { retries: 0 },
+    },
+    ({ signal }) =>
+      runExternalCommand(
+        {
+          command: input.command,
+          args: ["if-shell", "-F", input.condition, action, `display-message -p ${popupCasMiss}`],
+          signal,
+          maxOutputChars: 64 * 1024,
+          allowedExitCodes: [0, 129],
+        },
+        input.runner,
+      ),
+  );
+  if (!result.ok) {
+    throw tmuxProviderErrorFromUnknown(result.error, {
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to open the station popup.",
+    });
+  }
+  if (result.value.stdout.trim() === popupCasMiss) {
+    return "contended";
+  }
+  return result.value.exitCode === 129 ? "dismissed" : "opened";
+}
+
+function runClaimedPopupAction(input: ClaimedPopupActionInput): Promise<ClaimedPopupActionResult> {
+  return runGuardedPopupAction({
+    ...input,
+    condition: `#{==:#{${activePopupClaimOption}},${tmuxFormatLiteral(input.claim)}}`,
+  });
+}
+
+function runUnclaimedPopupAction(
+  input: Omit<GuardedPopupActionInput, "condition">,
+): Promise<ClaimedPopupActionResult> {
+  return runGuardedPopupAction({
+    ...input,
+    condition: `#{&&:#{==:#{${activePopupClaimOption}},},#{==:#{${activePopupClientOption}},${tmuxFormatLiteral(input.previousClientId ?? "")}}}`,
+  });
+}
+
 export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<TmuxPopupResult> {
   const command = defaultTmuxCommand(options.command ?? options.config?.command);
   const persistent = options.persistent !== false;
@@ -301,6 +403,8 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
   }
 
   let activeClaim: string | undefined;
+  let legacyPopupAction = false;
+  let previousPopupClientId: string | undefined;
   if (focusClientId !== undefined && focusClientId.length > 0 && currentClient !== undefined) {
     const claimClient: TmuxClientIdentity = {
       ...currentClient,
@@ -334,20 +438,25 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
           ) {
             continue;
           }
-          await setPopupClaimMirrors({
-            ...tmuxCommand,
-            clientId: claimState.claim.clientName,
-          });
+          let actionResult: ClaimedPopupActionResult | undefined;
           try {
-            await closeTmuxPopup({
-              ...tmuxCommand,
-              clientId: claimState.claim.clientName,
-            });
-          } finally {
-            await clearActivePopupClaimIfCurrent(tmuxCommand, {
+            actionResult = await runClaimedPopupAction({
+              args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
               claim: closingClaim,
               clientId: claimState.claim.clientName,
-            }).catch(() => undefined);
+              command,
+              ...(options.runner === undefined ? {} : { runner: options.runner }),
+            });
+          } finally {
+            if (actionResult !== "contended") {
+              await clearActivePopupClaimIfCurrent(tmuxCommand, {
+                claim: closingClaim,
+                clientId: claimState.claim.clientName,
+              }).catch(() => undefined);
+            }
+          }
+          if (actionResult === "contended") {
+            continue;
           }
           return { opened: false, closed: true };
         }
@@ -368,14 +477,25 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
         ) {
           continue;
         }
-        await setPopupClaimMirrors({ ...tmuxCommand, clientId: focusClientId });
+        let actionResult: ClaimedPopupActionResult | undefined;
         try {
-          await closeTmuxPopup({ ...tmuxCommand, clientId: focusClientId });
-        } finally {
-          await clearActivePopupClaimIfCurrent(tmuxCommand, {
+          actionResult = await runClaimedPopupAction({
+            args: ["display-popup", "-c", focusClientId, "-C"],
             claim: closingClaim,
             clientId: focusClientId,
-          }).catch(() => undefined);
+            command,
+            ...(options.runner === undefined ? {} : { runner: options.runner }),
+          });
+        } finally {
+          if (actionResult !== "contended") {
+            await clearActivePopupClaimIfCurrent(tmuxCommand, {
+              claim: closingClaim,
+              clientId: focusClientId,
+            }).catch(() => undefined);
+          }
+        }
+        if (actionResult === "contended") {
+          continue;
         }
         return { opened: false, closed: true };
       }
@@ -391,6 +511,11 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
         registrationNonce,
         state: "open",
       });
+      if (options.enterWorkbench === true) {
+        await enterWorkbenchForPopup(
+          enterWorkbenchInput(tmuxCommand, focusClientId, options.config),
+        );
+      }
       const replaced = await compareAndSetActivePopupClaim(tmuxCommand, {
         ...(claimState.kind === "absent" ? {} : { expected: claimState.raw }),
         replacement: nextClaim,
@@ -399,25 +524,8 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
         continue;
       }
       activeClaim = nextClaim;
-      try {
-        await setPopupClaimMirrors({ ...tmuxCommand, clientId: focusClientId });
-        const previousClient =
-          claimState.kind === "valid" ? claimState.claim.clientName : activeClientId;
-        if (previousClient !== undefined && previousClient !== focusClientId) {
-          await closeTmuxPopup({ ...tmuxCommand, clientId: previousClient });
-        }
-        if (options.enterWorkbench === true) {
-          await enterWorkbenchForPopup(
-            enterWorkbenchInput(tmuxCommand, focusClientId, options.config),
-          );
-        }
-      } catch (error) {
-        await clearActivePopupClaimIfCurrent(tmuxCommand, {
-          claim: nextClaim,
-          clientId: focusClientId,
-        }).catch(() => undefined);
-        throw error;
-      }
+      previousPopupClientId =
+        claimState.kind === "valid" ? claimState.claim.clientName : activeClientId;
       break;
     }
     if (activeClaim === undefined) {
@@ -439,17 +547,8 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
       await dismissTmuxPopup(dismissOptions(options, command, focusClientId));
       return { opened: false, closed: true };
     }
-    const replaced = await replaceLegacyPopupIfUnclaimed({
-      ...tmuxCommand,
-      clientId: focusClientId,
-      ...(activeClientId === undefined ? {} : { previousClientId: activeClientId }),
-    });
-    if (!replaced) {
-      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
-        code: "TERMINAL_OPEN_FAILED",
-        message: "tmux failed to claim the station popup.",
-      });
-    }
+    legacyPopupAction = true;
+    previousPopupClientId = activeClientId;
   } else {
     const legacyFocusClientId = await resolveFocusPopupClient(tmuxCommand);
     if (legacyFocusClientId !== undefined) {
@@ -476,7 +575,36 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
 
   let displayResult: PopupDisplayResult;
   try {
-    displayResult = await runPopupDisplay(displayInput);
+    if (activeClaim !== undefined && focusClientId !== undefined) {
+      const claimedResult = await runClaimedPopupAction({
+        ...displayInput,
+        claim: activeClaim,
+        clientId: focusClientId,
+        ...(previousPopupClientId === undefined ? {} : { previousClientId: previousPopupClientId }),
+      });
+      if (claimedResult === "contended") {
+        throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+          code: "TERMINAL_OPEN_FAILED",
+          message: "tmux failed to claim the station popup.",
+        });
+      }
+      displayResult = claimedResult;
+    } else if (legacyPopupAction && focusClientId !== undefined) {
+      const guardedResult = await runUnclaimedPopupAction({
+        ...displayInput,
+        clientId: focusClientId,
+        ...(previousPopupClientId === undefined ? {} : { previousClientId: previousPopupClientId }),
+      });
+      if (guardedResult === "contended") {
+        throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+          code: "TERMINAL_OPEN_FAILED",
+          message: "tmux failed to claim the station popup.",
+        });
+      }
+      displayResult = guardedResult;
+    } else {
+      displayResult = await runPopupDisplay(displayInput);
+    }
   } catch (error) {
     if (activeClaim !== undefined && focusClientId !== undefined) {
       await clearActivePopupClaimIfCurrent(tmuxCommand, {
@@ -569,14 +697,26 @@ export async function dismissTmuxPopup(
       claimContended = true;
       continue;
     }
-    await setPopupClaimMirrors({ ...input, clientId: claimState.claim.clientName });
+    let actionResult: ClaimedPopupActionResult | undefined;
     try {
-      await closeTmuxPopup({ ...input, clientId: claimState.claim.clientName });
-    } finally {
-      await clearActivePopupClaimIfCurrent(input, {
+      actionResult = await runClaimedPopupAction({
+        args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
         claim: closingClaim,
         clientId: claimState.claim.clientName,
-      }).catch(() => undefined);
+        command,
+        ...(options.runner === undefined ? {} : { runner: options.runner }),
+      });
+    } finally {
+      if (actionResult !== "contended") {
+        await clearActivePopupClaimIfCurrent(input, {
+          claim: closingClaim,
+          clientId: claimState.claim.clientName,
+        }).catch(() => undefined);
+      }
+    }
+    if (actionResult === "contended") {
+      claimContended = true;
+      continue;
     }
     return { dismissed: true };
   }

--- a/integrations/terminal/tmux/src/popup/persistentUi.ts
+++ b/integrations/terminal/tmux/src/popup/persistentUi.ts
@@ -11,6 +11,8 @@ import {
 import {
   defaultPersistentPopupSessionName,
   defaultPersistentPopupTuiCommand,
+  persistentUiLeaseOption,
+  persistentUiRouteOption,
   persistentUiSignatureOption,
   registeredDevPopupCommandOption,
   registeredDevPopupOwnerOption,
@@ -20,6 +22,12 @@ import {
   registeredPopupRootOption,
   registeredPopupSessionNameOption,
 } from "./constants.js";
+import {
+  buildNormalPopupRoute,
+  type NormalPopupRoute,
+  normalPopupRouteMatches,
+  parseNormalPopupRoute,
+} from "./fastProtocol.js";
 import type {
   ResolvePersistentPopupUiOptions,
   TmuxPersistentPopupSessionOptions,
@@ -35,10 +43,6 @@ type RegisteredDevPopupResultInput = {
   root?: string;
   sessionName: string;
 };
-
-function persistentPopupSignature(tuiCommand: string): string {
-  return `v1:${tuiCommand}`;
-}
 
 function registeredDevPopupResult(
   options: RegisteredDevPopupResultInput,
@@ -114,6 +118,69 @@ async function setPersistentPopupSessionSignature(
   });
 }
 
+async function resolvePersistentPopupSessionLease(
+  input: TmuxCommandInput,
+  sessionName: string,
+): Promise<string | undefined> {
+  return resolveTmuxOption(input, {
+    args: ["show-options", "-t", sessionName, "-qv", persistentUiLeaseOption],
+    operation: "provider.tmux.popup.persistentUiLease",
+    message: "tmux failed to resolve the persistent station popup UI lease.",
+    timeoutMessage: "tmux persistent popup UI lease lookup timed out.",
+  });
+}
+
+async function setPersistentPopupSessionLease(
+  input: TmuxCommandInput,
+  options: { lease: string; sessionName: string },
+): Promise<void> {
+  await runTmuxPopupCommand(input, {
+    args: ["set-option", "-t", options.sessionName, "-q", persistentUiLeaseOption, options.lease],
+    operation: "provider.tmux.popup.setPersistentUiLease",
+    message: "tmux failed to record the persistent station popup UI lease.",
+    timeoutMessage: "tmux persistent popup UI lease update timed out.",
+  });
+}
+
+function globalOptionEqualsFormat(optionName: string, value: string | undefined): string {
+  const literal = (value ?? "").replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
+  return `#{==:#{${optionName}},${literal}}`;
+}
+
+async function compareAndSetPersistentPopupRoute(
+  input: TmuxCommandInput,
+  options: { expected?: string; lease: string; route: string; sessionName: string },
+): Promise<boolean> {
+  const routeMatches = globalOptionEqualsFormat(persistentUiRouteOption, options.expected);
+  const leaseMatches = globalOptionEqualsFormat(persistentUiLeaseOption, options.lease);
+  await runTmuxPopupCommand(input, {
+    args: [
+      "if-shell",
+      "-F",
+      "-t",
+      `${options.sessionName}:`,
+      `#{&&:${routeMatches},${leaseMatches}}`,
+      `set-option -gq ${persistentUiRouteOption} ${options.route}`,
+    ],
+    operation: "provider.tmux.popup.commitPersistentUiRoute",
+    message: "tmux failed to commit the persistent station popup UI route.",
+    timeoutMessage: "tmux persistent popup UI route commit timed out.",
+  });
+  return (await resolveTmuxGlobalOption(input, persistentUiRouteOption)) === options.route;
+}
+
+function registeredRouteMatches(
+  route: NormalPopupRoute,
+  ui: TmuxPersistentPopupUi & { root: string },
+  signature: string,
+): boolean {
+  return normalPopupRouteMatches(route, {
+    root: ui.root,
+    sessionName: ui.sessionName,
+    signature,
+  });
+}
+
 async function killPersistentPopupSession(
   input: TmuxCommandInput,
   sessionName: string,
@@ -136,6 +203,10 @@ async function enablePersistentPopupSessionMouse(
     message: "tmux failed to enable mouse support for the persistent station popup UI.",
     timeoutMessage: "tmux persistent popup UI mouse setup timed out.",
   });
+}
+
+export function persistentPopupSignature(tuiCommand: string): string {
+  return `v1:${tuiCommand}`;
 }
 
 export async function ensurePersistentPopupSession(
@@ -240,14 +311,70 @@ export async function resolvePersistentPopupUi(
 export async function registerFastPopupUi(
   input: TmuxCommandInput,
   ui: TmuxPersistentPopupUi,
-): Promise<void> {
-  await setTmuxGlobalOption(input, registeredPopupSessionNameOption, ui.sessionName);
-  await setTmuxGlobalOption(
+): Promise<NormalPopupRoute | undefined> {
+  if (ui.root === undefined || !(await hasTmuxSession(input, ui.sessionName))) {
+    return undefined;
+  }
+  const signature = persistentPopupSignature(ui.command);
+  if ((await resolvePersistentPopupSessionSignature(input, ui.sessionName)) !== signature) {
+    return undefined;
+  }
+
+  const previousRouteValue = await resolveTmuxGlobalOption(input, persistentUiRouteOption);
+  const previousRoute =
+    previousRouteValue === undefined ? undefined : parseNormalPopupRoute(previousRouteValue);
+  if (
+    previousRouteValue !== undefined &&
+    previousRoute === undefined &&
+    previousRouteValue.length > 4096
+  ) {
+    return undefined;
+  }
+
+  const currentLease = await resolvePersistentPopupSessionLease(input, ui.sessionName);
+  const currentSessionName = await resolveTmuxGlobalOption(input, registeredPopupSessionNameOption);
+  const currentSignature = await resolveTmuxGlobalOption(
     input,
     registeredPopupExpectedSignatureOption,
-    persistentPopupSignature(ui.command),
   );
-  if (ui.root !== undefined) {
-    await setTmuxGlobalOption(input, registeredPopupRootOption, ui.root);
+  const currentRoot = await resolveTmuxGlobalOption(input, registeredPopupRootOption);
+  if (
+    previousRoute !== undefined &&
+    registeredRouteMatches(
+      previousRoute,
+      ui as TmuxPersistentPopupUi & { root: string },
+      signature,
+    ) &&
+    currentLease === previousRouteValue &&
+    currentSessionName === ui.sessionName &&
+    currentSignature === signature &&
+    currentRoot === ui.root
+  ) {
+    return previousRoute;
   }
+
+  const routeValue = buildNormalPopupRoute({
+    root: ui.root,
+    sessionName: ui.sessionName,
+    signature,
+  });
+  const route = parseNormalPopupRoute(routeValue);
+  if (route === undefined) {
+    return undefined;
+  }
+
+  await setPersistentPopupSessionLease(input, { lease: routeValue, sessionName: ui.sessionName });
+  await setTmuxGlobalOption(input, registeredPopupSessionNameOption, ui.sessionName);
+  await setTmuxGlobalOption(input, registeredPopupExpectedSignatureOption, signature);
+  await setTmuxGlobalOption(input, registeredPopupRootOption, ui.root);
+  const committed = await compareAndSetPersistentPopupRoute(input, {
+    lease: routeValue,
+    route: routeValue,
+    sessionName: ui.sessionName,
+    ...(previousRouteValue === undefined ? {} : { expected: previousRouteValue }),
+  });
+  if (!committed) {
+    return undefined;
+  }
+  return route;
 }

--- a/integrations/terminal/tmux/src/popup/state.ts
+++ b/integrations/terminal/tmux/src/popup/state.ts
@@ -1,6 +1,194 @@
 import type { TmuxCommandInput } from "../command.js";
-import { clearTmuxGlobalOption, resolveTmuxGlobalOption, setTmuxGlobalOption } from "./command.js";
-import { activePopupClientOption, focusPopupClientOption } from "./constants.js";
+import {
+  resolveTmuxGlobalOption,
+  runTmuxPopupCommand,
+  runTmuxPopupQuery,
+  setTmuxGlobalOption,
+} from "./command.js";
+import {
+  activePopupClaimOption,
+  activePopupClientOption,
+  focusPopupClientOption,
+} from "./constants.js";
+import {
+  isSafePopupClientName,
+  type PopupActiveClaim,
+  parsePopupActiveClaim,
+} from "./fastProtocol.js";
+
+export type TmuxActivePopupClaimState =
+  | { kind: "absent" }
+  | { claim: PopupActiveClaim; kind: "valid"; raw: string }
+  | { kind: "malformed"; raw: string };
+
+function formatLiteral(value: string): string {
+  return value.replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
+}
+
+function optionEqualsFormat(optionName: string, value: string | undefined): string {
+  return `#{==:#{${optionName}},${formatLiteral(value ?? "")}}`;
+}
+
+function claimEqualsFormat(value: string | undefined): string {
+  return optionEqualsFormat(activePopupClaimOption, value);
+}
+
+function legacyPopupCondition(clientId: string): string {
+  return `#{&&:${claimEqualsFormat(undefined)},#{||:${optionEqualsFormat(activePopupClientOption, clientId)},${optionEqualsFormat(focusPopupClientOption, clientId)}}}`;
+}
+
+function legacyPopupClearCommands(clientId: string): string {
+  return [
+    `if-shell -F "${optionEqualsFormat(activePopupClientOption, clientId)}" "set-option -gq -u ${activePopupClientOption}"`,
+    `if-shell -F "${optionEqualsFormat(focusPopupClientOption, clientId)}" "set-option -gq -u ${focusPopupClientOption}"`,
+  ].join(" ; ");
+}
+
+async function runLegacyPopupActionIfUnclaimed(
+  input: TmuxCommandInput & { clientId: string },
+  close: boolean,
+): Promise<boolean> {
+  if (!isSafePopupClientName(input.clientId)) {
+    return false;
+  }
+  const miss = "STATION_POPUP_CAS_MISS";
+  const commands = [
+    ...(close ? [`display-popup -c ${input.clientId} -C`] : []),
+    legacyPopupClearCommands(input.clientId),
+  ].join(" ; ");
+  const result = await runTmuxPopupQuery(input, {
+    args: [
+      "if-shell",
+      "-F",
+      legacyPopupCondition(input.clientId),
+      commands,
+      `display-message -p ${miss}`,
+    ],
+    operation: "provider.tmux.popup.clearLegacyState",
+    message: "tmux failed to clear the legacy station popup state.",
+    timeoutMessage: "tmux legacy popup state cleanup timed out.",
+  });
+  return result.stdout.trim() !== miss;
+}
+
+export async function resolveActivePopupClaimState(
+  input: TmuxCommandInput,
+): Promise<TmuxActivePopupClaimState> {
+  const raw = await resolveTmuxGlobalOption(input, activePopupClaimOption, {
+    operation: "provider.tmux.popup.activeClaim",
+    message: "tmux failed to resolve the active station popup claim.",
+    timeoutMessage: "tmux active popup claim lookup timed out.",
+  });
+  if (raw === undefined) {
+    return { kind: "absent" };
+  }
+  const claim = parsePopupActiveClaim(raw);
+  return claim === undefined ? { kind: "malformed", raw } : { claim, kind: "valid", raw };
+}
+
+export async function compareAndSetActivePopupClaim(
+  input: TmuxCommandInput,
+  options: { expected?: string; replacement: string },
+): Promise<boolean> {
+  await runTmuxPopupCommand(input, {
+    args: [
+      "if-shell",
+      "-F",
+      claimEqualsFormat(options.expected),
+      `set-option -gq ${activePopupClaimOption} ${options.replacement}`,
+    ],
+    operation: "provider.tmux.popup.replaceActiveClaim",
+    message: "tmux failed to claim the active station popup.",
+    timeoutMessage: "tmux active popup claim update timed out.",
+  });
+  return (await resolveTmuxGlobalOption(input, activePopupClaimOption)) === options.replacement;
+}
+
+export async function setPopupClaimMirrors(
+  input: TmuxCommandInput & { clientId: string },
+): Promise<void> {
+  await setActivePopupClient(input);
+  await setFocusPopupClient(input);
+}
+
+export async function clearActivePopupClaimIfCurrent(
+  input: TmuxCommandInput,
+  options: { claim: string; clientId: string },
+): Promise<void> {
+  const clearCommands = [
+    `set-option -gq -u ${activePopupClaimOption}`,
+    `if-shell -F "#{==:#{${activePopupClientOption}},${options.clientId}}" "set-option -gq -u ${activePopupClientOption}"`,
+    `if-shell -F "#{==:#{${focusPopupClientOption}},${options.clientId}}" "set-option -gq -u ${focusPopupClientOption}"`,
+  ].join(" ; ");
+  await runTmuxPopupCommand(input, {
+    args: ["if-shell", "-F", claimEqualsFormat(options.claim), clearCommands],
+    operation: "provider.tmux.popup.clearActiveClaim",
+    message: "tmux failed to clear the active station popup claim.",
+    timeoutMessage: "tmux active popup claim cleanup timed out.",
+  });
+}
+
+export async function clearLegacyPopupStateIfUnclaimed(
+  input: TmuxCommandInput & { clientId: string },
+): Promise<boolean> {
+  return runLegacyPopupActionIfUnclaimed(input, false);
+}
+
+export async function clearLegacyFocusIfUnclaimed(
+  input: TmuxCommandInput & { clientId: string },
+): Promise<boolean> {
+  if (!isSafePopupClientName(input.clientId)) {
+    return false;
+  }
+  const miss = "STATION_POPUP_CAS_MISS";
+  const condition = `#{&&:${claimEqualsFormat(undefined)},${optionEqualsFormat(focusPopupClientOption, input.clientId)}}`;
+  const result = await runTmuxPopupQuery(input, {
+    args: [
+      "if-shell",
+      "-F",
+      condition,
+      `set-option -gq -u ${focusPopupClientOption}`,
+      `display-message -p ${miss}`,
+    ],
+    operation: "provider.tmux.popup.clearLegacyFocus",
+    message: "tmux failed to clear the legacy station popup focus.",
+    timeoutMessage: "tmux legacy popup focus cleanup timed out.",
+  });
+  return result.stdout.trim() !== miss;
+}
+
+export async function dismissLegacyPopupIfUnclaimed(
+  input: TmuxCommandInput & { clientId: string },
+): Promise<boolean> {
+  return runLegacyPopupActionIfUnclaimed(input, true);
+}
+
+export async function replaceLegacyPopupIfUnclaimed(
+  input: TmuxCommandInput & { clientId: string; previousClientId?: string },
+): Promise<boolean> {
+  if (
+    !isSafePopupClientName(input.clientId) ||
+    (input.previousClientId !== undefined && !isSafePopupClientName(input.previousClientId))
+  ) {
+    return false;
+  }
+  const miss = "STATION_POPUP_CAS_MISS";
+  const condition = `#{&&:${claimEqualsFormat(undefined)},${optionEqualsFormat(activePopupClientOption, input.previousClientId)}}`;
+  const commands = [
+    ...(input.previousClientId === undefined
+      ? []
+      : [`display-popup -c ${input.previousClientId} -C`]),
+    `set-option -gq ${activePopupClientOption} ${input.clientId}`,
+    `set-option -gq ${focusPopupClientOption} ${input.clientId}`,
+  ].join(" ; ");
+  const result = await runTmuxPopupQuery(input, {
+    args: ["if-shell", "-F", condition, commands, `display-message -p ${miss}`],
+    operation: "provider.tmux.popup.replaceLegacyState",
+    message: "tmux failed to replace the legacy station popup state.",
+    timeoutMessage: "tmux legacy popup state replacement timed out.",
+  });
+  return result.stdout.trim() !== miss;
+}
 
 export async function resolveActivePopupClient(
   input: TmuxCommandInput,
@@ -39,21 +227,5 @@ export async function setFocusPopupClient(
     operation: "provider.tmux.popup.setFocusClient",
     message: "tmux failed to record the station popup focus client.",
     timeoutMessage: "tmux popup focus client update timed out.",
-  });
-}
-
-export async function clearActivePopupClient(input: TmuxCommandInput): Promise<void> {
-  await clearTmuxGlobalOption(input, activePopupClientOption, {
-    operation: "provider.tmux.popup.clearActiveClient",
-    message: "tmux failed to clear the active station popup.",
-    timeoutMessage: "tmux active popup clear timed out.",
-  });
-}
-
-export async function clearFocusPopupClient(input: TmuxCommandInput): Promise<void> {
-  await clearTmuxGlobalOption(input, focusPopupClientOption, {
-    operation: "provider.tmux.popup.clearFocusClient",
-    message: "tmux failed to clear the station popup focus client.",
-    timeoutMessage: "tmux popup focus client clear timed out.",
   });
 }

--- a/integrations/terminal/tmux/src/popup/types.ts
+++ b/integrations/terminal/tmux/src/popup/types.ts
@@ -45,6 +45,12 @@ export type TmuxCurrentClientInput = {
   timeoutMs?: number;
 };
 
+export type TmuxClientIdentity = {
+  name: string;
+  pid: number;
+  sessionName: string;
+};
+
 export type TmuxPersistentPopupSessionOptions = {
   command?: string;
   runner?: ExternalCommandRunner;
@@ -96,6 +102,8 @@ export type ResolvePersistentPopupUiOptions = {
 };
 
 export type TmuxPopupState = {
+  claim?: string;
+  claimOptionName?: string;
   clientId: string;
   focusOptionName?: string;
   optionName: string;

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -312,6 +312,8 @@ describeRealTmux("real tmux dev popup routing", () => {
     expect(secondPane.pid).toBe(firstPane.pid);
     expect(secondRenderer.pid).toBe(firstRenderer.pid);
     expect(secondRenderer.tty).toBe(secondPane.tty);
+    expect(secondClient.columns).toBe(firstClient.columns);
+    expect(secondClient.rows).toBe(firstClient.rows);
     await assertPathMissing(
       fixture.bareTmuxLogPath,
       "a child invoked bare tmux instead of the private wrapper",
@@ -319,7 +321,11 @@ describeRealTmux("real tmux dev popup routing", () => {
   }, 120_000);
 
   it("compiled managed binding cold-starts, reuses the warm UI, and fails without entering view mode", async () => {
-    const fixture = await createDashboardFixture(tmux);
+    const fixture = await createDashboardFixture(tmux, {
+      height: "50%",
+      position: "C",
+      width: "50%",
+    });
     const validConfig = await readFile(fixture.configPath, "utf8");
     cleanup = async () => {
       await writeFile(fixture.configPath, validConfig, "utf8");
@@ -336,11 +342,24 @@ describeRealTmux("real tmux dev popup routing", () => {
       sessionName: "base",
       env: fixture.env,
     });
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base-cross", "-c", fixture.projectRoot, "sleep 300"],
+      fixture.env,
+    );
+    const secondaryClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base-cross",
+      env: fixture.env,
+    });
+    fixture.otherPtyClients.push(secondaryClient);
+    const outerClients = [fixture.ptyClient, secondaryClient] as const;
 
     const installedRoot = dirname(await realpath(builtBinaryPath));
     const fallbackAlias = join(installedRoot, "stn-tmux-popup");
     expect(await realpath(fallbackAlias)).toBe(await realpath(builtBinaryPath));
     const runShellCommand = buildManagedFastPopupRunShellCommand({
+      configPath: fixture.configPath,
       installedRoot,
       fallbackAlias,
       tmuxCommand: fixture.wrapper,
@@ -351,9 +370,13 @@ describeRealTmux("real tmux dev popup routing", () => {
       fixture.env,
     );
 
-    await triggerPopupBinding(fixture.ptyClient);
+    await Promise.all(outerClients.map(triggerPopupBinding));
     await waitForTmuxSession(fixture.wrapper, persistentUiSessionName);
-    const firstClient = await waitForNestedClient(fixture);
+    const coldAction = await waitForCoherentActivePopup(fixture, outerClients);
+    const firstClient = coldAction.nestedClient;
+    const crossClient =
+      coldAction.owner === fixture.ptyClient ? secondaryClient : fixture.ptyClient;
+    const crossSession = crossClient === fixture.ptyClient ? "base" : "base-cross";
     await waitForHiddenPaneContent(
       fixture,
       isDashboardContent,
@@ -369,12 +392,12 @@ describeRealTmux("real tmux dev popup routing", () => {
     expect(await tmuxSessionOption(fixture, "@station_popup_ui_lease")).toBe(route);
     expect(await tmuxGlobalOption(fixture, "@station_popup_ui_root")).toBe(installedRoot);
 
-    await triggerPopupBinding(fixture.ptyClient);
+    await triggerPopupBinding(coldAction.owner);
     await waitForNestedClientGone(fixture);
     await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
 
     await writeFile(fixture.configPath, 'schema_version = "malformed"\n', "utf8");
-    await triggerPopupBinding(fixture.ptyClient);
+    await triggerPopupBinding(coldAction.owner);
     const warmClient = await waitForNestedClient(fixture);
     await waitForHiddenPaneContent(
       fixture,
@@ -389,18 +412,9 @@ describeRealTmux("real tmux dev popup routing", () => {
     expect(warmPane.pid).toBe(firstPane.pid);
     expect(warmProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
     expect(warmObserverPid).toBe(firstObserverPid);
+    expect(warmClient.columns).toBe(firstClient.columns);
+    expect(warmClient.rows).toBe(firstClient.rows);
 
-    await tmuxExec(
-      fixture.wrapper,
-      ["new-session", "-d", "-s", "base-cross", "-c", fixture.projectRoot, "sleep 300"],
-      fixture.env,
-    );
-    const crossClient = await startTmuxPtyClient({
-      tmux: fixture.wrapper,
-      sessionName: "base-cross",
-      env: fixture.env,
-    });
-    fixture.otherPtyClients.push(crossClient);
     await triggerPopupBinding(crossClient);
     await waitForGlobalOptionValue(fixture, "@station_popup_client", crossClient.clientName);
     const transferredClient = await waitForNestedClientReplacement(fixture, warmClient.pid);
@@ -417,8 +431,8 @@ describeRealTmux("real tmux dev popup routing", () => {
     await triggerPopupBinding(crossClient);
     await delay(1_000);
 
-    expect(await tmuxPaneInMode(fixture, "base-cross")).toBe("0");
-    const invokingPane = await captureTmuxPane(fixture, "base-cross");
+    expect(await tmuxPaneInMode(fixture, crossSession)).toBe("0");
+    const invokingPane = await captureTmuxPane(fixture, crossSession);
     const outputAfterFailure = crossClient.stdout.text().slice(outputBeforeFailure.length);
     expect(invokingPane).not.toContain("returned 1");
     expect(invokingPane).not.toContain("station-popup-binding");
@@ -444,13 +458,10 @@ describeRealTmux("real tmux dev popup routing", () => {
     await triggerPopupBinding(crossClient);
     await waitForNestedClientGone(fixture);
     await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
-    expect(await tmuxPaneInMode(fixture, "base-cross")).toBe("0");
+    expect(await tmuxPaneInMode(fixture, crossSession)).toBe("0");
 
-    await Promise.all([triggerPopupBinding(fixture.ptyClient), triggerPopupBinding(crossClient)]);
-    const competingAction = await waitForCoherentActivePopup(fixture, [
-      fixture.ptyClient,
-      crossClient,
-    ]);
+    await Promise.all(outerClients.map(triggerPopupBinding));
+    const competingAction = await waitForCoherentActivePopup(fixture, outerClients);
     expect(competingAction.nestedClient.pid).not.toBe(transferredClient.pid);
     expect((await readPaneEvidence(fixture)).pid).toBe(firstPane.pid);
     expect((await waitForDashboardProcessEvidence(fixture, transferredPane)).renderer.pid).toBe(
@@ -482,7 +493,14 @@ describeRealTmux("real tmux dev popup routing", () => {
   }, 180_000);
 });
 
-async function createDashboardFixture(tmux: string): Promise<DashboardFixture> {
+async function createDashboardFixture(
+  tmux: string,
+  geometry: { height: string; position: string; width: string } = {
+    height: "24",
+    position: "C",
+    width: "80",
+  },
+): Promise<DashboardFixture> {
   const root = await makeCheckoutTempRoot();
   try {
     const projectRoot = join(root, "project");
@@ -532,6 +550,7 @@ async function createDashboardFixture(tmux: string): Promise<DashboardFixture> {
       state,
       observerSocketPath,
       wrapper,
+      geometry,
     });
     const env = dashboardFixtureEnv({
       root,
@@ -617,6 +636,7 @@ function dashboardFixtureEnv(input: {
 
 async function writeDashboardConfig(input: {
   configPath: string;
+  geometry: { height: string; position: string; width: string };
   observerSocketPath: string;
   projectRoot: string;
   state: string;
@@ -641,9 +661,9 @@ async function writeDashboardConfig(input: {
       "",
       "[terminal.tmux]",
       `command = ${JSON.stringify(input.wrapper)}`,
-      'popup_width = "80"',
-      'popup_height = "24"',
-      'popup_position = "C"',
+      `popup_width = ${JSON.stringify(input.geometry.width)}`,
+      `popup_height = ${JSON.stringify(input.geometry.height)}`,
+      `popup_position = ${JSON.stringify(input.geometry.position)}`,
       "",
       "[repository.github]",
       "enabled = false",

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -1,12 +1,13 @@
 import { type ChildProcess, execFile, spawn } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 import { ObserverProcessIdentitySchema } from "@station/contracts";
 import { environmentWithoutGitLocals, resolveExecutablePath } from "@station/runtime";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
-import { openTmuxPopup } from "../../src/popup";
+import { buildManagedFastPopupRunShellCommand, openTmuxPopup } from "../../src/popup";
+import { parsePopupActiveClaim } from "../../src/popup/fastProtocol";
 import { shellQuote } from "../../src/shell";
 
 const execFileAsync = promisify(execFile);
@@ -14,6 +15,7 @@ const runRealTmux = process.env.STATION_REAL_TMUX === "1";
 const describeRealTmux = runRealTmux ? describe : describe.skip;
 const checkoutRoot = resolve(".");
 const builtCliPath = join(checkoutRoot, "apps/cli/dist/main.js");
+const builtBinaryPath = join(checkoutRoot, "station/dist/bin/stn");
 const persistentUiSessionName = "_station-ui";
 const rendererEntry = "src/dashboardRenderer/main.tsx";
 const outputTailBytes = 64 * 1024;
@@ -97,6 +99,7 @@ type DashboardFixture = {
   nestedClientPids: Set<number>;
   observerPids: Set<number>;
   observerSocketPath: string;
+  otherPtyClients: TmuxPtyClient[];
   panePids: Set<number>;
   projectRoot: string;
   ptyClient?: TmuxPtyClient;
@@ -161,6 +164,9 @@ describeRealTmux("real tmux dev popup routing", () => {
     await execFileAsync("python3", ["--version"], { timeout: 10_000 });
     await access(builtCliPath).catch(() => {
       throw new Error(`Built CLI not found at ${builtCliPath}; run pnpm build first.`);
+    });
+    await access(builtBinaryPath).catch(() => {
+      throw new Error(`Compiled CLI not found at ${builtBinaryPath}; run pnpm build:binary first.`);
     });
   });
 
@@ -258,7 +264,7 @@ describeRealTmux("real tmux dev popup routing", () => {
 
     const firstClient = await waitForNestedClient(fixture);
     const firstPane = await readPaneEvidence(fixture);
-    const firstProcesses = await waitForDashboardProcessEvidence(firstPane);
+    const firstProcesses = await waitForDashboardProcessEvidence(fixture, firstPane);
     const firstRenderer = firstProcesses.renderer;
     const popupAttach = await waitForPopupAttachRecord(fixture);
     await recordObserverPid(fixture);
@@ -299,7 +305,7 @@ describeRealTmux("real tmux dev popup routing", () => {
       "dashboard did not render after reopening the popup",
     );
     const secondPane = await readPaneEvidence(fixture);
-    const secondProcesses = await waitForDashboardProcessEvidence(secondPane);
+    const secondProcesses = await waitForDashboardProcessEvidence(fixture, secondPane);
     const secondRenderer = secondProcesses.renderer;
     recordRuntimeEvidence(fixture, secondClient, secondPane, secondProcesses);
 
@@ -311,6 +317,169 @@ describeRealTmux("real tmux dev popup routing", () => {
       "a child invoked bare tmux instead of the private wrapper",
     );
   }, 120_000);
+
+  it("compiled managed binding cold-starts, reuses the warm UI, and fails without entering view mode", async () => {
+    const fixture = await createDashboardFixture(tmux);
+    const validConfig = await readFile(fixture.configPath, "utf8");
+    cleanup = async () => {
+      await writeFile(fixture.configPath, validConfig, "utf8");
+      await cleanupDashboardFixture(fixture);
+    };
+
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base", "-c", fixture.projectRoot, "sleep 300"],
+      fixture.env,
+    );
+    fixture.ptyClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base",
+      env: fixture.env,
+    });
+
+    const installedRoot = dirname(await realpath(builtBinaryPath));
+    const fallbackAlias = join(installedRoot, "stn-tmux-popup");
+    expect(await realpath(fallbackAlias)).toBe(await realpath(builtBinaryPath));
+    const runShellCommand = buildManagedFastPopupRunShellCommand({
+      installedRoot,
+      fallbackAlias,
+      tmuxCommand: fixture.wrapper,
+    });
+    await tmuxExec(
+      fixture.wrapper,
+      ["bind-key", "Space", "run-shell", "-b", runShellCommand],
+      fixture.env,
+    );
+
+    await triggerPopupBinding(fixture.ptyClient);
+    await waitForTmuxSession(fixture.wrapper, persistentUiSessionName);
+    const firstClient = await waitForNestedClient(fixture);
+    await waitForHiddenPaneContent(
+      fixture,
+      isDashboardContent,
+      "compiled cold binding did not render the dashboard",
+    );
+    const firstPane = await readPaneEvidence(fixture);
+    const firstProcesses = await waitForDashboardProcessEvidence(fixture, firstPane);
+    const firstObserverPid = await recordObserverPid(fixture);
+    recordRuntimeEvidence(fixture, firstClient, firstPane, firstProcesses);
+
+    const route = await tmuxGlobalOption(fixture, "@station_popup_ui_route");
+    expect(route).toMatch(/^v1\.n\./);
+    expect(await tmuxSessionOption(fixture, "@station_popup_ui_lease")).toBe(route);
+    expect(await tmuxGlobalOption(fixture, "@station_popup_ui_root")).toBe(installedRoot);
+
+    await triggerPopupBinding(fixture.ptyClient);
+    await waitForNestedClientGone(fixture);
+    await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
+
+    await writeFile(fixture.configPath, 'schema_version = "malformed"\n', "utf8");
+    await triggerPopupBinding(fixture.ptyClient);
+    const warmClient = await waitForNestedClient(fixture);
+    await waitForHiddenPaneContent(
+      fixture,
+      isDashboardContent,
+      "compiled warm binding did not bypass malformed config",
+    );
+    const warmPane = await readPaneEvidence(fixture);
+    const warmProcesses = await waitForDashboardProcessEvidence(fixture, warmPane);
+    const warmObserverPid = await recordObserverPid(fixture);
+    recordRuntimeEvidence(fixture, warmClient, warmPane, warmProcesses);
+
+    expect(warmPane.pid).toBe(firstPane.pid);
+    expect(warmProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+    expect(warmObserverPid).toBe(firstObserverPid);
+
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base-cross", "-c", fixture.projectRoot, "sleep 300"],
+      fixture.env,
+    );
+    const crossClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base-cross",
+      env: fixture.env,
+    });
+    fixture.otherPtyClients.push(crossClient);
+    await triggerPopupBinding(crossClient);
+    await waitForGlobalOptionValue(fixture, "@station_popup_client", crossClient.clientName);
+    const transferredClient = await waitForNestedClientReplacement(fixture, warmClient.pid);
+    const transferredPane = await readPaneEvidence(fixture);
+    const transferredProcesses = await waitForDashboardProcessEvidence(fixture, transferredPane);
+    recordRuntimeEvidence(fixture, transferredClient, transferredPane, transferredProcesses);
+
+    expect(transferredPane.pid).toBe(firstPane.pid);
+    expect(transferredProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+    expect(await recordObserverPid(fixture)).toBe(firstObserverPid);
+
+    await setGlobalOption(fixture.wrapper, "@station_popup_ui_route", "malformed");
+    const outputBeforeFailure = crossClient.stdout.text();
+    await triggerPopupBinding(crossClient);
+    await delay(1_000);
+
+    expect(await tmuxPaneInMode(fixture, "base-cross")).toBe("0");
+    const invokingPane = await captureTmuxPane(fixture, "base-cross");
+    const outputAfterFailure = crossClient.stdout.text().slice(outputBeforeFailure.length);
+    expect(invokingPane).not.toContain("returned 1");
+    expect(invokingPane).not.toContain("station-popup-binding");
+    expect(outputAfterFailure).not.toContain("returned 1");
+    expect(outputAfterFailure).not.toContain("station-popup-binding");
+
+    const stillAttached = await waitForNestedClient(fixture);
+    expect(stillAttached.pid).toBe(transferredClient.pid);
+    expect((await readPaneEvidence(fixture)).pid).toBe(firstPane.pid);
+    expect((await waitForDashboardProcessEvidence(fixture, transferredPane)).renderer.pid).toBe(
+      firstProcesses.renderer.pid,
+    );
+    expect(await recordObserverPid(fixture)).toBe(firstObserverPid);
+
+    await crossClient.write(Buffer.from("?", "utf8"));
+    await waitForHiddenPaneContent(
+      fixture,
+      (content) => content.includes("station help"),
+      "dashboard was not usable after both popup routes failed",
+    );
+
+    await setGlobalOption(fixture.wrapper, "@station_popup_ui_route", route);
+    await triggerPopupBinding(crossClient);
+    await waitForNestedClientGone(fixture);
+    await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
+    expect(await tmuxPaneInMode(fixture, "base-cross")).toBe("0");
+
+    await Promise.all([triggerPopupBinding(fixture.ptyClient), triggerPopupBinding(crossClient)]);
+    const competingAction = await waitForCoherentActivePopup(fixture, [
+      fixture.ptyClient,
+      crossClient,
+    ]);
+    expect(competingAction.nestedClient.pid).not.toBe(transferredClient.pid);
+    expect((await readPaneEvidence(fixture)).pid).toBe(firstPane.pid);
+    expect((await waitForDashboardProcessEvidence(fixture, transferredPane)).renderer.pid).toBe(
+      firstProcesses.renderer.pid,
+    );
+    expect(await recordObserverPid(fixture)).toBe(firstObserverPid);
+    expect(await tmuxPaneInMode(fixture, "base")).toBe("0");
+    expect(await tmuxPaneInMode(fixture, "base-cross")).toBe("0");
+
+    await competingAction.owner.write(Buffer.from([0x1b]));
+    await waitForHiddenPaneContent(
+      fixture,
+      (content) => isDashboardContent(content) && !content.includes("station help"),
+      "competing managed actions left the dashboard unusable",
+    );
+    await competingAction.owner.write(Buffer.from("?", "utf8"));
+    await waitForHiddenPaneContent(
+      fixture,
+      (content) => content.includes("station help"),
+      "competing managed actions did not preserve dashboard input",
+    );
+    await triggerPopupBinding(competingAction.owner);
+    await waitForNestedClientGone(fixture);
+    await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
+    await assertPathMissing(
+      fixture.bareTmuxLogPath,
+      "a child invoked bare tmux instead of the private wrapper",
+    );
+  }, 180_000);
 });
 
 async function createDashboardFixture(tmux: string): Promise<DashboardFixture> {
@@ -358,7 +527,7 @@ async function createDashboardFixture(tmux: string): Promise<DashboardFixture> {
     const shimDir = await writeFailingTmuxShim(root, bareTmuxLogPath);
     const observerSocketPath = join(run, "observer.sock");
     const configPath = await writeDashboardConfig({
-      root,
+      configPath: join(home, ".config/station/config.toml"),
       projectRoot,
       state,
       observerSocketPath,
@@ -388,6 +557,7 @@ async function createDashboardFixture(tmux: string): Promise<DashboardFixture> {
       nestedClientPids: new Set<number>(),
       observerPids: new Set<number>(),
       observerSocketPath,
+      otherPtyClients: [],
       panePids: new Set<number>(),
       projectRoot,
       rendererPids: new Set<number>(),
@@ -446,15 +616,15 @@ function dashboardFixtureEnv(input: {
 }
 
 async function writeDashboardConfig(input: {
+  configPath: string;
   observerSocketPath: string;
   projectRoot: string;
-  root: string;
   state: string;
   wrapper: string;
 }): Promise<string> {
-  const configPath = join(input.root, "config.toml");
+  await mkdir(dirname(input.configPath), { recursive: true });
   await writeFile(
-    configPath,
+    input.configPath,
     [
       "schema_version = 1",
       "",
@@ -486,7 +656,7 @@ async function writeDashboardConfig(input: {
     ].join("\n"),
     "utf8",
   );
-  return configPath;
+  return input.configPath;
 }
 
 async function writeFailingTmuxShim(root: string, logPath: string): Promise<string> {
@@ -741,6 +911,29 @@ async function waitForPaneContent(
   );
 }
 
+async function waitForHiddenPaneContent(
+  fixture: DashboardFixture,
+  predicate: (content: string) => boolean,
+  failureMessage: string,
+): Promise<string> {
+  const deadline = Date.now() + 30_000;
+  let content = "";
+  while (Date.now() < deadline) {
+    content = await tmuxExec(
+      fixture.wrapper,
+      ["capture-pane", "-p", "-t", persistentUiSessionName],
+      fixture.env,
+    ).catch(() => "");
+    if (predicate(content)) {
+      return content;
+    }
+    await delay(100);
+  }
+  throw new Error(
+    `${failureMessage}\nLast hidden pane:\n${content.slice(-8_000)}${await fixtureDiagnostics(fixture)}`,
+  );
+}
+
 async function fixtureDiagnostics(fixture: DashboardFixture): Promise<string> {
   const sessions = await tmuxExec(
     fixture.wrapper,
@@ -812,43 +1005,71 @@ async function readAttachRecords(path: string): Promise<AttachRecord[]> {
 async function waitForNestedClient(fixture: DashboardFixture): Promise<NestedClientEvidence> {
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
-    const output = await tmuxExec(
-      fixture.wrapper,
-      [
-        "list-clients",
-        "-t",
-        persistentUiSessionName,
-        "-F",
-        "#{client_name}\t#{client_pid}\t#{client_width}\t#{client_height}\t#{client_tty}",
-      ],
-      fixture.env,
-    ).catch(() => "");
-    const lines = nonEmptyLines(output);
-    if (lines.length > 1) {
-      throw new Error(`expected one nested popup client, found ${lines.length}`);
-    }
-    const line = lines[0];
-    if (line !== undefined) {
-      const [name, pidText, columnsText, rowsText, tty] = line.split("\t");
-      if (
-        name !== undefined &&
-        pidText !== undefined &&
-        columnsText !== undefined &&
-        rowsText !== undefined &&
-        tty !== undefined
-      ) {
-        return {
-          name,
-          pid: positiveInteger(pidText, "nested client pid"),
-          columns: positiveInteger(columnsText, "nested client columns"),
-          rows: positiveInteger(rowsText, "nested client rows"),
-          tty: normalizeTty(tty),
-        };
-      }
+    const client = await readNestedClient(fixture);
+    if (client !== undefined) {
+      fixture.nestedClientPids.add(client.pid);
+      return client;
     }
     await delay(100);
   }
   throw new Error("nested popup tmux client did not attach");
+}
+
+async function waitForNestedClientReplacement(
+  fixture: DashboardFixture,
+  previousPid: number,
+): Promise<NestedClientEvidence> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const client = await readNestedClient(fixture);
+    if (client !== undefined && client.pid !== previousPid) {
+      fixture.nestedClientPids.add(client.pid);
+      return client;
+    }
+    await delay(100);
+  }
+  throw new Error(`nested popup client ${previousPid} was not replaced`);
+}
+
+async function readNestedClient(
+  fixture: DashboardFixture,
+): Promise<NestedClientEvidence | undefined> {
+  const output = await tmuxExec(
+    fixture.wrapper,
+    [
+      "list-clients",
+      "-t",
+      persistentUiSessionName,
+      "-F",
+      "#{client_name}\t#{client_pid}\t#{client_width}\t#{client_height}\t#{client_tty}",
+    ],
+    fixture.env,
+  ).catch(() => "");
+  const lines = nonEmptyLines(output);
+  if (lines.length > 1) {
+    throw new Error(`expected one nested popup client, found ${lines.length}`);
+  }
+  const line = lines[0];
+  if (line === undefined) {
+    return undefined;
+  }
+  const [name, pidText, columnsText, rowsText, tty] = line.split("\t");
+  if (
+    name === undefined ||
+    pidText === undefined ||
+    columnsText === undefined ||
+    rowsText === undefined ||
+    tty === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    name,
+    pid: positiveInteger(pidText, "nested client pid"),
+    columns: positiveInteger(columnsText, "nested client columns"),
+    rows: positiveInteger(rowsText, "nested client rows"),
+    tty: normalizeTty(tty),
+  };
 }
 
 async function waitForNestedClientGone(fixture: DashboardFixture): Promise<void> {
@@ -893,16 +1114,19 @@ async function readPaneEvidence(fixture: DashboardFixture): Promise<PaneEvidence
   ) {
     throw new Error(`invalid hidden pane evidence: ${output}`);
   }
-  return {
+  const pane = {
     id,
     pid: positiveInteger(pidText, "hidden pane pid"),
     tty: normalizeTty(tty),
     columns: positiveInteger(columnsText, "hidden pane columns"),
     rows: positiveInteger(rowsText, "hidden pane rows"),
   };
+  fixture.panePids.add(pane.pid);
+  return pane;
 }
 
 async function waitForDashboardProcessEvidence(
+  fixture: DashboardFixture,
   pane: PaneEvidence,
 ): Promise<DashboardProcessEvidence> {
   const deadline = Date.now() + 10_000;
@@ -915,6 +1139,8 @@ async function waitForDashboardProcessEvidence(
     );
     const cliMatches = processTree.filter(isNestedDashboardCliProcess);
     const rendererMatches = processTree.filter(isDashboardRendererProcess);
+    for (const cli of cliMatches) fixture.nestedCliPids.add(cli.pid);
+    for (const renderer of rendererMatches) fixture.rendererPids.add(renderer.pid);
     if (cliMatches.length > 1) {
       throw new Error(`expected one nested dashboard CLI, found ${cliMatches.length}`);
     }
@@ -947,12 +1173,16 @@ async function waitForDashboardProcessEvidence(
 }
 
 function isNestedDashboardCliProcess(record: ProcessRecord): boolean {
-  const [command, entry, ...args] = record.command.split(/\s+/);
-  const tuiIndex = args.indexOf("tui");
-  return (
+  const [command, ...commandArgs] = record.command.split(/\s+/);
+  const sourceCli =
     command !== undefined &&
     basename(command) === basename(process.execPath) &&
-    entry === builtCliPath &&
+    commandArgs[0] === builtCliPath;
+  const compiledCli = command !== undefined && resolve(command) === builtBinaryPath;
+  const args = sourceCli ? commandArgs.slice(1) : commandArgs;
+  const tuiIndex = args.indexOf("tui");
+  return (
+    (sourceCli || compiledCli) &&
     tuiIndex >= 0 &&
     args[tuiIndex + 1] === "--popup" &&
     args[tuiIndex + 2] === "--persistent"
@@ -961,7 +1191,11 @@ function isNestedDashboardCliProcess(record: ProcessRecord): boolean {
 
 function isDashboardRendererProcess(record: ProcessRecord): boolean {
   const [command, entry] = record.command.split(/\s+/);
-  return command !== undefined && basename(command) === "bun" && entry === rendererEntry;
+  const sourceRenderer =
+    command !== undefined && basename(command) === "bun" && entry === rendererEntry;
+  const compiledRenderer =
+    command !== undefined && resolve(command) === builtBinaryPath && entry === "__dashboard";
+  return sourceRenderer || compiledRenderer;
 }
 
 async function processRecords(): Promise<ProcessRecord[]> {
@@ -1026,7 +1260,7 @@ function recordRuntimeEvidence(
   fixture.rendererPids.add(processes.renderer.pid);
 }
 
-async function recordObserverPid(fixture: DashboardFixture): Promise<void> {
+async function recordObserverPid(fixture: DashboardFixture): Promise<number> {
   const identityPath = `${fixture.observerSocketPath}.pid`;
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
@@ -1035,7 +1269,7 @@ async function recordObserverPid(fixture: DashboardFixture): Promise<void> {
       const identity = ObserverProcessIdentitySchema.parse(JSON.parse(serialized));
       expect(identity.socketPath).toBe(fixture.observerSocketPath);
       fixture.observerPids.add(identity.pid);
-      return;
+      return identity.pid;
     }
     await delay(100);
   }
@@ -1047,6 +1281,98 @@ function assertPositiveDimensions(evidence: Record<string, Dimensions>): void {
     expect(dimensions.columns, `${label} columns`).toBeGreaterThan(0);
     expect(dimensions.rows, `${label} rows`).toBeGreaterThan(0);
   }
+}
+
+async function triggerPopupBinding(client: TmuxPtyClient): Promise<void> {
+  await client.write(Buffer.from([0x02]));
+  await delay(25);
+  await client.write(Buffer.from(" ", "utf8"));
+}
+
+async function tmuxGlobalOption(fixture: DashboardFixture, name: string): Promise<string> {
+  return tmuxExec(fixture.wrapper, ["show-options", "-gqv", name], fixture.env).then((value) =>
+    value.trimEnd(),
+  );
+}
+
+async function tmuxSessionOption(fixture: DashboardFixture, name: string): Promise<string> {
+  return tmuxExec(
+    fixture.wrapper,
+    ["show-options", "-t", persistentUiSessionName, "-qv", name],
+    fixture.env,
+  ).then((value) => value.trimEnd());
+}
+
+async function waitForGlobalOptionValue(
+  fixture: DashboardFixture,
+  name: string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let actual = "";
+  while (Date.now() < deadline) {
+    actual = await tmuxGlobalOption(fixture, name);
+    if (actual === expected) {
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error(
+    `tmux option ${name} did not become ${JSON.stringify(expected)}; last value was ${JSON.stringify(actual)}${await fixtureDiagnostics(fixture)}`,
+  );
+}
+
+async function waitForCoherentActivePopup(
+  fixture: DashboardFixture,
+  owners: readonly TmuxPtyClient[],
+): Promise<{
+  nestedClient: NestedClientEvidence;
+  owner: TmuxPtyClient;
+}> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const rawClaim = await tmuxGlobalOption(fixture, "@station_popup_active_claim");
+    const claim = parsePopupActiveClaim(rawClaim);
+    const owner = owners.find((client) => client.clientName === claim?.clientName);
+    const nestedClient = await readNestedClient(fixture);
+    if (
+      claim?.state === "open" &&
+      owner !== undefined &&
+      nestedClient !== undefined &&
+      (await tmuxGlobalOption(fixture, "@station_popup_client")) === claim.clientName &&
+      (await tmuxGlobalOption(fixture, "@station_popup_focus_client")) === claim.clientName
+    ) {
+      await delay(200);
+      const settledClaim = await tmuxGlobalOption(fixture, "@station_popup_active_claim");
+      const settledClient = await readNestedClient(fixture);
+      if (
+        settledClaim === rawClaim &&
+        settledClient?.pid === nestedClient.pid &&
+        (await tmuxGlobalOption(fixture, "@station_popup_client")) === claim.clientName &&
+        (await tmuxGlobalOption(fixture, "@station_popup_focus_client")) === claim.clientName
+      ) {
+        return { nestedClient, owner };
+      }
+    }
+    await delay(100);
+  }
+  throw new Error("competing managed bindings did not settle on one coherent popup owner");
+}
+
+async function tmuxPaneInMode(fixture: DashboardFixture, sessionName: string): Promise<string> {
+  return tmuxExec(
+    fixture.wrapper,
+    ["display-message", "-p", "-t", `${sessionName}:0.0`, "#{pane_in_mode}"],
+    fixture.env,
+  ).then((value) => value.trim());
+}
+
+async function captureTmuxPane(fixture: DashboardFixture, sessionName: string): Promise<string> {
+  return tmuxExec(
+    fixture.wrapper,
+    ["capture-pane", "-p", "-S", "-", "-t", `${sessionName}:0.0`],
+    fixture.env,
+  );
 }
 
 async function closeOuterPopup(fixture: DashboardFixture): Promise<void> {
@@ -1072,8 +1398,14 @@ async function expectSuccessfulExit(child: TrackedChild, timeoutMs: number): Pro
 async function cleanupDashboardFixture(fixture: DashboardFixture): Promise<void> {
   const failures: Error[] = [];
   await cleanupStep(failures, "close active popup and await popup CLIs", async () => {
-    if (fixture.cliProcesses.some((tracked) => isChildRunning(tracked.child))) {
-      await closeOuterPopup(fixture);
+    for (const client of [fixture.ptyClient, ...fixture.otherPtyClients]) {
+      if (client !== undefined) {
+        await tmuxExec(
+          fixture.wrapper,
+          ["display-popup", "-c", client.clientName, "-C"],
+          fixture.env,
+        ).catch(() => undefined);
+      }
     }
     for (const child of fixture.cliProcesses) {
       await expectSuccessfulExit(child, 10_000);
@@ -1092,6 +1424,10 @@ async function cleanupDashboardFixture(fixture: DashboardFixture): Promise<void>
     );
   });
   await cleanupStep(failures, "detach outer PTY client", async () => {
+    const otherPtyClients = fixture.otherPtyClients.splice(0);
+    for (const client of otherPtyClients) {
+      await client.close();
+    }
     const ptyClient = fixture.ptyClient;
     fixture.ptyClient = undefined;
     await ptyClient?.close();
@@ -1236,10 +1572,6 @@ function processExists(pid: number): boolean {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
-}
-
-function isChildRunning(child: ChildProcess): boolean {
-  return child.exitCode === null && child.signalCode === null;
 }
 
 async function assertPathMissing(path: string, message: string): Promise<void> {

--- a/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
@@ -184,6 +184,14 @@ describe("managed tmux popup fast binding", () => {
     expect(await fixture.calls()).toHaveLength(1);
   });
 
+  it("falls back from a valid route with a different configured UI signature", async () => {
+    const configPath = "/tmp/station config #{session_name}/config.toml";
+    const fixture = await createFixture({}, "managed bin", configPath, "/tmp/previous-config.toml");
+
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+    expect(await fixture.fallbackConfigCalls()).toEqual([`${configPath}\t--config\t${configPath}`]);
+  });
+
   it("falls back on legacy, mixed-version, and hostile state", async () => {
     const legacy = await createFixture({ activeClient: "/dev/ttys001" });
     await expect(runBinding(legacy)).resolves.toMatchObject({ code: 0 });
@@ -258,7 +266,7 @@ describe("managed tmux popup fast binding", () => {
       "3000",
       "Station popup failed; run stn popup for details",
     ]);
-  });
+  }, 15_000);
 
   it("quotes hostile installation paths, escapes tmux formats, and produces valid POSIX shell", async () => {
     const fixture = await createFixture({}, "station's #{session_name} managed bin");
@@ -271,18 +279,39 @@ describe("managed tmux popup fast binding", () => {
     expect(action).toContain("##{session_name}");
     expect(action).not.toContain("station's #{session_name} managed bin/tmux fake");
   });
+
+  it("rejects relative or control-character config paths", () => {
+    const options = {
+      fallbackAlias: "/opt/station/stn-tmux-popup",
+      installedRoot: "/opt/station",
+      tmuxCommand: "/opt/homebrew/bin/tmux",
+    };
+    for (const configPath of [
+      "relative.toml",
+      "/tmp/config\0.toml",
+      "/tmp/config\r.toml",
+      "/tmp/config\n.toml",
+    ]) {
+      expect(() => buildManagedFastPopupRunShellCommand({ ...options, configPath })).toThrow(
+        "safe absolute config path",
+      );
+    }
+  });
 });
 
 type Fixture = {
   calls: () => Promise<Array<{ args: string[] }>>;
   command: string;
   fallbackCalls: () => Promise<string[]>;
+  fallbackConfigCalls: () => Promise<string[]>;
   statePath: string;
 };
 
 async function createFixture(
   overrides: Partial<FakeState> = {},
   directoryName = "managed bin",
+  configPath?: string,
+  registeredConfigPath = configPath,
 ): Promise<Fixture> {
   const tempRoot = await mkdtemp(join(tmpdir(), "station-fast-binding-"));
   fixtureRoots.add(tempRoot);
@@ -292,12 +321,14 @@ async function createFixture(
   const statePath = join(tempRoot, "state.json");
   const logPath = join(tempRoot, "tmux.jsonl");
   const fallbackLogPath = join(tempRoot, "fallback.log");
+  const fallbackConfigLogPath = join(tempRoot, "fallback-config.log");
   await import("node:fs/promises").then(({ mkdir }) => mkdir(installedRoot, { recursive: true }));
+  const registeredSignature = fixturePopupSignature(installedRoot, registeredConfigPath);
   const route = buildNormalPopupRoute({
     registrationNonce,
     root: installedRoot,
     sessionName: "_station-ui",
-    signature,
+    signature: registeredSignature,
   });
   const state: FakeState = {
     clientName: "/dev/ttys001",
@@ -306,12 +337,13 @@ async function createFixture(
     lease: route,
     root: installedRoot,
     route,
-    sessionSignature: signature,
+    sessionSignature: registeredSignature,
     ...overrides,
   };
   await writeFile(statePath, JSON.stringify(state));
   await writeFile(logPath, "");
   await writeFile(fallbackLogPath, "");
+  await writeFile(fallbackConfigLogPath, "");
   await writeFile(
     tmuxCommand,
     `#!/usr/bin/env node
@@ -349,6 +381,7 @@ process.exit(0);
     fallbackAlias,
     `#!/bin/sh
 printf '%s\\n' "\${STATION_FOCUS_CLIENT_ID:-}" >> ${shellLiteral(fallbackLogPath)}
+printf '%s\\t%s\\t%s\\n' "\${STATION_CONFIG_PATH:-}" "\${1:-}" "\${2:-}" >> ${shellLiteral(fallbackConfigLogPath)}
 printf 'fallback output that must stay hidden\\n'
 printf 'fallback error that must stay hidden\\n' >&2
 exit \${FAKE_FALLBACK_EXIT:-0}
@@ -356,12 +389,29 @@ exit \${FAKE_FALLBACK_EXIT:-0}
   );
   await chmod(tmuxCommand, 0o700);
   await chmod(fallbackAlias, 0o700);
+  const commandOptions: Parameters<typeof buildManagedFastPopupRunShellCommand>[0] = {
+    fallbackAlias,
+    installedRoot,
+    tmuxCommand,
+  };
+  if (configPath !== undefined) commandOptions.configPath = configPath;
   return {
     calls: async () => readJsonLines(logPath),
-    command: buildManagedFastPopupRunShellCommand({ fallbackAlias, installedRoot, tmuxCommand }),
+    command: buildManagedFastPopupRunShellCommand(commandOptions),
     fallbackCalls: async () => readLines(fallbackLogPath),
+    fallbackConfigCalls: async () => readLines(fallbackConfigLogPath),
     statePath,
   };
+}
+
+function fixturePopupSignature(installedRoot: string, configPath: string | undefined): string {
+  return `v1:${[
+    shellLiteral(join(installedRoot, "stn")),
+    ...(configPath === undefined ? [] : ["--config", shellLiteral(configPath)]),
+    "tui",
+    "--popup",
+    "--persistent",
+  ].join(" ")}`;
 }
 
 function popupClaim(state: "closing" | "open", clientPid: number, clientName: string): string {

--- a/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
@@ -1,0 +1,448 @@
+import { spawn } from "node:child_process";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildManagedFastPopupRunShellCommand } from "../../src/popup";
+import {
+  buildNormalPopupRoute,
+  buildPopupActiveClaim,
+  parseNormalPopupRoute,
+  parsePopupActiveClaim,
+} from "../../src/popup/fastProtocol";
+
+const registrationNonce = "11".repeat(16);
+const actionNonce = "22".repeat(16);
+const signature = "v1:'/opt/station/bin/stn' --config '/tmp/missing.toml' tui --popup --persistent";
+const fixtureRoots = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...fixtureRoots].map((root) => rm(root, { force: true, recursive: true })));
+  fixtureRoots.clear();
+});
+
+type FakeState = {
+  actionExit?: number;
+  activeClient?: string;
+  casMisses?: number;
+  claim?: string;
+  clientName: string;
+  clientPid: number;
+  clientSession: string;
+  devCommand?: string;
+  devOwner?: string;
+  devRoot?: string;
+  devSession?: string;
+  fallbackExit?: number;
+  focusClient?: string;
+  lease: string;
+  root: string;
+  route: string;
+  sessionSignature: string;
+  snapshotExit?: number;
+};
+
+describe("managed tmux popup fast binding", () => {
+  it("strictly parses versioned routes and claims", () => {
+    const route = buildNormalPopupRoute({
+      registrationNonce,
+      root: "/opt/station/bin",
+      sessionName: "_station-ui",
+      signature,
+    });
+    expect(parseNormalPopupRoute(route)).toMatchObject({
+      kind: "normal",
+      registrationNonce,
+    });
+    expect(parseNormalPopupRoute(`${route}.extra`)).toBeUndefined();
+    expect(parseNormalPopupRoute(route.replace("v1.n", "v1.d"))).toBeUndefined();
+    expect(parseNormalPopupRoute(route.replace(registrationNonce, "A".repeat(32)))).toBeUndefined();
+
+    const claim = buildPopupActiveClaim({
+      actionNonce,
+      clientName: "/dev/ttys001",
+      clientPid: 1234,
+      registrationNonce,
+      state: "open",
+    });
+    expect(parsePopupActiveClaim(claim)).toEqual({
+      actionNonce,
+      clientName: "/dev/ttys001",
+      clientPid: 1234,
+      registrationNonce,
+      state: "open",
+    });
+    expect(parsePopupActiveClaim(`${claim}.extra`)).toBeUndefined();
+    expect(parsePopupActiveClaim(claim.replace("/dev/ttys001", "bad name"))).toBeUndefined();
+    expect(parsePopupActiveClaim(claim.replace(".1234.", ".0."))).toBeUndefined();
+  });
+
+  it("opens in exactly one snapshot and one atomic action", async () => {
+    const fixture = await createFixture();
+    const result = await runBinding(fixture);
+
+    expect(result).toEqual({ code: 0, stderr: "", stdout: "" });
+    const calls = await fixture.calls();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.args.slice(0, 4)).toEqual(["display-message", "-p", "-t", "_station-ui:"]);
+    expect(calls[0]?.args.at(-1)).not.toContain("#{client_");
+    expect(calls[1]?.args.slice(0, 4)).toEqual(["if-shell", "-F", "-t", "_station-ui:"]);
+    const action = calls[1]?.args.at(-2) ?? "";
+    const claim = /active_claim (v1\.open\.[^ ;]+)/.exec(action)?.[1];
+    expect(claim).toBeDefined();
+    expect(action).toContain("display-popup -c /dev/ttys001");
+    expect(action).toContain(
+      `if-shell -F '#{==:#{@station_popup_active_claim},${claim}}' 'set-option -gq -u @station_popup_active_claim ; if-shell -F "#{==:#{@station_popup_client},/dev/ttys001}" "set-option -gq -u @station_popup_client" ; if-shell -F "#{==:#{@station_popup_focus_client},/dev/ttys001}" "set-option -gq -u @station_popup_focus_client"'`,
+    );
+    expect(await fixture.fallbackCalls()).toEqual([]);
+  });
+
+  it("closes the same client without reopening", async () => {
+    const fixture = await createFixture({
+      activeClient: "/dev/ttys001",
+      claim: popupClaim("open", 1234, "/dev/ttys001"),
+      focusClient: "/dev/ttys001",
+    });
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action).toContain("v1.closing.");
+    expect(action).toContain("display-popup -c /dev/ttys001 -C");
+    expect(action.match(/display-popup/g)).toHaveLength(1);
+  });
+
+  it("closes the recorded outer client from a nested UI client", async () => {
+    const fixture = await createFixture({
+      activeClient: "/dev/ttys001",
+      claim: popupClaim("open", 1234, "/dev/ttys001"),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      clientSession: "_station-ui",
+      focusClient: "/dev/ttys001",
+    });
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action).toContain("display-popup -c /dev/ttys001 -C");
+    expect(action).not.toContain("display-popup -c /dev/ttys099 -w");
+  });
+
+  it("replaces a cross-client claim before closing and reopening", async () => {
+    const fixture = await createFixture({
+      activeClient: "/dev/ttys001",
+      claim: popupClaim("open", 1234, "/dev/ttys001"),
+      clientName: "/dev/ttys002",
+      clientPid: 5678,
+      clientSession: "other",
+      focusClient: "/dev/ttys001",
+    });
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action.indexOf("set-option -gq @station_popup_active_claim v1.open.")).toBeLessThan(
+      action.indexOf("display-popup -c /dev/ttys001 -C"),
+    );
+    expect(action).toContain("display-popup -c /dev/ttys002 -w 50% -h 50%");
+  });
+
+  it("forces fallback for live dev state but ignores a provably dead dev owner", async () => {
+    const live = await createFixture({
+      devCommand: "node dev-ui",
+      devOwner: `${process.pid}:test`,
+      devRoot: "/worktree",
+      devSession: "_station-ui-dev",
+    });
+    await expect(runBinding(live)).resolves.toMatchObject({ code: 0 });
+    expect(await live.calls()).toHaveLength(1);
+    expect(await live.fallbackCalls()).toEqual(["/dev/ttys001"]);
+
+    const signalDenied = await createFixture({
+      devCommand: "node dev-ui",
+      devOwner: "1:test",
+      devRoot: "/worktree",
+      devSession: "_station-ui-dev",
+    });
+    await expect(runBinding(signalDenied)).resolves.toMatchObject({ code: 0 });
+    expect(await signalDenied.calls()).toHaveLength(1);
+    expect(await signalDenied.fallbackCalls()).toEqual(["/dev/ttys001"]);
+
+    const stale = await createFixture({
+      devCommand: "node dev-ui",
+      devOwner: "999999999:test",
+      devRoot: "/worktree",
+      devSession: "_station-ui-dev",
+    });
+    await expect(runBinding(stale)).resolves.toMatchObject({ code: 0 });
+    expect(await stale.calls()).toHaveLength(2);
+    expect(await stale.fallbackCalls()).toEqual([]);
+  });
+
+  it("passes the outer binding caller to first-use fallback when the hidden session is missing", async () => {
+    const fixture = await createFixture({ snapshotExit: 1 });
+    await expect(runBinding(fixture)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+    expect(await fixture.fallbackCalls()).toEqual(["/dev/ttys001"]);
+    expect(await fixture.calls()).toHaveLength(1);
+  });
+
+  it("falls back on legacy, mixed-version, and hostile state", async () => {
+    const legacy = await createFixture({ activeClient: "/dev/ttys001" });
+    await expect(runBinding(legacy)).resolves.toMatchObject({ code: 0 });
+    expect(await legacy.fallbackCalls()).toEqual(["/dev/ttys001"]);
+
+    const mixed = await createFixture({
+      activeClient: "/dev/ttys001",
+      claim: popupClaim("open", 1234, "/dev/ttys001").replace(registrationNonce, "33".repeat(16)),
+      focusClient: "/dev/ttys001",
+    });
+    await expect(runBinding(mixed)).resolves.toMatchObject({ code: 0 });
+    expect(await mixed.fallbackCalls()).toEqual(["/dev/ttys001"]);
+
+    const hostile = await createFixture({ route: "v1.n.$(touch /tmp/nope)" });
+    await expect(runBinding(hostile)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+    expect(await hostile.fallbackCalls()).toEqual(["/dev/ttys001"]);
+
+    const leadingZeroPid = await createFixture();
+    const state = JSON.parse(await readFile(leadingZeroPid.statePath, "utf8")) as Record<
+      string,
+      unknown
+    >;
+    state.clientPid = "01234";
+    await writeFile(leadingZeroPid.statePath, JSON.stringify(state));
+    await expect(runBinding(leadingZeroPid)).resolves.toMatchObject({ code: 0 });
+    expect(await leadingZeroPid.fallbackCalls()).toEqual(["/dev/ttys001"]);
+  }, 15_000);
+
+  it("retries one CAS miss and falls back on persistent contention", async () => {
+    const retry = await createFixture({ casMisses: 1 });
+    await expect(runBinding(retry)).resolves.toMatchObject({ code: 0 });
+    expect((await retry.calls()).map((call) => call.args[0])).toEqual([
+      "display-message",
+      "if-shell",
+      "display-message",
+      "if-shell",
+    ]);
+    expect(await retry.fallbackCalls()).toEqual([]);
+
+    const contended = await createFixture({ casMisses: 2 });
+    await expect(runBinding(contended)).resolves.toMatchObject({ code: 0 });
+    expect(await contended.fallbackCalls()).toEqual(["/dev/ttys001"]);
+  });
+
+  it("cleans only its exact claim after an action failure before fallback", async () => {
+    const fixture = await createFixture({ actionExit: 1 });
+    await expect(runBinding(fixture)).resolves.toMatchObject({ code: 0 });
+
+    const calls = await fixture.calls();
+    expect(calls).toHaveLength(3);
+    expect(calls[2]?.args[4]).toMatch(/^#\{==:#\{@station_popup_active_claim\},v1\.open\./);
+    expect(await fixture.fallbackCalls()).toEqual(["/dev/ttys001"]);
+  });
+
+  it("normalizes action and fallback exits 0 and 129, and hides fallback failure output", async () => {
+    for (const actionExit of [0, 129]) {
+      const fixture = await createFixture({ actionExit });
+      await expect(runBinding(fixture)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+      expect(await fixture.fallbackCalls()).toEqual([]);
+    }
+
+    for (const fallbackExit of [0, 129]) {
+      const fixture = await createFixture({ fallbackExit, route: "malformed" });
+      await expect(runBinding(fixture)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+    }
+
+    const failed = await createFixture({ fallbackExit: 1, route: "malformed" });
+    await expect(runBinding(failed)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+    expect((await failed.calls()).at(-1)?.args).toEqual([
+      "display-message",
+      "-d",
+      "3000",
+      "Station popup failed; run stn popup for details",
+    ]);
+  });
+
+  it("quotes hostile installation paths, escapes tmux formats, and produces valid POSIX shell", async () => {
+    const fixture = await createFixture({}, "station's #{session_name} managed bin");
+    expect(fixture.command).not.toMatch(/[\r\n]/);
+    expect(fixture.command).toContain("##{session_name}");
+    const syntax = await runShell(fixture.command, ["-n", "-c"]);
+    expect(syntax).toEqual({ code: 0, stderr: "", stdout: "" });
+    await expect(runBinding(fixture)).resolves.toEqual({ code: 0, stderr: "", stdout: "" });
+    const action = (await fixture.calls())[1]?.args.at(-2) ?? "";
+    expect(action).toContain("##{session_name}");
+    expect(action).not.toContain("station's #{session_name} managed bin/tmux fake");
+  });
+});
+
+type Fixture = {
+  calls: () => Promise<Array<{ args: string[] }>>;
+  command: string;
+  fallbackCalls: () => Promise<string[]>;
+  statePath: string;
+};
+
+async function createFixture(
+  overrides: Partial<FakeState> = {},
+  directoryName = "managed bin",
+): Promise<Fixture> {
+  const tempRoot = await mkdtemp(join(tmpdir(), "station-fast-binding-"));
+  fixtureRoots.add(tempRoot);
+  const installedRoot = join(tempRoot, directoryName);
+  const tmuxCommand = join(installedRoot, "tmux fake");
+  const fallbackAlias = join(installedRoot, "stn-tmux-popup");
+  const statePath = join(tempRoot, "state.json");
+  const logPath = join(tempRoot, "tmux.jsonl");
+  const fallbackLogPath = join(tempRoot, "fallback.log");
+  await import("node:fs/promises").then(({ mkdir }) => mkdir(installedRoot, { recursive: true }));
+  const route = buildNormalPopupRoute({
+    registrationNonce,
+    root: installedRoot,
+    sessionName: "_station-ui",
+    signature,
+  });
+  const state: FakeState = {
+    clientName: "/dev/ttys001",
+    clientPid: 1234,
+    clientSession: "outer",
+    lease: route,
+    root: installedRoot,
+    route,
+    sessionSignature: signature,
+    ...overrides,
+  };
+  await writeFile(statePath, JSON.stringify(state));
+  await writeFile(logPath, "");
+  await writeFile(fallbackLogPath, "");
+  await writeFile(
+    tmuxCommand,
+    `#!/usr/bin/env node
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+const statePath = process.env.FAKE_TMUX_STATE;
+const logPath = process.env.FAKE_TMUX_LOG;
+const state = JSON.parse(readFileSync(statePath, "utf8"));
+const args = process.argv.slice(2);
+appendFileSync(logPath, JSON.stringify({ args }) + "\\n");
+if (args[0] === "display-message" && args[1] === "-p" && args[2] === "-t") {
+  if (state.snapshotExit !== undefined) process.exit(state.snapshotExit);
+  const fields = [
+    state.route, state.lease, state.claim ?? "", state.sessionSignature,
+    "_station-ui", state.sessionSignature, state.root,
+    state.activeClient ?? "", state.focusClient ?? "",
+    state.devSession ?? "", state.devCommand ?? "", state.devOwner ?? "", state.devRoot ?? "",
+    "v1",
+  ];
+  process.stdout.write(fields.join(String.fromCharCode(31)) + "\\n");
+  process.exit(0);
+}
+if (args[0] === "if-shell" && args.at(-1) === "display-message -p STATION_POPUP_CAS_MISS") {
+  if ((state.casMisses ?? 0) > 0) {
+    state.casMisses -= 1;
+    writeFileSync(statePath, JSON.stringify(state));
+    process.stdout.write("STATION_POPUP_CAS_MISS\\n");
+    process.exit(0);
+  }
+  process.exit(state.actionExit ?? 0);
+}
+process.exit(0);
+`,
+  );
+  await writeFile(
+    fallbackAlias,
+    `#!/bin/sh
+printf '%s\\n' "\${STATION_FOCUS_CLIENT_ID:-}" >> ${shellLiteral(fallbackLogPath)}
+printf 'fallback output that must stay hidden\\n'
+printf 'fallback error that must stay hidden\\n' >&2
+exit \${FAKE_FALLBACK_EXIT:-0}
+`,
+  );
+  await chmod(tmuxCommand, 0o700);
+  await chmod(fallbackAlias, 0o700);
+  return {
+    calls: async () => readJsonLines(logPath),
+    command: buildManagedFastPopupRunShellCommand({ fallbackAlias, installedRoot, tmuxCommand }),
+    fallbackCalls: async () => readLines(fallbackLogPath),
+    statePath,
+  };
+}
+
+function popupClaim(state: "closing" | "open", clientPid: number, clientName: string): string {
+  return buildPopupActiveClaim({
+    actionNonce,
+    clientName,
+    clientPid,
+    registrationNonce,
+    state,
+  });
+}
+
+async function runBinding(
+  fixture: Fixture,
+): Promise<{ code: number | null; stderr: string; stdout: string }> {
+  const state = JSON.parse(await readFile(fixture.statePath, "utf8")) as FakeState;
+  const expanded = expandTmuxBindingFormats(fixture.command, state);
+  return runShell(expanded, ["-c"], {
+    FAKE_FALLBACK_EXIT: String(state.fallbackExit ?? 0),
+    FAKE_TMUX_LOG: fixture.statePath.replace("state.json", "tmux.jsonl"),
+    FAKE_TMUX_STATE: fixture.statePath,
+  });
+}
+
+function expandTmuxBindingFormats(command: string, state: FakeState): string {
+  const formats = [
+    ["#{q:client_name}", state.clientName],
+    ["#{client_pid}", String(state.clientPid)],
+    ["#{q:client_session}", state.clientSession],
+  ] as const;
+  let expanded = "";
+  for (let index = 0; index < command.length; index += 1) {
+    if (command.startsWith("##", index)) {
+      expanded += "#";
+      index += 1;
+      continue;
+    }
+    const format = formats.find(([token]) => command.startsWith(token, index));
+    if (format === undefined) {
+      expanded += command[index];
+      continue;
+    }
+    expanded += format[1];
+    index += format[0].length - 1;
+  }
+  return expanded;
+}
+
+async function runShell(
+  command: string,
+  args: string[],
+  env: Record<string, string> = {},
+): Promise<{ code: number | null; stderr: string; stdout: string }> {
+  const child = spawn("/bin/sh", [...args, command], {
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout: Buffer[] = [];
+  const stderr: Buffer[] = [];
+  child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("exit", (code) =>
+      resolve({
+        code,
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        stdout: Buffer.concat(stdout).toString("utf8"),
+      }),
+    );
+  });
+}
+
+async function readJsonLines(path: string): Promise<Array<{ args: string[] }>> {
+  return (await readLines(path)).map((line) => JSON.parse(line) as { args: string[] });
+}
+
+async function readLines(path: string): Promise<string[]> {
+  return (await readFile(path, "utf8")).split(/\r?\n/).filter((line) => line.length > 0);
+}
+
+function shellLiteral(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -1,5 +1,5 @@
 import { setTimeout as sleep } from "node:timers/promises";
-import type { ExternalCommandInput } from "@station/runtime";
+import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import {
   buildTmuxPopupArgs,
@@ -9,12 +9,16 @@ import {
   resolveRegisteredDevPopupUi,
   resolveTmuxPopupFocusOrigin,
 } from "../../src/popup";
+import { buildNormalPopupRoute, buildPopupActiveClaim } from "../../src/popup/fastProtocol";
 import { tmuxCommandResult } from "../support/commands";
 
-const defaultPersistentSignature = "v1:stn tui --popup --persistent";
+const defaultCommand = "stn tui --popup --persistent";
+const defaultSignature = `v1:${defaultCommand}`;
+const registrationNonce = "11".repeat(16);
+const actionNonce = "22".repeat(16);
 
 describe("tmux popup", () => {
-  it("builds a persistent popup command that attaches the hidden UI session", () => {
+  it("builds persistent and transient popup commands", () => {
     expect(buildTmuxPopupArgs()).toEqual([
       "display-popup",
       "-w",
@@ -24,9 +28,6 @@ describe("tmux popup", () => {
       "-E",
       "env -u TMUX tmux -T hyperlinks attach-session -t _station-ui",
     ]);
-  });
-
-  it("keeps transient TUI popup command construction available", () => {
     expect(buildTmuxPopupArgs({ persistent: false, focusClientId: "client_1" })).toEqual([
       "display-popup",
       "-c",
@@ -40,25 +41,20 @@ describe("tmux popup", () => {
     ]);
   });
 
-  it("creates the persistent UI session only when it is missing", async () => {
-    const calls: ExternalCommandInput[] = [];
-
+  it("creates, reuses, and replaces the persistent UI by exact signature", async () => {
+    const missingCalls: ExternalCommandInput[] = [];
     await expect(
       ensurePersistentPopupSession({
         runner: async (input) => {
-          calls.push(input);
+          missingCalls.push(input);
           if (input.args?.[0] === "has-session") {
-            throw Object.assign(new Error("can't find session"), {
-              code: 1,
-              stderr: "can't find session",
-            });
+            throw Object.assign(new Error("missing"), { code: 1 });
           }
           return tmuxCommandResult(input);
         },
       }),
-    ).resolves.toEqual({ sessionName: "_station-ui", created: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
+    ).resolves.toEqual({ created: true, sessionName: "_station-ui" });
+    expect(missingCalls.map((call) => call.args)).toEqual([
       ["has-session", "-t", "_station-ui"],
       [
         "new-session",
@@ -69,542 +65,411 @@ describe("tmux popup", () => {
         "station-ui",
         "env STATION_TUI_POPUP=1 STATION_FOCUS_PROVIDER=tmux stn tui --popup --persistent",
       ],
-      [
-        "set-option",
-        "-t",
-        "_station-ui",
-        "-q",
-        "@station_popup_ui_signature",
-        defaultPersistentSignature,
-      ],
-      persistentPopupMouseCall("_station-ui"),
+      ["set-option", "-t", "_station-ui", "-q", "@station_popup_ui_signature", defaultSignature],
+      popupMouseCall,
     ]);
 
-    calls.length = 0;
+    const reusedCalls: ExternalCommandInput[] = [];
     await expect(
       ensurePersistentPopupSession({
         runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "show-options") {
-            return tmuxCommandResult(input, `${defaultPersistentSignature}\n`);
+          reusedCalls.push(input);
+          if (input.args?.includes("@station_popup_ui_signature")) {
+            return tmuxCommandResult(input, `${defaultSignature}\n`);
           }
           return tmuxCommandResult(input);
         },
       }),
-    ).resolves.toEqual({ sessionName: "_station-ui", created: false });
-    expect(calls.map((call) => call.args)).toEqual([
+    ).resolves.toEqual({ created: false, sessionName: "_station-ui" });
+    expect(reusedCalls.map((call) => call.args)).toEqual([
       ["has-session", "-t", "_station-ui"],
       ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
+      popupMouseCall,
     ]);
-  });
 
-  it("recreates the persistent UI session when its command signature changed", async () => {
-    const calls: ExternalCommandInput[] = [];
-
+    const replacedCalls: ExternalCommandInput[] = [];
     await expect(
       ensurePersistentPopupSession({
-        tuiCommand: "node stn tui --popup --persistent --config /tmp/config-b.toml",
+        tuiCommand: "node current tui --popup --persistent",
         runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "show-options") {
-            return tmuxCommandResult(
-              input,
-              "v1:node stn tui --popup --persistent --config /tmp/config-a.toml\n",
-            );
+          replacedCalls.push(input);
+          if (input.args?.includes("@station_popup_ui_signature")) {
+            return tmuxCommandResult(input, "v1:node stale tui --popup --persistent\n");
           }
           return tmuxCommandResult(input);
         },
       }),
-    ).resolves.toEqual({ sessionName: "_station-ui", created: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      ["kill-session", "-t", "_station-ui"],
-      [
-        "new-session",
-        "-d",
-        "-s",
-        "_station-ui",
-        "-n",
-        "station-ui",
-        "env STATION_TUI_POPUP=1 STATION_FOCUS_PROVIDER=tmux node stn tui --popup --persistent --config /tmp/config-b.toml",
-      ],
-      [
-        "set-option",
-        "-t",
-        "_station-ui",
-        "-q",
-        "@station_popup_ui_signature",
-        "v1:node stn tui --popup --persistent --config /tmp/config-b.toml",
-      ],
-      persistentPopupMouseCall("_station-ui"),
+    ).resolves.toEqual({ created: true, sessionName: "_station-ui" });
+    expect(replacedCalls.map((call) => call.args)).toContainEqual([
+      "kill-session",
+      "-t",
+      "_station-ui",
     ]);
   });
 
-  it("opens the popup by attaching the persistent UI session and recording tmux popup state", async () => {
-    const calls: ExternalCommandInput[] = [];
-
+  it("registers lease and mirrors before committing the route, then opens with a claim", async () => {
+    const fake = createPopupTmux({ root: "/opt/station/bin" });
     await expect(
       openTmuxPopup({
-        checkoutRoot: "/worktrees/current",
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, `${defaultPersistentSignature}\n`);
-          }
-          return tmuxCommandResult(input);
-        },
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
-        config: {
-          popupWidth: "90%",
-          popupHeight: "80%",
-          popupPosition: "C",
-        },
+        checkoutRoot: fake.root,
+        config: { popupHeight: "80%", popupPosition: "C", popupWidth: "90%" },
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
       }),
     ).resolves.toEqual({ opened: true });
 
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_1"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_1"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls(
-        "_station-ui",
-        "stn tui --popup --persistent",
-        "/worktrees/current",
-      ),
-      [
-        "display-popup",
-        "-c",
-        "client_1",
-        "-w",
-        "90%",
-        "-h",
-        "80%",
-        "-E",
-        expect.stringContaining("env -u TMUX tmux -T hyperlinks attach-session -t _station-ui"),
-      ],
+    const leaseIndex = fake.indexOfSet("@station_popup_ui_lease");
+    const sessionMirrorIndex = fake.indexOfSet("@station_popup_ui_session_name");
+    const signatureMirrorIndex = fake.indexOfSet("@station_popup_ui_expected_signature");
+    const rootMirrorIndex = fake.indexOfSet("@station_popup_ui_root");
+    const routeCommitIndex = fake.calls.findIndex(
+      (call) => call.args?.[0] === "if-shell" && call.args.at(-1)?.includes("popup_ui_route"),
+    );
+    const claimIndex = fake.calls.findIndex(
+      (call) =>
+        call.args?.[0] === "if-shell" &&
+        call.args.some((arg) => arg.includes("@station_popup_active_claim v1.open.")),
+    );
+    expect(leaseIndex).toBeGreaterThan(-1);
+    expect(leaseIndex).toBeLessThan(sessionMirrorIndex);
+    expect(sessionMirrorIndex).toBeLessThan(signatureMirrorIndex);
+    expect(signatureMirrorIndex).toBeLessThan(rootMirrorIndex);
+    expect(rootMirrorIndex).toBeLessThan(routeCommitIndex);
+    expect(routeCommitIndex).toBeLessThan(claimIndex);
+
+    const display = fake.calls.findLast((call) => call.args?.[0] === "display-popup");
+    expect(display?.args).toEqual([
+      "display-popup",
+      "-c",
+      "/dev/ttys001",
+      "-w",
+      "90%",
+      "-h",
+      "80%",
+      "-E",
+      expect.stringContaining("@station_popup_active_claim"),
     ]);
-    const displayPopupArgs = calls.at(-1)?.args;
-    const popupShellCommand = displayPopupArgs?.[displayPopupArgs.length - 1];
-    expect(popupShellCommand).toContain("tmux -T hyperlinks attach-session -t _station-ui");
-    expect(popupShellCommand).toContain("fi; if");
-    expect(popupShellCommand).not.toContain("fi if");
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toMatch(/^v1\.open\./);
   });
 
-  it("prefers a registered dev popup UI when requested", async () => {
-    const calls: ExternalCommandInput[] = [];
-    const devCommand =
-      "env STATION_TUI_DEV=1 node /worktrees/tui-layout/scripts/tui-watch-runner.mjs /worktrees/tui-layout/apps/cli/dist/main.js tui --popup --persistent";
-    const devSession = "_station-ui-dev-tui-layout-1234abcd";
+  it("reuses a valid route and transitions a same-client claim to closing without replacing UI", async () => {
+    const fake = createPopupTmux({ activeClaim: true, registered: true, root: "/opt/station/bin" });
+    await expect(
+      openTmuxPopup({
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
+      }),
+    ).resolves.toEqual({ closed: true, opened: false });
+
+    expect(fake.calls).toContainEqual(
+      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
+    );
+    expect(fake.calls.some((call) => call.args?.[0] === "kill-session")).toBe(false);
+    expect(fake.calls.some((call) => call.args?.[0] === "new-session")).toBe(false);
+    const claimWrites = fake.claimWrites();
+    expect(claimWrites).toHaveLength(1);
+    expect(claimWrites[0]).toMatch(/^v1\.closing\./);
+    expect(fake.globalOptions.has("@station_popup_active_claim")).toBe(false);
+  });
+
+  it("migrates a same-client legacy toggle through an exact closing claim", async () => {
+    const fake = createPopupTmux({ registered: true, root: "/opt/station/bin" });
+    fake.globalOptions.set("@station_popup_client", "/dev/ttys001");
+    fake.globalOptions.set("@station_popup_focus_client", "/dev/ttys001");
 
     await expect(
       openTmuxPopup({
-        preferRegisteredDevPopup: true,
-        registeredDevPopupRoot: "/worktrees/tui-layout",
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_tui_dev_session_name")
-          ) {
-            return tmuxCommandResult(input, `${devSession}\n`);
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_tui_dev_command")
-          ) {
-            return tmuxCommandResult(input, `${devCommand}\n`);
-          }
-          if (input.args?.[0] === "show-options" && input.args.includes("@station_tui_dev_owner")) {
-            return tmuxCommandResult(input, `${process.pid}:test\n`);
-          }
-          if (input.args?.[0] === "show-options" && input.args.includes("@station_tui_dev_root")) {
-            return tmuxCommandResult(input, "/worktrees/tui-layout\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, `v1:${devCommand}\n`);
-          }
-          return tmuxCommandResult(input);
-        },
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
       }),
-    ).resolves.toEqual({ opened: true });
+    ).resolves.toEqual({ closed: true, opened: false });
 
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_1"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_1"],
-      ["show-options", "-gqv", "@station_tui_dev_session_name"],
-      ["show-options", "-gqv", "@station_tui_dev_command"],
-      ["show-options", "-gqv", "@station_tui_dev_owner"],
-      ["show-options", "-gqv", "@station_tui_dev_root"],
-      ["has-session", "-t", devSession],
-      ["show-options", "-t", devSession, "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall(devSession),
-      expect.arrayContaining(["display-popup", "-c", "client_1"]),
-    ]);
-    const displayPopupArgs = calls.at(-1)?.args;
-    expect(displayPopupArgs?.at(-1)).toContain(`attach-session -t ${devSession}`);
+    expect(fake.claimWrites()).toEqual([expect.stringMatching(/^v1\.closing\./)]);
+    expect(fake.calls).toContainEqual(
+      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
+    );
+    expect(fake.globalOptions.has("@station_popup_active_claim")).toBe(false);
   });
 
-  it("resolves registered dev popup metadata only for a live owner", async () => {
-    const devCommand = "env STATION_TUI_DEV=1 node /wt/scripts/tui-watch-runner.mjs /wt/apps/cli";
-
-    await expect(
-      resolveRegisteredDevPopupUi({
-        runner: async (input) => {
-          if (input.args?.includes("@station_tui_dev_session_name")) {
-            return tmuxCommandResult(input, "_station-ui-dev-wt-1234abcd\n");
-          }
-          if (input.args?.includes("@station_tui_dev_command")) {
-            return tmuxCommandResult(input, `${devCommand}\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_owner")) {
-            return tmuxCommandResult(input, `${process.pid}:test\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_root")) {
-            return tmuxCommandResult(input, "/wt\n");
-          }
-          return tmuxCommandResult(input);
-        },
-      }),
-    ).resolves.toEqual({
-      command: devCommand,
-      owner: `${process.pid}:test`,
-      root: "/wt",
-      sessionName: "_station-ui-dev-wt-1234abcd",
+  it("replaces the claim before closing a cross-client popup", async () => {
+    const fake = createPopupTmux({
+      activeClaim: true,
+      clientName: "/dev/ttys002",
+      clientPid: 5678,
+      registered: true,
+      root: "/opt/station/bin",
     });
-
-    await expect(
-      resolveRegisteredDevPopupUi({
-        runner: async (input) => {
-          if (input.args?.includes("@station_tui_dev_session_name")) {
-            return tmuxCommandResult(input, "_station-ui-dev-stale-1234abcd\n");
-          }
-          if (input.args?.includes("@station_tui_dev_command")) {
-            return tmuxCommandResult(input, `${devCommand}\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_owner")) {
-            return tmuxCommandResult(input, "999999999:test\n");
-          }
-          return tmuxCommandResult(input);
-        },
-      }),
-    ).resolves.toBeUndefined();
-  });
-
-  it("falls back to the normal persistent UI when the registered dev owner is stale", async () => {
-    const calls: ExternalCommandInput[] = [];
-    const devCommand = "env STATION_TUI_DEV=1 node /stale/scripts/tui-watch-runner.mjs /stale/cli";
-
     await expect(
       openTmuxPopup({
-        preferRegisteredDevPopup: true,
-        tuiCommand: "node normal-station tui --popup --persistent",
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (input.args?.includes("@station_tui_dev_session_name")) {
-            return tmuxCommandResult(input, "_station-ui-dev-stale-1234abcd\n");
-          }
-          if (input.args?.includes("@station_tui_dev_command")) {
-            return tmuxCommandResult(input, `${devCommand}\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_owner")) {
-            return tmuxCommandResult(input, "999999999:test\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, "v1:node normal-station tui --popup --persistent\n");
-          }
-          return tmuxCommandResult(input);
-        },
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
       }),
     ).resolves.toEqual({ opened: true });
 
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_1"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_1"],
-      ["show-options", "-gqv", "@station_tui_dev_session_name"],
-      ["show-options", "-gqv", "@station_tui_dev_command"],
-      ["show-options", "-gqv", "@station_tui_dev_owner"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls("_station-ui", "node normal-station tui --popup --persistent"),
-      expect.arrayContaining(["display-popup", "-c", "client_1"]),
-    ]);
-    const displayPopupArgs = calls.at(-1)?.args;
-    expect(displayPopupArgs?.at(-1)).toContain("attach-session -t _station-ui");
+    const claimWriteIndex = fake.calls.findIndex((call) =>
+      call.args?.at(-1)?.includes("@station_popup_active_claim v1.open."),
+    );
+    const closeIndex = fake.calls.findIndex(
+      (call) => call.args?.[0] === "display-popup" && call.args.includes("-C"),
+    );
+    expect(claimWriteIndex).toBeLessThan(closeIndex);
+    expect(fake.calls[closeIndex]?.args).toEqual(["display-popup", "-c", "/dev/ttys001", "-C"]);
   });
 
-  it("falls back to the normal persistent UI when the registered dev root differs", async () => {
-    const calls: ExternalCommandInput[] = [];
-    const devCommand = "env STATION_TUI_DEV=1 node /other/scripts/tui-watch-runner.mjs /other/cli";
-
-    await expect(
-      openTmuxPopup({
-        preferRegisteredDevPopup: true,
-        registeredDevPopupRoot: "/current",
-        tuiCommand: "node current-station tui --popup --persistent",
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (input.args?.includes("@station_tui_dev_session_name")) {
-            return tmuxCommandResult(input, "_station-ui-dev-other-1234abcd\n");
-          }
-          if (input.args?.includes("@station_tui_dev_command")) {
-            return tmuxCommandResult(input, `${devCommand}\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_owner")) {
-            return tmuxCommandResult(input, `${process.pid}:test\n`);
-          }
-          if (input.args?.includes("@station_tui_dev_root")) {
-            return tmuxCommandResult(input, "/other\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, "v1:node current-station tui --popup --persistent\n");
-          }
-          return tmuxCommandResult(input);
-        },
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
-      }),
-    ).resolves.toEqual({ opened: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_1"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_1"],
-      ["show-options", "-gqv", "@station_tui_dev_session_name"],
-      ["show-options", "-gqv", "@station_tui_dev_command"],
-      ["show-options", "-gqv", "@station_tui_dev_owner"],
-      ["show-options", "-gqv", "@station_tui_dev_root"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls(
-        "_station-ui",
-        "node current-station tui --popup --persistent",
-        "/current",
-      ),
-      expect.arrayContaining(["display-popup", "-c", "client_1"]),
-    ]);
-  });
-
-  it("closes an active popup for the current client without killing the UI session", async () => {
-    const calls: ExternalCommandInput[] = [];
-
-    await expect(
-      openTmuxPopup({
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (input.args?.[0] === "show-options") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          return tmuxCommandResult(input);
-        },
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
-      }),
-    ).resolves.toEqual({ opened: false, closed: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["display-popup", "-c", "client_1", "-C"],
-      ["set-option", "-gq", "-u", "@station_popup_client"],
-      ["set-option", "-gq", "-u", "@station_popup_focus_client"],
-    ]);
-    expect(calls.some((call) => call.args?.[0] === "kill-session")).toBe(false);
-    expect(calls.some((call) => call.args?.[0] === "new-session")).toBe(false);
-  });
-
-  it("closes a popup active for another client before opening a new one", async () => {
-    const calls: ExternalCommandInput[] = [];
-
-    await expect(
-      openTmuxPopup({
-        env: {
-          STATION_FOCUS_CLIENT_ID: "client_2",
-        },
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "show-options" && input.args.includes("@station_popup_client")) {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, `${defaultPersistentSignature}\n`);
-          }
-          return tmuxCommandResult(input);
-        },
-      }),
-    ).resolves.toEqual({ opened: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["display-popup", "-c", "client_1", "-C"],
-      ["set-option", "-gq", "@station_popup_client", "client_2"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_2"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls("_station-ui", "stn tui --popup --persistent"),
-      expect.arrayContaining(["display-popup", "-c", "client_2"]),
-    ]);
-  });
-
-  it("resolves the focus origin from the current tmux popup client option", async () => {
-    await expect(
-      resolveTmuxPopupFocusOrigin({
-        runner: async (input) => tmuxCommandResult(input, "client_2\n"),
-      }),
-    ).resolves.toEqual({
+  it("uses a valid claim for focus origin and falls back to the compatibility mirror", async () => {
+    const claimed = createPopupTmux({ activeClaim: true, registered: true });
+    await expect(resolveTmuxPopupFocusOrigin({ runner: claimed.runner })).resolves.toEqual({
+      clientId: "/dev/ttys001",
       provider: "tmux",
-      clientId: "client_2",
+    });
+
+    const legacy = createPopupTmux();
+    legacy.globalOptions.set("@station_popup_focus_client", "legacy-client");
+    await expect(resolveTmuxPopupFocusOrigin({ runner: legacy.runner })).resolves.toEqual({
+      clientId: "legacy-client",
+      provider: "tmux",
     });
   });
 
-  it("dismisses the popup for the recorded focus client", async () => {
-    const calls: ExternalCommandInput[] = [];
+  it("dismisses through a closing claim and exact compare-clear", async () => {
+    const fake = createPopupTmux({ activeClaim: true, registered: true });
+    await expect(dismissTmuxPopup({ runner: fake.runner })).resolves.toEqual({ dismissed: true });
+    expect(fake.claimWrites()).toEqual([expect.stringMatching(/^v1\.closing\./)]);
+    expect(fake.calls).toContainEqual(
+      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
+    );
+    expect(fake.globalOptions.has("@station_popup_active_claim")).toBe(false);
+  });
 
+  it("does not let delayed cleanup erase a replacement claim", async () => {
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "44".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    const fake = createPopupTmux({
+      displayExit: 129,
+      replaceClaimBeforeCleanup: replacement,
+      root: "/opt/station/bin",
+    });
     await expect(
-      dismissTmuxPopup({
+      openTmuxPopup({
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
+      }),
+    ).resolves.toEqual({ opened: true });
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+    expect(fake.globalOptions.get("@station_popup_client")).toBe("/dev/ttys099");
+  });
+
+  it("does not let legacy cleanup or dismiss contention erase a replacement owner", async () => {
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "44".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    const legacy = createPopupTmux({
+      displayExit: 129,
+      replaceClaimBeforeLegacyAction: replacement,
+    });
+    await expect(
+      openTmuxPopup({
+        env: { STATION_FOCUS_CLIENT_ID: "/dev/ttys001" },
+        runner: legacy.runner,
+      }),
+    ).resolves.toEqual({ opened: true });
+    expect(legacy.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+    expect(legacy.globalOptions.get("@station_popup_client")).toBe("/dev/ttys099");
+
+    const contended = createPopupTmux({ activeClaim: true, claimCasMisses: 2 });
+    await expect(dismissTmuxPopup({ runner: contended.runner })).resolves.toEqual({
+      dismissed: false,
+    });
+    expect(contended.calls.some((call) => call.args?.[0] === "display-popup")).toBe(false);
+    expect(contended.globalOptions.has("@station_popup_active_claim")).toBe(true);
+  });
+
+  it("CAS-replaces malformed route state without an unconditional clear", async () => {
+    const replacementRoute = buildNormalPopupRoute({
+      registrationNonce: "55".repeat(16),
+      root: "/other/root",
+      sessionName: "_station-ui",
+      signature: defaultSignature,
+    });
+    const fake = createPopupTmux({
+      concurrentRouteBeforeCommit: replacementRoute,
+      malformedRoute: "hostile#,}route",
+      root: "/opt/station/bin",
+    });
+    await openTmuxPopup({
+      checkoutRoot: fake.root,
+      env: {},
+      runner: fake.runner,
+    });
+    expect(
+      fake.calls.some(
+        (call) =>
+          call.args?.[0] === "set-option" &&
+          call.args.includes("-u") &&
+          call.args.includes("@station_popup_ui_route"),
+      ),
+    ).toBe(false);
+    expect(fake.globalOptions.get("@station_popup_ui_route")).toBe(replacementRoute);
+  });
+
+  it("prefers only a live same-root dev UI and rejects stale or wrong-root registrations", async () => {
+    const fake = createPopupTmux({
+      devCommand: "node dev-ui tui --popup --persistent",
+      devOwner: `${process.pid}:test`,
+      devRoot: "/worktree",
+      devSession: "_station-ui-dev",
+      root: "/worktree",
+    });
+    fake.sessionSignatures.set("_station-ui-dev", `v1:${fake.devCommand}`);
+    await expect(
+      openTmuxPopup({
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        preferRegisteredDevPopup: true,
+        registeredDevPopupRoot: "/worktree",
+        runner: fake.runner,
+      }),
+    ).resolves.toEqual({ opened: true });
+    expect(
+      fake.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
+    ).toContain("attach-session -t _station-ui-dev");
+
+    await expect(resolveRegisteredDevPopupUi({ runner: fake.runner })).resolves.toMatchObject({
+      command: fake.devCommand,
+      root: "/worktree",
+      sessionName: "_station-ui-dev",
+    });
+
+    const stale = createPopupTmux({
+      devCommand: "node stale-ui tui --popup --persistent",
+      devOwner: "999999999:test",
+      devRoot: "/worktree",
+      devSession: "_station-ui-dev-stale",
+      root: "/worktree",
+    });
+    stale.sessionSignatures.set("_station-ui-dev-stale", `v1:${stale.devCommand}`);
+    await openTmuxPopup({
+      env: { TMUX: "/tmp/tmux/default,1,0" },
+      preferRegisteredDevPopup: true,
+      registeredDevPopupRoot: "/worktree",
+      runner: stale.runner,
+    });
+    expect(
+      stale.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
+    ).toContain("attach-session -t _station-ui");
+
+    const wrongRoot = createPopupTmux({
+      devCommand: "node other-ui tui --popup --persistent",
+      devOwner: `${process.pid}:test`,
+      devRoot: "/other",
+      devSession: "_station-ui-dev-other",
+      root: "/worktree",
+    });
+    wrongRoot.sessionSignatures.set("_station-ui-dev-other", `v1:${wrongRoot.devCommand}`);
+    await openTmuxPopup({
+      env: { TMUX: "/tmp/tmux/default,1,0" },
+      preferRegisteredDevPopup: true,
+      registeredDevPopupRoot: "/worktree",
+      runner: wrongRoot.runner,
+    });
+    expect(
+      wrongRoot.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
+    ).toContain("attach-session -t _station-ui");
+  });
+
+  it("enters the workbench before displaying the popup", async () => {
+    const fake = createPopupTmux({ root: "/opt/station/bin" });
+    await openTmuxPopup({
+      checkoutRoot: fake.root,
+      enterWorkbench: true,
+      env: { TMUX: "/tmp/tmux/default,1,0" },
+      runner: fake.runner,
+    });
+    const switchIndex = fake.calls.findIndex((call) => call.args?.[0] === "switch-client");
+    const displayIndex = fake.calls.findIndex(
+      (call) => call.args?.[0] === "display-popup" && !call.args.includes("-C"),
+    );
+    expect(fake.calls[switchIndex]?.args).toEqual([
+      "switch-client",
+      "-c",
+      "/dev/ttys001",
+      "-t",
+      "station",
+    ]);
+    expect(switchIndex).toBeLessThan(displayIndex);
+  });
+
+  it("guards compatibility open and legacy focus cleanup against claims", async () => {
+    for (const claim of ["valid", "malformed"] as const) {
+      const fake = createPopupTmux({ activeClaim: claim === "valid" });
+      if (claim === "malformed") {
+        fake.globalOptions.set("@station_popup_active_claim", "future.claim.format");
+      }
+      await expect(
+        openTmuxPopup({
+          env: { STATION_FOCUS_CLIENT_ID: "/dev/ttys001" },
+          runner: fake.runner,
+        }),
+      ).rejects.toMatchObject({ code: "TERMINAL_OPEN_FAILED" });
+      expect(
+        fake.calls.some(
+          (call) => call.args?.[0] === "set-option" && call.args.includes("@station_popup_client"),
+        ),
+      ).toBe(false);
+      expect(fake.calls.some((call) => call.args?.includes("-C"))).toBe(false);
+    }
+
+    const legacy = createPopupTmux();
+    legacy.globalOptions.set("@station_popup_focus_client", "/dev/ttys001");
+    await openTmuxPopup({ env: {}, runner: legacy.runner });
+    expect(legacy.globalOptions.has("@station_popup_focus_client")).toBe(false);
+  });
+
+  it("handles interactive duration, exit 129, and provider errors", async () => {
+    await expect(
+      openTmuxPopup({
+        env: {},
         runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "show-options") {
-            return tmuxCommandResult(input, "client_2\n");
+          if (input.args?.[0] === "display-popup") await sleep(10);
+          if (input.args?.includes("@station_popup_ui_signature")) {
+            return tmuxCommandResult(input, `${defaultSignature}\n`);
           }
           return tmuxCommandResult(input);
         },
-      }),
-    ).resolves.toEqual({ dismissed: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["show-options", "-gqv", "@station_popup_focus_client"],
-      ["display-popup", "-c", "client_2", "-C"],
-      ["set-option", "-gq", "-u", "@station_popup_client"],
-      ["set-option", "-gq", "-u", "@station_popup_focus_client"],
-    ]);
-  });
-
-  it("does not time out while the interactive popup is still open", async () => {
-    await expect(
-      openTmuxPopup({
         timeoutMs: 1,
-        env: {},
-        runner: async (input) => {
-          if (input.args?.[0] === "display-popup") {
-            await sleep(10);
-          }
-          return tmuxCommandResult(input);
-        },
       }),
     ).resolves.toEqual({ opened: true });
-  });
 
-  it("treats a user-dismissed popup as opened and clears recorded popup state", async () => {
-    const calls: ExternalCommandInput[] = [];
-
+    const dismissed = createPopupTmux({ displayExit: 129, root: "/opt/station/bin" });
     await expect(
       openTmuxPopup({
-        env: {
-          TMUX: "/tmp/tmux-501/default,123,0",
-        },
-        runner: async (input) => {
-          calls.push(input);
-          if (input.args?.[0] === "display-message") {
-            return tmuxCommandResult(input, "client_1\n");
-          }
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, `${defaultPersistentSignature}\n`);
-          }
-          if (input.args?.[0] === "display-popup") {
-            throw Object.assign(new Error("popup dismissed"), {
-              exitCode: 129,
-              stderr: "",
-              stdout: "",
-            });
-          }
-          return tmuxCommandResult(input);
-        },
+        checkoutRoot: dismissed.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: dismissed.runner,
       }),
     ).resolves.toEqual({ opened: true });
 
-    expect(calls.map((call) => call.args)).toEqual([
-      ["display-message", "-p", "#{client_name}"],
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_1"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_1"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls("_station-ui", "stn tui --popup --persistent"),
-      expect.arrayContaining(["display-popup", "-c", "client_1"]),
-      ["set-option", "-gq", "-u", "@station_popup_client"],
-      ["set-option", "-gq", "-u", "@station_popup_focus_client"],
-    ]);
-  });
-
-  it("reports popup failures with the provider-specific message", async () => {
     await expect(
       openTmuxPopup({
         env: {},
         runner: async (input) => {
           if (input.args?.[0] === "display-popup") {
-            throw Object.assign(new Error("tmux failed"), {
-              code: 1,
-              stderr: "display-popup failed",
-            });
+            throw Object.assign(new Error("failed"), { code: 1, stderr: "display failed" });
+          }
+          if (input.args?.includes("@station_popup_ui_signature")) {
+            return tmuxCommandResult(input, `${defaultSignature}\n`);
           }
           return tmuxCommandResult(input);
         },
@@ -615,71 +480,265 @@ describe("tmux popup", () => {
       provider: "tmux",
     });
   });
-
-  it("enters the workbench before opening when requested", async () => {
-    const calls: ExternalCommandInput[] = [];
-
-    await expect(
-      openTmuxPopup({
-        enterWorkbench: true,
-        env: {
-          STATION_FOCUS_CLIENT_ID: "client_from_binding",
-        },
-        runner: async (input) => {
-          calls.push(input);
-          if (
-            input.args?.[0] === "show-options" &&
-            input.args.includes("@station_popup_ui_signature")
-          ) {
-            return tmuxCommandResult(input, `${defaultPersistentSignature}\n`);
-          }
-          return tmuxCommandResult(input);
-        },
-      }),
-    ).resolves.toEqual({ opened: true });
-
-    expect(calls.map((call) => call.args)).toEqual([
-      ["show-options", "-gqv", "@station_popup_client"],
-      ["set-option", "-gq", "@station_popup_client", "client_from_binding"],
-      ["set-option", "-gq", "@station_popup_focus_client", "client_from_binding"],
-      ["has-session", "-t", "station"],
-      ["set-option", "-t", "station", "mouse", "on"],
-      ["set-option", "-t", "station", "history-limit", "100000"],
-      ["set-option", "-t", "station", "set-clipboard", "on"],
-      [
-        "list-panes",
-        "-s",
-        "-t",
-        "station",
-        "-F",
-        "#{window_id}\t#{pane_id}\t#{pane_dead}\t#{@station.role}",
-      ],
-      ["list-windows", "-t", "station", "-F", "#{window_id}"],
-      ["switch-client", "-c", "client_from_binding", "-t", "station"],
-      ["has-session", "-t", "_station-ui"],
-      ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
-      persistentPopupMouseCall("_station-ui"),
-      ...fastPopupRegistrationCalls("_station-ui", "stn tui --popup --persistent"),
-      expect.arrayContaining(["display-popup", "-c", "client_from_binding"]),
-    ]);
-  });
 });
 
-function fastPopupRegistrationCalls(
-  sessionName: string,
-  command: string,
-  root?: string,
-): string[][] {
-  const calls = [
-    ["set-option", "-gq", "@station_popup_ui_session_name", sessionName],
-    ["set-option", "-gq", "@station_popup_ui_expected_signature", `v1:${command}`],
-  ];
-  if (root !== undefined) {
-    calls.push(["set-option", "-gq", "@station_popup_ui_root", root]);
+const popupMouseCall = ["set-option", "-t", "_station-ui", "mouse", "on"];
+
+type PopupFakeOptions = {
+  activeClaim?: boolean;
+  claimCasMisses?: number;
+  clientName?: string;
+  clientPid?: number;
+  concurrentRouteBeforeCommit?: string;
+  devCommand?: string;
+  devOwner?: string;
+  devRoot?: string;
+  devSession?: string;
+  displayExit?: number;
+  malformedRoute?: string;
+  registered?: boolean;
+  replaceClaimBeforeCleanup?: string;
+  replaceClaimBeforeLegacyAction?: string;
+  root?: string;
+};
+
+function createPopupTmux(options: PopupFakeOptions = {}) {
+  const calls: ExternalCommandInput[] = [];
+  const root = options.root ?? "/opt/station/bin";
+  const clientName = options.clientName ?? "/dev/ttys001";
+  const clientPid = options.clientPid ?? 1234;
+  const route = buildNormalPopupRoute({
+    registrationNonce,
+    root,
+    sessionName: "_station-ui",
+    signature: defaultSignature,
+  });
+  const globalOptions = new Map<string, string>();
+  const sessionOptions = new Map<string, string>();
+  const sessionSignatures = new Map([["_station-ui", defaultSignature]]);
+  if (options.registered === true) {
+    globalOptions.set("@station_popup_ui_route", route);
+    globalOptions.set("@station_popup_ui_session_name", "_station-ui");
+    globalOptions.set("@station_popup_ui_expected_signature", defaultSignature);
+    globalOptions.set("@station_popup_ui_root", root);
+    sessionOptions.set("@station_popup_ui_lease", route);
   }
-  return calls;
+  if (options.malformedRoute !== undefined) {
+    globalOptions.set("@station_popup_ui_route", options.malformedRoute);
+  }
+  if (options.activeClaim === true) {
+    const claim = buildPopupActiveClaim({
+      actionNonce,
+      clientName: "/dev/ttys001",
+      clientPid: 1234,
+      registrationNonce,
+      state: "open",
+    });
+    globalOptions.set("@station_popup_active_claim", claim);
+    globalOptions.set("@station_popup_client", "/dev/ttys001");
+    globalOptions.set("@station_popup_focus_client", "/dev/ttys001");
+  }
+  if (options.devSession !== undefined) {
+    globalOptions.set("@station_tui_dev_session_name", options.devSession);
+  }
+  if (options.devCommand !== undefined) {
+    globalOptions.set("@station_tui_dev_command", options.devCommand);
+  }
+  if (options.devOwner !== undefined) {
+    globalOptions.set("@station_tui_dev_owner", options.devOwner);
+  }
+  if (options.devRoot !== undefined) {
+    globalOptions.set("@station_tui_dev_root", options.devRoot);
+  }
+
+  let concurrentRoutePending = options.concurrentRouteBeforeCommit;
+  let replacementPending = options.replaceClaimBeforeCleanup;
+  let legacyReplacementPending = options.replaceClaimBeforeLegacyAction;
+  let claimCasMisses = options.claimCasMisses ?? 0;
+
+  const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
+    calls.push(input);
+    const args = input.args ?? [];
+    if (
+      args[0] === "display-message" &&
+      args.includes("#{client_pid}\t#{client_name}\t#{client_session}")
+    ) {
+      return tmuxCommandResult(input, `${clientPid}\t${clientName}\touter\n`);
+    }
+    if (args[0] === "display-message" && args.includes("#{client_name}")) {
+      return tmuxCommandResult(input, `${clientName}\n`);
+    }
+    if (args[0] === "has-session") {
+      return tmuxCommandResult(input);
+    }
+    if (args[0] === "show-options") {
+      const optionName = args.at(-1) ?? "";
+      if (optionName === "@station_popup_ui_signature") {
+        return tmuxCommandResult(input, `${sessionSignatures.get(args[2] ?? "") ?? ""}\n`);
+      }
+      const value = args.includes("-gqv")
+        ? globalOptions.get(optionName)
+        : sessionOptions.get(optionName);
+      return tmuxCommandResult(input, value === undefined ? "" : `${value}\n`);
+    }
+    if (args[0] === "set-option") {
+      applySetOption(args, globalOptions, sessionOptions, sessionSignatures);
+      return tmuxCommandResult(input);
+    }
+    if (args[0] === "if-shell") {
+      const condition = args[args.indexOf("-t") >= 0 ? 4 : 2] ?? "";
+      const command = args[args.indexOf("-t") >= 0 ? 5 : 3] ?? "";
+      if (command.includes("@station_popup_ui_route")) {
+        if (concurrentRoutePending !== undefined) {
+          globalOptions.set("@station_popup_ui_route", concurrentRoutePending);
+          concurrentRoutePending = undefined;
+        }
+        const expected = condition.includes("hostile###,##}route")
+          ? "hostile#,}route"
+          : extractComparedValue(condition, "@station_popup_ui_route");
+        if ((globalOptions.get("@station_popup_ui_route") ?? "") === expected) {
+          setFromTmuxCommand(command, globalOptions);
+        }
+        return tmuxCommandResult(input);
+      }
+      if (command.startsWith("set-option -gq @station_popup_active_claim")) {
+        if (claimCasMisses > 0) {
+          claimCasMisses -= 1;
+          return tmuxCommandResult(input);
+        }
+        const expected = extractComparedValue(condition, "@station_popup_active_claim");
+        if ((globalOptions.get("@station_popup_active_claim") ?? "") === expected) {
+          setFromTmuxCommand(command, globalOptions);
+        }
+        return tmuxCommandResult(input);
+      }
+      if (command.startsWith("set-option -gq -u @station_popup_active_claim")) {
+        if (replacementPending !== undefined) {
+          globalOptions.set("@station_popup_active_claim", replacementPending);
+          globalOptions.set("@station_popup_client", "/dev/ttys099");
+          globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+          replacementPending = undefined;
+        }
+        const expected = extractComparedValue(condition, "@station_popup_active_claim");
+        if (globalOptions.get("@station_popup_active_claim") === expected) {
+          globalOptions.delete("@station_popup_active_claim");
+          const client = extractComparedValue(command, "@station_popup_client");
+          if (globalOptions.get("@station_popup_client") === client) {
+            globalOptions.delete("@station_popup_client");
+          }
+          if (globalOptions.get("@station_popup_focus_client") === client) {
+            globalOptions.delete("@station_popup_focus_client");
+          }
+        }
+        return tmuxCommandResult(input);
+      }
+      if (args.at(-1) === "display-message -p STATION_POPUP_CAS_MISS") {
+        if (legacyReplacementPending !== undefined && command.includes(" -u ")) {
+          globalOptions.set("@station_popup_active_claim", legacyReplacementPending);
+          globalOptions.set("@station_popup_client", "/dev/ttys099");
+          globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+          legacyReplacementPending = undefined;
+        }
+        const claimAbsent = !globalOptions.has("@station_popup_active_claim");
+        const hasActiveComparison = condition.includes("#{==:#{@station_popup_client},");
+        const hasFocusComparison = condition.includes("#{==:#{@station_popup_focus_client},");
+        const activeClient = extractComparedValue(condition, "@station_popup_client");
+        const focusClient = extractComparedValue(condition, "@station_popup_focus_client");
+        const activeMatches =
+          hasActiveComparison &&
+          (globalOptions.get("@station_popup_client") ?? "") === activeClient;
+        const focusMatches =
+          hasFocusComparison &&
+          (globalOptions.get("@station_popup_focus_client") ?? "") === focusClient;
+        if (!claimAbsent || (!activeMatches && !focusMatches)) {
+          return tmuxCommandResult(input, "STATION_POPUP_CAS_MISS\n");
+        }
+        if (activeMatches && command.includes(`-u @station_popup_client`)) {
+          globalOptions.delete("@station_popup_client");
+        }
+        if (focusMatches && command.includes(`-u @station_popup_focus_client`)) {
+          globalOptions.delete("@station_popup_focus_client");
+        }
+        const nextActive = /set-option -gq @station_popup_client ([^ ;]+)/.exec(command)?.[1];
+        const nextFocus = /set-option -gq @station_popup_focus_client ([^ ;]+)/.exec(command)?.[1];
+        if (nextActive !== undefined) {
+          globalOptions.set("@station_popup_client", nextActive);
+        }
+        if (nextFocus !== undefined) {
+          globalOptions.set("@station_popup_focus_client", nextFocus);
+        }
+        return tmuxCommandResult(input);
+      }
+      return tmuxCommandResult(input);
+    }
+    if (args[0] === "display-popup" && !args.includes("-C") && options.displayExit !== undefined) {
+      throw Object.assign(new Error("popup exited"), {
+        exitCode: options.displayExit,
+        stderr: "",
+        stdout: "",
+      });
+    }
+    return tmuxCommandResult(input);
+  };
+
+  return {
+    calls,
+    claimWrites: () =>
+      calls
+        .filter((call) => call.args?.[0] === "if-shell")
+        .map((call) => call.args?.find((arg) => arg.includes("active_claim v1.")) ?? "")
+        .filter((command) => command.length > 0)
+        .map((command) => /active_claim (v1\.[^ ;]+)/.exec(command)?.[1] ?? ""),
+    devCommand: options.devCommand,
+    globalOptions,
+    indexOfSet: (optionName: string) =>
+      calls.findIndex((call) => call.args?.includes(optionName) && call.args[0] === "set-option"),
+    root,
+    runner,
+    sessionSignatures,
+  };
 }
 
-function persistentPopupMouseCall(sessionName: string): string[] {
-  return ["set-option", "-t", sessionName, "mouse", "on"];
+function applySetOption(
+  args: string[],
+  globalOptions: Map<string, string>,
+  sessionOptions: Map<string, string>,
+  sessionSignatures: Map<string, string>,
+): void {
+  if (args.includes("-gq")) {
+    const optionName = args.at(-2);
+    const value = args.at(-1);
+    if (args.includes("-u")) {
+      if (value !== undefined) globalOptions.delete(value);
+    } else if (optionName !== undefined && value !== undefined) {
+      globalOptions.set(optionName, value);
+    }
+    return;
+  }
+  const optionName = args.at(-2);
+  const value = args.at(-1);
+  if (optionName === "@station_popup_ui_signature" && value !== undefined) {
+    sessionSignatures.set(args[2] ?? "", value);
+  } else if (optionName !== undefined && value !== undefined) {
+    sessionOptions.set(optionName, value);
+  }
+}
+
+function setFromTmuxCommand(command: string, globalOptions: Map<string, string>): void {
+  const match = /set-option -gq (@station_popup_(?:ui_route|active_claim)) ([^ ;]+)/.exec(command);
+  if (match?.[1] !== undefined && match[2] !== undefined) {
+    globalOptions.set(match[1], match[2]);
+  }
+}
+
+function extractComparedValue(format: string, optionName: string): string {
+  const marker = `#{==:#{${optionName}},`;
+  const start = format.indexOf(marker);
+  if (start < 0) return "";
+  const value = format.slice(start + marker.length).split("}")[0] ?? "";
+  return value
+    .replaceAll("#}", "}")
+    .replaceAll("#;", ";")
+    .replaceAll("#,", ",")
+    .replaceAll("##", "#");
 }

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -137,18 +137,9 @@ describe("tmux popup", () => {
     expect(rootMirrorIndex).toBeLessThan(routeCommitIndex);
     expect(routeCommitIndex).toBeLessThan(claimIndex);
 
-    const display = fake.calls.findLast((call) => call.args?.[0] === "display-popup");
-    expect(display?.args).toEqual([
-      "display-popup",
-      "-c",
-      "/dev/ttys001",
-      "-w",
-      "90%",
-      "-h",
-      "80%",
-      "-E",
-      expect.stringContaining("@station_popup_active_claim"),
-    ]);
+    const display = fake.calls.findLast(claimedPopupAction);
+    expect(display?.args?.[3]).toContain("display-popup -c /dev/ttys001 -w 90% -h 80% -E");
+    expect(display?.args?.[3]).toContain("@station_popup_active_claim");
     expect(fake.globalOptions.get("@station_popup_active_claim")).toMatch(/^v1\.open\./);
   });
 
@@ -162,9 +153,11 @@ describe("tmux popup", () => {
       }),
     ).resolves.toEqual({ closed: true, opened: false });
 
-    expect(fake.calls).toContainEqual(
-      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
-    );
+    expect(
+      fake.executedPopupActions.some((action) =>
+        action.includes("display-popup -c /dev/ttys001 -C"),
+      ),
+    ).toBe(true);
     expect(fake.calls.some((call) => call.args?.[0] === "kill-session")).toBe(false);
     expect(fake.calls.some((call) => call.args?.[0] === "new-session")).toBe(false);
     const claimWrites = fake.claimWrites();
@@ -187,9 +180,11 @@ describe("tmux popup", () => {
     ).resolves.toEqual({ closed: true, opened: false });
 
     expect(fake.claimWrites()).toEqual([expect.stringMatching(/^v1\.closing\./)]);
-    expect(fake.calls).toContainEqual(
-      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
-    );
+    expect(
+      fake.executedPopupActions.some((action) =>
+        action.includes("display-popup -c /dev/ttys001 -C"),
+      ),
+    ).toBe(true);
     expect(fake.globalOptions.has("@station_popup_active_claim")).toBe(false);
   });
 
@@ -212,11 +207,11 @@ describe("tmux popup", () => {
     const claimWriteIndex = fake.calls.findIndex((call) =>
       call.args?.at(-1)?.includes("@station_popup_active_claim v1.open."),
     );
-    const closeIndex = fake.calls.findIndex(
-      (call) => call.args?.[0] === "display-popup" && call.args.includes("-C"),
+    const closeIndex = fake.calls.findIndex((call) =>
+      call.args?.[3]?.includes("display-popup -c /dev/ttys001 -C"),
     );
     expect(claimWriteIndex).toBeLessThan(closeIndex);
-    expect(fake.calls[closeIndex]?.args).toEqual(["display-popup", "-c", "/dev/ttys001", "-C"]);
+    expect(fake.executedPopupActions.at(-1)).toContain("display-popup -c /dev/ttys001 -C");
   });
 
   it("uses a valid claim for focus origin and falls back to the compatibility mirror", async () => {
@@ -238,9 +233,11 @@ describe("tmux popup", () => {
     const fake = createPopupTmux({ activeClaim: true, registered: true });
     await expect(dismissTmuxPopup({ runner: fake.runner })).resolves.toEqual({ dismissed: true });
     expect(fake.claimWrites()).toEqual([expect.stringMatching(/^v1\.closing\./)]);
-    expect(fake.calls).toContainEqual(
-      expect.objectContaining({ args: ["display-popup", "-c", "/dev/ttys001", "-C"] }),
-    );
+    expect(
+      fake.executedPopupActions.some((action) =>
+        action.includes("display-popup -c /dev/ttys001 -C"),
+      ),
+    ).toBe(true);
     expect(fake.globalOptions.has("@station_popup_active_claim")).toBe(false);
   });
 
@@ -266,6 +263,52 @@ describe("tmux popup", () => {
     ).resolves.toEqual({ opened: true });
     expect(fake.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
     expect(fake.globalOptions.get("@station_popup_client")).toBe("/dev/ttys099");
+  });
+
+  it("does not display after a newer caller replaces its claim", async () => {
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "99".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    const fake = createPopupTmux({
+      replaceClaimBeforeDisplay: replacement,
+      root: "/opt/station/bin",
+    });
+
+    await expect(
+      openTmuxPopup({
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
+      }),
+    ).rejects.toMatchObject({ code: "TERMINAL_OPEN_FAILED" });
+
+    expect(fake.executedPopupActions).toEqual([]);
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+  });
+
+  it("does not display from the compatibility path after a claimed caller wins", async () => {
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "98".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    const fake = createPopupTmux({ replaceClaimBeforeDisplay: replacement });
+
+    await expect(
+      openTmuxPopup({
+        env: { STATION_FOCUS_CLIENT_ID: "/dev/ttys001" },
+        runner: fake.runner,
+      }),
+    ).rejects.toMatchObject({ code: "TERMINAL_OPEN_FAILED" });
+
+    expect(fake.executedPopupActions).toEqual([]);
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
   });
 
   it("does not let legacy cleanup or dismiss contention erase a replacement owner", async () => {
@@ -342,9 +385,9 @@ describe("tmux popup", () => {
         runner: fake.runner,
       }),
     ).resolves.toEqual({ opened: true });
-    expect(
-      fake.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
-    ).toContain("attach-session -t _station-ui-dev");
+    expect(fake.calls.findLast(claimedPopupAction)?.args?.[3]).toContain(
+      "attach-session -t _station-ui-dev",
+    );
 
     await expect(resolveRegisteredDevPopupUi({ runner: fake.runner })).resolves.toMatchObject({
       command: fake.devCommand,
@@ -366,9 +409,9 @@ describe("tmux popup", () => {
       registeredDevPopupRoot: "/worktree",
       runner: stale.runner,
     });
-    expect(
-      stale.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
-    ).toContain("attach-session -t _station-ui");
+    expect(stale.calls.findLast(claimedPopupAction)?.args?.[3]).toContain(
+      "attach-session -t _station-ui",
+    );
 
     const wrongRoot = createPopupTmux({
       devCommand: "node other-ui tui --popup --persistent",
@@ -384,9 +427,9 @@ describe("tmux popup", () => {
       registeredDevPopupRoot: "/worktree",
       runner: wrongRoot.runner,
     });
-    expect(
-      wrongRoot.calls.findLast((call) => call.args?.[0] === "display-popup")?.args.at(-1),
-    ).toContain("attach-session -t _station-ui");
+    expect(wrongRoot.calls.findLast(claimedPopupAction)?.args?.[3]).toContain(
+      "attach-session -t _station-ui",
+    );
   });
 
   it("enters the workbench before displaying the popup", async () => {
@@ -398,9 +441,7 @@ describe("tmux popup", () => {
       runner: fake.runner,
     });
     const switchIndex = fake.calls.findIndex((call) => call.args?.[0] === "switch-client");
-    const displayIndex = fake.calls.findIndex(
-      (call) => call.args?.[0] === "display-popup" && !call.args.includes("-C"),
-    );
+    const displayIndex = fake.calls.findIndex(claimedPopupAction);
     expect(fake.calls[switchIndex]?.args).toEqual([
       "switch-client",
       "-c",
@@ -498,12 +539,14 @@ type PopupFakeOptions = {
   malformedRoute?: string;
   registered?: boolean;
   replaceClaimBeforeCleanup?: string;
+  replaceClaimBeforeDisplay?: string;
   replaceClaimBeforeLegacyAction?: string;
   root?: string;
 };
 
 function createPopupTmux(options: PopupFakeOptions = {}) {
   const calls: ExternalCommandInput[] = [];
+  const executedPopupActions: string[] = [];
   const root = options.root ?? "/opt/station/bin";
   const clientName = options.clientName ?? "/dev/ttys001";
   const clientPid = options.clientPid ?? 1234;
@@ -553,6 +596,7 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
 
   let concurrentRoutePending = options.concurrentRouteBeforeCommit;
   let replacementPending = options.replaceClaimBeforeCleanup;
+  let displayReplacementPending = options.replaceClaimBeforeDisplay;
   let legacyReplacementPending = options.replaceClaimBeforeLegacyAction;
   let claimCasMisses = options.claimCasMisses ?? 0;
 
@@ -588,6 +632,16 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
     if (args[0] === "if-shell") {
       const condition = args[args.indexOf("-t") >= 0 ? 4 : 2] ?? "";
       const command = args[args.indexOf("-t") >= 0 ? 5 : 3] ?? "";
+      if (command.includes("display-popup") && displayReplacementPending !== undefined) {
+        globalOptions.set("@station_popup_active_claim", displayReplacementPending);
+        globalOptions.set("@station_popup_client", "/dev/ttys099");
+        globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+        displayReplacementPending = undefined;
+        const expected = extractComparedValue(condition, "@station_popup_active_claim");
+        if ((globalOptions.get("@station_popup_active_claim") ?? "") !== expected) {
+          return tmuxCommandResult(input, "STATION_POPUP_CAS_MISS\n");
+        }
+      }
       if (command.includes("@station_popup_ui_route")) {
         if (concurrentRoutePending !== undefined) {
           globalOptions.set("@station_popup_ui_route", concurrentRoutePending);
@@ -629,6 +683,21 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
           if (globalOptions.get("@station_popup_focus_client") === client) {
             globalOptions.delete("@station_popup_focus_client");
           }
+        }
+        return tmuxCommandResult(input);
+      }
+      if (condition.includes("@station_popup_active_claim") && command.includes("display-popup")) {
+        const expected = extractComparedValue(condition, "@station_popup_active_claim");
+        if ((globalOptions.get("@station_popup_active_claim") ?? "") !== expected) {
+          return tmuxCommandResult(input, "STATION_POPUP_CAS_MISS\n");
+        }
+        for (const optionName of ["@station_popup_client", "@station_popup_focus_client"]) {
+          const value = new RegExp(`set-option -gq ${optionName} ([^ ;]+)`).exec(command)?.[1];
+          if (value !== undefined) globalOptions.set(optionName, value);
+        }
+        executedPopupActions.push(command);
+        if (options.displayExit !== undefined && !command.trimEnd().endsWith(" -C")) {
+          return { ...tmuxCommandResult(input), exitCode: options.displayExit };
         }
         return tmuxCommandResult(input);
       }
@@ -678,6 +747,16 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
         stdout: "",
       });
     }
+    if (
+      args[0] === "display-popup" &&
+      !args.includes("-C") &&
+      displayReplacementPending !== undefined
+    ) {
+      globalOptions.set("@station_popup_active_claim", displayReplacementPending);
+      globalOptions.set("@station_popup_client", "/dev/ttys099");
+      globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+      displayReplacementPending = undefined;
+    }
     return tmuxCommandResult(input);
   };
 
@@ -690,6 +769,7 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
         .filter((command) => command.length > 0)
         .map((command) => /active_claim (v1\.[^ ;]+)/.exec(command)?.[1] ?? ""),
     devCommand: options.devCommand,
+    executedPopupActions,
     globalOptions,
     indexOfSet: (optionName: string) =>
       calls.findIndex((call) => call.args?.includes(optionName) && call.args[0] === "set-option"),
@@ -697,6 +777,14 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
     runner,
     sessionSignatures,
   };
+}
+
+function claimedPopupAction(call: ExternalCommandInput): boolean {
+  return (
+    call.args?.[0] === "if-shell" &&
+    call.args[2]?.includes("@station_popup_active_claim") === true &&
+    call.args[3]?.includes("display-popup") === true
+  );
 }
 
 function applySetOption(

--- a/scripts/maintenance/station-reset.mjs
+++ b/scripts/maintenance/station-reset.mjs
@@ -10,6 +10,8 @@ const tmux = process.env.STATION_TMUX_BIN ?? "tmux";
 const globalOptions = [
   "@station_popup_client",
   "@station_popup_focus_client",
+  "@station_popup_active_claim",
+  "@station_popup_ui_route",
   "@station_popup_ui_session_name",
   "@station_popup_ui_expected_signature",
   "@station_popup_ui_root",

--- a/scripts/maintenance/station-tmux-tui-reset.mjs
+++ b/scripts/maintenance/station-tmux-tui-reset.mjs
@@ -14,6 +14,8 @@ const skipOpen = args.has("--no-open");
 const globalOptions = [
   "@station_popup_client",
   "@station_popup_focus_client",
+  "@station_popup_active_claim",
+  "@station_popup_ui_route",
   "@station_popup_ui_session_name",
   "@station_popup_ui_expected_signature",
   "@station_popup_ui_root",

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -44,7 +44,7 @@ if (process.env.STATION_BINARY_SMOKE_FAKE_TMUX === "1") {
   };
   const popupEnv = {
     ...childEnv,
-    FAKE_TMUX_CLIENT_NAME: "binary-smoke-client",
+    FAKE_TMUX_CLIENT_NAME: "/dev/ttys901",
     FAKE_TMUX_CLIENT_PID: String(process.pid),
     FAKE_TMUX_CLIENT_SESSION: "binary-smoke",
     FAKE_TMUX_STATE_PATH: fakeTmuxStatePath,
@@ -91,11 +91,11 @@ if (process.env.STATION_BINARY_SMOKE_FAKE_TMUX === "1") {
       });
       assertIncludes(popupHelp.stdout, "stn popup", "popup symlink dispatch");
 
-      const setup = await run(
-        binaryPath,
-        ["--config", configPath, "setup", "check", "--json", "--no-brew"],
-        { cwd: root, env: popupEnv, allowedExitCodes: [1] },
-      );
+      const setup = await run(binaryPath, ["setup", "check", "--json", "--no-brew"], {
+        cwd: root,
+        env: popupEnv,
+        allowedExitCodes: [1],
+      });
       const setupPlan = JSON.parse(setup.stdout);
       assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
       assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
@@ -628,7 +628,11 @@ async function runManagedPopupBinding(command, env, fakeTmuxStatePath) {
 }
 
 function assertSilentHandledBinding(result, label) {
-  assertEqual(result.code, 0, `${label} status`);
+  if (result.code !== 0) {
+    fail(
+      `${label} status: expected 0, received ${result.code}; stdout=${JSON.stringify(result.stdout)} stderr=${JSON.stringify(result.stderr)}`,
+    );
+  }
   assertEqual(result.stdout, "", `${label} stdout`);
   assertEqual(result.stderr, "", `${label} stderr`);
 }
@@ -793,7 +797,7 @@ async function sourceFakeTmuxFile(state, args) {
 
 function fakeTmuxClient() {
   return {
-    name: process.env.FAKE_TMUX_CLIENT_NAME ?? "binary-smoke-client",
+    name: process.env.FAKE_TMUX_CLIENT_NAME ?? "/dev/ttys901",
     pid: process.env.FAKE_TMUX_CLIENT_PID ?? "41001",
     sessionName: process.env.FAKE_TMUX_CLIENT_SESSION ?? "binary-smoke",
   };

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1,261 +1,530 @@
 import { spawn } from "node:child_process";
 import { constants } from "node:fs";
-import { access, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  readlink,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { dirname, join, parse, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createObserverClient } from "../../packages/protocol/dist/index.js";
 import { createStationHostClient } from "../../packages/station-host/dist/index.js";
 
-const binaryPath = resolve(process.env.STATION_BINARY_PATH ?? "station/dist/bin/stn");
-const sourceCliPath = resolve("apps/cli/dist/main.js");
-const expectedVersion = parseExpectedVersion(process.argv.slice(2));
-const ptyOnly = process.env.STATION_BINARY_SMOKE_PTY_ONLY === "1";
-const root = await mkdtemp(join(tmpdir(), "station-binary-smoke-"));
-const homeDir = join(root, "home");
-const stateDir = join(root, "state");
-const runtimeDir = join(root, "runtime");
-const hostileDir = join(root, "hostile");
-const socketPath = join(runtimeDir, "observer.sock");
-const configPath = join(root, "config.toml");
-const markerPath = join(root, "ambient-config-pwned");
-const ptyReleasePath = join(root, "release-host-pty");
-const childEnv = isolatedBinaryEnv({ homeDir, runtimeDir });
+if (process.env.STATION_BINARY_SMOKE_FAKE_TMUX === "1") {
+  await runFakeTmuxProcess(process.argv.slice(2));
+} else {
+  const binaryPath = resolve(process.env.STATION_BINARY_PATH ?? "station/dist/bin/stn");
+  const sourceCliPath = resolve("apps/cli/dist/main.js");
+  const expectedVersion = parseExpectedVersion(process.argv.slice(2));
+  const ptyOnly = process.env.STATION_BINARY_SMOKE_PTY_ONLY === "1";
+  const root = await mkdtemp(join(tmpdir(), "station-binary-smoke-"));
+  const homeDir = join(root, "home");
+  const stateDir = join(root, "state");
+  const runtimeDir = join(root, "runtime");
+  const hostileDir = join(root, "hostile");
+  const socketPath = join(runtimeDir, "observer.sock");
+  const configPath = join(root, "config.toml");
+  const popupConfigPath = join(homeDir, ".config", "station", "config.toml");
+  const markerPath = join(root, "ambient-config-pwned");
+  const ptyReleasePath = join(root, "release-host-pty");
+  const fakeTmuxDir = join(root, "fake-bin");
+  const fakeTmuxPath = join(fakeTmuxDir, "tmux");
+  const fakeTmuxStatePath = join(root, "fake-tmux-state.json");
+  const childEnv = {
+    ...isolatedBinaryEnv({ homeDir, runtimeDir }),
+    STATION_TMUX_BIN: fakeTmuxPath,
+  };
+  const popupEnv = {
+    ...childEnv,
+    FAKE_TMUX_CLIENT_NAME: "binary-smoke-client",
+    FAKE_TMUX_CLIENT_PID: String(process.pid),
+    FAKE_TMUX_CLIENT_SESSION: "binary-smoke",
+    FAKE_TMUX_STATE_PATH: fakeTmuxStatePath,
+    PATH: `${fakeTmuxDir}:/usr/bin:/bin`,
+    STATION_TMUX_BIN: fakeTmuxPath,
+    TMUX: `${join(runtimeDir, "fake-tmux.sock")},${process.pid},0`,
+  };
 
-let observerClient;
-let observerPid;
-let hostClient;
-let hostProcess;
+  let observerClient;
+  let observerPid;
+  let hostClient;
+  let hostProcess;
 
-try {
-  await access(binaryPath, constants.X_OK);
-  await Promise.all([
-    mkdir(homeDir, { recursive: true, mode: 0o700 }),
-    mkdir(stateDir, { recursive: true, mode: 0o700 }),
-    mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
-    mkdir(hostileDir, { recursive: true, mode: 0o700 }),
-  ]);
-  await writeSmokeConfig(configPath, stateDir, socketPath);
-  await writeHostileConfig(hostileDir, markerPath);
+  try {
+    await access(binaryPath, constants.X_OK);
+    const installedRoot = dirname(await realpath(binaryPath));
+    if (installedRoot === parse(installedRoot).root) {
+      fail("compiled popup ownership unexpectedly resolved to filesystem root");
+    }
+    await assertExactBinaryAlias(installedRoot, "stn-ingress");
+    await assertExactBinaryAlias(installedRoot, "stn-tmux-popup");
+    await Promise.all([
+      mkdir(homeDir, { recursive: true, mode: 0o700 }),
+      mkdir(stateDir, { recursive: true, mode: 0o700 }),
+      mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
+      mkdir(hostileDir, { recursive: true, mode: 0o700 }),
+      mkdir(dirname(popupConfigPath), { recursive: true, mode: 0o700 }),
+      mkdir(fakeTmuxDir, { recursive: true, mode: 0o700 }),
+    ]);
+    await writeFakeTmux(fakeTmuxPath, fakeTmuxStatePath);
+    await writeSmokeConfig(configPath, stateDir, socketPath);
+    await writeSmokeConfig(popupConfigPath, stateDir, socketPath, "tmux");
+    await writeHostileConfig(hostileDir, markerPath);
 
-  if (!ptyOnly) {
-    const version = await run(binaryPath, ["--version"], { env: childEnv });
-    assertEqual(version.stdout.trim(), expectedVersion, "compiled --version");
+    if (!ptyOnly) {
+      const version = await run(binaryPath, ["--version"], { env: childEnv });
+      assertEqual(version.stdout.trim(), expectedVersion, "compiled --version");
 
-    const help = await run(binaryPath, ["--help"], { env: childEnv });
-    assertIncludes(help.stdout, "Usage:", "compiled --help");
+      const help = await run(binaryPath, ["--help"], { env: childEnv });
+      assertIncludes(help.stdout, "Usage:", "compiled --help");
 
-    const popupHelp = await run(join(dirname(binaryPath), "stn-tmux-popup"), ["--help"], {
-      env: childEnv,
-    });
-    assertIncludes(popupHelp.stdout, "stn popup", "popup symlink dispatch");
-
-    const setup = await run(
-      binaryPath,
-      ["--config", configPath, "setup", "check", "--json", "--no-brew"],
-      { cwd: root, env: childEnv, allowedExitCodes: [1] },
-    );
-    const setupPlan = JSON.parse(setup.stdout);
-    assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
-    assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
-    assertEqual(setupPlan.summary.requiredOk, false, "compiled setup requiredOk alias");
-
-    await run(binaryPath, ["--config", configPath, "observer", "start", "--timeout-ms", "30000"], {
-      env: childEnv,
-    });
-    observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
-    const health = await observerClient.health();
-    observerPid = health.pid;
-    assertEqual(health.status, "healthy", "compiled observer health");
-    await run(binaryPath, ["--config", configPath, "observer", "start", "--timeout-ms", "30000"], {
-      env: childEnv,
-    });
-    assertEqual((await observerClient.health()).pid, observerPid, "same-build observer reuse");
-    const snapshot = await observerClient.getSnapshot();
-    assertEqual(snapshot.observer.healthy, true, "compiled observer snapshot");
-
-    const ingress = await run(
-      join(dirname(binaryPath), "stn-ingress"),
-      ["--socket", socketPath, "--state-dir", stateDir, "worktrunk", "post-create"],
-      {
+      const popupHelp = await run(join(dirname(binaryPath), "stn-tmux-popup"), ["--help"], {
         env: childEnv,
-        input: JSON.stringify({ branch: "station/binary-smoke" }),
-      },
-    );
-    assertEqual(ingress.code, 0, "ingress symlink receipt");
-    assertEqual(
-      await directoryFileCount(join(stateDir, "spool", "hooks")),
-      0,
-      "online ingress must not spool",
-    );
-    assertEqual((await observerClient.health()).status, "healthy", "observer after ingress");
+      });
+      assertIncludes(popupHelp.stdout, "stn popup", "popup symlink dispatch");
 
-    const bootLog = await readFile(join(stateDir, "logs", "observer-boot.log"), "utf8");
-    const bootHeader = JSON.parse(bootLog.split(/\r?\n/, 1)[0] ?? "{}");
-    assertEqual(bootHeader.command?.[0], binaryPath, "detached observer executable");
-    assertEqual(bootHeader.command?.[1], "__observer", "detached observer internal route");
-
-    const piExtensionPath = await findFile(join(stateDir, "run", "assets", "pi"), (name) =>
-      name.endsWith(".mjs"),
-    );
-    const piExtension = await import(`${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`);
-    assertEqual(typeof piExtension.default, "function", "packaged Pi default export");
-    assertEqual(
-      typeof piExtension.registerStationPiExtension,
-      "function",
-      "packaged Pi named export",
-    );
-    const piHandlers = new Map();
-    const deliveredEvents = [];
-    piExtension.registerStationPiExtension(
-      { on: (eventType, handler) => piHandlers.set(eventType, handler) },
-      {
-        env: { STATION_WORKTREE_PATH: root },
-        sendReport: async (input) => deliveredEvents.push(input),
-      },
-    );
-    assertEqual(piHandlers.size > 0, true, "packaged Pi handler registration");
-    await piHandlers.get("session_start")?.({ reason: "startup" }, { cwd: root });
-    assertEqual(deliveredEvents.length, 1, "packaged Pi injected event delivery");
-  }
-
-  const hostSocketPath = join(runtimeDir, "station-host.sock");
-  hostProcess = spawn(
-    binaryPath,
-    ["__station-host", "--socket", hostSocketPath, "--state-dir", stateDir],
-    {
-      cwd: hostileDir,
-      env: childEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-  const hostDiagnostics = collectOutput(hostProcess);
-  hostClient = createStationHostClient({
-    socketPath: hostSocketPath,
-    timeoutMs: 1000,
-    expectedBuildVersion: expectedVersion,
-  });
-  await waitForHost(hostClient, hostDiagnostics);
-  const hostHealth = await hostClient.health();
-  assertEqual(hostHealth.buildVersion, expectedVersion, "compiled station-host build version");
-  await access(markerPath).then(
-    () => fail("hostile .env or bunfig preload created its marker"),
-    () => undefined,
-  );
-
-  const spawned = await hostClient.spawn({
-    terminalTargetId: "native:binary-smoke",
-    worktreeId: "binary-smoke",
-    projectId: "binary-smoke",
-    sessionId: "ses_binary_smoke",
-    worktreePath: root,
-    harnessProvider: "scripted",
-    command: "/bin/sh",
-    args: [
-      "-c",
-      'printf STATION_BINARY_PTY_OK; while [ ! -f "$1" ]; do sleep 1; done; exit 7',
-      "station-binary-pty",
-      ptyReleasePath,
-    ],
-    cwd: root,
-    cols: 80,
-    rows: 24,
-  });
-  const attachment = await hostClient.attach(spawned.ptyId);
-  if (!ptyOnly) {
-    const sourceVersion = (
-      await run(process.execPath, [sourceCliPath, "--version"], { env: childEnv })
-    ).stdout.trim();
-    if (expectedVersion.startsWith("0.0.0-") && sourceVersion !== expectedVersion) {
-      const previousObserverPid = observerPid;
-      await run(
-        process.execPath,
-        [sourceCliPath, "--config", configPath, "observer", "start", "--timeout-ms", "30000"],
-        { env: childEnv },
+      const setup = await run(
+        binaryPath,
+        ["--config", configPath, "setup", "check", "--json", "--no-brew"],
+        { cwd: root, env: popupEnv, allowedExitCodes: [1] },
       );
-      const successorHealth = await observerClient.health();
-      observerPid = successorHealth.pid;
-      assertEqual(successorHealth.version, sourceVersion, "higher source observer handoff");
+      const setupPlan = JSON.parse(setup.stdout);
+      assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
+      assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
+      assertEqual(setupPlan.summary.requiredOk, false, "compiled setup requiredOk alias");
+      const persistedBindingAction = requiredSetupAction(setupPlan, "tmux-popup-binding");
+      const liveBindingAction = requiredSetupAction(setupPlan, "tmux-live-popup-binding");
+      assertEqual(persistedBindingAction.tier, "recommended", "compiled popup binding tier");
+      assertEqual(persistedBindingAction.selected, false, "compiled popup binding remains opt-in");
       assertEqual(
-        observerPid === previousObserverPid,
-        false,
-        "higher source observer replaces lower compiled observer",
+        persistedBindingAction.data?.marker,
+        "# >>> station popup binding >>>",
+        "compiled popup binding start marker",
       );
-      if (previousObserverPid !== undefined) {
-        assertEqual(
-          await waitForProcessExit(previousObserverPid, 10_000),
-          true,
-          "replaced observer exact process exit",
-        );
+      const bindingBlock = persistedBindingAction.data?.appendedText;
+      if (typeof bindingBlock !== "string") {
+        fail("compiled setup popup binding action did not include its marked block");
       }
+      assertIncludes(bindingBlock, "bind-key Space run-shell -b", "compiled popup binding key");
+      assertIncludes(
+        bindingBlock,
+        "# <<< station popup binding <<<",
+        "compiled popup binding end marker",
+      );
+      const popupRunShellCommand = liveBindingAction.command?.at(-1);
+      if (typeof popupRunShellCommand !== "string") {
+        fail("compiled setup live popup binding action did not include its generated command");
+      }
+      assertEqual(
+        liveBindingAction.command?.[0],
+        fakeTmuxPath,
+        "compiled popup binding resolved tmux executable",
+      );
+      assertIncludes(
+        popupRunShellCommand,
+        join(installedRoot, "stn-tmux-popup"),
+        "compiled popup binding exact fallback alias",
+      );
+      assertIncludes(
+        popupRunShellCommand,
+        installedRoot,
+        "compiled popup binding installed ownership",
+      );
+      const tmuxConfigPath = join(homeDir, ".tmux.conf");
+      await writeFile(tmuxConfigPath, bindingBlock, { mode: 0o600 });
+      await run(fakeTmuxPath, ["source-file", tmuxConfigPath], { env: popupEnv });
+      const persistedPopupRunShellCommand = (
+        await readFakeTmuxState(fakeTmuxStatePath)
+      ).bindings.Space?.at(-1);
+      if (typeof persistedPopupRunShellCommand !== "string") {
+        fail("compiled setup popup binding did not load from its persisted marked block");
+      }
+      assertEqual(
+        persistedPopupRunShellCommand,
+        popupRunShellCommand,
+        "compiled persisted popup command round trip",
+      );
 
       await run(
         binaryPath,
         ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
-        { env: childEnv },
+        {
+          env: childEnv,
+        },
+      );
+      observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
+      const health = await observerClient.health();
+      observerPid = health.pid;
+      assertEqual(health.status, "healthy", "compiled observer health");
+      await run(
+        binaryPath,
+        ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
+        {
+          env: childEnv,
+        },
+      );
+      assertEqual((await observerClient.health()).pid, observerPid, "same-build observer reuse");
+      const snapshot = await observerClient.getSnapshot();
+      assertEqual(snapshot.observer.healthy, true, "compiled observer snapshot");
+
+      const coldPopup = await runManagedPopupBinding(
+        persistedPopupRunShellCommand,
+        popupEnv,
+        fakeTmuxStatePath,
+      );
+      assertSilentHandledBinding(coldPopup, "compiled cold popup binding");
+      const coldTmuxState = await readFakeTmuxState(fakeTmuxStatePath);
+      const coldSession = requiredFakeTmuxSession(coldTmuxState, "_station-ui");
+      const registeredRoute = coldTmuxState.serverOptions["@station_popup_ui_route"];
+      if (typeof registeredRoute !== "string" || !registeredRoute.startsWith("v1.n.")) {
+        fail("compiled cold popup did not commit a versioned fast route");
+      }
+      assertEqual(
+        coldSession.options["@station_popup_ui_lease"],
+        registeredRoute,
+        "compiled popup route lease",
+      );
+      assertEqual(
+        coldTmuxState.serverOptions["@station_popup_ui_root"],
+        installedRoot,
+        "compiled popup non-root installed ownership",
+      );
+      assertEqual(
+        coldTmuxState.serverOptions["@station_popup_ui_session_name"],
+        "_station-ui",
+        "compiled popup registered session",
+      );
+      assertEqual(coldTmuxState.rendererStarts, 1, "compiled popup renderer start count");
+      const rendererPid = coldSession.rendererPid;
+      assertEqual(processIsAlive(rendererPid), true, "compiled popup renderer process");
+      assertEqual(
+        (await observerClient.health()).pid,
+        observerPid,
+        "compiled cold popup reuses observer",
+      );
+
+      const closeCount = coldTmuxState.tmuxProcessCount;
+      const closePopup = await runManagedPopupBinding(
+        persistedPopupRunShellCommand,
+        popupEnv,
+        fakeTmuxStatePath,
+      );
+      assertSilentHandledBinding(closePopup, "compiled warm popup close");
+      const closedTmuxState = await readFakeTmuxState(fakeTmuxStatePath);
+      assertEqual(
+        closedTmuxState.tmuxProcessCount - closeCount,
+        2,
+        "compiled warm popup close tmux process budget",
+      );
+      assertEqual(
+        closedTmuxState.popups[popupEnv.FAKE_TMUX_CLIENT_NAME]?.open,
+        false,
+        "compiled warm popup closed",
+      );
+      assertActivePopupMarkersCleared(closedTmuxState, "compiled warm popup close");
+
+      await writeFile(popupConfigPath, 'schema_version = "malformed"\n', { mode: 0o600 });
+      const reopenCount = closedTmuxState.tmuxProcessCount;
+      const warmPopup = await runManagedPopupBinding(
+        persistedPopupRunShellCommand,
+        popupEnv,
+        fakeTmuxStatePath,
+      );
+      assertSilentHandledBinding(warmPopup, "compiled malformed-config warm popup");
+      const warmTmuxState = await readFakeTmuxState(fakeTmuxStatePath);
+      assertEqual(
+        warmTmuxState.tmuxProcessCount - reopenCount,
+        2,
+        "compiled warm popup open tmux process budget",
+      );
+      assertEqual(
+        warmTmuxState.popups[popupEnv.FAKE_TMUX_CLIENT_NAME]?.open,
+        true,
+        "compiled warm popup bypasses malformed config",
+      );
+      assertEqual(
+        requiredFakeTmuxSession(warmTmuxState, "_station-ui").rendererPid,
+        rendererPid,
+        "compiled warm popup renderer reuse",
       );
       assertEqual(
         (await observerClient.health()).pid,
         observerPid,
-        "lower compiled build reuses higher observer",
+        "compiled warm popup does not replace observer",
       );
-      await run(
+
+      const directFailure = await run(join(installedRoot, "stn-tmux-popup"), [], {
+        env: popupEnv,
+        allowedExitCodes: [1],
+      });
+      assertEqual(directFailure.stdout, "", "direct popup diagnostic stdout");
+      assertEqual(directFailure.stderr.length > 0, true, "direct popup diagnostic stderr");
+      const failingState = structuredClone(warmTmuxState);
+      failingState.serverOptions["@station_popup_ui_route"] = "malformed";
+      await writeFakeTmuxState(fakeTmuxStatePath, failingState);
+      const failedBinding = await runManagedPopupBinding(
+        persistedPopupRunShellCommand,
+        popupEnv,
+        fakeTmuxStatePath,
+      );
+      assertSilentHandledBinding(failedBinding, "compiled failing popup binding");
+      const failedTmuxState = await readFakeTmuxState(fakeTmuxStatePath);
+      assertEqual(
+        failedTmuxState.statusMessages.at(-1),
+        "Station popup failed; run stn popup for details",
+        "compiled popup nonblocking failure message",
+      );
+      assertEqual(failedTmuxState.paneInMode, 0, "compiled popup failure pane mode");
+      assertEqual(
+        failedTmuxState.paneContent.includes("returned 1"),
+        false,
+        "compiled popup failure returned-status view",
+      );
+      assertEqual(
+        failedTmuxState.paneContent.includes(persistedPopupRunShellCommand),
+        false,
+        "compiled popup failure dispatcher view",
+      );
+      assertEqual(
+        failedTmuxState.popups[popupEnv.FAKE_TMUX_CLIENT_NAME]?.open,
+        true,
+        "compiled popup failure preserves existing UI",
+      );
+      assertEqual(
+        requiredFakeTmuxSession(failedTmuxState, "_station-ui").rendererPid,
+        rendererPid,
+        "compiled popup failure preserves renderer",
+      );
+      assertEqual(
+        (await observerClient.health()).pid,
+        observerPid,
+        "compiled popup failure preserves observer",
+      );
+
+      failedTmuxState.serverOptions["@station_popup_ui_route"] = registeredRoute;
+      await writeFakeTmuxState(fakeTmuxStatePath, failedTmuxState);
+      const cleanupCount = failedTmuxState.tmuxProcessCount;
+      const cleanupPopup = await runManagedPopupBinding(
+        persistedPopupRunShellCommand,
+        popupEnv,
+        fakeTmuxStatePath,
+      );
+      assertSilentHandledBinding(cleanupPopup, "compiled popup cleanup");
+      const cleanedTmuxState = await readFakeTmuxState(fakeTmuxStatePath);
+      assertEqual(
+        cleanedTmuxState.tmuxProcessCount - cleanupCount,
+        2,
+        "compiled popup cleanup tmux process budget",
+      );
+      assertActivePopupMarkersCleared(cleanedTmuxState, "compiled popup cleanup");
+      assertEqual(
+        cleanedTmuxState.popups[popupEnv.FAKE_TMUX_CLIENT_NAME]?.open,
+        false,
+        "compiled popup cleanup closes existing UI",
+      );
+      await writeSmokeConfig(popupConfigPath, stateDir, socketPath, "tmux");
+
+      const ingress = await run(
         join(dirname(binaryPath), "stn-ingress"),
         ["--socket", socketPath, "--state-dir", stateDir, "worktrunk", "post-create"],
         {
           env: childEnv,
-          input: JSON.stringify({ branch: "station/binary-smoke-after-handoff" }),
+          input: JSON.stringify({ branch: "station/binary-smoke" }),
         },
       );
+      assertEqual(ingress.code, 0, "ingress symlink receipt");
       assertEqual(
         await directoryFileCount(join(stateDir, "spool", "hooks")),
         0,
-        "lower-build ingress reuses the higher observer",
+        "online ingress must not spool",
       );
-      assertEqual(processIsAlive(hostProcess.pid), true, "station-host survives observer handoff");
+      assertEqual((await observerClient.health()).status, "healthy", "observer after ingress");
+
+      const bootLog = await readFile(join(stateDir, "logs", "observer-boot.log"), "utf8");
+      const bootHeader = JSON.parse(bootLog.split(/\r?\n/, 1)[0] ?? "{}");
+      assertEqual(bootHeader.command?.[0], binaryPath, "detached observer executable");
+      assertEqual(bootHeader.command?.[1], "__observer", "detached observer internal route");
+
+      const piExtensionPath = await findFile(join(stateDir, "run", "assets", "pi"), (name) =>
+        name.endsWith(".mjs"),
+      );
+      const piExtension = await import(
+        `${pathToFileURL(piExtensionPath).href}?smoke=${Date.now()}`
+      );
+      assertEqual(typeof piExtension.default, "function", "packaged Pi default export");
       assertEqual(
-        (await hostClient.health()).buildVersion,
-        expectedVersion,
-        "station-host build remains unchanged across observer handoff",
+        typeof piExtension.registerStationPiExtension,
+        "function",
+        "packaged Pi named export",
       );
+      const piHandlers = new Map();
+      const deliveredEvents = [];
+      piExtension.registerStationPiExtension(
+        { on: (eventType, handler) => piHandlers.set(eventType, handler) },
+        {
+          env: { STATION_WORKTREE_PATH: root },
+          sendReport: async (input) => deliveredEvents.push(input),
+        },
+      );
+      assertEqual(piHandlers.size > 0, true, "packaged Pi handler registration");
+      await piHandlers.get("session_start")?.({ reason: "startup" }, { cwd: root });
+      assertEqual(deliveredEvents.length, 1, "packaged Pi injected event delivery");
     }
-  }
-  const livePty = (await hostClient.list()).find((entry) => entry.ptyId === spawned.ptyId);
-  assertEqual(
-    livePty?.ptyId,
-    spawned.ptyId,
-    "same host PTY remains listed across observer handoff",
-  );
-  assertEqual(livePty?.alive, true, "same host PTY remains live across observer handoff");
-  await writeFile(ptyReleasePath, "", { mode: 0o600 });
-  const terminalResult = await collectTerminalResult(attachment, 10_000);
-  assertIncludes(terminalResult.output, "STATION_BINARY_PTY_OK", "compiled host PTY output");
-  assertEqual(terminalResult.exitCode, 7, "compiled host PTY exit code");
 
-  const hostLog = await readFile(join(stateDir, "logs", "station-host.jsonl"), "utf8");
-  assertIncludes(hostLog, '"ptyImplementation":"bun"', "compiled host PTY implementation");
-  await findFile(join(stateDir, "run", "assets", "ctty"), (name) => name === "station-ctty-helper");
+    const hostSocketPath = join(runtimeDir, "station-host.sock");
+    hostProcess = spawn(
+      binaryPath,
+      ["__station-host", "--socket", hostSocketPath, "--state-dir", stateDir],
+      {
+        cwd: hostileDir,
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    const hostDiagnostics = collectOutput(hostProcess);
+    hostClient = createStationHostClient({
+      socketPath: hostSocketPath,
+      timeoutMs: 1000,
+      expectedBuildVersion: expectedVersion,
+    });
+    await waitForHost(hostClient, hostDiagnostics);
+    const hostHealth = await hostClient.health();
+    assertEqual(hostHealth.buildVersion, expectedVersion, "compiled station-host build version");
+    await access(markerPath).then(
+      () => fail("hostile .env or bunfig preload created its marker"),
+      () => undefined,
+    );
 
-  process.stdout.write("binary smoke passed\n");
-} finally {
-  if (observerClient !== undefined) {
-    await observerClient.stop().catch(() => undefined);
-    await waitForMissing(socketPath).catch(() => undefined);
-  }
-  if (observerPid !== undefined) {
-    await terminateProcess(observerPid);
-  }
-  hostClient?.dispose();
-  if (hostProcess !== undefined && hostProcess.exitCode === null) {
-    hostProcess.kill("SIGTERM");
-    try {
-      await waitForExit(hostProcess, 3000);
-    } catch {
-      hostProcess.kill("SIGKILL");
-      await waitForExit(hostProcess, 3000).catch(() => undefined);
+    const spawned = await hostClient.spawn({
+      terminalTargetId: "native:binary-smoke",
+      worktreeId: "binary-smoke",
+      projectId: "binary-smoke",
+      sessionId: "ses_binary_smoke",
+      worktreePath: root,
+      harnessProvider: "scripted",
+      command: "/bin/sh",
+      args: [
+        "-c",
+        'printf STATION_BINARY_PTY_OK; while [ ! -f "$1" ]; do sleep 1; done; exit 7',
+        "station-binary-pty",
+        ptyReleasePath,
+      ],
+      cwd: root,
+      cols: 80,
+      rows: 24,
+    });
+    const attachment = await hostClient.attach(spawned.ptyId);
+    if (!ptyOnly) {
+      const sourceVersion = (
+        await run(process.execPath, [sourceCliPath, "--version"], { env: childEnv })
+      ).stdout.trim();
+      if (expectedVersion.startsWith("0.0.0-") && sourceVersion !== expectedVersion) {
+        const previousObserverPid = observerPid;
+        await run(
+          process.execPath,
+          [sourceCliPath, "--config", configPath, "observer", "start", "--timeout-ms", "30000"],
+          { env: childEnv },
+        );
+        const successorHealth = await observerClient.health();
+        observerPid = successorHealth.pid;
+        assertEqual(successorHealth.version, sourceVersion, "higher source observer handoff");
+        assertEqual(
+          observerPid === previousObserverPid,
+          false,
+          "higher source observer replaces lower compiled observer",
+        );
+        if (previousObserverPid !== undefined) {
+          assertEqual(
+            await waitForProcessExit(previousObserverPid, 10_000),
+            true,
+            "replaced observer exact process exit",
+          );
+        }
+
+        await run(
+          binaryPath,
+          ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
+          { env: childEnv },
+        );
+        assertEqual(
+          (await observerClient.health()).pid,
+          observerPid,
+          "lower compiled build reuses higher observer",
+        );
+        await run(
+          join(dirname(binaryPath), "stn-ingress"),
+          ["--socket", socketPath, "--state-dir", stateDir, "worktrunk", "post-create"],
+          {
+            env: childEnv,
+            input: JSON.stringify({ branch: "station/binary-smoke-after-handoff" }),
+          },
+        );
+        assertEqual(
+          await directoryFileCount(join(stateDir, "spool", "hooks")),
+          0,
+          "lower-build ingress reuses the higher observer",
+        );
+        assertEqual(
+          processIsAlive(hostProcess.pid),
+          true,
+          "station-host survives observer handoff",
+        );
+        assertEqual(
+          (await hostClient.health()).buildVersion,
+          expectedVersion,
+          "station-host build remains unchanged across observer handoff",
+        );
+      }
     }
+    const livePty = (await hostClient.list()).find((entry) => entry.ptyId === spawned.ptyId);
+    assertEqual(
+      livePty?.ptyId,
+      spawned.ptyId,
+      "same host PTY remains listed across observer handoff",
+    );
+    assertEqual(livePty?.alive, true, "same host PTY remains live across observer handoff");
+    await writeFile(ptyReleasePath, "", { mode: 0o600 });
+    const terminalResult = await collectTerminalResult(attachment, 10_000);
+    assertIncludes(terminalResult.output, "STATION_BINARY_PTY_OK", "compiled host PTY output");
+    assertEqual(terminalResult.exitCode, 7, "compiled host PTY exit code");
+
+    const hostLog = await readFile(join(stateDir, "logs", "station-host.jsonl"), "utf8");
+    assertIncludes(hostLog, '"ptyImplementation":"bun"', "compiled host PTY implementation");
+    await findFile(
+      join(stateDir, "run", "assets", "ctty"),
+      (name) => name === "station-ctty-helper",
+    );
+
+    process.stdout.write("binary smoke passed\n");
+  } finally {
+    if (observerClient !== undefined) {
+      await observerClient.stop().catch(() => undefined);
+      await waitForMissing(socketPath).catch(() => undefined);
+    }
+    if (observerPid !== undefined) {
+      await terminateProcess(observerPid);
+    }
+    hostClient?.dispose();
+    if (hostProcess !== undefined && hostProcess.exitCode === null) {
+      hostProcess.kill("SIGTERM");
+      try {
+        await waitForExit(hostProcess, 3000);
+      } catch {
+        hostProcess.kill("SIGKILL");
+        await waitForExit(hostProcess, 3000).catch(() => undefined);
+      }
+    }
+    await stopFakeTmuxProcesses(fakeTmuxStatePath);
+    await rm(root, { recursive: true, force: true });
   }
-  await rm(root, { recursive: true, force: true });
 }
 
 function parseExpectedVersion(args) {
@@ -287,7 +556,7 @@ function isolatedBinaryEnv({ homeDir: home, runtimeDir: runtime }) {
   };
 }
 
-async function writeSmokeConfig(path, state, socket) {
+async function writeSmokeConfig(path, state, socket, terminal = "noop-terminal") {
   await writeFile(
     path,
     [
@@ -300,7 +569,7 @@ async function writeSmokeConfig(path, state, socket) {
       "",
       "[defaults]",
       'worktree_provider = "noop-worktree"',
-      'terminal = "noop-terminal"',
+      `terminal = ${JSON.stringify(terminal)}`,
       'harness = "noop-harness"',
       'layout = "agent-shell"',
       "",
@@ -322,6 +591,509 @@ async function writeHostileConfig(directory, marker) {
     join(directory, "preload.mjs"),
     `import { writeFileSync } from "node:fs"; writeFileSync(${JSON.stringify(marker)}, "pwned");\n`,
   );
+}
+
+async function assertExactBinaryAlias(installedRoot, name) {
+  const path = join(installedRoot, name);
+  const stat = await lstat(path);
+  assertEqual(stat.isSymbolicLink(), true, `${name} exact symlink`);
+  assertEqual(await readlink(path), "stn", `${name} exact symlink target`);
+  assertEqual(await realpath(path), join(installedRoot, "stn"), `${name} binary identity`);
+}
+
+function requiredSetupAction(plan, id) {
+  const action = plan.actions?.find((candidate) => candidate.id === id);
+  if (action === undefined) {
+    fail(`compiled setup did not offer ${id}`);
+  }
+  return action;
+}
+
+async function runManagedPopupBinding(command, env, fakeTmuxStatePath) {
+  const expandedCommand = command
+    .replaceAll("#{q:client_name}", env.FAKE_TMUX_CLIENT_NAME)
+    .replaceAll("#{client_pid}", env.FAKE_TMUX_CLIENT_PID)
+    .replaceAll("#{q:client_session}", env.FAKE_TMUX_CLIENT_SESSION);
+  const result = await run("/bin/sh", ["-c", expandedCommand], {
+    env,
+    allowedExitCodes: Array.from({ length: 256 }, (_, code) => code),
+  });
+  if (result.code !== 0) {
+    const state = await readFakeTmuxState(fakeTmuxStatePath);
+    state.paneInMode = 1;
+    state.paneContent += `returned ${result.code}\n${expandedCommand}\n`;
+    await writeFakeTmuxState(fakeTmuxStatePath, state);
+  }
+  return result;
+}
+
+function assertSilentHandledBinding(result, label) {
+  assertEqual(result.code, 0, `${label} status`);
+  assertEqual(result.stdout, "", `${label} stdout`);
+  assertEqual(result.stderr, "", `${label} stderr`);
+}
+
+function requiredFakeTmuxSession(state, sessionName) {
+  const session = state.sessions[sessionName];
+  if (session === undefined || !Number.isInteger(session.rendererPid)) {
+    fail(`fake tmux session ${sessionName} was not created with a renderer process`);
+  }
+  return session;
+}
+
+function assertActivePopupMarkersCleared(state, label) {
+  for (const optionName of [
+    "@station_popup_active_claim",
+    "@station_popup_client",
+    "@station_popup_focus_client",
+  ]) {
+    assertEqual(state.serverOptions[optionName], undefined, `${label} ${optionName}`);
+  }
+}
+
+function initialFakeTmuxState() {
+  return {
+    bindings: {},
+    commandLog: [],
+    paneContent: "",
+    paneInMode: 0,
+    popups: {},
+    rendererPids: [],
+    rendererStarts: 0,
+    serverOptions: {},
+    sessions: {},
+    statusMessages: [],
+    tmuxProcessCount: 0,
+  };
+}
+
+async function writeFakeTmux(path, statePath) {
+  await writeFakeTmuxState(statePath, initialFakeTmuxState());
+  const runnerPath = fileURLToPath(import.meta.url);
+  await writeFile(
+    path,
+    [
+      "#!/bin/sh",
+      "export STATION_BINARY_SMOKE_FAKE_TMUX=1",
+      `export FAKE_TMUX_STATE_PATH=${quoteShellWord(statePath)}`,
+      `exec ${quoteShellWord(process.execPath)} ${quoteShellWord(runnerPath)} "$@"`,
+      "",
+    ].join("\n"),
+    { mode: 0o700 },
+  );
+}
+
+async function readFakeTmuxState(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+async function writeFakeTmuxState(path, state) {
+  await writeFile(path, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+}
+
+async function stopFakeTmuxProcesses(path) {
+  let state;
+  try {
+    state = await readFakeTmuxState(path);
+  } catch {
+    return;
+  }
+  for (const pid of state.rendererPids ?? []) {
+    if (Number.isInteger(pid) && pid > 0) {
+      await terminateProcess(pid).catch(() => undefined);
+    }
+  }
+}
+
+async function runFakeTmuxProcess(args) {
+  const statePath = process.env.FAKE_TMUX_STATE_PATH;
+  if (statePath === undefined) {
+    process.stderr.write("fake tmux state path is missing\n");
+    process.exitCode = 2;
+    return;
+  }
+  const state = await readFakeTmuxState(statePath);
+  state.tmuxProcessCount += 1;
+  state.commandLog.push(args);
+  const result = await executeFakeTmuxCommand(state, args);
+  await writeFakeTmuxState(statePath, state);
+  if (result.stdout !== undefined) process.stdout.write(result.stdout);
+  if (result.stderr !== undefined) process.stderr.write(result.stderr);
+  process.exitCode = result.status;
+}
+
+async function executeFakeTmuxCommand(state, args) {
+  const [command] = args;
+  switch (command) {
+    case "-V":
+      return fakeTmuxResult(0, "tmux 3.5a\n");
+    case "bind-key":
+      return bindFakeTmuxKey(state, args);
+    case "display-message":
+      return displayFakeTmuxMessage(state, args);
+    case "display-popup":
+      return displayFakeTmuxPopup(state, args);
+    case "has-session":
+      return hasFakeTmuxSession(state, args);
+    case "if-shell":
+      return executeFakeTmuxIfShell(state, args);
+    case "kill-session":
+      return killFakeTmuxSession(state, args);
+    case "list-panes":
+      return fakeTmuxResult(0, "");
+    case "list-keys":
+      return listFakeTmuxKeys(state);
+    case "new-session":
+      return createFakeTmuxSession(state, args);
+    case "set-option":
+      return setFakeTmuxOption(state, args);
+    case "show-options":
+      return showFakeTmuxOption(state, args);
+    case "source-file":
+      return sourceFakeTmuxFile(state, args);
+    default:
+      return fakeTmuxResult(1, undefined, `unsupported fake tmux command: ${args.join(" ")}\n`);
+  }
+}
+
+function fakeTmuxResult(status, stdout, stderr, blocked = false) {
+  return { status, stdout, stderr, blocked };
+}
+
+function bindFakeTmuxKey(state, args) {
+  const key = args[1];
+  if (key === undefined) return fakeTmuxResult(1);
+  state.bindings[key] = args.slice(2);
+  return fakeTmuxResult(0);
+}
+
+function listFakeTmuxKeys(state) {
+  const lines = Object.entries(state.bindings).map(
+    ([key, args]) => `bind-key -T prefix ${key} ${args.join(" ")}`,
+  );
+  return fakeTmuxResult(0, lines.length === 0 ? "" : `${lines.join("\n")}\n`);
+}
+
+async function sourceFakeTmuxFile(state, args) {
+  const path = args[1];
+  if (path === undefined) return fakeTmuxResult(1);
+  const source = await readFile(path, "utf8");
+  for (const line of source.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) continue;
+    const words = splitFakeTmuxWords(trimmed);
+    if (words[0] !== "bind-key") {
+      return fakeTmuxResult(1, undefined, `unsupported fake tmux config: ${trimmed}\n`);
+    }
+    const result = bindFakeTmuxKey(state, words);
+    if (result.status !== 0) return result;
+  }
+  return fakeTmuxResult(0);
+}
+
+function fakeTmuxClient() {
+  return {
+    name: process.env.FAKE_TMUX_CLIENT_NAME ?? "binary-smoke-client",
+    pid: process.env.FAKE_TMUX_CLIENT_PID ?? "41001",
+    sessionName: process.env.FAKE_TMUX_CLIENT_SESSION ?? "binary-smoke",
+  };
+}
+
+function displayFakeTmuxMessage(state, args) {
+  if (args.includes("-d")) {
+    state.statusMessages.push(args.at(-1) ?? "");
+    return fakeTmuxResult(0);
+  }
+  if (!args.includes("-p")) return fakeTmuxResult(0);
+
+  const target = optionValue(args, "-t");
+  const format = args.at(-1) ?? "";
+  const client = fakeTmuxClient();
+  if (target !== undefined && format.includes("@station_popup_ui_route")) {
+    const sessionName = normalizeFakeTmuxSessionName(target);
+    const session = state.sessions[sessionName];
+    if (session === undefined) return fakeTmuxResult(1);
+    const fields = [
+      state.serverOptions["@station_popup_ui_route"],
+      session.options["@station_popup_ui_lease"],
+      state.serverOptions["@station_popup_active_claim"],
+      session.options["@station_popup_ui_signature"],
+      state.serverOptions["@station_popup_ui_session_name"],
+      state.serverOptions["@station_popup_ui_expected_signature"],
+      state.serverOptions["@station_popup_ui_root"],
+      state.serverOptions["@station_popup_client"],
+      state.serverOptions["@station_popup_focus_client"],
+      state.serverOptions["@station_tui_dev_session_name"],
+      state.serverOptions["@station_tui_dev_command"],
+      state.serverOptions["@station_tui_dev_owner"],
+      state.serverOptions["@station_tui_dev_root"],
+      "v1",
+    ].map((value) => value ?? "");
+    return fakeTmuxResult(0, `${fields.join("\u001f")}\n`);
+  }
+  if (format === "#{client_name}") return fakeTmuxResult(0, `${client.name}\n`);
+  if (format === "#{client_pid}") return fakeTmuxResult(0, `${client.pid}\n`);
+  if (format === "#{client_session}") return fakeTmuxResult(0, `${client.sessionName}\n`);
+  if (format.includes("\t")) {
+    return fakeTmuxResult(0, `${client.pid}\t${client.name}\t${client.sessionName}\n`);
+  }
+  return fakeTmuxResult(0, `${format}\n`);
+}
+
+function hasFakeTmuxSession(state, args) {
+  const sessionName = normalizeFakeTmuxSessionName(optionValue(args, "-t") ?? "");
+  return fakeTmuxResult(state.sessions[sessionName] === undefined ? 1 : 0);
+}
+
+function createFakeTmuxSession(state, args) {
+  const sessionName = normalizeFakeTmuxSessionName(optionValue(args, "-s") ?? "");
+  if (sessionName.length === 0) return fakeTmuxResult(1);
+  if (state.sessions[sessionName] !== undefined) return fakeTmuxResult(1);
+  const renderer = spawn("/bin/sleep", ["2147483647"], {
+    detached: true,
+    stdio: "ignore",
+  });
+  renderer.unref();
+  state.rendererStarts += 1;
+  state.rendererPids.push(renderer.pid);
+  state.sessions[sessionName] = {
+    command: args.at(-1) ?? "",
+    options: {},
+    rendererPid: renderer.pid,
+  };
+  return fakeTmuxResult(0);
+}
+
+function killFakeTmuxSession(state, args) {
+  const sessionName = normalizeFakeTmuxSessionName(optionValue(args, "-t") ?? "");
+  const session = state.sessions[sessionName];
+  if (session === undefined) return fakeTmuxResult(1);
+  signalProcess(session.rendererPid, "SIGTERM");
+  delete state.sessions[sessionName];
+  return fakeTmuxResult(0);
+}
+
+function showFakeTmuxOption(state, args) {
+  const target = optionValue(args, "-t");
+  const optionName = args.at(-1);
+  if (optionName === undefined) return fakeTmuxResult(1);
+  const source =
+    target === undefined
+      ? state.serverOptions
+      : state.sessions[normalizeFakeTmuxSessionName(target)]?.options;
+  if (source === undefined) return fakeTmuxResult(1);
+  const value = source[optionName];
+  return fakeTmuxResult(0, value === undefined ? "" : `${value}\n`);
+}
+
+function setFakeTmuxOption(state, args) {
+  let target;
+  let global = false;
+  let unset = false;
+  let optionName;
+  let value;
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "-t") {
+      target = args[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg?.startsWith("-")) {
+      global ||= arg.includes("g");
+      unset ||= arg.includes("u");
+      continue;
+    }
+    if (optionName === undefined) optionName = arg;
+    else if (value === undefined) value = arg;
+  }
+  if (optionName === undefined) return fakeTmuxResult(1);
+  const source = global
+    ? state.serverOptions
+    : state.sessions[normalizeFakeTmuxSessionName(target ?? "")]?.options;
+  if (source === undefined) return fakeTmuxResult(1);
+  if (unset) delete source[optionName];
+  else source[optionName] = value ?? "";
+  return fakeTmuxResult(0);
+}
+
+function displayFakeTmuxPopup(state, args) {
+  const client = optionValue(args, "-c") ?? fakeTmuxClient().name;
+  if (args.includes("-C")) {
+    state.popups[client] = { ...(state.popups[client] ?? {}), open: false };
+    return fakeTmuxResult(0);
+  }
+  if (state.failNextDisplay === true) {
+    state.failNextDisplay = false;
+    return fakeTmuxResult(1);
+  }
+  state.popups[client] = {
+    command: optionValue(args, "-E") ?? "",
+    open: true,
+  };
+  return fakeTmuxResult(0, undefined, undefined, true);
+}
+
+async function executeFakeTmuxIfShell(state, args) {
+  let index = 1;
+  let target;
+  while (index < args.length && args[index]?.startsWith("-")) {
+    if (args[index] === "-t") {
+      target = args[index + 1];
+      index += 2;
+    } else {
+      index += 1;
+    }
+  }
+  if (target !== undefined && state.sessions[normalizeFakeTmuxSessionName(target)] === undefined) {
+    return fakeTmuxResult(1);
+  }
+  const condition = args[index] ?? "";
+  const targetSession =
+    target === undefined ? undefined : state.sessions[normalizeFakeTmuxSessionName(target)];
+  const selected = fakeTmuxFormatTruthy(evaluateFakeTmuxFormat(state, condition, targetSession))
+    ? args[index + 1]
+    : args[index + 2];
+  if (selected === undefined || selected.length === 0) return fakeTmuxResult(0);
+  return executeFakeTmuxCommandList(state, selected);
+}
+
+async function executeFakeTmuxCommandList(state, source) {
+  let stdout = "";
+  for (const command of splitFakeTmuxCommands(source)) {
+    const words = splitFakeTmuxWords(command);
+    if (words.length === 0) continue;
+    const result = await executeFakeTmuxCommand(state, words);
+    if (result.stdout !== undefined) stdout += result.stdout;
+    if (result.status !== 0 || result.blocked === true) {
+      return fakeTmuxResult(result.status, stdout.length === 0 ? undefined : stdout, result.stderr);
+    }
+  }
+  return fakeTmuxResult(0, stdout.length === 0 ? undefined : stdout);
+}
+
+function evaluateFakeTmuxFormat(state, expression, targetSession) {
+  if (!isWholeFakeTmuxFormat(expression)) return expression;
+  const inner = expression.slice(2, -1);
+  if (inner.startsWith("==:")) {
+    const [left = "", right = ""] = splitFakeTmuxFormatArgs(inner.slice(3));
+    return evaluateFakeTmuxFormat(state, left, targetSession) ===
+      evaluateFakeTmuxFormat(state, right, targetSession)
+      ? "1"
+      : "0";
+  }
+  if (inner.startsWith("&&:")) {
+    const [left = "", right = ""] = splitFakeTmuxFormatArgs(inner.slice(3));
+    return fakeTmuxFormatTruthy(evaluateFakeTmuxFormat(state, left, targetSession)) &&
+      fakeTmuxFormatTruthy(evaluateFakeTmuxFormat(state, right, targetSession))
+      ? "1"
+      : "0";
+  }
+  if (inner.startsWith("@")) {
+    return state.serverOptions[inner] ?? targetSession?.options[inner] ?? "";
+  }
+  return "";
+}
+
+function isWholeFakeTmuxFormat(value) {
+  if (!value.startsWith("#{") || !value.endsWith("}")) return false;
+  let depth = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    if (value.startsWith("#{", index)) {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (value[index] === "}") {
+      depth -= 1;
+      if (depth === 0 && index !== value.length - 1) return false;
+    }
+  }
+  return depth === 0;
+}
+
+function splitFakeTmuxFormatArgs(source) {
+  let depth = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    if (source.startsWith("#{", index)) {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (source[index] === "}") {
+      depth -= 1;
+      continue;
+    }
+    if (source[index] === "," && depth === 0) {
+      return [source.slice(0, index), source.slice(index + 1)];
+    }
+  }
+  return [source];
+}
+
+function fakeTmuxFormatTruthy(value) {
+  return value.length > 0 && value !== "0";
+}
+
+function splitFakeTmuxCommands(source) {
+  return splitFakeTmuxShell(source, true);
+}
+
+function splitFakeTmuxWords(source) {
+  return splitFakeTmuxShell(source, false);
+}
+
+function splitFakeTmuxShell(source, commands) {
+  const result = [];
+  let current = "";
+  let quote;
+  let escaped = false;
+  for (const character of source) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      if (commands) current += character;
+      escaped = true;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) {
+        if (commands) current += character;
+        quote = undefined;
+      } else current += character;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      if (commands) current += character;
+      quote = character;
+      continue;
+    }
+    if (commands ? character === ";" : /\s/.test(character)) {
+      if (current.length > 0) result.push(current);
+      current = "";
+      continue;
+    }
+    current += character;
+  }
+  if (escaped) current += "\\";
+  if (current.length > 0) result.push(current);
+  return result;
+}
+
+function optionValue(args, option) {
+  const index = args.indexOf(option);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function normalizeFakeTmuxSessionName(value) {
+  return value.endsWith(":") ? value.slice(0, -1) : value;
+}
+
+function quoteShellWord(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function run(command, args, options = {}) {

--- a/station/src/bin/stnMain.ts
+++ b/station/src/bin/stnMain.ts
@@ -1,3 +1,5 @@
+import { realpathSync } from "node:fs";
+import { dirname } from "node:path";
 import { dispatchSelfExec, type SelfExecRunners } from "@station/cli/self-exec";
 import cttyHelperAsset from "../../dist/ctty-helper" with { type: "file" };
 import piExtensionAsset from "../../dist/piExtension.mjs" with { type: "file" };
@@ -16,9 +18,18 @@ function popupArgv(argv: readonly string[]): readonly string[] {
   return argv[0] === "popup" ? argv : ["popup", ...argv];
 }
 
-function compiledRunners(): SelfExecRunners {
+function compiledRunners(installedRoot: string): SelfExecRunners {
+  const cliOptions = {
+    popupDeps: {
+      checkoutRoot: installedRoot,
+      preferRegisteredDevPopup: false,
+    },
+    setupDeps: {
+      tmuxPopupOwnerRoot: installedRoot,
+    },
+  };
   return {
-    cli: async (argv) => (await import("@station/cli/main")).runCliMain(argv),
+    cli: async (argv) => (await import("@station/cli/main")).runCliMain(argv, cliOptions),
     observer: async (argv) => {
       const { runCliObserverMain } = await import("@station/cli/observer-main");
       process.exitCode = await runCliObserverMain(argv, {
@@ -36,23 +47,25 @@ function compiledRunners(): SelfExecRunners {
         preparePtyRuntime: prepareCompiledPtyRuntime,
       }),
     tmuxPopup: async (argv) =>
-      (await import("@station/cli/main")).runCliMain(popupArgv(argv)),
+      (await import("@station/cli/main")).runCliMain(popupArgv(argv), cliOptions),
   };
 }
 
 /**
  * COMPOSITION ROOT
  *
- * Binds compiled raw arguments to lazy process entries and packaged runtime assets.
+ * Binds compiled raw arguments to lazy process entries, packaged runtime assets, and
+ * installed popup ownership and setup wiring.
  */
 export async function runStationBinaryMain(): Promise<void> {
+  const installedRoot = dirname(realpathSync(process.execPath));
   await dispatchSelfExec(
     {
       // Bun preserves the invoked symlink in argv0 while process.argv[0] names the executable.
       argv0: process.argv0,
       argv: process.argv.slice(2),
     },
-    compiledRunners(),
+    compiledRunners(installedRoot),
   );
 }
 

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -180,7 +180,7 @@ describe("setup guided feedback e2e", () => {
       expect(result.timedOut).toBe(false);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(
-        "Tmux popup binding: Ctrl-b Space is persisted for future tmux servers; no current server was live-loaded.",
+        "Tmux popup binding: tmux prefix + Space is persisted for future tmux servers; no current server was live-loaded.",
       );
       expect(result.stdout).toContain("Direct fallback: stn popup");
 


### PR DESCRIPTION
## Summary

- add a strict versioned route, lease, and active-claim protocol for the persistent tmux popup
- generate a silent compiled warm-path binding that performs one snapshot and one guarded tmux action before falling back to the exact `stn-tmux-popup` sibling
- make claim validation, compatibility mirrors, prior-popup close, and display atomic so a superseded caller cannot open or close late
- bind warm reuse to the exact config identity; explicit `--config` and custom geometry use the config-aware alias, and guided setup replans the binding after writing its first config
- preserve user-owned keys in the marked `~/.tmux.conf` block while rejecting malformed blocks and unsafe paths conservatively
- extend unit, integration, binary smoke, private real-tmux, setup, and documentation coverage

## Root cause

The setup-managed binding always entered the full CLI path, so every toggle could start Bun, load configuration, and touch Observer state even when `_station-ui` was already warm. Compatibility options also lacked one authoritative versioned route and compare-and-set claim. During review, deterministic races showed that ownership could change after a caller's last check but before display, and that a generated binding could reuse a warm UI created for a different config or ignore custom geometry.

## User impact

With implicit default geometry, the first compiled open initializes `_station-ui`; later `tmux prefix + <key>` calls directly open, close, or transfer that same UI without reloading config. Concurrent callers cannot let an older claim display after a newer owner wins.

Explicit config paths and custom geometry take the config-aware alias path, so requested size, position, and config identity remain authoritative. Station-controlled binding outcomes remain silent and return zero; `stn popup` remains the diagnostic path.

Setup still offers the binding unselected, defaults new blocks to `Space`, and preserves supported key edits. Previously loaded keys are never unbound automatically.

## Validation

Exact rebased head `442c334` on current `origin/main`:

- isolated `pnpm test:pre-push` passed end to end
  - 1,512 unit tests, 28 contract tests, 464 integration tests, and 43 diagnostics tests
  - setup and Observer lifecycle E2E, installer smoke, Node/Bun SQLite compatibility, and boot-claim races
  - 1,000 renderer tests, 26 native PTY tests, compiled binary build, and binary smoke
- `STATION_REAL_TMUX=1 pnpm test:tmux-popup:real`: 3/3 passed, including simultaneous cold callers, custom geometry, warm PID reuse/transfer, and failure cleanup
- independent focused review: 149 tests passed; ownership, quoting, config identity, scope, and diff checks clean

## Manual UX check

Install the compiled artifact, accept the optional tmux binding in `stn setup`, then use `tmux prefix + Space`: the first open should initialize, the next close/reopen should reuse the same hidden session and renderer, and invoking it from a second client should transfer cleanly. With custom popup geometry, reopen and confirm the configured dimensions are retained.
