### PR TITLE
fix(popup): keep the renderer alive across dismissals

### DIFF
--- a/apps/cli/src/commands/registry/tui.ts
+++ b/apps/cli/src/commands/registry/tui.ts
@@ -19,7 +19,7 @@ export const tuiCliCommand: CliCommandNode = {
     { name: "--popup", description: "Run in popup mode." },
     {
       name: "--persistent",
-      description: "Accepted for tmux-popup compatibility (no separate behavior).",
+      description: "Keep the dashboard alive when the outer popup is dismissed.",
     },
   ],
   examples: ["pnpm stn tui", "pnpm stn tui --popup --persistent"],

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -3,6 +3,7 @@ import type { StationConfig } from "@station/config";
 import { TUI_STARTUP_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { isCompiledBinary, safeErrorFromUnknown, systemClock } from "@station/runtime";
+import { dismissTmuxPopup, resolveTmuxPopupFocusOrigin } from "@station/tmux";
 import { parsePositiveIntegerOption } from "../args.js";
 import type { CliEnv } from "../env.js";
 import {
@@ -18,6 +19,9 @@ import {
   resolveStationWorkspaceDir,
   stationUiInstallHint,
 } from "../stationWorkspace.js";
+import { attachTuiRendererControl, type TuiRendererControlAdapters } from "./tuiRendererControl.js";
+
+export type { TuiRendererControlAdapters } from "./tuiRendererControl.js";
 
 /** The renderer subprocess exited with this code (the CLI's `tui` result). */
 export type TuiRunResult = {
@@ -40,6 +44,7 @@ export type TuiCommandDeps = {
   spawnProcess?: typeof spawn;
   stationUiInstalled?: () => Promise<boolean>;
   selfExecRuntime?: SelfExecRuntime;
+  popupControl?: TuiRendererControlAdapters;
   env?: CliEnv;
 };
 
@@ -58,6 +63,11 @@ export type TuiCommandResult =
       observer: ObserverStatus;
     };
 
+/**
+ * COMPOSITION ROOT
+ *
+ * Owns Observer startup, renderer process selection, and persistent popup control wiring.
+ */
 export async function runTuiCommand(
   args: string[],
   options: TuiCommandOptions = {},
@@ -68,7 +78,12 @@ export async function runTuiCommand(
     // The Bun renderer carries its own mock source; the --fake-* counts are
     // accepted for back-compat but the mock uses its baseline scenario.
     // --dev-fake-dashboard previews the read-only dashboard with mock data.
-    return runRenderer(deps, buildRendererEnv(parsed, { STATION_SOURCE: "mock" }), "dashboard");
+    return runRenderer(
+      deps,
+      buildRendererEnv(parsed, { STATION_SOURCE: "mock" }),
+      "dashboard",
+      parsed.persistentPopup,
+    );
   }
 
   const paths = resolveObserverPaths(options.config);
@@ -113,13 +128,12 @@ export async function runTuiCommand(
     deps,
     buildRendererEnv(parsed, { STATION_OBSERVER_SOCKET_PATH: observer.paths.socketPath }),
     parsed.popupMode ? "dashboard" : "station",
+    parsed.persistentPopup,
   );
 }
 
-// Popup mode is signalled to the renderer via env. Any tmux focus origin
-// (STATION_FOCUS_PROVIDER / STATION_FOCUS_CLIENT_ID set by the tmux popup launcher) is
-// inherited through process.env; the tmux provider resolves the originating
-// client itself, so this command stays provider-agnostic.
+// Transient popups inherit their startup focus origin; persistent popups resolve
+// the current origin through the parent-owned control channel on every focus.
 function buildRendererEnv(
   parsed: ParsedTuiArgs,
   base: Record<string, string>,
@@ -135,13 +149,17 @@ function runRenderer(
   deps: TuiCommandDeps,
   env: Record<string, string>,
   entry: RendererEntry,
+  persistentPopup: boolean,
 ): Promise<TuiRunResult> {
-  return deps.spawnRenderer?.({ env, entry }) ?? spawnRenderer({ env, entry }, deps);
+  return (
+    deps.spawnRenderer?.({ env, entry }) ?? spawnRenderer({ env, entry }, deps, persistentPopup)
+  );
 }
 
 async function spawnRenderer(
   { env, entry }: RendererSpawnOptions,
   deps: TuiCommandDeps,
+  persistentPopup: boolean,
 ): Promise<TuiRunResult> {
   const childEnv = { ...process.env, ...env, STATION_QUIET_PRELAUNCH: "1" };
   const override = process.env.STATION_DASHBOARD_COMMAND;
@@ -158,32 +176,79 @@ async function spawnRenderer(
   if (override === undefined) {
     process.stderr.write(`Launching STATION ${entry === "dashboard" ? "dashboard" : "TUI"}…\n`);
   }
-  const developmentArgv = [
-    "bun",
-    "run",
-    "--silent",
-    "--cwd",
-    resolveStationWorkspaceDir(),
-    entry,
-  ] as const;
-  const rendererArgv = selfExecArgv(
-    entry === "dashboard" ? "dashboard" : "tui",
-    developmentArgv,
-    deps.selfExecRuntime,
-  );
-  const [command, ...args] = rendererArgv;
   const spawnProcess = deps.spawnProcess ?? spawn;
+  const workspaceDir = resolveStationWorkspaceDir();
+  const sourcePersistentDashboard =
+    override === undefined && !compiled && persistentPopup && entry === "dashboard";
+  if (sourcePersistentDashboard) {
+    const linkResult = await runStationLink(spawnProcess, workspaceDir, childEnv);
+    if (linkResult.code !== 0) return linkResult;
+  }
+  const developmentArgv = ["bun", "run", "--silent", "--cwd", workspaceDir, entry] as const;
+  const rendererArgv = sourcePersistentDashboard
+    ? (["bun", "src/dashboardRenderer/main.tsx"] as const)
+    : selfExecArgv(
+        entry === "dashboard" ? "dashboard" : "tui",
+        developmentArgv,
+        deps.selfExecRuntime,
+      );
+  const [command, ...args] = rendererArgv;
   const child =
     override !== undefined
-      ? spawnProcess(override, { shell: true, stdio: "inherit", env: childEnv })
-      : spawnProcess(command, args, {
-          stdio: "inherit",
+      ? spawnProcess(override, {
+          shell: true,
+          stdio: persistentPopup ? ["inherit", "inherit", "inherit", "ipc"] : "inherit",
           env: childEnv,
+        })
+      : spawnProcess(command, args, {
+          stdio: persistentPopup ? ["inherit", "inherit", "inherit", "ipc"] : "inherit",
+          env: childEnv,
+          ...(sourcePersistentDashboard ? { cwd: workspaceDir } : {}),
         });
+  const control = persistentPopup
+    ? attachTuiRendererControl(child, deps.popupControl ?? defaultPopupControl(deps.env))
+    : undefined;
   return new Promise<TuiRunResult>((resolve) => {
-    child.once("error", () => resolve({ status: "exited", code: 1 }));
-    child.once("exit", (code) => resolve({ status: "exited", code: code ?? 0 }));
+    child.once("error", () => {
+      control?.dispose();
+      resolve({ status: "exited", code: 1 });
+    });
+    child.once("exit", (code) => {
+      control?.dispose();
+      resolve({ status: "exited", code: code ?? 0 });
+    });
   });
+}
+
+async function runStationLink(
+  spawnProcess: typeof spawn,
+  workspaceDir: string,
+  env: NodeJS.ProcessEnv,
+): Promise<TuiRunResult> {
+  const child = spawnProcess("bun", ["run", "--silent", "--cwd", workspaceDir, "link:station"], {
+    stdio: "inherit",
+    env,
+  });
+  return new Promise<TuiRunResult>((resolve) => {
+    let settled = false;
+    const finish = (code: number) => {
+      if (settled) return;
+      settled = true;
+      resolve({ status: "exited", code });
+    };
+    child.once("error", () => finish(1));
+    child.once("exit", (code) => finish(code ?? 1));
+  });
+}
+
+function defaultPopupControl(env: CliEnv | undefined): TuiRendererControlAdapters {
+  const popupEnv = { ...(env ?? process.env) };
+  // The startup client is a delivery hint; runtime requests must follow the current popup claim.
+  delete popupEnv.STATION_FOCUS_CLIENT_ID;
+  return {
+    dismissPopup: () => dismissTmuxPopup({ env: popupEnv }),
+    resolveFocusOrigin: () => resolveTmuxPopupFocusOrigin({ env: popupEnv }),
+  };
 }
 
 function scheduleReconcileBeforeTui(input: {

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -3,7 +3,7 @@ import type { StationConfig } from "@station/config";
 import { TUI_STARTUP_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import { isCompiledBinary, safeErrorFromUnknown, systemClock } from "@station/runtime";
-import { dismissTmuxPopup, resolveTmuxPopupFocusOrigin } from "@station/tmux";
+import { dismissTmuxPopup, resolveTmuxPopupFocusTarget } from "@station/tmux";
 import { parsePositiveIntegerOption } from "../args.js";
 import type { CliEnv } from "../env.js";
 import {
@@ -83,6 +83,7 @@ export async function runTuiCommand(
       buildRendererEnv(parsed, { STATION_SOURCE: "mock" }),
       "dashboard",
       parsed.persistentPopup,
+      options.config?.terminal?.tmux?.command,
     );
   }
 
@@ -129,6 +130,7 @@ export async function runTuiCommand(
     buildRendererEnv(parsed, { STATION_OBSERVER_SOCKET_PATH: observer.paths.socketPath }),
     parsed.popupMode ? "dashboard" : "station",
     parsed.persistentPopup,
+    options.config?.terminal?.tmux?.command,
   );
 }
 
@@ -142,6 +144,9 @@ function buildRendererEnv(
   if (parsed.popupMode) {
     env.STATION_TUI_POPUP = "1";
   }
+  if (parsed.persistentPopup) {
+    env.STATION_TUI_PERSISTENT = "1";
+  }
   return env;
 }
 
@@ -150,9 +155,11 @@ function runRenderer(
   env: Record<string, string>,
   entry: RendererEntry,
   persistentPopup: boolean,
+  popupCommand: string | undefined,
 ): Promise<TuiRunResult> {
   return (
-    deps.spawnRenderer?.({ env, entry }) ?? spawnRenderer({ env, entry }, deps, persistentPopup)
+    deps.spawnRenderer?.({ env, entry }) ??
+    spawnRenderer({ env, entry }, deps, persistentPopup, popupCommand)
   );
 }
 
@@ -160,6 +167,7 @@ async function spawnRenderer(
   { env, entry }: RendererSpawnOptions,
   deps: TuiCommandDeps,
   persistentPopup: boolean,
+  popupCommand: string | undefined,
 ): Promise<TuiRunResult> {
   const childEnv = { ...process.env, ...env, STATION_QUIET_PRELAUNCH: "1" };
   const override = process.env.STATION_DASHBOARD_COMMAND;
@@ -206,7 +214,10 @@ async function spawnRenderer(
           ...(sourcePersistentDashboard ? { cwd: workspaceDir } : {}),
         });
   const control = persistentPopup
-    ? attachTuiRendererControl(child, deps.popupControl ?? defaultPopupControl(deps.env))
+    ? attachTuiRendererControl(
+        child,
+        deps.popupControl ?? defaultPopupControl(deps.env, popupCommand),
+      )
     : undefined;
   return new Promise<TuiRunResult>((resolve) => {
     child.once("error", () => {
@@ -241,14 +252,28 @@ async function runStationLink(
   });
 }
 
-function defaultPopupControl(env: CliEnv | undefined): TuiRendererControlAdapters {
+function defaultPopupControl(
+  env: CliEnv | undefined,
+  command: string | undefined,
+): TuiRendererControlAdapters {
   const popupEnv = { ...(env ?? process.env) };
   // The startup client is a delivery hint; runtime requests must follow the current popup claim.
   delete popupEnv.STATION_FOCUS_CLIENT_ID;
-  return {
-    dismissPopup: () => dismissTmuxPopup({ env: popupEnv }),
-    resolveFocusOrigin: () => resolveTmuxPopupFocusOrigin({ env: popupEnv }),
+  const popupOptions = {
+    env: popupEnv,
+    command: resolvePopupTmuxCommand(command, popupEnv),
   };
+  return {
+    dismissPopup: () => dismissTmuxPopup(popupOptions),
+    resolveFocusTarget: () => resolveTmuxPopupFocusTarget(popupOptions),
+  };
+}
+
+export function resolvePopupTmuxCommand(
+  configuredCommand: string | undefined,
+  env: CliEnv = process.env,
+): string {
+  return configuredCommand ?? env.STATION_TMUX_BIN ?? "tmux";
 }
 
 function scheduleReconcileBeforeTui(input: {

--- a/apps/cli/src/commands/tuiRendererControl.ts
+++ b/apps/cli/src/commands/tuiRendererControl.ts
@@ -10,7 +10,12 @@ import { safeErrorFromUnknown } from "@station/runtime";
 
 export type TuiRendererControlAdapters = {
   dismissPopup: () => Promise<{ dismissed: boolean }>;
-  resolveFocusOrigin: () => Promise<TerminalFocusOrigin | undefined>;
+  resolveFocusTarget: () => Promise<TuiRendererFocusTarget | undefined>;
+};
+
+export type TuiRendererFocusTarget = {
+  origin: TerminalFocusOrigin;
+  dismissExact: () => Promise<{ dismissed: boolean }>;
 };
 
 export type TuiRendererControlAttachment = {
@@ -30,6 +35,14 @@ export function attachTuiRendererControl(
 ): TuiRendererControlAttachment {
   let closed = false;
   const pendingRequestIds = new Set<string>();
+  let focusResolutionGeneration = 0;
+  let activeFocusTarget:
+    | {
+        requestId: string;
+        dismissExact: () => Promise<{ dismissed: boolean }>;
+      }
+    | undefined;
+  let manualDismissEffect: Promise<{ dismissed: boolean }> | undefined;
 
   const removeListeners = () => {
     child.off("message", onMessage);
@@ -40,6 +53,8 @@ export function attachTuiRendererControl(
   const close = (disconnect: boolean) => {
     if (closed) return;
     closed = true;
+    focusResolutionGeneration += 1;
+    activeFocusTarget = undefined;
     pendingRequestIds.clear();
     removeListeners();
     if (disconnect && child.connected) {
@@ -78,8 +93,10 @@ export function attachTuiRendererControl(
     pendingRequestIds.add(request.requestId);
     try {
       if (request.type === "dismiss") {
+        focusResolutionGeneration += 1;
+        activeFocusTarget = undefined;
         try {
-          const result = await adapters.dismissPopup();
+          const result = await coalescedManualDismiss();
           if (!result.dismissed) {
             sendError(request.requestId, undefined, popupDismissError);
             return;
@@ -95,20 +112,56 @@ export function attachTuiRendererControl(
         return;
       }
 
-      try {
-        const origin = await adapters.resolveFocusOrigin();
-        if (origin === undefined) {
-          sendError(request.requestId, undefined, focusOriginError);
+      if (request.type === "dismiss-focus-target") {
+        const focusTarget = activeFocusTarget;
+        if (focusTarget?.requestId !== request.focusRequestId) {
+          sendError(request.requestId, undefined, focusTargetStaleError);
           return;
         }
+        activeFocusTarget = undefined;
+        focusResolutionGeneration += 1;
+        try {
+          const result = await focusTarget.dismissExact();
+          if (!result.dismissed) {
+            sendError(request.requestId, undefined, focusTargetStaleError);
+            return;
+          }
+          send({
+            protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+            requestId: request.requestId,
+            type: "dismissed",
+          });
+        } catch (error) {
+          sendError(request.requestId, error, focusTargetStaleError);
+        }
+        return;
+      }
+
+      const generation = focusResolutionGeneration + 1;
+      focusResolutionGeneration = generation;
+      activeFocusTarget = undefined;
+      try {
+        const focusTarget = await adapters.resolveFocusTarget();
+        if (focusTarget === undefined) {
+          sendError(request.requestId, undefined, focusTargetUnavailableError);
+          return;
+        }
+        if (generation !== focusResolutionGeneration) {
+          sendError(request.requestId, undefined, focusTargetStaleError);
+          return;
+        }
+        activeFocusTarget = {
+          requestId: request.requestId,
+          dismissExact: focusTarget.dismissExact,
+        };
         send({
           protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
           requestId: request.requestId,
-          type: "focus-origin",
-          origin,
+          type: "focus-target",
+          origin: focusTarget.origin,
         });
       } catch (error) {
-        sendError(request.requestId, error, focusOriginError);
+        sendError(request.requestId, error, focusTargetUnavailableError);
       }
     } finally {
       pendingRequestIds.delete(request.requestId);
@@ -119,6 +172,22 @@ export function attachTuiRendererControl(
   }
   function onChildClosed(): void {
     close(false);
+  }
+
+  function coalescedManualDismiss(): Promise<{ dismissed: boolean }> {
+    const current = manualDismissEffect;
+    if (current !== undefined) {
+      return current;
+    }
+    const effect = adapters.dismissPopup();
+    manualDismissEffect = effect;
+    const clear = () => {
+      if (manualDismissEffect === effect) {
+        manualDismissEffect = undefined;
+      }
+    };
+    void effect.then(clear, clear);
+    return effect;
   }
 
   child.on("message", onMessage);
@@ -136,13 +205,19 @@ export function attachTuiRendererControl(
 const popupDismissError: SafeError = {
   tag: "TuiRendererControlError",
   code: "TUI_POPUP_DISMISS_FAILED",
-  message: "The tmux popup could not be dismissed.",
+  message: "The popup could not be dismissed.",
 };
 
-const focusOriginError: SafeError = {
+const focusTargetUnavailableError: SafeError = {
   tag: "TuiRendererControlError",
-  code: "TUI_POPUP_FOCUS_ORIGIN_UNAVAILABLE",
-  message: "The current tmux popup focus origin could not be resolved.",
+  code: "TUI_POPUP_FOCUS_TARGET_UNAVAILABLE",
+  message: "The current popup focus target could not be resolved.",
+};
+
+const focusTargetStaleError: SafeError = {
+  tag: "TuiRendererControlError",
+  code: "TUI_POPUP_FOCUS_TARGET_STALE",
+  message: "The popup focus target changed before dismissal.",
 };
 
 function controlSafeError(error: unknown, fallback: SafeError): SafeError {

--- a/apps/cli/src/commands/tuiRendererControl.ts
+++ b/apps/cli/src/commands/tuiRendererControl.ts
@@ -1,0 +1,164 @@
+import type { ChildProcess } from "node:child_process";
+import {
+  type SafeError,
+  type TerminalFocusOrigin,
+  TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+  TuiRendererControlRequestSchema,
+  type TuiRendererControlResponse,
+} from "@station/contracts";
+import { safeErrorFromUnknown } from "@station/runtime";
+
+export type TuiRendererControlAdapters = {
+  dismissPopup: () => Promise<{ dismissed: boolean }>;
+  resolveFocusOrigin: () => Promise<TerminalFocusOrigin | undefined>;
+};
+
+export type TuiRendererControlAttachment = {
+  dispose: () => void;
+};
+
+/**
+ * ADAPTER
+ *
+ * Translates strict renderer IPC requests into CLI-owned popup capabilities.
+ *
+ * Malformed or duplicate in-flight requests close the channel before any popup action runs.
+ */
+export function attachTuiRendererControl(
+  child: ChildProcess,
+  adapters: TuiRendererControlAdapters,
+): TuiRendererControlAttachment {
+  let closed = false;
+  const pendingRequestIds = new Set<string>();
+
+  const removeListeners = () => {
+    child.off("message", onMessage);
+    child.off("disconnect", onChildClosed);
+    child.off("error", onChildClosed);
+    child.off("exit", onChildClosed);
+  };
+  const close = (disconnect: boolean) => {
+    if (closed) return;
+    closed = true;
+    pendingRequestIds.clear();
+    removeListeners();
+    if (disconnect && child.connected) {
+      child.disconnect();
+    }
+  };
+  const send = (response: TuiRendererControlResponse) => {
+    if (closed || !child.connected || child.send === undefined) {
+      close(false);
+      return;
+    }
+    try {
+      child.send(response, (error) => {
+        if (error !== null && error !== undefined) close(true);
+      });
+    } catch {
+      close(true);
+    }
+  };
+  const sendError = (requestId: string, error: unknown, fallback: SafeError) => {
+    send({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId,
+      type: "error",
+      error: controlSafeError(error, fallback),
+    });
+  };
+  const handleMessage = async (message: unknown) => {
+    const parsed = TuiRendererControlRequestSchema.safeParse(message);
+    if (!parsed.success || pendingRequestIds.has(parsed.data.requestId)) {
+      close(true);
+      return;
+    }
+
+    const request = parsed.data;
+    pendingRequestIds.add(request.requestId);
+    try {
+      if (request.type === "dismiss") {
+        try {
+          const result = await adapters.dismissPopup();
+          if (!result.dismissed) {
+            sendError(request.requestId, undefined, popupDismissError);
+            return;
+          }
+          send({
+            protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+            requestId: request.requestId,
+            type: "dismissed",
+          });
+        } catch (error) {
+          sendError(request.requestId, error, popupDismissError);
+        }
+        return;
+      }
+
+      try {
+        const origin = await adapters.resolveFocusOrigin();
+        if (origin === undefined) {
+          sendError(request.requestId, undefined, focusOriginError);
+          return;
+        }
+        send({
+          protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+          requestId: request.requestId,
+          type: "focus-origin",
+          origin,
+        });
+      } catch (error) {
+        sendError(request.requestId, error, focusOriginError);
+      }
+    } finally {
+      pendingRequestIds.delete(request.requestId);
+    }
+  };
+  function onMessage(message: unknown): void {
+    void handleMessage(message);
+  }
+  function onChildClosed(): void {
+    close(false);
+  }
+
+  child.on("message", onMessage);
+  child.on("disconnect", onChildClosed);
+  child.on("error", onChildClosed);
+  child.on("exit", onChildClosed);
+
+  if (!child.connected || child.send === undefined) {
+    close(false);
+  }
+
+  return { dispose: () => close(false) };
+}
+
+const popupDismissError: SafeError = {
+  tag: "TuiRendererControlError",
+  code: "TUI_POPUP_DISMISS_FAILED",
+  message: "The tmux popup could not be dismissed.",
+};
+
+const focusOriginError: SafeError = {
+  tag: "TuiRendererControlError",
+  code: "TUI_POPUP_FOCUS_ORIGIN_UNAVAILABLE",
+  message: "The current tmux popup focus origin could not be resolved.",
+};
+
+function controlSafeError(error: unknown, fallback: SafeError): SafeError {
+  const normalized = safeErrorFromUnknown(error, fallback);
+  const result: SafeError = {
+    tag: normalized.tag,
+    code: normalized.code,
+    message: normalized.message,
+  };
+  if (normalized.hint !== undefined) result.hint = normalized.hint;
+  if (normalized.commandId !== undefined) result.commandId = normalized.commandId;
+  if (normalized.projectId !== undefined) result.projectId = normalized.projectId;
+  if (normalized.worktreeId !== undefined) result.worktreeId = normalized.worktreeId;
+  if (normalized.sessionId !== undefined) result.sessionId = normalized.sessionId;
+  if (normalized.provider !== undefined) result.provider = normalized.provider;
+  if (normalized.traceId !== undefined) result.traceId = normalized.traceId;
+  if (normalized.diagnosticId !== undefined) result.diagnosticId = normalized.diagnosticId;
+  return result;
+}

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { runCli } from "@station/cli";
 import {
   type ObserverProcessDeps,
+  resolvePopupTmuxCommand,
   runTuiCommand,
   type TuiCommandDeps,
 } from "@station/cli/internal";
@@ -98,6 +99,13 @@ function runningObserverDeps(
 }
 
 describe("CLI tui command", () => {
+  it("prefers the configured popup command over the environment and default", () => {
+    expect(resolvePopupTmuxCommand("config-tmux", { STATION_TMUX_BIN: "env-tmux" })).toBe(
+      "config-tmux",
+    );
+    expect(resolvePopupTmuxCommand(undefined, { STATION_TMUX_BIN: "env-tmux" })).toBe("env-tmux");
+    expect(resolvePopupTmuxCommand(undefined, {})).toBe("tmux");
+  });
   it("launches the native first-run TUI without writing an implicit config", async () => {
     const fixture = await createTempState();
     const envs: Array<Record<string, string>> = [];
@@ -340,7 +348,10 @@ describe("CLI tui command", () => {
 
     expect(result).toEqual({ code: 0, output: { status: "exited", code: 0 } });
     expect(envs).toEqual([
-      { STATION_OBSERVER_SOCKET_PATH: fixture.socketPath, STATION_TUI_POPUP: "1" },
+      {
+        STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
+        STATION_TUI_POPUP: "1",
+      },
     ]);
   });
 
@@ -552,7 +563,11 @@ describe("CLI tui command", () => {
 
     expect(result).toEqual({ code: 0, output: { status: "exited", code: 0 } });
     expect(envs).toEqual([
-      { STATION_OBSERVER_SOCKET_PATH: fixture.socketPath, STATION_TUI_POPUP: "1" },
+      {
+        STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
+        STATION_TUI_PERSISTENT: "1",
+        STATION_TUI_POPUP: "1",
+      },
     ]);
   });
 
@@ -631,21 +646,21 @@ describe("CLI tui command", () => {
 
   it("routes correlated popup requests and resolves the current focus origin each time", async () => {
     const dismissPopup = vi.fn(async () => ({ dismissed: true }));
-    const resolveFocusOrigin = vi
+    const resolveFocusTarget = vi
       .fn()
-      .mockResolvedValueOnce({ provider: "tmux", clientId: "client-a" })
-      .mockResolvedValueOnce({ provider: "tmux", clientId: "client-b" });
+      .mockResolvedValueOnce(focusTarget("client-a"))
+      .mockResolvedValueOnce(focusTarget("client-b"));
     const persistent = await startPersistentRenderer({
-      popupControl: { dismissPopup, resolveFocusOrigin },
+      popupControl: { dismissPopup, resolveFocusTarget },
     });
 
     try {
-      persistent.child.emit("message", controlRequest("resolve-1", "resolve-focus-origin"));
+      persistent.child.emit("message", controlRequest("resolve-1", "resolve-focus-target"));
       await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(1));
       expect(persistent.child.sent[0]).toEqual({
         protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
         requestId: "resolve-1",
-        type: "focus-origin",
+        type: "focus-target",
         origin: { provider: "tmux", clientId: "client-a" },
       });
 
@@ -657,16 +672,96 @@ describe("CLI tui command", () => {
         type: "dismissed",
       });
 
-      persistent.child.emit("message", controlRequest("resolve-2", "resolve-focus-origin"));
+      persistent.child.emit("message", controlRequest("resolve-2", "resolve-focus-target"));
       await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(3));
       expect(persistent.child.sent[2]).toEqual({
         protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
         requestId: "resolve-2",
-        type: "focus-origin",
+        type: "focus-target",
         origin: { provider: "tmux", clientId: "client-b" },
       });
-      expect(resolveFocusOrigin).toHaveBeenCalledTimes(2);
+      expect(resolveFocusTarget).toHaveBeenCalledTimes(2);
       expect(dismissPopup).toHaveBeenCalledOnce();
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("does not let a late focus completion dismiss a newer popup target", async () => {
+    const dismissA = vi.fn(async () => ({ dismissed: true }));
+    const dismissB = vi.fn(async () => ({ dismissed: true }));
+    const resolveFocusTarget = vi
+      .fn()
+      .mockResolvedValueOnce(focusTarget("client-a", dismissA))
+      .mockResolvedValueOnce(focusTarget("client-b", dismissB));
+    const persistent = await startPersistentRenderer({
+      popupControl: {
+        dismissPopup: async () => ({ dismissed: true }),
+        resolveFocusTarget,
+      },
+    });
+
+    try {
+      persistent.child.emit("message", controlRequest("focus-a", "resolve-focus-target"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(1));
+      persistent.child.emit("message", controlRequest("focus-b", "resolve-focus-target"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(2));
+
+      persistent.child.emit("message", {
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "dismiss-a",
+        type: "dismiss-focus-target",
+        focusRequestId: "focus-a",
+      });
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(3));
+      expect(persistent.child.sent[2]).toMatchObject({
+        requestId: "dismiss-a",
+        type: "error",
+        error: { code: "TUI_POPUP_FOCUS_TARGET_STALE" },
+      });
+      expect(dismissA).not.toHaveBeenCalled();
+      expect(dismissB).not.toHaveBeenCalled();
+
+      persistent.child.emit("message", {
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "dismiss-b",
+        type: "dismiss-focus-target",
+        focusRequestId: "focus-b",
+      });
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(4));
+      expect(persistent.child.sent[3]).toMatchObject({
+        requestId: "dismiss-b",
+        type: "dismissed",
+      });
+      expect(dismissB).toHaveBeenCalledOnce();
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("coalesces duplicate manual dismiss effects", async () => {
+    let finishDismiss = (_result: { dismissed: boolean }) => undefined;
+    const dismissal = new Promise<{ dismissed: boolean }>((resolve) => {
+      finishDismiss = resolve;
+    });
+    const dismissPopup = vi.fn(() => dismissal);
+    const persistent = await startPersistentRenderer({
+      popupControl: {
+        dismissPopup,
+        resolveFocusTarget: async () => focusTarget("client-a"),
+      },
+    });
+
+    try {
+      persistent.child.emit("message", controlRequest("dismiss-1", "dismiss"));
+      persistent.child.emit("message", controlRequest("dismiss-2", "dismiss"));
+      await vi.waitFor(() => expect(dismissPopup).toHaveBeenCalledOnce());
+      finishDismiss({ dismissed: true });
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(2));
+      expect(persistent.child.sent).toEqual([
+        expect.objectContaining({ requestId: "dismiss-1", type: "dismissed" }),
+        expect.objectContaining({ requestId: "dismiss-2", type: "dismissed" }),
+      ]);
     } finally {
       await persistent.finish();
     }
@@ -675,8 +770,10 @@ describe("CLI tui command", () => {
   it("returns correlated SafeErrors without closing a valid control channel", async () => {
     const persistent = await startPersistentRenderer({
       popupControl: {
-        dismissPopup: async () => ({ dismissed: false }),
-        resolveFocusOrigin: async () => {
+        dismissPopup: async () => {
+          throw new Error("provider dismissal failed");
+        },
+        resolveFocusTarget: async () => {
           throw {
             tag: "TmuxProviderError",
             code: "TMUX_CLIENT_LOOKUP_FAILED",
@@ -696,12 +793,12 @@ describe("CLI tui command", () => {
         error: {
           tag: "TuiRendererControlError",
           code: "TUI_POPUP_DISMISS_FAILED",
-          message: "The tmux popup could not be dismissed.",
+          message: "The popup could not be dismissed.",
         },
       });
       expect(persistent.child.connected).toBe(true);
 
-      persistent.child.emit("message", controlRequest("resolve-failed", "resolve-focus-origin"));
+      persistent.child.emit("message", controlRequest("resolve-failed", "resolve-focus-target"));
       await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(2));
       expect(persistent.child.sent[1]).toEqual({
         protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
@@ -721,9 +818,9 @@ describe("CLI tui command", () => {
 
   it("disconnects after a renderer response send failure and ignores later requests", async () => {
     const dismissPopup = vi.fn(async () => ({ dismissed: true }));
-    const resolveFocusOrigin = vi.fn(async () => ({ provider: "tmux", clientId: "client-a" }));
+    const resolveFocusTarget = vi.fn(async () => focusTarget("client-a"));
     const persistent = await startPersistentRenderer({
-      popupControl: { dismissPopup, resolveFocusOrigin },
+      popupControl: { dismissPopup, resolveFocusTarget },
       sendError: new Error("ipc write failed"),
     });
 
@@ -735,10 +832,10 @@ describe("CLI tui command", () => {
 
       persistent.child.emit(
         "message",
-        controlRequest("ignored-after-error", "resolve-focus-origin"),
+        controlRequest("ignored-after-error", "resolve-focus-target"),
       );
       await Promise.resolve();
-      expect(resolveFocusOrigin).not.toHaveBeenCalled();
+      expect(resolveFocusTarget).not.toHaveBeenCalled();
       expect(persistent.child.sent).toHaveLength(1);
     } finally {
       await persistent.finish();
@@ -747,9 +844,9 @@ describe("CLI tui command", () => {
 
   it("fails closed before acting on malformed renderer control frames", async () => {
     const dismissPopup = vi.fn(async () => ({ dismissed: true }));
-    const resolveFocusOrigin = vi.fn(async () => ({ provider: "tmux", clientId: "client-a" }));
+    const resolveFocusTarget = vi.fn(async () => focusTarget("client-a"));
     const persistent = await startPersistentRenderer({
-      popupControl: { dismissPopup, resolveFocusOrigin },
+      popupControl: { dismissPopup, resolveFocusTarget },
     });
 
     try {
@@ -760,33 +857,33 @@ describe("CLI tui command", () => {
       await vi.waitFor(() => expect(persistent.child.connected).toBe(false));
       expect(persistent.child.sent).toEqual([]);
       expect(dismissPopup).not.toHaveBeenCalled();
-      expect(resolveFocusOrigin).not.toHaveBeenCalled();
+      expect(resolveFocusTarget).not.toHaveBeenCalled();
     } finally {
       await persistent.finish();
     }
   });
 
   it("closes on duplicate in-flight correlation ids and ignores late adapter completion", async () => {
-    let completeResolution = (_origin: { provider: string; clientId: string }) => undefined;
-    const resolution = new Promise<{ provider: string; clientId: string }>((resolve) => {
+    let completeResolution = (_target: ReturnType<typeof focusTarget>) => undefined;
+    const resolution = new Promise<ReturnType<typeof focusTarget>>((resolve) => {
       completeResolution = resolve;
     });
-    const resolveFocusOrigin = vi.fn(() => resolution);
+    const resolveFocusTarget = vi.fn(() => resolution);
     const persistent = await startPersistentRenderer({
       popupControl: {
         dismissPopup: async () => ({ dismissed: true }),
-        resolveFocusOrigin,
+        resolveFocusTarget,
       },
     });
 
     try {
-      const request = controlRequest("duplicate", "resolve-focus-origin");
+      const request = controlRequest("duplicate", "resolve-focus-target");
       persistent.child.emit("message", request);
       persistent.child.emit("message", request);
       await vi.waitFor(() => expect(persistent.child.connected).toBe(false));
-      completeResolution({ provider: "tmux", clientId: "too-late" });
+      completeResolution(focusTarget("too-late"));
       await Promise.resolve();
-      expect(resolveFocusOrigin).toHaveBeenCalledOnce();
+      expect(resolveFocusTarget).toHaveBeenCalledOnce();
       expect(persistent.child.sent).toEqual([]);
     } finally {
       await persistent.finish();
@@ -795,24 +892,24 @@ describe("CLI tui command", () => {
 
   it("cleans up control listeners and ignores late adapter completion on child exit or disconnect", async () => {
     for (const childEvent of ["exit", "disconnect"] as const) {
-      let completeResolution = (_origin: { provider: string; clientId: string }) => undefined;
-      const resolution = new Promise<{ provider: string; clientId: string }>((resolve) => {
+      let completeResolution = (_target: ReturnType<typeof focusTarget>) => undefined;
+      const resolution = new Promise<ReturnType<typeof focusTarget>>((resolve) => {
         completeResolution = resolve;
       });
       const persistent = await startPersistentRenderer({
         popupControl: {
           dismissPopup: async () => ({ dismissed: true }),
-          resolveFocusOrigin: () => resolution,
+          resolveFocusTarget: () => resolution,
         },
       });
 
-      persistent.child.emit("message", controlRequest(childEvent, "resolve-focus-origin"));
+      persistent.child.emit("message", controlRequest(childEvent, "resolve-focus-target"));
       if (childEvent === "exit") {
         await persistent.finish();
       } else {
         persistent.child.disconnect();
       }
-      completeResolution({ provider: "tmux", clientId: "too-late" });
+      completeResolution(focusTarget("too-late"));
       await Promise.resolve();
 
       expect(persistent.child.listenerCount("message")).toBe(0);
@@ -1114,7 +1211,7 @@ async function startPersistentRenderer(
     options.popupControl ??
     ({
       dismissPopup: async () => ({ dismissed: true }),
-      resolveFocusOrigin: async () => ({ provider: "tmux", clientId: "client-a" }),
+      resolveFocusTarget: async () => focusTarget("client-a"),
     } satisfies NonNullable<TuiCommandDeps["popupControl"]>);
   const result = runTuiCommand(
     ["--popup", "--persistent"],
@@ -1149,7 +1246,17 @@ async function startPersistentRenderer(
 
 function controlRequest(
   requestId: string,
-  type: "dismiss" | "resolve-focus-origin",
-): { protocolVersion: 1; requestId: string; type: "dismiss" | "resolve-focus-origin" } {
+  type: "dismiss" | "resolve-focus-target",
+): { protocolVersion: 1; requestId: string; type: "dismiss" | "resolve-focus-target" } {
   return { protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION, requestId, type };
+}
+
+function focusTarget(
+  clientId: string,
+  dismissExact: () => Promise<{ dismissed: boolean }> = async () => ({ dismissed: true }),
+) {
+  return {
+    origin: { provider: "tmux", clientId },
+    dismissExact,
+  };
 }

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -2,8 +2,13 @@ import { EventEmitter } from "node:events";
 import { access, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
-import { type ObserverProcessDeps, runTuiCommand } from "@station/cli/internal";
+import {
+  type ObserverProcessDeps,
+  runTuiCommand,
+  type TuiCommandDeps,
+} from "@station/cli/internal";
 import type { TuiConfig } from "@station/config";
+import { TUI_RENDERER_CONTROL_PROTOCOL_VERSION } from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
@@ -530,7 +535,7 @@ describe("CLI tui command", () => {
     );
   });
 
-  it("accepts --popup --persistent (no separate lifecycle) and signals popup mode", async () => {
+  it("accepts --popup --persistent without exposing renderer-owned tmux state", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const envs: Array<Record<string, string>> = [];
@@ -549,6 +554,272 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       { STATION_OBSERVER_SOCKET_PATH: fixture.socketPath, STATION_TUI_POPUP: "1" },
     ]);
+  });
+
+  it("opens an IPC channel only for the persistent compiled popup renderer", async () => {
+    const persistent = await startPersistentRenderer();
+
+    try {
+      expect(persistent.spawnProcess).toHaveBeenCalledWith(
+        "/opt/station/stn",
+        ["__dashboard"],
+        expect.objectContaining({
+          stdio: ["inherit", "inherit", "inherit", "ipc"],
+        }),
+      );
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("preserves the persistent source Bun renderer command with IPC", async () => {
+    const persistent = await startPersistentRenderer({ source: true });
+    const workspaceDir = resolveStationWorkspaceDir();
+
+    try {
+      expect(persistent.spawnProcess).toHaveBeenNthCalledWith(
+        1,
+        "bun",
+        ["run", "--silent", "--cwd", workspaceDir, "link:station"],
+        expect.objectContaining({ stdio: "inherit" }),
+      );
+      expect(persistent.spawnProcess).toHaveBeenNthCalledWith(
+        2,
+        "bun",
+        ["src/dashboardRenderer/main.tsx"],
+        expect.objectContaining({
+          cwd: workspaceDir,
+          stdio: ["inherit", "inherit", "inherit", "ipc"],
+        }),
+      );
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("does not spawn the persistent source renderer when station linking fails", async () => {
+    const persistent = await startPersistentRenderer({ source: true, linkExitCode: 23 });
+
+    expect(persistent.spawnProcess).toHaveBeenCalledOnce();
+    expect(persistent.spawnProcess).toHaveBeenCalledWith(
+      "bun",
+      ["run", "--silent", "--cwd", resolveStationWorkspaceDir(), "link:station"],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+    await persistent.finish();
+  });
+
+  it("preserves the persistent dashboard shell override with IPC", async () => {
+    const previousOverride = process.env.STATION_DASHBOARD_COMMAND;
+    process.env.STATION_DASHBOARD_COMMAND = "custom-dashboard --flag";
+    const persistent = await startPersistentRenderer();
+
+    try {
+      expect(persistent.spawnProcess).toHaveBeenCalledWith(
+        "custom-dashboard --flag",
+        expect.objectContaining({
+          shell: true,
+          stdio: ["inherit", "inherit", "inherit", "ipc"],
+        }),
+      );
+    } finally {
+      await persistent.finish();
+      if (previousOverride === undefined) delete process.env.STATION_DASHBOARD_COMMAND;
+      else process.env.STATION_DASHBOARD_COMMAND = previousOverride;
+    }
+  });
+
+  it("routes correlated popup requests and resolves the current focus origin each time", async () => {
+    const dismissPopup = vi.fn(async () => ({ dismissed: true }));
+    const resolveFocusOrigin = vi
+      .fn()
+      .mockResolvedValueOnce({ provider: "tmux", clientId: "client-a" })
+      .mockResolvedValueOnce({ provider: "tmux", clientId: "client-b" });
+    const persistent = await startPersistentRenderer({
+      popupControl: { dismissPopup, resolveFocusOrigin },
+    });
+
+    try {
+      persistent.child.emit("message", controlRequest("resolve-1", "resolve-focus-origin"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(1));
+      expect(persistent.child.sent[0]).toEqual({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "resolve-1",
+        type: "focus-origin",
+        origin: { provider: "tmux", clientId: "client-a" },
+      });
+
+      persistent.child.emit("message", controlRequest("dismiss-1", "dismiss"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(2));
+      expect(persistent.child.sent[1]).toEqual({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "dismiss-1",
+        type: "dismissed",
+      });
+
+      persistent.child.emit("message", controlRequest("resolve-2", "resolve-focus-origin"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(3));
+      expect(persistent.child.sent[2]).toEqual({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "resolve-2",
+        type: "focus-origin",
+        origin: { provider: "tmux", clientId: "client-b" },
+      });
+      expect(resolveFocusOrigin).toHaveBeenCalledTimes(2);
+      expect(dismissPopup).toHaveBeenCalledOnce();
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("returns correlated SafeErrors without closing a valid control channel", async () => {
+    const persistent = await startPersistentRenderer({
+      popupControl: {
+        dismissPopup: async () => ({ dismissed: false }),
+        resolveFocusOrigin: async () => {
+          throw {
+            tag: "TmuxProviderError",
+            code: "TMUX_CLIENT_LOOKUP_FAILED",
+            message: "The active tmux client could not be read.",
+          };
+        },
+      },
+    });
+
+    try {
+      persistent.child.emit("message", controlRequest("dismiss-failed", "dismiss"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(1));
+      expect(persistent.child.sent[0]).toEqual({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "dismiss-failed",
+        type: "error",
+        error: {
+          tag: "TuiRendererControlError",
+          code: "TUI_POPUP_DISMISS_FAILED",
+          message: "The tmux popup could not be dismissed.",
+        },
+      });
+      expect(persistent.child.connected).toBe(true);
+
+      persistent.child.emit("message", controlRequest("resolve-failed", "resolve-focus-origin"));
+      await vi.waitFor(() => expect(persistent.child.sent).toHaveLength(2));
+      expect(persistent.child.sent[1]).toEqual({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "resolve-failed",
+        type: "error",
+        error: {
+          tag: "TmuxProviderError",
+          code: "TMUX_CLIENT_LOOKUP_FAILED",
+          message: "The active tmux client could not be read.",
+        },
+      });
+      expect(persistent.child.connected).toBe(true);
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("disconnects after a renderer response send failure and ignores later requests", async () => {
+    const dismissPopup = vi.fn(async () => ({ dismissed: true }));
+    const resolveFocusOrigin = vi.fn(async () => ({ provider: "tmux", clientId: "client-a" }));
+    const persistent = await startPersistentRenderer({
+      popupControl: { dismissPopup, resolveFocusOrigin },
+      sendError: new Error("ipc write failed"),
+    });
+
+    try {
+      persistent.child.emit("message", controlRequest("dismiss-before-error", "dismiss"));
+      await vi.waitFor(() => expect(persistent.child.connected).toBe(false));
+      expect(dismissPopup).toHaveBeenCalledOnce();
+      expect(persistent.child.sent).toHaveLength(1);
+
+      persistent.child.emit(
+        "message",
+        controlRequest("ignored-after-error", "resolve-focus-origin"),
+      );
+      await Promise.resolve();
+      expect(resolveFocusOrigin).not.toHaveBeenCalled();
+      expect(persistent.child.sent).toHaveLength(1);
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("fails closed before acting on malformed renderer control frames", async () => {
+    const dismissPopup = vi.fn(async () => ({ dismissed: true }));
+    const resolveFocusOrigin = vi.fn(async () => ({ provider: "tmux", clientId: "client-a" }));
+    const persistent = await startPersistentRenderer({
+      popupControl: { dismissPopup, resolveFocusOrigin },
+    });
+
+    try {
+      persistent.child.emit("message", {
+        ...controlRequest("unsafe", "dismiss"),
+        command: "display-popup -C",
+      });
+      await vi.waitFor(() => expect(persistent.child.connected).toBe(false));
+      expect(persistent.child.sent).toEqual([]);
+      expect(dismissPopup).not.toHaveBeenCalled();
+      expect(resolveFocusOrigin).not.toHaveBeenCalled();
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("closes on duplicate in-flight correlation ids and ignores late adapter completion", async () => {
+    let completeResolution = (_origin: { provider: string; clientId: string }) => undefined;
+    const resolution = new Promise<{ provider: string; clientId: string }>((resolve) => {
+      completeResolution = resolve;
+    });
+    const resolveFocusOrigin = vi.fn(() => resolution);
+    const persistent = await startPersistentRenderer({
+      popupControl: {
+        dismissPopup: async () => ({ dismissed: true }),
+        resolveFocusOrigin,
+      },
+    });
+
+    try {
+      const request = controlRequest("duplicate", "resolve-focus-origin");
+      persistent.child.emit("message", request);
+      persistent.child.emit("message", request);
+      await vi.waitFor(() => expect(persistent.child.connected).toBe(false));
+      completeResolution({ provider: "tmux", clientId: "too-late" });
+      await Promise.resolve();
+      expect(resolveFocusOrigin).toHaveBeenCalledOnce();
+      expect(persistent.child.sent).toEqual([]);
+    } finally {
+      await persistent.finish();
+    }
+  });
+
+  it("cleans up control listeners and ignores late adapter completion on child exit or disconnect", async () => {
+    for (const childEvent of ["exit", "disconnect"] as const) {
+      let completeResolution = (_origin: { provider: string; clientId: string }) => undefined;
+      const resolution = new Promise<{ provider: string; clientId: string }>((resolve) => {
+        completeResolution = resolve;
+      });
+      const persistent = await startPersistentRenderer({
+        popupControl: {
+          dismissPopup: async () => ({ dismissed: true }),
+          resolveFocusOrigin: () => resolution,
+        },
+      });
+
+      persistent.child.emit("message", controlRequest(childEvent, "resolve-focus-origin"));
+      if (childEvent === "exit") {
+        await persistent.finish();
+      } else {
+        persistent.child.disconnect();
+      }
+      completeResolution({ provider: "tmux", clientId: "too-late" });
+      await Promise.resolve();
+
+      expect(persistent.child.listenerCount("message")).toBe(0);
+      expect(persistent.child.listenerCount("disconnect")).toBe(0);
+      expect(persistent.child.sent).toEqual([]);
+      if (childEvent === "disconnect") await persistent.finish();
+    }
   });
 
   it("does not block popup renderer startup on observer reconcile", async () => {
@@ -797,4 +1068,88 @@ async function withIsolatedHome<T>(home: string, run: () => Promise<T>): Promise
     if (previousRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR;
     else process.env.XDG_RUNTIME_DIR = previousRuntimeDir;
   }
+}
+
+class FakeRendererChild extends EventEmitter {
+  connected = true;
+  readonly sent: unknown[] = [];
+
+  constructor(private readonly sendError: Error | null = null) {
+    super();
+  }
+
+  send(message: unknown, callback?: (error: Error | null) => void): boolean {
+    this.sent.push(message);
+    callback?.(this.sendError);
+    return this.sendError === null;
+  }
+
+  disconnect(): void {
+    if (!this.connected) return;
+    this.connected = false;
+    this.emit("disconnect");
+  }
+}
+
+async function startPersistentRenderer(
+  options: {
+    linkExitCode?: number;
+    popupControl?: NonNullable<TuiCommandDeps["popupControl"]>;
+    sendError?: Error;
+    source?: boolean;
+  } = {},
+) {
+  const fixture = await createTempState();
+  const child = new FakeRendererChild(options.sendError ?? null);
+  const linkChild = new EventEmitter();
+  const linkExitCode = options.linkExitCode ?? 0;
+  const spawnProcess = vi.fn(() => {
+    if (options.source === true && spawnProcess.mock.calls.length === 1) {
+      queueMicrotask(() => linkChild.emit("exit", linkExitCode));
+      return linkChild as never;
+    }
+    return child as never;
+  });
+  const popupControl =
+    options.popupControl ??
+    ({
+      dismissPopup: async () => ({ dismissed: true }),
+      resolveFocusOrigin: async () => ({ provider: "tmux", clientId: "client-a" }),
+    } satisfies NonNullable<TuiCommandDeps["popupControl"]>);
+  const result = runTuiCommand(
+    ["--popup", "--persistent"],
+    { config: fixture.config },
+    {
+      observer: runningObserverDeps(),
+      selfExecRuntime:
+        options.source === true
+          ? { compiled: false, execPath: "/unused/stn" }
+          : { compiled: true, execPath: "/opt/station/stn" },
+      stationUiInstalled: async () => true,
+      spawnProcess: spawnProcess as never,
+      popupControl,
+    },
+  );
+  const expectedSpawnCount = options.source === true && linkExitCode === 0 ? 2 : 1;
+  await vi.waitFor(() => expect(spawnProcess).toHaveBeenCalledTimes(expectedSpawnCount));
+
+  return {
+    child,
+    spawnProcess,
+    finish: async () => {
+      if (options.source === true && linkExitCode !== 0) {
+        await expect(result).resolves.toEqual({ status: "exited", code: linkExitCode });
+        return;
+      }
+      child.emit("exit", 0);
+      await expect(result).resolves.toEqual({ status: "exited", code: 0 });
+    },
+  };
+}
+
+function controlRequest(
+  requestId: string,
+  type: "dismiss" | "resolve-focus-origin",
+): { protocolVersion: 1; requestId: string; type: "dismiss" | "resolve-focus-origin" } {
+  return { protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION, requestId, type };
 }

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -76,7 +76,7 @@ describe("observer protocol server", () => {
       };
       await expect(
         runObserverMain(
-          ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "100"],
+          ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "1000"],
           { providerRegistryFactory, buildVersion: "0.0.0", incumbentLifecycle },
         ),
       ).resolves.toBe(0);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -489,11 +489,13 @@ Generated launch/hook env vars are internal context, not hand-authored config:
 `STATION_PROJECT_ID`, `STATION_WORKTREE_ID`, `STATION_WORKTREE_PATH`,
 `STATION_SESSION_ID`, `STATION_HARNESS_PROVIDER`, `STATION_TERMINAL_PROVIDER`,
 `STATION_TERMINAL_TARGET_ID`, `STATION_OBSERVER_STATE_DIR`, `STATION_STATE_DIR`,
-`STATION_HOOK_SPOOL_DIR`, `STATION_TUI_POPUP`, `STATION_FOCUS_PROVIDER`, and
-`STATION_FOCUS_CLIENT_ID`. Hook scripts and launched agents receive these so they
-can report back to the right observer/session. `STATION_STATE_DIR` is a hook-script
-fallback for `stn-ingress --state-dir`; it is **not** a global observer relocation
-knob. Use `observer.state_dir` in config for isolation.
+`STATION_HOOK_SPOOL_DIR`, `STATION_TUI_POPUP`, `STATION_TUI_PERSISTENT`,
+`STATION_FOCUS_PROVIDER`, and `STATION_FOCUS_CLIENT_ID`. The CLI sets
+`STATION_TUI_PERSISTENT=1` when the renderer requires its lifecycle-control IPC channel; it is not
+a standalone launch mode. Hook scripts and launched agents receive the other context variables so
+they can report back to the right observer/session. `STATION_STATE_DIR` is a hook-script fallback
+for `stn-ingress --state-dir`; it is **not** a global observer relocation knob. Use
+`observer.state_dir` in config for isolation.
 
 ---
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -17,6 +17,14 @@ Launch is driven by `apps/cli/src/commands/tui.ts`. The Node CLI shells out to t
 - Inside tmux, `stn` opens the read-only dashboard in a tmux popup, since tmux owns the panes there.
 - `stn tui --dev-fake-dashboard` previews the dashboard with mock data (`STATION_SOURCE=mock`).
 
+Persistent popups use a strict child-process IPC channel between the Node CLI and the Bun
+dashboard renderer. The CLI composition root retains all terminal-provider authority; the
+renderer sends only provider-neutral focus-origin and dismiss intents. When the CLI marks that
+channel as required, a renderer that starts without it or loses it exits instead of continuing
+without lifecycle control. Focus-success dismissal is scoped to the exact origin resolved for the
+operation and the provider-owned popup claim/lease, preventing a stale renderer from dismissing a
+replacement popup.
+
 You can also run the renderer directly during development:
 
 ```bash
@@ -29,6 +37,9 @@ bun run dashboard                     # read-only dashboard renderer
 ## Boundaries
 
 - Keep the Station UI provider-neutral. Do not import provider packages, read SQLite, run `wt`, run `tmux`, run `git` or `gh`, or parse raw provider payloads.
+- Keep terminal-provider mechanics behind CLI composition. The renderer-control contract carries
+  typed product intents, results, and normalized focus origins, never provider commands, arguments,
+  raw claims, or lease representations.
 - Render normalized contracts from `@station/contracts` and use `@station/protocol` through the Station service/source layer.
 - OpenTUI/React components should stay plain and readable. Runtime orchestration belongs in services or the Station state store, not presentation components.
 - Selectors, screen transitions, command builders, event reducers, and fixtures should stay pure TypeScript. The render-framework-free dashboard logic lives in `@station/dashboard-core` and is consumed by the OpenTUI render layer.

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -49,6 +49,7 @@ import type {
   TmuxPopupDismissOptions,
   TmuxPopupDismissResult,
   TmuxPopupFocusOriginOptions,
+  TmuxPopupFocusTarget,
   TmuxPopupOptions,
   TmuxPopupResult,
   TmuxPopupState,
@@ -62,6 +63,7 @@ export { ensurePersistentPopupSession, resolveRegisteredDevPopupUi } from "./per
 export type {
   TmuxPersistentPopupSessionResult,
   TmuxPopupDismissResult,
+  TmuxPopupFocusTarget,
   TmuxPopupOptions,
   TmuxPopupResult,
   TmuxRegisteredDevPopupUi,
@@ -101,8 +103,8 @@ type PopupArgsInput = {
 const popupCasMiss = "STATION_POPUP_CAS_MISS";
 const safeTmuxCommandTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;
 
-function defaultTmuxCommand(command: string | undefined): string {
-  return command ?? process.env.STATION_TMUX_BIN ?? "tmux";
+function defaultTmuxCommand(command: string | undefined, env: NodeJS.ProcessEnv): string {
+  return command ?? env.STATION_TMUX_BIN ?? "tmux";
 }
 
 function currentClientInput(options: TmuxPopupOptions, command: string): TmuxCurrentClientInput {
@@ -369,8 +371,123 @@ function runUnclaimedPopupAction(
   });
 }
 
+async function dismissLegacyTmuxPopupForClient(
+  options: TmuxPopupDismissOptions,
+  clientId: string,
+): Promise<TmuxPopupDismissResult> {
+  const command = defaultTmuxCommand(options.command, options.env ?? process.env);
+  const input = popupCommandInput(options, command);
+  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
+}
+
+function popupDismissOptions(
+  options: TmuxPopupFocusOriginOptions,
+  command: string,
+): TmuxPopupDismissOptions {
+  const result: TmuxPopupDismissOptions = {
+    command,
+    env: options.env ?? process.env,
+  };
+  if (options.runner !== undefined) result.runner = options.runner;
+  if (options.timeoutMs !== undefined) result.timeoutMs = options.timeoutMs;
+  return result;
+}
+
+async function dismissTmuxPopupWithExpectedClaim(
+  options: TmuxPopupDismissOptions,
+  expectedClaim?: string,
+): Promise<TmuxPopupDismissResult> {
+  const env = options.env ?? process.env;
+  const command = defaultTmuxCommand(options.command, env);
+  const input = popupCommandInput(options, command);
+  const requestedFocusClientId =
+    options.focusClientId !== undefined && options.focusClientId.length > 0
+      ? options.focusClientId
+      : undefined;
+  const envFocusClientId =
+    env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
+      ? env.STATION_FOCUS_CLIENT_ID
+      : undefined;
+  let boundClaim = expectedClaim;
+  let claimContended = false;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const claimState = await resolveActivePopupClaimState(input);
+    if (
+      claimState.kind === "malformed" ||
+      (claimState.kind === "valid" && claimState.claim.state !== "open")
+    ) {
+      return { dismissed: false };
+    }
+    if (boundClaim !== undefined) {
+      if (claimState.kind !== "valid" || claimState.raw !== boundClaim) {
+        return { dismissed: false };
+      }
+    } else if (claimState.kind === "valid") {
+      boundClaim = claimState.raw;
+    }
+    if (claimState.kind === "absent") {
+      break;
+    }
+    const closingClaim = buildPopupActiveClaim({
+      clientName: claimState.claim.clientName,
+      clientPid: claimState.claim.clientPid,
+      registrationNonce: claimState.claim.registrationNonce,
+      state: "closing",
+    });
+    if (
+      !(await compareAndSetActivePopupClaim(input, {
+        expected: claimState.raw,
+        replacement: closingClaim,
+      }))
+    ) {
+      claimContended = true;
+      continue;
+    }
+    let actionResult: ClaimedPopupActionResult | undefined;
+    try {
+      actionResult = await runClaimedPopupAction({
+        args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
+        claim: closingClaim,
+        clientId: claimState.claim.clientName,
+        command,
+        ...(options.runner === undefined ? {} : { runner: options.runner }),
+      });
+    } finally {
+      if (actionResult !== "contended") {
+        await clearActivePopupClaimIfCurrent(input, {
+          claim: closingClaim,
+          clientId: claimState.claim.clientName,
+        }).catch(() => undefined);
+      }
+    }
+    if (actionResult === "contended") {
+      claimContended = true;
+      continue;
+    }
+    return { dismissed: true };
+  }
+  if (claimContended) {
+    return { dismissed: false };
+  }
+  if (boundClaim !== undefined) {
+    return { dismissed: false };
+  }
+  const clientId =
+    requestedFocusClientId ??
+    envFocusClientId ??
+    (await resolveFocusPopupClient(input)) ??
+    (await resolveActivePopupClient(input));
+  if (clientId === undefined) {
+    return { dismissed: false };
+  }
+  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
+}
+
 export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<TmuxPopupResult> {
-  const command = defaultTmuxCommand(options.command ?? options.config?.command);
+  const command = defaultTmuxCommand(
+    options.command ?? options.config?.command,
+    options.env ?? process.env,
+  );
   const persistent = options.persistent !== false;
   const clientInput = currentClientInput(options, command);
   const currentClient = await resolveCurrentTmuxClient(clientInput);
@@ -633,8 +750,14 @@ export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<Tmu
 export async function resolveTmuxPopupFocusOrigin(
   options: TmuxPopupFocusOriginOptions = {},
 ): Promise<TerminalFocusOrigin | undefined> {
+  return (await resolveTmuxPopupFocusTarget(options))?.origin;
+}
+
+export async function resolveTmuxPopupFocusTarget(
+  options: TmuxPopupFocusOriginOptions = {},
+): Promise<TmuxPopupFocusTarget | undefined> {
   const env = options.env ?? process.env;
-  const command = defaultTmuxCommand(options.command);
+  const command = defaultTmuxCommand(options.command, env);
   const requestedFocusClientId =
     options.focusClientId !== undefined && options.focusClientId.length > 0
       ? options.focusClientId
@@ -645,91 +768,36 @@ export async function resolveTmuxPopupFocusOrigin(
       : undefined;
   const input = popupCommandInput(options, command);
   const claimState = await resolveActivePopupClaimState(input);
+  if (claimState.kind === "malformed") {
+    return undefined;
+  }
+  if (claimState.kind === "valid") {
+    if (claimState.claim.state !== "open") {
+      return undefined;
+    }
+    const exactDismissOptions = popupDismissOptions(options, command);
+    return {
+      origin: {
+        provider: "tmux",
+        clientId: claimState.claim.clientName,
+      },
+      dismissExact: () => dismissTmuxPopupWithExpectedClaim(exactDismissOptions, claimState.raw),
+    };
+  }
   const clientId =
-    requestedFocusClientId ??
-    envFocusClientId ??
-    (claimState.kind === "valid" ? claimState.claim.clientName : undefined) ??
-    (await resolveFocusPopupClient(input));
+    requestedFocusClientId ?? envFocusClientId ?? (await resolveFocusPopupClient(input));
   if (clientId === undefined) {
     return undefined;
   }
+  const legacyDismissOptions = popupDismissOptions(options, command);
   return {
-    provider: "tmux",
-    clientId,
+    origin: { provider: "tmux", clientId },
+    dismissExact: () => dismissLegacyTmuxPopupForClient(legacyDismissOptions, clientId),
   };
 }
 
 export async function dismissTmuxPopup(
   options: TmuxPopupDismissOptions = {},
 ): Promise<TmuxPopupDismissResult> {
-  const env = options.env ?? process.env;
-  const command = defaultTmuxCommand(options.command);
-  const input = popupCommandInput(options, command);
-  const requestedFocusClientId =
-    options.focusClientId !== undefined && options.focusClientId.length > 0
-      ? options.focusClientId
-      : undefined;
-  const envFocusClientId =
-    env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
-      ? env.STATION_FOCUS_CLIENT_ID
-      : undefined;
-  let claimContended = false;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const claimState = await resolveActivePopupClaimState(input);
-    if (claimState.kind === "malformed") {
-      return { dismissed: false };
-    }
-    if (claimState.kind === "absent") {
-      break;
-    }
-    const closingClaim = buildPopupActiveClaim({
-      clientName: claimState.claim.clientName,
-      clientPid: claimState.claim.clientPid,
-      registrationNonce: claimState.claim.registrationNonce,
-      state: "closing",
-    });
-    if (
-      !(await compareAndSetActivePopupClaim(input, {
-        expected: claimState.raw,
-        replacement: closingClaim,
-      }))
-    ) {
-      claimContended = true;
-      continue;
-    }
-    let actionResult: ClaimedPopupActionResult | undefined;
-    try {
-      actionResult = await runClaimedPopupAction({
-        args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
-        claim: closingClaim,
-        clientId: claimState.claim.clientName,
-        command,
-        ...(options.runner === undefined ? {} : { runner: options.runner }),
-      });
-    } finally {
-      if (actionResult !== "contended") {
-        await clearActivePopupClaimIfCurrent(input, {
-          claim: closingClaim,
-          clientId: claimState.claim.clientName,
-        }).catch(() => undefined);
-      }
-    }
-    if (actionResult === "contended") {
-      claimContended = true;
-      continue;
-    }
-    return { dismissed: true };
-  }
-  if (claimContended) {
-    return { dismissed: false };
-  }
-  const clientId =
-    requestedFocusClientId ??
-    envFocusClientId ??
-    (await resolveFocusPopupClient(input)) ??
-    (await resolveActivePopupClient(input));
-  if (clientId === undefined) {
-    return { dismissed: false };
-  }
-  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
+  return dismissTmuxPopupWithExpectedClaim(options);
 }

--- a/integrations/terminal/tmux/src/popup/types.ts
+++ b/integrations/terminal/tmux/src/popup/types.ts
@@ -72,6 +72,14 @@ export type TmuxPopupDismissOptions = {
   timeoutMs?: number;
 };
 
+export type TmuxPopupFocusTarget = {
+  origin: {
+    provider: "tmux";
+    clientId: string;
+  };
+  dismissExact: () => Promise<TmuxPopupDismissResult>;
+};
+
 export type TmuxPopupFocusOriginOptions = {
   command?: string;
   env?: NodeJS.ProcessEnv;

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -344,6 +344,7 @@ describeRealTmux("real tmux dev popup routing", () => {
       api: popupFocusObserver(focusCommands),
     });
     delete fixture.env.STATION_SOURCE;
+    delete fixture.env.STATION_TMUX_BIN;
     fixture.env.STATION_FOCUS_CLIENT_ID = "stale-startup-client";
 
     await tmuxExec(fixture.wrapper, ["new-session", "-d", "-s", "base", "sleep 300"], fixture.env);
@@ -451,7 +452,7 @@ describeRealTmux("real tmux dev popup routing", () => {
     );
   }, 180_000);
 
-  it("compiled managed binding cold-starts, reuses the warm UI, and fails without entering view mode", async () => {
+  it("compiled managed binding honors dashboard dismissal, reuses the warm UI, and fails without entering view mode", async () => {
     const fixture = await createDashboardFixture(tmux, {
       height: "50%",
       position: "C",
@@ -523,17 +524,39 @@ describeRealTmux("real tmux dev popup routing", () => {
     expect(await tmuxSessionOption(fixture, "@station_popup_ui_lease")).toBe(route);
     expect(await tmuxGlobalOption(fixture, "@station_popup_ui_root")).toBe(installedRoot);
 
-    await triggerPopupBinding(coldAction.owner);
+    await coldAction.owner.write(Buffer.from([0x1b]));
     await waitForNestedClientGone(fixture);
     await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
 
     await writeFile(fixture.configPath, 'schema_version = "malformed"\n', "utf8");
     await triggerPopupBinding(coldAction.owner);
+    const qClient = await waitForNestedClient(fixture);
+    await waitForHiddenPaneContent(
+      fixture,
+      isDashboardContent,
+      "compiled dashboard did not reopen after Esc",
+    );
+    const qPane = await readPaneEvidence(fixture);
+    const qProcesses = await waitForDashboardProcessEvidence(fixture, qPane);
+    const qObserverPid = await recordObserverPid(fixture);
+    recordRuntimeEvidence(fixture, qClient, qPane, qProcesses);
+
+    expect(qPane.pid).toBe(firstPane.pid);
+    expect(qProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+    expect(qObserverPid).toBe(firstObserverPid);
+    expect(qClient.columns).toBe(firstClient.columns);
+    expect(qClient.rows).toBe(firstClient.rows);
+
+    await coldAction.owner.write(Buffer.from("Q", "utf8"));
+    await waitForNestedClientGone(fixture);
+    await waitForGlobalOptionValue(fixture, "@station_popup_active_claim", "");
+
+    await triggerPopupBinding(coldAction.owner);
     const warmClient = await waitForNestedClient(fixture);
     await waitForHiddenPaneContent(
       fixture,
       isDashboardContent,
-      "compiled warm binding did not bypass malformed config",
+      "compiled warm binding did not bypass malformed config after Q",
     );
     const warmPane = await readPaneEvidence(fixture);
     const warmProcesses = await waitForDashboardProcessEvidence(fixture, warmPane);

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -3,9 +3,23 @@ import { access, chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from
 import { basename, dirname, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
-import { ObserverProcessIdentitySchema } from "@station/contracts";
-import { environmentWithoutGitLocals, resolveExecutablePath } from "@station/runtime";
+import {
+  type CommandId,
+  type CommandRecord,
+  type ObserverApi,
+  ObserverProcessIdentitySchema,
+  STATION_SCHEMA_VERSION,
+  type StationCommand,
+  type StationEvent,
+} from "@station/contracts";
+import { startProtocolServer, type UnixSocketServer } from "@station/protocol";
+import {
+  environmentWithoutGitLocals,
+  resolveExecutablePath,
+  stationBuildInfo,
+} from "@station/runtime";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { mockObserverSnapshot } from "../../../../../station/src/sources/fixtures/mockObserverSnapshot.js";
 import { buildManagedFastPopupRunShellCommand, openTmuxPopup } from "../../src/popup";
 import { parsePopupActiveClaim } from "../../src/popup/fastProtocol";
 import { shellQuote } from "../../src/shell";
@@ -98,6 +112,7 @@ type DashboardFixture = {
   nestedCliPids: Set<number>;
   nestedClientPids: Set<number>;
   observerPids: Set<number>;
+  observerServer?: UnixSocketServer;
   observerSocketPath: string;
   otherPtyClients: TmuxPtyClient[];
   panePids: Set<number>;
@@ -319,6 +334,122 @@ describeRealTmux("real tmux dev popup routing", () => {
       "a child invoked bare tmux instead of the private wrapper",
     );
   }, 120_000);
+
+  it("persistent dashboard dismisses with Esc and Q, preserves its renderer, and resolves the current focus client", async () => {
+    const fixture = await createDashboardFixture(tmux);
+    cleanup = () => cleanupDashboardFixture(fixture);
+    const focusCommands: StationCommand[] = [];
+    fixture.observerServer = await startProtocolServer({
+      socketPath: fixture.observerSocketPath,
+      api: popupFocusObserver(focusCommands),
+    });
+    delete fixture.env.STATION_SOURCE;
+    fixture.env.STATION_FOCUS_CLIENT_ID = "stale-startup-client";
+
+    await tmuxExec(fixture.wrapper, ["new-session", "-d", "-s", "base", "sleep 300"], fixture.env);
+    fixture.ptyClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base",
+      env: fixture.env,
+    });
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base-other", "sleep 300"],
+      fixture.env,
+    );
+    const otherClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base-other",
+      env: fixture.env,
+    });
+    fixture.otherPtyClients.push(otherClient);
+
+    const escPopup = spawnPopupCli(fixture, fixture.ptyClient.clientName);
+    await waitForPaneContent(fixture, escPopup, isDashboardContent, "dashboard did not render");
+    const firstClient = await waitForNestedClient(fixture);
+    const firstPane = await readPaneEvidence(fixture);
+    const firstProcesses = await waitForDashboardProcessEvidence(fixture, firstPane);
+    recordRuntimeEvidence(fixture, firstClient, firstPane, firstProcesses);
+
+    await fixture.ptyClient.write(Buffer.from([0x1b]));
+    await waitForNestedClientGone(fixture);
+    await expectSuccessfulExit(escPopup, 10_000);
+
+    const qPopup = spawnPopupCli(fixture, fixture.ptyClient.clientName);
+    await waitForPaneContent(
+      fixture,
+      qPopup,
+      isDashboardContent,
+      "dashboard did not reopen after Esc",
+    );
+    const afterEscClient = await waitForNestedClient(fixture);
+    const afterEscPane = await readPaneEvidence(fixture);
+    const afterEscProcesses = await waitForDashboardProcessEvidence(fixture, afterEscPane);
+    recordRuntimeEvidence(fixture, afterEscClient, afterEscPane, afterEscProcesses);
+    expect(afterEscPane.pid).toBe(firstPane.pid);
+    expect(afterEscProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+
+    await fixture.ptyClient.write(Buffer.from("Q", "utf8"));
+    await waitForNestedClientGone(fixture);
+    await expectSuccessfulExit(qPopup, 10_000);
+
+    const failedFocusPopup = spawnPopupCli(fixture, otherClient.clientName);
+    await waitForPaneContent(
+      fixture,
+      failedFocusPopup,
+      isDashboardContent,
+      "dashboard did not reopen after Q",
+    );
+    const otherNestedClient = await waitForNestedClient(fixture);
+    const otherPane = await readPaneEvidence(fixture);
+    const otherProcesses = await waitForDashboardProcessEvidence(fixture, otherPane);
+    recordRuntimeEvidence(fixture, otherNestedClient, otherPane, otherProcesses);
+    expect(otherPane.pid).toBe(firstPane.pid);
+    expect(otherProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+
+    await otherClient.write(Buffer.from("1", "utf8"));
+    await waitForPaneContent(
+      fixture,
+      failedFocusPopup,
+      (content) => content.includes("Private popup focus failed."),
+      "failed focus did not leave the popup visible with its error toast",
+    );
+    expect((await waitForNestedClient(fixture)).pid).toBe(otherNestedClient.pid);
+
+    await otherClient.write(Buffer.from("1", "utf8"));
+    await waitForNestedClientGone(fixture);
+    await expectSuccessfulExit(failedFocusPopup, 10_000);
+    expect(focusOrigin(focusCommands.at(-1))).toEqual({
+      provider: "tmux",
+      clientId: otherClient.clientName,
+    });
+
+    const currentClientPopup = spawnPopupCli(fixture, fixture.ptyClient.clientName);
+    await waitForPaneContent(
+      fixture,
+      currentClientPopup,
+      isDashboardContent,
+      "dashboard did not reopen after successful focus",
+    );
+    const currentNestedClient = await waitForNestedClient(fixture);
+    const currentPane = await readPaneEvidence(fixture);
+    const currentProcesses = await waitForDashboardProcessEvidence(fixture, currentPane);
+    recordRuntimeEvidence(fixture, currentNestedClient, currentPane, currentProcesses);
+    expect(currentPane.pid).toBe(firstPane.pid);
+    expect(currentProcesses.renderer.pid).toBe(firstProcesses.renderer.pid);
+
+    await fixture.ptyClient.write(Buffer.from("1", "utf8"));
+    await waitForNestedClientGone(fixture);
+    await expectSuccessfulExit(currentClientPopup, 10_000);
+    expect(focusOrigin(focusCommands.at(-1))).toEqual({
+      provider: "tmux",
+      clientId: fixture.ptyClient.clientName,
+    });
+    await assertPathMissing(
+      fixture.bareTmuxLogPath,
+      "a child invoked bare tmux instead of the private wrapper",
+    );
+  }, 180_000);
 
   it("compiled managed binding cold-starts, reuses the warm UI, and fails without entering view mode", async () => {
     const fixture = await createDashboardFixture(tmux, {
@@ -1432,6 +1563,12 @@ async function cleanupDashboardFixture(fixture: DashboardFixture): Promise<void>
     }
   });
   await cleanupStep(failures, "stop isolated observer", async () => {
+    if (fixture.observerServer !== undefined) {
+      const observerServer = fixture.observerServer;
+      fixture.observerServer = undefined;
+      await observerServer.close();
+      return;
+    }
     await recordObserverPidIfPresent(fixture);
     await execFileAsync(
       process.execPath,
@@ -1460,28 +1597,42 @@ async function cleanupDashboardFixture(fixture: DashboardFixture): Promise<void>
     });
   });
   await cleanupStep(failures, "wait for fixture processes", async () => {
-    const pids = new Set([
-      ...fixture.cliProcesses.flatMap((tracked) =>
+    const pidLabels = new Map<number, string[]>();
+    const recordPids = (pids: Iterable<number>, label: string) => {
+      for (const pid of pids) {
+        const labels = pidLabels.get(pid) ?? [];
+        labels.push(label);
+        pidLabels.set(pid, labels);
+      }
+    };
+    recordPids(
+      fixture.cliProcesses.flatMap((tracked) =>
         tracked.child.pid === undefined ? [] : [tracked.child.pid],
       ),
-      ...fixture.nestedCliPids,
-      ...fixture.nestedClientPids,
-      ...fixture.panePids,
-      ...fixture.rendererPids,
-      ...fixture.observerPids,
-    ]);
+      "outer popup CLI",
+    );
+    recordPids(fixture.nestedCliPids, "nested dashboard CLI");
+    recordPids(fixture.nestedClientPids, "nested tmux client");
+    recordPids(fixture.panePids, "hidden pane");
+    recordPids(fixture.rendererPids, "dashboard renderer");
+    recordPids(fixture.observerPids, "observer");
     const processFailures: Error[] = [];
     await Promise.all(
-      [...pids].map(async (pid) => {
+      [...pidLabels].map(async ([pid, labels]) => {
         if (await waitForPidExit(pid, 5_000)) {
           return;
         }
-        processFailures.push(new Error(`fixture process ${pid} did not exit without a signal`));
+        processFailures.push(
+          new Error(`fixture ${labels.join("/")} process ${pid} did not exit without a signal`),
+        );
         await terminateRecordedPid(pid);
       }),
     );
     if (processFailures.length > 0) {
-      throw new AggregateError(processFailures, "fixture processes required forced cleanup");
+      throw new AggregateError(
+        processFailures,
+        `fixture processes required forced cleanup: ${processFailures.map((error) => error.message).join(", ")}`,
+      );
     }
   });
   await cleanupStep(failures, "prove private isolation", async () => {
@@ -1498,8 +1649,87 @@ async function cleanupDashboardFixture(fixture: DashboardFixture): Promise<void>
     await assertPathMissing(fixture.root, "fixture root still exists after removal");
   });
   if (failures.length > 0) {
-    throw new AggregateError(failures, "real dashboard popup cleanup failed");
+    throw new AggregateError(
+      failures,
+      `real dashboard popup cleanup failed: ${failures.map((error) => error.message).join("; ")}`,
+    );
   }
+}
+
+function popupFocusObserver(focusCommands: StationCommand[]): ObserverApi {
+  const records = new Map<CommandId, CommandRecord>();
+  let commandCounter = 0;
+  return {
+    health: async () => ({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      status: "healthy",
+      pid: process.pid,
+      startedAt: new Date(Date.now() - 1_000).toISOString(),
+      version: stationBuildInfo().version,
+    }),
+    stop: async () => ({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      stopped: true,
+      at: new Date().toISOString(),
+    }),
+    getSnapshot: async () => mockObserverSnapshot,
+    subscribe: () => neverStationEvents(),
+    dispatch: async (command) => {
+      commandCounter += 1;
+      const commandId = `cmd_popup_real_${commandCounter}` as CommandId;
+      const failed = commandCounter === 1;
+      const now = new Date().toISOString();
+      const record: CommandRecord = {
+        id: commandId,
+        type: command.type,
+        command,
+        status: failed ? "failed" : "succeeded",
+        createdAt: now,
+        startedAt: now,
+        finishedAt: now,
+      };
+      if (failed) {
+        record.error = {
+          tag: "TerminalProviderError",
+          code: "PRIVATE_POPUP_FOCUS_FAILED",
+          message: "Private popup focus failed.",
+        };
+      }
+      records.set(commandId, record);
+      if (command.type === "terminal.focus") {
+        focusCommands.push(command);
+      }
+      return { commandId, accepted: true, status: "accepted" };
+    },
+    getCommand: async (commandId) => records.get(commandId),
+    reconcile: async (reason = "manual") => ({
+      schemaVersion: STATION_SCHEMA_VERSION,
+      reason,
+      reconciledAt: new Date().toISOString(),
+      snapshot: mockObserverSnapshot,
+    }),
+    ingestProviderHookEvent: async () => unsupportedObserverCall("ingestProviderHookEvent"),
+    reportHarnessEvent: async () => unsupportedObserverCall("reportHarnessEvent"),
+    prepareExternalLaunch: async () => unsupportedObserverCall("prepareExternalLaunch"),
+    reportExternalExit: async () => unsupportedObserverCall("reportExternalExit"),
+    runDoctor: async () => unsupportedObserverCall("runDoctor"),
+    collectDiagnostics: async () => unsupportedObserverCall("collectDiagnostics"),
+  };
+}
+
+async function* neverStationEvents(): AsyncIterable<StationEvent> {
+  await new Promise<never>(() => {});
+}
+
+function unsupportedObserverCall(operation: string): never {
+  throw new Error(`Unexpected private popup Observer call: ${operation}`);
+}
+
+function focusOrigin(command: StationCommand | undefined): unknown {
+  if (command?.type !== "terminal.focus") {
+    throw new Error("Expected a terminal.focus command.");
+  }
+  return command.payload.origin;
 }
 
 async function cleanupMarkerFixture(fixture: MarkerFixture): Promise<void> {

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -8,6 +8,7 @@ import {
   openTmuxPopup,
   resolveRegisteredDevPopupUi,
   resolveTmuxPopupFocusOrigin,
+  resolveTmuxPopupFocusTarget,
 } from "../../src/popup";
 import { buildNormalPopupRoute, buildPopupActiveClaim } from "../../src/popup/fastProtocol";
 import { tmuxCommandResult } from "../support/commands";
@@ -227,6 +228,68 @@ describe("tmux popup", () => {
       clientId: "legacy-client",
       provider: "tmux",
     });
+
+    const legacyTarget = await resolveTmuxPopupFocusTarget({ runner: legacy.runner });
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "88".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    legacy.globalOptions.set("@station_popup_active_claim", replacement);
+    await expect(legacyTarget?.dismissExact()).resolves.toEqual({ dismissed: false });
+    expect(legacy.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+  });
+
+  it("fails focus resolution closed for malformed or closing claims", async () => {
+    const malformed = createPopupTmux();
+    malformed.globalOptions.set("@station_popup_active_claim", "future.claim.format");
+    malformed.globalOptions.set("@station_popup_focus_client", "legacy-client");
+    await expect(
+      resolveTmuxPopupFocusOrigin({ runner: malformed.runner }),
+    ).resolves.toBeUndefined();
+
+    const closing = createPopupTmux();
+    closing.globalOptions.set(
+      "@station_popup_active_claim",
+      buildPopupActiveClaim({
+        actionNonce,
+        clientName: "/dev/ttys001",
+        clientPid: 1234,
+        registrationNonce,
+        state: "closing",
+      }),
+    );
+    closing.globalOptions.set("@station_popup_focus_client", "legacy-client");
+    await expect(resolveTmuxPopupFocusOrigin({ runner: closing.runner })).resolves.toBeUndefined();
+  });
+
+  it("binds focus dismissal to the exact claim and honors explicit command precedence", async () => {
+    const fake = createPopupTmux({ activeClaim: true, registered: true });
+    const target = await resolveTmuxPopupFocusTarget({
+      command: "config-tmux",
+      env: { STATION_TMUX_BIN: "env-tmux" },
+      runner: fake.runner,
+    });
+    expect(target?.origin).toEqual({ provider: "tmux", clientId: "/dev/ttys001" });
+    expect(fake.calls.every((call) => call.command === "config-tmux")).toBe(true);
+
+    const replacement = buildPopupActiveClaim({
+      actionNonce: "77".repeat(16),
+      clientName: "/dev/ttys099",
+      clientPid: 9999,
+      registrationNonce,
+      state: "open",
+    });
+    fake.globalOptions.set("@station_popup_active_claim", replacement);
+    fake.globalOptions.set("@station_popup_client", "/dev/ttys099");
+    fake.globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+
+    await expect(target?.dismissExact()).resolves.toEqual({ dismissed: false });
+    expect(fake.calls.every((call) => call.command === "config-tmux")).toBe(true);
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+    expect(fake.executedPopupActions).toEqual([]);
   });
 
   it("dismisses through a closing claim and exact compare-clear", async () => {
@@ -338,6 +401,16 @@ describe("tmux popup", () => {
     });
     expect(contended.calls.some((call) => call.args?.[0] === "display-popup")).toBe(false);
     expect(contended.globalOptions.has("@station_popup_active_claim")).toBe(true);
+
+    const transferred = createPopupTmux({
+      activeClaim: true,
+      replaceClaimBeforeClaimCas: replacement,
+    });
+    await expect(dismissTmuxPopup({ runner: transferred.runner })).resolves.toEqual({
+      dismissed: false,
+    });
+    expect(transferred.globalOptions.get("@station_popup_active_claim")).toBe(replacement);
+    expect(transferred.executedPopupActions).toEqual([]);
   });
 
   it("CAS-replaces malformed route state without an unconditional clear", async () => {
@@ -539,6 +612,7 @@ type PopupFakeOptions = {
   malformedRoute?: string;
   registered?: boolean;
   replaceClaimBeforeCleanup?: string;
+  replaceClaimBeforeClaimCas?: string;
   replaceClaimBeforeDisplay?: string;
   replaceClaimBeforeLegacyAction?: string;
   root?: string;
@@ -596,6 +670,7 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
 
   let concurrentRoutePending = options.concurrentRouteBeforeCommit;
   let replacementPending = options.replaceClaimBeforeCleanup;
+  let claimCasReplacementPending = options.replaceClaimBeforeClaimCas;
   let displayReplacementPending = options.replaceClaimBeforeDisplay;
   let legacyReplacementPending = options.replaceClaimBeforeLegacyAction;
   let claimCasMisses = options.claimCasMisses ?? 0;
@@ -656,6 +731,12 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
         return tmuxCommandResult(input);
       }
       if (command.startsWith("set-option -gq @station_popup_active_claim")) {
+        if (claimCasReplacementPending !== undefined) {
+          globalOptions.set("@station_popup_active_claim", claimCasReplacementPending);
+          globalOptions.set("@station_popup_client", "/dev/ttys099");
+          globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
+          claimCasReplacementPending = undefined;
+        }
         if (claimCasMisses > 0) {
           claimCasMisses -= 1;
           return tmuxCommandResult(input);

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -16,3 +16,4 @@ export * from "./recoveryBreadcrumbs.js";
 export * from "./snapshot.js";
 export * from "./terminalIntents.js";
 export * from "./terminalTargets.js";
+export * from "./tuiRendererControl.js";

--- a/packages/contracts/src/tuiRendererControl.ts
+++ b/packages/contracts/src/tuiRendererControl.ts
@@ -22,20 +22,33 @@ export const TuiRendererDismissRequestSchema = z
 
 export type TuiRendererDismissRequest = z.infer<typeof TuiRendererDismissRequestSchema>;
 
-export const TuiRendererResolveFocusOriginRequestSchema = z
+export const TuiRendererDismissFocusTargetRequestSchema = z
   .object({
     ...frameShape,
-    type: z.literal("resolve-focus-origin"),
+    type: z.literal("dismiss-focus-target"),
+    focusRequestId: TuiRendererControlRequestIdSchema,
   })
   .strict();
 
-export type TuiRendererResolveFocusOriginRequest = z.infer<
-  typeof TuiRendererResolveFocusOriginRequestSchema
+export type TuiRendererDismissFocusTargetRequest = z.infer<
+  typeof TuiRendererDismissFocusTargetRequestSchema
+>;
+
+export const TuiRendererResolveFocusTargetRequestSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("resolve-focus-target"),
+  })
+  .strict();
+
+export type TuiRendererResolveFocusTargetRequest = z.infer<
+  typeof TuiRendererResolveFocusTargetRequestSchema
 >;
 
 export const TuiRendererControlRequestSchema = z.discriminatedUnion("type", [
   TuiRendererDismissRequestSchema,
-  TuiRendererResolveFocusOriginRequestSchema,
+  TuiRendererDismissFocusTargetRequestSchema,
+  TuiRendererResolveFocusTargetRequestSchema,
 ]);
 
 export type TuiRendererControlRequest = z.infer<typeof TuiRendererControlRequestSchema>;
@@ -49,15 +62,15 @@ export const TuiRendererDismissedResponseSchema = z
 
 export type TuiRendererDismissedResponse = z.infer<typeof TuiRendererDismissedResponseSchema>;
 
-export const TuiRendererFocusOriginResponseSchema = z
+export const TuiRendererFocusTargetResponseSchema = z
   .object({
     ...frameShape,
-    type: z.literal("focus-origin"),
+    type: z.literal("focus-target"),
     origin: TerminalFocusOriginSchema,
   })
   .strict();
 
-export type TuiRendererFocusOriginResponse = z.infer<typeof TuiRendererFocusOriginResponseSchema>;
+export type TuiRendererFocusTargetResponse = z.infer<typeof TuiRendererFocusTargetResponseSchema>;
 
 export const TuiRendererControlErrorResponseSchema = z
   .object({
@@ -71,7 +84,7 @@ export type TuiRendererControlErrorResponse = z.infer<typeof TuiRendererControlE
 
 export const TuiRendererControlResponseSchema = z.discriminatedUnion("type", [
   TuiRendererDismissedResponseSchema,
-  TuiRendererFocusOriginResponseSchema,
+  TuiRendererFocusTargetResponseSchema,
   TuiRendererControlErrorResponseSchema,
 ]);
 

--- a/packages/contracts/src/tuiRendererControl.ts
+++ b/packages/contracts/src/tuiRendererControl.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import { TerminalFocusOriginSchema } from "./commands.js";
+import { SafeErrorSchema } from "./errors.js";
+
+export const TUI_RENDERER_CONTROL_PROTOCOL_VERSION = 1 as const;
+
+export const TuiRendererControlRequestIdSchema = z.string().min(1).max(128);
+
+export type TuiRendererControlRequestId = z.infer<typeof TuiRendererControlRequestIdSchema>;
+
+const frameShape = {
+  protocolVersion: z.literal(TUI_RENDERER_CONTROL_PROTOCOL_VERSION),
+  requestId: TuiRendererControlRequestIdSchema,
+};
+
+export const TuiRendererDismissRequestSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("dismiss"),
+  })
+  .strict();
+
+export type TuiRendererDismissRequest = z.infer<typeof TuiRendererDismissRequestSchema>;
+
+export const TuiRendererResolveFocusOriginRequestSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("resolve-focus-origin"),
+  })
+  .strict();
+
+export type TuiRendererResolveFocusOriginRequest = z.infer<
+  typeof TuiRendererResolveFocusOriginRequestSchema
+>;
+
+export const TuiRendererControlRequestSchema = z.discriminatedUnion("type", [
+  TuiRendererDismissRequestSchema,
+  TuiRendererResolveFocusOriginRequestSchema,
+]);
+
+export type TuiRendererControlRequest = z.infer<typeof TuiRendererControlRequestSchema>;
+
+export const TuiRendererDismissedResponseSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("dismissed"),
+  })
+  .strict();
+
+export type TuiRendererDismissedResponse = z.infer<typeof TuiRendererDismissedResponseSchema>;
+
+export const TuiRendererFocusOriginResponseSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("focus-origin"),
+    origin: TerminalFocusOriginSchema,
+  })
+  .strict();
+
+export type TuiRendererFocusOriginResponse = z.infer<typeof TuiRendererFocusOriginResponseSchema>;
+
+export const TuiRendererControlErrorResponseSchema = z
+  .object({
+    ...frameShape,
+    type: z.literal("error"),
+    error: SafeErrorSchema,
+  })
+  .strict();
+
+export type TuiRendererControlErrorResponse = z.infer<typeof TuiRendererControlErrorResponseSchema>;
+
+export const TuiRendererControlResponseSchema = z.discriminatedUnion("type", [
+  TuiRendererDismissedResponseSchema,
+  TuiRendererFocusOriginResponseSchema,
+  TuiRendererControlErrorResponseSchema,
+]);
+
+export type TuiRendererControlResponse = z.infer<typeof TuiRendererControlResponseSchema>;

--- a/packages/contracts/test/schema/tui-renderer-control-schema.test.ts
+++ b/packages/contracts/test/schema/tui-renderer-control-schema.test.ts
@@ -21,12 +21,19 @@ describe("TUI renderer control schemas", () => {
     expect(
       TuiRendererControlRequestSchema.parse({
         ...frame,
-        type: "resolve-focus-origin",
+        type: "resolve-focus-target",
       }),
-    ).toEqual({ ...frame, type: "resolve-focus-origin" });
+    ).toEqual({ ...frame, type: "resolve-focus-target" });
+    expect(
+      TuiRendererControlRequestSchema.parse({
+        ...frame,
+        type: "dismiss-focus-target",
+        focusRequestId: "focus-request-1",
+      }),
+    ).toEqual({ ...frame, type: "dismiss-focus-target", focusRequestId: "focus-request-1" });
   });
 
-  it("parses dismissed, focus-origin, and error responses", () => {
+  it("parses dismissed, focus-target, and error responses", () => {
     expect(
       TuiRendererControlResponseSchema.parse({
         ...frame,
@@ -36,12 +43,12 @@ describe("TUI renderer control schemas", () => {
     expect(
       TuiRendererControlResponseSchema.parse({
         ...frame,
-        type: "focus-origin",
+        type: "focus-target",
         origin: { provider: "tmux", clientId: "client-2" },
       }),
     ).toEqual({
       ...frame,
-      type: "focus-origin",
+      type: "focus-target",
       origin: { provider: "tmux", clientId: "client-2" },
     });
     expect(
@@ -60,8 +67,14 @@ describe("TUI renderer control schemas", () => {
   it.each([
     { ...frame, type: "dismiss", command: "tmux kill-pane" },
     { ...frame, type: "dismiss", clientId: "client-2" },
-    { ...frame, type: "resolve-focus-origin", argv: ["-t", "client-2"] },
-    { ...frame, type: "resolve-focus-origin", payload: { clientId: "client-2" } },
+    { ...frame, type: "resolve-focus-target", argv: ["-t", "client-2"] },
+    { ...frame, type: "resolve-focus-target", payload: { clientId: "client-2" } },
+    {
+      ...frame,
+      type: "dismiss-focus-target",
+      focusRequestId: "focus-request-1",
+      claim: "v1.open.secret",
+    },
     { ...frame, type: "run-command" },
   ])("rejects unsupported or authority-bearing request %#", (request) => {
     expect(TuiRendererControlRequestSchema.safeParse(request).success).toBe(false);
@@ -78,11 +91,17 @@ describe("TUI renderer control schemas", () => {
 
   it.each([
     { ...frame, type: "dismissed", clientId: "client-2" },
-    { ...frame, type: "focus-origin" },
+    { ...frame, type: "focus-target" },
     {
       ...frame,
-      type: "focus-origin",
+      type: "focus-target",
       origin: { provider: "tmux", clientId: "client-2", command: "display-message" },
+    },
+    {
+      ...frame,
+      type: "focus-target",
+      origin: { provider: "tmux", clientId: "client-2" },
+      claim: "provider-private-claim",
     },
     { ...frame, type: "ok" },
     {

--- a/packages/contracts/test/schema/tui-renderer-control-schema.test.ts
+++ b/packages/contracts/test/schema/tui-renderer-control-schema.test.ts
@@ -1,0 +1,100 @@
+import {
+  TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+  TuiRendererControlRequestSchema,
+  TuiRendererControlResponseSchema,
+} from "@station/contracts";
+import { describe, expect, it } from "vitest";
+
+const frame = {
+  protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+  requestId: "request-1",
+};
+
+describe("TUI renderer control schemas", () => {
+  it("parses the supported requests", () => {
+    expect(
+      TuiRendererControlRequestSchema.parse({
+        ...frame,
+        type: "dismiss",
+      }),
+    ).toEqual({ ...frame, type: "dismiss" });
+    expect(
+      TuiRendererControlRequestSchema.parse({
+        ...frame,
+        type: "resolve-focus-origin",
+      }),
+    ).toEqual({ ...frame, type: "resolve-focus-origin" });
+  });
+
+  it("parses dismissed, focus-origin, and error responses", () => {
+    expect(
+      TuiRendererControlResponseSchema.parse({
+        ...frame,
+        type: "dismissed",
+      }),
+    ).toEqual({ ...frame, type: "dismissed" });
+    expect(
+      TuiRendererControlResponseSchema.parse({
+        ...frame,
+        type: "focus-origin",
+        origin: { provider: "tmux", clientId: "client-2" },
+      }),
+    ).toEqual({
+      ...frame,
+      type: "focus-origin",
+      origin: { provider: "tmux", clientId: "client-2" },
+    });
+    expect(
+      TuiRendererControlResponseSchema.parse({
+        ...frame,
+        type: "error",
+        error: {
+          tag: "TuiRendererControlError",
+          code: "TUI_RENDERER_CONTROL_FAILED",
+          message: "The popup control request failed.",
+        },
+      }),
+    ).toMatchObject({ ...frame, type: "error" });
+  });
+
+  it.each([
+    { ...frame, type: "dismiss", command: "tmux kill-pane" },
+    { ...frame, type: "dismiss", clientId: "client-2" },
+    { ...frame, type: "resolve-focus-origin", argv: ["-t", "client-2"] },
+    { ...frame, type: "resolve-focus-origin", payload: { clientId: "client-2" } },
+    { ...frame, type: "run-command" },
+  ])("rejects unsupported or authority-bearing request %#", (request) => {
+    expect(TuiRendererControlRequestSchema.safeParse(request).success).toBe(false);
+  });
+
+  it.each([
+    { type: "dismiss", requestId: "request-1" },
+    { ...frame, protocolVersion: 2, type: "dismiss" },
+    { ...frame, requestId: "", type: "dismiss" },
+    { ...frame, requestId: "x".repeat(129), type: "dismiss" },
+  ])("rejects malformed request framing %#", (request) => {
+    expect(TuiRendererControlRequestSchema.safeParse(request).success).toBe(false);
+  });
+
+  it.each([
+    { ...frame, type: "dismissed", clientId: "client-2" },
+    { ...frame, type: "focus-origin" },
+    {
+      ...frame,
+      type: "focus-origin",
+      origin: { provider: "tmux", clientId: "client-2", command: "display-message" },
+    },
+    { ...frame, type: "ok" },
+    {
+      ...frame,
+      type: "error",
+      error: {
+        tag: "TuiRendererControlError",
+        code: "TUI_RENDERER_CONTROL_FAILED",
+        message: "Failure.\n    at secret (/tmp/control.ts:1:1)",
+      },
+    },
+  ])("rejects malformed or unsupported response %#", (response) => {
+    expect(TuiRendererControlResponseSchema.safeParse(response).success).toBe(false);
+  });
+});

--- a/packages/dashboard-core/src/state/operations/createSession.ts
+++ b/packages/dashboard-core/src/state/operations/createSession.ts
@@ -1,10 +1,13 @@
-import type { CommandId, SafeError, StationCommand } from "@station/contracts";
+import type { CommandId, SafeError } from "@station/contracts";
 import type { StoreApi } from "zustand/vanilla";
 import { toSafeError } from "../../services/errors/errors.js";
 import type { TuiObserverService } from "../../services/types.js";
 import { bindPendingCreateSessionRow, removeCreateSessionLocalRow } from "../localRows.js";
 import type { TuiStore } from "../store.js";
-import { type CommandRuntimeOptions, prepareCommandForRuntime } from "./runtimeCommands.js";
+import {
+  type CommandRuntimeOptions,
+  prepareCreateSessionCommandForRuntime,
+} from "./runtimeCommands.js";
 import type { CreateSessionOperation } from "./types.js";
 
 export async function runCreateSessionOperation(
@@ -18,10 +21,8 @@ export async function runCreateSessionOperation(
   addSafeErrorToast: (error: SafeError) => void,
 ): Promise<void> {
   try {
-    const command = (await prepareCommandForRuntime(operation.command, runtime)) as Extract<
-      StationCommand,
-      { type: "session.create" }
-    >;
+    const prepared = await prepareCreateSessionCommandForRuntime(operation.command, runtime);
+    const command = prepared.command;
     const receipt = await service.dispatch(command);
     if (!receipt.accepted) {
       const safeError = receipt.error ?? {
@@ -40,6 +41,13 @@ export async function runCreateSessionOperation(
     const completion = await service.waitForCommandCompletion(receipt.commandId);
     if (completion.status === "succeeded") {
       store.setState(removeCreateSessionLocalRow(store.getState(), operation.localId));
+      if (prepared.target?.onFocusSuccess !== undefined) {
+        try {
+          await prepared.target.onFocusSuccess();
+        } catch (error: unknown) {
+          addSafeErrorToast(toSafeError(error, { clientLabel: runtime.clientLabel }));
+        }
+      }
       return;
     }
 

--- a/packages/dashboard-core/src/state/operations/runtimeCommands.ts
+++ b/packages/dashboard-core/src/state/operations/runtimeCommands.ts
@@ -4,7 +4,12 @@ export type CommandRuntimeOptions = {
   clientLabel: string;
   persistentPopup: boolean;
   focusOrigin?: TerminalFocusOrigin;
-  resolveFocusOrigin?: () => Promise<TerminalFocusOrigin | undefined>;
+  resolveFocusTarget?: () => Promise<TuiFocusTarget | undefined>;
+};
+
+export type TuiFocusTarget = {
+  origin: TerminalFocusOrigin;
+  onFocusSuccess?: () => Promise<void>;
 };
 
 type CreateSessionCommand = Extract<StationCommand, { type: "session.create" }>;
@@ -12,22 +17,23 @@ type StartAgentCommand = Extract<StationCommand, { type: "session.startAgent" }>
 type ResumeAgentCommand = Extract<StationCommand, { type: "session.resumeAgent" }>;
 type RuntimeTerminalOptions = NonNullable<StartAgentCommand["payload"]["terminal"]>;
 
-async function prepareCreateSessionCommandForRuntime(
+export async function prepareCreateSessionCommandForRuntime(
   command: CreateSessionCommand,
   runtime: CommandRuntimeOptions,
-): Promise<CreateSessionCommand> {
+): Promise<{ command: CreateSessionCommand; target?: TuiFocusTarget }> {
   if (!shouldFocusSessionCommand(runtime)) {
-    return command;
+    return { command };
   }
 
-  const origin = await resolveFocusOrigin(runtime);
-  return {
+  const target = await resolveFocusTarget(runtime);
+  const prepared = {
     ...command,
     payload: {
       ...command.payload,
-      terminal: terminalWithRuntimeFocus(command.payload.terminal, origin),
+      terminal: terminalWithRuntimeFocus(command.payload.terminal, target?.origin),
     },
   };
+  return target === undefined ? { command: prepared } : { command: prepared, target };
 }
 
 async function prepareStartAgentCommandForRuntime(
@@ -38,7 +44,7 @@ async function prepareStartAgentCommandForRuntime(
     return command;
   }
 
-  const origin = await resolveFocusOrigin(runtime);
+  const origin = (await resolveFocusTarget(runtime))?.origin;
   return {
     ...command,
     payload: {
@@ -69,17 +75,20 @@ function shouldFocusSessionCommand(runtime: CommandRuntimeOptions): boolean {
   return (
     runtime.persistentPopup ||
     runtime.focusOrigin !== undefined ||
-    runtime.resolveFocusOrigin !== undefined
+    runtime.resolveFocusTarget !== undefined
   );
 }
 
-async function resolveFocusOrigin(
-  runtime: Pick<CommandRuntimeOptions, "focusOrigin" | "resolveFocusOrigin">,
-): Promise<TerminalFocusOrigin | undefined> {
-  if (runtime.resolveFocusOrigin === undefined) {
-    return runtime.focusOrigin;
+async function resolveFocusTarget(
+  runtime: Pick<CommandRuntimeOptions, "focusOrigin" | "resolveFocusTarget">,
+): Promise<TuiFocusTarget | undefined> {
+  if (runtime.resolveFocusTarget === undefined) {
+    return runtime.focusOrigin === undefined ? undefined : { origin: runtime.focusOrigin };
   }
-  return (await runtime.resolveFocusOrigin()) ?? runtime.focusOrigin;
+  return (
+    (await runtime.resolveFocusTarget()) ??
+    (runtime.focusOrigin === undefined ? undefined : { origin: runtime.focusOrigin })
+  );
 }
 
 export async function prepareCommandForRuntime(
@@ -87,7 +96,7 @@ export async function prepareCommandForRuntime(
   runtime: CommandRuntimeOptions,
 ): Promise<StationCommand> {
   if (command.type === "session.create") {
-    return prepareCreateSessionCommandForRuntime(command, runtime);
+    return (await prepareCreateSessionCommandForRuntime(command, runtime)).command;
   }
   if (command.type === "session.startAgent") {
     return prepareStartAgentCommandForRuntime(command, runtime);
@@ -98,19 +107,25 @@ export async function prepareCommandForRuntime(
   return command;
 }
 
-export async function withResolvedFocusOrigin(
+export async function prepareFocusCommandForRuntime(
   command: Extract<StationCommand, { type: "terminal.focus" }>,
-  runtime: Pick<CommandRuntimeOptions, "focusOrigin" | "resolveFocusOrigin">,
-): Promise<Extract<StationCommand, { type: "terminal.focus" }>> {
-  const origin = await resolveFocusOrigin(runtime);
-  if (origin === undefined) {
-    return command;
+  runtime: Pick<CommandRuntimeOptions, "focusOrigin" | "resolveFocusTarget">,
+): Promise<{
+  command: Extract<StationCommand, { type: "terminal.focus" }>;
+  target?: TuiFocusTarget;
+}> {
+  const target = await resolveFocusTarget(runtime);
+  if (target === undefined) {
+    return { command };
   }
   return {
-    type: "terminal.focus",
-    payload: {
-      ...command.payload,
-      origin,
+    command: {
+      type: "terminal.focus",
+      payload: {
+        ...command.payload,
+        origin: target.origin,
+      },
     },
+    target,
   };
 }

--- a/packages/dashboard-core/src/state/store.ts
+++ b/packages/dashboard-core/src/state/store.ts
@@ -24,7 +24,11 @@ import {
   createTuiLocalOperationRunner,
   type TuiLocalOperationRunner,
 } from "./operations/localOperationRunner.js";
-import { prepareCommandForRuntime, withResolvedFocusOrigin } from "./operations/runtimeCommands.js";
+import {
+  prepareCommandForRuntime,
+  prepareFocusCommandForRuntime,
+  type TuiFocusTarget,
+} from "./operations/runtimeCommands.js";
 import { createInitialTuiState, replaceSnapshot } from "./screen.js";
 import { attachTuiSnapshotSource, type TuiSnapshotSource } from "./sourceBridge.js";
 import { addTuiToast, expireTuiToasts, refreshActiveTuiToastExpiry } from "./toasts.js";
@@ -58,7 +62,7 @@ export type TuiStoreOptions = {
   initialState?: Omit<CreateInitialTuiStateOptions, "initialSnapshot" | "runtime">;
   exitOnFocusSuccess?: boolean;
   focusOrigin?: TerminalFocusOrigin;
-  resolveFocusOrigin?: () => Promise<TerminalFocusOrigin | undefined>;
+  resolveFocusTarget?: () => Promise<TuiFocusTarget | undefined>;
   onFocusSuccess?: () => Promise<void>;
   onDismiss?: () => Promise<void>;
   persistentPopup?: boolean;
@@ -116,7 +120,7 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
         persistentPopup: runtime.persistentPopup,
         canDismissPopup: runtime.onDismiss !== undefined,
         exitOnFocusSuccess: runtime.exitOnFocusSuccess,
-        canResolveFocusOrigin: runtime.resolveFocusOrigin !== undefined,
+        canResolveFocusOrigin: runtime.resolveFocusTarget !== undefined,
         hasFocusSuccessCallback: runtime.onFocusSuccess !== undefined,
         ...(runtime.focusOrigin === undefined ? {} : { focusOrigin: runtime.focusOrigin }),
       },
@@ -196,7 +200,7 @@ type RuntimeOptions = {
   exitOnFocusSuccess: boolean;
   persistentPopup: boolean;
   focusOrigin?: TerminalFocusOrigin;
-  resolveFocusOrigin?: () => Promise<TerminalFocusOrigin | undefined>;
+  resolveFocusTarget?: () => Promise<TuiFocusTarget | undefined>;
   onFocusSuccess?: () => Promise<void>;
   onDismiss?: () => Promise<void>;
   onExit?: (code: number) => void;
@@ -211,8 +215,8 @@ function createRuntimeOptions(options: TuiStoreOptions): RuntimeOptions {
   if (options.focusOrigin !== undefined) {
     runtime.focusOrigin = options.focusOrigin;
   }
-  if (options.resolveFocusOrigin !== undefined) {
-    runtime.resolveFocusOrigin = options.resolveFocusOrigin;
+  if (options.resolveFocusTarget !== undefined) {
+    runtime.resolveFocusTarget = options.resolveFocusTarget;
   }
   if (options.onFocusSuccess !== undefined) {
     runtime.onFocusSuccess = options.onFocusSuccess;
@@ -340,7 +344,7 @@ function shouldUseFocusLifecycle(
   command: StationCommand,
   runtime: Pick<
     RuntimeOptions,
-    "exitOnFocusSuccess" | "persistentPopup" | "resolveFocusOrigin" | "onFocusSuccess"
+    "exitOnFocusSuccess" | "persistentPopup" | "resolveFocusTarget" | "onFocusSuccess"
   >,
   snapshot: StationSnapshot | undefined,
 ): command is Extract<StationCommand, { type: "terminal.focus" }> {
@@ -348,7 +352,7 @@ function shouldUseFocusLifecycle(
     command.type === "terminal.focus" &&
     (runtime.exitOnFocusSuccess ||
       runtime.persistentPopup ||
-      runtime.resolveFocusOrigin !== undefined ||
+      runtime.resolveFocusTarget !== undefined ||
       runtime.onFocusSuccess !== undefined ||
       turnReadinessForFocusCommand(snapshot, command) !== undefined)
   );
@@ -377,8 +381,11 @@ async function dispatchFocusWithLifecycle(
   runtime: RuntimeOptions,
 ): Promise<void> {
   let focusCommand: Extract<StationCommand, { type: "terminal.focus" }>;
+  let focusTarget: TuiFocusTarget | undefined;
   try {
-    focusCommand = await withResolvedFocusOrigin(command, runtime);
+    const prepared = await prepareFocusCommandForRuntime(command, runtime);
+    focusCommand = prepared.command;
+    focusTarget = prepared.target;
   } catch (error: unknown) {
     addToast(store, safeErrorToToast(toSafeError(error, { clientLabel: runtime.clientLabel })));
     return;
@@ -389,6 +396,7 @@ async function dispatchFocusWithLifecycle(
     runtime.exitOnFocusSuccess ||
     runtime.persistentPopup ||
     runtime.onFocusSuccess !== undefined ||
+    focusTarget?.onFocusSuccess !== undefined ||
     turnReadiness !== undefined;
   if (!waitsForCompletion) {
     await dispatchCommand(store, service, focusCommand, runtime);
@@ -406,18 +414,27 @@ async function dispatchFocusWithLifecycle(
   }
 
   if (turnReadiness !== undefined) {
-    try {
-      await acknowledgeTurnReadiness(service, turnReadiness);
-    } catch (error: unknown) {
-      addToast(store, safeErrorToToast(toSafeError(error, { clientLabel: runtime.clientLabel })));
+    const acknowledged = await dispatchCommandAndWaitForCompletion(
+      store,
+      service,
+      {
+        type: "session.acknowledgeTurn",
+        payload: turnReadiness,
+      },
+      runtime,
+    );
+    if (!acknowledged) {
+      return;
     }
   }
 
-  if (runtime.onFocusSuccess !== undefined) {
+  const onFocusSuccess = focusTarget?.onFocusSuccess ?? runtime.onFocusSuccess;
+  if (onFocusSuccess !== undefined) {
     try {
-      await runtime.onFocusSuccess();
+      await onFocusSuccess();
     } catch (error: unknown) {
       addToast(store, safeErrorToToast(toSafeError(error, { clientLabel: runtime.clientLabel })));
+      return;
     }
   }
 
@@ -449,19 +466,6 @@ function turnReadinessForFocusCommand(
     sessionId: agent.sessionId,
     token: agent.turnReadiness.token,
   };
-}
-
-async function acknowledgeTurnReadiness(
-  service: TuiObserverService,
-  readiness: { sessionId: string; token: string },
-): Promise<void> {
-  const receipt = await service.dispatch({
-    type: "session.acknowledgeTurn",
-    payload: readiness,
-  });
-  if (receipt.accepted) {
-    await service.waitForCommandCompletion(receipt.commandId);
-  }
 }
 
 async function dismissPersistentPopup(

--- a/packages/dashboard-core/test/unit/state/createSession.test.ts
+++ b/packages/dashboard-core/test/unit/state/createSession.test.ts
@@ -1,0 +1,119 @@
+import type { SafeError } from "@station/contracts";
+import { createTuiStore } from "@station/dashboard-core";
+import { describe, expect, it, vi } from "vitest";
+import { runCreateSessionOperation } from "../../../src/state/operations/createSession.js";
+import { createCommandSnapshot } from "../../fixtures/snapshots.js";
+import { FakeTuiObserverService } from "../../support/fakeObserverService.js";
+
+describe("create session operation", () => {
+  it("dismisses the exact focus target after successful creation", async () => {
+    const fixture = createFixture();
+    const dismiss = vi.fn(async () => {});
+
+    await fixture.run({ onFocusSuccess: dismiss });
+
+    expect(dismiss).toHaveBeenCalledOnce();
+    expect(fixture.service.dispatched).toEqual([
+      {
+        ...operation.command,
+        payload: {
+          ...operation.command.payload,
+          terminal: {
+            ...operation.command.payload.terminal,
+            focus: true,
+            origin: { provider: "fixture-terminal", clientId: "client-current" },
+          },
+        },
+      },
+    ]);
+    expect(fixture.failures).toEqual([]);
+    expect(fixture.toasts).toEqual([]);
+  });
+
+  it("keeps the focus target open when creation fails", async () => {
+    const fixture = createFixture();
+    const failure = safeError("CREATE_FAILED", "Session creation failed.");
+    fixture.service.nextCompletion = {
+      status: "failed",
+      commandId: "cmd_tui_1",
+      error: failure,
+    };
+    const dismiss = vi.fn(async () => {});
+
+    await fixture.run({ onFocusSuccess: dismiss });
+
+    expect(dismiss).not.toHaveBeenCalled();
+    expect(fixture.failures).toEqual([failure]);
+    expect(fixture.toasts).toEqual([failure]);
+  });
+
+  it("toasts a stale exact-target dismissal without failing successful creation", async () => {
+    const fixture = createFixture();
+    const stale = safeError(
+      "TUI_POPUP_FOCUS_TARGET_STALE",
+      "The popup focus target changed before dismissal.",
+    );
+
+    await fixture.run({
+      onFocusSuccess: async () => {
+        throw stale;
+      },
+    });
+
+    expect(fixture.failures).toEqual([]);
+    expect(fixture.toasts).toEqual([stale]);
+  });
+});
+
+const operation = {
+  type: "createSession" as const,
+  localId: "local_create_1",
+  projectId: "web",
+  branch: "feature/new-session",
+  harnessProvider: "codex",
+  command: {
+    type: "session.create" as const,
+    payload: {
+      projectId: "web",
+      branch: "feature/new-session",
+      harness: { provider: "codex", mode: "interactive" as const },
+      terminal: { provider: "fixture-terminal", layout: "agent-build-shell", focus: false },
+    },
+  },
+};
+
+function createFixture() {
+  const snapshot = createCommandSnapshot("idle");
+  const service = new FakeTuiObserverService(snapshot);
+  const store = createTuiStore({ service, initialSnapshot: snapshot });
+  const failures: SafeError[] = [];
+  const toasts: SafeError[] = [];
+
+  return {
+    service,
+    failures,
+    toasts,
+    run: (target: { onFocusSuccess: () => Promise<void> }) =>
+      runCreateSessionOperation(
+        store,
+        service,
+        {
+          clientLabel: "station",
+          persistentPopup: true,
+          resolveFocusTarget: async () => ({
+            origin: { provider: "fixture-terminal", clientId: "client-current" },
+            onFocusSuccess: target.onFocusSuccess,
+          }),
+        },
+        operation,
+        (_localId, error) => failures.push(error),
+        () => {},
+        () => false,
+        (error) => toasts.push(error),
+      ),
+  };
+}
+
+function safeError(code: string, message: string): SafeError {
+  return { tag: "CreateSessionTestError", code, message };
+}

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -234,6 +234,46 @@ describe("tui keymap metadata", () => {
   });
 });
 
+describe("dashboard popup lifecycle keys", () => {
+  it("dismisses a persistent popup with Q or Esc without exiting", () => {
+    const state = createInitialTuiState({
+      initialSnapshot: createDashboardSnapshot(),
+      runtime: { persistentPopup: true, canDismissPopup: true },
+    });
+
+    for (const key of [{ input: "Q" }, { input: "", escape: true }]) {
+      const transition = handleTuiKey(state, key, KEY_CONTEXT);
+      expect(transition.dismissPopup).toBe(true);
+      expect(transition.exitCode).toBeUndefined();
+      expect(transition.state).toBe(state);
+    }
+  });
+
+  it("keeps fullscreen and transient popup Q/Esc behavior unchanged", () => {
+    const states = [
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      createInitialTuiState({
+        initialSnapshot: createDashboardSnapshot(),
+        runtime: {
+          exitOnFocusSuccess: true,
+          focusOrigin: { provider: "tmux", clientId: "client-startup" },
+        },
+      }),
+    ];
+
+    for (const state of states) {
+      const quit = handleTuiKey(state, { input: "Q" }, KEY_CONTEXT);
+      expect(quit.exitCode).toBe(0);
+      expect(quit.dismissPopup).toBeUndefined();
+
+      const escapeKey = handleTuiKey(state, { input: "", escape: true }, KEY_CONTEXT);
+      expect(escapeKey.exitCode).toBeUndefined();
+      expect(escapeKey.dismissPopup).toBeUndefined();
+      expect(escapeKey.state).toBe(state);
+    }
+  });
+});
+
 describe("dashboard footer", () => {
   it("keeps the first-project action at wide and compact widths", () => {
     for (const columns of [120, 40]) {

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -179,6 +179,37 @@ describe("TUI store", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1", "cmd_tui_1"]);
   });
 
+  it.each([
+    ["rejected", "The readiness acknowledgment was rejected."],
+    ["failed", "The readiness acknowledgment failed."],
+    ["thrown", "The readiness acknowledgment was unavailable."],
+  ] as const)("keeps the popup open when readiness acknowledgment is %s", async (failure, message) => {
+    const snapshot = withTurnReadiness(createCommandSnapshot("idle"));
+    const service = new ReadinessFailureService(snapshot, failure);
+    let focusSuccessCount = 0;
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      resolveFocusTarget: async () => ({
+        origin: { provider: "fixture-terminal", clientId: "client-current" },
+        onFocusSuccess: async () => {
+          focusSuccessCount += 1;
+        },
+      }),
+    });
+
+    store.getState().handleKey({ input: "1" });
+
+    await waitFor(() => store.getState().toasts.some((entry) => entry.toast.message === message));
+    expect(focusSuccessCount).toBe(0);
+    expect(store.getState().screen).toEqual({ name: "dashboard" });
+    expect(service.dispatched.map((command) => command.type)).toEqual([
+      "terminal.focus",
+      "session.acknowledgeTurn",
+    ]);
+  });
+
   it("resolves current focus, completes focus and readiness, then dismisses", async () => {
     const snapshot = withTurnReadiness(createCommandSnapshot("idle"));
     const order: string[] = [];
@@ -187,12 +218,14 @@ describe("TUI store", () => {
       service,
       initialSnapshot: snapshot,
       persistentPopup: true,
-      resolveFocusOrigin: async () => {
+      resolveFocusTarget: async () => {
         order.push("resolve-origin");
-        return { provider: "tmux", clientId: "client-current" };
-      },
-      onFocusSuccess: async () => {
-        order.push("dismiss");
+        return {
+          origin: { provider: "fixture-terminal", clientId: "client-current" },
+          onFocusSuccess: async () => {
+            order.push("dismiss");
+          },
+        };
       },
     });
 
@@ -211,7 +244,7 @@ describe("TUI store", () => {
       type: "terminal.focus",
       payload: {
         sessionId: "ses_wt_web_idle",
-        origin: { provider: "tmux", clientId: "client-current" },
+        origin: { provider: "fixture-terminal", clientId: "client-current" },
       },
     });
   });
@@ -247,7 +280,7 @@ describe("TUI store", () => {
     expect(focusSuccessCount).toBe(0);
   });
 
-  it("leaves a persistent popup open when focus-origin resolution fails", async () => {
+  it("leaves a persistent popup open when focus-target resolution fails", async () => {
     const snapshot = createCommandSnapshot("idle");
     const service = new FakeTuiObserverService(snapshot);
     let focusSuccessCount = 0;
@@ -255,7 +288,7 @@ describe("TUI store", () => {
       service,
       initialSnapshot: snapshot,
       persistentPopup: true,
-      resolveFocusOrigin: async () => {
+      resolveFocusTarget: async () => {
         throw {
           tag: "TuiRendererControlError",
           code: "TUI_POPUP_FOCUS_ORIGIN_UNAVAILABLE",
@@ -279,6 +312,39 @@ describe("TUI store", () => {
     expect(service.dispatched).toEqual([]);
     expect(focusSuccessCount).toBe(0);
     expect(store.getState().screen).toEqual({ name: "dashboard" });
+  });
+
+  it("does not exit after a target-scoped focus-success callback fails", async () => {
+    const snapshot = createCommandSnapshot("idle");
+    const service = new FakeTuiObserverService(snapshot);
+    const exitCodes: number[] = [];
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      exitOnFocusSuccess: true,
+      resolveFocusTarget: async () => ({
+        origin: { provider: "fixture-terminal", clientId: "client-current" },
+        onFocusSuccess: async () => {
+          throw {
+            tag: "TuiRendererControlError",
+            code: "TUI_POPUP_FOCUS_TARGET_STALE",
+            message: "The popup focus target changed before dismissal.",
+          } satisfies SafeError;
+        },
+      }),
+      onExit: (code) => exitCodes.push(code),
+    });
+
+    store.getState().handleKey({ input: "1" });
+
+    await waitFor(() =>
+      store
+        .getState()
+        .toasts.some(
+          (entry) => entry.toast.message === "The popup focus target changed before dismissal.",
+        ),
+    );
+    expect(exitCodes).toEqual([]);
   });
 
   it("leaves a persistent popup open and shows a toast when dismissal fails", async () => {
@@ -768,6 +834,58 @@ class OrderedFocusService extends FakeTuiObserverService {
       status: "succeeded" as const,
       commandId,
     };
+  }
+}
+
+class ReadinessFailureService extends FakeTuiObserverService {
+  constructor(
+    snapshot: StationSnapshot,
+    private readonly failure: "rejected" | "failed" | "thrown",
+  ) {
+    super(snapshot);
+  }
+
+  override async dispatch(command: StationCommand) {
+    this.dispatched.push(command);
+    if (command.type === "terminal.focus") {
+      return { accepted: true as const, commandId: "cmd_focus", status: "accepted" as const };
+    }
+    if (this.failure === "thrown") {
+      throw {
+        tag: "ObserverCommandError",
+        code: "READINESS_ACK_UNAVAILABLE",
+        message: "The readiness acknowledgment was unavailable.",
+      } satisfies SafeError;
+    }
+    if (this.failure === "rejected") {
+      return {
+        accepted: false as const,
+        commandId: "cmd_ack",
+        status: "rejected" as const,
+        error: {
+          tag: "ObserverCommandError",
+          code: "READINESS_ACK_REJECTED",
+          message: "The readiness acknowledgment was rejected.",
+        } satisfies SafeError,
+      };
+    }
+    return { accepted: true as const, commandId: "cmd_ack", status: "accepted" as const };
+  }
+
+  override async waitForCommandCompletion(commandId: string) {
+    this.waitedForCommandIds.push(commandId);
+    if (commandId === "cmd_ack" && this.failure === "failed") {
+      return {
+        status: "failed" as const,
+        commandId,
+        error: {
+          tag: "ObserverCommandError",
+          code: "READINESS_ACK_FAILED",
+          message: "The readiness acknowledgment failed.",
+        } satisfies SafeError,
+      };
+    }
+    return { status: "succeeded" as const, commandId };
   }
 }
 

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -1,6 +1,7 @@
 import type {
   ProviderId,
   SafeError,
+  StationCommand,
   StationEvent,
   StationSnapshot,
   WorktreeRow,
@@ -178,6 +179,43 @@ describe("TUI store", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1", "cmd_tui_1"]);
   });
 
+  it("resolves current focus, completes focus and readiness, then dismisses", async () => {
+    const snapshot = withTurnReadiness(createCommandSnapshot("idle"));
+    const order: string[] = [];
+    const service = new OrderedFocusService(snapshot, order);
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      resolveFocusOrigin: async () => {
+        order.push("resolve-origin");
+        return { provider: "tmux", clientId: "client-current" };
+      },
+      onFocusSuccess: async () => {
+        order.push("dismiss");
+      },
+    });
+
+    store.getState().handleKey({ input: "1" });
+
+    await waitFor(() => order.includes("dismiss"));
+    expect(order).toEqual([
+      "resolve-origin",
+      "dispatch:terminal.focus",
+      "wait:cmd_focus",
+      "dispatch:session.acknowledgeTurn",
+      "wait:cmd_ack",
+      "dismiss",
+    ]);
+    expect(service.dispatched[0]).toEqual({
+      type: "terminal.focus",
+      payload: {
+        sessionId: "ses_wt_web_idle",
+        origin: { provider: "tmux", clientId: "client-current" },
+      },
+    });
+  });
+
   it("does not acknowledge a ready turn when focus fails", async () => {
     const snapshot = withTurnReadiness(createCommandSnapshot("idle"));
     const service = new FakeTuiObserverService(snapshot);
@@ -190,7 +228,15 @@ describe("TUI store", () => {
         message: "The terminal could not be focused.",
       },
     };
-    const store = createTuiStore({ service, initialSnapshot: snapshot });
+    let focusSuccessCount = 0;
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      onFocusSuccess: async () => {
+        focusSuccessCount += 1;
+      },
+    });
 
     store.getState().handleKey({ input: "1" });
 
@@ -198,6 +244,72 @@ describe("TUI store", () => {
     expect(service.dispatched).toEqual([
       { type: "terminal.focus", payload: { sessionId: "ses_wt_web_idle" } },
     ]);
+    expect(focusSuccessCount).toBe(0);
+  });
+
+  it("leaves a persistent popup open when focus-origin resolution fails", async () => {
+    const snapshot = createCommandSnapshot("idle");
+    const service = new FakeTuiObserverService(snapshot);
+    let focusSuccessCount = 0;
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      resolveFocusOrigin: async () => {
+        throw {
+          tag: "TuiRendererControlError",
+          code: "TUI_POPUP_FOCUS_ORIGIN_UNAVAILABLE",
+          message: "The current popup origin could not be resolved.",
+        } satisfies SafeError;
+      },
+      onFocusSuccess: async () => {
+        focusSuccessCount += 1;
+      },
+    });
+
+    store.getState().handleKey({ input: "1" });
+
+    await waitFor(() =>
+      store
+        .getState()
+        .toasts.some(
+          (entry) => entry.toast.message === "The current popup origin could not be resolved.",
+        ),
+    );
+    expect(service.dispatched).toEqual([]);
+    expect(focusSuccessCount).toBe(0);
+    expect(store.getState().screen).toEqual({ name: "dashboard" });
+  });
+
+  it("leaves a persistent popup open and shows a toast when dismissal fails", async () => {
+    const snapshot = createCommandSnapshot("idle");
+    const service = new FakeTuiObserverService(snapshot);
+    const exitCodes: number[] = [];
+    const store = createTuiStore({
+      service,
+      initialSnapshot: snapshot,
+      persistentPopup: true,
+      onDismiss: async () => {
+        throw {
+          tag: "TuiRendererControlError",
+          code: "TUI_POPUP_DISMISS_FAILED",
+          message: "The popup could not be dismissed.",
+        } satisfies SafeError;
+      },
+      onExit: (code) => exitCodes.push(code),
+    });
+
+    const result = store.getState().handleKey({ input: "Q" });
+
+    expect(result).toEqual({ dismissPopup: true });
+    await waitFor(() =>
+      store
+        .getState()
+        .toasts.some((entry) => entry.toast.message === "The popup could not be dismissed."),
+    );
+    expect(exitCodes).toEqual([]);
+    expect(store.getState().snapshot).toBe(snapshot);
+    expect(store.getState().screen).toEqual({ name: "dashboard" });
   });
 
   it("does not treat a retained no-agent session as completed start truth", async () => {
@@ -630,6 +742,33 @@ function snapshotWithProjectHarness(
         : project,
     ),
   };
+}
+
+class OrderedFocusService extends FakeTuiObserverService {
+  constructor(
+    snapshot: StationSnapshot,
+    private readonly order: string[],
+  ) {
+    super(snapshot);
+  }
+
+  override async dispatch(command: StationCommand) {
+    this.order.push(`dispatch:${command.type}`);
+    this.nextReceipt = {
+      commandId: command.type === "terminal.focus" ? "cmd_focus" : "cmd_ack",
+      accepted: true,
+      status: "accepted",
+    };
+    return super.dispatch(command);
+  }
+
+  override async waitForCommandCompletion(commandId: string) {
+    this.order.push(`wait:${commandId}`);
+    return {
+      status: "succeeded" as const,
+      commandId,
+    };
+  }
 }
 
 class SnapshotConnectFailingService extends FakeTuiObserverService {

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -5,52 +5,39 @@
 // dispatches the same observer commands the Ink TUI did (no Station panes).
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
-import type { ProviderId, TerminalFocusOrigin } from "@station/contracts";
 import { createTuiStore } from "@station/dashboard-core";
 import { STATION_KEYBOARD_PROTOCOL } from "../input/keyboardProtocol.js";
 import { createStationClient } from "../sources/createStationClient.js";
 import { sanitizePastedText } from "../station/input/sequenceToTuiKey.js";
 import { FullscreenDashboard } from "./FullscreenDashboard.js";
 import { createDashboardSequenceHandler } from "./inputBridge.js";
-
-function focusOriginFromEnv(
-  env: Record<string, string | undefined>,
-): TerminalFocusOrigin | undefined {
-  const provider = env.STATION_FOCUS_PROVIDER;
-  if (provider === undefined || provider.length === 0) {
-    return undefined;
-  }
-  const origin: TerminalFocusOrigin = { provider: provider as ProviderId };
-  const clientId = env.STATION_FOCUS_CLIENT_ID;
-  if (clientId !== undefined && clientId.length > 0) {
-    origin.clientId = clientId;
-  }
-  return origin;
-}
+import {
+  createPopupRuntime,
+  createProcessRendererControlChannel,
+} from "./popupRuntime.js";
 
 /** Callable entry for the read-only OpenTUI dashboard renderer. */
 export async function runDashboardMain(): Promise<void> {
   const env = process.env;
-  // In a tmux popup the launcher exports STATION_TUI_POPUP=1 plus the focus origin;
-  // the dashboard then exits as soon as a focus lands (closing the popup) and
-  // asks the observer to focus the originating tmux client.
-  const isPopup = env.STATION_TUI_POPUP === "1";
 
   let rendererForExit: { destroy(): void } | undefined;
   function exit(code: number): void {
     rendererForExit?.destroy();
     process.exit(code);
   }
+  const popupRuntime = createPopupRuntime(
+    env,
+    createProcessRendererControlChannel(),
+    () => exit(1),
+  );
 
   const client = createStationClient(env);
-  const focusOrigin = isPopup ? focusOriginFromEnv(env) : undefined;
   const store = createTuiStore({
     source: client.state,
     service: client.service,
     clientLabel: "station",
-    exitOnFocusSuccess: isPopup,
     onExit: exit,
-    ...(focusOrigin === undefined ? {} : { focusOrigin }),
+    ...popupRuntime.storeOptions,
   });
 
   // Attach the snapshot source first, then start the client runtime feeding it
@@ -78,6 +65,7 @@ export async function runDashboardMain(): Promise<void> {
   root.render(<FullscreenDashboard store={store} />);
 
   process.on("exit", () => {
+    popupRuntime.dispose();
     detachSource();
     void client.stop();
   });

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -1,5 +1,5 @@
 // Standalone OpenTUI dashboard renderer — the sole STATION dashboard UI after the
-// Ink TUI (apps/tui) was retired. The Node CLI (`stn tui` / the tmux popup)
+// Ink TUI (apps/tui) was retired. The Node CLI (`stn tui` / persistent popup)
 // starts the observer and spawns this entry under Bun for both fullscreen and
 // popup; it renders Station's dashboard view over the observer socket and
 // dispatches the same observer commands the Ink TUI did (no Station panes).

--- a/station/src/dashboardRenderer/popupRuntime.test.ts
+++ b/station/src/dashboardRenderer/popupRuntime.test.ts
@@ -3,10 +3,7 @@ import {
   type TuiRendererControlRequest,
 } from "@station/contracts";
 import { describe, expect, it } from "bun:test";
-import {
-  createPopupRuntime,
-  type RendererControlChannel,
-} from "./popupRuntime.js";
+import { createPopupRuntime, type RendererControlChannel } from "./popupRuntime.js";
 
 describe("createPopupRuntime", () => {
   it("keeps fullscreen and transient popup exit behavior separate from persistent IPC", () => {
@@ -15,7 +12,7 @@ describe("createPopupRuntime", () => {
     const transient = createPopupRuntime(
       {
         STATION_TUI_POPUP: "1",
-        STATION_FOCUS_PROVIDER: "tmux",
+        STATION_FOCUS_PROVIDER: "fixture-terminal",
         STATION_FOCUS_CLIENT_ID: "client-startup",
       },
       undefined,
@@ -25,14 +22,36 @@ describe("createPopupRuntime", () => {
     expect(fullscreenChannel.subscribeCount).toBe(0);
     expect(transient.storeOptions).toEqual({
       exitOnFocusSuccess: true,
-      focusOrigin: { provider: "tmux", clientId: "client-startup" },
+      focusOrigin: { provider: "fixture-terminal", clientId: "client-startup" },
     });
   });
 
-  it("makes a popup persistent only when the CLI control channel is connected", async () => {
+  it("fails closed when a generated persistent renderer starts without live IPC", () => {
+    let missingControlLossCount = 0;
+    const missing = createPopupRuntime(persistentPopupEnv(), undefined, () => {
+      missingControlLossCount += 1;
+    });
+    expect(missingControlLossCount).toBe(1);
+    expect(missing.storeOptions).toMatchObject({
+      exitOnFocusSuccess: false,
+      persistentPopup: true,
+    });
+
+    const disconnectedChannel = new FakeRendererControlChannel();
+    disconnectedChannel.connected = false;
+    let disconnectedControlLossCount = 0;
+    createPopupRuntime(persistentPopupEnv(), disconnectedChannel, () => {
+      disconnectedControlLossCount += 1;
+    });
+    expect(disconnectedChannel.subscribeCount).toBe(1);
+    expect(disconnectedChannel.unsubscribeCount).toBe(1);
+    expect(disconnectedControlLossCount).toBe(1);
+  });
+
+  it("uses manual dismissal and an exact one-shot focus target separately", async () => {
     const channel = new FakeRendererControlChannel();
     let controlLossCount = 0;
-    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+    const runtime = createPopupRuntime(persistentPopupEnv(), channel, () => {
       controlLossCount += 1;
     });
 
@@ -40,92 +59,86 @@ describe("createPopupRuntime", () => {
       exitOnFocusSuccess: false,
       persistentPopup: true,
     });
-    expect(runtime.storeOptions.focusOrigin).toBeUndefined();
 
     const dismiss = runtime.storeOptions.onDismiss?.();
-    expect(dismiss).toBeDefined();
-    const dismissRequest = channel.requests.at(-1);
-    expect(dismissRequest).toMatchObject({
-      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-      type: "dismiss",
-    });
-    channel.respond({
-      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-      requestId: requiredRequest(dismissRequest).requestId,
-      type: "dismissed",
-    });
+    const dismissRequest = requiredRequest(channel.requests.at(-1));
+    expect(dismissRequest.type).toBe("dismiss");
+    channel.respond(dismissedResponse(dismissRequest.requestId));
     await dismiss;
 
-    const focusSuccessDismiss = runtime.storeOptions.onFocusSuccess?.();
-    expect(focusSuccessDismiss).toBeDefined();
-    const focusSuccessRequest = requiredRequest(channel.requests.at(-1));
-    expect(focusSuccessRequest.type).toBe("dismiss");
+    const targetPromise = runtime.storeOptions.resolveFocusTarget?.();
+    const focusRequest = requiredRequest(channel.requests.at(-1));
+    expect(focusRequest.type).toBe("resolve-focus-target");
     channel.respond({
       protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-      requestId: focusSuccessRequest.requestId,
-      type: "dismissed",
+      requestId: focusRequest.requestId,
+      type: "focus-target",
+      origin: { provider: "fixture-terminal", clientId: "client-current" },
     });
-    await focusSuccessDismiss;
+    const target = await targetPromise;
+    expect(target?.origin).toEqual({
+      provider: "fixture-terminal",
+      clientId: "client-current",
+    });
+
+    const focusDismiss = target?.onFocusSuccess?.();
+    const focusDismissRequest = requiredRequest(channel.requests.at(-1));
+    expect(focusDismissRequest).toMatchObject({
+      type: "dismiss-focus-target",
+      focusRequestId: focusRequest.requestId,
+    });
+    channel.respond(dismissedResponse(focusDismissRequest.requestId));
+    await focusDismiss;
     expect(controlLossCount).toBe(0);
   });
 
-  it("resolves the current focus origin for every request", async () => {
+  it("resolves a separately leased focus target for every request", async () => {
     const channel = new FakeRendererControlChannel();
-    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel);
-    const resolveFocusOrigin = runtime.storeOptions.resolveFocusOrigin;
-    expect(resolveFocusOrigin).toBeDefined();
+    const runtime = createPopupRuntime(persistentPopupEnv(), channel);
+    const resolveFocusTarget = runtime.storeOptions.resolveFocusTarget;
 
-    const first = resolveFocusOrigin?.();
+    const first = resolveFocusTarget?.();
     const firstRequest = requiredRequest(channel.requests.at(-1));
     channel.respond({
       protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
       requestId: firstRequest.requestId,
-      type: "focus-origin",
-      origin: { provider: "tmux", clientId: "client-a" },
+      type: "focus-target",
+      origin: { provider: "fixture-terminal", clientId: "client-a" },
     });
-    await expect(first).resolves.toEqual({ provider: "tmux", clientId: "client-a" });
+    await expect(first).resolves.toMatchObject({
+      origin: { provider: "fixture-terminal", clientId: "client-a" },
+    });
 
-    const second = resolveFocusOrigin?.();
+    const second = resolveFocusTarget?.();
     const secondRequest = requiredRequest(channel.requests.at(-1));
     channel.respond({
       protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
       requestId: secondRequest.requestId,
-      type: "focus-origin",
-      origin: { provider: "tmux", clientId: "client-b" },
+      type: "focus-target",
+      origin: { provider: "fixture-terminal", clientId: "client-b" },
     });
-    await expect(second).resolves.toEqual({ provider: "tmux", clientId: "client-b" });
+    await expect(second).resolves.toMatchObject({
+      origin: { provider: "fixture-terminal", clientId: "client-b" },
+    });
     expect(secondRequest.requestId).not.toBe(firstRequest.requestId);
   });
 
-  it("correlates concurrent dismiss and focus-origin responses", async () => {
+  it("coalesces duplicate manual dismiss effects", async () => {
     const channel = new FakeRendererControlChannel();
-    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel);
+    const runtime = createPopupRuntime(persistentPopupEnv(), channel);
 
-    const dismiss = runtime.storeOptions.onDismiss?.();
-    const focusOrigin = runtime.storeOptions.resolveFocusOrigin?.();
-    const dismissRequest = requiredRequest(channel.requests[0]);
-    const focusRequest = requiredRequest(channel.requests[1]);
+    const first = runtime.storeOptions.onDismiss?.();
+    const second = runtime.storeOptions.onDismiss?.();
 
-    channel.respond({
-      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-      requestId: focusRequest.requestId,
-      type: "focus-origin",
-      origin: { provider: "tmux", clientId: "client-current" },
-    });
-    channel.respond({
-      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-      requestId: dismissRequest.requestId,
-      type: "dismissed",
-    });
-
-    await expect(focusOrigin).resolves.toEqual({ provider: "tmux", clientId: "client-current" });
-    await expect(dismiss).resolves.toEqual(undefined);
+    expect(channel.requests).toHaveLength(1);
+    channel.respond(dismissedResponse(requiredRequest(channel.requests[0]).requestId));
+    await Promise.all([first, second]);
   });
 
   it("surfaces correlated parent errors without closing the channel", async () => {
     const channel = new FakeRendererControlChannel();
     let controlLossCount = 0;
-    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+    const runtime = createPopupRuntime(persistentPopupEnv(), channel, () => {
       controlLossCount += 1;
     });
 
@@ -138,7 +151,7 @@ describe("createPopupRuntime", () => {
       error: {
         tag: "TuiRendererControlError",
         code: "TUI_POPUP_DISMISS_FAILED",
-        message: "The tmux popup could not be dismissed.",
+        message: "The popup could not be dismissed.",
       },
     });
 
@@ -158,18 +171,18 @@ describe("createPopupRuntime", () => {
         protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
         requestId: request.requestId,
         type: "dismissed",
-        command: "tmux kill-popup",
+        command: "provider-command",
       }),
       (request: TuiRendererControlRequest) => ({
         protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
         requestId: request.requestId,
-        type: "focus-origin",
-        origin: { provider: "tmux" },
+        type: "focus-target",
+        origin: { provider: "fixture-terminal" },
       }),
     ]) {
       const channel = new FakeRendererControlChannel();
       let controlLossCount = 0;
-      const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+      const runtime = createPopupRuntime(persistentPopupEnv(), channel, () => {
         controlLossCount += 1;
       });
       const dismiss = runtime.storeOptions.onDismiss?.();
@@ -177,9 +190,7 @@ describe("createPopupRuntime", () => {
 
       channel.respond(responseFor(request));
 
-      await expect(dismiss).rejects.toMatchObject({
-        tag: "TuiRendererControlError",
-      });
+      await expect(dismiss).rejects.toMatchObject({ tag: "TuiRendererControlError" });
       expect(channel.closeCount).toBe(1);
       expect(controlLossCount).toBe(1);
     }
@@ -189,14 +200,14 @@ describe("createPopupRuntime", () => {
     const disconnectedChannel = new FakeRendererControlChannel();
     let disconnectedControlLossCount = 0;
     const disconnected = createPopupRuntime(
-      { STATION_TUI_POPUP: "1" },
+      persistentPopupEnv(),
       disconnectedChannel,
       () => {
         disconnectedControlLossCount += 1;
       },
     );
     disconnectedChannel.disconnect();
-    const afterDisconnect = disconnected.storeOptions.resolveFocusOrigin?.();
+    const afterDisconnect = disconnected.storeOptions.resolveFocusTarget?.();
 
     await expect(afterDisconnect).rejects.toMatchObject({
       code: "TUI_RENDERER_CONTROL_DISCONNECTED",
@@ -206,7 +217,7 @@ describe("createPopupRuntime", () => {
 
     const disposedChannel = new FakeRendererControlChannel();
     let disposedControlLossCount = 0;
-    const disposed = createPopupRuntime({ STATION_TUI_POPUP: "1" }, disposedChannel, () => {
+    const disposed = createPopupRuntime(persistentPopupEnv(), disposedChannel, () => {
       disposedControlLossCount += 1;
     });
     const pendingDispose = disposed.storeOptions.onDismiss?.();
@@ -221,6 +232,21 @@ describe("createPopupRuntime", () => {
   });
 });
 
+function dismissedResponse(requestId: string) {
+  return {
+    protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+    requestId,
+    type: "dismissed" as const,
+  };
+}
+
+function persistentPopupEnv(): Record<string, string> {
+  return {
+    STATION_TUI_POPUP: "1",
+    STATION_TUI_PERSISTENT: "1",
+  };
+}
+
 function requiredRequest(
   request: TuiRendererControlRequest | undefined,
 ): TuiRendererControlRequest {
@@ -233,6 +259,7 @@ function requiredRequest(
 class FakeRendererControlChannel implements RendererControlChannel {
   readonly requests: TuiRendererControlRequest[] = [];
   closeCount = 0;
+  connected = true;
   subscribeCount = 0;
   unsubscribeCount = 0;
   private handlers:
@@ -241,6 +268,10 @@ class FakeRendererControlChannel implements RendererControlChannel {
         onDisconnect(): void;
       }
     | undefined;
+
+  isConnected(): boolean {
+    return this.connected;
+  }
 
   send(request: TuiRendererControlRequest): void {
     this.requests.push(request);
@@ -261,6 +292,7 @@ class FakeRendererControlChannel implements RendererControlChannel {
   }
 
   close(): void {
+    this.connected = false;
     this.closeCount += 1;
   }
 
@@ -277,6 +309,7 @@ class FakeRendererControlChannel implements RendererControlChannel {
     if (handlers === undefined) {
       throw new Error("Renderer control channel has no subscriber.");
     }
+    this.connected = false;
     handlers.onDisconnect();
   }
 }

--- a/station/src/dashboardRenderer/popupRuntime.test.ts
+++ b/station/src/dashboardRenderer/popupRuntime.test.ts
@@ -1,0 +1,282 @@
+import {
+  TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+  type TuiRendererControlRequest,
+} from "@station/contracts";
+import { describe, expect, it } from "bun:test";
+import {
+  createPopupRuntime,
+  type RendererControlChannel,
+} from "./popupRuntime.js";
+
+describe("createPopupRuntime", () => {
+  it("keeps fullscreen and transient popup exit behavior separate from persistent IPC", () => {
+    const fullscreenChannel = new FakeRendererControlChannel();
+    const fullscreen = createPopupRuntime({}, fullscreenChannel);
+    const transient = createPopupRuntime(
+      {
+        STATION_TUI_POPUP: "1",
+        STATION_FOCUS_PROVIDER: "tmux",
+        STATION_FOCUS_CLIENT_ID: "client-startup",
+      },
+      undefined,
+    );
+
+    expect(fullscreen.storeOptions).toEqual({});
+    expect(fullscreenChannel.subscribeCount).toBe(0);
+    expect(transient.storeOptions).toEqual({
+      exitOnFocusSuccess: true,
+      focusOrigin: { provider: "tmux", clientId: "client-startup" },
+    });
+  });
+
+  it("makes a popup persistent only when the CLI control channel is connected", async () => {
+    const channel = new FakeRendererControlChannel();
+    let controlLossCount = 0;
+    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+      controlLossCount += 1;
+    });
+
+    expect(runtime.storeOptions).toMatchObject({
+      exitOnFocusSuccess: false,
+      persistentPopup: true,
+    });
+    expect(runtime.storeOptions.focusOrigin).toBeUndefined();
+
+    const dismiss = runtime.storeOptions.onDismiss?.();
+    expect(dismiss).toBeDefined();
+    const dismissRequest = channel.requests.at(-1);
+    expect(dismissRequest).toMatchObject({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      type: "dismiss",
+    });
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: requiredRequest(dismissRequest).requestId,
+      type: "dismissed",
+    });
+    await dismiss;
+
+    const focusSuccessDismiss = runtime.storeOptions.onFocusSuccess?.();
+    expect(focusSuccessDismiss).toBeDefined();
+    const focusSuccessRequest = requiredRequest(channel.requests.at(-1));
+    expect(focusSuccessRequest.type).toBe("dismiss");
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: focusSuccessRequest.requestId,
+      type: "dismissed",
+    });
+    await focusSuccessDismiss;
+    expect(controlLossCount).toBe(0);
+  });
+
+  it("resolves the current focus origin for every request", async () => {
+    const channel = new FakeRendererControlChannel();
+    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel);
+    const resolveFocusOrigin = runtime.storeOptions.resolveFocusOrigin;
+    expect(resolveFocusOrigin).toBeDefined();
+
+    const first = resolveFocusOrigin?.();
+    const firstRequest = requiredRequest(channel.requests.at(-1));
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: firstRequest.requestId,
+      type: "focus-origin",
+      origin: { provider: "tmux", clientId: "client-a" },
+    });
+    await expect(first).resolves.toEqual({ provider: "tmux", clientId: "client-a" });
+
+    const second = resolveFocusOrigin?.();
+    const secondRequest = requiredRequest(channel.requests.at(-1));
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: secondRequest.requestId,
+      type: "focus-origin",
+      origin: { provider: "tmux", clientId: "client-b" },
+    });
+    await expect(second).resolves.toEqual({ provider: "tmux", clientId: "client-b" });
+    expect(secondRequest.requestId).not.toBe(firstRequest.requestId);
+  });
+
+  it("correlates concurrent dismiss and focus-origin responses", async () => {
+    const channel = new FakeRendererControlChannel();
+    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel);
+
+    const dismiss = runtime.storeOptions.onDismiss?.();
+    const focusOrigin = runtime.storeOptions.resolveFocusOrigin?.();
+    const dismissRequest = requiredRequest(channel.requests[0]);
+    const focusRequest = requiredRequest(channel.requests[1]);
+
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: focusRequest.requestId,
+      type: "focus-origin",
+      origin: { provider: "tmux", clientId: "client-current" },
+    });
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: dismissRequest.requestId,
+      type: "dismissed",
+    });
+
+    await expect(focusOrigin).resolves.toEqual({ provider: "tmux", clientId: "client-current" });
+    await expect(dismiss).resolves.toEqual(undefined);
+  });
+
+  it("surfaces correlated parent errors without closing the channel", async () => {
+    const channel = new FakeRendererControlChannel();
+    let controlLossCount = 0;
+    const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+      controlLossCount += 1;
+    });
+
+    const dismiss = runtime.storeOptions.onDismiss?.();
+    const request = requiredRequest(channel.requests.at(-1));
+    channel.respond({
+      protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+      requestId: request.requestId,
+      type: "error",
+      error: {
+        tag: "TuiRendererControlError",
+        code: "TUI_POPUP_DISMISS_FAILED",
+        message: "The tmux popup could not be dismissed.",
+      },
+    });
+
+    await expect(dismiss).rejects.toMatchObject({ code: "TUI_POPUP_DISMISS_FAILED" });
+    expect(channel.closeCount).toBe(0);
+    expect(controlLossCount).toBe(0);
+  });
+
+  it("fails closed on malformed, uncorrelated, or mismatched responses", async () => {
+    for (const responseFor of [
+      () => ({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: "wrong",
+        type: "dismissed",
+      }),
+      (request: TuiRendererControlRequest) => ({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: request.requestId,
+        type: "dismissed",
+        command: "tmux kill-popup",
+      }),
+      (request: TuiRendererControlRequest) => ({
+        protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+        requestId: request.requestId,
+        type: "focus-origin",
+        origin: { provider: "tmux" },
+      }),
+    ]) {
+      const channel = new FakeRendererControlChannel();
+      let controlLossCount = 0;
+      const runtime = createPopupRuntime({ STATION_TUI_POPUP: "1" }, channel, () => {
+        controlLossCount += 1;
+      });
+      const dismiss = runtime.storeOptions.onDismiss?.();
+      const request = requiredRequest(channel.requests.at(-1));
+
+      channel.respond(responseFor(request));
+
+      await expect(dismiss).rejects.toMatchObject({
+        tag: "TuiRendererControlError",
+      });
+      expect(channel.closeCount).toBe(1);
+      expect(controlLossCount).toBe(1);
+    }
+  });
+
+  it("reports idle control loss and removes listeners on disconnect or disposal", async () => {
+    const disconnectedChannel = new FakeRendererControlChannel();
+    let disconnectedControlLossCount = 0;
+    const disconnected = createPopupRuntime(
+      { STATION_TUI_POPUP: "1" },
+      disconnectedChannel,
+      () => {
+        disconnectedControlLossCount += 1;
+      },
+    );
+    disconnectedChannel.disconnect();
+    const afterDisconnect = disconnected.storeOptions.resolveFocusOrigin?.();
+
+    await expect(afterDisconnect).rejects.toMatchObject({
+      code: "TUI_RENDERER_CONTROL_DISCONNECTED",
+    });
+    expect(disconnectedChannel.unsubscribeCount).toBe(1);
+    expect(disconnectedControlLossCount).toBe(1);
+
+    const disposedChannel = new FakeRendererControlChannel();
+    let disposedControlLossCount = 0;
+    const disposed = createPopupRuntime({ STATION_TUI_POPUP: "1" }, disposedChannel, () => {
+      disposedControlLossCount += 1;
+    });
+    const pendingDispose = disposed.storeOptions.onDismiss?.();
+
+    disposed.dispose();
+
+    await expect(pendingDispose).rejects.toMatchObject({
+      code: "TUI_RENDERER_CONTROL_DISPOSED",
+    });
+    expect(disposedChannel.unsubscribeCount).toBe(1);
+    expect(disposedControlLossCount).toBe(0);
+  });
+});
+
+function requiredRequest(
+  request: TuiRendererControlRequest | undefined,
+): TuiRendererControlRequest {
+  if (request === undefined) {
+    throw new Error("Expected a renderer control request.");
+  }
+  return request;
+}
+
+class FakeRendererControlChannel implements RendererControlChannel {
+  readonly requests: TuiRendererControlRequest[] = [];
+  closeCount = 0;
+  subscribeCount = 0;
+  unsubscribeCount = 0;
+  private handlers:
+    | {
+        onMessage(message: unknown): void;
+        onDisconnect(): void;
+      }
+    | undefined;
+
+  send(request: TuiRendererControlRequest): void {
+    this.requests.push(request);
+  }
+
+  subscribe(handlers: {
+    onMessage(message: unknown): void;
+    onDisconnect(): void;
+  }): () => void {
+    this.subscribeCount += 1;
+    this.handlers = handlers;
+    return () => {
+      if (this.handlers === handlers) {
+        this.handlers = undefined;
+      }
+      this.unsubscribeCount += 1;
+    };
+  }
+
+  close(): void {
+    this.closeCount += 1;
+  }
+
+  respond(message: unknown): void {
+    const handlers = this.handlers;
+    if (handlers === undefined) {
+      throw new Error("Renderer control channel has no subscriber.");
+    }
+    handlers.onMessage(message);
+  }
+
+  disconnect(): void {
+    const handlers = this.handlers;
+    if (handlers === undefined) {
+      throw new Error("Renderer control channel has no subscriber.");
+    }
+    handlers.onDisconnect();
+  }
+}

--- a/station/src/dashboardRenderer/popupRuntime.ts
+++ b/station/src/dashboardRenderer/popupRuntime.ts
@@ -7,9 +7,10 @@ import {
   type TuiRendererControlRequest,
   type TuiRendererControlResponse,
 } from "@station/contracts";
-import type { TuiStoreOptions } from "@station/dashboard-core";
+import type { TuiFocusTarget, TuiStoreOptions } from "@station/dashboard-core";
 
 export type RendererControlChannel = {
+  isConnected(): boolean;
   send(request: TuiRendererControlRequest): void;
   subscribe(handlers: {
     onMessage(message: unknown): void;
@@ -25,7 +26,7 @@ type PopupStoreOptions = Pick<
   | "onDismiss"
   | "onFocusSuccess"
   | "persistentPopup"
-  | "resolveFocusOrigin"
+  | "resolveFocusTarget"
 >;
 
 export type PopupRuntime = {
@@ -42,7 +43,7 @@ export function createPopupRuntime(
     return { storeOptions: {}, dispose: () => {} };
   }
 
-  if (channel === undefined) {
+  if (env.STATION_TUI_PERSISTENT !== "1") {
     const focusOrigin = focusOriginFromEnv(env);
     return {
       storeOptions: {
@@ -53,15 +54,24 @@ export function createPopupRuntime(
     };
   }
 
+  if (channel === undefined) {
+    onControlLoss();
+    return {
+      storeOptions: {
+        exitOnFocusSuccess: false,
+        persistentPopup: true,
+      },
+      dispose: () => {},
+    };
+  }
+
   const control = createRendererControlClient(channel, onControlLoss);
-  const dismiss = async (): Promise<void> => control.dismiss();
   return {
     storeOptions: {
       exitOnFocusSuccess: false,
       persistentPopup: true,
-      onDismiss: dismiss,
-      onFocusSuccess: dismiss,
-      resolveFocusOrigin: async () => control.resolveFocusOrigin(),
+      onDismiss: () => control.dismiss(),
+      resolveFocusTarget: () => control.resolveFocusTarget(),
     },
     dispose: control.dispose,
   };
@@ -73,6 +83,7 @@ export function createProcessRendererControlChannel(): RendererControlChannel | 
   }
 
   return {
+    isConnected: (): boolean => process.connected === true && typeof process.send === "function",
     send: (request): void => {
       if (process.connected !== true || process.send === undefined) {
         throw rendererControlError(
@@ -105,14 +116,19 @@ type PendingRequest =
       reject(error: SafeError): void;
     }
   | {
-      type: "resolve-focus-origin";
-      resolve(origin: TerminalFocusOrigin): void;
+      type: "dismiss-focus-target";
+      resolve(): void;
+      reject(error: SafeError): void;
+    }
+  | {
+      type: "resolve-focus-target";
+      resolve(target: TuiFocusTarget): void;
       reject(error: SafeError): void;
     };
 
 type RendererControlClient = {
   dismiss(): Promise<void>;
-  resolveFocusOrigin(): Promise<TerminalFocusOrigin>;
+  resolveFocusTarget(): Promise<TuiFocusTarget>;
   dispose(): void;
 };
 
@@ -123,6 +139,7 @@ function createRendererControlClient(
   const pending = new Map<string, PendingRequest>();
   let nextRequestId = 1;
   let closedError: SafeError | undefined;
+  let manualDismissEffect: Promise<void> | undefined;
 
   const unsubscribe = channel.subscribe({
     onMessage: (message) => {
@@ -149,6 +166,15 @@ function createRendererControlClient(
       );
     },
   });
+  if (!channel.isConnected()) {
+    loseControl(
+      rendererControlError(
+        "TUI_RENDERER_CONTROL_DISCONNECTED",
+        "The popup renderer control channel disconnected.",
+      ),
+      false,
+    );
+  }
 
   function newRequestId(): string {
     const requestId = `renderer-${nextRequestId}`;
@@ -193,14 +219,20 @@ function createRendererControlClient(
       request.reject(response.error);
       return;
     }
-    if (response.type === "dismissed" && request.type === "dismiss") {
+    if (
+      response.type === "dismissed" &&
+      (request.type === "dismiss" || request.type === "dismiss-focus-target")
+    ) {
       pending.delete(response.requestId);
       request.resolve();
       return;
     }
-    if (response.type === "focus-origin" && request.type === "resolve-focus-origin") {
+    if (response.type === "focus-target" && request.type === "resolve-focus-target") {
       pending.delete(response.requestId);
-      request.resolve(response.origin);
+      request.resolve({
+        origin: response.origin,
+        onFocusSuccess: () => dismissFocusTarget(response.requestId),
+      });
       return;
     }
 
@@ -235,30 +267,58 @@ function createRendererControlClient(
     return true;
   }
 
+  function requestManualDismiss(): Promise<void> {
+    const current = manualDismissEffect;
+    if (current !== undefined) {
+      return current;
+    }
+    const effect = new Promise<void>((resolve, reject) => {
+      const requestId = newRequestId();
+      send(
+        {
+          protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+          requestId,
+          type: "dismiss",
+        },
+        { type: "dismiss", resolve, reject },
+      );
+    });
+    manualDismissEffect = effect;
+    void effect.then(clearManualDismiss, clearManualDismiss);
+    return effect;
+  }
+
+  function clearManualDismiss(): void {
+    manualDismissEffect = undefined;
+  }
+
+  function dismissFocusTarget(focusRequestId: string): Promise<void> {
+    const requestId = newRequestId();
+    return new Promise<void>((resolve, reject) => {
+      send(
+        {
+          protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+          requestId,
+          type: "dismiss-focus-target",
+          focusRequestId,
+        },
+        { type: "dismiss-focus-target", resolve, reject },
+      );
+    });
+  }
+
   return {
-    dismiss: async (): Promise<void> => {
+    dismiss: requestManualDismiss,
+    resolveFocusTarget: async (): Promise<TuiFocusTarget> => {
       const requestId = newRequestId();
-      return new Promise<void>((resolve, reject) => {
+      return new Promise<TuiFocusTarget>((resolve, reject) => {
         send(
           {
             protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
             requestId,
-            type: "dismiss",
+            type: "resolve-focus-target",
           },
-          { type: "dismiss", resolve, reject },
-        );
-      });
-    },
-    resolveFocusOrigin: async (): Promise<TerminalFocusOrigin> => {
-      const requestId = newRequestId();
-      return new Promise<TerminalFocusOrigin>((resolve, reject) => {
-        send(
-          {
-            protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
-            requestId,
-            type: "resolve-focus-origin",
-          },
-          { type: "resolve-focus-origin", resolve, reject },
+          { type: "resolve-focus-target", resolve, reject },
         );
       });
     },

--- a/station/src/dashboardRenderer/popupRuntime.ts
+++ b/station/src/dashboardRenderer/popupRuntime.ts
@@ -1,0 +1,299 @@
+import {
+  TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+  TerminalFocusOriginSchema,
+  TuiRendererControlResponseSchema,
+  type SafeError,
+  type TerminalFocusOrigin,
+  type TuiRendererControlRequest,
+  type TuiRendererControlResponse,
+} from "@station/contracts";
+import type { TuiStoreOptions } from "@station/dashboard-core";
+
+export type RendererControlChannel = {
+  send(request: TuiRendererControlRequest): void;
+  subscribe(handlers: {
+    onMessage(message: unknown): void;
+    onDisconnect(): void;
+  }): () => void;
+  close(): void;
+};
+
+type PopupStoreOptions = Pick<
+  TuiStoreOptions,
+  | "exitOnFocusSuccess"
+  | "focusOrigin"
+  | "onDismiss"
+  | "onFocusSuccess"
+  | "persistentPopup"
+  | "resolveFocusOrigin"
+>;
+
+export type PopupRuntime = {
+  storeOptions: PopupStoreOptions;
+  dispose(): void;
+};
+
+export function createPopupRuntime(
+  env: Record<string, string | undefined>,
+  channel: RendererControlChannel | undefined,
+  onControlLoss: () => void = () => {},
+): PopupRuntime {
+  if (env.STATION_TUI_POPUP !== "1") {
+    return { storeOptions: {}, dispose: () => {} };
+  }
+
+  if (channel === undefined) {
+    const focusOrigin = focusOriginFromEnv(env);
+    return {
+      storeOptions: {
+        exitOnFocusSuccess: true,
+        ...(focusOrigin === undefined ? {} : { focusOrigin }),
+      },
+      dispose: () => {},
+    };
+  }
+
+  const control = createRendererControlClient(channel, onControlLoss);
+  const dismiss = async (): Promise<void> => control.dismiss();
+  return {
+    storeOptions: {
+      exitOnFocusSuccess: false,
+      persistentPopup: true,
+      onDismiss: dismiss,
+      onFocusSuccess: dismiss,
+      resolveFocusOrigin: async () => control.resolveFocusOrigin(),
+    },
+    dispose: control.dispose,
+  };
+}
+
+export function createProcessRendererControlChannel(): RendererControlChannel | undefined {
+  if (process.connected !== true || typeof process.send !== "function") {
+    return undefined;
+  }
+
+  return {
+    send: (request): void => {
+      if (process.connected !== true || process.send === undefined) {
+        throw rendererControlError(
+          "TUI_RENDERER_CONTROL_DISCONNECTED",
+          "The popup renderer control channel disconnected.",
+        );
+      }
+      process.send(request);
+    },
+    subscribe: ({ onMessage, onDisconnect }): (() => void) => {
+      process.on("message", onMessage);
+      process.on("disconnect", onDisconnect);
+      return () => {
+        process.off("message", onMessage);
+        process.off("disconnect", onDisconnect);
+      };
+    },
+    close: (): void => {
+      if (process.connected === true) {
+        process.disconnect?.();
+      }
+    },
+  };
+}
+
+type PendingRequest =
+  | {
+      type: "dismiss";
+      resolve(): void;
+      reject(error: SafeError): void;
+    }
+  | {
+      type: "resolve-focus-origin";
+      resolve(origin: TerminalFocusOrigin): void;
+      reject(error: SafeError): void;
+    };
+
+type RendererControlClient = {
+  dismiss(): Promise<void>;
+  resolveFocusOrigin(): Promise<TerminalFocusOrigin>;
+  dispose(): void;
+};
+
+function createRendererControlClient(
+  channel: RendererControlChannel,
+  onControlLoss: () => void,
+): RendererControlClient {
+  const pending = new Map<string, PendingRequest>();
+  let nextRequestId = 1;
+  let closedError: SafeError | undefined;
+
+  const unsubscribe = channel.subscribe({
+    onMessage: (message) => {
+      const parsed = TuiRendererControlResponseSchema.safeParse(message);
+      if (!parsed.success) {
+        loseControl(
+          rendererControlError(
+            "TUI_RENDERER_CONTROL_INVALID_RESPONSE",
+            "The popup renderer received an invalid control response.",
+          ),
+          true,
+        );
+        return;
+      }
+      settle(parsed.data);
+    },
+    onDisconnect: () => {
+      loseControl(
+        rendererControlError(
+          "TUI_RENDERER_CONTROL_DISCONNECTED",
+          "The popup renderer control channel disconnected.",
+        ),
+        false,
+      );
+    },
+  });
+
+  function newRequestId(): string {
+    const requestId = `renderer-${nextRequestId}`;
+    nextRequestId += 1;
+    return requestId;
+  }
+
+  function send(request: TuiRendererControlRequest, requestState: PendingRequest): void {
+    if (closedError !== undefined) {
+      requestState.reject(closedError);
+      return;
+    }
+    pending.set(request.requestId, requestState);
+    try {
+      channel.send(request);
+    } catch {
+      loseControl(
+        rendererControlError(
+          "TUI_RENDERER_CONTROL_SEND_FAILED",
+          "The popup renderer could not send a control request.",
+        ),
+        true,
+      );
+    }
+  }
+
+  function settle(response: TuiRendererControlResponse): void {
+    const request = pending.get(response.requestId);
+    if (request === undefined) {
+      loseControl(
+        rendererControlError(
+          "TUI_RENDERER_CONTROL_CORRELATION_FAILED",
+          "The popup renderer received an uncorrelated control response.",
+        ),
+        true,
+      );
+      return;
+    }
+
+    if (response.type === "error") {
+      pending.delete(response.requestId);
+      request.reject(response.error);
+      return;
+    }
+    if (response.type === "dismissed" && request.type === "dismiss") {
+      pending.delete(response.requestId);
+      request.resolve();
+      return;
+    }
+    if (response.type === "focus-origin" && request.type === "resolve-focus-origin") {
+      pending.delete(response.requestId);
+      request.resolve(response.origin);
+      return;
+    }
+
+    loseControl(
+      rendererControlError(
+        "TUI_RENDERER_CONTROL_CORRELATION_FAILED",
+        "The popup renderer received a mismatched control response.",
+      ),
+      true,
+    );
+  }
+
+  function loseControl(error: SafeError, close: boolean): void {
+    if (fail(error, close)) {
+      onControlLoss();
+    }
+  }
+
+  function fail(error: SafeError, close: boolean): boolean {
+    if (closedError !== undefined) {
+      return false;
+    }
+    closedError = error;
+    unsubscribe();
+    for (const request of pending.values()) {
+      request.reject(error);
+    }
+    pending.clear();
+    if (close) {
+      channel.close();
+    }
+    return true;
+  }
+
+  return {
+    dismiss: async (): Promise<void> => {
+      const requestId = newRequestId();
+      return new Promise<void>((resolve, reject) => {
+        send(
+          {
+            protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+            requestId,
+            type: "dismiss",
+          },
+          { type: "dismiss", resolve, reject },
+        );
+      });
+    },
+    resolveFocusOrigin: async (): Promise<TerminalFocusOrigin> => {
+      const requestId = newRequestId();
+      return new Promise<TerminalFocusOrigin>((resolve, reject) => {
+        send(
+          {
+            protocolVersion: TUI_RENDERER_CONTROL_PROTOCOL_VERSION,
+            requestId,
+            type: "resolve-focus-origin",
+          },
+          { type: "resolve-focus-origin", resolve, reject },
+        );
+      });
+    },
+    dispose: (): void => {
+      fail(
+        rendererControlError(
+          "TUI_RENDERER_CONTROL_DISPOSED",
+          "The popup renderer control channel was disposed.",
+        ),
+        false,
+      );
+    },
+  };
+}
+
+function focusOriginFromEnv(
+  env: Record<string, string | undefined>,
+): TerminalFocusOrigin | undefined {
+  const provider = env.STATION_FOCUS_PROVIDER;
+  if (provider === undefined || provider.length === 0) {
+    return undefined;
+  }
+  const candidate: { provider: string; clientId?: string } = { provider };
+  const clientId = env.STATION_FOCUS_CLIENT_ID;
+  if (clientId !== undefined && clientId.length > 0) {
+    candidate.clientId = clientId;
+  }
+  const parsed = TerminalFocusOriginSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function rendererControlError(code: string, message: string): SafeError {
+  return {
+    tag: "TuiRendererControlError",
+    code,
+    message,
+  };
+}

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const roots = ["apps", "packages", "integrations"];
 const providerNeutralSourceRoots = [
   "packages/contracts/src",
+  "packages/dashboard-core/src",
   "packages/observability/src",
   "packages/protocol/src",
   "packages/runtime/src",

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -385,7 +385,7 @@ async function createFixture(input: {
         ]);
       } finally {
         await Promise.all([
-          rm(root, { recursive: true, force: true }),
+          rm(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }),
           rm(runtimeDir, { recursive: true, force: true }),
         ]);
       }


### PR DESCRIPTION
## Summary

- Make `tui --popup --persistent` a real persistent renderer lifecycle: Esc, Q, and successful focus dismiss only the outer popup while the hidden renderer and store stay alive.
- Add a versioned, strictly parsed CLI-owned IPC channel with only `dismiss` and `resolve-focus-origin` requests; malformed, duplicate, mismatched, and disconnected frames fail closed.
- Resolve the active tmux client for every focus, preserve focus completion and readiness ordering, and leave focus failures visible with their toast.
- Keep source and compiled renderers as direct IPC children and terminate a persistent renderer when its owning control channel is lost.

## Safety and scope

- tmux authority remains in the CLI adapter; the Station renderer stays provider-neutral.
- No mouse routing, geometry, widgets, tmux devbox, or native focus acknowledgment changes.
- Scope is the plan's seven production files and six test files.

## UX

Press Esc, reopen, press Q, reopen, then focus a tmux row. Each successful close is immediate and the hidden pane/renderer PID remains constant; a failed focus remains open with its error toast.

## Validation

- Focused: contracts 44/44, CLI 30/30, dashboard-core 34/34, popup runtime 7/7
- Locked native Station set: 297/297, 12 snapshots unchanged
- Full Station: 1,014/1,014, 36 snapshots
- `pnpm test:all`
- Private real-tmux lane: 4/4 using a disposable `tmux -L ... -f /dev/null` environment
- `pnpm test:pre-push`
