### PR TITLE
fix(terminal): ignore daemon color controls in host PTYs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,14 @@ When these disagree, reconcile from config, providers, and current observer stat
 - Station-managed terminal lifecycle is supplied as an explicit application role. Observer application code may forward opaque managed-terminal attachments returned by that role, but must not select its adapter by provider ID, reconstruct provider-owned target IDs, or expose Station Host PTY and socket mechanics.
 - Station resolves managed-terminal attachments through its own host attacher. An absent attachment permits the existing local launch; an advertised attachment that cannot resolve fails visibly and must never fall through to a local spawn.
 - The Station UI is a client. It renders snapshots/events and dispatches typed commands; it must not import providers, read SQLite, run `wt`, run `tmux`, run `git`/`gh`, or parse raw provider payloads for core behavior.
-- The outer terminal environment is authoritative only for Station's OpenTUI renderer. Every Station-owned child PTY receives Station's terminal identity and supported capabilities at the final native spawn boundary; local bridge, Bun, and Station Host paths must not expose outer-emulator identity as child capability evidence. A persistent Station Host process is never renderer provenance, so Host PTYs fail closed on inherited and launch-plan tmux context.
+- The outer terminal environment is authoritative only for Station's OpenTUI
+  renderer. Every Station-owned child PTY receives Station's terminal identity
+  and supported capabilities at the final native spawn boundary; local bridge,
+  Bun, and Station Host paths must not expose outer-emulator identity as child
+  capability evidence. A persistent Station Host process is never renderer
+  provenance, so Host PTYs fail closed on inherited and launch-plan tmux
+  context and on daemon-inherited color controls; only color controls carried
+  by the explicit launch request are authoritative.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
 - The protocol validates transport messages and keeps consumer APIs simple. It should not become a provider boundary.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -510,8 +510,11 @@ launch mode. Native Station child PTYs also receive standard terminal values
 inherited and per-launch environment merging. Outer-renderer identity and
 feature hints are removed at that boundary, while ordinary locale,
 authentication, provider, project, worktree, and user environment passes
-through. This includes functional values such as Git askpass configuration and
-the `NO_COLOR` / `FORCE_COLOR` user preferences; these terminal values are
+through. This includes functional values such as Git askpass configuration.
+Local PTYs preserve inherited `NO_COLOR` / `FORCE_COLOR` preferences, while
+persistent Host PTYs discard daemon-inherited copies and preserve only values
+carried by the explicit launch request; a Host may have been auto-started from a
+headless provider hook rather than a user terminal. These terminal values are
 generated behavior, not hand-authored configuration.
 
 Native Station removes `TMUX` and `TMUX_PANE` from its children because they are

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -90,11 +90,15 @@ identity and feature hints are removed, and Station applies `TERM=xterm-256color
 those fields or the derived `STATION_PANE` marker.
 
 Ordinary locale, authentication, provider, project, worktree, and user environment
-continues to pass through, including functional Git askpass and provider context plus
-the `NO_COLOR` / `FORCE_COLOR` user preferences. Until Station supports a feature end
-to end, children must not infer it from Ghostty, Kitty, WezTerm, iTerm2, Windows
-Terminal, Warp, or another outer renderer; native Station currently advertises true
-color but neither an image protocol nor OSC 8 hyperlinks.
+continues to pass through, including functional Git askpass and provider context.
+Local PTYs preserve inherited `NO_COLOR` / `FORCE_COLOR` preferences. A
+persistent Host may inherit those values from a headless provider hook rather
+than a user terminal, so Host PTYs discard daemon-inherited copies and preserve
+only values carried by the explicit launch request. Until Station supports a
+feature end to end, children must not infer it from Ghostty, Kitty, WezTerm,
+iTerm2, Windows Terminal, Warp, or another outer renderer; native Station
+currently advertises true color but neither an image protocol nor OSC 8
+hyperlinks.
 
 Outer-renderer variables are application conventions, not an exhaustive standard
 registry. Station therefore maintains a curated set of known identity and capability

--- a/station/src/host/ptyTable.smoke.test.ts
+++ b/station/src/host/ptyTable.smoke.test.ts
@@ -25,10 +25,14 @@ if (SMOKE) {
     it("keeps a spawned PTY alive with no client attached and captures output", async () => {
       const table = createPtyTable();
       try {
+        const inheritedForceColor = process.env.FORCE_COLOR;
+        const inheritedNoColor = process.env.NO_COLOR;
         const inheritedTmux = process.env.TMUX;
         const inheritedTmuxPane = process.env.TMUX_PANE;
         let ptyId: string;
         try {
+          process.env.FORCE_COLOR = "0";
+          process.env.NO_COLOR = "1";
           process.env.TMUX = "/tmp/tmux-501/stale-host,111,0";
           process.env.TMUX_PANE = "%3";
           ({ ptyId } = table.spawn({
@@ -51,8 +55,6 @@ if (SMOKE) {
               KITTY_WINDOW_ID: "7",
               WEZTERM_PANE: "4",
               __CFBundleIdentifier: "com.mitchellh.ghostty",
-              NO_COLOR: "1",
-              FORCE_COLOR: "0",
               CURSOR_TRACE_ID: "provider-trace",
               VSCODE_GIT_ASKPASS_MAIN: "/opt/vscode/askpass-main.js",
               TMUX: "/tmp/tmux-501/stale-launch,222,0",
@@ -63,6 +65,10 @@ if (SMOKE) {
             rows: 24,
           }));
         } finally {
+          if (inheritedForceColor === undefined) delete process.env.FORCE_COLOR;
+          else process.env.FORCE_COLOR = inheritedForceColor;
+          if (inheritedNoColor === undefined) delete process.env.NO_COLOR;
+          else process.env.NO_COLOR = inheritedNoColor;
           if (inheritedTmux === undefined) delete process.env.TMUX;
           else process.env.TMUX = inheritedTmux;
           if (inheritedTmuxPane === undefined) delete process.env.TMUX_PANE;
@@ -87,8 +93,8 @@ if (SMOKE) {
           "TMUX_PANE=unset",
           "STATION_OUTER_TMUX=unset",
           "STATION_OUTER_TMUX_PANE=unset",
-          "NO_COLOR=1",
-          "FORCE_COLOR=0",
+          "NO_COLOR=unset",
+          "FORCE_COLOR=unset",
           "VSCODE_GIT_ASKPASS_MAIN=/opt/vscode/askpass-main.js",
           "CURSOR_TRACE_ID=provider-trace",
           "USER_SETTING=ordinary",

--- a/station/src/host/ptyTable.test.ts
+++ b/station/src/host/ptyTable.test.ts
@@ -41,7 +41,7 @@ function singleTable() {
 }
 
 describe("createPtyTable", () => {
-  it("fails closed on tmux provenance for persistent Host spawns", () => {
+  it("fails closed on daemon color controls and tmux provenance for persistent Host spawns", () => {
     const scripted = createScriptedTerminal({ cols: 80, rows: 24 });
     let received: StationTerminalSpawnOptions | undefined;
     const table = createPtyTable({
@@ -61,9 +61,37 @@ describe("createPtyTable", () => {
     });
 
     expect(received?.env).toEqual({
+      FORCE_COLOR: undefined,
+      NO_COLOR: undefined,
       TMUX: undefined,
       TMUX_PANE: undefined,
       USER_SETTING: "ordinary",
+    });
+    expect(Object.hasOwn(received?.env ?? {}, "FORCE_COLOR")).toBe(true);
+    expect(Object.hasOwn(received?.env ?? {}, "NO_COLOR")).toBe(true);
+  });
+
+  it("preserves color controls explicitly carried by the launch request", () => {
+    const scripted = createScriptedTerminal({ cols: 80, rows: 24 });
+    let received: StationTerminalSpawnOptions | undefined;
+    const table = createPtyTable({
+      createTerminal: (options) => {
+        received = options;
+        return scripted.terminal;
+      },
+    });
+
+    table.spawn({
+      ...baseParams,
+      env: {
+        FORCE_COLOR: "0",
+        NO_COLOR: "1",
+      },
+    });
+
+    expect(received?.env).toMatchObject({
+      FORCE_COLOR: "0",
+      NO_COLOR: "1",
     });
   });
 

--- a/station/src/host/ptyTable.ts
+++ b/station/src/host/ptyTable.ts
@@ -137,9 +137,12 @@ export function createPtyTable(options: PtyTableOptions = {}): PtyTable {
 
       const cols = Math.max(MIN_COLS, params.cols);
       const rows = Math.max(MIN_ROWS, params.rows);
-      // A persistent Host can outlive or reattach through renderers, so no inherited or launch-plan tmux pair is authoritative.
       const env: Record<string, string | undefined> = {
         ...params.env,
+        // A Host may inherit styling controls from a headless provider hook, so only launch-request values are authoritative for its PTYs.
+        FORCE_COLOR: params.env?.FORCE_COLOR,
+        NO_COLOR: params.env?.NO_COLOR,
+        // A persistent Host can outlive or reattach through renderers, so no inherited or launch-plan tmux pair is authoritative.
         TMUX: undefined,
         TMUX_PANE: undefined,
       };


### PR DESCRIPTION
## Summary

- prevent persistent Station Host PTYs from inheriting `NO_COLOR` and `FORCE_COLOR` from a headless provider-hook startup environment
- preserve color controls when an explicit launch request intentionally supplies them
- document the renderer/Host environment boundary and cover both bridge and Bun PTY implementations

## Why

A provider hook can auto-start the Observer and persistent Host with `NO_COLOR=1`. Codex and Claude honor that daemon-derived value and render monochrome, while Pi appears unaffected because it ignores the preference.

## Testing

- full pre-push gate (`pnpm test:pre-push`) via the repository hook
- `cd station && bun test src/host/ptyTable.test.ts`
- `cd station && bun run test:pty`
- `cd station && bun run test:pty:bun`
- `cd station && bun run typecheck`
- `pnpm lint`

## UX / manual verification

After installing the build, replace an idle Station Host and open fresh Codex and Claude panes. They should render with their normal colors, and their process environments should not contain daemon-derived `NO_COLOR` or `FORCE_COLOR`. Existing live PTYs retain their spawn environment and must be reopened.
