### PR TITLE
feat(release): prepare public native distribution

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,26 +1,155 @@
-name: Bump Homebrew formula
+name: Prepare Homebrew formula update
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Published Station source tag to package
+        description: Published stable Station tag to package
         required: true
         type: string
 
 permissions:
   contents: read
 
+concurrency:
+  group: homebrew-bump-${{ inputs.tag }}
+  cancel-in-progress: false
+
 jobs:
-  bump-formula:
-    runs-on: ubuntu-latest
+  validate:
+    runs-on: ubuntu-24.04
+    outputs:
+      commit: ${{ steps.release.outputs.commit }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: mislav/bump-homebrew-formula-action@ccf2332299a883f6af50a1d2d41e5df7904dd769 # v4.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          formula-name: station
-          homebrew-tap: jeremy0dell/homebrew-station
-          push-to: jeremy0dell/homebrew-station
-          tag-name: ${{ inputs.tag }}
-          download-url: https://github.com/jeremy0dell/station.git
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.tag }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.x
+      - name: Validate public stable release
+        id: release
         env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+          TAP_REPOSITORY: jeremy0dell/homebrew-station
+        run: |
+          node -e '
+            const tag = process.argv[1];
+            const stable = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+            if (!stable.test(tag)) throw new Error(`Homebrew requires a stable release tag: ${tag}`);
+          ' "$TAG"
+
+          version="$(node -p 'require("./package.json").version')"
+          test "$TAG" = "v$version"
+          commit="$(git rev-parse "$TAG^{commit}")"
+          test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"
+          test "$(gh api "repos/$GITHUB_REPOSITORY" --jq .visibility)" = public
+          test "$(gh api "repos/$TAP_REPOSITORY" --jq .visibility)" = public
+
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$TAG")"
+          test "$(jq -r .draft <<<"$release_json")" = false
+          test "$(jq -r .prerelease <<<"$release_json")" = false
+          test "$(jq -r .immutable <<<"$release_json")" = true
+          test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
+
+          comparison_status="$(
+            gh api "repos/$GITHUB_REPOSITORY/compare/$commit...main" --jq .status
+          )"
+          case "$comparison_status" in
+            ahead|identical) ;;
+            *) echo "Release commit $commit is not on main." >&2; exit 1 ;;
+          esac
+
+          echo "commit=$commit" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+  open-formula-pr:
+    needs: validate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: station
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: jeremy0dell/homebrew-station
+          path: tap
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.x
+      - name: Render and push formula branch
+        id: formula
+        env:
+          BRANCH: automation/station-${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          REVISION: ${{ needs.validate.outputs.commit }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          test -n "$GH_TOKEN"
+          gh auth setup-git
+          base="$(git -C tap branch --show-current)"
+          base_sha="$(git -C tap rev-parse HEAD)"
+          test -n "$base"
+          git -C tap config user.name station-release
+          git -C tap config user.email station@example.invalid
+
+          if git -C tap ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git -C tap fetch origin "$BRANCH"
+            git -C tap checkout -B "$BRANCH" FETCH_HEAD
+            git -C tap rebase "$base_sha"
+          else
+            git -C tap checkout -b "$BRANCH" "$base_sha"
+          fi
+
+          node station/scripts/release/render-homebrew-formula.mjs \
+            --template station/packaging/homebrew/station.rb.template \
+            --output tap/Formula/station.rb \
+            --tag "$TAG" \
+            --revision "$REVISION"
+          ruby -c tap/Formula/station.rb
+
+          if ! git -C tap diff --quiet -- Formula/station.rb; then
+            git -C tap add Formula/station.rb
+            git -C tap commit -m "station $VERSION"
+          fi
+          if git -C tap diff --quiet "$base_sha...HEAD"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git -C tap push --set-upstream origin "$BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+      - name: Open or locate formula pull request
+        if: steps.formula.outputs.changed == 'true'
+        env:
+          BRANCH: automation/station-${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          TAP_REPOSITORY: jeremy0dell/homebrew-station
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          existing="$(
+            gh pr list --repo "$TAP_REPOSITORY" --head "$BRANCH" --state open \
+              --json url --jq '.[0].url // empty'
+          )"
+          if [[ -n "$existing" ]]; then
+            printf 'Formula pull request: %s\n' "$existing"
+            exit 0
+          fi
+
+          base="$(gh repo view "$TAP_REPOSITORY" --json defaultBranchRef --jq .defaultBranchRef.name)"
+          gh pr create \
+            --repo "$TAP_REPOSITORY" \
+            --base "$base" \
+            --head "$BRANCH" \
+            --title "station $VERSION" \
+            --body "Package immutable public release \`$TAG\`. Merge only after the Homebrew test-bot matrix passes."

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -16,9 +16,7 @@ on:
         required: true
         type: boolean
 
-permissions:
-  actions: read
-  contents: write
+permissions: {}
 
 concurrency:
   group: promote-release-${{ inputs.tag }}
@@ -28,6 +26,9 @@ jobs:
   promote:
     if: inputs.manual_acceptance
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Verify accepted candidate and publish its draft
         env:
@@ -103,6 +104,7 @@ jobs:
 
           expected=(
             SHA256SUMS
+            install.sh
             "stn-v$version-darwin-arm64.tar.gz"
             "stn-v$version-darwin-x64.tar.gz"
             "stn-v$version-linux-arm64.tar.gz"
@@ -147,3 +149,75 @@ jobs:
             jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$published_release_json"
           )" = "$current_ids"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"
+
+  verify-public-install:
+    name: verify public install (${{ matrix.target }})
+    needs: promote
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-15-intel
+            target: darwin-x64
+          - runner: macos-15
+            target: darwin-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Download public installer
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          installer="$RUNNER_TEMP/station-install.sh"
+          tagged_url="https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG/install.sh"
+          for attempt in {1..12}; do
+            if env -u GH_TOKEN -u GITHUB_TOKEN curl \
+              --fail --silent --show-error --location \
+              --proto '=https' --proto-redir '=https' --tlsv1.2 \
+              --output "$installer" "$tagged_url"; then
+              break
+            fi
+            test "$attempt" -lt 12
+            sleep 5
+          done
+          test -s "$installer"
+          /bin/sh -n "$installer"
+          grep -Fx "embedded_version=\"$TAG\"" "$installer"
+
+          case "$TAG" in
+            *-*) ;;
+            *)
+              latest_installer="$RUNNER_TEMP/station-install-latest.sh"
+              env -u GH_TOKEN -u GITHUB_TOKEN curl \
+                --fail --silent --show-error --location \
+                --proto '=https' --proto-redir '=https' --tlsv1.2 \
+                --output "$latest_installer" \
+                "https://github.com/$GITHUB_REPOSITORY/releases/latest/download/install.sh"
+              cmp "$installer" "$latest_installer"
+              ;;
+          esac
+      - name: Install and verify public artifact
+        env:
+          EXPECTED_VERSION: ${{ inputs.tag }}
+        run: |
+          version="${EXPECTED_VERSION#v}"
+          install_home="$RUNNER_TEMP/public-install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          mkdir -p "$install_home"
+
+          env -u GH_TOKEN -u GITHUB_TOKEN \
+            HOME="$install_home" \
+            XDG_DATA_HOME="$data_home" \
+            PATH="/usr/bin:/bin" \
+            /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
+
+          test "$("$bin_dir/stn" --version)" = "$version"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+          test -f "$data_home/station/LICENSE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,12 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      # Tag validation runs on an ephemeral hosted runner with no dependency-cache input.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 24.x
       - name: Validate release tag
@@ -82,11 +83,12 @@ jobs:
     needs: validate
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - uses: actions/setup-node@v4
+      # Release smoke runs on an ephemeral hosted runner with no dependency-cache input.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 24.x
       - name: Enable pnpm 11
@@ -119,18 +121,19 @@ jobs:
             target: darwin-arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - uses: actions/setup-node@v4
+      # Native builds run after full CI on ephemeral runners with no dependency-cache inputs.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # zizmor: ignore[cache-poisoning]
         with:
           node-version: 24.x
       - name: Enable pnpm 11
         run: |
           corepack enable
           corepack prepare pnpm@11.0.0 --activate
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # zizmor: ignore[cache-poisoning]
         with:
           bun-version: 1.3.14
       - name: Install (pnpm)
@@ -168,7 +171,7 @@ jobs:
             echo "runner=$RUNNER_LABEL"
             echo "floor=$floor"
           } > "platform-metadata-$TARGET.txt"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: native-${{ matrix.target }}
           path: |
@@ -189,11 +192,25 @@ jobs:
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: native-*
           path: release
           merge-multiple: true
+      - name: Render version-stamped installer
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          node scripts/release/render-release-installer.mjs \
+            --source scripts/install.sh \
+            --output release/install.sh \
+            --version "$VERSION"
+          /bin/sh -n release/install.sh
+          test -x release/install.sh
       - name: Verify assets and checksums
         env:
           VERSION: ${{ needs.validate.outputs.version }}
@@ -213,8 +230,8 @@ jobs:
           fi
 
           : > SHA256SUMS
-          for archive in "${expected[@]}"; do
-            sha256sum "$archive" >> SHA256SUMS
+          for asset in "${expected[@]}" install.sh; do
+            sha256sum "$asset" >> SHA256SUMS
           done
 
           mapfile -t metadata < <(find . -maxdepth 1 -type f -name 'platform-metadata-*.txt' -printf '%f\n' | sort)
@@ -231,7 +248,7 @@ jobs:
             echo "Station $TAG native binaries."
             printf 'Build commit: `%s`.\n' "$GITHUB_SHA"
             echo
-            echo "Install through the authenticated installer documented in the repository."
+            echo "Install with the version-stamped install.sh asset after this release is published."
             echo
             echo "## Native platform floors"
             echo
@@ -266,6 +283,7 @@ jobs:
             "stn-v$VERSION-darwin-x64.tar.gz"
             "stn-v$VERSION-linux-arm64.tar.gz"
             "stn-v$VERSION-linux-x64.tar.gz"
+            install.sh
             SHA256SUMS
           )
           args=(
@@ -319,7 +337,7 @@ jobs:
               releaseId: $releaseId,
               checksumFileSha256: $checksumFileSha256
             }' > candidate/manifest.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: release/candidate
@@ -348,15 +366,16 @@ jobs:
             target: darwin-arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - name: Fetch tagged installer
+      - name: Fetch version-stamped draft installer
         env:
           GH_HOST: github.com
           GH_TOKEN: ${{ github.token }}
           COMMIT: ${{ needs.validate.outputs.commit }}
+          RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
@@ -364,12 +383,17 @@ jobs:
             echo "Release tag $TAG moved from validated commit $COMMIT to $remote_commit." >&2
             exit 1
           fi
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          test "$(jq -r .draft <<<"$release_json")" = true
+          test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
+          installer_asset_id="$(
+            jq -r '[.assets[] | select(.name == "install.sh") | .id] |
+              if length == 1 then .[0] else empty end' <<<"$release_json"
+          )"
+          [[ "$installer_asset_id" =~ ^[0-9]+$ ]]
           installer="$RUNNER_TEMP/station-install.sh"
-          gh api --method GET \
-            -f ref="$COMMIT" \
-            -H "Accept: application/vnd.github.raw+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/$GITHUB_REPOSITORY/contents/scripts/install.sh" > "$installer"
+          gh api -H 'Accept: application/octet-stream' \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$installer_asset_id" > "$installer"
           test -s "$installer"
           /bin/sh -n "$installer"
           chmod 0700 "$installer"
@@ -407,7 +431,7 @@ jobs:
           umask 0777
           HOME="$install_home" \
             XDG_DATA_HOME="$data_home" \
-            /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+            /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
       - name: Verify installed artifact
         env:
           EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
@@ -474,7 +498,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
           ) > "$RUNNER_TEMP/locked-install.stdout" 2> "$lock_stderr"; then
             echo "Installer unexpectedly succeeded while $lock_dir was owned." >&2
             exit 1
@@ -496,7 +520,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
           )
 
           test ! -e "$lock_dir"
@@ -520,7 +544,7 @@ jobs:
       # GitHub exposes draft releases only to identities with push access.
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: candidate
@@ -534,6 +558,7 @@ jobs:
         run: |
           expected=(
             SHA256SUMS
+            install.sh
             "stn-v$VERSION-darwin-arm64.tar.gz"
             "stn-v$VERSION-darwin-x64.tar.gz"
             "stn-v$VERSION-linux-arm64.tar.gz"
@@ -583,7 +608,7 @@ jobs:
           done
           cmp candidate/SHA256SUMS downloaded/SHA256SUMS
           (cd downloaded && sha256sum -c SHA256SUMS)
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: accepted-release-candidate-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: candidate

--- a/README.md
+++ b/README.md
@@ -34,58 +34,37 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 
 ## Install the binary
 
-This procedure installs Station from authenticated GitHub release assets and
-assumes your GitHub account can read the private `jeremy0dell/station`
-repository. Install the [GitHub CLI](https://cli.github.com/) first. The binary
-does not require Node.js, pnpm, Bun, or a source checkout.
-
-### 1. Authenticate GitHub CLI
+The public stable release installs with curl and does not require a GitHub
+account, Node.js, pnpm, Bun, Homebrew, or a source checkout:
 
 ```sh
-gh auth login --hostname github.com
-gh auth status --hostname github.com
-gh repo view jeremy0dell/station --json nameWithOwner --jq '.nameWithOwner'
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/latest/download/install.sh | sh
 ```
 
-If GitHub CLI is already authenticated, skip the login command. The repository
-check should print `jeremy0dell/station`; a not-found response means the active
-account cannot read the private repository. The commands below use the existing
-authentication, so do not paste credentials into the install command.
+This command becomes live when the first public stable release is published.
+It follows GitHub's latest stable release to a version-stamped `install.sh`,
+which downloads the matching native archive, verifies `SHA256SUMS`, and installs
+`stn`, `stn-ingress`, and `stn-tmux-popup` under `~/.local/bin` by default.
 
-### 2. Install the current preview candidate
-
-Run this from any directory:
+To inspect the same installer before running it:
 
 ```sh
-(
-  set -eu
-  umask 077
-  export GH_HOST=github.com
-  tag=v0.7.1-rc.4
-  # After the first stable release, use:
-  # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
-  installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  gh api --method GET \
-    -H 'Accept: application/vnd.github.raw+json' \
-    -f ref="$tag" \
-    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
-  test -s "$installer"
-  sh -n "$installer"
-  sh "$installer" --version "$tag"
-)
+installer="$(mktemp)"
+trap 'rm -f "$installer"' EXIT
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/latest/download/install.sh \
+  -o "$installer"
+sh -n "$installer"
+less "$installer"
+sh "$installer"
 ```
 
-`v0.7.1-rc.4` is the current private-binary candidate. `v0.7.1-rc.3` remains
-published as its immutable rollback; the earlier `v0.7.0` and `v0.7.1-rc.1`
-candidates remained unpublished. Run the recipe after the candidate is
-published. It fetches the installer and binary from the same immutable release
-tag, verifies the release checksum, and installs `stn`, `stn-ingress`, and
-`stn-tmux-popup` in `~/.local/bin` by default. It does not expose or print your
-GitHub credentials. After the first stable release, the commented assignment
-resolves the latest stable tag.
+The currently published private preview still uses the authenticated exact-tag
+procedure in [Install](docs/install.md) until a new release contains the stamped
+installer asset.
 
-### 3. Verify and start Station
+### Verify and start Station
 
 The installer prints an exact PATH command if `~/.local/bin` is not visible in
 the current shell. For the default install directory, run:
@@ -113,21 +92,18 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
-
-Use the private GitHub repository jeremy0dell/station through GitHub CLI.
+Install the latest public stable Station release and validate setup on this machine.
 
 Safety and scope:
-- First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. Never ask me to paste,
-  extract, or print credentials. If authentication or repository access fails,
-  stop and ask me to run `gh auth login --hostname github.com` myself.
-- Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
-  `gh api`, and follow its temporary-file installer procedure. If that release
-  is not published yet, stop instead of falling back to another ref.
-- Never fetch installer code from `main` and never pipe network output directly
-  into a shell.
+- Do not clone the repository or build from source. Download
+  `https://github.com/jeremy0dell/station/releases/latest/download/install.sh`
+  into a private temporary file with curl, require the download to succeed, run
+  `sh -n` on it, and then execute that file. Do not fall back to `main`.
+- Do not request, extract, print, or pass GitHub credentials; public installation
+  must work without authentication.
+- Do not pipe network output directly into a shell in this agent-led path; use
+  the inspectable temporary file even though the documented human convenience
+  command supports `curl | sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. Apply PATH changes only to the current shell and show me
   the exact export I can add later.

--- a/docs/development.md
+++ b/docs/development.md
@@ -185,7 +185,8 @@ pnpm smoke:install
 ```
 
 `pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
-authenticated GitHub responses and temporary homes, including startup-file
+public curl downloads, authenticated draft GitHub responses, and temporary
+homes, including startup-file
 non-interaction, safely evaluated minimal-PATH guidance, physical launcher
 resolution, and normalized-colon preflight coverage. It is deterministic, does
 not download a real release, and does not read or modify real shell startup
@@ -301,7 +302,12 @@ must show B's build and protocol versions. Legacy or different-protocol hosts
 refuse automatic replacement and must be stopped explicitly only after their
 sessions are accounted for.
 
-## Private Binary Release
+## Binary Release
+
+The draft-acceptance mechanics below remain the executable release foundation.
+For repository publication, unauthenticated distribution, signing/notarization,
+and the public Homebrew source channel, also complete the
+[Public release checklist](public-release-checklist.md).
 
 Before tagging, an administrator must enable GitHub immutable releases; the
 workflow token cannot read that administration setting. The workflow validates
@@ -311,18 +317,23 @@ and have no existing GitHub release. Pushing a `v*` tag runs the callable
 standard CI workflow, `pnpm smoke:release`, native binary build and smoke jobs
 for all four supported targets, archive/checksum assembly, and an authenticated
 installer smoke against the resulting GitHub release draft. The four native
-release builds use one archive-packaging helper, and the draft-install jobs
-consume those exact uploaded archives. Draft acceptance revalidates the tag but
-fetches `scripts/install.sh` by the validated commit SHA, then passes the tag
-with `--version`; a moved tag cannot substitute different installer code. After
-all four native installs pass, the workflow re-downloads the five draft assets,
-verifies them against the build checksum, and uploads an immutable
+release builds use one archive-packaging helper. Draft creation stamps the exact
+tag into `install.sh`, includes that script in `SHA256SUMS`, and uploads it with
+the four archives. The draft-install jobs download that exact installer asset by
+release ID and consume the uploaded archive for their platform; a moved tag
+cannot substitute different installer code. After all four native installs
+pass, the workflow re-downloads the six draft assets, verifies them against the
+build checksum, and uploads an immutable
 `accepted-release-candidate-*` Actions artifact containing the commit, release
 ID, asset IDs, and checksums. Draft install and candidate-recording jobs use
 contents write permission because GitHub exposes draft releases only to
 identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
-workflow never publishes the draft automatically.
+workflow never publishes the draft automatically. Promotion publishes only the
+accepted draft, then a four-platform matrix downloads the public stamped
+installer without GitHub credentials and verifies the installed runtime. A
+post-publication smoke cannot undo an immutable release; failure requires
+rollback guidance and a superseding version.
 
 The current immutable binary candidate is `v0.7.1-rc.4`. `v0.7.1-rc.3` is the
 prior published binary, and `v0.7.1-rc.2` remains an older published rollback;
@@ -375,9 +386,9 @@ The staged binary's `--version` probe must finish within 10 seconds. Its
 watchdog returns 124 for timeout and 125 for timer failure, bounds output at the
 filesystem level, TERM/KILLs and reaps the probe, removes common GitHub and
 Actions token variables from the child environment, and shows at most 4096
-sanitized bytes of compatibility stderr. Every potentially blocking `gh`
-operation is a tracked file-backed child; HUP, INT, and TERM forward to that
-child, use the same TERM/KILL/reap cleanup, and exit 129, 130, and 143.
+sanitized bytes of compatibility stderr. Every potentially blocking curl or
+`gh` operation is a tracked file-backed child; HUP, INT, and TERM forward to
+that child, use the same TERM/KILL/reap cleanup, and exit 129, 130, and 143.
 
 The verified `stn` rename is the sole runtime commit point. Immediately before
 it, both aliases must still be exact symlinks to `stn` and binary/license
@@ -505,13 +516,18 @@ promotion will verify:
     ''|*[!0-9]*) echo "candidate release ID must be numeric" >&2; exit 1 ;;
   esac
   test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq '.sha')" = "$commit"
-  gh api --method GET \
-    -H 'Accept: application/vnd.github.raw+json' \
-    -f ref="$commit" \
-    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
+  asset_ids="$candidate_dir/asset-ids.txt"
+  test -f "$asset_ids"
+  installer_asset_id="$(awk -F= '$1 == "install.sh" { print $2 }' "$asset_ids")"
+  case "$installer_asset_id" in
+    ''|*[!0-9]*) echo "candidate installer asset ID must be numeric" >&2; exit 1 ;;
+  esac
+  gh api -H 'Accept: application/octet-stream' \
+    "repos/jeremy0dell/station/releases/assets/$installer_asset_id" > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer" --version "$tag"
+  grep -Fx "embedded_version=\"$tag\"" "$installer"
+  STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer"
 )
 ```
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,65 +1,54 @@
 # Homebrew Packaging
 
-Status: live, internal/team **source formula** at
-[`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station).
-Station is not ready for `homebrew/core` yet: the `station` repo itself is
-private, uses Node.js 24.2+ (and below 25) plus a separate Bun workspace, and requires explicit
-first-run setup. v0.1.0 is the first source-formula baseline.
+Status: live private-preview **source formula** in
+[`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station),
+with a public third-party tap as the stable-release target. This is not a
+`homebrew/core` formula.
 
-The authenticated compiled binary is the primary private user channel. The tap
-remains a separate source-build option for development and internal packaging
-validation; it does not consume A5 binary archives and is not updated when a
-binary release is published. A binary Homebrew formula remains deferred until
-private release-asset downloads have a tested Homebrew authentication strategy.
+The compiled binary remains the primary install channel. Homebrew is a separate
+source-build option: it clones an immutable Git tag and revision, installs the
+Node and Bun workspaces, and retains the repository-relative runtime layout.
+It does not consume Station's native binary release archives.
 
-Because `jeremy0dell/station` is a private GitHub repo, this tap is for
-internal/team use, not public onboarding. There is no built-in Homebrew
-download strategy for private-repo archive tarballs (verified against
-Homebrew 6.x source -- no such strategy exists), so the formula clones via
-git+https instead (`url "...git", tag:, revision:`). This authenticates
-transparently using whatever git credentials the installing user already has
-for github.com (SSH key, or `gh auth login`'s git credential helper) -- no
-extra token/env var needed at install time. Revisit this once `station` goes
-public.
+## User flow
 
-## Source-formula user flow
+While both repositories are private, authenticate Git once before installing:
 
 ```bash
-brew tap jeremy0dell/station
-brew trust jeremy0dell/station
-brew install station
+gh auth login --hostname github.com
+gh auth setup-git
+brew install jeremy0dell/station/station
 stn setup
 stn doctor
 stn
 ```
 
-Setup is independent of the current directory. On first launch, choose **Add
-your first project** and select an existing Git repository.
+The fully qualified `brew install` command taps `jeremy0dell/homebrew-station`
+and trusts only its `station` formula. After both repositories become public,
+the GitHub authentication steps are unnecessary and the remaining command is
+the public Homebrew install path.
 
-Homebrew should install Station and its machine-level dependencies. It should not
-write `~/.config/station/config.toml`, install provider hooks, install the tmux
-popup binding, start the observer, or run `stn doctor` during formula install.
-Those steps are user and runtime aware and belong to `stn setup`; explicit
-project selection belongs to the first-project flow in Station.
+Setup is independent of the current directory. Homebrew must not write
+`~/.config/station/config.toml`, install provider hooks, install the tmux popup
+binding, start the Observer, or run `stn doctor` during formula installation.
+Those runtime-aware actions belong to `stn setup`; the user chooses the first
+Git project explicitly from Station afterward.
 
-## Formula shape
+## Formula source of truth
 
-The formula lives in the
-[`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station)
-tap as `Formula/station.rb`, kept in sync with
+The live formula is `Formula/station.rb` in the tap. Its maintained shape is
 [`packaging/homebrew/station.rb.template`](../packaging/homebrew/station.rb.template)
-in this repo.
+in this repository.
 
-The current install is source-tree based, not a single binary. The formula must
-preserve the repository-relative layout because:
+The formula intentionally uses a Git URL with both `tag:` and `revision:`.
+`scripts/build-identity.mjs` computes the production identity from the full Git
+HEAD plus tracked and untracked-nonignored production inputs, so a
+GitHub-generated source archive without `.git` is not an equivalent build
+input. The public source tap should retain the Git strategy rather than adding
+an archive-only fallback to the build-identity contract.
 
-- `bin/stn` resolves `apps/cli/dist/main.js` relative to the launcher.
-- `bin/stn-ingress` resolves `apps/cli/dist/ingressMain.js`.
-- The CLI resolves the Bun TUI workspace at `station/`.
-- `station/` needs its own Bun `node_modules` and linked built `@station/*`
-  packages.
-
-The formula template builds with:
+The source build requires Node.js 24.2+ (and below 25), pnpm 11, and the Bun
+version pinned by the release workflow. It runs:
 
 ```bash
 pnpm install --frozen-lockfile
@@ -70,64 +59,102 @@ bun run link:station
 bun run repair:node-pty
 ```
 
-Runtime launchers should wrap the installed tree and prepend Homebrew's
-`node@24` path because `node@24` is keg-only.
+The formula preserves the source-tree layout under `libexec`, wraps all three
+launchers, and prepends Homebrew's keg-only `node@24` plus Bun paths. It declares
+all direct build/runtime dependencies, including `git-delta`; it must not rely
+on another formula to provide a transitive runtime tool.
 
-## Release checklist
+## Tap CI and review
 
-Binary publication never updates the source formula. When a published Station
-source tag should be packaged separately:
+The tap uses Homebrew's generated `brew test-bot` workflow shape on Intel macOS,
+Apple silicon macOS, and Linux. Pull requests run formula installation, the
+formula test, audits, and bottle construction. Bottle artifacts are CI evidence
+only for the initial public source channel; do not run the bottle-publishing
+workflow until binary Homebrew distribution is an explicit supported channel.
 
-1. Confirm the tag contains the source checkout version intended for the
-   formula and that its normal CI is green.
-2. Manually dispatch the source-formula workflow with the exact published tag:
+The formula test must prove the installed wrapper reports the formula version
+and that installed `stn setup check --json` completes through its packaged
+runtime and reports the launcher and config facts. A missing agent or
+zero-project config keeps `requiredOk` false in the isolated test home by
+design.
 
-   ```bash
-   gh workflow run homebrew-bump.yml -f tag=vX.Y.Z
-   ```
+Required tap checks before merging a formula update:
 
-   `.github/workflows/homebrew-bump.yml` is `workflow_dispatch` only; it does
-   not listen to `release: published`. The workflow updates
-   `Formula/station.rb`'s `tag` and revision in the tap and commits directly to
-   the tap's default branch.
-3. `COMMITTER_TOKEN` remains intentionally unconfigured for A5. A future
-   source-formula dispatch needs a PAT with cross-repository contents write
-   access on `jeremy0dell/homebrew-station`; the default `GITHUB_TOKEN` cannot
-   push to that repository. Until then, update the tap formula manually.
-4. Test locally:
+```bash
+brew style jeremy0dell/station/station
+brew audit --strict jeremy0dell/station/station
+brew install --build-from-source jeremy0dell/station/station
+brew test jeremy0dell/station/station
+stn --version
+stn setup check --json
+```
 
-   ```bash
-   brew untap jeremy0dell/station; brew tap jeremy0dell/station
-   brew trust jeremy0dell/station
-   brew install --build-from-source station
-   brew audit --strict station
-   brew test station
-   stn setup check --json
-   stn doctor
-   stn
-   ```
+The tap's default branch should be `main`, require pull requests, and require the
+complete `brew test-bot` matrix. Dependabot maintains pinned GitHub Actions.
+While the upstream Station repository remains private, same-repository tap CI
+needs a temporary fine-grained `STATION_REPOSITORY_TOKEN` secret with read-only
+Station contents access; remove the credential step and secret after Station is
+public. GitHub does not expose that secret to fork pull requests.
 
-5. Publish bottles from the tap once the formula is reviewed and the tap CI is
-   green.
+## Stable formula update
 
-## Known issues
+Binary publication does not mutate the tap. After a stable Station release is
+public and immutable, manually dispatch:
 
-- `brew install` prints a non-fatal warning: `Failed changing dylib ID of
-  .../node_modules/@opentui/core-darwin-arm64/libopentui.dylib`. Homebrew's
-  automatic post-install relinking pass scans every Mach-O file in the keg,
-  including vendored prebuilt native node_modules binaries, and this
-  particular upstream binary doesn't have enough Mach-O header padding to be
-  rewritten. The CLI still works (`stn`, `stn setup check --json`, `brew
-  test` all pass) -- Node loads the addon by direct path, not via dyld
-  rpath resolution -- but expect the warning on every install/upgrade until
-  `@opentui/core` ships a binary built with `-headerpad_max_install_names`.
+```bash
+gh workflow run homebrew-bump.yml -f tag=vX.Y.Z
+```
 
-## Core-readiness blockers
+`.github/workflows/homebrew-bump.yml` accepts stable SemVer tags only and
+revalidates all of these facts before touching the tap:
 
-- `station` itself must go public (private repos cannot be in `homebrew/core`).
-- Public, stable tagged releases with real version numbers.
-- A formula test that proves more than `--help`.
-- A cleaner installed-mode TUI smoke for the Bun/native PTY path.
-- License metadata acceptable to Homebrew core (FSL-1.1-ALv2 is a valid SPDX
-  id but is not DFSG-compliant, which `homebrew/core` requires).
-- Runtime compatibility with Homebrew-supported macOS and Linux targets.
+- the checked-out package version exactly matches the tag;
+- the tag commit is on `main` and still resolves to the validated commit;
+- the Station repository and tap are public;
+- the GitHub release is published, stable, and immutable.
+
+The workflow renders the tagged revision into the maintained formula template,
+pushes `automation/station-X.Y.Z` in the tap, and opens or reuses a formula pull
+request. It never commits directly to the tap's default branch. Merge only after
+the tap CI matrix and a clean-machine source install pass.
+
+`COMMITTER_TOKEN` must be configured in the Station repository before the first
+public stable dispatch. Use a fine-grained token scoped only to
+`jeremy0dell/homebrew-station` with contents write and pull-request write
+permissions. The ordinary Station workflow token remains read-only.
+
+## Public-release transition
+
+Before publishing the first public formula:
+
+1. Complete the repository-history, issue, release, and Actions-log review in
+   [Public release checklist](public-release-checklist.md).
+2. Make `jeremy0dell/station` public and validate the final public release
+   candidate through the unauthenticated binary path.
+3. Make `jeremy0dell/homebrew-station` public, rename its default branch to
+   `main`, and enable the required tap ruleset and security settings.
+4. Test the stable formula update in a pull request on all three Homebrew CI
+   platforms.
+5. Merge the formula only after the corresponding stable Station release is
+   published and immutable.
+6. From a clean unauthenticated machine, run
+   `brew install jeremy0dell/station/station`, then manually verify setup,
+   doctor, the TUI, and popup reopen.
+
+## Known source-formula issue
+
+On macOS, `brew install` can print a non-fatal warning while attempting to
+rewrite the dylib ID of a vendored `@opentui/core` binary. The upstream binary
+lacks enough Mach-O header padding for Homebrew's relinking pass. The installed
+runtime currently loads it by direct path, but the warning remains a public UX
+issue until upstream publishes a compatible binary or Station owns a verified
+packaging workaround. Record the warning in release notes while it remains
+reproducible.
+
+## `homebrew/core` remains out of scope
+
+A public third-party tap does not imply core readiness. Core still requires a
+compatible license/policy posture, sustained stable releases, broader platform
+compatibility, and an upstream-quality formula test and maintenance history.
+Keep the source tap supported independently rather than making core acceptance
+a `v0.7.1` gate.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,8 @@ Station is a terminal workspace for running AI coding agents in isolated Git wor
 
 ## Start Here
 
-- [Install Station](install.md) — install and verify the authenticated binary.
+- [Install Station](install.md) — install the public stable binary or the
+  current authenticated preview.
 - [Agent-led install prompt](install.md#let-your-agent-install-and-validate-station) — let a coding agent install the binary and validate `stn setup` safely.
 - [Quick start](quick-start.md) — add a project and create your first agent session.
 - [Overview](overview.md) — understand projects, worktrees, sessions, providers, and the observer.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,9 +1,8 @@
 # Install Station
 
-Station is distributed through authenticated GitHub release assets in the
-private `jeremy0dell/station` repository. This procedure assumes your GitHub
-account already has read access; it does not require or display a personal
-access token.
+Station's public stable channel is distributed through immutable GitHub release
+assets and does not require a GitHub account. The currently published preview
+assets remain private until the public release transition is complete.
 
 ## Binary Requirements
 
@@ -14,10 +13,12 @@ The compiled binary supports these targets:
 - Linux on arm64 (`linux-arm64`)
 - Linux on x64 (`linux-x64`)
 
-Install the [GitHub CLI](https://cli.github.com/) before continuing. The binary
-install itself does not require a source checkout, Node.js, pnpm, Bun, Xcode, or
+Public installation requires curl plus the platform `tar` and SHA-256 utility;
+macOS and the supported Linux distributions provide these tools by default. It
+does not require GitHub CLI, a source checkout, Node.js, pnpm, Bun, Xcode, or
 Homebrew. `stn setup` handles the separate tools needed for the complete agent
-workflow after Station is installed.
+workflow after Station is installed. GitHub CLI remains required only for
+installing an unpublished draft or the current private preview.
 
 Station uses the platform `lsof` executable (`/usr/sbin/lsof` on macOS,
 `/usr/bin/lsof` on Linux) to prove that an unreachable Unix socket has no live
@@ -27,27 +28,76 @@ to proceed without that evidence. Linux VM images can install it with
 `sudo apt-get install lsof` (Debian/Ubuntu) or `sudo dnf install lsof`
 (Fedora/RHEL); macOS normally includes it.
 
+## Install the Public Stable Release
+
+After the first public stable release is published, run from any directory:
+
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/latest/download/install.sh | sh
+```
+
+The stable URL resolves to the version-stamped `install.sh` asset attached to
+GitHub's latest stable release. That asset carries its own immutable tag, so every
+archive and checksum request remains pinned even if a newer release is
+published during the install.
+
+For an inspect-first installation of the same asset:
+
+```sh
+(
+  set -eu
+  umask 077
+  installer="$(mktemp)"
+  trap 'rm -f "$installer"' EXIT
+  curl --proto '=https' --tlsv1.2 -fsSL \
+    https://github.com/jeremy0dell/station/releases/latest/download/install.sh \
+    -o "$installer"
+  test -s "$installer"
+  sh -n "$installer"
+  less "$installer"
+  sh "$installer"
+)
+```
+
+The convenience pipeline and inspect-first procedure execute the same stamped
+asset. Neither fetches installer code from `main`. The installer itself verifies
+the selected native archive against the release's `SHA256SUMS` before replacing
+an existing installation.
+
+To install an exact public version, replace the latest URL with:
+
+```text
+https://github.com/jeremy0dell/station/releases/download/vX.Y.Z/install.sh
+```
+
+The exact release asset already carries `vX.Y.Z`; no `--version` argument is
+required. Arguments for the piped form follow `sh -s --`, for example:
+
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/latest/download/install.sh |
+  sh -s -- --install-dir "$HOME/bin"
+```
+
 ## Let Your Agent Install and Validate Station
 
 If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
-
-Use the private GitHub repository jeremy0dell/station through GitHub CLI.
+Install the latest public stable Station release and validate setup on this machine.
 
 Safety and scope:
-- First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. Never ask me to paste,
-  extract, or print credentials. If authentication or repository access fails,
-  stop and ask me to run `gh auth login --hostname github.com` myself.
-- Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
-  `gh api`, and follow its temporary-file installer procedure. If that release
-  is not published yet, stop instead of falling back to another ref.
-- Never fetch installer code from `main` and never pipe network output directly
-  into a shell.
+- Do not clone the repository or build from source. Download
+  `https://github.com/jeremy0dell/station/releases/latest/download/install.sh`
+  into a private temporary file with curl, require the download to succeed, run
+  `sh -n` on it, and then execute that file. Do not fall back to `main`.
+- Do not request, extract, print, or pass GitHub credentials; public installation
+  must work without authentication.
+- Do not pipe network output directly into a shell in this agent-led path; use
+  the inspectable temporary file even though the documented human convenience
+  command supports `curl | sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. Apply PATH changes only to the current shell and show me
   the exact export I can add later.
@@ -67,10 +117,16 @@ Validation:
    required check is failing.
 ```
 
-The agent should stop at authentication or approval boundaries rather than
-inventing credentials or setup choices.
+The agent should stop at download, verification, or approval boundaries rather
+than inventing credentials or setup choices.
 
-## 1. Authenticate GitHub CLI
+## Current Private Preview Fallback
+
+The current preview predates the public `install.sh` release asset. Until a new
+candidate is built by the updated release workflow, use the authenticated exact
+procedure below.
+
+### 1. Authenticate GitHub CLI
 
 Sign in with the GitHub account that can read `jeremy0dell/station`:
 
@@ -85,7 +141,7 @@ check should print `jeremy0dell/station`; a not-found response means the active
 account cannot read the private repository. GitHub CLI supplies its stored
 authentication to the API calls below, so do not add credentials to the recipe.
 
-## 2. Install the Current Preview Candidate
+### 2. Install the Current Preview Candidate
 
 From any directory, run:
 
@@ -133,7 +189,7 @@ It also installs the redistributed license under
 After this candidate is published, immutable rollback to `v0.7.1-rc.3` uses the
 same exact-version procedure below.
 
-## 3. Verify the Install
+## Verify the Install
 
 The installer physically verifies all three launchers. If the install directory
 is not visible in the current shell, it prints an exact current-shell recovery
@@ -159,31 +215,38 @@ shells. The installer does not read, create, or edit shell startup files.
 
 ## Install an Exact Version
 
-To install an exact release or return to published `v0.7.1-rc.3`, use the same
-recipe with this assignment instead of the latest-release lookup:
+For a public release that includes the stamped installer asset, use its exact
+immutable URL:
 
-```bash
-tag=v0.7.1-rc.3
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/download/vX.Y.Z/install.sh | sh
 ```
 
-The installer code and artifacts still come from that same tag. The earlier
-`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
+To return to the older private `v0.7.1-rc.3` release, use the authenticated
+preview fallback above with `tag=v0.7.1-rc.3`; that release predates the public
+installer asset. The earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained
+unpublished.
 
 ## Use a Custom Install Directory
 
-Change the final installer invocation to pass an absolute or home-relative
-path:
+Pass installer arguments after `sh -s --` in the convenience pipeline:
 
-```bash
-sh "$installer" --version "$tag" --install-dir "$HOME/bin"
+```sh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://github.com/jeremy0dell/station/releases/latest/download/install.sh |
+  sh -s -- --install-dir "$HOME/bin"
 ```
+
+For an inspect-first or private-preview install, pass the same
+`--install-dir "$HOME/bin"` argument to the final `sh "$installer"` command.
 
 Use the PATH and absolute commands printed by that install rather than the
 default `~/.local/bin` examples. The normalized install directory cannot
 contain `:` because PATH uses `:` to separate entries. This validation happens
 before GitHub requests, temporary-directory creation, or destination mutation.
 
-## 4. Complete First-Run Setup
+## Complete First-Run Setup
 
 Run setup only after `stn --version` succeeds:
 
@@ -227,7 +290,7 @@ The installer and setup have separate ownership:
 The installer:
 
 - accepts only `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`;
-- downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` through authenticated `gh api` calls (`{version}` excludes the tag's leading `v`);
+- downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` over public HTTPS with curl (`{version}` excludes the tag's leading `v`), while authenticated draft acceptance remains isolated behind `STATION_INSTALL_RELEASE_ID` and GitHub CLI;
 - verifies the matching SHA-256 before extraction and rejects an unexpected archive manifest;
 - stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command; compatibility failures include at most 4096 sanitized bytes of probe stderr;
 - keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
@@ -293,7 +356,8 @@ retrying after a machine loss.
 
 The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
 
-Rollback is the same authenticated explicit-version install. Published tags and
+Rollback uses the prior release's exact stamped installer URL; releases that
+predate `install.sh` use the authenticated preview fallback. Published tags and
 assets are immutable; do not delete, move, or overwrite them. If a published
 binary is bad, reinstall the prior published version and ship a higher version
 containing the revert or fix.
@@ -358,8 +422,9 @@ Optional integrations can be added later.
 
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
-`pnpm smoke:install` exercises latest, explicit, and draft selection; strict
-authenticated API arguments; all four platform mappings; startup-file
+`pnpm smoke:install` exercises public latest and explicit curl downloads,
+version-stamped release installers, authenticated draft API arguments, all four
+platform mappings, startup-file
 non-interaction, safely evaluated PATH guidance for spaces and apostrophes,
 normalized-colon preflight, and physical PATH shadow behavior;
 checksum/archive/probe failures; dual-lock concurrency and stale recovery;

--- a/docs/public-release-checklist.md
+++ b/docs/public-release-checklist.md
@@ -1,0 +1,232 @@
+# Public Release Checklist
+
+Status: living gate for the first public stable Station release. The target is
+`v0.7.1`, distributed through native GitHub binaries and the public
+`jeremy0dell/station` Homebrew source tap.
+
+This checklist complements, rather than replaces:
+
+- [Development](development.md) for deterministic and native release gates;
+- [Install](install.md) for the binary installer contract;
+- [Homebrew packaging](homebrew.md) for source-formula ownership and CI;
+- [Single binary](single-binary.md) for compiled artifact design; and
+- `.github/workflows/release.yml` plus `promote-release.yml` for executable
+  draft-acceptance and immutable-promotion policy.
+
+Product behavior blockers are tracked separately. A packaging or publication
+owner may advance the preparation sections while those fixes are in flight, but
+must not cut the final candidate until both tracks are green.
+
+## Release definition
+
+- [ ] Native binaries support `darwin-arm64`, `darwin-x64`, `linux-arm64`, and
+      `linux-x64` with their platform floors recorded in release notes.
+- [ ] Published binary installation requires no GitHub account or credentials.
+- [ ] Homebrew is a public third-party source tap, not a `homebrew/core` formula
+      and not a wrapper around the native installer.
+- [ ] The documented Homebrew command is
+      `brew install jeremy0dell/station/station`.
+- [ ] Both channels finish at the same `stn --version` and preserve the three
+      `stn`, `stn-ingress`, and `stn-tmux-popup` launchers.
+- [ ] Updates and rollback use immutable versions; published tags, assets, and
+      formula revisions are never replaced.
+
+## 1. Public-data review
+
+Making a private GitHub repository public exposes more than the current tree.
+Complete and record a human review before changing visibility.
+
+- [ ] Scan the complete Git history for credentials, private endpoints, personal
+      data, proprietary fixtures, and generated diagnostic bundles.
+- [ ] Review every issue, pull request, review comment, attachment, release,
+      release note, Actions artifact, and retained Actions log intended to
+      become public.
+- [ ] Review Git tags and branches; preserve immutable published releases and
+      remove only unpublished material through an explicit audited decision.
+- [ ] Confirm screenshots, transcripts, user names, home paths, repository names,
+      and runtime traces are safe to publish.
+- [ ] Run repository secret scanning and independently review its findings.
+- [ ] Verify no public documentation tells users to paste, print, or export
+      credentials.
+- [ ] Record the approving reviewer and date outside this reusable checklist.
+
+## 2. Public repository controls
+
+- [ ] Add `.github/SECURITY.md` with a private vulnerability-reporting route,
+      supported versions, and response expectations.
+- [ ] Enable private vulnerability reporting, Dependabot alerts, dependency
+      updates, secret scanning, and push protection where GitHub supports them.
+- [ ] Add CodeQL or document the equivalent JavaScript/TypeScript security lane.
+- [ ] Keep the `main` ready-PR ruleset active and confirm its required check is
+      the full `standard-ci` pull-request job.
+- [ ] Restrict workflow-token permissions by default and retain explicit job
+      permissions for release mutation.
+- [ ] Confirm the FSL license and source-available status are described
+      accurately; do not imply OSI approval or `homebrew/core` eligibility.
+- [ ] Add public update, rollback, uninstall, support, and diagnostic-bundle
+      instructions.
+
+## 3. Public binary transport
+
+- [ ] Published installs use HTTPS without requiring authenticated `gh`.
+- [ ] The canonical convenience command pipes the version-stamped latest release
+      asset to `sh`; an adjacent inspect-first procedure downloads that same
+      asset to a private temporary file, checks it with `sh -n`, and invokes it
+      explicitly. Neither path fetches from `main`.
+- [ ] Draft acceptance retains its authenticated release-ID path and exact
+      candidate manifest.
+- [ ] Deterministic installer smoke covers public latest, public exact-version,
+      authenticated draft, redirects, partial downloads, HTTP failures,
+      checksum rejection, locks, signals, rollback, and atomic activation.
+- [ ] A post-promotion matrix verifies the actual public assets on all four
+      native targets without repository credentials.
+- [ ] `releases/latest` resolves to the intended stable release, not the old
+      source-only `v0.1.0` release.
+
+Expected implementation files:
+
+- `scripts/install.sh`
+- `scripts/test-runners/run-install-smoke.mjs`
+- `scripts/release/render-release-installer.mjs`
+- `.github/workflows/release.yml`
+- `.github/workflows/promote-release.yml`
+- `README.md`
+- `docs/install.md`
+- `docs/development.md`
+- `docs/single-binary.md`
+- `tests/diagnostics/release-readiness-docs.test.ts`
+
+No backend or connector seam changes are expected, so this transport slice has
+no planned architectural JSDoc updates.
+
+## 4. Artifact signing and provenance
+
+- [ ] Obtain and protect the Apple Developer ID Application certificate and
+      App Store Connect notarization credentials through GitHub environments.
+- [ ] Sign the final macOS `stn` executable before archive assembly on both
+      architectures.
+- [ ] Submit the exact signed artifacts for notarization, staple where the
+      artifact shape supports it, and verify with `codesign` and `spctl` on a
+      clean machine.
+- [ ] Stop treating quarantine removal as the public trust mechanism; retain it
+      only if the signed/notarized UX has a documented need.
+- [ ] Bind release artifacts to GitHub Actions build provenance and document the
+      optional verification command.
+- [ ] Decide and document whether `SHA256SUMS` also receives a detached
+      signature; an unsigned checksum beside the archives is integrity evidence,
+      not an independent publisher identity.
+- [ ] Confirm release jobs cannot expose signing credentials to pull requests,
+      forks, or unsigned local builds.
+
+Expected implementation files are `.github/workflows/release.yml`, the focused
+sign/notarize helper under `scripts/release/`, `scripts/release/package-archive.sh`,
+`scripts/test-runners/run-binary-smoke.mjs`, `docs/development.md`, and
+`docs/single-binary.md`. No backend or connector JSDoc updates are expected.
+
+## 5. Homebrew source tap
+
+- [ ] `packaging/homebrew/station.rb.template` and the live
+      `Formula/station.rb` have the same formula shape.
+- [ ] The formula pins both stable tag and full revision and declares every
+      direct dependency.
+- [ ] The installed wrapper reports the formula version and setup check loads
+      the packaged runtime from an isolated home.
+- [ ] The tap has pinned Dependabot-managed Actions and Homebrew `test-bot` on
+      Intel macOS, Apple silicon macOS, and Linux.
+- [ ] Bottle artifacts remain unpublished while this channel is source-only.
+- [ ] The tap default branch is `main` and requires pull requests plus the full
+      platform matrix.
+- [ ] Station's Homebrew dispatch validates a public, stable, immutable release
+      and opens a tap pull request instead of pushing the default branch.
+- [ ] `COMMITTER_TOKEN` is fine-grained to the tap with contents and pull-request
+      write permissions only.
+- [ ] Remove the temporary read-only `STATION_REPOSITORY_TOKEN` from tap CI after
+      Station becomes public.
+- [ ] Formula release notes disclose the vendored OpenTUI dylib warning until it
+      is resolved and reverified.
+
+Expected Station files are `.github/workflows/homebrew-bump.yml`,
+`packaging/homebrew/station.rb.template`,
+`scripts/release/render-homebrew-formula.mjs`, `docs/homebrew.md`,
+`docs/install.md`, `README.md`, and Homebrew diagnostics tests. Expected tap
+files are `Formula/station.rb`, `README.md`, `.github/dependabot.yml`, and
+`.github/workflows/tests.yml`. No backend or connector JSDoc updates are
+expected.
+
+## 6. Final public release candidate
+
+- [ ] Product release blockers are closed and the exact candidate commit is on
+      `main` with full ready-PR CI green.
+- [ ] The repositories pass the public-data review before visibility changes.
+- [ ] Make Station public, then make the tap public and apply their rulesets and
+      security settings.
+- [ ] Cut `v0.7.1-rc.5` from a version-consistent commit.
+- [ ] Confirm standard CI, release smoke, all native builds, all binary smokes,
+      all four draft installs, and candidate recording pass.
+- [ ] Perform the complete manual acceptance gate in [Development](development.md)
+      before promotion.
+- [ ] Promote the candidate and test an unauthenticated install on four clean
+      native systems.
+- [ ] Test the Homebrew formula against the candidate in a pull request or
+      non-default test branch; do not publish a prerelease formula as stable.
+- [ ] Exercise the candidate in daily real terminal, popup, setup, provider-hook,
+      and worktree use for the agreed soak period.
+- [ ] Restart the candidate gate after any production-code change.
+
+Stop-ship findings include data loss or repository mutation, install/upgrade or
+rollback failure, mixed launcher versions, unhealthy clean setup/doctor,
+Observer replacement or socket-ownership failure, terminal loss across upgrade,
+macOS trust failure, and a failing supported-platform packaging lane.
+
+## 7. Stable `v0.7.1`
+
+The version-only release change is expected to update:
+
+- `package.json`
+- `packages/runtime/src/buildInfo.ts`
+- `README.md`
+- `docs/install.md`
+- `docs/development.md`
+- `docs/single-binary.md`
+- `apps/cli/test/integration/manual-smoke-commands.test.ts`
+- `packages/runtime/test/unit/buildInfo.test.ts`
+- `scripts/test-runners/run-binary-smoke.mjs`
+- `tests/diagnostics/release-readiness-docs.test.ts`
+
+No backend or connector JSDoc updates are expected for the version-only change.
+
+- [ ] Keep production behavior identical to the accepted final candidate except
+      for release version and truthful stable-channel documentation.
+- [ ] Run `pnpm test:pre-push` on the exact version commit.
+- [ ] Tag `v0.7.1`; never move or reuse the tag.
+- [ ] Require the complete draft and candidate-recording workflow to pass.
+- [ ] Repeat manual acceptance against the stable draft.
+- [ ] Promote only the accepted immutable draft.
+- [ ] Verify an unauthenticated latest install reports `0.7.1` on four targets.
+- [ ] Verify candidate-to-stable upgrade, stable reinstall, and explicit rollback
+      while continuously resolving all three launchers.
+- [ ] Dispatch the Homebrew update, review its exact tag/revision, wait for the
+      full tap matrix, and merge the formula pull request.
+- [ ] Verify the one-command Homebrew install from a clean, unauthenticated
+      machine and confirm `brew upgrade station` remains coherent.
+- [ ] Publish release notes with platform floors, signing/provenance instructions,
+      known limitations, rollback, uninstall, and support links.
+
+## Manual UX sign-off
+
+For both channels, record the exact first failure and do not substitute a source
+checkout for the installed artifact.
+
+1. Start from a clean home and shell with Station absent.
+2. Install without GitHub authentication.
+3. Physically resolve all three launchers and confirm `stn --version`.
+4. Run guided `stn setup`, `stn setup check --json`, and `stn doctor`.
+5. Add the first Git project explicitly, create a real agent session, and verify
+   transcript and diff projection.
+6. Quit and reopen the TUI; confirm session and terminal continuity.
+7. Verify cold and warm tmux popup behavior and provider ingress.
+8. Open a new login shell and confirm the documented PATH behavior.
+9. Upgrade, reinstall, and roll back without a command-not-found interval or
+   mixed aliases.
+10. Follow the public uninstall instructions and confirm only Station-owned
+    files and integrations are removed.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -28,11 +28,10 @@ agent CLIs) gates *features*, never launch — captured precisely by the
 
 Non-goals:
 
-- **Public distribution.** The repo is private; binaries ship as private
-  GitHub release assets fetched by an authenticated install script. A
-  binary Homebrew formula is **deferred** until a tested private-asset
-  download strategy exists (see A5); the authenticated script is the only
-  binary channel meanwhile.
+- **Binary Homebrew distribution.** Public binaries ship through a
+  version-stamped GitHub release installer; the supported Homebrew channel is a
+  separate source formula. Publishing Homebrew bottles from these native
+  archives remains out of scope.
 - **Windows targets.**
 - **Any observer replacement / eviction in this roadmap.** Coordinated
   single-observer behavior is owned entirely by
@@ -390,50 +389,44 @@ Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
 duplicate targets, emits a stably sorted `SHA256SUMS`, and creates a GitHub
 release **draft** without clobbering an existing release. A second native
-matrix revalidates the tag, fetches the installer by the validated commit SHA
-through the authenticated Contents API, invokes it with the explicit tag against
-that real draft, and verifies the binary version, both argv0 aliases, license,
-and launch without Node or Bun on the runtime PATH. The four native builds use
-one archive-packaging helper, and the draft-install matrix consumes those exact
-uploaded archives. Publication remains a manual decision after the real-TTY
-acceptance below. GitHub's tag endpoint
-exposes published releases only, so the workflow captures the new draft's
-numeric release ID from the authenticated release list and passes it only to
-these acceptance jobs; normal installs keep using the latest/published-tag
-endpoints.
+matrix revalidates the tag, downloads the version-stamped `install.sh` from the
+captured draft release ID, and verifies the binary version, both argv0 aliases,
+license, and launch without Node or Bun on the runtime PATH. The four native
+builds use one archive-packaging helper, and the draft-install matrix consumes
+those exact uploaded archives. Publication remains a manual decision after the
+real-TTY acceptance below. GitHub exposes draft assets only to identities with
+push access, so the workflow passes the numeric release ID only to these
+acceptance jobs; normal published installs use unauthenticated HTTPS.
 
 After all native acceptance jobs pass, the release workflow re-downloads the
-five draft assets, checks them against the build-generated `SHA256SUMS`, and
+six draft assets, checks them against the build-generated `SHA256SUMS`, and
 uploads an immutable `accepted-release-candidate-*` Actions artifact containing
 the validated commit, workflow run/attempt, release ID, asset IDs, and checksums.
 The manually dispatched `promote-release.yml` downloads that exact artifact,
 rechecks the successful run, tag commit, draft identity, asset IDs, and hashes,
 then publishes the unchanged draft. Draft assets cannot drift between acceptance
-and promotion without failing that workflow.
+and promotion without failing that workflow. Publication is followed by a
+four-platform unauthenticated install of the actual public stamped script.
 
 `SHA256SUMS` is unsigned in A5 because no signing-key infrastructure exists;
-the trust chain is authenticated GitHub access plus immutable release assets.
+the current trust chain is HTTPS plus immutable GitHub release assets while the
+public signing/notarization gate is completed.
 The pipeline pins inputs, gates, targets, names, and manifest, but does not
 claim bit-for-bit reproducible Bun executables or archives.
 
 `scripts/install.sh` supports latest stable, explicit `--version`, and
-`--install-dir` (default `~/.local/bin`). The supported binary-install baseline
-starts at `v0.7.1-rc.2`; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates
-remained unpublished.
-Explicit installs set a tag, fetch
-`scripts/install.sh` from that tag through the authenticated Contents API, and
-invoke it with `--version` set to the same tag. Latest install first resolves
-the latest stable tag, then performs the same tagged fetch and explicit invoke.
-There is no silent `main` fallback, so installer code and release artifacts are
-always paired. `v0.7.1-rc.2` is the first published binary,
-`v0.7.1-rc.3` is the latest published binary, and publishing `v0.7.1-rc.4`
-makes immutable rollback to `v0.7.1-rc.3` available.
+`--install-dir` (default `~/.local/bin`). Release assembly stamps the selected
+immutable tag into the uploaded `install.sh`; an explicit CLI version can still
+override it for rollback and testing. The generic source script resolves latest
+stable through GitHub's HTTPS redirect. Neither path falls back to `main`, so
+installer code and release artifacts remain paired.
 
-The installer uses authenticated `gh api` release endpoints, accepts only the
-four supported targets, verifies the one matching `SHA256SUMS` entry and exact
-archive manifest before touching an existing install, and stages replacement
-on each destination filesystem. Every potentially blocking `gh` operation is a
-tracked file-backed child rather than a command substitution.
+Published installation uses curl with HTTPS-only redirect policy and accepts
+only the four supported targets. Authenticated `gh api` remains isolated to the
+captured draft-release acceptance path. Both transports run as tracked,
+file-backed children. The installer verifies the one matching `SHA256SUMS`
+entry and exact archive manifest before touching an existing install, then
+stages replacement on each destination filesystem.
 
 The staged binary's `--version` probe has a 10-second supervised deadline and
 a POSIX file-size limit on stdout/stderr. Watchdog exit 124 reports timeout;
@@ -483,8 +476,9 @@ still gives coherent process-level visibility to continuous readers. Power loss
 is not equivalent: the installer does not fsync files or containing directories
 and therefore makes no post-power-loss durability guarantee; old/new
 cross-filesystem `LICENSE` metadata may also remain. The deterministic
-`smoke:install` suite exercises this boundary with fake authenticated release
-assets and is part of `test:all`.
+`smoke:install` exercises this boundary with fake public curl downloads,
+authenticated draft assets, and a rendered version-stamped installer; it is part
+of `test:all`.
 
 After success, all three bare launchers are resolved physically. If every one
 points into the new install directory, the installer prints only
@@ -512,9 +506,10 @@ the unchanged tag workflow rerun; a source fix uses a new prerelease tag, while
 published releases are never deleted or mutated.
 
 The source-based Homebrew formula remains separate and manually dispatched.
-The default release `GITHUB_TOKEN` cannot trigger another workflow, and the tap
-`COMMITTER_TOKEN` is intentionally not configured for A5; no binary Homebrew
-formula is claimed until private asset authentication is proven there.
+The default release `GITHUB_TOKEN` cannot trigger another workflow; the
+fine-grained tap token opens a reviewed formula pull request only after a
+public, stable, immutable release is verified. No binary Homebrew formula is
+claimed.
 
 Implementation sources: the target and manifest policy above; the existing
 [`build:binary` staging](../scripts/build-binary.mjs),

--- a/packaging/homebrew/station.rb.template
+++ b/packaging/homebrew/station.rb.template
@@ -1,15 +1,9 @@
-# Draft formula for the upstream Station tap.
+# Source formula for the upstream Station tap.
 #
-# station is a PRIVATE repo. There is no built-in Homebrew download strategy
-# for private-repo archive tarballs (verified against Homebrew 6.x source --
-# no such strategy exists). Instead this clones via git+https, which
-# transparently authenticates using whatever git credentials the installing
-# user already has for github.com (SSH key, or `gh auth login`'s git
-# credential helper) -- no extra token/env var needed. This formula is for
-# internal/team use, not public onboarding, until the repo goes public.
-#
-# Copy this file to Formula/station.rb in the tap and replace the tag/revision
-# placeholders with a new tagged release before publishing.
+# The Git tag and full revision are intentional: Station's deterministic build
+# identity consumes repository metadata that GitHub-generated source archives
+# do not contain. Source access to the upstream repository is required during
+# installation and upgrade.
 class Station < Formula
   desc "Terminal-native control plane for AI-agent worktree sessions"
   homepage "https://github.com/jeremy0dell/station"
@@ -23,6 +17,7 @@ class Station < Formula
   depends_on "python" => :build
   depends_on "bun"
   depends_on "diffnav"
+  depends_on "git-delta"
   depends_on "node@24"
   depends_on "tmux"
   depends_on "worktrunk"
@@ -64,18 +59,18 @@ class Station < Formula
 
   def caveats
     <<~EOS
-      Homebrew installed the Station launchers. Configure the first project explicitly:
-        cd /path/to/first/git/project
+      Homebrew installed the Station launchers. Complete setup from any directory:
         stn setup
         stn doctor
         stn
 
+      Add the first Git project explicitly from Station after setup.
+
       Runtime config: ~/.config/station/config.toml
       Runtime state:  ~/.local/state/station
 
-      station is a private repo. Installing or upgrading this formula requires
-      git access to jeremy0dell/station (SSH key, or `gh auth login`'s git
-      credential helper).
+      Source access to https://github.com/jeremy0dell/station is required when
+      installing or upgrading this formula.
     EOS
   end
 
@@ -84,7 +79,10 @@ class Station < Formula
     ENV["XDG_RUNTIME_DIR"] = testpath/"run"
     mkdir_p ENV["XDG_RUNTIME_DIR"]
 
+    assert_equal version.to_s, shell_output("#{bin}/stn --version").strip
+
     output = shell_output("#{bin}/stn setup check --json", 1)
+    assert_match "\"station-launchers\"", output
     assert_match "\"requiredOk\": false", output
     assert_match "\"configPath\"", output
   end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,8 @@ github_host="github.com"
 export GH_HOST=$github_host
 requested_version=""
 requested_version_set=0
+# Release packaging stamps this field so the latest installer asset selects its own immutable tag.
+embedded_version=""
 install_dir=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
@@ -49,10 +51,10 @@ line_feed='
 tab='	'
 
 usage() {
-  cat <<'EOF'
+	cat <<'EOF'
 Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH]
 
-Install the latest stable private Station release, or an explicit version.
+Install the latest stable public Station release, or an explicit version.
 
 Options:
   --version VERSION   Install an immutable v-prefixed release version.
@@ -62,338 +64,356 @@ EOF
 }
 
 fail() {
-  printf 'Station install failed: %s\n' "$1" >&2
-  exit 1
+	printf 'Station install failed: %s\n' "$1" >&2
+	exit 1
 }
 
 warn() {
-  printf 'Station install warning: %s\n' "$1" >&2 || true
+	printf 'Station install warning: %s\n' "$1" >&2 || true
 }
 
 print_shell_word() {
-  quote_value=$1
-  printf "'"
-  while :; do
-    case "$quote_value" in
-      *"'"*)
-        quote_prefix=${quote_value%%"'"*}
-        printf "%s'\\\\''" "$quote_prefix"
-        quote_value=${quote_value#*"'"}
-        ;;
-      *)
-        printf "%s'" "$quote_value"
-        return 0
-        ;;
-    esac
-  done
+	quote_value=$1
+	printf "'"
+	while :; do
+		case "$quote_value" in
+		*"'"*)
+			quote_prefix=${quote_value%%"'"*}
+			printf "%s'\\\\''" "$quote_prefix"
+			quote_value=${quote_value#*"'"}
+			;;
+		*)
+			printf "%s'" "$quote_value"
+			return 0
+			;;
+		esac
+	done
 }
 
 readlink_target() {
-  if ! raw_link=$(
-    readlink -n "$1"
-    readlink_status=$?
-    printf x
-    exit "$readlink_status"
-  ); then
-    return 1
-  fi
-  link_target=${raw_link%x}
+	if ! raw_link=$(
+		readlink -n "$1"
+		readlink_status=$?
+		printf x
+		exit "$readlink_status"
+	); then
+		return 1
+	fi
+	link_target=${raw_link%x}
 }
 
 alias_inode() {
-  if ! raw_inode=$(LC_ALL=C ls -di "$1" 2>/dev/null); then
-    return 1
-  fi
-  set -- $raw_inode
-  case "${1:-}" in
-    ''|*[!0-9]*) return 1 ;;
-  esac
-  alias_inode_result=$1
+	if ! raw_inode=$(LC_ALL=C ls -di "$1" 2>/dev/null); then
+		return 1
+	fi
+	set -- $raw_inode
+	case "${1:-}" in
+	'' | *[!0-9]*) return 1 ;;
+	esac
+	alias_inode_result=$1
 }
 
 remove_tree() {
-  path=$1
-  [ -n "$path" ] || return 0
-  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
-    return 0
-  fi
-  rm -rf "$path" 2>/dev/null || warn "could not remove residual path '$path'; remove it manually."
+	path=$1
+	[ -n "$path" ] || return 0
+	if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+		return 0
+	fi
+	rm -rf "$path" 2>/dev/null || warn "could not remove residual path '$path'; remove it manually."
 }
 
 remove_created_alias() {
-  path=$1
-  created=$2
-  expected_inode=$3
-  quarantine=$4
-  [ "$created" -eq 1 ] || return 0
-  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
-    return 0
-  fi
-  if ! alias_inode "$path" || [ -z "$expected_inode" ] || [ "$alias_inode_result" != "$expected_inode" ]; then
-    rollback_failed=1
-    warn "created alias '$path' changed during cleanup; inspect it manually."
-    return 0
-  fi
-  if ! mv "$path" "$quarantine" 2>/dev/null; then
-    rollback_failed=1
-    warn "could not quarantine created alias '$path' for safe cleanup; inspect it manually."
-    return 0
-  fi
-  if alias_inode "$quarantine" && [ "$alias_inode_result" = "$expected_inode" ] && [ -L "$quarantine" ] && readlink_target "$quarantine" 2>/dev/null && [ "$link_target" = stn ]; then
-    if ! rm -f "$quarantine" 2>/dev/null; then
-      rollback_failed=1
-      preserve_install_stage=1
-      warn "could not remove residual alias '$quarantine'; remove it manually."
-    fi
-    return 0
-  fi
+	path=$1
+	created=$2
+	expected_inode=$3
+	quarantine=$4
+	[ "$created" -eq 1 ] || return 0
+	if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+		return 0
+	fi
+	if ! alias_inode "$path" || [ -z "$expected_inode" ] || [ "$alias_inode_result" != "$expected_inode" ]; then
+		rollback_failed=1
+		warn "created alias '$path' changed during cleanup; inspect it manually."
+		return 0
+	fi
+	if ! mv "$path" "$quarantine" 2>/dev/null; then
+		rollback_failed=1
+		warn "could not quarantine created alias '$path' for safe cleanup; inspect it manually."
+		return 0
+	fi
+	if alias_inode "$quarantine" && [ "$alias_inode_result" = "$expected_inode" ] && [ -L "$quarantine" ] && readlink_target "$quarantine" 2>/dev/null && [ "$link_target" = stn ]; then
+		if ! rm -f "$quarantine" 2>/dev/null; then
+			rollback_failed=1
+			preserve_install_stage=1
+			warn "could not remove residual alias '$quarantine'; remove it manually."
+		fi
+		return 0
+	fi
 
-  rollback_failed=1
-  if { [ ! -e "$path" ] && [ ! -L "$path" ]; } && mv "$quarantine" "$path" 2>/dev/null; then
-    warn "created alias '$path' changed during cleanup; the changed path was restored for manual inspection."
-  else
-    preserve_install_stage=1
-    warn "created alias '$path' changed during cleanup; inspect '$quarantine' and '$path' manually."
-  fi
+	rollback_failed=1
+	if { [ ! -e "$path" ] && [ ! -L "$path" ]; } && mv "$quarantine" "$path" 2>/dev/null; then
+		warn "created alias '$path' changed during cleanup; the changed path was restored for manual inspection."
+	else
+		preserve_install_stage=1
+		warn "created alias '$path' changed during cleanup; inspect '$quarantine' and '$path' manually."
+	fi
 }
 
 report_activation_ambiguity() {
-  [ "$activation_ambiguity_reported" -eq 0 ] || return 0
-  activation_ambiguity_reported=1
-  printf 'Station install failed: the staged binary disappeared during final activation; Station may have been updated.\n' >&2
-  printf 'Inspect the installed runtime with: ' >&2
-  print_shell_word "$binary_path" >&2
-  printf ' --version\n' >&2
+	[ "$activation_ambiguity_reported" -eq 0 ] || return 0
+	activation_ambiguity_reported=1
+	printf 'Station install failed: the staged binary disappeared during final activation; Station may have been updated.\n' >&2
+	printf 'Inspect the installed runtime with: ' >&2
+	print_shell_word "$binary_path" >&2
+	printf ' --version\n' >&2
 }
 
 stop_children() {
-  children_present=0
-  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
-    [ -n "$child_pid" ] || continue
-    children_present=1
-    kill -TERM "$child_pid" 2>/dev/null || true
-  done
-  if [ "$children_present" -eq 1 ]; then
-    sleep 1 2>/dev/null || true
-  fi
-  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
-    [ -n "$child_pid" ] || continue
-    kill -KILL "$child_pid" 2>/dev/null || true
-    wait "$child_pid" 2>/dev/null || true
-  done
-  tracked_child_pid=""
-  watchdog_pid=""
-  probe_pid=""
+	children_present=0
+	for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+		[ -n "$child_pid" ] || continue
+		children_present=1
+		kill -TERM "$child_pid" 2>/dev/null || true
+	done
+	if [ "$children_present" -eq 1 ]; then
+		sleep 1 2>/dev/null || true
+	fi
+	for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+		[ -n "$child_pid" ] || continue
+		kill -KILL "$child_pid" 2>/dev/null || true
+		wait "$child_pid" 2>/dev/null || true
+	done
+	tracked_child_pid=""
+	watchdog_pid=""
+	probe_pid=""
 }
 
 release_lock() {
-  release_path=$1
-  release_token=$2
-  release_inode=$3
-  release_owner=$release_path/owner-$release_token
-  if [ ! -e "$release_path" ] && [ ! -L "$release_path" ]; then
-    return 0
-  fi
-  if ! alias_inode "$release_path" || [ -z "$release_inode" ] || [ "$alias_inode_result" != "$release_inode" ]; then
-    warn "install lock '$release_path' changed ownership; it was not removed."
-    return 0
-  fi
-  lock_token_result=""
-  lock_token_count=0
-  if [ -f "$release_owner" ] && [ ! -L "$release_owner" ] && [ -r "$release_owner" ]; then
-    while IFS='=' read -r owner_key owner_value; do
-      if [ "$owner_key" = token ]; then
-        lock_token_count=$((lock_token_count + 1))
-        lock_token_result=$owner_value
-      fi
-    done < "$release_owner"
-  fi
-  if [ "$lock_token_count" -ne 1 ] || [ -z "$release_token" ] || [ "$lock_token_result" != "$release_token" ]; then
-    warn "install lock '$release_path' changed ownership; it was not removed."
-    return 0
-  fi
-  rm -f "$release_owner" 2>/dev/null || warn "could not remove lock owner '$release_owner'."
-  if ! alias_inode "$release_path" || [ "$alias_inode_result" != "$release_inode" ]; then
-    warn "install lock '$release_path' changed ownership; it was not removed."
-    return 0
-  fi
-  if ! rmdir "$release_path" 2>/dev/null; then
-    warn "could not remove install lock '$release_path'; inspect and remove it manually before retrying."
-  fi
+	release_path=$1
+	release_token=$2
+	release_inode=$3
+	release_owner=$release_path/owner-$release_token
+	if [ ! -e "$release_path" ] && [ ! -L "$release_path" ]; then
+		return 0
+	fi
+	if ! alias_inode "$release_path" || [ -z "$release_inode" ] || [ "$alias_inode_result" != "$release_inode" ]; then
+		warn "install lock '$release_path' changed ownership; it was not removed."
+		return 0
+	fi
+	lock_token_result=""
+	lock_token_count=0
+	if [ -f "$release_owner" ] && [ ! -L "$release_owner" ] && [ -r "$release_owner" ]; then
+		while IFS='=' read -r owner_key owner_value; do
+			if [ "$owner_key" = token ]; then
+				lock_token_count=$((lock_token_count + 1))
+				lock_token_result=$owner_value
+			fi
+		done <"$release_owner"
+	fi
+	if [ "$lock_token_count" -ne 1 ] || [ -z "$release_token" ] || [ "$lock_token_result" != "$release_token" ]; then
+		warn "install lock '$release_path' changed ownership; it was not removed."
+		return 0
+	fi
+	rm -f "$release_owner" 2>/dev/null || warn "could not remove lock owner '$release_owner'."
+	if ! alias_inode "$release_path" || [ "$alias_inode_result" != "$release_inode" ]; then
+		warn "install lock '$release_path' changed ownership; it was not removed."
+		return 0
+	fi
+	if ! rmdir "$release_path" 2>/dev/null; then
+		warn "could not remove install lock '$release_path'; inspect and remove it manually before retrying."
+	fi
 }
 
 cleanup() {
-  status=$?
-  trap - EXIT
-  trap '' HUP INT TERM
-  set +e
+	status=$?
+	trap - EXIT
+	trap '' HUP INT TERM
+	set +e
 
-  stop_children
+	stop_children
 
-  if [ "$license_displaced" -eq 0 ] && [ -n "$license_backup" ] && [ -e "$license_backup" ]; then
-    license_displaced=1
-  fi
-  if [ "$runtime_committed" -eq 0 ] && [ "$commit_started" -eq 1 ] && [ -n "$install_stage" ] && [ ! -e "$install_stage/stn" ] && [ ! -L "$install_stage/stn" ]; then
-    runtime_committed=1
-    report_activation_ambiguity
-  fi
+	if [ "$license_displaced" -eq 0 ] && [ -n "$license_backup" ] && [ -e "$license_backup" ]; then
+		license_displaced=1
+	fi
+	if [ "$runtime_committed" -eq 0 ] && [ "$commit_started" -eq 1 ] && [ -n "$install_stage" ] && [ ! -e "$install_stage/stn" ] && [ ! -L "$install_stage/stn" ]; then
+		runtime_committed=1
+		report_activation_ambiguity
+	fi
 
-  if [ "$runtime_committed" -eq 0 ]; then
-    if [ "$license_displaced" -eq 1 ]; then
-      if ! mv -f "$license_backup" "$license_path" 2>/dev/null; then
-        rollback_failed=1
-        warn "could not restore the previous license from '$license_backup' to '$license_path'."
-        license_stage=""
-      fi
-    elif [ "$license_installed" -eq 1 ]; then
-      if ! rm -f "$license_path" 2>/dev/null; then
-        rollback_failed=1
-        warn "could not remove the new license '$license_path'."
-      fi
-    fi
-    remove_created_alias "$install_dir/stn-ingress" "$created_ingress" "$created_ingress_inode" "$install_stage/stn-ingress.rollback"
-    remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup" "$created_popup_inode" "$install_stage/stn-tmux-popup.rollback"
-    if [ "$activation_failed_precommit" -eq 1 ] && [ "$rollback_failed" -eq 0 ]; then
-      printf 'The existing Station installation was unchanged.\n' >&2
-    fi
-  fi
+	if [ "$runtime_committed" -eq 0 ]; then
+		if [ "$license_displaced" -eq 1 ]; then
+			if ! mv -f "$license_backup" "$license_path" 2>/dev/null; then
+				rollback_failed=1
+				warn "could not restore the previous license from '$license_backup' to '$license_path'."
+				license_stage=""
+			fi
+		elif [ "$license_installed" -eq 1 ]; then
+			if ! rm -f "$license_path" 2>/dev/null; then
+				rollback_failed=1
+				warn "could not remove the new license '$license_path'."
+			fi
+		fi
+		remove_created_alias "$install_dir/stn-ingress" "$created_ingress" "$created_ingress_inode" "$install_stage/stn-ingress.rollback"
+		remove_created_alias "$install_dir/stn-tmux-popup" "$created_popup" "$created_popup_inode" "$install_stage/stn-tmux-popup.rollback"
+		if [ "$activation_failed_precommit" -eq 1 ] && [ "$rollback_failed" -eq 0 ]; then
+			printf 'The existing Station installation was unchanged.\n' >&2
+		fi
+	fi
 
-  remove_tree "$temp_dir"
-  if [ "$preserve_install_stage" -eq 0 ]; then
-    remove_tree "$install_stage"
-  fi
-  remove_tree "$license_stage"
+	remove_tree "$temp_dir"
+	if [ "$preserve_install_stage" -eq 0 ]; then
+		remove_tree "$install_stage"
+	fi
+	remove_tree "$license_stage"
 
-  if [ "$license_lock_owned" -eq 1 ]; then
-    release_lock "$license_lock_dir" "$license_lock_token" "$license_lock_inode"
-  fi
-  if [ "$command_lock_owned" -eq 1 ]; then
-    release_lock "$command_lock_dir" "$command_lock_token" "$command_lock_inode"
-  fi
+	if [ "$license_lock_owned" -eq 1 ]; then
+		release_lock "$license_lock_dir" "$license_lock_token" "$license_lock_inode"
+	fi
+	if [ "$command_lock_owned" -eq 1 ]; then
+		release_lock "$command_lock_dir" "$command_lock_token" "$command_lock_inode"
+	fi
 
-  exit "$status"
+	exit "$status"
 }
 
 on_signal() {
-  signal=$1
-  status=$2
-  if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ]; then
-    if [ "$pending_signal_status" -eq 0 ]; then
-      pending_signal_name=$signal
-      pending_signal_status=$status
-    fi
-    return 0
-  fi
-  printf 'Station install interrupted by %s; cleaning up.\n' "$signal" >&2 || true
-  for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
-    [ -n "$child_pid" ] || continue
-    kill -"$signal" "$child_pid" 2>/dev/null || true
-  done
-  exit "$status"
+	signal=$1
+	status=$2
+	if [ "$lock_acquiring" -eq 1 ] || [ "$child_starting" -eq 1 ]; then
+		if [ "$pending_signal_status" -eq 0 ]; then
+			pending_signal_name=$signal
+			pending_signal_status=$status
+		fi
+		return 0
+	fi
+	printf 'Station install interrupted by %s; cleaning up.\n' "$signal" >&2 || true
+	for child_pid in "$tracked_child_pid" "$watchdog_pid" "$probe_pid"; do
+		[ -n "$child_pid" ] || continue
+		kill -"$signal" "$child_pid" 2>/dev/null || true
+	done
+	exit "$status"
 }
 
 finish_pending_signal() {
-  [ "$pending_signal_status" -eq 0 ] || on_signal "$pending_signal_name" "$pending_signal_status"
+	[ "$pending_signal_status" -eq 0 ] || on_signal "$pending_signal_name" "$pending_signal_status"
 }
 
 run_gh() {
-  gh_output=$1
-  gh_error=$2
-  shift 2
-  child_starting=1
-  gh "$@" > "$gh_output" 2> "$gh_error" &
-  tracked_child_pid=$!
-  child_starting=0
-  finish_pending_signal
-  if wait "$tracked_child_pid"; then
-    tracked_status=0
-  else
-    tracked_status=$?
-  fi
-  tracked_child_pid=""
-  return "$tracked_status"
+	gh_output=$1
+	gh_error=$2
+	shift 2
+	child_starting=1
+	gh "$@" >"$gh_output" 2>"$gh_error" &
+	tracked_child_pid=$!
+	child_starting=0
+	finish_pending_signal
+	if wait "$tracked_child_pid"; then
+		tracked_status=0
+	else
+		tracked_status=$?
+	fi
+	tracked_child_pid=""
+	return "$tracked_status"
+}
+
+run_curl() {
+	curl_output=$1
+	curl_error=$2
+	shift 2
+	child_starting=1
+	curl "$@" >"$curl_output" 2>"$curl_error" &
+	tracked_child_pid=$!
+	child_starting=0
+	finish_pending_signal
+	if wait "$tracked_child_pid"; then
+		tracked_status=0
+	else
+		tracked_status=$?
+	fi
+	tracked_child_pid=""
+	return "$tracked_status"
 }
 
 read_file_value() {
-  value_file=$1
-  if ! file_value=$(
-    cat "$value_file"
-    cat_status=$?
-    printf x
-    exit "$cat_status"
-  ); then
-    return 1
-  fi
-  file_value=${file_value%x}
-  case "$file_value" in
-    *"$line_feed") file_value=${file_value%"$line_feed"} ;;
-  esac
+	value_file=$1
+	if ! file_value=$(
+		cat "$value_file"
+		cat_status=$?
+		printf x
+		exit "$cat_status"
+	); then
+		return 1
+	fi
+	file_value=${file_value%x}
+	case "$file_value" in
+	*"$line_feed") file_value=${file_value%"$line_feed"} ;;
+	esac
 }
 
 acquire_lock() {
-  acquire_path=$1
-  acquire_kind=$2
-  lock_acquiring=1
-  # Ignore signals only across atomic mkdir so cleanup never guesses whether this process owns the lock.
-  if (
-    trap '' HUP INT TERM
-    mkdir "$acquire_path" 2>/dev/null
-  ); then
-    if ! alias_inode "$acquire_path"; then
-      fail "could not identify acquired install lock '$acquire_path'."
-    fi
-    acquire_inode=$alias_inode_result
-    acquire_token=$install_lock_token-$acquire_kind
-    case "$acquire_kind" in
-      command)
-        command_lock_owned=1
-        command_lock_token=$acquire_token
-        command_lock_inode=$acquire_inode
-        ;;
-      license)
-        license_lock_owned=1
-        license_lock_token=$acquire_token
-        license_lock_inode=$acquire_inode
-        ;;
-    esac
-    acquire_owner=$acquire_path/owner-$acquire_token
-    if ! printf 'pid=%s\nrequested=%s\ntoken=%s\n' "$$" "$owner_request" "$acquire_token" > "$acquire_owner"; then
-      fail "could not write install lock owner '$acquire_owner'."
-    fi
-    lock_acquiring=0
-    finish_pending_signal
-    return 0
-  fi
+	acquire_path=$1
+	acquire_kind=$2
+	lock_acquiring=1
+	# Ignore signals only across atomic mkdir so cleanup never guesses whether this process owns the lock.
+	if (
+		trap '' HUP INT TERM
+		mkdir "$acquire_path" 2>/dev/null
+	); then
+		if ! alias_inode "$acquire_path"; then
+			fail "could not identify acquired install lock '$acquire_path'."
+		fi
+		acquire_inode=$alias_inode_result
+		acquire_token=$install_lock_token-$acquire_kind
+		case "$acquire_kind" in
+		command)
+			command_lock_owned=1
+			command_lock_token=$acquire_token
+			command_lock_inode=$acquire_inode
+			;;
+		license)
+			license_lock_owned=1
+			license_lock_token=$acquire_token
+			license_lock_inode=$acquire_inode
+			;;
+		esac
+		acquire_owner=$acquire_path/owner-$acquire_token
+		if ! printf 'pid=%s\nrequested=%s\ntoken=%s\n' "$$" "$owner_request" "$acquire_token" >"$acquire_owner"; then
+			fail "could not write install lock owner '$acquire_owner'."
+		fi
+		lock_acquiring=0
+		finish_pending_signal
+		return 0
+	fi
 
-  lock_acquiring=0
-  finish_pending_signal
-  if [ ! -e "$acquire_path" ] && [ ! -L "$acquire_path" ]; then
-    fail "could not acquire install lock '$acquire_path'; check the destination permissions."
-  fi
-  owner_pid=""
-  owner_file=""
-  owner_file_count=0
-  for owner_candidate in "$acquire_path/owner" "$acquire_path"/owner-*; do
-    if [ ! -e "$owner_candidate" ] && [ ! -L "$owner_candidate" ]; then
-      continue
-    fi
-    owner_file_count=$((owner_file_count + 1))
-    owner_file=$owner_candidate
-  done
-  if [ "$owner_file_count" -eq 1 ] && [ -f "$owner_file" ] && [ ! -L "$owner_file" ] && [ -r "$owner_file" ]; then
-    while IFS='=' read -r owner_key owner_value; do
-      if [ "$owner_key" = pid ]; then
-        case "$owner_value" in
-          ''|*[!0-9]*) ;;
-          *) owner_pid=$owner_value ;;
-        esac
-      fi
-    done < "$owner_file"
-  fi
-  if [ -n "$owner_pid" ]; then
-    fail "another Station installer owns '$acquire_path' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$acquire_path' and retry."
-  fi
-  fail "another Station installer owns '$acquire_path' (owner PID unavailable). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process is alive, then manually remove '$acquire_path' and retry."
+	lock_acquiring=0
+	finish_pending_signal
+	if [ ! -e "$acquire_path" ] && [ ! -L "$acquire_path" ]; then
+		fail "could not acquire install lock '$acquire_path'; check the destination permissions."
+	fi
+	owner_pid=""
+	owner_file=""
+	owner_file_count=0
+	for owner_candidate in "$acquire_path/owner" "$acquire_path"/owner-*; do
+		if [ ! -e "$owner_candidate" ] && [ ! -L "$owner_candidate" ]; then
+			continue
+		fi
+		owner_file_count=$((owner_file_count + 1))
+		owner_file=$owner_candidate
+	done
+	if [ "$owner_file_count" -eq 1 ] && [ -f "$owner_file" ] && [ ! -L "$owner_file" ] && [ -r "$owner_file" ]; then
+		while IFS='=' read -r owner_key owner_value; do
+			if [ "$owner_key" = pid ]; then
+				case "$owner_value" in
+				'' | *[!0-9]*) ;;
+				*) owner_pid=$owner_value ;;
+				esac
+			fi
+		done <"$owner_file"
+	fi
+	if [ -n "$owner_pid" ]; then
+		fail "another Station installer owns '$acquire_path' (owner PID $owner_pid). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process with PID $owner_pid is alive, then manually remove '$acquire_path' and retry."
+	fi
+	fail "another Station installer owns '$acquire_path' (owner PID unavailable). The existing Station installation was unchanged. Wait for it to finish. If it was interrupted, first confirm no installer process is alive, then manually remove '$acquire_path' and retry."
 }
 
 trap cleanup EXIT
@@ -402,106 +422,104 @@ trap 'on_signal INT 130' INT
 trap 'on_signal TERM 143' TERM
 
 absolute_path() {
-  case "$1" in
-    /*) absolute_result=$1 ;;
-    *) absolute_result=$current_dir/$1 ;;
-  esac
+	case "$1" in
+	/*) absolute_result=$1 ;;
+	*) absolute_result=$current_dir/$1 ;;
+	esac
 }
 
 valid_version() {
-  version=$1
-  case "$version" in
-    ''|*[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.+-]*) return 1 ;;
-  esac
-  if ! printf '%s\n' "$version" | LC_ALL=C grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
-    return 1
-  fi
+	version=$1
+	case "$version" in
+	'' | *[!0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz.+-]*) return 1 ;;
+	esac
+	if ! printf '%s\n' "$version" | LC_ALL=C grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'; then
+		return 1
+	fi
 
-  case "$version" in
-    *-*) prerelease=${version#*-} ;;
-    *) return 0 ;;
-  esac
+	case "$version" in
+	*-*) prerelease=${version#*-} ;;
+	*) return 0 ;;
+	esac
 
-  old_ifs=$IFS
-  IFS=.
-  set -- $prerelease
-  IFS=$old_ifs
-  for identifier do
-    case "$identifier" in
-      *[!0-9]*) ;;
-      0) ;;
-      0*) return 1 ;;
-    esac
-  done
+	if printf '%s\n' "$prerelease" | LC_ALL=C grep -Eq '(^|\.)0[0-9]+($|\.)'; then
+		return 1
+	fi
 }
 
 while [ "$#" -gt 0 ]; do
-  case "$1" in
-    --version)
-      [ "$#" -ge 2 ] || fail "--version requires a value."
-      [ "$requested_version_set" -eq 0 ] || fail "--version may be specified only once."
-      requested_version=$2
-      requested_version_set=1
-      shift 2
-      ;;
-    --install-dir)
-      [ "$#" -ge 2 ] || fail "--install-dir requires a path."
-      [ -z "$install_dir" ] || fail "--install-dir may be specified only once."
-      [ -n "$2" ] || fail "--install-dir requires a non-empty path."
-      install_dir=$2
-      shift 2
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      fail "unknown option '$1'; run with --help for usage."
-      ;;
-  esac
+	case "$1" in
+	--version)
+		[ "$#" -ge 2 ] || fail "--version requires a value."
+		[ "$requested_version_set" -eq 0 ] || fail "--version may be specified only once."
+		requested_version=$2
+		requested_version_set=1
+		shift 2
+		;;
+	--install-dir)
+		[ "$#" -ge 2 ] || fail "--install-dir requires a path."
+		[ -z "$install_dir" ] || fail "--install-dir may be specified only once."
+		[ -n "$2" ] || fail "--install-dir requires a non-empty path."
+		install_dir=$2
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		fail "unknown option '$1'; run with --help for usage."
+		;;
+	esac
 done
 
+if [ "$requested_version_set" -eq 0 ]; then
+	requested_version=$embedded_version
+	if [ -n "$requested_version" ]; then
+		requested_version_set=1
+	fi
+fi
 if [ "$requested_version_set" -eq 1 ] && ! valid_version "$requested_version"; then
-  fail "version must be valid v-prefixed SemVer, for example v0.7.0 or v0.7.1-rc.1."
+	fail "version must be valid v-prefixed SemVer, for example v0.7.0 or v0.7.1-rc.1."
 fi
 if [ -n "$release_id" ]; then
-  case "$release_id" in
-    *[!0-9]*) fail "STATION_INSTALL_RELEASE_ID must be a numeric GitHub release ID." ;;
-  esac
-  [ "$requested_version_set" -eq 1 ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
+	case "$release_id" in
+	*[!0-9]*) fail "STATION_INSTALL_RELEASE_ID must be a numeric GitHub release ID." ;;
+	esac
+	[ "$requested_version_set" -eq 1 ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
 fi
 
 if ! raw_current_dir=$(
-  pwd -P
-  pwd_status=$?
-  printf x
-  exit "$pwd_status"
+	pwd -P
+	pwd_status=$?
+	printf x
+	exit "$pwd_status"
 ); then
-  fail "could not resolve the current directory."
+	fail "could not resolve the current directory."
 fi
 raw_current_dir=${raw_current_dir%x}
 case "$raw_current_dir" in
-  *"$line_feed") current_dir=${raw_current_dir%"$line_feed"} ;;
-  *) current_dir=$raw_current_dir ;;
+*"$line_feed") current_dir=${raw_current_dir%"$line_feed"} ;;
+*) current_dir=$raw_current_dir ;;
 esac
 if [ -z "$install_dir" ]; then
-  [ -n "${HOME:-}" ] || fail "HOME is unset; pass --install-dir explicitly."
-  install_dir=$HOME/.local/bin
+	[ -n "${HOME:-}" ] || fail "HOME is unset; pass --install-dir explicitly."
+	install_dir=$HOME/.local/bin
 fi
 absolute_path "$install_dir"
 install_dir=$absolute_result
 # Reject after absolutizing and before external or local mutation because PATH cannot encode a literal colon in one entry.
 case "$install_dir" in
-  *:*) fail "install directory cannot contain ':' because PATH uses ':' to separate entries." ;;
+*:*) fail "install directory cannot contain ':' because PATH uses ':' to separate entries." ;;
 esac
 
 if [ -n "${XDG_DATA_HOME:-}" ]; then
-  absolute_path "$XDG_DATA_HOME"
-  data_home=$absolute_result
+	absolute_path "$XDG_DATA_HOME"
+	data_home=$absolute_result
 else
-  [ -n "${HOME:-}" ] || fail "HOME is unset; set an absolute XDG_DATA_HOME for the Station license."
-  absolute_path "$HOME/.local/share"
-  data_home=$absolute_result
+	[ -n "${HOME:-}" ] || fail "HOME is unset; set an absolute XDG_DATA_HOME for the Station license."
+	absolute_path "$HOME/.local/share"
+	data_home=$absolute_result
 fi
 license_dir=$data_home/station
 license_path=$license_dir/LICENSE
@@ -509,25 +527,31 @@ absolute_path "${TMPDIR:-/tmp}"
 tmp_base=$absolute_result
 
 case "$(uname -s 2>/dev/null || true):$(uname -m 2>/dev/null || true)" in
-  Darwin:arm64|Darwin:aarch64) target=darwin-arm64 ;;
-  Darwin:x86_64|Darwin:amd64) target=darwin-x64 ;;
-  Linux:arm64|Linux:aarch64) target=linux-arm64 ;;
-  Linux:x86_64|Linux:amd64) target=linux-x64 ;;
-  *) fail "unsupported platform; Station binaries support macOS and glibc Linux on arm64 or x64." ;;
+Darwin:arm64 | Darwin:aarch64) target=darwin-arm64 ;;
+Darwin:x86_64 | Darwin:amd64) target=darwin-x64 ;;
+Linux:arm64 | Linux:aarch64) target=linux-arm64 ;;
+Linux:x86_64 | Linux:amd64) target=linux-x64 ;;
+*) fail "unsupported platform; Station binaries support macOS and glibc Linux on arm64 or x64." ;;
 esac
 
-command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
+if [ -n "$release_id" ]; then
+	command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required for draft release acceptance; install 'gh', then run 'gh auth login --hostname github.com'."
+else
+	command -v curl >/dev/null 2>&1 || fail "curl is required to download the public Station release."
+fi
 temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
 install_lock_token=$$-${temp_dir##*/}
-if ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
-  fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
+if [ -n "$release_id" ]; then
+	if ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
+		fail "GitHub authentication is required for draft release acceptance; run 'gh auth login --hostname github.com', then retry."
+	fi
 fi
 
 mkdir -p "$install_dir" || fail "could not create Station install directory '$install_dir'."
 if [ "$requested_version_set" -eq 1 ]; then
-  owner_request=$requested_version
+	owner_request=$requested_version
 else
-  owner_request=latest
+	owner_request=latest
 fi
 command_lock_dir=$install_dir/.station-install.lock
 acquire_lock "$command_lock_dir" command
@@ -535,7 +559,7 @@ acquire_lock "$command_lock_dir" command
 mkdir -p "$license_dir" || fail "could not create Station data directory '$license_dir'."
 license_lock_dir=$license_dir/.station-install.lock
 if [ "$license_lock_dir" != "$command_lock_dir" ] && ! [ "$license_dir" -ef "$install_dir" ]; then
-  acquire_lock "$license_lock_dir" license
+	acquire_lock "$license_lock_dir" license
 fi
 
 binary_path=$install_dir/stn
@@ -543,183 +567,191 @@ ingress_path=$install_dir/stn-ingress
 popup_path=$install_dir/stn-tmux-popup
 
 if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
-  if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
-    fail "existing Station binary '$binary_path' must be a regular non-symlink file."
-  fi
+	if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
+		fail "existing Station binary '$binary_path' must be a regular non-symlink file."
+	fi
 fi
 for launcher_path in "$ingress_path" "$popup_path"; do
-  if [ -e "$launcher_path" ] || [ -L "$launcher_path" ]; then
-    if [ ! -L "$launcher_path" ] || ! readlink_target "$launcher_path" 2>/dev/null || [ "$link_target" != stn ]; then
-      fail "existing launcher '$launcher_path' must be absent or a symlink to 'stn'; it was not changed."
-    fi
-  fi
+	if [ -e "$launcher_path" ] || [ -L "$launcher_path" ]; then
+		if [ ! -L "$launcher_path" ] || ! readlink_target "$launcher_path" 2>/dev/null || [ "$link_target" != stn ]; then
+			fail "existing launcher '$launcher_path' must be absent or a symlink to 'stn'; it was not changed."
+		fi
+	fi
 done
 if [ -e "$license_path" ] || [ -L "$license_path" ]; then
-  if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
-    fail "existing Station license '$license_path' must be a regular non-symlink file."
-  fi
+	if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
+		fail "existing Station license '$license_path' must be a regular non-symlink file."
+	fi
 fi
 
 require_single_numeric_id() {
-  case "$1" in
-    ''|*[!0-9]*) fail "$2" ;;
-  esac
+	case "$1" in
+	'' | *[!0-9]*) fail "$2" ;;
+	esac
 }
 
 read_numeric_result() {
-  numeric_file=$1
-  numeric_error=$2
-  if ! read_file_value "$numeric_file"; then
-    fail "could not read the GitHub CLI response from '$numeric_file'."
-  fi
-  require_single_numeric_id "$file_value" "$numeric_error"
-  numeric_result=$file_value
+	numeric_file=$1
+	numeric_error=$2
+	if ! read_file_value "$numeric_file"; then
+		fail "could not read the GitHub CLI response from '$numeric_file'."
+	fi
+	require_single_numeric_id "$file_value" "$numeric_error"
+	numeric_result=$file_value
 }
 
 if [ -n "$release_id" ]; then
-  tag=$requested_version
-  version=${tag#v}
-  archive_name="stn-v${version}-${target}.tar.gz"
-  # Draft release lists can lag creation, so acceptance addresses the captured release ID directly.
-  draft_endpoint="repos/$repository/releases/$release_id"
-  draft_match="select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
-  if ! run_gh "$temp_dir/draft-release.stdout" "$temp_dir/draft-release.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$draft_match | .id"; then
-    fail "could not read draft release $release_id; check your authentication and repository access."
-  fi
-  read_numeric_result "$temp_dir/draft-release.stdout" "no single draft matched ID $release_id and requested version '$tag'."
+	tag=$requested_version
+	version=${tag#v}
+	archive_name="stn-v${version}-${target}.tar.gz"
+	# Draft release lists can lag creation, so acceptance addresses the captured release ID directly.
+	draft_endpoint="repos/$repository/releases/$release_id"
+	draft_match="select(.draft == true and .id == $release_id and .tag_name == \"$tag\")"
+	if ! run_gh "$temp_dir/draft-release.stdout" "$temp_dir/draft-release.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$draft_match | .id"; then
+		fail "could not read draft release $release_id; check your authentication and repository access."
+	fi
+	read_numeric_result "$temp_dir/draft-release.stdout" "no single draft matched ID $release_id and requested version '$tag'."
 
-  lookup_draft_asset() {
-    asset_name=$1
-    asset_slug=$2
-    filter="$draft_match | .assets[] | select(.name == \"$asset_name\") | .id"
-    if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$filter"; then
-      fail "could not read assets for draft release $tag."
-    fi
-    read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
-    asset_result=$numeric_result
-  }
+	lookup_draft_asset() {
+		asset_name=$1
+		asset_slug=$2
+		filter="$draft_match | .assets[] | select(.name == \"$asset_name\") | .id"
+		if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api -H "X-GitHub-Api-Version: 2022-11-28" "$draft_endpoint" --jq "$filter"; then
+			fail "could not read assets for draft release $tag."
+		fi
+		read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
+		asset_result=$numeric_result
+	}
 
-  lookup_draft_asset "$archive_name" draft-archive
-  archive_id=$asset_result
-  lookup_draft_asset SHA256SUMS draft-checksums
-  checksums_id=$asset_result
+	lookup_draft_asset "$archive_name" draft-archive
+	archive_id=$asset_result
+	lookup_draft_asset SHA256SUMS draft-checksums
+	checksums_id=$asset_result
 elif [ "$requested_version_set" -eq 1 ]; then
-  tag=$requested_version
-  release_endpoint="repos/$repository/releases/tags/$tag"
+	tag=$requested_version
 else
-  if ! run_gh "$temp_dir/latest.stdout" "$temp_dir/latest.stderr" api "repos/$repository/releases/latest" --jq '.tag_name'; then
-    fail "could not resolve the latest stable Station release; check 'gh auth status' and repository access."
-  fi
-  if ! read_file_value "$temp_dir/latest.stdout"; then
-    fail "could not read the latest stable Station release tag."
-  fi
-  tag=$file_value
-  if ! valid_version "$tag"; then
-    fail "the latest Station release returned an invalid tag."
-  fi
-  release_endpoint="repos/$repository/releases/tags/$tag"
+	if ! run_curl "$temp_dir/latest.stdout" "$temp_dir/latest.stderr" \
+		--fail --silent --show-error --location \
+		--proto '=https' --proto-redir '=https' --tlsv1.2 \
+		--output /dev/null --write-out '%{url_effective}' \
+		"https://github.com/$repository/releases/latest"; then
+		fail "could not resolve the latest stable Station release."
+	fi
+	if ! read_file_value "$temp_dir/latest.stdout"; then
+		fail "could not read the latest stable Station release URL."
+	fi
+	latest_prefix="https://github.com/$repository/releases/tag/"
+	case "$file_value" in
+	"$latest_prefix"*) tag=${file_value#"$latest_prefix"} ;;
+	*) fail "the latest Station release resolved to an unexpected URL." ;;
+	esac
+	if ! valid_version "$tag"; then
+		fail "the latest Station release returned an invalid tag."
+	fi
+	case "$tag" in
+	*-*) fail "the latest Station release unexpectedly resolved to a prerelease." ;;
+	esac
 fi
 
 if [ -z "$release_id" ]; then
-  version=${tag#v}
-  archive_name="stn-v${version}-${target}.tar.gz"
-fi
-
-lookup_asset() {
-  asset_name=$1
-  asset_slug=$2
-  if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api "$release_endpoint" --jq ".assets[] | select(.name == \"$asset_name\") | .id"; then
-    fail "could not read release $tag; check that the release exists and your account can access it."
-  fi
-  read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
-  asset_result=$numeric_result
-}
-
-if [ -z "$release_id" ]; then
-  lookup_asset "$archive_name" release-archive
-  archive_id=$asset_result
-  lookup_asset SHA256SUMS release-checksums
-  checksums_id=$asset_result
+	version=${tag#v}
+	archive_name="stn-v${version}-${target}.tar.gz"
 fi
 archive_path=$temp_dir/$archive_name
 checksums_path=$temp_dir/SHA256SUMS
 
-if ! run_gh "$archive_path" "$temp_dir/archive-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id"; then
-  fail "could not download $archive_name from release $tag."
-fi
-if ! run_gh "$checksums_path" "$temp_dir/checksums-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id"; then
-  fail "could not download SHA256SUMS from release $tag."
+if [ -n "$release_id" ]; then
+	if ! run_gh "$archive_path" "$temp_dir/archive-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id"; then
+		fail "could not download $archive_name from draft release $tag."
+	fi
+	if ! run_gh "$checksums_path" "$temp_dir/checksums-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id"; then
+		fail "could not download SHA256SUMS from draft release $tag."
+	fi
+else
+	release_url="https://github.com/$repository/releases/download/$tag"
+	if ! run_curl "$archive_path" "$temp_dir/archive-download.stderr" \
+		--fail --silent --show-error --location \
+		--proto '=https' --proto-redir '=https' --tlsv1.2 \
+		"$release_url/$archive_name"; then
+		fail "could not download $archive_name from public release $tag."
+	fi
+	if ! run_curl "$checksums_path" "$temp_dir/checksums-download.stderr" \
+		--fail --silent --show-error --location \
+		--proto '=https' --proto-redir '=https' --tlsv1.2 \
+		"$release_url/SHA256SUMS"; then
+		fail "could not download SHA256SUMS from public release $tag."
+	fi
 fi
 
 expected_hashes=$(awk -v name="$archive_name" '$2 == name || $2 == "*" name { print $1 }' "$checksums_path")
 case "$expected_hashes" in
-  ''|*'
+'' | *'
 '*) fail "SHA256SUMS must contain exactly one checksum for $archive_name." ;;
 esac
 if ! printf '%s\n' "$expected_hashes" | grep -Eq '^[0-9A-Fa-f]{64}$'; then
-  fail "SHA256SUMS contains an invalid checksum for $archive_name."
+	fail "SHA256SUMS contains an invalid checksum for $archive_name."
 fi
 
 if command -v sha256sum >/dev/null 2>&1; then
-  if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | sha256sum -c - >/dev/null 2>&1); then
-    fail "checksum verification failed for $archive_name; the existing installation was not changed."
-  fi
+	if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | sha256sum -c - >/dev/null 2>&1); then
+		fail "checksum verification failed for $archive_name; the existing installation was not changed."
+	fi
 elif command -v shasum >/dev/null 2>&1; then
-  if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | shasum -a 256 -c - >/dev/null 2>&1); then
-    fail "checksum verification failed for $archive_name; the existing installation was not changed."
-  fi
+	if ! (cd "$temp_dir" && printf '%s  %s\n' "$expected_hashes" "$archive_name" | shasum -a 256 -c - >/dev/null 2>&1); then
+		fail "checksum verification failed for $archive_name; the existing installation was not changed."
+	fi
 else
-  fail "sha256sum or shasum is required to verify the release archive."
+	fail "sha256sum or shasum is required to verify the release archive."
 fi
 
 manifest_path=$temp_dir/manifest
-if ! tar -tzf "$archive_path" > "$manifest_path"; then
-  fail "$archive_name is not a readable gzip-compressed tar archive."
+if ! tar -tzf "$archive_path" >"$manifest_path"; then
+	fail "$archive_name is not a readable gzip-compressed tar archive."
 fi
 actual_manifest=$(LC_ALL=C sort "$manifest_path")
 expected_manifest=$(printf '%s\n' LICENSE stn stn-ingress stn-tmux-popup | LC_ALL=C sort)
 if [ "$actual_manifest" != "$expected_manifest" ]; then
-  fail "$archive_name does not contain the exact Station release manifest; nothing was installed."
+	fail "$archive_name does not contain the exact Station release manifest; nothing was installed."
 fi
 verbose_manifest_path=$temp_dir/manifest.verbose
 manifest_types_path=$temp_dir/manifest.types
-if ! tar -tvzf "$archive_path" > "$verbose_manifest_path"; then
-  fail "$archive_name does not expose readable Station member types."
+if ! tar -tvzf "$archive_path" >"$verbose_manifest_path"; then
+	fail "$archive_name does not expose readable Station member types."
 fi
-awk '{ print substr($1, 1, 1) }' "$verbose_manifest_path" > "$manifest_types_path"
+awk '{ print substr($1, 1, 1) }' "$verbose_manifest_path" >"$manifest_types_path"
 actual_typed_manifest=$(LC_ALL=C paste "$manifest_path" "$manifest_types_path" | LC_ALL=C sort)
 expected_typed_manifest=$(printf 'LICENSE\t-\nstn\t-\nstn-ingress\tl\nstn-tmux-popup\tl\n' | LC_ALL=C sort)
 if [ "$actual_typed_manifest" != "$expected_typed_manifest" ]; then
-  fail "$archive_name does not contain the required Station member types; nothing was installed."
+	fail "$archive_name does not contain the required Station member types; nothing was installed."
 fi
 
 extracted_dir=$temp_dir/extracted
 mkdir "$extracted_dir"
 # Extract only the approved names so an archive cannot write outside the staging directory.
 if ! tar -xzf "$archive_path" -C "$extracted_dir" stn stn-ingress stn-tmux-popup LICENSE; then
-  fail "could not extract the verified Station release archive."
+	fail "could not extract the verified Station release archive."
 fi
 if [ ! -f "$extracted_dir/stn" ] || [ -L "$extracted_dir/stn" ]; then
-  fail "the Station release manifest must contain a regular 'stn' binary."
+	fail "the Station release manifest must contain a regular 'stn' binary."
 fi
 if [ ! -f "$extracted_dir/LICENSE" ] || [ -L "$extracted_dir/LICENSE" ]; then
-  fail "the Station release manifest must contain a regular 'LICENSE' file."
+	fail "the Station release manifest must contain a regular 'LICENSE' file."
 fi
 for launcher in stn-ingress stn-tmux-popup; do
-  if [ ! -L "$extracted_dir/$launcher" ] || ! readlink_target "$extracted_dir/$launcher" || [ "$link_target" != stn ]; then
-    fail "the Station release manifest must contain '$launcher' as a symlink to 'stn'."
-  fi
+	if [ ! -L "$extracted_dir/$launcher" ] || ! readlink_target "$extracted_dir/$launcher" || [ "$link_target" != stn ]; then
+		fail "the Station release manifest must contain '$launcher' as a symlink to 'stn'."
+	fi
 done
 
 # Stage on each destination filesystem so every final rename is atomic.
 install_stage=$(mktemp -d "$install_dir/.station-install.XXXXXX") || fail "cannot stage files in $install_dir."
 license_stage=$(mktemp -d "$license_dir/.station-install.XXXXXX") || fail "cannot stage the license in $license_dir."
 if ! cp "$extracted_dir/stn" "$install_stage/stn"; then
-  fail "could not stage the Station binary in $install_dir."
+	fail "could not stage the Station binary in $install_dir."
 fi
 chmod 0755 "$install_stage/stn" || fail "could not set executable permissions on the staged Station binary."
 if { [ "$target" = darwin-arm64 ] || [ "$target" = darwin-x64 ]; } && command -v xattr >/dev/null 2>&1; then
-  xattr -d com.apple.quarantine "$install_stage/stn" 2>/dev/null || true
+	xattr -d com.apple.quarantine "$install_stage/stn" 2>/dev/null || true
 fi
 
 probe_output=$temp_dir/probe.stdout
@@ -728,239 +760,239 @@ watchdog_ready=$temp_dir/watchdog.ready
 watchdog_failed=$temp_dir/watchdog.failed
 child_starting=1
 (
-  if ! ulimit -f 8; then
-    exit 125
-  fi
-  # The untrusted compatibility probe must not inherit download or CI credentials.
-  unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
-  unset ACTIONS_RUNTIME_TOKEN ACTIONS_ID_TOKEN_REQUEST_TOKEN STATION_INSTALL_RELEASE_ID
-  exec "$install_stage/stn" --version
-) > "$probe_output" 2> "$probe_error" &
+	if ! ulimit -f 8; then
+		exit 125
+	fi
+	# The untrusted compatibility probe must not inherit download or CI credentials.
+	unset GH_TOKEN GITHUB_TOKEN GH_ENTERPRISE_TOKEN GITHUB_ENTERPRISE_TOKEN
+	unset ACTIONS_RUNTIME_TOKEN ACTIONS_ID_TOKEN_REQUEST_TOKEN STATION_INSTALL_RELEASE_ID
+	exec "$install_stage/stn" --version
+) >"$probe_output" 2>"$probe_error" &
 probe_pid=$!
 child_starting=0
 finish_pending_signal
 child_starting=1
 (
-  watchdog_timer=""
-  watchdog_result=0
+	watchdog_timer=""
+	watchdog_result=0
 
-  stop_watchdog() {
-    if [ -n "$watchdog_timer" ]; then
-      kill -TERM "$watchdog_timer" 2>/dev/null || true
-      kill -KILL "$watchdog_timer" 2>/dev/null || true
-      wait "$watchdog_timer" 2>/dev/null || true
-    fi
-    exit "$watchdog_result"
-  }
+	stop_watchdog() {
+		if [ -n "$watchdog_timer" ]; then
+			kill -TERM "$watchdog_timer" 2>/dev/null || true
+			kill -KILL "$watchdog_timer" 2>/dev/null || true
+			wait "$watchdog_timer" 2>/dev/null || true
+		fi
+		exit "$watchdog_result"
+	}
 
-  stop_probe() {
-    watchdog_result=$1
-    kill -TERM "$probe_pid" 2>/dev/null || true
-    if ! sleep 1; then
-      watchdog_result=125
-      kill -KILL "$probe_pid" 2>/dev/null || true
-      exit "$watchdog_result"
-    fi
-    kill -KILL "$probe_pid" 2>/dev/null || true
-    exit "$watchdog_result"
-  }
+	stop_probe() {
+		watchdog_result=$1
+		kill -TERM "$probe_pid" 2>/dev/null || true
+		if ! sleep 1; then
+			watchdog_result=125
+			kill -KILL "$probe_pid" 2>/dev/null || true
+			exit "$watchdog_result"
+		fi
+		kill -KILL "$probe_pid" 2>/dev/null || true
+		exit "$watchdog_result"
+	}
 
-  report_watchdog_setup_failure() {
-    [ -e "$watchdog_ready" ] || : > "$watchdog_failed"
-  }
-  trap report_watchdog_setup_failure EXIT
-  trap '' HUP INT TERM
+	report_watchdog_setup_failure() {
+		[ -e "$watchdog_ready" ] || : >"$watchdog_failed"
+	}
+	trap report_watchdog_setup_failure EXIT
+	trap '' HUP INT TERM
 
-  sleep 10 &
-  watchdog_timer=$!
-  trap stop_watchdog HUP INT TERM
-  if ! : > "$watchdog_ready"; then
-    watchdog_result=125
-    stop_watchdog
-  fi
-  trap - EXIT
-  if wait "$watchdog_timer"; then
-    watchdog_timer=""
-    if kill -0 "$probe_pid" 2>/dev/null; then
-      stop_probe 124
-    fi
-    exit 0
-  else
-    timer_status=$?
-    watchdog_result=125
-  fi
-  watchdog_timer=""
+	sleep 10 &
+	watchdog_timer=$!
+	trap stop_watchdog HUP INT TERM
+	if ! : >"$watchdog_ready"; then
+		watchdog_result=125
+		stop_watchdog
+	fi
+	trap - EXIT
+	if wait "$watchdog_timer"; then
+		watchdog_timer=""
+		if kill -0 "$probe_pid" 2>/dev/null; then
+			stop_probe 124
+		fi
+		exit 0
+	else
+		timer_status=$?
+		watchdog_result=125
+	fi
+	watchdog_timer=""
 
-  if kill -0 "$probe_pid" 2>/dev/null; then
-    stop_probe 125
-  fi
-  [ "$timer_status" -eq 0 ] || exit 125
-  exit 0
+	if kill -0 "$probe_pid" 2>/dev/null; then
+		stop_probe 125
+	fi
+	[ "$timer_status" -eq 0 ] || exit 125
+	exit 0
 ) &
 watchdog_pid=$!
 # Do not cancel a fast probe's watchdog until its timer and cleanup trap are coherent.
 while [ ! -e "$watchdog_ready" ] && [ ! -e "$watchdog_failed" ] && [ "$pending_signal_status" -eq 0 ]; do
-  sleep 0.01 2>/dev/null || true
+	sleep 0.01 2>/dev/null || true
 done
 child_starting=0
 finish_pending_signal
 if [ ! -e "$watchdog_ready" ]; then
-  wait "$watchdog_pid" 2>/dev/null || true
-  watchdog_pid=""
-  fail "the compatibility probe supervisor failed; the existing Station installation was unchanged."
+	wait "$watchdog_pid" 2>/dev/null || true
+	watchdog_pid=""
+	fail "the compatibility probe supervisor failed; the existing Station installation was unchanged."
 fi
 
 probe_status=0
 if wait "$probe_pid"; then
-  probe_status=0
+	probe_status=0
 else
-  probe_status=$?
+	probe_status=$?
 fi
 probe_pid=""
 kill -TERM "$watchdog_pid" 2>/dev/null || true
 if wait "$watchdog_pid"; then
-  watchdog_status=0
+	watchdog_status=0
 else
-  watchdog_status=$?
+	watchdog_status=$?
 fi
 watchdog_pid=""
 
 print_probe_diagnostics() {
-  [ -s "$probe_error" ] || return 0
-  printf 'Compatibility probe stderr (up to 4096 sanitized bytes):\n' >&2
-  dd if="$probe_error" bs=4096 count=1 2>/dev/null | LC_ALL=C tr -cd "[:print:]$tab$line_feed" >&2
-  printf '\n' >&2
+	[ -s "$probe_error" ] || return 0
+	printf 'Compatibility probe stderr (up to 4096 sanitized bytes):\n' >&2
+	dd if="$probe_error" bs=4096 count=1 2>/dev/null | LC_ALL=C tr -cd "[:print:]$tab$line_feed" >&2
+	printf '\n' >&2
 }
 
 if [ "$watchdog_status" -eq 124 ]; then
-  print_probe_diagnostics
-  fail "the verified Station binary did not respond to '--version' within 10 seconds; the existing Station installation was unchanged."
+	print_probe_diagnostics
+	fail "the verified Station binary did not respond to '--version' within 10 seconds; the existing Station installation was unchanged."
 fi
 if [ "$watchdog_status" -eq 125 ]; then
-  print_probe_diagnostics
-  fail "the compatibility probe timer failed; the existing Station installation was unchanged."
+	print_probe_diagnostics
+	fail "the compatibility probe timer failed; the existing Station installation was unchanged."
 fi
 if [ "$watchdog_status" -ne 0 ]; then
-  print_probe_diagnostics
-  fail "the compatibility probe supervisor failed; the existing Station installation was unchanged."
+	print_probe_diagnostics
+	fail "the compatibility probe supervisor failed; the existing Station installation was unchanged."
 fi
 if [ "$probe_status" -ne 0 ]; then
-  print_probe_diagnostics
-  fail "the verified Station binary cannot run on this system; the existing installation was not changed."
+	print_probe_diagnostics
+	fail "the verified Station binary cannot run on this system; the existing installation was not changed."
 fi
 if ! probed_version=$(cat "$probe_output"); then
-  fail "could not read the verified Station binary version; the existing installation was not changed."
+	fail "could not read the verified Station binary version; the existing installation was not changed."
 fi
 if [ "$probed_version" != "$version" ]; then
-  fail "the verified Station binary reports an unexpected version; expected '$version'. The existing installation was not changed."
+	fail "the verified Station binary reports an unexpected version; expected '$version'. The existing installation was not changed."
 fi
 
 create_alias() {
-  alias_path=$1
-  alias_kind=$2
-  alias_name=${alias_path##*/}
-  alias_source_dir=$install_stage/$alias_kind.alias-source
-  alias_source=$alias_source_dir/$alias_name
-  alias_owner=$install_stage/$alias_kind.alias-inode
-  child_starting=1
-  # Publish the recorded symlink inode atomically so cleanup never adopts an external replacement.
-  if (
-    trap '' HUP INT TERM
-    mkdir "$alias_source_dir" || exit
-    ln -s stn "$alias_source" || exit
-    alias_inode "$alias_source" || exit
-    printf '%s\n' "$alias_inode_result" > "$alias_owner" || exit
-    alias_status=0
-    ln -P "$alias_source" "$install_dir" || alias_status=$?
-    rm -rf "$alias_source_dir"
-    exit "$alias_status"
-  ); then
-    if ! read_file_value "$alias_owner"; then
-      child_starting=0
-      finish_pending_signal
-      fail "created Station launcher '$alias_path' but could not read its ownership record; inspect it manually."
-    fi
-    case "$file_value" in
-      ''|*[!0-9]*)
-        child_starting=0
-        finish_pending_signal
-        fail "created Station launcher '$alias_path' with an invalid ownership record; inspect it manually."
-        ;;
-    esac
-    case "$alias_kind" in
-      ingress)
-        created_ingress=1
-        created_ingress_inode=$file_value
-        ;;
-      popup)
-        created_popup=1
-        created_popup_inode=$file_value
-        ;;
-    esac
-    child_starting=0
-    finish_pending_signal
-    return 0
-  fi
-  child_starting=0
-  finish_pending_signal
-  fail "could not create Station launcher '$alias_path'."
+	alias_path=$1
+	alias_kind=$2
+	alias_name=${alias_path##*/}
+	alias_source_dir=$install_stage/$alias_kind.alias-source
+	alias_source=$alias_source_dir/$alias_name
+	alias_owner=$install_stage/$alias_kind.alias-inode
+	child_starting=1
+	# Publish the recorded symlink inode atomically so cleanup never adopts an external replacement.
+	if (
+		trap '' HUP INT TERM
+		mkdir "$alias_source_dir" || exit
+		ln -s stn "$alias_source" || exit
+		alias_inode "$alias_source" || exit
+		printf '%s\n' "$alias_inode_result" >"$alias_owner" || exit
+		alias_status=0
+		ln -P "$alias_source" "$install_dir" || alias_status=$?
+		rm -rf "$alias_source_dir"
+		exit "$alias_status"
+	); then
+		if ! read_file_value "$alias_owner"; then
+			child_starting=0
+			finish_pending_signal
+			fail "created Station launcher '$alias_path' but could not read its ownership record; inspect it manually."
+		fi
+		case "$file_value" in
+		'' | *[!0-9]*)
+			child_starting=0
+			finish_pending_signal
+			fail "created Station launcher '$alias_path' with an invalid ownership record; inspect it manually."
+			;;
+		esac
+		case "$alias_kind" in
+		ingress)
+			created_ingress=1
+			created_ingress_inode=$file_value
+			;;
+		popup)
+			created_popup=1
+			created_popup_inode=$file_value
+			;;
+		esac
+		child_starting=0
+		finish_pending_signal
+		return 0
+	fi
+	child_starting=0
+	finish_pending_signal
+	fail "could not create Station launcher '$alias_path'."
 }
 
 if [ ! -L "$ingress_path" ]; then
-  create_alias "$ingress_path" ingress
+	create_alias "$ingress_path" ingress
 fi
 if [ ! -L "$popup_path" ]; then
-  create_alias "$popup_path" popup
+	create_alias "$popup_path" popup
 fi
 
 revalidate_managed_paths() {
-  if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
-    if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
-      fail "Station binary destination '$binary_path' changed during installation; it must remain absent or a regular non-symlink file."
-    fi
-  fi
-  for managed_launcher in "$ingress_path" "$popup_path"; do
-    if [ ! -L "$managed_launcher" ] || ! readlink_target "$managed_launcher" 2>/dev/null || [ "$link_target" != stn ]; then
-      fail "Station launcher '$managed_launcher' changed during installation; it must remain a symlink exactly targeting 'stn'."
-    fi
-  done
-  if [ -e "$license_path" ] || [ -L "$license_path" ]; then
-    if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
-      fail "Station license destination '$license_path' changed during installation; it must remain absent or a regular non-symlink file."
-    fi
-  fi
+	if [ -e "$binary_path" ] || [ -L "$binary_path" ]; then
+		if [ ! -f "$binary_path" ] || [ -L "$binary_path" ]; then
+			fail "Station binary destination '$binary_path' changed during installation; it must remain absent or a regular non-symlink file."
+		fi
+	fi
+	for managed_launcher in "$ingress_path" "$popup_path"; do
+		if [ ! -L "$managed_launcher" ] || ! readlink_target "$managed_launcher" 2>/dev/null || [ "$link_target" != stn ]; then
+			fail "Station launcher '$managed_launcher' changed during installation; it must remain a symlink exactly targeting 'stn'."
+		fi
+	done
+	if [ -e "$license_path" ] || [ -L "$license_path" ]; then
+		if [ ! -f "$license_path" ] || [ -L "$license_path" ]; then
+			fail "Station license destination '$license_path' changed during installation; it must remain absent or a regular non-symlink file."
+		fi
+	fi
 }
 
 new_license=$license_stage/LICENSE.new
 if ! cp "$extracted_dir/LICENSE" "$new_license"; then
-  fail "could not stage the Station license in $license_dir."
+	fail "could not stage the Station license in $license_dir."
 fi
 chmod 0644 "$new_license" || fail "could not set permissions on the staged Station license."
 revalidate_managed_paths
 if [ -e "$license_path" ] || [ -L "$license_path" ]; then
-  license_backup=$license_stage/LICENSE.previous
-  if ! mv "$license_path" "$license_backup"; then
-    fail "could not back up the existing Station license '$license_path'."
-  fi
-  license_displaced=1
+	license_backup=$license_stage/LICENSE.previous
+	if ! mv "$license_path" "$license_backup"; then
+		fail "could not back up the existing Station license '$license_path'."
+	fi
+	license_displaced=1
 fi
 license_installed=1
 if ! mv "$new_license" "$license_path"; then
-  fail "could not install the Station license '$license_path'."
+	fail "could not install the Station license '$license_path'."
 fi
 
 # Renaming the verified binary is the sole runtime commit point; aliases already resolve through stn.
 revalidate_managed_paths
 commit_started=1
 if mv -f "$install_stage/stn" "$binary_path"; then
-  runtime_committed=1
+	runtime_committed=1
 elif [ -e "$install_stage/stn" ] || [ -L "$install_stage/stn" ]; then
-  activation_failed_precommit=1
-  fail "could not activate the verified Station binary; restoring the previous installation."
+	activation_failed_precommit=1
+	fail "could not activate the verified Station binary; restoring the previous installation."
 else
-  runtime_committed=1
-  report_activation_ambiguity
-  exit 1
+	runtime_committed=1
+	report_activation_ambiguity
+	exit 1
 fi
 
 set +e
@@ -970,32 +1002,32 @@ printf '\n'
 
 path_mismatch=0
 check_launcher_resolution() {
-  launcher_name=$1
-  expected_launcher=$2
-  if ! raw_resolved=$(
-    command -v "$launcher_name" 2>/dev/null
-    resolve_status=$?
-    printf x
-    exit "$resolve_status"
-  ); then
-    printf 'PATH mismatch: %s is not available in the current shell.\n' "$launcher_name"
-    path_mismatch=1
-    return 0
-  fi
-  raw_resolved=${raw_resolved%x}
-  case "$raw_resolved" in
-    *"$line_feed") resolved_launcher=${raw_resolved%"$line_feed"} ;;
-    *) resolved_launcher=$raw_resolved ;;
-  esac
-  if { [ -e "$resolved_launcher" ] || [ -L "$resolved_launcher" ]; } && [ "$resolved_launcher" -ef "$expected_launcher" ]; then
-    return 0
-  fi
-  printf 'PATH mismatch: %s resolves to ' "$launcher_name"
-  print_shell_word "$resolved_launcher"
-  printf ', not the newly installed launcher '
-  print_shell_word "$expected_launcher"
-  printf '.\n'
-  path_mismatch=1
+	launcher_name=$1
+	expected_launcher=$2
+	if ! raw_resolved=$(
+		command -v "$launcher_name" 2>/dev/null
+		resolve_status=$?
+		printf x
+		exit "$resolve_status"
+	); then
+		printf 'PATH mismatch: %s is not available in the current shell.\n' "$launcher_name"
+		path_mismatch=1
+		return 0
+	fi
+	raw_resolved=${raw_resolved%x}
+	case "$raw_resolved" in
+	*"$line_feed") resolved_launcher=${raw_resolved%"$line_feed"} ;;
+	*) resolved_launcher=$raw_resolved ;;
+	esac
+	if { [ -e "$resolved_launcher" ] || [ -L "$resolved_launcher" ]; } && [ "$resolved_launcher" -ef "$expected_launcher" ]; then
+		return 0
+	fi
+	printf 'PATH mismatch: %s resolves to ' "$launcher_name"
+	print_shell_word "$resolved_launcher"
+	printf ', not the newly installed launcher '
+	print_shell_word "$expected_launcher"
+	printf '.\n'
+	path_mismatch=1
 }
 
 check_launcher_resolution stn "$binary_path"
@@ -1003,20 +1035,20 @@ check_launcher_resolution stn-ingress "$ingress_path"
 check_launcher_resolution stn-tmux-popup "$popup_path"
 
 if [ "$path_mismatch" -eq 0 ]; then
-  printf 'Next: run stn setup\n'
+	printf 'Next: run stn setup\n'
 else
-  printf 'To use Station in future shells, add this command to your chosen shell configuration:\n'
-  printf '  export PATH='
-  print_shell_word "$install_dir"
-  printf '${PATH:+":$PATH"}\n\n'
-  printf 'Run this block in the current shell, then continue setup:\n'
-  printf '  PATH='
-  print_shell_word "$install_dir"
-  printf '${PATH:+":$PATH"}\n'
-  printf '  export PATH\n'
-  printf '  hash -r\n'
-  printf '  stn setup\n'
-  printf 'Absolute fallback: '
-  print_shell_word "$binary_path"
-  printf ' setup\n'
+	printf 'To use Station in future shells, add this command to your chosen shell configuration:\n'
+	printf '  export PATH='
+	print_shell_word "$install_dir"
+	printf '${PATH:+":$PATH"}\n\n'
+	printf 'Run this block in the current shell, then continue setup:\n'
+	printf '  PATH='
+	print_shell_word "$install_dir"
+	printf '${PATH:+":$PATH"}\n'
+	printf '  export PATH\n'
+	printf '  hash -r\n'
+	printf '  stn setup\n'
+	printf 'Absolute fallback: '
+	print_shell_word "$binary_path"
+	printf ' setup\n'
 fi

--- a/scripts/release/render-homebrew-formula.mjs
+++ b/scripts/release/render-homebrew-formula.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+function fail(message) {
+  throw new Error(`Homebrew formula render failed: ${message}`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    if (!name?.startsWith("--")) fail(`unknown argument '${name ?? ""}'.`);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) fail(`${name} requires a value.`);
+    if (name in options) fail(`${name} may be specified only once.`);
+    options[name] = value;
+    index += 1;
+  }
+
+  const allowed = new Set(["--output", "--revision", "--tag", "--template"]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) fail(`unknown option '${name}'.`);
+  }
+  for (const name of allowed) {
+    if (options[name] === undefined) fail(`${name} is required.`);
+  }
+  return options;
+}
+
+function replaceExactlyOnce(source, pattern, replacement, label) {
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) {
+    fail(`expected exactly one ${label} field in the formula template; found ${matches.length}.`);
+  }
+  return source.replace(pattern, replacement);
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const tag = options["--tag"];
+  const revision = options["--revision"];
+  if (
+    !/^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u.test(
+      tag,
+    )
+  ) {
+    fail(`tag must be v-prefixed SemVer without build metadata: '${tag}'.`);
+  }
+  if (!/^[0-9a-f]{40}$/u.test(revision)) {
+    fail(`revision must be a full lowercase 40-character Git commit: '${revision}'.`);
+  }
+
+  const templatePath = resolve(options["--template"]);
+  const outputPath = resolve(options["--output"]);
+  let formula = await readFile(templatePath, "utf8");
+  formula = replaceExactlyOnce(
+    formula,
+    /^(\s*)tag:\s+"[^"]+",$/gmu,
+    `$1tag:      "${tag}",`,
+    "tag",
+  );
+  formula = replaceExactlyOnce(
+    formula,
+    /^(\s*)revision:\s+"[0-9a-f]+"$/gmu,
+    `$1revision: "${revision}"`,
+    "revision",
+  );
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, formula, { mode: 0o644 });
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/release/render-release-installer.mjs
+++ b/scripts/release/render-release-installer.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+import { chmod, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+function fail(message) {
+  throw new Error(`Release installer render failed: ${message}`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith("--")) fail(`unknown argument '${name ?? ""}'.`);
+    if (value === undefined || value.startsWith("--")) fail(`${name} requires a value.`);
+    if (name in options) fail(`${name} may be specified only once.`);
+    options[name] = value;
+    index += 1;
+  }
+
+  const allowed = new Set(["--output", "--source", "--version"]);
+  for (const name of Object.keys(options)) {
+    if (!allowed.has(name)) fail(`unknown option '${name}'.`);
+  }
+  for (const name of allowed) {
+    if (options[name] === undefined) fail(`${name} is required.`);
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const version = options["--version"];
+  if (
+    !/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/u.test(
+      version,
+    )
+  ) {
+    fail(`version must be SemVer without build metadata: '${version}'.`);
+  }
+
+  const sourcePath = resolve(options["--source"]);
+  const outputPath = resolve(options["--output"]);
+  const source = await readFile(sourcePath, "utf8");
+  const marker = 'embedded_version=""';
+  const occurrences = source.split(marker).length - 1;
+  if (occurrences !== 1) {
+    fail(`expected exactly one embedded-version marker; found ${occurrences}.`);
+  }
+  const rendered = source.replace(marker, `embedded_version="v${version}"`);
+
+  await mkdir(dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, rendered, { mode: 0o755 });
+  await chmod(outputPath, 0o755);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -32,12 +32,14 @@ if (!/^(?:[1-9]|10)$/.test(timeoutScaleText)) {
 }
 const timeoutScale = Number(timeoutScaleText);
 const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
+const stampedInstaller = join(root, "stamped-install.sh");
 const releasesDir = join(root, "releases");
 const fakeBinDir = join(root, "bin");
 const homeDir = join(root, "home");
 const dataDir = join(root, "data");
 const tempDir = join(root, "tmp");
 const ghLogsDir = join(root, "gh-logs");
+const curlLogsDir = join(root, "curl-logs");
 const stableTag = "v1.2.3";
 const rollbackTag = "v1.2.3-rc.1";
 const removedPersistenceOption = ["--persist", "path"].join("-");
@@ -85,9 +87,9 @@ try {
     await scenarioDefaultHomeAndPathResolution();
     await scenarioPathGuidanceAndStartupFileNonOwnership();
     await scenarioExplicitRollbackAndDraft();
-    await scenarioStrictGhFlows();
+    await scenarioStrictDownloadFlows();
     await scenarioAuthenticatedReleaseValidation();
-    await scenarioGhFailuresAndRetries();
+    await scenarioDownloadFailuresAndRetries();
     await scenarioArtifactValidation();
     await scenarioStrictVersionValidation();
     await scenarioCliParsing();
@@ -104,7 +106,7 @@ try {
     await scenarioManagedPathReplacement();
     await scenarioContinuousReaders();
     await scenarioCaughtSignals();
-    await scenarioGhSignalSupervision();
+    await scenarioDownloadSignalSupervision();
     await scenarioRepeatedSignalCleanup();
     await scenarioAliasCreationSignal();
     await scenarioSignalDuringLockAcquisition();
@@ -121,10 +123,23 @@ try {
 }
 
 function prepareFixtures() {
-  for (const path of [releasesDir, fakeBinDir, homeDir, dataDir, tempDir, ghLogsDir]) {
+  for (const path of [releasesDir, fakeBinDir, homeDir, dataDir, tempDir, ghLogsDir, curlLogsDir]) {
     makeDirectory(path);
   }
   writeFakeCommands();
+  spawnChecked(
+    process.execPath,
+    [
+      join(repoRoot, "scripts", "release", "render-release-installer.mjs"),
+      "--source",
+      installer,
+      "--output",
+      stampedInstaller,
+      "--version",
+      stableTag.slice(1),
+    ],
+    "render stamped installer fixture",
+  );
 
   createRelease(
     stableTag,
@@ -385,6 +400,7 @@ function scenarioPathGuidanceAndStartupFileNonOwnership() {
   assertFailure(colon, "install directory cannot contain ':'", "normalized colon preflight");
   assertIncludes(colon.stderr, "PATH uses ':' to separate entries", "normalized colon rationale");
   assertEqual(ghCalls(colon), [], "normalized colon preflight makes no gh calls");
+  assertEqual(curlCalls(colon), [], "normalized colon preflight makes no curl calls");
   assert(
     !existsSync(colonInstallDir),
     "normalized colon preflight does not create install directory",
@@ -459,21 +475,29 @@ function scenarioExplicitRollbackAndDraft() {
   assertInstalled({ installDir: draftDir, tag: rollbackTag, target: "linux-x64" });
 }
 
-function scenarioStrictGhFlows() {
-  const latest = runInstaller({
-    installDir: join(root, "strict-gh-latest-bin"),
+function scenarioStrictDownloadFlows() {
+  const stamped = runInstaller({
+    installDir: join(root, "strict-stamped-bin"),
+    installerPath: stampedInstaller,
     platform: linuxX64(),
   });
-  assertSuccess(latest, "strict gh latest flow");
-  assertStrictGhFlow(latest, { tag: stableTag, target: "linux-x64", latest: true });
+  assertSuccess(stamped, "strict stamped installer flow");
+  assertStrictPublicFlow(stamped, { tag: stableTag, target: "linux-x64" });
+
+  const latest = runInstaller({
+    installDir: join(root, "strict-public-latest-bin"),
+    platform: linuxX64(),
+  });
+  assertSuccess(latest, "strict public latest flow");
+  assertStrictPublicFlow(latest, { tag: stableTag, target: "linux-x64", latest: true });
 
   const explicit = runInstaller({
-    installDir: join(root, "strict-gh-explicit-bin"),
+    installDir: join(root, "strict-public-explicit-bin"),
     platform: linuxX64(),
     version: rollbackTag,
   });
-  assertSuccess(explicit, "strict gh explicit flow");
-  assertStrictGhFlow(explicit, { tag: rollbackTag, target: "linux-x64" });
+  assertSuccess(explicit, "strict public explicit flow");
+  assertStrictPublicFlow(explicit, { tag: rollbackTag, target: "linux-x64" });
 
   const draft = runInstaller({
     installDir: join(root, "strict-gh-draft-bin"),
@@ -508,11 +532,6 @@ function scenarioAuthenticatedReleaseValidation() {
       options: { version: "v1.2.6" },
     },
     {
-      label: "duplicate asset rejection",
-      expected: "exactly one",
-      options: { version: stableTag, duplicateArchiveAsset: true },
-    },
-    {
       label: "duplicate draft asset rejection",
       expected: "exactly one",
       options: {
@@ -539,7 +558,7 @@ function scenarioAuthenticatedReleaseValidation() {
     {
       label: "authentication failure",
       expected: "gh auth login",
-      options: { auth: false },
+      options: { auth: false, releaseId: "42", version: stableTag },
     },
     {
       label: "unsupported platform",
@@ -558,24 +577,38 @@ function scenarioAuthenticatedReleaseValidation() {
   }
 }
 
-function scenarioGhFailuresAndRetries() {
-  const noGhBin = join(root, "no-gh-bin");
-  makeDirectory(noGhBin);
-  symlinkSync(join(fakeBinDir, "uname"), join(noGhBin, "uname"));
+function scenarioDownloadFailuresAndRetries() {
+  const noDownloadBin = join(root, "no-download-bin");
+  makeDirectory(noDownloadBin);
+  symlinkSync(join(fakeBinDir, "uname"), join(noDownloadBin, "uname"));
+  const missingCurl = runInstaller({
+    installDir: join(root, "missing-curl-install"),
+    platform: linuxX64(),
+    pathEntries: [noDownloadBin],
+  });
+  assertFailure(missingCurl, "curl is required", "missing curl");
+  assertEqual(curlCalls(missingCurl), [], "missing curl makes no curl calls");
+
+  const curlOnlyBin = join(root, "curl-only-bin");
+  makeDirectory(curlOnlyBin);
+  symlinkSync(join(fakeBinDir, "curl"), join(curlOnlyBin, "curl"));
+  symlinkSync(resolveCommand("grep"), join(curlOnlyBin, "grep"));
+  symlinkSync(join(fakeBinDir, "uname"), join(curlOnlyBin, "uname"));
   const missingGh = runInstaller({
     installDir: join(root, "missing-gh-install"),
     platform: linuxX64(),
-    pathEntries: [noGhBin],
+    pathEntries: [curlOnlyBin],
+    releaseId: "42",
+    version: stableTag,
   });
-  assertFailure(missingGh, "GitHub CLI is required", "missing gh");
-  assertEqual(ghCalls(missingGh), [], "missing gh makes no gh calls");
+  assertFailure(missingGh, "GitHub CLI is required", "missing draft gh");
+  assertEqual(ghCalls(missingGh), [], "missing draft gh makes no gh calls");
 
-  const installDir = join(root, "gh-failure-bin");
+  const installDir = join(root, "download-failure-bin");
   const dataHome = join(root, "gh-failure-data");
   seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
   const failures = [
     ["latest", {}, "latest release API failure"],
-    ["release", { version: stableTag }, "release asset API failure"],
     ["release", { version: stableTag, releaseId: "42" }, "draft release API failure"],
     ["archive-download", { version: stableTag }, "archive download failure"],
     ["checksums-download", { version: stableTag }, "checksum download failure"],
@@ -607,6 +640,7 @@ function scenarioGhFailuresAndRetries() {
       installDir,
       platform: linuxX64(),
       version: stableTag,
+      releaseId: "42",
       dataHome,
       environment,
     });
@@ -617,7 +651,7 @@ function scenarioGhFailuresAndRetries() {
   }
 
   const retry = runInstaller({ installDir, platform: linuxX64(), version: stableTag, dataHome });
-  assertSuccess(retry, "retry after gh failures");
+  assertSuccess(retry, "retry after download failures");
   assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
 }
 
@@ -674,6 +708,7 @@ function scenarioStrictVersionValidation() {
     "1.2.3",
     "v01.2.3",
     "v1.2.3+build.1",
+    "v1.2.3-01",
     "v1.2.3 ",
     "v1.2.3\r",
     "v1.2.3\nv9.9.9",
@@ -683,6 +718,11 @@ function scenarioStrictVersionValidation() {
     const result = runInstaller({ installDir, platform: linuxX64(), version });
     assertFailure(result, "v-prefixed SemVer", `invalid version ${JSON.stringify(version)}`);
     assertEqual(ghCalls(result).length, 0, `invalid version ${JSON.stringify(version)} gh calls`);
+    assertEqual(
+      curlCalls(result).length,
+      0,
+      `invalid version ${JSON.stringify(version)} curl calls`,
+    );
   }
 
   const duplicateEmpty = runInstaller({
@@ -693,18 +733,24 @@ function scenarioStrictVersionValidation() {
   });
   assertFailure(duplicateEmpty, "only once", "duplicate version after empty value");
   assertEqual(ghCalls(duplicateEmpty).length, 0, "duplicate version after empty value gh calls");
+  assertEqual(
+    curlCalls(duplicateEmpty).length,
+    0,
+    "duplicate version after empty value curl calls",
+  );
 
-  for (const apiTag of ["v1.2.3\nv9.9.9", "v1.2.3\n"]) {
+  for (const apiTag of ["v1.2.3\nv9.9.9"]) {
     const apiResult = runInstaller({
       installDir,
       platform: linuxX64(),
       environment: { FAKE_LATEST_TAG: apiTag },
     });
     assertFailure(apiResult, "invalid tag", `invalid latest API tag ${JSON.stringify(apiTag)}`);
+    assertEqual(ghCalls(apiResult), [], `invalid latest tag ${JSON.stringify(apiTag)} gh calls`);
     assertEqual(
-      ghCalls(apiResult).filter((call) => call.startsWith("api ")).length,
+      curlCalls(apiResult).length,
       1,
-      `invalid latest API tag ${JSON.stringify(apiTag)} stops after lookup`,
+      `invalid latest tag ${JSON.stringify(apiTag)} stops after redirect lookup`,
     );
   }
 }
@@ -737,6 +783,7 @@ function scenarioCliParsing() {
     });
     assertFailure(result, expected, label);
     assertEqual(ghCalls(result), [], `${label} makes no gh calls`);
+    assertEqual(curlCalls(result), [], `${label} makes no curl calls`);
   }
   assert(!existsSync(installDir), "CLI parsing failures do not create the install directory");
 }
@@ -1503,12 +1550,17 @@ async function scenarioManagedPathReplacement() {
       },
     });
     await waitForPath(replacementMarker, `${resource} revalidation point`);
-    const replacementPath =
-      resource === "popup"
-        ? join(replacementInstallDir, "stn-tmux-popup")
-        : resource === "binary"
-          ? join(replacementInstallDir, "stn")
-          : join(replacementDataHome, "station", "LICENSE");
+    let replacementPath;
+    switch (resource) {
+      case "popup":
+        replacementPath = join(replacementInstallDir, "stn-tmux-popup");
+        break;
+      case "binary":
+        replacementPath = join(replacementInstallDir, "stn");
+        break;
+      default:
+        replacementPath = join(replacementDataHome, "station", "LICENSE");
+    }
     rmSync(replacementPath, { recursive: true, force: true });
     if (resource === "popup") symlinkSync("external-stn", replacementPath);
     else makeDirectory(replacementPath);
@@ -1664,25 +1716,36 @@ async function scenarioCaughtSignals() {
   }
 }
 
-async function scenarioGhSignalSupervision() {
+async function scenarioDownloadSignalSupervision() {
   const phases = [
-    { name: "auth", version: stableTag },
     { name: "latest" },
-    { name: "published-archive-asset", version: stableTag },
-    { name: "published-checksum-asset", version: stableTag },
     { name: "archive-download", version: stableTag },
     { name: "checksum-download", version: stableTag },
+    { draft: true, label: "draft-auth", name: "auth", version: rollbackTag },
     { draft: true, name: "draft-release", version: rollbackTag },
     { draft: true, name: "draft-archive-asset", version: rollbackTag },
     { draft: true, name: "draft-checksum-asset", version: rollbackTag },
+    {
+      draft: true,
+      label: "draft-archive-download",
+      name: "archive-download",
+      version: rollbackTag,
+    },
+    {
+      draft: true,
+      label: "draft-checksum-download",
+      name: "checksum-download",
+      version: rollbackTag,
+    },
   ];
 
   for (const phase of phases) {
-    const installDir = join(root, `gh-${phase.name}-signal-bin`);
-    const dataHome = join(root, `gh-${phase.name}-signal-data`);
-    const marker = join(root, `gh-${phase.name}-signal.ready`);
-    const childPidFile = join(root, `gh-${phase.name}-signal.pid`);
-    const releaseFile = join(root, `gh-${phase.name}-signal.release`);
+    const label = phase.label ?? phase.name;
+    const installDir = join(root, `${label}-signal-bin`);
+    const dataHome = join(root, `${label}-signal-data`);
+    const marker = join(root, `${label}-signal.ready`);
+    const childPidFile = join(root, `${label}-signal.pid`);
+    const releaseFile = join(root, `${label}-signal.release`);
     seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
     const running = runInstaller({
       installDir,
@@ -1698,14 +1761,14 @@ async function scenarioGhSignalSupervision() {
         FAKE_BLOCK_RELEASE: releaseFile,
       },
     });
-    await waitForPath(marker, `${phase.name} signal injection point`);
-    await waitForPath(childPidFile, `${phase.name} child PID`);
+    await waitForPath(marker, `${label} signal injection point`);
+    await waitForPath(childPidFile, `${label} child PID`);
     running.child.kill("SIGTERM");
-    const result = await settleWithin(running, 5_000, `${phase.name} signal cleanup`);
-    assertExactStatus(result, 143, `${phase.name} parent-only SIGTERM`);
-    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${phase.name} gh child`);
-    assertRuntimeVersion(installDir, "v0.9.0", `${phase.name} runtime preservation`);
-    assertLicense(dataHome, "v0.9.0", `${phase.name} license preservation`);
+    const result = await settleWithin(running, 5_000, `${label} signal cleanup`);
+    assertExactStatus(result, 143, `${label} parent-only SIGTERM`);
+    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${label} download child`);
+    assertRuntimeVersion(installDir, "v0.9.0", `${label} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${label} license preservation`);
     assertNoInstallerResidue(installDir, dataHome);
   }
 }
@@ -2419,12 +2482,80 @@ function writeFakeCommands() {
       "",
     ].join("\n"),
   );
+  writeExecutable(
+    join(fakeBinDir, "curl"),
+    [
+      "#!/bin/sh",
+      "set -eu",
+      'printf \'%s\\n\' "$*" >> "$FAKE_CURL_LOG"',
+      "{",
+      "  printf 'CALL\\n'",
+      "  for argument do printf 'ARG=%s\\n' \"$argument\"; done",
+      "  printf 'END\\n'",
+      '} >> "$FAKE_CURL_ARGV_LOG"',
+      'chmod 600 "$FAKE_CURL_LOG" "$FAKE_CURL_ARGV_LOG"',
+      "block_phase() {",
+      "  phase=$1",
+      `  if [ "\${FAKE_GH_BLOCK_PHASE:-}" != "$phase" ]; then`,
+      `    if [ "$phase" != archive-download ] || [ "\${FAKE_GH_BLOCK_DOWNLOAD:-0}" != 1 ]; then return 0; fi`,
+      "  fi",
+      '  : > "$FAKE_BLOCK_MARKER"',
+      '  chmod 600 "$FAKE_BLOCK_MARKER"',
+      `  if [ -n "\${FAKE_BLOCK_PID_FILE:-}" ]; then printf "%s\\n" "$$" > "$FAKE_BLOCK_PID_FILE"; chmod 600 "$FAKE_BLOCK_PID_FILE"; fi`,
+      "  trap 'exit 129' HUP",
+      "  trap 'exit 130' INT",
+      "  trap 'exit 143' TERM",
+      '  while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done',
+      "}",
+      'output=""',
+      'write_out=""',
+      'url=""',
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      "    --fail|--silent|--show-error|--location|--tlsv1.2) shift ;;",
+      '    --proto|--proto-redir|--output|--write-out) [ "$#" -ge 2 ]; name=$1; value=$2; shift 2; case "$name" in --output) output=$value ;; --write-out) write_out=$value ;; esac ;;',
+      '    https://*) [ -z "$url" ]; url=$1; shift ;;',
+      "    *) exit 2 ;;",
+      "  esac",
+      "done",
+      'case "$url" in',
+      '  "https://github.com/jeremy0dell/station/releases/latest")',
+      '    [ "$output" = /dev/null ]',
+      '    [ "$write_out" = "%{url_effective}" ]',
+      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != latest ] || exit 74`,
+      "    block_phase latest",
+      '    printf "https://github.com/jeremy0dell/station/releases/tag/%s" "$FAKE_LATEST_TAG"',
+      "    ;;",
+      '  "https://github.com/jeremy0dell/station/releases/download/$FAKE_TAG/$FAKE_ARCHIVE")',
+      '    [ -z "$output" ] && [ -z "$write_out" ]',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      archive-download) exit 74 ;;",
+      "      partial-archive) printf 'partial archive'; exit 74 ;;",
+      "    esac",
+      "    block_phase archive-download",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE"',
+      "    ;;",
+      '  "https://github.com/jeremy0dell/station/releases/download/$FAKE_TAG/SHA256SUMS")',
+      '    [ -z "$output" ] && [ -z "$write_out" ]',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      checksums-download) exit 74 ;;",
+      "      partial-checksums) printf 'partial checksum'; exit 74 ;;",
+      "    esac",
+      "    block_phase checksum-download",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS"',
+      "    ;;",
+      "  *) exit 2 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
 }
 
 function runInstaller({
   installDir,
   platform,
   version,
+  installerPath = installer,
   auth = true,
   duplicateArchiveAsset = false,
   includeInstallDirOnPath = false,
@@ -2457,6 +2588,8 @@ function runInstaller({
   }
   const ghLog = join(ghLogsDir, `${++invocationCount}.log`);
   const ghArgvLog = join(ghLogsDir, `${invocationCount}.argv.log`);
+  const curlLog = join(curlLogsDir, `${invocationCount}.log`);
+  const curlArgvLog = join(curlLogsDir, `${invocationCount}.argv.log`);
   const env = applyEnvironmentOverrides(
     {
       HOME: home,
@@ -2466,6 +2599,8 @@ function runInstaller({
       XDG_DATA_HOME: unsetXdgDataHome ? undefined : dataHome,
       FAKE_ARCHIVE: archive,
       FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
+      FAKE_CURL_ARGV_LOG: curlArgvLog,
+      FAKE_CURL_LOG: curlLog,
       FAKE_GH_AUTH: auth ? "1" : "0",
       FAKE_GH_ARGV_LOG: ghArgvLog,
       FAKE_GH_LOG: ghLog,
@@ -2481,7 +2616,7 @@ function runInstaller({
     environment,
   );
   if (releaseId !== undefined) env.STATION_INSTALL_RELEASE_ID = releaseId;
-  const invocation = buildShellInvocation(childShell, args, umask);
+  const invocation = buildShellInvocation(childShell, installerPath, args, umask);
   const options = { cwd, env };
 
   if (!asynchronous) {
@@ -2523,7 +2658,7 @@ function runInstaller({
       );
     }
     for (const path of [supervisorPidFile, stdoutFile, stderrFile]) rmSync(path, { force: true });
-    return { ...result, ghArgvLog, ghLog, stderr, stdout };
+    return { ...result, curlArgvLog, curlLog, ghArgvLog, ghLog, stderr, stdout };
   }
 
   const child = spawn(invocation.command, invocation.args, {
@@ -2531,10 +2666,16 @@ function runInstaller({
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
   });
-  return trackChild(child, { ghArgvLog, ghLog, label: `installer ${tag}` });
+  return trackChild(child, {
+    curlArgvLog,
+    curlLog,
+    ghArgvLog,
+    ghLog,
+    label: `installer ${tag}`,
+  });
 }
 
-function trackChild(child, { ghArgvLog, ghLog, label }) {
+function trackChild(child, { curlArgvLog, curlLog, ghArgvLog, ghLog, label }) {
   activeChildren.add(child);
   let stdout = "";
   let stderr = "";
@@ -2558,7 +2699,7 @@ function trackChild(child, { ghArgvLog, ghLog, label }) {
     dumpHarnessState(`${label} exceeded ${timeoutMs}ms`);
     signalProcessGroup(child, "SIGKILL");
   }, timeoutMs);
-  const running = { child, ghArgvLog, ghLog, label, settled: false };
+  const running = { child, curlArgvLog, curlLog, ghArgvLog, ghLog, label, settled: false };
   running.completion = new Promise((resolveCompletion) => {
     child.on("close", (status, signal) => {
       clearTimeout(timeout);
@@ -2570,6 +2711,8 @@ function trackChild(child, { ghArgvLog, ghLog, label }) {
         });
       }
       resolveCompletion({
+        curlArgvLog,
+        curlLog,
         error: spawnError,
         ghArgvLog,
         ghLog,
@@ -2600,9 +2743,9 @@ function remainingOverallTime() {
   return remaining;
 }
 
-function buildShellInvocation(childShell, installerArgs, umask) {
+function buildShellInvocation(childShell, installerPath, installerArgs, umask) {
   if (umask === undefined) {
-    return { command: childShell, args: [installer, ...installerArgs] };
+    return { command: childShell, args: [installerPath, ...installerArgs] };
   }
   return {
     command: childShell,
@@ -2612,7 +2755,7 @@ function buildShellInvocation(childShell, installerArgs, umask) {
       "station-install",
       umask,
       childShell,
-      installer,
+      installerPath,
       ...installerArgs,
     ],
   };
@@ -2855,6 +2998,7 @@ function makeNoChecksumBin() {
   ]) {
     symlinkSync(resolveCommand(command), join(directory, command));
   }
+  symlinkSync(join(fakeBinDir, "curl"), join(directory, "curl"));
   symlinkSync(join(fakeBinDir, "gh"), join(directory, "gh"));
   symlinkSync(join(fakeBinDir, "uname"), join(directory, "uname"));
   return directory;
@@ -3152,48 +3296,84 @@ function ghCalls(result) {
   return readFileSync(result.ghLog, "utf8").trimEnd().split("\n");
 }
 
+function curlCalls(result) {
+  if (!existsSync(result.curlLog)) return [];
+  return readFileSync(result.curlLog, "utf8").trimEnd().split("\n");
+}
+
+function curlInvocations(result) {
+  if (!result.curlArgvLog || !existsSync(result.curlArgvLog)) return [];
+  return parseInvocationLog(result.curlArgvLog, "curl");
+}
+
 function ghInvocations(result) {
   if (!result.ghArgvLog || !existsSync(result.ghArgvLog)) return [];
+  return parseInvocationLog(result.ghArgvLog, "gh");
+}
+
+function parseInvocationLog(path, command) {
   const invocations = [];
   let current;
-  for (const line of readFileSync(result.ghArgvLog, "utf8").trimEnd().split("\n")) {
+  for (const line of readFileSync(path, "utf8").trimEnd().split("\n")) {
     if (line === "CALL") {
-      assert(current === undefined, "fake gh argv log does not nest calls");
+      assert(current === undefined, `fake ${command} argv log does not nest calls`);
       current = [];
     } else if (line === "END") {
-      assert(current !== undefined, "fake gh argv log ends a call after CALL");
+      assert(current !== undefined, `fake ${command} argv log ends a call after CALL`);
       invocations.push(current);
       current = undefined;
     } else if (line.startsWith("ARG=")) {
-      assert(current !== undefined, "fake gh argv log records arguments inside a call");
+      assert(current !== undefined, `fake ${command} argv log records arguments inside a call`);
       current.push(line.slice(4));
     } else if (line !== "") {
-      throw new Error(`unexpected fake gh argv log line: ${line}`);
+      throw new Error(`unexpected fake ${command} argv log line: ${line}`);
     }
   }
-  assert(current === undefined, "fake gh argv log closes every call");
+  assert(current === undefined, `fake ${command} argv log closes every call`);
   return invocations;
 }
 
-function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
+function assertStrictPublicFlow(result, { latest = false, tag, target }) {
+  const baseUrl = `https://github.com/jeremy0dell/station/releases`;
+  const archiveName = `stn-${tag}-${target}.tar.gz`;
+  const common = [
+    "--fail",
+    "--silent",
+    "--show-error",
+    "--location",
+    "--proto",
+    "=https",
+    "--proto-redir",
+    "=https",
+    "--tlsv1.2",
+  ];
+  const expected = [];
+  if (latest) {
+    expected.push([
+      ...common,
+      "--output",
+      "/dev/null",
+      "--write-out",
+      "%{url_effective}",
+      `${baseUrl}/latest`,
+    ]);
+  }
+  expected.push([...common, `${baseUrl}/download/${tag}/${archiveName}`]);
+  expected.push([...common, `${baseUrl}/download/${tag}/SHA256SUMS`]);
+  assertEqual(curlInvocations(result), expected, `${tag} strict public curl argv flow`);
+  assertEqual(ghInvocations(result), [], `${tag} public flow makes no gh calls`);
+}
+
+function assertStrictGhFlow(result, { draftId, tag, target }) {
   const repository = "repos/jeremy0dell/station";
   const archiveName = `stn-${tag}-${target}.tar.gz`;
-  const tagEndpoint = `${repository}/releases/tags/${tag}`;
-  const archiveFilter = `.assets[] | select(.name == "${archiveName}") | .id`;
-  const checksumFilter = '.assets[] | select(.name == "SHA256SUMS") | .id';
   const expected = [["auth", "status", "--hostname", "github.com"]];
-  if (latest) expected.push(["api", `${repository}/releases/latest`, "--jq", ".tag_name"]);
-  if (draftId === undefined) {
-    expected.push(["api", tagEndpoint, "--jq", archiveFilter]);
-    expected.push(["api", tagEndpoint, "--jq", checksumFilter]);
-  } else {
-    const endpoint = `${repository}/releases/${draftId}`;
-    const match = `select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
-    const prefix = ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--jq"];
-    expected.push([...prefix, `${match} | .id`]);
-    expected.push([...prefix, `${match} | .assets[] | select(.name == "${archiveName}") | .id`]);
-    expected.push([...prefix, `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`]);
-  }
+  const endpoint = `${repository}/releases/${draftId}`;
+  const match = `select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
+  const prefix = ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--jq"];
+  expected.push([...prefix, `${match} | .id`]);
+  expected.push([...prefix, `${match} | .assets[] | select(.name == "${archiveName}") | .id`]);
+  expected.push([...prefix, `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`]);
   expected.push([
     "api",
     "-H",
@@ -3207,6 +3387,7 @@ function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
     `${repository}/releases/assets/2`,
   ]);
   assertEqual(ghInvocations(result), expected, `${tag} strict gh argv flow`);
+  assertEqual(curlInvocations(result), [], `${tag} draft flow makes no curl calls`);
 }
 
 function assertNoGhApiCalls(result, label) {
@@ -3215,6 +3396,7 @@ function assertNoGhApiCalls(result, label) {
     [],
     `${label} release API calls`,
   );
+  assertEqual(curlCalls(result), [], `${label} public release requests`);
 }
 
 function spawnChecked(command, args, label) {

--- a/tests/diagnostics/homebrew-packaging.test.ts
+++ b/tests/diagnostics/homebrew-packaging.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+
+function read(path: string): string {
+  return readFileSync(join(root, path), "utf8");
+}
+
+describe("Homebrew packaging", () => {
+  it("keeps the source formula ready for reviewed stable updates", () => {
+    const formula = read("packaging/homebrew/station.rb.template");
+    const homebrew = read("docs/homebrew.md");
+    const checklist = read("docs/public-release-checklist.md");
+    const workflow = read(".github/workflows/homebrew-bump.yml");
+
+    expect(formula).toContain('depends_on "git-delta"');
+    expect(formula).toContain(
+      'assert_equal version.to_s, shell_output("#{bin}/stn --version").strip',
+    );
+    expect(formula).toContain('assert_match "\\"station-launchers\\"", output');
+    expect(formula).not.toContain("cd /path/to/first/git/project");
+
+    expect(workflow).toContain("Validate public stable release");
+    expect(workflow).toContain("Homebrew requires a stable release tag");
+    expect(workflow).toContain(".immutable");
+    expect(workflow).toContain('.visibility)" = public');
+    expect(workflow).toContain("gh pr create");
+    expect(workflow).toContain("automation/station-");
+    expect(workflow).not.toContain("mislav/bump-homebrew-formula-action");
+    expect(workflow).not.toContain("push-to:");
+
+    expect(homebrew).toContain("brew install jeremy0dell/station/station");
+    const normalizedHomebrew = homebrew.replace(/\s+/gu, " ");
+    expect(normalizedHomebrew).toContain("opens or reuses a formula pull request");
+    expect(normalizedHomebrew).toContain("contents write and pull-request write");
+    expect(checklist).toContain("Artifact signing and provenance");
+    expect(checklist).toContain("Final public release candidate");
+    expect(checklist).toContain("Stable `v0.7.1`");
+  });
+
+  it("renders one exact tag and revision into a valid formula shape", () => {
+    const temporaryRoot = mkdtempSync(join(tmpdir(), "station-homebrew-render-"));
+    const output = join(temporaryRoot, "Formula", "station.rb");
+    const revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          "scripts/release/render-homebrew-formula.mjs",
+          "--template",
+          "packaging/homebrew/station.rb.template",
+          "--output",
+          output,
+          "--tag",
+          "v9.8.7",
+          "--revision",
+          revision,
+        ],
+        { cwd: root, stdio: "pipe" },
+      );
+      const rendered = readFileSync(output, "utf8");
+      expect(rendered.match(/tag:\s+"v9\.8\.7"/gu)).toHaveLength(1);
+      expect(rendered.match(/revision: "a{40}"/gu)).toHaveLength(1);
+
+      const ruby = spawnSync("ruby", ["-c", output], { encoding: "utf8" });
+      if (ruby.error?.message.includes("ENOENT") !== true) {
+        expect(ruby.status, ruby.stderr).toBe(0);
+      }
+    } finally {
+      rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/diagnostics/public-installer-release.test.ts
+++ b/tests/diagnostics/public-installer-release.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const root = new URL("../../", import.meta.url);
+
+function read(path: string): string {
+  return readFileSync(new URL(path, root), "utf8");
+}
+
+describe("public installer release", () => {
+  it("publishes a version-stamped installer and preserves authenticated draft acceptance", () => {
+    const installer = read("scripts/install.sh");
+    const release = read(".github/workflows/release.yml");
+
+    expect(installer).toContain('embedded_version=""');
+    expect(installer).toContain("run_curl");
+    expect(installer).toContain("https://github.com/$repository/releases/download/$tag");
+    expect(installer).toContain("STATION_INSTALL_RELEASE_ID");
+
+    expect(release).toContain("render-release-installer.mjs");
+    expect(release).toContain('"install.sh"');
+    expect(release).toContain("release/install.sh");
+    expect(release).toContain("STATION_INSTALL_RELEASE_ID");
+  });
+
+  it("runs an unauthenticated public install after immutable promotion", () => {
+    const promote = read(".github/workflows/promote-release.yml");
+
+    expect(promote).toContain("verify-public-install");
+    expect(promote).toContain("releases/download/$TAG/install.sh");
+    expect(promote).toContain("releases/latest/download/install.sh");
+    expect(promote).toContain("env -u GH_TOKEN");
+  });
+});

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -57,9 +57,11 @@ describe("release readiness docs", () => {
     for (const document of documents) {
       const normalized = document.replace(/\s+/g, " ").toLowerCase();
       expect(normalized).toContain("let your agent install and validate station");
-      expect(document).toContain("gh auth status --hostname github.com");
-      expect(document).toContain("gh repo view jeremy0dell/station");
-      expect(document).toContain("docs/install.md");
+      expect(document).toContain(
+        "https://github.com/jeremy0dell/station/releases/latest/download/install.sh",
+      );
+      expect(normalized).toContain("without authentication");
+      expect(normalized).toContain("private temporary file");
       expect(document).toContain("stn setup plan --json");
       expect(document).toContain("stn setup check --json");
       expect(document).toContain("stn doctor");
@@ -89,7 +91,7 @@ describe("release readiness docs", () => {
     expect(packageManifest.engines.node).toBe(">=24.2 <25");
   });
 
-  it("documents the authenticated private binary release contract", async () => {
+  it("documents the public binary release and authenticated draft contract", async () => {
     const [readme, install, development, singleBinary, homebrew, release, promote] =
       await Promise.all(
         [
@@ -104,9 +106,10 @@ describe("release readiness docs", () => {
       );
     const packageJson = await readPackageManifest();
 
-    expect(readme).toContain("authenticated GitHub release assets");
-    expect(readme).toContain("does not require Node.js, pnpm, Bun");
-    expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
+    const normalizedReadme = readme.replace(/\s+/g, " ");
+    expect(normalizedReadme).toContain("public stable release");
+    expect(normalizedReadme).toContain("does not require a GitHub account");
+    expect(install.replace(/\s+/g, " ")).toContain("latest stable release");
     expect(install).toContain("tag=v0.7.1-rc.4");
     for (const [path, document] of [
       ["README.md", readme],
@@ -115,43 +118,15 @@ describe("release readiness docs", () => {
       expect(document, path).not.toContain("ref=main");
       expect(document, path).not.toContain("gh auth token");
       expect(document, path).not.toContain("Authorization: Bearer");
-      expect(document, path).not.toContain("curl");
-      const recipes = shellBlocks(document).filter((block) =>
-        block.includes("repos/jeremy0dell/station/contents/scripts/install.sh"),
+      expect(document, path).toContain(
+        "https://github.com/jeremy0dell/station/releases/latest/download/install.sh",
       );
-      expect(recipes, path).toHaveLength(1);
-      for (const recipe of recipes) {
-        expect(recipe, path).not.toContain("cd /path/to/your/git-project");
-        expect(recipe, path).toContain("umask 077");
-        expect(recipe, path).toContain("export GH_HOST=github.com");
-        expect(recipe, path).toContain("releases/latest");
-        expect(recipe.indexOf("export GH_HOST=github.com"), path).toBeLessThan(
-          recipe.indexOf("gh api --method GET"),
-        );
-        expect(recipe, path).toContain('installer="$(mktemp)"');
-        expect(recipe, path).toContain("trap 'rm -f \"$installer\"' EXIT");
-        expect(recipe, path).toContain('test -s "$installer"');
-        expect(recipe, path).toContain('sh -n "$installer"');
-        expect(recipe, path).toContain('sh "$installer" --version "$tag"');
-
-        const installerFetches = continuedShellCommands(recipe).filter((command) =>
-          command.includes("contents/scripts/install.sh"),
-        );
-        expect(installerFetches, path).toHaveLength(1);
-        const command = installerFetches[0] ?? "";
-        expect(command, path).toContain("gh api --method GET");
-        expect(command, path).toContain("Accept: application/vnd.github.raw+json");
-        expect(command, path).toContain('-f ref="$tag"');
-        expect(command, path).toContain(
-          'repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"',
-        );
-        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
-      }
+      expect(document, path).toContain("curl --proto '=https' --tlsv1.2 -fsSL");
+      expect(document, path).toContain("sh -n");
+      expect(document, path).toContain("curl | sh");
+      expect(document, path).not.toContain("cd /path/to/your/git-project");
     }
-    expect(install).toContain(
-      'tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest',
-    );
-    expect(install.replace(/\s+/g, " ")).toContain("installer code and artifacts");
+    expect(install).toContain("version-stamped `install.sh`");
     expect(install).toContain("SHA256SUMS");
     expect(install).toContain("stn-tmux-popup");
     for (const target of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]) {
@@ -180,11 +155,18 @@ describe("release readiness docs", () => {
     expect(acceptanceRecipe).toContain(
       'test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq \'.sha\')" = "$commit"',
     );
-    expect(acceptanceRecipe).toContain('-f ref="$commit"');
+    expect(acceptanceRecipe).toContain('asset_ids="$candidate_dir/asset-ids.txt"');
+    expect(acceptanceRecipe).toContain(
+      '"repos/jeremy0dell/station/releases/assets/$installer_asset_id"',
+    );
+    expect(acceptanceRecipe).toContain('grep -Fx "embedded_version=\\"$tag\\""');
+    expect(acceptanceRecipe).toContain('STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer"');
+    expect(acceptanceRecipe).not.toContain('sh "$installer" --version');
     expect(acceptanceRecipe).not.toContain(
       'commit="$(gh api "repos/jeremy0dell/station/commits/$tag"',
     );
-    expect(release).toContain('-f ref="$COMMIT"');
+    expect(release).toContain("render-release-installer.mjs");
+    expect(release).toContain("release/install.sh");
     expect(release).toContain("persist-credentials: false");
     const validateRelease = release.slice(
       release.indexOf("      - name: Validate release tag"),
@@ -205,6 +187,7 @@ describe("release readiness docs", () => {
     expect(createDraft).toContain('[[ "$release_id" =~ ^[0-9]+$ ]] && break');
     expect(createDraft).not.toContain("releases?per_page=100");
     expect(createDraft).toContain('--argjson releaseId "$release_id"');
+    expect(createDraft).toContain("install.sh");
     expect(release).toContain("accepted-release-candidate-");
     const installDraft = release.slice(
       release.indexOf("  install-draft:"),
@@ -214,6 +197,7 @@ describe("release readiness docs", () => {
     for (const job of [installDraft, recordCandidate]) {
       expect(job).toContain("contents: write");
       expect(job).not.toContain("contents: read");
+      expect(job).toContain("install.sh");
     }
     expect(promote).toContain("workflow_dispatch");
     expect(promote).toContain("manual_acceptance");
@@ -221,10 +205,14 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
+    expect(promote).toContain("verify-public-install");
+    expect(promote).toContain("releases/latest/download/install.sh");
     expect(packageJson.version).toBe("0.7.1-rc.4");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
-    expect(homebrew).toContain("`workflow_dispatch` only");
-    expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");
+    expect(homebrew).toContain("manually dispatch");
+    expect(homebrew).toContain("It never commits directly to the tap's default branch");
+    expect(homebrew).toContain("`COMMITTER_TOKEN` must be configured");
+    expect(homebrew).toContain("fine-grained token");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );
@@ -372,14 +360,6 @@ async function readPackageManifest(): Promise<PackageManifest> {
   } catch (cause) {
     throw new Error("package.json must contain valid JSON", { cause });
   }
-}
-
-function continuedShellCommands(document: string): string[] {
-  return document
-    .replace(/\\\r?\n\s*/g, " ")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => /^(?:[A-Z_]+=[^ ]+\s+)*(?:curl|gh)\s/.test(line));
 }
 
 function shellBlocks(document: string): string[] {


### PR DESCRIPTION
## Summary

- add an unauthenticated HTTPS installer for published releases while retaining authenticated draft-release acceptance
- stamp the immutable release tag into the uploaded `install.sh`, include it in `SHA256SUMS`, and validate it across all four native targets before and after publication
- automate reviewed Homebrew source-formula updates through the existing tap instead of pushing formula changes directly
- document the public native, Homebrew, signing/notarization, and promotion gates in a concrete release checklist
- expand installer and packaging diagnostics for redirects, failures, interruption, rollback, and release-workflow policy

Companion tap changes: jeremy0dell/homebrew-station#1.

## Release behavior

Published stable releases expose:

```sh
curl --proto '=https' --tlsv1.2 -fsSL \
  https://github.com/jeremy0dell/station/releases/latest/download/install.sh | sh
```

The installer downloads the matching macOS/Linux arm64/x64 archive, verifies `SHA256SUMS` and the exact archive manifest, then atomically installs `stn`, `stn-ingress`, `stn-tmux-popup`, and `LICENSE`. It does not edit shell startup files or run interactive setup.

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm smoke:install`
- `pnpm test:diagnostics` (52 tests)
- root unit, contract, and integration suites
- Station renderer, PTY, and Bun PTY suites
- native binary build and `pnpm smoke:binary -- --expected-version 0.0.0-local`
- `ruby -c Formula/station.rb`
- `brew style Formula/station.rb`

The pre-push suite was also exercised with Station ownership variables removed. One parallel setup-check invocation exceeded its 5-second budget; the isolated test passed in 894ms, and the branch was pushed after the full constituent gates above passed.

## Release gates outside this PR

- make the repositories public before final unauthenticated acceptance
- configure Apple signing/notarization credentials and release/tap tokens
- resolve remaining product release blockers
- complete the manual checks in `docs/public-release-checklist.md`

## UX implication

After a stable release is published, a new user can install the native binary with the command above and then run `stn setup`. The promotion workflow manually verifies the same published installer URL on every supported platform.
