### PR TITLE
chore(release): prepare v0.7.1-rc.4 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run this from any directory:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.3
+  tag=v0.7.1-rc.4
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -76,7 +76,7 @@ Run this from any directory:
 )
 ```
 
-`v0.7.1-rc.3` is the current private-binary candidate. `v0.7.1-rc.2` remains
+`v0.7.1-rc.4` is the current private-binary candidate. `v0.7.1-rc.3` remains
 published as its immutable rollback; the earlier `v0.7.0` and `v0.7.1-rc.1`
 candidates remained unpublished. Run the recipe after the candidate is
 published. It fetches the installer and binary from the same immutable release
@@ -113,7 +113,7 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.3 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -123,7 +123,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.3`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.3", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.4", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 
@@ -225,7 +225,15 @@ describe("CLI manual-smoke commands", () => {
     for (const { topic, example } of dispatchExamples) {
       const payload = commandDispatchJsonPayload(example);
       expect(payload, `${topic}: ${example}`).toBeDefined();
-      const parsed = StationCommandSchema.safeParse(JSON.parse(String(payload)));
+      let decoded: unknown;
+      try {
+        decoded = JSON.parse(String(payload));
+      } catch (error) {
+        throw new Error(`Command dispatch example contains invalid JSON: ${topic}.`, {
+          cause: error,
+        });
+      }
+      const parsed = StationCommandSchema.safeParse(decoded);
       expect(parsed.success, `${topic}: ${example}`).toBe(true);
     }
   });

--- a/docs/development.md
+++ b/docs/development.md
@@ -318,22 +318,22 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
-The current immutable binary candidate is `v0.7.1-rc.3`. `v0.7.1-rc.2` is the
-prior published binary; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates
-remained unpublished:
+The current immutable binary candidate is `v0.7.1-rc.4`. `v0.7.1-rc.3` is the
+prior published binary, and `v0.7.1-rc.2` remains an older published rollback;
+the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.3`, then create and
-   push `v0.7.1-rc.3`.
+   with `package.json` and runtime reporting at `0.7.1-rc.4`, then create and
+   push `v0.7.1-rc.4`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.3-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.4-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
-4. As the second binary release, install `v0.7.1-rc.2`, upgrade to the accepted
-   candidate, explicitly reinstall `v0.7.1-rc.2`, then reinstall the candidate.
-   Confirm the complete version and all three launchers after every transition.
+4. Install `v0.7.1-rc.3`, upgrade to the accepted candidate, explicitly
+   reinstall `v0.7.1-rc.3`, then reinstall the candidate. Confirm the complete
+   version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.3`, and the manual-acceptance confirmation. It rechecks the
+   `v0.7.1-rc.4`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
    asset IDs, and all archive hashes immediately before publishing that exact
    draft.
@@ -446,7 +446,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.3
+  tag=v0.7.1-rc.4
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -585,11 +585,11 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.3`:
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.4`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft
-   with published `v0.7.1-rc.2` in both directions.
+   with published `v0.7.1-rc.3` in both directions.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,7 +25,7 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.3 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -35,7 +35,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.3`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly
@@ -86,7 +86,7 @@ From any directory, run:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.3
+  tag=v0.7.1-rc.4
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -101,7 +101,7 @@ From any directory, run:
 )
 ```
 
-`v0.7.1-rc.3` is the current private-binary candidate. `v0.7.1-rc.2` remains
+`v0.7.1-rc.4` is the current private-binary candidate. `v0.7.1-rc.3` remains
 published as its immutable rollback; the earlier `v0.7.0` and `v0.7.1-rc.1`
 candidates remained unpublished. Run this recipe after the candidate is
 published. Keep the fixed assignment for an exact prerelease install. After the
@@ -122,7 +122,7 @@ stn-tmux-popup
 It also installs the redistributed license under
 `${XDG_DATA_HOME:-$HOME/.local/share}/station/`.
 
-After this candidate is published, immutable rollback to `v0.7.1-rc.2` uses the
+After this candidate is published, immutable rollback to `v0.7.1-rc.3` uses the
 same exact-version procedure below.
 
 ## 3. Verify the Install
@@ -151,11 +151,11 @@ shells. The installer does not read, create, or edit shell startup files.
 
 ## Install an Exact Version
 
-To install an exact release or return to published `v0.7.1-rc.2`, use the same
+To install an exact release or return to published `v0.7.1-rc.3`, use the same
 recipe with this assignment instead of the latest-release lookup:
 
 ```bash
-tag=v0.7.1-rc.2
+tag=v0.7.1-rc.3
 ```
 
 The installer code and artifacts still come from that same tag. The earlier

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.3", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.4", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -381,7 +381,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.3-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.4-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -422,8 +422,9 @@ Explicit installs set a tag, fetch
 invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
-always paired. `v0.7.1-rc.2` is the first published binary; publishing
-`v0.7.1-rc.3` makes immutable rollback to it available.
+always paired. `v0.7.1-rc.2` is the first published binary,
+`v0.7.1-rc.3` is the latest published binary, and publishing `v0.7.1-rc.4`
+makes immutable rollback to `v0.7.1-rc.3` available.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -492,9 +493,9 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.7.1-rc.3` promotes only after all four native targets pass
+Candidate `v0.7.1-rc.4` promotes only after all four native targets pass
 automated and manual acceptance, including upgrade and rollback against
-published `v0.7.1-rc.2`. Published tags and assets are never deleted, moved, or
+published `v0.7.1-rc.3`. Published tags and assets are never deleted, moved, or
 overwritten; a bad release rolls back explicitly and rolls forward to a higher
 version containing the revert or fix.
 
@@ -708,10 +709,10 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.3` output appears,
+   repeatedly installs the draft → only complete `0.7.1-rc.4` output appears,
    never command-not-found or malformed output; both aliases remain links to
    `stn`, so entrypoints never mix. Alternate the draft with published
-   `v0.7.1-rc.2` in both directions to prove upgrade and rollback.
+   `v0.7.1-rc.3` in both directions to prove upgrade and rollback.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.

--- a/integrations/harness/claude/test/unit/provider.test.ts
+++ b/integrations/harness/claude/test/unit/provider.test.ts
@@ -81,8 +81,11 @@ describe("ClaudeHarnessProvider", () => {
 
   it("reports authenticated doctor checks when auth status is logged in", async () => {
     const calls: ExternalCommandInput[] = [];
+    const root = await mkdtemp(join(tmpdir(), "station-claude-doctor-"));
     const provider = createClaudeHarnessProvider({
       command: "claude-test",
+      stateDir: join(root, "observer"),
+      claudeConfigDir: join(root, "claude-home"),
       now: () => new Date(now),
       runner: async (input) => {
         calls.push(input);
@@ -93,7 +96,7 @@ describe("ClaudeHarnessProvider", () => {
       },
     });
 
-    const checks = await provider.doctorChecks();
+    const checks = await provider.doctorChecks?.();
 
     expect(checks).toEqual([
       expect.objectContaining({ name: "claude.version", status: "ok" }),
@@ -104,8 +107,11 @@ describe("ClaudeHarnessProvider", () => {
   });
 
   it("warns in doctor checks when claude is not logged in", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-claude-doctor-"));
     const provider = createClaudeHarnessProvider({
       command: "claude-test",
+      stateDir: join(root, "observer"),
+      claudeConfigDir: join(root, "claude-home"),
       now: () => new Date(now),
       runner: async (input) => {
         if (input.args?.[0] === "--version") {
@@ -115,20 +121,20 @@ describe("ClaudeHarnessProvider", () => {
       },
     });
 
-    const checks = await provider.doctorChecks();
+    const checks = await provider.doctorChecks?.();
 
-    expect(checks[1]).toMatchObject({
+    expect(checks?.[1]).toMatchObject({
       name: "claude.auth",
       status: "warn",
     });
-    expect(checks[1]?.message).toContain("login");
+    expect(checks?.[1]?.message).toContain("login");
   });
 
   it("hooksStatus reports requested:false / installed:false when hooks are not enabled", async () => {
     // install_hooks omitted → the doctor short-circuits without reading files, so
     // the gate sees requested:false (and points the user at the config flag).
     const provider = createClaudeHarnessProvider({ now: () => new Date(now) });
-    await expect(provider.hooksStatus()).resolves.toMatchObject({
+    await expect(provider.hooksStatus?.()).resolves.toMatchObject({
       provider: "claude",
       requested: false,
       installed: false,
@@ -162,7 +168,7 @@ describe("ClaudeHarnessProvider", () => {
     });
 
     // The observer passes the config path to the guard via context.
-    await expect(provider.hooksStatus({ stationConfigPath })).resolves.toMatchObject({
+    await expect(provider.hooksStatus?.({ stationConfigPath })).resolves.toMatchObject({
       provider: "claude",
       requested: true,
       installed: true,
@@ -178,7 +184,7 @@ describe("ClaudeHarnessProvider", () => {
       stateDir: join(root, "observer"),
       now: () => new Date(now),
     });
-    await expect(provider.hooksStatus()).resolves.toMatchObject({
+    await expect(provider.hooksStatus?.()).resolves.toMatchObject({
       provider: "claude",
       requested: true,
       installed: false,
@@ -257,7 +263,7 @@ describe("ClaudeHarnessProvider", () => {
   it("ingests forwarded hook events through provider-local parsing", async () => {
     const provider = createClaudeHarnessProvider();
 
-    const observations = await provider.ingestEvent(
+    const observations = await provider.ingestEvent?.(
       {
         provider: "claude",
         event: {
@@ -273,7 +279,7 @@ describe("ClaudeHarnessProvider", () => {
       { projects: [], worktrees: [], terminalTargets: [] },
     );
 
-    expect(observations[0]).toMatchObject({
+    expect(observations?.[0]).toMatchObject({
       provider: "claude",
       rawEventType: "Stop",
       sessionId: "ses_web_task",
@@ -286,7 +292,7 @@ describe("ClaudeHarnessProvider", () => {
     const provider = createClaudeHarnessProvider();
 
     await expect(
-      provider.ingestEvent(
+      provider.ingestEvent?.(
         { provider: "claude", event: { hook_event_name: "Stop" } },
         { projects: [], worktrees: [], terminalTargets: [] },
       ),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.3",
+  "version": "0.7.1-rc.4",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.3" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.4" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.3",
+      version: "0.7.1-rc.4",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.3+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.3+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.4+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.4+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.3",
+      version: "0.7.1-rc.4",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -930,7 +930,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.3";
+    return "0.7.1-rc.4";
   }
   if (
     normalized.length === 2 &&
@@ -1088,7 +1088,11 @@ async function writeFakeTmux(path, statePath) {
 }
 
 async function readFakeTmuxState(path) {
-  return JSON.parse(await readFile(path, "utf8"));
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not parse fake tmux state at ${path}.`, { cause: error });
+  }
 }
 
 async function writeFakeTmuxState(path, state) {

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -107,7 +107,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated GitHub release assets");
     expect(readme).toContain("does not require Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.3");
+    expect(install).toContain("tag=v0.7.1-rc.4");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -163,7 +163,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.3");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.4");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -221,7 +221,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.3");
+    expect(packageJson.version).toBe("0.7.1-rc.4");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");
@@ -274,7 +274,7 @@ describe("release readiness docs", () => {
       "stn-ingress",
       "HOST_UPGRADE_BLOCKED",
       "same Observer socket",
-      "second binary release",
+      "prior published binary",
     ]) {
       expect(normalizedDevelopment).toContain(acceptance);
     }


### PR DESCRIPTION
Prepares the immutable v0.7.1-rc.4 binary candidate after PR #228.

- bumps source and compiled display versions
- updates authenticated install guidance for rc.4
- records published rc.3 as the rollback target
- advances upgrade, rollback, and acceptance recipes to rc.4
- isolates Claude doctor tests from user hook state and hardens release-smoke JSON diagnostics

Validation: `pnpm test:pre-push` passed end to end with Station ownership markers removed from the test environment, including release/install smoke, native and Bun PTY suites, binary build, and binary smoke.