### PR TITLE
fix(terminal): preserve synchronized redraw history

### DIFF
--- a/station/src/terminal/protocol/controlBytes.ts
+++ b/station/src/terminal/protocol/controlBytes.ts
@@ -9,6 +9,16 @@ export const ControlByte = {
   Csi: "\x1b[",
 } as const;
 
+export const CsiFinal = {
+  /** ED — Erase in Display (CSI Ps J). */
+  EraseInDisplay: "J",
+} as const;
+
+export const EraseInDisplayMode = {
+  /** ED2 — erase the entire display. */
+  EntireDisplay: 2,
+} as const;
+
 /** Regex-source escapes of the same bytes, for patterns built via `new RegExp`. */
 export const ControlBytePattern = {
   /** ESC (0x1b) as regex source. */

--- a/station/src/terminal/vt/screen.sync.test.ts
+++ b/station/src/terminal/vt/screen.sync.test.ts
@@ -19,6 +19,8 @@ const esuPlusRestB = "\x1b[?2026l" + "\r\n" + frameBRows.slice(2).join("\r\n");
 
 const gridText = (screen: StationVtScreen): string[] =>
   Array.from({ length: SIZE.rows }, (_, index) => screen.rowText(index));
+const renderedText = (screen: StationVtScreen): string[] =>
+  screen.buildRows().map((row) => row.spans.map((span) => span.text).join("").trimEnd());
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -27,6 +29,13 @@ const feedAndFlush = async (screen: StationVtScreen, data: string): Promise<void
   screen.feed(data);
   await screen.whenIdle();
   await waitFor(() => screen.getVersion() > before);
+};
+
+const synchronizedRedraw = async (screen: StationVtScreen, rows: string[]): Promise<void> => {
+  await feedAndFlush(
+    screen,
+    `\x1b[?2026h\x1b[2J\x1b[H${rows.join("\r\n")}\x1b[?2026l`,
+  );
 };
 
 describe("synchronized output (DECSET 2026)", () => {
@@ -109,6 +118,94 @@ describe("synchronized output (DECSET 2026)", () => {
       expect(snapshot.syncActive).toBe(false);
       expect(snapshot.rows).toEqual(frameBRows);
     }
+  });
+
+  it("retains the replaced normal-buffer frame in scrollback", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(screen, frameA);
+
+    await feedAndFlush(screen, "\x1b[?2026h\x1b[2J\x1b[Hreplacement\x1b[?2026l");
+
+    expect(screen.bufferStats().baseY).toBe(SIZE.rows);
+    expect(screen.scrollBy(100)).toBe(true);
+    expect(Array.from({ length: SIZE.rows }, (_, row) => screen.viewRowText(row).trimEnd())).toEqual(
+      frameARows,
+    );
+  });
+
+  it("preserves anchored rows across a synchronized full-screen redraw", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(
+      screen,
+      Array.from({ length: 10 }, (_, index) => `L${index}`).join("\r\n"),
+    );
+    screen.scrollBy(2);
+
+    // Split BSU from the ED2 frame to pin mode tracking across PTY chunk boundaries.
+    screen.feed("\x1b[?2026h");
+    await screen.whenIdle();
+    screen.feed("\x1b[2J\x1b[Hreplacement\x1b[?2026l");
+    await screen.whenIdle();
+    await waitFor(() => screen.unsafeEngine.modes.synchronizedOutputMode === false);
+    await waitFor(() => screen.unsafeEngine.options.scrollOnEraseInDisplay === false);
+
+    expect(Array.from({ length: SIZE.rows }, (_, row) => screen.viewRowText(row).trimEnd())).toEqual([
+      "L3",
+      "L4",
+      "L5",
+      "L6",
+      "L7",
+    ]);
+  });
+
+  it("preserves a frozen view across repeated partially filled redraws", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(
+      screen,
+      Array.from({ length: 10 }, (_, index) => `L${index}`).join("\r\n"),
+    );
+    screen.scrollBy(2);
+
+    await synchronizedRedraw(screen, ["first frame"]);
+    expect(renderedText(screen)).toEqual(["L3", "L4", "L5", "L6", "L7"]);
+
+    await synchronizedRedraw(screen, ["second frame"]);
+    expect(renderedText(screen)).toEqual(["L3", "L4", "L5", "L6", "L7"]);
+  });
+
+  it("does not let repeated redraw frames evict real history at the scrollback cap", async () => {
+    const screen = track(
+      createStationVtScreen({ size: SIZE, scrollback: 10, flushIntervalMs: 1 }),
+    );
+    await feedAndFlush(
+      screen,
+      Array.from({ length: 15 }, (_, index) => `H${index}`).join("\r\n"),
+    );
+
+    for (let index = 0; index < 5; index += 1) {
+      await synchronizedRedraw(
+        screen,
+        Array.from({ length: SIZE.rows }, (_, row) => `redraw-${row}`),
+      );
+    }
+
+    screen.scrollBy(100);
+    expect(renderedText(screen)).toEqual(["H5", "H6", "H7", "H8", "H9"]);
+  });
+
+  it("archives a later ordinary-to-synchronized screen transition", async () => {
+    const screen = track(createStationVtScreen({ size: SIZE, flushIntervalMs: 1 }));
+    await feedAndFlush(screen, frameA);
+    await synchronizedRedraw(screen, ["first app frame"]);
+    await synchronizedRedraw(screen, ["repaint frame"]);
+
+    await feedAndFlush(screen, "\x1b[2J\x1b[Hshell prompt");
+    const before = screen.bufferStats().baseY;
+    await synchronizedRedraw(screen, ["next app frame"]);
+
+    expect(screen.bufferStats().baseY).toBe(before + 1);
+    screen.scrollBy(1);
+    expect(renderedText(screen)[0]).toBe("shell prompt");
   });
 
   it("a stuck BSU with no ESU still paints after the bounded hold", async () => {

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -7,9 +7,7 @@ import {
   type TerminalCorruptionKind,
   writePaneEvidenceDump,
 } from "../diagnostics.js";
-import type { StationTerminalSize } from "../types.js";
-import { buildVisibleRows, type VtRow } from "./rows.js";
-import { type StationVtTheme, stationVtTheme } from "./theme.js";
+import { CsiFinal, EraseInDisplayMode } from "../protocol/controlBytes.js";
 import { DecMode } from "../protocol/decset.js";
 import {
   MouseEncoding,
@@ -17,6 +15,9 @@ import {
   type MouseEncodingValue,
   type MouseTrackingValue,
 } from "../protocol/mouse.js";
+import type { StationTerminalSize } from "../types.js";
+import { buildVisibleRows, type VtRow } from "./rows.js";
+import { type StationVtTheme, stationVtTheme } from "./theme.js";
 
 const DEFAULT_FLUSH_INTERVAL_MS = 33;
 const SYNC_OUTPUT_HOLD_MAX_MS = 1000;
@@ -282,6 +283,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   };
   // Lines scrolled up from the live bottom (0 = at the bottom).
   let scrollOffset = 0;
+  let normalBufferIsSynchronizedFrame = false;
   let kittyKeyboardFlags = 0;
   // The most recent OSC 0/2 title; mirrors xterm's onTitleChange so the pane
   // border can show it without reaching into the engine.
@@ -415,16 +417,33 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     }
     return false;
   });
+  terminal.parser.registerCsiHandler({ final: CsiFinal.EraseInDisplay }, (params) => {
+    const isNormalBufferFullScreenErase =
+      params[0] === EraseInDisplayMode.EntireDisplay &&
+      terminal.buffer.active.type === "normal";
+    const isSynchronizedFullScreenErase =
+      isNormalBufferFullScreenErase && terminal.modes.synchronizedOutputMode;
+    // Archive the transition into an app-owned screen, not its subsequent repaint frames.
+    // xterm consults this option only for ED2; flush restores it after parsing.
+    terminal.options.scrollOnEraseInDisplay =
+      isSynchronizedFullScreenErase && !normalBufferIsSynchronizedFrame;
+    if (isNormalBufferFullScreenErase) {
+      normalBufferIsSynchronizedFrame = isSynchronizedFullScreenErase;
+    }
+    return false;
+  });
   // RIS and DECSTR both restore a visible cursor; without these a `reset`
   // after a cursor-hiding app leaves the pane cursorless forever. RIS also
   // clears mouse modes (xterm resets the flavor; clear our SGR bit to match).
   terminal.parser.registerEscHandler({ final: "c" }, () => {
     cursorVisible = true;
     sgrMouse = false;
+    normalBufferIsSynchronizedFrame = false;
     return false;
   });
   terminal.parser.registerCsiHandler({ intermediates: "!", final: "p" }, () => {
     cursorVisible = true;
+    normalBufferIsSynchronizedFrame = false;
     return false;
   });
   terminal.parser.registerCsiHandler({ prefix: ">", final: "u" }, (params) => {
@@ -526,9 +545,11 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     // observed off would reuse a stale (already-expired) deadline and tear; a
     // genuinely stuck frame just re-holds ~1s at a time.
     syncHoldUntil = undefined;
+    terminal.options.scrollOnEraseInDisplay = false;
     lastFlushAt = Date.now();
     applyScrollOnOutput();
     clampScrollOffset();
+    reanchorScroll();
     notifyListeners();
     scanForEscapeFragments();
   };


### PR DESCRIPTION
## Summary

- Preserve the outgoing normal-buffer frame when a synchronized full-screen app first takes ownership of the screen.
- Name the ED/ED2 protocol values used at the xterm boundary.
- Let the existing buffer marker measure the actual scroll caused by partially filled ED2 redraws.
- Archive only the transition into a synchronized app screen, not each subsequent repaint frame.
- Cover partial redraw anchoring, scrollback-cap retention, and a later ordinary-to-synchronized transition with renderer-row regressions.

## Root cause

Codex repaints through DEC synchronized output and ED2. xterm can preserve the replaced normal-buffer frame by enabling `scrollOnEraseInDisplay`, but two details matter:

1. ED2 scrolls only through the last non-empty row. Adding `terminal.rows` to Station's frozen offset therefore overcorrected partially filled frames; the existing marker already reports the actual `baseY` movement.
2. Enabling scroll-on-erase for every synchronized ED2 archived obsolete repaint frames until they displaced real conversation history. The option now applies only when entering a synchronized app-owned screen.

## UX impact

A user who scrolls up while Codex is working remains on the same visible conversation rows across repeated, partially filled redraws. Repaint frames no longer consume the fixed scrollback budget, while leaving a shell or ordinary screen for a synchronized full-screen app still preserves the screen being replaced.

## Validation

- Red-before-green renderer regressions reproduced both reported failures:
  - repeated partial redraw changed the anchored view from `L3…L7` to `L0…L4`;
  - repeated redraws at the cap replaced retained `H5…H9` history with `redraw-0…redraw-4`.
- Focused terminal/conformance matrix: 98 passed, 0 failed.
- Station typecheck and repository lint passed.
- Full `pnpm test:pre-push` passed, including builds, typechecks, lint, all repository and Station tests, PTY tests, install smoke, and binary smoke.

## Manual verification

In a fresh Station native pane, start Codex, scroll up to a recognizable five-line block, and let several short status frames repaint. The same block should remain visible. Return to the bottom after many redraws and scroll back: earlier conversation should still be present instead of repeated obsolete frames.