### PR TITLE
fix(observer): define canonical session membership

### DIFF
--- a/apps/cli/src/commands/configDiagnostics.ts
+++ b/apps/cli/src/commands/configDiagnostics.ts
@@ -167,6 +167,7 @@ function emptySnapshot(now: string): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,

--- a/apps/cli/src/commands/observe/snapshotContext.ts
+++ b/apps/cli/src/commands/observe/snapshotContext.ts
@@ -155,6 +155,7 @@ function applySessionPatch(
 ): SessionView {
   const next: SessionView = { ...current };
   if (patch.id !== undefined) next.id = patch.id;
+  if (patch.origin !== undefined) next.origin = patch.origin;
   if (patch.projectId !== undefined) next.projectId = patch.projectId;
   if (patch.worktreeId !== undefined) next.worktreeId = patch.worktreeId;
   if (patch.createdAt !== undefined) next.createdAt = patch.createdAt;

--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -219,7 +219,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -18,7 +18,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -34,7 +34,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.7.0",
+        schemaVersion: "0.8.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -140,7 +140,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -174,7 +174,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -210,7 +210,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -272,7 +272,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -312,7 +312,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -662,12 +662,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -695,17 +695,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.7.0",
     },
     snapshot: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -714,6 +714,7 @@ function diagnosticSnapshot(): DiagnosticSnapshot {
       sessions: [],
       counts: {
         projects: 0,
+        sessions: 0,
         worktrees: 0,
         agents: 0,
         working: 0,

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -56,7 +56,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -286,7 +286,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -297,7 +297,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -309,7 +309,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},
@@ -318,6 +318,7 @@ function snapshotFixture(): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -265,7 +265,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -280,7 +280,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -304,7 +304,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -317,7 +317,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -391,7 +391,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},
@@ -400,6 +400,7 @@ function snapshotFixture(): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -22,7 +22,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -31,7 +31,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.7.0", stopped: true, at: now };
+            return { schemaVersion: "0.8.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -68,7 +68,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -77,7 +77,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.7.0", stopped: true, at: now };
+            return { schemaVersion: "0.8.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -136,7 +136,7 @@ describe("CLI observer commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
           }),
         }) as never,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -31,7 +31,7 @@ describe("CLI popup command", () => {
           health: async () => {
             if (!running) throw new Error("stopped");
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -103,7 +103,7 @@ describe("CLI popup command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.7.0",
+                    schemaVersion: "0.8.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -172,7 +172,7 @@ describe("CLI popup command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.7.0",
+                    schemaVersion: "0.8.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -566,7 +566,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -583,11 +583,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -596,6 +596,7 @@ function emptySnapshot(reason: string) {
       sessions: [],
       counts: {
         projects: 0,
+        sessions: 0,
         worktrees: 0,
         agents: 0,
         working: 0,
@@ -629,7 +630,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -106,7 +106,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -27,11 +27,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -40,6 +40,7 @@ function emptySnapshot(reason: string) {
       sessions: [],
       counts: {
         projects: 0,
+        sessions: 0,
         worktrees: 0,
         agents: 0,
         working: 0,
@@ -72,7 +73,7 @@ function runningObserverDeps(
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -212,7 +213,7 @@ describe("CLI tui command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.7.0",
+                    schemaVersion: "0.8.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -277,7 +278,7 @@ describe("CLI tui command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.7.0",
+                    schemaVersion: "0.8.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -84,7 +84,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!running) throw new Error("offline");
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 hookId: event.hookId ?? "hook_final_command",
                 provider: event.provider,
                 event: event.event,
@@ -154,7 +154,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!(await fileExists(argvPath))) throw new Error("offline");
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 hookId: event.hookId ?? "hook_child_timeout",
                 provider: event.provider,
                 event: event.event,
@@ -200,7 +200,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -255,7 +255,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -319,7 +319,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -383,7 +383,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -553,7 +553,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -613,7 +613,7 @@ describe("provider hook ingress command", () => {
         clientFactory: (_socketPath, options) => {
           observedTimeoutMs = options.timeoutMs;
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => ({
-            schemaVersion: "0.7.0",
+            schemaVersion: "0.8.0",
             hookId: event.hookId ?? "hook_timeout_1",
             provider: event.provider,
             event: event.event,
@@ -767,7 +767,7 @@ function stationEnv(): Record<string, string> {
 
 function healthyObserver(paths: { socketPath: string; stateDir: string }): ObserverHealth {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     status: "healthy",
     pid: 12345,
     startedAt: now,

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},
@@ -129,6 +129,7 @@ function snapshotFixture(): StationSnapshot {
           lastCheckedAt: now,
         },
         counts: {
+          sessions: 1,
           worktrees: 1,
           agents: 1,
           working: 1,
@@ -142,6 +143,7 @@ function snapshotFixture(): StationSnapshot {
     sessions: [sessionFixture()],
     counts: {
       projects: 1,
+      sessions: 1,
       worktrees: 1,
       agents: 1,
       working: 1,
@@ -188,6 +190,7 @@ function rowFixture(): WorktreeRow {
 function sessionFixture(): SessionView {
   return {
     id: "ses_1",
+    origin: "station",
     projectId: "api",
     worktreeId: "wt_api",
     createdAt: now,

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -54,7 +54,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -104,7 +104,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -215,7 +215,7 @@ describe("CLI observer process lifecycle", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.7.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },
@@ -253,7 +253,7 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -284,7 +284,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -293,7 +293,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.7.0", stopped: true, at: now };
+              return { schemaVersion: "0.8.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -329,7 +329,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -340,7 +340,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.7.0", stopped: true, at: now };
+              return { schemaVersion: "0.8.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -370,7 +370,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               pid,
               startedAt: now,
@@ -379,7 +379,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.7.0", stopped: true, at: now };
+              return { schemaVersion: "0.8.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -409,7 +409,7 @@ describe("CLI observer process lifecycle", () => {
               healthAttempts += 1;
               if (!spawned || healthAttempts < 3) {
                 return {
-                  schemaVersion: "0.7.0",
+                  schemaVersion: "0.8.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -418,7 +418,7 @@ describe("CLI observer process lifecycle", () => {
                 };
               }
               return {
-                schemaVersion: "0.7.0",
+                schemaVersion: "0.8.0",
                 status: "healthy",
                 pid: 5678,
                 startedAt: now,
@@ -457,7 +457,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.7.0",
+              schemaVersion: "0.8.0",
               status: "healthy",
               ...identity,
             }),

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -10,7 +10,7 @@ const now = "2026-05-20T12:00:00.000Z";
 
 const healthyObserver = (pid = 1234, version = stationBuildInfo().version) =>
   ({
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     status: "healthy",
     pid,
     startedAt: now,

--- a/apps/observer/src/commands/session/close.ts
+++ b/apps/observer/src/commands/session/close.ts
@@ -1,8 +1,9 @@
 import type { RuntimeClock } from "@station/runtime";
-import type { EventJournal } from "../../persistence/index.js";
+import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import {
   assertSessionCloseAllowed,
@@ -20,7 +21,7 @@ export type CreateSessionCloseHandlerOptions = {
   providers: ProviderRegistry;
   terminalIntentRunner: TerminalIntentRunner;
   core: ObserverCore;
-  persistence: EventJournal;
+  persistence: EventJournal & SessionStore;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
@@ -51,6 +52,12 @@ export function createSessionCloseHandler(
       commandTimeoutMs: options.commandTimeoutMs,
     });
     throwIfAborted(context.signal);
+    if (session.origin === "station" && payload.mode !== "harness") {
+      await options.persistence.markSessionsEnded({
+        subject: { kind: "session", sessionId: session.id },
+        endedAt: nowIso(options.clock),
+      });
+    }
 
     const nextSnapshot = await reconcileAndPublish({
       core: options.core,

--- a/apps/observer/src/commands/session/resumeAgent.ts
+++ b/apps/observer/src/commands/session/resumeAgent.ts
@@ -160,6 +160,7 @@ export function createSessionResumeAgentHandler(
       throw receipt.error;
     }
     throwIfAborted(context.signal);
+    await options.persistence.reopenSession(sessionId);
 
     const nextSnapshot = await reconcileAndPublish({
       core: options.core,

--- a/apps/observer/src/commands/terminal.ts
+++ b/apps/observer/src/commands/terminal.ts
@@ -1,9 +1,10 @@
 import type { SafeError, StationSnapshot, TerminalClosePayload } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
-import type { EventJournal } from "../persistence/index.js";
+import type { EventJournal, SessionStore } from "../persistence/index.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import type { ObserverEventBus } from "../runtime/eventBus.js";
+import { nowIso } from "../utils/time.js";
 import { assertCommandType } from "./assertCommand.js";
 import { throwIfAborted } from "./cancellation.js";
 import { publishRemovedSessionIfAbsent } from "./cleanup/events.js";
@@ -33,7 +34,7 @@ export type CreateTerminalCloseHandlerOptions = {
   core: ObserverCore;
   providers: ProviderRegistry;
   terminalIntentRunner: TerminalIntentRunner;
-  persistence?: EventJournal | undefined;
+  persistence?: (EventJournal & SessionStore) | undefined;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
@@ -86,6 +87,12 @@ export function createTerminalCloseHandler(
       commandTimeoutMs: options.commandTimeoutMs,
     });
     throwIfAborted(context.signal);
+    if (resolved.session?.origin === "station" && options.persistence !== undefined) {
+      await options.persistence.markSessionsEnded({
+        subject: { kind: "session", sessionId: resolved.session.id },
+        endedAt: nowIso(options.clock),
+      });
+    }
 
     const nextSnapshot = await reconcileAndPublish({
       core: options.core,
@@ -124,8 +131,15 @@ function resolveTerminalClosePolicySubject(
   const row = resolveWorktreeRowOrThrow(snapshot, payload.worktreeId);
   const session =
     row.agent?.sessionId === undefined
-      ? undefined
-      : snapshot.sessions.find((candidate) => candidate.id === row.agent?.sessionId);
+      ? snapshot.sessions.find(
+          (candidate) =>
+            candidate.origin === "station" &&
+            candidate.worktreeId === row.id &&
+            candidate.terminal !== undefined,
+        )
+      : snapshot.sessions.find(
+          (candidate) => candidate.origin === "station" && candidate.id === row.agent?.sessionId,
+        );
   return { row, session };
 }
 

--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -4,11 +4,12 @@ import {
   WorktreeRemovalRefusalDiagnosticDetailSchema,
 } from "@station/contracts";
 import type { RuntimeClock } from "@station/runtime";
-import type { EventJournal } from "../../persistence/index.js";
+import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
 import type { StationLogger } from "../../stationLogger.js";
+import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import {
   assertWorktreeRemovalAllowed,
@@ -31,7 +32,7 @@ export type CreateWorktreeRemoveHandlerOptions = {
   providers: ProviderRegistry;
   terminalIntentRunner: TerminalIntentRunner;
   core: ObserverCore;
-  persistence: EventJournal;
+  persistence: EventJournal & SessionStore;
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
@@ -56,7 +57,10 @@ export function createWorktreeRemoveHandler(
     const row = resolveWorktreeRowOrThrow(snapshot, payload.worktreeId, payload.projectId);
     const projectView = snapshot.projects.find((candidate) => candidate.id === row.projectId);
     const project = findProjectOrThrow(options.getProjects(), row.projectId);
-    const previousSessionId = row.agent?.sessionId;
+    const stationSession = snapshot.sessions.find(
+      (session) => session.origin === "station" && session.worktreeId === row.id,
+    );
+    const previousSessionId = stationSession?.id ?? row.agent?.sessionId;
     const force = payload.force === true;
     const currentWorktrees = await runProviderMutation(
       {
@@ -142,6 +146,10 @@ export function createWorktreeRemoveHandler(
       throw error;
     }
     throwIfAborted(context.signal);
+    await options.persistence.markSessionsEnded({
+      subject: { kind: "worktree", projectId: row.projectId, worktreeId: row.id },
+      endedAt: nowIso(options.clock),
+    });
 
     const nextSnapshot = await reconcileAndPublish({
       core: options.core,

--- a/apps/observer/src/diagnostics/environmentCheck.ts
+++ b/apps/observer/src/diagnostics/environmentCheck.ts
@@ -31,7 +31,7 @@ export function buildSessionEnvironmentCheck(
 }
 
 function isDetachedOrStale(session: SessionView): boolean {
-  return session.terminal.state === "detached" || session.terminal.state === "stale";
+  return session.terminal?.state === "detached" || session.terminal?.state === "stale";
 }
 
 /** ` — station: 4 open · tmux: 3 detached` (empty for zero sessions). */
@@ -40,7 +40,12 @@ function summarizeProviders(sessions: readonly SessionView[]): string {
     return "";
   }
   const byProvider = new Map<string, Map<string, number>>();
+  let withoutTerminal = 0;
   for (const session of sessions) {
+    if (session.terminal === undefined) {
+      withoutTerminal += 1;
+      continue;
+    }
     const states = byProvider.get(session.terminal.provider) ?? new Map<string, number>();
     states.set(session.terminal.state, (states.get(session.terminal.state) ?? 0) + 1);
     byProvider.set(session.terminal.provider, states);
@@ -48,6 +53,9 @@ function summarizeProviders(sessions: readonly SessionView[]): string {
   const segments = sortedEntries(byProvider).map(
     ([provider, states]) => `${provider}: ${countText(states)}`,
   );
+  if (withoutTerminal > 0) {
+    segments.push(`no terminal: ${withoutTerminal}`);
+  }
   return ` — ${segments.join(" · ")}`;
 }
 
@@ -57,7 +65,7 @@ const MAX_LISTED = 4;
 function describeSessions(sessions: readonly SessionView[]): string {
   const shown = sessions
     .slice(0, MAX_LISTED)
-    .map((session) => `${session.title} [${session.terminal.provider}]`);
+    .map((session) => `${session.title} [${session.terminal?.provider ?? "no terminal"}]`);
   const remainder = sessions.length - shown.length;
   return remainder > 0 ? `${shown.join(", ")}, +${remainder} more` : shown.join(", ");
 }

--- a/apps/observer/src/migrations/012_session_lifecycle.ts
+++ b/apps/observer/src/migrations/012_session_lifecycle.ts
@@ -1,0 +1,16 @@
+import type { ObserverSqliteMigration } from "./index.js";
+
+export const sessionLifecycleMigration: ObserverSqliteMigration = {
+  version: 12,
+  name: "session_lifecycle",
+  // NULL deliberately means legacy/unknown: ended_at had no production writer
+  // before this migration, so historical NULL rows are not proof of an open session.
+  sql: `
+    ALTER TABLE sessions
+      ADD COLUMN lifecycle TEXT CHECK (lifecycle IN ('open', 'ended'));
+
+    UPDATE sessions
+      SET lifecycle = 'ended'
+      WHERE ended_at IS NOT NULL;
+  `,
+};

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -9,6 +9,7 @@ import { hookIngressDedupeMigration } from "./008_hook_ingress_dedupe.js";
 import { sessionTitleMigration } from "./009_session_title.js";
 import { sessionRecoveryHandlesMigration } from "./010_session_recovery_handles.js";
 import { sessionTurnReadinessMigration } from "./011_session_turn_readiness.js";
+import { sessionLifecycleMigration } from "./012_session_lifecycle.js";
 
 export type ObserverSqliteMigration = {
   version: number;
@@ -28,6 +29,7 @@ export const migrations = [
   sessionTitleMigration,
   sessionRecoveryHandlesMigration,
   sessionTurnReadinessMigration,
+  sessionLifecycleMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/persistence/correlations.ts
+++ b/apps/observer/src/persistence/correlations.ts
@@ -11,6 +11,7 @@ import {
   TerminalTargetObservationSchema,
   WorktreeObservationSchema,
 } from "@station/contracts";
+import { harnessRunCanActivateSession, terminalCanActivateSession } from "../sessionActivation.js";
 import type { SqlDatabase } from "../sqlite/driver.js";
 import { maxIso, optionalJson } from "./json.js";
 import { insertProviderObservation } from "./observations.js";
@@ -163,6 +164,52 @@ export function renameSession(
   return row === undefined ? undefined : sessionFromRow(row);
 }
 
+export function markSessionsEnded(
+  database: SqlDatabase,
+  input: {
+    subject:
+      | { kind: "session"; sessionId: string }
+      | { kind: "worktree"; projectId: string; worktreeId: string };
+    endedAt: string;
+  },
+): number {
+  const result =
+    input.subject.kind === "session"
+      ? database
+          .prepare(
+            `
+              UPDATE sessions
+              SET lifecycle = 'ended', ended_at = ?
+              WHERE id = ? AND (lifecycle IS NULL OR lifecycle = 'open')
+            `,
+          )
+          .run(input.endedAt, input.subject.sessionId)
+      : database
+          .prepare(
+            `
+              UPDATE sessions
+              SET lifecycle = 'ended', ended_at = ?
+              WHERE project_id = ? AND worktree_id = ?
+                AND (lifecycle IS NULL OR lifecycle = 'open')
+            `,
+          )
+          .run(input.endedAt, input.subject.projectId, input.subject.worktreeId);
+  return Number(result.changes);
+}
+
+export function reopenSession(
+  database: SqlDatabase,
+  sessionId: string,
+): PersistedSession | undefined {
+  database
+    .prepare("UPDATE sessions SET lifecycle = 'open', ended_at = NULL WHERE id = ?")
+    .run(sessionId);
+  const row = database.prepare("SELECT * FROM sessions WHERE id = ?").get(sessionId) as
+    | SqliteSessionRow
+    | undefined;
+  return row === undefined ? undefined : sessionFromRow(row);
+}
+
 export function seedSessionTitle(
   database: SqlDatabase,
   input: {
@@ -178,13 +225,17 @@ export function seedSessionTitle(
     .prepare(
       `
         INSERT INTO sessions
-          (id, project_id, worktree_id, title, created_at, ended_at, last_seen_at)
-        VALUES (?, ?, ?, ?, ?, NULL, ?)
+          (id, project_id, worktree_id, title, created_at, ended_at, last_seen_at, lifecycle)
+        VALUES (?, ?, ?, ?, ?, NULL, ?, 'open')
         ON CONFLICT(id) DO UPDATE SET
           project_id = excluded.project_id,
           worktree_id = excluded.worktree_id,
           title = COALESCE(sessions.title, excluded.title),
-          last_seen_at = excluded.last_seen_at
+          last_seen_at = excluded.last_seen_at,
+          lifecycle = CASE
+            WHEN sessions.lifecycle = 'ended' THEN 'ended'
+            ELSE 'open'
+          END
       `,
     )
     .run(
@@ -360,18 +411,26 @@ function upsertSessions(
     ) {
       continue;
     }
+    const existing = sessions.get(target.sessionId);
+    const activates = terminalCanActivateSession({ target, runs: harnessRuns });
     const session: PersistedSession = {
       id: target.sessionId,
       projectId: target.projectId,
       worktreeId: target.worktreeId,
+      lifecycle: activates || existing?.lifecycle === "open" ? "open" : "legacy",
       terminalProvider: target.provider,
       state: target.state,
-      createdAt: target.observedAt,
-      lastSeenAt: target.observedAt,
+      createdAt: existing?.createdAt ?? target.observedAt,
+      lastSeenAt: maxIso(existing?.lastSeenAt, target.observedAt),
     };
     const title = sessionTitleForWorktree(worktreesById, target.worktreeId);
     if (title !== undefined) {
       session.title = title;
+    } else if (existing?.title !== undefined) {
+      session.title = existing.title;
+    }
+    if (existing?.harness !== undefined) {
+      session.harness = existing.harness;
     }
     sessions.set(target.sessionId, session);
   }
@@ -385,10 +444,16 @@ function upsertSessions(
       continue;
     }
     const existing = sessions.get(run.sessionId);
+    const activates = harnessRunCanActivateSession({
+      run,
+      terminals: terminalTargets,
+      runs: harnessRuns,
+    });
     const session: PersistedSession = {
       id: run.sessionId,
       projectId: run.projectId,
       worktreeId: run.worktreeId,
+      lifecycle: activates || existing?.lifecycle === "open" ? "open" : "legacy",
       harness: run.provider,
       state: run.state,
       createdAt: existing?.createdAt ?? run.observedAt,
@@ -411,8 +476,8 @@ function upsertSessions(
       .prepare(
         `
           INSERT INTO sessions
-            (id, project_id, worktree_id, title, harness, terminal_provider, state, created_at, ended_at, last_seen_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+            (id, project_id, worktree_id, title, harness, terminal_provider, state, created_at, ended_at, last_seen_at, lifecycle)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             project_id = excluded.project_id,
             worktree_id = excluded.worktree_id,
@@ -420,7 +485,12 @@ function upsertSessions(
             harness = COALESCE(excluded.harness, sessions.harness),
             terminal_provider = COALESCE(excluded.terminal_provider, sessions.terminal_provider),
             state = excluded.state,
-            last_seen_at = excluded.last_seen_at
+            last_seen_at = excluded.last_seen_at,
+            lifecycle = CASE
+              WHEN sessions.lifecycle = 'ended' THEN 'ended'
+              WHEN sessions.lifecycle = 'open' OR excluded.lifecycle = 'open' THEN 'open'
+              ELSE NULL
+            END
         `,
       )
       .run(
@@ -433,6 +503,7 @@ function upsertSessions(
         session.state ?? null,
         session.createdAt,
         session.lastSeenAt,
+        session.lifecycle === "legacy" ? null : session.lifecycle,
       );
   }
 }

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -131,7 +131,7 @@ export interface ReconcileStore {
 /**
  * DRIVEN PORT
  *
- * Maintains Observer-owned sessions, titles, remembered harness selection, recovery handles, and turn readiness.
+ * Maintains Observer-owned session lifecycle, titles, remembered harness selection, recovery handles, and turn readiness.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;
@@ -149,6 +149,13 @@ export interface SessionStore {
     lastSeenAt: string;
   }): Promise<PersistedSession>;
   deleteSessionTitleSeed(sessionId: string): Promise<number>;
+  markSessionsEnded(input: {
+    subject:
+      | { kind: "session"; sessionId: string }
+      | { kind: "worktree"; projectId: string; worktreeId: string };
+    endedAt: string;
+  }): Promise<number>;
+  reopenSession(sessionId: string): Promise<PersistedSession | undefined>;
   renameSession(input: { sessionId: string; title: string }): Promise<PersistedSession | undefined>;
   upsertSessionRecoveryHandle(input: SessionRecoveryHandle): Promise<SessionRecoveryHandle>;
   getSessionRecoveryHandle(handleId: string): Promise<SessionRecoveryHandle | undefined>;

--- a/apps/observer/src/persistence/rows.ts
+++ b/apps/observer/src/persistence/rows.ts
@@ -69,6 +69,7 @@ export type SqliteSessionRow = {
   state: string | null;
   created_at: string;
   ended_at: string | null;
+  lifecycle: "open" | "ended" | null;
   last_seen_at: string;
 };
 
@@ -139,6 +140,7 @@ export function sessionFromRow(row: SqliteSessionRow): PersistedSession {
     id: row.id,
     projectId: row.project_id,
     worktreeId: row.worktree_id,
+    lifecycle: row.lifecycle ?? "legacy",
     createdAt: row.created_at,
     lastSeenAt: row.last_seen_at,
   };

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -278,6 +278,12 @@ export function createSqliteObserverPersistence(
     deleteSessionTitleSeed: (sessionId) =>
       transaction((database) => correlationStore.deleteSessionTitleSeed(database, sessionId)),
 
+    markSessionsEnded: (input) =>
+      transaction((database) => correlationStore.markSessionsEnded(database, input)),
+
+    reopenSession: (sessionId) =>
+      transaction((database) => correlationStore.reopenSession(database, sessionId)),
+
     renameSession: (input) =>
       transaction((database) => correlationStore.renameSession(database, input)),
 

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -174,10 +174,13 @@ export type PersistedWorktreeMetadataCurrent<
   lastError?: SafeError;
 };
 
+export type PersistedSessionLifecycle = "legacy" | "open" | "ended";
+
 export type PersistedSession = {
   id: string;
   projectId: string;
   worktreeId: string;
+  lifecycle: PersistedSessionLifecycle;
   title?: string;
   harness?: string;
   terminalProvider?: string;

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -20,8 +20,9 @@ import type {
 } from "@station/contracts";
 import { STATION_SCHEMA_VERSION, worktreeHasLiveAgent } from "@station/contracts";
 import { pathIsSameOrInside } from "@station/runtime";
+import { harnessRunCanActivateSession, terminalCanActivateSession } from "../sessionActivation.js";
 import type { ObserverHarnessRun } from "./harnessEventStatus.js";
-import { countsForRows, statusPolicy } from "./statusPolicy.js";
+import { countsForSnapshot, statusPolicy } from "./statusPolicy.js";
 
 export type ObserverGraphInput = {
   generatedAt: string;
@@ -48,7 +49,16 @@ export type ObserverGraphInput = {
 
 export type ObserverSessionMetadata = {
   id: string;
+  projectId: string;
+  worktreeId: string;
+  lifecycle: "legacy" | "open" | "ended";
   title?: string;
+  harness?: string;
+  terminalProvider?: string;
+  state?: string;
+  createdAt: string;
+  endedAt?: string;
+  lastSeenAt: string;
 };
 
 export type ObserverTurnReadiness = {
@@ -78,6 +88,11 @@ const confidenceRank = {
   low: 1,
 };
 
+/**
+ * POLICY
+ *
+ * Correlates provider observations and durable session records into canonical snapshot truth.
+ */
 export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot {
   const projectsById = new Map(input.projects.map((project) => [project.id, project]));
   const configuredWorktrees = input.worktrees.filter(
@@ -89,6 +104,7 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
   const sessionMetadataById = new Map(
     input.sessionMetadata?.map((session) => [session.id, session]),
   );
+  const retainedSessionByWorktree = newestRetainedSessionByWorktree(input.sessionMetadata ?? []);
   const turnReadinessBySessionId = new Map(
     input.turnReadiness?.map((readiness) => [readiness.sessionId, readiness]),
   );
@@ -138,10 +154,13 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
         if (terminalCapabilities !== undefined) {
           sessionInput.terminalCapabilities = terminalCapabilities;
         }
-        const session = buildSession(sessionInput);
-        if (session !== undefined) {
-          sessions.push(session);
+        const retainedSession = retainedSessionByWorktree.get(
+          sessionWorktreeKey(project.id, worktree.id),
+        );
+        if (retainedSession !== undefined) {
+          sessionInput.retainedSession = retainedSession;
         }
+        sessions.push(...buildSessions(sessionInput));
 
         return row;
       })
@@ -152,19 +171,20 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
 
   const projects = input.projects.map((project) => {
     const rows = allRows.filter((row) => row.projectId === project.id);
+    const projectSessions = sessions.filter((session) => session.projectId === project.id);
     return {
       id: project.id,
       label: project.label,
       root: project.root,
       defaults: project.defaults,
       health: input.providerHealth[input.worktreeProviderId] ?? unknownProviderHealth(input),
-      counts: countsForRows(rows),
+      counts: countsForSnapshot(rows, projectSessions),
     };
   });
 
   const counts = {
     projects: input.projects.length,
-    ...countsForRows(allRows),
+    ...countsForSnapshot(allRows, sessions),
   };
 
   const observerHealthy =
@@ -369,52 +389,259 @@ type BuildSessionInput = {
   harnessRun?: ObserverHarnessRun;
   harnessCapabilities: Record<string, HarnessCapabilities>;
   sessionMetadataById: ReadonlyMap<string, ObserverSessionMetadata>;
+  retainedSession?: ObserverSessionMetadata;
   terminalCapabilities?: Record<string, boolean>;
 };
 
-function buildSession(input: BuildSessionInput): SessionView | undefined {
-  if (input.terminal === undefined || input.harnessRun === undefined) {
+function buildSessions(input: BuildSessionInput): SessionView[] {
+  const sessions: SessionView[] = [];
+  const stationSession = buildStationSession(input);
+  if (stationSession !== undefined) sessions.push(stationSession);
+  const externalSession = buildExternalSession(input);
+  if (externalSession !== undefined) sessions.push(externalSession);
+  return sessions;
+}
+
+function buildStationSession(input: BuildSessionInput): SessionView | undefined {
+  const identity = stationSessionIdentity(input);
+  if (identity === undefined) return undefined;
+  const run = identity.harnessRun?.run;
+  const harnessProvider = run?.provider ?? identity.metadata?.harness;
+  if (harnessProvider === undefined) return undefined;
+  const terminal = terminalForStationSession({
+    terminal: input.terminal,
+    sessionId: identity.id,
+    sessionRunId: identity.harnessRun?.run.id,
+    observedOtherRunId: identity.harnessRun === undefined ? input.harnessRun?.run.id : undefined,
+  });
+  const status =
+    identity.harnessRun?.status ??
+    retainedSessionStatus(identity.metadata, input.worktree.observedAt);
+  const createdAt = identity.metadata?.createdAt ?? run?.observedAt ?? terminal?.observedAt;
+  if (createdAt === undefined) return undefined;
+
+  return sessionView({
+    id: identity.id,
+    origin: "station",
+    input,
+    harnessProvider,
+    status,
+    createdAt,
+    title: identity.metadata?.title ?? input.worktree.branch,
+    ...(identity.harnessRun === undefined ? {} : { harnessRun: identity.harnessRun }),
+    ...(terminal === undefined ? {} : { terminal }),
+  });
+}
+
+function buildExternalSession(input: BuildSessionInput): SessionView | undefined {
+  const harnessRun = input.harnessRun;
+  const run = harnessRun?.run;
+  if (
+    harnessRun === undefined ||
+    run === undefined ||
+    run.sessionId !== undefined ||
+    !externalRunRepresentsSession(harnessRun)
+  ) {
     return undefined;
   }
-
-  const run = input.harnessRun.run;
-  const status = input.harnessRun.status;
-  const sessionId = run.sessionId ?? input.terminal.sessionId;
-  if (sessionId === undefined) {
-    return undefined;
-  }
-  const metadata = input.sessionMetadataById.get(sessionId);
-
-  const harness: SessionView["harness"] = {
-    provider: run.provider,
-    mode: "unknown",
-    runId: run.id,
-    capabilities: input.harnessCapabilities[run.provider] ?? emptyHarnessCapabilities,
-  };
-  if (run.pid !== undefined) harness.pid = run.pid;
-
-  const terminal: SessionView["terminal"] = {
-    ...terminalAttachment(input.terminal, input.harnessRun, input.terminalCapabilities),
-  };
-
-  return {
-    id: sessionId,
-    projectId: input.project.id,
-    worktreeId: input.worktree.id,
+  const terminal = terminalForExternalRun(input.terminal, run.id);
+  return sessionView({
+    id: run.id,
+    origin: "external",
+    input,
+    harnessProvider: run.provider,
+    harnessRun,
+    status: harnessRun.status,
     createdAt: run.observedAt,
-    updatedAt: status.updatedAt,
+    title: input.worktree.branch,
+    ...(terminal === undefined ? {} : { terminal }),
+  });
+}
+
+type StationSessionIdentity = {
+  id: string;
+  metadata?: ObserverSessionMetadata;
+  harnessRun?: ObserverHarnessRun;
+};
+
+function stationSessionIdentity(input: BuildSessionInput): StationSessionIdentity | undefined {
+  const harnessRun = input.harnessRun;
+  if (harnessRun?.run.sessionId !== undefined) {
+    const runSessionId = harnessRun.run.sessionId;
+    const metadata = input.sessionMetadataById.get(runSessionId);
+    if (
+      !sessionMetadataIsEnded(metadata) &&
+      (metadata?.lifecycle === "open" ||
+        harnessRunCanActivateSession({
+          run: harnessRun.run,
+          terminals: input.terminal === undefined ? [] : [input.terminal],
+          runs: [harnessRun.run],
+        }))
+    ) {
+      return {
+        id: runSessionId,
+        harnessRun,
+        ...(metadata === undefined ? {} : { metadata }),
+      };
+    }
+  }
+
+  const terminalSessionId = input.terminal?.sessionId;
+  if (
+    terminalSessionId !== undefined &&
+    input.terminal !== undefined &&
+    terminalCanActivateSession({
+      target: input.terminal,
+      runs: input.harnessRun === undefined ? [] : [input.harnessRun.run],
+    })
+  ) {
+    const metadata = input.sessionMetadataById.get(terminalSessionId);
+    if (metadata !== undefined && !sessionMetadataIsEnded(metadata)) {
+      return { id: metadata.id, metadata };
+    }
+  }
+
+  const retained = input.retainedSession;
+  return retained === undefined ? undefined : { id: retained.id, metadata: retained };
+}
+
+function sessionMetadataIsEnded(metadata: ObserverSessionMetadata | undefined): boolean {
+  return metadata?.lifecycle === "ended" || metadata?.endedAt !== undefined;
+}
+
+function terminalForStationSession(input: {
+  terminal: TerminalTargetObservation | undefined;
+  sessionId: string;
+  sessionRunId: string | undefined;
+  observedOtherRunId: string | undefined;
+}): TerminalTargetObservation | undefined {
+  const { terminal } = input;
+  if (terminal === undefined) return undefined;
+  if (terminal.sessionId === undefined) {
+    return input.sessionRunId !== undefined && terminal.harnessRunId === input.sessionRunId
+      ? terminal
+      : undefined;
+  }
+  if (terminal.sessionId !== input.sessionId) return undefined;
+  if (terminal.harnessRunId === undefined) return terminal;
+  if (input.sessionRunId !== undefined) {
+    return terminal.harnessRunId === input.sessionRunId ? terminal : undefined;
+  }
+  return terminal.harnessRunId === input.observedOtherRunId ? undefined : terminal;
+}
+
+function terminalForExternalRun(
+  terminal: TerminalTargetObservation | undefined,
+  runId: string,
+): TerminalTargetObservation | undefined {
+  if (terminal?.sessionId !== undefined) return undefined;
+  return terminal?.harnessRunId === runId ? terminal : undefined;
+}
+
+function sessionView(input: {
+  id: string;
+  origin: SessionView["origin"];
+  input: BuildSessionInput;
+  harnessProvider: string;
+  harnessRun?: ObserverHarnessRun;
+  terminal?: TerminalTargetObservation;
+  status: SessionView["status"];
+  createdAt: string;
+  title: string;
+}): SessionView {
+  const run = input.harnessRun?.run;
+  const harness: SessionView["harness"] = {
+    provider: input.harnessProvider,
+    mode: "unknown",
+    capabilities:
+      input.input.harnessCapabilities[input.harnessProvider] ?? emptyHarnessCapabilities,
+  };
+  if (run !== undefined) harness.runId = run.id;
+  if (run?.pid !== undefined) harness.pid = run.pid;
+
+  const session: SessionView = {
+    id: input.id,
+    origin: input.origin,
+    projectId: input.input.project.id,
+    worktreeId: input.input.worktree.id,
+    createdAt: input.createdAt,
+    updatedAt: input.status.updatedAt,
     harness,
-    terminal,
     status: {
-      value: status.value,
-      confidence: status.confidence,
-      reason: status.reason,
-      source: status.source,
-      updatedAt: status.updatedAt,
+      value: input.status.value,
+      confidence: input.status.confidence,
+      reason: input.status.reason,
+      source: input.status.source,
+      updatedAt: input.status.updatedAt,
     },
-    title: metadata?.title ?? input.worktree.branch,
+    title: input.title,
     tags: [],
   };
+  if (input.status.attention !== undefined) session.status.attention = input.status.attention;
+  if (input.terminal !== undefined) {
+    session.terminal = terminalAttachment(
+      input.terminal,
+      input.harnessRun,
+      input.input.terminalCapabilities,
+    );
+  }
+  return session;
+}
+
+function externalRunRepresentsSession(run: ObserverHarnessRun): boolean {
+  return (
+    run.status.value !== "none" && run.status.value !== "unknown" && run.status.value !== "exited"
+  );
+}
+
+function retainedSessionStatus(
+  metadata: ObserverSessionMetadata | undefined,
+  fallbackUpdatedAt: string,
+): SessionView["status"] {
+  const updatedAt = metadata?.lastSeenAt ?? fallbackUpdatedAt;
+  return {
+    value: "none",
+    confidence: "low",
+    reason: "No harness run is currently observed for this Station session.",
+    source: "reconcile",
+    updatedAt,
+  };
+}
+
+function newestRetainedSessionByWorktree(
+  sessions: readonly ObserverSessionMetadata[],
+): ReadonlyMap<string, ObserverSessionMetadata> {
+  const retained = new Map<string, ObserverSessionMetadata>();
+  for (const session of sessions) {
+    if (
+      session.lifecycle !== "open" ||
+      session.endedAt !== undefined ||
+      session.harness === undefined
+    ) {
+      continue;
+    }
+    const key = sessionWorktreeKey(session.projectId, session.worktreeId);
+    const current = retained.get(key);
+    if (current === undefined || compareSessionRecency(session, current) > 0) {
+      retained.set(key, session);
+    }
+  }
+  return retained;
+}
+
+function sessionWorktreeKey(projectId: string, worktreeId: string): string {
+  return JSON.stringify([projectId, worktreeId]);
+}
+
+function compareSessionRecency(
+  left: ObserverSessionMetadata,
+  right: ObserverSessionMetadata,
+): number {
+  return (
+    Date.parse(left.lastSeenAt) - Date.parse(right.lastSeenAt) ||
+    Date.parse(left.createdAt) - Date.parse(right.createdAt) ||
+    left.id.localeCompare(right.id)
+  );
 }
 
 function isFocusableTerminalState(state: TerminalTargetObservation["state"]): boolean {

--- a/apps/observer/src/reconcile/statusPolicy.ts
+++ b/apps/observer/src/reconcile/statusPolicy.ts
@@ -1,4 +1,4 @@
-import type { AgentState, ProjectView, WorktreeRow } from "@station/contracts";
+import type { AgentState, ProjectView, SessionView, WorktreeRow } from "@station/contracts";
 
 export const statusPolicy: Record<
   AgentState | "no_agent",
@@ -65,21 +65,30 @@ export const statusPolicy: Record<
   },
 };
 
-export function countsForRows(rows: readonly WorktreeRow[]): ProjectView["counts"] {
-  return rows.reduce(
-    (counts, row) => {
-      counts.worktrees += 1;
-      if (row.agent !== undefined) {
+/**
+ * POLICY
+ *
+ * Derives session and activity totals from canonical sessions while retaining worktree inventory.
+ */
+export function countsForSnapshot(
+  rows: readonly WorktreeRow[],
+  sessions: readonly SessionView[],
+): ProjectView["counts"] {
+  return sessions.reduce(
+    (counts, session) => {
+      counts.sessions += 1;
+      if (session.status.value !== "none") {
         counts.agents += 1;
-        if (row.agent.state === "working") counts.working += 1;
-        if (row.agent.state === "idle") counts.idle += 1;
-        if (row.agent.state === "needs_attention") counts.attention += 1;
-        if (row.agent.state === "unknown") counts.unknown += 1;
+        if (session.status.value === "working") counts.working += 1;
+        if (session.status.value === "idle") counts.idle += 1;
+        if (session.status.value === "needs_attention") counts.attention += 1;
+        if (session.status.value === "unknown") counts.unknown += 1;
       }
       return counts;
     },
     {
-      worktrees: 0,
+      sessions: 0,
+      worktrees: rows.length,
       agents: 0,
       working: 0,
       idle: 0,

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -8,7 +8,7 @@ import type {
   WorktreeRow,
 } from "@station/contracts";
 import { pathIsSameOrInside } from "@station/runtime";
-import { countsForRows, statusPolicy } from "./statusPolicy.js";
+import { countsForSnapshot, statusPolicy } from "./statusPolicy.js";
 
 type WorktreeAgent = NonNullable<WorktreeRow["agent"]>;
 type CorrelatedBy = "harnessRunId" | "sessionId" | "worktreeId";
@@ -156,10 +156,7 @@ function sessionTitleForAgent(
   sessions: readonly SessionView[],
   agent: WorktreeAgent,
 ): string | undefined {
-  if (agent.sessionId === undefined) {
-    return undefined;
-  }
-  return sessions.find((session) => session.id === agent.sessionId)?.title;
+  return sessionForAgent(sessions, agent)?.title;
 }
 
 function unprojected(snapshot: StationSnapshot): StatusProjectionResult {
@@ -284,18 +281,33 @@ function projectSession(
   event?: StationEvent;
   sessionId?: string;
 } {
-  const sessionId = agent.sessionId;
-  if (sessionId === undefined) {
+  const projectedSession = sessionForAgent(sessions, agent);
+  if (projectedSession === undefined) {
     return {
       sessions: [...sessions],
       changed: false,
+    };
+  }
+  const sessionId = projectedSession.id;
+
+  if (
+    projectedSession.origin === "external" &&
+    (status.value === "exited" || status.value === "none")
+  ) {
+    return {
+      sessions: sessions.filter(
+        (session) => !(session.origin === "external" && session.id === sessionId),
+      ),
+      changed: true,
+      event: { type: "session.removed", sessionId },
+      sessionId,
     };
   }
 
   let changed = false;
   let event: StationEvent | undefined;
   const nextSessions = sessions.map((session) => {
-    if (session.id !== sessionId) {
+    if (session.origin !== projectedSession.origin || session.id !== sessionId) {
       return session;
     }
     const nextSession: SessionView = {
@@ -332,6 +344,21 @@ function projectSession(
   };
 }
 
+function sessionForAgent(
+  sessions: readonly SessionView[],
+  agent: WorktreeAgent,
+): SessionView | undefined {
+  if (agent.sessionId !== undefined) {
+    return sessions.find(
+      (session) => session.origin === "station" && session.id === agent.sessionId,
+    );
+  }
+  if (agent.runId === undefined) return undefined;
+  return sessions.find(
+    (session) => session.origin === "external" && session.harness.runId === agent.runId,
+  );
+}
+
 function rebuildSnapshot(input: {
   snapshot: StationSnapshot;
   rows: WorktreeRow[];
@@ -339,9 +366,13 @@ function rebuildSnapshot(input: {
   generatedAt: string;
 }): StationSnapshot {
   const projects = input.snapshot.projects.map((project) => {
+    const projectSessions = input.sessions.filter((session) => session.projectId === project.id);
     const nextProject: ProjectView = {
       ...project,
-      counts: countsForRows(input.rows.filter((row) => row.projectId === project.id)),
+      counts: countsForSnapshot(
+        input.rows.filter((row) => row.projectId === project.id),
+        projectSessions,
+      ),
     };
     return nextProject;
   });
@@ -353,7 +384,7 @@ function rebuildSnapshot(input: {
     sessions: input.sessions,
     counts: {
       projects: projects.length,
-      ...countsForRows(input.rows),
+      ...countsForSnapshot(input.rows, input.sessions),
     },
   };
 }

--- a/apps/observer/src/sessionActivation.ts
+++ b/apps/observer/src/sessionActivation.ts
@@ -1,0 +1,67 @@
+import type { HarnessRunObservation, TerminalTargetObservation } from "@station/contracts";
+
+type ActivationTerminal = Pick<TerminalTargetObservation, "harnessRunId" | "sessionId" | "state">;
+
+type ActivationRun = Pick<HarnessRunObservation, "id" | "sessionId" | "state">;
+
+/** Returns whether a reachable terminal's resolved run binding agrees with its Station session. */
+export function terminalCanActivateSession(input: {
+  target: ActivationTerminal;
+  runs: readonly ActivationRun[];
+}): boolean {
+  const { target } = input;
+  if (target.sessionId === undefined || (target.state !== "open" && target.state !== "detached")) {
+    return false;
+  }
+  if (target.harnessRunId === undefined) return true;
+  const boundRun = input.runs.find((run) => run.id === target.harnessRunId);
+  return boundRun === undefined || boundRun.sessionId === target.sessionId;
+}
+
+/** Returns whether current run or matching terminal evidence can activate Station membership. */
+export function harnessRunCanActivateSession(input: {
+  run: ActivationRun;
+  terminals: readonly ActivationTerminal[];
+  runs: readonly ActivationRun[];
+}): boolean {
+  const correlatedTerminals = input.terminals.filter((target) =>
+    terminalIsCorrelatedToRun(target, input.run),
+  );
+  if (
+    input.run.state === "starting" ||
+    input.run.state === "idle" ||
+    input.run.state === "working" ||
+    input.run.state === "needs_attention" ||
+    input.run.state === "stuck"
+  ) {
+    if (correlatedTerminals.length === 0) return true;
+    return correlatedTerminals.some((target) => terminalCanCorroborateRun(target, input.run));
+  }
+
+  const sessionId = input.run.sessionId;
+  if (sessionId === undefined) return false;
+  return input.terminals.some(
+    (target) =>
+      terminalCanCorroborateRun(target, input.run) ||
+      (target.harnessRunId === undefined &&
+        terminalCanActivateSession({ target, runs: input.runs }) &&
+        target.sessionId === sessionId),
+  );
+}
+
+function terminalCanCorroborateRun(target: ActivationTerminal, run: ActivationRun): boolean {
+  return (
+    terminalIsCorrelatedToRun(target, run) &&
+    (target.state === "open" || target.state === "detached") &&
+    (target.sessionId === undefined || target.sessionId === run.sessionId)
+  );
+}
+
+function terminalIsCorrelatedToRun(target: ActivationTerminal, run: ActivationRun): boolean {
+  return (
+    target.harnessRunId === run.id ||
+    (target.harnessRunId === undefined &&
+      target.sessionId !== undefined &&
+      target.sessionId === run.sessionId)
+  );
+}

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -46,6 +46,19 @@ describe("cleanup command handlers", () => {
       status: "succeeded",
     });
     expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({ state: "exited" });
+    expect(fixture.core.getSnapshot().sessions).toEqual([
+      expect.objectContaining({ id: "ses_web_cleanup", origin: "station" }),
+    ]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ses_web_cleanup", lifecycle: "open" }),
+      ]),
+    );
+    await expect(
+      fixture.persistence.listEvents({ commandId: receipt.commandId }),
+    ).resolves.not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "session.removed" })]),
+    );
     fixture.sqlite.close();
   });
 
@@ -123,6 +136,60 @@ describe("cleanup command handlers", () => {
       ]),
     );
     expect(fixture.core.getSnapshot().sessions).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "ses_web_cleanup",
+          lifecycle: "ended",
+          endedAt: now,
+        }),
+      ]),
+    );
+    fixture.sqlite.close();
+  });
+
+  it("ends a retained Station session when terminal.close targets its worktree", async () => {
+    const fixture = createFixture({ state: "terminal" });
+    await fixture.persistence.persistReconcileResult({
+      projects: config.projects,
+      worktrees: [fixture.worktreeObservation],
+      terminalTargets: [],
+      harnessRuns: [
+        createFakeHarnessRun({
+          id: "run_web_cleanup_previous",
+          projectId: "web",
+          worktreeId: "wt_web_cleanup",
+          sessionId: "ses_web_cleanup",
+          state: "idle",
+          now,
+        }),
+      ],
+      observedAt: now,
+    });
+    await fixture.core.reconcile("pre-retained-terminal-close");
+    expect(fixture.core.getSnapshot().rows[0]?.agent).toBeUndefined();
+    expect(fixture.core.getSnapshot().sessions[0]).toMatchObject({
+      id: "ses_web_cleanup",
+      origin: "station",
+      terminal: expect.objectContaining({ closeable: true }),
+    });
+
+    const receipt = await fixture.queue.dispatch({
+      type: "terminal.close",
+      payload: { worktreeId: "wt_web_cleanup" },
+    });
+    await fixture.queue.drain();
+
+    expect(fixture.terminal.snapshot().closed).toEqual(["term_web_cleanup"]);
+    expect(fixture.core.getSnapshot().sessions).toEqual([]);
+    await expect(fixture.persistence.listEvents({ commandId: receipt.commandId })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "session.removed",
+          event: { type: "session.removed", sessionId: "ses_web_cleanup" },
+        }),
+      ]),
+    );
     fixture.sqlite.close();
   });
 
@@ -157,6 +224,38 @@ describe("cleanup command handlers", () => {
       }),
     ]);
     expect(fixture.terminal.snapshot().closed).toEqual([]);
+    expect(fixture.core.getSnapshot().sessions).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ses_web_cleanup", lifecycle: "ended", endedAt: now }),
+      ]),
+    );
+    fixture.sqlite.close();
+  });
+
+  it("ends Station membership after session.close all succeeds", async () => {
+    const fixture = createFixture({ state: "working" });
+    await fixture.core.reconcile("pre-session-close-all");
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.close",
+      payload: { sessionId: "ses_web_cleanup", mode: "all", force: true },
+    });
+    await fixture.queue.drain();
+
+    expect(fixture.harness.snapshot().stopped).toEqual([
+      { runId: "run_web_cleanup", sessionId: "ses_web_cleanup", force: true },
+    ]);
+    expect(fixture.terminal.snapshot().closed).toEqual(["term_web_cleanup"]);
+    expect(fixture.core.getSnapshot().sessions).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "ses_web_cleanup", lifecycle: "ended", endedAt: now }),
+      ]),
+    );
+    await expect(fixture.persistence.listEvents({ commandId: receipt.commandId })).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "session.removed" })]),
+    );
     fixture.sqlite.close();
   });
 
@@ -274,6 +373,14 @@ describe("cleanup command handlers", () => {
 
   it("force-removes an active worktree after stopping harness and closing terminal", async () => {
     const fixture = createFixture({ dirty: true, state: "working" });
+    await fixture.persistence.seedSessionTitle({
+      sessionId: "ses_web_cleanup_older",
+      projectId: "web",
+      worktreeId: "wt_web_cleanup",
+      title: "older cleanup session",
+      createdAt: "2026-05-21T11:00:00.000Z",
+      lastSeenAt: "2026-05-21T11:00:00.000Z",
+    });
     await fixture.core.reconcile("pre-cleanup");
 
     const receipt = await fixture.queue.dispatch({
@@ -316,6 +423,14 @@ describe("cleanup command handlers", () => {
       ]),
     );
     expect(fixture.core.getSnapshot().rows).toEqual([]);
+    expect(
+      (await fixture.persistence.listSessions())
+        .filter((session) => session.worktreeId === "wt_web_cleanup")
+        .map((session) => ({ id: session.id, lifecycle: session.lifecycle })),
+    ).toEqual([
+      { id: "ses_web_cleanup", lifecycle: "ended" },
+      { id: "ses_web_cleanup_older", lifecycle: "ended" },
+    ]);
     fixture.sqlite.close();
   });
 
@@ -439,7 +554,7 @@ describe("cleanup command handlers", () => {
 
 function createFixture(input: {
   dirty?: boolean;
-  state: "none" | "working";
+  state: "none" | "terminal" | "working";
   harnessStopSupported?: boolean;
   terminalCloseTargetMissing?: boolean;
   projectRootPath?: boolean;
@@ -495,9 +610,8 @@ function createFixture(input: {
   const harness = new FakeHarnessProvider({
     now,
     runs:
-      input.state === "none"
-        ? []
-        : [
+      input.state === "working"
+        ? [
             createFakeHarnessRun({
               id: "run_web_cleanup",
               projectId: "web",
@@ -506,7 +620,8 @@ function createFixture(input: {
               state: "working",
               now,
             }),
-          ],
+          ]
+        : [],
   });
   const harnessProvider =
     input.harnessStopSupported === false ? withoutNativeStop(harness) : harness;

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -39,7 +39,7 @@ describe("observer diagnostics collector", () => {
     };
 
     await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       providerHealth: {
         "fake-worktree": { status: "healthy" },
       },

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1103,6 +1103,33 @@ describe("session command vertical slice", () => {
         ],
       }),
     });
+    await fixture.persistence.persistReconcileResult({
+      projects: config.projects,
+      worktrees: [
+        createFakeWorktree({
+          id: "wt_web_resume",
+          projectId: "web",
+          branch: "resume",
+          now,
+        }),
+      ],
+      terminalTargets: [],
+      harnessRuns: [
+        createFakeHarnessRun({
+          id: "run_previous",
+          projectId: "web",
+          worktreeId: "wt_web_resume",
+          sessionId: "ses_previous",
+          state: "idle",
+          now,
+        }),
+      ],
+      observedAt: now,
+    });
+    await fixture.persistence.markSessionsEnded({
+      subject: { kind: "session", sessionId: "ses_previous" },
+      endedAt: now,
+    });
     const handle = await fixture.persistence.upsertSessionRecoveryHandle({
       id: "report_resume",
       provider: "fake-harness",
@@ -1156,6 +1183,15 @@ describe("session command vertical slice", () => {
           recoveryHandleId: handle.id,
         },
       }),
+    ]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "ses_previous", lifecycle: "open" })]),
+    );
+    expect(
+      (await fixture.persistence.listSessions()).find((session) => session.id === "ses_previous"),
+    ).not.toHaveProperty("endedAt");
+    expect(fixture.core.getSnapshot().sessions).toEqual([
+      expect.objectContaining({ id: "ses_previous", origin: "station" }),
     ]);
     fixture.sqlite.close();
   });

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -1,6 +1,16 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createFakeHarnessRun,
+  createFakeTerminalTarget,
+  createFakeWorktree,
+} from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { latestSchemaVersion, migrations } from "../../src/migrations";
 import { createSqliteObserverPersistence, type IngressJournal } from "../../src/persistence";
 import { openObserverSqlite } from "../../src/sqlite";
+import { openSqlDatabase } from "../../src/sqlite/driver";
 import { observerPersistenceContract } from "../support/observerPersistenceContract";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -14,6 +24,161 @@ observerPersistenceContract("SQLite", ({ clock, idFactory }) => {
 });
 
 describe("SQLite-only Observer persistence behavior", () => {
+  it("migrates historical session lifecycle without treating legacy NULL as open", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-session-lifecycle-"));
+    const path = join(directory, "observer.sqlite");
+    const legacyDatabase = openSqlDatabase(path);
+    try {
+      for (const migration of migrations.slice(0, -1)) {
+        legacyDatabase.exec(migration.sql);
+        legacyDatabase
+          .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")
+          .run(migration.version, migration.name, now);
+      }
+      const insert = legacyDatabase.prepare(`
+        INSERT INTO sessions
+          (id, project_id, worktree_id, harness, created_at, ended_at, last_seen_at)
+        VALUES (?, 'web', 'wt_legacy', 'codex', ?, ?, ?)
+      `);
+      insert.run("ses_legacy_unknown", now, null, now);
+      insert.run("ses_legacy_close", now, null, now);
+      insert.run("ses_legacy_conflict", now, null, now);
+      insert.run("ses_legacy_ended", now, now, now);
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const sqlite = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    try {
+      const persistence = createSqliteObserverPersistence({
+        sqlite,
+        clock: { now: () => new Date(now) },
+      });
+      expect(sqlite.health().schemaVersion).toBe(latestSchemaVersion);
+      await expect(persistence.listSessions()).resolves.toEqual([
+        expect.objectContaining({ id: "ses_legacy_close", lifecycle: "legacy" }),
+        expect.objectContaining({ id: "ses_legacy_conflict", lifecycle: "legacy" }),
+        expect.objectContaining({
+          id: "ses_legacy_ended",
+          lifecycle: "ended",
+          endedAt: now,
+        }),
+        expect.objectContaining({ id: "ses_legacy_unknown", lifecycle: "legacy" }),
+      ]);
+      await expect(
+        persistence.markSessionsEnded({
+          subject: { kind: "session", sessionId: "ses_legacy_close" },
+          endedAt: now,
+        }),
+      ).resolves.toBe(1);
+      const worktree = createFakeWorktree({
+        id: "wt_legacy",
+        projectId: "web",
+        branch: "legacy",
+        now,
+      });
+      await persistence.persistReconcileResult({
+        projects: [
+          {
+            id: "web",
+            label: "web",
+            root: "/tmp/station/web",
+            defaults: {
+              harness: "codex",
+              terminal: "tmux",
+              layout: "agent-shell",
+            },
+            worktrunk: { enabled: true },
+          },
+        ],
+        worktrees: [worktree],
+        terminalTargets: [
+          createFakeTerminalTarget({
+            id: "term_legacy_stale",
+            projectId: "web",
+            worktreeId: worktree.id,
+            sessionId: "ses_legacy_unknown",
+            state: "stale",
+            now,
+          }),
+          createFakeTerminalTarget({
+            id: "term_legacy_conflict",
+            projectId: "web",
+            worktreeId: worktree.id,
+            sessionId: "ses_legacy_conflict",
+            harnessRunId: "run_legacy_external",
+            state: "open",
+            now,
+          }),
+        ],
+        harnessRuns: [
+          createFakeHarnessRun({
+            id: "run_legacy_bound_idle",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: worktree.id,
+            sessionId: "ses_legacy_unknown",
+            state: "idle",
+            now,
+          }),
+          createFakeHarnessRun({
+            id: "run_legacy_closed_stale",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: worktree.id,
+            sessionId: "ses_legacy_close",
+            now,
+          }),
+          createFakeHarnessRun({
+            id: "run_legacy_external",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: worktree.id,
+            state: "working",
+            now,
+          }),
+        ],
+        observedAt: now,
+      });
+      await expect(persistence.listSessions()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "ses_legacy_unknown", lifecycle: "legacy" }),
+          expect.objectContaining({ id: "ses_legacy_conflict", lifecycle: "legacy" }),
+          expect.objectContaining({
+            id: "ses_legacy_close",
+            lifecycle: "ended",
+            endedAt: now,
+          }),
+        ]),
+      );
+      await persistence.persistReconcileResult({
+        projects: [],
+        worktrees: [worktree],
+        terminalTargets: [],
+        harnessRuns: [
+          createFakeHarnessRun({
+            id: "run_legacy_current",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: worktree.id,
+            sessionId: "ses_legacy_unknown",
+            state: "working",
+            now,
+          }),
+        ],
+        observedAt: now,
+      });
+      await expect(persistence.listSessions()).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "ses_legacy_unknown", lifecycle: "open" }),
+        ]),
+      );
+    } finally {
+      sqlite.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("exposes healthy SQLite status in addition to the seven application ports", () => {
     const sqlite = openObserverSqlite({ clock: { now: () => new Date(now) } });
     try {

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -65,6 +65,10 @@ import type {
   WorktreeMetadataCurrentKind,
   WorktreeMetadataCurrentPayloadByKind,
 } from "../../src/persistence/types.js";
+import {
+  harnessRunCanActivateSession,
+  terminalCanActivateSession,
+} from "../../src/sessionActivation.js";
 
 type CreateInMemoryObserverPersistenceOptions = {
   clock?: RuntimeClock;
@@ -348,6 +352,7 @@ export function createInMemoryObserverPersistence(
             id: input.sessionId,
             projectId: input.projectId,
             worktreeId: input.worktreeId,
+            lifecycle: "open",
             title: input.title,
             createdAt: input.createdAt,
             lastSeenAt: input.lastSeenAt,
@@ -359,11 +364,38 @@ export function createInMemoryObserverPersistence(
         existing.worktreeId = input.worktreeId;
         if (existing.title === undefined) existing.title = input.title;
         existing.lastSeenAt = input.lastSeenAt;
+        if (existing.lifecycle !== "ended") existing.lifecycle = "open";
         return existing;
       }),
 
     deleteSessionTitleSeed: (sessionId) =>
       transaction((draft) => (draft.sessions.delete(sessionId) ? 1 : 0)),
+
+    markSessionsEnded: (input) =>
+      transaction((draft) => {
+        let changed = 0;
+        for (const session of draft.sessions.values()) {
+          const matches =
+            input.subject.kind === "session"
+              ? session.id === input.subject.sessionId
+              : session.projectId === input.subject.projectId &&
+                session.worktreeId === input.subject.worktreeId;
+          if (!matches || session.lifecycle === "ended") continue;
+          session.lifecycle = "ended";
+          session.endedAt = input.endedAt;
+          changed += 1;
+        }
+        return changed;
+      }),
+
+    reopenSession: (sessionId) =>
+      transaction((draft) => {
+        const session = draft.sessions.get(sessionId);
+        if (session === undefined) return undefined;
+        session.lifecycle = "open";
+        delete session.endedAt;
+        return session;
+      }),
 
     renameSession: (input) =>
       transaction((draft) => {
@@ -876,17 +908,22 @@ function upsertSessions(
     ) {
       continue;
     }
+    const existing = sessions.get(target.sessionId);
+    const activates = terminalCanActivateSession({ target, runs: harnessRuns });
     const session: PersistedSession = {
       id: target.sessionId,
       projectId: target.projectId,
       worktreeId: target.worktreeId,
+      lifecycle: activates || existing?.lifecycle === "open" ? "open" : "legacy",
       terminalProvider: target.provider,
       state: target.state,
-      createdAt: target.observedAt,
-      lastSeenAt: target.observedAt,
+      createdAt: existing?.createdAt ?? target.observedAt,
+      lastSeenAt: maxIso(existing?.lastSeenAt, target.observedAt),
     };
     const title = worktreesById.get(target.worktreeId)?.branch;
     if (title !== undefined) session.title = title;
+    else if (existing?.title !== undefined) session.title = existing.title;
+    if (existing?.harness !== undefined) session.harness = existing.harness;
     sessions.set(target.sessionId, session);
   }
 
@@ -899,10 +936,16 @@ function upsertSessions(
       continue;
     }
     const existing = sessions.get(run.sessionId);
+    const activates = harnessRunCanActivateSession({
+      run,
+      terminals: terminalTargets,
+      runs: harnessRuns,
+    });
     const session: PersistedSession = {
       id: run.sessionId,
       projectId: run.projectId,
       worktreeId: run.worktreeId,
+      lifecycle: activates || existing?.lifecycle === "open" ? "open" : "legacy",
       harness: run.provider,
       state: run.state,
       createdAt: existing?.createdAt ?? run.observedAt,
@@ -933,6 +976,10 @@ function upsertSessions(
     if (session.state === undefined) delete existing.state;
     else existing.state = session.state;
     existing.lastSeenAt = session.lastSeenAt;
+    if (existing.lifecycle !== "ended") {
+      existing.lifecycle =
+        existing.lifecycle === "open" || session.lifecycle === "open" ? "open" : "legacy";
+    }
   }
 }
 

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -1146,6 +1146,7 @@ export function observerPersistenceContract(
               id: "ses_graph",
               projectId: "web",
               worktreeId: "wt_graph",
+              lifecycle: "open",
               title: "feature/graph",
               harness: "fake-harness",
               terminalProvider: "fake-terminal",
@@ -1257,6 +1258,200 @@ export function observerPersistenceContract(
     });
 
     describe("SessionStore", () => {
+      it("records weak session correlations without activating membership", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          const worktree = createFakeWorktree({
+            id: "wt_activation_evidence",
+            projectId: project.id,
+            now,
+          });
+          await persistence.persistReconcileResult({
+            projects: [project],
+            worktrees: [worktree],
+            terminalTargets: [
+              createFakeTerminalTarget({
+                id: "term_activation_stale",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_terminal",
+                state: "stale",
+                now,
+              }),
+              createFakeTerminalTarget({
+                id: "term_activation_external_conflict",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_external_conflict",
+                harnessRunId: "run_activation_external",
+                state: "open",
+                now,
+              }),
+            ],
+            harnessRuns: [
+              createFakeHarnessRun({
+                id: "run_activation_bound_idle",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_terminal",
+                state: "idle",
+                now,
+              }),
+              createFakeHarnessRun({
+                id: "run_activation_none",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_none",
+                state: "none",
+                now,
+              }),
+              createFakeHarnessRun({
+                id: "run_activation_exited",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_exited",
+                state: "exited",
+                now,
+              }),
+              createFakeHarnessRun({
+                id: "run_activation_unknown",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_unknown",
+                state: "unknown",
+                now,
+              }),
+              createFakeHarnessRun({
+                id: "run_activation_external",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                state: "working",
+                now,
+              }),
+            ],
+            observedAt: now,
+          });
+          expect(await persistence.listSessions()).toEqual([
+            expect.objectContaining({
+              id: "ses_activation_exited",
+              lifecycle: "legacy",
+              harness: "fake-harness",
+            }),
+            expect.objectContaining({
+              id: "ses_activation_external_conflict",
+              lifecycle: "legacy",
+              terminalProvider: "fake-terminal",
+            }),
+            expect.objectContaining({
+              id: "ses_activation_none",
+              lifecycle: "legacy",
+              harness: "fake-harness",
+            }),
+            expect.objectContaining({
+              id: "ses_activation_terminal",
+              lifecycle: "legacy",
+              harness: "fake-harness",
+              terminalProvider: "fake-terminal",
+            }),
+            expect.objectContaining({
+              id: "ses_activation_unknown",
+              lifecycle: "legacy",
+              harness: "fake-harness",
+            }),
+          ]);
+          await expect(
+            persistence.findRememberedHarnessProviderForWorktree({
+              projectId: project.id,
+              worktreeId: worktree.id,
+              worktreePath: worktree.path,
+            }),
+          ).resolves.toBe("fake-harness");
+
+          await persistence.persistReconcileResult({
+            projects: [project],
+            worktrees: [worktree],
+            terminalTargets: [
+              createFakeTerminalTarget({
+                id: "term_activation_detached",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_terminal",
+                state: "detached",
+                now: later,
+              }),
+              createFakeTerminalTarget({
+                id: "term_activation_unknown_run",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_unknown",
+                harnessRunId: "run_activation_unknown",
+                state: "open",
+                now: later,
+              }),
+            ],
+            harnessRuns: [
+              createFakeHarnessRun({
+                id: "run_activation_none",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_none",
+                state: "working",
+                now: later,
+              }),
+              createFakeHarnessRun({
+                id: "run_activation_unknown",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_unknown",
+                state: "unknown",
+                now: later,
+              }),
+            ],
+            observedAt: later,
+          });
+          expect(await persistence.listSessions()).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ id: "ses_activation_none", lifecycle: "open" }),
+              expect.objectContaining({
+                id: "ses_activation_terminal",
+                lifecycle: "open",
+                harness: "fake-harness",
+              }),
+              expect.objectContaining({ id: "ses_activation_unknown", lifecycle: "open" }),
+              expect.objectContaining({
+                id: "ses_activation_exited",
+                lifecycle: "legacy",
+              }),
+              expect.objectContaining({
+                id: "ses_activation_external_conflict",
+                lifecycle: "legacy",
+              }),
+            ]),
+          );
+
+          await persistence.persistReconcileResult({
+            projects: [project],
+            worktrees: [worktree],
+            terminalTargets: [],
+            harnessRuns: [
+              createFakeHarnessRun({
+                id: "run_activation_none",
+                projectId: project.id,
+                worktreeId: worktree.id,
+                sessionId: "ses_activation_none",
+                state: "exited",
+                now: latest,
+              }),
+            ],
+            observedAt: latest,
+          });
+          expect(
+            (await persistence.listSessions()).find(
+              (session) => session.id === "ses_activation_none",
+            ),
+          ).toMatchObject({ lifecycle: "open", lastSeenAt: latest });
+        });
+      });
+
       it("orders sessions by ID and preserves seeded and renamed titles", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           await persistence.seedSessionTitle({
@@ -1298,6 +1493,7 @@ export function observerPersistenceContract(
           });
           expect(reseeded).toMatchObject({
             title: "original title",
+            lifecycle: "open",
             createdAt: earlier,
             lastSeenAt: later,
           });
@@ -1362,6 +1558,80 @@ export function observerPersistenceContract(
           });
           await expect(persistence.deleteSessionTitleSeed("ses_delete")).resolves.toBe(1);
           await expect(persistence.deleteSessionTitleSeed("ses_delete")).resolves.toBe(0);
+        });
+      });
+
+      it("ends open sessions without generic evidence reviving them and reopens explicitly", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          for (const sessionId of ["ses_lifecycle_a", "ses_lifecycle_b"]) {
+            await persistHarnessSession(persistence, {
+              project,
+              worktreeId: "wt_lifecycle",
+              sessionId,
+              provider: "codex",
+              path: "/var/tmp/station/lifecycle",
+              observedAt: earlier,
+            });
+          }
+          expect(
+            (await persistence.listSessions())
+              .filter((session) => session.worktreeId === "wt_lifecycle")
+              .map((session) => session.lifecycle),
+          ).toEqual(["open", "open"]);
+
+          await expect(
+            persistence.markSessionsEnded({
+              subject: { kind: "worktree", projectId: project.id, worktreeId: "wt_lifecycle" },
+              endedAt: now,
+            }),
+          ).resolves.toBe(2);
+          expect(
+            (await persistence.listSessions())
+              .filter((session) => session.worktreeId === "wt_lifecycle")
+              .map((session) => ({ lifecycle: session.lifecycle, endedAt: session.endedAt })),
+          ).toEqual([
+            { lifecycle: "ended", endedAt: now },
+            { lifecycle: "ended", endedAt: now },
+          ]);
+
+          await persistHarnessSession(persistence, {
+            project,
+            worktreeId: "wt_lifecycle",
+            sessionId: "ses_lifecycle_a",
+            provider: "codex",
+            path: "/var/tmp/station/lifecycle",
+            observedAt: later,
+          });
+          await expect(persistence.listSessions()).resolves.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                id: "ses_lifecycle_a",
+                lifecycle: "ended",
+                endedAt: now,
+              }),
+            ]),
+          );
+          await expect(persistence.reopenSession("ses_lifecycle_a")).resolves.toMatchObject({
+            lifecycle: "open",
+          });
+          const reopened = (await persistence.listSessions()).find(
+            (session) => session.id === "ses_lifecycle_a",
+          );
+          expect(reopened).not.toHaveProperty("endedAt");
+
+          await expect(
+            persistence.markSessionsEnded({
+              subject: { kind: "session", sessionId: "ses_lifecycle_a" },
+              endedAt: latest,
+            }),
+          ).resolves.toBe(1);
+          await expect(
+            persistence.markSessionsEnded({
+              subject: { kind: "session", sessionId: "ses_lifecycle_a" },
+              endedAt: latest,
+            }),
+          ).resolves.toBe(0);
+          await expect(persistence.reopenSession("ses_missing")).resolves.toBeUndefined();
         });
       });
 

--- a/apps/observer/test/support/testObserver.ts
+++ b/apps/observer/test/support/testObserver.ts
@@ -40,6 +40,7 @@ export function emptyStationSnapshot(generatedAt: string): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,

--- a/apps/observer/test/unit/environmentCheck.test.ts
+++ b/apps/observer/test/unit/environmentCheck.test.ts
@@ -7,6 +7,10 @@ function session(title: string, provider: string, state: string): SessionView {
   return { title, terminal: { provider, state } } as unknown as SessionView;
 }
 
+function sessionWithoutTerminal(title: string): SessionView {
+  return { title } as unknown as SessionView;
+}
+
 function orphan(kind: OrphanedRuntimeState["kind"]): OrphanedRuntimeState {
   return { kind } as unknown as OrphanedRuntimeState;
 }
@@ -26,6 +30,16 @@ describe("buildSessionEnvironmentCheck", () => {
     });
     expect(check.status).toBe("ok");
     expect(check.message).toBe("2 session(s) — native: 2 open.");
+  });
+
+  it("reports canonical sessions that have no observed terminal", () => {
+    const check = buildSessionEnvironmentCheck({
+      sessions: [sessionWithoutTerminal("external")],
+      orphans: [],
+    });
+
+    expect(check.status).toBe("ok");
+    expect(check.message).toBe("1 session(s) — no terminal: 1.");
   });
 
   it("warns and names detached sessions with their provider (the silent-click case)", () => {

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -7,7 +7,11 @@ import type {
 } from "@station/contracts";
 import { StationSnapshotSchema } from "@station/contracts";
 import { describe, expect, it } from "vitest";
-import { buildStationSnapshot, type ObserverTurnReadiness } from "../../src/reconcile/graph";
+import {
+  buildStationSnapshot,
+  type ObserverSessionMetadata,
+  type ObserverTurnReadiness,
+} from "../../src/reconcile/graph";
 import {
   type ObserverHarnessRun,
   observerHarnessRunFromRun,
@@ -145,6 +149,7 @@ function build(overrides: {
   worktrees?: WorktreeObservation[];
   terminals?: TerminalTargetObservation[];
   harnessRuns?: ObserverHarnessRun[];
+  sessionMetadata?: ObserverSessionMetadata[];
   turnReadiness?: ObserverTurnReadiness[];
   providerHealth?: Record<string, ProviderHealth>;
 }) {
@@ -159,11 +164,483 @@ function build(overrides: {
     worktrees: overrides.worktrees ?? [],
     terminalTargets: overrides.terminals ?? [],
     harnessRuns: overrides.harnessRuns ?? [],
+    sessionMetadata: overrides.sessionMetadata ?? [],
     turnReadiness: overrides.turnReadiness ?? [],
   });
 }
 
 describe("observer graph derivation", () => {
+  it("counts one canonical session alongside ten unattached worktrees", () => {
+    const attached = worktree("wt_web_session", "web", "session");
+    const unattached = Array.from({ length: 10 }, (_, index) =>
+      worktree(`wt_web_bare_${index}`, "web", `bare-${index}`),
+    );
+
+    const snapshot = build({
+      projects: projects.slice(0, 1),
+      worktrees: [attached, ...unattached],
+      terminals: [terminal("term_session", attached.id, "run_session")],
+      harnessRuns: [harness("run_session", attached.id, "idle")],
+    });
+
+    expect(snapshot.rows).toHaveLength(11);
+    expect(snapshot.sessions).toHaveLength(1);
+    expect(snapshot.sessions[0]).toMatchObject({
+      id: "ses_wt_web_session",
+      worktreeId: attached.id,
+      origin: "station",
+    });
+    expect(snapshot.projects[0]?.counts).toMatchObject({
+      sessions: 1,
+      worktrees: 11,
+      agents: 1,
+      idle: 1,
+    });
+    expect(snapshot.counts).toMatchObject({
+      sessions: 1,
+      worktrees: 11,
+      agents: 1,
+      idle: 1,
+    });
+  });
+
+  it("retains the newest unended Station session without a live agent", () => {
+    const retainedAt = "2026-05-20T11:58:00.000Z";
+    const retained = worktree("wt_web_retained", "web", "retained");
+    const snapshot = build({
+      projects: projects.slice(0, 1),
+      worktrees: [retained],
+      sessionMetadata: [
+        {
+          id: "ses_older",
+          projectId: "web",
+          worktreeId: retained.id,
+          lifecycle: "open",
+          harness: "fake-harness",
+          createdAt: "2026-05-20T11:45:00.000Z",
+          lastSeenAt: "2026-05-20T11:50:00.000Z",
+        },
+        {
+          id: "ses_retained",
+          projectId: "web",
+          worktreeId: retained.id,
+          lifecycle: "open",
+          title: "retained title",
+          harness: "fake-harness",
+          createdAt: retainedAt,
+          lastSeenAt: retainedAt,
+        },
+      ],
+    });
+
+    expect(snapshot.rows[0]?.agent).toBeUndefined();
+    expect(snapshot.sessions).toEqual([
+      expect.objectContaining({
+        id: "ses_retained",
+        worktreeId: retained.id,
+        origin: "station",
+        title: "retained title",
+        status: expect.objectContaining({ value: "none", source: "reconcile" }),
+      }),
+    ]);
+    expect(snapshot.sessions[0]).not.toHaveProperty("terminal");
+    expect(snapshot.counts.sessions).toBe(1);
+    expect(snapshot.counts.agents).toBe(0);
+  });
+
+  it("does not resurrect a durably ended Station session from terminal or run evidence", () => {
+    const ended = worktree("wt_web_ended", "web", "ended");
+    const endedMetadata: ObserverSessionMetadata = {
+      id: "ses_wt_web_ended",
+      projectId: "web",
+      worktreeId: ended.id,
+      lifecycle: "ended",
+      title: "ended",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:57:00.000Z",
+      endedAt: "2026-05-20T11:59:00.000Z",
+      lastSeenAt: "2026-05-20T11:59:00.000Z",
+    };
+    const observedTerminal = terminal("term_ended", ended.id, "run_ended");
+
+    const terminalOnly = build({
+      projects: projects.slice(0, 1),
+      worktrees: [ended],
+      terminals: [observedTerminal],
+      sessionMetadata: [endedMetadata],
+    });
+    const runPresent = build({
+      projects: projects.slice(0, 1),
+      worktrees: [ended],
+      terminals: [observedTerminal],
+      harnessRuns: [harness("run_ended", ended.id, "working")],
+      sessionMetadata: [endedMetadata],
+    });
+
+    expect(terminalOnly.sessions).toEqual([]);
+    expect(runPresent.sessions).toEqual([]);
+    expect(terminalOnly.counts.sessions).toBe(0);
+    expect(runPresent.counts.sessions).toBe(0);
+  });
+
+  it("retains Station membership independently from qualifying external run evidence", () => {
+    const mixed = worktree("wt_web_mixed", "web", "mixed");
+    const retained: ObserverSessionMetadata = {
+      id: "ses_wt_web_mixed",
+      projectId: "web",
+      worktreeId: mixed.id,
+      lifecycle: "open",
+      title: "retained",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:50:00.000Z",
+      lastSeenAt: "2026-05-20T11:55:00.000Z",
+    };
+    const externalRun = observerHarnessRunFromRun({
+      id: "codex:external:native_mixed",
+      provider: "codex",
+      projectId: "web",
+      worktreeId: mixed.id,
+      state: "working",
+      confidence: "high",
+      reason: "External Codex run is active.",
+      observedAt: generatedAt,
+    });
+    const observedTerminal = terminal("term_mixed", mixed.id, externalRun.run.id);
+
+    const active = build({
+      projects: projects.slice(0, 1),
+      worktrees: [mixed],
+      terminals: [observedTerminal],
+      harnessRuns: [externalRun],
+      sessionMetadata: [retained],
+    });
+    const inactive = build({
+      projects: projects.slice(0, 1),
+      worktrees: [mixed],
+      terminals: [observedTerminal],
+      harnessRuns: [
+        {
+          ...externalRun,
+          run: { ...externalRun.run, state: "exited" },
+          status: { ...externalRun.status, value: "exited" },
+        },
+      ],
+      sessionMetadata: [retained],
+    });
+
+    expect(active.sessions).toEqual([
+      expect.objectContaining({ id: retained.id, origin: "station" }),
+      expect.objectContaining({ id: externalRun.run.id, origin: "external" }),
+    ]);
+    expect(active.sessions.every((session) => session.terminal === undefined)).toBe(true);
+    expect(active.counts).toMatchObject({ sessions: 2, agents: 1, working: 1 });
+    expect(inactive.sessions).toEqual([
+      expect.objectContaining({ id: retained.id, origin: "station" }),
+    ]);
+    expect(inactive.counts).toMatchObject({ sessions: 1, agents: 0, working: 0 });
+  });
+
+  it("does not activate legacy Station membership from a terminal bound to an external run", () => {
+    const legacy = worktree("wt_web_external_conflict", "web", "external-conflict");
+    const externalRun = observerHarnessRunFromRun({
+      id: "codex:external:native_conflict",
+      provider: "codex",
+      projectId: "web",
+      worktreeId: legacy.id,
+      state: "working",
+      confidence: "high",
+      reason: "External Codex run is active.",
+      observedAt: generatedAt,
+    });
+    const observedTerminal = terminal("term_external_conflict", legacy.id, externalRun.run.id);
+
+    const snapshot = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      terminals: [observedTerminal],
+      harnessRuns: [externalRun],
+      sessionMetadata: [
+        {
+          id: observedTerminal.sessionId as string,
+          projectId: "web",
+          worktreeId: legacy.id,
+          lifecycle: "legacy",
+          harness: "fake-harness",
+          createdAt: "2026-05-20T11:50:00.000Z",
+          lastSeenAt: "2026-05-20T11:55:00.000Z",
+        },
+      ],
+    });
+
+    expect(snapshot.sessions).toEqual([
+      expect.objectContaining({ id: externalRun.run.id, origin: "external" }),
+    ]);
+  });
+
+  it("uses current evidence to activate legacy identity without retaining legacy-only rows", () => {
+    const legacy = worktree("wt_web_legacy", "web", "legacy");
+    const metadata: ObserverSessionMetadata = {
+      id: "ses_wt_web_legacy",
+      projectId: "web",
+      worktreeId: legacy.id,
+      lifecycle: "legacy",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:50:00.000Z",
+      lastSeenAt: "2026-05-20T11:55:00.000Z",
+    };
+
+    const withoutEvidence = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      sessionMetadata: [metadata],
+    });
+    const withEvidence = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      harnessRuns: [harness("run_legacy", legacy.id, "working")],
+      sessionMetadata: [metadata],
+    });
+
+    expect(withoutEvidence.sessions).toEqual([]);
+    expect(withEvidence.sessions).toEqual([
+      expect.objectContaining({ id: metadata.id, origin: "station" }),
+    ]);
+  });
+
+  it("requires strong current evidence before activating legacy membership", () => {
+    const legacy = worktree("wt_web_legacy_evidence", "web", "legacy-evidence");
+    const metadata: ObserverSessionMetadata = {
+      id: `ses_${legacy.id}`,
+      projectId: "web",
+      worktreeId: legacy.id,
+      lifecycle: "legacy",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:50:00.000Z",
+      lastSeenAt: "2026-05-20T11:55:00.000Z",
+    };
+
+    for (const state of ["none", "exited", "unknown"] as const) {
+      const snapshot = build({
+        projects: projects.slice(0, 1),
+        worktrees: [legacy],
+        harnessRuns: [harness(`run_legacy_${state}`, legacy.id, state)],
+        sessionMetadata: [metadata],
+      });
+      expect(snapshot.sessions, `${state} run`).toEqual([]);
+    }
+
+    for (const state of ["none", "stale", "unknown"] as const) {
+      const snapshot = build({
+        projects: projects.slice(0, 1),
+        worktrees: [legacy],
+        terminals: [terminal(`term_legacy_${state}`, legacy.id, "run_missing", state)],
+        sessionMetadata: [metadata],
+      });
+      expect(snapshot.sessions, `${state} terminal`).toEqual([]);
+    }
+
+    const staleSessionCorrelatedTerminal = terminal(
+      "term_legacy_bound_stale",
+      legacy.id,
+      "run_legacy_bound_idle",
+      "stale",
+    );
+    delete staleSessionCorrelatedTerminal.harnessRunId;
+    const staleBoundActiveRun = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      terminals: [staleSessionCorrelatedTerminal],
+      harnessRuns: [harness("run_legacy_bound_idle", legacy.id, "idle")],
+      sessionMetadata: [metadata],
+    });
+    expect(staleBoundActiveRun.sessions).toEqual([]);
+
+    const corroboratedUnknown = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      terminals: [terminal("term_legacy_open", legacy.id, "run_legacy_unknown")],
+      harnessRuns: [harness("run_legacy_unknown", legacy.id, "unknown")],
+      sessionMetadata: [metadata],
+    });
+    expect(corroboratedUnknown.sessions).toEqual([
+      expect.objectContaining({
+        id: metadata.id,
+        origin: "station",
+        status: expect.objectContaining({ value: "unknown" }),
+      }),
+    ]);
+
+    const explicitlyOpen = build({
+      projects: projects.slice(0, 1),
+      worktrees: [legacy],
+      harnessRuns: [harness("run_legacy_exited", legacy.id, "exited")],
+      sessionMetadata: [{ ...metadata, lifecycle: "open" }],
+    });
+    expect(explicitlyOpen.sessions).toEqual([
+      expect.objectContaining({
+        id: metadata.id,
+        origin: "station",
+        status: expect.objectContaining({ value: "exited" }),
+      }),
+    ]);
+  });
+
+  it("falls back to the newest open Station session when terminal identity is unknown or ended", () => {
+    const retainedWorktree = worktree("wt_web_terminal_fallback", "web", "fallback");
+    const retained: ObserverSessionMetadata = {
+      id: "ses_retained_fallback",
+      projectId: "web",
+      worktreeId: retainedWorktree.id,
+      lifecycle: "open",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:55:00.000Z",
+      lastSeenAt: "2026-05-20T11:58:00.000Z",
+    };
+    const ended: ObserverSessionMetadata = {
+      id: "ses_ended_fallback",
+      projectId: "web",
+      worktreeId: retainedWorktree.id,
+      lifecycle: "ended",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:56:00.000Z",
+      endedAt: "2026-05-20T11:59:00.000Z",
+      lastSeenAt: "2026-05-20T11:59:00.000Z",
+    };
+    const unknownTerminal = terminal("term_unknown_session", retainedWorktree.id, "run_unknown");
+    unknownTerminal.sessionId = "ses_unknown_fallback";
+    const endedTerminal = terminal("term_ended_session", retainedWorktree.id, "run_ended");
+    endedTerminal.sessionId = ended.id;
+
+    for (const observedTerminal of [unknownTerminal, endedTerminal]) {
+      const snapshot = build({
+        projects: projects.slice(0, 1),
+        worktrees: [retainedWorktree],
+        terminals: [observedTerminal],
+        sessionMetadata: [retained, ended],
+      });
+      expect(snapshot.sessions).toEqual([
+        expect.objectContaining({ id: retained.id, origin: "station" }),
+      ]);
+      expect(snapshot.sessions[0]).not.toHaveProperty("terminal");
+    }
+  });
+
+  it("attaches terminals only through matching session or run identity", () => {
+    const attached = worktree("wt_web_terminal_identity", "web", "terminal-identity");
+    const run = harness("run_terminal_identity", attached.id, "idle");
+    const sessionBound = terminal("term_session_bound", attached.id, run.run.id);
+    delete sessionBound.harnessRunId;
+    const runBound = terminal("term_run_bound", attached.id, run.run.id);
+    delete runBound.sessionId;
+    const unbound = terminal("term_unbound", attached.id, run.run.id);
+    delete unbound.sessionId;
+    delete unbound.harnessRunId;
+
+    const attachment = (observedTerminal: TerminalTargetObservation) =>
+      build({
+        projects: projects.slice(0, 1),
+        worktrees: [attached],
+        terminals: [observedTerminal],
+        harnessRuns: [run],
+      }).sessions[0]?.terminal;
+
+    expect(attachment(sessionBound)).toBeDefined();
+    expect(attachment(runBound)).toBeDefined();
+    expect(attachment(unbound)).toBeUndefined();
+  });
+
+  it("does not attach an unbound terminal to a retained Station session", () => {
+    const retainedWorktree = worktree("wt_web_unbound_terminal", "web", "unbound-terminal");
+    const retained: ObserverSessionMetadata = {
+      id: "ses_unbound_terminal",
+      projectId: "web",
+      worktreeId: retainedWorktree.id,
+      lifecycle: "open",
+      harness: "fake-harness",
+      createdAt: "2026-05-20T11:50:00.000Z",
+      lastSeenAt: "2026-05-20T11:55:00.000Z",
+    };
+    const unbound = terminal("term_unbound_retained", retainedWorktree.id, "run_unbound");
+    delete unbound.sessionId;
+    delete unbound.harnessRunId;
+
+    const snapshot = build({
+      projects: projects.slice(0, 1),
+      worktrees: [retainedWorktree],
+      terminals: [unbound],
+      sessionMetadata: [retained],
+    });
+
+    expect(snapshot.sessions).toEqual([
+      expect.objectContaining({ id: retained.id, origin: "station" }),
+    ]);
+    expect(snapshot.sessions[0]).not.toHaveProperty("terminal");
+  });
+
+  it("surfaces active external run evidence without fabricating terminal or Station identity", () => {
+    const external = worktree("wt_web_external", "web", "external");
+    const externalRun = observerHarnessRunFromRun({
+      id: "codex:external:native_1",
+      provider: "codex",
+      projectId: "web",
+      worktreeId: external.id,
+      state: "working",
+      confidence: "high",
+      reason: "External Codex run is active.",
+      observedAt: generatedAt,
+    });
+
+    const active = build({
+      projects: projects.slice(0, 1),
+      worktrees: [external],
+      harnessRuns: [externalRun],
+    });
+    const runBoundTerminal = terminal("term_external", external.id, externalRun.run.id);
+    delete runBoundTerminal.sessionId;
+    const attached = build({
+      projects: projects.slice(0, 1),
+      worktrees: [external],
+      terminals: [runBoundTerminal],
+      harnessRuns: [externalRun],
+    });
+    const inactiveSnapshots = (["none", "unknown", "exited"] as const).map((state) =>
+      build({
+        projects: projects.slice(0, 1),
+        worktrees: [external],
+        harnessRuns: [
+          {
+            ...externalRun,
+            run: { ...externalRun.run, state },
+            status: { ...externalRun.status, value: state },
+          },
+        ],
+      }),
+    );
+
+    expect(active.sessions).toEqual([
+      expect.objectContaining({
+        id: externalRun.run.id,
+        worktreeId: external.id,
+        origin: "external",
+      }),
+    ]);
+    expect(active.sessions[0]).not.toHaveProperty("terminal");
+    expect(attached.sessions[0]?.terminal).toBeDefined();
+    expect(active.counts.sessions).toBe(1);
+    expect(active.counts).toMatchObject({ agents: 1, working: 1 });
+    expect(
+      inactiveSnapshots.map((snapshot) => ({
+        sessions: snapshot.sessions,
+        sessionCount: snapshot.counts.sessions,
+        agentCount: snapshot.counts.agents,
+      })),
+    ).toEqual([
+      { sessions: [], sessionCount: 0, agentCount: 0 },
+      { sessions: [], sessionCount: 0, agentCount: 0 },
+      { sessions: [], sessionCount: 0, agentCount: 0 },
+    ]);
+  });
+
   it("keeps configured projects visible even when a project has zero worktrees", () => {
     const snapshot = build({
       projects,
@@ -277,20 +754,20 @@ describe("observer graph derivation", () => {
     });
     expect(snapshot.projects.find((project) => project.id === "api")?.counts).toMatchObject({
       worktrees: 3,
-      agents: 3,
+      agents: 1,
       working: 0,
       idle: 0,
       attention: 0,
-      unknown: 1,
+      unknown: 0,
     });
     expect(snapshot.counts).toMatchObject({
       projects: 2,
       worktrees: 7,
-      agents: 6,
+      agents: 4,
       working: 1,
       idle: 1,
       attention: 1,
-      unknown: 1,
+      unknown: 0,
     });
     expect(snapshot.rows.find((row) => row.id === "wt_api_unknown")?.display).toMatchObject({
       statusLabel: "unknown",

--- a/apps/observer/test/unit/observerEventHooks.test.ts
+++ b/apps/observer/test/unit/observerEventHooks.test.ts
@@ -197,6 +197,7 @@ function snapshot(rows: StationSnapshot["rows"]): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: rows.length,
       agents: rows.filter((candidate) => candidate.agent !== undefined).length,
       working: rows.filter((candidate) => candidate.agent?.state === "working").length,

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -147,7 +147,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.7.0" as const,
+        schemaVersion: "0.8.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -226,7 +226,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.listening = false;
       return {
-        schemaVersion: "0.7.0" as const,
+        schemaVersion: "0.8.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -245,7 +245,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.7.0" as const,
+        schemaVersion: "0.8.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -263,7 +263,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.7.0" as const,
+        schemaVersion: "0.8.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -301,7 +301,7 @@ function decisionFor(candidateVersion: string, incumbentVersion: string) {
 
 function handoffFixture() {
   const incumbentHealth: ObserverHealth = {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     status: "healthy",
     pid: 100,
     startedAt: "2026-07-12T11:00:00.000Z",
@@ -322,7 +322,7 @@ function handoffFixture() {
     incumbentHealth,
     health: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => incumbentHealth),
     stop: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => ({
-      schemaVersion: "0.7.0" as const,
+      schemaVersion: "0.8.0" as const,
       stopped: true,
       at: "2026-07-12T12:00:00.000Z",
     })),

--- a/apps/observer/test/unit/statusProjection.test.ts
+++ b/apps/observer/test/unit/statusProjection.test.ts
@@ -104,6 +104,63 @@ describe("live harness status projection", () => {
     });
   });
 
+  it("projects an external run from working to idle with canonical counts", () => {
+    const result = projectHarnessEventReportOntoSnapshot({
+      snapshot: externalSnapshotFor("working"),
+      report: report({
+        status: status("idle", "high", "External Codex turn completed."),
+        correlation: { harnessRunId: "run_web_external" },
+      }),
+      projectedAt: eventAt,
+    });
+
+    expect(result.snapshot.rows[0]?.agent?.state).toBe("idle");
+    expect(result.snapshot.sessions).toEqual([
+      expect.objectContaining({
+        id: "run_web_external",
+        origin: "external",
+        status: expect.objectContaining({ value: "idle" }),
+      }),
+    ]);
+    expect(result.snapshot.counts).toMatchObject({
+      sessions: 1,
+      agents: 1,
+      working: 0,
+      idle: 1,
+    });
+    expect(result.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "worktree.agentStateChanged" }),
+        expect.objectContaining({ type: "session.updated", sessionId: "run_web_external" }),
+      ]),
+    );
+  });
+
+  it.each([
+    "exited",
+    "none",
+  ] as const)("removes external membership when a live report becomes %s", (value) => {
+    const result = projectHarnessEventReportOntoSnapshot({
+      snapshot: externalSnapshotFor("working"),
+      report: report({
+        status: status(value, "high", `External Codex run is ${value}.`),
+        correlation: { harnessRunId: "run_web_external" },
+      }),
+      projectedAt: eventAt,
+    });
+
+    expect(result.snapshot.sessions).toEqual([]);
+    expect(result.snapshot.counts).toMatchObject({ sessions: 0, agents: 0, working: 0 });
+    expect(result.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "session.removed",
+          sessionId: "run_web_external",
+        }),
+      ]),
+    );
+  });
+
   it("keeps unknown, mismatched, and ambiguous reports diagnostic-only", () => {
     const unknown = projectHarnessEventReportOntoSnapshot({
       snapshot: snapshotFor({ state: "working", confidence: "high" }),
@@ -387,6 +444,45 @@ function snapshotFor(input: { state?: AgentState; confidence?: Confidence; now?:
     worktrees,
     terminalTargets: terminals,
     harnessRuns,
+  });
+}
+
+function externalSnapshotFor(state: AgentState) {
+  const worktree = createFakeWorktree({
+    id: "wt_web_external",
+    projectId: "web",
+    branch: "external",
+    path: "/tmp/station/web/external",
+    now,
+  });
+  return buildStationSnapshot({
+    generatedAt: now,
+    observer: { pid: 4242, startedAt: now, version: "0.0.0", healthy: true },
+    projects: [
+      {
+        id: "web",
+        label: "web",
+        root: "/tmp/station/web",
+        defaults: { harness: "codex", terminal: "tmux", layout: "agent-shell" },
+        worktrunk: { enabled: true },
+      },
+    ],
+    worktreeProviderId: "fake-worktree",
+    providerHealth: {},
+    worktrees: [worktree],
+    terminalTargets: [],
+    harnessRuns: [
+      observerHarnessRunFromRun(
+        createFakeHarnessRun({
+          id: "run_web_external",
+          provider: "codex",
+          projectId: "web",
+          worktreeId: worktree.id,
+          state,
+          now,
+        }),
+      ),
+    ],
   });
 }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,8 +47,10 @@ No single layer owns all truth.
 - Terminal providers are authoritative for terminal topology and provider-owned target identity.
 - Harness providers are authoritative for agent launch, discovery, event ingestion, and status signals they can prove.
 - Repository providers are authoritative only for code-host metadata they fetch or cache through their integration boundary.
-- Observer SQLite is durable observer memory for commands, events, correlations, provider observations, and current metadata cache rows.
-- Observer snapshots are the normalized current graph exposed to clients.
+- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, provider observations, and current metadata cache rows.
+- Observer snapshots are the normalized current graph exposed to clients. `rows` is configured
+  worktree inventory; `sessions` is canonical session membership. Session and activity counts
+  derive from `sessions`, while worktree counts derive from `rows`.
 - JSONL logs and debug bundles are diagnostic evidence, not runtime truth.
 
 When these disagree, reconcile from config, providers, and current observer state first. Treat stale logs, old bundles, and historical plans as evidence to inspect, not as authority.

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -71,9 +71,12 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
    decision (`Harness event report processed.` / `skipped.` with
    `projected`/`correlatedBy`/`deduped`). An accepted report with
    `projected: false` is a correlation failure and must stay visible.
-6. **Evolution is additive.** New fields optional, enums keep catch-all
-   members (`input`), schema stamps (`schemaVersion`) travel with payloads.
-   New signal kinds require census evidence, not speculation.
+6. **Evolution is explicit.** Prefer optional fields and keep enum catch-all
+   members (`input`). Schema stamps (`schemaVersion`) travel with payloads, and
+   any required shared-shape change bumps the exact `STATION_SCHEMA_VERSION`.
+   After such a bump, reinstall the binary and rerun `stn setup` or
+   `stn hooks install <target> --yes` for every enabled provider before testing
+   ingress. New signal kinds require census evidence, not speculation.
 7. **Busy statuses decay.** `working`/`starting` are claims that signals are
    still flowing; reconcile projects a run whose newest signal is older than
    15 minutes to `unknown` (low confidence, source `reconcile`) instead of

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -127,7 +127,12 @@ Some names are compatibility aliases, not the preferred vocabulary:
 - `hook.ingested` and `hook.spoolDrained` are removed, not aliased. Use `providerHook.ingested` and `providerHook.spoolDrained`; the retired strings error as input rather than silently upgrading.
 - `hookSpool` names are acceptable for filesystem compatibility, but new code should prefer `providerHookSpool` or a broader `providerIngressSpool` when the spool contains both provider hook events and harness event reports.
 
-Because STATION is pre-alpha — no shipped installs, no externally persisted payloads, no generated scripts in the wild — there is no compatibility surface to preserve for STATION's own retired names. Remove a retired name instead of aliasing it. Do not add alias-only wrappers for names that are not part of a real external contract.
+Because STATION is pre-alpha, there is no compatibility surface to preserve for
+STATION's own retired names. Remove a retired name instead of aliasing it. Do
+not add alias-only wrappers for names that are not part of a real external
+contract. This does not permit silent shared-schema drift: breaking payload
+changes bump the exact schema version and require generated provider hooks to
+be reinstalled.
 
 ## Status Sources
 
@@ -158,7 +163,15 @@ Three lifecycle units are easy to conflate. Keep them distinct in names, command
 
 ### Session
 
-A session is one agent / harness run. The observer mints its id as `ses_<uuid>` (`apps/observer/src/commands/session/shared.ts`). A session lives inside a worktree but is not the worktree — ending a session leaves the checkout and panes intact.
+A session is one agent/harness lifecycle inside a worktree, not the worktree
+itself. `StationSnapshot.sessions` is canonical membership. `origin: "station"`
+identifies Observer-owned lifecycle state: the Observer mints its id as
+`ses_<uuid>` (`apps/observer/src/commands/session/shared.ts`), and the newest
+explicitly open durable record can remain a member without a currently observed
+run or terminal. `origin: "external"` identifies current external run evidence: the
+view reuses the normalized harness run id and is removed when that evidence is
+expired, `none`, `unknown`, or `exited`. Ending a session leaves the checkout
+and panes intact.
 
 There is no deletable "session" unit and no `session.remove` command. The durable, deletable unit is the worktree.
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -242,7 +242,7 @@ No single layer owns all truth.
 | Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, version, socketPath}` identity published by the process that successfully bound the socket. It corroborates process identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
 | In-memory persistence adapter | Process-local test state that preserves the seven persistence ports' observable transaction semantics. It is neither restart-durable nor selectable by production runtime composition. |
-| `StationSnapshot` | Current normalized graph held in memory. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
+| `StationSnapshot` | Current normalized graph held in memory. `rows` is configured worktree inventory; `sessions` is canonical session membership. Reconcile replaces its base projection; accepted harness reports can project status and readiness between reconciles. It is derived and not a durable replay log. |
 | Live event bus | Future-only, process-local delivery. Subscriber queues are currently unbounded, events have no sequence numbers, and reconnects cannot request replay. |
 | Persisted event rows | Historical and diagnostic observer memory. They are not currently the source for live subscription replay. |
 | Hook spool | Durable delivery fallback while ingress cannot reach the observer. A queued record is pending evidence, not current graph truth. Its stable spool identity drives replay completion after primary dedupe, and the filesystem record remains until all derived durable work finishes. |
@@ -369,6 +369,26 @@ Reconcile reads worktree and terminal actors, derives the worktree context for
 harness reads, applies cached metadata and durable overlays, correlates the
 graph, persists the result, and replaces the in-memory snapshot. It then
 publishes state-change and reconcile events and schedules metadata refresh.
+
+Session reconciliation keeps the newest explicitly open Station-owned durable
+session for each still-configured worktree when its harness is known, even when
+no live run or terminal is observed. Legacy rows with no explicit lifecycle are
+not retained. A Station-bound run in `starting`, `idle`, `working`,
+`needs_attention`, or `stuck`, or an `open`/`detached` terminal explicitly bound
+to the same Station session, activates them as open. A run correlated to a terminal
+by run ID, or by session ID when no terminal run ID exists, also requires a reachable
+matching terminal; an uncorrelated active run may stand alone. When a terminal's
+run binding resolves, that run must claim the same session. Weak or conflicting
+evidence may refresh legacy correlation metadata, including the remembered harness,
+without activating membership.
+Cleanup records both `ended` lifecycle and `endedAt`, and generic terminal or run
+evidence cannot reopen that record. An explicit resume can reopen the same
+session. External sessions are derived independently and exist only from current,
+unexpired harness-run evidence whose status is neither `none`, `unknown`, nor
+`exited`; they reuse the normalized run id and are not persisted as Station-owned
+sessions. Terminal attachment requires matching session or run identity. Session
+and activity totals derive from canonical sessions; only worktree totals derive
+from rows.
 
 Observer core serializes full reconciles. The scheduler debounces and coalesces
 reasons while ensuring only one scheduled run is active. Startup-compatible
@@ -506,8 +526,8 @@ when it changes several tables:
 - `ObservationStore` owns typed provider observations, current-observation
   queries, and expiry.
 - `ReconcileStore` owns the complete atomic `persistReconcileResult` operation.
-- `SessionStore` owns sessions, titles, recovery handles, turn readiness, and
-  purpose-specific remembered-harness lookup.
+- `SessionStore` owns explicit session lifecycle, titles, recovery handles, turn
+  readiness, and purpose-specific remembered-harness lookup.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -34,6 +34,9 @@ bun run dashboard                     # read-only dashboard renderer
 - Selectors, screen transitions, command builders, event reducers, and fixtures should stay pure TypeScript. The render-framework-free dashboard logic lives in `@station/dashboard-core` and is consumed by the OpenTUI render layer.
 - Station service code may use `@station/runtime` (and the shared `@station/client`) for observer IO, subscriptions, command dispatch, timeout, retry, cancellation, and cleanup boundaries. Prefer Effect in boundary code when a single path must coordinate async iterators, cancellation/interruption, cleanup, retry/reconnect, timeouts, and typed error conversion. Keep that Effect usage behind Promise/AsyncIterable facades for React callers.
 - The UI may filter, group, sort, label, and decorate snapshot rows. It must not infer agent truth from provider-specific details.
+- Treat `snapshot.sessions` as session-membership and session/activity-count truth;
+  `snapshot.rows` remains worktree inventory. Do not infer membership from row agent or terminal
+  presence. Migrating dashboard rows and action gating to that truth is a separate UI slice.
 
 ## Surface Rules
 

--- a/packages/client/src/snapshotReducer.ts
+++ b/packages/client/src/snapshotReducer.ts
@@ -34,19 +34,31 @@ export function applyStationEvent(
     });
   }
   if (event.type === "session.created") {
-    return withSnapshot(snapshot, { sessions: upsertSession(snapshot.sessions, event.session) });
+    return withSnapshot(
+      snapshot,
+      { sessions: upsertSession(snapshot.sessions, event.session) },
+      true,
+    );
   }
   if (event.type === "session.updated") {
-    return withSnapshot(snapshot, {
-      sessions: snapshot.sessions.map((session) =>
-        session.id === event.sessionId ? mergeSessionPatch(session, event.patch) : session,
-      ),
-    });
+    return withSnapshot(
+      snapshot,
+      {
+        sessions: snapshot.sessions.map((session) =>
+          session.id === event.sessionId ? mergeSessionPatch(session, event.patch) : session,
+        ),
+      },
+      true,
+    );
   }
   if (event.type === "session.removed") {
-    return withSnapshot(snapshot, {
-      sessions: snapshot.sessions.filter((session) => session.id !== event.sessionId),
-    });
+    return withSnapshot(
+      snapshot,
+      {
+        sessions: snapshot.sessions.filter((session) => session.id !== event.sessionId),
+      },
+      true,
+    );
   }
   if (event.type === "provider.healthChanged") {
     return {
@@ -90,6 +102,7 @@ export function applyStationEvent(
 function withSnapshot(
   snapshot: StationSnapshot,
   patch: Partial<Pick<StationSnapshot, "rows" | "sessions">>,
+  needsSnapshotRefresh = false,
 ): ApplyStationEventResult {
   const nextSnapshot: StationSnapshot = {
     ...snapshot,
@@ -98,7 +111,7 @@ function withSnapshot(
   };
   return {
     snapshot: nextSnapshot,
-    needsSnapshotRefresh: false,
+    needsSnapshotRefresh,
     notices: [],
   };
 }
@@ -210,18 +223,22 @@ function displayForAgent(agent: NonNullable<WorktreeRow["agent"]>): WorktreeRow[
 function mergeSessionPatch(session: SessionView, patch: OptionalPatch<SessionView>): SessionView {
   const next: SessionView = {
     id: patch.id ?? session.id,
+    origin: patch.origin ?? session.origin,
     projectId: patch.projectId ?? session.projectId,
     worktreeId: patch.worktreeId ?? session.worktreeId,
     createdAt: patch.createdAt ?? session.createdAt,
     updatedAt: patch.updatedAt ?? session.updatedAt,
     harness: session.harness,
-    terminal: session.terminal,
     status: session.status,
     title: patch.title ?? session.title,
     tags: patch.tags ?? session.tags,
   };
+  if (session.terminal !== undefined) next.terminal = session.terminal;
   if (patch.harness !== undefined) next.harness = { ...session.harness, ...patch.harness };
-  if (patch.terminal !== undefined) next.terminal = { ...session.terminal, ...patch.terminal };
+  if (patch.terminal !== undefined) {
+    next.terminal =
+      session.terminal === undefined ? patch.terminal : { ...session.terminal, ...patch.terminal };
+  }
   if (patch.status !== undefined) next.status = { ...session.status, ...patch.status };
   return next;
 }

--- a/packages/client/test/support/snapshots.ts
+++ b/packages/client/test/support/snapshots.ts
@@ -162,6 +162,7 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     terminal.observedAt = candidate.terminal.observedAt;
   return {
     id: candidate.agent.sessionId ?? `ses_${candidate.id}`,
+    origin: "station",
     projectId: candidate.projectId,
     worktreeId: candidate.id,
     createdAt: "2026-05-20T11:59:00.000Z",
@@ -241,6 +242,7 @@ function reasonForState(state: NonNullable<WorktreeRow["agent"]>["state"]): stri
 
 function countsForRows(rows: readonly WorktreeRow[]) {
   return {
+    sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
     working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
@@ -254,6 +256,7 @@ function countsForRows(rows: readonly WorktreeRow[]) {
 function countsForProject(rows: readonly WorktreeRow[]): ProjectView["counts"] {
   const counts = countsForRows(rows);
   return {
+    sessions: counts.sessions,
     worktrees: counts.worktrees,
     agents: counts.agents,
     working: counts.working,

--- a/packages/client/test/unit/snapshotReducer.test.ts
+++ b/packages/client/test/unit/snapshotReducer.test.ts
@@ -81,6 +81,74 @@ describe("client snapshot reducer", () => {
     expect(removed.snapshot.rows.map((candidate) => candidate.id)).not.toContain("wt_web_added");
   });
 
+  it("requests canonical totals after session membership changes", () => {
+    const snapshot = createCommandSnapshot("idle");
+    const existingSession = snapshot.sessions[0];
+    if (existingSession === undefined) {
+      throw new Error("Expected idle fixture snapshot to have a session.");
+    }
+
+    const created = applyStationEvent(snapshot, {
+      type: "session.created",
+      session: {
+        ...existingSession,
+        id: "ses_web_second",
+      },
+    });
+
+    expect(created.snapshot.sessions).toHaveLength(2);
+    expect(created.snapshot.counts.sessions).toBe(1);
+    expect(created.needsSnapshotRefresh).toBe(true);
+
+    const removed = applyStationEvent(created.snapshot, {
+      type: "session.removed",
+      sessionId: "ses_web_second",
+    });
+
+    expect(removed.snapshot.sessions).toHaveLength(1);
+    expect(removed.needsSnapshotRefresh).toBe(true);
+  });
+
+  it("requests canonical totals after session status changes", () => {
+    const idleSnapshot = createCommandSnapshot("idle");
+    const existingSession = idleSnapshot.sessions[0];
+    if (existingSession === undefined) {
+      throw new Error("Expected idle fixture snapshot to have a session.");
+    }
+    const snapshot = {
+      ...idleSnapshot,
+      sessions: [
+        {
+          ...existingSession,
+          status: {
+            ...existingSession.status,
+            value: "working" as const,
+          },
+        },
+      ],
+      counts: {
+        ...idleSnapshot.counts,
+        working: 1,
+        idle: 0,
+      },
+    };
+
+    const updated = applyStationEvent(snapshot, {
+      type: "session.updated",
+      sessionId: existingSession.id,
+      patch: {
+        status: {
+          ...existingSession.status,
+          value: "idle",
+        },
+      },
+    });
+
+    expect(updated.snapshot.sessions[0]?.status.value).toBe("idle");
+    expect(updated.snapshot.counts).toMatchObject({ working: 1, idle: 0 });
+    expect(updated.needsSnapshotRefresh).toBe(true);
+  });
+
   it("updates row display from live agent state events", () => {
     const snapshot = createCommandSnapshot("idle");
     const result = applyStationEvent(snapshot, {

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.7.0" as const;
+export const STATION_SCHEMA_VERSION = "0.8.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -44,6 +44,7 @@ export const ProjectViewSchema = z
     health: ProviderHealthSchema,
     counts: z
       .object({
+        sessions: z.number().int().nonnegative(),
         worktrees: z.number().int().nonnegative(),
         agents: z.number().int().nonnegative(),
         working: z.number().int().nonnegative(),
@@ -170,9 +171,14 @@ export const WorktreeViewSchema = WorktreeRowSchema;
 export type WorktreeRow = z.infer<typeof WorktreeRowSchema>;
 export type WorktreeView = WorktreeRow;
 
+export const SessionOriginSchema = z.enum(["station", "external"]);
+
+export type SessionOrigin = z.infer<typeof SessionOriginSchema>;
+
 export const SessionViewSchema = z
   .object({
     id: SessionIdSchema,
+    origin: SessionOriginSchema,
     projectId: ProjectIdSchema,
     worktreeId: WorktreeIdSchema,
     createdAt: TimestampSchema,
@@ -186,7 +192,7 @@ export const SessionViewSchema = z
         capabilities: HarnessCapabilitiesSchema,
       })
       .strict(),
-    terminal: TerminalAttachmentSchema,
+    terminal: TerminalAttachmentSchema.optional(),
     status: ObservedStatusSchema,
     title: nonEmptyStringSchema,
     tags: z.array(nonEmptyStringSchema),
@@ -263,6 +269,7 @@ export const StationSnapshotSchema = z
     counts: z
       .object({
         projects: z.number().int().nonnegative(),
+        sessions: z.number().int().nonnegative(),
         worktrees: z.number().int().nonnegative(),
         agents: z.number().int().nonnegative(),
         working: z.number().int().nonnegative(),

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -92,7 +92,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.7.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.8.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -296,6 +296,32 @@ describe("contract schemas", () => {
       "snapshot with provider-neutral terminal attachment",
     );
 
+    const externalSessionSnapshot = structuredClone(snapshots.idleAgent) as {
+      sessions: Array<{ id: string; origin?: string; terminal?: unknown }>;
+    };
+    const externalSession = externalSessionSnapshot.sessions[0];
+    if (externalSession === undefined) {
+      throw new Error("idleAgent fixture must include a session.");
+    }
+    externalSession.id = "codex:external:native_1";
+    externalSession.origin = "external";
+    delete externalSession.terminal;
+    expectParses(
+      StationSnapshotSchema,
+      externalSessionSnapshot,
+      "external session without fabricated terminal attachment",
+    );
+
+    const missingOriginSnapshot = structuredClone(snapshots.idleAgent) as {
+      sessions: Array<{ origin?: string }>;
+    };
+    const missingOriginSession = missingOriginSnapshot.sessions[0];
+    if (missingOriginSession === undefined) {
+      throw new Error("idleAgent fixture must include a session.");
+    }
+    delete missingOriginSession.origin;
+    expectFails(StationSnapshotSchema, missingOriginSnapshot, "session without explicit origin");
+
     expectFails(
       StationSnapshotSchema,
       await loadJson("snapshots/invalid-snapshot.json"),
@@ -393,6 +419,7 @@ describe("contract schemas", () => {
         sessions: [],
         counts: {
           projects: 0,
+          sessions: 0,
           worktrees: 0,
           agents: 0,
           working: 0,
@@ -616,6 +643,7 @@ describe("contract schemas", () => {
       sessions: [],
       counts: {
         projects: 0,
+        sessions: 0,
         worktrees: 1,
         agents: 0,
         working: 0,

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -92,6 +92,7 @@ describe("diagnostics schemas", () => {
           sessions: [],
           counts: {
             projects: 0,
+            sessions: 0,
             worktrees: 0,
             agents: 0,
             working: 0,

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -213,10 +213,19 @@ export function sessionForWorktreeRow(
 ): SessionView | undefined {
   const sessionId = row.agent?.sessionId;
   if (sessionId !== undefined) {
-    const direct = sessions.find((session) => session.id === sessionId);
+    const direct = sessions.find(
+      (session) => session.origin === "station" && session.id === sessionId,
+    );
     if (direct !== undefined) {
       return direct;
     }
+  }
+  const runId = row.agent?.runId;
+  if (runId !== undefined) {
+    const external = sessions.find(
+      (session) => session.origin === "external" && session.harness.runId === runId,
+    );
+    if (external !== undefined) return external;
   }
   return sessions.find((session) => session.worktreeId === row.id);
 }

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -53,7 +53,7 @@ export function isExternalAgentRemovalUnavailable(
   return (
     agent !== undefined &&
     isRunningAgentState(agent.state) &&
-    sessionForWorktreeRow(row, snapshot.sessions) === undefined &&
+    sessionForWorktreeRow(row, snapshot.sessions)?.origin !== "station" &&
     snapshot.providerHealth[agent.harness]?.capabilities?.canStop === false &&
     row.terminal?.closeable !== true
   );

--- a/packages/dashboard-core/src/state/screens/sessionRows.ts
+++ b/packages/dashboard-core/src/state/screens/sessionRows.ts
@@ -55,7 +55,7 @@ function resolveCurrentRowSession(
     return undefined;
   }
   const session = sessionForWorktreeRow(row, snapshot.sessions);
-  if (session === undefined) {
+  if (session?.origin !== "station") {
     return undefined;
   }
   return { row, session, snapshot };

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -62,12 +62,23 @@ export function createExternalAgentSnapshot(): StationSnapshot {
   if (externalRow?.agent === undefined) {
     throw new Error("Fixture row wt_web_idle must have an agent.");
   }
+  const stationSession = snapshot.sessions.find((session) => session.worktreeId === externalRow.id);
+  if (stationSession === undefined || externalRow.agent.runId === undefined) {
+    throw new Error("Fixture row wt_web_idle must have a Station session and run id.");
+  }
   const rowWithoutStationOwnership: WorktreeRow = {
     ...externalRow,
     agent: { ...externalRow.agent },
   };
   delete rowWithoutStationOwnership.terminal;
   delete rowWithoutStationOwnership.agent?.sessionId;
+  const externalSession: SessionView = {
+    ...stationSession,
+    id: String(externalRow.agent.runId),
+    origin: "external",
+    harness: { ...stationSession.harness, runId: externalRow.agent.runId },
+  };
+  delete externalSession.terminal;
 
   return {
     ...snapshot,
@@ -84,8 +95,8 @@ export function createExternalAgentSnapshot(): StationSnapshot {
     rows: snapshot.rows.map((candidate) =>
       candidate.id === rowWithoutStationOwnership.id ? rowWithoutStationOwnership : candidate,
     ),
-    sessions: snapshot.sessions.filter(
-      (session) => session.worktreeId !== rowWithoutStationOwnership.id,
+    sessions: snapshot.sessions.map((session) =>
+      session.id === stationSession.id ? externalSession : session,
     ),
   };
 }
@@ -114,6 +125,7 @@ export function createNoProjectsSnapshot(): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,
@@ -246,6 +258,7 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     terminal.observedAt = candidate.terminal.observedAt;
   return {
     id: candidate.agent.sessionId ?? `ses_${candidate.id}`,
+    origin: "station",
     projectId: candidate.projectId,
     worktreeId: candidate.id,
     createdAt: "2026-05-20T11:59:00.000Z",
@@ -325,6 +338,7 @@ function reasonForState(state: NonNullable<WorktreeRow["agent"]>["state"]): stri
 
 function countsForRows(rows: readonly WorktreeRow[]) {
   return {
+    sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
     working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
@@ -338,6 +352,7 @@ function countsForRows(rows: readonly WorktreeRow[]) {
 function countsForProject(rows: readonly WorktreeRow[]): ProjectView["counts"] {
   const counts = countsForRows(rows);
   return {
+    sessions: counts.sessions,
     worktrees: counts.worktrees,
     agents: counts.agents,
     working: counts.working,

--- a/packages/dashboard-core/test/unit/selectors/selectors.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/selectors.test.ts
@@ -12,10 +12,11 @@ import {
   selectProjectChoices,
   selectProjectGroups,
   selectVisibleRows,
+  sessionForWorktreeRow,
   worktreeRowDisplayTitle,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import { createDashboardSnapshot, createExternalAgentSnapshot } from "../../fixtures/snapshots.js";
 
 describe("TUI selectors", () => {
   it("assigns selection keys in order without 0 or uppercase keys and caps at 35", () => {
@@ -194,6 +195,19 @@ describe("TUI selectors", () => {
     expect(
       worktreeRowDisplayTitle({ ...row, agent: undefined }, [], createInitialTuiState().localRows),
     ).toBe(row.branch);
+  });
+
+  it("resolves an external row by run identity before retained Station membership", () => {
+    const external = createExternalAgentSnapshot();
+    const station = createDashboardSnapshot();
+    const row = external.rows.find((candidate) => candidate.id === "wt_web_idle");
+    const retained = station.sessions.find((session) => session.worktreeId === row?.id);
+    if (row === undefined || retained === undefined) throw new Error("missing fixture membership");
+
+    expect(sessionForWorktreeRow(row, [retained, ...external.sessions])).toMatchObject({
+      origin: "external",
+      id: row.agent?.runId,
+    });
   });
 
   it("filters by search and collapses project groups without changing snapshot truth", () => {

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -512,6 +512,12 @@ describe("TUI screen transitions", () => {
     expect(openRenameEditForRow(search, "wt_web_idle")).toBe(search);
   });
 
+  it("does not open rename for external session membership", () => {
+    const state = createInitialTuiState({ initialSnapshot: createExternalAgentSnapshot() });
+
+    expect(openRenameEditForRow(state, "wt_web_idle")).toBe(state);
+  });
+
   it("edits the rename draft at the cursor position", () => {
     const opened = handleTuiKey(
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -158,17 +158,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       generatedAt: now,
       observer: {
         pid: 1234,
@@ -182,6 +182,7 @@ function minimalSnapshot(): DiagnosticSnapshot {
       sessions: [],
       counts: {
         projects: 0,
+        sessions: 0,
         worktrees: 0,
         agents: 0,
         working: 0,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.7.0",
+      "schemaVersion": "0.8.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -284,7 +284,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.7.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.8.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/support/fixtures.ts
+++ b/packages/protocol/test/support/fixtures.ts
@@ -87,6 +87,7 @@ export function emptySnapshot(): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.7.0",
+        schemaVersion: "0.8.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -205,12 +205,19 @@ describe("buildContextMenuItems", () => {
       stationState,
     );
 
-    expect(items.at(-1)).toEqual({
-      id: "station.removeWorktree",
-      label: "Delete Worktree…",
-      danger: true,
-      action: { kind: "removeWorktree", rowId: "wt_station_idle" },
-    });
+    expect(items).toEqual([
+      {
+        id: "station.forkSession",
+        label: "Fork Session",
+        action: { kind: "forkSession", rowId: "wt_station_idle" },
+      },
+      {
+        id: "station.removeWorktree",
+        label: "Delete Worktree…",
+        danger: true,
+        action: { kind: "removeWorktree", rowId: "wt_station_idle" },
+      },
+    ]);
   });
 
   it("hides remove-worktree for project root rows", () => {

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -117,7 +117,7 @@ function buildStationItems(
   }
   const project = state.snapshot.projects.find((candidate) => candidate.id === row.projectId);
   const items: ContextMenuItem[] = [];
-  if (sessionForWorktreeRow(row, state.snapshot.sessions) !== undefined) {
+  if (sessionForWorktreeRow(row, state.snapshot.sessions)?.origin === "station") {
     items.push({
       id: "station.renameSession",
       label: "Rename Session",

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.7.0",
+  schemaVersion: "0.8.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,
@@ -65,6 +65,7 @@ export const mockObserverSnapshot = {
         lastCheckedAt: fixtureNow,
       },
       counts: {
+        sessions: 2,
         worktrees: 3,
         agents: 2,
         working: 1,
@@ -193,6 +194,7 @@ export const mockObserverSnapshot = {
   sessions: [
     {
       id: "ses_station_design",
+      origin: "station",
       projectId: "station",
       worktreeId: "wt_station_design",
       createdAt: "2026-06-11T11:59:00.000Z",
@@ -226,6 +228,7 @@ export const mockObserverSnapshot = {
     },
     {
       id: "ses_notify_cleanup",
+      origin: "station",
       projectId: "station",
       worktreeId: "wt_notify_cleanup",
       createdAt: "2026-06-11T10:42:00.000Z",
@@ -260,6 +263,7 @@ export const mockObserverSnapshot = {
   ],
   counts: {
     projects: 1,
+    sessions: 2,
     worktrees: 3,
     agents: 2,
     working: 1,

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -106,12 +106,25 @@ export function externalAgentSnapshot(): StationSnapshot {
   if (externalRow?.agent === undefined) {
     throw new Error("Fixture row wt_station_idle must have an agent.");
   }
+  const stationSession = snapshot.sessions.find(
+    (session) => session.worktreeId === externalRow.id,
+  );
+  if (stationSession === undefined || externalRow.agent.runId === undefined) {
+    throw new Error("Fixture row wt_station_idle must have a Station session and run id.");
+  }
   const rowWithoutStationOwnership: WorktreeRow = {
     ...externalRow,
     agent: { ...externalRow.agent },
   };
   delete rowWithoutStationOwnership.terminal;
   delete rowWithoutStationOwnership.agent?.sessionId;
+  const externalSession: SessionView = {
+    ...stationSession,
+    id: String(externalRow.agent.runId),
+    origin: "external",
+    harness: { ...stationSession.harness, runId: externalRow.agent.runId },
+  };
+  delete externalSession.terminal;
 
   return {
     ...snapshot,
@@ -128,8 +141,8 @@ export function externalAgentSnapshot(): StationSnapshot {
     rows: snapshot.rows.map((candidate) =>
       candidate.id === rowWithoutStationOwnership.id ? rowWithoutStationOwnership : candidate,
     ),
-    sessions: snapshot.sessions.filter(
-      (session) => session.worktreeId !== rowWithoutStationOwnership.id,
+    sessions: snapshot.sessions.map((session) =>
+      session.id === stationSession.id ? externalSession : session,
     ),
   };
 }
@@ -398,6 +411,7 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
   }
   return {
     id: candidate.agent.sessionId ?? `ses_${candidate.id}`,
+    origin: "station",
     projectId: candidate.projectId,
     worktreeId: candidate.id,
     createdAt: "2026-06-12T11:59:00.000Z",
@@ -489,6 +503,7 @@ function reasonForState(state: Exclude<AgentScenarioState, "none">): string {
 
 function countsForRows(rows: readonly WorktreeRow[]) {
   return {
+    sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
     working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,

--- a/station/src/station/test/fixtures/snapshots.ts
+++ b/station/src/station/test/fixtures/snapshots.ts
@@ -101,6 +101,7 @@ export function createNoProjectsSnapshot(): StationSnapshot {
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,
@@ -232,6 +233,7 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     terminal.observedAt = candidate.terminal.observedAt;
   return {
     id: candidate.agent.sessionId ?? `ses_${candidate.id}`,
+    origin: "station",
     projectId: candidate.projectId,
     worktreeId: candidate.id,
     createdAt: "2026-05-20T11:59:00.000Z",
@@ -311,6 +313,7 @@ function reasonForState(state: NonNullable<WorktreeRow["agent"]>["state"]): stri
 
 function countsForRows(rows: readonly WorktreeRow[]) {
   return {
+    sessions: rows.filter((candidate) => candidate.agent?.sessionId !== undefined).length,
     worktrees: rows.length,
     agents: rows.filter((candidate) => candidate.agent !== undefined).length,
     working: rows.filter((candidate) => candidate.display.statusLabel === "working").length,
@@ -324,6 +327,7 @@ function countsForRows(rows: readonly WorktreeRow[]) {
 function countsForProject(rows: readonly WorktreeRow[]): ProjectView["counts"] {
   const counts = countsForRows(rows);
   return {
+    sessions: counts.sessions,
     worktrees: counts.worktrees,
     agents: counts.agents,
     working: counts.working,

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,
@@ -100,7 +100,8 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },

--- a/tests/contract-fixtures/events/events.json
+++ b/tests/contract-fixtures/events/events.json
@@ -63,6 +63,7 @@
     "type": "session.created",
     "session": {
       "id": "ses_web_feature_auth",
+      "origin": "station",
       "projectId": "web",
       "worktreeId": "wt_web_feature_auth",
       "createdAt": "2026-05-20T11:59:00.000Z",

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,
@@ -13,6 +13,7 @@
   "sessions": [],
   "counts": {
     "projects": 0,
+    "sessions": 0,
     "worktrees": 0,
     "agents": 0,
     "working": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -19,12 +19,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -67,7 +68,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       },
       {
@@ -91,7 +93,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -104,12 +107,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -140,7 +144,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -153,12 +158,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -189,7 +195,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -223,12 +230,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "idleAgent": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -259,7 +267,8 @@
           "working": 0,
           "idle": 1,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 1
         }
       }
     ],
@@ -340,7 +349,8 @@
           "updatedAt": "2026-05-20T11:59:35.000Z"
         },
         "title": "web idle-agent",
-        "tags": ["codex", "tmux"]
+        "tags": ["codex", "tmux"],
+        "origin": "station"
       }
     ],
     "counts": {
@@ -350,12 +360,13 @@
       "working": 0,
       "idle": 1,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 1
     },
     "alerts": []
   },
   "workingAgent": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -386,7 +397,8 @@
           "working": 1,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -435,12 +447,13 @@
       "working": 1,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -471,7 +484,8 @@
           "working": 0,
           "idle": 0,
           "attention": 1,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -519,12 +533,13 @@
       "working": 0,
       "idle": 0,
       "attention": 1,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -555,7 +570,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -604,12 +620,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -640,7 +657,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -686,12 +704,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -722,7 +741,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 1
+          "unknown": 1,
+          "sessions": 0
         }
       }
     ],
@@ -770,12 +790,13 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 1
+      "unknown": 1,
+      "sessions": 0
     },
     "alerts": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -794,7 +815,8 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": [],
     "orphans": [
@@ -809,7 +831,7 @@
     ]
   },
   "providerFailure": {
-    "schemaVersion": "0.7.0",
+    "schemaVersion": "0.8.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -865,7 +887,8 @@
           "working": 0,
           "idle": 0,
           "attention": 0,
-          "unknown": 0
+          "unknown": 0,
+          "sessions": 0
         }
       }
     ],
@@ -878,7 +901,8 @@
       "working": 0,
       "idle": 0,
       "attention": 0,
-      "unknown": 0
+      "unknown": 0,
+      "sessions": 0
     },
     "alerts": [
       {

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.7.0",
+          schemaVersion: "0.8.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -74,7 +74,7 @@ describe("observer lifecycle e2e", () => {
         code: "ENOENT",
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.7.0",
+        schemaVersion: "0.8.0",
         counts: { projects: 0 },
       });
       await expect(access(join(fixture.root, "config.toml"))).rejects.toMatchObject({
@@ -631,7 +631,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.7.0",
+        schemaVersion: "0.8.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -45,10 +45,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.7.0",
+      schemaVersion: "0.8.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -66,7 +66,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.7.0",
+    schemaVersion: "0.8.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,
@@ -80,6 +80,7 @@ export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): S
     sessions: [],
     counts: {
       projects: 0,
+      sessions: 0,
       worktrees: 0,
       agents: 0,
       working: 0,


### PR DESCRIPTION
## Summary

- add explicit durable Station session lifecycle and explicit Station/external session origin
- derive Station and external membership independently from correlated run and terminal evidence
- align canonical session counts, status projection, cleanup semantics, and origin-aware action guards
- bump the snapshot schema to 0.8.0 and update governing documentation and fixtures

## Scope

This is the session-membership truth slice of #159. It intentionally does not close the parent issue.

The primary dashboard rendering/search/empty-state slice and any substantial unattached-worktree inventory remain follow-up work.

## Validation

- isolated `pnpm test:pre-push` passed through build, typecheck, lint, unit, contract, integration, diagnostics, setup and Observer E2E, install smoke, cross-runtime checks, Station tests, PTY tests, binary build, and binary smoke
- final fixture-only delta passed the contract schema lane, 16/16
- independent final review found no release-blocking issues at exact head

## Compatibility

This bumps the protocol/snapshot schema to 0.8.0. Clients and the Observer must be rebuilt and restarted together after switching to this revision.

## UX and manual verification

The canonical snapshot no longer lets an unrelated external run hijack a Station session, and stale or exited evidence no longer creates permanent session membership. Start one Station session and one external run for the same worktree, inspect `stn snapshot --json`, then end the external run: the Station session should remain, the external session should disappear, and Station-only rename/remove actions should not target the external session.