### PR TITLE
ci(actions): gate ready PRs and defer native builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,10 @@ jobs:
   # Checked 2026-07-11: these hosted labels cover the four supported native targets.
   build-native:
     name: build (${{ matrix.target }})
-    needs: validate
+    needs:
+      - validate
+      - standard-ci
+      - release-smoke
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -2,10 +2,14 @@ name: standard-ci
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
   workflow_call:
+
+permissions:
+  contents: read
 
 concurrency:
   group: standard-ci-${{ github.event.pull_request.number || github.ref }}
@@ -13,19 +17,32 @@ concurrency:
 
 jobs:
   standard-ci:
+    # Reusable release calls retain the caller's tag context and must keep the full gate.
+    if: >-
+      github.ref_type == 'tag' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11
         run: |
           corepack enable
           corepack prepare pnpm@11.0.0 --activate
+      # Release acceptance stays cold so branch caches cannot enter candidate validation.
+      - name: Restore Turbo cache
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
@@ -36,3 +53,33 @@ jobs:
         working-directory: station
       - name: Test
         run: pnpm test:pre-push
+
+  main-smoke:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.x
+      - name: Enable pnpm 11
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
+      - name: Restore Turbo cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-
+      - name: Install
+        run: pnpm install --frozen-lockfile
+      - name: Smoke
+        run: |
+          pnpm build
+          pnpm typecheck
+          pnpm lint

--- a/apps/observer/test/unit/socketOwnership.test.ts
+++ b/apps/observer/test/unit/socketOwnership.test.ts
@@ -48,11 +48,14 @@ describe("watchSocketOwnership", () => {
     dir = await mkdtemp(join(tmpdir(), "stn-ownership-"));
     const socketPath = join(dir, "observer.sock");
     await writeFile(socketPath, "");
+    const identity = await readSocketIdentity(socketPath);
+    if (identity === undefined) throw new Error("expected a socket identity");
 
     let lost = false;
     const watch = watchSocketOwnership({
       socketPath,
       intervalMs: 20,
+      expectedIdentity: identity,
       onLost: () => {
         lost = true;
       },

--- a/docs/development.md
+++ b/docs/development.md
@@ -156,12 +156,14 @@ the `station/` Bun dependencies before pushing.
 
 Ready, non-draft pull requests run `pnpm test:pre-push` once on
 `ubuntu-24.04`; release tags call that same full gate before adding the four
-native build and draft-install targets. Draft pull request activity allocates no
-runner, including synchronization before `ready_for_review`. Pushes to `main`
-run only build, typecheck, and lint as a cheap post-merge smoke. The repository
-ruleset must require the pull-request `standard-ci` check and block direct
-`main` pushes; the cheap smoke is a post-merge backstop, not a substitute for
-the full required gate.
+native build and draft-install targets. Both that gate and `smoke:release` must
+pass before any native release build starts.
+Draft pull request activity allocates no
+runner, including synchronization before `ready_for_review`.
+Pushes to `main` run only build, typecheck, and lint as a cheap post-merge
+smoke. The repository ruleset must require the pull-request `standard-ci` check
+and block direct `main` pushes; the cheap smoke is a post-merge backstop, not a
+substitute for the full required gate.
 
 Useful focused commands:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -152,9 +152,16 @@ pnpm test:pre-push
 In addition to `test:all`, it checks cross-runtime SQLite compatibility, the
 Station renderer, the native PTY implementation, and the compiled binary on
 the developer's current platform. Install both the root pnpm dependencies and
-the `station/` Bun dependencies before pushing. GitHub-hosted CI runs this same
-gate once on `ubuntu-24.04` for pull requests and `main`; release tags add the
-four native build and draft-install targets.
+the `station/` Bun dependencies before pushing.
+
+Ready, non-draft pull requests run `pnpm test:pre-push` once on
+`ubuntu-24.04`; release tags call that same full gate before adding the four
+native build and draft-install targets. Draft pull request activity allocates no
+runner, including synchronization before `ready_for_review`. Pushes to `main`
+run only build, typecheck, and lint as a cheap post-merge smoke. The repository
+ruleset must require the pull-request `standard-ci` check and block direct
+`main` pushes; the cheap smoke is a post-merge backstop, not a substitute for
+the full required gate.
 
 Useful focused commands:
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -48,13 +48,13 @@ Non-goals:
 Pinned so the release job, install script, and acceptance suite agree.
 
 | Axis | Policy |
-|------|--------|
+| ------ | -------- |
 | Targets | `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. No Windows. |
 | Build runners | Native per target (no cross-compile — only the host-matching `@opentui/core-*` optional dep installs). Use *currently available* GitHub-hosted labels resolved at implementation time; do **not** hard-code `macos-13` (F9 — Intel macOS labels are being retired). Pin exact labels in the workflow with a comment naming the check date. |
 | macOS floor | Match the oldest OS the chosen Intel/arm runners image supports; state it in release notes. |
 | Linux floor | glibc only for v1.1 (bun's default). Declare the built-against glibc version (the runner's) as the floor; musl is a later target, not silently implied. |
 | CPU | x64 uses Bun's explicit `-baseline` targets for older SSE4.2-era CPUs; arm64 = Apple/ARMv8. |
-| Artifact | `stn-v{ver}-{darwin|linux}-{arm64|x64}.tar.gz`. **Manifest below is exhaustive.** |
+| Artifact | `stn-v{ver}-{platform}-{arch}.tar.gz`, using the target values above. **Manifest below is exhaustive.** |
 
 **Artifact manifest** (every file the binary needs on disk that
 `bun build --compile` does *not* embed — F8):

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const root = new URL("../../", import.meta.url);
+
+function read(path: string): string {
+  return readFileSync(new URL(path, root), "utf8");
+}
+
+function between(document: string, start: string, end?: string): string {
+  const startIndex = document.indexOf(start);
+  expect(startIndex, `missing section start: ${start}`).toBeGreaterThanOrEqual(0);
+  const endIndex = end === undefined ? document.length : document.indexOf(end, startIndex + 1);
+  expect(endIndex, `missing section end: ${end}`).toBeGreaterThan(startIndex);
+  return document.slice(startIndex, endIndex);
+}
+
+describe("hosted CI policy", () => {
+  it("runs the full gate for ready pull requests and release calls but not main pushes", () => {
+    const standardCi = read(".github/workflows/standard-ci.yml");
+    const release = read(".github/workflows/release.yml");
+    const development = read("docs/development.md");
+
+    expect(standardCi).toContain("types: [opened, synchronize, reopened, ready_for_review]");
+
+    const fullGate = between(standardCi, "  standard-ci:", "  main-smoke:");
+    expect(fullGate).toContain("github.ref_type == 'tag'");
+    expect(fullGate).toContain("github.event.pull_request.draft == false");
+    expect(fullGate).toContain("run: pnpm test:pre-push");
+
+    const mainSmoke = between(standardCi, "  main-smoke:");
+    expect(mainSmoke).toContain("github.ref == 'refs/heads/main'");
+    expect(mainSmoke).toContain("pnpm build");
+    expect(mainSmoke).toContain("pnpm typecheck");
+    expect(mainSmoke).toContain("pnpm lint");
+    expect(mainSmoke).not.toContain("test:pre-push");
+    expect(mainSmoke).not.toContain("setup-bun");
+
+    const releaseStandardCi = between(release, "  standard-ci:", "  release-smoke:");
+    expect(releaseStandardCi).toContain("uses: ./.github/workflows/standard-ci.yml");
+
+    expect(development).toContain("Ready, non-draft pull requests run `pnpm test:pre-push`");
+    expect(development).toMatch(/Draft pull request activity allocates no\s+runner/);
+    expect(development).toMatch(/Pushes to `main`\s+run only build, typecheck, and lint/);
+  });
+
+  it("scopes the local Turbo cache to the runner and dependency state", () => {
+    const standardCi = read(".github/workflows/standard-ci.yml");
+    const fullGate = between(standardCi, "  standard-ci:", "  main-smoke:");
+    const mainSmoke = between(standardCi, "  main-smoke:");
+
+    for (const job of [fullGate, mainSmoke]) {
+      expect(job).toMatch(/uses: actions\/cache@[0-9a-f]{40}/);
+      expect(job).toContain("path: .turbo");
+      expect(job).toContain("runner.os");
+      expect(job).toContain("runner.arch");
+      expect(job).toContain("hashFiles('pnpm-lock.yaml', 'turbo.json')");
+      expect(job).toContain("github.sha");
+      expect(job).toContain("restore-keys:");
+    }
+
+    expect(fullGate).toContain("if: github.event_name == 'pull_request'");
+    expect(standardCi).not.toMatch(/path:\s+.*station-build-id/);
+  });
+});

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -38,8 +38,11 @@ describe("hosted CI policy", () => {
 
     const releaseStandardCi = between(release, "  standard-ci:", "  release-smoke:");
     expect(releaseStandardCi).toContain("uses: ./.github/workflows/standard-ci.yml");
+    const nativeBuilds = between(release, "  build-native:", "  create-draft:");
+    expect(nativeBuilds).toMatch(/needs:\s+- validate\s+- standard-ci\s+- release-smoke/);
 
     expect(development).toContain("Ready, non-draft pull requests run `pnpm test:pre-push`");
+    expect(development).toContain("before any native release build starts");
     expect(development).toMatch(/Draft pull request activity allocates no\s+runner/);
     expect(development).toMatch(/Pushes to `main`\s+run only build, typecheck, and lint/);
   });


### PR DESCRIPTION
## Summary

- run the release-grade `pnpm test:pre-push` gate only for ready, non-draft pull requests and reusable release-tag calls
- replace duplicate full `main` runs with a build, typecheck, and lint smoke
- restore an OS/toolchain-scoped Turbo cache for PR and `main` jobs while keeping release acceptance cold
- make every native release build wait for tag validation, the full standard gate, and `smoke:release`
- pin routine CI actions, reduce workflow permissions, document the policy, and add regression coverage
- seed the socket-disappearance watcher test like production to remove an observed async-baseline race

Part of #207.

## Safety and rollout

Release tags retain the full gate through their caller tag context. PR caches are not restored during release acceptance, and `station-build-id` remains outside Turbo's cached outputs. Native builds cannot start until `validate`, `standard-ci`, and `release-smoke` all pass.

Active ruleset `main ready-PR gate` (19124445) requires the latest-head pull-request `standard-ci` check, blocks direct `main` pushes, and has no bypass actors. The cheap `main-smoke` job is a post-merge backstop, not a replacement for that rule. The Actions budget is capped at $20.

## Validation

- full isolated `pnpm test:pre-push` after rebasing onto merged #206 and #208, rerun after the socket watcher test fix
- 1,587 unit, 49 contract, 518 integration, 47 diagnostics, 3 scripted-agent, 15 setup E2E, and 17 Observer lifecycle tests
- 1,046 Station tests and 27 Bun PTY tests
- installer, cross-runtime races, binary build, and binary smoke
- focused workflow policy/docs tests, lint, YAML syntax, and `git diff --check`
- socket ownership test passed 25 consecutive focused runs after seeding its production identity
- merged #206+#208 full `main` gate passed; the preceding one-off failure was the now-fixed socket-test race
- required final-head hosted gate passed for `fd28b07` in run 29624631502
- post-merge `main-smoke` passed for merge `59e82f4` in run 29625027839; full `standard-ci` correctly skipped

## UX implication

Draft PR updates allocate no runner. Marking a PR ready starts one full Linux gate; merging starts only `main-smoke`. A release tag runs the full standard gate and release smoke before any native build starts.

