### PR TITLE
Update images in README with external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
   <img width="1728" height="1048" alt="image" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
   <br>
   <em>Terminal multi-plexing with a toggleable dashboard</em>
-  <img width="1042" height="608" alt="image" src="https://github.com/user-attachments/assets/270390db-ab1d-488e-afc7-8882d9e1fc32" />
+  <img width="1030" height="613" alt="image" src="https://github.com/user-attachments/assets/fe73f04d-bb05-461d-ae01-92e10d42b929" />
   <br>
   <em>One live view of every project, worktree, and agent session.</em>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 Station gives every agent an isolated Git worktree, keeps its terminal session alive, and shows all active projects and sessions in one terminal workspace. Bring Claude Code, Codex, Cursor, OpenCode, or Pi; Station coordinates the surrounding work without replacing the harness.
 
 <p align="center">
-  <img width="1728" height="1048" alt="image" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
+  <img width="1728" height="1048" alt="Station terminal workspace showing multiple agent panes and a toggleable dashboard" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
   <br>
-  <em>Terminal multi-plexing with a toggleable dashboard</em>
-  <img width="1030" height="613" alt="image" src="https://github.com/user-attachments/assets/fe73f04d-bb05-461d-ae01-92e10d42b929" />
+  <em>Terminal multiplexing with a toggleable dashboard.</em>
+  <br><br>
+  <img width="1030" height="613" alt="Station dashboard listing projects, worktrees, and live agent sessions" src="https://github.com/user-attachments/assets/fe73f04d-bb05-461d-ae01-92e10d42b929" />
   <br>
   <em>One live view of every project, worktree, and agent session.</em>
 </p>
@@ -26,7 +27,7 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 - **Built-in diagnostics** provide health checks, trace lookup, and redacted debug bundles.
 
 <p align="center">
-  <img width="1728" height="1047" alt="image" src="https://github.com/user-attachments/assets/6aaa96da-4827-4216-b994-4cfb2b0fb29f" />
+  <img width="1728" height="1047" alt="Station diff view showing an agent transcript beside its working-tree changes" src="https://github.com/user-attachments/assets/6aaa96da-4827-4216-b994-4cfb2b0fb29f" />
   <br>
   <em>Follow an agent and review its changes without leaving the terminal.</em>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 Station gives every agent an isolated Git worktree, keeps its terminal session alive, and shows all active projects and sessions in one terminal workspace. Bring Claude Code, Codex, Cursor, OpenCode, or Pi; Station coordinates the surrounding work without replacing the harness.
 
 <p align="center">
+  <img width="1728" height="1048" alt="image" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
+  <br>
+  <em>Terminal multi-plexing with a toggleable dashboard</em>
   <img width="1029" height="607" alt="image" src="https://github.com/user-attachments/assets/16deac8a-c591-40c9-af23-b993d5107070" />
   <br>
   <em>One live view of every project, worktree, and agent session.</em>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
   <img width="1728" height="1048" alt="image" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
   <br>
   <em>Terminal multi-plexing with a toggleable dashboard</em>
-  <img width="1029" height="607" alt="image" src="https://github.com/user-attachments/assets/16deac8a-c591-40c9-af23-b993d5107070" />
+  <img width="1042" height="608" alt="image" src="https://github.com/user-attachments/assets/270390db-ab1d-488e-afc7-8882d9e1fc32" />
   <br>
   <em>One live view of every project, worktree, and agent session.</em>
 </p>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Station gives every agent an isolated Git worktree, keeps its terminal session alive, and shows all active projects and sessions in one terminal workspace. Bring Claude Code, Codex, Cursor, OpenCode, or Pi; Station coordinates the surrounding work without replacing the harness.
 
 <p align="center">
-  <img src="./station/assets/screenshots/fleet-overview.png" alt="Station TUI listing projects, worktrees, and live agent sessions, with a session-create dialog open" width="820">
+  <img width="1029" height="607" alt="image" src="https://github.com/user-attachments/assets/16deac8a-c591-40c9-af23-b993d5107070" />
   <br>
   <em>One live view of every project, worktree, and agent session.</em>
 </p>
@@ -23,7 +23,7 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 - **Built-in diagnostics** provide health checks, trace lookup, and redacted debug bundles.
 
 <p align="center">
-  <img src="./station/assets/screenshots/agent-session-diff.png" alt="Split view showing an agent transcript and its live working-tree diff" width="880">
+  <img width="1728" height="1047" alt="image" src="https://github.com/user-attachments/assets/6aaa96da-4827-4216-b994-4cfb2b0fb29f" />
   <br>
   <em>Follow an agent and review its changes without leaving the terminal.</em>
 </p>


### PR DESCRIPTION
## Summary

- replace the README's bundled screenshots with the three current GitHub-hosted images
- preserve the task-oriented onboarding now on `main`
- give each screenshot meaningful alt text and keep the stacked dashboard images on separate lines

## Validation

- isolated `pnpm test:pre-push`
- 1,587 unit tests, 49 contract tests, 518 integration tests
- 1,052 native Station tests and 27 Bun PTY tests
- compiled binary build and binary smoke
- `git diff --check`
