### PR TITLE
test(tmux): keep the HMR smoke probe visible

### DIFF
--- a/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
@@ -215,7 +215,10 @@ try {
   const insertion = "        <DashboardRoot store={store} columns={width} rows={height} />";
   assert(source.includes(insertion), `HMR insertion point missing from ${hmrTarget}`);
   const nextProbeTargetBytes = Buffer.from(
-    source.replace(insertion, `        <text>${probe}</text>\n${insertion}`),
+    source.replace(
+      insertion,
+      `        <text position="absolute" left={0} top={2} zIndex={100}>${probe}</text>\n${insertion}`,
+    ),
     "utf8",
   );
   assertTargetUnchanged("before the HMR probe write");


### PR DESCRIPTION
## What changed

- render the temporary devbox HMR probe as an absolute, high-z-index overlay
- keep the probe visible after the dashboard became a full-height surface
- leave production renderer and popup behavior untouched

## Why

The documented `station:devbox:tmux:smoke` lane deterministically failed after the full-height dashboard change because its ordinary flex child was outside the visible frame. The renderer did hot-reload correctly; the smoke could not observe its probe.

## Validation

- `pnpm station:devbox:tmux:smoke` — 3/3 fresh private-server runs passed with stable tmux, CLI, renderer, Observer, and nested-client PIDs
- isolated `CI=true pnpm test:pre-push` — passed
- pre-commit Biome/source-order checks — passed

## UX impact

No product UX changes. Manual verification is the private tmux smoke itself: its probe appears and disappears in the warm popup without replacing any runtime owner.