### PR TITLE
fix(dashboard): keep empty-session action readable on hover

### DIFF
--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -447,7 +447,7 @@ function EmptySessionButton({ projectId }: { projectId: string }) {
     <text
       flexShrink={0}
       fg={hover ? STATION_COLORS.background : STATION_COLORS.cyan}
-      {...(hover ? { backgroundColor: STATION_COLORS.cyan } : {})}
+      {...(hover ? { bg: STATION_COLORS.cyan } : {})}
       {...stationMouseProps(dispatch, { kind: "quickSessionForProject", projectId })}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -14,7 +14,6 @@ import {
   externalAgentSnapshot,
   manyProjectsSnapshot,
   noProjectsSnapshot,
-  scenarioState,
 } from "../fixtures/scenarios.js";
 import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import type { StationMouseTarget } from "../input/stationMouse.js";
@@ -334,6 +333,44 @@ describe("dashboard golden frames", () => {
     // button) and no slot cell.
     expect(frame).toContain("no sessions yet · ");
     expect(frame).toContain("[ + add session ]");
+  });
+
+  it("keeps the empty-project add-session action readable on hover", async () => {
+    const setup = await renderDashboard({ width: 120, height: 40, snapshot: manyProjectsSnapshot() });
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("[ + add session ]"));
+    const col = lines[row]?.indexOf("[ + add session ]") ?? -1;
+    expect(row).toBeGreaterThan(0);
+    expect(col).toBeGreaterThan(0);
+
+    const ordinarySpan = spanAtFrameCell(setup.captureSpans(), row, col);
+    const ordinaryForeground = spanHex(ordinarySpan);
+    const ordinaryBackground = spanBgHex(ordinarySpan);
+    expect(ordinaryForeground).toBe(STATION_COLORS.cyan);
+    expect(ordinaryForeground).not.toBe(ordinaryBackground);
+
+    await act(async () => {
+      await setup.mockMouse.moveTo(col, row);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await setup.flush();
+
+    const hoveredSpan = spanAtFrameCell(setup.captureSpans(), row, col);
+    const hoveredForeground = spanHex(hoveredSpan);
+    const hoveredBackground = spanBgHex(hoveredSpan);
+    expect(hoveredForeground).toBe(STATION_COLORS.background);
+    expect(hoveredBackground).toBe(STATION_COLORS.cyan);
+    expect(hoveredForeground).not.toBe(hoveredBackground);
+
+    await act(async () => {
+      await setup.mockMouse.moveTo(0, 0);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await setup.flush();
+
+    const restoredSpan = spanAtFrameCell(setup.captureSpans(), row, col);
+    expect(spanHex(restoredSpan)).toBe(ordinaryForeground);
+    expect(spanBgHex(restoredSpan)).toBe(ordinaryBackground);
   });
 
   it("renders the focus cursor and jumps it to the next session needing you", async () => {


### PR DESCRIPTION
## Summary
- use OpenTUI's supported `bg` prop for the empty-project add-session hover background
- add span-level coverage for rest, hover, and mouse-out foreground/background restoration

## Validation
- `pnpm build`
- `pnpm lint`
- `cd station && bun run typecheck`
- focused dashboard, popup dispatch, store, and mouse tests (82 passed)
- full Station suite (1,038 passed)
- pre-push gate

## UX
`[ + add session ]` remains cyan at rest, renders dark text on cyan while hovered, and restores its rest styling on mouse-out.

Fixes #201
