### PR TITLE
fix(tui): use session name as rename placeholder

### DIFF
--- a/packages/dashboard-core/src/state/screens/renameSession.ts
+++ b/packages/dashboard-core/src/state/screens/renameSession.ts
@@ -76,7 +76,17 @@ function submitRename(state: TuiState): TuiTransition {
     return { state };
   }
 
-  const title = state.screen.draftTitle.value.trim();
+  const draftTitle = state.screen.draftTitle.value;
+  if (draftTitle.length === 0) {
+    return {
+      state: {
+        ...state,
+        screen: { name: "dashboard" },
+      },
+    };
+  }
+
+  const title = draftTitle.trim();
   if (title.length === 0) {
     return {
       state: {

--- a/packages/dashboard-core/src/state/screens/sessionRows.ts
+++ b/packages/dashboard-core/src/state/screens/sessionRows.ts
@@ -1,3 +1,4 @@
+import type { WorktreeRow } from "@station/contracts";
 import { createEditableTextInputState } from "../../components/EditableTextInput/editing.js";
 import {
   selectDashboardSessionRow,
@@ -29,7 +30,7 @@ export function openRenameEditForRow(
     rowId: resolved.id,
     sessionId: resolved.session.id,
     currentTitle,
-    draftTitle: createEditableTextInputState(currentTitle),
+    draftTitle: createEditableTextInputState(),
   };
   if (options.returnTo !== undefined) {
     screen.returnTo = options.returnTo;
@@ -50,7 +51,7 @@ function resolveCurrentRowSession(state: TuiState, rowId: string) {
     return undefined;
   }
   const direct = selectDashboardSessionRow(snapshot, rowId);
-  const worktree = snapshot.rows.find((candidate) => candidate.id === rowId);
+  const worktree = snapshot.rows.find((candidate: WorktreeRow) => candidate.id === rowId);
   const paneSession =
     worktree === undefined ? undefined : sessionForWorktreeRow(worktree, snapshot.sessions);
   const row =

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -497,6 +497,7 @@ describe("TUI screen transitions", () => {
       rowId: "ses_wt_web_attention",
       sessionId: "ses_wt_web_attention",
       currentTitle: "checkout-copy",
+      draftTitle: { value: "", cursor: 0 },
     });
   });
 
@@ -540,6 +541,7 @@ describe("TUI screen transitions", () => {
       rowId: "ses_wt_web_idle",
       sessionId: "ses_wt_web_idle",
       currentTitle: "fix-nav-mobile",
+      draftTitle: { value: "", cursor: 0 },
     });
   });
 
@@ -561,23 +563,20 @@ describe("TUI screen transitions", () => {
     expect(openRenameEditForRow(state, "run_wt_web_idle")).toBe(state);
   });
 
-  it("edits the rename draft at the cursor position", () => {
+  it("starts a blank rename draft so typing replaces the current title", () => {
     const opened = handleTuiKey(
       handleTuiKey(createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }), {
         input: "R",
       }).state,
       { input: "4" },
     ).state;
-    const left = handleTuiKey(opened, { input: "", leftArrow: true }).state;
-    const inserted = handleTuiKey(left, { input: "!" }).state;
+    const inserted = handleTuiKey(opened, { input: "!" }).state;
 
     expect(inserted.screen).toMatchObject({
       name: "renameSession",
       step: "editName",
-      draftTitle: {
-        value: "fix-nav-mobil!e",
-        cursor: "fix-nav-mobil!".length,
-      },
+      currentTitle: "fix-nav-mobile",
+      draftTitle: { value: "!", cursor: 1 },
     });
   });
 
@@ -683,25 +682,23 @@ describe("TUI screen transitions", () => {
       { input: "4" },
     ).state;
 
-    const typed = " updated"
+    const typed = "updated"
       .split("")
       .reduce((current, input) => handleTuiKey(current, { input }).state, state);
     const transition = handleTuiKey(typed, { input: "\r", return: true });
 
     expect(transition.state.screen).toEqual({ name: "dashboard" });
-    expect(transition.state.localRows.pendingRenameTitles?.ses_wt_web_idle?.title).toBe(
-      "fix-nav-mobile updated",
-    );
+    expect(transition.state.localRows.pendingRenameTitles?.ses_wt_web_idle?.title).toBe("updated");
     expect(transition.operations).toEqual([
       {
         type: "renameSession",
         sessionId: "ses_wt_web_idle",
-        title: "fix-nav-mobile updated",
+        title: "updated",
         command: {
           type: "session.rename",
           payload: {
             sessionId: "ses_wt_web_idle",
-            title: "fix-nav-mobile updated",
+            title: "updated",
           },
         },
       },

--- a/station/src/station/store/stationViewStore.test.ts
+++ b/station/src/station/store/stationViewStore.test.ts
@@ -81,7 +81,7 @@ describe("createStationViewStore", () => {
     store.getState().handleKey({ input: "\r", return: true });
 
     expect(store.getState().localRows.pendingRenameTitles?.ses_wt_station_idle).toMatchObject({
-      title: "pty-bufferx",
+      title: "x",
     });
     await waitForMockRejectionToast(store);
   });

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -357,7 +357,7 @@ FLEET  ● 0 ready  ⠋ 1 working  ! 3 needs you  ? 1 unknown  x 1 exited  ○ 0
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ Rename Session                                                               │
 │                                                                              │
-│ Name       hook-scope|                                                       │
+│ Name       |hook-scope                                                       │
 │ Enter:rename   Esc:back                                                      │
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -146,7 +146,7 @@ const CASES: ModalCase[] = [
     name: "rename sheet",
     keys: [{ input: "R" }, { input: "1" }],
     snapshot: attentionAndFailuresSnapshot,
-    expect: ["Rename Session", "Name", "Enter:rename   Esc:back"],
+    expect: ["Rename Session", "Name       |hook-scope", "Enter:rename   Esc:back"],
   },
   {
     name: "fork slot sheet",

--- a/station/src/station/view/sheets/RenameSessionSheetView.tsx
+++ b/station/src/station/view/sheets/RenameSessionSheetView.tsx
@@ -29,7 +29,7 @@ export function RenameSessionSheetView({ state, columns, rows }: RenameSessionSh
         width={contentWidth}
         label="Name"
         labelWidth={10}
-        value={<EditableTextInputView {...state.draftTitle} />}
+        value={<EditableTextInputView {...state.draftTitle} placeholder={state.currentTitle} />}
       />
       {state.validationError === undefined ? null : (
         <text fg={STATION_COLORS.red}>{truncateCells(` ${state.validationError}`, contentWidth)}</text>


### PR DESCRIPTION
## Summary
- start session renames with an empty draft and show the current name as the gray placeholder
- let the first typed character replace the existing name while keeping an empty submission as a no-op
- update dashboard-core transitions, Station store coverage, and the modal golden frame

## Tests
- `pnpm test:pre-push` (via the pre-push hook)
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/dashboard-core/test/unit/state/transition.test.ts`
- `cd station && bun test src/station/view/modals.golden.test.tsx`
- `cd station && bun test src/station/store/stationViewStore.test.ts`

## UX verification
Open **Rename Session** for an existing session. Its current name should appear gray with the cursor before it; typing should immediately replace the placeholder without requiring deletion.
