### PR TITLE
fix(tui): block nested native Station workspaces

### DIFF
--- a/apps/cli/src/commands/registry/tui.ts
+++ b/apps/cli/src/commands/registry/tui.ts
@@ -14,15 +14,19 @@ export const tuiCliCommand: CliCommandNode = {
   requiresConfig: true,
   run: runTuiCliCommand,
   handleConfigError: handleTuiConfigError,
-  usage: ["stn tui [--popup] [--persistent]"],
+  usage: ["stn tui [--popup] [--persistent] [--allow-nested]"],
   options: [
     { name: "--popup", description: "Run in popup mode." },
     {
       name: "--persistent",
       description: "Keep the dashboard alive when the outer popup is dismissed.",
     },
+    {
+      name: "--allow-nested",
+      description: "Allow this TUI launch from a Station-owned pane.",
+    },
   ],
-  examples: ["pnpm stn tui", "pnpm stn tui --popup --persistent"],
+  examples: ["pnpm stn tui", "pnpm stn tui --popup --persistent", "pnpm stn tui --allow-nested"],
 };
 
 async function handleTuiConfigError(error: unknown, context: CliCommandConfigErrorContext) {

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -4,6 +4,7 @@ import { TUI_STARTUP_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import {
   isCompiledBinary,
+  type RuntimeSafeError,
   safeErrorFromUnknown,
   stationObserverBuildVersion,
   systemClock,
@@ -70,6 +71,13 @@ export type TuiCommandResult =
       observer: ObserverStatus;
     };
 
+const nestedTuiDisabledError = {
+  tag: "TuiCommandError",
+  code: "NESTED_TUI_DISABLED",
+  message: "Nested Station is disabled.",
+  hint: "Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.",
+} satisfies RuntimeSafeError;
+
 /**
  * COMPOSITION ROOT
  *
@@ -81,6 +89,21 @@ export async function runTuiCommand(
   deps: TuiCommandDeps = {},
 ): Promise<TuiCommandResult> {
   const parsed = parseTuiArgs(args, options.timeoutMs);
+  const env = deps.env ?? process.env;
+  const stationPaneMarker =
+    env.TMUX !== undefined && env.TMUX_PANE !== undefined
+      ? JSON.stringify([env.TMUX, env.TMUX_PANE])
+      : "1";
+  // Only the incoming launcher marker exempts popup mode; buildRendererEnv stamps the child later for routing.
+  const popupLauncherChild = parsed.popupMode && env.STATION_TUI_POPUP === "1";
+  if (
+    env.STATION_PANE === stationPaneMarker &&
+    !parsed.allowNested &&
+    !parsed.devFakeDashboard &&
+    !popupLauncherChild
+  ) {
+    throw nestedTuiDisabledError;
+  }
   if (parsed.devFakeDashboard) {
     // The Bun renderer carries its own mock source; the --fake-* counts are
     // accepted for back-compat but the mock uses its baseline scenario.
@@ -345,6 +368,7 @@ async function reconcileBeforeTui(input: {
 }
 
 type ParsedTuiArgs = {
+  allowNested: boolean;
   devFakeDashboard: boolean;
   fakeProjects: number;
   fakeWorktreesPerProject: number;
@@ -361,7 +385,7 @@ function parseTuiArgs(args: string[], timeoutMs: number | undefined): ParsedTuiA
     "--fake-worktrees-per-project",
   );
   const remainingArgs = fakeWorktreesPerProject.args;
-  const knownFlags = new Set(["--popup", "--persistent", "--dev-fake-dashboard"]);
+  const knownFlags = new Set(["--allow-nested", "--popup", "--persistent", "--dev-fake-dashboard"]);
   const unknown = remainingArgs.find((arg) => !knownFlags.has(arg));
   if (unknown !== undefined) {
     throw new Error(`Unknown tui option: ${unknown}`);
@@ -380,6 +404,7 @@ function parseTuiArgs(args: string[], timeoutMs: number | undefined): ParsedTuiA
   }
 
   const result: ParsedTuiArgs = {
+    allowNested: remainingArgs.includes("--allow-nested"),
     devFakeDashboard,
     fakeProjects: fakeProjects.value ?? 4,
     fakeWorktreesPerProject: fakeWorktreesPerProject.value ?? 24,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -300,6 +300,7 @@ describe("CLI popup command", () => {
           config: fixture.config,
           env: {
             TMUX: "/tmp/tmux-501/default,123,0",
+            STATION_PANE: "1",
           },
           tuiCommand: "node stn tui --popup --persistent",
         },
@@ -324,6 +325,7 @@ describe("CLI popup command", () => {
         enterWorkbench: false,
         env: {
           TMUX: "/tmp/tmux-501/default,123,0",
+          STATION_PANE: "1",
         },
         tuiCommand: "node stn tui --popup --persistent",
       },
@@ -374,6 +376,7 @@ describe("CLI popup command", () => {
         popupDeps: {
           env: {
             TMUX: "/tmp/tmux-501/default,123,0",
+            STATION_PANE: "1",
           },
           openTmuxPopup: async (options) => {
             calls.push(options);
@@ -392,6 +395,7 @@ describe("CLI popup command", () => {
       checkoutRoot: repoRoot,
       env: {
         TMUX: "/tmp/tmux-501/default,123,0",
+        STATION_PANE: "1",
       },
       preferRegisteredDevPopup: true,
     });
@@ -481,6 +485,7 @@ describe("CLI popup command", () => {
         popupDeps: {
           env: {
             TMUX: "/tmp/tmux-501/default,123,0",
+            STATION_PANE: "1",
           },
           openTmuxPopup: async (options) => {
             calls.push(options);

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -5,6 +5,7 @@ import { runCli } from "@station/cli";
 import {
   type ObserverProcessDeps,
   resolvePopupTmuxCommand,
+  runCliMain,
   runTuiCommand,
   type TuiCommandDeps,
 } from "@station/cli/internal";
@@ -16,6 +17,12 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 const observerBuildVersion = `0.7.0+station.${"a".repeat(64)}`;
+const nestedTuiDisabledError = {
+  tag: "TuiCommandError",
+  code: "NESTED_TUI_DISABLED",
+  message: "Nested Station is disabled.",
+  hint: "Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.",
+} as const;
 const tuiConfig: TuiConfig = {
   widgets: [
     {
@@ -100,6 +107,7 @@ function runningObserverDeps(
           }
           return Promise.resolve(emptySnapshot(reason));
         },
+        getSnapshot: async () => emptySnapshot("nested-snapshot").snapshot,
       }) as never,
     sleep: async () => undefined,
   };
@@ -389,6 +397,216 @@ describe("CLI tui command", () => {
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
       },
     ]);
+  });
+
+  it.each([
+    { label: "bare native launch", args: [], env: { STATION_PANE: "1" } },
+    { label: "explicit native launch", args: ["tui"], env: { STATION_PANE: "1" } },
+    {
+      label: "native launch from a Station workspace running inside tmux",
+      args: ["tui"],
+      env: {
+        STATION_PANE: JSON.stringify(["/tmp/tmux-501/default,123,0", "%4"]),
+        TMUX: "/tmp/tmux-501/default,123,0",
+        TMUX_PANE: "%4",
+      },
+    },
+    {
+      label: "direct popup renderer launch",
+      args: ["tui", "--popup"],
+      env: { STATION_PANE: "1" },
+    },
+  ])("blocks $label before Observer or renderer effects", async ({ args, env }) => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const health = vi.fn();
+    const reconcile = vi.fn();
+    const spawnObserver = vi.fn(async () => ({ pid: 1234, unref: () => undefined }));
+    const clientFactory = vi.fn(
+      () =>
+        ({
+          health,
+          reconcile,
+        }) as never,
+    );
+    const stationUiInstalled = vi.fn(async () => true);
+    const spawnRenderer = vi.fn(async () => ({ status: "exited" as const, code: 0 }));
+
+    await expect(
+      runCli(["--config", configPath, ...args], {
+        env,
+        observerDeps: { clientFactory, spawnObserver },
+        tuiDeps: { spawnRenderer, stationUiInstalled },
+      }),
+    ).rejects.toEqual(nestedTuiDisabledError);
+
+    expect(spawnObserver).not.toHaveBeenCalled();
+    expect(clientFactory).not.toHaveBeenCalled();
+    expect(health).not.toHaveBeenCalled();
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(stationUiInstalled).not.toHaveBeenCalled();
+    expect(spawnRenderer).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "different pane on the same tmux server",
+      currentTmux: "/tmp/tmux-501/station-origin,123,0",
+      currentPane: "%8",
+    },
+    {
+      label: "same-numbered pane on another tmux server",
+      currentTmux: "/tmp/tmux-501/later-server,456,0",
+      currentPane: "%0",
+    },
+  ])("ignores a Station marker copied into a $label", async ({ currentTmux, currentPane }) => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const launches: Array<{ entry: string }> = [];
+    const originTmux = "/tmp/tmux-501/station-origin,123,0";
+
+    await expect(
+      runCli(["--config", configPath, "tui"], {
+        env: {
+          STATION_PANE: JSON.stringify([originTmux, "%0"]),
+          TMUX: currentTmux,
+          TMUX_PANE: currentPane,
+        },
+        observerDeps: runningObserverDeps(),
+        tuiDeps: {
+          spawnRenderer: async ({ entry }) => {
+            launches.push({ entry });
+            return { status: "exited", code: 0 };
+          },
+        },
+      }),
+    ).resolves.toEqual({ code: 0, output: { status: "exited", code: 0 } });
+
+    expect(launches).toEqual([{ entry: "station" }]);
+  });
+
+  it("requires the override again at each nested native depth", async () => {
+    const fixture = await createTempState();
+    const spawnRenderer = vi.fn(async () => ({ status: "exited" as const, code: 0 }));
+    const runNested = (args: string[]) =>
+      runTuiCommand(
+        args,
+        { config: fixture.config },
+        {
+          env: { STATION_PANE: "1" },
+          observer: runningObserverDeps(),
+          spawnRenderer,
+        },
+      );
+
+    await expect(runNested(["--allow-nested"])).resolves.toEqual({
+      status: "exited",
+      code: 0,
+    });
+    await expect(runNested([])).rejects.toEqual(nestedTuiDisabledError);
+    await expect(runNested(["--allow-nested"])).resolves.toEqual({
+      status: "exited",
+      code: 0,
+    });
+    expect(spawnRenderer).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: "transient launcher child",
+      args: ["--popup"],
+      env: { STATION_PANE: "1", STATION_TUI_POPUP: "1" },
+      expectedPersistent: false,
+    },
+    {
+      label: "persistent launcher child",
+      args: ["--popup", "--persistent"],
+      env: { STATION_PANE: "1", STATION_TUI_POPUP: "1" },
+      expectedPersistent: true,
+    },
+    {
+      label: "direct popup with explicit override",
+      args: ["--popup", "--allow-nested"],
+      env: { STATION_PANE: "1" },
+      expectedPersistent: false,
+    },
+  ])("allows $label", async ({ args, env, expectedPersistent }) => {
+    const fixture = await createTempState();
+    const launches: Array<{ entry: string; env: Record<string, string> }> = [];
+
+    await expect(
+      runTuiCommand(
+        args,
+        { config: fixture.config },
+        {
+          env,
+          observer: runningObserverDeps(),
+          spawnRenderer: async (launch) => {
+            launches.push(launch);
+            return { status: "exited", code: 0 };
+          },
+        },
+      ),
+    ).resolves.toEqual({ status: "exited", code: 0 });
+
+    expect(launches).toHaveLength(1);
+    expect(launches[0]?.entry).toBe("dashboard");
+    expect(launches[0]?.env.STATION_TUI_POPUP).toBe("1");
+    expect(launches[0]?.env.STATION_TUI_PERSISTENT).toBe(expectedPersistent ? "1" : undefined);
+  });
+
+  it("keeps non-TUI routes and help available inside a Station pane", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const env = { STATION_PANE: "1" };
+
+    await expect(
+      runCli(["--config", configPath, "snapshot", "--json"], {
+        env,
+        observerDeps: runningObserverDeps(),
+      }),
+    ).resolves.toEqual({
+      code: 0,
+      output: emptySnapshot("nested-snapshot").snapshot,
+    });
+
+    for (const topic of ["doctor", "debug", "observer", "command", "setup"]) {
+      const result = await runCli([topic, "--help"], { env });
+      expect(result.code).toBe(0);
+      expect(result.output).toContain("Usage");
+    }
+
+    const tuiHelp = await runCli(["tui", "--help"], { env });
+    expect(tuiHelp).toMatchObject({ code: 0 });
+    expect(tuiHelp.output).toContain("--allow-nested");
+    await expect(runCli(["--help"], { env })).resolves.toMatchObject({ code: 0 });
+    await expect(runCli(["--version"], { env })).resolves.toMatchObject({ code: 0 });
+  });
+
+  it("prints the nested launch SafeError and exits one through the CLI process adapter", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const previousExitCode = process.exitCode;
+    process.exitCode = undefined;
+
+    try {
+      await runCliMain(["--config", configPath, "tui"], {
+        env: { STATION_PANE: "1" },
+      });
+
+      expect(stderrWrite).toHaveBeenCalledWith(
+        [
+          "Nested Station is disabled. (NESTED_TUI_DISABLED)",
+          "Hint: Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.",
+          "",
+        ].join("\n"),
+      );
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+      stderrWrite.mockRestore();
+    }
   });
 
   it("signals popup mode to the renderer via env", async () => {
@@ -1083,6 +1301,7 @@ describe("CLI tui command", () => {
               },
             }) as never,
         },
+        env: { STATION_PANE: "1" },
         spawnRenderer: async ({ env }) => {
           envs.push(env);
           return { status: "exited", code: 0 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,7 +491,8 @@ Generated launch/hook env vars are internal context, not hand-authored config:
 `STATION_SESSION_ID`, `STATION_HARNESS_PROVIDER`, `STATION_TERMINAL_PROVIDER`,
 `STATION_TERMINAL_TARGET_ID`, `STATION_OBSERVER_STATE_DIR`, `STATION_STATE_DIR`,
 `STATION_HOOK_SPOOL_DIR`, `STATION_CLIENT_BUILD_VERSION`,
-`STATION_OBSERVER_BUILD_VERSION`, `STATION_TUI_POPUP`, `STATION_TUI_PERSISTENT`,
+`STATION_OBSERVER_BUILD_VERSION`, `STATION_PANE`, `STATION_TUI_POPUP`,
+`STATION_TUI_PERSISTENT`,
 `STATION_FOCUS_PROVIDER`, and `STATION_FOCUS_CLIENT_ID`. The CLI supplies the two
 build variables as a pair: the first identifies the renderer artifact and the
 second pins it to the exact Observer selector the CLI accepted. A directly
@@ -500,9 +501,18 @@ renderer fixes that selector when it creates its Observer client; each later
 operation checks the socket owner on the same connection without running Git or
 hashing source from the UI. The CLI sets `STATION_TUI_PERSISTENT=1` when the
 renderer requires its lifecycle-control IPC channel; it is not a standalone
-launch mode. These variables are not hand-authored overrides. Hook scripts and
-launched agents receive the other context so they can report back to the right
-observer/session. `STATION_STATE_DIR` is a hook-script fallback for
+launch mode. After inherited and per-launch PTY environment merging, native
+Station assigns `STATION_PANE` to the full inherited tmux server-and-pane
+context, or `1` when there is none, so launch input cannot clear or replace the
+pane context. The CLI honors it only while that terminal context still matches,
+preventing a long-lived tmux server from leaking Station ownership into a later
+pane even when two servers reuse the same pane id. It is not hand-authored
+configuration, and there is no persistent nesting override;
+`stn tui --allow-nested` applies to one launch. Tmux launchers use
+`STATION_TUI_POPUP=1` as routing provenance for their renderer child, not as
+authentication. These variables are not hand-authored overrides. Hook scripts
+and launched agents receive the other context so they can report back to the
+right observer/session. `STATION_STATE_DIR` is a hook-script fallback for
 `stn-ingress --state-dir`; it is **not** a global observer relocation knob. Use
 `observer.state_dir` in config for isolation.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -17,6 +17,35 @@ Launch is driven by `apps/cli/src/commands/tui.ts`. The Node CLI shells out to t
 - Inside tmux, `stn` opens the read-only dashboard in a tmux popup, since tmux owns the panes there.
 - `stn tui --dev-fake-dashboard` previews the dashboard with mock data (`STATION_SOURCE=mock`).
 
+## Nested Workspaces
+
+Station-owned PTYs carry a `STATION_PANE` marker bound to their current tmux
+server and pane, or `1` when Station itself is outside tmux. From that context,
+bare `stn` outside tmux and explicit `stn tui` refuse to open another native
+workspace:
+
+```text
+Nested Station is disabled. (NESTED_TUI_DISABLED)
+Hint: Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.
+```
+
+`stn tui --allow-nested` permits only that launch. PTYs created by the nested
+workspace are marked again, so another native workspace requires another
+explicit override. There is no persistent config setting for nesting.
+
+The policy targets only TUI entrypoints. CLI commands such as `snapshot`,
+`doctor`, `debug`, `observer`, `command`, and `setup` remain available in
+Station panes, as do help and version output. Bare `stn` inside tmux and
+explicit `stn popup` keep their popup behavior. Tmux launchers mark their
+`tui --popup` child, while a direct `stn tui --popup` still requires
+`--allow-nested`. The mock dashboard remains available without an override.
+
+The controlling-TTY single-instance guard is not sufficient here: each nested
+pane has its own child PTY, so the outer workspace is not a same-TTY rival. The
+tmux-context binding also prevents a server started from a Station shell or
+Observer descendant from copying the marker into unrelated later panes, even
+when different servers reuse the same pane id.
+
 Persistent popups use a strict child-process IPC channel between the Node CLI and the Bun
 dashboard renderer. The CLI composition root retains all terminal-provider authority; the
 renderer sends only provider-neutral focus-origin and dismiss intents. When the CLI marks that

--- a/station/src/host/ptyTable.smoke.test.ts
+++ b/station/src/host/ptyTable.smoke.test.ts
@@ -29,14 +29,26 @@ if (SMOKE) {
           worktreePath: process.cwd(),
           harnessProvider: "scripted",
           command: "/bin/sh",
-          args: ["-c", "printf READY; sleep 2"],
+          args: ["-c", 'printf "READY:%s" "$STATION_PANE"; sleep 2'],
           cwd: process.cwd(),
+          env: { STATION_PANE: "0" },
           cols: 80,
           rows: 24,
         });
 
-        await waitUntil(() => table.snapshot(ptyId).scrollback.join("").includes("READY"), 2000);
-        expect(table.snapshot(ptyId).scrollback.join("")).toContain("READY");
+        const stationPaneMarker =
+          process.env.TMUX !== undefined && process.env.TMUX_PANE !== undefined
+            ? JSON.stringify([process.env.TMUX, process.env.TMUX_PANE])
+            : "1";
+        await waitUntil(
+          () =>
+            table
+              .snapshot(ptyId)
+              .scrollback.join("")
+              .includes(`READY:${stationPaneMarker}`),
+          2000,
+        );
+        expect(table.snapshot(ptyId).scrollback.join("")).toContain(`READY:${stationPaneMarker}`);
 
         // The PTY is parented to the host, not a client: it survives with none attached.
         await delay(1100);

--- a/station/src/terminal/pty/localPtyTerminal.test.ts
+++ b/station/src/terminal/pty/localPtyTerminal.test.ts
@@ -11,6 +11,42 @@ declare const Bun: {
 };
 
 describe("createPtyEnv", () => {
+  it("marks inherited and launch environments as Station-owned panes", () => {
+    const previousStationPane = process.env.STATION_PANE;
+    const previousTmux = process.env.TMUX;
+    const previousTmuxPane = process.env.TMUX_PANE;
+    try {
+      delete process.env.TMUX;
+      delete process.env.TMUX_PANE;
+      for (const inherited of ["0", "", undefined]) {
+        restoreEnv("STATION_PANE", inherited);
+        expect(createPtyEnv(undefined).STATION_PANE).toBe("1");
+      }
+
+      process.env.STATION_PANE = "inherited";
+      for (const launchStationPane of ["0", "", undefined]) {
+        expect(createPtyEnv({ STATION_PANE: launchStationPane }).STATION_PANE).toBe("1");
+      }
+
+      process.env.TMUX = "/tmp/tmux-501/origin,123,0";
+      process.env.TMUX_PANE = "%3";
+      expect(createPtyEnv(undefined).STATION_PANE).toBe(
+        JSON.stringify(["/tmp/tmux-501/origin,123,0", "%3"]),
+      );
+      expect(
+        createPtyEnv({
+          STATION_PANE: "0",
+          TMUX: "/tmp/tmux-501/launch,456,0",
+          TMUX_PANE: "%7",
+        }).STATION_PANE,
+      ).toBe(JSON.stringify(["/tmp/tmux-501/launch,456,0", "%7"]));
+    } finally {
+      restoreEnv("STATION_PANE", previousStationPane);
+      restoreEnv("TMUX", previousTmux);
+      restoreEnv("TMUX_PANE", previousTmuxPane);
+    }
+  });
+
   it("commits to color-capable defaults and strips color-suppressing vars", () => {
     const previousNoColor = process.env.NO_COLOR;
     const previousForceColor = process.env.FORCE_COLOR;

--- a/station/src/terminal/pty/localPtyTerminal.ts
+++ b/station/src/terminal/pty/localPtyTerminal.ts
@@ -419,6 +419,12 @@ export function createPtyEnv(
   delete nextEnv.NO_COLOR;
   delete nextEnv.FORCE_COLOR;
 
+  // Bind ownership to the full tmux context so different servers may safely reuse pane ids.
+  nextEnv.STATION_PANE =
+    nextEnv.TMUX !== undefined && nextEnv.TMUX_PANE !== undefined
+      ? JSON.stringify([nextEnv.TMUX, nextEnv.TMUX_PANE])
+      : "1";
+
   return nextEnv;
 }
 


### PR DESCRIPTION
## Summary

- mark every Station-owned native PTY with authoritative `STATION_PANE=1`
- refuse nested native TUI launches before Observer or renderer side effects
- add the one-launch `stn tui --allow-nested` override
- preserve launcher-marked tmux popups, the mock dashboard, and non-TUI commands
- document the nesting policy and internal environment provenance

## Why

The existing single-instance guard only detects rivals on the same controlling
TTY. A shell inside Station runs on a child PTY, so launching another native
workspace from that shell can bypass the guard and recursively create another
workspace.

The CLI now applies the narrow policy at the shared TUI command boundary. Popup
launchers remain usable through their incoming `STATION_TUI_POPUP=1` marker,
while ordinary CLI, setup, observer, and debugging commands remain available
inside Station panes.

## UX

Inside a Station-owned pane, bare `stn` outside tmux and `stn tui` now return:

```text
Nested Station is disabled. (NESTED_TUI_DISABLED)
Hint: Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.
```

The override permits one launch only; panes created by that nested workspace
are marked again.

## Validation

- `pnpm test:pre-push`
- focused CLI TUI and popup integration suites
- tmux popup unit suite
- local and host-backed PTY smoke tests
- Node bridge and Bun controlling-terminal PTY lanes

Closes #178
