### PR TITLE
fix(tui): render and durably persist standalone widgets

### DIFF
--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -81,7 +81,8 @@ const nestedTuiDisabledError = {
 /**
  * COMPOSITION ROOT
  *
- * Owns Observer startup, renderer process selection, and persistent popup control wiring.
+ * Owns Observer startup, resolved-config propagation, renderer process selection,
+ * and persistent popup control wiring.
  */
 export async function runTuiCommand(
   args: string[],
@@ -110,7 +111,7 @@ export async function runTuiCommand(
     // --dev-fake-dashboard previews the read-only dashboard with mock data.
     return runRenderer(
       deps,
-      buildRendererEnv(parsed, { STATION_SOURCE: "mock" }),
+      buildRendererEnv(parsed, { STATION_SOURCE: "mock" }, options.configPath),
       "dashboard",
       parsed.persistentPopup,
       options.config?.terminal?.tmux?.command,
@@ -169,11 +170,15 @@ export async function runTuiCommand(
   // tmux popup we keep the read-only dashboard, since tmux owns the panes there.
   return runRenderer(
     deps,
-    buildRendererEnv(parsed, {
-      STATION_CLIENT_BUILD_VERSION: clientBuildVersion,
-      STATION_OBSERVER_SOCKET_PATH: observer.paths.socketPath,
-      STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
-    }),
+    buildRendererEnv(
+      parsed,
+      {
+        STATION_CLIENT_BUILD_VERSION: clientBuildVersion,
+        STATION_OBSERVER_SOCKET_PATH: observer.paths.socketPath,
+        STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
+      },
+      options.configPath,
+    ),
     parsed.popupMode ? "dashboard" : "station",
     parsed.persistentPopup,
     options.config?.terminal?.tmux?.command,
@@ -185,8 +190,13 @@ export async function runTuiCommand(
 function buildRendererEnv(
   parsed: ParsedTuiArgs,
   base: Record<string, string>,
+  resolvedConfigPath: string | undefined,
 ): Record<string, string> {
   const env = { ...base };
+  if (resolvedConfigPath !== undefined) {
+    // The CLI-selected file is authoritative over any inherited renderer environment.
+    env.STATION_CONFIG_PATH = resolvedConfigPath;
+  }
   if (parsed.popupMode) {
     env.STATION_TUI_POPUP = "1";
   }

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -9,7 +9,7 @@ import {
   runTuiCommand,
   type TuiCommandDeps,
 } from "@station/cli/internal";
-import type { TuiConfig } from "@station/config";
+import { loadConfig, setTuiWidgetsInConfig, type TuiConfig } from "@station/config";
 import { TUI_RENDERER_CONTROL_PROTOCOL_VERSION } from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
@@ -244,6 +244,7 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       {
         STATION_CLIENT_BUILD_VERSION: observerBuildVersion,
+        STATION_CONFIG_PATH: configPath,
         STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
       },
@@ -393,6 +394,7 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       {
         STATION_CLIENT_BUILD_VERSION: observerBuildVersion,
+        STATION_CONFIG_PATH: configPath,
         STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
       },
@@ -628,6 +630,7 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       {
         STATION_CLIENT_BUILD_VERSION: observerBuildVersion,
+        STATION_CONFIG_PATH: configPath,
         STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
         STATION_TUI_POPUP: "1",
@@ -676,6 +679,58 @@ describe("CLI tui command", () => {
     );
 
     expect(entries).toEqual(["station", "dashboard", "dashboard"]);
+  });
+
+  it("forwards the resolved explicit config to every renderer path and persists that file", async () => {
+    const explicit = await createTempState();
+    explicit.config.tui = { widgets: [{ type: "time" }] };
+    const explicitPath = await writeConfigToml(explicit.root, explicit.config);
+    const inherited = await createTempState();
+    inherited.config.tui = { widgets: [{ type: "time", timeFormat: "24h" }] };
+    const inheritedPath = await writeConfigToml(inherited.root, inherited.config);
+    const entries: string[] = [];
+    let persisted = false;
+    const spawnRenderer = async ({
+      entry,
+      env,
+    }: {
+      entry: string;
+      env: Record<string, string>;
+    }) => {
+      entries.push(entry);
+      expect(env.STATION_CONFIG_PATH).toBe(explicitPath);
+      if (!persisted) {
+        persisted = true;
+        const rendererConfigPath = env.STATION_CONFIG_PATH;
+        expect(rendererConfigPath).toBe(explicitPath);
+        if (rendererConfigPath === undefined) {
+          throw new Error("renderer did not receive the resolved config path");
+        }
+        await setTuiWidgetsInConfig({
+          configPath: rendererConfigPath,
+          widgets: [{ type: "fleet" }],
+        });
+      }
+      return { status: "exited" as const, code: 0 };
+    };
+    const launchOptions = {
+      env: { STATION_CONFIG_PATH: inheritedPath },
+      observerDeps: runningObserverDeps(),
+      tuiDeps: { spawnRenderer },
+    };
+
+    await runCli(["--config", explicitPath], launchOptions);
+    await runCli(["--config", explicitPath, "tui", "--popup"], launchOptions);
+    await runCli(["--config", explicitPath, "tui", "--popup", "--persistent"], launchOptions);
+    await runCli(["--config", explicitPath, "tui", "--dev-fake-dashboard"], launchOptions);
+
+    expect(entries).toEqual(["station", "dashboard", "dashboard", "dashboard"]);
+    expect((await loadConfig({ configPath: explicitPath })).config.tui?.widgets).toEqual([
+      { type: "fleet" },
+    ]);
+    expect((await loadConfig({ configPath: inheritedPath })).config.tui?.widgets).toEqual([
+      { type: "time", timeFormat: "24h" },
+    ]);
   });
 
   it("uses compiled self-exec and skips the source workspace installation preflight", async () => {
@@ -845,6 +900,7 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       {
         STATION_CLIENT_BUILD_VERSION: observerBuildVersion,
+        STATION_CONFIG_PATH: configPath,
         STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
         STATION_TUI_PERSISTENT: "1",
@@ -1434,6 +1490,7 @@ describe("CLI tui command", () => {
     expect(envs).toEqual([
       {
         STATION_CLIENT_BUILD_VERSION: observerBuildVersion,
+        STATION_CONFIG_PATH: configPath,
         STATION_OBSERVER_BUILD_VERSION: observerBuildVersion,
         STATION_OBSERVER_SOCKET_PATH: fixture.socketPath,
       },

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ branch is configured.
 
 | File | Path (default) | What it controls | Read by | Relocate with |
 | --- | --- | --- | --- | --- |
-| **Runtime config** | `~/.config/station/config.toml` | Everything: projects, defaults, the observer daemon, providers (worktree/terminal/harness), event hooks, retention, feature flags, the `[tui]` widgets, and the `[workspace]` native-UI behavior | observer, `stn` CLI, native TUI | `STATION_CONFIG_PATH` or `stn --config <path>` |
+| **Runtime config** | `~/.config/station/config.toml` | Everything: projects, defaults, the observer daemon, providers (worktree/terminal/harness), event hooks, retention, feature flags, the `[tui]` widgets, and the `[workspace]` native-UI behavior | observer, `stn` CLI, native and standalone/tmux TUIs | `STATION_CONFIG_PATH` or `stn --config <path>` |
 | **Project-local config** | `<project.root>/.station/config.toml` | Opt-in per-project overrides: harness/layout defaults, extra commands, display | config loader (merged into the project) | set its `path` in `[projects.local_config]` |
 
 Not config, but adjacent:
@@ -278,9 +278,11 @@ Each `Automation` is `{ id, label, enabled?, steps[] }`; each step under
 > clock/weather strip; `[workspace]` is interaction behavior (scroll, welcome,
 > automations). They never overlap.
 
-`[tui].widgets` is an array discriminated on `type`. Every widget accepts an
-optional `enabled` (bool; default true — `false` keeps the entry in config but
-hides it). Array order is display order, left to right:
+`[tui].widgets` configures the shared title strip in both the native Station
+overlay and the standalone dashboard used by fullscreen and tmux popup launches.
+It is an array discriminated on `type`. Every widget accepts an optional `enabled`
+(bool; default true — `false` keeps the entry in config but hides it). Array order
+is display order, left to right:
 
 - **`type = "time"`** — optional `time_format` (`12h` \| `24h`).
 - **`type = "weather"`** — required `city`; optional `label`, `temperature_unit`
@@ -547,9 +549,10 @@ section hard-fails validation, the TUI keeps running with workspace defaults and
 a warning before rendering. Fix the core config error to restore custom scroll,
 welcome, and automation settings.
 
-**`[tui]` vs `[workspace]`?** `[tui]` is decorative widgets (clock/weather);
-`[workspace]` is native-UI interaction behavior (scroll/welcome/automations). Both
-live in `config.toml`; both are read only by the TUI.
+**`[tui]` vs `[workspace]`?** `[tui]` is decorative title widgets shared by the
+native overlay and standalone/fullscreen/tmux dashboards; `[workspace]` is
+native-UI-only interaction behavior (scroll/welcome/automations). Both live in
+`config.toml`; only the TUI consumes their display and interaction behavior.
 
 **Why is `permission_mode = "auto"` rejected?** `auto` is Claude-only — valid only
 under `[harness.claude]`, never as a global default or for other harnesses.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -12,6 +12,10 @@ Station is built on OpenTUI (`@opentui/core` + `@opentui/react`) and `react`, ru
 - `station/src/dashboardRenderer/main.tsx` — the standalone observer-backed dashboard (live
   observer data and commands, no panes).
 
+Both entry points load `[tui].widgets` from the runtime config and render the same
+configured-widget title chrome; widget settings update that shared config when a
+config path is available.
+
 Launch is driven by `apps/cli/src/commands/tui.ts`. The Node CLI shells out to the Bun renderer (dual-runtime, accepted for alpha):
 
 - Bare `stn` in a plain terminal launches the native workspace (Station owns its own panes).

--- a/integrations/terminal/tmux/test/fixtures/real-dashboard-99x25.frame.json
+++ b/integrations/terminal/tmux/test/fixtures/real-dashboard-99x25.frame.json
@@ -2,7 +2,7 @@
   "columns": 99,
   "rows": 25,
   "lines": [
-    "                                                                                                   ",
+    "   station · overview                                                  20 agents · 1 open PR [+]   ",
     "FLEET  ● 0 ready  ⠿ 0 working  ! 0 needs you  ○ 20 idle        1 project · 20 sessions · 20 agents ",
     "────────────────────────────────────────────────────────────────────────────────────────────────── ",
     "       SESSION                                   AGENT     STATUS                        DIFF · PR ",

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -377,8 +377,9 @@ describeRealTmux("real tmux dev popup routing", () => {
     await waitForPaneContent(
       fixture,
       firstPopup,
-      isAcceptanceDashboardContent,
-      "deterministic real dashboard did not render",
+      (content) =>
+        isAcceptanceDashboardContent(content) && content.includes("20 agents · 1 open PR"),
+      "deterministic real dashboard did not render configured widgets",
     );
     const firstRuntime = await waitForDashboardRuntimeEvidence(fixture, firstPopup, process.pid);
     const popupAttach = await waitForPopupAttachRecord(fixture);
@@ -388,7 +389,21 @@ describeRealTmux("real tmux dev popup routing", () => {
 
     const baseline = await captureStableFrame(fixture);
     assertStructuralDashboardFrame(baseline);
+    assertConfiguredWidgetChrome(baseline.lines[0] ?? "", "20 agents · 1 open PR");
     expect(baseline).toEqual(await readExpectedDashboardFrame());
+
+    await fixture.ptyClient.write(Buffer.from("W", "utf8"));
+    await waitForPaneContent(
+      fixture,
+      firstPopup,
+      (content) =>
+        content.includes("[on ] fleet") &&
+        content.includes("[on ] open PRs") &&
+        !content.includes("no widgets yet"),
+      "widget settings did not receive the configured standalone widget definitions",
+    );
+    await fixture.ptyClient.write(Buffer.from([0x1b]));
+    await waitForExactFrame(fixture, baseline);
 
     await fixture.ptyClient.write(Buffer.from("?", "utf8"));
     await waitForPaneContent(
@@ -414,6 +429,7 @@ describeRealTmux("real tmux dev popup routing", () => {
       await resizeDashboardSurface(fixture, dimensions);
       const resized = await captureStableFrame(fixture);
       assertStructuralDashboardFrame(resized);
+      assertConfiguredWidgetChrome(resized.lines[0] ?? "", "20 agents · 1 open PR");
       expectDashboardRuntimeUnchanged(
         firstRuntime,
         await currentDashboardRuntimeEvidence(fixture, firstPopup, process.pid),
@@ -428,9 +444,12 @@ describeRealTmux("real tmux dev popup routing", () => {
     await waitForPaneContent(
       fixture,
       secondPopup,
-      isAcceptanceDashboardContent,
-      "dashboard did not render after outer-input dismissal and reopen",
+      (content) =>
+        isAcceptanceDashboardContent(content) && content.includes("20 agents · 1 open PR"),
+      "dashboard did not render configured widgets after outer-input dismissal and reopen",
     );
+    const reopenedFrame = await captureStableFrame(fixture);
+    assertConfiguredWidgetChrome(reopenedFrame.lines[0] ?? "", "20 agents · 1 open PR");
     const reopened = await currentDashboardRuntimeEvidence(fixture, secondPopup, process.pid);
     expect(reopened.panePid).toBe(firstRuntime.panePid);
     expect(reopened.cliPid).toBe(firstRuntime.cliPid);
@@ -698,6 +717,9 @@ describeRealTmux("real tmux dev popup routing", () => {
         `${geometry.label} dashboard frame did not converge`,
       );
       assertDashboardFrameGeometry(content, geometry.pane, geometry.label);
+      if (geometry.pane.columns === 80 || geometry.pane.columns === 99) {
+        assertConfiguredWidgetChrome(dashboardFrameLines(content)[0] ?? "");
+      }
 
       const processes = await waitForDashboardProcessEvidence(fixture, pane);
       recordRuntimeEvidence(fixture, nestedClient, pane, processes);
@@ -2586,6 +2608,16 @@ function framesEqual(left: CapturedFrame, right: CapturedFrame): boolean {
 function assertStructuralDashboardFrame(frame: CapturedFrame): void {
   expect(frame.lines).toHaveLength(frame.rows);
   expect(frame.lines.at(-1)).toContain("? help");
+}
+
+function assertConfiguredWidgetChrome(titleRow: string, expectedWidgets?: string): void {
+  expect(titleRow).toContain("station · overview");
+  expect(titleRow).toContain("[+]");
+  if (expectedWidgets === undefined) {
+    expect(titleRow).toMatch(/\d+ agents? · \d+ open PRs?/u);
+  } else {
+    expect(titleRow).toContain(expectedWidgets);
+  }
 }
 
 async function waitForDashboardRuntimeEvidence(

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -1,8 +1,10 @@
-import { setTuiWidgetsInConfig } from "@station/config";
 import type { TuiStore } from "@station/dashboard-core";
-import { safeErrorFromUnknown } from "@station/runtime";
 import type { StoreApi } from "zustand/vanilla";
 import type { Automation } from "../config/stationConfig.js";
+import {
+  startWidgetConfigWrites,
+  type WidgetConfigWrites,
+} from "../config/tuiConfig.js";
 import {
   type ClipboardEffects,
   copyToClipboard,
@@ -216,7 +218,7 @@ function createLifecycle(deps: {
   let detachReconcile: (() => void) | undefined;
   let detachSessionReconcile: (() => void) | undefined;
   let detachLayoutWriter: (() => void) | undefined;
-  let detachWidgetConfigWrites: (() => void) | undefined;
+  let widgetConfigWrites: WidgetConfigWrites | undefined;
   let disposed = false;
 
   const disposeInternal = (disposeTerminals: boolean): void => {
@@ -234,8 +236,8 @@ function createLifecycle(deps: {
     detachSessionReconcile = undefined;
     detachLayoutWriter?.();
     detachLayoutWriter = undefined;
-    detachWidgetConfigWrites?.();
-    detachWidgetConfigWrites = undefined;
+    void widgetConfigWrites?.dispose();
+    widgetConfigWrites = undefined;
     // Real shutdown flushes pending layout synchronously (process.exit follows);
     // an HMR teardown just drops the timer — the reused store/registry keep it.
     if (disposeTerminals) {
@@ -273,7 +275,7 @@ function createLifecycle(deps: {
         detachLayoutWriter = store.subscribe(() => layoutWriter.schedule());
       }
       if (tuiConfigPath !== undefined) {
-        detachWidgetConfigWrites = startWidgetConfigWrites(stationViewStore, tuiConfigPath);
+        widgetConfigWrites = startWidgetConfigWrites(stationViewStore, tuiConfigPath);
       }
       detachStationSource = stationViewStore.getState().start();
       // The overlay bridge may synchronize immediately, so its dashboard source
@@ -284,54 +286,6 @@ function createLifecycle(deps: {
     disposeForShutdown: (): void => disposeInternal(true),
     disposeForHotReload: (): void => disposeInternal(false),
   };
-}
-
-function startWidgetConfigWrites(
-  stationViewStore: StoreApi<TuiStore>,
-  configPath: string,
-): () => void {
-  let pending: TuiStore["widgets"] | undefined;
-  let saving = false;
-
-  // Single-flight writer: `saving` keeps at most one drain running while
-  // `pending` coalesces to the newest widget set, so rapid edits (e.g. held
-  // reorder keys) collapse into sequential whole-file writes, never interleaved.
-  const drain = async (): Promise<void> => {
-    if (saving) {
-      return;
-    }
-    saving = true;
-    try {
-      while (pending !== undefined) {
-        const widgets = pending;
-        pending = undefined;
-        try {
-          await setTuiWidgetsInConfig({ configPath, widgets });
-        } catch (error) {
-          const safeError = safeErrorFromUnknown(error, {
-            tag: "StationWidgetConfigError",
-            code: "STATION_WIDGET_CONFIG_SAVE_FAILED",
-            message: "Could not save widgets to config.toml.",
-          });
-          stationViewStore.getState().pushToast({
-            kind: "error",
-            message: "Could not save widgets to config.toml.",
-            hint: safeError.message,
-          });
-        }
-      }
-    } finally {
-      saving = false;
-    }
-  };
-
-  return stationViewStore.subscribe((state, previous) => {
-    if (state.widgets === previous.widgets) {
-      return;
-    }
-    pending = state.widgets;
-    void drain();
-  });
 }
 
 /** Build the input runtime; aux shell placement uses the host when a socket is set. */

--- a/station/src/app/createStation.ts
+++ b/station/src/app/createStation.ts
@@ -65,6 +65,7 @@ export function createStation(options: CreateStationOptions): Station {
     layoutWriter,
     tuiConfigPath: options.tuiConfigPath,
   });
+  let shutdownStarted = false;
 
   // Input runtime; its shutdown tears down this composition, then exits the app.
   const stationInput = createInputRuntime(options, {
@@ -74,8 +75,11 @@ export function createStation(options: CreateStationOptions): Station {
     observerService: stationClient.service,
     automations,
     onShutdown: () => {
-      lifecycle.disposeForShutdown();
-      options.shutdown();
+      if (shutdownStarted) {
+        return;
+      }
+      shutdownStarted = true;
+      void lifecycle.disposeForShutdown().then(() => options.shutdown());
     },
   });
 
@@ -95,7 +99,9 @@ export function createStation(options: CreateStationOptions): Station {
     stationViewStore,
     stationInput,
     start: lifecycle.start,
-    dispose: lifecycle.disposeForShutdown,
+    dispose: () => {
+      void lifecycle.disposeForShutdown();
+    },
     disposeForShutdown: lifecycle.disposeForShutdown,
     disposeForHotReload: lifecycle.disposeForHotReload,
   };
@@ -220,10 +226,11 @@ function createLifecycle(deps: {
   let detachLayoutWriter: (() => void) | undefined;
   let widgetConfigWrites: WidgetConfigWrites | undefined;
   let disposed = false;
+  let pendingWidgetWrites: Promise<void> | undefined;
 
-  const disposeInternal = (disposeTerminals: boolean): void => {
+  const disposeInternal = (disposeTerminals: boolean): Promise<void> => {
     if (disposed) {
-      return;
+      return pendingWidgetWrites ?? Promise.resolve();
     }
     disposed = true;
     detachOverlayRowFocus?.();
@@ -236,7 +243,7 @@ function createLifecycle(deps: {
     detachSessionReconcile = undefined;
     detachLayoutWriter?.();
     detachLayoutWriter = undefined;
-    void widgetConfigWrites?.dispose();
+    pendingWidgetWrites = widgetConfigWrites?.dispose() ?? Promise.resolve();
     widgetConfigWrites = undefined;
     // Real shutdown flushes pending layout synchronously (process.exit follows);
     // an HMR teardown just drops the timer — the reused store/registry keep it.
@@ -255,6 +262,7 @@ function createLifecycle(deps: {
     if (disposeTerminals) {
       registry.disposeAll();
     }
+    return pendingWidgetWrites;
   };
 
   return {
@@ -283,8 +291,10 @@ function createLifecycle(deps: {
       detachOverlayRowFocus = createOverlayRowFocusReconciler(store, stationViewStore);
       stationClient.start();
     },
-    disposeForShutdown: (): void => disposeInternal(true),
-    disposeForHotReload: (): void => disposeInternal(false),
+    disposeForShutdown: (): Promise<void> => disposeInternal(true),
+    disposeForHotReload: (): void => {
+      void disposeInternal(false);
+    },
   };
 }
 

--- a/station/src/app/types.ts
+++ b/station/src/app/types.ts
@@ -89,6 +89,7 @@ export type Station = {
   stationInput: StationInputRuntime;
   start(): void;
   dispose(): void;
-  disposeForShutdown(): void;
+  /** Detach runtime resources and resolve after pending config edits are durable. */
+  disposeForShutdown(): Promise<void>;
   disposeForHotReload(): void;
 };

--- a/station/src/config/tuiConfig.test.ts
+++ b/station/src/config/tuiConfig.test.ts
@@ -2,7 +2,13 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "bun:test";
-import { loadStationTuiConfig } from "./tuiConfig.js";
+import { createTuiStore } from "@station/dashboard-core";
+import { createStationViewStore } from "../station/store/stationViewStore.js";
+import { manyProjectsSnapshot } from "../station/fixtures/scenarios.js";
+import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
+import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
+import { makeStationTestStore } from "../station/test/support/makeStationTestStore.js";
+import { loadStationTuiConfig, startWidgetConfigWrites } from "./tuiConfig.js";
 
 describe("loadStationTuiConfig", () => {
   const dirs: string[] = [];
@@ -36,14 +42,10 @@ harness = "codex"
 layout = "agent-build-shell"
 
 [[tui.widgets]]
-type = "time"
-time_format = "24h"
+type = "fleet"
 
 [[tui.widgets]]
-type = "weather"
-city = "New York, NY"
-label = "NYC"
-temperature_unit = "fahrenheit"
+type = "prs"
 
 [[projects]]
 id = "web"
@@ -63,15 +65,7 @@ enabled = true
 
     await expect(loadStationTuiConfig({ env: { STATION_CONFIG_PATH: configPath } })).resolves.toEqual({
       config: {
-        widgets: [
-          { type: "time", timeFormat: "24h" },
-          {
-            type: "weather",
-            city: "New York, NY",
-            label: "NYC",
-            temperatureUnit: "fahrenheit",
-          },
-        ],
+        widgets: [{ type: "fleet" }, { type: "prs" }],
       },
       configPath,
     });
@@ -123,4 +117,190 @@ root = "${projectRoot}"
     expect(result.config).toBeUndefined();
     expect(result.warning).toContain("widgets disabled");
   });
+
+  it("serializes widget writes and stops observing changes after disposal", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
+    dirs.push(dir);
+    const configPath = await writeWidgetTestConfig(dir);
+
+    const { store } = makeStationTestStore();
+    store.setState({ widgets: [{ type: "time" }] });
+    const writes = startWidgetConfigWrites(store, configPath);
+    store.setState({ widgets: [{ type: "time" }, { type: "moon" }] });
+    store.setState({ widgets: [{ type: "time" }, { type: "moon" }, { type: "fleet" }] });
+    store.setState({
+      widgets: [{ type: "time" }, { type: "moon" }, { type: "fleet" }, { type: "prs" }],
+    });
+
+    await writes.flush();
+    await writes.dispose();
+    store.setState({ widgets: [{ type: "moon" }] });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const loadedAfterDispose = await loadStationTuiConfig({ path: configPath });
+    expect(loadedAfterDispose.config?.widgets).toEqual([
+      { type: "time" },
+      { type: "moon" },
+      { type: "fleet" },
+      { type: "prs" },
+    ]);
+  });
+
+  it("flushes the real standalone input flow before immediate exit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
+    dirs.push(dir);
+    const configPath = await writeWidgetTestConfig(dir);
+
+    const source = new FakeStationSource(manyProjectsSnapshot());
+    const service = new FakeTuiObserverService(manyProjectsSnapshot());
+    let writes: ReturnType<typeof startWidgetConfigWrites> | undefined;
+    let durableExit: Promise<void> | undefined;
+    let exitCode: number | undefined;
+    const store = createTuiStore({
+      source,
+      service,
+      initialState: { widgets: [{ type: "time" }], widgetsPersisted: true },
+      onExit: (code) => {
+        exitCode = code;
+        if (writes === undefined) {
+          throw new Error("widget writer was not attached before exit");
+        }
+        durableExit = writes.dispose();
+      },
+    });
+    writes = startWidgetConfigWrites(store, configPath);
+
+    store.getState().handleKey({ input: "W" });
+    store.getState().handleKey({ input: " " });
+    store.getState().handleKey({ input: "", escape: true });
+    store.getState().handleKey({ input: "Q" });
+
+    expect(exitCode).toBe(0);
+    if (durableExit === undefined) {
+      throw new Error("standalone exit did not wait for widget durability");
+    }
+    await durableExit;
+    expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
+      { type: "time", enabled: false },
+    ]);
+  });
+
+  it("rebases independent additions and fails closed after a conflicting edit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
+    dirs.push(dir);
+    const configPath = await writeWidgetTestConfig(dir);
+
+    const initialWidgets = [{ type: "time" }] as const;
+    const nativeSource = new FakeStationSource(manyProjectsSnapshot());
+    const nativeStore = createStationViewStore(
+      {
+        state: nativeSource,
+        service: new FakeTuiObserverService(manyProjectsSnapshot()),
+        start: () => nativeSource.start(),
+        stop: () => nativeSource.stop(),
+      },
+      { widgets: initialWidgets, widgetsPersisted: true },
+    );
+    const popupSource = new FakeStationSource(manyProjectsSnapshot());
+    const popupStore = createTuiStore({
+      source: popupSource,
+      service: new FakeTuiObserverService(manyProjectsSnapshot()),
+      initialState: { widgets: initialWidgets, widgetsPersisted: true },
+      persistentPopup: true,
+      onDismiss: async () => {},
+    });
+    const nativeWrites = startWidgetConfigWrites(nativeStore, configPath);
+    const popupWrites = startWidgetConfigWrites(popupStore, configPath);
+
+    addWidgetThroughSettings(nativeStore, 3);
+    await nativeWrites.flush();
+    addWidgetThroughSettings(popupStore, 1);
+    await popupWrites.flush();
+
+    expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
+      { type: "time" },
+      { type: "fleet" },
+      { type: "moon" },
+    ]);
+
+    nativeStore.getState().handleKey({ input: "", escape: true });
+    nativeStore.getState().handleKey({ input: "W" });
+    nativeStore.getState().handleKey({ input: " " });
+    await nativeWrites.flush();
+    addWidgetThroughSettings(popupStore, 2);
+    await popupWrites.flush();
+
+    expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
+      { type: "time", enabled: false },
+      { type: "moon" },
+      { type: "fleet" },
+    ]);
+    expect(popupStore.getState().toasts.at(-1)?.toast.message).toBe(
+      "Could not save widgets to config.toml.",
+    );
+    await Promise.all([nativeWrites.dispose(), popupWrites.dispose()]);
+  });
+
+  it("keeps persistent-popup Q on the dismiss path instead of process exit", async () => {
+    const source = new FakeStationSource(manyProjectsSnapshot());
+    let dismisses = 0;
+    let exits = 0;
+    const store = createTuiStore({
+      source,
+      service: new FakeTuiObserverService(manyProjectsSnapshot()),
+      persistentPopup: true,
+      onDismiss: async () => {
+        dismisses += 1;
+      },
+      onExit: () => {
+        exits += 1;
+      },
+    });
+
+    store.getState().handleKey({ input: "Q" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(dismisses).toBe(1);
+    expect(exits).toBe(0);
+  });
 });
+
+function addWidgetThroughSettings(
+  store: ReturnType<typeof createTuiStore>,
+  pickerIndex: number,
+): void {
+  store.getState().handleKey({ input: "W" });
+  store.getState().handleKey({ input: "a" });
+  for (let index = 0; index < pickerIndex; index += 1) {
+    store.getState().handleKey({ input: "", downArrow: true });
+  }
+  store.getState().handleKey({ input: "\r", return: true });
+}
+
+async function writeWidgetTestConfig(dir: string): Promise<string> {
+  const projectRoot = join(dir, "project");
+  await mkdir(projectRoot);
+  const configPath = join(dir, "config.toml");
+  await writeFile(
+    configPath,
+    `
+schema_version = 1
+
+[defaults]
+worktree_provider = "worktrunk"
+terminal = "tmux"
+harness = "codex"
+layout = "agent-build-shell"
+
+[[tui.widgets]]
+type = "time"
+
+[[projects]]
+id = "web"
+label = "web"
+root = "${projectRoot}"
+`,
+    "utf8",
+  );
+  return configPath;
+}

--- a/station/src/config/tuiConfig.test.ts
+++ b/station/src/config/tuiConfig.test.ts
@@ -8,6 +8,9 @@ import { manyProjectsSnapshot } from "../station/fixtures/scenarios.js";
 import { FakeStationSource } from "../station/test/support/fakeStationSource.js";
 import { FakeTuiObserverService } from "../station/test/support/fakeObserverService.js";
 import { makeStationTestStore } from "../station/test/support/makeStationTestStore.js";
+import { createStation } from "../app/createStation.js";
+import { NO_OP_CLIPBOARD_EFFECTS } from "../copy/testing.js";
+import { createStationStore } from "../state/store.js";
 import { loadStationTuiConfig, startWidgetConfigWrites } from "./tuiConfig.js";
 
 describe("loadStationTuiConfig", () => {
@@ -185,6 +188,40 @@ root = "${projectRoot}"
     ]);
   });
 
+  it("flushes the native Station input flow before its shutdown callback", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
+    dirs.push(dir);
+    const configPath = await writeWidgetTestConfig(dir);
+    const source = new FakeStationSource(manyProjectsSnapshot());
+    let resolveShutdown: (() => void) | undefined;
+    const shutdown = new Promise<void>((resolve) => {
+      resolveShutdown = resolve;
+    });
+    const composition = createStation({
+      store: createStationStore(),
+      clipboardEffects: NO_OP_CLIPBOARD_EFFECTS,
+      stationClient: {
+        state: source,
+        service: new FakeTuiObserverService(manyProjectsSnapshot()),
+        start: () => source.start(),
+        stop: () => source.stop(),
+      },
+      tuiConfig: { widgets: [{ type: "time" }] },
+      tuiConfigPath: configPath,
+      shutdown: () => resolveShutdown?.(),
+    });
+    composition.start();
+
+    composition.stationViewStore.getState().handleKey({ input: "W" });
+    composition.stationViewStore.getState().handleKey({ input: " " });
+    composition.stationInput.handleSequence("\x11");
+
+    await shutdown;
+    expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
+      { type: "time", enabled: false },
+    ]);
+  });
+
   it("rebases independent additions and fails closed after a conflicting edit", async () => {
     const dir = await mkdtemp(join(tmpdir(), "station-tui-config-"));
     dirs.push(dir);
@@ -219,8 +256,8 @@ root = "${projectRoot}"
 
     expect((await loadStationTuiConfig({ path: configPath })).config?.widgets).toEqual([
       { type: "time" },
-      { type: "fleet" },
       { type: "moon" },
+      { type: "fleet" },
     ]);
 
     nativeStore.getState().handleKey({ input: "", escape: true });

--- a/station/src/config/tuiConfig.ts
+++ b/station/src/config/tuiConfig.ts
@@ -141,24 +141,80 @@ function rebaseWidgetChange(
     return change.after;
   }
 
-  // A stale store may safely replay over widgets another surface only appended.
-  // Any removal, toggle, or reorder of its base fails closed instead of being overwritten.
-  const remoteAdditions: TuiWidgetConfig[] = [];
-  let baseIndex = 0;
-  for (const widget of latest) {
-    const expected = change.before[baseIndex];
-    if (expected !== undefined && isDeepStrictEqual(widget, expected)) {
-      baseIndex += 1;
-    } else {
-      remoteAdditions.push(widget);
+  const basePositions = findWidgetPositions(change.before, latest);
+  if (basePositions === undefined) {
+    throw staleWidgetConfigError();
+  }
+
+  // Widget settings emits one append, removal, toggle, or adjacent swap per transition.
+  // Rebase non-order edits onto the durable order; a stale reorder is ambiguous and fails closed.
+  if (
+    change.after.length === change.before.length + 1 &&
+    isDeepStrictEqual(change.after.slice(0, -1), change.before)
+  ) {
+    const added = change.after.at(-1);
+    if (added !== undefined) {
+      return [...latest, added];
     }
   }
-  if (baseIndex !== change.before.length) {
-    throw new Error(
-      "Widget config changed in another Station surface; reopen widget settings and retry this edit.",
+
+  if (change.after.length === change.before.length) {
+    const changed = change.before.flatMap((widget, index) =>
+      isDeepStrictEqual(widget, change.after[index]) ? [] : [index],
     );
+    const changedIndex = changed.length === 1 ? changed[0] : undefined;
+    if (changedIndex !== undefined) {
+      const latestIndex = basePositions[changedIndex];
+      const replacement = change.after[changedIndex];
+      if (latestIndex === undefined || replacement === undefined) {
+        throw staleWidgetConfigError();
+      }
+      const result = [...latest];
+      result[latestIndex] = replacement;
+      return result;
+    }
+    throw staleWidgetConfigError();
   }
-  return [...change.after, ...remoteAdditions];
+
+  if (change.after.length === change.before.length - 1) {
+    const removedIndex = change.before.findIndex((_, index) =>
+      isDeepStrictEqual(
+        change.before.filter((__, candidate) => candidate !== index),
+        change.after,
+      ),
+    );
+    if (removedIndex !== -1) {
+      const removeAt = basePositions[removedIndex];
+      return latest.filter((_, index) => index !== removeAt);
+    }
+  }
+
+  throw staleWidgetConfigError();
+}
+
+function findWidgetPositions(
+  widgets: readonly TuiWidgetConfig[],
+  latest: readonly TuiWidgetConfig[],
+): number[] | undefined {
+  const positions: number[] = [];
+  let latestIndex = 0;
+  for (const widget of widgets) {
+    while (latestIndex < latest.length && !isDeepStrictEqual(latest[latestIndex], widget)) {
+      latestIndex += 1;
+    }
+    if (latestIndex === latest.length) {
+      return undefined;
+    }
+    positions.push(latestIndex);
+    latestIndex += 1;
+  }
+  return positions;
+}
+
+function staleWidgetConfigError(): Error {
+  return new Error(
+    "Widget config changed in another Station surface; reopen widget settings and retry this edit.",
+  );
 }
 
 async function withWidgetConfigLock<T>(configPath: string, action: () => Promise<T>): Promise<T> {

--- a/station/src/config/tuiConfig.ts
+++ b/station/src/config/tuiConfig.ts
@@ -1,5 +1,17 @@
-import { ConfigError, loadConfig, type TuiConfig } from "@station/config";
+import { lstat, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import {
+  ConfigError,
+  loadConfig,
+  setTuiWidgetsInConfig,
+  type TuiConfig,
+  type TuiWidgetConfig,
+} from "@station/config";
+import type { createTuiStore } from "@station/dashboard-core";
 import { safeErrorFromUnknown } from "@station/runtime";
+
+type TuiStoreApi = ReturnType<typeof createTuiStore>;
 
 export type StationTuiConfigLoadResult = {
   config?: TuiConfig;
@@ -42,6 +54,168 @@ export async function loadStationTuiConfig(options?: {
     return {
       warning: `${error.message}; widgets disabled.`,
     };
+  }
+}
+
+export type WidgetConfigWrites = {
+  /** Stop observing and resolve after every queued or in-flight edit is durable. */
+  dispose(): Promise<void>;
+  /** Resolve after every currently queued or in-flight widget edit is durable. */
+  flush(): Promise<void>;
+};
+
+type WidgetChange = {
+  before: readonly TuiWidgetConfig[];
+  after: readonly TuiWidgetConfig[];
+};
+
+const WIDGET_LOCK_TIMEOUT_MS = 5_000;
+const WIDGET_LOCK_WAIT_MS = 10;
+const WIDGET_LOCK_OWNER_GRACE_MS = 100;
+const WIDGET_LOCK_OWNER_PREFIX = "owner-";
+
+/**
+ * Persist each local widget transition against config.toml as the authority.
+ * A cross-process lock serializes reload/rebase/write, so stale native and popup
+ * stores preserve independent edits instead of replacing one another's arrays.
+ * `flush()` preserves observation; `dispose()` detaches and awaits durability.
+ */
+export function startWidgetConfigWrites(
+  stationViewStore: TuiStoreApi,
+  configPath: string,
+): WidgetConfigWrites {
+  let writes = Promise.resolve();
+  let disposed = false;
+
+  const reportWriteFailure = (cause: unknown): void => {
+    const error = safeErrorFromUnknown(cause, {
+      tag: "StationWidgetConfigError",
+      code: "STATION_WIDGET_CONFIG_SAVE_FAILED",
+      message: "Could not save widgets to config.toml.",
+    });
+    stationViewStore.getState().pushToast({
+      kind: "error",
+      message: "Could not save widgets to config.toml.",
+      hint: error.message,
+    });
+  };
+
+  const detach = stationViewStore.subscribe((state, previous) => {
+    if (state.widgets === previous.widgets) {
+      return;
+    }
+    const change = { before: previous.widgets, after: state.widgets };
+    writes = writes
+      .then(() => persistWidgetChange(configPath, change))
+      .catch(reportWriteFailure);
+  });
+
+  return {
+    dispose: async (): Promise<void> => {
+      if (!disposed) {
+        disposed = true;
+        detach();
+      }
+      await writes;
+    },
+    flush: () => writes,
+  };
+}
+
+async function persistWidgetChange(configPath: string, change: WidgetChange): Promise<void> {
+  await withWidgetConfigLock(configPath, async () => {
+    const loaded = await loadConfig({ configPath });
+    const latest = loaded.config.tui?.widgets ?? [];
+    await setTuiWidgetsInConfig({ configPath, widgets: rebaseWidgetChange(change, latest) });
+  });
+}
+
+function rebaseWidgetChange(
+  change: WidgetChange,
+  latest: readonly TuiWidgetConfig[],
+): readonly TuiWidgetConfig[] {
+  if (isDeepStrictEqual(change.before, change.after)) {
+    return latest;
+  }
+  if (isDeepStrictEqual(change.before, latest)) {
+    return change.after;
+  }
+
+  // A stale store may safely replay over widgets another surface only appended.
+  // Any removal, toggle, or reorder of its base fails closed instead of being overwritten.
+  const remoteAdditions: TuiWidgetConfig[] = [];
+  let baseIndex = 0;
+  for (const widget of latest) {
+    const expected = change.before[baseIndex];
+    if (expected !== undefined && isDeepStrictEqual(widget, expected)) {
+      baseIndex += 1;
+    } else {
+      remoteAdditions.push(widget);
+    }
+  }
+  if (baseIndex !== change.before.length) {
+    throw new Error(
+      "Widget config changed in another Station surface; reopen widget settings and retry this edit.",
+    );
+  }
+  return [...change.after, ...remoteAdditions];
+}
+
+async function withWidgetConfigLock<T>(configPath: string, action: () => Promise<T>): Promise<T> {
+  const lockDir = join(dirname(configPath), `.${basename(configPath)}.station-widgets.lock`);
+  const deadline = Date.now() + WIDGET_LOCK_TIMEOUT_MS;
+  while (true) {
+    try {
+      await mkdir(lockDir, { mode: 0o700 });
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw cause;
+      }
+      if (!(await widgetLockHasLiveOwner(lockDir))) {
+        await rm(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for widget config lock ${lockDir}.`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, WIDGET_LOCK_WAIT_MS));
+      continue;
+    }
+
+    try {
+      await writeFile(join(lockDir, `${WIDGET_LOCK_OWNER_PREFIX}${process.pid}`), "", {
+        flag: "wx",
+        mode: 0o600,
+      });
+      return await action();
+    } finally {
+      await rm(lockDir, { recursive: true, force: true });
+    }
+  }
+}
+
+async function widgetLockHasLiveOwner(lockDir: string): Promise<boolean> {
+  let names: string[];
+  try {
+    names = await readdir(lockDir);
+  } catch (cause) {
+    return (cause as NodeJS.ErrnoException).code !== "ENOENT";
+  }
+  const owner = names.find((name) => name.startsWith(WIDGET_LOCK_OWNER_PREFIX));
+  if (owner === undefined) {
+    const stats = await lstat(lockDir).catch(() => undefined);
+    return stats !== undefined && Date.now() - stats.mtimeMs < WIDGET_LOCK_OWNER_GRACE_MS;
+  }
+  const pid = Number(owner.slice(WIDGET_LOCK_OWNER_PREFIX.length));
+  return Number.isSafeInteger(pid) && pid > 0 && processIsAlive(pid);
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (cause) {
+    return (cause as NodeJS.ErrnoException).code !== "ESRCH";
   }
 }
 

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -1,12 +1,14 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { MouseButtons } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
+import type { TuiWidgetConfig } from "@station/dashboard-core/widgets/types";
 import { act } from "react";
 import { makeStationTestStore } from "../station/test/support/makeStationTestStore.js";
 import type { DashboardMouseEffects } from "./dashboardMouse.js";
 import { FullscreenDashboard } from "./FullscreenDashboard.js";
 
 const SURFACE = { width: 80, height: 24 };
+const WIDGET_SURFACE = { width: 99, height: 25 };
 const TEST_EFFECTS: DashboardMouseEffects = {
   openShell: () => {},
   openUrl: () => {},
@@ -161,6 +163,54 @@ describe("FullscreenDashboard mouse composition", () => {
 
     expect(fixture.store.getState().screen).toEqual({ name: "dashboard" });
     expect(setup.captureCharFrame()).toContain("The test observer rejected this command.");
+  });
+});
+
+describe("FullscreenDashboard configured widgets", () => {
+  async function renderWidgets(widgets: readonly TuiWidgetConfig[]) {
+    const fixture = makeStationTestStore({ terminalRows: WIDGET_SURFACE.height });
+    fixture.store.setState({ widgets });
+    const setup = await render(fixture.store, WIDGET_SURFACE);
+    return { setup, store: fixture.store };
+  }
+
+  it("renders resolved configured widgets in the standalone title row at 99x25", async () => {
+    const { setup } = await renderWidgets([{ type: "fleet" }, { type: "prs" }]);
+
+    const titleRow = setup.captureCharFrame().split("\n")[0] ?? "";
+    expect(titleRow).toContain("station · overview");
+    expect(titleRow).toContain("7 agents · 7 open PRs");
+    expect(titleRow).toContain("[+]");
+  });
+
+  it("shows the configured definitions in widget settings", async () => {
+    const { setup, store } = await renderWidgets([{ type: "fleet" }, { type: "prs" }]);
+
+    await actOn(async () => {
+      store.getState().handleKey({ input: "W" });
+      await setup.flush();
+    });
+
+    const frame = setup.captureCharFrame();
+    expect(frame).toContain("[on ] fleet");
+    expect(frame).toContain("[on ] open PRs");
+    expect(frame).not.toContain("no widgets yet");
+  });
+
+  it("keeps the default title stable without fabricating widget values", async () => {
+    const { setup, store } = await renderWidgets([]);
+
+    const titleRow = setup.captureCharFrame().split("\n")[0] ?? "";
+    expect(titleRow).toContain("station · overview");
+    expect(titleRow).toContain("[+]");
+    expect(titleRow).not.toContain("agents");
+    expect(titleRow).not.toContain("open PR");
+
+    await actOn(async () => {
+      store.getState().handleKey({ input: "W" });
+      await setup.flush();
+    });
+    expect(setup.captureCharFrame()).toContain("no widgets yet");
   });
 });
 

--- a/station/src/dashboardRenderer/FullscreenDashboard.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.tsx
@@ -2,8 +2,11 @@ import type { MouseEvent } from "@opentui/core";
 import { useTerminalDimensions } from "@opentui/react";
 import type { TuiStore } from "@station/dashboard-core";
 import { useCallback } from "react";
+import { useStore } from "zustand/react";
 import type { StoreApi } from "zustand/vanilla";
 import { normalizeStationMouseEvent } from "../input/mouse.js";
+import { useTopRowWidgets } from "../station/widgets/useTopRowWidgets.js";
+import { DashboardFrameTitle } from "../station/view/DashboardFrameTitle.js";
 import { DashboardRoot } from "../station/view/DashboardRoot.js";
 import { StationMouseProvider, type StationMouseDispatch } from "../station/view/stationMouseContext.js";
 import { type DashboardMouseEffects, routeDashboardMouse } from "./dashboardMouse.js";
@@ -13,6 +16,7 @@ import { type DashboardMouseEffects, routeDashboardMouse } from "./dashboardMous
  * fullscreen counterpart to Station's in-app `StationOverlay`: it drops the
  * backdrop, centering, and border so the same `DashboardRoot` owns the whole
  * screen (the CLI `tui`/`popup` surface that replaced the retired Ink UI).
+ * The reserved first row reuses Station's title and configured-widget chrome.
  *
  * Mouse targets route through the standalone dashboard adapter, which reuses
  * shared dashboard actions and delegates terminal effects to its environment.
@@ -25,6 +29,8 @@ export function FullscreenDashboard({
   effects: DashboardMouseEffects;
 }) {
   const { width, height } = useTerminalDimensions();
+  const widgets = useStore(store, (state) => state.widgets);
+  const topRowWidgets = useTopRowWidgets(widgets);
   const dispatch = useCallback<StationMouseDispatch>(
     (target, event: MouseEvent) => {
       routeDashboardMouse(target, normalizeStationMouseEvent(event), store, effects);
@@ -35,6 +41,12 @@ export function FullscreenDashboard({
     <StationMouseProvider value={dispatch}>
       <box width={width} height={height} flexDirection="column">
         <DashboardRoot store={store} columns={width} rows={height} />
+        <DashboardFrameTitle
+          store={store}
+          frame={{ left: 0, top: 0, width }}
+          topRowWidgets={topRowWidgets}
+          zIndex={1}
+        />
       </box>
     </StationMouseProvider>
   );

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -6,6 +6,11 @@
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
 import { createTuiStore } from "@station/dashboard-core";
+import {
+  loadStationTuiConfig,
+  startWidgetConfigWrites,
+  type WidgetConfigWrites,
+} from "../config/tuiConfig.js";
 import { STATION_KEYBOARD_PROTOCOL } from "../input/keyboardProtocol.js";
 import { openExternalUrl } from "../openUrl.js";
 import { createStationClient } from "../sources/createStationClient.js";
@@ -31,7 +36,8 @@ function dashboardHotSlots(): DashboardHotSlots {
 
 /**
  * Callable entry for the interactive observer-backed dashboard without native Station panes.
- * Source HMR recreates renderer/client resources while preserving the Bun process and parent IPC.
+ * Configured widgets seed the live store and share the config-write subscription;
+ * normal process exits await widget durability before releasing renderer resources.
  */
 export async function runDashboardMain(): Promise<void> {
   const env = process.env;
@@ -41,10 +47,27 @@ export async function runDashboardMain(): Promise<void> {
   hotSlots.__stationDashboardHotDispose?.();
   hotSlots.__stationDashboardHotRenderer?.destroy();
 
+  const tuiConfig = await loadStationTuiConfig({ env });
+  // Print config degradation before OpenTUI takes over the terminal.
+  if (tuiConfig.warning !== undefined) {
+    console.error(`[station] ${tuiConfig.warning}`);
+  }
+
   let disposeResources = (): void => {};
+  let widgetConfigWrites: WidgetConfigWrites | undefined;
+  let exiting = false;
   function exit(code: number): void {
-    disposeResources();
-    process.exit(code);
+    if (exiting) {
+      return;
+    }
+    exiting = true;
+    void (async () => {
+      if (widgetConfigWrites !== undefined) {
+        await widgetConfigWrites.dispose();
+      }
+      disposeResources();
+      process.exit(code);
+    })();
   }
   const popupRuntime = createPopupRuntime(
     env,
@@ -58,6 +81,10 @@ export async function runDashboardMain(): Promise<void> {
     service: client.service,
     clientLabel: "station",
     onExit: exit,
+    initialState: {
+      widgets: tuiConfig.config?.widgets ?? [],
+      widgetsPersisted: tuiConfig.configPath !== undefined,
+    },
     ...popupRuntime.storeOptions,
   });
   const mouseEffects: DashboardMouseEffects = {
@@ -79,6 +106,9 @@ export async function runDashboardMain(): Promise<void> {
     },
     openUrl: openExternalUrl,
   };
+  if (tuiConfig.configPath !== undefined) {
+    widgetConfigWrites = startWidgetConfigWrites(store, tuiConfig.configPath);
+  }
 
   // Attach the snapshot source first, then start the client runtime feeding it
   // (the order Station's lifecycle uses), so the first frame already sees the
@@ -97,6 +127,7 @@ export async function runDashboardMain(): Promise<void> {
     disposed = true;
     root?.unmount();
     popupRuntime.dispose();
+    void widgetConfigWrites?.dispose();
     detachSource();
     void client.stop();
     renderer?.destroy();


### PR DESCRIPTION
## Summary

- load `[tui].widgets` into the standalone dashboard store and render the existing Station title/widget chrome without changing dashboard geometry
- share the coalesced config writer while making native shutdown await its durable flush before process exit
- preserve the latest durable widget order across non-conflicting stale surfaces and fail closed with feedback on reorder conflicts
- cover resolved values, widget settings, empty defaults, native Ctrl-Q shutdown, stale-surface edits, warm reuse, and real-tmux geometry
- document that configured widgets apply to both native Station and standalone dashboards

Addresses item 5 from #169.

## Safety

Widget arrays are ordered UI state. Stale surfaces may rebase only non-conflicting append, update, or removal edits onto the latest durable order; stale reorder/conflict edits are rejected instead of silently overwriting another surface. Native shutdown is one-shot and completes the config writer before the exit callback runs.

## Validation

- full isolated `pnpm test:pre-push` after rebasing onto merged #206
- 1,046 Station tests, including native Ctrl-Q durability and two-surface order/conflict reproductions
- 518 integration tests, including 49 CLI TUI tests
- 8/8 opt-in real private-tmux production-popup scenarios after a package-version binary build
- build, typecheck, lint, unit, contract, diagnostics, setup/Observer E2E, cross-runtime races, PTY, installer, and binary smoke

## UX implication

Standalone/fullscreen/tmux dashboards show configured widget text in the title. Toggle a widget and immediately press Ctrl-Q, then reopen Station to verify the edit persisted. Two open surfaces retain the established left-to-right order; a conflicting stale reorder is rejected with a toast. Press `W` to verify definitions, and use a 99×25 popup to confirm the title, dividers, and footer remain visible.
