### PR TITLE
fix(tmux): disable all-motion tracking in Station popups

### DIFF
--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -462,7 +462,7 @@ describeRealTmux("real tmux dev popup routing", () => {
     );
   }, 120_000);
 
-  it("uses button-only tracking without opening tmux's popup menu", async () => {
+  it("uses click-only tracking without opening tmux's popup menu or latching hover", async () => {
     const fixture = await createDashboardFixture(tmux);
     fixture.env.STATION_SCENARIO = "many-projects";
     cleanup = () => cleanupDashboardFixture(fixture);
@@ -487,11 +487,20 @@ describeRealTmux("real tmux dev popup routing", () => {
     const outerDimensions = await readOuterClientDimensions(fixture, fixture.ptyClient.clientName);
     const headerCell = paneCell(dashboard, "▼ station");
     const headerOuter = centeredPopupOuterCell(outerDimensions, nestedClient, headerCell);
-    const mouseAllFlag = await tmuxExec(
+    const blankOuter = centeredPopupOuterCell(outerDimensions, nestedClient, { col: 0, row: 0 });
+    const headerStyleBefore = await captureHiddenStyledLine(fixture, headerCell.row);
+    const mouseFlags = await tmuxExec(
       fixture.wrapper,
-      ["display-message", "-p", "-t", persistentUiSessionName, "#{mouse_all_flag}"],
+      [
+        "display-message",
+        "-p",
+        "-t",
+        persistentUiSessionName,
+        "#{mouse_standard_flag}:#{mouse_button_flag}:#{mouse_all_flag}:#{mouse_sgr_flag}",
+      ],
       fixture.env,
     );
+    const [, , mouseAllFlag] = mouseFlags.trim().split(":");
     const clientOutput: Buffer[] = [];
     const captureClientOutput = (chunk: Buffer): void => {
       clientOutput.push(chunk);
@@ -503,13 +512,25 @@ describeRealTmux("real tmux dev popup routing", () => {
     };
     fixture.ptyClient.child.stdout?.on("data", captureClientOutput);
     try {
-      if (mouseAllFlag.trim() === "1") {
+      if (mouseAllFlag === "1") {
         // A terminal only reports motion when requested; SGR 34 reaches tmux's 3.7 menu branch.
         await fixture.ptyClient.write(sgrMouse(34, { column: 1, row: 1 }));
         await delay(500);
       }
       expectNoTmuxPopupMenu();
-      expect(mouseAllFlag.trim(), "popup renderer requested all-motion mouse tracking").toBe("0");
+      expect(mouseFlags.trim(), "popup renderer did not request click-only SGR tracking").toBe(
+        "1:0:0:1",
+      );
+
+      await fixture.ptyClient.write(sgrMouse(1, blankOuter));
+      await fixture.ptyClient.write(sgrMouse(33, headerOuter));
+      await fixture.ptyClient.write(sgrMouse(1, headerOuter, "m"));
+      await fixture.ptyClient.write(sgrMouse(35, blankOuter));
+      await delay(500);
+      expect(
+        await captureHiddenStyledLine(fixture, headerCell.row),
+        "a button drag left the project-header hover style latched",
+      ).toBe(headerStyleBefore);
 
       await writeSgrClick(fixture.ptyClient, headerOuter);
       await waitForPaneContent(
@@ -518,6 +539,10 @@ describeRealTmux("real tmux dev popup routing", () => {
         (content) => content.includes("▶ station") && !content.includes("station-overlay"),
         "one outer SGR down/up click did not collapse exactly once",
       );
+      expect(
+        (await captureHiddenStyledLine(fixture, headerCell.row)).replace("▶", "▼"),
+        "a deliberate click left the project-header hover style latched",
+      ).toBe(headerStyleBefore);
       await writeSgrClick(fixture.ptyClient, headerOuter);
       await waitForPaneContent(
         fixture,
@@ -1725,6 +1750,19 @@ async function waitForHiddenPaneContent(
   throw new Error(
     `${failureMessage}\nLast hidden pane:\n${content.slice(-8_000)}${await fixtureDiagnostics(fixture)}`,
   );
+}
+
+async function captureHiddenStyledLine(fixture: DashboardFixture, row: number): Promise<string> {
+  const content = await tmuxExec(
+    fixture.wrapper,
+    ["capture-pane", "-e", "-p", "-N", "-t", persistentUiSessionName],
+    fixture.env,
+  );
+  const line = content.split("\n")[row];
+  if (line === undefined) {
+    throw new Error(`hidden pane does not contain row ${row}`);
+  }
+  return line;
 }
 
 function paneCell(content: string, needle: string): { col: number; row: number } {

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -462,7 +462,7 @@ describeRealTmux("real tmux dev popup routing", () => {
     );
   }, 120_000);
 
-  it("uses button-only tracking while forwarding outer clicks and wheel input exactly once", async () => {
+  it("uses button-only tracking without opening tmux's popup menu", async () => {
     const fixture = await createDashboardFixture(tmux);
     fixture.env.STATION_SCENARIO = "many-projects";
     cleanup = () => cleanupDashboardFixture(fixture);
@@ -492,45 +492,66 @@ describeRealTmux("real tmux dev popup routing", () => {
       ["display-message", "-p", "-t", persistentUiSessionName, "#{mouse_all_flag}"],
       fixture.env,
     );
-    expect(mouseAllFlag.trim(), "popup renderer requested all-motion mouse tracking").toBe("0");
+    const clientOutput: Buffer[] = [];
+    const captureClientOutput = (chunk: Buffer): void => {
+      clientOutput.push(chunk);
+    };
+    const expectNoTmuxPopupMenu = (): void => {
+      const output = Buffer.concat(clientOutput).toString("utf8");
+      expect(output, "mouse input opened tmux's popup menu").not.toContain("Fill Space");
+      expect(output, "mouse input opened tmux's popup menu").not.toContain("To Horizontal Pane");
+    };
+    fixture.ptyClient.child.stdout?.on("data", captureClientOutput);
+    try {
+      if (mouseAllFlag.trim() === "1") {
+        // A terminal only reports motion when requested; SGR 34 reaches tmux's 3.7 menu branch.
+        await fixture.ptyClient.write(sgrMouse(34, { column: 1, row: 1 }));
+        await delay(500);
+      }
+      expectNoTmuxPopupMenu();
+      expect(mouseAllFlag.trim(), "popup renderer requested all-motion mouse tracking").toBe("0");
 
-    await writeSgrClick(fixture.ptyClient, headerOuter);
-    await waitForPaneContent(
-      fixture,
-      popup,
-      (content) => content.includes("▶ station") && !content.includes("station-overlay"),
-      "one outer SGR down/up click did not collapse exactly once",
-    );
-    await writeSgrClick(fixture.ptyClient, headerOuter);
-    await waitForPaneContent(
-      fixture,
-      popup,
-      (content) => content.includes("▼ station") && content.includes("station-overlay"),
-      "the first deliberate repeated click did not expand the project",
-    );
-    await writeSgrClick(fixture.ptyClient, headerOuter);
-    await waitForPaneContent(
-      fixture,
-      popup,
-      (content) => content.includes("▶ station") && !content.includes("station-overlay"),
-      "the second deliberate repeated click did not collapse the project",
-    );
-    await writeSgrClick(fixture.ptyClient, headerOuter);
-    const expandedDashboard = await waitForPaneContent(
-      fixture,
-      popup,
-      (content) => content.includes("▼ station") && content.includes("docs-cleanup"),
-      "project did not re-expand before the wheel characterization",
-    );
-    const childCell = paneCell(expandedDashboard, "docs-cleanup");
-    const childOuter = centeredPopupOuterCell(outerDimensions, nestedClient, childCell);
-    await fixture.ptyClient.write(sgrMouse(65, childOuter));
-    await waitForPaneContent(
-      fixture,
-      popup,
-      (content) => !content.includes("▼ station") && content.includes("docs-cleanup"),
-      "outer SGR wheel input over a child row did not change visible content",
-    );
+      await writeSgrClick(fixture.ptyClient, headerOuter);
+      await waitForPaneContent(
+        fixture,
+        popup,
+        (content) => content.includes("▶ station") && !content.includes("station-overlay"),
+        "one outer SGR down/up click did not collapse exactly once",
+      );
+      await writeSgrClick(fixture.ptyClient, headerOuter);
+      await waitForPaneContent(
+        fixture,
+        popup,
+        (content) => content.includes("▼ station") && content.includes("station-overlay"),
+        "the first deliberate repeated click did not expand the project",
+      );
+      await writeSgrClick(fixture.ptyClient, headerOuter);
+      await waitForPaneContent(
+        fixture,
+        popup,
+        (content) => content.includes("▶ station") && !content.includes("station-overlay"),
+        "the second deliberate repeated click did not collapse the project",
+      );
+      await writeSgrClick(fixture.ptyClient, headerOuter);
+      const expandedDashboard = await waitForPaneContent(
+        fixture,
+        popup,
+        (content) => content.includes("▼ station") && content.includes("docs-cleanup"),
+        "project did not re-expand before the wheel characterization",
+      );
+      const childCell = paneCell(expandedDashboard, "docs-cleanup");
+      const childOuter = centeredPopupOuterCell(outerDimensions, nestedClient, childCell);
+      await fixture.ptyClient.write(sgrMouse(65, childOuter));
+      await waitForPaneContent(
+        fixture,
+        popup,
+        (content) => !content.includes("▼ station") && content.includes("docs-cleanup"),
+        "outer SGR wheel input over a child row did not change visible content",
+      );
+      expectNoTmuxPopupMenu();
+    } finally {
+      fixture.ptyClient.child.stdout?.off("data", captureClientOutput);
+    }
 
     await closeOuterPopup(fixture);
     await expectSuccessfulExit(popup, 10_000);

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -462,7 +462,7 @@ describeRealTmux("real tmux dev popup routing", () => {
     );
   }, 120_000);
 
-  it("forwards outer SGR hover, deliberate clicks, and wheel input exactly once", async () => {
+  it("uses button-only tracking while forwarding outer clicks and wheel input exactly once", async () => {
     const fixture = await createDashboardFixture(tmux);
     fixture.env.STATION_SCENARIO = "many-projects";
     cleanup = () => cleanupDashboardFixture(fixture);
@@ -487,15 +487,12 @@ describeRealTmux("real tmux dev popup routing", () => {
     const outerDimensions = await readOuterClientDimensions(fixture, fixture.ptyClient.clientName);
     const headerCell = paneCell(dashboard, "▼ station");
     const headerOuter = centeredPopupOuterCell(outerDimensions, nestedClient, headerCell);
-    const headerStyleBefore = await captureHiddenStyledLine(fixture, "▼ station");
-
-    await fixture.ptyClient.write(sgrMouse(35, headerOuter));
-    await waitForHiddenStyledLine(
-      fixture,
-      "▼ station",
-      (line) => line !== headerStyleBefore,
-      "outer SGR motion did not reach project-header hover",
+    const mouseAllFlag = await tmuxExec(
+      fixture.wrapper,
+      ["display-message", "-p", "-t", persistentUiSessionName, "#{mouse_all_flag}"],
+      fixture.env,
     );
+    expect(mouseAllFlag.trim(), "popup renderer requested all-motion mouse tracking").toBe("0");
 
     await writeSgrClick(fixture.ptyClient, headerOuter);
     await waitForPaneContent(
@@ -1706,39 +1703,6 @@ async function waitForHiddenPaneContent(
   }
   throw new Error(
     `${failureMessage}\nLast hidden pane:\n${content.slice(-8_000)}${await fixtureDiagnostics(fixture)}`,
-  );
-}
-
-async function captureHiddenStyledLine(fixture: DashboardFixture, needle: string): Promise<string> {
-  const content = await tmuxExec(
-    fixture.wrapper,
-    ["capture-pane", "-e", "-p", "-N", "-t", persistentUiSessionName],
-    fixture.env,
-  );
-  const line = content.split("\n").find((candidate) => candidate.includes(needle));
-  if (line === undefined) {
-    throw new Error(`hidden pane does not contain ${JSON.stringify(needle)}`);
-  }
-  return line;
-}
-
-async function waitForHiddenStyledLine(
-  fixture: DashboardFixture,
-  needle: string,
-  predicate: (line: string) => boolean,
-  failureMessage: string,
-): Promise<string> {
-  const deadline = Date.now() + 10_000;
-  let line = "";
-  while (Date.now() < deadline) {
-    line = await captureHiddenStyledLine(fixture, needle).catch(() => "");
-    if (line !== "" && predicate(line)) {
-      return line;
-    }
-    await delay(100);
-  }
-  throw new Error(
-    `${failureMessage}\nLast styled line:\n${line}${await fixtureDiagnostics(fixture)}`,
   );
 }
 

--- a/station/src/dashboardRenderer/FullscreenDashboard.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.tsx
@@ -8,7 +8,11 @@ import { normalizeStationMouseEvent } from "../input/mouse.js";
 import { useTopRowWidgets } from "../station/widgets/useTopRowWidgets.js";
 import { DashboardFrameTitle } from "../station/view/DashboardFrameTitle.js";
 import { DashboardRoot } from "../station/view/DashboardRoot.js";
-import { StationMouseProvider, type StationMouseDispatch } from "../station/view/stationMouseContext.js";
+import {
+  StationHoverProvider,
+  StationMouseProvider,
+  type StationMouseDispatch,
+} from "../station/view/stationMouseContext.js";
 import { type DashboardMouseEffects, routeDashboardMouse } from "./dashboardMouse.js";
 
 /**
@@ -24,9 +28,11 @@ import { type DashboardMouseEffects, routeDashboardMouse } from "./dashboardMous
 export function FullscreenDashboard({
   store,
   effects,
+  hoverEnabled = true,
 }: {
   store: StoreApi<TuiStore>;
   effects: DashboardMouseEffects;
+  hoverEnabled?: boolean;
 }) {
   const { width, height } = useTerminalDimensions();
   const widgets = useStore(store, (state) => state.widgets);
@@ -38,16 +44,18 @@ export function FullscreenDashboard({
     [effects, store],
   );
   return (
-    <StationMouseProvider value={dispatch}>
-      <box width={width} height={height} flexDirection="column">
-        <DashboardRoot store={store} columns={width} rows={height} />
-        <DashboardFrameTitle
-          store={store}
-          frame={{ left: 0, top: 0, width }}
-          topRowWidgets={topRowWidgets}
-          zIndex={1}
-        />
-      </box>
-    </StationMouseProvider>
+    <StationHoverProvider value={hoverEnabled}>
+      <StationMouseProvider value={dispatch}>
+        <box width={width} height={height} flexDirection="column">
+          <DashboardRoot store={store} columns={width} rows={height} />
+          <DashboardFrameTitle
+            store={store}
+            frame={{ left: 0, top: 0, width }}
+            topRowWidgets={topRowWidgets}
+            zIndex={1}
+          />
+        </box>
+      </StationMouseProvider>
+    </StationHoverProvider>
   );
 }

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -143,7 +143,8 @@ export async function runDashboardMain(): Promise<void> {
   // tmux 3.7 can open its button-3 menu while Station reports mouse movement.
   // Re-enable popup movement once Station requires a tmux release containing
   // tmux/tmux@ad6832e, which removes the popup menu.
-  const enableMouseMovement = env.STATION_TUI_POPUP !== "1";
+  const popupRenderer = env.STATION_TUI_POPUP === "1";
+  const enableMouseMovement = !popupRenderer;
 
   try {
     const nextRenderer = await createCliRenderer({
@@ -153,6 +154,10 @@ export async function runDashboardMain(): Promise<void> {
       useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,
     });
     renderer = nextRenderer;
+    if (popupRenderer) {
+      // OpenTUI keeps 1002 drag tracking on when 1003 movement is off; popups need click-only 1000 + 1006.
+      process.stdout.write("\u001b[?1002l\u001b[?1000h");
+    }
     hotSlots.__stationDashboardHotRenderer = nextRenderer;
     hotSlots.__stationDashboardHotDispose = disposeResources;
     // OpenTUI routes paste around the sequence handlers; forward it as sanitized
@@ -166,7 +171,13 @@ export async function runDashboardMain(): Promise<void> {
 
     const nextRoot = createRoot(nextRenderer);
     root = nextRoot;
-    nextRoot.render(<FullscreenDashboard store={store} effects={mouseEffects} />);
+    nextRoot.render(
+      <FullscreenDashboard
+        store={store}
+        effects={mouseEffects}
+        hoverEnabled={!popupRenderer}
+      />,
+    );
     process.on("exit", onProcessExit);
 
     if (import.meta.hot) {

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -142,6 +142,8 @@ export async function runDashboardMain(): Promise<void> {
 
   try {
     const nextRenderer = await createCliRenderer({
+      // Tmux 3.7 treats buttonless SGR motion outside a popup as its button-3 menu.
+      enableMouseMovement: env.STATION_TUI_POPUP !== "1",
       exitOnCtrlC: false,
       prependInputHandlers: [createDashboardSequenceHandler(store)],
       useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -140,7 +140,7 @@ export async function runDashboardMain(): Promise<void> {
     }
   };
 
-  // tmux 3.7 misreads buttonless SGR motion outside a popup as button 3.
+  // tmux 3.7 can open its button-3 menu while Station reports mouse movement.
   // Re-enable popup movement once Station requires a tmux release containing
   // tmux/tmux@ad6832e, which removes the popup menu.
   const enableMouseMovement = env.STATION_TUI_POPUP !== "1";

--- a/station/src/dashboardRenderer/main.tsx
+++ b/station/src/dashboardRenderer/main.tsx
@@ -140,10 +140,14 @@ export async function runDashboardMain(): Promise<void> {
     }
   };
 
+  // tmux 3.7 misreads buttonless SGR motion outside a popup as button 3.
+  // Re-enable popup movement once Station requires a tmux release containing
+  // tmux/tmux@ad6832e, which removes the popup menu.
+  const enableMouseMovement = env.STATION_TUI_POPUP !== "1";
+
   try {
     const nextRenderer = await createCliRenderer({
-      // Tmux 3.7 treats buttonless SGR motion outside a popup as its button-3 menu.
-      enableMouseMovement: env.STATION_TUI_POPUP !== "1",
+      enableMouseMovement,
       exitOnCtrlC: false,
       prependInputHandlers: [createDashboardSequenceHandler(store)],
       useKittyKeyboard: STATION_KEYBOARD_PROTOCOL,

--- a/station/src/station/view/DashboardFrameTitle.tsx
+++ b/station/src/station/view/DashboardFrameTitle.tsx
@@ -1,5 +1,4 @@
 import { TextAttributes } from "@opentui/core";
-import { useState } from "react";
 import { useStore } from "zustand/react";
 import type { StoreApi } from "zustand/vanilla";
 import stringWidth from "string-width";
@@ -12,7 +11,11 @@ import {
 import { resolveTopRowWidgets } from "@station/dashboard-core/widgets/snapshotWidgets";
 import type { TopRowWidgetView } from "@station/dashboard-core/widgets/types";
 import { STATION_COLORS } from "./theme.js";
-import { stationMouseProps, useStationMouse } from "./stationMouseContext.js";
+import {
+  stationMouseProps,
+  useStationHoverState,
+  useStationMouse,
+} from "./stationMouseContext.js";
 
 const PRODUCT_LABEL = "station";
 const OVERVIEW_SUBTITLE = "· overview";
@@ -40,7 +43,7 @@ export function DashboardFrameTitle({
   zIndex,
 }: DashboardFrameTitleProps) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const snapshot = useStore(store, (state) => state.snapshot);
   const observerConnectionStatus = useStore(store, (state) => state.observerConnectionStatus);
 

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -3,7 +3,6 @@
 // hover is component-local and color-only so golden frames stay layout-stable.
 import { TextAttributes } from "@opentui/core";
 import type { ProjectView, SessionId, StationSnapshot } from "@station/contracts";
-import { useState } from "react";
 import {
   dashboardFooterLabel,
   fleetCountsLabel,
@@ -33,7 +32,11 @@ import type { StationMouseTarget } from "../input/stationMouse.js";
 import { SegmentLinkTargets, Segments } from "./segments.js";
 import { Throbber } from "./Throbber.js";
 import { STATION_COLORS } from "./theme.js";
-import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
+import {
+  useStationHoverState,
+  useStationMouse,
+  stationMouseProps,
+} from "./stationMouseContext.js";
 
 const HOVER_BG = STATION_COLORS.hoverBackground;
 
@@ -334,7 +337,7 @@ function SessionRowLine({
   focused?: boolean;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   // Persistent cursor fill sits under the transient hover fill.
   const background = hover
     ? { backgroundColor: HOVER_BG }
@@ -372,7 +375,7 @@ function ShellAffordance({
   compact?: boolean;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const label = compact ? SHELL_AFFORDANCE_LABEL_COMPACT : SHELL_AFFORDANCE_LABEL;
   return (
     // flexShrink={0}: content grows/clips first, affordance width is never clipped.
@@ -409,8 +412,8 @@ function QuickSessionAffordance({
   compact?: boolean;
 }) {
   const dispatch = useStationMouse();
-  const [quickHover, setQuickHover] = useState(false);
-  const [pickerHover, setPickerHover] = useState(false);
+  const [quickHover, setQuickHover] = useStationHoverState();
+  const [pickerHover, setPickerHover] = useStationHoverState();
   const sessionLabel = compact ? QUICK_SESSION_AFFORDANCE_LABEL_COMPACT : QUICK_SESSION_AFFORDANCE_LABEL;
   return (
     <>
@@ -442,7 +445,7 @@ const EMPTY_SESSION_BUTTON_LABEL = "[ + add session ]";
 // for the project — the same command as the project header's [quick session].
 function EmptySessionButton({ projectId }: { projectId: string }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   return (
     <text
       flexShrink={0}
@@ -467,7 +470,7 @@ function ProjectHeaderLine({
   collapsed: boolean;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const compact = columns < RESPONSIVE_AFFORDANCE_BREAKPOINT;
   const shellWidth = compact ? SHELL_AFFORDANCE_WIDTH_COMPACT : SHELL_AFFORDANCE_WIDTH;
   const quickSessionWidth = compact ? QUICK_SESSION_AFFORDANCE_WIDTH_COMPACT : QUICK_SESSION_AFFORDANCE_WIDTH;

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -19,7 +19,7 @@ import { makeStationTestStore } from "../test/support/makeStationTestStore.js";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 import { DashboardRoot } from "./DashboardRoot.js";
 import { STATION_COLORS } from "./theme.js";
-import { StationMouseProvider } from "./stationMouseContext.js";
+import { StationHoverProvider, StationMouseProvider } from "./stationMouseContext.js";
 
 function spanHex(span: ReturnType<typeof spanAtFrameCell>): string | undefined {
   return span?.fg === undefined ? undefined : rgbToHex(span.fg);
@@ -58,6 +58,7 @@ describe("dashboard golden frames", () => {
     snapshot?: StationSnapshot;
     connection?: StationClientConnectionState;
     dispatchMouse?: (target: StationMouseTarget) => void;
+    hoverEnabled?: boolean;
   }): Promise<RenderedDashboard> {
     const { store } = makeStationTestStore({
       snapshot: input.snapshot ?? null,
@@ -72,14 +73,18 @@ describe("dashboard golden frames", () => {
         rows={input.height}
       />
     );
-    const setup = await testRender(
+    const mouseDashboard =
       input.dispatchMouse === undefined ? (
         dashboard
       ) : (
         <StationMouseProvider value={(target) => input.dispatchMouse?.(target)}>
           {dashboard}
         </StationMouseProvider>
-      ),
+      );
+    const setup = await testRender(
+      <StationHoverProvider value={input.hoverEnabled ?? true}>
+        {mouseDashboard}
+      </StationHoverProvider>,
       { width: input.width, height: input.height },
     );
     teardowns.push(() => {
@@ -419,5 +424,31 @@ describe("dashboard golden frames", () => {
 
     const spans = setup.captureSpans();
     expect(spanBgHex(spanAtFrameCell(spans, row, 78))).toBe(STATION_COLORS.hoverBackground);
+  });
+
+  it("suppresses popup hover styling without removing click targets", async () => {
+    let clicked: StationMouseTarget | undefined;
+    const setup = await renderDashboard({
+      width: 80,
+      height: 24,
+      snapshot: manyProjectsSnapshot(),
+      hoverEnabled: false,
+      dispatchMouse: (target) => {
+        clicked = target;
+      },
+    });
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("docs-cleanup"));
+    const col = Math.max(0, lines[row]?.indexOf("docs-cleanup") ?? 0);
+
+    await setup.mockMouse.moveTo(col, row);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await setup.flush();
+
+    expect(spanBgHex(spanAtFrameCell(setup.captureSpans(), row, 78))).not.toBe(
+      STATION_COLORS.hoverBackground,
+    );
+    await setup.mockMouse.click(col, row, MouseButtons.LEFT);
+    expect(clicked).toMatchObject({ kind: "row" });
   });
 });

--- a/station/src/station/view/segments.tsx
+++ b/station/src/station/view/segments.tsx
@@ -5,7 +5,11 @@ import { useHoverPointer } from "../../useHoverPointer.js";
 import { type StationMouseTarget } from "../input/stationMouse.js";
 import { rowColorToHex } from "./theme.js";
 import { Throbber } from "./Throbber.js";
-import { useStationMouse, stationMouseProps } from "./stationMouseContext.js";
+import {
+  useStationHoverEnabled,
+  useStationMouse,
+  stationMouseProps,
+} from "./stationMouseContext.js";
 
 type TextRowSegment = Extract<RowSegment, { kind: "text" }>;
 type SegmentLink = {
@@ -47,7 +51,7 @@ export function SegmentLinkTargets({ segments }: { segments: readonly RowSegment
 
 function SegmentLinkTarget({ link }: { link: SegmentLink }) {
   const dispatch = useStationMouse();
-  const pointerProps = useHoverPointer();
+  const pointerProps = useHoverPointer({ enabled: useStationHoverEnabled() });
   const { left, segment, url, width } = link;
   const attributes = textSegmentAttributes(segment);
   const fg = rowColorToHex(segment.color);

--- a/station/src/station/view/settings/ProjectSettingsPanelView.tsx
+++ b/station/src/station/view/settings/ProjectSettingsPanelView.tsx
@@ -18,11 +18,14 @@ import {
   type TuiScreen,
   type TuiSelectionState,
 } from "@station/dashboard-core";
-import { useState } from "react";
 import { EditableTextInputView } from "../EditableTextInputView.js";
 import { AgentChoiceListView } from "../sheets/AgentChoiceListView.js";
 import { fit, SheetLine } from "../sheets/parts.js";
-import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
+import {
+  useStationHoverState,
+  useStationMouse,
+  stationMouseProps,
+} from "../stationMouseContext.js";
 import { STATION_COLORS } from "../theme.js";
 
 type ProjectSettingsScreen = Extract<TuiScreen, { name: "projectSettings" }>;
@@ -136,7 +139,7 @@ function SettingsItemRow({
   width: number;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   return (
     <text
       fg={active ? STATION_COLORS.cyan : STATION_COLORS.foreground}
@@ -256,7 +259,7 @@ function RemoveDetail({
 // narrow pane while the highlight still hugs the visible text.
 function RemoveButton({ armed, width }: { armed: boolean; width: number }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const hot = armed && hover;
   const label = "[ Remove project (R) ]".slice(0, Math.max(0, width - 1));
   return (

--- a/station/src/station/view/settings/WidgetSettingsPanelView.tsx
+++ b/station/src/station/view/settings/WidgetSettingsPanelView.tsx
@@ -1,5 +1,4 @@
 import { TextAttributes } from "@opentui/core";
-import { useState } from "react";
 import type { WidgetSettingsFocus } from "@station/dashboard-core";
 import {
   widgetSettingsPanelLayout,
@@ -10,7 +9,11 @@ import {
 import type { TuiWidgetConfig } from "@station/dashboard-core/widgets/types";
 import { fit } from "../sheets/parts.js";
 import { STATION_COLORS } from "../theme.js";
-import { stationMouseProps, useStationMouse } from "../stationMouseContext.js";
+import {
+  stationMouseProps,
+  useStationHoverState,
+  useStationMouse,
+} from "../stationMouseContext.js";
 
 const UNSELECTABLE_TEXT = { selectable: false } as const;
 
@@ -101,7 +104,7 @@ function PanelLine({
   focus: WidgetSettingsFocus;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   if (line.kind === "empty") {
     return (
       <text fg={STATION_COLORS.gray} bg={STATION_COLORS.background} {...UNSELECTABLE_TEXT}>
@@ -174,7 +177,7 @@ function PanelLine({
 // Its own element so the click hits only the remove action, never row-toggle.
 function RemoveMark({ index, rowHovered }: { index: number; rowHovered: boolean }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   return (
     <text
       fg={hover ? STATION_COLORS.red : rowHovered ? STATION_COLORS.gray : STATION_COLORS.hairline}

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -3,9 +3,13 @@
 // single-line rows. Ink's dimColor becomes the DIM attribute; named colors
 // come from the theme.
 import { TextAttributes } from "@opentui/core";
-import { isValidElement, type ReactNode, useState } from "react";
+import { isValidElement, type ReactNode } from "react";
 import type { StationMouseTarget } from "../../input/stationMouse.js";
-import { useStationMouse, stationMouseProps } from "../stationMouseContext.js";
+import {
+  useStationHoverState,
+  useStationMouse,
+  stationMouseProps,
+} from "../stationMouseContext.js";
 import { Throbber } from "../Throbber.js";
 import { STATION_COLORS } from "../theme.js";
 
@@ -107,7 +111,7 @@ export function SheetChoiceLine({
   note?: string | undefined;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const focused = hover || selected;
   // The marker reuses the prefix's leading margin column so the key/label
   // columns stay aligned and the row width is unchanged whether or not it is set.
@@ -173,7 +177,7 @@ export function SheetButton({
   mouseTarget: StationMouseTarget;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const color = BUTTON_TONE_COLORS[tone];
   return (
     <text
@@ -294,7 +298,7 @@ export function SheetPickerLine({
   mouseTarget?: StationMouseTarget;
 }) {
   const dispatch = useStationMouse();
-  const [hover, setHover] = useState(false);
+  const [hover, setHover] = useStationHoverState();
   const prefix = selected ? " > " : "   ";
   const detailText = detail.length === 0 ? "" : ` ${detail}`;
   const maxDetailWidth = Math.max(0, width - prefix.length - 10);

--- a/station/src/station/view/stationMouseContext.tsx
+++ b/station/src/station/view/stationMouseContext.tsx
@@ -1,18 +1,36 @@
 // Mouse boundary plumbing: renderables dispatch {target, event}; Station input
 // runtime routes it (routeMouse -> station bindings). Hit-testing and
 // stopPropagation happen here. Default is no-op (golden tests don't need provider).
-import { createContext, useContext } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 import type { MouseEvent } from "@opentui/core";
 import type { StationMouseTarget } from "../input/stationMouse.js";
 
 export type StationMouseDispatch = (target: StationMouseTarget, event: MouseEvent) => void;
 
 const StationMouseContext = createContext<StationMouseDispatch>(() => {});
+const StationHoverContext = createContext(true);
 
 export const StationMouseProvider = StationMouseContext.Provider;
+export const StationHoverProvider = StationHoverContext.Provider;
 
 export function useStationMouse(): StationMouseDispatch {
   return useContext(StationMouseContext);
+}
+
+export function useStationHoverEnabled(): boolean {
+  return useContext(StationHoverContext);
+}
+
+export function useStationHoverState(): readonly [boolean, (hover: boolean) => void] {
+  const enabled = useStationHoverEnabled();
+  const [hover, setHoverState] = useState(false);
+  const setHover = useCallback(
+    (next: boolean) => {
+      setHoverState(enabled && next);
+    },
+    [enabled],
+  );
+  return [enabled && hover, setHover] as const;
 }
 
 /** onMouseDown/onMouseScroll handlers for a target, stopping propagation so

--- a/station/src/useHoverPointer.ts
+++ b/station/src/useHoverPointer.ts
@@ -19,6 +19,7 @@ function syncPointer(renderer: ReturnType<typeof useRenderer>): void {
 }
 
 type HoverPointerOptions = {
+  enabled?: boolean | undefined;
   onHoverChange?: ((hover: boolean) => void) | undefined;
 };
 
@@ -37,6 +38,9 @@ export function useHoverPointer(options: HoverPointerOptions = {}) {
   }, []);
 
   const activate = useCallback(() => {
+    if (options.enabled === false) {
+      return;
+    }
     clearLeaveTimer();
     hoveredRegions.add(region.current);
     if (!hovered.current) {
@@ -44,7 +48,7 @@ export function useHoverPointer(options: HoverPointerOptions = {}) {
       options.onHoverChange?.(true);
     }
     syncPointer(renderer);
-  }, [clearLeaveTimer, options.onHoverChange, renderer]);
+  }, [clearLeaveTimer, options.enabled, options.onHoverChange, renderer]);
 
   const deactivate = useCallback(() => {
     clearLeaveTimer();


### PR DESCRIPTION
## Summary

- keep popup mouse input click-only with DECSET 1000 + SGR 1006, explicitly disabling drag/all-motion modes 1002 and 1003
- suppress presentation-only hover state in popup renderers while preserving click targets, repeated clicks, and wheel scrolling
- retain native/fullscreen hover behavior
- add real-tmux regression coverage for stale hover after both a middle-button drag and a layout-changing click

This addresses the tmux mouse-menu symptom reported under #169 without trading it for sticky popup hover or broken clicks.

## Root cause

OpenTUI's `enableMouseMovement: false` disables all-motion mode 1003, but OpenTUI 0.4.1 still requests button-event mode 1002. Button-held motion can therefore paint hover state; after release, the popup no longer receives ordinary motion to clear it. OpenTUI can also re-check and latch hover after a click changes layout.

tmux treats the mouse tracking flavors as alternatives, so simply disabling 1002 also removes normal click tracking. Popup startup now disables 1002 and then explicitly enables standard click tracking 1000, while keeping SGR encoding 1006. Popup-only hover presentation is gated off at the shared dashboard boundary; native/fullscreen Station keeps it enabled.

## User impact

Moving or dragging the pointer around a Station tmux popup no longer opens tmux's internal menu or leaves Station rows visually stuck in a hovered state. Popup controls remain clickable and scrollable, and native Station retains hover feedback.

## Validation

- `pnpm test:pre-push`: passed in a clean user-config environment
  - build, typecheck, lint, 1,587 unit tests, contracts, integration, diagnostics, scripted-agent, setup/observer E2E, install smoke, cross-runtime SQLite/observer claims, 1,052 Station UI tests, PTY smoke, binary build, and binary smoke
- focused Station UI coverage: 36/36 passed
- `STATION_REAL_TMUX=1 pnpm test:tmux-popup:real`: 8/8 passed on an isolated tmux server
  - verifies `mouse_standard:mouse_button:mouse_all:mouse_sgr = 1:0:0:1`
  - verifies no tmux menu and no stale hover after drag or click
  - retains deliberate click, repeated-click, wheel, resize, warm-reuse, dismissal, focus, and compiled-binding coverage
- real native mouse acceptance: 1/1 passed
  - raw SGR hover and click still dispatch exactly once
- `pnpm build:binary -- --version 0.7.1-rc.1`: passed

The default tmux server was not touched; all tmux acceptance ran on disposable private servers.