### PR TITLE
chore(release): prepare v0.7.1-rc.2 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run this from any directory:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.1
+  tag=v0.7.1-rc.2
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -76,14 +76,15 @@ Run this from any directory:
 )
 ```
 
-`v0.7.1-rc.1` is the first supported private-binary candidate; the earlier
-`v0.7.0` candidate remained unpublished. Run the recipe after the candidate is
-published. It fetches the installer and binary from the same immutable release
-tag, verifies the release checksum, and installs `stn`, `stn-ingress`, and
-`stn-tmux-popup` in `~/.local/bin` by default. It does not expose or print your
-GitHub credentials. After the first stable release, the commented assignment
-resolves the latest stable tag. Immutable rollback begins with the second
-published binary release because there is no earlier published binary artifact.
+`v0.7.1-rc.2` is the current private-binary candidate; the earlier
+`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished. Run the recipe
+after the candidate is published. It fetches the installer and binary from the
+same immutable release tag, verifies the release checksum, and installs `stn`,
+`stn-ingress`, and `stn-tmux-popup` in `~/.local/bin` by default. It does not
+expose or print your GitHub credentials. After the first stable release, the
+commented assignment resolves the latest stable tag. Immutable rollback begins
+with the second published binary release because there is no earlier published
+binary artifact.
 
 ### 3. Verify and start Station
 
@@ -113,7 +114,7 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.1 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.2 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -123,7 +124,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.1`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.2`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.1", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.2", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -313,20 +313,21 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
-The initial immutable binary candidate is `v0.7.1-rc.1`; the earlier `v0.7.0`
-candidate remained unpublished:
+The current immutable binary candidate is `v0.7.1-rc.2`; the earlier `v0.7.0`
+and `v0.7.1-rc.1` candidates remained unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.1`, then create and
-   push `v0.7.1-rc.1`.
+   with `package.json` and runtime reporting at `0.7.1-rc.2`, then create and
+   push `v0.7.1-rc.2`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.1-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.2-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
 4. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.1`, and the manual-acceptance confirmation. It rechecks the successful
-   run SHA, immutable candidate manifest, tag commit, release ID, asset IDs, and
-   all archive hashes immediately before publishing that exact draft.
+   `v0.7.1-rc.2`, and the manual-acceptance confirmation. It rechecks the
+   successful run SHA, immutable candidate manifest, tag commit, release ID,
+   asset IDs, and all archive hashes immediately before publishing that exact
+   draft.
 5. Treat cross-version immutable rollback as a gate for the second published
    binary release. This candidate has no prior binary artifact to reinstall.
 
@@ -438,7 +439,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.1
+  tag=v0.7.1-rc.2
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -577,8 +578,8 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.1`: never
-   command-not-found or malformed output. After each transition, confirm
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.2`:
+   never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat this with two versions when preparing the
    second binary release.

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.1 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.2 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -35,7 +35,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.1`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.2`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly
@@ -86,7 +86,7 @@ From any directory, run:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.1
+  tag=v0.7.1-rc.2
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -101,13 +101,14 @@ From any directory, run:
 )
 ```
 
-`v0.7.1-rc.1` is the first supported private-binary candidate; the earlier
-`v0.7.0` candidate remained unpublished. Run this recipe after the candidate is
-published. Keep the fixed assignment for an exact prerelease install. After the
-first stable release, use the commented assignment to resolve the latest stable
-tag while still fetching installer code and artifacts from that same immutable
-tag. The recipe never falls back to `main`, never prints GitHub credentials,
-and never pipes network output directly into a shell.
+`v0.7.1-rc.2` is the current private-binary candidate; the earlier
+`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished. Run this recipe
+after the candidate is published. Keep the fixed assignment for an exact
+prerelease install. After the first stable release, use the commented assignment
+to resolve the latest stable tag while still fetching installer code and
+artifacts from that same immutable tag. The recipe never falls back to `main`,
+never prints GitHub credentials, and never pipes network output directly into a
+shell.
 
 The installer selects the matching platform archive, verifies it against
 `SHA256SUMS`, and installs these launchers in `~/.local/bin` by default:
@@ -150,16 +151,16 @@ shells. The installer does not read, create, or edit shell startup files.
 
 ## Install an Exact Version
 
-To install or return to an immutable release such as `v0.7.1-rc.1`, use the
+To install or return to an immutable release such as `v0.7.1-rc.2`, use the
 same recipe with this assignment instead of the latest-release lookup:
 
 ```bash
-tag=v0.7.1-rc.1
+tag=v0.7.1-rc.2
 ```
 
 The installer code and artifacts still come from that same tag. The earlier
-`v0.7.0` candidate remained unpublished, so rollback to an earlier binary starts
-with the second published version.
+`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished, so rollback to an
+earlier binary starts with the second published version.
 
 ## Use a Custom Install Directory
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.1", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.2", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -381,7 +381,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.1-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.2-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -415,7 +415,8 @@ claim bit-for-bit reproducible Bun executables or archives.
 
 `scripts/install.sh` supports latest stable, explicit `--version`, and
 `--install-dir` (default `~/.local/bin`). The supported binary-install baseline
-starts at `v0.7.1-rc.1`; the earlier `v0.7.0` candidate remained unpublished.
+starts at `v0.7.1-rc.2`; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates
+remained unpublished.
 Explicit installs set a tag, fetch
 `scripts/install.sh` from that tag through the authenticated Contents API, and
 invoke it with `--version` set to the same tag. Latest install first resolves
@@ -491,11 +492,11 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-The first binary candidate is `v0.7.1-rc.1` and promotes only after all four
-native targets pass automated and manual acceptance. Published tags and assets
-are never deleted, moved, or overwritten. Cross-version rollback is intentionally
-deferred until a second binary version exists; a bad first release rolls forward
-to a higher version containing the revert or fix.
+Candidate `v0.7.1-rc.2` promotes only after all four native targets pass
+automated and manual acceptance. Published tags and assets are never deleted,
+moved, or overwritten. Cross-version rollback is intentionally deferred until a
+second binary version exists; a bad first release rolls forward to a higher
+version containing the revert or fix.
 
 Drafts are still mutable. Release notes record the workflow commit, while the
 accepted-candidate artifact immutably records that commit plus the draft release
@@ -707,8 +708,8 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.1` output appears, never
-   command-not-found or malformed output; both aliases remain links to `stn`,
+   repeatedly installs the draft → only complete `0.7.1-rc.2` output appears,
+   never command-not-found or malformed output; both aliases remain links to `stn`,
    so entrypoints never mix. Repeat with two immutable versions when preparing
    the second binary release and first rollback gate.
 10. Abandoned command and license `.station-install.lock` directories each

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.1",
+  "version": "0.7.1-rc.2",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.1" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.2" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.1",
+      version: "0.7.1-rc.2",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.1+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.1+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.2+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.2+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.1",
+      version: "0.7.1-rc.2",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -930,7 +930,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.1";
+    return "0.7.1-rc.2";
   }
   if (
     normalized.length === 2 &&

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -107,7 +107,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated GitHub release assets");
     expect(readme).toContain("does not require Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.1");
+    expect(install).toContain("tag=v0.7.1-rc.2");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -163,7 +163,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.1");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.2");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -221,7 +221,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.1");
+    expect(packageJson.version).toBe("0.7.1-rc.2");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");


### PR DESCRIPTION
## Summary

- bump the package/runtime version and release-facing examples to `v0.7.1-rc.2`
- preserve the immutable, unpublished `v0.7.1-rc.1` candidate
- align the release diagnostics and binary smoke expectations with the new candidate

## Validation

- isolated `pnpm test:pre-push` passed on the exact tree
- release smoke passed
- compiled `0.7.1-rc.2` binary smoke passed
- rebased tree is byte-identical to the validated tree