### PR TITLE
fix(terminal): keep native sessions in their owning terminal

### DIFF
--- a/apps/observer/test/integration/reconcile-station-terminal.test.ts
+++ b/apps/observer/test/integration/reconcile-station-terminal.test.ts
@@ -3,7 +3,7 @@ import {
   compactClaudeHookPayload,
   createClaudeHarnessProvider,
 } from "@station/claude";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { ProviderProjectConfig, WorktreeObservation } from "@station/contracts";
 import { HOST_PROTOCOL_VERSION, type HostListEntry, type StationHostClient } from "@station/host";
 import { stationBuildInfo } from "@station/runtime";
@@ -18,8 +18,13 @@ import {
   FakeTerminalProvider,
   FakeWorktreeProvider,
 } from "@station/testing";
-import { describe, expect, it } from "vitest";
-import { createObserverCore, ProviderRegistry } from "../../src/internal";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createObserverCore,
+  ProviderRegistry,
+  registerObserverCommandHandlers,
+} from "../../src/internal";
+import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter";
 import { createTestObserver } from "../support/testObserver";
 
 const now = "2026-06-11T12:00:00.000Z";
@@ -125,44 +130,101 @@ describe("observer reconcile with a station-hosted target", () => {
     );
   });
 
-  it("re-derives the one station session from host.list after losing in-memory targets", async () => {
-    // Observer-restart proxy: the provider's #targets are empty, but the host
-    // still owns the PTY. listTargets must rebuild the single target from
-    // host.list (cwd === harnessBinding.worktreePath) so reconcile derives exactly
-    // one session — never a duplicate, never zero.
+  it("keeps a host-backed session non-focusable before and after provider reconstruction", async () => {
+    const client = fakeHostClient({
+      list: async () => [
+        hostListEntry({
+          ptyId: "pty-1",
+          worktree: stationWorktree,
+          sessionId: "ses_station",
+          pid: 99,
+        }),
+      ],
+    });
+    const station = hostBackedStation(client);
+    await station.openWorkspace({
+      project,
+      worktree: stationWorktree,
+      harness: "claude",
+      layout: "agent-shell",
+      sessionId: "ses_station",
+    });
+
+    const core = createObserverCore({ config, providers: providers(station), clock });
+    const snapshot = await core.reconcile("station-host-backed");
+    const stationSession = snapshot.sessions.find((session) => session.id === "ses_station");
+    expect(stationSession).toMatchObject({
+      worktreeId: "wt_web_station",
+      terminal: { provider: "native", closeable: true },
+    });
+    expect(stationSession?.terminal?.focusable).toBeUndefined();
+
+    // Observer-restart proxy: a fresh provider has no in-memory targets and must
+    // rebuild the same non-focusable projection from host.list.
+    const rebuiltStation = hostBackedStation(client);
+    const rebuiltCore = createObserverCore({
+      config,
+      providers: providers(rebuiltStation),
+      clock,
+    });
+    const rebuiltSnapshot = await rebuiltCore.reconcile("station-provider-reconstructed");
+    const rebuiltSession = rebuiltSnapshot.sessions.find((session) => session.id === "ses_station");
+    expect(rebuiltSession).toMatchObject({
+      worktreeId: "wt_web_station",
+      terminal: { provider: "native", closeable: true },
+    });
+    expect(rebuiltSession?.terminal?.focusable).toBeUndefined();
+  });
+
+  it("fails a direct native focus command without calling Station Host focus", async () => {
+    const focus = vi.fn(async () => undefined);
     const station = hostBackedStation(
       fakeHostClient({
         list: async () => [
-          {
+          hostListEntry({
             ptyId: "pty-1",
-            terminalTargetId: stationTargetId("wt_web_station"),
-            worktreeId: "wt_web_station",
-            projectId: "web",
+            worktree: stationWorktree,
             sessionId: "ses_station",
-            worktreePath: "/tmp/station/web/station",
-            harnessProvider: "claude",
             pid: 99,
-            alive: true,
-            cols: 80,
-            rows: 24,
-          },
+          }),
         ],
+        focus,
       }),
     );
+    const registry = providers(station);
+    const { sqlite, persistence, eventBus, core, api, commandQueue } = createTestObserver({
+      config,
+      providers: registry,
+      clock,
+    });
+    registerObserverCommandHandlers({
+      projectConfigWriter: createUnexpectedProjectConfigWriter(),
+      queue: commandQueue,
+      core,
+      providers: registry,
+      projects: config.projects,
+      persistence,
+      eventBus,
+      clock,
+    });
+    await core.reconcile("station-direct-focus");
 
-    const core = createObserverCore({ config, providers: providers(station), clock });
-    const snapshot = await core.reconcile("station-restart");
+    const receipt = await api.dispatch({
+      type: "terminal.focus",
+      payload: { sessionId: "ses_station" },
+    });
+    await commandQueue.drain();
 
-    const stationSessions = snapshot.sessions.filter(
-      (session) => session.worktreeId === "wt_web_station",
-    );
-    expect(stationSessions.map((session) => session.id)).toEqual(["ses_station"]);
-    expect(snapshot.rows.find((row) => row.id === "wt_web_station")?.terminal?.provider).toBe(
-      "native",
-    );
-    expect(snapshot.rows.find((row) => row.id === "wt_web_station")?.terminal?.focusable).toBe(
-      true,
-    );
+    await expect(api.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "failed",
+      error: {
+        code: "TERMINAL_STATION_HOSTED",
+        message: "Native Station sessions cannot be focused from an external dashboard.",
+        hint: "Open native Station and select the session there.",
+      },
+    });
+    expect(focus).not.toHaveBeenCalled();
+    sqlite.close();
   });
 
   it("keeps host-backed Station fallback targets live but not dashboard-focusable", async () => {
@@ -420,6 +482,7 @@ function hostListEntry(input: {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -164,9 +164,11 @@ The split is allowed because both pieces are outer wiring. Application modules
 must not compensate for it by selecting concrete adapters at runtime.
 
 The Station terminal adapter may use Station Host when CLI composition enables
-host-backed terminals. Observer application code knows only the injected
-`ManagedTerminalLifecycle` and its opaque managed-terminal attachment; Station
-resolves that attachment to host socket and PTY mechanics at its own boundary.
+host-backed terminals. Host backing supplies process lifecycle, close, and opaque
+attachment identity, but not external presentation control: native targets remain
+non-focusable from dashboards. Observer application code knows only the injected
+`ManagedTerminalLifecycle`; Station resolves its attachment to host socket and PTY
+mechanics at its own boundary and selects or reveals the session locally.
 
 ## Port, Actor, And Adapter Map
 
@@ -181,7 +183,7 @@ ownership even where current ownership is still a deviation.
 | Harness status delivery | Driving | harness event report ingress | harness hooks, provider hook adapters, protocol clients | Reports are deduplicated, queued, projected, persisted, and followed by reconcile. |
 | Worktree operations | Driven | `WorktreeProvider` | Worktrunk and test adapters | Strong purpose-owned port. |
 | Terminal operations | Driven | `TerminalProvider` | tmux, Station terminal, and test adapters | General topology and operations are provider-owned. |
-| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity; Station owns host attachment resolution. |
+| Managed terminal lifecycle | Driven | `ManagedTerminalLifecycle` | Station terminal adapter, optionally backed by Station Host | Explicit injected role returning only an opaque target identity; Host backing may add spawn/list/close/attachment lifecycle, while Station retains native presentation and host-backed targets remain externally non-focusable. |
 | Harness operations | Driven | `HarnessProvider` | Claude, Codex, Cursor, OpenCode, Pi, scripted, and test adapters | Strong purpose-owned port with provider-local parsing and compatibility admission for observations persisted by earlier builds. |
 | Repository metadata | Driven | `RepositoryProvider` | GitHub and test repository adapters | Adapters declare deterministic remote support; provider-neutral metadata policy selects zero or one match and rejects overlaps. |
 | Durable observer memory | Driven | `CommandJournal`, `EventJournal`, `IngressJournal`, `ObservationStore`, `ReconcileStore`, `SessionStore`, `WorktreeMetadataStore` | Production SQLite adapter and test-only in-memory adapter | Observer-private, application-purpose ports separate current conversations from storage representation. Consumers receive only the named ports they use; the unmarked `ObserverPersistenceBundle` intersection exists only at adapter and composition seams. |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -14,7 +14,10 @@ Station is built on OpenTUI (`@opentui/core` + `@opentui/react`) and `react`, ru
 Launch is driven by `apps/cli/src/commands/tui.ts`. The Node CLI shells out to the Bun renderer (dual-runtime, accepted for alpha):
 
 - Bare `stn` in a plain terminal launches the native workspace (Station owns its own panes).
-- Inside tmux, `stn` opens the read-only dashboard in a tmux popup, since tmux owns the panes there.
+- Inside tmux, `stn` opens the read-only dashboard in a tmux popup, since
+  tmux owns the panes there. Selecting a native Station session shows that it
+  runs in another terminal, dispatches no focus command, and keeps the popup
+  open.
 - `stn tui --dev-fake-dashboard` previews the dashboard with mock data (`STATION_SOURCE=mock`).
 
 ## Nested Workspaces
@@ -87,6 +90,10 @@ bun run dashboard                     # read-only dashboard renderer
 - Treat `snapshot.sessions` as session-membership and session/activity-count truth. Dashboard rows,
   search, selection, and actions project those sessions and join `snapshot.rows` only for checkout
   metadata; bare worktrees remain inventory and do not appear in the primary session list.
+- `terminal.focusable` describes external dashboard control, not native Station
+  interaction. Native row activation resolves an advertised managed attachment
+  and creates or reveals the local pane without dispatching `terminal.focus`;
+  no attachment leaves the overlay open with an actionable notice.
 
 ## Surface Rules
 

--- a/integrations/terminal/station/src/errors.ts
+++ b/integrations/terminal/station/src/errors.ts
@@ -6,12 +6,7 @@ export type StationTerminalProviderErrorCode =
   | "TERMINAL_STATION_HOSTED"
   | "TERMINAL_TARGET_MISSING";
 
-/**
- * SafeError raised by the native (Station) terminal provider when it is not host-backed:
- * the provider owns no terminal of its own (the PTY lives in the Station UI), so
- * observer-side focus/close cannot drive it. When a host is attached, those
- * operations are real host-backed calls instead.
- */
+/** Native focus remains Station-owned; Host backing adds lifecycle close but not external focus. */
 export class StationTerminalProviderError extends Error implements SafeError {
   readonly tag = "TerminalProviderError";
   readonly provider = STATION_TERMINAL_PROVIDER_ID;

--- a/integrations/terminal/station/src/provider.ts
+++ b/integrations/terminal/station/src/provider.ts
@@ -38,10 +38,10 @@ const DEFAULT_ROWS = 24;
 export type StationTerminalProviderOptions = {
   clock?: RuntimeClock;
   /**
-   * When present (the `stationPersistentAgents` flag is on), the provider is
-   * host-backed: it spawns into / focuses / closes / lists the standalone
-   * station-station-host. Absent ⇒ the Station UI owns the PTY locally and focus/close
-   * throw, capabilities stay false.
+   * When present (the `stationPersistentAgents` flag is on), Station Host supplies
+   * spawn, list, close, and attachment lifecycle. Native Station still owns
+   * presentation, so external focus remains unsupported. Without Host, the Station
+   * UI owns the PTY locally and close is unsupported too.
    */
   host?: StationHostController;
 };
@@ -50,8 +50,8 @@ export type StationTerminalProviderOptions = {
  * ADAPTER
  *
  * Station terminal provider: UI-hosted mode is a registration shim; host-backed
- * mode uses `host.list` as liveness truth and exposes only opaque target identity
- * for Station-side attachment resolution.
+ * mode supplies process lifecycle and opaque attachment identity. Native
+ * presentation remains locally owned by Station and is never externally focusable.
  */
 export class StationTerminalProvider implements ManagedTerminalLifecycle {
   readonly id: ProviderId = STATION_TERMINAL_PROVIDER_ID;
@@ -60,7 +60,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
   readonly #host: StationHostController | undefined;
   readonly #targets = new Map<TerminalTargetId, TerminalTargetObservation>();
   // Targets backed by a host PTY (spawned via launchProcess or rebuilt from
-  // host.list). listTargets drops ONLY these when their PTY is gone; a UI-hosted
+  // host.list). listTargets drops ONLY these when their process is gone; a UI-hosted
   // fallback target (host was unavailable at launch) is kept until releaseTarget.
   readonly #hostBackedTargets = new Set<string>();
 
@@ -73,8 +73,8 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
     const hostBacked = this.#host !== undefined;
     return {
       canOpenWorkspace: true,
-      // Observer-side focus/close are real only when a host owns the PTY.
-      canFocusTarget: hostBacked,
+      // Host backing grants lifecycle cleanup and attachment, not presentation control.
+      canFocusTarget: false,
       canCloseTarget: hostBacked,
       canCaptureOutput: false,
       canSendInput: false,
@@ -151,9 +151,9 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
     for (const entry of live) {
       // Aux PTYs are owned by the Station UI (splits / [+sh] shells). They must
       // never enter reconcile: #rebuildObservation stamps every rebuilt entry
-      // `main-agent`, which would mint phantom sessions/runs and rank them for
-      // focus/close. Excluding them here is the single chokepoint — every other
-      // host.list consumer reads the observations this produces, not host.list.
+      // `main-agent`, which would mint phantom sessions/runs and expose them for
+      // lifecycle cleanup. Excluding them here is the single chokepoint — every
+      // other host.list consumer reads the observations this produces, not host.list.
       if (!entry.alive || entry.kind === "aux" || aliveById.has(entry.terminalTargetId)) {
         continue;
       }
@@ -264,10 +264,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
   }
 
   async focusTarget(targetId: TerminalTargetId): Promise<void> {
-    if (this.#host === undefined) {
-      throw this.#hostedError(targetId, "focus");
-    }
-    await this.#host.client().focus(await this.#requirePtyId(targetId));
+    throw this.#hostedError(targetId, "focus");
   }
 
   async closeTarget(targetId: TerminalTargetId): Promise<void> {
@@ -324,7 +321,7 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
       id: entry.terminalTargetId as TerminalTargetId,
       provider: this.id,
       state: "open",
-      focusable: true,
+      focusable: false,
       closeable: true,
       confidence: "high",
       reason: "Rehydrated from station-host liveness after reconnect.",
@@ -347,13 +344,18 @@ export class StationTerminalProvider implements ManagedTerminalLifecycle {
   ): StationTerminalProviderError {
     const target = this.#targets.get(targetId);
     const options: ConstructorParameters<typeof StationTerminalProviderError>[2] = {
-      hint: `This agent is hosted by the Station UI; ${action} it from Station instead.`,
+      hint:
+        action === "focus"
+          ? "Open native Station and select the session there."
+          : "This agent is hosted by the Station UI; close it from Station instead.",
     };
     if (target?.worktreeId !== undefined) options.worktreeId = target.worktreeId;
     if (target?.sessionId !== undefined) options.sessionId = target.sessionId;
     return new StationTerminalProviderError(
       "TERMINAL_STATION_HOSTED",
-      `The station terminal provider cannot ${action} an externally-hosted target.`,
+      action === "focus"
+        ? "Native Station sessions cannot be focused from an external dashboard."
+        : "The station terminal provider cannot close an externally-hosted target.",
       options,
     );
   }

--- a/integrations/terminal/station/test/unit/provider.test.ts
+++ b/integrations/terminal/station/test/unit/provider.test.ts
@@ -66,7 +66,7 @@ describe("StationTerminalProvider", () => {
     expect(provider.id).toBe("native");
     expect(provider.capabilities()).toMatchObject({
       canOpenWorkspace: true,
-      // No host injected: focus/close cannot be driven observer-side.
+      // Native presentation is never externally focusable; without Host, close is unavailable too.
       canFocusTarget: false,
       canCloseTarget: false,
       canCaptureOutput: false,
@@ -175,6 +175,8 @@ describe("StationTerminalProvider", () => {
       tag: "TerminalProviderError",
       code: "TERMINAL_STATION_HOSTED",
       provider: "native",
+      message: "Native Station sessions cannot be focused from an external dashboard.",
+      hint: "Open native Station and select the session there.",
       worktreeId: "wt_web_feature",
       sessionId: "ses_web_feature",
     });
@@ -268,13 +270,16 @@ const launchPlan = {
 };
 
 describe("StationTerminalProvider (host-backed)", () => {
-  it("flips focus/close capabilities on when a host is injected", () => {
+  it("enables host-backed close without advertising external focus", () => {
     const provider = hostBackedProvider(fakeHostClient());
-    expect(provider.capabilities()).toMatchObject({ canFocusTarget: true, canCloseTarget: true });
+    expect(provider.capabilities()).toMatchObject({ canFocusTarget: false, canCloseTarget: true });
   });
 
   it("launchProcess spawns into the host and reports started", async () => {
-    const spawn = vi.fn(async () => ({ ptyId: "pty-1", pid: 99 }));
+    const spawn = vi.fn(async (_input: Parameters<StationHostClient["spawn"]>[0]) => ({
+      ptyId: "pty-1",
+      pid: 99,
+    }));
     const provider = hostBackedProvider(fakeHostClient({ spawn }));
     const opened = await provider.openWorkspace(openRequest());
     const result = await provider.launchProcess({
@@ -416,7 +421,7 @@ describe("StationTerminalProvider (host-backed)", () => {
     await expect(provider.listTargets()).resolves.toEqual([]);
   });
 
-  it("marks UI-hosted fallback targets non-focusable until a host PTY is live", async () => {
+  it("changes only closeability when a UI-hosted target gains a live host PTY", async () => {
     let live: HostListEntry[] = [];
     const provider = hostBackedProvider(fakeHostClient({ list: async () => live }));
     await provider.openWorkspace(openRequest());
@@ -427,7 +432,7 @@ describe("StationTerminalProvider (host-backed)", () => {
 
     live = [liveEntry()];
     await expect(provider.listTargets()).resolves.toMatchObject([
-      { id: stationTargetId(worktree.id), focusable: true, closeable: true },
+      { id: stationTargetId(worktree.id), focusable: false, closeable: true },
     ]);
   });
 
@@ -506,7 +511,7 @@ describe("StationTerminalProvider (host-backed)", () => {
       id: stationTargetId(worktree.id),
       provider: "native",
       state: "open",
-      focusable: true,
+      focusable: false,
       closeable: true,
       worktreeId: worktree.id,
       sessionId: "ses_web_feature",
@@ -601,15 +606,25 @@ describe("StationTerminalProvider (host-backed)", () => {
     });
   });
 
-  it("focus/close resolve the host PTY id and drive the host", async () => {
+  it("rejects host-backed focus without calling the host focus protocol", async () => {
     const focus = vi.fn(async () => undefined);
+    const provider = hostBackedProvider(fakeHostClient({ list: async () => [liveEntry()], focus }));
+    await provider.listTargets();
+
+    await expect(provider.focusTarget(stationTargetId(worktree.id))).rejects.toMatchObject({
+      code: "TERMINAL_STATION_HOSTED",
+      message: "Native Station sessions cannot be focused from an external dashboard.",
+      hint: "Open native Station and select the session there.",
+    });
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("closeTarget resolves the host PTY id and drives host cleanup", async () => {
     const close = vi.fn(async () => ({ closed: true }));
-    const provider = hostBackedProvider(
-      fakeHostClient({ list: async () => [liveEntry()], focus, close }),
-    );
-    await provider.focusTarget(stationTargetId(worktree.id));
+    const provider = hostBackedProvider(fakeHostClient({ list: async () => [liveEntry()], close }));
+
     await provider.closeTarget(stationTargetId(worktree.id));
-    expect(focus).toHaveBeenCalledWith("pty-1");
+
     expect(close).toHaveBeenCalledWith("pty-1");
   });
 

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -738,6 +738,12 @@ describeRealTmux("real tmux dev popup routing", () => {
       },
     });
 
+    await tmuxExec(
+      fixture.wrapper,
+      ["switch-client", "-c", fixture.ptyClient.clientName, "-t", "base"],
+      fixture.env,
+    );
+
     const nativePopup = spawnPopupCli(fixture, fixture.ptyClient.clientName);
     await waitForPaneContent(
       fixture,
@@ -766,6 +772,19 @@ describeRealTmux("real tmux dev popup routing", () => {
     expect(nativeFrame).toContain(nativeMessage);
     expect((await waitForNestedClient(fixture)).pid).toBe(reopenedRuntime.nestedClientPid);
     expect(focusCommands).toHaveLength(1);
+
+    await fixture.ptyClient.write(Buffer.from("1", "utf8"));
+    await waitForNestedClientGone(fixture);
+    await expectSuccessfulExit(nativePopup, 10_000);
+    expect(await waitForTmuxClientTarget(fixture, destination)).toEqual(visibleTarget);
+    expect(focusCommands).toHaveLength(2);
+    expect(focusCommands[1]).toMatchObject({
+      type: "terminal.focus",
+      payload: {
+        sessionId: "ses_popup_tmux",
+        origin: { provider: "tmux", clientId: fixture.ptyClient.clientName },
+      },
+    });
     await assertWrapperAudit(fixture);
   }, 120_000);
 

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -249,24 +249,28 @@ describe("TUI screen transitions", () => {
     ]);
   });
 
-  it("shows a notice instead of dispatching focus when the agent's terminal is not focusable", () => {
+  it("keeps the dashboard active when a native session is not externally focusable", () => {
     const base = createCommandSnapshot("idle");
     const snapshot = {
       ...base,
       sessions: base.sessions.map((session) =>
         session.terminal === undefined
           ? session
-          : { ...session, terminal: { ...session.terminal, focusable: false } },
+          : {
+              ...session,
+              terminal: { ...session.terminal, provider: "native", focusable: false },
+            },
       ),
     };
     const transition = handleTuiKey(createInitialTuiState({ initialSnapshot: snapshot }), {
       input: "1",
     });
 
-    // A Station-hosted (non-focusable) agent must not spam a focus the provider
-    // can only reject: no command is dispatched, just a one-time info notice.
     expect(transition.commands).toBeUndefined();
+    expect(transition.operations).toBeUndefined();
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
     expect(transition.state.toasts.at(-1)?.toast).toMatchObject({ kind: "info" });
+    expect(transition.state.toasts.at(-1)?.toast.message).toContain('"native" terminal');
     expect(transition.state.toasts.at(-1)?.toast.message).toContain("can't be focused");
   });
 

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1210,9 +1210,6 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     };
   }
 
-  // A snapshot whose ROW_ID is Station-hosted (terminal.provider "native")
-  // rather than the fixture's tmux, so externalTerminalProviderForWorktree
-  // returns undefined and the existing-session path focuses instead of warning.
   function stationHostedSnapshot(
     terminalOverrides: Partial<NonNullable<WorktreeRow["terminal"]>> = {},
   ): StationSnapshot {
@@ -1233,6 +1230,29 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
           ...session,
           terminal: { ...session.terminal, provider: "native", ...terminalOverrides },
         };
+      }),
+    };
+  }
+
+  function liveAgentWithoutTerminalSnapshot(): StationSnapshot {
+    const snapshot = manyProjectsSnapshot();
+    return {
+      ...snapshot,
+      rows: snapshot.rows.map((row): WorktreeRow => {
+        if (row.id !== WORKTREE_ID) {
+          return row;
+        }
+        const next = { ...row };
+        delete next.terminal;
+        return next;
+      }),
+      sessions: snapshot.sessions.map((session) => {
+        if (session.id !== ROW_ID) {
+          return session;
+        }
+        const next = { ...session };
+        delete next.terminal;
+        return next;
       }),
     };
   }
@@ -1409,44 +1429,42 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     expect(selectStationOverlayVisible(store.getState())).toBe(true);
   });
 
-  it("focuses the existing session for a focusable Station-hosted worktree and closes the overlay", async () => {
-    // The live agent here is Station-hosted (terminal.provider "native"), so
-    // externalTerminalProviderForWorktree returns undefined: instead of warning,
-    // Station dispatches a terminal.focus, waits for it, then lands on the pane.
-    const { store, dispatch, settle, observerService } = agentHarness(
-      { kind: "existing-session", sessionId: "ses_elsewhere", harnessProvider: "codex" },
-      stationHostedSnapshot({ focusable: true }),
+  it("attaches a non-focusable native session from its slot key and acknowledges readiness", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-host`,
+    } as const;
+    const resolutions: unknown[] = [];
+    const scripted = createScriptedTerminal();
+    const { store, pressKey, settle, observerService, stationViewStore } = agentHarness(
+      {
+        kind: "existing-session",
+        sessionId: "ses_wt_station_idle",
+        harnessProvider: "codex",
+        attachment,
+      },
+      withTurnReadiness(stationHostedSnapshot({ focusable: false })),
+      {
+        resolve: async (candidate) => {
+          resolutions.push(candidate);
+          return () => scripted.terminal;
+        },
+      },
     );
     store.actions.openOverlay(STATION_OVERLAY_ID);
 
-    dispatch({ kind: "row", rowId: ROW_ID });
+    expect(pressKey(slotKeyFor(stationViewStore))).toBe(true);
     await settle();
 
+    expect(resolutions).toEqual([attachment]);
     expect(observerService.dispatched).toEqual([
-      { type: "terminal.focus", payload: { sessionId: "ses_elsewhere" } },
-    ]);
-    expect(observerService.waitedForCommandIds).toEqual(["cmd_tui_1"]);
-    expect(selectStationOverlayVisible(store.getState())).toBe(false);
-  });
-
-  it("acknowledges a ready turn after focusing an existing Station-hosted session", async () => {
-    const { store, dispatch, settle, observerService } = agentHarness(
-      { kind: "existing-session", sessionId: "ses_wt_station_idle", harnessProvider: "codex" },
-      withTurnReadiness(stationHostedSnapshot({ focusable: true })),
-    );
-    store.actions.openOverlay(STATION_OVERLAY_ID);
-
-    dispatch({ kind: "row", rowId: ROW_ID });
-    await settle();
-
-    expect(observerService.dispatched).toEqual([
-      { type: "terminal.focus", payload: { sessionId: "ses_wt_station_idle" } },
       {
         type: "session.acknowledgeTurn",
         payload: { sessionId: "ses_wt_station_idle", token: "report_station_ready" },
       },
     ]);
-    expect(observerService.waitedForCommandIds).toEqual(["cmd_tui_1", "cmd_tui_1"]);
+    expect(observerService.waitedForCommandIds).toEqual(["cmd_tui_1"]);
+    expect(selectStationOverlayVisible(store.getState())).toBe(false);
   });
 
   it("toasts for an existing Station-hosted worktree with no attachable host PTY", async () => {
@@ -1560,14 +1578,14 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     } as const;
     const resolutions: unknown[] = [];
     const scripted = createScriptedTerminal();
-    const { store, dispatch, settle } = agentHarness(
+    const { store, calls, dispatch, settle, observerService } = agentHarness(
       {
         kind: "existing-session",
         sessionId: "ses_live",
         harnessProvider: "codex",
         attachment,
       },
-      stationHostedSnapshot({ focusable: true }),
+      stationHostedSnapshot({ focusable: false }),
       {
         resolve: async (candidate) => {
           resolutions.push(candidate);
@@ -1581,6 +1599,11 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     await settle();
 
     expect(resolutions).toEqual([attachment]);
+    expect(calls).toEqual([
+      `ensure:${AGENT_PANE_ID}:${CWD}::`,
+      `createPane:${AGENT_PANE_ID}:primary-agent`,
+      `setPrimaryAgent:${AGENT_PANE_ID}:ses_live:${attachment.terminalTargetId}`,
+    ]);
     expect(
       store.getState().workspace.panes.find((pane) => pane.id === AGENT_PANE_ID)?.agentIdentity,
     ).toEqual({
@@ -1588,6 +1611,8 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
       terminalTargetId: attachment.terminalTargetId,
       harnessProvider: "codex",
     });
+    expect(observerService.dispatched).toEqual([]);
+    expect(selectStationOverlayVisible(store.getState())).toBe(false);
   });
 
   it("toasts attachment resolution failures without creating or locally spawning a pane", async () => {
@@ -1695,21 +1720,23 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
   it("toasts and keeps the overlay open when focusing an existing session is rejected", async () => {
     const { store, dispatch, settle, observerService, stationViewStore } = agentHarness(
       { kind: "existing-session", sessionId: "ses_elsewhere", harnessProvider: "codex" },
-      stationHostedSnapshot({ focusable: true }),
+      liveAgentWithoutTerminalSnapshot(),
     );
     observerService.nextReceipt = {
       commandId: "cmd_tui_1",
       accepted: false,
       status: "rejected",
-      error: { tag: "ClientObserverError", code: "STATION_FOCUS_REJECTED", message: "Focus was rejected." },
+      error: {
+        tag: "ClientObserverError",
+        code: "STATION_FOCUS_REJECTED",
+        message: "Focus was rejected.",
+      },
     };
     store.actions.openOverlay(STATION_OVERLAY_ID);
 
     dispatch({ kind: "row", rowId: ROW_ID });
     await settle();
 
-    // The focus is dispatched but rejected, so focusExistingSession returns false and
-    // the land-on-pane tail never runs: error toast, overlay stays open.
     expect(observerService.dispatched).toEqual([
       { type: "terminal.focus", payload: { sessionId: "ses_elsewhere" } },
     ]);
@@ -1723,12 +1750,16 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
   it("toasts and keeps the overlay open when the focus command completion fails", async () => {
     const { store, dispatch, settle, observerService, stationViewStore } = agentHarness(
       { kind: "existing-session", sessionId: "ses_elsewhere", harnessProvider: "codex" },
-      stationHostedSnapshot({ focusable: true }),
+      liveAgentWithoutTerminalSnapshot(),
     );
     observerService.nextCompletion = {
       status: "failed",
       commandId: "cmd_tui_1",
-      error: { tag: "ClientObserverError", code: "STATION_FOCUS_FAILED", message: "Focus never completed." },
+      error: {
+        tag: "ClientObserverError",
+        code: "STATION_FOCUS_FAILED",
+        message: "Focus never completed.",
+      },
     };
     store.actions.openOverlay(STATION_OVERLAY_ID);
 
@@ -1746,10 +1777,14 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
   it("toasts and keeps the overlay open when the focus dispatch throws", async () => {
     const { store, dispatch, settle, observerService, stationViewStore } = agentHarness(
       { kind: "existing-session", sessionId: "ses_elsewhere", harnessProvider: "codex" },
-      stationHostedSnapshot({ focusable: true }),
+      liveAgentWithoutTerminalSnapshot(),
     );
     observerService.dispatch = async () => {
-      throw { tag: "ClientObserverError", code: "STATION_FOCUS_THREW", message: "Observer is gone." };
+      throw {
+        tag: "ClientObserverError",
+        code: "STATION_FOCUS_THREW",
+        message: "Observer is gone.",
+      };
     };
     store.actions.openOverlay(STATION_OVERLAY_ID);
 


### PR DESCRIPTION
## Summary
- keep Station-native targets externally non-focusable even when Station Host supplies spawn/list/close/attachment lifecycle
- reject direct native focus commands with an actionable owning-terminal error while preserving Host-backed close and native attachment behavior
- cover Observer projection/reconstruction, dashboard activation, native Station attachment, and real tmux popup behavior; document the ownership boundary

## Testing
- `CLAUDE_CONFIG_DIR="$(mktemp -d)" STATION_INSTALL_SMOKE_TIMEOUT_SCALE=4 pnpm test:all`
- `cd station && bun test src/input/stationInput.test.ts && bun run typecheck`
- focused Station provider, Observer reconciliation, and dashboard transition suites (92 tests)
- real tmux popup regression test for native notice/no-command/popup preservation and subsequent tmux focus
- `pnpm lint`
- pi-lens diagnostics: no blocking errors

## UX implication
Selecting a native Station session from an external dashboard now shows the existing wrong-terminal notice, sends no focus command, and leaves the popup open. Native Station still attaches to or reveals the session locally.

## Manual verification
Open a tmux dashboard popup with both native and tmux sessions. Select the native row and confirm the notice appears without closing the popup; then select the tmux row and confirm focus succeeds and the popup dismisses.
