### PR TITLE
chore(release): prepare v0.7.1-rc.1 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gh auth login --hostname github.com
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.0
+  tag=v0.7.1-rc.1
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
   gh api --method GET \
@@ -86,12 +86,13 @@ On the cold-boot welcome screen, press `Enter` or `Space` to open project view. 
 
 The installer selects one of the four supported native targets (`darwin-arm64`, `darwin-x64`, `linux-arm64`, or `linux-x64`), verifies the release archive against `SHA256SUMS`, and installs `stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default. It checks all three physical launcher resolutions rather than relying on textual PATH membership. The compiled `stn` launches without Node.js, pnpm, Bun, or a source checkout. A useful default workflow additionally requires a Git repository, Worktrunk (`wt`), tmux, diffnav/git-delta, and one supported agent CLI; `stn setup` and `stn doctor` establish and verify those capabilities.
 
-`v0.7.0` is the first supported private-binary baseline. The installer code
-and artifacts always come from the same immutable tag. The latest-install
-recipe resolves the current stable tag before fetching and invoking its
-installer. Immutable rollback begins with the second binary release because
-`v0.7.0` has no earlier binary artifact. See [Install](docs/install.md) for the
-recipe, version pinning, PATH recovery, custom install directories, and the
+`v0.7.1-rc.1` is the first supported private-binary candidate; the earlier
+`v0.7.0` candidate remained unpublished. The installer code and artifacts
+always come from the same immutable tag. The latest-install recipe resolves the
+current stable tag before fetching and invoking its installer. Immutable
+rollback begins with the second published binary release because there is no
+earlier published binary artifact. See [Install](docs/install.md) for the recipe,
+version pinning, PATH recovery, custom install directories, and the
 supported-platform and recovery contracts.
 
 ### Development checkout

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.0", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.1", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -313,21 +313,22 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
-The initial immutable binary baseline is `v0.7.0`:
+The initial immutable binary candidate is `v0.7.1-rc.1`; the earlier `v0.7.0`
+candidate remained unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.0`, then create and push
-   `v0.7.0`.
+   with `package.json` and runtime reporting at `0.7.1-rc.1`, then create and
+   push `v0.7.1-rc.1`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.0-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.1-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
 4. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.0`, and the manual-acceptance confirmation. It rechecks the successful
+   `v0.7.1-rc.1`, and the manual-acceptance confirmation. It rechecks the successful
    run SHA, immutable candidate manifest, tag commit, release ID, asset IDs, and
    all archive hashes immediately before publishing that exact draft.
-5. Treat cross-version immutable rollback as a gate for the second binary
-   release. `v0.7.0` has no prior binary artifact to reinstall.
+5. Treat cross-version immutable rollback as a gate for the second published
+   binary release. This candidate has no prior binary artifact to reinstall.
 
 Published tags and assets are immutable. Once two binary releases exist,
 recovery may explicitly reinstall the prior version, but the release line moves
@@ -437,7 +438,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.0
+  tag=v0.7.1-rc.1
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -576,7 +577,7 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.0`: never
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.1`: never
    command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat this with two versions when preparing the

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Station is distributed internally as authenticated private GitHub release assets
 
 On a development-ready Mac, have Xcode Command Line Tools, Homebrew, GitHub CLI access to `jeremy0dell/station`, and Codex or another supported agent CLI ready. Node.js can be present, but the compiled Station binary does not use it.
 
-From any directory, authenticate `gh`, then fetch and run the installer for the first binary baseline:
+From any directory, authenticate `gh`, then fetch and run the installer for the first binary candidate after it is published:
 
 ```bash
 gh auth login --hostname github.com
@@ -14,7 +14,7 @@ gh auth login --hostname github.com
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.0
+  tag=v0.7.1-rc.1
   installer="$(mktemp)"
   trap 'rm -f "$installer"' EXIT
   gh api --method GET \
@@ -27,13 +27,13 @@ gh auth login --hostname github.com
 )
 ```
 
-Keep `tag=v0.7.0` for an exact install. After `v0.7.0` is published, replace that assignment with the following to resolve the latest stable tag while still fetching installer code and artifacts from that same tag:
+Keep `tag=v0.7.1-rc.1` for an exact prerelease install. After the first stable release is published, replace that assignment with the following to resolve the latest stable tag while still fetching installer code and artifacts from that same tag:
 
 ```bash
 tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
 ```
 
-The recipe never falls back to `main`. `gh` handles private-repository authentication for both the bootstrap and the installer's release discovery and asset downloads. Because `v0.7.0` is the first binary release, immutable rollback to a prior binary becomes available only after the next binary release.
+The recipe never falls back to `main`. `gh` handles private-repository authentication for both the bootstrap and the installer's release discovery and asset downloads. The earlier `v0.7.0` candidate remained unpublished, so immutable rollback to a prior binary becomes available only after a second binary release is published.
 
 ### Complete first-run setup
 
@@ -144,8 +144,9 @@ The compiled binary launches the native TUI and Observer without Node.js, pnpm, 
 
 After a second binary version exists, rollback is the same authenticated
 explicit-version install. Published tags and assets are immutable; do not
-delete, move, or overwrite them. If `v0.7.0` itself is bad, publish a higher
-version containing the revert or fix because there is no earlier binary tag.
+delete, move, or overwrite them. If the first published binary is bad, publish a
+higher version containing the revert or fix because there is no earlier binary
+release.
 
 ## Development Checkout
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.0", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.1", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -381,7 +381,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.0-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.1-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -415,13 +415,14 @@ claim bit-for-bit reproducible Bun executables or archives.
 
 `scripts/install.sh` supports latest stable, explicit `--version`, and
 `--install-dir` (default `~/.local/bin`). The supported binary-install baseline
-starts at `v0.7.0`. Explicit installs set a tag, fetch
+starts at `v0.7.1-rc.1`; the earlier `v0.7.0` candidate remained unpublished.
+Explicit installs set a tag, fetch
 `scripts/install.sh` from that tag through the authenticated Contents API, and
 invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
 always paired. Immutable rollback becomes available with the second binary
-release because `v0.7.0` has no earlier binary artifact.
+published release because no earlier binary artifact exists.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -490,11 +491,11 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-The first binary release is immutable `v0.7.0` and promotes only after all four
+The first binary candidate is `v0.7.1-rc.1` and promotes only after all four
 native targets pass automated and manual acceptance. Published tags and assets
 are never deleted, moved, or overwritten. Cross-version rollback is intentionally
-deferred until a second binary version exists; a bad `v0.7.0` rolls forward to a
-higher version containing the revert or fix.
+deferred until a second binary version exists; a bad first release rolls forward
+to a higher version containing the revert or fix.
 
 Drafts are still mutable. Release notes record the workflow commit, while the
 accepted-candidate artifact immutably records that commit plus the draft release
@@ -706,7 +707,7 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.0` output appears, never
+   repeatedly installs the draft → only complete `0.7.1-rc.1` output appears, never
    command-not-found or malformed output; both aliases remain links to `stn`,
    so entrypoints never mix. Repeat with two immutable versions when preparing
    the second binary release and first rollback gate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.0",
+  "version": "0.7.1-rc.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.0" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.1" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.0",
+      version: "0.7.1-rc.1",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.0+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.0+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.1+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.1+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.0",
+      version: "0.7.1-rc.1",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -930,7 +930,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.0";
+    return "0.7.1-rc.1";
   }
   if (
     normalized.length === 2 &&

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -66,7 +66,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated private binary");
     expect(readme).toContain("without Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.0");
+    expect(install).toContain("tag=v0.7.1-rc.1");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -121,7 +121,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.0");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.1");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -179,7 +179,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.0");
+    expect(packageJson.version).toBe("0.7.1-rc.1");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");


### PR DESCRIPTION
## What changed

- advance the package and source runtime version to `0.7.1-rc.1`
- update the source-version, binary-smoke, and release-readiness assertions
- make release and install documentation identify `v0.7.0` as unpublished and use the replacement prerelease candidate

## Why

The existing `v0.7.0` tag and draft were created before the repaired #206, #208, #209, and #210 changes. Repository policy requires preserving that pushed tag and using the next prerelease tag when source changes.

## Validation

- isolated `CI=true pnpm test:pre-push` — passed
- `pnpm smoke:release` — passed
- `pnpm build:binary -- --version 0.7.1-rc.1` — passed
- `pnpm smoke:binary -- --expected-version 0.7.1-rc.1` — passed
- focused runtime, CLI source-version, and release-readiness tests — passed
- `pnpm stn --version` — `0.7.1-rc.1`

## UX impact

The visible version becomes `0.7.1-rc.1`. Manual verification is `stn --version`, followed by installing the accepted draft on each native target through the documented candidate recipe.