### PR TITLE
fix(terminal): advertise Station-owned child PTY capabilities

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,6 +61,7 @@ When these disagree, reconcile from config, providers, and current observer stat
 - Station-managed terminal lifecycle is supplied as an explicit application role. Observer application code may forward opaque managed-terminal attachments returned by that role, but must not select its adapter by provider ID, reconstruct provider-owned target IDs, or expose Station Host PTY and socket mechanics.
 - Station resolves managed-terminal attachments through its own host attacher. An absent attachment permits the existing local launch; an advertised attachment that cannot resolve fails visibly and must never fall through to a local spawn.
 - The Station UI is a client. It renders snapshots/events and dispatches typed commands; it must not import providers, read SQLite, run `wt`, run `tmux`, run `git`/`gh`, or parse raw provider payloads for core behavior.
+- The outer terminal environment is authoritative only for Station's OpenTUI renderer. Every Station-owned child PTY receives Station's terminal identity and supported capabilities at the final native spawn boundary; local bridge, Bun, and Station Host paths must not expose outer-emulator identity as child capability evidence.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
 - The protocol validates transport messages and keeps consumer APIs simple. It should not become a provider boundary.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -504,14 +504,22 @@ renderer fixes that selector when it creates its Observer client; each later
 operation checks the socket owner on the same connection without running Git or
 hashing source from the UI. The CLI sets `STATION_TUI_PERSISTENT=1` when the
 renderer requires its lifecycle-control IPC channel; it is not a standalone
-launch mode. After inherited and per-launch PTY environment merging, native
-Station assigns `STATION_PANE` to the full inherited tmux server-and-pane
-context, or `1` when there is none, so launch input cannot clear or replace the
-pane context. The CLI honors it only while that terminal context still matches,
-preventing a long-lived tmux server from leaking Station ownership into a later
-pane even when two servers reuse the same pane id. It is not hand-authored
-configuration, and there is no persistent nesting override;
-`stn tui --allow-nested` applies to one launch. Tmux launchers use
+launch mode. Native Station child PTYs also receive standard terminal values
+`TERM=xterm-256color`, `COLORTERM=truecolor`, and `TERM_PROGRAM=Station` after
+inherited and per-launch environment merging. Outer-renderer identity and
+feature hints are removed at that boundary, while ordinary locale,
+authentication, provider, project, worktree, and user environment passes
+through; these terminal values are generated behavior, not hand-authored
+configuration.
+
+`TMUX` and `TMUX_PANE` remain available for command connectivity. Native Station
+uses their merged values to assign `STATION_PANE` to the full tmux
+server-and-pane context, or `1` when there is none, so launch input cannot clear
+or replace Station ownership. The CLI honors it only while that terminal
+context still matches, preventing a long-lived tmux server from leaking Station
+ownership into a later pane even when two servers reuse the same pane id. There
+is no persistent nesting override; `stn tui --allow-nested` applies to one
+launch. Tmux launchers use
 `STATION_TUI_POPUP=1` as routing provenance for their renderer child, not as
 authentication. These variables are not hand-authored overrides. Hook scripts
 and launched agents receive the other context so they can report back to the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -494,7 +494,8 @@ Generated launch/hook env vars are internal context, not hand-authored config:
 `STATION_SESSION_ID`, `STATION_HARNESS_PROVIDER`, `STATION_TERMINAL_PROVIDER`,
 `STATION_TERMINAL_TARGET_ID`, `STATION_OBSERVER_STATE_DIR`, `STATION_STATE_DIR`,
 `STATION_HOOK_SPOOL_DIR`, `STATION_CLIENT_BUILD_VERSION`,
-`STATION_OBSERVER_BUILD_VERSION`, `STATION_PANE`, `STATION_TUI_POPUP`,
+`STATION_OBSERVER_BUILD_VERSION`, `STATION_PANE`, `STATION_OUTER_TMUX`,
+`STATION_OUTER_TMUX_PANE`, `STATION_TUI_POPUP`,
 `STATION_TUI_PERSISTENT`,
 `STATION_FOCUS_PROVIDER`, and `STATION_FOCUS_CLIENT_ID`. The CLI supplies the two
 build variables as a pair: the first identifies the renderer artifact and the
@@ -512,14 +513,16 @@ authentication, provider, project, worktree, and user environment passes
 through; these terminal values are generated behavior, not hand-authored
 configuration.
 
-`TMUX` and `TMUX_PANE` remain available for command connectivity. Native Station
-uses their merged values to assign `STATION_PANE` to the full tmux
-server-and-pane context, or `1` when there is none, so launch input cannot clear
-or replace Station ownership. The CLI honors it only while that terminal
-context still matches, preventing a long-lived tmux server from leaking Station
-ownership into a later pane even when two servers reuse the same pane id. There
-is no persistent nesting override; `stn tui --allow-nested` applies to one
-launch. Tmux launchers use
+Native Station removes `TMUX` and `TMUX_PANE` from its children because they are
+widely interpreted as direct-terminal capability evidence. If Station itself was
+launched inside tmux, it exposes the captured outer values as
+`STATION_OUTER_TMUX` and `STATION_OUTER_TMUX_PANE` for deliberate tmux commands
+without misidentifying the child renderer. Station-owned PTYs use
+`STATION_PANE=1`, so launch input cannot clear or replace Station ownership. If a
+new tmux server is started inside one, its real server-and-pane context differs
+from that marker and cannot leak Station ownership into later panes. There is no
+persistent nesting override; `stn tui --allow-nested` applies to one launch.
+Tmux launchers use
 `STATION_TUI_POPUP=1` as routing provenance for their renderer child, not as
 authentication. These variables are not hand-authored overrides. Hook scripts
 and launched agents receive the other context so they can report back to the

--- a/docs/development.md
+++ b/docs/development.md
@@ -223,6 +223,10 @@ bun run build:ctty-helper
 bun run test:pty:bun             # Bun.Terminal + controlling-terminal helper
 ```
 
+Both PTY lanes include deterministic child-environment probes for local and
+Station Host-backed spawns, so capability-policy changes must keep the two
+implementations equivalent.
+
 To daily-drive the Bun implementation in the isolated devbox, return to the
 repo root and start a fresh host with the selector in its environment:
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -81,6 +81,31 @@ STATION_SOURCE=mock bun run station   # native workspace, deterministic fixtures
 bun run dashboard                     # interactive dashboard renderer without native panes
 ```
 
+## Child PTY Capability Environment
+
+The outer terminal environment belongs to OpenTUI and remains unchanged so the
+renderer can use the real host terminal. At the final Station-owned PTY spawn
+boundary, inherited and per-launch environment values are merged, outer-renderer
+identity and feature hints are removed, and Station applies `TERM=xterm-256color`,
+`COLORTERM=truecolor`, and `TERM_PROGRAM=Station`. Per-launch values cannot replace
+those fields or the derived `STATION_PANE` marker.
+
+Ordinary locale, authentication, provider, project, worktree, and user environment
+continues to pass through. Until Station supports a feature end to end, children must
+not infer it from Ghostty, Kitty, WezTerm, iTerm2, Windows Terminal, Warp, or another
+outer renderer; native Station currently advertises true color but neither an image
+protocol nor OSC 8 hyperlinks.
+
+`TMUX` and `TMUX_PANE` are retained deliberately because they provide command
+connectivity and bind `STATION_PANE` to the outer server and pane. They are not part
+of Station's renderer capability declaration. External tmux-provider sessions remain
+authoritative for their own environment and do not pass through this native PTY
+policy.
+
+The policy applies only when a local bridge, Bun, or Station Host PTY is created.
+Existing live PTYs keep the environment captured at spawn and are never torn down to
+adopt a capability-policy update.
+
 ## Boundaries
 
 - Keep the Station UI provider-neutral. Do not import provider packages, read SQLite, run `wt`, run `tmux`, run `git` or `gh`, or parse raw provider payloads.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -27,8 +27,8 @@ Launch is driven by `apps/cli/src/commands/tui.ts`. A source checkout uses the N
 
 ## Nested Workspaces
 
-Station-owned PTYs carry a `STATION_PANE` marker bound to their current tmux
-server and pane, or `1` when Station itself is outside tmux. From that context,
+Station-owned PTYs carry `STATION_PANE=1` because Station, rather than any outer
+tmux client, is their direct terminal boundary. From that context,
 bare `stn` outside tmux and explicit `stn tui` refuse to open another native
 workspace:
 
@@ -49,10 +49,9 @@ explicit `stn popup` keep their popup behavior. Tmux launchers mark their
 `--allow-nested`. The mock dashboard remains available without an override.
 
 The controlling-TTY single-instance guard is not sufficient here: each nested
-pane has its own child PTY, so the outer workspace is not a same-TTY rival. The
-tmux-context binding also prevents a server started from a Station shell or
-Observer descendant from copying the marker into unrelated later panes, even
-when different servers reuse the same pane id.
+pane has its own child PTY, so the outer workspace is not a same-TTY rival. A
+tmux server started from a Station shell supplies its own `TMUX` context, which
+no longer matches the copied `STATION_PANE=1` marker in later panes.
 
 Persistent popups use a strict child-process IPC channel between the Node CLI and the Bun
 dashboard renderer. The CLI composition root retains all terminal-provider authority; the
@@ -96,11 +95,13 @@ not infer it from Ghostty, Kitty, WezTerm, iTerm2, Windows Terminal, Warp, or an
 outer renderer; native Station currently advertises true color but neither an image
 protocol nor OSC 8 hyperlinks.
 
-`TMUX` and `TMUX_PANE` are retained deliberately because they provide command
-connectivity and bind `STATION_PANE` to the outer server and pane. They are not part
-of Station's renderer capability declaration. External tmux-provider sessions remain
-authoritative for their own environment and do not pass through this native PTY
-policy.
+`TMUX` and `TMUX_PANE` are removed because conventional capability probes treat
+them as proof that tmux renders the child. When native Station itself was launched
+inside tmux, the captured values remain available as `STATION_OUTER_TMUX` and
+`STATION_OUTER_TMUX_PANE` for deliberate commands such as
+`TMUX="$STATION_OUTER_TMUX" TMUX_PANE="$STATION_OUTER_TMUX_PANE" tmux ...`.
+External tmux-provider sessions remain authoritative for their own environment and
+do not pass through this native PTY policy.
 
 The policy applies only when a local bridge, Bun, or Station Host PTY is created.
 Existing live PTYs keep the environment captured at spawn and are never torn down to

--- a/station/package.json
+++ b/station/package.json
@@ -20,8 +20,8 @@
     "host:dev": "bun run link:station && bun run repair:node-pty && bun src/host/e2eReattachDemo.ts --dev --hold",
     "host:list": "bun run link:station && bun src/host/listHostAgents.ts",
     "test:agents": "bun run repair:node-pty && STATION_PTY_SMOKE=1 STATION_PTY_SMOKE_TUI=1 bun test src/input/stationInput.e2e.test.tsx src/terminal/ptyPipeline.smoke.test.ts",
-    "test:pty": "bun run repair:node-pty && STATION_PTY_SMOKE=1 bun test src/terminal/pty/localPtyTerminal.test.ts src/terminal/ptyPipeline.smoke.test.ts src/terminal/pty/localPtyBridgeHardening.test.ts src/input/stationInput.e2e.test.tsx",
-    "test:pty:bun": "bun run build:ctty-helper && STATION_PTY_SMOKE=1 STATION_PTY_IMPL=bun bun test src/terminal/pty/terminalProcessEmitter.test.ts src/terminal/pty/localPtyTerminal.test.ts src/terminal/pty/bunTerminalProcess.test.ts",
+    "test:pty": "bun run repair:node-pty && STATION_PTY_SMOKE=1 bun test src/terminal/pty/childPtyEnvironment.test.ts src/terminal/pty/localPtyTerminal.test.ts src/terminal/pty/auxShellPlacement.test.ts src/terminal/ptyPipeline.smoke.test.ts src/host/ptyTable.smoke.test.ts src/terminal/pty/localPtyBridgeHardening.test.ts src/input/stationInput.e2e.test.tsx",
+    "test:pty:bun": "bun run build:ctty-helper && STATION_PTY_SMOKE=1 STATION_PTY_IMPL=bun bun test src/terminal/pty/terminalProcessEmitter.test.ts src/terminal/pty/childPtyEnvironment.test.ts src/terminal/pty/localPtyTerminal.test.ts src/terminal/pty/auxShellPlacement.test.ts src/terminal/pty/bunTerminalProcess.test.ts src/host/ptyTable.smoke.test.ts",
     "test:stress": "STATION_VT_STRESS=1 bun test src/terminal/vt/screen.stress.test.ts",
     "test:vt": "bun test src/terminal",
     "typecheck": "bun run link:station && tsc -p tsconfig.json --noEmit"

--- a/station/src/host/ptyTable.smoke.test.ts
+++ b/station/src/host/ptyTable.smoke.test.ts
@@ -29,9 +29,19 @@ if (SMOKE) {
           worktreePath: process.cwd(),
           harnessProvider: "scripted",
           command: "/bin/sh",
-          args: ["-c", 'printf "READY:%s" "$STATION_PANE"; sleep 2'],
+          args: [
+            "-c",
+            'printf "READY:%s|%s|%s|%s|%s|%s" "$STATION_PANE" "$TERM" "$COLORTERM" "$TERM_PROGRAM" "${GHOSTTY_RESOURCES_DIR-unset}" "$USER_SETTING"; sleep 2',
+          ],
           cwd: process.cwd(),
-          env: { STATION_PANE: "0" },
+          env: {
+            STATION_PANE: "0",
+            TERM: "xterm-kitty",
+            COLORTERM: "station-test-color",
+            TERM_PROGRAM: "ghostty",
+            GHOSTTY_RESOURCES_DIR: "/ghostty",
+            USER_SETTING: "ordinary",
+          },
           cols: 80,
           rows: 24,
         });
@@ -40,15 +50,12 @@ if (SMOKE) {
           process.env.TMUX !== undefined && process.env.TMUX_PANE !== undefined
             ? JSON.stringify([process.env.TMUX, process.env.TMUX_PANE])
             : "1";
+        const expected = `READY:${stationPaneMarker}|xterm-256color|truecolor|Station|unset|ordinary`;
         await waitUntil(
-          () =>
-            table
-              .snapshot(ptyId)
-              .scrollback.join("")
-              .includes(`READY:${stationPaneMarker}`),
+          () => table.snapshot(ptyId).scrollback.join("").includes(expected),
           2000,
         );
-        expect(table.snapshot(ptyId).scrollback.join("")).toContain(`READY:${stationPaneMarker}`);
+        expect(table.snapshot(ptyId).scrollback.join("")).toContain(expected);
 
         // The PTY is parented to the host, not a client: it survives with none attached.
         await delay(1100);

--- a/station/src/host/ptyTable.smoke.test.ts
+++ b/station/src/host/ptyTable.smoke.test.ts
@@ -31,7 +31,7 @@ if (SMOKE) {
           command: "/bin/sh",
           args: [
             "-c",
-            'printf "READY:%s|%s|%s|%s|%s|%s" "$STATION_PANE" "$TERM" "$COLORTERM" "$TERM_PROGRAM" "${GHOSTTY_RESOURCES_DIR-unset}" "$USER_SETTING"; sleep 2',
+            'printf "READY:%s|%s|%s|%s|%s|%s|%s|%s|%s|%s" "$STATION_PANE" "$TERM" "$COLORTERM" "$TERM_PROGRAM" "${GHOSTTY_RESOURCES_DIR-unset}" "${TMUX-unset}" "${TMUX_PANE-unset}" "$STATION_OUTER_TMUX" "$STATION_OUTER_TMUX_PANE" "$USER_SETTING"; sleep 2',
           ],
           cwd: process.cwd(),
           env: {
@@ -40,17 +40,17 @@ if (SMOKE) {
             COLORTERM: "station-test-color",
             TERM_PROGRAM: "ghostty",
             GHOSTTY_RESOURCES_DIR: "/ghostty",
+            TMUX: "/tmp/tmux-501/station-smoke,123,0",
+            TMUX_PANE: "%7",
             USER_SETTING: "ordinary",
           },
           cols: 80,
           rows: 24,
         });
 
-        const stationPaneMarker =
-          process.env.TMUX !== undefined && process.env.TMUX_PANE !== undefined
-            ? JSON.stringify([process.env.TMUX, process.env.TMUX_PANE])
-            : "1";
-        const expected = `READY:${stationPaneMarker}|xterm-256color|truecolor|Station|unset|ordinary`;
+        const expected =
+          "READY:1|xterm-256color|truecolor|Station|unset|unset|unset|" +
+          "/tmp/tmux-501/station-smoke,123,0|%7|ordinary";
         await waitUntil(
           () => table.snapshot(ptyId).scrollback.join("").includes(expected),
           2000,

--- a/station/src/terminal/pty/auxShellPlacement.test.ts
+++ b/station/src/terminal/pty/auxShellPlacement.test.ts
@@ -56,19 +56,33 @@ describe("resolveAuxShellPlacement", () => {
       const spawns: unknown[] = [];
       const placeShell = resolveAuxShellPlacement(path, () => fakeClient(spawns));
       const createTerminal = placeShell("pane-split-0");
-      expect(createTerminal).toBeDefined();
+      if (createTerminal === undefined) {
+        throw new Error("Expected the host-backed aux terminal factory.");
+      }
 
-      const terminal = createTerminal!({ cwd: "/work/sub", size: { cols: 120, rows: 40 } });
+      const terminal = createTerminal({
+        cwd: "/work/sub",
+        env: { TERM: "xterm-kitty", GHOSTTY_RESOURCES_DIR: "/ghostty" },
+        size: { cols: 120, rows: 40 },
+      });
       await flush();
 
       expect(spawns).toHaveLength(1);
-      const params = spawns[0] as { kind: string; terminalTargetId: string; cwd: string; cols: number; rows: number };
+      const params = spawns[0] as {
+        kind: string;
+        terminalTargetId: string;
+        cwd: string;
+        cols: number;
+        rows: number;
+        env?: Record<string, string>;
+      };
       expect(params.kind).toBe("aux");
       // Derived from the pane id, so a later boot recomputes the same key.
       expect(params.terminalTargetId).toBe("aux:pane-split-0");
       expect(params.cwd).toBe("/work/sub");
       expect(params.cols).toBe(120);
       expect(params.rows).toBe(40);
+      expect(params.env).toBeUndefined();
       expect(terminal.id).toBe("aux:pane-split-0");
       expect(terminal.command).toBe("host-aux");
       terminal.dispose();

--- a/station/src/terminal/pty/auxShellPlacement.ts
+++ b/station/src/terminal/pty/auxShellPlacement.ts
@@ -16,7 +16,6 @@ const DEFAULT_ROWS = 24;
  * exception — it carries the real cwd so a recovered orphan reopens in place.)
  */
 const AUX_IDENTITY_PLACEHOLDER = "aux";
-const AUX_ENV: Record<string, string> = { TERM: "xterm-256color", COLORTERM: "truecolor" };
 
 /** Resolves whether a Station-owned shell should land in the host or stay local. */
 export type AuxShellPlacement = (
@@ -41,6 +40,7 @@ export function resolveAuxShellPlacement(
       // have defaulted both); mirror the local shell so an aux pane is identical
       // whether it lands in the host or stays local.
       const cwd = spawnOptions.cwd ?? process.cwd();
+      // The host applies child capability policy at final PTY spawn, so aux placement must not duplicate TERM values.
       const spawn: HostSpawnParamsInput = {
         kind: "aux",
         terminalTargetId: auxTerminalTargetId(paneId),
@@ -51,7 +51,6 @@ export function resolveAuxShellPlacement(
         worktreePath: cwd,
         command: defaultShell(),
         args: defaultShellArgs(),
-        env: AUX_ENV,
         cwd,
         cols,
         rows,

--- a/station/src/terminal/pty/bunTerminalProcess.test.ts
+++ b/station/src/terminal/pty/bunTerminalProcess.test.ts
@@ -11,7 +11,8 @@ import {
   createBunTerminalProcess,
   type BunTerminalProcessOptions,
 } from "./bunTerminalProcess.js";
-import { createLocalPtyTerminal, createPtyEnv } from "./localPtyTerminal.js";
+import { createStationChildPtyEnvironment } from "./childPtyEnvironment.js";
+import { createLocalPtyTerminal } from "./localPtyTerminal.js";
 
 const RUN_REAL_BUN_PTY = process.env.STATION_PTY_IMPL === "bun";
 const cleanups: Array<() => Promise<unknown> | unknown> = [];
@@ -31,7 +32,7 @@ function resolvedOptions(
     command,
     args,
     cwd: process.cwd(),
-    env: createPtyEnv(undefined),
+    env: createStationChildPtyEnvironment(process.env),
     name: "xterm-256color",
     size: { cols: 80, rows: 24 },
   };
@@ -250,19 +251,22 @@ if (RUN_REAL_BUN_PTY) {
       expect(observed.exit()).toEqual({ exitCode: 0 });
     });
 
-    it("passes the sanitized color-capable environment", async () => {
+    it("passes the Station-owned capability environment", async () => {
       const terminal = trackTerminal(
         createLocalPtyTerminal({
           command: "/bin/sh",
           args: [
             "-c",
-            'printf "%s|%s|%s|%s" "$TERM" "$COLORTERM" "${NO_COLOR-unset}" "${FORCE_COLOR-unset}"',
+            'printf "%s|%s|%s|%s|%s|%s|%s" "$TERM" "$COLORTERM" "$TERM_PROGRAM" "${NO_COLOR-unset}" "${FORCE_COLOR-unset}" "${GHOSTTY_RESOURCES_DIR-unset}" "$USER_SETTING"',
           ],
           env: {
-            TERM: "station-test-term",
+            TERM: "xterm-kitty",
             COLORTERM: "station-test-color",
+            TERM_PROGRAM: "ghostty",
             NO_COLOR: "1",
             FORCE_COLOR: "0",
+            GHOSTTY_RESOURCES_DIR: "/ghostty",
+            USER_SETTING: "ordinary",
           },
         }),
       );
@@ -270,7 +274,9 @@ if (RUN_REAL_BUN_PTY) {
 
       await waitFor(() => observed.exit() !== undefined, 5_000);
 
-      expect(observed.output()).toBe("station-test-term|station-test-color|unset|unset");
+      expect(observed.output()).toBe(
+        "xterm-256color|truecolor|Station|unset|unset|unset|ordinary",
+      );
     });
 
     it("dispose terminates a long-running payload before closing the terminal", async () => {

--- a/station/src/terminal/pty/childPtyEnvironment.test.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.test.ts
@@ -95,24 +95,40 @@ describe("createStationChildPtyEnvironment", () => {
     });
   });
 
-  it("retains tmux connectivity and binds Station ownership to the merged tmux context", () => {
+  it("removes direct tmux identity while preserving explicit outer-server access", () => {
     const child = createStationChildPtyEnvironment(
       {
         TMUX: "/tmp/tmux-501/origin,123,0",
         TMUX_PANE: "%3",
+        STATION_OUTER_TMUX: "stale-origin",
+        STATION_OUTER_TMUX_PANE: "stale-origin-pane",
         STATION_PANE: "inherited",
       },
       {
         TMUX: "/tmp/tmux-501/launch,456,0",
         TMUX_PANE: "%7",
+        STATION_OUTER_TMUX: "stale-launch",
+        STATION_OUTER_TMUX_PANE: "stale-launch-pane",
         STATION_PANE: "launch",
       },
     );
 
-    expect(child.TMUX).toBe("/tmp/tmux-501/launch,456,0");
-    expect(child.TMUX_PANE).toBe("%7");
-    expect(child.STATION_PANE).toBe(
-      JSON.stringify(["/tmp/tmux-501/launch,456,0", "%7"]),
-    );
+    expect(child.TMUX).toBeUndefined();
+    expect(child.TMUX_PANE).toBeUndefined();
+    expect(child.STATION_OUTER_TMUX).toBe("/tmp/tmux-501/launch,456,0");
+    expect(child.STATION_OUTER_TMUX_PANE).toBe("%7");
+    expect(child.STATION_PANE).toBe("1");
+  });
+
+  it("clears stale outer-tmux access when no complete direct tmux context exists", () => {
+    const child = createStationChildPtyEnvironment({
+      TMUX: "/tmp/tmux-501/incomplete,123,0",
+      STATION_OUTER_TMUX: "stale",
+      STATION_OUTER_TMUX_PANE: "stale-pane",
+    });
+
+    expect(child.TMUX).toBeUndefined();
+    expect(child.STATION_OUTER_TMUX).toBeUndefined();
+    expect(child.STATION_OUTER_TMUX_PANE).toBeUndefined();
   });
 });

--- a/station/src/terminal/pty/childPtyEnvironment.test.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "bun:test";
+import { createStationChildPtyEnvironment } from "./childPtyEnvironment.js";
+
+const outerTerminalHints = {
+  ALACRITTY_SOCKET: "/tmp/alacritty.sock",
+  CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+  COLORTERM_BCE: "1",
+  COLORFGBG: "15;0",
+  ConEmuPID: "123",
+  FORCE_COLOR: "3",
+  FORCE_HYPERLINK: "1",
+  GHOSTTY_RESOURCES_DIR: "/Applications/Ghostty.app/Contents/Resources/ghostty",
+  GNOME_TERMINAL_SCREEN: "/org/gnome/Terminal/screen/1",
+  ITERM_SESSION_ID: "w0t0p0:session",
+  KITTY_WINDOW_ID: "7",
+  KONSOLE_VERSION: "240800",
+  LC_TERMINAL: "iTerm2",
+  NO_COLOR: "1",
+  STY: "screen-session",
+  TERMINAL_EMULATOR: "JetBrains-JediTerm",
+  TERM_PROGRAM_VERSION: "9.9.9",
+  TERM_SESSION_ID: "terminal-session",
+  TILIX_ID: "tilix-session",
+  VSCODE_INJECTION: "1",
+  VTE_VERSION: "7600",
+  WARP_SESSION_ID: "warp-session",
+  WARP_TERMINAL_SESSION_UUID: "warp-terminal-session",
+  WEZTERM_PANE: "4",
+  WT_PROFILE_ID: "{profile}",
+  WT_SESSION: "{session}",
+  XTERM_VERSION: "XTerm(999)",
+  ZELLIJ: "0",
+} as const;
+
+describe("createStationChildPtyEnvironment", () => {
+  it("replaces inherited and launch terminal identity with Station's", () => {
+    const inherited = {
+      ...outerTerminalHints,
+      TERM: "xterm-ghostty",
+      COLORTERM: "24bit",
+      TERM_PROGRAM: "ghostty",
+      STATION_PANE: "inherited",
+    };
+    const launch = {
+      ...outerTerminalHints,
+      TERM: "xterm-kitty",
+      COLORTERM: "station-test-color",
+      TERM_PROGRAM: "WezTerm",
+      STATION_PANE: "launch",
+    };
+    const inheritedBefore = { ...inherited };
+    const launchBefore = { ...launch };
+
+    const child = createStationChildPtyEnvironment(inherited, launch);
+
+    expect(child.TERM).toBe("xterm-256color");
+    expect(child.COLORTERM).toBe("truecolor");
+    expect(child.TERM_PROGRAM).toBe("Station");
+    expect(child.STATION_PANE).toBe("1");
+    for (const key of Object.keys(outerTerminalHints)) {
+      expect(child[key]).toBeUndefined();
+    }
+    expect(inherited).toEqual(inheritedBefore);
+    expect(launch).toEqual(launchBefore);
+  });
+
+  it("passes ordinary process and launch environment through with launch precedence", () => {
+    const child = createStationChildPtyEnvironment(
+      {
+        PATH: "/usr/bin:/bin",
+        HOME: "/home/station",
+        LANG: "en_US.UTF-8",
+        SSH_AUTH_SOCK: "/tmp/agent.sock",
+        TERMINFO: "/home/station/.terminfo",
+        CODEX_HOME: "/home/station/.codex",
+        STATION_SESSION_ID: "session-1",
+        USER_SETTING: "inherited",
+      },
+      {
+        USER_SETTING: "launch",
+        PROJECT_SETTING: "enabled",
+      },
+    );
+
+    expect(child).toMatchObject({
+      PATH: "/usr/bin:/bin",
+      HOME: "/home/station",
+      LANG: "en_US.UTF-8",
+      SSH_AUTH_SOCK: "/tmp/agent.sock",
+      TERMINFO: "/home/station/.terminfo",
+      CODEX_HOME: "/home/station/.codex",
+      STATION_SESSION_ID: "session-1",
+      USER_SETTING: "launch",
+      PROJECT_SETTING: "enabled",
+    });
+  });
+
+  it("retains tmux connectivity and binds Station ownership to the merged tmux context", () => {
+    const child = createStationChildPtyEnvironment(
+      {
+        TMUX: "/tmp/tmux-501/origin,123,0",
+        TMUX_PANE: "%3",
+        STATION_PANE: "inherited",
+      },
+      {
+        TMUX: "/tmp/tmux-501/launch,456,0",
+        TMUX_PANE: "%7",
+        STATION_PANE: "launch",
+      },
+    );
+
+    expect(child.TMUX).toBe("/tmp/tmux-501/launch,456,0");
+    expect(child.TMUX_PANE).toBe("%7");
+    expect(child.STATION_PANE).toBe(
+      JSON.stringify(["/tmp/tmux-501/launch,456,0", "%7"]),
+    );
+  });
+});

--- a/station/src/terminal/pty/childPtyEnvironment.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.ts
@@ -1,0 +1,91 @@
+export const STATION_CHILD_TERMINAL_ENV = {
+  TERM: "xterm-256color",
+  COLORTERM: "truecolor",
+  TERM_PROGRAM: "Station",
+} as const;
+
+const OUTER_TERMINAL_ENVIRONMENT_KEYS = new Set([
+  "COLORTERM_BCE",
+  "COLORFGBG",
+  "COLUMNS",
+  "FORCE_COLOR",
+  "FORCE_HYPERLINK",
+  "FORCE_HYPERLINKS",
+  "LC_TERMINAL",
+  "LC_TERMINAL_VERSION",
+  "LINES",
+  "MSYSCON",
+  "NO_COLOR",
+  "SHELL_SESSION_ID",
+  "STY",
+  "TERMCAP",
+  "TERMINAL_EMULATOR",
+  "TERM_PROGRAM_VERSION",
+  "TERM_SESSION_ID",
+  "VSCODE_INJECTION",
+  "VSCODE_NONCE",
+  "VSCODE_PID",
+  "VSCODE_SHELL_INTEGRATION",
+  "VTE_VERSION",
+  "WINDOW",
+  "WINDOWID",
+  "WT_PROFILE_ID",
+  "WT_SESSION",
+  "XTERM_VERSION",
+  "ZELLIJ",
+  "ZELLIJ_PANE_ID",
+]);
+
+const OUTER_TERMINAL_ENVIRONMENT_PREFIXES = [
+  "ALACRITTY_",
+  "CMUX_",
+  "ConEmu",
+  "GHOSTTY_",
+  "GNOME_TERMINAL_",
+  "ITERM_",
+  "KITTY_",
+  "KONSOLE_",
+  "TILIX_",
+  "WARP_",
+  "WEZTERM_",
+] as const;
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+/**
+ * Builds the environment for a Station-rendered child PTY without mutating the
+ * outer renderer environment; ordinary launch values pass through, while
+ * Station-owned terminal identity is applied after outer-only hints are removed.
+ */
+export function createStationChildPtyEnvironment(
+  inheritedEnvironment: Environment,
+  launchEnvironment?: Environment,
+): Record<string, string | undefined> {
+  const childEnvironment: Record<string, string | undefined> = {
+    ...inheritedEnvironment,
+    ...launchEnvironment,
+  };
+  const tmux = childEnvironment.TMUX;
+  const tmuxPane = childEnvironment.TMUX_PANE;
+
+  for (const key of Object.keys(childEnvironment)) {
+    if (isOuterTerminalEnvironmentKey(key)) {
+      delete childEnvironment[key];
+    }
+  }
+
+  Object.assign(childEnvironment, STATION_CHILD_TERMINAL_ENV);
+
+  // TMUX remains a connectivity channel and STATION_PANE binding, not evidence of Station's renderer.
+  childEnvironment.STATION_PANE =
+    tmux !== undefined && tmuxPane !== undefined ? JSON.stringify([tmux, tmuxPane]) : "1";
+
+  return childEnvironment;
+}
+
+function isOuterTerminalEnvironmentKey(key: string): boolean {
+  return (
+    OUTER_TERMINAL_ENVIRONMENT_KEYS.has(key) ||
+    OUTER_TERMINAL_ENVIRONMENT_PREFIXES.some((prefix) => key.startsWith(prefix))
+  );
+}

--- a/station/src/terminal/pty/childPtyEnvironment.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.ts
@@ -76,9 +76,18 @@ export function createStationChildPtyEnvironment(
 
   Object.assign(childEnvironment, STATION_CHILD_TERMINAL_ENV);
 
-  // TMUX remains a connectivity channel and STATION_PANE binding, not evidence of Station's renderer.
-  childEnvironment.STATION_PANE =
-    tmux !== undefined && tmuxPane !== undefined ? JSON.stringify([tmux, tmuxPane]) : "1";
+  // TMUX claims the child is rendered by tmux, so keep outer-server access only
+  // under Station-owned names that capability probes do not treat as terminal identity.
+  delete childEnvironment.TMUX;
+  delete childEnvironment.TMUX_PANE;
+  if (tmux !== undefined && tmuxPane !== undefined) {
+    childEnvironment.STATION_OUTER_TMUX = tmux;
+    childEnvironment.STATION_OUTER_TMUX_PANE = tmuxPane;
+  } else {
+    delete childEnvironment.STATION_OUTER_TMUX;
+    delete childEnvironment.STATION_OUTER_TMUX_PANE;
+  }
+  childEnvironment.STATION_PANE = "1";
 
   return childEnvironment;
 }

--- a/station/src/terminal/pty/localPtyTerminal.test.ts
+++ b/station/src/terminal/pty/localPtyTerminal.test.ts
@@ -1,91 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import type { StationTerminalProcess } from "../types.js";
-import {
-  createLocalPtyTerminal,
-  createPtyEnv,
-  resolvePtyImplementation,
-} from "./localPtyTerminal.js";
+import { createLocalPtyTerminal, resolvePtyImplementation } from "./localPtyTerminal.js";
 
 declare const Bun: {
   env: Record<string, string | undefined>;
 };
-
-describe("createPtyEnv", () => {
-  it("marks inherited and launch environments as Station-owned panes", () => {
-    const previousStationPane = process.env.STATION_PANE;
-    const previousTmux = process.env.TMUX;
-    const previousTmuxPane = process.env.TMUX_PANE;
-    try {
-      delete process.env.TMUX;
-      delete process.env.TMUX_PANE;
-      for (const inherited of ["0", "", undefined]) {
-        restoreEnv("STATION_PANE", inherited);
-        expect(createPtyEnv(undefined).STATION_PANE).toBe("1");
-      }
-
-      process.env.STATION_PANE = "inherited";
-      for (const launchStationPane of ["0", "", undefined]) {
-        expect(createPtyEnv({ STATION_PANE: launchStationPane }).STATION_PANE).toBe("1");
-      }
-
-      process.env.TMUX = "/tmp/tmux-501/origin,123,0";
-      process.env.TMUX_PANE = "%3";
-      expect(createPtyEnv(undefined).STATION_PANE).toBe(
-        JSON.stringify(["/tmp/tmux-501/origin,123,0", "%3"]),
-      );
-      expect(
-        createPtyEnv({
-          STATION_PANE: "0",
-          TMUX: "/tmp/tmux-501/launch,456,0",
-          TMUX_PANE: "%7",
-        }).STATION_PANE,
-      ).toBe(JSON.stringify(["/tmp/tmux-501/launch,456,0", "%7"]));
-    } finally {
-      restoreEnv("STATION_PANE", previousStationPane);
-      restoreEnv("TMUX", previousTmux);
-      restoreEnv("TMUX_PANE", previousTmuxPane);
-    }
-  });
-
-  it("commits to color-capable defaults and strips color-suppressing vars", () => {
-    const previousNoColor = process.env.NO_COLOR;
-    const previousForceColor = process.env.FORCE_COLOR;
-    process.env.NO_COLOR = "1";
-    process.env.FORCE_COLOR = "0";
-    try {
-      // A NO_COLOR/FORCE_COLOR leaked into the host's own env must not reach panes.
-      const inherited = createPtyEnv(undefined);
-      expect(inherited.NO_COLOR).toBeUndefined();
-      expect(inherited.FORCE_COLOR).toBeUndefined();
-      expect(inherited.COLORTERM).toEqual("truecolor");
-      expect(inherited.TERM).toBeDefined();
-
-      // ...and an explicit per-spawn env carrying them is sanitized too.
-      const explicit = createPtyEnv({ NO_COLOR: "1", FORCE_COLOR: "0", TERM: "screen-256color" });
-      expect(explicit.NO_COLOR).toBeUndefined();
-      expect(explicit.FORCE_COLOR).toBeUndefined();
-      expect(explicit.TERM).toEqual("screen-256color");
-    } finally {
-      restoreEnv("NO_COLOR", previousNoColor);
-      restoreEnv("FORCE_COLOR", previousForceColor);
-    }
-  });
-
-  it("treats empty terminal capability values as absent", () => {
-    const previousTerm = process.env.TERM;
-    const previousColorTerm = process.env.COLORTERM;
-    process.env.TERM = "";
-    process.env.COLORTERM = "";
-    try {
-      const env = createPtyEnv({ TERM: "", COLORTERM: "" });
-      expect(env.TERM).toBe("xterm-256color");
-      expect(env.COLORTERM).toBe("truecolor");
-    } finally {
-      restoreEnv("TERM", previousTerm);
-      restoreEnv("COLORTERM", previousColorTerm);
-    }
-  });
-});
 
 describe("resolvePtyImplementation", () => {
   it("keeps the bridge as the default", () => {
@@ -133,13 +52,13 @@ describe("createLocalPtyTerminal", () => {
     }
   });
 
-  it("spawns a command in a pty when the smoke probe is enabled", async () => {
+  it("passes Station-owned capabilities to a real child when the smoke probe is enabled", async () => {
     if (Bun.env.STATION_PTY_SMOKE !== "1") {
       expect(true).toEqual(true);
       return;
     }
 
-    const expected = "station-node-pty-ready";
+    const expected = "xterm-256color|truecolor|Station|unset|unset|ordinary";
     let terminal: StationTerminalProcess | undefined;
 
     try {
@@ -175,8 +94,19 @@ describe("createLocalPtyTerminal", () => {
         }, 2_000);
 
         terminal = createLocalPtyTerminal({
-          args: ["-lc", `printf ${expected}`],
+          args: [
+            "-c",
+            'printf "%s|%s|%s|%s|%s|%s" "$TERM" "$COLORTERM" "$TERM_PROGRAM" "${GHOSTTY_RESOURCES_DIR-unset}" "${KITTY_WINDOW_ID-unset}" "$USER_SETTING"',
+          ],
           command: "/bin/sh",
+          env: {
+            TERM: "xterm-kitty",
+            COLORTERM: "station-test-color",
+            TERM_PROGRAM: "ghostty",
+            GHOSTTY_RESOURCES_DIR: "/ghostty",
+            KITTY_WINDOW_ID: "7",
+            USER_SETTING: "ordinary",
+          },
           size: {
             cols: 80,
             rows: 24,

--- a/station/src/terminal/pty/localPtyTerminal.ts
+++ b/station/src/terminal/pty/localPtyTerminal.ts
@@ -17,6 +17,10 @@ import {
   createBunTerminalProcess,
   type BunTerminalProcessOptions,
 } from "./bunTerminalProcess.js";
+import {
+  createStationChildPtyEnvironment,
+  STATION_CHILD_TERMINAL_ENV,
+} from "./childPtyEnvironment.js";
 import { StationTerminalSpawnError } from "./errors.js";
 import { TerminalProcessEmitter } from "./terminalProcessEmitter.js";
 
@@ -81,12 +85,13 @@ function ensureSpawnHelperExecutable(): void {
   }
 }
 
+/** Spawns a native PTY after applying Station's child-terminal environment policy. */
 export function createLocalPtyTerminal(
   options: StationTerminalSpawnOptions = {},
   runtime: LocalPtyTerminalRuntime = {},
 ): StationTerminalProcess {
   const size = normalizeSize(options.size);
-  const env = createPtyEnv(options.env);
+  const env = createStationChildPtyEnvironment(process.env, options.env);
   const command = options.command ?? defaultShell();
   const args = options.args === undefined ? defaultShellArgs() : [...options.args];
   let implementation: PtyImplementation;
@@ -100,7 +105,7 @@ export function createLocalPtyTerminal(
   }
   const id = options.id ?? createTerminalId();
   const cwd = options.cwd ?? process.cwd();
-  const name = options.name ?? env.TERM ?? "xterm-256color";
+  const name = STATION_CHILD_TERMINAL_ENV.TERM;
 
   if (implementation !== "bridge") {
     const bunOptions: BunTerminalProcessOptions = {
@@ -400,32 +405,6 @@ export function defaultShellArgs(): string[] {
   }
 
   return ["-i"];
-}
-
-export function createPtyEnv(
-  env: Readonly<Record<string, string | undefined>> | undefined,
-): Record<string, string | undefined> {
-  const nextEnv = {
-    ...process.env,
-    ...env,
-  };
-
-  // Station renders panes itself, so children should see stable xterm-style capabilities.
-  nextEnv.TERM = env?.TERM || process.env.TERM || "xterm-256color";
-  nextEnv.COLORTERM = env?.COLORTERM || process.env.COLORTERM || "truecolor";
-
-  // The host owns terminal capabilities; a NO_COLOR/FORCE_COLOR leaked from the
-  // observer's env would override the COLORTERM we just set, so drop both.
-  delete nextEnv.NO_COLOR;
-  delete nextEnv.FORCE_COLOR;
-
-  // Bind ownership to the full tmux context so different servers may safely reuse pane ids.
-  nextEnv.STATION_PANE =
-    nextEnv.TMUX !== undefined && nextEnv.TMUX_PANE !== undefined
-      ? JSON.stringify([nextEnv.TMUX, nextEnv.TMUX_PANE])
-      : "1";
-
-  return nextEnv;
 }
 
 function normalizeSize(size: Partial<StationTerminalSize> | undefined): StationTerminalSize {

--- a/station/src/terminal/ptyPipeline.smoke.test.ts
+++ b/station/src/terminal/ptyPipeline.smoke.test.ts
@@ -20,7 +20,11 @@ type Pipeline = {
 };
 
 /** The production wiring: real bridge pty feeding a real vt screen. */
-function startPipeline(command: string, size = { cols: 80, rows: 24 }): Pipeline {
+function startPipeline(
+  command: string,
+  size = { cols: 80, rows: 24 },
+  env: Readonly<Record<string, string | undefined>> = {},
+): Pipeline {
   const screen = createStationVtScreen({
     size,
     onResponse: (data) => {
@@ -31,7 +35,7 @@ function startPipeline(command: string, size = { cols: 80, rows: 24 }): Pipeline
     command: "/bin/sh",
     args: ["-c", command],
     size,
-    env: { LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8" },
+    env: { LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8", ...env },
   });
   terminal.onData((data) => {
     screen.feed(data);
@@ -65,6 +69,41 @@ describe("pty pipeline smoke", () => {
       const col = visibleRowText(pipeline.screen, row).indexOf("SMOKE-RED");
       const span = spanAtColumn(pipeline.screen, row, col);
       expect(span?.fg).toBe("#cd3131");
+    } finally {
+      pipeline.dispose();
+    }
+  });
+
+  it("the child sees Station-owned terminal capabilities", async () => {
+    if (gated()) return;
+    const pipeline = startPipeline(
+      [
+        "printf 'TERM=%s\\nCOLORTERM=%s\\nTERM_PROGRAM=%s\\nGHOSTTY=%s\\nKITTY=%s\\nUSER=%s\\n'",
+        '"$TERM" "$COLORTERM" "$TERM_PROGRAM"',
+        '"${GHOSTTY_RESOURCES_DIR-unset}" "${KITTY_WINDOW_ID-unset}" "$USER_SETTING"',
+      ].join(" "),
+      { cols: 80, rows: 24 },
+      {
+        TERM: "xterm-kitty",
+        COLORTERM: "station-test-color",
+        TERM_PROGRAM: "ghostty",
+        GHOSTTY_RESOURCES_DIR: "/ghostty",
+        KITTY_WINDOW_ID: "7",
+        USER_SETTING: "ordinary",
+      },
+    );
+    try {
+      await waitFor(() => someRowIncludes(pipeline.screen, "USER=ordinary") >= 0, 5_000);
+      for (const expected of [
+        "TERM=xterm-256color",
+        "COLORTERM=truecolor",
+        "TERM_PROGRAM=Station",
+        "GHOSTTY=unset",
+        "KITTY=unset",
+        "USER=ordinary",
+      ]) {
+        expect(someRowIncludes(pipeline.screen, expected)).toBeGreaterThanOrEqual(0);
+      }
     } finally {
       pipeline.dispose();
     }

--- a/station/src/terminal/types.ts
+++ b/station/src/terminal/types.ts
@@ -16,7 +16,6 @@ export type StationTerminalSpawnOptions = {
   args?: readonly string[];
   cwd?: string;
   env?: Readonly<Record<string, string | undefined>>;
-  name?: string;
   size?: Partial<StationTerminalSize>;
 };
 


### PR DESCRIPTION
## Summary

- centralize native child-PTY environment ownership at the final bridge/Bun spawn boundary
- advertise `TERM=xterm-256color`, `COLORTERM=truecolor`, and `TERM_PROGRAM=Station` while stripping outer-emulator identity and feature hints
- preserve ordinary launch environment and explicit tmux connectivity/`STATION_PANE` binding
- apply the same policy to local, Bun, Station Host, managed-agent, and auxiliary-shell spawns
- document the renderer-versus-child authority boundary and fresh-spawn rollout behavior

Closes #223.

## Testing

- `pnpm test:all` (with caller terminal ownership variables unset and isolated Claude config)
- `cd station && bun run typecheck`
- `cd station && bun run test` — 1053 passed
- `cd station && bun run test:pty` — 39 passed
- `cd station && bun run test:pty:bun` — 30 passed
- `pnpm build:binary -- --version 0.0.0-local`
- `pnpm smoke:binary -- --expected-version 0.0.0-local`
- full pre-push gate passed while pushing the branch

## UX implication

Fresh native Station panes now identify Station—not Ghostty, Kitty, WezTerm, iTerm2, Windows Terminal, or Warp—as their direct terminal boundary. Capability-aware children retain true color but no longer select Kitty images or OSC 8 solely from the outer renderer. Existing live Host PTYs keep their spawn-time environment until safely closed and recreated.

Manual check in a fresh pane:

```sh
env | grep -E '^(TERM|COLORTERM|TERM_PROGRAM|TMUX|TMUX_PANE|GHOSTTY_|KITTY_|WEZTERM_|ITERM_|WARP_|WT_)'
```
