### PR TITLE
fix(dashboard): render canonical sessions

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -34,9 +34,9 @@ bun run dashboard                     # read-only dashboard renderer
 - Selectors, screen transitions, command builders, event reducers, and fixtures should stay pure TypeScript. The render-framework-free dashboard logic lives in `@station/dashboard-core` and is consumed by the OpenTUI render layer.
 - Station service code may use `@station/runtime` (and the shared `@station/client`) for observer IO, subscriptions, command dispatch, timeout, retry, cancellation, and cleanup boundaries. Prefer Effect in boundary code when a single path must coordinate async iterators, cancellation/interruption, cleanup, retry/reconnect, timeouts, and typed error conversion. Keep that Effect usage behind Promise/AsyncIterable facades for React callers.
 - The UI may filter, group, sort, label, and decorate snapshot rows. It must not infer agent truth from provider-specific details.
-- Treat `snapshot.sessions` as session-membership and session/activity-count truth;
-  `snapshot.rows` remains worktree inventory. Do not infer membership from row agent or terminal
-  presence. Migrating dashboard rows and action gating to that truth is a separate UI slice.
+- Treat `snapshot.sessions` as session-membership and session/activity-count truth. Dashboard rows,
+  search, selection, and actions project those sessions and join `snapshot.rows` only for checkout
+  metadata; bare worktrees remain inventory and do not appear in the primary session list.
 
 ## Surface Rules
 

--- a/packages/dashboard-core/src/components/Dashboard/content.ts
+++ b/packages/dashboard-core/src/components/Dashboard/content.ts
@@ -1,4 +1,4 @@
-import type { ProjectView, WorktreeId } from "@station/contracts";
+import type { ProjectView, SessionId } from "@station/contracts";
 import stringWidth from "string-width";
 import type {
   DashboardSessionOverflow,
@@ -102,7 +102,7 @@ export function projectHeaderLabelParts(
   collapsed: boolean,
 ): { title: string; counts: string } {
   const caret = collapsed ? "▶" : "▼";
-  const sessions = `${project.counts.worktrees} ${plural(project.counts.worktrees, "session")}`;
+  const sessions = `${project.counts.sessions} ${plural(project.counts.sessions, "session")}`;
   const agents =
     project.counts.agents > 0
       ? ` · ${project.counts.agents} ${plural(project.counts.agents, "agent")}`
@@ -133,9 +133,9 @@ export function scrollIndicatorLabel(
 export function rowGridInputForViewportItem(
   item: DashboardViewportItem,
   keyByRow: ReadonlyMap<string, string>,
-  focusedRowId?: WorktreeId,
+  focusedRowId?: SessionId,
 ): RowGridRowInput | undefined {
-  if (item.type === "worktree") {
+  if (item.type === "session") {
     const focused = focusedRowId !== undefined && item.row.id === focusedRowId;
     if (item.pendingRemove !== undefined) {
       return worktreeStyleRowGridInput({
@@ -165,7 +165,7 @@ export function rowGridInputForViewportItem(
     }
     return worktreeRowGridInput({
       id: item.id,
-      row: item.row,
+      row: item.row.presentation,
       slot: keyByRow.get(item.row.id),
       title: item.displayTitle,
       focused,

--- a/packages/dashboard-core/src/selectors/dashboardViewport.ts
+++ b/packages/dashboard-core/src/selectors/dashboardViewport.ts
@@ -1,4 +1,4 @@
-import type { ProjectId, ProjectView, StationSnapshot, WorktreeRow } from "@station/contracts";
+import type { ProjectId, ProjectView, StationSnapshot } from "@station/contracts";
 import { clampDashboardScrollOffset, dashboardBodyRows } from "../components/Dashboard/layout.js";
 import type {
   FailedCreateSessionRow,
@@ -8,10 +8,11 @@ import type {
 } from "../state/localRows.js";
 import type { TuiViewState } from "../state/types.js";
 import {
+  type DashboardSessionRow,
   type KeyedChoice,
   keyChoices,
   selectProjectGroups,
-  worktreeRowDisplayTitle,
+  sessionRowDisplayTitle,
 } from "./selectors.js";
 
 export type DashboardCreateSessionLocalRow =
@@ -36,9 +37,9 @@ export type DashboardViewportItem =
       project: ProjectView;
     }
   | {
-      type: "worktree";
+      type: "session";
       id: string;
-      row: WorktreeRow;
+      row: DashboardSessionRow;
       displayTitle: string;
       pendingRemove?: PendingRemoveWorktreeRow;
       pendingStart?: PendingStartAgentRow;
@@ -56,8 +57,8 @@ export type DashboardViewport = {
   hiddenBelow: number;
   items: DashboardViewportItem[];
   visibleItems: DashboardViewportItem[];
-  rowChoices: Array<KeyedChoice<WorktreeRow>>;
-  displayRowChoices: Array<KeyedChoice<WorktreeRow>>;
+  rowChoices: Array<KeyedChoice<DashboardSessionRow>>;
+  displayRowChoices: Array<KeyedChoice<DashboardSessionRow>>;
   sessionOverflow: DashboardSessionOverflow;
 };
 
@@ -83,10 +84,10 @@ export function selectDashboardViewport(
   const visibleItems = items.slice(clampedScrollOffset, clampedScrollOffset + bodyRows);
   const hiddenAbove = clampedScrollOffset;
   const hiddenBelow = Math.max(0, items.length - clampedScrollOffset - bodyRows);
-  const displayRowChoices = keyChoices(displayWorktreeRowsFromItems(visibleItems));
+  const displayRowChoices = keyChoices(displaySessionRowsFromItems(visibleItems));
   const pendingStartWorktreeIds = new Set(
     visibleItems.flatMap((item) =>
-      item.type === "worktree" && item.pendingStart !== undefined ? [item.row.id] : [],
+      item.type === "session" && item.pendingStart !== undefined ? [item.row.worktree.id] : [],
     ),
   );
   const above = countSessionRows(items.slice(0, clampedScrollOffset));
@@ -99,14 +100,16 @@ export function selectDashboardViewport(
     hiddenBelow,
     items,
     visibleItems,
-    rowChoices: displayRowChoices.filter((choice) => !pendingStartWorktreeIds.has(choice.value.id)),
+    rowChoices: displayRowChoices.filter(
+      (choice) => !pendingStartWorktreeIds.has(choice.value.worktree.id),
+    ),
     displayRowChoices,
     sessionOverflow: { above, below: total - above - visible, visible, total },
   };
 }
 
 function countSessionRows(items: readonly DashboardViewportItem[]): number {
-  return items.filter((item) => item.type === "worktree" || item.type === "createLocalRow").length;
+  return items.filter((item) => item.type === "session" || item.type === "createLocalRow").length;
 }
 
 export function selectDashboardItems(
@@ -135,7 +138,7 @@ export function selectDashboardItems(
     const projectLocalRows = localRows
       .filter((row) => row.projectId === group.project.id)
       .filter((row) => localRowMatchesSearch(row, group.project, state.searchQuery));
-    const rows = mergeRowsAndCreateSessionLocalRows(group.rows, projectLocalRows, snapshot, state);
+    const rows = mergeRowsAndCreateSessionLocalRows(group.rows, projectLocalRows, state);
     if (rows.length === 0) {
       items.push({
         type: "emptyProject",
@@ -145,21 +148,21 @@ export function selectDashboardItems(
       return items;
     }
     for (const row of rows) {
-      if (row.type === "worktree") {
-        const item: Extract<DashboardViewportItem, { type: "worktree" }> = {
-          type: "worktree",
-          id: `worktree:${row.row.id}`,
+      if (row.type === "session") {
+        const item: Extract<DashboardViewportItem, { type: "session" }> = {
+          type: "session",
+          id: `session:${row.row.id}`,
           row: row.row,
-          displayTitle: worktreeRowDisplayTitle(row.row, snapshot.sessions, state.localRows),
+          displayTitle: sessionRowDisplayTitle(row.row, state.localRows),
         };
         const pendingRemove = state.localRows.pendingRemove.find(
-          (localRow) => localRow.worktreeId === row.row.id,
+          (localRow) => localRow.worktreeId === row.row.worktree.id,
         );
         if (pendingRemove !== undefined) {
           item.pendingRemove = pendingRemove;
         }
         const pendingStart = state.localRows.pendingStart.find(
-          (localRow) => localRow.worktreeId === row.row.id,
+          (localRow) => localRow.worktreeId === row.row.worktree.id,
         );
         if (pendingStart !== undefined) {
           item.pendingStart = pendingStart;
@@ -177,16 +180,18 @@ export function selectDashboardItems(
   });
 }
 
-function displayWorktreeRowsFromItems(items: readonly DashboardViewportItem[]): WorktreeRow[] {
+function displaySessionRowsFromItems(
+  items: readonly DashboardViewportItem[],
+): DashboardSessionRow[] {
   return items.flatMap((item) =>
-    item.type === "worktree" && item.pendingRemove === undefined ? [item.row] : [],
+    item.type === "session" && item.pendingRemove === undefined ? [item.row] : [],
   );
 }
 
 type GroupDashboardRow =
   | {
-      type: "worktree";
-      row: WorktreeRow;
+      type: "session";
+      row: DashboardSessionRow;
     }
   | {
       type: "createLocalRow";
@@ -197,7 +202,13 @@ function visibleCreateSessionLocalRows(
   snapshot: StationSnapshot,
   state: TuiViewState,
 ): DashboardCreateSessionLocalRow[] {
-  const realRows = new Set(snapshot.rows.map((row) => `${row.projectId}\u0000${row.branch}`));
+  const rowsById = new Map(snapshot.rows.map((row) => [row.id, row]));
+  const realRows = new Set(
+    snapshot.sessions.flatMap((session) => {
+      const row = rowsById.get(session.worktreeId);
+      return row === undefined ? [] : [`${session.projectId}\u0000${row.branch}`];
+    }),
+  );
   return [
     ...state.localRows.pendingCreate
       .filter((row) => !realRows.has(`${row.projectId}\u0000${row.branch}`))
@@ -210,48 +221,44 @@ function visibleCreateSessionLocalRows(
 }
 
 function mergeRowsAndCreateSessionLocalRows(
-  rows: readonly WorktreeRow[],
+  rows: readonly DashboardSessionRow[],
   localRows: readonly DashboardCreateSessionLocalRow[],
-  snapshot: StationSnapshot,
   state: TuiViewState,
 ): GroupDashboardRow[] {
   return [
-    ...rows.map((row) => ({ type: "worktree" as const, row })),
+    ...rows.map((row) => ({ type: "session" as const, row })),
     ...localRows.map((row) => ({ type: "createLocalRow" as const, row })),
-  ].sort((left, right) => compareDashboardRows(left, right, snapshot, state));
+  ].sort((left, right) => compareDashboardRows(left, right, state));
 }
 
 function compareDashboardRows(
   left: GroupDashboardRow,
   right: GroupDashboardRow,
-  snapshot: StationSnapshot,
   state: TuiViewState,
 ): number {
-  const titleOrder = rowTitle(left, snapshot, state).localeCompare(
-    rowTitle(right, snapshot, state),
-  );
+  const titleOrder = rowTitle(left, state).localeCompare(rowTitle(right, state));
   if (titleOrder !== 0) return titleOrder;
   const branchOrder = rowBranch(left).localeCompare(rowBranch(right));
   if (branchOrder !== 0) return branchOrder;
   if (left.type !== right.type) {
-    return left.type === "worktree" ? -1 : 1;
+    return left.type === "session" ? -1 : 1;
   }
   return rowId(left).localeCompare(rowId(right));
 }
 
-function rowTitle(row: GroupDashboardRow, snapshot: StationSnapshot, state: TuiViewState): string {
+function rowTitle(row: GroupDashboardRow, state: TuiViewState): string {
   if (row.type === "createLocalRow") {
     return row.row.branch;
   }
-  return worktreeRowDisplayTitle(row.row, snapshot.sessions, state.localRows);
+  return sessionRowDisplayTitle(row.row, state.localRows);
 }
 
 function rowBranch(row: GroupDashboardRow): string {
-  return row.row.branch;
+  return row.type === "session" ? row.row.worktree.branch : row.row.branch;
 }
 
 function rowId(row: GroupDashboardRow): string {
-  return row.type === "worktree" ? row.row.id : row.row.localId;
+  return row.type === "session" ? row.row.id : row.row.localId;
 }
 
 function localRowMatchesSearch(

--- a/packages/dashboard-core/src/selectors/fleetSummary.ts
+++ b/packages/dashboard-core/src/selectors/fleetSummary.ts
@@ -1,9 +1,10 @@
 import type { StationSnapshot } from "@station/contracts";
 import { isReadyToRead } from "../components/WorktreeRow/rowInput.js";
+import { selectDashboardSessionRows } from "./selectors.js";
 
 // Fleet triage counts derived client-side: the observer's snapshot.counts carry
 // only working/idle/attention/unknown and fold "ready" into idle, so the fleet
-// bar computes the full disjoint breakdown from the rows. "needsYou" = attention
+// bar computes the full disjoint breakdown from canonical sessions. "needsYou" = attention
 // OR stuck (snapshot.counts.attention deliberately excludes stuck).
 export type FleetSummary = {
   ready: number;
@@ -25,13 +26,13 @@ export function selectFleetSummary(snapshot: StationSnapshot): FleetSummary {
     exited: 0,
     unknown: 0,
   };
-  for (const row of snapshot.rows) {
-    const state = row.agent?.state;
+  for (const row of selectDashboardSessionRows(snapshot)) {
+    const state = row.session.status.value;
     if (state === "needs_attention" || state === "stuck") {
       summary.needsYou += 1;
     } else if (state === "working") {
       summary.working += 1;
-    } else if (isReadyToRead(row)) {
+    } else if (isReadyToRead(row.presentation)) {
       summary.ready += 1;
     } else if (state === "idle") {
       summary.idle += 1;
@@ -42,8 +43,7 @@ export function selectFleetSummary(snapshot: StationSnapshot): FleetSummary {
     } else if (state === "unknown") {
       summary.unknown += 1;
     }
-    // No agent (state === undefined) is a session without a harness — not a
-    // fleet-status lane, so it is intentionally uncounted.
+    // A retained session with no agent is not a fleet-status lane.
   }
   return summary;
 }

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -3,6 +3,7 @@ import type {
   ProjectView,
   ProviderHealth,
   ProviderId,
+  SessionId,
   SessionView,
   SnapshotHarness,
   StationSnapshot,
@@ -62,8 +63,16 @@ export type KeyedChoice<T> = {
 
 export type ProjectGroup = {
   project: ProjectView;
-  rows: WorktreeRow[];
+  rows: DashboardSessionRow[];
   collapsed: boolean;
+};
+
+export type DashboardSessionRow = {
+  /** Dashboard identity is the canonical session id, never the checkout id. */
+  id: SessionId;
+  session: SessionView;
+  worktree: WorktreeRow;
+  presentation: WorktreeRow;
 };
 
 export type NewSessionHarnessOption = {
@@ -102,19 +111,15 @@ export function selectProjectGroups(
   state: TuiViewState,
 ): ProjectGroup[] {
   const query = normalizeSearch(state.searchQuery);
+  const sessionRows = selectDashboardSessionRows(snapshot);
   return snapshot.projects.map((project) => {
     const collapsed = state.collapsedProjectIds.has(project.id);
-    const matchingRows = snapshot.rows
-      .filter((row) => row.projectId === project.id)
+    const matchingRows = sessionRows
+      .filter((row) => row.worktree.projectId === project.id)
       .filter((row) =>
-        rowMatchesSearch(
-          row,
-          project,
-          query,
-          worktreeRowDisplayTitle(row, snapshot.sessions, state.localRows),
-        ),
+        rowMatchesSearch(row, project, query, sessionRowDisplayTitle(row, state.localRows)),
       )
-      .sort((left, right) => compareRows(left, right, snapshot.sessions, state.localRows));
+      .sort((left, right) => compareRows(left, right, state.localRows));
     return {
       project,
       rows: collapsed ? [] : matchingRows,
@@ -123,8 +128,29 @@ export function selectProjectGroups(
   });
 }
 
-export function selectVisibleRows(snapshot: StationSnapshot, state: TuiViewState): WorktreeRow[] {
+export function selectVisibleRows(
+  snapshot: StationSnapshot,
+  state: TuiViewState,
+): DashboardSessionRow[] {
   return selectProjectGroups(snapshot, state).flatMap((group) => group.rows);
+}
+
+export function selectDashboardSessionRows(snapshot: StationSnapshot): DashboardSessionRow[] {
+  const worktreesById = new Map(snapshot.rows.map((row) => [row.id, row]));
+  return snapshot.sessions.flatMap((session) => {
+    const source = worktreesById.get(session.worktreeId);
+    if (source === undefined || source.projectId !== session.projectId) {
+      return [];
+    }
+    return [dashboardSessionRow(session, source)];
+  });
+}
+
+export function selectDashboardSessionRow(
+  snapshot: StationSnapshot,
+  sessionId: SessionId,
+): DashboardSessionRow | undefined {
+  return selectDashboardSessionRows(snapshot).find((row) => row.id === sessionId);
 }
 
 export function selectProjectChoices(
@@ -242,6 +268,13 @@ export function worktreeRowDisplayTitle(
   return pendingRenameTitles(localRows)[session.id]?.title ?? session.title;
 }
 
+export function sessionRowDisplayTitle(
+  row: Pick<DashboardSessionRow, "session">,
+  localRows: TuiLocalRows,
+): string {
+  return pendingRenameTitles(localRows)[row.session.id]?.title ?? row.session.title;
+}
+
 /**
  * The default harness to render as a project's current selection: the optimistic
  * pending value (set the moment a new agent is picked) until the snapshot
@@ -260,23 +293,22 @@ export function selectProjectDefaultHarness(
 }
 
 function compareRows(
-  left: WorktreeRow,
-  right: WorktreeRow,
-  sessions: readonly SessionView[],
+  left: DashboardSessionRow,
+  right: DashboardSessionRow,
   localRows: TuiLocalRows,
 ): number {
   return (
-    worktreeRowDisplayTitle(left, sessions, localRows).localeCompare(
-      worktreeRowDisplayTitle(right, sessions, localRows),
+    sessionRowDisplayTitle(left, localRows).localeCompare(
+      sessionRowDisplayTitle(right, localRows),
     ) ||
-    left.branch.localeCompare(right.branch) ||
-    left.path.localeCompare(right.path) ||
+    left.worktree.branch.localeCompare(right.worktree.branch) ||
+    left.worktree.path.localeCompare(right.worktree.path) ||
     left.id.localeCompare(right.id)
   );
 }
 
 function rowMatchesSearch(
-  row: WorktreeRow,
+  row: DashboardSessionRow,
   project: ProjectView,
   query: string,
   displayTitle: string,
@@ -286,13 +318,101 @@ function rowMatchesSearch(
   }
   return [
     displayTitle,
-    row.branch,
-    row.display.statusLabel,
-    row.display.reason,
-    row.agent?.harness,
-    row.terminal?.provider,
+    row.worktree.branch,
+    row.session.status.value,
+    row.session.status.reason,
+    row.session.harness.provider,
+    row.session.terminal?.provider,
     project.label,
   ].some((value) => normalizeSearch(value ?? "").includes(query));
+}
+
+function dashboardSessionRow(session: SessionView, source: WorktreeRow): DashboardSessionRow {
+  return {
+    id: session.id,
+    session,
+    worktree: source,
+    presentation: sessionPresentation(session, source),
+  };
+}
+
+function sessionPresentation(session: SessionView, source: WorktreeRow): WorktreeRow {
+  const row: WorktreeRow = {
+    ...source,
+    display: sessionDisplay(session),
+  };
+  row.agent = sessionAgent(session, source);
+  if (session.terminal === undefined) {
+    delete row.terminal;
+  } else {
+    row.terminal = session.terminal;
+  }
+  if (session.origin === "external") {
+    delete row.recovery;
+  }
+  return row;
+}
+
+function sessionAgent(
+  session: SessionView,
+  source: WorktreeRow,
+): NonNullable<WorktreeRow["agent"]> {
+  const agent: NonNullable<WorktreeRow["agent"]> = {
+    harness: session.harness.provider,
+    state: session.status.value,
+    confidence: session.status.confidence,
+    reason: session.status.reason,
+    updatedAt: session.status.updatedAt,
+  };
+  if (session.harness.pid !== undefined) agent.pid = session.harness.pid;
+  if (session.harness.runId !== undefined) agent.runId = session.harness.runId;
+  if (session.origin === "station") agent.sessionId = session.id;
+  if (session.status.attention !== undefined) agent.attention = session.status.attention;
+  if (sourceAgentMatchesSession(source, session) && source.agent?.turnReadiness !== undefined) {
+    agent.turnReadiness = source.agent.turnReadiness;
+  }
+  return agent;
+}
+
+function sourceAgentMatchesSession(source: WorktreeRow, session: SessionView): boolean {
+  if (session.origin === "station") {
+    return source.agent?.sessionId === session.id;
+  }
+  return session.harness.runId !== undefined && source.agent?.runId === session.harness.runId;
+}
+
+function sessionDisplay(session: SessionView): WorktreeRow["display"] {
+  const value = session.status.value;
+  const display: WorktreeRow["display"] = {
+    statusLabel:
+      value === "needs_attention" ? "needs attention" : value === "none" ? "no agent" : value,
+    sortPriority: sessionStatusPriority(value),
+    alert: value === "needs_attention" || value === "stuck",
+    reason: session.status.reason,
+  };
+  if (value === "stuck") display.warning = true;
+  return display;
+}
+
+function sessionStatusPriority(value: SessionView["status"]["value"]): number {
+  switch (value) {
+    case "needs_attention":
+      return 10;
+    case "stuck":
+      return 20;
+    case "working":
+      return 30;
+    case "starting":
+      return 35;
+    case "idle":
+      return 40;
+    case "unknown":
+      return 50;
+    case "exited":
+      return 60;
+    case "none":
+      return 70;
+  }
 }
 
 function normalizeSearch(value: string): string {

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -3,6 +3,7 @@ import type {
   ProviderId,
   SafeError,
   SessionId,
+  SessionView,
   StationCommand,
   TerminalFocusOrigin,
   WorktreeId,
@@ -73,6 +74,19 @@ export function buildFocusCommand(
     type: "terminal.focus",
     payload,
   };
+}
+
+export function buildSessionFocusCommand(
+  session: Pick<SessionView, "id">,
+  options: BuildFocusCommandOptions = {},
+): Extract<StationCommand, { type: "terminal.focus" }> {
+  const payload: Extract<StationCommand, { type: "terminal.focus" }>["payload"] = {
+    sessionId: session.id,
+  };
+  if (options.origin !== undefined) {
+    payload.origin = options.origin;
+  }
+  return { type: "terminal.focus", payload };
 }
 
 export function buildStartAgentCommand(

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -1,30 +1,24 @@
-import type { SessionId, WorktreeRow } from "@station/contracts";
+import type { SessionId } from "@station/contracts";
 import { clampDashboardScrollOffset, dashboardBodyRows } from "../components/Dashboard/layout.js";
 import {
   type DashboardViewportItem,
   selectDashboardItems,
 } from "../selectors/dashboardViewport.js";
+import type { DashboardSessionRow } from "../selectors/selectors.js";
 import { scrollDashboard } from "./dashboardScroll.js";
 import { activateDashboardRow } from "./rowActivation.js";
 import type { TuiTransition } from "./transition.js";
 import type { TuiState } from "./types.js";
 
-type WorktreeItem = Extract<DashboardViewportItem, { type: "worktree" }>;
+type SessionItem = Extract<DashboardViewportItem, { type: "session" }>;
 
 /** Focuses the visible dashboard row for a canonical session identity. */
 export function focusDashboardSession(state: TuiState, sessionId: SessionId): TuiState {
   if (state.snapshot === undefined) {
     return clearDashboardFocus(state);
   }
-  // Match only canonical session identity; worktree and row ids are not session ids.
-  const session = state.snapshot.sessions.find((candidate) => candidate.id === sessionId);
-  if (session === undefined) {
-    return clearDashboardFocus(state);
-  }
   const items = selectDashboardItems(state.snapshot, state);
-  const index = items.findIndex(
-    (item) => item.type === "worktree" && item.row.id === session.worktreeId,
-  );
+  const index = items.findIndex((item) => item.type === "session" && item.row.id === sessionId);
   return index === -1 ? clearDashboardFocus(state) : focusItem(state, items, index);
 }
 
@@ -62,7 +56,7 @@ export function focusNextNeedsMe(state: TuiState): TuiState {
   }
   const items = selectDashboardItems(state.snapshot, state);
   const candidates = focusableIndexes(items).filter((index) => {
-    const item = items[index] as WorktreeItem;
+    const item = items[index] as SessionItem;
     return rowNeedsYou(item.row);
   });
   if (candidates.length === 0) {
@@ -85,25 +79,25 @@ export function activateFocusedDashboardRow(state: TuiState): TuiTransition {
  * dashboard activation both refuse — a pending row, or one filtered out of the
  * view (viewport scroll does not unfocus; the cursor rule keeps it committable).
  */
-export function focusedSelectableRow(state: TuiState): WorktreeRow | undefined {
+export function focusedSelectableRow(state: TuiState): DashboardSessionRow | undefined {
   if (state.snapshot === undefined) {
     return undefined;
   }
   const items = selectDashboardItems(state.snapshot, state);
   const index = focusedItemIndex(items, state);
-  const item = index === undefined ? undefined : (items[index] as WorktreeItem);
+  const item = index === undefined ? undefined : (items[index] as SessionItem);
   if (item === undefined || item.pendingRemove !== undefined || item.pendingStart !== undefined) {
     return undefined;
   }
   return item.row;
 }
 
-export function rowNeedsYou(row: WorktreeRow): boolean {
-  return row.agent?.state === "needs_attention" || row.agent?.state === "stuck";
+export function rowNeedsYou(row: DashboardSessionRow): boolean {
+  return row.session.status.value === "needs_attention" || row.session.status.value === "stuck";
 }
 
 function focusableIndexes(items: readonly DashboardViewportItem[]): number[] {
-  return items.flatMap((item, index) => (item.type === "worktree" ? [index] : []));
+  return items.flatMap((item, index) => (item.type === "session" ? [index] : []));
 }
 
 function focusedItemIndex(
@@ -114,7 +108,7 @@ function focusedItemIndex(
     return undefined;
   }
   const index = items.findIndex(
-    (item) => item.type === "worktree" && item.row.id === state.focusedRowId,
+    (item) => item.type === "session" && item.row.id === state.focusedRowId,
   );
   return index === -1 ? undefined : index;
 }
@@ -140,7 +134,7 @@ function focusItem(
   index: number,
 ): TuiState {
   const item = items[index];
-  if (item === undefined || item.type !== "worktree") {
+  if (item === undefined || item.type !== "session") {
     return { ...state };
   }
   const { bodyRows, offset } = viewportWindow(state, items.length);

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -135,7 +135,7 @@ export type TuiHelpContentLine =
   | { text: string; align?: "center" }
   | { key: string; description: string };
 
-const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
+const slotHelp = { keys: "1-9 a-z", label: "open visible session" };
 
 // Dashboard dispatch resolves through this table before executing the binding's
 // action. Other mode tables feed copy/tests so documented chords cannot drift

--- a/packages/dashboard-core/src/state/localRows.ts
+++ b/packages/dashboard-core/src/state/localRows.ts
@@ -337,10 +337,25 @@ export function pruneLocalRowsForSnapshot(
   localRows: TuiLocalRows,
   snapshot: StationSnapshot,
 ): TuiLocalRows {
-  const realRows = new Set(snapshot.rows.map((row) => `${row.projectId}\u0000${row.branch}`));
-  const realWorktreeIds = new Set(snapshot.rows.map((row) => row.id));
   const rowsByWorktreeId = new Map(snapshot.rows.map((row) => [row.id, row]));
-  const sessionWorktreeIds = new Set(snapshot.sessions.map((session) => session.worktreeId));
+  const realRows = new Set(
+    snapshot.sessions.flatMap((session) => {
+      const row = rowsByWorktreeId.get(session.worktreeId);
+      return row === undefined ? [] : [`${session.projectId}\u0000${row.branch}`];
+    }),
+  );
+  const realWorktreeIds = new Set(snapshot.rows.map((row) => row.id));
+  const launchableSessionWorktreeIds = new Set(
+    snapshot.sessions
+      .filter(
+        (session) =>
+          session.origin === "station" &&
+          (session.status.value === "none" ||
+            session.status.value === "exited" ||
+            session.status.value === "unknown"),
+      )
+      .map((session) => session.worktreeId),
+  );
   const pruned = withPendingRenameTitles(
     {
       ...localRows,
@@ -353,7 +368,7 @@ export function pruneLocalRowsForSnapshot(
         return (
           realRow !== undefined &&
           realRow.agent === undefined &&
-          !sessionWorktreeIds.has(row.worktreeId)
+          launchableSessionWorktreeIds.has(row.worktreeId)
         );
       }),
     },

--- a/packages/dashboard-core/src/state/localRows.ts
+++ b/packages/dashboard-core/src/state/localRows.ts
@@ -345,17 +345,6 @@ export function pruneLocalRowsForSnapshot(
     }),
   );
   const realWorktreeIds = new Set(snapshot.rows.map((row) => row.id));
-  const launchableSessionWorktreeIds = new Set(
-    snapshot.sessions
-      .filter(
-        (session) =>
-          session.origin === "station" &&
-          (session.status.value === "none" ||
-            session.status.value === "exited" ||
-            session.status.value === "unknown"),
-      )
-      .map((session) => session.worktreeId),
-  );
   const pruned = withPendingRenameTitles(
     {
       ...localRows,
@@ -368,7 +357,9 @@ export function pruneLocalRowsForSnapshot(
         return (
           realRow !== undefined &&
           realRow.agent === undefined &&
-          launchableSessionWorktreeIds.has(row.worktreeId)
+          snapshot.sessions.some(
+            (session) => session.origin === "station" && session.worktreeId === row.worktreeId,
+          )
         );
       }),
     },

--- a/packages/dashboard-core/src/state/operations/startAgent.ts
+++ b/packages/dashboard-core/src/state/operations/startAgent.ts
@@ -1,9 +1,10 @@
-import type {
-  CommandId,
-  SafeError,
-  StationCommand,
-  StationSnapshot,
-  WorktreeRow,
+import {
+  type CommandId,
+  type SafeError,
+  type StationCommand,
+  type StationSnapshot,
+  type WorktreeRow,
+  worktreeHasLiveAgent,
 } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
 import { toSafeError } from "../../services/errors/errors.js";
@@ -116,10 +117,7 @@ function startedRowForSnapshot(
   if (row === undefined) {
     return undefined;
   }
-  if (
-    row.agent === undefined &&
-    !snapshot.sessions.some((session) => session.worktreeId === worktreeId)
-  ) {
+  if (!worktreeHasLiveAgent(row)) {
     return undefined;
   }
   return { snapshot, row };

--- a/packages/dashboard-core/src/state/rowActivation.ts
+++ b/packages/dashboard-core/src/state/rowActivation.ts
@@ -1,9 +1,10 @@
 import type { TerminalFocusOrigin, WorktreeRow } from "@station/contracts";
 import { worktreeHasLiveAgent } from "@station/contracts";
+import type { DashboardSessionRow } from "../selectors/selectors.js";
 import { safeErrorToToast } from "../services/errors/errors.js";
 import {
-  buildFocusCommand,
   buildResumeAgentCommand,
+  buildSessionFocusCommand,
   buildStartAgentCommand,
 } from "./commandBuilders.js";
 import { addPendingStartAgentRow } from "./localRows.js";
@@ -11,15 +12,35 @@ import { addTuiToast } from "./toasts.js";
 import type { TuiTransition } from "./transition.js";
 import type { TuiState } from "./types.js";
 
-export function activateDashboardRow(state: TuiState, row: WorktreeRow): TuiTransition {
+export function activateDashboardRow(
+  state: TuiState,
+  sessionRow: DashboardSessionRow,
+): TuiTransition {
+  const { presentation: row, session, worktree } = sessionRow;
   // Launch (or resume) unless the row has a genuinely live agent to focus. A "?"
   // (unknown) row whose terminal is dead is launchable here, not a dead focus -
   // the dashboard-side half of the observer's relaunch-unknown-rows fix.
-  if (row.recovery !== undefined || !worktreeHasLiveAgent(row)) {
-    return startOrResumeAgentForRow(state, row);
+  if (!worktreeHasLiveAgent(row)) {
+    if (session.origin === "external") {
+      return {
+        state: addTuiToast(state, {
+          kind: "info",
+          message: "This external session is no longer active. Refresh the dashboard.",
+        }),
+      };
+    }
+    if (otherSessionHasLiveAgent(sessionRow)) {
+      return {
+        state: addTuiToast(state, {
+          kind: "info",
+          message: "Another session is already active in this checkout.",
+        }),
+      };
+    }
+    return startOrResumeAgentForRow(state, worktree);
   }
 
-  if (row.terminal !== undefined && row.terminal.focusable !== true) {
+  if (session.terminal?.focusable !== true) {
     // The agent's terminal cannot be focused from the dashboard (e.g. it is
     // hosted by Station, whose provider reports canFocusTarget:false). Surface a
     // one-time notice instead of dispatching a focus the provider can only
@@ -27,15 +48,28 @@ export function activateDashboardRow(state: TuiState, row: WorktreeRow): TuiTran
     return {
       state: addTuiToast(state, {
         kind: "info",
-        message: `This agent runs in the "${row.terminal.provider}" terminal and can't be focused from the dashboard.`,
+        message:
+          session.terminal === undefined
+            ? "This session has no focusable terminal."
+            : `This agent runs in the "${session.terminal.provider}" terminal and can't be focused from the dashboard.`,
       }),
     };
   }
 
   return {
     state,
-    commands: [buildFocusCommand(row, focusCommandOptions(state.runtime.focusOrigin))],
+    commands: [buildSessionFocusCommand(session, focusCommandOptions(state.runtime.focusOrigin))],
   };
+}
+
+function otherSessionHasLiveAgent(row: DashboardSessionRow): boolean {
+  if (!worktreeHasLiveAgent(row.worktree)) {
+    return false;
+  }
+  if (row.session.origin === "station") {
+    return row.worktree.agent?.sessionId !== row.session.id;
+  }
+  return row.worktree.agent?.runId !== row.session.harness.runId;
 }
 
 function startOrResumeAgentForRow(state: TuiState, row: WorktreeRow): TuiTransition {

--- a/packages/dashboard-core/src/state/screens/fork.ts
+++ b/packages/dashboard-core/src/state/screens/fork.ts
@@ -1,10 +1,11 @@
-import type { WorktreeRow } from "@station/contracts";
+import type { SessionId, WorktreeRow } from "@station/contracts";
 import { isRunningAgentState } from "@station/contracts";
 import {
   createEditableTextInputState,
   editableTextInputIntentForInput,
   transitionEditableTextInput,
 } from "../../components/EditableTextInput/editing.js";
+import { selectDashboardSessionRow } from "../../selectors/selectors.js";
 import { buildForkSessionCommand } from "../commandBuilders.js";
 import type { TuiKey } from "../keys.js";
 import { isReturnKey } from "../keys.js";
@@ -75,7 +76,7 @@ export function handleForkKey(state: TuiState, key: TuiKey): TuiTransition {
 // open it directly for a clicked row (skipping chooseSlot), like renameSession.
 export function openForkDetailsForRow(
   state: TuiState,
-  rowId: string,
+  rowId: SessionId,
   returnTo?: "dashboard",
 ): TuiState {
   if (state.screen.name !== "dashboard" && state.screen.name !== "fork") {
@@ -85,10 +86,11 @@ export function openForkDetailsForRow(
   if (snapshot === undefined) {
     return state;
   }
-  const row = snapshot.rows.find((candidate) => candidate.id === rowId);
-  if (row === undefined) {
+  const sessionRow = selectDashboardSessionRow(snapshot, rowId);
+  if (sessionRow === undefined) {
     return state;
   }
+  const row = sessionRow.worktree;
   const project = snapshot.projects.find((candidate) => candidate.id === row.projectId);
   if (project === undefined) {
     return state;
@@ -102,7 +104,9 @@ export function openForkDetailsForRow(
     projectLabel: row.projectLabel,
     sourceBranch: row.branch,
     sourceDirty: row.worktree.dirty === true,
-    sourceAgentRunning: isRunningAgentState(row.agent?.state),
+    sourceAgentRunning: snapshot.sessions.some(
+      (session) => session.worktreeId === row.id && isRunningAgentState(session.status.value),
+    ),
     draftBranch: createEditableTextInputState(
       suggestForkBranch(row.branch, snapshot.rows, row.projectId),
     ),

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -1,5 +1,9 @@
-import { isRunningAgentState, type StationSnapshot, type WorktreeRow } from "@station/contracts";
-import { sessionForWorktreeRow, worktreeRowDisplayTitle } from "../../selectors/selectors.js";
+import { isRunningAgentState, type SessionId, type StationSnapshot } from "@station/contracts";
+import {
+  type DashboardSessionRow,
+  selectDashboardSessionRow,
+  sessionRowDisplayTitle,
+} from "../../selectors/selectors.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
 import { buildRemoveWorktreeCommand, cleanupForceRequired } from "../commandBuilders.js";
 import type { TuiKey } from "../keys.js";
@@ -46,20 +50,20 @@ export function handleRemoveWorktreeKey(state: TuiState, key: TuiKey): TuiTransi
 }
 
 export function isExternalAgentRemovalUnavailable(
-  row: WorktreeRow,
+  row: DashboardSessionRow,
   snapshot: StationSnapshot,
 ): boolean {
-  const agent = row.agent;
-  return (
-    agent !== undefined &&
-    isRunningAgentState(agent.state) &&
-    sessionForWorktreeRow(row, snapshot.sessions)?.origin !== "station" &&
-    snapshot.providerHealth[agent.harness]?.capabilities?.canStop === false &&
-    row.terminal?.closeable !== true
+  return snapshot.sessions.some(
+    (session) =>
+      session.worktreeId === row.worktree.id &&
+      session.origin === "external" &&
+      isRunningAgentState(session.status.value) &&
+      snapshot.providerHealth[session.harness.provider]?.capabilities?.canStop === false &&
+      session.terminal?.closeable !== true,
   );
 }
 
-export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: string): TuiState {
+export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: SessionId): TuiState {
   if (state.screen.name !== "dashboard" && state.screen.name !== "removeWorktree") {
     return state;
   }
@@ -67,11 +71,12 @@ export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: string):
   if (snapshot === undefined) {
     return state;
   }
-  const row = snapshot.rows.find((candidate) => candidate.id === rowId);
-  if (row === undefined) {
+  const sessionRow = selectDashboardSessionRow(snapshot, rowId);
+  if (sessionRow === undefined) {
     return state;
   }
-  if (isExternalAgentRemovalUnavailable(row, snapshot)) {
+  const row = sessionRow.worktree;
+  if (isExternalAgentRemovalUnavailable(sessionRow, snapshot)) {
     return {
       ...state,
       screen: {
@@ -80,15 +85,14 @@ export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: string):
       },
     };
   }
-  const label =
-    worktreeRowDisplayTitle(row, snapshot.sessions, state.localRows).trim() || row.branch;
+  const label = sessionRowDisplayTitle(sessionRow, state.localRows).trim() || row.branch;
   return {
     ...state,
     screen: {
       name: "removeWorktree",
       step: "confirm",
-      rowId: row.id,
-      forceRequired: cleanupForceRequired(row, "remove-worktree"),
+      rowId: sessionRow.id,
+      forceRequired: removeWorktreeForceRequired(sessionRow, snapshot),
       label,
     },
   };
@@ -115,12 +119,25 @@ function handleConfirmKey(state: TuiState, key: TuiKey): TuiTransition {
   }
 
   const screen = state.screen;
-  const row = state.snapshot?.rows.find((candidate) => candidate.id === screen.rowId);
-  if (row === undefined) {
+  const snapshot = state.snapshot;
+  if (snapshot === undefined) {
+    return { state: { ...state, screen: { name: "dashboard" } } };
+  }
+  const sessionRow = selectDashboardSessionRow(snapshot, screen.rowId);
+  if (sessionRow === undefined) {
     return {
       state: {
         ...state,
         screen: { name: "dashboard" },
+      },
+    };
+  }
+  const row = sessionRow.worktree;
+  if (isExternalAgentRemovalUnavailable(sessionRow, snapshot)) {
+    return {
+      state: {
+        ...state,
+        screen: { name: "removeWorktree", step: "unavailable" },
       },
     };
   }
@@ -143,7 +160,10 @@ function handleConfirmKey(state: TuiState, key: TuiKey): TuiTransition {
     };
   }
 
-  const command = buildRemoveWorktreeCommand(row, screen.forceRequired);
+  const command = buildRemoveWorktreeCommand(
+    row,
+    screen.forceRequired || removeWorktreeForceRequired(sessionRow, snapshot),
+  );
   if (command.type !== "worktree.remove") {
     return { state };
   }
@@ -174,4 +194,14 @@ function handleConfirmKey(state: TuiState, key: TuiKey): TuiTransition {
       },
     ],
   };
+}
+
+function removeWorktreeForceRequired(row: DashboardSessionRow, snapshot: StationSnapshot): boolean {
+  return (
+    cleanupForceRequired(row.worktree, "remove-worktree") ||
+    snapshot.sessions.some(
+      (session) =>
+        session.worktreeId === row.worktree.id && isRunningAgentState(session.status.value),
+    )
+  );
 }

--- a/packages/dashboard-core/src/state/screens/rowChoose.ts
+++ b/packages/dashboard-core/src/state/screens/rowChoose.ts
@@ -1,4 +1,4 @@
-import type { WorktreeId } from "@station/contracts";
+import type { SessionId } from "@station/contracts";
 import { selectDashboardViewport } from "../../selectors/dashboardViewport.js";
 import { choiceValueByKey } from "../../selectors/selectors.js";
 import { focusedSelectableRow, moveDashboardFocus } from "../dashboardFocus.js";
@@ -19,7 +19,7 @@ import type { TuiState } from "../types.js";
 export function handleDashboardRowChoiceKey(
   state: TuiState,
   key: TuiKey,
-  commit: (state: TuiState, rowId: WorktreeId) => TuiTransition,
+  commit: (state: TuiState, rowId: SessionId) => TuiTransition,
 ): TuiTransition {
   if (key.upArrow === true) {
     return { state: moveDashboardFocus(state, -1) };

--- a/packages/dashboard-core/src/state/screens/sessionRows.ts
+++ b/packages/dashboard-core/src/state/screens/sessionRows.ts
@@ -1,6 +1,9 @@
-import type { SessionView, StationSnapshot, WorktreeRow } from "@station/contracts";
 import { createEditableTextInputState } from "../../components/EditableTextInput/editing.js";
-import { sessionForWorktreeRow, worktreeRowDisplayTitle } from "../../selectors/selectors.js";
+import {
+  selectDashboardSessionRow,
+  sessionForWorktreeRow,
+  sessionRowDisplayTitle,
+} from "../../selectors/selectors.js";
 import type { TuiState } from "../types.js";
 
 export type OpenRenameEditForRowOptions = {
@@ -19,13 +22,12 @@ export function openRenameEditForRow(
   if (resolved === undefined) {
     return state;
   }
-  const { row, session, snapshot } = resolved;
-  const currentTitle = worktreeRowDisplayTitle(row, snapshot.sessions, state.localRows);
+  const currentTitle = sessionRowDisplayTitle(resolved, state.localRows);
   const screen: Extract<TuiState["screen"], { name: "renameSession"; step: "editName" }> = {
     name: "renameSession",
     step: "editName",
-    rowId: row.id,
-    sessionId: session.id,
+    rowId: resolved.id,
+    sessionId: resolved.session.id,
     currentTitle,
     draftTitle: createEditableTextInputState(currentTitle),
   };
@@ -42,21 +44,20 @@ function canOpenRenameFromScreen(state: TuiState): boolean {
   );
 }
 
-function resolveCurrentRowSession(
-  state: TuiState,
-  rowId: string,
-): { row: WorktreeRow; session: SessionView; snapshot: StationSnapshot } | undefined {
+function resolveCurrentRowSession(state: TuiState, rowId: string) {
   const snapshot = state.snapshot;
   if (snapshot === undefined) {
     return undefined;
   }
-  const row = snapshot.rows.find((candidate) => candidate.id === rowId);
-  if (row === undefined) {
+  const direct = selectDashboardSessionRow(snapshot, rowId);
+  const worktree = snapshot.rows.find((candidate) => candidate.id === rowId);
+  const paneSession =
+    worktree === undefined ? undefined : sessionForWorktreeRow(worktree, snapshot.sessions);
+  const row =
+    direct ??
+    (paneSession === undefined ? undefined : selectDashboardSessionRow(snapshot, paneSession.id));
+  if (row?.session.origin !== "station") {
     return undefined;
   }
-  const session = sessionForWorktreeRow(row, snapshot.sessions);
-  if (session?.origin !== "station") {
-    return undefined;
-  }
-  return { row, session, snapshot };
+  return row;
 }

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -30,7 +30,7 @@ export type TuiViewState = {
   terminalRows: number;
   localRows: TuiLocalRows;
   /** List cursor; native overlays synchronize it once per open and clear it on close. */
-  focusedRowId?: WorktreeId;
+  focusedRowId?: SessionId;
   /** Per-list cursor for screens migrated onto the shared selection engine. */
   selection: TuiSelectionState;
 };
@@ -76,7 +76,7 @@ export type TuiScreen =
   | {
       name: "removeWorktree";
       step: "confirm";
-      rowId: WorktreeId;
+      rowId: SessionId;
       forceRequired: boolean;
       label: string;
     }
@@ -84,7 +84,7 @@ export type TuiScreen =
   | {
       name: "renameSession";
       step: "editName";
-      rowId: WorktreeId;
+      rowId: SessionId;
       sessionId: SessionId;
       currentTitle: string;
       draftTitle: EditableTextInputState;
@@ -135,7 +135,7 @@ export type CreateInitialTuiStateOptions = {
   scrollOffset?: number;
   terminalRows?: number;
   localRows?: TuiLocalRows;
-  focusedRowId?: WorktreeId;
+  focusedRowId?: SessionId;
   widgets?: readonly TuiWidgetConfig[];
   widgetsPersisted?: boolean;
   runtime?: Partial<TuiRuntimeState>;

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -45,7 +45,7 @@ export function createCommandSnapshot(
   state: "none" | "idle" = "idle",
   options: { dirty?: boolean } = {},
 ): StationSnapshot {
-  return snapshotFromRows([
+  const snapshot = snapshotFromRows([
     row({
       id: state === "none" ? "wt_web_no_agent" : "wt_web_idle",
       projectId: "web",
@@ -54,6 +54,23 @@ export function createCommandSnapshot(
       ...(options.dirty === undefined ? {} : { dirty: options.dirty }),
     }),
   ]);
+  if (state !== "none") {
+    return snapshot;
+  }
+  const source = snapshot.rows[0];
+  if (source === undefined) {
+    throw new Error("Command fixture requires a worktree.");
+  }
+  return {
+    ...snapshot,
+    sessions: [retainedSessionForRow(source)],
+    counts: { ...snapshot.counts, sessions: 1 },
+    projects: snapshot.projects.map((project) =>
+      project.id === source.projectId
+        ? { ...project, counts: { ...project.counts, sessions: 1 } }
+        : project,
+    ),
+  };
 }
 
 export function createExternalAgentSnapshot(): StationSnapshot {
@@ -279,6 +296,31 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     },
     title: candidate.branch,
     tags: [candidate.agent.harness, candidate.terminal.provider],
+  };
+}
+
+function retainedSessionForRow(candidate: WorktreeRow): SessionView {
+  return {
+    id: `ses_${candidate.id}`,
+    origin: "station",
+    projectId: candidate.projectId,
+    worktreeId: candidate.id,
+    createdAt: "2026-05-20T11:59:00.000Z",
+    updatedAt: fixtureNow,
+    harness: {
+      provider: candidate.projectId === "api" ? "opencode" : "codex",
+      mode: "interactive",
+      capabilities: defaultCapabilities,
+    },
+    status: {
+      value: "none",
+      confidence: "high",
+      reason: "No harness run is associated with this session.",
+      source: "observer_command",
+      updatedAt: fixtureNow,
+    },
+    title: candidate.branch,
+    tags: [],
   };
 }
 

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -4,29 +4,49 @@ import {
   selectDashboardViewport,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import { createCommandSnapshot, createDashboardSnapshot } from "../../fixtures/snapshots.js";
 
 describe("dashboard viewport selector", () => {
+  it("does not flatten bare worktrees into dashboard session items", () => {
+    const snapshot = createDashboardSnapshot();
+    const items = selectDashboardItems(snapshot, createInitialTuiState());
+
+    expect(items.map((item) => item.id)).not.toContain("session:ses_wt_web_no_agent");
+  });
+
+  it("renders a project empty when its only remaining checkout is bare", () => {
+    const base = createDashboardSnapshot();
+    const snapshot = {
+      ...base,
+      sessions: base.sessions.filter((session) => session.projectId !== "web"),
+    };
+    const items = selectDashboardItems(snapshot, createInitialTuiState());
+
+    expect(items.map((item) => item.id)).toContain("empty:web");
+    expect(
+      items.some((item) => item.type === "session" && item.row.worktree.id === "wt_web_no_agent"),
+    ).toBe(false);
+  });
+
   it("flattens projects into dashboard render items", () => {
     const snapshot = createDashboardSnapshot();
     const state = createInitialTuiState();
 
     expect(
       selectDashboardItems(snapshot, state).map((item) =>
-        item.type === "worktree" ? `${item.type}:${item.row.id}` : item.id,
+        item.type === "session" ? `${item.type}:${item.row.id}` : item.id,
       ),
     ).toEqual([
       "project:web",
-      "worktree:wt_web_working",
-      "worktree:wt_web_attention",
-      "worktree:wt_web_exited",
-      "worktree:wt_web_no_agent",
-      "worktree:wt_web_idle",
-      "worktree:wt_web_unknown",
-      "worktree:wt_web_stuck",
+      "session:ses_wt_web_working",
+      "session:ses_wt_web_attention",
+      "session:ses_wt_web_exited",
+      "session:ses_wt_web_idle",
+      "session:ses_wt_web_unknown",
+      "session:ses_wt_web_stuck",
       "gap:api",
       "project:api",
-      "worktree:wt_api_working",
+      "session:ses_wt_api_working",
     ]);
   });
 
@@ -41,15 +61,15 @@ describe("dashboard viewport selector", () => {
     expect(viewport.bodyRows).toBe(3);
     expect(viewport.clampedScrollOffset).toBe(1);
     expect(viewport.hiddenAbove).toBe(1);
-    expect(viewport.hiddenBelow).toBe(7);
+    expect(viewport.hiddenBelow).toBe(6);
     expect(
       viewport.visibleItems.map((item) =>
-        item.type === "worktree" ? item.row.id : `${item.type}:${item.id}`,
+        item.type === "session" ? item.row.id : `${item.type}:${item.id}`,
       ),
-    ).toEqual(["wt_web_working", "wt_web_attention", "wt_web_exited"]);
+    ).toEqual(["ses_wt_web_working", "ses_wt_web_attention", "ses_wt_web_exited"]);
   });
 
-  it("uses only viewport-visible worktrees for row choices", () => {
+  it("uses only viewport-visible sessions for row choices", () => {
     const snapshot = createDashboardSnapshot();
     const state = createInitialTuiState({
       scrollOffset: 4,
@@ -58,9 +78,9 @@ describe("dashboard viewport selector", () => {
     const viewport = selectDashboardViewport(snapshot, state);
 
     expect(viewport.rowChoices.map((choice) => [choice.key, choice.value.id])).toEqual([
-      ["1", "wt_web_no_agent"],
-      ["2", "wt_web_idle"],
-      ["3", "wt_web_unknown"],
+      ["1", "ses_wt_web_idle"],
+      ["2", "ses_wt_web_unknown"],
+      ["3", "ses_wt_web_stuck"],
     ]);
   });
 
@@ -74,10 +94,10 @@ describe("dashboard viewport selector", () => {
       }),
     );
 
-    expect(viewport.clampedScrollOffset).toBe(8);
-    expect(viewport.hiddenAbove).toBe(8);
+    expect(viewport.clampedScrollOffset).toBe(7);
+    expect(viewport.hiddenAbove).toBe(7);
     expect(viewport.hiddenBelow).toBe(0);
-    expect(viewport.visibleItems.at(-1)?.id).toBe("worktree:wt_api_working");
+    expect(viewport.visibleItems.at(-1)?.id).toBe("session:ses_wt_api_working");
   });
 
   it("keeps empty project rows in the flattened body when no worktrees match", () => {
@@ -127,7 +147,7 @@ describe("dashboard viewport selector", () => {
         item.type === "createLocalRow" ? `${item.type}:${item.row.branch}` : item.id,
       ),
     ).toContain("createLocalRow:feature/pending");
-    expect(viewport.rowChoices.map((choice) => choice.value.branch)).not.toContain(
+    expect(viewport.rowChoices.map((choice) => choice.value.worktree.branch)).not.toContain(
       "feature/pending",
     );
   });
@@ -190,12 +210,16 @@ describe("dashboard viewport selector", () => {
 
     expect(
       viewport.items
-        .filter((item) => item.type === "worktree" || item.type === "createLocalRow")
+        .filter((item) => item.type === "session" || item.type === "createLocalRow")
         .slice(0, 3)
         .map((item) =>
-          item.type === "worktree" ? `worktree:${item.row.id}` : `create:${item.row.branch}`,
+          item.type === "session" ? `session:${item.row.id}` : `create:${item.row.branch}`,
         ),
-    ).toEqual(["worktree:wt_web_stuck", "create:bbb pending task", "worktree:wt_web_working"]);
+    ).toEqual([
+      "session:ses_wt_web_stuck",
+      "create:bbb pending task",
+      "session:ses_wt_web_working",
+    ]);
   });
 
   it("renders one observer row when branch metadata changes but the session title stays stable", () => {
@@ -213,15 +237,15 @@ describe("dashboard viewport selector", () => {
     };
     const viewport = selectDashboardViewport(changed, createInitialTuiState());
     const titledItems = viewport.items.filter(
-      (item) => item.type === "worktree" && item.displayTitle === "fix-nav-mobile",
+      (item) => item.type === "session" && item.displayTitle === "fix-nav-mobile",
     );
 
     expect(titledItems).toEqual([
       expect.objectContaining({
-        type: "worktree",
+        type: "session",
         row: expect.objectContaining({
-          id: "wt_web_idle",
-          branch: "agent-created-branch",
+          id: "ses_wt_web_idle",
+          worktree: expect.objectContaining({ branch: "agent-created-branch" }),
         }),
       }),
     ]);
@@ -252,19 +276,19 @@ describe("dashboard viewport selector", () => {
     );
 
     const item = viewport.items.find(
-      (candidate) => candidate.type === "worktree" && candidate.row.id === "wt_web_idle",
+      (candidate) => candidate.type === "session" && candidate.row.id === "ses_wt_web_idle",
     );
     expect(item).toMatchObject({
-      type: "worktree",
+      type: "session",
       pendingRemove: {
         localId: "remove:wt_web_idle",
       },
     });
-    expect(viewport.rowChoices.map((choice) => choice.value.id)).not.toContain("wt_web_idle");
+    expect(viewport.rowChoices.map((choice) => choice.value.id)).not.toContain("ses_wt_web_idle");
   });
 
   it("keeps pending start rows slotted for display but removes them from actions", () => {
-    const snapshot = createDashboardSnapshot();
+    const snapshot = createCommandSnapshot("none");
     const viewport = selectDashboardViewport(
       snapshot,
       createInitialTuiState({
@@ -287,28 +311,24 @@ describe("dashboard viewport selector", () => {
     );
 
     const item = viewport.items.find(
-      (candidate) => candidate.type === "worktree" && candidate.row.id === "wt_web_no_agent",
+      (candidate) => candidate.type === "session" && candidate.row.id === "ses_wt_web_no_agent",
     );
     expect(item).toMatchObject({
-      type: "worktree",
+      type: "session",
       pendingStart: {
         localId: "start:wt_web_no_agent",
       },
     });
     expect(
       viewport.displayRowChoices.map((choice) => [choice.key, choice.value.id]),
-    ).toContainEqual(["4", "wt_web_no_agent"]);
+    ).toContainEqual(["1", "ses_wt_web_no_agent"]);
     expect(viewport.rowChoices.map((choice) => [choice.key, choice.value.id])).not.toContainEqual([
-      "4",
-      "wt_web_no_agent",
-    ]);
-    expect(viewport.rowChoices.map((choice) => [choice.key, choice.value.id])).toContainEqual([
-      "5",
-      "wt_web_idle",
+      "1",
+      "ses_wt_web_no_agent",
     ]);
   });
 
-  it("carries resolved titles for dashboard worktree rendering", () => {
+  it("carries resolved titles for dashboard session rendering", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {
       ...snapshot,
@@ -319,10 +339,10 @@ describe("dashboard viewport selector", () => {
     const viewport = selectDashboardViewport(titled, createInitialTuiState());
 
     const item = viewport.items.find(
-      (candidate) => candidate.type === "worktree" && candidate.row.id === "wt_web_idle",
+      (candidate) => candidate.type === "session" && candidate.row.id === "ses_wt_web_idle",
     );
     expect(item).toMatchObject({
-      type: "worktree",
+      type: "session",
       displayTitle: "Readable feature task",
     });
   });

--- a/packages/dashboard-core/test/unit/selectors/selectors.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/selectors.test.ts
@@ -74,9 +74,33 @@ describe("TUI selectors", () => {
     const groups = selectProjectGroups(snapshot, createInitialTuiState());
 
     expect(groups.map((group) => [group.project.id, group.rows.length])).toEqual([
-      ["web", 7],
+      ["web", 6],
       ["api", 1],
     ]);
+  });
+
+  it("uses canonical session membership, including concurrent Station and external sessions", () => {
+    const external = createExternalAgentSnapshot();
+    const retained = createDashboardSnapshot().sessions.find(
+      (session) => session.worktreeId === "wt_web_idle",
+    );
+    const externalSession = external.sessions.find(
+      (session) => session.worktreeId === "wt_web_idle",
+    );
+    if (retained === undefined || externalSession === undefined) {
+      throw new Error("missing mixed-membership fixture sessions");
+    }
+    const snapshot = {
+      ...external,
+      sessions: [retained, ...external.sessions],
+    };
+    const web = selectProjectGroups(snapshot, createInitialTuiState()).find(
+      (group) => group.project.id === "web",
+    );
+
+    expect(web?.rows.map((candidate) => candidate.id)).toContain(retained.id);
+    expect(web?.rows.map((candidate) => candidate.id)).toContain(externalSession.id);
+    expect(web?.rows.map((candidate) => candidate.id)).not.toContain("wt_web_no_agent");
   });
 
   it("sorts rows inside project groups by resolved display title, not live status", () => {
@@ -85,20 +109,18 @@ describe("TUI selectors", () => {
       (group) => group.project.id === "web",
     );
 
-    expect(web?.rows.map((candidate) => candidate.branch)).toEqual([
+    expect(web?.rows.map((candidate) => candidate.worktree.branch)).toEqual([
       "cache-refactor",
       "checkout-copy",
       "done-run",
-      "feature-auth",
       "fix-nav-mobile",
       "ghost-signal",
       "slow-tests",
     ]);
-    expect(web?.rows.map((candidate) => candidate.display.statusLabel)).toEqual([
+    expect(web?.rows.map((candidate) => candidate.presentation.display.statusLabel)).toEqual([
       "working",
       "needs attention",
       "exited",
-      "no agent",
       "idle",
       "unknown",
       "stuck",
@@ -130,22 +152,18 @@ describe("TUI selectors", () => {
     expect(after?.rows.map((candidate) => candidate.id)).toEqual(
       before?.rows.map((candidate) => candidate.id),
     );
-    expect(after?.rows.map((candidate) => candidate.id)).toContain("wt_web_idle");
+    expect(after?.rows.map((candidate) => candidate.id)).toContain("ses_wt_web_idle");
   });
 
   it("keeps the same row position when status priority changes", () => {
     const snapshot = createDashboardSnapshot();
     const changed = {
       ...snapshot,
-      rows: snapshot.rows.map((candidate) =>
-        candidate.id === "wt_web_no_agent"
+      sessions: snapshot.sessions.map((candidate) =>
+        candidate.id === "ses_wt_web_exited"
           ? {
               ...candidate,
-              display: {
-                statusLabel: "needs attention" as const,
-                sortPriority: 10,
-                alert: true,
-              },
+              status: { ...candidate.status, value: "needs_attention" as const },
             }
           : candidate,
       ),
@@ -221,7 +239,7 @@ describe("TUI selectors", () => {
       selection: new Map(),
     };
     expect(selectVisibleRows(snapshot, searched).map((candidate) => candidate.id)).toEqual([
-      "wt_web_idle",
+      "ses_wt_web_idle",
     ]);
 
     const collapsed: TuiViewState = {
@@ -234,9 +252,23 @@ describe("TUI selectors", () => {
     };
     const groups = selectProjectGroups(snapshot, collapsed);
     expect(groups.find((group) => group.project.id === "web")?.collapsed).toBe(true);
-    expect(selectVisibleRows(snapshot, collapsed).map((candidate) => candidate.projectId)).toEqual([
-      "api",
-    ]);
+    expect(
+      selectVisibleRows(snapshot, collapsed).map((candidate) => candidate.worktree.projectId),
+    ).toEqual(["api"]);
+  });
+
+  it("does not make a bare worktree searchable as a session", () => {
+    const snapshot = createDashboardSnapshot();
+    const searched: TuiViewState = {
+      searchQuery: "feature-auth",
+      collapsedProjectIds: new Set(),
+      scrollOffset: 0,
+      terminalRows: 24,
+      localRows: { pendingCreate: [], failedCreate: [], pendingRemove: [], pendingStart: [] },
+      selection: new Map(),
+    };
+
+    expect(selectVisibleRows(snapshot, searched)).toEqual([]);
   });
 
   it("searches by resolved session title while sorting uses resolved titles", () => {
@@ -259,13 +291,13 @@ describe("TUI selectors", () => {
     };
 
     expect(selectVisibleRows(titled, searched).map((candidate) => candidate.id)).toEqual([
-      "wt_web_stuck",
+      "ses_wt_web_stuck",
     ]);
 
     const web = selectProjectGroups(titled, createInitialTuiState()).find(
       (group) => group.project.id === "web",
     );
-    expect(web?.rows.map((candidate) => candidate.id)[0]).toBe("wt_web_stuck");
+    expect(web?.rows.map((candidate) => candidate.id)[0]).toBe("ses_wt_web_stuck");
   });
 
   it("assigns project choices from rendered project headers", () => {

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -9,7 +9,7 @@ import {
   selectDashboardItems,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import { createCommandSnapshot, createDashboardSnapshot } from "../../fixtures/snapshots.js";
 import { FakeTuiObserverService } from "../../support/fakeObserverService.js";
 
 const DOWN = { input: "", downArrow: true } as const;
@@ -17,8 +17,8 @@ const UP = { input: "", upArrow: true } as const;
 const NEXT_NEEDS_ME = { input: "i", ctrl: true } as const;
 const RETURN = { input: "\r", return: true } as const;
 
-// Fixture worktree order under project web: working, attention, exited,
-// no_agent, idle, unknown, stuck — then project api: api_working.
+// Canonical session order under project web: working, attention, exited,
+// idle, unknown, stuck — then project api: api_working.
 function state(options: Partial<Parameters<typeof createInitialTuiState>[0]> = {}): TuiState {
   return createInitialTuiState({ initialSnapshot: createDashboardSnapshot(), ...options });
 }
@@ -38,8 +38,8 @@ describe("dashboard focus cursor", () => {
     });
     const focused = focusDashboardSession(initial, "ses_wt_api_working");
 
-    expect(focused.focusedRowId).toBe("wt_api_working");
-    expect(focused.scrollOffset).toBe(6);
+    expect(focused.focusedRowId).toBe("ses_wt_api_working");
+    expect(focused.scrollOffset).toBe(5);
   });
 
   it.each([
@@ -53,7 +53,7 @@ describe("dashboard focus cursor", () => {
       "ses_wt_api_working",
     ],
   ])("clears focus for a %s without moving the viewport", (_label, updateSnapshot, sessionId) => {
-    const initial = state({ focusedRowId: "wt_web_attention", scrollOffset: 3 });
+    const initial = state({ focusedRowId: "ses_wt_web_attention", scrollOffset: 3 });
     const snapshot = updateSnapshot(initial.snapshot as StationSnapshot);
     const focused = focusDashboardSession({ ...initial, snapshot }, sessionId);
 
@@ -63,7 +63,7 @@ describe("dashboard focus cursor", () => {
 
   it("clears focus when search filters out the session without changing search or scroll", () => {
     const initial = state({
-      focusedRowId: "wt_web_attention",
+      focusedRowId: "ses_wt_web_attention",
       searchQuery: "cache-refactor",
       scrollOffset: 2,
     });
@@ -76,7 +76,7 @@ describe("dashboard focus cursor", () => {
 
   it("clears focus when the session project is collapsed without changing collapse or scroll", () => {
     const initial = state({
-      focusedRowId: "wt_web_attention",
+      focusedRowId: "ses_wt_web_attention",
       collapsedProjectIds: ["api"],
       scrollOffset: 2,
     });
@@ -88,7 +88,7 @@ describe("dashboard focus cursor", () => {
   });
 
   it("removes transient focus without changing the viewport", () => {
-    const initial = state({ focusedRowId: "wt_web_attention", scrollOffset: 2 });
+    const initial = state({ focusedRowId: "ses_wt_web_attention", scrollOffset: 2 });
     const cleared = clearDashboardFocus(initial);
 
     expect("focusedRowId" in cleared).toBe(false);
@@ -106,7 +106,7 @@ describe("dashboard focus cursor", () => {
     store.getState().focusDashboardSession("ses_wt_web_attention");
     store.getState().handleKey(DOWN);
 
-    expect(store.getState().focusedRowId).toBe("wt_web_exited");
+    expect(store.getState().focusedRowId).toBe("ses_wt_web_exited");
 
     store.getState().clearDashboardFocus();
 
@@ -116,17 +116,17 @@ describe("dashboard focus cursor", () => {
 
   it("enters on the first visible session row and walks rows, skipping headers", () => {
     const first = handleTuiKey(state({ terminalRows: 12 }), DOWN).state;
-    expect(first.focusedRowId).toBe("wt_web_working");
+    expect(first.focusedRowId).toBe("ses_wt_web_working");
     expect(first.scrollOffset).toBe(0);
 
     const second = handleTuiKey(first, DOWN).state;
-    expect(second.focusedRowId).toBe("wt_web_attention");
+    expect(second.focusedRowId).toBe("ses_wt_web_attention");
   });
 
   it("enters upward on the last visible session row", () => {
     const entered = handleTuiKey(state({ terminalRows: 12 }), UP).state;
     // terminalRows 12 -> bodyRows 5: header + four session rows visible.
-    expect(entered.focusedRowId).toBe("wt_web_no_agent");
+    expect(entered.focusedRowId).toBe("ses_wt_web_idle");
   });
 
   it("scrolls the viewport to keep the cursor visible when walking past the bottom", () => {
@@ -134,38 +134,38 @@ describe("dashboard focus cursor", () => {
     for (let presses = 0; presses < 5; presses += 1) {
       current = handleTuiKey(current, DOWN).state;
     }
-    expect(current.focusedRowId).toBe("wt_web_idle");
+    expect(current.focusedRowId).toBe("ses_wt_web_unknown");
     // Item index 5 must sit inside the 5-row window: offset = 5 - 5 + 1.
     expect(current.scrollOffset).toBe(1);
   });
 
   it("clamps at both ends of the session list", () => {
     const top = handleTuiKey(handleTuiKey(state(), DOWN).state, UP).state;
-    expect(handleTuiKey(top, UP).state.focusedRowId).toBe("wt_web_working");
+    expect(handleTuiKey(top, UP).state.focusedRowId).toBe("ses_wt_web_working");
 
     let bottom = state({ terminalRows: 40 });
     for (let presses = 0; presses < 12; presses += 1) {
       bottom = handleTuiKey(bottom, DOWN).state;
     }
-    expect(bottom.focusedRowId).toBe("wt_api_working");
+    expect(bottom.focusedRowId).toBe("ses_wt_api_working");
   });
 
   it("re-enters from the viewport when the focused row leaves the snapshot", () => {
     const stale = { ...state({ terminalRows: 12 }), focusedRowId: "wt_gone" };
-    expect(handleTuiKey(stale, DOWN).state.focusedRowId).toBe("wt_web_working");
+    expect(handleTuiKey(stale, DOWN).state.focusedRowId).toBe("ses_wt_web_working");
   });
 
   it("jumps to the next needs-attention or stuck row and wraps", () => {
     const first = handleTuiKey(state({ terminalRows: 12 }), NEXT_NEEDS_ME).state;
-    expect(first.focusedRowId).toBe("wt_web_attention");
+    expect(first.focusedRowId).toBe("ses_wt_web_attention");
 
     const second = handleTuiKey(first, NEXT_NEEDS_ME).state;
-    expect(second.focusedRowId).toBe("wt_web_stuck");
+    expect(second.focusedRowId).toBe("ses_wt_web_stuck");
     // The stuck row (item index 7) scrolled into the 5-row window.
-    expect(second.scrollOffset).toBe(3);
+    expect(second.scrollOffset).toBe(2);
 
     const wrapped = handleTuiKey(second, NEXT_NEEDS_ME).state;
-    expect(wrapped.focusedRowId).toBe("wt_web_attention");
+    expect(wrapped.focusedRowId).toBe("ses_wt_web_attention");
   });
 
   it("activates the focused row with return", () => {
@@ -187,13 +187,14 @@ describe("dashboard focus cursor", () => {
   });
 
   it("does not re-dispatch for a row whose start is already pending", () => {
-    const initial = state();
-    const items = selectDashboardItems(createDashboardSnapshot(), initial);
-    expect(items.some((item) => item.type === "worktree")).toBe(true);
+    const snapshot = createCommandSnapshot("none");
+    const initial = createInitialTuiState({ initialSnapshot: snapshot });
+    const items = selectDashboardItems(snapshot, initial);
+    expect(items.some((item) => item.type === "session")).toBe(true);
 
     const pending: TuiState = {
       ...initial,
-      focusedRowId: "wt_web_no_agent",
+      focusedRowId: "ses_wt_web_no_agent",
       localRows: {
         ...initial.localRows,
         pendingStart: [

--- a/packages/dashboard-core/test/unit/state/localRows.test.ts
+++ b/packages/dashboard-core/test/unit/state/localRows.test.ts
@@ -73,4 +73,24 @@ describe("TUI local rows", () => {
       pruneLocalRowsForSnapshot(localRows, createCommandSnapshot("none")).pendingStart,
     ).toEqual(localRows.pendingStart);
   });
+
+  it("prunes pending start-agent rows when the retained session disappears", () => {
+    const snapshot = createCommandSnapshot("none");
+    const localRows = {
+      ...createEmptyTuiLocalRows(),
+      pendingStart: [
+        {
+          localId: "start:wt_web_no_agent",
+          projectId: "web",
+          worktreeId: "wt_web_no_agent",
+          branch: "feature-start",
+          createdAt: "2026-06-01T12:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(
+      pruneLocalRowsForSnapshot(localRows, { ...snapshot, sessions: [] }).pendingStart,
+    ).toEqual([]);
+  });
 });

--- a/packages/dashboard-core/test/unit/state/screens/fork.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/fork.test.ts
@@ -139,7 +139,7 @@ describe("fork screen", () => {
     };
     const opened = openForkDetailsForRow(
       createInitialTuiState({ initialSnapshot: snapshot }),
-      "wt_web_idle",
+      "ses_wt_web_idle",
     );
     const screen = detailsScreen(opened);
     expect(screen.draftBranch.value).toBe("fix-nav-mobile-fork");

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -200,6 +200,18 @@ describe("TUI store", () => {
     ]);
   });
 
+  it("does not treat a retained no-agent session as completed start truth", async () => {
+    const snapshot = createCommandSnapshot("none");
+    const service = new FakeTuiObserverService(snapshot);
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.getState().handleKey({ input: "1" });
+
+    await waitFor(() => service.loadCount === 1);
+    expect(store.getState().localRows.pendingStart).toHaveLength(1);
+    expect(service.dispatched).toEqual([expect.objectContaining({ type: "session.startAgent" })]);
+  });
+
   it("syncs terminal rows into view state and clamps dashboard scroll", () => {
     const snapshot = createDashboardSnapshot();
     const service = new FakeTuiObserverService(snapshot);

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -4,6 +4,7 @@ import {
   handleTuiKey,
   openProjectDefaultAgentPicker,
   openRenameEditForRow,
+  selectDashboardViewport,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import {
@@ -47,7 +48,7 @@ describe("TUI screen transitions", () => {
     const base = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
     const withPending: typeof base = {
       ...base,
-      focusedRowId: "wt_api_working",
+      focusedRowId: "ses_wt_api_working",
       localRows: {
         ...base.localRows,
         pendingRemove: [
@@ -72,7 +73,7 @@ describe("TUI screen transitions", () => {
       initialSnapshot: createDashboardSnapshot(),
       collapsedProjectIds: ["api"],
     });
-    const state: typeof base = { ...base, focusedRowId: "wt_api_working" };
+    const state: typeof base = { ...base, focusedRowId: "ses_wt_api_working" };
     const opened = handleTuiKey(state, { input: "X" }).state;
     const committed = handleTuiKey(opened, { input: "\r", return: true }).state;
     // The row is filtered out of view; ↵ must not act on a row the user cannot see.
@@ -101,7 +102,7 @@ describe("TUI screen transitions", () => {
       terminalRows: 10,
     });
 
-    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(8);
+    expect(handleTuiKey(state, { input: "", mouseScroll: "down" }).state.scrollOffset).toBe(7);
     expect(
       handleTuiKey({ ...state, scrollOffset: 0 }, { input: "", mouseScroll: "up" }).state
         .scrollOffset,
@@ -205,14 +206,57 @@ describe("TUI screen transitions", () => {
     expect(transition.state.localRows.pendingStart).toEqual([]);
   });
 
+  it("focuses the exact external session when a checkout has mixed membership", () => {
+    const external = createExternalAgentSnapshot();
+    const retained = createDashboardSnapshot().sessions.find(
+      (session) => session.worktreeId === "wt_web_idle",
+    );
+    const externalSession = external.sessions.find(
+      (session) => session.worktreeId === "wt_web_idle",
+    );
+    if (retained === undefined || externalSession === undefined) {
+      throw new Error("missing mixed-membership fixture sessions");
+    }
+    const focusableExternal = {
+      ...externalSession,
+      terminal: {
+        provider: "tmux",
+        state: "open" as const,
+        focusable: true,
+        closeable: true,
+      },
+    };
+    const snapshot = {
+      ...external,
+      sessions: [
+        retained,
+        ...external.sessions.map((session) =>
+          session.id === externalSession.id ? focusableExternal : session,
+        ),
+      ],
+    };
+    const state = createInitialTuiState({ initialSnapshot: snapshot });
+    const choice = selectDashboardViewport(snapshot, state).rowChoices.find(
+      (candidate) => candidate.value.id === externalSession.id,
+    );
+    if (choice === undefined) throw new Error("external session must be selectable");
+
+    const transition = handleTuiKey(state, { input: choice.key });
+
+    expect(transition.operations).toBeUndefined();
+    expect(transition.commands).toEqual([
+      { type: "terminal.focus", payload: { sessionId: externalSession.id } },
+    ]);
+  });
+
   it("shows a notice instead of dispatching focus when the agent's terminal is not focusable", () => {
     const base = createCommandSnapshot("idle");
     const snapshot = {
       ...base,
-      rows: base.rows.map((row) =>
-        row.agent === undefined || row.terminal === undefined
-          ? row
-          : { ...row, terminal: { ...row.terminal, focusable: false } },
+      sessions: base.sessions.map((session) =>
+        session.terminal === undefined
+          ? session
+          : { ...session, terminal: { ...session.terminal, focusable: false } },
       ),
     };
     const transition = handleTuiKey(createInitialTuiState({ initialSnapshot: snapshot }), {
@@ -258,12 +302,12 @@ describe("TUI screen transitions", () => {
       createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
       { input: "X" },
     );
-    const transition = handleTuiKey(opened.state, { input: "5" });
+    const transition = handleTuiKey(opened.state, { input: "4" });
 
     expect(transition.state.screen).toEqual({
       name: "removeWorktree",
       step: "confirm",
-      rowId: "wt_web_idle",
+      rowId: "ses_wt_web_idle",
       forceRequired: true,
       label: "fix-nav-mobile",
     });
@@ -272,7 +316,7 @@ describe("TUI screen transitions", () => {
   it("opens removal information without dispatching for an external unstoppable agent", () => {
     const snapshot = createExternalAgentSnapshot();
     const state = createInitialTuiState({ initialSnapshot: snapshot });
-    const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "5" });
+    const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "4" });
 
     expect(opened.state.screen).toEqual({
       name: "removeWorktree",
@@ -312,27 +356,27 @@ describe("TUI screen transitions", () => {
     };
     const withTerminalStop = {
       ...stoppableSnapshot,
-      rows: stoppableSnapshot.rows.map((row) =>
-        row.id === "wt_web_idle"
+      sessions: stoppableSnapshot.sessions.map((session) =>
+        session.id === "run_wt_web_idle"
           ? {
-              ...row,
+              ...session,
               terminal: {
                 provider: "tmux",
                 state: "open" as const,
                 closeable: true,
               },
             }
-          : row,
+          : session,
       ),
     };
 
     for (const snapshot of [withProviderStop, withTerminalStop]) {
       const state = createInitialTuiState({ initialSnapshot: snapshot });
-      const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "5" });
+      const opened = handleTuiKey(handleTuiKey(state, { input: "X" }).state, { input: "4" });
       expect(opened.state.screen).toMatchObject({
         name: "removeWorktree",
         step: "confirm",
-        rowId: "wt_web_idle",
+        rowId: "run_wt_web_idle",
       });
     }
   });
@@ -342,7 +386,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "X",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
 
     const transition = handleTuiKey(state, { input: "y" });
@@ -388,7 +432,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: { ...snapshot, rows } }), {
         input: "X",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
 
     const transition = handleTuiKey(state, { input: "y" });
@@ -422,7 +466,7 @@ describe("TUI screen transitions", () => {
     expect(transition.state.screen).toMatchObject({
       name: "removeWorktree",
       step: "confirm",
-      rowId: "wt_web_attention",
+      rowId: "ses_wt_web_attention",
     });
   });
 
@@ -446,7 +490,7 @@ describe("TUI screen transitions", () => {
     expect(transition.state.screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      rowId: "wt_web_attention",
+      rowId: "ses_wt_web_attention",
       sessionId: "ses_wt_web_attention",
       currentTitle: "checkout-copy",
     });
@@ -467,41 +511,36 @@ describe("TUI screen transitions", () => {
     expect(transition.state.scrollOffset).toBe(1);
   });
 
-  it("shows an error toast when the picked rename row has no session", () => {
-    const opened = handleTuiKey(
-      createInitialTuiState({ initialSnapshot: createCommandSnapshot("none") }),
-      { input: "R" },
-    );
+  it("does not offer a rename slot for a bare worktree", () => {
+    const base = createDashboardSnapshot();
+    const bare = base.rows.filter((row) => row.id === "wt_web_no_agent");
+    const snapshot = { ...base, rows: bare, sessions: [] };
+    const opened = handleTuiKey(createInitialTuiState({ initialSnapshot: snapshot }), {
+      input: "R",
+    });
 
     const transition = handleTuiKey(opened.state, { input: "1" });
 
     expect(transition.state.screen).toEqual({ name: "renameSession", step: "chooseSlot" });
-    expect(transition.state.toasts).toEqual([
-      expect.objectContaining({
-        toast: expect.objectContaining({
-          kind: "error",
-          message: "No session exists for that row.",
-        }),
-      }),
-    ]);
+    expect(transition.state.toasts).toEqual([]);
   });
 
   it("opens the rename editor directly for a dashboard row", () => {
     const state = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
 
-    const next = openRenameEditForRow(state, "wt_web_idle");
+    const next = openRenameEditForRow(state, "ses_wt_web_idle");
 
     expect(next.screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      rowId: "wt_web_idle",
+      rowId: "ses_wt_web_idle",
       sessionId: "ses_wt_web_idle",
       currentTitle: "fix-nav-mobile",
     });
   });
 
   it("guards direct rename open for stale, no-session, and unrelated screens", () => {
-    const dashboard = createInitialTuiState({ initialSnapshot: createCommandSnapshot("none") });
+    const dashboard = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
     expect(openRenameEditForRow(dashboard, "missing")).toBe(dashboard);
     expect(openRenameEditForRow(dashboard, "wt_web_no_agent")).toBe(dashboard);
 
@@ -509,13 +548,13 @@ describe("TUI screen transitions", () => {
       ...createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
       screen: { name: "search", value: "" } as const,
     };
-    expect(openRenameEditForRow(search, "wt_web_idle")).toBe(search);
+    expect(openRenameEditForRow(search, "ses_wt_web_idle")).toBe(search);
   });
 
   it("does not open rename for external session membership", () => {
     const state = createInitialTuiState({ initialSnapshot: createExternalAgentSnapshot() });
 
-    expect(openRenameEditForRow(state, "wt_web_idle")).toBe(state);
+    expect(openRenameEditForRow(state, "run_wt_web_idle")).toBe(state);
   });
 
   it("edits the rename draft at the cursor position", () => {
@@ -523,7 +562,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
     const left = handleTuiKey(opened, { input: "", leftArrow: true }).state;
     const inserted = handleTuiKey(left, { input: "!" }).state;
@@ -541,7 +580,7 @@ describe("TUI screen transitions", () => {
   it("lets direct rename flows skip back to the dashboard on escape", () => {
     const opened = openRenameEditForRow(
       createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
-      "wt_web_idle",
+      "ses_wt_web_idle",
       { returnTo: "dashboard" },
     );
 
@@ -550,7 +589,7 @@ describe("TUI screen transitions", () => {
     expect(opened.screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      rowId: "wt_web_idle",
+      rowId: "ses_wt_web_idle",
       returnTo: "dashboard",
     });
     expect(transition.state.screen).toEqual({ name: "dashboard" });
@@ -561,7 +600,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
     if (opened.screen.name !== "renameSession" || opened.screen.step !== "editName") {
       throw new Error("expected rename edit screen");
@@ -589,7 +628,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
     if (opened.screen.name !== "renameSession" || opened.screen.step !== "editName") {
       throw new Error("expected rename edit screen");
@@ -623,7 +662,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
 
     const transition = handleTuiKey(state, { input: "\r", return: true });
@@ -637,7 +676,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
 
     const typed = " updated"
@@ -675,7 +714,7 @@ describe("TUI screen transitions", () => {
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "X",
       }).state,
-      { input: "5" },
+      { input: "4" },
     ).state;
 
     const transition = handleTuiKey(state, key);

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
+import type { StationSnapshot } from "@station/contracts";
 import type { TopRowWidgetRuntimeDeps, TuiConfig } from "@station/dashboard-core/widgets/types";
 import type { StationMouseEvent } from "../input/mouse.js";
 import { createStation, StationApp } from "./createStation.js";
@@ -14,7 +15,11 @@ import type { StationLayoutSnapshot } from "../state/layout/layoutSnapshot.js";
 import { agentWorktreePaneId, MAIN_PANE_ID, STATION_OVERLAY_ID } from "../state/types.js";
 import { createScriptedTerminal } from "../terminal/testing/scriptedTerminal.js";
 import { waitFor } from "../terminal/testing/waitFor.js";
-import { manyProjectsSnapshot, noProjectsSnapshot } from "../station/fixtures/scenarios.js";
+import {
+  attentionAndFailuresSnapshot,
+  manyProjectsSnapshot,
+  noProjectsSnapshot,
+} from "../station/fixtures/scenarios.js";
 import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
 import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
 import { createStationStubObserverService } from "../station/store/stubObserverService.js";
@@ -129,6 +134,41 @@ describe("Station app composition", () => {
     await waitFor(
       () => station.composition.stationViewStore.getState().focusedRowId === "ses_wt_station_idle",
     );
+  });
+
+  it("opens the attention dashboard instead of focusing another session in the same worktree", async () => {
+    const base = attentionAndFailuresSnapshot();
+    const flagged = base.sessions.find((session) => session.status.value === "needs_attention");
+    const local = base.sessions.find((session) => session.status.value === "working");
+    if (flagged === undefined || local === undefined) {
+      throw new Error("fixture is expected to contain attention and working sessions");
+    }
+    const snapshot: StationSnapshot = {
+      ...base,
+      sessions: base.sessions.map((session) =>
+        session.id === local.id
+          ? {
+              ...session,
+              projectId: flagged.projectId,
+              worktreeId: flagged.worktreeId,
+            }
+          : session,
+      ),
+    };
+    const station = await renderComposedStation({ snapshot });
+    const paneId = agentWorktreePaneId(flagged.worktreeId);
+    station.store.actions.createPane(paneId, { role: "primary-agent" });
+    station.store.actions.setPrimaryAgent(paneId, {
+      sessionId: local.id,
+      terminalTargetId: `native:${flagged.worktreeId}`,
+    });
+    station.store.actions.focusPane(MAIN_PANE_ID);
+    await waitForFrame(station, (frame) => frame.includes("!!!!"));
+
+    await station.setup.mockMouse.click(SURFACE.width - 1, 0, MouseButtons.LEFT);
+
+    await waitFor(() => overlayVisible(station));
+    expect(station.store.getState().workspace.activePaneId).toBe(MAIN_PANE_ID);
   });
 
   it("renders configured widgets in the Station overlay header", async () => {
@@ -582,11 +622,12 @@ async function renderComposedStation(options: {
   tuiConfig?: TuiConfig;
   topRowWidgetDeps?: TopRowWidgetRuntimeDeps;
   boot?: "empty";
+  snapshot?: StationSnapshot;
 } = {}) {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
   const store =
     options?.boot === "empty" ? createStationStore({ boot: "empty" }) : createStationStore();
-  const source = new TrackingStationSource(manyProjectsSnapshot());
+  const source = new TrackingStationSource(options.snapshot ?? manyProjectsSnapshot());
   const scripted = createScriptedTerminal();
   const shutdowns: number[] = [];
   let spawnCount = 0;

--- a/station/src/app/StationApp.test.tsx
+++ b/station/src/app/StationApp.test.tsx
@@ -116,7 +116,7 @@ describe("Station app composition", () => {
     station.store.actions.focusPane(firstPaneId);
     station.setup.mockInput.pressKey("o", { ctrl: true });
     await waitFor(
-      () => station.composition.stationViewStore.getState().focusedRowId === "wt_station_working",
+      () => station.composition.stationViewStore.getState().focusedRowId === "ses_wt_station_working",
     );
 
     station.setup.mockInput.pressKey("o", { ctrl: true });
@@ -127,7 +127,7 @@ describe("Station app composition", () => {
     station.store.actions.focusPane(secondPaneId);
     station.setup.mockInput.pressKey("o", { ctrl: true });
     await waitFor(
-      () => station.composition.stationViewStore.getState().focusedRowId === "wt_station_idle",
+      () => station.composition.stationViewStore.getState().focusedRowId === "ses_wt_station_idle",
     );
   });
 
@@ -250,7 +250,7 @@ describe("Station app composition", () => {
     expect(station.spawnCount()).toBe(0);
 
     station.composition.stationInput.dispatchMouse(
-      { kind: "station", target: { kind: "openShellForRow", rowId: "wt_station_idle" } },
+      { kind: "station", target: { kind: "openShellForRow", rowId: "ses_wt_station_idle" } },
       LEFT_DOWN,
     );
     await waitFor(() => station.store.getState().workspace.panes.length === 1);

--- a/station/src/contextMenu/items.test.ts
+++ b/station/src/contextMenu/items.test.ts
@@ -9,6 +9,8 @@ import {
 import type { Automation } from "../config/stationConfig.js";
 import { buildContextMenuItems, resolveContextMenuAction } from "./items.js";
 
+const STATION_IDLE_SESSION_ID = "ses_wt_station_idle";
+
 describe("buildContextMenuItems", () => {
   it("builds pane menu items with split actions enabled", () => {
     const store = createStationStore();
@@ -146,7 +148,7 @@ describe("buildContextMenuItems", () => {
 
     expect(
       buildContextMenuItems(
-        { kind: "station", target: { kind: "row", rowId: "wt_station_idle" } },
+        { kind: "station", target: { kind: "row", rowId: STATION_IDLE_SESSION_ID } },
         store.getState(),
         stationState,
       ),
@@ -154,43 +156,68 @@ describe("buildContextMenuItems", () => {
       {
         id: "station.renameSession",
         label: "Rename Session",
-        action: { kind: "renameSession", rowId: "wt_station_idle" },
+        action: { kind: "renameSession", rowId: STATION_IDLE_SESSION_ID },
       },
       {
         id: "station.forkSession",
         label: "Fork Session",
-        action: { kind: "forkSession", rowId: "wt_station_idle" },
+        action: { kind: "forkSession", rowId: STATION_IDLE_SESSION_ID },
       },
       {
         id: "station.removeWorktree",
         label: "Delete Session",
         danger: true,
-        action: { kind: "removeWorktree", rowId: "wt_station_idle" },
+        action: { kind: "removeWorktree", rowId: STATION_IDLE_SESSION_ID },
       },
     ]);
   });
 
-  it("offers remove-worktree for rows without a current session", () => {
+  it("keeps retained Station sessions actionable without a current agent", () => {
     const store = createStationStore();
     const stationState = createInitialTuiState({ initialSnapshot: manyProjectsSnapshot() });
 
     expect(
       buildContextMenuItems(
-        { kind: "station", target: { kind: "row", rowId: "wt_station_none" } },
+        { kind: "station", target: { kind: "row", rowId: "ses_wt_station_none" } },
         store.getState(),
         stationState,
       ),
     ).toEqual([
       {
+        id: "station.renameSession",
+        label: "Rename Session",
+        action: { kind: "renameSession", rowId: "ses_wt_station_none" },
+      },
+      {
         id: "station.forkSession",
         label: "Fork Session",
-        action: { kind: "forkSession", rowId: "wt_station_none" },
+        action: { kind: "forkSession", rowId: "ses_wt_station_none" },
       },
       {
         id: "station.removeWorktree",
         label: "Delete Session",
         danger: true,
-        action: { kind: "removeWorktree", rowId: "wt_station_none" },
+        action: { kind: "removeWorktree", rowId: "ses_wt_station_none" },
+      },
+    ]);
+  });
+
+  it("keeps bare worktrees out of dashboard row actions", () => {
+    const store = createStationStore();
+    const stationState = createInitialTuiState({ initialSnapshot: manyProjectsSnapshot() });
+
+    expect(
+      buildContextMenuItems(
+        { kind: "station", target: { kind: "row", rowId: "wt_scripts_none" } },
+        store.getState(),
+        stationState,
+      ),
+    ).toEqual([
+      {
+        id: "station.noActions",
+        label: "No Actions Available",
+        disabled: true,
+        action: { kind: "noop" },
       },
     ]);
   });
@@ -200,7 +227,7 @@ describe("buildContextMenuItems", () => {
     const stationState = createInitialTuiState({ initialSnapshot: externalAgentSnapshot() });
 
     const items = buildContextMenuItems(
-      { kind: "station", target: { kind: "row", rowId: "wt_station_idle" } },
+      { kind: "station", target: { kind: "row", rowId: "run_wt_station_idle" } },
       store.getState(),
       stationState,
     );
@@ -209,14 +236,47 @@ describe("buildContextMenuItems", () => {
       {
         id: "station.forkSession",
         label: "Fork Session",
-        action: { kind: "forkSession", rowId: "wt_station_idle" },
+        action: { kind: "forkSession", rowId: "run_wt_station_idle" },
       },
       {
         id: "station.removeWorktree",
         label: "Delete Worktree…",
         danger: true,
-        action: { kind: "removeWorktree", rowId: "wt_station_idle" },
+        action: { kind: "removeWorktree", rowId: "run_wt_station_idle" },
       },
+    ]);
+  });
+
+  it("keeps management actions session-specific when Station and external sessions share a checkout", () => {
+    const store = createStationStore();
+    const external = externalAgentSnapshot();
+    const retained = manyProjectsSnapshot().sessions.find(
+      (session) => session.id === STATION_IDLE_SESSION_ID,
+    );
+    if (retained === undefined) throw new Error("fixture is missing the retained Station session");
+    const stationState = createInitialTuiState({
+      initialSnapshot: { ...external, sessions: [retained, ...external.sessions] },
+    });
+
+    const stationItems = buildContextMenuItems(
+      { kind: "station", target: { kind: "row", rowId: retained.id } },
+      store.getState(),
+      stationState,
+    );
+    const externalItems = buildContextMenuItems(
+      { kind: "station", target: { kind: "row", rowId: "run_wt_station_idle" } },
+      store.getState(),
+      stationState,
+    );
+
+    expect(stationItems.map((item) => item.label)).toEqual([
+      "Rename Session",
+      "Fork Session",
+      "Delete Worktree…",
+    ]);
+    expect(externalItems.map((item) => item.label)).toEqual([
+      "Fork Session",
+      "Delete Worktree…",
     ]);
   });
 
@@ -236,7 +296,7 @@ describe("buildContextMenuItems", () => {
 
     expect(
       buildContextMenuItems(
-        { kind: "station", target: { kind: "row", rowId: "wt_station_idle" } },
+        { kind: "station", target: { kind: "row", rowId: STATION_IDLE_SESSION_ID } },
         store.getState(),
         stationState,
       ),
@@ -244,12 +304,12 @@ describe("buildContextMenuItems", () => {
       {
         id: "station.renameSession",
         label: "Rename Session",
-        action: { kind: "renameSession", rowId: "wt_station_idle" },
+        action: { kind: "renameSession", rowId: STATION_IDLE_SESSION_ID },
       },
       {
         id: "station.forkSession",
         label: "Fork Session",
-        action: { kind: "forkSession", rowId: "wt_station_idle" },
+        action: { kind: "forkSession", rowId: STATION_IDLE_SESSION_ID },
       },
     ]);
   });
@@ -259,7 +319,7 @@ describe("buildContextMenuItems", () => {
     const stationState = createInitialTuiState({ initialSnapshot: manyProjectsSnapshot() });
 
     for (const target of [
-      { kind: "openShellForRow", rowId: "wt_station_idle" } as const,
+      { kind: "openShellForRow", rowId: STATION_IDLE_SESSION_ID } as const,
       { kind: "body" } as const,
     ]) {
       expect(
@@ -300,7 +360,7 @@ describe("buildContextMenuItems", () => {
 
     expect(
       buildContextMenuItems(
-        { kind: "station", target: { kind: "row", rowId: "wt_station_idle" } },
+        { kind: "station", target: { kind: "row", rowId: STATION_IDLE_SESSION_ID } },
         store.getState(),
         stationState,
       )[0]?.disabled,

--- a/station/src/contextMenu/items.ts
+++ b/station/src/contextMenu/items.ts
@@ -4,7 +4,6 @@ import { MAIN_PANE_ID, worktreeIdFromAgentPaneId, type StationState } from "../s
 import {
   selectDashboardViewport,
   isExternalAgentRemovalUnavailable,
-  sessionForWorktreeRow,
   type TuiState,
 } from "@station/dashboard-core";
 import type {
@@ -115,9 +114,11 @@ function buildStationItems(
   if (row === undefined) {
     return [noActionsItem()];
   }
-  const project = state.snapshot.projects.find((candidate) => candidate.id === row.projectId);
+  const project = state.snapshot.projects.find(
+    (candidate) => candidate.id === row.worktree.projectId,
+  );
   const items: ContextMenuItem[] = [];
-  if (sessionForWorktreeRow(row, state.snapshot.sessions)?.origin === "station") {
+  if (row.session.origin === "station") {
     items.push({
       id: "station.renameSession",
       label: "Rename Session",
@@ -130,7 +131,7 @@ function buildStationItems(
     label: "Fork Session",
     action: { kind: "forkSession", rowId: row.id },
   });
-  if (project === undefined || !samePath(row.path, project.root)) {
+  if (project === undefined || !samePath(row.worktree.path, project.root)) {
     items.push({
       id: "station.removeWorktree",
       label: isExternalAgentRemovalUnavailable(row, state.snapshot)

--- a/station/src/input/keymap/stationBindings.ts
+++ b/station/src/input/keymap/stationBindings.ts
@@ -4,7 +4,7 @@ import { selectPaneRecord } from "../../state/selectors.js";
 import { createStationOverlayLayer } from "../../station/input/stationOverlayLayer.js";
 import { routeStationMouse } from "../../station/input/stationMouse.js";
 import { rowNeedsUser } from "../../stationButton/status.js";
-import type { TuiStore } from "@station/dashboard-core";
+import { selectDashboardSessionRows, type TuiStore } from "@station/dashboard-core";
 import { createKeymapStack, type KeymapLayer, type KeymapStack } from "./keymaps.js";
 import {
   paneLaunchForkSessionOutcome,
@@ -139,7 +139,12 @@ const contextMenuLayer: KeymapLayer<RouteOutcome> = {
 function createStationButtonLayer(
   stationViewStore: StoreApi<TuiStore>,
 ): KeymapLayer<RouteOutcome> {
-  const attentionRow = () => stationViewStore.getState().snapshot?.rows.find(rowNeedsUser);
+  const attentionRow = () => {
+    const snapshot = stationViewStore.getState().snapshot;
+    return snapshot === undefined
+      ? undefined
+      : selectDashboardSessionRows(snapshot).find((row) => rowNeedsUser(row.presentation));
+  };
   return {
     id: "station-button",
     isActive: (state) =>
@@ -156,8 +161,12 @@ function createStationButtonLayer(
           }
           // Mirror the island's click: focus the flagged session's live agent
           // pane, else open the dashboard so the user can act on it.
-          const paneId = agentWorktreePaneId(row.id);
-          if (selectPaneRecord(state, paneId)?.role === "primary-agent") {
+          const paneId = agentWorktreePaneId(row.worktree.id);
+          const pane = selectPaneRecord(state, paneId);
+          if (
+            pane?.role === "primary-agent" &&
+            pane.agentIdentity?.sessionId === row.session.id
+          ) {
             return { kind: "focus", target: { kind: "pane", paneId } };
           }
           return { kind: "overlay-open", overlayId: STATION_OVERLAY_ID };

--- a/station/src/input/router.test.ts
+++ b/station/src/input/router.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createTuiStore } from "@station/dashboard-core";
+import { createTuiStore, selectDashboardSessionRows } from "@station/dashboard-core";
 import type { StationSnapshot } from "@station/contracts";
 import {
   attentionAndFailuresSnapshot,
@@ -350,16 +350,16 @@ describe("the station-button layer (island ↵ jump)", () => {
     return createStationKeymap(stationViewStore);
   }
 
-  function flaggedRowId(snapshot: StationSnapshot): string {
-    const row = snapshot.rows.find(
+  function flaggedSession(snapshot: StationSnapshot) {
+    const row = selectDashboardSessionRows(snapshot).find(
       (candidate) =>
-        candidate.display.statusLabel === "needs attention" ||
-        candidate.display.statusLabel === "stuck",
+        candidate.session.status.value === "needs_attention" ||
+        candidate.session.status.value === "stuck",
     );
     if (row === undefined) {
-      throw new Error("fixture is expected to contain a flagged row");
+      throw new Error("fixture is expected to contain a flagged session");
     }
-    return row.id;
+    return row;
   }
 
   it("opens the overlay on ↵ while hovering the alerting island with no local agent pane", () => {
@@ -374,13 +374,52 @@ describe("the station-button layer (island ↵ jump)", () => {
 
   it("focuses the flagged session's agent pane on ↵ when it is hosted locally", () => {
     const snapshot = attentionAndFailuresSnapshot();
-    const paneId = agentWorktreePaneId(flaggedRowId(snapshot));
+    const flagged = flaggedSession(snapshot);
+    const paneId = agentWorktreePaneId(flagged.worktree.id);
     const store = createStationStore();
     store.actions.createPane(paneId, { role: "primary-agent" });
+    store.actions.setPrimaryAgent(paneId, {
+      sessionId: flagged.session.id,
+      terminalTargetId: `native:${flagged.worktree.id}`,
+    });
     store.actions.setStationButtonHover(true);
     expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
       kind: "focus",
       target: { kind: "pane", paneId },
+    });
+  });
+
+  it("opens the overlay instead of focusing another session in the same worktree", () => {
+    const base = attentionAndFailuresSnapshot();
+    const flagged = flaggedSession(base);
+    const local = base.sessions.find((session) => session.status.value === "working");
+    if (local === undefined) {
+      throw new Error("fixture is expected to contain a working session");
+    }
+    const snapshot: StationSnapshot = {
+      ...base,
+      sessions: base.sessions.map((session) =>
+        session.id === local.id
+          ? {
+              ...session,
+              projectId: flagged.session.projectId,
+              worktreeId: flagged.worktree.id,
+            }
+          : session,
+      ),
+    };
+    const paneId = agentWorktreePaneId(flagged.worktree.id);
+    const store = createStationStore();
+    store.actions.createPane(paneId, { role: "primary-agent" });
+    store.actions.setPrimaryAgent(paneId, {
+      sessionId: local.id,
+      terminalTargetId: `native:${flagged.worktree.id}`,
+    });
+    store.actions.setStationButtonHover(true);
+
+    expect(routeKey("\r", store.getState(), keymapFor(snapshot))).toEqual({
+      kind: "overlay-open",
+      overlayId: STATION_OVERLAY_ID,
     });
   });
 

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -324,7 +324,7 @@ describe("createStationInputRuntime", () => {
     expect(stationViewStore.getState().screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      rowId: "wt_station_idle",
+      rowId: "ses_wt_station_idle",
       returnTo: "dashboard",
     });
 
@@ -658,8 +658,9 @@ describe("createStationInputRuntime", () => {
 
 describe("createStationInputRuntime open-pane wiring", () => {
   // wt_station_idle -> branch pty-buffer; the fixture derives both ids and path.
-  const ROW_ID = "wt_station_idle";
-  const PANE_ID = worktreePaneId(ROW_ID);
+  const WORKTREE_ID = "wt_station_idle";
+  const SESSION_ID = "ses_wt_station_idle";
+  const PANE_ID = worktreePaneId(WORKTREE_ID);
   const CWD = "/Users/example/.worktrees/station/pty-buffer";
 
   function paneHarness(options?: {
@@ -707,7 +708,7 @@ describe("createStationInputRuntime open-pane wiring", () => {
     });
     const clickRowAffordance = (): boolean =>
       runtime.dispatchMouse(
-        { kind: "station", target: { kind: "openShellForRow", rowId: ROW_ID } },
+        { kind: "station", target: { kind: "openShellForRow", rowId: SESSION_ID } },
         LEFT_DOWN,
       );
     return { runtime, store, calls, clickRowAffordance };
@@ -825,7 +826,7 @@ describe("createStationInputRuntime open-pane wiring", () => {
 
   it("opens a worktree shell as a split beside its primary agent pane", () => {
     const { store, calls, clickRowAffordance } = paneHarness();
-    const agentPaneId = agentWorktreePaneId(ROW_ID);
+    const agentPaneId = agentWorktreePaneId(WORKTREE_ID);
     store.actions.createPane(agentPaneId, { role: "primary-agent" });
     store.actions.setPrimaryAgent(agentPaneId, {
       sessionId: "ses_managed",
@@ -922,11 +923,11 @@ describe("createStationInputRuntime open-pane wiring", () => {
     store.subscribe(reconcile);
     reconcile();
     const runtime = createStationInputRuntime({ store, shutdown: () => {}, stationViewStore, registry });
-    const expectedCwd = snapshot.rows.find((row) => row.id === ROW_ID)?.path;
+    const expectedCwd = snapshot.rows.find((row) => row.id === WORKTREE_ID)?.path;
 
     store.actions.openOverlay(STATION_OVERLAY_ID);
     runtime.dispatchMouse(
-      { kind: "station", target: { kind: "openShellForRow", rowId: ROW_ID } },
+      { kind: "station", target: { kind: "openShellForRow", rowId: SESSION_ID } },
       LEFT_DOWN,
     );
     // Lazy spawn-on-first-resize: the shell starts here, at the cwd that must
@@ -955,7 +956,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
       stationViewStore,
     });
     store.actions.openOverlay(STATION_OVERLAY_ID);
-    const rightClickRow = (rowId = "wt_station_idle"): boolean =>
+    const rightClickRow = (rowId = "ses_wt_station_idle"): boolean =>
       runtime.dispatchMouse({ kind: "station", target: { kind: "row", rowId } }, RIGHT_DOWN);
     return { runtime, store, stationViewStore, rightClickRow };
   }
@@ -970,7 +971,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     expect(stationViewStore.getState().screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      rowId: "wt_station_idle",
+      rowId: "ses_wt_station_idle",
       sessionId: "ses_wt_station_idle",
       currentTitle: "pty-buffer",
     });
@@ -1006,7 +1007,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
     expect(stationViewStore.getState().screen).toEqual({
       name: "removeWorktree",
       step: "confirm",
-      rowId: "wt_station_idle",
+      rowId: "ses_wt_station_idle",
       forceRequired: true,
       label: "pty-buffer",
     });
@@ -1017,7 +1018,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
       externalAgentSnapshot(),
     );
 
-    rightClickRow();
+    rightClickRow("run_wt_station_idle");
     // Menu order: Fork, Delete Worktree… — one down reaches the informational action.
     runtime.handleSequence("\x1b[B");
     runtime.handleSequence("\r");
@@ -1111,10 +1112,11 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
   // Same fixture row as the shell wiring suite (wt_station_idle, branch pty-buffer,
   // project station), but the agent lands in the distinct agent pane id, not the
   // [+sh] shell pane. The launch command/args/env come from the observer's plan.
-  const ROW_ID = "wt_station_idle";
-  const AGENT_PANE_ID = agentWorktreePaneId(ROW_ID);
+  const WORKTREE_ID = "wt_station_idle";
+  const ROW_ID = "ses_wt_station_idle";
+  const AGENT_PANE_ID = agentWorktreePaneId(WORKTREE_ID);
   const CWD = "/Users/example/.worktrees/station/pty-buffer";
-  const TERMINAL_TARGET_ID = `native:${ROW_ID}`;
+  const TERMINAL_TARGET_ID = `native:${WORKTREE_ID}`;
 
   function preparedPlan(): AgentPrepareExternalLaunchResult {
     return {
@@ -1218,10 +1220,19 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     return {
       ...snapshot,
       rows: snapshot.rows.map((row): WorktreeRow => {
-        if (row.id !== ROW_ID || row.terminal === undefined) {
+        if (row.id !== WORKTREE_ID || row.terminal === undefined) {
           return row;
         }
         return { ...row, terminal: { ...row.terminal, provider: "native", ...terminalOverrides } };
+      }),
+      sessions: snapshot.sessions.map((session) => {
+        if (session.id !== ROW_ID || session.terminal === undefined) {
+          return session;
+        }
+        return {
+          ...session,
+          terminal: { ...session.terminal, provider: "native", ...terminalOverrides },
+        };
       }),
     };
   }
@@ -1230,7 +1241,7 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     return {
       ...snapshot,
       rows: snapshot.rows.map((row): WorktreeRow => {
-        if (row.id !== ROW_ID || row.agent === undefined) {
+        if (row.id !== WORKTREE_ID || row.agent === undefined) {
           return row;
         }
         return {
@@ -1272,7 +1283,9 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     expect(dispatch({ kind: "row", rowId: ROW_ID })).toBe(true);
     await settle();
 
-    expect(observerService.preparedLaunches).toEqual([{ projectId: "station", worktreeId: ROW_ID }]);
+    expect(observerService.preparedLaunches).toEqual([
+      { projectId: "station", worktreeId: WORKTREE_ID },
+    ]);
     // Order is load-bearing: ensure (with the observer's plan) → createPane → setPrimaryAgent.
     expect(calls).toEqual([
       `ensure:${AGENT_PANE_ID}:${CWD}:codex:--exec`,
@@ -1301,7 +1314,9 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     expect(pressKey(slotKeyFor(stationViewStore))).toBe(true);
     await settle();
 
-    expect(observerService.preparedLaunches).toEqual([{ projectId: "station", worktreeId: ROW_ID }]);
+    expect(observerService.preparedLaunches).toEqual([
+      { projectId: "station", worktreeId: WORKTREE_ID },
+    ]);
     expect(calls).toEqual([
       `ensure:${AGENT_PANE_ID}:${CWD}:codex:--exec`,
       `createPane:${AGENT_PANE_ID}:primary-agent`,
@@ -1463,9 +1478,14 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     const snapshot: StationSnapshot = {
       ...base,
       rows: base.rows.map((row): WorktreeRow =>
-        row.id === ROW_ID && row.terminal !== undefined
+        row.id === WORKTREE_ID && row.terminal !== undefined
           ? { ...row, terminal: { ...row.terminal, state: "detached" } }
           : row,
+      ),
+      sessions: base.sessions.map((session) =>
+        session.id === ROW_ID && session.terminal !== undefined
+          ? { ...session, terminal: { ...session.terminal, state: "detached" } }
+          : session,
       ),
     };
     const { store, calls, dispatch, settle, observerService, stationViewStore } = agentHarness(
@@ -1662,7 +1682,7 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
 
     expect(dispatch({ kind: "openShellForRow", rowId: ROW_ID })).toBe(true);
 
-    const shellPaneId = worktreePaneId(ROW_ID);
+    const shellPaneId = worktreePaneId(WORKTREE_ID);
     // No command/args seeded (default shell), role shell, and no observer prepare.
     expect(calls).toEqual([`ensure:${shellPaneId}:${CWD}::`, `createPane:${shellPaneId}:shell`]);
     expect(store.getState().workspace.panes.find((pane) => pane.id === shellPaneId)?.role).toEqual(

--- a/station/src/state/reconcilers/overlayRowFocus.test.ts
+++ b/station/src/state/reconcilers/overlayRowFocus.test.ts
@@ -29,7 +29,7 @@ describe("createOverlayRowFocusReconciler", () => {
 
       stationStore.actions.openOverlay(STATION_OVERLAY_ID);
 
-      expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+      expect(stationViewStore.getState().focusedRowId).toBe(FIRST_SESSION_ID);
       dispose();
     }
   });
@@ -72,7 +72,7 @@ describe("createOverlayRowFocusReconciler", () => {
       const stationStore = createStationStore({ boot: "empty" });
       arrangePane(stationStore);
       const stationViewStore = loadedViewStore();
-      stationViewStore.setState({ focusedRowId: SECOND_ROW_ID, scrollOffset: 2 });
+      stationViewStore.setState({ focusedRowId: SECOND_SESSION_ID, scrollOffset: 2 });
       const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
 
       stationStore.actions.openOverlay(STATION_OVERLAY_ID);
@@ -92,14 +92,14 @@ describe("createOverlayRowFocusReconciler", () => {
     const dispose = createOverlayRowFocusReconciler(stationStore, stationViewStore);
 
     stationStore.actions.openOverlay(STATION_OVERLAY_ID);
-    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_SESSION_ID);
 
     stationStore.actions.closeOverlay();
     expect("focusedRowId" in stationViewStore.getState()).toBe(false);
 
     stationStore.actions.focusPane("pane-second");
     stationStore.actions.openOverlay(STATION_OVERLAY_ID);
-    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_ROW_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_SESSION_ID);
     dispose();
   });
 
@@ -113,11 +113,11 @@ describe("createOverlayRowFocusReconciler", () => {
 
     const firstSnapshot = manyProjectsSnapshot();
     stationViewStore.setState({ snapshot: firstSnapshot, loading: false });
-    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_ROW_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(FIRST_SESSION_ID);
 
     stationViewStore.getState().handleKey({ input: "", downArrow: true });
     const navigatedRowId = stationViewStore.getState().focusedRowId;
-    expect(navigatedRowId).not.toBe(FIRST_ROW_ID);
+    expect(navigatedRowId).not.toBe(FIRST_SESSION_ID);
 
     stationViewStore.setState(scrollDashboard(stationViewStore.getState(), 1));
     const scrolledOffset = stationViewStore.getState().scrollOffset;
@@ -159,9 +159,9 @@ describe("createOverlayRowFocusReconciler", () => {
     stationViewStore.setState({ snapshot: manyProjectsSnapshot(), loading: false });
     expect("focusedRowId" in stationViewStore.getState()).toBe(false);
 
-    stationViewStore.setState({ focusedRowId: SECOND_ROW_ID });
+    stationViewStore.setState({ focusedRowId: SECOND_SESSION_ID });
     stationStore.actions.closeOverlay();
-    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_ROW_ID);
+    expect(stationViewStore.getState().focusedRowId).toBe(SECOND_SESSION_ID);
   });
 });
 

--- a/station/src/station/StationOverlay.test.tsx
+++ b/station/src/station/StationOverlay.test.tsx
@@ -105,7 +105,7 @@ describe("StationOverlay", () => {
 
     expect(calls.at(-1)?.target).toEqual({
       kind: "station",
-      target: { kind: "row", rowId: "wt_station_working" },
+      target: { kind: "row", rowId: "ses_wt_station_working" },
     });
   });
 });

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -88,6 +88,7 @@ export function manyProjectsSnapshot(): StationSnapshot {
     ],
     {
       projects: [STATION, OBSERVER, SCRIPTS, EMPTY],
+      retainedSessionWorktreeIds: ["wt_station_none"],
       alerts: [
         {
           id: "alert_station_mock",
@@ -343,15 +344,21 @@ function scenarioChecks(
 
 type SnapshotExtras = {
   projects: readonly ScenarioProject[];
+  retainedSessionWorktreeIds?: readonly string[];
   providerHealth?: Record<string, ProviderHealth>;
   alerts?: StationSnapshot["alerts"];
 };
 
 function snapshotFromRows(rows: WorktreeRow[], extras: SnapshotExtras): StationSnapshot {
-  const projects = extras.projects.map((project) => projectView(project, rows));
+  const retainedSessionWorktreeIds = new Set(extras.retainedSessionWorktreeIds ?? []);
   const sessions = rows.flatMap((candidate) =>
-    candidate.agent?.sessionId === undefined ? [] : [sessionForRow(candidate)],
+    candidate.agent?.sessionId !== undefined
+      ? [sessionForRow(candidate)]
+      : retainedSessionWorktreeIds.has(candidate.id)
+        ? [retainedSessionForRow(candidate)]
+        : [],
   );
+  const projects = extras.projects.map((project) => projectView(project, rows, sessions));
   const counts = countsForRows(rows);
   return {
     schemaVersion: STATION_SCHEMA_VERSION,
@@ -379,12 +386,17 @@ function snapshotFromRows(rows: WorktreeRow[], extras: SnapshotExtras): StationS
     counts: {
       projects: projects.length,
       ...counts,
+      sessions: sessions.length,
     },
     alerts: extras.alerts ?? [],
   } satisfies StationSnapshot;
 }
 
-function projectView(project: ScenarioProject, rows: readonly WorktreeRow[]): ProjectView {
+function projectView(
+  project: ScenarioProject,
+  rows: readonly WorktreeRow[],
+  sessions: readonly SessionView[],
+): ProjectView {
   const projectRows = rows.filter((candidate) => candidate.projectId === project.id);
   return {
     id: project.id,
@@ -401,7 +413,10 @@ function projectView(project: ScenarioProject, rows: readonly WorktreeRow[]): Pr
       status: "healthy",
       lastCheckedAt: SCENARIO_NOW,
     },
-    counts: countsForRows(projectRows),
+    counts: {
+      ...countsForRows(projectRows),
+      sessions: sessions.filter((session) => session.projectId === project.id).length,
+    },
   };
 }
 
@@ -453,6 +468,42 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     },
     title: candidate.branch,
     tags: [candidate.agent.harness, candidate.terminal.provider],
+  };
+}
+
+function retainedSessionForRow(candidate: WorktreeRow): SessionView {
+  return {
+    id: `ses_${candidate.id}`,
+    origin: "station",
+    projectId: candidate.projectId,
+    worktreeId: candidate.id,
+    createdAt: "2026-06-12T11:59:00.000Z",
+    updatedAt: SCENARIO_NOW,
+    harness: {
+      provider: "codex",
+      mode: "interactive",
+      capabilities: {
+        canLaunch: true,
+        canDiscoverRuns: true,
+        canEmitEvents: true,
+        canClassifyStatus: true,
+        canReceivePrompt: false,
+        canResume: true,
+        canStop: true,
+        canRunNonInteractive: true,
+        canExposeApprovalState: true,
+        supportsModifiedEnterSoftNewline: true,
+      },
+    },
+    status: {
+      value: "none",
+      confidence: "high",
+      reason: "No harness run is associated with this session.",
+      source: "observer_command",
+      updatedAt: SCENARIO_NOW,
+    },
+    title: candidate.branch,
+    tags: [],
   };
 }
 

--- a/station/src/station/input/focusedRowActivate.test.ts
+++ b/station/src/station/input/focusedRowActivate.test.ts
@@ -47,15 +47,21 @@ describe("resolveKeyFocusedRowAgentTarget", () => {
     if (focusedRowId === undefined) {
       throw new Error("Expected a focused row.");
     }
+    const worktreeId = store
+      .getState()
+      .snapshot?.sessions.find((session) => session.id === focusedRowId)?.worktreeId;
+    if (worktreeId === undefined) {
+      throw new Error("Expected the focused session's worktree.");
+    }
     store.setState({
       localRows: {
         ...store.getState().localRows,
         pendingStart: [
           {
-            localId: `start:${focusedRowId}`,
+            localId: `start:${worktreeId}`,
             operation: "startAgent",
             projectId: "station",
-            worktreeId: focusedRowId,
+            worktreeId,
             branch: "station-overlay",
             createdAt: "2026-07-02T12:00:00.000Z",
           },

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -5,11 +5,11 @@
 // path in apps/tui (direct project-header collapse, wheel paging). Every
 // mutation here lands via store.handleKey or a shared pure state function — no
 // bespoke screen logic, except where a Station-only action diverges from the
-// shared machine: a worktree-row slot key (resolveKeyRowAgentTarget) and the New
+// shared machine: a session-row slot key (resolveKeyRowAgentTarget) and the New
 // Session submit (resolveKeyNewSessionSubmit) are resolved here so keyboard and
 // mouse reach the same Station managed-launch path.
 import type { StoreApi } from "zustand/vanilla";
-import type { ProviderId } from "@station/contracts";
+import { worktreeHasLiveAgent, type ProviderId } from "@station/contracts";
 import {
   choiceValueByKey,
   createNewSessionNameToken,
@@ -20,6 +20,7 @@ import {
   openWidgetSettings as openWidgetSettingsState,
   selectAddProjectRow as selectAddProjectRowState,
   selectDashboardItems,
+  selectDashboardSessionRow,
   selectDashboardViewport,
   widgetSettingsAddFromPicker,
   widgetSettingsOpenPicker,
@@ -113,7 +114,7 @@ export function representativeKeyForBinding(binding: StationBinding): TuiKey | u
 /**
  * Dispatches a row interaction as the row's current slot key, so a click
  * means exactly what the slot accelerator means in the active mode
- * (dashboard: start-or-focus; remove/rename choose-slot: choose this row).
+ * (dashboard: open session; remove/rename choose-slot: choose this row).
  * Rows without a slot (pending-operation rows) are inert.
  */
 export function dispatchRowSlot(store: StoreApi<TuiStore>, rowId: string): StationKeyOutcome {
@@ -168,13 +169,17 @@ export function resolveRowAgentTarget(store: StoreApi<TuiStore>, rowId: string):
   if (snapshot === undefined) {
     return { kind: "none" };
   }
-  const row = snapshot.rows.find((candidate) => candidate.id === rowId);
-  if (row === undefined) {
+  const sessionRow = selectDashboardSessionRow(snapshot, rowId);
+  if (sessionRow === undefined || sessionRow.session.origin !== "station") {
+    return { kind: "none" };
+  }
+  const row = sessionRow.worktree;
+  if (worktreeHasLiveAgent(row) && row.agent?.sessionId !== sessionRow.session.id) {
     return { kind: "none" };
   }
   return {
     kind: "launch-managed",
-    rowId: row.id,
+    rowId: sessionRow.id,
     projectId: row.projectId,
     worktreeId: row.id,
     paneId: agentWorktreePaneId(row.id),
@@ -221,11 +226,11 @@ export function resolveKeyFocusedRowAgentTarget(
     return { kind: "none" };
   }
   const item = selectDashboardItems(state.snapshot, state).find(
-    (candidate) => candidate.type === "worktree" && candidate.row.id === focusedRowId,
+    (candidate) => candidate.type === "session" && candidate.row.id === focusedRowId,
   );
   if (
     item === undefined ||
-    item.type !== "worktree" ||
+    item.type !== "session" ||
     item.pendingRemove !== undefined ||
     item.pendingStart !== undefined
   ) {
@@ -423,8 +428,8 @@ export function addWidgetSettingsPickerChoice(store: StoreApi<TuiStore>, index: 
 }
 
 /**
- * Resolve `[+sh]` from snapshot rows, not dashboard choices: pending-start/remove
- * rows still represent real worktrees even when `rowChoices` filters them out.
+ * Resolve `[shell]` through canonical dashboard membership while allowing a
+ * pending operation to hide the row from `rowChoices`.
  */
 export function resolveRowPaneTarget(
   store: StoreApi<TuiStore>,
@@ -434,10 +439,11 @@ export function resolveRowPaneTarget(
   if (snapshot === undefined) {
     return undefined;
   }
-  const row = snapshot.rows.find((candidate) => candidate.id === rowId);
-  if (row === undefined) {
+  const sessionRow = selectDashboardSessionRow(snapshot, rowId);
+  if (sessionRow === undefined) {
     return undefined;
   }
+  const row = sessionRow.worktree;
   return { paneId: worktreePaneId(row.id), cwd: row.path, role: "shell", worktreeId: row.id };
 }
 

--- a/station/src/station/input/stationKeymap.test.ts
+++ b/station/src/station/input/stationKeymap.test.ts
@@ -140,7 +140,7 @@ function representativeStates(): Record<StationInputMode, TuiState> {
     projectSettingsPicker: drive(base, [{ input: "P" }]),
     removeChooseSlot: drive(base, [{ input: "X" }]),
     removeConfirm: drive(base, [{ input: "X" }, { input: "1" }]),
-    removeUnavailable: openRemoveWorktreeConfirmForRow(externalBase, "wt_station_idle"),
+    removeUnavailable: openRemoveWorktreeConfirmForRow(externalBase, "run_wt_station_idle"),
     projectSettings: openProjectSettings(base, "station"),
     renameChooseSlot: drive(renameBase, [{ input: "R" }]),
     renameEdit: drive(renameBase, [{ input: "R" }, { input: "1" }]),

--- a/station/src/station/input/stationKeymap.ts
+++ b/station/src/station/input/stationKeymap.ts
@@ -113,7 +113,7 @@ export type StationBinding = {
   help?: { keys: string; label: string };
 };
 
-const slotHelp = { keys: "1-9 a-z", label: "start or focus visible row" };
+const slotHelp = { keys: "1-9 a-z", label: "open visible session" };
 
 /**
  * The cursor/edit key block shared by every single-field edit mode: arrow
@@ -333,7 +333,7 @@ export const STATION_HELP_CONTENT = [
   { key: "↵", description: "open focused session" },
   { key: "tab", description: "next session needing you" },
   { key: "wheel", description: "scroll project list" },
-  { key: "1-9/a-z", description: "start or focus row" },
+  { key: "1-9/a-z", description: "open visible session" },
   { key: "N/A/R/C/F/P", description: "new/add/rename/fold/fork/settings" },
   { key: "W", description: "widgets" },
   { key: "X", description: "delete session" },

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -76,7 +76,8 @@ function snapshotWithHarness(projectId: string, harness: string): StationSnapsho
 describe("routeStationMouse", () => {
   it("launches the row's primary agent (managed) on a dashboard row click", () => {
     const store = makeStore();
-    const rowId = "wt_station_idle";
+    const worktreeId = "wt_station_idle";
+    const rowId = `ses_${worktreeId}`;
 
     const outcome = routeStationMouse({ kind: "row", rowId }, LEFT_DOWN, store);
 
@@ -84,9 +85,9 @@ describe("routeStationMouse", () => {
       kind: "launch-managed",
       rowId,
       projectId: "station",
-      worktreeId: rowId,
-      paneId: agentWorktreePaneId(rowId),
-      cwd: rowPath(rowId),
+      worktreeId,
+      paneId: agentWorktreePaneId(worktreeId),
+      cwd: rowPath(worktreeId),
     });
     // The dashboard click no longer dispatches the start-or-focus slot key, so
     // no pending-start row is queued.
@@ -96,7 +97,11 @@ describe("routeStationMouse", () => {
   it("emits launch-managed regardless of harness (the observer resolves it)", () => {
     const store = makeStore(snapshotWithHarness("station", "ghost"));
 
-    const outcome = routeStationMouse({ kind: "row", rowId: "wt_station_idle" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "row", rowId: "ses_wt_station_idle" },
+      LEFT_DOWN,
+      store,
+    );
 
     expect(outcome).toMatchObject({ kind: "launch-managed", worktreeId: "wt_station_idle" });
     // No local toast: harness resolution (and any failure) is the observer's job now.
@@ -115,7 +120,7 @@ describe("routeStationMouse", () => {
   it("chooses the clicked row in remove mode, same as the slot key", () => {
     const clicked = makeStore();
     const keyed = makeStore();
-    const rowId = "wt_station_working";
+    const rowId = "ses_wt_station_working";
     clicked.getState().handleKey({ input: "X" });
     keyed.getState().handleKey({ input: "X" });
     const slot = slotForRow(keyed, rowId);
@@ -129,7 +134,8 @@ describe("routeStationMouse", () => {
 
   it("confirms remove with the sheet yes button", () => {
     const store = makeStore();
-    const rowId = "wt_station_working";
+    const worktreeId = "wt_station_working";
+    const rowId = `ses_${worktreeId}`;
     store.getState().handleKey({ input: "X" });
     store.getState().handleKey({ input: slotForRow(store, rowId) });
 
@@ -138,13 +144,13 @@ describe("routeStationMouse", () => {
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toEqual({ name: "dashboard" });
     expect(store.getState().localRows.pendingRemove).toMatchObject([
-      { localId: `remove:${rowId}`, worktreeId: rowId },
+      { localId: `remove:${worktreeId}`, worktreeId },
     ]);
   });
 
   it("cancels remove with the sheet no button", () => {
     const store = makeStore();
-    const rowId = "wt_station_working";
+    const rowId = "ses_wt_station_working";
     store.getState().handleKey({ input: "X" });
     store.getState().handleKey({ input: slotForRow(store, rowId) });
 
@@ -174,7 +180,7 @@ describe("routeStationMouse", () => {
   it("chooses the clicked row in fork mode, same as the slot key", () => {
     const clicked = makeStore();
     const keyed = makeStore();
-    const rowId = "wt_station_working";
+    const rowId = "ses_wt_station_working";
     clicked.getState().handleKey({ input: "F" });
     keyed.getState().handleKey({ input: "F" });
     const slot = slotForRow(keyed, rowId);
@@ -188,7 +194,8 @@ describe("routeStationMouse", () => {
 
   it("launches a fork from the sheet submit button", () => {
     const store = makeStore();
-    const rowId = "wt_station_working";
+    const worktreeId = "wt_station_working";
+    const rowId = `ses_${worktreeId}`;
     store.getState().handleKey({ input: "F" });
     store.getState().handleKey({ input: slotForRow(store, rowId) });
     expect(store.getState().screen).toMatchObject({ name: "fork", step: "details" });
@@ -198,7 +205,7 @@ describe("routeStationMouse", () => {
     expect(outcome.kind).toBe("launch-fork");
     if (outcome.kind === "launch-fork") {
       expect(outcome.projectId).toBe("station");
-      expect(outcome.sourceWorktreeId).toBe(rowId);
+      expect(outcome.sourceWorktreeId).toBe(worktreeId);
       expect(outcome.copyDirty).toBe(true);
       expect(outcome.branch.length).toBeGreaterThan(0);
     }
@@ -218,7 +225,11 @@ describe("routeStationMouse", () => {
     store.getState().handleKey({ input: "/" });
     const before = store.getState();
 
-    const outcome = routeStationMouse({ kind: "row", rowId: "wt_station_idle" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "row", rowId: "ses_wt_station_idle" },
+      LEFT_DOWN,
+      store,
+    );
 
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toEqual(before.screen);
@@ -358,7 +369,11 @@ describe("routeStationMouse", () => {
     const store = makeStore();
     // Derive cwd from the live snapshot, not a duplicated path literal, so the
     // assertion proves the resolver reads row.path (not some equivalent format).
-    const outcome = routeStationMouse({ kind: "openShellForRow", rowId: "wt_station_idle" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "openShellForRow", rowId: "ses_wt_station_idle" },
+      LEFT_DOWN,
+      store,
+    );
     expect(outcome).toEqual({
       kind: "open-pane",
       paneId: "pane-wt-wt_station_idle",
@@ -381,20 +396,21 @@ describe("routeStationMouse", () => {
 
   it("keeps [+sh] live on a worktree that has a pending agent start", () => {
     const store = makeStore();
-    const rowId = "wt_station_none";
+    const worktreeId = "wt_station_none";
+    const rowId = `ses_${worktreeId}`;
     // Put the row into a pending-start (transient) state via the start-or-focus
     // slot key: it drops out of rowChoices but still renders a clickable [+sh].
     // Opening a shell is orthogonal to agent activation, so the affordance must
-    // still resolve against snapshot.rows. (The dashboard *mouse* row-click now
-    // opens the primary agent, so the pending-start is driven by the keyboard.)
+    // still resolve the session's backing checkout. (The dashboard *mouse*
+    // row-click opens the primary agent, so keyboard drives the pending start.)
     store.getState().handleKey({ input: slotForRow(store, rowId) });
     const outcome = routeStationMouse({ kind: "openShellForRow", rowId }, LEFT_DOWN, store);
     expect(outcome).toEqual({
       kind: "open-pane",
-      paneId: `pane-wt-${rowId}`,
-      cwd: rowPath(rowId),
+      paneId: `pane-wt-${worktreeId}`,
+      cwd: rowPath(worktreeId),
       role: "shell",
-      worktreeId: rowId,
+      worktreeId,
     });
   });
 
@@ -402,7 +418,7 @@ describe("routeStationMouse", () => {
     const store = makeStore();
     store.getState().handleKey({ input: "/" }); // enter search (non-dashboard) mode
 
-    expect(routeStationMouse({ kind: "openShellForRow", rowId: "wt_station_idle" }, LEFT_DOWN, store)).toEqual({
+    expect(routeStationMouse({ kind: "openShellForRow", rowId: "ses_wt_station_idle" }, LEFT_DOWN, store)).toEqual({
       kind: "handled",
     });
     expect(
@@ -577,7 +593,7 @@ describe("resolveKeyRowAgentTarget", () => {
     // The keyboard "open" and the click are one path: the key resolves to the
     // same target a click on that row resolves.
     const store = makeStore();
-    const rowId = "wt_station_idle";
+    const rowId = "ses_wt_station_idle";
 
     expect(resolveKeyRowAgentTarget(store, slotForRow(store, rowId))).toEqual(
       resolveRowAgentTarget(store, rowId),
@@ -588,7 +604,7 @@ describe("resolveKeyRowAgentTarget", () => {
     // The same slot key that opens an agent in dashboard mode must instead
     // select the row for removal here — so it defers to the machine, not launch.
     const store = makeStore();
-    const slot = slotForRow(store, "wt_station_idle");
+    const slot = slotForRow(store, "ses_wt_station_idle");
     store.getState().handleKey({ input: "X" }); // enter remove choose-slot mode
 
     expect(resolveKeyRowAgentTarget(store, slot)).toEqual({ kind: "none" });

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -42,7 +42,7 @@ export type StationMouseTarget =
   | { kind: "row"; rowId: string }
   | { kind: "projectHeader"; projectId: string }
   | { kind: "link"; url: string }
-  /** The `[+sh]` affordance on a worktree row: open a shell in its checkout. */
+  /** The `[+sh]` affordance on a session row: open a shell in its checkout. */
   | { kind: "openShellForRow"; rowId: string }
   /** The `[+sh]` affordance on a project header: open a shell in its root. */
   | { kind: "openShellForProject"; projectId: string }
@@ -170,7 +170,10 @@ export function routeStationMouse(
       // The choose-slot modes (remove/rename) keep their slot semantics: a
       // click selects that row.
       if (mode === "dashboard") {
-        return fromRowAgentTarget(resolveRowAgentTarget(store, target.rowId));
+        const targetRow = resolveRowAgentTarget(store, target.rowId);
+        return targetRow.kind === "launch-managed"
+          ? fromRowAgentTarget(targetRow)
+          : fromKeyOutcome(dispatchRowSlot(store, target.rowId));
       }
       return fromKeyOutcome(dispatchRowSlot(store, target.rowId));
     case "link":

--- a/station/src/station/input/stationOverlayLayer.ts
+++ b/station/src/station/input/stationOverlayLayer.ts
@@ -6,7 +6,7 @@
 // reserved chords (Ctrl-O/Ctrl-Q) pierce any catchAll by stack rule. Every
 // sequence is consumed (modal); dismiss/exit intents surface as the
 // overlay-close outcome so the coordination store owns visibility and focus
-// restore. One exception — a worktree-row slot key — resolves to a managed
+// restore. One exception — a Station-session slot key — resolves to a managed
 // launch (see catchAll) so the keyboard opens an agent exactly as a click does.
 import type { StoreApi } from "zustand/vanilla";
 import type { KeymapLayer } from "../../input/keymap/keymaps.js";

--- a/station/src/station/store/stationCommandDispatch.test.ts
+++ b/station/src/station/store/stationCommandDispatch.test.ts
@@ -9,7 +9,7 @@ import { createObserverStationClient } from "../../sources/observerStationClient
 import type { StationClient } from "../../sources/types.js";
 import { waitFor } from "../../terminal/testing/waitFor.js";
 import type { StationMouseEvent } from "../../input/mouse.js";
-import { manyProjectsSnapshot } from "../fixtures/scenarios.js";
+import { externalAgentSnapshot, manyProjectsSnapshot } from "../fixtures/scenarios.js";
 import { routeStationMouse } from "../input/stationMouse.js";
 import { FakeTuiObserverService } from "../test/support/fakeObserverService.js";
 import { createStationViewStore } from "./stationViewStore.js";
@@ -34,8 +34,8 @@ describe("station command dispatch through the shared client", () => {
     }
   });
 
-  async function makeLiveStore(): Promise<Harness> {
-    const fake = new FakeTuiObserverService(manyProjectsSnapshot());
+  async function makeLiveStore(snapshot = manyProjectsSnapshot()): Promise<Harness> {
+    const fake = new FakeTuiObserverService(snapshot);
     const client = createObserverStationClient({ service: fake });
     const store = createStationViewStore(client);
     const detach = store.getState().start();
@@ -52,7 +52,7 @@ describe("station command dispatch through the shared client", () => {
 
   it("row activation dispatches terminal.focus and waits for completion", async () => {
     const { fake, store } = await makeLiveStore();
-    const slot = slotForRow(store, "wt_station_idle");
+    const slot = slotForRow(store, "ses_wt_station_idle");
 
     store.getState().handleKey({ input: slot });
 
@@ -67,7 +67,11 @@ describe("station command dispatch through the shared client", () => {
   it("launches the worktree's managed primary agent on row click instead of dispatching focus", async () => {
     const { fake, store } = await makeLiveStore();
 
-    const outcome = routeStationMouse({ kind: "row", rowId: "wt_station_idle" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "row", rowId: "ses_wt_station_idle" },
+      LEFT_DOWN,
+      store,
+    );
 
     // The mouse row-click now launches the session's managed primary agent (a
     // router outcome the Station store consumes that asks the observer to
@@ -84,6 +88,37 @@ describe("station command dispatch through the shared client", () => {
     expect(fake.dispatched).toEqual([]);
     expect(fake.waitedForCommandIds).toEqual([]);
     expect(errorToastMessages(store)).toEqual([]);
+  });
+
+  it("routes an external session click through exact observer focus", async () => {
+    const base = externalAgentSnapshot();
+    const external = base.sessions.find((session) => session.origin === "external");
+    if (external === undefined) throw new Error("external fixture session is missing");
+    const snapshot = {
+      ...base,
+      sessions: base.sessions.map((session) =>
+        session.id === external.id
+          ? {
+              ...session,
+              terminal: {
+                provider: "tmux",
+                state: "open" as const,
+                focusable: true,
+                closeable: true,
+              },
+            }
+          : session,
+      ),
+    };
+    const { fake, store } = await makeLiveStore(snapshot);
+
+    const outcome = routeStationMouse({ kind: "row", rowId: external.id }, LEFT_DOWN, store);
+
+    expect(outcome).toEqual({ kind: "handled" });
+    await waitFor(() => fake.waitedForCommandIds.length === 1);
+    expect(fake.dispatched).toEqual([
+      { type: "terminal.focus", payload: { sessionId: external.id } },
+    ]);
   });
 
   it("routes Z refresh through the client runtime", async () => {

--- a/station/src/station/store/stationViewStore.test.ts
+++ b/station/src/station/store/stationViewStore.test.ts
@@ -12,7 +12,7 @@ import { createStationViewStore } from "./stationViewStore.js";
 describe("createStationViewStore", () => {
   it("routes row activation through the stubbed command service with real pending state", async () => {
     const store = makeStore();
-    const slot = slotForRow(store, "wt_station_none");
+    const slot = slotForRow(store, "ses_wt_station_none");
 
     store.getState().handleKey({ input: slot });
 
@@ -55,7 +55,7 @@ describe("createStationViewStore", () => {
 
   it("routes X through remove pending state and stub rejection feedback", async () => {
     const store = makeStore();
-    const slot = slotForRow(store, "wt_station_idle");
+    const slot = slotForRow(store, "ses_wt_station_idle");
 
     store.getState().handleKey({ input: "X" });
     store.getState().handleKey({ input: slot });
@@ -73,7 +73,7 @@ describe("createStationViewStore", () => {
 
   it("routes R through rename pending state and stub rejection feedback", async () => {
     const store = makeStore();
-    const slot = slotForRow(store, "wt_station_idle");
+    const slot = slotForRow(store, "ses_wt_station_idle");
 
     store.getState().handleKey({ input: "R" });
     store.getState().handleKey({ input: slot });

--- a/station/src/station/test/fixtures/snapshots.ts
+++ b/station/src/station/test/fixtures/snapshots.ts
@@ -45,7 +45,7 @@ export function createCommandSnapshot(
   state: "none" | "idle" = "idle",
   options: { dirty?: boolean } = {},
 ): StationSnapshot {
-  return snapshotFromRows([
+  const snapshot = snapshotFromRows([
     row({
       id: state === "none" ? "wt_web_no_agent" : "wt_web_idle",
       projectId: "web",
@@ -54,6 +54,23 @@ export function createCommandSnapshot(
       ...(options.dirty === undefined ? {} : { dirty: options.dirty }),
     }),
   ]);
+  if (state !== "none") {
+    return snapshot;
+  }
+  const source = snapshot.rows[0];
+  if (source === undefined) {
+    throw new Error("Command fixture requires a worktree.");
+  }
+  return {
+    ...snapshot,
+    sessions: [retainedSessionForRow(source)],
+    counts: { ...snapshot.counts, sessions: 1 },
+    projects: snapshot.projects.map((project) =>
+      project.id === source.projectId
+        ? { ...project, counts: { ...project.counts, sessions: 1 } }
+        : project,
+    ),
+  };
 }
 
 export function createPromptCapableSnapshot(): StationSnapshot {
@@ -254,6 +271,31 @@ function sessionForRow(candidate: WorktreeRow): SessionView {
     },
     title: candidate.branch,
     tags: [candidate.agent.harness, candidate.terminal.provider],
+  };
+}
+
+function retainedSessionForRow(candidate: WorktreeRow): SessionView {
+  return {
+    id: `ses_${candidate.id}`,
+    origin: "station",
+    projectId: candidate.projectId,
+    worktreeId: candidate.id,
+    createdAt: "2026-05-20T11:59:00.000Z",
+    updatedAt: fixtureNow,
+    harness: {
+      provider: candidate.projectId === "api" ? "opencode" : "codex",
+      mode: "interactive",
+      capabilities: defaultCapabilities,
+    },
+    status: {
+      value: "none",
+      confidence: "high",
+      reason: "No harness run is associated with this session.",
+      source: "observer_command",
+      updatedAt: fixtureNow,
+    },
+    title: candidate.branch,
+    tags: [],
   };
 }
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -2,7 +2,7 @@
 // viewport selector. Mouse targets report through the station mouse context;
 // hover is component-local and color-only so golden frames stay layout-stable.
 import { TextAttributes } from "@opentui/core";
-import type { ProjectView, StationSnapshot, WorktreeId } from "@station/contracts";
+import type { ProjectView, SessionId, StationSnapshot } from "@station/contracts";
 import { useState } from "react";
 import {
   dashboardFooterLabel,
@@ -137,7 +137,7 @@ function FleetBar({
   columns,
 }: {
   summary: FleetSummary;
-  counts: { projects: number; worktrees: number; agents: number };
+  counts: { projects: number; sessions: number; agents: number };
   columns: number;
 }) {
   const parts: { glyph: string; color: string; label: string; animate?: boolean }[] = [
@@ -160,7 +160,7 @@ function FleetBar({
   const lanesWidth =
     "FLEET".length + parts.reduce((total, part) => total + 3 + 1 + part.label.length, 0);
   const totals = fleetCountsLabel(
-    { projects: counts.projects, sessions: counts.worktrees, agents: counts.agents },
+    { projects: counts.projects, sessions: counts.sessions, agents: counts.agents },
     Math.max(0, columns - lanesWidth - 2),
   );
   return (
@@ -242,7 +242,7 @@ function dashboardRowLayouts(
   items: readonly DashboardViewportItem[],
   keyByRow: ReadonlyMap<string, string>,
   columns: number,
-  focusedRowId?: WorktreeId,
+  focusedRowId?: SessionId,
 ): { headerLayout: RowGridLayout | undefined; layoutByItem: Map<string, RowGridLayout> } {
   const rowInputs = items.flatMap((item) => {
     const input = rowGridInputForViewportItem(item, keyByRow, focusedRowId);
@@ -270,7 +270,7 @@ function DashboardBody({
   columns: number;
   items: readonly DashboardViewportItem[];
   layoutByItem: ReadonlyMap<string, RowGridLayout>;
-  focusedRowId?: WorktreeId | undefined;
+  focusedRowId?: SessionId | undefined;
 }) {
   return (
     <box flexDirection="column" flexGrow={1}>
@@ -296,7 +296,7 @@ function DashboardViewportRow({
   columns: number;
   item: DashboardViewportItem;
   layout: RowGridLayout | undefined;
-  focusedRowId?: WorktreeId | undefined;
+  focusedRowId?: SessionId | undefined;
 }) {
   switch (item.type) {
     case "projectGap":
@@ -310,9 +310,9 @@ function DashboardViewportRow({
           <EmptySessionButton projectId={item.project.id} />
         </box>
       );
-    case "worktree":
+    case "session":
       return layout === undefined ? null : (
-        <WorktreeRowLine rowId={item.row.id} layout={layout} focused={item.row.id === focusedRowId} />
+        <SessionRowLine rowId={item.row.id} layout={layout} focused={item.row.id === focusedRowId} />
       );
     case "createLocalRow":
       // Local create rows have no slot and no activation target.
@@ -324,7 +324,7 @@ function DashboardViewportRow({
   }
 }
 
-function WorktreeRowLine({
+function SessionRowLine({
   rowId,
   layout,
   focused,

--- a/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/dashboard.golden.test.tsx.snap
@@ -7,7 +7,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-overlay                    codex     working      +412 -96 #76 … 
@@ -17,11 +17,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
                                                                                 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -30,12 +30,12 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 
 exports[`dashboard golden frames renders many-projects at 120x40 1`] = `
 "                                                                                                                        
-FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 11 sessions · 9 agents 
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle     4 projects · 10 sessions · 9 agents 
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
        SESSION                                   AGENT     STATUS                                             DIFF · PR 
 ▼ station  5 sessions · 4 agents                                                            [shell] [quick session] [▾] 
  [1] ○ cli-help-man                              codex     idle                                            +14 -6 #70 ✓ 
- [2] - docs-cleanup                              -         no agent                                                     
+ [2] - docs-cleanup                              codex     no agent                                                     
  [3] ○ pty-buffer                                codex     idle                                                   #73 ✓ 
  [4] + session-resume                            codex     starting                                                     
  [5] ⠋ station-overlay                           codex     working                                       +412 -96 #76 … 
@@ -45,13 +45,13 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                            opencode  working                                         +32 -8 #16 … 
  [8] ○ trace-bundle                              opencode  idle                                              +1 -1 #4 ✓ 
                                                                                                                         
-▼ scripts  3 sessions · 2 agents                                                            [shell] [quick session] [▾] 
+▼ scripts  2 sessions · 2 agents                                                            [shell] [quick session] [▾] 
  [9] ○ api-cache                                 opencode  idle                                            +14 -6 #5 x1 
  [a] ? metadata-refresh                          opencode  unknown                                            +3 -1 #10 
- [b] - old-experiment                            -         no agent                                                     
                                                                                                                         
 ▼ empty-project  0 sessions                                                                 [shell] [quick session] [▾] 
  no sessions yet · [ + add session ]                                                                                    
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         
@@ -79,14 +79,14 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown
        SESSION                 AGENT     STATUS          PR 
 ▼ station  5 sessions · 4 agents              [sh] [qs] [▾] 
  [1] ○ cli-help-man            codex     idle         #70 ✓ 
- [2] - docs-cleanup            -         no agent           
+ [2] - docs-cleanup            codex     no agent           
  [3] ○ pty-buffer              codex     idle         #73 ✓ 
  [4] + session-resume          codex     starting           
  [5] ⠋ station-overlay         codex     working      #76 … 
                                                             
 ▼ observer  3 sessions · 3 agents             [sh] [qs] [▾] 
  [6] x batch-export            opencode  exited        #8 ✓ 
-▼ 5 below · showing 6 of 11                                 
+▼ 4 below · showing 6 of 10                                 
 ─────────────────────────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X delete  ? help  Q/esc:c… 
 "
@@ -102,7 +102,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0
  [2] - docs-cleanup        no agent     
  [3] ○ pty-buffer          idle         
  [4] + session-resume      starting     
-▼ 7 below · showing 4 of 11             
+▼ 6 below · showing 4 of 10             
 ─────────────────────────────────────── 
 ↵ open  N new  ⇥ next  / search  X del… 
 "

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -20,8 +20,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ▼ script│  ↵          open focused session                             │qs] [▾] 
  [9] ○ a│  tab        next session needing you                         │6 #5 x1 
  [a] ? m│  wheel      scroll project list                              │ -1 #10 
- [b] - o│  1-9/a-z    start or focus row                               │        
-        │  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │        
+        │  1-9/a-z    open visible session                             │        
+▼ empty-│  N/A/R/C/F/P  new/add/rename/fold/fork/settings              │qs] [▾] 
         ╰──────────────────────────────────────────────────────────────╯        
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -35,7 +35,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -45,11 +45,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
-search: api                                                                     
+                                                                                
+search: apiject  0 sessions                                       [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -63,7 +63,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
@@ -119,7 +119,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
@@ -160,8 +160,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -188,8 +188,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ←/esc back                                                             │   
+   │                          │                                             │   
+▼ e│ ←/esc back                                                             │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -216,8 +216,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ▼ s│                          │                                             │▾] 
  [9│                          │                                             │x1 
  [a│                          │                                             │10 
- [b│                          │                                             │   
-   │ ↑↓ move   →/enter edit   esc close                                     │   
+   │                          │                                             │   
+▼ e│ ↑↓ move   →/enter edit   esc close                                     │▾] 
    └────────────────────────────────────────────────────────────────────────┘   
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -231,7 +231,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -241,11 +241,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
 │ Select session to delete                   │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ ↑↓ move · ↵ choose · slot or click         │                                  
+│                                            │                                  
+│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -259,7 +259,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -272,8 +272,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Delete session?                            │                    [sh] [qs] [▾] 
 │ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
 │ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ Yes (y)     No (n)                         │                                  
+│                                            │                                  
+│ Yes (y)     No (n)                         │                    [sh] [qs] [▾] 
 │ Esc/Enter:cancel                           │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -287,7 +287,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
@@ -301,7 +301,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ This agent was started outside Station.                          │14 -6 #5 x1
 │ Station can see its status, but cannot stop it.                  │  +3 -1 #10
 │                                                                  │
-│ Stop or remove it from its original terminal or external tooling.│
+│ Stop or remove it from its original terminal or external tooling.│h] [qs] [▾]
 │                                                                  │
 │ Esc/Enter:close                                                  │───────────
 └──────────────────────────────────────────────────────────────────┘/esc:close
@@ -315,7 +315,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -325,11 +325,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1 
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10 
- [b] - old-experiment                     -         no agent                    
-Rename: ↑↓ move · ↵ choose · 1-9/a-z or click                                   
+                                                                                
+Rename: ↑↓ move · ↵ choose · 1-9/a-z or click                     [sh] [qs] [▾] 
                                                                                 
 ─────────────────────────────────────────────────────────────────────────────── 
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close  
@@ -371,7 +371,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -381,11 +381,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
  [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
                                                                                 
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾] 
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾] 
 ┌────────────────────────────────────────────┐code  idle           +14 -6 #5 x1 
 │ Select session to fork                     │code  unknown           +3 -1 #10 
-│                                            │      no agent                    
-│ ↑↓ move · ↵ choose · slot or click         │                                  
+│                                            │                                  
+│ ↑↓ move · ↵ choose · slot or click         │                    [sh] [qs] [▾] 
 │ Esc:cancel                                 │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -399,7 +399,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -412,8 +412,8 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
 │ > Branch cli-help-man-fork|                │code  idle           +14 -6 #5 x1 
 │   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
-│ Source keeps running — copy is read-only.  │      no agent                    
-│                                            │                                  
+│ Source keeps running — copy is read-only.  │                                  
+│                                            │                    [sh] [qs] [▾] 
 │ Fork (enter)                               │                                  
 │ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
 └────────────────────────────────────────────┘h  X delete  ? help  Q/esc:close  
@@ -427,7 +427,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -455,7 +455,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -483,7 +483,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -511,7 +511,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR 
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
- [2] - docs-cleanup                       -         no agent                    
+ [2] - docs-cleanup                       codex     no agent                    
  [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
  [4] + session-resume                     codex     starting                    
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
@@ -539,7 +539,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffer                         codex     idle                  #73 ✓
  [4] + session-resume                     codex     starting
  [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 …
@@ -623,7 +623,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
  [4] + session-r│ widgets                                      │
  [5] ⠋ station-o│ saved to config.toml                         │ +412 -96 #76 …
@@ -633,11 +633,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-│   [ + add widget ]                           │   +32 -8 #16 …
  [8] ○ trace-bun│ ↵ toggle   [ ] reorder   x remove   a add   e│     +1 -1 #4 ✓
                 └──────────────────────────────────────────────┘
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾]
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
- [b] - old-experiment                     -         no agent
 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close
@@ -651,7 +651,7 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
        SESSION                            AGENT     STATUS            DIFF · PR
 ▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾]
  [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓
- [2] - docs-cleanup                       -         no agent
+ [2] - docs-cleanup                       codex     no agent
  [3] ○ pty-buffe┌──────────────────────────────────────────────┐          #73 ✓
  [4] + session-r│ add widget                                   │
  [5] ⠋ station-o│ weather and tz require config.toml           │ +412 -96 #76 …
@@ -661,11 +661,11 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
  [7] ⠋ provider-│   moon                                       │   +32 -8 #16 …
  [8] ○ trace-bun│ ↵ add   esc back                             │     +1 -1 #4 ✓
                 └──────────────────────────────────────────────┘
-▼ scripts  3 sessions · 2 agents                                  [sh] [qs] [▾]
+▼ scripts  2 sessions · 2 agents                                  [sh] [qs] [▾]
  [9] ○ api-cache                          opencode  idle           +14 -6 #5 x1
  [a] ? metadata-refresh                   opencode  unknown           +3 -1 #10
- [b] - old-experiment                     -         no agent
 
+▼ empty-project  0 sessions                                       [sh] [qs] [▾]
 
 ───────────────────────────────────────────────────────────────────────────────
 ↵ open  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  Q/esc:close

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -10,6 +10,7 @@ import type { StationSnapshot } from "@station/contracts";
 import { spanAtFrameCell } from "../../terminal/testing/frameProbe.js";
 import {
   attentionAndFailuresSnapshot,
+  externalAgentSnapshot,
   manyProjectsSnapshot,
   noProjectsSnapshot,
   scenarioState,
@@ -149,6 +150,17 @@ describe("dashboard golden frames", () => {
     // Project headers with the disclosure marker and session/agent counts.
     expect(frame).toContain("▼ station  4 sessions");
     expect(frame).toContain("▼ observer  2 sessions");
+  });
+
+  it("renders external sessions while hiding bare worktrees", async () => {
+    const snapshot = externalAgentSnapshot();
+    const setup = await renderDashboard({ width: 120, height: 40, snapshot });
+    const frame = setup.captureCharFrame();
+
+    expect(frame).toContain("pty-buffer");
+    expect(frame).toContain("docs-cleanup");
+    expect(frame).not.toContain("old-experiment");
+    expect(frame).toContain(`${snapshot.counts.sessions} sessions`);
   });
 
   it("colors alert rows red and check glyphs by state", async () => {
@@ -317,7 +329,7 @@ describe("dashboard golden frames", () => {
     expect(lines.find((line) => line.startsWith("▏"))).toContain("popup-latency");
   });
 
-  it("paints hovered worktree rows through the trailing action column", async () => {
+  it("paints hovered session rows through the trailing action column", async () => {
     const setup = await renderDashboard({ width: 80, height: 24, snapshot: manyProjectsSnapshot() });
     const before = setup.captureCharFrame();
     const lines = before.split("\n");

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -40,7 +40,7 @@ const CASES: ModalCase[] = [
   {
     name: "help overlay",
     keys: [{ input: "H" }],
-    expect: ["station help", "Ctrl-\\", "split pane right", "1-9/a-z", "start or focus row", "╭", "╰"],
+    expect: ["station help", "Ctrl-\\", "split pane right", "1-9/a-z", "open visible session", "╭", "╰"],
   },
   {
     name: "search prompt",
@@ -126,7 +126,7 @@ const CASES: ModalCase[] = [
     snapshot: externalAgentSnapshot,
     trimSnapshotTrailingWhitespace: true,
     prepare: (store) => {
-      store.setState(openRemoveWorktreeConfirmForRow(store.getState(), "wt_station_idle"));
+      store.setState(openRemoveWorktreeConfirmForRow(store.getState(), "run_wt_station_idle"));
     },
     expect: [
       "Cannot delete worktree",

--- a/station/src/stationButton/StationButton.tsx
+++ b/station/src/stationButton/StationButton.tsx
@@ -48,12 +48,16 @@ export function StationButton({ store, stationViewStore, dispatchMouse, island }
   const onFocusSession = useCallback(
     (event: StationMouseEvent) => {
       const worktreeId = status.attentionWorktreeId;
-      // The agent pane id is deterministic from the worktree id; focus it only
-      // when that pane actually hosts a primary agent in this workspace.
+      const sessionId = status.attentionSessionId;
+      // A worktree can contain multiple canonical sessions, while its local
+      // primary-agent pane id is shared; require the exact session identity.
       const candidate = worktreeId === undefined ? undefined : agentWorktreePaneId(worktreeId);
+      const candidatePane =
+        candidate === undefined ? undefined : selectPaneRecord(store.getState(), candidate);
       const paneId =
-        candidate !== undefined &&
-        selectPaneRecord(store.getState(), candidate)?.role === "primary-agent"
+        candidatePane?.role === "primary-agent" &&
+        sessionId !== undefined &&
+        candidatePane.agentIdentity?.sessionId === sessionId
           ? candidate
           : undefined;
       if (paneId !== undefined) {
@@ -67,7 +71,7 @@ export function StationButton({ store, stationViewStore, dispatchMouse, island }
         dispatchMouse({ kind: "header" }, event);
       }
     },
-    [dispatchMouse, status.attentionWorktreeId, store],
+    [dispatchMouse, status.attentionSessionId, status.attentionWorktreeId, store],
   );
 
   return (

--- a/station/src/stationButton/status.test.ts
+++ b/station/src/stationButton/status.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { createInitialTuiState, selectFleetSummary } from "@station/dashboard-core";
+import {
+  createInitialTuiState,
+  selectDashboardSessionRows,
+  selectFleetSummary,
+} from "@station/dashboard-core";
 import {
   attentionAndFailuresSnapshot,
   manyProjectsSnapshot,
@@ -37,14 +41,13 @@ describe("selectStationButtonStatus", () => {
   it("flags the first session needing the user and counts the queue", () => {
     const snapshot = attentionAndFailuresSnapshot();
     const status = selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }));
-    const flagged = snapshot.rows.filter(
-      (row) =>
-        row.display.statusLabel === "needs attention" || row.display.statusLabel === "stuck",
+    const flagged = selectDashboardSessionRows(snapshot).filter(
+      (row) => row.session.status.value === "needs_attention" || row.session.status.value === "stuck",
     );
 
     expect(status.attention).toBe(true);
     expect(status.needsYouCount).toBe(flagged.length);
-    expect(status.attentionWorktreeId).toBe(flagged[0]?.id);
+    expect(status.attentionWorktreeId).toBe(flagged[0]?.worktree.id);
     expect(typeof status.sessionName).toBe("string");
   });
 
@@ -74,17 +77,41 @@ describe("selectStationButtonStatus", () => {
     }
 
     // One entry per project holding sessions, in row display order.
-    const projectIds = [...new Set(snapshot.rows.map((row) => row.projectId))];
+    const sessionRows = selectDashboardSessionRows(snapshot);
+    const projectIds = [...new Set(sessionRows.map((row) => row.worktree.projectId))];
     expect(rollup.map((entry) => entry.projectId)).toEqual(projectIds);
 
     // A project with a flagged session rolls up to needsYou even when it also
     // has calmer sessions.
-    const flagged = snapshot.rows.find(
-      (row) =>
-        row.display.statusLabel === "needs attention" || row.display.statusLabel === "stuck",
+    const flagged = sessionRows.find(
+      (row) => row.session.status.value === "needs_attention" || row.session.status.value === "stuck",
     );
-    const flaggedEntry = rollup.find((entry) => entry.projectId === flagged?.projectId);
+    const flaggedEntry = rollup.find((entry) => entry.projectId === flagged?.worktree.projectId);
     expect(flaggedEntry?.status).toBe("needsYou");
+  });
+
+  it("does not include a bare worktree in button counts or project rollups", () => {
+    const base = manyProjectsSnapshot();
+    const bare = base.rows.find((row) => row.id === "wt_scripts_none");
+    if (bare === undefined) throw new Error("fixture is expected to contain a bare worktree");
+    const snapshot = {
+      ...base,
+      rows: [bare],
+      sessions: [],
+    };
+
+    expect(
+      selectStationButtonStatus(createInitialTuiState({ initialSnapshot: snapshot }), {
+        projectRollup: true,
+      }),
+    ).toEqual({
+      attention: false,
+      needsYouCount: 0,
+      workingCount: 0,
+      readyCount: 0,
+      idleCount: 0,
+      projectRollup: [],
+    });
   });
 
   it("compares field-wise so the snapshot reference can stay stable", () => {

--- a/station/src/stationButton/status.test.ts
+++ b/station/src/stationButton/status.test.ts
@@ -34,6 +34,7 @@ describe("selectStationButtonStatus", () => {
     expect(status.attention).toBe(false);
     expect(status.needsYouCount).toBe(0);
     expect(status.sessionName).toBeUndefined();
+    expect(status.attentionSessionId).toBeUndefined();
     expect(status.attentionWorktreeId).toBeUndefined();
     expect(status.projectRollup).toBeUndefined();
   });
@@ -47,6 +48,7 @@ describe("selectStationButtonStatus", () => {
 
     expect(status.attention).toBe(true);
     expect(status.needsYouCount).toBe(flagged.length);
+    expect(status.attentionSessionId).toBe(flagged[0]?.session.id);
     expect(status.attentionWorktreeId).toBe(flagged[0]?.worktree.id);
     expect(typeof status.sessionName).toBe("string");
   });
@@ -64,6 +66,7 @@ describe("selectStationButtonStatus", () => {
 
     expect(status.attention).toBe(true);
     expect(status.needsYouCount).toBe(1);
+    expect(status.attentionSessionId).toBe(stuckRow.agent?.sessionId);
     expect(status.attentionWorktreeId).toBe(stuckRow.id);
   });
 
@@ -122,6 +125,7 @@ describe("selectStationButtonStatus", () => {
 
     expect(stationButtonStatusEqual(a, b)).toBe(true);
     expect(stationButtonStatusEqual(a, { ...a, workingCount: a.workingCount + 1 })).toBe(false);
+    expect(stationButtonStatusEqual(a, { ...a, attentionSessionId: "ses_other" })).toBe(false);
     // Roll-up presence and content participate in the comparison.
     expect(stationButtonStatusEqual(a, { ...a, projectRollup: undefined })).toBe(false);
     if (a.projectRollup !== undefined && a.projectRollup.length > 0) {

--- a/station/src/stationButton/status.ts
+++ b/station/src/stationButton/status.ts
@@ -1,9 +1,11 @@
 import type { WorktreeId, WorktreeRow } from "@station/contracts";
 import {
   isReadyToRead,
+  selectDashboardSessionRows,
   selectFleetSummary,
+  sessionRowDisplayTitle,
+  type DashboardSessionRow,
   type TuiState,
-  worktreeRowDisplayTitle,
 } from "@station/dashboard-core";
 
 /** Worst agent status across a project's sessions, calmest last. */
@@ -56,9 +58,8 @@ export function selectStationButtonStatus(
     return EMPTY_STATUS;
   }
   const fleet = selectFleetSummary(snapshot);
-  // The attention identity is the first row asking for the user (rows are
-  // already in display order).
-  const attentionRow = snapshot.rows.find(rowNeedsUser);
+  const sessionRows = selectDashboardSessionRows(snapshot);
+  const attentionRow = sessionRows.find((row) => rowNeedsUser(row.presentation));
   const status: StationButtonStatus = {
     attention: attentionRow !== undefined,
     needsYouCount: fleet.needsYou,
@@ -67,11 +68,11 @@ export function selectStationButtonStatus(
     idleCount: fleet.idle,
   };
   if (attentionRow !== undefined) {
-    status.sessionName = worktreeRowDisplayTitle(attentionRow, snapshot.sessions, state.localRows);
-    status.attentionWorktreeId = attentionRow.id;
+    status.sessionName = sessionRowDisplayTitle(attentionRow, state.localRows);
+    status.attentionWorktreeId = attentionRow.worktree.id;
   }
   if (options?.projectRollup === true) {
-    status.projectRollup = rollupProjects(snapshot.rows);
+    status.projectRollup = rollupProjects(sessionRows);
   }
   return status;
 }
@@ -83,15 +84,15 @@ const ROLLUP_SEVERITY: Record<ProjectRollupStatus, number> = {
   idle: 0,
 };
 
-function rowRollupStatus(row: WorktreeRow): ProjectRollupStatus {
-  const state = row.agent?.state;
+function rowRollupStatus(row: DashboardSessionRow): ProjectRollupStatus {
+  const state = row.session.status.value;
   if (state === "needs_attention" || state === "stuck") {
     return "needsYou";
   }
   if (state === "working") {
     return "working";
   }
-  if (isReadyToRead(row)) {
+  if (isReadyToRead(row.presentation)) {
     return "ready";
   }
   // Calm lanes (idle/starting/exited/unknown/no agent) all read as idle here;
@@ -99,13 +100,17 @@ function rowRollupStatus(row: WorktreeRow): ProjectRollupStatus {
   return "idle";
 }
 
-function rollupProjects(rows: readonly WorktreeRow[]): readonly ProjectRollupEntry[] {
+function rollupProjects(rows: readonly DashboardSessionRow[]): readonly ProjectRollupEntry[] {
   const byProject = new Map<string, ProjectRollupEntry>();
   for (const row of rows) {
     const status = rowRollupStatus(row);
-    const existing = byProject.get(row.projectId);
+    const existing = byProject.get(row.worktree.projectId);
     if (existing === undefined) {
-      byProject.set(row.projectId, { projectId: row.projectId, name: row.projectLabel, status });
+      byProject.set(row.worktree.projectId, {
+        projectId: row.worktree.projectId,
+        name: row.worktree.projectLabel,
+        status,
+      });
     } else if (ROLLUP_SEVERITY[status] > ROLLUP_SEVERITY[existing.status]) {
       existing.status = status;
     }

--- a/station/src/stationButton/status.ts
+++ b/station/src/stationButton/status.ts
@@ -1,4 +1,4 @@
-import type { WorktreeId, WorktreeRow } from "@station/contracts";
+import type { SessionId, WorktreeId, WorktreeRow } from "@station/contracts";
 import {
   isReadyToRead,
   selectDashboardSessionRows,
@@ -28,6 +28,8 @@ export type StationButtonStatus = {
   /** Disjoint from ready; the totals summary shows ready + idle as "idle". */
   idleCount: number;
   sessionName?: string;
+  /** The canonical session behind the attention state. */
+  attentionSessionId?: SessionId;
   /** The worktree behind the attention state, so a click can focus its pane. */
   attentionWorktreeId?: WorktreeId;
   /** Worst status per project, in row display order; built only when requested. */
@@ -69,6 +71,7 @@ export function selectStationButtonStatus(
   };
   if (attentionRow !== undefined) {
     status.sessionName = sessionRowDisplayTitle(attentionRow, state.localRows);
+    status.attentionSessionId = attentionRow.session.id;
     status.attentionWorktreeId = attentionRow.worktree.id;
   }
   if (options?.projectRollup === true) {
@@ -127,6 +130,7 @@ export function stationButtonStatusEqual(a: StationButtonStatus, b: StationButto
     a.readyCount === b.readyCount &&
     a.idleCount === b.idleCount &&
     a.sessionName === b.sessionName &&
+    a.attentionSessionId === b.attentionSessionId &&
     a.attentionWorktreeId === b.attentionWorktreeId &&
     rollupEqual(a.projectRollup, b.projectRollup)
   );


### PR DESCRIPTION
## Summary

- render one dashboard row per canonical `snapshot.sessions` member while joining `snapshot.rows` only for checkout metadata
- align fleet and project counts, labels, search, selection, empty states, popup/native rendering, and action eligibility with canonical session membership
- keep optimistic starts visible until observer truth reports a live agent; retained session membership alone is not launch completion
- preserve exact canonical session identity when the Station attention button focuses a local pane

## Why

After PR #181, a retained logical session can exist before it has a live harness run. Dashboard membership therefore comes from `snapshot.sessions`, while start completion still requires launch liveness. Attention routing must also retain the selected session ID because multiple sessions can share one checkout.

## Scope

Dashboard behavior slice only. Bare worktrees are hidden from the primary session list; the separate worktree inventory remains follow-up work. No Observer or contract changes.

## Validation

- focused attention click and hover+Enter regressions — passed
- dashboard-core and full Station coverage — 1,007 Station tests passed
- isolated `pnpm test:pre-push` — passed, including native PTY, installer smoke, cross-runtime SQLite, compiled binary build, and binary smoke
- exact rebase onto current `main` after PR #175

## UX implication

The primary dashboard now shows sessions rather than every discovered worktree. Counts match visible sessions, retained no-agent sessions remain visible, and attention actions cannot jump to another session that happens to share the same checkout.

## Manual verification

Create several bare worktrees under a configured project and one real Station session. Confirm the dashboard shows and counts only the real session. With two sessions sharing one checkout and only the non-alerting session hosted locally, click the attention island and hover it then press Enter; both actions must open the dashboard instead of switching to the wrong pane.

Refs #159
