### PR TITLE
fix(git): prevent linked-worktree hook corruption and surface blocked sessions

### DIFF
--- a/apps/cli/test/integration/first-project-default-branch.test.ts
+++ b/apps/cli/test/integration/first-project-default-branch.test.ts
@@ -41,6 +41,9 @@ describe("first-project default branch", () => {
         useLifecycleHooks: false,
         resolveRegistrationIdentity: async (path) => `git-registration:${path}`,
         runner: async (input) => {
+          if (input.command === "git") {
+            return result(input, "false\n");
+          }
           calls.push(input);
           await mkdir(dirname(worktreePath), { recursive: true });
           await git(repo, "worktree", "add", "-b", "feature", worktreePath, defaultBranch);

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -1,12 +1,16 @@
+import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { runCli } from "@station/cli";
 import { addProjectToConfig, removeProjectFromConfig } from "@station/config";
 import type { CommandReceipt, CommandRecord, StationCommand } from "@station/contracts";
+import { environmentWithoutGitLocals } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
+const execFileAsync = promisify(execFile);
 
 describe("CLI project commands", () => {
   it("lists configured projects", async () => {
@@ -88,12 +92,46 @@ describe("CLI project commands", () => {
       },
     });
   });
+
+  it("reports a configured bare checkout with safe manual repair guidance", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const repo = await makeGitRepo(fixture.root, "bare-project");
+    await addProjectToConfig({ path: repo, configPath, homeDir: fixture.root });
+    await git(repo, ["config", "--local", "core.bare", "true"]);
+
+    const result = await runCli(["--config", configPath, "project", "doctor", "bare-project"]);
+
+    expect(result).toMatchObject({
+      code: 1,
+      output: {
+        action: "doctor",
+        status: "warn",
+        project: { id: "bare-project", root: repo },
+        messages: [
+          "Project checkout is configured as a bare repository.",
+          expect.stringContaining("config --local core.bare false"),
+        ],
+      },
+    });
+  });
 });
 
 async function makeRepo(root: string, name: string): Promise<string> {
   const repo = join(root, name);
   await mkdir(join(repo, ".git"), { recursive: true });
   return repo;
+}
+
+async function makeGitRepo(root: string, name: string): Promise<string> {
+  const repo = join(root, name);
+  await mkdir(repo, { recursive: true });
+  await git(repo, ["init", "--quiet"]);
+  return repo;
+}
+
+async function git(root: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd: root, env: environmentWithoutGitLocals() });
 }
 
 function runningObserverDeps(options: {

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
@@ -148,6 +148,96 @@ describe("Worktrunk diagnostics", () => {
     sqlite.close();
   });
 
+  it("scopes corrupted-root diagnostics and preserves the typed project error", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-wt-diag-bare-root-"));
+    const clock = { now: () => new Date(now) };
+    const webRoot = join(stateDir, "web");
+    const apiRoot = join(stateDir, "api");
+    await Promise.all([
+      mkdir(join(webRoot, ".git"), { recursive: true }),
+      mkdir(join(apiRoot, ".git"), { recursive: true }),
+    ]);
+    const projects = [project("web", webRoot), project("api", apiRoot)];
+    const stationConfig = config(stateDir, projects);
+    const listCalls: ExternalCommandInput[] = [];
+    const providers = new ProviderRegistry({
+      worktree: new WorktrunkProvider({
+        command: "wt",
+        useLifecycleHooks: false,
+        clock,
+        runner: async (input) => {
+          if (input.command === "git") {
+            return commandResult(
+              input,
+              input.args?.includes(webRoot) === true ? "true\n" : "false\n",
+            );
+          }
+          if (input.args?.includes("list")) {
+            listCalls.push(input);
+            return commandResult(input, "[]");
+          }
+          return commandResult(
+            input,
+            input.args?.includes("--version") ? "wt 0.64.0" : "--no-hooks",
+          );
+        },
+      }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+    });
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config: stationConfig,
+      providers,
+      clock,
+      sqlitePath: join(stateDir, "observer.sqlite"),
+    });
+
+    await core.reconcile("bare-root-diagnostics");
+    expect(
+      core.getSnapshot().projects.find((candidate) => candidate.id === "web")?.health,
+    ).toMatchObject({
+      status: "unavailable",
+      lastError: {
+        code: "WORKTRUNK_PROJECT_ROOT_BARE",
+        projectId: "web",
+        hint: expect.stringContaining("config --local core.bare false"),
+      },
+    });
+
+    listCalls.length = 0;
+    const report = await runDoctor(
+      {
+        config: stationConfig,
+        core,
+        persistence,
+        persistenceHealth: persistence,
+        providers,
+        paths: { stateDir },
+        clock,
+      },
+      { projectId: "web" },
+    );
+
+    expect(report.status).toBe("degraded");
+    expect(listCalls).toEqual([]);
+    expect(report.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-project-root-web",
+          status: "warn",
+          error: expect.objectContaining({
+            code: "WORKTRUNK_PROJECT_ROOT_BARE",
+            projectId: "web",
+          }),
+        }),
+      ]),
+    );
+    expect(report.checks).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "worktrunk-project-root-api" })]),
+    );
+    sqlite.close();
+  });
+
   it("returns partial stale evidence before the outer provider timeout", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-wt-diag-timeout-"));
     const clock = { now: () => new Date(now) };
@@ -257,11 +347,11 @@ function config(stateDir: string, projects: ProviderProjectConfig[] = []): Stati
   };
 }
 
-function project(id: string): ProviderProjectConfig {
+function project(id: string, root = `/tmp/station/${id}`): ProviderProjectConfig {
   return {
     id,
     label: id,
-    root: `/tmp/station/${id}`,
+    root,
     defaults: {
       harness: "fake-harness",
       terminal: "fake-terminal",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -245,6 +245,18 @@ Nested project tables:
 | `[projects.local_config]` | `enabled` | bool | Required inside the table; only `true` reads the project-local file. |
 | `[projects.local_config]` | `path` | string | Required inside the table; `~/` expands against `$HOME`, anything else resolves against `project.root`. |
 
+`stn project add` refuses both a first add and an idempotent re-add when the
+checkout-style `root` has local `core.bare=true`; the failed mutation leaves the
+TOML unchanged. Existing config remains loadable so `stn project doctor <id>`
+and `stn doctor --project <id>` can report the damaged checkout. Station never
+rewrites this Git setting automatically. Inspect and repair an intended checkout
+manually, or correct `projects.root` when it points at the wrong repository:
+
+```bash
+git -C '<project-root>' config --show-origin --get core.bare
+git -C '<project-root>' config --local core.bare false
+```
+
 ### `[workspace]` — native Station UI behavior (optional, best-effort)
 
 Read **only by the native Station TUI** (the observer and CLI ignore it). A bad value

--- a/docs/development.md
+++ b/docs/development.md
@@ -116,8 +116,11 @@ intermediate repaint.
 
 Git-backed fixtures and child processes must clear Git's repository-local environment variables;
 `cwd` and `git -C` do not isolate a command when variables such as `GIT_DIR` or `GIT_WORK_TREE`
-are inherited. Remove linked worktrees and other Git-created resources through Git before deleting
-their directories.
+are inherited. Lefthook commands run through `scripts/run-without-git-locals.mjs`, which removes
+the complete variable list reported by the installed Git before launching any hook descendants.
+This hook boundary is defense in depth: independently invoked Git-backed fixtures must still clear
+their own child environments. Remove linked worktrees and other Git-created resources through Git
+before deleting their directories.
 
 `pnpm build` computes one immutable Observer build identity from the current
 Git `HEAD`, the sorted production inputs from tracked plus untracked-nonignored

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -109,6 +109,15 @@ expected; explicitly disabled hooks are reported as the skip-hooks automation
 mode instead. Provider command failures from `wt` are recorded through provider
 health, command records, logs, debug traces, and debug bundle evidence.
 
+A checkout-style configured root with local `core.bare=true` is reported as
+`WORKTRUNK_PROJECT_ROOT_BARE`. `stn project doctor <projectId>` reports the
+configuration-side warning, while `stn doctor --project <projectId>` reports the
+scoped Worktrunk project check and degraded project health. Worktrunk list,
+create, and remove operations are blocked before `wt` runs. Station does not
+repair Git config automatically; use the reported commands to inspect the
+setting and either set local `core.bare=false` for the intended checkout or
+correct `projects.root`.
+
 Doctor also reports Worktrunk registrations whose working directories are
 missing or prunable. `stn doctor --project <id>` limits this scan to one project;
 the unscoped command scans configured projects with bounded concurrency and

--- a/integrations/worktree/worktrunk/src/errors.ts
+++ b/integrations/worktree/worktrunk/src/errors.ts
@@ -8,6 +8,7 @@ export type WorktrunkProviderErrorCode =
   | "WORKTRUNK_HOOK_APPROVAL_REQUIRED"
   | "WORKTRUNK_INVALID_OUTPUT"
   | "WORKTRUNK_BASE_MISSING"
+  | "WORKTRUNK_PROJECT_ROOT_BARE"
   | "WORKTRUNK_SEED_FAILED"
   | "WORKTRUNK_TIMEOUT"
   | "WORKTRUNK_UNAVAILABLE"
@@ -21,12 +22,18 @@ export class WorktrunkProviderError extends Error implements SafeError {
   readonly provider = "worktrunk";
   readonly code: WorktrunkProviderErrorCode;
   readonly hint?: string;
+  readonly projectId?: string;
   readonly diagnosticDetails?: DiagnosticDetail[];
 
   constructor(
     code: WorktrunkProviderErrorCode,
     message: string,
-    options: { hint?: string; cause?: unknown; diagnosticDetails?: DiagnosticDetail[] } = {},
+    options: {
+      hint?: string;
+      projectId?: string;
+      cause?: unknown;
+      diagnosticDetails?: DiagnosticDetail[];
+    } = {},
   ) {
     super(message, { cause: options.cause });
     Object.defineProperty(this, "name", {
@@ -37,6 +44,9 @@ export class WorktrunkProviderError extends Error implements SafeError {
     this.code = code;
     if (options.hint !== undefined) {
       this.hint = options.hint;
+    }
+    if (options.projectId !== undefined) {
+      this.projectId = options.projectId;
     }
     if (options.diagnosticDetails !== undefined) {
       this.diagnosticDetails = options.diagnosticDetails;

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -27,7 +27,9 @@ import type {
 import { ExternalCommandDiagnosticDetailSchema } from "@station/contracts";
 import {
   type ExternalCommandRunner,
+  gitCheckoutBareRepairHint,
   gitLocalEnvironmentVariables,
+  isGitCheckoutConfiguredBare,
   type RuntimeClock,
   runExternalCommand,
   runRuntimeBoundaryWithRetryAndTimeout,
@@ -82,7 +84,7 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Removal revalidates native Git registration identity, path, and branch immediately before invoking Worktrunk.
+ * Checkout roots are validated before Worktrunk runs, and removal revalidates native Git registration identity, path, and branch immediately before mutation.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -216,6 +218,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       return [];
     }
     this.#projects.set(project.id, project);
+    await this.#assertProjectRootUsable(project, policy);
 
     const observations = await this.#readWorktrees(project, policy);
     const managedObservations = observations.filter((observation) =>
@@ -257,6 +260,7 @@ export class WorktrunkProvider implements WorktreeProvider {
 
   async createWorktree(request: CreateWorktreeRequest): Promise<WorktreeObservation> {
     this.#projects.set(request.project.id, request.project);
+    await this.#assertProjectRootUsable(request.project);
     const base = request.base ?? request.project.worktrunk.base;
     const output = await this.#run(
       this.#args([
@@ -432,6 +436,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         refusalReason: "protection_unverified",
       });
     }
+    await this.#assertProjectRootUsable(project);
 
     const currentWorktrees = await this.#readWorktrees(project, { retries: 1 });
     const identityMatches = currentWorktrees.filter(
@@ -543,6 +548,21 @@ export class WorktrunkProvider implements WorktreeProvider {
     return [];
   }
 
+  async #assertProjectRootUsable(
+    project: ProviderProjectConfig,
+    policy: WorktrunkRunPolicy = {},
+  ): Promise<void> {
+    if (
+      await isGitCheckoutConfiguredBare(project.root, {
+        ...(this.#runner === undefined ? {} : { runner: this.#runner }),
+        ...(policy.signal === undefined ? {} : { signal: policy.signal }),
+        timeoutMs: policy.timeoutMs ?? this.#timeoutMs,
+      })
+    ) {
+      throw projectRootBareError(project);
+    }
+  }
+
   async #automationCapabilityCheck(options: {
     signal: AbortSignal;
     timeoutMs: number;
@@ -625,6 +645,31 @@ export class WorktrunkProvider implements WorktreeProvider {
         batch.map(async (project, batchIndex) => {
           if (options.signal.aborted) return;
           const index = offset + batchIndex;
+          if (
+            await isGitCheckoutConfiguredBare(project.root, {
+              ...(this.#runner === undefined ? {} : { runner: this.#runner }),
+              signal: options.signal,
+              timeoutMs: options.timeoutMs,
+            })
+          ) {
+            const providerError = projectRootBareError(project);
+            const error: SafeError = {
+              tag: providerError.tag,
+              code: providerError.code,
+              message: providerError.message,
+              provider: providerError.provider,
+              projectId: project.id,
+            };
+            if (providerError.hint !== undefined) error.hint = providerError.hint;
+            checks[index] = {
+              name: `worktrunk-project-root-${project.id}`,
+              status: "warn",
+              message: `${providerError.message} ${providerError.hint}`,
+              error,
+            };
+            completed += 1;
+            return;
+          }
           let missing: WorktreeObservation[];
           try {
             missing = (
@@ -792,6 +837,17 @@ export class WorktrunkProvider implements WorktreeProvider {
       });
     }
   }
+}
+
+function projectRootBareError(project: ProviderProjectConfig): WorktrunkProviderError {
+  return new WorktrunkProviderError(
+    "WORKTRUNK_PROJECT_ROOT_BARE",
+    "Project checkout is configured as a bare repository.",
+    {
+      projectId: project.id,
+      hint: gitCheckoutBareRepairHint(project.root),
+    },
+  );
 }
 
 function dependencyDiagnostics(status: WorktrunkDependencyStatus): Record<string, string> {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -930,6 +930,99 @@ describe("WorktrunkProvider", () => {
     ]);
   });
 
+  it("refuses corrupted checkout roots before invoking Worktrunk", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-bare-root-"));
+    await mkdir(join(root, ".git"));
+    const bareProject = { ...project, root };
+    const calls: ExternalCommandInput[] = [];
+    const provider = testProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        return result(input, input.command === "git" ? "true\n" : "[]");
+      },
+    });
+
+    await expect(provider.listWorktrees(bareProject)).rejects.toMatchObject({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_PROJECT_ROOT_BARE",
+      projectId: "web",
+      hint: expect.stringContaining("config --local core.bare false"),
+    });
+    await expect(
+      provider.createWorktree({ project: bareProject, branch: "feature" }),
+    ).rejects.toMatchObject({
+      code: "WORKTRUNK_PROJECT_ROOT_BARE",
+      projectId: "web",
+    });
+    expect(calls).toHaveLength(2);
+    expect(calls.every((call) => call.command === "git")).toBe(true);
+
+    calls.length = 0;
+    const checks = await provider.doctorChecks({ projects: [bareProject] });
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "worktrunk-project-root-web",
+          status: "warn",
+          message: expect.stringContaining("config --show-origin --get core.bare"),
+          error: expect.objectContaining({
+            code: "WORKTRUNK_PROJECT_ROOT_BARE",
+            projectId: "web",
+            hint: expect.stringContaining("config --local core.bare false"),
+          }),
+        }),
+      ]),
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls.every((call) => call.command === "git")).toBe(true);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("rechecks the configured root before removing a previously listed worktree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-remove-bare-root-"));
+    await mkdir(join(root, ".git"));
+    const guardedProject = { ...project, root };
+    const calls: ExternalCommandInput[] = [];
+    let configuredBare = false;
+    const provider = testProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        return result(
+          input,
+          input.command === "git"
+            ? `${configuredBare}\n`
+            : JSON.stringify([{ path: join(root, "feature"), branch: "feature" }]),
+        );
+      },
+    });
+    const listed = await provider.listWorktrees(guardedProject);
+    const selected = listed[0];
+    if (selected?.registrationIdentity === undefined) {
+      throw new Error("worktree fixture missing registration identity");
+    }
+    calls.length = 0;
+    configuredBare = true;
+
+    await expect(
+      provider.removeWorktree({
+        worktreeId: selected.id,
+        expectedPath: selected.path,
+        expectedBranch: selected.branch,
+        expectedRegistrationIdentity: selected.registrationIdentity,
+      }),
+    ).rejects.toMatchObject({
+      code: "WORKTRUNK_PROJECT_ROOT_BARE",
+      projectId: "web",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe("git");
+    await rm(root, { recursive: true, force: true });
+  });
+
   it("warns about missing registrations with safe prune commands", async () => {
     const provider = testProvider({
       command: "wt",

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,9 +1,9 @@
 pre-commit:
   commands:
     biome:
-      run: pnpm lint
+      run: node scripts/run-without-git-locals.mjs pnpm lint
 
 pre-push:
   commands:
     test:
-      run: pnpm test:pre-push
+      run: node scripts/run-without-git-locals.mjs pnpm test:pre-push

--- a/packages/config/src/projects/add.ts
+++ b/packages/config/src/projects/add.ts
@@ -1,3 +1,4 @@
+import { gitCheckoutBareRepairHint, isGitCheckoutConfiguredBare } from "@station/runtime";
 import { loadConfig, loadConfigFromToml } from "../load/index.js";
 import { projectConfigSafeError } from "./errors.js";
 import { detectGitDefaultBranch, findGitRoot, resolveExistingDirectory } from "./git.js";
@@ -31,6 +32,13 @@ export async function addProjectToConfig(
   }
 
   const root = gitRoot ?? selectedPath;
+  if (await isGitCheckoutConfiguredBare(root)) {
+    throw projectConfigSafeError({
+      code: "PROJECT_ROOT_BARE",
+      message: "Project checkout is configured as a bare repository.",
+      hint: gitCheckoutBareRepairHint(root),
+    });
+  }
   const existingProject = loaded.loaded.projects.find((project) => samePath(project.root, root));
   if (existingProject !== undefined) {
     return {

--- a/packages/config/src/projects/doctor.ts
+++ b/packages/config/src/projects/doctor.ts
@@ -1,4 +1,5 @@
 import { stat } from "node:fs/promises";
+import { gitCheckoutBareRepairHint, isGitCheckoutConfiguredBare } from "@station/runtime";
 import type { ProjectConfig } from "../schema.js";
 import { findGitRoot } from "./git.js";
 import type { ProjectDoctorResult } from "./types.js";
@@ -20,6 +21,10 @@ export async function doctorProject(project: ProjectConfig): Promise<ProjectDoct
   const gitRoot = rootExists ? await findGitRoot(project.root) : undefined;
   if (gitRoot === undefined) {
     messages.push("Git root was not detected from the project root.");
+  }
+  if (rootExists && (await isGitCheckoutConfiguredBare(project.root))) {
+    messages.push("Project checkout is configured as a bare repository.");
+    messages.push(gitCheckoutBareRepairHint(project.root));
   }
 
   return {

--- a/packages/config/test/unit/project-mutation.test.ts
+++ b/packages/config/test/unit/project-mutation.test.ts
@@ -1,15 +1,21 @@
+import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   addProjectToConfig,
   ConfigError,
+  doctorProject,
   loadConfig,
   removeProjectFromConfig,
   setProjectDefaultHarnessInConfig,
   setTuiWidgetsInConfig,
 } from "@station/config";
+import { environmentWithoutGitLocals } from "@station/runtime";
 import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
 
 async function makeTempDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "station-project-config-"));
@@ -19,6 +25,17 @@ async function makeRepo(root: string, name: string): Promise<string> {
   const repo = join(root, name);
   await mkdir(join(repo, ".git"), { recursive: true });
   return repo;
+}
+
+async function makeGitRepo(root: string, name: string): Promise<string> {
+  const repo = join(root, name);
+  await mkdir(repo, { recursive: true });
+  await git(repo, ["init", "--quiet"]);
+  return repo;
+}
+
+async function git(root: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd: root, env: environmentWithoutGitLocals() });
 }
 
 async function writeBaseConfig(root: string, projectsToml = "projects = []"): Promise<string> {
@@ -95,6 +112,51 @@ describe("project config mutation", () => {
     expect(result.status).toBe("unchanged");
     const source = await readFile(configPath, "utf8");
     expect(source.match(/\[\[projects\]\]/g)).toHaveLength(1);
+  });
+
+  it("rejects a first add when the checkout is configured bare without changing TOML", async () => {
+    const tempDir = await makeTempDir();
+    const configPath = await writeBaseConfig(tempDir);
+    const repo = await makeGitRepo(tempDir, "bare-first-add");
+    await git(repo, ["config", "--local", "core.bare", "true"]);
+    const before = await readFile(configPath, "utf8");
+
+    await expect(
+      addProjectToConfig({ path: repo, configPath, homeDir: tempDir }),
+    ).rejects.toMatchObject({
+      tag: "ProjectConfigError",
+      code: "PROJECT_ROOT_BARE",
+      hint: expect.stringContaining("config --local core.bare false"),
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+  });
+
+  it("rejects a re-add when the checkout becomes bare and doctor clears after repair", async () => {
+    const tempDir = await makeTempDir();
+    const configPath = await writeBaseConfig(tempDir);
+    const repo = await makeGitRepo(tempDir, "bare-readd");
+    await addProjectToConfig({ path: repo, configPath, homeDir: tempDir });
+    await git(repo, ["config", "--local", "core.bare", "true"]);
+    const before = await readFile(configPath, "utf8");
+
+    await expect(
+      addProjectToConfig({ path: repo, configPath, homeDir: tempDir }),
+    ).rejects.toMatchObject({ code: "PROJECT_ROOT_BARE" });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+
+    const loaded = await loadConfig({ configPath, homeDir: tempDir });
+    const project = loaded.projects[0];
+    if (project === undefined) throw new Error("project fixture missing");
+    await expect(doctorProject(project)).resolves.toMatchObject({
+      status: "warn",
+      messages: [
+        "Project checkout is configured as a bare repository.",
+        expect.stringContaining("config --show-origin --get core.bare"),
+      ],
+    });
+
+    await git(repo, ["config", "--local", "core.bare", "false"]);
+    await expect(doctorProject(project)).resolves.toMatchObject({ status: "ok", messages: [] });
   });
 
   it("suffixes generated IDs when a different root uses the same basename", async () => {

--- a/packages/dashboard-core/src/flows/newSession.ts
+++ b/packages/dashboard-core/src/flows/newSession.ts
@@ -116,6 +116,19 @@ export type NewSessionCreateValidation =
       error: SafeError;
     };
 
+export type NewSessionProjectResolution =
+  | {
+      kind: "available";
+      project: NonNullable<ReturnType<typeof selectNewSessionProject>>;
+    }
+  | {
+      kind: "blocked";
+      error: SafeError;
+    }
+  | {
+      kind: "missing";
+    };
+
 export function createNewSessionFlow(
   snapshot: StationSnapshot,
   token: string,
@@ -210,8 +223,8 @@ export function validateNewSessionCreate(
   snapshot: StationSnapshot,
   state: NewSessionFlowState,
 ): NewSessionCreateValidation {
-  const project = selectedProject(snapshot, state);
-  if (project === undefined) {
+  const resolution = resolveNewSessionProjectAvailability(selectedProject(snapshot, state));
+  if (resolution.kind === "missing") {
     return {
       ok: false,
       error: {
@@ -222,21 +235,13 @@ export function validateNewSessionCreate(
       },
     };
   }
-
-  if (project.health.status === "unavailable") {
+  if (resolution.kind === "blocked") {
     return {
       ok: false,
-      error:
-        project.health.lastError ??
-        ({
-          tag: "ProviderUnavailableError",
-          code: "WORKTREE_PROVIDER_UNAVAILABLE",
-          message: "The worktree provider is unavailable.",
-          hint: "Run station doctor for provider diagnostics.",
-          provider: project.health.providerId,
-        } satisfies SafeError),
+      error: resolution.error,
     };
   }
+  const project = resolution.project;
 
   const harness = selectNewSessionHarnessOptions(snapshot, project).find(
     (option) => option.id === state.selectedHarness,
@@ -262,6 +267,29 @@ export function validateNewSessionCreate(
     branch: state.branch,
     harnessProvider: state.selectedHarness,
   };
+}
+
+export function resolveNewSessionProjectAvailability(
+  project: ReturnType<typeof selectNewSessionProject>,
+): NewSessionProjectResolution {
+  if (project === undefined) {
+    return { kind: "missing" };
+  }
+  if (project.health.status === "unavailable") {
+    return {
+      kind: "blocked",
+      error:
+        project.health.lastError ??
+        ({
+          tag: "ProviderUnavailableError",
+          code: "WORKTREE_PROVIDER_UNAVAILABLE",
+          message: "The worktree provider is unavailable.",
+          hint: "Run station doctor for provider diagnostics.",
+          provider: project.health.providerId,
+        } satisfies SafeError),
+    };
+  }
+  return { kind: "available", project };
 }
 
 export function generatedSessionBranch(projectId: ProjectId, token: string): string {

--- a/packages/dashboard-core/src/state/screens/quickSession.ts
+++ b/packages/dashboard-core/src/state/screens/quickSession.ts
@@ -1,7 +1,13 @@
-import type { ProviderId } from "@station/contracts";
-import { createNewSessionNameToken, generatedSessionBranch } from "../../flows/newSession.js";
+import type { ProviderId, SafeError } from "@station/contracts";
+import {
+  createNewSessionNameToken,
+  generatedSessionBranch,
+  resolveNewSessionProjectAvailability,
+} from "../../flows/newSession.js";
+import { safeErrorToToast } from "../../services/errors/errors.js";
 import { buildCreateSessionCommand } from "../commandBuilders.js";
 import { addPendingCreateSessionRow } from "../localRows.js";
+import { addTuiToast } from "../toasts.js";
 import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
 
@@ -12,15 +18,25 @@ export type QuickSessionIntent = {
   token: string;
 };
 
-/** Resolves the project-owned defaults for a quick session before terminal-specific execution. */
+export type QuickSessionResolution =
+  | ({ kind: "submit" } & QuickSessionIntent)
+  | { kind: "blocked"; error: SafeError }
+  | { kind: "missing" };
+
+/** Resolves a quick session as submit, blocked with its exact provider error, or missing. */
 export function resolveQuickSessionIntent(
   state: TuiState,
   projectId: string,
-): QuickSessionIntent | undefined {
-  const project = state.snapshot?.projects.find((candidate) => candidate.id === projectId);
-  if (project === undefined || project.health.status === "unavailable") return undefined;
+): QuickSessionResolution {
+  if (state.snapshot === undefined) return { kind: "missing" };
+  const resolution = resolveNewSessionProjectAvailability(
+    state.snapshot.projects.find((candidate) => candidate.id === projectId),
+  );
+  if (resolution.kind !== "available") return resolution;
+  const project = resolution.project;
   const token = createNewSessionNameToken();
   return {
+    kind: "submit",
     projectId: project.id,
     branch: generatedSessionBranch(project.id, token),
     harnessProvider: project.defaults.harness,
@@ -30,12 +46,17 @@ export function resolveQuickSessionIntent(
 
 /** Builds the immediate configured-terminal transition for a resolved quick-session intent. */
 export function submitQuickSession(state: TuiState, projectId: string): TuiTransition {
-  const intent = resolveQuickSessionIntent(state, projectId);
-  if (intent === undefined) return { state };
-  const project = state.snapshot?.projects.find((candidate) => candidate.id === intent.projectId);
+  const resolution = resolveQuickSessionIntent(state, projectId);
+  if (resolution.kind === "missing") return { state };
+  if (resolution.kind === "blocked") {
+    return { state: addTuiToast(state, safeErrorToToast(resolution.error)) };
+  }
+  const project = state.snapshot?.projects.find(
+    (candidate) => candidate.id === resolution.projectId,
+  );
   if (project === undefined) return { state };
 
-  const { branch, harnessProvider, token } = intent;
+  const { branch, harnessProvider, token } = resolution;
   const localId = `create:${project.id}:${token}`;
   const command = buildCreateSessionCommand({ project, branch, harnessProvider });
   if (command.type !== "session.create") {

--- a/packages/dashboard-core/test/unit/state/quickSession.test.ts
+++ b/packages/dashboard-core/test/unit/state/quickSession.test.ts
@@ -28,7 +28,44 @@ describe("quick session", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
   });
 
-  it("leaves unavailable or stale projects inert", () => {
+  it("shows the unavailable project's exact error without dispatching", () => {
+    const snapshot = createCommandSnapshot("idle");
+    const project = snapshot.projects[0];
+    if (project === undefined) throw new Error("project fixture missing");
+    const error = {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_PROJECT_ROOT_BARE",
+      message: "Project checkout is configured as a bare repository.",
+      hint: `Inspect with git -C '${project.root}' config --show-origin --get core.bare. If this is the intended checkout, run git -C '${project.root}' config --local core.bare false; otherwise correct projects.root.`,
+      provider: "worktrunk",
+      projectId: project.id,
+    } as const;
+    const unavailable = {
+      ...snapshot,
+      projects: snapshot.projects.map((candidate) =>
+        candidate.id === project.id
+          ? {
+              ...candidate,
+              health: { ...candidate.health, status: "unavailable" as const, lastError: error },
+            }
+          : candidate,
+      ),
+    };
+    const service = new FakeTuiObserverService(unavailable);
+    const store = createTuiStore({ service, initialSnapshot: unavailable });
+
+    store.getState().createQuickSession(project.id);
+
+    expect(service.dispatched).toEqual([]);
+    expect(store.getState().localRows.pendingCreate).toEqual([]);
+    expect(store.getState().toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: error.message,
+      hint: error.hint,
+    });
+  });
+
+  it("leaves a missing project inert", () => {
     const snapshot = createCommandSnapshot("idle");
     const service = new FakeTuiObserverService(snapshot);
     const store = createTuiStore({ service, initialSnapshot: snapshot });
@@ -37,5 +74,6 @@ describe("quick session", () => {
 
     expect(service.dispatched).toEqual([]);
     expect(store.getState().localRows.pendingCreate).toEqual([]);
+    expect(store.getState().toasts).toEqual([]);
   });
 });

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -755,6 +755,44 @@ describe("TUI screen transitions", () => {
     });
   });
 
+  it("surfaces the unavailable project's exact error on New Session submit", () => {
+    const snapshot = createDashboardSnapshot();
+    const project = snapshot.projects.find((candidate) => candidate.id === "web");
+    if (project === undefined) throw new Error("project fixture missing");
+    const error = {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_PROJECT_ROOT_BARE",
+      message: "Project checkout is configured as a bare repository.",
+      hint: `Inspect with git -C '${project.root}' config --show-origin --get core.bare. If this is the intended checkout, run git -C '${project.root}' config --local core.bare false; otherwise correct projects.root.`,
+      provider: "worktrunk",
+      projectId: project.id,
+    } as const;
+    const unavailable = {
+      ...snapshot,
+      projects: snapshot.projects.map((candidate) =>
+        candidate.id === project.id
+          ? {
+              ...candidate,
+              health: { ...candidate.health, status: "unavailable" as const, lastError: error },
+            }
+          : candidate,
+      ),
+    };
+    const opened = handleTuiKey(createInitialTuiState({ initialSnapshot: unavailable }), {
+      input: "N",
+    });
+
+    const submitted = handleTuiKey(opened.state, { input: "\r", return: true });
+
+    expect(submitted.operations).toBeUndefined();
+    expect(submitted.state.localRows.pendingCreate).toEqual([]);
+    expect(submitted.state.toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: error.message,
+      hint: error.hint,
+    });
+  });
+
   it("seeds and moves the new-session project cursor, committing the choice on enter", () => {
     const base = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
     const review = handleTuiKey(base, { input: "N" }).state;

--- a/packages/runtime/src/gitEnvironment.ts
+++ b/packages/runtime/src/gitEnvironment.ts
@@ -1,3 +1,7 @@
+import { lstat } from "node:fs/promises";
+import { join } from "node:path";
+import { type ExternalCommandRunner, runExternalCommand } from "./externalCommand.js";
+
 export const gitLocalEnvironmentVariables = [
   "GIT_ALTERNATE_OBJECT_DIRECTORIES",
   "GIT_CONFIG",
@@ -22,4 +26,46 @@ export function environmentWithoutGitLocals(
   const sanitized = { ...env };
   for (const key of gitLocalEnvironmentVariables) delete sanitized[key];
   return sanitized;
+}
+
+export type GitCheckoutBareProbeOptions = {
+  runner?: ExternalCommandRunner;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export function gitCheckoutBareRepairHint(root: string): string {
+  const quotedRoot = `'${root.replaceAll("'", `'\\''`)}'`;
+  return `Inspect with git -C ${quotedRoot} config --show-origin --get core.bare. If this is the intended checkout, run git -C ${quotedRoot} config --local core.bare false; otherwise correct projects.root.`;
+}
+
+/**
+ * Read-only check for checkout roots whose local Git config marks them bare.
+ * Bare repositories, missing checkout markers, and inconclusive probes return false.
+ */
+export async function isGitCheckoutConfiguredBare(
+  root: string,
+  options: GitCheckoutBareProbeOptions = {},
+): Promise<boolean> {
+  try {
+    const marker = await lstat(join(root, ".git"));
+    if (!marker.isDirectory() && !marker.isFile()) {
+      return false;
+    }
+
+    const result = await runExternalCommand(
+      {
+        command: "git",
+        args: ["-C", root, "config", "--local", "--type=bool", "--get", "core.bare"],
+        unsetEnv: gitLocalEnvironmentVariables,
+        allowedExitCodes: [0, 1],
+        timeoutMs: options.timeoutMs ?? 5_000,
+        ...(options.signal === undefined ? {} : { signal: options.signal }),
+      },
+      options.runner,
+    );
+    return result.exitCode === 0 && result.stdout.trim() === "true";
+  } catch {
+    return false;
+  }
 }

--- a/packages/runtime/test/unit/buildIdentity.test.ts
+++ b/packages/runtime/test/unit/buildIdentity.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -9,6 +9,7 @@ import {
   computeBuildIdentity,
   publishBuildIdentity,
   readBuildIdentity,
+  runBuildChild,
   verifyBuildIdentity,
 } from "../../../../scripts/build-identity.mjs";
 import { environmentWithoutGitLocals } from "../../src/gitEnvironment.js";
@@ -144,6 +145,45 @@ describe("build identity", () => {
 
     await expect(readBuildIdentity(root)).rejects.toMatchObject({ code: "ENOENT" });
   });
+
+  it("isolates spawned build children from a linked-worktree Git environment", async () => {
+    const victim = await createRepository();
+    const fixture = await createRepository();
+    const victimLinked = `${victim}-linked`;
+    const fixtureLinked = `${fixture}-linked`;
+    roots.push(victim, fixture, victimLinked, fixtureLinked);
+    git(victim, ["branch", "victim-linked"]);
+    git(victim, ["worktree", "add", victimLinked, "victim-linked"]);
+
+    const before = {
+      config: await readFile(join(victim, ".git", "config"), "utf8"),
+      head: gitOutput(victimLinked, ["rev-parse", "HEAD"]),
+      status: gitOutput(victimLinked, ["status", "--porcelain=v2", "--branch"]),
+      worktrees: gitOutput(victim, ["worktree", "list", "--porcelain"]),
+    };
+    const hostileGitDir = gitOutput(victimLinked, ["rev-parse", "--absolute-git-dir"]).trim();
+    const childScript = `
+      const { execFileSync } = require("node:child_process");
+      const linked = process.argv[1];
+      execFileSync("git", ["config", "--local", "station.fixture", "isolated"]);
+      execFileSync("git", ["commit", "--allow-empty", "-m", "fixture child"]);
+      execFileSync("git", ["worktree", "add", "-b", "fixture-child", linked]);
+    `;
+
+    await runBuildChild(process.execPath, ["-e", childScript, fixtureLinked], fixture, {
+      ...environmentWithoutGitLocals(),
+      GIT_DIR: hostileGitDir,
+      GIT_WORK_TREE: victimLinked,
+    });
+
+    await expect(readFile(join(victim, ".git", "config"), "utf8")).resolves.toBe(before.config);
+    expect(gitOutput(victimLinked, ["rev-parse", "HEAD"])).toBe(before.head);
+    expect(gitOutput(victimLinked, ["status", "--porcelain=v2", "--branch"])).toBe(before.status);
+    expect(gitOutput(victim, ["worktree", "list", "--porcelain"])).toBe(before.worktrees);
+    expect(gitOutput(fixture, ["config", "--local", "--get", "station.fixture"]).trim()).toBe(
+      "isolated",
+    );
+  });
 });
 
 async function createRepository(): Promise<string> {
@@ -180,5 +220,13 @@ function git(root: string, args: string[]): void {
     cwd: root,
     env: environmentWithoutGitLocals(),
     stdio: "ignore",
+  });
+}
+
+function gitOutput(root: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: root,
+    env: environmentWithoutGitLocals(),
+    encoding: "utf8",
   });
 }

--- a/packages/runtime/test/unit/gitEnvironment.test.ts
+++ b/packages/runtime/test/unit/gitEnvironment.test.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
   type ExternalCommandInput,
@@ -11,6 +12,8 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const repoRoot = fileURLToPath(new URL("../../../..", import.meta.url));
+const hookBoundaryPath = join(repoRoot, "scripts", "run-without-git-locals.mjs");
 
 describe("Git environment", () => {
   const roots: string[] = [];
@@ -73,6 +76,101 @@ describe("Git environment", () => {
       expect.arrayContaining(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"]),
     );
   });
+
+  it("clears every Git-local variable while preserving unrelated hook environment", async () => {
+    const localVariables = (await gitOutput(repoRoot, ["rev-parse", "--local-env-vars"]))
+      .trim()
+      .split("\n");
+    const hostileEnv: NodeJS.ProcessEnv = {
+      ...environmentWithoutGitLocals(),
+      STATION_HOOK_ENV_SENTINEL: "preserved",
+    };
+    for (const variable of localVariables) hostileEnv[variable] = "hostile";
+    hostileEnv.GIT_CONFIG_COUNT = "0";
+    const childScript = `
+      const localVariables = JSON.parse(process.argv[1]);
+      const inherited = localVariables.filter((name) => process.env[name] !== undefined);
+      process.stdout.write(JSON.stringify({ inherited, sentinel: process.env.STATION_HOOK_ENV_SENTINEL }));
+    `;
+
+    const result = await execFileAsync(
+      process.execPath,
+      [hookBoundaryPath, process.execPath, "-e", childScript, JSON.stringify(localVariables)],
+      { cwd: repoRoot, env: hostileEnv },
+    );
+
+    expect(JSON.parse(result.stdout)).toEqual({ inherited: [], sentinel: "preserved" });
+  });
+
+  it("isolates every Git-hook child from the invoking linked worktree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-git-hook-boundary-"));
+    const victim = join(root, "victim");
+    const linked = join(root, "linked");
+    const fixture = join(root, "fixture");
+    roots.push(root);
+    await Promise.all([mkdir(victim), mkdir(fixture)]);
+    await git(victim, ["init", "--quiet", "-b", "main"]);
+    await git(victim, ["config", "user.email", "station@example.invalid"]);
+    await git(victim, ["config", "user.name", "Station Test"]);
+    await git(victim, ["commit", "--allow-empty", "--quiet", "-m", "initial"]);
+    await git(victim, ["worktree", "add", "--quiet", "-b", "linked", linked]);
+
+    const before = {
+      config: await readFile(join(victim, ".git", "config"), "utf8"),
+      head: await gitOutput(linked, ["rev-parse", "HEAD"]),
+      status: await gitOutput(linked, ["status", "--porcelain=v2", "--branch"]),
+      worktrees: await gitOutput(victim, ["worktree", "list", "--porcelain"]),
+    };
+    const hostileGitDir = (await gitOutput(linked, ["rev-parse", "--absolute-git-dir"])).trim();
+
+    await execFileAsync(process.execPath, [hookBoundaryPath, "git", "init", "-b", "main"], {
+      cwd: fixture,
+      env: { ...environmentWithoutGitLocals(), GIT_DIR: hostileGitDir },
+    });
+
+    await expect(readFile(join(victim, ".git", "config"), "utf8")).resolves.toBe(before.config);
+    await expect(gitOutput(linked, ["rev-parse", "HEAD"])).resolves.toBe(before.head);
+    await expect(gitOutput(linked, ["status", "--porcelain=v2", "--branch"])).resolves.toBe(
+      before.status,
+    );
+    await expect(gitOutput(victim, ["worktree", "list", "--porcelain"])).resolves.toBe(
+      before.worktrees,
+    );
+    await expect(gitOutput(fixture, ["rev-parse", "--is-bare-repository"])).resolves.toBe(
+      "false\n",
+    );
+
+    const lefthook = await readFile(join(repoRoot, "lefthook.yml"), "utf8");
+    expect(lefthook.match(/run: node scripts\/run-without-git-locals\.mjs /gu)).toHaveLength(2);
+    await git(victim, ["worktree", "remove", "--force", linked]);
+  });
+
+  it("fails closed when Git-local environment discovery is unavailable", async () => {
+    await expect(
+      execFileAsync(
+        process.execPath,
+        [hookBoundaryPath, process.execPath, "-e", "process.exit(0)"],
+        { cwd: repoRoot, env: { ...environmentWithoutGitLocals(), PATH: "" } },
+      ),
+    ).rejects.toMatchObject({ code: 1 });
+  });
+
+  it("preserves a failing hook child's exit status and termination signal", async () => {
+    await expect(
+      execFileAsync(
+        process.execPath,
+        [hookBoundaryPath, process.execPath, "-e", "process.exit(23)"],
+        { cwd: repoRoot, env: environmentWithoutGitLocals() },
+      ),
+    ).rejects.toMatchObject({ code: 23 });
+    await expect(
+      execFileAsync(
+        process.execPath,
+        [hookBoundaryPath, process.execPath, "-e", 'process.kill(process.pid, "SIGTERM")'],
+        { cwd: repoRoot, env: environmentWithoutGitLocals() },
+      ),
+    ).rejects.toMatchObject({ signal: "SIGTERM" });
+  });
 });
 
 async function createRepository(): Promise<string> {
@@ -83,4 +181,13 @@ async function createRepository(): Promise<string> {
 
 async function git(root: string, args: string[]): Promise<void> {
   await execFileAsync("git", args, { cwd: root, env: environmentWithoutGitLocals() });
+}
+
+async function gitOutput(root: string, args: string[]): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd: root,
+    encoding: "utf8",
+    env: environmentWithoutGitLocals(),
+  });
+  return result.stdout;
 }

--- a/packages/runtime/test/unit/gitEnvironment.test.ts
+++ b/packages/runtime/test/unit/gitEnvironment.test.ts
@@ -1,0 +1,86 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import {
+  type ExternalCommandInput,
+  environmentWithoutGitLocals,
+  isGitCheckoutConfiguredBare,
+} from "@station/runtime";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("Git environment", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it("distinguishes normal and corrupted checkout config", async () => {
+    const root = await createRepository();
+    roots.push(root);
+
+    await expect(isGitCheckoutConfiguredBare(root)).resolves.toBe(false);
+    await git(root, ["config", "--local", "core.bare", "true"]);
+    await expect(isGitCheckoutConfiguredBare(root)).resolves.toBe(true);
+  });
+
+  it("does not classify an intentional bare repository", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-git-bare-"));
+    roots.push(root);
+    await git(root, ["init", "--bare"]);
+
+    await expect(isGitCheckoutConfiguredBare(root)).resolves.toBe(false);
+  });
+
+  it("returns false when the probe fails", async () => {
+    const root = await createRepository();
+    roots.push(root);
+
+    await expect(
+      isGitCheckoutConfiguredBare(root, {
+        runner: async () => {
+          throw new Error("probe failed");
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("clears inherited Git-local variables for the probe", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-git-probe-"));
+    roots.push(root);
+    await mkdir(join(root, ".git"));
+    let captured: ExternalCommandInput | undefined;
+
+    await expect(
+      isGitCheckoutConfiguredBare(root, {
+        runner: async (input) => {
+          captured = input;
+          return {
+            command: input.command,
+            args: input.args ?? [],
+            stdout: "true\n",
+            stderr: "",
+            exitCode: 0,
+          };
+        },
+      }),
+    ).resolves.toBe(true);
+    expect(captured?.unsetEnv).toEqual(
+      expect.arrayContaining(["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"]),
+    );
+  });
+});
+
+async function createRepository(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "station-git-checkout-"));
+  await git(root, ["init", "--quiet"]);
+  return root;
+}
+
+async function git(root: string, args: string[]): Promise<void> {
+  await execFileAsync("git", args, { cwd: root, env: environmentWithoutGitLocals() });
+}

--- a/scripts/build-identity.mjs
+++ b/scripts/build-identity.mjs
@@ -235,7 +235,9 @@ export async function buildWithIdentity(root, runBuildTask) {
 }
 
 async function build() {
-  await buildWithIdentity(repoRoot, () => run("pnpm", ["exec", "turbo", "run", "build"], repoRoot));
+  await buildWithIdentity(repoRoot, () =>
+    runBuildChild("pnpm", ["exec", "turbo", "run", "build"], repoRoot),
+  );
 }
 
 async function requireCurrentBuildIdentity(identity) {
@@ -246,10 +248,10 @@ async function requireCurrentBuildIdentity(identity) {
   }
 }
 
-async function run(command, args, cwd) {
+export async function runBuildChild(command, args, cwd, env = process.env) {
   const child = spawn(command, args, {
     cwd,
-    env: process.env,
+    env: environmentWithoutGitLocals(env),
     stdio: "inherit",
   });
   const exitCode = await new Promise((resolveExit, reject) => {
@@ -276,8 +278,8 @@ async function runGit(root, args) {
   return stdout;
 }
 
-function environmentWithoutGitLocals() {
-  const env = { ...process.env };
+function environmentWithoutGitLocals(source = process.env) {
+  const env = { ...source };
   for (const key of gitLocalEnvironmentVariables) delete env[key];
   return env;
 }

--- a/scripts/run-without-git-locals.mjs
+++ b/scripts/run-without-git-locals.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { execFileSync, spawn } from "node:child_process";
+
+const [command, ...args] = process.argv.slice(2);
+if (command === undefined) {
+  process.stderr.write("Usage: run-without-git-locals <command> [...args]\n");
+  process.exitCode = 2;
+} else {
+  run(command, args);
+}
+
+function run(command, args) {
+  let localVariables;
+  try {
+    localVariables = execFileSync("git", ["rev-parse", "--local-env-vars"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+      .split(/\r?\n/u)
+      .filter((variable) => variable.length > 0);
+  } catch (error) {
+    fail(`Unable to discover Git-local environment variables: ${formatError(error)}`);
+    return;
+  }
+
+  if (localVariables.length === 0) {
+    fail("Git returned no repository-local environment variables; refusing to launch the child.");
+    return;
+  }
+
+  const env = { ...process.env };
+  for (const variable of localVariables) delete env[variable];
+
+  const child = spawn(command, args, { env, stdio: "inherit" });
+  const signalHandlers = new Map();
+  let settled = false;
+
+  const removeSignalHandlers = () => {
+    for (const [signal, handler] of signalHandlers) process.off(signal, handler);
+  };
+
+  // Direct signals to the wrapper must reach the same child process that owns the hook gate.
+  for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"]) {
+    const handler = () => {
+      if (!settled) child.kill(signal);
+    };
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  child.once("error", (error) => {
+    if (settled) return;
+    settled = true;
+    removeSignalHandlers();
+    fail(`Unable to launch ${command}: ${formatError(error)}`);
+  });
+  child.once("exit", (code, signal) => {
+    if (settled) return;
+    settled = true;
+    removeSignalHandlers();
+    if (signal !== null) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}
+
+function formatError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -11,12 +11,14 @@
 import type { StoreApi } from "zustand/vanilla";
 import { worktreeHasLiveAgent, type ProviderId } from "@station/contracts";
 import {
+  addTuiToast,
   choiceValueByKey,
   newSessionIntentForInput,
   focusProjectSettingsItem as focusProjectSettingsItemState,
   openProjectDefaultAgentPicker,
   openWidgetSettings as openWidgetSettingsState,
   resolveQuickSessionIntent,
+  safeErrorToToast,
   selectAddProjectRow as selectAddProjectRowState,
   selectDashboardItems,
   selectDashboardSessionRow,
@@ -350,8 +352,8 @@ export function resolveKeyForkSessionSubmit(
 /**
  * Resolve a project header's quick-session click to its create target. Uses
  * the project's default harness and a generated branch name — no wizard, no
- * review screen. Returns `none` if the project is unavailable or missing, so
- * the click is an inert miss.
+ * review screen. Blocked projects preserve their provider error as a toast;
+ * only a missing or stale project is an inert miss.
  */
 export type QuickSessionSubmitTarget =
   | { kind: "submit"; projectId: string; branch: string; harness: ProviderId }
@@ -362,7 +364,11 @@ export function resolveQuickSessionSubmit(
   projectId: string,
 ): QuickSessionSubmitTarget {
   const intent = resolveQuickSessionIntent(store.getState(), projectId);
-  if (intent === undefined) return { kind: "none" };
+  if (intent.kind === "missing") return { kind: "none" };
+  if (intent.kind === "blocked") {
+    store.setState(addTuiToast(store.getState(), safeErrorToToast(intent.error)));
+    return { kind: "none" };
+  }
   return {
     kind: "submit",
     projectId: intent.projectId,

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -73,6 +73,34 @@ function snapshotWithHarness(projectId: string, harness: string): StationSnapsho
   };
 }
 
+function snapshotWithBareProject(projectId: string): StationSnapshot {
+  const base = manyProjectsSnapshot();
+  const project = base.projects.find((candidate) => candidate.id === projectId);
+  if (project === undefined) throw new Error(`no fixture project ${projectId}`);
+  return {
+    ...base,
+    projects: base.projects.map((candidate) =>
+      candidate.id === projectId
+        ? {
+            ...candidate,
+            health: {
+              ...candidate.health,
+              status: "unavailable",
+              lastError: {
+                tag: "WorktreeProviderError",
+                code: "WORKTRUNK_PROJECT_ROOT_BARE",
+                message: "Project checkout is configured as a bare repository.",
+                hint: `Inspect with git -C '${candidate.root}' config --show-origin --get core.bare. If this is the intended checkout, run git -C '${candidate.root}' config --local core.bare false; otherwise correct projects.root.`,
+                provider: "worktrunk",
+                projectId,
+              },
+            },
+          }
+        : candidate,
+    ),
+  };
+}
+
 describe("routeStationMouse", () => {
   it("launches the row's primary agent (managed) on a dashboard row click", () => {
     const store = makeStore();
@@ -445,6 +473,25 @@ describe("routeStationMouse", () => {
       expect(outcome.harness).toBe("codex"); // project.defaults.harness
       expect(outcome.branch).toMatch(/^station-[0-9a-f]+$/);
     }
+  });
+
+  it("shows the blocked Quick Session error without emitting a launch outcome", () => {
+    const store = makeStore(snapshotWithBareProject("station"));
+
+    expect(
+      routeStationMouse(
+        { kind: "quickSessionForProject", projectId: "station" },
+        LEFT_DOWN,
+        store,
+      ),
+    ).toEqual({ kind: "handled" });
+    expect(store.getState().localRows.pendingCreate).toEqual([]);
+    const toast = store.getState().toasts.at(-1)?.toast;
+    expect(toast).toMatchObject({
+      kind: "error",
+      message: "Project checkout is configured as a bare repository.",
+    });
+    expect(toast?.hint).toContain("config --local core.bare false");
   });
 
   it("gates quick-session and default-agent picker to dashboard mode", () => {

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -399,7 +399,8 @@ function fromPaneTarget(target: OpenPaneTarget | undefined): StationMouseOutcome
 /**
  * Map a quick-session submit to an outcome: `submit` surfaces a
  * `launch-new-session` router outcome (the executor creates the worktree and
- * hosts the agent), `none` (no project / unavailable) is an inert click.
+ * hosts the agent). Blocked projects have already emitted an error toast;
+ * `none` means only a stale or missing target and remains inert.
  */
 function fromQuickSessionSubmit(
   result: ReturnType<typeof resolveQuickSessionSubmit>,

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { loadConfig } from "@station/config";
 import { createObserverClient } from "@station/protocol";
+import { environmentWithoutGitLocals } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import { waitForSocketClosed } from "../support/sockets";
 
@@ -350,7 +351,10 @@ describe("setup core flow e2e", () => {
       await writeShim(bin, "diffnav", "exit 0\n");
       await writeShim(bin, "delta", "exit 0\n");
       await writeShim(bin, "bun", "exit 0\n");
-      run("git", ["init", "-b", "main"], { cwd: repo });
+      run("git", ["init", "-b", "main"], {
+        cwd: repo,
+        env: environmentWithoutGitLocals(),
+      });
 
       const env = {
         ...process.env,
@@ -410,7 +414,10 @@ describe("setup core flow e2e", () => {
         "codex",
         'if [ "$1" = "--version" ]; then echo "codex 0.1.0"; exit 0; fi\nexit 0\n',
       );
-      run("git", ["init", "-b", "main"], { cwd: repo });
+      run("git", ["init", "-b", "main"], {
+        cwd: repo,
+        env: environmentWithoutGitLocals(),
+      });
 
       const result = runStation(["--config", configPath, "setup", "check", "--json"], {
         cwd: repo,
@@ -561,7 +568,7 @@ function run(
 ): { stdout: string; stderr: string; status: number | null } {
   const result = spawnSync(command, args, {
     cwd: options.cwd,
-    env: options.env,
+    env: environmentWithoutGitLocals(options.env),
     encoding: "utf8",
   });
   if (options.allowFailure !== true && result.status !== 0) {

--- a/tests/e2e/worktrunk-real.test.ts
+++ b/tests/e2e/worktrunk-real.test.ts
@@ -42,11 +42,13 @@ describeReal("real Worktrunk provider smoke", () => {
       projects: [],
     });
     const branch = `station-real-${Date.now()}`;
+    const git = (...args: string[]) =>
+      execFileAsync("git", args, { cwd: repo, env: environmentWithoutGitLocals() });
     await mkdir(repo, { recursive: true });
-    await execFileAsync("git", ["init", "-b", "main"], { cwd: repo });
-    await execFileAsync("git", ["config", "user.email", "station@example.invalid"], { cwd: repo });
-    await execFileAsync("git", ["config", "user.name", "station"], { cwd: repo });
-    await execFileAsync("git", ["commit", "--allow-empty", "-m", "initial"], { cwd: repo });
+    await git("init", "-b", "main");
+    await git("config", "user.email", "station@example.invalid");
+    await git("config", "user.name", "station");
+    await git("commit", "--allow-empty", "-m", "initial");
 
     const provider = new WorktrunkProvider({
       command: wt,
@@ -191,6 +193,13 @@ describeReal("real Worktrunk provider smoke", () => {
       await expect(git("show-ref", "--verify", "refs/heads/duplicate")).resolves.toMatchObject({
         stdout: expect.stringContaining("refs/heads/duplicate"),
       });
+      await expect(git("config", "--local", "--get", "core.bare")).resolves.toMatchObject({
+        stdout: "false\n",
+      });
+      await expect(git("rev-parse", "--is-bare-repository")).resolves.toMatchObject({
+        stdout: "false\n",
+      });
+      await expect(git("status", "--porcelain=v1")).resolves.toMatchObject({ stdout: "" });
     } finally {
       await git("worktree", "remove", "--force", linked).catch(() => undefined);
       await rm(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- clear every Git-reported repository-local environment variable at the Lefthook boundary before any hook descendant starts
- independently isolate build children, setup fixtures, and Git probes from inherited Git-local variables
- reject checkout roots with local `core.bare=true` before config or Worktrunk mutations and report actionable Doctor guidance
- preserve the exact provider error in New Session and Quick Session so blocked projects show a toast without dispatching `worktree.create`
- retain selected-checkout removal, duplicate-branch behavior, and fail-open handling for inconclusive probes

## Root cause

Git exports an absolute linked-worktree `GIT_DIR` while running hooks. Lefthook previously passed it into `pnpm test:pre-push`, and setup fixtures then ran `git init` with only a temporary `cwd`. Because `GIT_DIR` overrides both `cwd` and `git -C`, those fixture commands reinitialized the invoking linked worktree's shared repository metadata and wrote `core.bare=true` into the primary checkout's shared config. Repeated agent pushes from linked worktrees therefore repeatedly corrupted the primary checkout. Worktrunk 0.64 removal does not set `core.bare`.

All Lefthook commands now run through `scripts/run-without-git-locals.mjs`. The wrapper asks the installed Git for its complete `--local-env-vars` list, removes every returned variable, preserves unrelated environment, forwards termination signals, preserves exit status, and fails closed if discovery or launch fails. Git-backed setup fixtures also sanitize their own child boundary so direct test invocation remains safe.

Detection remains read-only: Station never rewrites Git config automatically.

## UX impact

Both Quick Session and `N` now display `WORKTRUNK_PROJECT_ROOT_BARE` with the inspection and manual-repair hint, while emitting no create command. `stn project doctor <id>` and `stn doctor --project <id>` identify the affected project. Missing or stale Quick Session targets remain inert.

## Validation

- hostile linked-worktree regression verifies config bytes, HEAD, status, and worktree registrations remain unchanged while a fixture safely runs `git init`
- hostile direct setup E2E run verifies the two historical fixture paths without relying on the hook wrapper
- full repository pre-push hook / `pnpm test:pre-push` passed through the new wrapper; `core.bare` remained `false`
- targeted runtime, config, Worktrunk, Observer, dashboard-core, and native Station regression suites
- full native Station suite: 1,058 tests
- Node and Bun PTY smoke suites
- cross-runtime SQLite and Observer boot-claim races
- real Worktrunk 0.64 end-to-end test
- binary build and binary smoke
