### PR TITLE
feat(dev): add a private tmux Station devbox

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,7 @@ Status: current living doc for development, test, and documentation workflow.
 | CLI/package-output watcher | `pnpm dev` / `pnpm station:tui-dev` | Isolated by default, not Bun HMR |
 | Isolated Station sandbox | `pnpm station:devbox` | Isolated observer, host, state, and supported hooks |
 | Isolated Station sandbox with UI HMR | `pnpm station:devbox dev` | Same devbox isolation, Bun renderer hot reload |
+| Isolated real tmux popup with UI HMR | `pnpm station:devbox tmux dev` | Private tmux server, Observer, config/state, and production popup CLI |
 
 Do not use `station:dev` as a catch-all name until it truthfully owns the UI,
 CLI/package, observer, provider, protocol, and host restart boundaries.
@@ -40,8 +41,69 @@ CLI/package, observer, provider, protocol, and host restart boundaries.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
 - `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. Its watcher restarts the TUI only after the identity-aware whole-graph build publishes a stable `station-build-id` sentinel. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
 - `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.
+- `pnpm station:devbox tmux dev` starts a checkout-keyed private tmux server and isolated live Observer, then keeps the foreground command as the signal-cleanup owner. Attach with `pnpm station:devbox tmux attach`; inside that client, `Ctrl-b Space` invokes the built production `popup` command while its Bun dashboard child hot-reloads `station/src/**`.
 - `pnpm station:reset` clears station tmux popup registrations for the current checkout and opens station normally from built code. Inside tmux that means a fresh popup; outside tmux that means the fullscreen TUI.
 - `pnpm station:reset:tmux-tui` is the heavier tmux TUI refresh for this checkout. It requires clean `main`, pulls `origin/main`, clears only station TUI/popup tmux state, rebuilds, restarts the observer, then opens station from the rebuilt checkout. It does not kill worktree sessions or harness agents.
+
+### Private tmux popup devbox
+
+Install the root and Station dependencies, then build once before starting:
+
+```bash
+pnpm install
+pnpm build
+cd station && bun install && cd ..
+
+pnpm station:devbox tmux dev
+# another terminal:
+pnpm station:devbox tmux attach
+```
+
+The lane creates `/tmp/stn-dbx-<checkout-hash>` at mode `0700`, one private
+`tmux -L stn-dbx-<checkout-hash> -f /dev/null` server, an isolated live
+Observer, empty provider homes, a committed disposable Git project, and a
+strict minimal config. It never seeds real auth, Git, SSH, hooks, config, or
+default tmux state. `status` inspects only the recorded private manifest,
+server, sockets, and matching processes.
+
+Use `Ctrl-b Space` in the attached base session. The binding enters the built
+CLI's production `popup` command; `_station-ui` owns the long-lived CLI parent,
+which retains the renderer-control IPC channel while the Bun renderer reloads
+in place. `dev` remains in the foreground so Ctrl-C, SIGHUP, or SIGTERM performs
+the same scoped cleanup as `stop`. Use `start` instead when automation needs the
+lane to return immediately.
+
+| Changed surface | Required action |
+| --- | --- |
+| Dashboard-imported `station/src/**` | Bun HMR only |
+| Linked `packages/*` output, CLI, Observer, providers, protocol, or tmux integration | `tmux stop` → `pnpm build` → `tmux dev` |
+| Station Host or PTY runtime | Full `tmux stop` / `tmux dev` |
+| Dependencies or Station package links | Stop, install/relink, then start |
+| Generated root/config/wrapper ownership | `tmux reset --yes` → `tmux dev` |
+
+There is intentionally no `tmux restart`: a rebuild boundary must replace the
+CLI, Observer, popup signature, and any optional Host coherently. Diagnostics
+and cleanup commands are:
+
+```bash
+pnpm station:devbox tmux status
+pnpm station:devbox tmux logs --follow
+pnpm station:devbox tmux stop
+pnpm station:devbox tmux reset --yes
+```
+
+The explicit real-lane smoke is excluded from `test:all` because it requires
+tmux, Bun, Python 3, PTY interaction, and a temporary source edit:
+
+```bash
+pnpm station:devbox:tmux:smoke
+```
+
+That smoke owns public grammar, generated-environment isolation, wrapper
+auditing, attach UX, live repaint, signal exits, and cleanup. The existing
+`popup-real.test.ts` remains the authority for production popup claims, input,
+dismiss/focus semantics, warm reuse, compiled binding behavior, and its own
+private fixture cleanup.
 
 ## Deterministic Gates
 
@@ -539,6 +601,7 @@ pnpm test:e2e
 pnpm test:e2e:real
 pnpm test:e2e:worktrunk:real
 STATION_REAL_TMUX=1 pnpm test:tmux-popup:real
+pnpm station:devbox:tmux:smoke
 pnpm test:e2e:claude:real
 pnpm test:e2e:codex:real
 pnpm test:e2e:cursor:real
@@ -555,6 +618,9 @@ Bun dependencies, Bun 1.3.14, Python 3, tmux, and these prerequisite builds:
 pnpm build
 pnpm build:binary -- --version 0.0.0-local
 ```
+
+`pnpm station:devbox:tmux:smoke` requires only the source build (`pnpm build`);
+the compiled popup lane additionally requires `pnpm build:binary`.
 
 Set `STATION_TMUX_BIN` when the tmux executable is not available as `tmux`. The lane
 creates a disposable Git project and isolates `HOME`, the XDG directories,

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -72,10 +72,9 @@ terminal = "noop-terminal"
 
 The `native` terminal provider is always registered separately, so host-backed
 Station launches still work. The exception is when you are specifically testing
-the **classic tmux integration** — then you *want* the tmux provider and you
-accept seeing your real tmux agents (tmux state is inherently global; the only
-way to fully isolate it is a separate tmux server via a custom `STATION_TMUX_BIN`/
-socket, which is rarely worth it).
+the **classic tmux integration**. Do not point an isolated Observer at the
+default tmux server: use the private tmux devbox in §2a, which supplies a
+checkout-keyed wrapper/socket and never enumerates or mutates default tmux.
 
 ---
 
@@ -173,6 +172,101 @@ bun run host:list       # inspect it (defaults to this worktree's host)
 
 These use their own worktree-local state under `station/.dev-state`
 and touch nothing global.
+
+---
+
+## 2a. Private tmux popup devbox (+ live dashboard reload)
+
+Use this lane when the surface under test is the real tmux popup rather than
+the native Station workspace:
+
+```bash
+# prerequisites for this checkout
+pnpm build
+cd station && bun install && cd ..
+
+# terminal A: start/reuse and remain the cleanup owner
+pnpm station:devbox tmux dev
+
+# terminal B: attach an ordinary client to the private base session
+pnpm station:devbox tmux attach
+# inside it: Ctrl-b Space opens/toggles the production Station popup
+```
+
+`tmux dev` prints the checkout identity, disposable root, exact tmux binary,
+private label/socket/wrapper, `/dev/null` config, Station config/state/socket
+paths, base and `_station-ui` sessions, discovered CLI/renderer/Observer/Host
+owners, and the exact attach/log/stop commands. `tmux start` creates the same
+HMR-enabled lane but returns immediately.
+
+The disposable root is `/tmp/stn-dbx-<checkout-hash>` and contains:
+
+- isolated `HOME`, XDG, runtime, temp, config, state, layout, log, spool, and
+  diagnostics paths;
+- empty Codex, Claude, Cursor, and OpenCode homes—no copied or linked auth,
+  config, Git, or SSH material;
+- a committed disposable Git project;
+- one recorded wrapper that always executes the resolved tmux binary with the
+  private `-L` label and `-f /dev/null`;
+- a failing bare-`tmux` shim, so a child cannot silently reach default tmux.
+
+The generated config uses `noop-worktree`, `tmux`, and `noop-harness`, disables
+GitHub metadata and hook auto-start, and points at the isolated live Observer.
+The popup binding invokes the built CLI's `popup` command. Its long-lived hidden
+CLI owns renderer-control IPC; only the Bun dashboard child is overridden with
+`bun --hot --no-clear-screen src/dashboardRenderer/main.tsx`.
+
+During an edit reachable from the dashboard under `station/src/**`, the tmux
+server, attached base client, `_station-ui` pane/CLI parent, Bun PID, IPC
+channel, Observer, visible nested client, and optional Host remain stable.
+React/OpenTUI renderer resources, the dashboard store, Station client/source,
+and popup listeners are disposed and recreated inside that Bun process.
+
+Changes outside that source-only boundary need a coherent restart:
+
+```bash
+pnpm station:devbox tmux stop
+pnpm build
+pnpm station:devbox tmux dev
+```
+
+Use a full stop/start for package output, CLI, Observer, provider, protocol,
+tmux integration, Host, PTY, dependency, or Station-link changes. There is no
+`tmux restart` command because those processes and the popup build signature
+must move together.
+
+Inspect or clean up without touching global Station/default tmux:
+
+```bash
+pnpm station:devbox tmux status
+pnpm station:devbox tmux logs --follow
+pnpm station:devbox tmux stop
+pnpm station:devbox tmux reset --yes
+```
+
+`status` is private/read-only. `stop`, Ctrl-C, SIGHUP, and SIGTERM kill only the
+recorded private server, then validate Observer/Host socket, pidfile, `lsof`,
+process command, and start-time evidence before escalating. If ownership cannot
+be proven gone, cleanup retains the root and wrapper as evidence instead of
+using `pkill` or broad/default-server operations.
+
+Manual HMR check:
+
+1. Open the popup with `Ctrl-b Space` and record `tmux status`.
+2. Add a harmless visible label in
+   `station/src/dashboardRenderer/FullscreenDashboard.tsx`.
+3. Confirm the open popup repaints and the reported server, base pane, hidden
+   CLI, Bun renderer, Observer, nested client, and optional Host PIDs are stable.
+4. Revert the label and confirm it disappears.
+5. Press Esc, reopen with `Ctrl-b Space`, and confirm the hidden CLI/renderer
+   and Observer are reused.
+6. Detach and stop the lane; `status` should report stopped and the private root
+   and sockets should be absent.
+
+The opt-in automated version is `pnpm station:devbox:tmux:smoke`. It temporarily
+edits that component in place, restores its exact bytes in `finally`, audits
+every wrapper call, and verifies startup rollback plus SIGINT/SIGHUP/SIGTERM
+cleanup.
 
 ---
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -54,6 +54,16 @@ without lifecycle control. Focus-success dismissal is scoped to the exact origin
 operation and the provider-owned popup claim/lease, preventing a stale renderer from dismissing a
 replacement popup.
 
+When the private tmux devbox runs the dashboard under Bun `--hot`, the CLI
+parent and its IPC channel remain authoritative for the lifetime of
+`_station-ui`. A source reload synchronously releases the prior OpenTUI stdin
+owner, then unmounts the old React root, removes popup listeners, detaches the
+old source/store, stops the old Station client, and recreates those renderer
+resources inside the same Bun process. The renderer disposer deliberately does
+not disconnect the CLI-owned IPC channel. Source build identity is verified
+once per OS process so a harmless reload reuses the accepted identity; a new
+process still verifies the current checkout and outputs.
+
 You can also run the renderer directly during development:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev": "node scripts/tui-dev.mjs",
     "station:devbox": "node scripts/station-devbox.mjs",
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
+    "station:devbox:tmux:smoke": "node scripts/test-runners/run-station-tmux-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
     "smoke:install": "node scripts/test-runners/run-install-smoke.mjs",
     "typecheck": "turbo run typecheck",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -10,7 +10,9 @@ declare const STATION_BUILD_IDENTITY: string;
 const BUILD_IDENTITY_PATTERN = /^[0-9a-f]{64}$/u;
 const OBSERVER_BUILD_IDENTITY_MARKER = /\+(?:[0-9A-Za-z-]+\.)*station\./u;
 const OBSERVER_BUILD_IDENTITY_PATTERN = /^(.+)([+.])station\.([0-9a-f]{64})$/u;
-let verifiedSourceBuildIdentity: string | undefined;
+const verifiedSourceBuildIdentitySlot = Symbol.for(
+  "@station/runtime/verified-source-build-identity",
+);
 
 export type StationBuildInfo = {
   version: string;
@@ -19,7 +21,10 @@ export type StationBuildInfo = {
   buildIdentity: string;
 };
 
-/** Returns compiled identity or one source identity verified for this process lifetime. */
+/**
+ * Returns compiled identity or one source identity verified for the OS process lifetime,
+ * including Bun hot reloads that replace the module registry.
+ */
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.0" : STATION_BUILD_VERSION,
@@ -74,8 +79,10 @@ export function isCompiledBinary(): boolean {
 }
 
 function sourceBuildIdentity(): string {
-  if (verifiedSourceBuildIdentity !== undefined) {
-    return verifiedSourceBuildIdentity;
+  const processSlots = globalThis as typeof globalThis & Record<symbol, string | undefined>;
+  const verifiedIdentity = processSlots[verifiedSourceBuildIdentitySlot];
+  if (verifiedIdentity !== undefined) {
+    return verifiedIdentity;
   }
   const moduleDirectory = dirname(fileURLToPath(import.meta.url));
   const root = join(moduleDirectory, "..", "..", "..");
@@ -112,6 +119,6 @@ function sourceBuildIdentity(): string {
       { cause: error },
     );
   }
-  verifiedSourceBuildIdentity = identity;
-  return verifiedSourceBuildIdentity;
+  processSlots[verifiedSourceBuildIdentitySlot] = identity;
+  return identity;
 }

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -6,6 +6,9 @@ import {
 
 const buildIdentity = "a".repeat(64);
 const verifyBuildIdentity = vi.hoisted(() => vi.fn());
+const verifiedSourceBuildIdentitySlot = Symbol.for(
+  "@station/runtime/verified-source-build-identity",
+);
 
 vi.mock("node:fs", () => ({
   readFileSync: () => `${buildIdentity}\n`,
@@ -18,9 +21,10 @@ describe("station build info", () => {
   beforeEach(() => {
     vi.resetModules();
     verifyBuildIdentity.mockReset();
+    Reflect.deleteProperty(globalThis, verifiedSourceBuildIdentitySlot);
   });
 
-  it("caches one verified source identity for the process lifetime", async () => {
+  it("caches one verified source identity across module resets in the same process", async () => {
     const {
       isCompiledBinary,
       stationBuildInfo,
@@ -47,6 +51,11 @@ describe("station build info", () => {
       expect.objectContaining({ stdio: "ignore" }),
     );
     expect(verifyBuildIdentity).toHaveBeenCalledTimes(1);
+
+    vi.resetModules();
+    const reloaded = await import("../../src/buildInfo.js");
+    expect(reloaded.stationBuildInfo()).toMatchObject({ buildIdentity });
+    expect(verifyBuildIdentity).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a source build whose published input or output identity is stale", async () => {
@@ -57,6 +66,11 @@ describe("station build info", () => {
 
     expect(() => stationBuildInfo()).toThrow("does not match the current checkout");
     expect(stationBuildInfo()).toMatchObject({ buildIdentity });
+    expect(verifyBuildIdentity).toHaveBeenCalledTimes(2);
+
+    vi.resetModules();
+    const reloaded = await import("../../src/buildInfo.js");
+    expect(reloaded.stationBuildInfo()).toMatchObject({ buildIdentity });
     expect(verifyBuildIdentity).toHaveBeenCalledTimes(2);
   });
 

--- a/scripts/station-devbox.mjs
+++ b/scripts/station-devbox.mjs
@@ -4,7 +4,7 @@
 // the whole sandbox lifecycle is one command from any checkout/worktree root.
 // Repo root is resolved from THIS script's own location, so a worktree root
 // targets its own .dev-state, never the main checkout's.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -23,23 +23,33 @@ const HOST_SOCK = join(SOCKET_DIR, "station-host.sock");
 const LOG_DIR = join(DS, "observer", "logs");
 const STATION_DIR = join(repoRoot, "station");
 const ISOLATED_SCRIPT = join(repoRoot, "station", "scripts", "station-isolated.sh");
+const TMUX_DEVBOX_SCRIPT = join(repoRoot, "scripts", "station-tmux-devbox.mjs");
 
 const handlers = { start, dev, restart, status, logs, stop, reset, help };
 
 const [rawVerb = "start", ...rest] = process.argv.slice(2);
 const verb =
   rawVerb === "-h" || rawVerb === "--help" ? "help" : rawVerb === "--hot" ? "dev" : rawVerb;
-const handler = handlers[verb];
-if (handler === undefined) {
-  process.stderr.write(`Unknown station:devbox command: ${verb}\n\n`);
-  help();
-  process.exit(1);
-}
-try {
-  handler(rest);
-} catch (error) {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+if (verb === "tmux") {
+  try {
+    process.exitCode = await delegateTmux(rest);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+} else {
+  const handler = handlers[verb];
+  if (handler === undefined) {
+    process.stderr.write(`Unknown station:devbox command: ${verb}\n\n`);
+    help();
+    process.exit(1);
+  }
+  try {
+    handler(rest);
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  }
 }
 
 function start() {
@@ -139,9 +149,39 @@ function help() {
       "  logs [--follow]  tail the isolated observer/host/cli logs",
       "  stop             stop the isolated observer + host (preserves .dev-state for reattach)",
       "  reset --yes      stop, then delete .dev-state for this checkout",
+      "  tmux ...         private checkout-keyed tmux popup devbox (run `tmux help`)",
       "",
     ].join("\n"),
   );
+}
+
+async function delegateTmux(args) {
+  const child = spawn(process.execPath, [TMUX_DEVBOX_SCRIPT, ...args], {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  const signalHandlers = new Map();
+  for (const signal of ["SIGINT", "SIGHUP", "SIGTERM"]) {
+    const handler = () => child.kill(signal);
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+  try {
+    return await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => {
+        if (code !== null) {
+          resolve(code);
+          return;
+        }
+        resolve(signal === "SIGHUP" ? 129 : signal === "SIGINT" ? 130 : 143);
+      });
+    });
+  } finally {
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+  }
 }
 
 function run(command, args, options = {}) {

--- a/scripts/station-tmux-devbox.mjs
+++ b/scripts/station-tmux-devbox.mjs
@@ -1,0 +1,1514 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  accessSync,
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = realpathSync(join(dirname(fileURLToPath(import.meta.url)), ".."));
+const checkoutKey = createHash("sha256").update(repoRoot).digest("hex").slice(0, 12);
+const privateRoot = join("/tmp", `stn-dbx-${checkoutKey}`);
+const manifestPath = join(privateRoot, "manifest.json");
+const cliPath = join(repoRoot, "apps", "cli", "dist", "main.js");
+const stationDir = join(repoRoot, "station");
+const hostEntry = join(stationDir, "src", "host", "hostMain.ts");
+const baseSession = "station-devbox";
+const hiddenSession = "_station-ui";
+const manifestKeys = [
+  "schemaVersion",
+  "checkoutRoot",
+  "checkoutKey",
+  "root",
+  "createdAt",
+  "status",
+  "tmuxBinary",
+  "tmuxLabel",
+  "tmuxWrapper",
+  "tmuxTmpDir",
+  "tmuxSocketPath",
+  "tmuxLogPath",
+  "tmuxServerPid",
+  "baseSession",
+  "hiddenSession",
+  "configPath",
+  "homeDir",
+  "xdgConfigDir",
+  "xdgStateDir",
+  "xdgDataDir",
+  "runtimeDir",
+  "stateDir",
+  "tempDir",
+  "projectRoot",
+  "providerCodexHome",
+  "providerClaudeHome",
+  "providerCursorHome",
+  "providerOpenCodeHome",
+  "observerSocketPath",
+  "hostSocketPath",
+  "layoutPath",
+  "binDir",
+  "bareTmuxShimPath",
+  "bareTmuxLogPath",
+  "popupLauncherPath",
+  "popupLogPath",
+  "observerIdentity",
+  "devOwnerPid",
+  "devOwnerStartTime",
+];
+const lanePassthroughEnvironmentVariables = new Set([
+  "CLICOLOR",
+  "CLICOLOR_FORCE",
+  "COLORTERM",
+  "FORCE_COLOR",
+  "LANG",
+  "LOGNAME",
+  "NO_COLOR",
+  "PATH",
+  "TERM",
+  "TERM_PROGRAM",
+  "TERM_PROGRAM_VERSION",
+  "TZ",
+  "USER",
+]);
+const signalExitCodes = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143 };
+const psPath = process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps";
+
+const [rawCommand = "dev", ...commandArgs] = process.argv.slice(2);
+const command =
+  rawCommand === "-h" || rawCommand === "--help"
+    ? "help"
+    : rawCommand === "tmux"
+      ? "dev"
+      : rawCommand;
+
+try {
+  switch (command) {
+    case "dev":
+      await dev();
+      break;
+    case "start":
+      await start();
+      break;
+    case "attach":
+      attach();
+      break;
+    case "status":
+      status();
+      break;
+    case "logs":
+      logs(commandArgs);
+      break;
+    case "stop":
+      await stop();
+      break;
+    case "reset":
+      await reset(commandArgs);
+      break;
+    case "help":
+      help();
+      break;
+    default:
+      throw new Error(`Unknown station:devbox tmux command: ${command}`);
+  }
+} catch (error) {
+  process.stderr.write(`${errorMessage(error)}\n`);
+  process.exitCode = 1;
+}
+
+async function dev() {
+  let manifest = await ensureLaneStarted();
+  const currentStartTime = processStartTime(process.pid);
+  if (currentStartTime === undefined) {
+    throw new Error(`Could not verify the tmux devbox owner process ${process.pid}.`);
+  }
+  if (
+    manifest.devOwnerPid !== null &&
+    manifest.devOwnerPid !== process.pid &&
+    manifest.devOwnerStartTime !== null &&
+    processMatchesStart(manifest.devOwnerPid, manifest.devOwnerStartTime)
+  ) {
+    throw new Error(
+      `The private tmux lane already has foreground owner ${manifest.devOwnerPid}. ` +
+        `Stop it with: pnpm station:devbox tmux stop`,
+    );
+  }
+  manifest = {
+    ...manifest,
+    devOwnerPid: process.pid,
+    devOwnerStartTime: currentStartTime,
+  };
+  writeManifest(manifest);
+  printOwnership(manifest, collectEvidence(manifest));
+  log("");
+  log("Foreground owner active. Ctrl-C, SIGHUP, SIGTERM, or `tmux stop` cleans this lane.");
+  await waitAsForegroundOwner();
+}
+
+async function start() {
+  const manifest = await ensureLaneStarted();
+  printOwnership(manifest, collectEvidence(manifest));
+}
+
+function attach() {
+  const manifest = requireRunningManifest();
+  if (!privateServerAlive(manifest) || !privateSessionExists(manifest, manifest.baseSession)) {
+    throw staleLaneError(manifest);
+  }
+  const result = run(manifest.tmuxWrapper, ["attach-session", "-t", manifest.baseSession], {
+    cwd: manifest.projectRoot,
+    env: laneEnvironment(manifest),
+    stdio: "inherit",
+    check: false,
+    timeoutMs: undefined,
+  });
+  process.exitCode = result.status;
+}
+
+function status() {
+  if (!existsSync(privateRoot)) {
+    log(`Station private tmux devbox: stopped (${privateRoot} is absent)`);
+    return;
+  }
+  const manifest = readManifest();
+  printOwnership(manifest, collectEvidence(manifest));
+}
+
+function logs(args) {
+  const unknown = args.find((arg) => !["--", "-f", "--follow"].includes(arg));
+  if (unknown !== undefined) {
+    throw new Error(`Unknown station:devbox tmux logs option: ${unknown}`);
+  }
+  const manifest = requireManifest();
+  const follow = args.includes("-f") || args.includes("--follow");
+  const files = [
+    manifest.tmuxLogPath,
+    manifest.popupLogPath,
+    join(manifest.stateDir, "logs", "observer-boot.log"),
+    join(manifest.stateDir, "logs", "observer.jsonl"),
+    join(manifest.stateDir, "logs", "cli.jsonl"),
+    join(manifest.stateDir, "logs", "tui.jsonl"),
+    join(manifest.stateDir, "logs", "station-host.jsonl"),
+  ].filter(existsSync);
+  if (files.length === 0) {
+    log(`No private tmux devbox logs exist under ${manifest.root}.`);
+    return;
+  }
+  log("Private tmux devbox logs:");
+  for (const file of files) {
+    log(`  ${file}`);
+  }
+  log("");
+  const tail = requireExecutable("tail");
+  const result = run(tail, follow ? ["-f", ...files] : ["-n", "80", ...files], {
+    stdio: "inherit",
+    check: false,
+    timeoutMs: undefined,
+  });
+  process.exitCode = result.status;
+}
+
+async function stop() {
+  if (!existsSync(privateRoot)) {
+    log(`Station private tmux devbox already stopped (${privateRoot} is absent).`);
+    return;
+  }
+  const manifest = readManifest();
+  await cleanupLane(manifest);
+  log(`Stopped the private tmux lane and removed ${privateRoot}.`);
+}
+
+async function reset(args) {
+  if (!args.some((arg) => arg === "--yes" || arg === "-y")) {
+    throw new Error(
+      "Refusing to reset without --yes.\n\n" + "  pnpm station:devbox tmux reset --yes",
+    );
+  }
+  if (!existsSync(privateRoot)) {
+    log(`Station private tmux devbox already reset (${privateRoot} is absent).`);
+    return;
+  }
+  const manifest = readManifest();
+  await cleanupLane(manifest);
+  log(`Reset the verified private tmux lane at ${privateRoot}.`);
+}
+
+function help() {
+  process.stdout.write(
+    [
+      "Usage: pnpm station:devbox tmux [dev|start|attach|status|logs|stop|reset|help]",
+      "",
+      "  dev              (default) start/reuse the HMR lane and remain its cleanup owner",
+      "  start            start/reuse the HMR lane and return",
+      "  attach           attach an ordinary client to the private base session",
+      "  status           inspect only the private manifest/server/socket/process evidence",
+      "  logs [--follow]  show wrapper, popup, Observer, CLI, TUI, and Host logs",
+      "  stop             stop recorded private resources and remove the disposable root",
+      "  reset --yes      recover a verified partial/stale lane and remove its root",
+      "  help             show this nested grammar",
+      "",
+      "Inside the attached client, press Ctrl-b Space to open or toggle Station.",
+      "Package/CLI/Observer changes require: stop → pnpm build → tmux dev.",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function ensureLaneStarted() {
+  const prerequisites = resolvePrerequisites();
+  if (existsSync(privateRoot)) {
+    let manifest = readManifest();
+    if (!privateServerAlive(manifest) || !privateSessionExists(manifest, manifest.baseSession)) {
+      throw staleLaneError(manifest);
+    }
+    if (!observerIdentityAlive(manifest, manifest.observerIdentity)) {
+      startObserver(manifest);
+      manifest = {
+        ...manifest,
+        observerIdentity: readObserverIdentity(manifest.observerSocketPath),
+      };
+      writeManifest(manifest);
+    }
+    return manifest;
+  }
+
+  mkdirSync(privateRoot, { mode: 0o700 });
+  chmodSync(privateRoot, 0o700);
+  let manifest = createManifest(prerequisites);
+  writeManifest(manifest);
+  try {
+    createDisposableEnvironment(manifest, prerequisites);
+    run(prerequisites.bun, ["run", "--silent", "--cwd", stationDir, "link:station"], {
+      cwd: repoRoot,
+      env: laneEnvironment(manifest),
+    });
+    startObserver(manifest);
+    manifest = {
+      ...manifest,
+      observerIdentity: readObserverIdentity(manifest.observerSocketPath),
+    };
+    writeManifest(manifest);
+
+    // A non-login shell preserves the private PATH so bare tmux cannot bypass the failing shim.
+    run(
+      manifest.tmuxWrapper,
+      ["new-session", "-d", "-s", manifest.baseSession, "-c", manifest.projectRoot, "/bin/sh"],
+      {
+        cwd: manifest.projectRoot,
+        env: laneEnvironment(manifest),
+      },
+    );
+    // Tmux defaults import SSH agent variables from later clients into the server.
+    run(manifest.tmuxWrapper, ["set-option", "-g", "update-environment", ""], {
+      cwd: manifest.projectRoot,
+      env: laneEnvironment(manifest),
+    });
+    manifest = {
+      ...manifest,
+      tmuxServerPid: positiveInteger(
+        privateTmuxOutput(manifest, ["display-message", "-p", "#{pid}"]),
+        "private tmux server pid",
+      ),
+    };
+    writeManifest(manifest);
+    run(
+      manifest.tmuxWrapper,
+      ["set-environment", "-g", "STATION_DASHBOARD_COMMAND", dashboardCommand(prerequisites.bun)],
+      {
+        cwd: manifest.projectRoot,
+        env: laneEnvironment(manifest),
+      },
+    );
+    const popupCommand = `${shellQuote(manifest.popupLauncherPath)} '#{client_name}'`;
+    run(manifest.tmuxWrapper, ["bind-key", "Space", "run-shell", "-b", popupCommand], {
+      cwd: manifest.projectRoot,
+      env: laneEnvironment(manifest),
+    });
+    manifest = { ...manifest, status: "running" };
+    writeManifest(manifest);
+    return manifest;
+  } catch (startupError) {
+    try {
+      await cleanupLane(manifest);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [startupError, cleanupError],
+        `Private tmux devbox startup failed and cleanup retained ${privateRoot} as evidence.`,
+      );
+    }
+    throw startupError;
+  }
+}
+
+function resolvePrerequisites() {
+  const tmux = requireExecutable(
+    process.env.STATION_TMUX_DEVBOX_TMUX_BIN ?? process.env.STATION_REAL_TMUX_BIN ?? "tmux",
+  );
+  const bun = requireExecutable(process.env.STATION_BUN ?? "bun");
+  const git = requireExecutable("git");
+  const lsof = requireExecutable("lsof");
+  run(tmux, ["-V"]);
+  if (!existsSync(cliPath)) {
+    throw new Error(`Built Station CLI missing at ${cliPath}. Run pnpm build.`);
+  }
+  if (!existsSync(join(stationDir, "node_modules", "@opentui", "core", "package.json"))) {
+    throw new Error(`Station Bun dependencies are missing. Run: cd ${stationDir} && bun install`);
+  }
+  return {
+    node: process.execPath,
+    bun,
+    git,
+    lsof,
+    tmux: realpathSync(tmux),
+  };
+}
+
+function createManifest(prerequisites) {
+  const tmuxLabel = `stn-dbx-${checkoutKey}`;
+  const tmuxTmpDir = join(privateRoot, "tmux");
+  const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+  return {
+    schemaVersion: 1,
+    checkoutRoot: repoRoot,
+    checkoutKey,
+    root: privateRoot,
+    createdAt: new Date().toISOString(),
+    status: "starting",
+    tmuxBinary: prerequisites.tmux,
+    tmuxLabel,
+    tmuxWrapper: join(privateRoot, "tmux-wrapper"),
+    tmuxTmpDir,
+    tmuxSocketPath: join(tmuxTmpDir, `tmux-${uid}`, tmuxLabel),
+    tmuxLogPath: join(privateRoot, "logs", "tmux-wrapper.log"),
+    tmuxServerPid: null,
+    baseSession,
+    hiddenSession,
+    configPath: join(privateRoot, "config.toml"),
+    homeDir: join(privateRoot, "home"),
+    xdgConfigDir: join(privateRoot, "xdg-config"),
+    xdgStateDir: join(privateRoot, "xdg-state"),
+    xdgDataDir: join(privateRoot, "xdg-data"),
+    runtimeDir: join(privateRoot, "run"),
+    stateDir: join(privateRoot, "state"),
+    tempDir: join(privateRoot, "tmp"),
+    projectRoot: join(privateRoot, "project"),
+    providerCodexHome: join(privateRoot, "providers", "codex"),
+    providerClaudeHome: join(privateRoot, "providers", "claude"),
+    providerCursorHome: join(privateRoot, "providers", "cursor"),
+    providerOpenCodeHome: join(privateRoot, "providers", "opencode"),
+    observerSocketPath: join(privateRoot, "run", "observer.sock"),
+    hostSocketPath: join(privateRoot, "run", "station-host.sock"),
+    layoutPath: join(privateRoot, "state", "station", "layout.json"),
+    binDir: join(privateRoot, "bin"),
+    bareTmuxShimPath: join(privateRoot, "bin", "tmux"),
+    bareTmuxLogPath: join(privateRoot, "logs", "bare-tmux.log"),
+    popupLauncherPath: join(privateRoot, "popup"),
+    popupLogPath: join(privateRoot, "logs", "popup.log"),
+    observerIdentity: null,
+    devOwnerPid: null,
+    devOwnerStartTime: null,
+  };
+}
+
+function createDisposableEnvironment(manifest, prerequisites) {
+  for (const directory of [
+    manifest.homeDir,
+    manifest.xdgConfigDir,
+    manifest.xdgStateDir,
+    manifest.xdgDataDir,
+    manifest.runtimeDir,
+    manifest.stateDir,
+    manifest.tempDir,
+    manifest.projectRoot,
+    manifest.providerCodexHome,
+    manifest.providerClaudeHome,
+    manifest.providerCursorHome,
+    manifest.providerOpenCodeHome,
+    manifest.binDir,
+    manifest.tmuxTmpDir,
+    dirname(manifest.tmuxLogPath),
+    dirname(manifest.layoutPath),
+  ]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+    chmodSync(directory, 0o700);
+  }
+
+  writeManagedFile(manifest.configPath, renderConfig(manifest), 0o600);
+  writeManagedFile(manifest.tmuxWrapper, renderTmuxWrapper(manifest), 0o700);
+  writeManagedFile(manifest.bareTmuxShimPath, renderBareTmuxShim(manifest), 0o700);
+  writeManagedFile(manifest.popupLauncherPath, renderPopupLauncher(manifest, prerequisites), 0o700);
+  writeManagedFile(
+    join(manifest.projectRoot, "README.md"),
+    "# Station private tmux devbox\n",
+    0o600,
+  );
+
+  const gitEnv = laneEnvironment(manifest, { GIT_CONFIG_NOSYSTEM: "1" });
+  run(prerequisites.git, ["init", "-q", "--initial-branch=main"], {
+    cwd: manifest.projectRoot,
+    env: gitEnv,
+  });
+  run(prerequisites.git, ["config", "user.name", "Station Devbox"], {
+    cwd: manifest.projectRoot,
+    env: gitEnv,
+  });
+  run(prerequisites.git, ["config", "user.email", "station-devbox@example.invalid"], {
+    cwd: manifest.projectRoot,
+    env: gitEnv,
+  });
+  run(prerequisites.git, ["add", "README.md"], {
+    cwd: manifest.projectRoot,
+    env: gitEnv,
+  });
+  run(
+    prerequisites.git,
+    ["-c", "core.hooksPath=/dev/null", "commit", "-q", "-m", "Initialize Station devbox"],
+    {
+      cwd: manifest.projectRoot,
+      env: gitEnv,
+    },
+  );
+}
+
+function renderConfig(manifest) {
+  return [
+    "schema_version = 1",
+    "",
+    "[observer]",
+    `socket_path = ${JSON.stringify(manifest.observerSocketPath)}`,
+    `state_dir = ${JSON.stringify(manifest.stateDir)}`,
+    "auto_start = false",
+    "auto_start_from_hooks = false",
+    "",
+    "[defaults]",
+    'worktree_provider = "noop-worktree"',
+    'terminal = "tmux"',
+    'harness = "noop-harness"',
+    'layout = "agent-shell"',
+    "",
+    "[terminal.tmux]",
+    `command = ${JSON.stringify(manifest.tmuxWrapper)}`,
+    "",
+    "[repository.github]",
+    "enabled = false",
+    "",
+    "[harness.noop-harness]",
+    "enabled = true",
+    "install_hooks = false",
+    "",
+    "[[projects]]",
+    'id = "station-tmux-devbox"',
+    'label = "Station private tmux devbox"',
+    `root = ${JSON.stringify(manifest.projectRoot)}`,
+    "",
+  ].join("\n");
+}
+
+function renderTmuxWrapper(manifest) {
+  return [
+    "#!/bin/sh",
+    "set -eu",
+    "umask 077",
+    `tmux_bin=${shellQuote(manifest.tmuxBinary)}`,
+    `tmux_label=${shellQuote(manifest.tmuxLabel)}`,
+    `tmux_log=${shellQuote(manifest.tmuxLogPath)}`,
+    `export TMUX_TMPDIR=${shellQuote(manifest.tmuxTmpDir)}`,
+    'mkdir -p "$(dirname "$tmux_log")"',
+    "rejected=",
+    "parsing_global=1",
+    'for arg in "$@"; do',
+    '  if [ "$parsing_global" -eq 1 ]; then',
+    '    case "$arg" in',
+    '      -L|-L*|-S|-S*|-f|-f*) rejected="$arg" ;;',
+    "      --) parsing_global=0 ;;",
+    "      -*) ;;",
+    "      *) parsing_global=0 ;;",
+    "    esac",
+    "  fi",
+    "done",
+    "tab=$(printf '\\t')",
+    `record="$(date -u +%Y-%m-%dT%H:%M:%SZ)\${tab}pid=$$\${tab}\${tmux_bin}\${tab}-L\${tab}\${tmux_label}\${tab}-f\${tab}/dev/null"`,
+    `for arg in "$@"; do record="\${record}\${tab}\${arg}"; done`,
+    'printf "%s\\n" "$record" >> "$tmux_log"',
+    'if [ -n "$rejected" ]; then',
+    '  printf "private tmux wrapper rejects server/config override: %s\\n" "$rejected" >&2',
+    "  exit 64",
+    "fi",
+    "unset TMUX",
+    'exec "$tmux_bin" -L "$tmux_label" -f /dev/null "$@"',
+    "",
+  ].join("\n");
+}
+
+function renderBareTmuxShim(manifest) {
+  return [
+    "#!/bin/sh",
+    `printf '%s\\n' "$*" >> ${shellQuote(manifest.bareTmuxLogPath)}`,
+    'printf "bare tmux is disabled inside the Station private tmux devbox\\n" >&2',
+    "exit 97",
+    "",
+  ].join("\n");
+}
+
+function renderPopupLauncher(manifest, prerequisites) {
+  return [
+    "#!/bin/sh",
+    "set +e",
+    "umask 077",
+    `export HOME=${shellQuote(manifest.homeDir)}`,
+    `export XDG_CONFIG_HOME=${shellQuote(manifest.xdgConfigDir)}`,
+    `export XDG_STATE_HOME=${shellQuote(manifest.xdgStateDir)}`,
+    `export XDG_DATA_HOME=${shellQuote(manifest.xdgDataDir)}`,
+    `export XDG_RUNTIME_DIR=${shellQuote(manifest.runtimeDir)}`,
+    `export TMPDIR=${shellQuote(manifest.tempDir)}`,
+    `export CODEX_HOME=${shellQuote(manifest.providerCodexHome)}`,
+    `export CLAUDE_CONFIG_DIR=${shellQuote(manifest.providerClaudeHome)}`,
+    `export STATION_CURSOR_HOME=${shellQuote(manifest.providerCursorHome)}`,
+    `export OPENCODE_CONFIG_DIR=${shellQuote(manifest.providerOpenCodeHome)}`,
+    `export STATION_CONFIG_PATH=${shellQuote(manifest.configPath)}`,
+    `export STATION_OBSERVER_SOCKET_PATH=${shellQuote(manifest.observerSocketPath)}`,
+    `export STATION_HOST_SOCKET_PATH=${shellQuote(manifest.hostSocketPath)}`,
+    `export STATION_LAYOUT_PATH=${shellQuote(manifest.layoutPath)}`,
+    `export STATION_TMUX_BIN=${shellQuote(manifest.tmuxWrapper)}`,
+    `export STATION_BUN=${shellQuote(prerequisites.bun)}`,
+    `export STATION_HOST_ENTRY=${shellQuote(hostEntry)}`,
+    `export TMUX_TMPDIR=${shellQuote(manifest.tmuxTmpDir)}`,
+    `export PATH=${shellQuote(`${manifest.binDir}:${process.env.PATH ?? ""}`)}`,
+    `export STATION_DASHBOARD_COMMAND=${shellQuote(dashboardCommand(prerequisites.bun))}`,
+    "unset STATION_SOURCE STATION_SCENARIO STATION_TUI_COMMAND STATION_TUI_SESSION_NAME",
+    `if [ -n "\${1:-}" ]; then export STATION_FOCUS_CLIENT_ID="$1"; else unset STATION_FOCUS_CLIENT_ID; fi`,
+    `${shellQuote(prerequisites.node)} ${shellQuote(cliPath)} --config ${shellQuote(manifest.configPath)} popup >> ${shellQuote(manifest.popupLogPath)} 2>&1`,
+    "status=$?",
+    'case "$status" in 0|129) exit 0 ;; esac',
+    `${shellQuote(manifest.tmuxWrapper)} display-message -d 3000 ` +
+      `${shellQuote("Station popup failed; run pnpm station:devbox tmux logs")} ` +
+      `>> ${shellQuote(manifest.popupLogPath)} 2>&1 || :`,
+    "exit 0",
+    "",
+  ].join("\n");
+}
+
+function dashboardCommand(bun) {
+  return (
+    `cd ${shellQuote(stationDir)} && exec ${shellQuote(bun)} ` +
+    `--hot --no-clear-screen ${shellQuote("src/dashboardRenderer/main.tsx")}`
+  );
+}
+
+function startObserver(manifest) {
+  const result = run(
+    process.execPath,
+    [cliPath, "--config", manifest.configPath, "observer", "start"],
+    {
+      cwd: manifest.projectRoot,
+      env: laneEnvironment(manifest),
+      check: false,
+      timeoutMs: 30_000,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `Private Observer startup failed (exit ${result.status}).\n${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+function requireRunningManifest() {
+  const manifest = requireManifest();
+  if (manifest.status !== "running") {
+    throw staleLaneError(manifest);
+  }
+  return manifest;
+}
+
+function requireManifest() {
+  if (!existsSync(privateRoot)) {
+    throw new Error("Private tmux devbox is not started. Run: pnpm station:devbox tmux dev");
+  }
+  return readManifest();
+}
+
+function readManifest() {
+  validateRoot();
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `Refusing to manage ${privateRoot}: its validated manifest is missing. Preserve it as evidence.`,
+    );
+  }
+  const manifestStat = lstatSync(manifestPath);
+  if (
+    !manifestStat.isFile() ||
+    manifestStat.isSymbolicLink() ||
+    (manifestStat.mode & 0o077) !== 0
+  ) {
+    throw new Error(`Refusing unsafe private tmux manifest at ${manifestPath}.`);
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Private tmux manifest is invalid JSON: ${manifestPath}`, { cause: error });
+  }
+  validateManifest(manifest);
+  return manifest;
+}
+
+function validateRoot() {
+  const rootStat = lstatSync(privateRoot);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error(`Refusing unsafe private tmux root: ${privateRoot}`);
+  }
+  if ((rootStat.mode & 0o077) !== 0) {
+    throw new Error(`Private tmux root must use mode 0700: ${privateRoot}`);
+  }
+  if (typeof process.getuid === "function" && rootStat.uid !== process.getuid()) {
+    throw new Error(`Private tmux root is not owned by the current user: ${privateRoot}`);
+  }
+}
+
+function validateManifest(manifest) {
+  if (manifest === null || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error(`Private tmux manifest must be an object: ${manifestPath}`);
+  }
+  const keys = Object.keys(manifest).sort();
+  const expectedKeys = [...manifestKeys].sort();
+  if (JSON.stringify(keys) !== JSON.stringify(expectedKeys)) {
+    throw new Error(`Private tmux manifest has an unsupported shape: ${manifestPath}`);
+  }
+  if (
+    manifest.schemaVersion !== 1 ||
+    manifest.checkoutRoot !== repoRoot ||
+    manifest.checkoutKey !== checkoutKey ||
+    manifest.root !== privateRoot ||
+    !["starting", "running"].includes(manifest.status)
+  ) {
+    throw new Error(`Private tmux manifest does not belong to this checkout: ${manifestPath}`);
+  }
+  if (!Number.isFinite(Date.parse(manifest.createdAt))) {
+    throw new Error(`Private tmux manifest has an invalid creation timestamp: ${manifestPath}`);
+  }
+  const expected = createManifest({
+    tmux: manifest.tmuxBinary,
+  });
+  for (const key of manifestKeys) {
+    if (
+      [
+        "createdAt",
+        "status",
+        "tmuxBinary",
+        "tmuxServerPid",
+        "observerIdentity",
+        "devOwnerPid",
+        "devOwnerStartTime",
+      ].includes(key)
+    ) {
+      continue;
+    }
+    if (manifest[key] !== expected[key]) {
+      throw new Error(`Private tmux manifest field ${key} is not checkout-scoped.`);
+    }
+  }
+  if (!isAbsolute(manifest.tmuxBinary)) {
+    throw new Error("Private tmux manifest must record an absolute tmux executable.");
+  }
+  if (
+    !nullablePositiveInteger(manifest.tmuxServerPid) ||
+    !nullablePositiveInteger(manifest.devOwnerPid)
+  ) {
+    throw new Error("Private tmux manifest contains an invalid recorded PID.");
+  }
+  if (
+    manifest.devOwnerStartTime !== null &&
+    (typeof manifest.devOwnerStartTime !== "string" || manifest.devOwnerStartTime.length === 0)
+  ) {
+    throw new Error("Private tmux manifest contains an invalid owner start time.");
+  }
+  if (manifest.observerIdentity !== null) {
+    validateObserverIdentity(manifest.observerIdentity, manifest.observerSocketPath);
+  }
+  for (const key of manifestKeys.filter(
+    (candidate) =>
+      candidate.endsWith("Path") ||
+      candidate.endsWith("Dir") ||
+      candidate.endsWith("Home") ||
+      candidate === "root" ||
+      candidate === "projectRoot" ||
+      candidate === "binDir",
+  )) {
+    if (key === "checkoutRoot") {
+      continue;
+    }
+    const value = manifest[key];
+    if (typeof value !== "string" || !pathInside(privateRoot, value)) {
+      throw new Error(`Private tmux manifest path ${key} escapes ${privateRoot}.`);
+    }
+  }
+}
+
+function writeManifest(manifest) {
+  validateManifest(manifest);
+  const temporaryPath = join(privateRoot, `.manifest.${process.pid}.${randomUUID()}.tmp`);
+  const fd = openSync(temporaryPath, "wx", 0o600);
+  try {
+    writeFileSync(fd, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  chmodSync(temporaryPath, 0o600);
+  renameSync(temporaryPath, manifestPath);
+  chmodSync(manifestPath, 0o600);
+}
+
+function validateObserverIdentity(identity, socketPath) {
+  const keys = Object.keys(identity).sort();
+  if (
+    JSON.stringify(keys) !== JSON.stringify(["osStartTime", "pid", "socketPath", "version"]) ||
+    !Number.isInteger(identity.pid) ||
+    identity.pid <= 0 ||
+    typeof identity.osStartTime !== "string" ||
+    identity.osStartTime.length === 0 ||
+    typeof identity.version !== "string" ||
+    identity.version.length === 0 ||
+    identity.socketPath !== socketPath
+  ) {
+    throw new Error(`Private Observer identity is invalid for ${socketPath}.`);
+  }
+}
+
+function readObserverIdentity(socketPath) {
+  const identityPath = `${socketPath}.pid`;
+  if (!existsSync(identityPath)) {
+    throw new Error(`Private Observer identity did not appear at ${identityPath}.`);
+  }
+  let identity;
+  try {
+    identity = JSON.parse(readFileSync(identityPath, "utf8"));
+  } catch (error) {
+    throw new Error(`Private Observer identity is invalid at ${identityPath}.`, { cause: error });
+  }
+  validateObserverIdentity(identity, socketPath);
+  return identity;
+}
+
+function collectEvidence(manifest) {
+  const serverAlive = privateServerAlive(manifest);
+  const sessions = serverAlive
+    ? privateTmuxOutput(
+        manifest,
+        ["list-sessions", "-F", "#{session_name}\t#{session_attached}"],
+        false,
+      )
+    : "";
+  const basePane = serverAlive
+    ? privateTmuxOutput(
+        manifest,
+        ["list-panes", "-t", manifest.baseSession, "-F", "#{pane_id}\t#{pane_pid}"],
+        false,
+      )
+    : "";
+  const hiddenPane =
+    serverAlive && privateSessionExists(manifest, manifest.hiddenSession)
+      ? privateTmuxOutput(
+          manifest,
+          ["list-panes", "-t", manifest.hiddenSession, "-F", "#{pane_id}\t#{pane_pid}"],
+          false,
+        )
+      : "";
+  const nestedClients =
+    serverAlive && privateSessionExists(manifest, manifest.hiddenSession)
+      ? privateTmuxOutput(
+          manifest,
+          ["list-clients", "-t", manifest.hiddenSession, "-F", "#{client_name}\t#{client_pid}"],
+          false,
+        )
+      : "";
+  const records = processRecords();
+  const hiddenPid = panePidFromEvidence(hiddenPane);
+  const hiddenProcess =
+    hiddenPid === undefined ? undefined : records.find((record) => record.pid === hiddenPid);
+  const processTree =
+    hiddenPid === undefined
+      ? []
+      : [
+          ...(hiddenProcess === undefined ? [] : [hiddenProcess]),
+          ...descendantRecords(records, hiddenPid),
+        ];
+  const cli = processTree.find(
+    (record) =>
+      record.command.includes(cliPath) &&
+      record.command.includes("tui") &&
+      record.command.includes("--popup") &&
+      record.command.includes("--persistent"),
+  );
+  const renderer = processTree.find(
+    (record) =>
+      record.command.includes("bun") && record.command.includes("src/dashboardRenderer/main.tsx"),
+  );
+  const observer =
+    manifest.observerIdentity === null ? undefined : processRecord(manifest.observerIdentity.pid);
+  const host = findHostRecord(records, manifest);
+  const server =
+    manifest.tmuxServerPid === null ? undefined : processRecord(manifest.tmuxServerPid);
+  const basePid = panePidFromEvidence(basePane);
+  const baseDescendants = basePid === undefined ? [] : descendantRecords(records, basePid);
+  const nestedPids = nestedClients
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .flatMap((line) => {
+      const pid = Number(line.split("\t")[1]);
+      return Number.isInteger(pid) && pid > 0 ? [pid] : [];
+    });
+  const runtimeRecords = [
+    server,
+    basePid === undefined ? undefined : processRecord(basePid),
+    hiddenPid === undefined ? undefined : processRecord(hiddenPid),
+    cli,
+    renderer,
+    observer,
+    host,
+    ...nestedPids.map(processRecord),
+  ].filter((record) => record !== undefined);
+  return {
+    serverAlive,
+    sessions,
+    basePane,
+    hiddenPane,
+    nestedClients,
+    cli,
+    renderer,
+    observer,
+    host,
+    baseDescendants,
+    runtimeRecords,
+  };
+}
+
+function printOwnership(manifest, evidence) {
+  log(`Station private tmux devbox: ${evidence.serverAlive ? "running" : "stale"}`);
+  log(`checkout:       ${manifest.checkoutRoot}`);
+  log(`checkout key:   ${manifest.checkoutKey}`);
+  log(`private root:   ${manifest.root}`);
+  log(`tmux label:     ${manifest.tmuxLabel}`);
+  log(`tmux binary:    ${manifest.tmuxBinary}`);
+  log(`tmux wrapper:   ${manifest.tmuxWrapper}`);
+  log("tmux config:    /dev/null");
+  log(`tmux socket:    ${manifest.tmuxSocketPath}`);
+  log(`config:         ${manifest.configPath}`);
+  log(`state root:     ${manifest.stateDir}`);
+  log(`Observer socket:${manifest.observerSocketPath}`);
+  log(`Host socket:    ${manifest.hostSocketPath}`);
+  log(`layout:         ${manifest.layoutPath}`);
+  log(`base session:   ${manifest.baseSession}${formatPane(evidence.basePane)}`);
+  log(
+    `hidden session: ${evidence.hiddenPane.length === 0 ? `${manifest.hiddenSession} (not created until first popup)` : `${manifest.hiddenSession}${formatPane(evidence.hiddenPane)}`}`,
+  );
+  log(
+    `Observer:       ${evidence.observer === undefined ? "not running" : `${evidence.observer.pid} ${evidence.observer.command}`}`,
+  );
+  log(
+    `CLI parent:     ${evidence.cli === undefined ? "not created until first popup" : `${evidence.cli.pid} ${evidence.cli.command}`}`,
+  );
+  log(
+    `Bun renderer:   ${evidence.renderer === undefined ? "not created until first popup" : `${evidence.renderer.pid} ${evidence.renderer.command}`}`,
+  );
+  log(
+    `renderer IPC:   ${evidence.cli !== undefined && evidence.renderer !== undefined ? `${evidence.cli.pid} -> ${evidence.renderer.pid}` : "not established until first popup"}`,
+  );
+  log(
+    `nested client:  ${evidence.nestedClients.length === 0 ? "not attached" : evidence.nestedClients.replaceAll("\n", ", ")}`,
+  );
+  log(
+    `Station Host:   ${evidence.host === undefined ? "absent (expected for this read-only lane)" : `${evidence.host.pid} ${evidence.host.command}`}`,
+  );
+  log("");
+  log("Open:");
+  log("  pnpm station:devbox tmux attach");
+  log("  then press Ctrl-b Space");
+  log("Debug:");
+  log("  pnpm station:devbox tmux status");
+  log("  pnpm station:devbox tmux logs --follow");
+  log("Stop:");
+  log("  pnpm station:devbox tmux stop");
+}
+
+async function cleanupLane(manifest) {
+  const failures = [];
+  const evidence = collectEvidence(manifest);
+
+  if (existsSync(manifest.tmuxWrapper)) {
+    run(manifest.tmuxWrapper, ["kill-server"], {
+      cwd: manifest.projectRoot,
+      env: laneEnvironment(manifest),
+      check: false,
+      timeoutMs: 10_000,
+    });
+  }
+  if (privateServerAlive(manifest)) {
+    failures.push(new Error(`private tmux server ${manifest.tmuxLabel} survived kill-server`));
+  }
+
+  for (const record of evidence.baseDescendants) {
+    try {
+      await terminateRecordedPrivateProcess(record);
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+
+  if (existsSync(cliPath) && existsSync(manifest.configPath)) {
+    run(
+      process.execPath,
+      [cliPath, "--config", manifest.configPath, "observer", "stop", "--timeout-ms", "5000"],
+      {
+        cwd: manifest.projectRoot,
+        env: laneEnvironment(manifest),
+        check: false,
+        timeoutMs: 10_000,
+      },
+    );
+  }
+
+  try {
+    await terminateObserver(manifest);
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await terminateHost(manifest);
+  } catch (error) {
+    failures.push(error);
+  }
+
+  for (const record of evidence.runtimeRecords) {
+    if (
+      manifest.observerIdentity?.pid === record.pid ||
+      evidence.host?.pid === record.pid ||
+      record.pid === process.pid
+    ) {
+      continue;
+    }
+    if (!(await waitForRecordedProcessExit(record, 5_000))) {
+      failures.push(
+        new Error(`recorded private process ${record.pid} did not exit: ${record.command}`),
+      );
+    }
+  }
+  for (const socketPath of [manifest.observerSocketPath, manifest.hostSocketPath]) {
+    const holders = socketHolders(socketPath, manifest);
+    if (holders.length > 0) {
+      failures.push(
+        new Error(`private socket ${socketPath} still has owners: ${holders.join(", ")}`),
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new AggregateError(
+      failures,
+      `Private tmux cleanup could not prove every owner exited; retained ${manifest.root}.`,
+    );
+  }
+  rmSync(manifest.root, { recursive: true, force: true });
+  if (existsSync(manifest.root)) {
+    throw new Error(`Private tmux root remained after cleanup: ${manifest.root}`);
+  }
+}
+
+async function terminateObserver(manifest) {
+  const identity = manifest.observerIdentity;
+  if (identity === null || !processExists(identity.pid)) {
+    return;
+  }
+  if (await waitForPidExit(identity.pid, identity.osStartTime, 2_000)) {
+    return;
+  }
+  assertObserverOwnership(manifest, identity);
+  process.kill(identity.pid, "SIGTERM");
+  if (await waitForPidExit(identity.pid, identity.osStartTime, 3_000)) {
+    return;
+  }
+  assertObserverOwnership(manifest, identity);
+  process.kill(identity.pid, "SIGKILL");
+  if (!(await waitForPidExit(identity.pid, identity.osStartTime, 2_000))) {
+    throw new Error(`Private Observer ${identity.pid} survived SIGKILL.`);
+  }
+}
+
+function assertObserverOwnership(manifest, identity) {
+  const currentIdentity = readObserverIdentity(manifest.observerSocketPath);
+  if (JSON.stringify(currentIdentity) !== JSON.stringify(identity)) {
+    throw new Error(`Private Observer pidfile changed for process ${identity.pid}.`);
+  }
+  const record = processRecord(identity.pid);
+  if (
+    record === undefined ||
+    record.startTime !== identity.osStartTime ||
+    !record.command.includes("observerMain.js") ||
+    !record.command.includes(`--socket ${manifest.observerSocketPath}`) ||
+    !record.command.includes(`--state-dir ${manifest.stateDir}`)
+  ) {
+    throw new Error(`Private Observer process evidence no longer matches pid ${identity.pid}.`);
+  }
+  if (existsSync(manifest.observerSocketPath)) {
+    const holders = socketHolders(manifest.observerSocketPath, manifest);
+    if (holders.length !== 1 || holders[0] !== identity.pid) {
+      throw new Error(
+        `Private Observer socket ownership is ambiguous: ${holders.join(", ") || "none"}.`,
+      );
+    }
+  }
+}
+
+async function terminateHost(manifest) {
+  const records = processRecords();
+  const host = findHostRecord(records, manifest);
+  if (host === undefined) {
+    return;
+  }
+  const matches = records.filter((record) => isHostRecord(record, manifest));
+  if (matches.length !== 1) {
+    throw new Error(
+      `Private Station Host ownership is ambiguous: ${matches.map((record) => record.pid).join(", ")}`,
+    );
+  }
+  assertHostOwnership(manifest, host);
+  process.kill(host.pid, "SIGTERM");
+  if (await waitForPidExit(host.pid, host.startTime, 3_000)) {
+    return;
+  }
+  const current = processRecord(host.pid);
+  if (
+    current === undefined ||
+    current.startTime !== host.startTime ||
+    current.command !== host.command
+  ) {
+    throw new Error(`Private Station Host ${host.pid} changed before forced cleanup.`);
+  }
+  assertHostOwnership(manifest, current);
+  process.kill(host.pid, "SIGKILL");
+  if (!(await waitForPidExit(host.pid, host.startTime, 2_000))) {
+    throw new Error(`Private Station Host ${host.pid} survived SIGKILL.`);
+  }
+}
+
+function assertHostOwnership(manifest, host) {
+  if (!isHostRecord(host, manifest)) {
+    throw new Error(`Private Station Host process evidence changed for pid ${host.pid}.`);
+  }
+  if (existsSync(manifest.hostSocketPath)) {
+    const holders = socketHolders(manifest.hostSocketPath, manifest);
+    if (!holders.includes(host.pid)) {
+      throw new Error(`Private Station Host ${host.pid} no longer owns its recorded socket.`);
+    }
+  }
+}
+
+async function waitAsForegroundOwner() {
+  await new Promise((resolveWait, rejectWait) => {
+    let finishing = false;
+    const handlers = new Map();
+    const timer = setInterval(() => {
+      if (!existsSync(manifestPath)) {
+        finish();
+        resolveWait();
+        return;
+      }
+      try {
+        const manifest = readManifest();
+        if (manifest.devOwnerPid !== process.pid) {
+          finish();
+          resolveWait();
+        }
+      } catch (error) {
+        finish();
+        rejectWait(error);
+      }
+    }, 500);
+    const finish = () => {
+      if (finishing) {
+        return false;
+      }
+      finishing = true;
+      clearInterval(timer);
+      for (const [signal, handler] of handlers) {
+        process.off(signal, handler);
+      }
+      return true;
+    };
+    for (const signal of Object.keys(signalExitCodes)) {
+      const handler = () => {
+        if (!finish()) {
+          return;
+        }
+        void (async () => {
+          try {
+            if (existsSync(privateRoot)) {
+              await cleanupLane(readManifest());
+            }
+            process.exitCode = signalExitCodes[signal];
+            resolveWait();
+          } catch (error) {
+            rejectWait(error);
+          }
+        })();
+      };
+      handlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+  });
+}
+
+function observerIdentityAlive(manifest, identity) {
+  if (identity === null || !processExists(identity.pid)) {
+    return false;
+  }
+  try {
+    assertObserverOwnership(manifest, identity);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function privateServerAlive(manifest) {
+  if (!existsSync(manifest.tmuxWrapper)) {
+    return false;
+  }
+  return (
+    run(manifest.tmuxWrapper, ["list-sessions"], {
+      cwd: manifest.root,
+      env: laneEnvironment(manifest),
+      check: false,
+      timeoutMs: 5_000,
+    }).status === 0
+  );
+}
+
+function privateSessionExists(manifest, sessionName) {
+  return (
+    run(manifest.tmuxWrapper, ["has-session", "-t", sessionName], {
+      cwd: manifest.root,
+      env: laneEnvironment(manifest),
+      check: false,
+      timeoutMs: 5_000,
+    }).status === 0
+  );
+}
+
+function privateTmuxOutput(manifest, args, check = true) {
+  const result = run(manifest.tmuxWrapper, args, {
+    cwd: manifest.root,
+    env: laneEnvironment(manifest),
+    check,
+    timeoutMs: 5_000,
+  });
+  return result.stdout.trim();
+}
+
+function socketHolders(socketPath, manifest) {
+  if (!existsSync(socketPath)) {
+    return [];
+  }
+  const lsof = requireExecutableFromManifest(manifest, "lsof");
+  const result = run(lsof, ["-t", socketPath], {
+    check: false,
+    timeoutMs: 5_000,
+  });
+  return result.stdout
+    .split(/\r?\n/u)
+    .map(Number)
+    .filter((pid) => Number.isInteger(pid) && pid > 0);
+}
+
+function requireExecutableFromManifest(_manifest, name) {
+  return requireExecutable(name);
+}
+
+function processRecords() {
+  const result = run(psPath, ["-axww", "-o", "pid=,ppid=,lstart=,command="], {
+    check: false,
+    timeoutMs: 10_000,
+    env: { ...process.env, LC_ALL: "C" },
+  });
+  return result.stdout.split(/\r?\n/u).flatMap((line) => {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.{24})\s+(.*)$/u.exec(line);
+    if (match === null) {
+      return [];
+    }
+    return [
+      {
+        pid: Number(match[1]),
+        ppid: Number(match[2]),
+        startTime: match[3].trim(),
+        command: match[4],
+      },
+    ];
+  });
+}
+
+function processRecord(pid) {
+  return processRecords().find((record) => record.pid === pid);
+}
+
+function processStartTime(pid) {
+  return processRecord(pid)?.startTime;
+}
+
+function processMatchesStart(pid, startTime) {
+  return processRecord(pid)?.startTime === startTime;
+}
+
+function descendantRecords(records, ancestorPid) {
+  const byPid = new Map(records.map((record) => [record.pid, record]));
+  return records.filter((record) => {
+    const visited = new Set();
+    let current = record.ppid;
+    while (current > 0 && !visited.has(current)) {
+      if (current === ancestorPid) {
+        return true;
+      }
+      visited.add(current);
+      current = byPid.get(current)?.ppid ?? 0;
+    }
+    return false;
+  });
+}
+
+function findHostRecord(records, manifest) {
+  const matches = records.filter((record) => isHostRecord(record, manifest));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function isHostRecord(record, manifest) {
+  return (
+    record.command.includes("hostMain.ts") &&
+    record.command.includes(`--socket ${manifest.hostSocketPath}`) &&
+    record.command.includes(`--state-dir ${manifest.stateDir}`)
+  );
+}
+
+function panePidFromEvidence(evidence) {
+  const pid = Number(evidence.split("\t")[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : undefined;
+}
+
+function formatPane(evidence) {
+  if (evidence.length === 0) {
+    return " (missing)";
+  }
+  const [pane, pid] = evidence.split("\t");
+  return ` (${pane ?? "pane?"}, pid ${pid ?? "?"})`;
+}
+
+async function waitForRecordedProcessExit(record, timeoutMs) {
+  return waitForPidExit(record.pid, record.startTime, timeoutMs);
+}
+
+async function terminateRecordedPrivateProcess(record) {
+  if (await waitForRecordedProcessExit(record, 1_000)) {
+    return;
+  }
+  assertRecordedProcessOwnership(record);
+  process.kill(record.pid, "SIGTERM");
+  if (await waitForRecordedProcessExit(record, 3_000)) {
+    return;
+  }
+  assertRecordedProcessOwnership(record);
+  process.kill(record.pid, "SIGKILL");
+  if (!(await waitForRecordedProcessExit(record, 2_000))) {
+    throw new Error(`Private base-shell process ${record.pid} survived SIGKILL.`);
+  }
+}
+
+function assertRecordedProcessOwnership(record) {
+  const current = processRecord(record.pid);
+  if (
+    current === undefined ||
+    current.startTime !== record.startTime ||
+    current.command !== record.command
+  ) {
+    throw new Error(`Private base-shell process ${record.pid} changed before cleanup.`);
+  }
+}
+
+async function waitForPidExit(pid, startTime, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processMatchesStart(pid, startTime)) {
+      return true;
+    }
+    await delay(100);
+  }
+  return !processMatchesStart(pid, startTime);
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+function laneEnvironment(manifest, additions = {}) {
+  const env = {};
+  // Private homes do not isolate credentials exported through the caller's environment.
+  for (const [key, value] of Object.entries(process.env)) {
+    if (
+      value !== undefined &&
+      (lanePassthroughEnvironmentVariables.has(key) || key.startsWith("LC_"))
+    ) {
+      env[key] = value;
+    }
+  }
+  return {
+    ...env,
+    PATH: `${manifest.binDir}:${env.PATH ?? ""}`,
+    HOME: manifest.homeDir,
+    XDG_CONFIG_HOME: manifest.xdgConfigDir,
+    XDG_STATE_HOME: manifest.xdgStateDir,
+    XDG_DATA_HOME: manifest.xdgDataDir,
+    XDG_RUNTIME_DIR: manifest.runtimeDir,
+    TMPDIR: manifest.tempDir,
+    CODEX_HOME: manifest.providerCodexHome,
+    CLAUDE_CONFIG_DIR: manifest.providerClaudeHome,
+    STATION_CURSOR_HOME: manifest.providerCursorHome,
+    OPENCODE_CONFIG_DIR: manifest.providerOpenCodeHome,
+    STATION_CONFIG_PATH: manifest.configPath,
+    STATION_OBSERVER_SOCKET_PATH: manifest.observerSocketPath,
+    STATION_HOST_SOCKET_PATH: manifest.hostSocketPath,
+    STATION_LAYOUT_PATH: manifest.layoutPath,
+    STATION_TMUX_BIN: manifest.tmuxWrapper,
+    STATION_BUN: resolveExecutable(process.env.STATION_BUN ?? "bun") ?? "bun",
+    STATION_HOST_ENTRY: hostEntry,
+    TMUX_TMPDIR: manifest.tmuxTmpDir,
+    SHELL: "/bin/sh",
+    TERM: env.TERM ?? "xterm-256color",
+    ...additions,
+  };
+}
+
+function requireExecutable(requested) {
+  const resolved = resolveExecutable(requested);
+  if (resolved === undefined) {
+    throw new Error(`Missing required executable: ${requested}`);
+  }
+  return resolved;
+}
+
+function resolveExecutable(requested) {
+  if (requested.includes("/")) {
+    const candidate = resolve(requested);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      return undefined;
+    }
+  }
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (directory.length === 0) {
+      continue;
+    }
+    const candidate = join(directory, requested);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // continue
+    }
+  }
+  return undefined;
+}
+
+function run(command, args, options = {}) {
+  const { check = true, cwd = repoRoot, env = process.env, stdio = "pipe" } = options;
+  const timeoutMs = Object.hasOwn(options, "timeoutMs") ? options.timeoutMs : 30_000;
+  const result = spawnSync(command, args, {
+    cwd,
+    env,
+    stdio,
+    encoding: stdio === "pipe" ? "utf8" : undefined,
+    ...(timeoutMs === undefined ? {} : { timeout: timeoutMs }),
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  const status = result.status ?? 1;
+  const output = {
+    status,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+  if (check && status !== 0) {
+    throw new Error(
+      `\`${command} ${args.join(" ")}\` failed (exit ${status}).\n${output.stderr || output.stdout}`,
+    );
+  }
+  return output;
+}
+
+function writeManagedFile(path, content, mode) {
+  writeFileSync(path, content, { encoding: "utf8", flag: "wx", mode });
+  chmodSync(path, mode);
+}
+
+function pathInside(root, path) {
+  const rel = relative(root, path);
+  return rel.length === 0 || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function nullablePositiveInteger(value) {
+  return value === null || (Number.isInteger(value) && value > 0);
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} was not a positive integer: ${value}`);
+  }
+  return parsed;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function staleLaneError(manifest) {
+  return new Error(
+    `The private tmux lane at ${manifest.root} is partial or stale. Recover it with:\n\n` +
+      "  pnpm station:devbox tmux reset --yes\n" +
+      "  pnpm station:devbox tmux dev",
+  );
+}
+
+function errorMessage(error) {
+  if (error instanceof AggregateError) {
+    return `${error.message}\n${error.errors.map((entry) => `- ${errorMessage(entry)}`).join("\n")}`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function log(message) {
+  process.stdout.write(`${message}\n`);
+}

--- a/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
@@ -1,0 +1,912 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+const wrapperPath = join(repoRoot, "scripts", "station-devbox.mjs");
+const cliPath = join(repoRoot, "apps", "cli", "dist", "main.js");
+const hmrTarget = join(repoRoot, "station", "src", "dashboardRenderer", "FullscreenDashboard.tsx");
+const hmrTargetRelative = "station/src/dashboardRenderer/FullscreenDashboard.tsx";
+const checkoutKey = createHash("sha256").update(resolve(repoRoot)).digest("hex").slice(0, 12);
+const privateRoot = join("/tmp", `stn-dbx-${checkoutKey}`);
+const manifestPath = join(privateRoot, "manifest.json");
+const probe = "tmux-devbox-hmr-probe";
+const timeoutMs = Number(process.env.STATION_TMUX_DEVBOX_SMOKE_TIMEOUT_MS ?? 180_000);
+const ptyBridgeScript = `
+import fcntl
+import os
+import pty
+import select
+import struct
+import sys
+import termios
+
+winsize = struct.pack("HHHH", 40, 120, 0, 0)
+pid, fd = pty.fork()
+if pid == 0:
+    fcntl.ioctl(sys.stdin.fileno(), termios.TIOCSWINSZ, winsize)
+    os.environ.setdefault("TERM", "xterm-256color")
+    os.execvp(sys.argv[1], sys.argv[1:])
+
+fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
+while True:
+    readable, _, _ = select.select([sys.stdin.buffer, fd], [], [])
+    if sys.stdin.buffer in readable:
+        data = os.read(sys.stdin.fileno(), 4096)
+        if not data:
+            break
+        os.write(fd, data)
+    if fd in readable:
+        try:
+            data = os.read(fd, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        os.write(sys.stdout.fileno(), data)
+
+try:
+    _, status = os.waitpid(pid, 0)
+    sys.exit(os.waitstatus_to_exitcode(status))
+except ChildProcessError:
+    sys.exit(0)
+`;
+
+const outerRoot = mkdtempSync("/tmp/stn-tmux-devbox-smoke-");
+const outerHome = join(outerRoot, "home");
+const outerConfig = join(outerRoot, "xdg-config");
+const outerState = join(outerRoot, "xdg-state");
+const outerRuntime = join(outerRoot, "run");
+const outerSentinels = [
+  join(outerHome, ".config", "station", "config.toml"),
+  join(outerHome, ".codex", "auth.json"),
+  join(outerHome, ".claude", "settings.json"),
+  join(outerState, "station", "observer.sock"),
+  join(outerState, "station", "hooks", "sentinel"),
+];
+const credentialSentinels = {
+  ANTHROPIC_API_KEY: "station-tmux-smoke-anthropic",
+  AWS_SECRET_ACCESS_KEY: "station-tmux-smoke-aws",
+  GH_TOKEN: "station-tmux-smoke-gh",
+  GITHUB_TOKEN: "station-tmux-smoke-github",
+  OPENAI_API_KEY: "station-tmux-smoke-openai",
+  SSH_AUTH_SOCK: join(outerRoot, "ssh-agent.sock"),
+};
+const outerEnv = sanitizeGitEnvironment({
+  ...process.env,
+  ...credentialSentinels,
+  HOME: outerHome,
+  XDG_CONFIG_HOME: outerConfig,
+  XDG_STATE_HOME: outerState,
+  XDG_RUNTIME_DIR: outerRuntime,
+  STATION_CONFIG_PATH: outerSentinels[0],
+  STATION_OBSERVER_SOCKET_PATH: outerSentinels[3],
+  STATION_HOOK_SPOOL_DIR: dirname(outerSentinels[4]),
+  STATION_SOURCE: "mock",
+});
+const targetBytes = readFileSync(hmrTarget);
+const targetMode = statSync(hmrTarget).mode & 0o777;
+const preStatus = git(["status", "--porcelain=v1"]);
+const preDiff = git(["diff", "--no-ext-diff", "--binary"]);
+const sentinelBytes = new Map();
+let ptyClient;
+let probeTargetBytes;
+let finalRestorationError;
+let ownsPrivateLane = false;
+
+process.stderr.write(
+  "station:devbox:tmux smoke — real private tmux, Observer, popup, PTY, and source HMR.\n",
+);
+
+try {
+  assert(!existsSync(privateRoot), `private lane is already running at ${privateRoot}`);
+  assert(
+    gitStatus(["diff", "--quiet", "--", hmrTargetRelative]) === 0,
+    `HMR target is dirty; refusing to edit ${hmrTarget}`,
+  );
+  assert(existsSync(cliPath), `built CLI missing at ${cliPath}; run pnpm build`);
+  checked("python3", ["--version"], { env: outerEnv });
+  checked("tmux", ["-V"], { env: outerEnv });
+  checked("bun", ["--version"], { env: outerEnv });
+  checked("node", [cliPath, "--version"], { env: outerEnv });
+  createOuterSentinels();
+
+  const help = devbox(["tmux", "help"]);
+  assertIncludes(help.stdout, "tmux dev", "nested help");
+  const resetRefusal = devbox(["tmux", "reset"], { check: false });
+  assert(resetRefusal.status !== 0, "reset unexpectedly succeeded without --yes");
+  assertIncludes(resetRefusal.stderr, "Refusing to reset without --yes", "reset refusal");
+
+  const firstStart = devbox(["tmux", "start"]);
+  ownsPrivateLane = true;
+  const manifest = readManifest();
+  assertOwnershipOutput(firstStart.stdout, manifest);
+  const preexistingLaneRefusal = checked(process.execPath, [fileURLToPath(import.meta.url)], {
+    env: outerEnv,
+    check: false,
+  });
+  assert(preexistingLaneRefusal.status !== 0, "nested smoke reused a preexisting private lane");
+  assertIncludes(
+    preexistingLaneRefusal.stderr,
+    `private lane is already running at ${privateRoot}`,
+    "preexisting lane refusal",
+  );
+  const manifestAfterRefusal = readManifest();
+  assert(
+    manifestAfterRefusal.tmuxServerPid === manifest.tmuxServerPid &&
+      manifestAfterRefusal.observerIdentity.pid === manifest.observerIdentity.pid &&
+      privateSessionExists(manifest, manifest.baseSession),
+    "preexisting lane refusal stopped or replaced the private lane",
+  );
+  const secondStart = devbox(["tmux", "start"]);
+  assertOwnershipOutput(secondStart.stdout, manifest);
+  const initialStatus = devbox(["tmux", "status"]);
+  assertOwnershipOutput(initialStatus.stdout, manifest);
+  devbox(["tmux", "logs"]);
+
+  proveManifestAndIsolation(manifest);
+  ptyClient = await startPtyClient(manifest);
+  assertPrivateServerEnvironment(manifest);
+  await proveBaseShellIsolation(manifest);
+  await triggerPopup(ptyClient);
+  await waitFor(
+    () => privateSessionExists(manifest, manifest.hiddenSession),
+    "hidden Station session did not appear",
+  );
+  await waitFor(
+    () => captureHiddenPane(manifest).includes("SESSION"),
+    "real dashboard did not paint",
+  );
+
+  const beforeHmr = runtimeEvidence(manifest);
+  assert(beforeHmr.cli !== undefined, "hidden pane is not the production CLI parent");
+  assert(beforeHmr.renderer !== undefined, "Bun dashboard renderer child was not found");
+  const popupLauncher = readFileSync(manifest.popupLauncherPath, "utf8");
+  assert(
+    popupLauncher.includes("--hot --no-clear-screen") &&
+      popupLauncher.includes("src/dashboardRenderer/main.tsx"),
+    "popup launcher does not use the required Bun hot renderer command",
+  );
+  const serverDashboardCommand = tmux(manifest, [
+    "show-environment",
+    "-g",
+    "STATION_DASHBOARD_COMMAND",
+  ]).stdout;
+  assert(
+    serverDashboardCommand.includes("--hot --no-clear-screen") &&
+      serverDashboardCommand.includes("src/dashboardRenderer/main.tsx"),
+    "private tmux server did not retain the hot dashboard command",
+  );
+  assert(beforeHmr.nestedClientPid !== undefined, "nested popup client was not found");
+  const rendererTerminalLog = join(manifest.root, "logs", "renderer-terminal.log");
+  tmux(manifest, [
+    "pipe-pane",
+    "-o",
+    "-t",
+    manifest.hiddenSession,
+    `cat >> ${rendererTerminalLog}`,
+  ]);
+
+  const liveStatus = devbox(["tmux", "status"]);
+  for (const expected of [
+    `CLI parent:     ${beforeHmr.cli.pid}`,
+    `Bun renderer:   ${beforeHmr.renderer.pid}`,
+    `renderer IPC:   ${beforeHmr.cli.pid} -> ${beforeHmr.renderer.pid}`,
+  ]) {
+    assertIncludes(liveStatus.stdout, expected, "live ownership status");
+  }
+
+  const source = targetBytes.toString("utf8");
+  const insertion = "        <DashboardRoot store={store} columns={width} rows={height} />";
+  assert(source.includes(insertion), `HMR insertion point missing from ${hmrTarget}`);
+  const nextProbeTargetBytes = Buffer.from(
+    source.replace(insertion, `        <text>${probe}</text>\n${insertion}`),
+    "utf8",
+  );
+  assertTargetUnchanged("before the HMR probe write");
+  writeFileSync(hmrTarget, nextProbeTargetBytes);
+  probeTargetBytes = nextProbeTargetBytes;
+  try {
+    await waitFor(
+      () => captureHiddenPane(manifest).includes(probe),
+      "Bun HMR did not repaint the open popup with the source probe",
+      30_000,
+    );
+  } catch (error) {
+    const rendererOutput = existsSync(rendererTerminalLog)
+      ? readFileSync(rendererTerminalLog, "utf8").slice(-16_000)
+      : "<renderer terminal log absent>";
+    throw new Error(
+      `${error.message}\nHidden pane:\n${captureHiddenPane(manifest)}\nRenderer output:\n${rendererOutput}`,
+      { cause: error },
+    );
+  }
+  const duringHmr = runtimeEvidence(manifest);
+  assertStableRuntime(beforeHmr, duringHmr, "probe insertion");
+
+  const restorationError = restoreTarget();
+  if (restorationError !== undefined) {
+    throw restorationError;
+  }
+  await waitFor(
+    () => !captureHiddenPane(manifest).includes(probe),
+    "Bun HMR did not remove the restored source probe",
+    30_000,
+  );
+  const afterHmr = runtimeEvidence(manifest);
+  assertStableRuntime(beforeHmr, afterHmr, "probe restoration");
+
+  await ptyClient.write(Buffer.from([0x1b]));
+  await waitFor(
+    () => runtimeEvidence(manifest).nestedClientPid === undefined,
+    "Esc did not dismiss the original popup IPC channel",
+  );
+  const afterDismiss = runtimeEvidence(manifest);
+  assert(afterDismiss.cli?.pid === beforeHmr.cli.pid, "dismiss replaced the CLI parent");
+  assert(
+    afterDismiss.renderer?.pid === beforeHmr.renderer.pid,
+    "dismiss replaced the Bun renderer",
+  );
+  assertWrapperAudit(manifest);
+  assert(!existsSync(manifest.bareTmuxLogPath), "a child invoked bare/default tmux");
+
+  await ptyClient.close();
+  ptyClient = undefined;
+  devbox(["tmux", "stop"]);
+  devbox(["tmux", "stop"]);
+  assert(!existsSync(privateRoot), "stop did not remove the private root");
+
+  await proveBaseDescendantCleanup();
+  await proveVerifiedPartialReset();
+  await proveFailedStartupRollback();
+  await proveSignals();
+  proveOuterSentinels();
+  assert(readFileSync(hmrTarget).equals(targetBytes), "HMR target bytes changed after smoke");
+  assert(git(["status", "--porcelain=v1"]) === preStatus, "git status changed during smoke");
+  assert(git(["diff", "--no-ext-diff", "--binary"]) === preDiff, "git diff changed during smoke");
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        status: "station:devbox:tmux smoke passed",
+        privateRoot,
+        stablePids: {
+          tmuxServer: beforeHmr.serverPid,
+          basePane: beforeHmr.basePanePid,
+          hiddenPane: beforeHmr.hiddenPanePid,
+          cli: beforeHmr.cli.pid,
+          renderer: beforeHmr.renderer.pid,
+          observer: beforeHmr.observerPid,
+          nestedClient: beforeHmr.nestedClientPid,
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+} finally {
+  finalRestorationError = restoreTarget();
+  if (ptyClient !== undefined) {
+    await ptyClient.close().catch(() => undefined);
+  }
+  if (ownsPrivateLane) {
+    devbox(["tmux", "stop"], { check: false });
+  }
+  rmSync(outerRoot, { recursive: true, force: true });
+  if (finalRestorationError !== undefined) {
+    process.stderr.write(`${finalRestorationError.message}\n`);
+  }
+}
+if (finalRestorationError !== undefined) {
+  throw finalRestorationError;
+}
+
+function createOuterSentinels() {
+  for (const [index, path] of outerSentinels.entries()) {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const bytes = Buffer.from(`outer-sentinel-${index}\n`);
+    writeFileSync(path, bytes, { mode: 0o600 });
+    sentinelBytes.set(path, bytes);
+  }
+}
+
+function proveOuterSentinels() {
+  for (const [path, bytes] of sentinelBytes) {
+    assert(readFileSync(path).equals(bytes), `outer sentinel changed: ${path}`);
+  }
+}
+
+function proveManifestAndIsolation(manifest) {
+  const rootStat = statSync(manifest.root);
+  const manifestStat = statSync(manifestPath);
+  assert((rootStat.mode & 0o077) === 0, "private root is not mode 0700");
+  assert((manifestStat.mode & 0o077) === 0, "manifest is not mode 0600");
+  for (const key of [
+    "configPath",
+    "homeDir",
+    "xdgConfigDir",
+    "xdgStateDir",
+    "xdgDataDir",
+    "runtimeDir",
+    "stateDir",
+    "tempDir",
+    "projectRoot",
+    "providerCodexHome",
+    "providerClaudeHome",
+    "providerCursorHome",
+    "providerOpenCodeHome",
+    "observerSocketPath",
+    "hostSocketPath",
+    "layoutPath",
+    "tmuxWrapper",
+    "tmuxTmpDir",
+    "tmuxSocketPath",
+    "tmuxLogPath",
+    "bareTmuxShimPath",
+    "bareTmuxLogPath",
+    "popupLauncherPath",
+    "popupLogPath",
+  ]) {
+    assert(pathInside(manifest.root, manifest[key]), `manifest path escapes root: ${key}`);
+  }
+  for (const socketPath of [
+    manifest.observerSocketPath,
+    manifest.hostSocketPath,
+    manifest.tmuxSocketPath,
+  ]) {
+    assert(socketPath.length < 104, `Unix socket path is too long: ${socketPath}`);
+  }
+  assert(existsSync(manifest.observerSocketPath), "private Observer socket is absent");
+  assert(existsSync(manifest.tmuxSocketPath), "private tmux socket is absent");
+  assert(!existsSync(manifest.hostSocketPath), "read-only lane unexpectedly started Station Host");
+  assert(!existsSync(manifest.bareTmuxLogPath), "a child invoked the failing bare tmux shim");
+  assertPrivateServerEnvironment(manifest);
+  assertNoLinks(manifest.providerCodexHome);
+  assertNoLinks(manifest.providerClaudeHome);
+  assertNoLinks(manifest.providerCursorHome);
+  assertNoLinks(manifest.providerOpenCodeHome);
+  assert(
+    git(["-C", manifest.projectRoot, "rev-parse", "--verify", "HEAD"]).length > 0,
+    "project is uncommitted",
+  );
+  assert(
+    git(["-C", manifest.projectRoot, "status", "--porcelain=v1"]).length === 0,
+    "disposable project is dirty",
+  );
+  checked(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      "import { loadConfig } from './packages/config/dist/index.js'; await loadConfig(process.argv[1]);",
+      manifest.configPath,
+    ],
+    { cwd: repoRoot, env: outerEnv },
+  );
+  assertWrapperAudit(manifest);
+}
+
+function assertWrapperAudit(manifest) {
+  const wrapperLines = readFileSync(manifest.tmuxLogPath, "utf8").split(/\r?\n/u).filter(Boolean);
+  assert(wrapperLines.length > 0, "private wrapper log is empty");
+  for (const line of wrapperLines) {
+    assertIncludes(line, `\t-L\t${manifest.tmuxLabel}\t-f\t/dev/null`, "wrapper audit");
+  }
+}
+
+function assertPrivateServerEnvironment(manifest) {
+  assert(
+    tmux(manifest, ["show-options", "-gv", "update-environment"]).stdout.trim() === "",
+    "private tmux server can import client environment variables",
+  );
+  const serverEnvironment = tmux(manifest, ["show-environment", "-g"], {
+    check: false,
+  }).stdout;
+  for (const name of Object.keys(credentialSentinels)) {
+    assert(
+      !new RegExp(`(^|\\n)${name}=`, "u").test(serverEnvironment),
+      `private tmux server inherited ${name}`,
+    );
+  }
+}
+
+async function proveBaseShellIsolation(manifest) {
+  const reportPath = join(manifest.root, "base-shell-tmux-path");
+  tmux(manifest, [
+    "send-keys",
+    "-t",
+    `${manifest.baseSession}:0.0`,
+    `command -v tmux > ${reportPath}`,
+    "Enter",
+  ]);
+  await waitFor(() => existsSync(reportPath), "base shell did not write its tmux path");
+  const resolvedTmux = readFileSync(reportPath, "utf8").trim();
+  assert(
+    resolvedTmux === manifest.bareTmuxShimPath,
+    `base shell resolves bare tmux outside the private guard: ${resolvedTmux}`,
+  );
+}
+
+async function proveBaseDescendantCleanup() {
+  devbox(["tmux", "start"]);
+  const manifest = readManifest();
+  const pidPath = join(manifest.root, "base-descendant.pid");
+  tmux(manifest, [
+    "send-keys",
+    "-t",
+    `${manifest.baseSession}:0.0`,
+    `/usr/bin/nohup /bin/sleep 300 >/dev/null 2>&1 & echo $! > ${pidPath}`,
+    "Enter",
+  ]);
+  await waitFor(() => existsSync(pidPath), "base descendant pid did not appear");
+  const pid = positiveInteger(readFileSync(pidPath, "utf8"), "base descendant pid");
+  await waitFor(() => processExists(pid), "base descendant did not start");
+  try {
+    devbox(["tmux", "stop"]);
+    assert(!processExists(pid), `private base descendant ${pid} survived stop`);
+  } finally {
+    if (processExists(pid)) {
+      process.kill(pid, "SIGKILL");
+    }
+    devbox(["tmux", "stop"], { check: false });
+  }
+}
+
+async function proveVerifiedPartialReset() {
+  devbox(["tmux", "start"]);
+  const manifest = readManifest();
+  tmux(manifest, ["kill-server"], { check: false });
+  assert(existsSync(manifest.root), "partial root disappeared before reset proof");
+  devbox(["tmux", "reset", "--yes"]);
+  assert(!existsSync(manifest.root), "reset did not remove verified partial root");
+}
+
+async function proveFailedStartupRollback() {
+  const fakeTmux = join(outerRoot, "fake-tmux");
+  writeFileSync(
+    fakeTmux,
+    [
+      "#!/bin/sh",
+      `if [ "\${1:-}" = "-V" ]; then echo "tmux fake-smoke"; exit 0; fi`,
+      "exit 88",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  chmodSync(fakeTmux, 0o700);
+  const failed = devbox(["tmux", "start"], {
+    check: false,
+    env: { ...outerEnv, STATION_TMUX_DEVBOX_TMUX_BIN: fakeTmux },
+  });
+  assert(failed.status !== 0, "fake tmux startup unexpectedly succeeded");
+  assert(!existsSync(privateRoot), "failed startup retained private resources");
+}
+
+async function proveSignals() {
+  for (const [signal, expectedCode] of [
+    ["SIGINT", 130],
+    ["SIGHUP", 129],
+    ["SIGTERM", 143],
+  ]) {
+    const owner = spawn(process.execPath, [wrapperPath, "tmux", "dev"], {
+      cwd: repoRoot,
+      env: outerEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    owner.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    owner.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    const exit = new Promise((resolveExit, rejectExit) => {
+      owner.once("error", rejectExit);
+      owner.once("exit", (code, exitedSignal) => resolveExit({ code, signal: exitedSignal }));
+    });
+    await waitFor(
+      () => stdout.includes("Foreground owner active."),
+      `${signal} owner did not become ready\n${stdout}\n${stderr}`,
+      30_000,
+    );
+    owner.kill(signal);
+    const result = await withTimeout(exit, 30_000, `${signal} owner did not exit`);
+    assert(
+      result.code === expectedCode && result.signal === null,
+      `${signal} owner exited as ${JSON.stringify(result)}\n${stdout}\n${stderr}`,
+    );
+    assert(!existsSync(privateRoot), `${signal} cleanup retained ${privateRoot}`);
+  }
+}
+
+function assertStableRuntime(before, after, label) {
+  for (const key of [
+    "serverPid",
+    "basePanePid",
+    "hiddenPanePid",
+    "observerPid",
+    "nestedClientPid",
+  ]) {
+    assert(after[key] === before[key], `${label} changed ${key}: ${before[key]} -> ${after[key]}`);
+  }
+  assert(after.cli?.pid === before.cli?.pid, `${label} changed the CLI parent`);
+  assert(after.renderer?.pid === before.renderer?.pid, `${label} changed the Bun renderer`);
+  assert(after.hostPid === before.hostPid, `${label} changed Station Host ownership`);
+}
+
+function runtimeEvidence(manifest) {
+  const serverPid = positiveInteger(
+    tmux(manifest, ["display-message", "-p", "#{pid}"]).stdout,
+    "tmux server pid",
+  );
+  const basePanePid = positiveInteger(
+    tmux(manifest, ["display-message", "-p", "-t", `${manifest.baseSession}:0.0`, "#{pane_pid}"])
+      .stdout,
+    "base pane pid",
+  );
+  const hiddenPanePid = positiveInteger(
+    tmux(manifest, ["display-message", "-p", "-t", `${manifest.hiddenSession}:0.0`, "#{pane_pid}"])
+      .stdout,
+    "hidden pane pid",
+  );
+  const nested = tmux(
+    manifest,
+    ["list-clients", "-t", manifest.hiddenSession, "-F", "#{client_pid}"],
+    { check: false },
+  ).stdout.trim();
+  const nestedClientPid =
+    nested.length === 0 ? undefined : positiveInteger(nested, "nested client pid");
+  const records = processRecords();
+  const processTree = [
+    records.find((record) => record.pid === hiddenPanePid),
+    ...descendants(records, hiddenPanePid),
+  ].filter((record) => record !== undefined);
+  const cli = processTree.find(
+    (record) =>
+      record.command.includes(cliPath) &&
+      record.command.includes("tui") &&
+      record.command.includes("--popup") &&
+      record.command.includes("--persistent"),
+  );
+  const renderer = processTree.find(
+    (record) =>
+      record.command.includes("bun") && record.command.includes("src/dashboardRenderer/main.tsx"),
+  );
+  const observerPid = readManifest().observerIdentity.pid;
+  const host = records.find(
+    (record) =>
+      record.command.includes("hostMain.ts") && record.command.includes(manifest.hostSocketPath),
+  );
+  return {
+    serverPid,
+    basePanePid,
+    hiddenPanePid,
+    nestedClientPid,
+    cli,
+    renderer,
+    observerPid,
+    hostPid: host?.pid,
+  };
+}
+
+async function startPtyClient(manifest) {
+  const child = spawn(
+    "python3",
+    ["-c", ptyBridgeScript, process.execPath, wrapperPath, "tmux", "attach"],
+    {
+      cwd: manifest.projectRoot,
+      env: { ...outerEnv, TERM: "xterm-256color" },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  const exit = new Promise((resolveExit, rejectExit) => {
+    child.once("error", rejectExit);
+    child.once("exit", (code, signal) => resolveExit({ code, signal }));
+  });
+  let clientName;
+  await waitFor(() => {
+    const output = tmux(
+      manifest,
+      ["list-clients", "-t", manifest.baseSession, "-F", "#{client_name}"],
+      { check: false },
+    ).stdout.trim();
+    clientName = output.split(/\r?\n/u).find(Boolean);
+    return clientName !== undefined;
+  }, "ordinary PTY client did not attach");
+  return {
+    child,
+    clientName,
+    exit,
+    async write(bytes) {
+      if (!child.stdin.write(bytes)) {
+        await new Promise((resolveDrain, rejectDrain) => {
+          child.stdin.once("drain", resolveDrain);
+          child.stdin.once("error", rejectDrain);
+        });
+      }
+    },
+    async close() {
+      if (clientName !== undefined && privateSessionExists(manifest, manifest.baseSession)) {
+        tmux(manifest, ["detach-client", "-t", clientName], { check: false });
+      }
+      child.stdin.end();
+      child.kill("SIGTERM");
+      await withTimeout(exit, 5_000, "ordinary PTY client did not exit").catch(() => undefined);
+    },
+  };
+}
+
+async function triggerPopup(client) {
+  await client.write(Buffer.from([0x02]));
+  await delay(25);
+  await client.write(Buffer.from(" "));
+}
+
+function captureHiddenPane(manifest) {
+  return tmux(manifest, ["capture-pane", "-p", "-t", manifest.hiddenSession], {
+    check: false,
+  }).stdout;
+}
+
+function privateSessionExists(manifest, sessionName) {
+  return tmux(manifest, ["has-session", "-t", sessionName], { check: false }).status === 0;
+}
+
+function tmux(manifest, args, options = {}) {
+  return checked(manifest.tmuxWrapper, args, {
+    cwd: manifest.root,
+    env: outerEnv,
+    ...options,
+  });
+}
+
+function readManifest() {
+  return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
+
+function assertOwnershipOutput(output, manifest) {
+  for (const expected of [
+    "Station private tmux devbox: running",
+    `checkout key:   ${manifest.checkoutKey}`,
+    `private root:   ${manifest.root}`,
+    `tmux label:     ${manifest.tmuxLabel}`,
+    `tmux wrapper:   ${manifest.tmuxWrapper}`,
+    "tmux config:    /dev/null",
+    `config:         ${manifest.configPath}`,
+    `state root:     ${manifest.stateDir}`,
+    `Observer socket:${manifest.observerSocketPath}`,
+    `Host socket:    ${manifest.hostSocketPath}`,
+    `base session:   ${manifest.baseSession}`,
+    `hidden session: ${manifest.hiddenSession}`,
+    "pnpm station:devbox tmux attach",
+    "pnpm station:devbox tmux logs --follow",
+    "pnpm station:devbox tmux stop",
+  ]) {
+    assertIncludes(output, expected, "ownership output");
+  }
+}
+
+function assertNoLinks(root) {
+  for (const name of readdirSync(root)) {
+    const path = join(root, name);
+    const stat = lstatSync(path);
+    assert(
+      !stat.isSymbolicLink(),
+      `provider home contains a symlink: ${path} -> ${readlinkSync(path)}`,
+    );
+    if (stat.isDirectory()) {
+      assertNoLinks(path);
+    }
+  }
+}
+
+function processRecords() {
+  return checked(
+    process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps",
+    ["-axww", "-o", "pid=,ppid=,command="],
+    { env: { ...outerEnv, LC_ALL: "C" } },
+  )
+    .stdout.split(/\r?\n/u)
+    .flatMap((line) => {
+      const match = /^\s*(\d+)\s+(\d+)\s+(.*)$/u.exec(line);
+      return match === null
+        ? []
+        : [{ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] }];
+    });
+}
+
+function descendants(records, ancestorPid) {
+  const byPid = new Map(records.map((record) => [record.pid, record]));
+  return records.filter((record) => {
+    const visited = new Set();
+    let pid = record.ppid;
+    while (pid > 0 && !visited.has(pid)) {
+      if (pid === ancestorPid) {
+        return true;
+      }
+      visited.add(pid);
+      pid = byPid.get(pid)?.ppid ?? 0;
+    }
+    return false;
+  });
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+function devbox(args, options = {}) {
+  return checked(process.execPath, [wrapperPath, ...args], {
+    cwd: repoRoot,
+    env: options.env ?? outerEnv,
+    ...options,
+  });
+}
+
+function checked(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? outerEnv,
+    encoding: "utf8",
+    timeout: options.timeoutMs ?? timeoutMs,
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  const output = {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+  if (options.check !== false && output.status !== 0) {
+    throw new Error(
+      `\`${command} ${args.join(" ")}\` failed (${output.status}).\n${output.stdout}\n${output.stderr}`,
+    );
+  }
+  return output;
+}
+
+async function waitFor(predicate, message, waitMs = 10_000) {
+  const deadline = Date.now() + waitMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await delay(100);
+  }
+  throw new Error(message);
+}
+
+async function withTimeout(promise, waitMs, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), waitMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function assertTargetUnchanged(stage) {
+  assert(
+    targetMatches(targetBytes),
+    `HMR target changed ${stage}; preserving current bytes at ${hmrTarget}`,
+  );
+}
+
+function restoreTarget() {
+  if (probeTargetBytes === undefined || targetMatches(targetBytes)) {
+    probeTargetBytes = undefined;
+    return undefined;
+  }
+  if (!targetMatches(probeTargetBytes)) {
+    return new Error(
+      `HMR target changed while the smoke probe was active; preserving current bytes at ${hmrTarget}. Remove ${JSON.stringify(probe)} manually if it remains.`,
+    );
+  }
+  try {
+    writeFileSync(hmrTarget, targetBytes);
+    chmodSync(hmrTarget, targetMode);
+    probeTargetBytes = undefined;
+    return undefined;
+  } catch (error) {
+    return new Error(`Could not restore the smoke-owned HMR probe at ${hmrTarget}.`, {
+      cause: error,
+    });
+  }
+}
+
+function targetMatches(bytes) {
+  if (!existsSync(hmrTarget)) {
+    return false;
+  }
+  const targetStat = lstatSync(hmrTarget);
+  return (
+    targetStat.isFile() &&
+    !targetStat.isSymbolicLink() &&
+    (targetStat.mode & 0o777) === targetMode &&
+    readFileSync(hmrTarget).equals(bytes)
+  );
+}
+
+function git(args) {
+  return checked("git", args, { cwd: repoRoot, env: outerEnv }).stdout;
+}
+
+function gitStatus(args) {
+  return checked("git", args, { cwd: repoRoot, env: outerEnv, check: false }).status;
+}
+
+function pathInside(root, path) {
+  const prefix = root.endsWith("/") ? root : `${root}/`;
+  return path === root || path.startsWith(prefix);
+}
+
+function positiveInteger(value, label) {
+  const parsed = Number(String(value).trim());
+  assert(Number.isInteger(parsed) && parsed > 0, `${label} is invalid: ${value}`);
+  return parsed;
+}
+
+function assertIncludes(value, expected, label) {
+  assert(value.includes(expected), `${label} missing ${JSON.stringify(expected)}\n${value}`);
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function sanitizeGitEnvironment(env) {
+  const sanitized = { ...env };
+  for (const key of [
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+  ]) {
+    delete sanitized[key];
+  }
+  return sanitized;
+}

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -16,13 +16,32 @@ import {
   createProcessRendererControlChannel,
 } from "./popupRuntime.js";
 
-/** Callable entry for the read-only OpenTUI dashboard renderer. */
+type DashboardHotRenderer = { destroy(): void };
+type DashboardHotRoot = { unmount(): void };
+type DashboardHotSlots = typeof globalThis & {
+  __stationDashboardHotDispose?: () => void;
+  __stationDashboardHotRenderer?: DashboardHotRenderer;
+};
+
+function dashboardHotSlots(): DashboardHotSlots {
+  return globalThis as DashboardHotSlots;
+}
+
+/**
+ * Callable entry for the read-only OpenTUI dashboard renderer.
+ * Source HMR recreates renderer/client resources while preserving the Bun process and parent IPC.
+ */
 export async function runDashboardMain(): Promise<void> {
   const env = process.env;
+  const hotSlots = dashboardHotSlots();
 
-  let rendererForExit: { destroy(): void } | undefined;
+  // The prior OpenTUI owner must release process-global stdin synchronously before replacement.
+  hotSlots.__stationDashboardHotDispose?.();
+  hotSlots.__stationDashboardHotRenderer?.destroy();
+
+  let disposeResources = (): void => {};
   function exit(code: number): void {
-    rendererForExit?.destroy();
+    disposeResources();
     process.exit(code);
   }
   const popupRuntime = createPopupRuntime(
@@ -46,29 +65,60 @@ export async function runDashboardMain(): Promise<void> {
   const detachSource = store.getState().start();
   client.start();
 
-  const renderer = await createCliRenderer({
-    exitOnCtrlC: false,
-    prependInputHandlers: [createDashboardSequenceHandler(store)],
-    useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,
-  });
-  rendererForExit = renderer;
-  // OpenTUI routes paste around the sequence handlers; forward it as sanitized
-  // text so a paste into search / the new-session name lands as input.
-  renderer.keyInput.on("paste", (event) => {
-    const text = sanitizePastedText(new TextDecoder().decode(event.bytes));
-    if (text.length > 0) {
-      store.getState().handleKey({ input: text });
+  let disposed = false;
+  let renderer: DashboardHotRenderer | undefined;
+  let root: DashboardHotRoot | undefined;
+  const onProcessExit = (): void => disposeResources();
+  disposeResources = (): void => {
+    if (disposed) {
+      return;
     }
-  });
-
-  const root = createRoot(renderer);
-  root.render(<FullscreenDashboard store={store} />);
-
-  process.on("exit", () => {
+    disposed = true;
+    root?.unmount();
     popupRuntime.dispose();
     detachSource();
     void client.stop();
-  });
+    renderer?.destroy();
+    process.off("exit", onProcessExit);
+    if (hotSlots.__stationDashboardHotDispose === disposeResources) {
+      delete hotSlots.__stationDashboardHotDispose;
+    }
+    if (hotSlots.__stationDashboardHotRenderer === renderer) {
+      delete hotSlots.__stationDashboardHotRenderer;
+    }
+  };
+
+  try {
+    const nextRenderer = await createCliRenderer({
+      exitOnCtrlC: false,
+      prependInputHandlers: [createDashboardSequenceHandler(store)],
+      useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,
+    });
+    renderer = nextRenderer;
+    hotSlots.__stationDashboardHotRenderer = nextRenderer;
+    hotSlots.__stationDashboardHotDispose = disposeResources;
+    // OpenTUI routes paste around the sequence handlers; forward it as sanitized
+    // text so a paste into search / the new-session name lands as input.
+    nextRenderer.keyInput.on("paste", (event) => {
+      const text = sanitizePastedText(new TextDecoder().decode(event.bytes));
+      if (text.length > 0) {
+        store.getState().handleKey({ input: text });
+      }
+    });
+
+    const nextRoot = createRoot(nextRenderer);
+    root = nextRoot;
+    nextRoot.render(<FullscreenDashboard store={store} />);
+    process.on("exit", onProcessExit);
+
+    if (import.meta.hot) {
+      import.meta.hot.accept();
+      import.meta.hot.dispose(disposeResources);
+    }
+  } catch (error) {
+    disposeResources();
+    throw error;
+  }
 }
 
 if (import.meta.main) {

--- a/station/src/dashboardRenderer/popupRuntime.test.ts
+++ b/station/src/dashboardRenderer/popupRuntime.test.ts
@@ -228,6 +228,7 @@ describe("createPopupRuntime", () => {
       code: "TUI_RENDERER_CONTROL_DISPOSED",
     });
     expect(disposedChannel.unsubscribeCount).toBe(1);
+    expect(disposedChannel.closeCount).toBe(0);
     expect(disposedControlLossCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- add a checkout-keyed `station:devbox tmux` namespace with dev, start, attach, status, logs, stop, reset, and help workflows
- run the production popup CLI on a private tmux server with isolated HOME, XDG, provider, config, Observer, socket, log, and disposable-project state
- keep the CLI-owned renderer IPC and Bun process stable while dashboard resources hot-reload in place
- add an opt-in real lifecycle/HMR smoke and document ownership, restart boundaries, safety, cleanup, and manual verification

Implements item 7 of #169.

## Why

Real popup development previously required assembling private tmux, isolated Station state, popup ownership, and renderer hot reload by hand. This lane makes that workflow repeatable without reading from or mutating the default tmux server or the developer's real Station/auth configuration.

## UX

Run `pnpm station:devbox tmux dev`, attach from another terminal with `pnpm station:devbox tmux attach`, and press `Ctrl-b Space`. Dashboard source edits repaint the open popup without restarting the tmux server, CLI parent, renderer process, Observer, or nested client.

## Validation

- `pnpm test:pre-push`
- `pnpm station:devbox:smoke -- --skip-build`
- `pnpm station:devbox:tmux:smoke`
- focused runtime build-info and dashboard popup-runtime tests
- root and Station typechecks and lint
- local binary build and two-artifact binary smoke

The existing real-tmux suite passes its first three scenarios. Its compiled managed-binding reopen scenario times out identically on an untouched `origin/main` checkout at `b41a9a3`; this PR does not modify that fixture or fast-binding implementation.

## Hosted CI

`standard-ci` did not start a runner or execute any steps. GitHub annotated the check as blocked because recent account payments failed or the spending limit needs to be increased. The complete local pre-push gate passed before publication.
