### PR TITLE
refactor(installer): prefer explicit PATH guidance over profile mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ gh auth login --hostname github.com
     repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  sh "$installer" --version "$tag" --persist-path
+  sh "$installer" --version "$tag"
 )
 ```
 
-The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to your login-shell profile. It does not infer a project from the install directory. In the same shell, make the default install available immediately, run guided setup, verify it, and launch the full workspace:
+The installer installs and physically verifies all three Station launchers, but it does not read, create, or edit shell startup files and does not infer a project from the install directory. If any launcher is missing or shadowed in the current process, it prints one safely quoted `export PATH=...` command for future shells; add that command to the shell configuration you choose. It also prints a current-shell recovery block ending in `stn setup` and an `Absolute fallback` using the installed `stn`. In the same shell, the default install can be made available explicitly before guided setup, verification, and launch:
 
 ```sh
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -78,13 +78,13 @@ stn doctor
 stn tui
 ```
 
-`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, and writes a valid zero-project `~/.config/station/config.toml`; it never adds the current directory implicitly. It can also add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell; `--persist-path` makes the same directory available to future login shells. Omit that flag to leave profiles unchanged and receive an exact opt-in command instead. If you chose a custom install directory, use the exact PATH block printed by the installer instead.
+`stn setup` can install missing Worktrunk, tmux, diffnav, and git-delta through Homebrew, requires one supported agent CLI, and writes a valid zero-project `~/.config/station/config.toml`; it never adds the current directory implicitly. It can also add provider hooks and the tmux popup binding. Complete the selected agent CLI's own sign-in if needed before starting a real session. The PATH assignment above lasts only for the current shell. For future shells, place the installer's exact export in your chosen shell configuration yourself; the installer never chooses or edits that file. If you chose a custom install directory, use its printed PATH block or the printed absolute `stn setup` fallback instead.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. On the empty dashboard, press `Enter` (or `A`) on **Add your first project**, choose a folder inside an existing Git repository, and confirm it. Station resolves nested selections to their Git root and will not add an ordinary non-Git folder. Then press `N`, review the project, generated session name, and agent in the **Create Session** dialog, and press `Enter` on **Create session** to start the agent session.
 
 `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
-The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
+The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. It checks all three physical launcher resolutions rather than relying on textual PATH membership. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
 
 `v0.7.0` is the first supported private-binary baseline. The installer code
 and artifacts always come from the same immutable tag. The latest-install

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,10 +107,11 @@ pnpm smoke:install
 ```
 
 `pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
-authenticated GitHub responses and temporary homes, including isolated zsh
-login-profile and minimal-PATH fresh-shell coverage, so it is deterministic and
-does not download a real release or modify the real profile. The single Ubuntu
-CI gate runs it once. On a heavily contended local host, run
+authenticated GitHub responses and temporary homes, including startup-file
+non-interaction, safely evaluated minimal-PATH guidance, physical launcher
+resolution, and normalized-colon preflight coverage. It is deterministic, does
+not download a real release, and does not read or modify real shell startup
+files. The single Ubuntu CI gate runs it once. On a heavily contended local host, run
 `STATION_INSTALL_SMOKE_TIMEOUT_SCALE=4 pnpm smoke:install` to scale only the
 harness deadlines; the default and hosted gate remain strict.
 The release workflow builds and smokes the compiled binary on all four native
@@ -450,9 +451,12 @@ then quit and reopen `stn tui` and confirm the session remains.
 If the compiled tmux binding was enabled, use `tmux prefix + Space` for the cold
 open, close the popup with the same chord, and use it again for a warm reopen.
 Confirm both opens are silent in the calling pane and the warm open reuses the
-existing `_station-ui` session. Finally confirm the installer did not edit a
-shell profile, run the exact idempotent future-shell PATH opt-in command it
-printed, open a new login shell, and verify `stn --version` still resolves.
+existing `_station-ui` session. Finally confirm the installer did not read or
+edit shell startup files. Copy the one future-shell export it printed into a
+shell configuration you choose,
+open a new login shell, and verify all three physical launcher resolutions and
+`stn --version`. The installer, not the user-facing PATH text alone, must have
+verified those launchers after installation.
 Preserve the exact command and output at the first failure; for a runtime
 failure with no known trace ID, start with `stn debug trace --latest-failure`.
 
@@ -461,17 +465,19 @@ manually verify the actual user experience, not a dashboard override:
 
 1. Install into a clean default `HOME` with `XDG_DATA_HOME` unset and an install
    directory absent from `PATH`. Confirm all three missing launchers are named,
-   the profile is unchanged without `--persist-path`, the printed exact opt-in
-   command is idempotent, the current-shell block prepends the safely quoted
-   directory and runs `hash -r` plus `stn setup`, and the absolute `stn`
-   fallback works.
-2. Repeat with `--persist-path`, an existing zsh `.zprofile` containing only
-   Homebrew setup, and an older launcher shadowing the install. Confirm the
-   profile content and mode are preserved, one entry prepends the exact install
-   directory, a new login shell resolves all three launchers there, and a
-   second install adds no duplicate entry. With all three launchers already
-   resolving physically to the install directory, confirm the short
-   `Next: run stn setup` success message.
+   every shell startup file remains absent, the one future-shell export is
+   safely quoted for a user-chosen shell configuration, the current-shell block
+   runs `hash -r` plus `stn setup`, and the absolute `stn` fallback works.
+2. Repeat with existing zsh and bash startup files containing distinct sentinel
+   bytes and modes, startup-file symlinks, an older launcher shadowing the
+   install, and custom install directories containing spaces and apostrophes.
+   Confirm two installs leave every startup file, inode, mode, symlink, and
+   target unchanged. Copy the printed export manually into the file you choose,
+   open a new login shell, and physically verify all three launchers. Also
+   confirm a normalized install path containing `:` fails before any GitHub
+   request or installer-created path. With all three launchers already resolving
+   physically to the install directory, confirm the short `Next: run stn setup`
+   success message.
 3. With the installed binary's runtime `PATH` containing neither Node nor Bun,
    run bare `stn` outside tmux. Confirm the real OpenTUI first-run screen draws
    and connects to a healthy Observer.

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@ gh auth login --hostname github.com
     repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  sh "$installer" --version "$tag" --persist-path
+  sh "$installer" --version "$tag"
 )
 ```
 
@@ -37,7 +37,20 @@ The recipe never falls back to `main`. `gh` handles private-repository authentic
 
 ### Complete first-run setup
 
-The installer block installs the Station binaries and, with the explicit `--persist-path` consent above, adds the install directory to the supported login-shell profile. It does not infer a project from the install directory. Because profile changes apply to future login shells, the remaining handoff for the current shell is:
+The installer installs the Station artifacts and physically verifies all three bare launchers. It does not infer a project from the install directory, and it does not read, create, or edit shell startup files. Shell configuration placement is always user-owned:
+
+| Concern | Owner |
+| --- | --- |
+| Download and install artifacts | Station installer |
+| Verify all launcher paths physically resolve to the installed runtime | Station installer |
+| Detect current-process PATH mismatch | Station installer |
+| Print a current-shell recovery block | Station installer |
+| Print one future-shell export command | Station installer |
+| Choose a shell startup file | User |
+| Modify `.zprofile`, `.zshrc`, `.bash_profile`, `.bash_login`, `.bashrc`, `.profile`, or files under ZDOTDIR | Never the installer |
+| Run `stn setup` | User, with an absolute fallback supplied by the installer |
+
+For immediate availability in the current shell with the default install directory, run:
 
 ```bash
 PATH="$HOME/.local/bin${PATH:+":$PATH"}"
@@ -50,15 +63,15 @@ stn doctor
 stn tui
 ```
 
-If the installer reported a PATH mismatch, its printed current-shell block is the authoritative equivalent and already ends with `stn setup`. It is safe to run that block from `HOME`, Desktop, or another ordinary directory. If you used `--install-dir`, use its printed path instead of `~/.local/bin`.
+If any launcher is missing or physically resolves somewhere else, the installer names every mismatch. It then prints one safely quoted `export PATH=...` command to add to your chosen shell configuration for future shells, followed by the authoritative current-shell block ending in `stn setup` and an `Absolute fallback` that invokes the installed binary directly. It is safe to run the current-shell block from `HOME`, Desktop, or another ordinary directory. If you used `--install-dir`, use the exact printed commands instead of substituting `~/.local/bin`.
 
 Guided setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta through Homebrew; requires one supported agent CLI; writes a valid zero-project `~/.config/station/config.toml`; starts or restarts the Observer; and optionally installs Worktrunk and agent hooks, Worktrunk shell integration, and the `Ctrl-b Space` tmux popup binding. Setup never adopts its current directory or an ancestor repository. Setup checks that the selected agent command runs, but it does not authenticate that provider, so complete the agent CLI's normal sign-in before starting a real session. The compiled Station binary itself does not require Node.js, pnpm, or Bun.
 
-The PATH assignment above affects only the current shell. `--persist-path` adds an idempotent entry to the login-shell profile selected from `SHELL` (`.zprofile` for zsh, the first existing bash login profile, or `.profile` for POSIX shells) while preserving existing content such as Homebrew setup. Omit the flag to leave profiles unchanged; unless the exact entry is already present, the installer prints the idempotent command you can run instead, even when its own shell temporarily resolves the launchers. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
+The PATH assignment above affects only the current shell. To make Station available in future shells, copy the installer's export into the shell configuration you choose; the installer never chooses or edits that file. `stn tui` forces the full workspace both inside and outside tmux. After onboarding, bare `stn` opens that workspace outside tmux and the read-only popup dashboard inside tmux.
 
 On the cold-boot welcome screen, press `Enter` or `Space` to open project view. On the empty dashboard, press `Enter` (or `A`) on **Add your first project**, choose a folder inside an existing Git repository, and confirm it. A nested folder resolves to its Git root; an ordinary non-Git folder cannot be added from this flow. Then press `N`, review the project, generated session name, and agent in the **Create Session** dialog, and press `Enter` on **Create session** to start the agent session.
 
-Pass `--install-dir PATH` to override the default `~/.local/bin`, and combine it with `--persist-path` to persist that exact custom directory; run `scripts/install.sh --help` from a checkout for the complete command surface.
+Pass `--install-dir PATH` to override the default `~/.local/bin`; run `scripts/install.sh --help` from a checkout for the complete command surface. The normalized install directory cannot contain `:` because PATH uses `:` to separate entries. This validation happens before GitHub requests, temporary-directory creation, or destination mutation.
 
 The installer:
 
@@ -68,7 +81,7 @@ The installer:
 - stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command; compatibility failures include at most 4096 sanitized bytes of probe stderr;
 - keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
 - removes `com.apple.quarantine` from the verified binary defensively on macOS; and
-- resolves all three bare launchers after installation. If any is missing or shadowed, it names every mismatch, prints a safely quoted current-shell block that prepends the install directory, runs `hash -r`, and starts `stn setup`, and also prints the absolute installed `stn` path. Profile persistence occurs only with `--persist-path`; otherwise it prints an exact opt-in command and leaves the profile unchanged.
+- physically resolves all three bare launchers after installation. If any is missing or shadowed, it names every mismatch, prints one safely quoted future-shell export for the user's chosen shell configuration, prints a current-shell block that prepends the install directory, runs `hash -r`, and starts `stn setup`, and prints an absolute installed `stn` fallback. If all three launchers already resolve to the installed runtime, it prints only `Next: run stn setup`.
 
 ### Concurrent and interrupted installs
 
@@ -191,8 +204,9 @@ Optional integrations can be added later.
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
 `pnpm smoke:install` exercises latest, explicit, and draft selection; strict
-authenticated API arguments; all four platform mappings; isolated-home login
-profile persistence, minimal-PATH fresh shells, PATH shadow behavior;
+authenticated API arguments; all four platform mappings; startup-file
+non-interaction, safely evaluated PATH guidance for spaces and apostrophes,
+normalized-colon preflight, and physical PATH shadow behavior;
 checksum/archive/probe failures; dual-lock concurrency and stale recovery;
 rollback and ambiguous commit points; continuous readers; HUP/INT/TERM/SIGKILL;
 and runner self-interruption against local fake release assets. Every child and

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -481,13 +481,14 @@ cross-filesystem `LICENSE` metadata may also remain. The deterministic
 assets and is part of `test:all`.
 
 After success, all three bare launchers are resolved physically. If every one
-points into the new install directory, the installer prints
+points into the new install directory, the installer prints only
 `Next: run stn setup`. Otherwise it names every missing or shadowed launcher,
-prints a safely shell-quoted current-shell block that prepends the directory,
-runs `hash -r`, and invokes `stn setup`, plus the absolute installed `stn`
-fallback. Profile persistence is explicit: `--persist-path` appends one
-idempotent login-profile entry, while an install without the flag leaves the
-profile unchanged and prints an exact opt-in command.
+prints one safely shell-quoted future-shell export for the user's chosen shell
+configuration, prints a current-shell block that prepends the directory, runs
+`hash -r`, and invokes `stn setup`, plus the absolute installed `stn` fallback.
+The future-shell export appears only when physical current-process resolution
+is incomplete. The installer never reads, selects, creates, or edits shell
+startup files.
 
 The first binary release is immutable `v0.7.0` and promotes only after all four
 native targets pass automated and manual acceptance. Published tags and assets
@@ -671,11 +672,15 @@ flow:
 
 1. Install in a clean default home with the directory missing from `PATH`,
    then with an older `stn` and one sibling launcher shadowing it → every
-   mismatch is named, the current-shell recovery block works, and an install
-   without `--persist-path` leaves the profile unchanged. Repeat with explicit
-   persistence into a Homebrew-only `.zprofile`; a fresh shell must resolve all
-   three launchers, and a second install must not duplicate the entry. With all
-   three physical resolutions correct, the short setup next step is printed.
+   mismatch is named, the one future-shell export and current-shell recovery
+   block both evaluate safely, and the absolute fallback works. Repeat with
+   startup files containing sentinel bytes, modes, and symlinks, plus custom
+   install directories containing spaces and apostrophes; two installs must
+   leave every startup path unchanged. Copy the export manually into a shell
+   configuration chosen by the user, then verify a fresh shell physically
+   resolves all three launchers. A normalized install path containing `:` must
+   fail before GitHub access or local mutation. With all three physical
+   resolutions correct, only the short setup next step is printed.
 2. Launch bare `stn` outside tmux in a sanitized, isolated env → real
    OpenTUI renderer draws, observer connects, first-run screen shows.
 3. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,10 +9,6 @@ export GH_HOST=$github_host
 requested_version=""
 requested_version_set=0
 install_dir=""
-persist_path=0
-path_profile=""
-path_profile_entry=""
-path_profile_error=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
 install_stage=""
@@ -43,29 +39,24 @@ runtime_committed=0
 activation_ambiguity_reported=0
 activation_failed_precommit=0
 rollback_failed=0
-profile_update_failed=0
-profile_updating=0
 created_ingress=0
 created_popup=0
 created_ingress_inode=""
 created_popup_inode=""
 preserve_install_stage=0
-preserve_temp_dir=0
 line_feed='
 '
 tab='	'
-carriage_return=$(printf '\r')
 
 usage() {
   cat <<'EOF'
-Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH] [--persist-path]
+Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH]
 
 Install the latest stable private Station release, or an explicit version.
 
 Options:
   --version VERSION   Install an immutable v-prefixed release version.
   --install-dir PATH  Install commands here (default: ~/.local/bin).
-  --persist-path      Add the install directory to the login-shell profile.
   -h, --help          Show this help.
 EOF
 }
@@ -95,142 +86,6 @@ print_shell_word() {
         ;;
     esac
   done
-}
-
-select_path_profile() {
-  path_profile=""
-  path_profile_error=""
-  path_profile_shell=${SHELL:-}
-  path_profile_shell=${path_profile_shell##*/}
-  [ -n "${HOME:-}" ] || return 1
-  case "$path_profile_shell" in
-    zsh)
-      if [ "${ZDOTDIR+x}" != x ]; then
-        if "$SHELL" -l -c 'if [ "${ZDOTDIR+x}" = x ]; then exit 42; fi; exit 0' </dev/null >/dev/null 2>&1; then
-          :
-        else
-          zsh_probe_status=$?
-          if [ "$zsh_probe_status" -eq 42 ]; then
-            path_profile_error="zsh has a non-exported ZDOTDIR; export ZDOTDIR before using --persist-path."
-          else
-            path_profile_error="could not determine zsh's profile directory; export ZDOTDIR before using --persist-path."
-          fi
-          return 1
-        fi
-      fi
-      path_profile=${ZDOTDIR:-$HOME}/.zprofile
-      path_profile_shell=zsh
-      ;;
-    bash)
-      path_profile_shell=bash
-      for profile_candidate in "$HOME/.bash_profile" "$HOME/.bash_login" "$HOME/.profile"; do
-        if [ -e "$profile_candidate" ] || [ -L "$profile_candidate" ]; then
-          path_profile=$profile_candidate
-          break
-        fi
-      done
-      [ -n "$path_profile" ] || path_profile=$HOME/.bash_profile
-      ;;
-    sh|dash|ksh)
-      path_profile=$HOME/.profile
-      ;;
-    *) return 1 ;;
-  esac
-}
-
-prepare_path_profile() {
-  select_path_profile || return 1
-  case "$install_dir" in
-    *:*|*"$line_feed"*|*"$carriage_return"*) return 1 ;;
-  esac
-  path_profile_entry=$(
-    printf 'export PATH='
-    print_shell_word "$install_dir"
-    printf '%s' '${PATH:+":$PATH"}'
-  )
-}
-
-validate_path_profile() {
-  path_profile_parent=${path_profile%/*}
-  if [ -e "$path_profile" ] || [ -L "$path_profile" ]; then
-    [ -f "$path_profile" ] || fail "--persist-path requires '$path_profile' to be a regular file."
-    [ -r "$path_profile" ] && [ -w "$path_profile" ] || fail "--persist-path requires '$path_profile' to be readable and writable."
-    return 0
-  fi
-  [ -d "$path_profile_parent" ] && [ -w "$path_profile_parent" ] || fail "--persist-path cannot create '$path_profile'; its parent directory must be writable."
-}
-
-path_profile_entry_present() {
-  [ -f "$path_profile" ] || return 1
-  if grep -F -x -q "$path_profile_entry" "$path_profile" 2>/dev/null; then
-    return 0
-  fi
-  [ "$install_dir" = "$HOME/.local/bin" ] || return 1
-  grep -F -x -q 'export PATH="$HOME/.local/bin:$PATH"' "$path_profile" 2>/dev/null
-}
-
-print_path_persistence_command() {
-  printf 'Future-shell PATH was not changed. To persist Station for %s login shells in ' "$path_profile_shell"
-  print_shell_word "$path_profile"
-  printf ', run:\n  if ! grep -F -x -q '
-  print_shell_word "$path_profile_entry"
-  printf ' '
-  print_shell_word "$path_profile"
-  printf ' 2>/dev/null; then if [ -s '
-  print_shell_word "$path_profile"
-  printf ' ]; then printf '
-  print_shell_word '\n%s\n'
-  printf ' '
-  print_shell_word "$path_profile_entry"
-  printf '; else printf '
-  print_shell_word '%s\n'
-  printf ' '
-  print_shell_word "$path_profile_entry"
-  printf '; fi >> '
-  print_shell_word "$path_profile"
-  printf '; fi\n'
-}
-
-persist_path_profile() {
-  if path_profile_entry_present; then
-    printf 'Future-shell PATH is already configured in '
-    print_shell_word "$path_profile"
-    printf '.\n'
-    return 0
-  fi
-  profile_existed=0
-  profile_backup=$temp_dir/path-profile.previous
-  if [ -e "$path_profile" ] || [ -L "$path_profile" ]; then
-    cp "$path_profile" "$profile_backup" || return 1
-    profile_existed=1
-  fi
-  # Defer caught signals until a failed in-place append can restore the original profile bytes.
-  profile_updating=1
-  profile_append_status=0
-  # Append in place so an existing profile keeps its ownership, mode, and symlink target.
-  if [ -s "$path_profile" ]; then
-    printf '\n%s\n' "$path_profile_entry" >> "$path_profile" || profile_append_status=$?
-  else
-    printf '%s\n' "$path_profile_entry" >> "$path_profile" || profile_append_status=$?
-  fi
-  if [ "$profile_append_status" -ne 0 ] || [ "$pending_signal_status" -ne 0 ]; then
-    if [ "$profile_existed" -eq 1 ]; then
-      if ! cat "$profile_backup" > "$path_profile"; then
-        preserve_temp_dir=1
-        warn "could not restore '$path_profile'; its original bytes remain at '$profile_backup'."
-      fi
-    elif ! rm -f "$path_profile"; then
-      warn "could not remove the partial profile '$path_profile'."
-    fi
-    profile_updating=0
-    finish_pending_signal
-    return 1
-  fi
-  profile_updating=0
-  finish_pending_signal
-  printf 'Added Station to future %s login shells in ' "$path_profile_shell"
-  print_shell_word "$path_profile"
-  printf '.\n'
 }
 
 readlink_target() {
@@ -403,9 +258,7 @@ cleanup() {
     fi
   fi
 
-  if [ "$preserve_temp_dir" -eq 0 ]; then
-    remove_tree "$temp_dir"
-  fi
+  remove_tree "$temp_dir"
   if [ "$preserve_install_stage" -eq 0 ]; then
     remove_tree "$install_stage"
   fi
@@ -424,7 +277,7 @@ cleanup() {
 on_signal() {
   signal=$1
   status=$2
-  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ] || [ "$profile_updating" -eq 1 ]; then
+  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ]; then
     if [ "$pending_signal_status" -eq 0 ]; then
       pending_signal_name=$signal
       pending_signal_status=$status
@@ -598,11 +451,6 @@ while [ "$#" -gt 0 ]; do
       install_dir=$2
       shift 2
       ;;
-    --persist-path)
-      [ "$persist_path" -eq 0 ] || fail "--persist-path may be specified only once."
-      persist_path=1
-      shift
-      ;;
     -h|--help)
       usage
       exit 0
@@ -642,13 +490,10 @@ if [ -z "$install_dir" ]; then
 fi
 absolute_path "$install_dir"
 install_dir=$absolute_result
-if [ "$persist_path" -eq 1 ]; then
-  if ! prepare_path_profile; then
-    [ -z "$path_profile_error" ] || fail "$path_profile_error"
-    fail "--persist-path requires a supported login shell (zsh, bash, sh, dash, or ksh) and an install directory without colons or line breaks."
-  fi
-  validate_path_profile
-fi
+# Reject after absolutizing and before external or local mutation because PATH cannot encode a literal colon in one entry.
+case "$install_dir" in
+  *:*) fail "install directory cannot contain ':' because PATH uses ':' to separate entries." ;;
+esac
 
 if [ -n "${XDG_DATA_HOME:-}" ]; then
   absolute_path "$XDG_DATA_HOME"
@@ -1157,33 +1002,13 @@ check_launcher_resolution stn "$binary_path"
 check_launcher_resolution stn-ingress "$ingress_path"
 check_launcher_resolution stn-tmux-popup "$popup_path"
 
-if [ "$persist_path" -eq 1 ]; then
-  if ! persist_path_profile; then
-    warn "Station was installed, but '$path_profile' could not be updated for future shells."
-    print_path_persistence_command
-    profile_update_failed=1
-  fi
-else
-  if prepare_path_profile; then
-    if path_profile_entry_present; then
-      printf 'Future-shell PATH is already configured in '
-      print_shell_word "$path_profile"
-      printf '.\n'
-    else
-      print_path_persistence_command
-    fi
-  else
-    printf 'Future-shell PATH was not changed. Add '
-    print_shell_word "$install_dir"
-    printf ' ahead of PATH in the startup file for login shell '
-    print_shell_word "${SHELL:-unknown}"
-    printf '.\n'
-  fi
-fi
-
 if [ "$path_mismatch" -eq 0 ]; then
   printf 'Next: run stn setup\n'
 else
+  printf 'To use Station in future shells, add this command to your chosen shell configuration:\n'
+  printf '  export PATH='
+  print_shell_word "$install_dir"
+  printf '${PATH:+":$PATH"}\n\n'
   printf 'Run this block in the current shell, then continue setup:\n'
   printf '  PATH='
   print_shell_word "$install_dir"
@@ -1195,4 +1020,3 @@ else
   print_shell_word "$binary_path"
   printf ' setup\n'
 fi
-exit "$profile_update_failed"

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -40,6 +40,7 @@ const tempDir = join(root, "tmp");
 const ghLogsDir = join(root, "gh-logs");
 const stableTag = "v1.2.3";
 const rollbackTag = "v1.2.3-rc.1";
+const removedPersistenceOption = ["--persist", "path"].join("-");
 const activeChildren = new Set();
 const childTimeoutMs = 30_000 * timeoutScale;
 const markerTimeoutMs = 10_000 * timeoutScale;
@@ -82,7 +83,7 @@ try {
     prepareFixtures();
     await scenarioPlatformInstalls();
     await scenarioDefaultHomeAndPathResolution();
-    await scenarioFutureShellPathPersistence();
+    await scenarioPathGuidanceAndStartupFileNonOwnership();
     await scenarioExplicitRollbackAndDraft();
     await scenarioStrictGhFlows();
     await scenarioAuthenticatedReleaseValidation();
@@ -188,18 +189,9 @@ function prepareFixtures() {
 }
 
 function scenarioPlatformInstalls() {
-  const shellWithoutShell = join(root, "shell-without-shell");
-  writeExecutable(
-    shellWithoutShell,
-    '#!/bin/sh\ninstaller=$1\nshift\nunset SHELL\n. "$installer"\n',
-  );
-  for (const [index, platform] of platforms.entries()) {
+  for (const platform of platforms) {
     const installDir = join(root, `install-${platform.target}`);
-    const result = runInstaller({
-      installDir,
-      platform,
-      childShell: index === 0 ? shellWithoutShell : "/bin/sh",
-    });
+    const result = runInstaller({ installDir, platform });
     assertSuccess(result, `${platform.target} latest install`);
     assertInstalled({ installDir, tag: stableTag, target: platform.target });
     assertPathRecovery(result, installDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
@@ -226,9 +218,34 @@ function scenarioDefaultHomeAndPathResolution() {
     target: "linux-x64",
   });
   assertPathRecovery(defaultInstall, defaultInstallDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
-  for (const profile of [".profile", ".bashrc", ".zprofile", ".zshrc"]) {
-    assert(!existsSync(join(cleanHome, profile)), `installer leaves ${profile} absent`);
+  for (const startupFile of [
+    ".zprofile",
+    ".zshrc",
+    ".bash_profile",
+    ".bash_login",
+    ".bashrc",
+    ".profile",
+  ]) {
+    assert(!existsSync(join(cleanHome, startupFile)), `installer leaves ${startupFile} absent`);
   }
+
+  const partialPathDir = join(root, "partial-launcher-path");
+  const partialPathInstall = join(root, "partial-launcher-bin");
+  makeDirectory(partialPathDir);
+  symlinkSync(join(partialPathInstall, "stn"), join(partialPathDir, "stn"));
+  symlinkSync(join(partialPathInstall, "stn-ingress"), join(partialPathDir, "stn-ingress"));
+  const partialPath = runInstaller({
+    installDir: partialPathInstall,
+    platform: linuxX64(),
+    pathEntries: [partialPathDir, fakeBinDir, "/usr/bin", "/bin"],
+  });
+  assertSuccess(partialPath, "one missing launcher");
+  assertPathRecovery(
+    partialPath,
+    partialPathInstall,
+    ["stn-tmux-popup"],
+    [partialPathDir, fakeBinDir, "/usr/bin", "/bin"],
+  );
 
   const shadowedStnDir = join(root, "shadowed-stn-path");
   const shadowedStnInstall = join(root, "shadowed-stn-bin");
@@ -274,319 +291,139 @@ function scenarioDefaultHomeAndPathResolution() {
   );
 
   const correctInstallDir = join(root, "correct-path-bin");
-  const correctPathHome = join(root, "correct-path-home");
-  makeDirectory(correctPathHome);
   const correctPath = runInstaller({
     installDir: correctInstallDir,
     platform: linuxX64(),
-    home: correctPathHome,
     pathEntries: [correctInstallDir, fakeBinDir, "/usr/bin", "/bin"],
-    environment: { SHELL: "/bin/zsh" },
   });
   assertSuccess(correctPath, "all launchers on correct PATH");
   assertIncludes(correctPath.stdout, "Next: run stn setup", "correct PATH next step");
-  assertNotIncludes(correctPath.stdout, "hash -r", "correct PATH omits recovery block");
-  assertIncludes(
-    correctPath.stdout,
-    "Future-shell PATH was not changed",
-    "temporary correct PATH still receives future-shell guidance",
-  );
-  assert(!existsSync(join(correctPathHome, ".zprofile")), "correct PATH leaves profile absent");
+  assertNotIncludes(correctPath.stdout, "PATH mismatch:", "correct PATH mismatch omission");
+  assertNotIncludes(correctPath.stdout, "future shells", "correct PATH future guidance omission");
+  assertNotIncludes(correctPath.stdout, "hash -r", "correct PATH recovery omission");
+  assertNotIncludes(correctPath.stdout, "Absolute fallback:", "correct PATH fallback omission");
 }
 
-function scenarioFutureShellPathPersistence() {
-  const installDir = join(root, "Station's custom bin");
-  const zsh = join(fakeBinDir, "zsh");
-  const shadowDir = join(root, "future-shell-shadow-bin");
-  const currentPath = [shadowDir, fakeBinDir, "/usr/bin", "/bin"];
-  const homebrewProfile = [
-    "# Homebrew shell environment",
-    'export HOMEBREW_PREFIX="/opt/homebrew"',
-    "",
-  ].join("\n");
-  const expectedEntry = `export PATH=${shellWord(installDir)}\${PATH:+":$PATH"}`;
-  makeDirectory(shadowDir);
-  for (const launcher of ["stn", "stn-ingress", "stn-tmux-popup"]) {
-    writeExecutable(join(shadowDir, launcher), "#!/bin/sh\nexit 99\n");
-  }
-
-  const consentHome = join(root, "future-shell-consent-home");
-  const consentProfile = join(consentHome, ".zprofile");
-  makeDirectory(consentHome);
-  writeText(consentProfile, homebrewProfile, 0o640);
-  const profileBefore = statSync(consentProfile);
-  const consent = runInstaller({
-    installDir,
-    platform: linuxX64(),
-    home: consentHome,
-    pathEntries: currentPath,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
-  });
-  assertSuccess(consent, "explicit future-shell PATH persistence");
-  assertIncludes(
-    consent.stdout,
-    "Added Station to future zsh login shells",
-    "explicit persistence confirmation",
-  );
-  const persistedProfile = readFileSync(consentProfile, "utf8");
-  assert(persistedProfile.startsWith(homebrewProfile), "persistence preserves Homebrew setup");
-  assertEqual(
-    countExactLines(persistedProfile, expectedEntry),
-    1,
-    "explicit persistence adds one exact PATH entry",
-  );
-  const profileAfter = statSync(consentProfile);
-  assertEqual(profileAfter.ino, profileBefore.ino, "persistence appends to the existing profile");
-  assertEqual(
-    profileAfter.mode & 0o777,
-    profileBefore.mode & 0o777,
-    "persistence preserves profile mode",
-  );
-  assertFutureShellLauncherResolution({
-    home: consentHome,
-    installDir,
-    profile: consentProfile,
-    shadowDir,
-  });
-
-  const idempotent = runInstaller({
-    installDir,
-    platform: linuxX64(),
-    home: consentHome,
-    pathEntries: currentPath,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
-  });
-  assertSuccess(idempotent, "idempotent future-shell PATH persistence");
-  assertIncludes(
-    idempotent.stdout,
-    "Future-shell PATH is already configured",
-    "idempotent persistence confirmation",
-  );
-  assertEqual(
-    readFileSync(consentProfile, "utf8"),
-    persistedProfile,
-    "repeated persistence leaves profile byte-identical",
-  );
-
-  const noConsentHome = join(root, "future-shell-no-consent-home");
-  const noConsentProfile = join(noConsentHome, ".zprofile");
-  makeDirectory(noConsentHome);
-  writeText(noConsentProfile, homebrewProfile, 0o600);
-  const noConsent = runInstaller({
-    installDir,
-    platform: linuxX64(),
-    home: noConsentHome,
-    pathEntries: currentPath,
-    environment: { SHELL: zsh },
-  });
-  assertSuccess(noConsent, "future-shell PATH without consent");
-  assertEqual(
-    readFileSync(noConsentProfile, "utf8"),
-    homebrewProfile,
-    "no-flag install leaves profile unchanged",
-  );
-  const persistenceCommand = extractPathPersistenceCommand(noConsent.stdout);
-  const commandResult = spawnSync(
-    "/bin/sh",
-    ["-c", persistenceCommand],
-    syncOptions({ env: { HOME: noConsentHome, PATH: "/usr/bin:/bin" } }),
-  );
-  assertSuccess(commandResult, "printed future-shell PATH command");
-  assertEqual(
-    countExactLines(readFileSync(noConsentProfile, "utf8"), expectedEntry),
-    1,
-    "printed command adds one exact PATH entry",
-  );
-  assertFutureShellLauncherResolution({
-    home: noConsentHome,
-    installDir,
-    profile: noConsentProfile,
-    shadowDir,
-  });
-
-  const missingProfileHome = join(root, "future-shell-missing-profile-home");
-  const missingProfile = join(missingProfileHome, ".zprofile");
-  const missingProfileInstall = join(root, "future-shell-missing-profile-bin");
-  makeDirectory(missingProfileHome);
-  const created = runInstaller({
-    installDir: missingProfileInstall,
-    platform: linuxX64(),
-    home: missingProfileHome,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
-  });
-  assertSuccess(created, "future-shell PATH creates a missing zprofile");
-  assertEqual(
-    readFileSync(missingProfile, "utf8"),
-    `export PATH=${shellWord(missingProfileInstall)}\${PATH:+":$PATH"}\n`,
-    "new zprofile contains only the exact PATH entry",
-  );
-  assertMode(missingProfile, 0o600, "new zprofile mode");
-
-  const partialAppendShell = join(root, "partial-profile-append-shell");
-  writeExecutable(
-    partialAppendShell,
-    `#!/bin/sh
-printf() {
-  if [ "\${FAKE_PROFILE_APPEND_MODE:-}" != '' ] && [ "\${2-}" = "$FAKE_PROFILE_ENTRY" ]; then
-    command printf '\\n%.20s' "$2"
-    if [ "$FAKE_PROFILE_APPEND_MODE" = signal ]; then
-      kill -TERM "$$"
-      return 0
-    fi
-    return 1
-  fi
-  command printf "$@"
-}
-installer=$1
-shift
-. "$installer"
-`,
-  );
-  for (const [mode, expectedStatus] of [
-    ["failure", 1],
-    ["signal", 143],
-  ]) {
-    const partialHome = join(root, `future-shell-partial-${mode}-home`);
-    const partialProfile = join(partialHome, ".zprofile");
-    const originalProfile = `# profile before ${mode}\n`;
-    makeDirectory(partialHome);
-    writeText(partialProfile, originalProfile, 0o640);
-    const partial = runInstaller({
-      installDir,
+function scenarioPathGuidanceAndStartupFileNonOwnership() {
+  const startupHome = join(root, "startup-files-home");
+  const startupTargets = join(startupHome, "startup-targets");
+  const hostileZdotDir = join(startupHome, "hostile-zdotdir");
+  makeDirectory(startupTargets);
+  makeDirectory(hostileZdotDir);
+  writeText(join(startupHome, ".zprofile"), "# zprofile sentinel\n", 0o600);
+  writeText(join(startupHome, ".bash_profile"), "# bash profile sentinel\n", 0o640);
+  writeText(join(startupHome, ".bashrc"), "# bashrc sentinel\n", 0o400);
+  writeText(join(startupTargets, "zshrc"), "# linked zshrc sentinel\n", 0o440);
+  writeText(join(startupTargets, "profile"), "# linked profile sentinel\n", 0o600);
+  writeText(join(hostileZdotDir, ".zprofile"), "# hostile ZDOTDIR sentinel\n", 0o400);
+  symlinkSync("startup-targets/zshrc", join(startupHome, ".zshrc"));
+  symlinkSync("startup-targets/missing-bash-login", join(startupHome, ".bash_login"));
+  symlinkSync("startup-targets/profile", join(startupHome, ".profile"));
+  const startupPaths = [
+    ...[".zprofile", ".zshrc", ".bash_profile", ".bash_login", ".bashrc", ".profile"].map((name) =>
+      join(startupHome, name),
+    ),
+    join(startupTargets, "zshrc"),
+    join(startupTargets, "profile"),
+    join(hostileZdotDir, ".zprofile"),
+  ];
+  const startupBefore = snapshotPaths(startupPaths);
+  const shellProbeMarker = join(root, "startup-shell-probe.marker");
+  const shellProbeDir = join(root, "startup-shell-probe-bin");
+  const shellProbe = join(shellProbeDir, "zsh");
+  makeDirectory(shellProbeDir);
+  writeExecutable(shellProbe, '#!/bin/sh\n: > "$PROFILE_PROBE_MARKER"\nexit 42\n');
+  const startupInstallDir = join(root, "startup-files-bin");
+  for (const iteration of [1, 2]) {
+    const result = runInstaller({
+      installDir: startupInstallDir,
       platform: linuxX64(),
-      home: partialHome,
-      childShell: partialAppendShell,
-      extraArguments: ["--persist-path"],
+      home: startupHome,
       environment: {
-        FAKE_PROFILE_APPEND_MODE: mode,
-        FAKE_PROFILE_ENTRY: expectedEntry,
-        SHELL: zsh,
+        PROFILE_PROBE_MARKER: shellProbeMarker,
+        SHELL: shellProbe,
+        ...(iteration === 2 ? { ZDOTDIR: hostileZdotDir } : {}),
       },
     });
-    assertExactStatus(partial, expectedStatus, `partial profile ${mode}`);
+    assertSuccess(result, `startup-file non-ownership install ${iteration}`);
+    assertPathRecovery(result, startupInstallDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
     assertEqual(
-      readFileSync(partialProfile, "utf8"),
-      originalProfile,
-      `partial profile ${mode} restores the original bytes`,
+      snapshotPaths(startupPaths),
+      startupBefore,
+      `startup files remain identical after install ${iteration}`,
+    );
+    assert(
+      !existsSync(shellProbeMarker),
+      `installer does not execute the login shell on install ${iteration}`,
     );
   }
 
-  const customZdotHome = join(root, "future-shell-custom-zdot-home");
-  const customZdotDir = join(customZdotHome, "custom-zdotdir");
-  const customZdotProfile = join(customZdotDir, ".zprofile");
-  makeDirectory(customZdotDir);
-  writeText(
-    join(customZdotHome, ".zshenv"),
-    `[ "\${FAKE_ZSH_LOGIN:-}" != 1 ] || ZDOTDIR="$HOME/custom-zdotdir"\n`,
-    0o600,
-  );
-  writeText(customZdotProfile, "# custom zprofile\n", 0o600);
-  const customZdot = runInstaller({
-    installDir,
-    platform: linuxX64(),
-    home: customZdotHome,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
-  });
-  assertFailure(customZdot, "non-exported ZDOTDIR", "non-exported zsh ZDOTDIR");
-  assertEqual(ghCalls(customZdot), [], "non-exported zsh ZDOTDIR makes no gh calls");
-  assert(
-    !existsSync(join(customZdotHome, ".zprofile")),
-    "non-exported ZDOTDIR leaves HOME profile absent",
-  );
-  assertEqual(
-    readFileSync(customZdotProfile, "utf8"),
-    "# custom zprofile\n",
-    "non-exported ZDOTDIR leaves the effective profile unchanged",
-  );
+  for (const [label, installDir] of [
+    ["space", join(root, "Station custom bin")],
+    ["apostrophe", join(root, "Station's-bin")],
+    ["space and apostrophe", join(root, "Station's custom bin")],
+  ]) {
+    const result = runInstaller({ installDir, platform: linuxX64() });
+    assertSuccess(result, `${label} install directory`);
+    assertPathRecovery(result, installDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
+    if (installDir.includes("'")) {
+      assertIncludes(result.stdout, "'\\''", `${label} install directory apostrophe quoting`);
+    }
+    assertNoInstallerResidue(installDir, dataDir);
+  }
 
-  const colonHome = join(root, "future-shell-colon-home");
-  const colonProfile = join(colonHome, ".zprofile");
-  const colonProfileBefore = "# colon profile\n";
-  makeDirectory(colonHome);
-  writeText(colonProfile, colonProfileBefore, 0o600);
+  const colonCwd = join(root, "normalized:colon-cwd");
+  const colonDataHome = join(root, "normalized-colon-data");
+  const colonInstallDir = join(colonCwd, "relative-bin");
+  makeDirectory(colonCwd);
   const colon = runInstaller({
-    installDir: join(root, "future-shell:colon-bin"),
+    installDir: "relative-bin",
     platform: linuxX64(),
-    home: colonHome,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
+    cwd: colonCwd,
+    dataHome: colonDataHome,
   });
-  assertFailure(colon, "without colons or line breaks", "colon in persisted install directory");
-  assertEqual(ghCalls(colon), [], "colon in persisted install directory makes no gh calls");
-  assertEqual(
-    readFileSync(colonProfile, "utf8"),
-    colonProfileBefore,
-    "colon in persisted install directory leaves the profile unchanged",
+  assertFailure(colon, "install directory cannot contain ':'", "normalized colon preflight");
+  assertIncludes(colon.stderr, "PATH uses ':' to separate entries", "normalized colon rationale");
+  assertEqual(ghCalls(colon), [], "normalized colon preflight makes no gh calls");
+  assert(
+    !existsSync(colonInstallDir),
+    "normalized colon preflight does not create install directory",
   );
-
-  const legacyHome = join(root, "future-shell-legacy-home");
-  const legacyProfile = join(legacyHome, ".zprofile");
-  const legacyEntry = 'export PATH="$HOME/.local/bin:$PATH"\n';
-  makeDirectory(legacyHome);
-  writeText(legacyProfile, legacyEntry, 0o600);
-  const legacy = runInstaller({
-    platform: linuxX64(),
-    home: legacyHome,
-    omitInstallDir: true,
-    extraArguments: ["--persist-path"],
-    environment: { SHELL: zsh },
-  });
-  assertSuccess(legacy, "legacy documented PATH persistence");
-  assertIncludes(
-    legacy.stdout,
-    "Future-shell PATH is already configured",
-    "legacy documented PATH recognition",
-  );
-  assertEqual(
-    readFileSync(legacyProfile, "utf8"),
-    legacyEntry,
-    "legacy documented PATH entry remains byte-identical",
-  );
+  assert(!existsSync(colonDataHome), "normalized colon preflight does not create data directory");
+  assertNoInstallerResidue(colonInstallDir, colonDataHome);
 }
 
-function shellWord(value) {
+function snapshotPaths(paths) {
+  return paths.map((path) => {
+    let status;
+    try {
+      status = lstatSync(path);
+    } catch {
+      return { exists: false, path };
+    }
+    if (status.isSymbolicLink()) {
+      return {
+        exists: true,
+        inode: status.ino,
+        mode: status.mode & 0o7777,
+        path,
+        target: readlinkSync(path),
+        type: "symlink",
+      };
+    }
+    return {
+      bytes: readFileSync(path, "base64"),
+      exists: true,
+      inode: status.ino,
+      mode: status.mode & 0o7777,
+      path,
+      type: "file",
+    };
+  });
+}
+
+function expectedShellWord(value) {
   return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function countExactLines(value, expected) {
-  return value.split("\n").filter((line) => line === expected).length;
-}
-
-function extractPathPersistenceCommand(stdout) {
-  const marker = ", run:\n  ";
-  const commandStart = stdout.indexOf(marker);
-  assert(commandStart >= 0, "no-flag install prints a future-shell PATH command");
-  const lineStart = commandStart + marker.length;
-  const lineEnd = stdout.indexOf("\n", lineStart);
-  assert(lineEnd > lineStart, "future-shell PATH command occupies one line");
-  const command = stdout.slice(lineStart, lineEnd);
-  assert(command.startsWith("if ! grep -F -x -q "), "future-shell PATH command is idempotent");
-  return command;
-}
-
-function assertFutureShellLauncherResolution({ home, installDir, profile, shadowDir }) {
-  const result = spawnSync(
-    "/bin/sh",
-    [
-      "-c",
-      '. "$1"; for launcher in stn stn-ingress stn-tmux-popup; do command -v "$launcher" || exit; done',
-      "station-future-shell",
-      profile,
-    ],
-    syncOptions({ env: { HOME: home, PATH: `${shadowDir}:/usr/bin:/bin` } }),
-  );
-  assertSuccess(result, "minimal-PATH future shell launcher resolution");
-  assertEqual(
-    result.stdout,
-    `${["stn", "stn-ingress", "stn-tmux-popup"]
-      .map((launcher) => join(installDir, launcher))
-      .join("\n")}\n`,
-    "future shell prepends installed launchers ahead of shadows",
-  );
 }
 
 function scenarioExplicitRollbackAndDraft() {
@@ -887,11 +724,7 @@ function scenarioCliParsing() {
       "--install-dir may be specified only once",
       "duplicate install-dir flag",
     ],
-    [
-      ["--persist-path", "--persist-path"],
-      "--persist-path may be specified only once",
-      "duplicate persist-path flag",
-    ],
+    [[removedPersistenceOption], "unknown option", "removed persistence flag"],
     [["--install-dir", ""], "non-empty path", "empty install-dir path"],
     [["--unknown"], "unknown option", "unknown option"],
   ];
@@ -905,6 +738,7 @@ function scenarioCliParsing() {
     assertFailure(result, expected, label);
     assertEqual(ghCalls(result), [], `${label} makes no gh calls`);
   }
+  assert(!existsSync(installDir), "CLI parsing failures do not create the install directory");
 }
 
 function scenarioHostileUmaskModes() {
@@ -2264,7 +2098,7 @@ function scenarioHelp() {
   const help = spawnSync("/bin/sh", [installer, "--help"], syncOptions());
   assertSuccess(help, "installer help");
   assertIncludes(help.stdout, "--install-dir", "installer help options");
-  assertIncludes(help.stdout, "--persist-path", "installer persistence help option");
+  assertNotIncludes(help.stdout, removedPersistenceOption, "installer removed persistence option");
 }
 
 function linuxX64() {
@@ -2447,19 +2281,6 @@ fi
 }
 
 function writeFakeCommands() {
-  writeExecutable(
-    join(fakeBinDir, "zsh"),
-    `#!/bin/sh
-set -eu
-[ "\${1:-}" = -l ] || exit 2
-FAKE_ZSH_LOGIN=1
-shift
-[ "\${1:-}" = -c ] || exit 2
-[ ! -f "$HOME/.zshenv" ] || . "$HOME/.zshenv"
-shift
-eval "$1"
-`,
-  );
   writeExecutable(
     join(fakeBinDir, "uname"),
     [
@@ -3167,17 +2988,53 @@ function assertPathRecovery(
       assertNotIncludes(result.stdout, `PATH mismatch: ${launcher} `, `${launcher} PATH match`);
     }
   }
-  assertIncludes(result.stdout, "export PATH", "PATH recovery export");
-  assertIncludes(result.stdout, "hash -r", "PATH recovery command cache reset");
-  assertIncludes(result.stdout, "stn setup", "PATH recovery setup command");
-  assertIncludes(result.stdout, "Absolute fallback:", "PATH recovery absolute fallback");
 
-  const blockStart = result.stdout.indexOf("  PATH=");
-  const blockEnd = result.stdout.indexOf("Absolute fallback:", blockStart);
-  assert(blockStart >= 0 && blockEnd > blockStart, "PATH recovery block boundaries");
-  const recoveryBlock = result.stdout
-    .slice(blockStart + 2, blockEnd)
-    .replace(/\n {2}(export PATH|hash -r|stn setup)\n/g, "\n$1\n");
+  const initialPathText = initialPath.join(":");
+  const quotedInstallDir = expectedShellWord(installDir);
+  const futureHeading =
+    "To use Station in future shells, add this command to your chosen shell configuration:\n  ";
+  const futureStart = result.stdout.indexOf(futureHeading);
+  const currentHeading = "Run this block in the current shell, then continue setup:\n";
+  const currentStart = result.stdout.indexOf(currentHeading, futureStart);
+  assert(futureStart >= 0 && currentStart > futureStart, "future-shell guidance boundaries");
+  assertEqual(
+    result.stdout.lastIndexOf(futureHeading),
+    futureStart,
+    "one future-shell guidance command",
+  );
+  const futureCommand = result.stdout
+    .slice(futureStart + futureHeading.length, currentStart)
+    .replace(/\n\n$/, "");
+  assertEqual(
+    futureCommand,
+    `export PATH=${quotedInstallDir}\${PATH:+":$PATH"}`,
+    "future-shell export command",
+  );
+  const futureEvaluation = spawnSync(
+    "/bin/sh",
+    ["-c", `${futureCommand}\nprintf '%s\\n' "$PATH"`],
+    syncOptions({ env: { HOME: homeDir, PATH: initialPathText } }),
+  );
+  assertSuccess(futureEvaluation, "future-shell export execution");
+  assertEqual(
+    futureEvaluation.stdout,
+    `${installDir}:${initialPathText}\n`,
+    "future-shell export prepends the exact install directory",
+  );
+
+  const fallbackMarker = "Absolute fallback: ";
+  const blockStart = currentStart + currentHeading.length;
+  const blockEnd = result.stdout.indexOf(fallbackMarker, blockStart);
+  assert(blockEnd > blockStart, "current-shell recovery block boundaries");
+  const printedRecoveryBlock = result.stdout.slice(blockStart, blockEnd);
+  assertEqual(
+    printedRecoveryBlock,
+    `  PATH=${quotedInstallDir}\${PATH:+":$PATH"}\n  export PATH\n  hash -r\n  stn setup\n`,
+    "current-shell recovery block",
+  );
+  const recoveryBlock = printedRecoveryBlock
+    .replace(/^ {2}PATH=/, "PATH=")
+    .replace(/\n {2}(export PATH|hash -r|stn setup)(?=\n|$)/g, "\n$1");
   const reportDir = join(root, `path-recovery-${++invocationCount}`);
   makeDirectory(reportDir);
   const verification = spawnSync(
@@ -3189,7 +3046,7 @@ function assertPathRecovery(
     syncOptions({
       env: {
         HOME: homeDir,
-        PATH: initialPath.join(":"),
+        PATH: initialPathText,
         PATH_REPORT_DIR: reportDir,
       },
     }),
@@ -3203,11 +3060,16 @@ function assertPathRecovery(
     );
   }
 
-  const fallbackCommand = result.stdout.slice(blockEnd + "Absolute fallback:".length).trim();
+  const fallbackCommand = result.stdout.slice(blockEnd + fallbackMarker.length).trim();
+  assertEqual(
+    fallbackCommand,
+    `${expectedShellWord(join(installDir, "stn"))} setup`,
+    "absolute PATH fallback command",
+  );
   const fallback = spawnSync(
     "/bin/sh",
     ["-c", fallbackCommand],
-    syncOptions({ env: { HOME: homeDir, PATH: initialPath.join(":") } }),
+    syncOptions({ env: { HOME: homeDir, PATH: initialPathText } }),
   );
   assertSuccess(fallback, "absolute PATH fallback execution");
 }

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -2,6 +2,8 @@ import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
+const removedPersistenceOption = ["--persist", "path"].join("-");
+
 describe("release readiness docs", () => {
   it("documents install, known issues, system dependencies, and deterministic versus real gates", async () => {
     const [readme, install, knownIssues, systemDependencies, testsReadme, localRealConfig] =
@@ -242,9 +244,13 @@ describe("release readiness docs", () => {
     );
 
     for (const [path, document] of documents) {
-      expect(document, path).toContain("--persist-path");
-      expect(document, path).toContain("explicit");
-      expect(document, path).toContain("login-shell profile");
+      expect(document, path).not.toContain(removedPersistenceOption);
+      expect(document, path).toMatch(/does not (?:read, create, or )?edit shell startup files/);
+      expect(document, path).toContain("chosen shell configuration");
+      expect(document, path).toContain("future shells");
+      expect(document, path).toContain("Absolute fallback");
+      expect(document, path).toContain("all three");
+      expect(document, path).toContain("physically");
       expect(document, path).toContain("From any directory");
       expect(document, path).toContain("zero-project");
       expect(document, path).toContain("Add your first project");
@@ -255,10 +261,19 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("stn doctor");
       expect(document, path).toContain("stn tui");
       expect(document, path).toContain("~/.config/station/config.toml");
-      expect(document, path).toContain("future login shells");
       expect(document, path).toContain("empty dashboard");
       expect(document, path).toContain("Create Session");
       expect(document, path).toContain("start the agent session");
+    }
+
+    const install = await read("docs/install.md");
+    expect(install).toContain("PATH uses `:` to separate entries");
+    expect(install).toMatch(
+      /before GitHub requests[^.]*temporary-directory creation[^.]*destination mutation/,
+    );
+
+    for (const path of ["docs/development.md", "docs/single-binary.md"]) {
+      expect(await read(path), path).not.toContain(removedPersistenceOption);
     }
   });
 
@@ -276,7 +291,8 @@ describe("release readiness docs", () => {
     expect(virtualBuddy.indexOf("**Add your first project**")).toBeLessThan(
       virtualBuddy.indexOf("press `N`"),
     );
-    expect(normalizedVirtualBuddy).toContain("exact idempotent future-shell PATH opt-in command");
+    expect(normalizedVirtualBuddy).toContain("one future-shell export");
+    expect(normalizedVirtualBuddy).toContain("shell configuration you choose");
     expect(normalizedVirtualBuddy).toContain("`tmux prefix + Space`");
     expect(normalizedVirtualBuddy).toContain("cold open");
     expect(normalizedVirtualBuddy).toContain("warm reopen");


### PR DESCRIPTION
## Summary

- remove the unreleased PATH persistence option and all installer-owned shell startup-file selection, mutation, rollback, and signal handling
- reject normalized install directories containing `:` before network or filesystem mutation, while preserving physical launcher verification and binary rollback safety
- print one safely quoted future-shell export only on PATH mismatch, followed by the current-shell recovery block and absolute setup fallback
- update installer smoke coverage, release-readiness assertions, and installation/release documentation around user-owned shell configuration

## Validation

- `/bin/sh -n scripts/install.sh`
- `zsh -n scripts/install.sh`
- removed-option and installer startup-file static searches
- `pnpm smoke:install`
- `pnpm build`
- `pnpm lint`
- `pnpm test:diagnostics`
- isolated `pnpm test:all` with short `/var/tmp` HOME/XDG roots

## UX implication

The installer never reads or edits shell startup files. When current-process launcher resolution is incomplete, users receive one future-shell export, an immediately runnable current-shell recovery block, and an absolute `stn setup` fallback.

Closes #167
