### PR TITLE
fix(worktrunk): unify setup and doctor hook expectations

### DIFF
--- a/apps/cli/src/cliTypes.ts
+++ b/apps/cli/src/cliTypes.ts
@@ -21,4 +21,5 @@ export type CliRunOptions = {
   notifyDeps?: NotifyCommandDeps;
   observeDeps?: ObserveCommandDeps;
   setupDeps?: SetupCommandDeps;
+  providerHookIngressLauncher?: string;
 };

--- a/apps/cli/src/commands/cliCommand/helpers.ts
+++ b/apps/cli/src/commands/cliCommand/helpers.ts
@@ -4,6 +4,7 @@ import type { CliCommandRunContext } from "./types.js";
 export type LoadedCommandOptions = {
   config?: StationConfig;
   configPath?: string;
+  providerHookIngressLauncher?: string;
 };
 
 export function loadedCommandOptions(context: CliCommandRunContext): LoadedCommandOptions {
@@ -13,6 +14,9 @@ export function loadedCommandOptions(context: CliCommandRunContext): LoadedComma
   }
   if (context.resolvedConfigPath !== undefined) {
     options.configPath = context.resolvedConfigPath;
+  }
+  if (context.options.providerHookIngressLauncher !== undefined) {
+    options.providerHookIngressLauncher = context.options.providerHookIngressLauncher;
   }
   return options;
 }

--- a/apps/cli/src/commands/cliCommand/helpers.ts
+++ b/apps/cli/src/commands/cliCommand/helpers.ts
@@ -1,10 +1,15 @@
 import type { StationConfig } from "@station/config";
+import type { SafeError } from "@station/contracts";
 import type { CliCommandRunContext } from "./types.js";
 
 export type LoadedCommandOptions = {
   config?: StationConfig;
   configPath?: string;
   providerHookIngressLauncher?: string;
+};
+
+type LoadedConfigCommandOptions = LoadedCommandOptions & {
+  config: StationConfig;
 };
 
 export function loadedCommandOptions(context: CliCommandRunContext): LoadedCommandOptions {
@@ -19,6 +24,19 @@ export function loadedCommandOptions(context: CliCommandRunContext): LoadedComma
     options.providerHookIngressLauncher = context.options.providerHookIngressLauncher;
   }
   return options;
+}
+
+export function loadedConfigCommandOptions(
+  context: CliCommandRunContext,
+): LoadedConfigCommandOptions {
+  if (context.config === undefined) {
+    throw {
+      tag: "CliCommandError",
+      code: "CLI_CONFIG_NOT_LOADED",
+      message: `Station config was not loaded for the ${context.path.join(" ")} command.`,
+    } satisfies SafeError;
+  }
+  return { ...loadedCommandOptions(context), config: context.config };
 }
 
 export function hookCommandExitCode(result: object): number {

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -17,10 +17,12 @@ import {
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
 import { isStationUiInstalled, stationUiInstallHint } from "../stationWorkspace.js";
+import { resolveDefaultIngressLauncher } from "../worktrunkHookExpectation.js";
 
 export type DoctorCommandOptions = {
   config?: StationConfig;
   configPath?: string;
+  providerHookIngressLauncher?: string;
   timeoutMs?: number;
 };
 
@@ -29,7 +31,12 @@ export async function runDoctorCommand(
   options: DoctorCommandOptions = {},
   deps: ObserverProcessDeps = {},
 ): Promise<DoctorReport> {
-  const doctorOptions = parseDoctorOptions(args);
+  const parsedDoctorOptions = parseDoctorOptions(args);
+  const doctorOptions = DoctorOptionsSchema.parse({
+    ...(parsedDoctorOptions ?? {}),
+    providerHookIngressLauncher:
+      options.providerHookIngressLauncher ?? resolveDefaultIngressLauncher(),
+  });
   const timeoutMs = options.timeoutMs ?? 30_000;
   const paths = resolveObserverPaths(options.config);
   const observerOptions: Parameters<typeof startObserver>[0] = { paths, timeoutMs };

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -17,7 +17,10 @@ import {
 } from "../observerProcess.js";
 import { resolveObserverPaths } from "../paths.js";
 import { isStationUiInstalled, stationUiInstallHint } from "../stationWorkspace.js";
-import { resolveDefaultIngressLauncher } from "../worktrunkHookExpectation.js";
+import {
+  createProviderHookRuntime,
+  type ProviderHookRuntimeOptions,
+} from "../worktrunkHookExpectation.js";
 
 export type DoctorCommandOptions = {
   config?: StationConfig;
@@ -26,17 +29,34 @@ export type DoctorCommandOptions = {
   timeoutMs?: number;
 };
 
+/**
+ * USE CASE
+ *
+ * Coordinates Observer diagnostics, requester hook identity, and local checks for one CLI request.
+ */
 export async function runDoctorCommand(
   args: string[],
   options: DoctorCommandOptions = {},
   deps: ObserverProcessDeps = {},
 ): Promise<DoctorReport> {
   const parsedDoctorOptions = parseDoctorOptions(args);
-  const doctorOptions = DoctorOptionsSchema.parse({
-    ...(parsedDoctorOptions ?? {}),
-    providerHookIngressLauncher:
-      options.providerHookIngressLauncher ?? resolveDefaultIngressLauncher(),
-  });
+  const hookRuntimeOptions: ProviderHookRuntimeOptions = {};
+  if (options.providerHookIngressLauncher !== undefined) {
+    hookRuntimeOptions.ingressLauncher = options.providerHookIngressLauncher;
+  }
+  if (options.configPath !== undefined) {
+    hookRuntimeOptions.stationConfigPath = options.configPath;
+  }
+  const doctorOptionsInput: NonNullable<DoctorOptions> = {
+    providerHookRuntime: createProviderHookRuntime(options.config, hookRuntimeOptions),
+  };
+  if (parsedDoctorOptions?.projectId !== undefined) {
+    doctorOptionsInput.projectId = parsedDoctorOptions.projectId;
+  }
+  if (parsedDoctorOptions?.deep !== undefined) {
+    doctorOptionsInput.deep = parsedDoctorOptions.deep;
+  }
+  const doctorOptions = DoctorOptionsSchema.parse(doctorOptionsInput);
   const timeoutMs = options.timeoutMs ?? 30_000;
   const paths = resolveObserverPaths(options.config);
   const observerOptions: Parameters<typeof startObserver>[0] = { paths, timeoutMs };

--- a/apps/cli/src/commands/providerHookAdapters.ts
+++ b/apps/cli/src/commands/providerHookAdapters.ts
@@ -78,6 +78,10 @@ export type OpenCodeHooksCommandResult =
   | OpenCodePluginInstallResult
   | OpenCodePluginDoctorResult;
 
+export type WorktrunkHooksCommandOptions = ProviderHooksCommandOptions & {
+  config: StationConfig;
+};
+
 export type WorktrunkHooksCommandResult =
   | WorktrunkHookPlan
   | WorktrunkHookInstallResult
@@ -232,8 +236,9 @@ export function runOpenCodeHooksCommand(
 
 export function runWorktrunkHooksCommand(
   args: string[],
-  options: ProviderHooksCommandOptions = {},
+  options: WorktrunkHooksCommandOptions,
 ): Promise<WorktrunkHooksCommandResult> {
+  const config = options.config;
   const runner = createProviderHooksRunner<WorktrunkHookPlanOptions>(
     {
       provider: "worktrunk",
@@ -242,27 +247,23 @@ export function runWorktrunkHooksCommand(
       uninstall: uninstallWorktrunkHooks,
       doctor: doctorWorktrunkHooks,
       buildOptions: (flags, context) => {
-        if (context.config === undefined) {
-          throw new Error("Worktrunk hook commands require loaded Station config.");
-        }
-        const expectation = createWorktrunkHookExpectation(context.config, {
+        const expectation = createWorktrunkHookExpectation(config, {
           stationConfigPath: context.configPath,
           ingressLauncher: context.providerHookIngressLauncher,
         });
         if (flags.hookBin !== undefined) {
           expectation.hookBin = flags.hookBin;
         }
-        const options: WorktrunkHookPlanOptions = { expectation };
+        const planOptions: WorktrunkHookPlanOptions = { expectation };
         // Fall back to the station-config worktrunk config_path when --worktrunk-config is absent.
-        const worktrunkConfigPath =
-          flags.providerConfig ?? context.config.worktree?.worktrunk?.configPath;
+        const worktrunkConfigPath = flags.providerConfig ?? config.worktree?.worktrunk?.configPath;
         if (worktrunkConfigPath !== undefined) {
-          options.worktrunkConfigPath = worktrunkConfigPath;
+          planOptions.worktrunkConfigPath = worktrunkConfigPath;
         }
         if (context.env !== undefined) {
-          options.env = context.env;
+          planOptions.env = context.env;
         }
-        return options;
+        return planOptions;
       },
       isEnabled: isWorktrunkEnabled,
     },

--- a/apps/cli/src/commands/providerHookAdapters.ts
+++ b/apps/cli/src/commands/providerHookAdapters.ts
@@ -49,14 +49,14 @@ import {
   type WorktrunkHookPlan,
   type WorktrunkHookPlanOptions,
 } from "@station/worktrunk";
-import type { CliEnv } from "../env.js";
-import { buildCommonHookOptions, createProviderHooksRunner } from "./providerHooks.js";
+import { createWorktrunkHookExpectation } from "../worktrunkHookExpectation.js";
+import {
+  buildCommonHookOptions,
+  createProviderHooksRunner,
+  type ProviderHooksCommandOptions,
+} from "./providerHooks.js";
 
-export type ProviderHooksCommandOptions = {
-  config?: StationConfig;
-  configPath?: string;
-  env?: CliEnv;
-};
+export type { ProviderHooksCommandOptions } from "./providerHooks.js";
 
 export type ClaudeHooksCommandResult =
   | ClaudeHookPlan
@@ -242,15 +242,25 @@ export function runWorktrunkHooksCommand(
       uninstall: uninstallWorktrunkHooks,
       doctor: doctorWorktrunkHooks,
       buildOptions: (flags, context) => {
-        const options: WorktrunkHookPlanOptions = buildCommonHookOptions(context);
+        if (context.config === undefined) {
+          throw new Error("Worktrunk hook commands require loaded Station config.");
+        }
+        const expectation = createWorktrunkHookExpectation(context.config, {
+          stationConfigPath: context.configPath,
+          ingressLauncher: context.providerHookIngressLauncher,
+        });
+        if (flags.hookBin !== undefined) {
+          expectation.hookBin = flags.hookBin;
+        }
+        const options: WorktrunkHookPlanOptions = { expectation };
         // Fall back to the station-config worktrunk config_path when --worktrunk-config is absent.
         const worktrunkConfigPath =
-          flags.providerConfig ?? context.config?.worktree?.worktrunk?.configPath;
+          flags.providerConfig ?? context.config.worktree?.worktrunk?.configPath;
         if (worktrunkConfigPath !== undefined) {
           options.worktrunkConfigPath = worktrunkConfigPath;
         }
-        if (flags.hookBin !== undefined) {
-          options.hookBin = flags.hookBin;
+        if (context.env !== undefined) {
+          options.env = context.env;
         }
         return options;
       },

--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -28,6 +28,7 @@ type HookCommandContext = {
   config?: StationConfig;
   configPath?: string;
   env?: CliEnv;
+  providerHookIngressLauncher?: string;
 };
 
 type ParsedHookFlags = {
@@ -50,6 +51,7 @@ export type ProviderHooksCommandOptions = {
   config?: StationConfig;
   configPath?: string;
   env?: CliEnv;
+  providerHookIngressLauncher?: string;
 };
 
 export type ProviderHooksCommandResult = unknown;

--- a/apps/cli/src/commands/registry/hooks.ts
+++ b/apps/cli/src/commands/registry/hooks.ts
@@ -2,6 +2,7 @@ import {
   actionNeedsYes,
   hookCommandExitCode,
   loadedCommandOptions,
+  loadedConfigCommandOptions,
 } from "../cliCommand/helpers.js";
 import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
 import type { EventHooksCommandOptions } from "../eventHooks.js";
@@ -57,7 +58,7 @@ async function runProviderHookCliCommand(context: CliCommandRunContext) {
   const hookArgs = [hookAction, ...context.args.slice(1)];
   switch (hookTarget) {
     case "worktrunk": {
-      const result = await runWorktrunkHooksCommand(hookArgs, loadedCommandOptions(context));
+      const result = await runWorktrunkHooksCommand(hookArgs, loadedConfigCommandOptions(context));
       return { code: hookCommandExitCode(result), output: result };
     }
     case "claude": {

--- a/apps/cli/src/commands/registry/worktrunk.ts
+++ b/apps/cli/src/commands/registry/worktrunk.ts
@@ -2,7 +2,7 @@ import {
   actionNeedsYes,
   capitalize,
   hookCommandExitCode,
-  loadedCommandOptions,
+  loadedConfigCommandOptions,
 } from "../cliCommand/helpers.js";
 import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
 import { runWorktrunkHooksCommand } from "../providerHookAdapters.js";
@@ -41,7 +41,7 @@ export const worktrunkCliCommand: CliCommandNode = {
 };
 
 async function runWorktrunkHooksCliCommand(context: CliCommandRunContext) {
-  const result = await runWorktrunkHooksCommand(context.args, loadedCommandOptions(context));
+  const result = await runWorktrunkHooksCommand(context.args, loadedConfigCommandOptions(context));
   return { code: hookCommandExitCode(result), output: result };
 }
 

--- a/apps/cli/src/commands/setup/checks/launchers.ts
+++ b/apps/cli/src/commands/setup/checks/launchers.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { access as nodeAccess, stat as nodeStat } from "node:fs/promises";
+import { access as nodeAccess, stat as nodeStat, realpath } from "node:fs/promises";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CliEnv } from "../../../env.js";
@@ -9,6 +9,8 @@ export type CheckSetupLaunchersOptions = {
   env?: CliEnv;
   access?: (path: string) => Promise<void>;
   packageRoot?: string;
+  compiled?: boolean;
+  providerHookIngressLauncher?: string;
 };
 
 const launcherDefinitions = {
@@ -32,6 +34,25 @@ export async function checkSetupLaunchers(
   const env = options.env ?? process.env;
   const packageRoot = options.packageRoot ?? setupPackageRoot();
   const access = options.access ?? executableAccess;
+  if (options.providerHookIngressLauncher !== undefined) {
+    const runtimeRoot = dirname(options.providerHookIngressLauncher);
+    const source = options.compiled === true ? "installed" : "checkout";
+    const [station, ingress, tmuxPopup] = await Promise.all([
+      checkRuntimeLauncher(launcherDefinitions.station, join(runtimeRoot, "stn"), source, {
+        access,
+        env,
+        packageRoot,
+      }),
+      checkRuntimeLauncher(
+        launcherDefinitions.ingress,
+        options.providerHookIngressLauncher,
+        source,
+        { access, env, packageRoot },
+      ),
+      checkLauncher(launcherDefinitions.tmuxPopup, { access, env, packageRoot }),
+    ]);
+    return { packageRoot, station, ingress, tmuxPopup };
+  }
   const [station, ingress, tmuxPopup] = await Promise.all([
     checkLauncher(launcherDefinitions.station, { access, env, packageRoot }),
     checkLauncher(launcherDefinitions.ingress, { access, env, packageRoot }),
@@ -43,6 +64,56 @@ export async function checkSetupLaunchers(
     ingress,
     tmuxPopup,
   };
+}
+
+async function checkRuntimeLauncher(
+  definition: (typeof launcherDefinitions)["station" | "ingress"],
+  runtimePath: string,
+  runtimeSource: "installed" | "checkout",
+  options: {
+    access: (path: string) => Promise<void>;
+    env: CliEnv | NodeJS.ProcessEnv;
+    packageRoot: string;
+  },
+): Promise<SetupLauncherFact> {
+  const checkoutPath = join(options.packageRoot, definition.relativePath);
+  try {
+    await options.access(runtimePath);
+  } catch {
+    return {
+      status: "missing",
+      source: "missing",
+      command: runtimePath,
+      checkoutPath,
+      message: `The active ${definition.command} runtime launcher is missing or not executable at ${runtimePath}.`,
+    };
+  }
+
+  const pathMatch = await resolveOnPath(definition.command, options.env.PATH, options.access);
+  const onPath =
+    pathMatch !== undefined && (await pathsResolveToSameLauncher(pathMatch, runtimePath));
+  const launcher: SetupLauncherFact = {
+    status: "ok",
+    source: onPath ? "path" : runtimeSource,
+    command: runtimePath,
+    resolvedPath: runtimePath,
+    checkoutPath,
+  };
+  if (pathMatch !== undefined && !onPath) {
+    launcher.message = `${definition.command} on PATH belongs to a different runtime; setup will use ${runtimePath}.`;
+  } else if (pathMatch === undefined && runtimeSource === "checkout") {
+    launcher.message = `${definition.command} is not on PATH; setup will use the current checkout launcher.`;
+  }
+  return launcher;
+}
+
+async function pathsResolveToSameLauncher(left: string, right: string): Promise<boolean> {
+  if (resolve(left) === resolve(right)) return true;
+  try {
+    return (await realpath(left)) === (await realpath(right));
+  } catch {
+    return false;
+  }
 }
 
 export function setupLauncherExecutable(launcher: SetupLauncherFact): string {

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -32,7 +32,11 @@ import { setupEnv } from "./env.js";
 import { type CheckGitOptions, checkSetupGit } from "./git.js";
 import { checkSetupGitDelta } from "./gitDelta.js";
 import { type CheckHarnessesOptions, checkSetupHarnesses } from "./harnesses.js";
-import { checkSetupLaunchers, setupLauncherExecutable } from "./launchers.js";
+import {
+  type CheckSetupLaunchersOptions,
+  checkSetupLaunchers,
+  setupLauncherExecutable,
+} from "./launchers.js";
 import { checkSetupStateDir, type SetupStateDirFileSystem } from "./stateDir.js";
 import { checkSetupTmux } from "./tmux.js";
 import { checkSetupTmuxBinding, tmuxPopupRunShellCommand } from "./tmuxBinding.js";
@@ -63,6 +67,7 @@ export type CollectSetupFactsOptions = {
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
   compiled?: boolean;
+  providerHookIngressLauncher?: string;
   tmuxPopupOwnerRoot?: string;
   stateDirExecute?: (path: string) => Promise<void>;
   stateDirFs?: SetupStateDirFileSystem;
@@ -90,6 +95,10 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   if (options.runner !== undefined) dependencyInput.runner = options.runner;
   if (options.access !== undefined) dependencyInput.access = options.access;
   const dependencyOptions = dependencyCheckOptions(dependencyInput);
+  const launcherOptions: CheckSetupLaunchersOptions = { ...dependencyOptions, compiled };
+  if (options.providerHookIngressLauncher !== undefined) {
+    launcherOptions.providerHookIngressLauncher = options.providerHookIngressLauncher;
+  }
   const git = await checkSetupGit(commandOptions);
   const gitRoot = git.status === "ok" ? git.root : undefined;
   const setupConfigInput: {
@@ -136,7 +145,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
       : checkSetupXcode(xcodeOptions),
     checkSetupHarnesses(commandOptions),
     checkSetupConfig({ ...configPathOptions, configPath }),
-    checkSetupLaunchers(dependencyOptions),
+    checkSetupLaunchers(launcherOptions),
   ]);
   const worktrunkAutomation = await checkSetupWorktrunkAutomation({
     worktrunk,

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -37,6 +37,9 @@ export function collectForCommand(
   if (deps.now !== undefined) collectOptions.now = deps.now;
   if (deps.platform !== undefined) collectOptions.platform = deps.platform;
   if (deps.compiled !== undefined) collectOptions.compiled = deps.compiled;
+  if (deps.providerHookIngressLauncher !== undefined) {
+    collectOptions.providerHookIngressLauncher = deps.providerHookIngressLauncher;
+  }
   if (deps.tmuxPopupOwnerRoot !== undefined) {
     collectOptions.tmuxPopupOwnerRoot = deps.tmuxPopupOwnerRoot;
   }

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -761,8 +761,6 @@ function hookSetupActions(
         "install",
         "worktrunk",
         "--yes",
-        "--hook-bin",
-        setupLauncherExecutable(facts.launchers.ingress),
       ],
       data: { setupRole: "hook" },
     });

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -30,6 +30,7 @@ export type SetupCommandDeps = {
   // macOS Command Line Tools check on any host.
   platform?: NodeJS.Platform;
   compiled?: boolean;
+  providerHookIngressLauncher?: string;
   tmuxPopupOwnerRoot?: string;
   stateDirExecute?: (path: string) => Promise<void>;
   stateDirFs?: SetupStateDirFileSystem;

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -13,6 +13,7 @@ import {
 } from "./commandRegistry.js";
 import type { CliEnv } from "./env.js";
 import { isCliHelpFlag, renderCliHelpFromArgs } from "./help.js";
+import { resolveDefaultIngressLauncher } from "./worktrunkHookExpectation.js";
 
 export type { CliRunOptions, CliRunResult } from "./cliTypes.js";
 
@@ -20,6 +21,7 @@ export async function runCli(
   argv = process.argv.slice(2),
   options: CliRunOptions = {},
 ): Promise<CliRunResult> {
+  const commandOptions = withProviderHookSetupComposition(options);
   const { args, configPath } = parseGlobalOptions(argv);
   const help = renderCliHelpFromArgs(args);
   if (help !== undefined) {
@@ -28,7 +30,7 @@ export async function runCli(
   if (args.length === 1 && args[0] === "--version") {
     return { code: 0, output: stationBuildInfo().version, outputFormat: "text" };
   }
-  const command = args[0] ?? defaultCommand(defaultCommandEnv(options));
+  const command = args[0] ?? defaultCommand(defaultCommandEnv(commandOptions));
   const commandArgs = args[0] === undefined ? [] : args.slice(1);
   const route = resolveCliCommandRoute(command, commandArgs);
   if (route === undefined) {
@@ -49,7 +51,7 @@ export async function runCli(
       cliEntryPath: fileURLToPath(import.meta.url),
       renderHelpTopic: renderCliCommandHelpTopic,
       ...(configPath === undefined ? {} : { configPath }),
-      options,
+      options: commandOptions,
     });
     if (handled !== undefined) {
       return handled;
@@ -65,7 +67,7 @@ export async function runCli(
     ...(configPath === undefined ? {} : { configPath }),
     ...(loaded?.config === undefined ? {} : { config: loaded.config }),
     ...(loaded?.configPath === undefined ? {} : { resolvedConfigPath: loaded.configPath }),
-    options,
+    options: commandOptions,
   });
 }
 
@@ -78,13 +80,14 @@ function defaultCommandEnv(options: CliRunOptions): CliEnv {
 }
 
 /**
- * Runs the CLI as a process adapter around `runCli`, rendering output and errors
- * and applying the existing command-specific exit policy.
+ * Runs the CLI as a process adapter around `runCli`, composing the process-owned
+ * provider-hook launcher before rendering output and applying exit policy.
  */
 export async function runCliMain(
   argv: readonly string[] = process.argv.slice(2),
   options: CliRunOptions = {},
 ): Promise<void> {
+  const processOptions = withProcessComposition(options);
   let suppressOutput = false;
   try {
     suppressOutput = shouldSuppressCliProcessOutput(parseGlobalOptions([...argv]).args);
@@ -92,7 +95,7 @@ export async function runCliMain(
     suppressOutput = false;
   }
   try {
-    const result = await runCli([...argv], options);
+    const result = await runCli([...argv], processOptions);
     if (!suppressOutput && result.output !== undefined) {
       process.stdout.write(formatCliOutput(result));
     }
@@ -107,6 +110,26 @@ export async function runCliMain(
     process.stderr.write(`${formatCliError(error)}\n`);
     process.exitCode = 1;
   }
+}
+
+function withProcessComposition(options: CliRunOptions): CliRunOptions {
+  const providerHookIngressLauncher =
+    options.providerHookIngressLauncher ?? resolveDefaultIngressLauncher();
+  return {
+    ...options,
+    providerHookIngressLauncher,
+  };
+}
+
+function withProviderHookSetupComposition(options: CliRunOptions): CliRunOptions {
+  if (options.providerHookIngressLauncher === undefined) return options;
+  return {
+    ...options,
+    setupDeps: {
+      ...options.setupDeps,
+      providerHookIngressLauncher: options.providerHookIngressLauncher,
+    },
+  };
 }
 
 if (import.meta.main) {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -17,6 +17,11 @@ import { resolveDefaultIngressLauncher } from "./worktrunkHookExpectation.js";
 
 export type { CliRunOptions, CliRunResult } from "./cliTypes.js";
 
+/**
+ * ADAPTER
+ *
+ * Translates CLI arguments and loaded configuration into registered command execution.
+ */
 export async function runCli(
   argv = process.argv.slice(2),
   options: CliRunOptions = {},
@@ -80,8 +85,10 @@ function defaultCommandEnv(options: CliRunOptions): CliEnv {
 }
 
 /**
- * Runs the CLI as a process adapter around `runCli`, composing the process-owned
- * provider-hook launcher before rendering output and applying exit policy.
+ * ADAPTER
+ *
+ * Translates process arguments, output, and exit semantics around `runCli` while composing
+ * process-owned provider-hook identity.
  */
 export async function runCliMain(
   argv: readonly string[] = process.argv.slice(2),

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -4,13 +4,14 @@ import { type CreateProviderRegistryOptions, createProviderRegistry } from "./ob
 
 export type RunCliObserverMainOptions = {
   preparePiExtension?: (stateDir: string) => string | Promise<string>;
+  providerHookIngressLauncher?: string;
 };
 
 /**
  * ADAPTER
  *
- * Translates raw process arguments and optional compiled Pi asset preparation
- * into CLI-owned Observer provider composition.
+ * Translates raw process arguments plus compiled asset and provider-hook launcher
+ * inputs into CLI-owned Observer provider composition.
  */
 export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),
@@ -26,6 +27,9 @@ export async function runCliObserverMain(
         registryOptions.piExtensionPath = await options.preparePiExtension(
           providerOptions.stateDir,
         );
+      }
+      if (options.providerHookIngressLauncher !== undefined) {
+        registryOptions.providerHookIngressLauncher = options.providerHookIngressLauncher;
       }
       return createProviderRegistry(config, registryOptions);
     },

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -51,17 +51,20 @@ import { createStationHostController, StationTerminalProvider } from "@station/t
 import { TmuxProvider } from "@station/tmux";
 import { WorktrunkProvider, worktrunkHookAdapter } from "@station/worktrunk";
 import { selfExecArgv } from "./selfExec.js";
+import { createWorktrunkHookExpectation } from "./worktrunkHookExpectation.js";
 
 export type CreateProviderRegistryOptions = {
   configPath?: string | undefined;
   piExtensionPath?: string | undefined;
+  providerHookIngressLauncher?: string | undefined;
 };
 
 /**
  * COMPOSITION ROOT
  *
  * Constructs concrete provider adapters, including the packaged Pi extension
- * path supplied by compiled CLI composition, and assigns their Observer roles.
+ * path and canonical provider-hook launcher supplied by compiled CLI composition,
+ * and assigns their Observer roles.
  *
  * Observer application use cases are composed by the Observer runtime, not
  * stored in the provider registry.
@@ -70,7 +73,7 @@ export function createProviderRegistry(
   config: StationConfig,
   options: CreateProviderRegistryOptions = {},
 ): ProviderRegistry {
-  const worktree = createWorktreeProvider(config);
+  const worktree = createWorktreeProvider(config, options);
   const terminal = createTerminalProvider(config);
   const harnesses = createHarnessProviders(config, options);
   const repositories = createRepositoryProviders(config);
@@ -121,7 +124,10 @@ function resolveStationHostCommand() {
   ]);
 }
 
-function createWorktreeProvider(config: StationConfig): WorktreeProvider {
+function createWorktreeProvider(
+  config: StationConfig,
+  registryOptions: CreateProviderRegistryOptions,
+): WorktreeProvider {
   if (config.defaults.worktreeProvider === "worktrunk") {
     const options: ConstructorParameters<typeof WorktrunkProvider>[0] = {};
     if (config.worktree?.worktrunk?.command !== undefined) {
@@ -133,6 +139,10 @@ function createWorktreeProvider(config: StationConfig): WorktreeProvider {
     if (config.worktree?.worktrunk?.useLifecycleHooks !== undefined) {
       options.useLifecycleHooks = config.worktree.worktrunk.useLifecycleHooks;
     }
+    options.hookExpectation = createWorktrunkHookExpectation(config, {
+      stationConfigPath: registryOptions.configPath,
+      ingressLauncher: registryOptions.providerHookIngressLauncher,
+    });
     return new WorktrunkProvider(options);
   }
 

--- a/apps/cli/src/worktrunkHookExpectation.ts
+++ b/apps/cli/src/worktrunkHookExpectation.ts
@@ -1,10 +1,11 @@
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveObserverPaths, type StationConfig } from "@station/config";
+import type { ProviderHookRuntime } from "@station/contracts";
 import { isCompiledBinary } from "@station/runtime";
 import type { WorktrunkHookExpectation } from "@station/worktrunk";
 
-export type WorktrunkHookExpectationOptions = {
+export type ProviderHookRuntimeOptions = {
   stationConfigPath?: string | undefined;
   ingressLauncher?: string | undefined;
   compiled?: boolean | undefined;
@@ -15,24 +16,42 @@ export type WorktrunkHookExpectationOptions = {
 /** Builds the one Worktrunk hook expectation shared by CLI setup and provider diagnostics. */
 export function createWorktrunkHookExpectation(
   config: StationConfig,
-  options: WorktrunkHookExpectationOptions = {},
+  options: ProviderHookRuntimeOptions = {},
 ): WorktrunkHookExpectation {
-  const observerPaths = resolveObserverPaths(config);
+  const runtime = createProviderHookRuntime(config, options);
   const expectation: WorktrunkHookExpectation = {
-    hookBin: options.ingressLauncher ?? resolveDefaultIngressLauncher(options),
-    observerSocketPath: observerPaths.socketPath,
-    stateDir: observerPaths.stateDir,
-    hookSpoolDir: observerPaths.hookSpoolDir,
-    autoStartFromHooks: config.observer?.autoStartFromHooks !== false,
+    hookBin: runtime.ingressLauncher,
+    observerSocketPath: runtime.observerSocketPath,
+    stateDir: runtime.stateDir,
+    hookSpoolDir: runtime.hookSpoolDir,
+    autoStartFromHooks: runtime.autoStartFromHooks,
   };
-  if (options.stationConfigPath !== undefined) {
-    expectation.stationConfigPath = options.stationConfigPath;
+  if (runtime.stationConfigPath !== undefined) {
+    expectation.stationConfigPath = runtime.stationConfigPath;
   }
   return expectation;
 }
 
+export function createProviderHookRuntime(
+  config: StationConfig | undefined,
+  options: ProviderHookRuntimeOptions = {},
+): ProviderHookRuntime {
+  const observerPaths = resolveObserverPaths(config);
+  const runtime: ProviderHookRuntime = {
+    ingressLauncher: options.ingressLauncher ?? resolveDefaultIngressLauncher(options),
+    observerSocketPath: observerPaths.socketPath,
+    stateDir: observerPaths.stateDir,
+    hookSpoolDir: observerPaths.hookSpoolDir,
+    autoStartFromHooks: config?.observer?.autoStartFromHooks !== false,
+  };
+  if (options.stationConfigPath !== undefined) {
+    runtime.stationConfigPath = options.stationConfigPath;
+  }
+  return runtime;
+}
+
 export function resolveDefaultIngressLauncher(
-  options: Pick<WorktrunkHookExpectationOptions, "compiled" | "execPath" | "sourceRoot"> = {},
+  options: Pick<ProviderHookRuntimeOptions, "compiled" | "execPath" | "sourceRoot"> = {},
 ): string {
   if (options.compiled ?? isCompiledBinary()) {
     return join(dirname(options.execPath ?? process.execPath), "stn-ingress");

--- a/apps/cli/src/worktrunkHookExpectation.ts
+++ b/apps/cli/src/worktrunkHookExpectation.ts
@@ -1,0 +1,43 @@
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveObserverPaths, type StationConfig } from "@station/config";
+import { isCompiledBinary } from "@station/runtime";
+import type { WorktrunkHookExpectation } from "@station/worktrunk";
+
+export type WorktrunkHookExpectationOptions = {
+  stationConfigPath?: string | undefined;
+  ingressLauncher?: string | undefined;
+  compiled?: boolean | undefined;
+  execPath?: string | undefined;
+  sourceRoot?: string | undefined;
+};
+
+/** Builds the one Worktrunk hook expectation shared by CLI setup and provider diagnostics. */
+export function createWorktrunkHookExpectation(
+  config: StationConfig,
+  options: WorktrunkHookExpectationOptions = {},
+): WorktrunkHookExpectation {
+  const observerPaths = resolveObserverPaths(config);
+  const expectation: WorktrunkHookExpectation = {
+    hookBin: options.ingressLauncher ?? resolveDefaultIngressLauncher(options),
+    observerSocketPath: observerPaths.socketPath,
+    stateDir: observerPaths.stateDir,
+    hookSpoolDir: observerPaths.hookSpoolDir,
+    autoStartFromHooks: config.observer?.autoStartFromHooks !== false,
+  };
+  if (options.stationConfigPath !== undefined) {
+    expectation.stationConfigPath = options.stationConfigPath;
+  }
+  return expectation;
+}
+
+export function resolveDefaultIngressLauncher(
+  options: Pick<WorktrunkHookExpectationOptions, "compiled" | "execPath" | "sourceRoot"> = {},
+): string {
+  if (options.compiled ?? isCompiledBinary()) {
+    return join(dirname(options.execPath ?? process.execPath), "stn-ingress");
+  }
+  const sourceRoot =
+    options.sourceRoot ?? resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+  return join(sourceRoot, "bin", "stn-ingress");
+}

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -4,7 +4,12 @@ import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { runCli } from "@station/cli";
 import { observerRuntimeFreshnessCheck, rendererRuntimeCheck } from "@station/cli/internal";
-import type { DiagnosticEvidenceIndex, DiagnosticSnapshot, DoctorReport } from "@station/contracts";
+import type {
+  DiagnosticEvidenceIndex,
+  DiagnosticSnapshot,
+  DoctorOptions,
+  DoctorReport,
+} from "@station/contracts";
 import { describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 
@@ -15,6 +20,8 @@ describe("CLI diagnostic commands", () => {
   it("routes doctor through the observer diagnostics API", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const providerHookIngressLauncher = "/checkout/requester/bin/stn-ingress";
+    let requestedDoctorOptions: DoctorOptions;
     const deps = {
       buildVersion: observerBuildVersion,
       clientFactory: () =>
@@ -26,13 +33,19 @@ describe("CLI diagnostic commands", () => {
             startedAt: now,
             version: observerBuildVersion,
           }),
-          runDoctor: async () => doctorReport(fixture.stateDir),
+          runDoctor: async (options?: DoctorOptions) => {
+            requestedDoctorOptions = options;
+            return doctorReport(fixture.stateDir);
+          },
         }) as never,
       sleep: async () => undefined,
     };
 
     await expect(
-      runCli(["--config", configPath, "doctor"], { observerDeps: deps }),
+      runCli(["--config", configPath, "doctor"], {
+        observerDeps: deps,
+        providerHookIngressLauncher,
+      }),
     ).resolves.toMatchObject({
       code: 0,
       output: {
@@ -43,6 +56,7 @@ describe("CLI diagnostic commands", () => {
         },
       },
     });
+    expect(requestedDoctorOptions).toEqual({ providerHookIngressLauncher });
   });
 
   it("reports stale local observer runtime evidence without restarting anything", async () => {

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -56,7 +56,16 @@ describe("CLI diagnostic commands", () => {
         },
       },
     });
-    expect(requestedDoctorOptions).toEqual({ providerHookIngressLauncher });
+    expect(requestedDoctorOptions).toEqual({
+      providerHookRuntime: {
+        ingressLauncher: providerHookIngressLauncher,
+        observerSocketPath: fixture.socketPath,
+        stateDir: fixture.stateDir,
+        hookSpoolDir: fixture.hookSpoolDir,
+        autoStartFromHooks: true,
+        stationConfigPath: configPath,
+      },
+    });
   });
 
   it("reports stale local observer runtime evidence without restarting anything", async () => {

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -93,6 +93,43 @@ describe("CLI setup command", () => {
     expect(plan.actions.some((action) => action.id === "install-bun")).toBe(false);
   });
 
+  it("threads the process-owned launcher into setup instead of accepting a split PATH", async () => {
+    const root = await tempRoot(tempRoots);
+    const runtimeBin = join(root, "runtime");
+    const shadowBin = join(root, "shadow");
+    const providerHookIngressLauncher = join(runtimeBin, "stn-ingress");
+    const result = await runCli(["setup", "check", "--json"], {
+      providerHookIngressLauncher,
+      setupDeps: {
+        compiled: true,
+        cwd: root,
+        homeDir: join(root, "home"),
+        env: { PATH: shadowBin },
+        runner: fakeRunner([], {}),
+        access: fakeAccess([
+          join(runtimeBin, "stn"),
+          join(shadowBin, "stn"),
+          join(shadowBin, "stn-ingress"),
+          join(shadowBin, "stn-tmux-popup"),
+        ]),
+        fs: readOnlyFs({}),
+      },
+    });
+    const plan = result.output as {
+      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+      actions: Array<{ id: string }>;
+    };
+
+    expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
+      status: "warning",
+      details: {
+        station: join(runtimeBin, "stn"),
+        ingress: providerHookIngressLauncher,
+      },
+    });
+    expect(plan.actions.find((action) => action.id === "worktrunk-hooks")).toBeUndefined();
+  });
+
   it("generates the compiled binding from installed ownership while preserving its key", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -1,9 +1,11 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
+import { loadConfig } from "@station/config";
 import { providerHookCommandLine } from "@station/runtime";
 import { describe, expect, it } from "vitest";
+import { createProviderRegistry } from "../../src/observerProviders";
 
 describe("CLI Worktrunk hook commands", () => {
   it("plans Worktrunk hook changes without applying them", async () => {
@@ -92,6 +94,67 @@ describe("CLI Worktrunk hook commands", () => {
     });
   });
 
+  it("uses one composed expectation for install and standalone doctor", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-wt-hooks-"));
+    const worktrunkCommand = join(root, "wt");
+    await writeFile(
+      worktrunkCommand,
+      '#!/bin/sh\ncase "$*" in\n  "--version") echo "wt 0.68.0" ;;\n  *) echo "--no-hooks --yes" ;;\nesac\n',
+    );
+    await chmod(worktrunkCommand, 0o700);
+    const configPath = await writeConfig(root, worktrunkCommand);
+    const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+    const ingressLauncher = join(root, "installed", "stn-ingress");
+    const cliOptions = { providerHookIngressLauncher: ingressLauncher };
+
+    const installed = await runCli(
+      [
+        "--config",
+        configPath,
+        "hooks",
+        "install",
+        "worktrunk",
+        "--yes",
+        "--worktrunk-config",
+        worktrunkConfigPath,
+      ],
+      cliOptions,
+    );
+    const doctored = await runCli(
+      [
+        "--config",
+        configPath,
+        "hooks",
+        "doctor",
+        "worktrunk",
+        "--worktrunk-config",
+        worktrunkConfigPath,
+      ],
+      cliOptions,
+    );
+
+    expect(installed).toMatchObject({ code: 0, output: { installed: true } });
+    expect(doctored).toMatchObject({
+      code: 0,
+      output: {
+        status: "ok",
+        commands: {
+          "post-create": expect.stringContaining(ingressLauncher),
+        },
+      },
+    });
+    await expect(readFile(worktrunkConfigPath, "utf8")).resolves.toContain(ingressLauncher);
+
+    const loaded = await loadConfig(configPath);
+    const registry = createProviderRegistry(loaded.config, {
+      configPath: loaded.configPath,
+      providerHookIngressLauncher: ingressLauncher,
+    });
+    await expect(registry.worktree.doctorChecks?.()).resolves.toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "worktrunk-hooks", status: "ok" })]),
+    );
+  });
+
   it("installs through both worktrunk hooks and generic hooks aliases", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cli-wt-hooks-"));
     const configPath = await writeConfig(root);
@@ -173,7 +236,7 @@ describe("CLI Worktrunk hook commands", () => {
   });
 });
 
-async function writeConfig(root: string): Promise<string> {
+async function writeConfig(root: string, worktrunkCommand = "wt"): Promise<string> {
   const configPath = join(root, "config.toml");
   await mkdir(join(root, "state"), { recursive: true });
   await writeFile(
@@ -193,7 +256,8 @@ async function writeConfig(root: string): Promise<string> {
       'layout = "agent-shell"',
       "",
       "[worktree.worktrunk]",
-      'command = "wt"',
+      `command = ${JSON.stringify(worktrunkCommand)}`,
+      `config_path = ${JSON.stringify(join(root, "worktrunk", "config.toml"))}`,
       "",
     ].join("\n"),
   );

--- a/apps/cli/test/unit/cli-command-helpers.test.ts
+++ b/apps/cli/test/unit/cli-command-helpers.test.ts
@@ -1,0 +1,31 @@
+import { isSafeError } from "@station/runtime";
+import { describe, expect, it } from "vitest";
+import { loadedConfigCommandOptions } from "../../src/commands/cliCommand/helpers.js";
+import type { CliCommandRunContext } from "../../src/commands/cliCommand/types.js";
+
+describe("CLI command helpers", () => {
+  it("reports a SafeError when a config-required route violates its loading invariant", () => {
+    const context: CliCommandRunContext = {
+      path: ["hooks", "doctor"],
+      args: ["worktrunk"],
+      allArgs: ["hooks", "doctor", "worktrunk"],
+      cliEntryPath: "/tmp/main.js",
+      renderHelpTopic: () => "",
+      options: {},
+    };
+
+    let thrown: unknown;
+    try {
+      loadedConfigCommandOptions(context);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(isSafeError(thrown)).toBe(true);
+    expect(thrown).toEqual({
+      tag: "CliCommandError",
+      code: "CLI_CONFIG_NOT_LOADED",
+      message: "Station config was not loaded for the hooks doctor command.",
+    });
+  });
+});

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -1,7 +1,11 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import {
+  DEFAULT_WORKSPACE_CONFIG,
+  HarnessProvidersConfigSchema,
+  type StationConfig,
+} from "@station/config";
 import * as contracts from "@station/contracts";
 import { installCursorHooks } from "@station/cursor";
 import { openCodeHookAdapter } from "@station/opencode";
@@ -547,13 +551,13 @@ describe("observer providers", () => {
   it("passes Claude config defaults into the Claude harness provider", async () => {
     const registry = createProviderRegistry({
       ...config,
-      harness: {
+      harness: HarnessProvidersConfigSchema.parse({
         claude: {
           command: "claude-custom",
           profile: "team-profile",
           permissionMode: "auto",
         },
-      },
+      }),
     });
     const provider = registry.harnesses.get("claude");
     const project = config.projects[0];
@@ -865,6 +869,7 @@ const config: StationConfig = {
     harness: "codex",
     layout: "agent-shell",
   },
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   projects: [
     {
       id: "web",

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1246,6 +1246,42 @@ scroll_on_output = "teleport"
     });
   });
 
+  it("rejects a split PATH when the active runtime ingress sibling is missing", async () => {
+    const root = await tempRoot(tempRoots);
+    const runtimeBin = join(root, "runtime");
+    const shadowBin = join(root, "shadow");
+    await Promise.all([
+      mkdir(runtimeBin, { recursive: true }),
+      mkdir(shadowBin, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(join(runtimeBin, "stn"), "#!/bin/sh\n"),
+      writeFile(join(shadowBin, "stn-ingress"), "#!/bin/sh\n"),
+    ]);
+    await Promise.all([
+      chmod(join(runtimeBin, "stn"), 0o755),
+      chmod(join(shadowBin, "stn-ingress"), 0o755),
+    ]);
+    const runtimeIngress = join(runtimeBin, "stn-ingress");
+
+    const launchers = await checkSetupLaunchers({
+      env: { PATH: `${runtimeBin}${delimiter}${shadowBin}` },
+      packageRoot: join(root, "empty-checkout"),
+      providerHookIngressLauncher: runtimeIngress,
+    });
+
+    expect(launchers.station).toMatchObject({
+      status: "ok",
+      resolvedPath: join(runtimeBin, "stn"),
+    });
+    expect(launchers.ingress).toMatchObject({
+      status: "missing",
+      command: runtimeIngress,
+      message: expect.stringContaining(runtimeIngress),
+    });
+    expect(launchers.ingress).not.toMatchObject({ resolvedPath: join(shadowBin, "stn-ingress") });
+  });
+
   it("skips executable directories that shadow launcher names on PATH", async () => {
     const root = await tempRoot(tempRoots);
     const shadowDir = join(root, "shadow");

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -57,7 +57,9 @@ describe("guided setup command", () => {
           activations.push(input);
         },
         prompt: prompt({ confirms: [false, false, true, false, false] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
         now: () => new Date("2026-06-08T12:00:00.000Z"),
       },
     );
@@ -120,7 +122,9 @@ describe("guided setup command", () => {
             return "codex";
           },
         },
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -171,7 +175,9 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, true, false] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -224,7 +230,9 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, true, false] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -337,7 +345,9 @@ describe("guided setup command", () => {
           activations += 1;
         },
         prompt: prompt({ confirms: [false, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -375,7 +385,9 @@ describe("guided setup command", () => {
           };
         },
         prompt: prompt({ confirms: [false, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -469,7 +481,9 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -530,7 +544,9 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -600,7 +616,9 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: prompt({ confirms: [false, false, true, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -615,7 +633,7 @@ describe("guided setup command", () => {
     ).toHaveLength(3);
   });
 
-  it("installs accepted Worktrunk and agent hooks with resolved ingress launcher", async () => {
+  it("delegates Worktrunk launcher composition while resolving the agent ingress launcher", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
@@ -629,8 +647,7 @@ describe("guided setup command", () => {
       "wt --version": "worktrunk 1.2.3\n",
       "tmux -V": "tmux 3.5a\n",
       "codex --version": "codex 0.1.0\n",
-      [`stn --config ${configPath} hooks install worktrunk --yes --hook-bin /fake/bin/stn-ingress`]:
-        "",
+      [`stn --config ${configPath} hooks install worktrunk --yes`]: "",
       [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]: "",
     });
 
@@ -675,16 +692,7 @@ describe("guided setup command", () => {
       expect.arrayContaining([
         expect.objectContaining({
           command: "/fake/bin/stn",
-          args: [
-            "--config",
-            configPath,
-            "hooks",
-            "install",
-            "worktrunk",
-            "--yes",
-            "--hook-bin",
-            "/fake/bin/stn-ingress",
-          ],
+          args: ["--config", configPath, "hooks", "install", "worktrunk", "--yes"],
           stdio: "inherit",
         }),
         expect.objectContaining({
@@ -743,7 +751,9 @@ describe("guided setup command", () => {
           activations += 1;
         },
         prompt: prompt({ confirms: [true, false, true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -811,7 +821,9 @@ describe("guided setup command", () => {
             return "codex";
           },
         },
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -860,7 +872,9 @@ describe("guided setup command", () => {
             closed = true;
           },
         },
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -899,7 +913,9 @@ describe("guided setup command", () => {
         access: fakeAccess([]),
         fs,
         prompt: prompt({ confirms: [true] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -939,7 +955,9 @@ describe("guided setup command", () => {
         access: fakeAccess([]),
         fs,
         prompt: prompt({ confirms: [false] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 
@@ -978,7 +996,9 @@ describe("guided setup command", () => {
         access: fakeAccess(["/fake/bin/wt", "/fake/bin/tmux", "/fake/bin/delta"]),
         fs,
         prompt: prompt({ confirms: [false] }),
-        writeStdout: (chunk) => chunks.push(chunk),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
       },
     );
 

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -329,6 +329,29 @@ describe("setup planner", () => {
     ]);
   });
 
+  it("omits hook installation when the active runtime ingress sibling is missing", () => {
+    const base = facts();
+    const plan = buildSetupPlan(
+      facts({
+        launchers: {
+          ...base.launchers,
+          ingress: {
+            status: "missing",
+            source: "missing",
+            command: "/runtime/bin/stn-ingress",
+            checkoutPath: "/tmp/station/bin/stn-ingress",
+            message: "The active runtime ingress launcher is missing.",
+          },
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
+      status: "warning",
+    });
+    expect(plan.actions.find((action) => action.id === "worktrunk-hooks")).toBeUndefined();
+  });
+
   it("plans the exact popup command and preserved key for a reachable tmux server", () => {
     const plan = buildSetupPlan(
       facts({

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -279,13 +279,18 @@ describe("setup planner", () => {
   });
 
   it("plans the optional tmux popup binding with the preserved key and exact command", () => {
-    const base = facts();
     const plan = buildSetupPlan(
       facts({
         tmuxBinding: {
-          ...base.tmuxBinding,
-          bindingKey: "C-s",
+          status: "missing",
+          path: "/tmp/home/.tmux.conf",
+          marker: "# >>> station popup binding >>>",
+          launcherCommand: "/tmp/bin/stn-tmux-popup",
           runShellCommand: "managed-fast-command",
+          bindingKey: "C-s",
+          insideTmux: false,
+          liveStatus: "unknown",
+          message: "Optional tmux popup binding is not installed.",
         },
       }),
     );
@@ -310,8 +315,6 @@ describe("setup planner", () => {
       "install",
       "worktrunk",
       "--yes",
-      "--hook-bin",
-      "/tmp/bin/stn-ingress",
     ]);
     expect(plan.actions.find((action) => action.id === "codex-hooks")?.command).toEqual([
       "/tmp/bin/stn",
@@ -394,7 +397,7 @@ describe("setup planner", () => {
             message: "missing",
           },
         },
-        tmuxBinding: { ...base.tmuxBinding, insideTmux: true, liveStatus: "missing" },
+        tmuxBinding: { ...base.tmuxBinding, insideTmux: true, liveStatus: "unknown" },
       }),
     );
 

--- a/apps/cli/test/unit/worktrunkHookExpectation.test.ts
+++ b/apps/cli/test/unit/worktrunkHookExpectation.test.ts
@@ -1,0 +1,51 @@
+import { join } from "node:path";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { describe, expect, it } from "vitest";
+import {
+  createWorktrunkHookExpectation,
+  resolveDefaultIngressLauncher,
+} from "../../src/worktrunkHookExpectation";
+
+const config: StationConfig = {
+  schemaVersion: 1,
+  observer: {
+    socketPath: "/tmp/station/run/custom.sock",
+    stateDir: "/tmp/station/state",
+    autoStartFromHooks: false,
+  },
+  defaults: {
+    worktreeProvider: "worktrunk",
+    terminal: "noop-terminal",
+    harness: "noop-harness",
+    layout: "agent-shell",
+  },
+  projects: [],
+  workspace: DEFAULT_WORKSPACE_CONFIG,
+};
+
+describe("Worktrunk hook expectation composition", () => {
+  it("collects every command input from resolved CLI composition", () => {
+    expect(
+      createWorktrunkHookExpectation(config, {
+        stationConfigPath: "/tmp/station/config.toml",
+        ingressLauncher: "/opt/station/stn-ingress",
+      }),
+    ).toEqual({
+      hookBin: "/opt/station/stn-ingress",
+      stationConfigPath: "/tmp/station/config.toml",
+      observerSocketPath: "/tmp/station/run/custom.sock",
+      stateDir: "/tmp/station/state",
+      hookSpoolDir: "/tmp/station/state/spool/hooks",
+      autoStartFromHooks: false,
+    });
+  });
+
+  it("resolves source and compiled launchers to absolute sibling paths", () => {
+    expect(
+      resolveDefaultIngressLauncher({ compiled: false, sourceRoot: "/checkout/station" }),
+    ).toBe(join("/checkout/station", "bin", "stn-ingress"));
+    expect(resolveDefaultIngressLauncher({ compiled: true, execPath: "/opt/station/stn" })).toBe(
+      join("/opt/station", "stn-ingress"),
+    );
+  });
+});

--- a/apps/observer/src/diagnostics/collector.ts
+++ b/apps/observer/src/diagnostics/collector.ts
@@ -147,6 +147,11 @@ export async function collectDiagnosticSnapshot(
   return DiagnosticSnapshotSchema.parse(diagnosticSnapshot);
 }
 
+/**
+ * USE CASE
+ *
+ * Aggregates current runtime, persistence, and provider evidence into the read-only health report.
+ */
 export async function runDoctor(
   deps: ObserverDiagnosticsDeps,
   options: DoctorOptions = {},
@@ -450,11 +455,15 @@ async function collectProviderDoctorChecks(
         ? deps.config.projects
         : deps.config.projects.filter((project) => project.id === options.projectId),
   };
-  if (deps.configPath !== undefined) {
-    context.stationConfigPath = deps.configPath;
-  }
-  if (options?.providerHookIngressLauncher !== undefined) {
-    context.providerHookIngressLauncher = options.providerHookIngressLauncher;
+  if (options?.providerHookRuntime === undefined) {
+    if (deps.configPath !== undefined) {
+      context.stationConfigPath = deps.configPath;
+    }
+  } else {
+    context.providerHookRuntime = options.providerHookRuntime;
+    if (options.providerHookRuntime.stationConfigPath !== undefined) {
+      context.stationConfigPath = options.providerHookRuntime.stationConfigPath;
+    }
   }
   const providers = providerEntries(deps.providers);
 

--- a/apps/observer/src/diagnostics/collector.ts
+++ b/apps/observer/src/diagnostics/collector.ts
@@ -453,6 +453,9 @@ async function collectProviderDoctorChecks(
   if (deps.configPath !== undefined) {
     context.stationConfigPath = deps.configPath;
   }
+  if (options?.providerHookIngressLauncher !== undefined) {
+    context.providerHookIngressLauncher = options.providerHookIngressLauncher;
+  }
   const providers = providerEntries(deps.providers);
 
   for (const { provider } of providers) {

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput } from "@station/runtime";
 import { FakeHarnessProvider, FakeTerminalProvider } from "@station/testing";
@@ -254,6 +254,7 @@ function config(stateDir: string, projects: ProviderProjectConfig[] = []): Stati
       },
     },
     projects,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
   };
 }
 

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -5,7 +5,11 @@ import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput } from "@station/runtime";
 import { FakeHarnessProvider, FakeTerminalProvider } from "@station/testing";
-import { WorktrunkProvider } from "@station/worktrunk";
+import {
+  installWorktrunkHooks,
+  type WorktrunkHookExpectation,
+  WorktrunkProvider,
+} from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 import { ProviderRegistry, runDoctor } from "../../src/internal";
 import { createTestObserverCore } from "../support/testObserver";
@@ -13,6 +17,79 @@ import { createTestObserverCore } from "../support/testObserver";
 const now = "2026-05-21T12:00:00.000Z";
 
 describe("Worktrunk diagnostics", () => {
+  it("uses the requester hook launcher while retaining the incumbent fallback", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-diag-requester-"));
+    const stateDir = join(root, "state");
+    const stationConfigPath = join(root, "config.toml");
+    const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+    const incumbentLauncher = "/checkout/A/bin/stn-ingress";
+    const requesterLauncher = "/checkout/B/bin/stn-ingress";
+    await mkdir(stateDir, { recursive: true });
+    const hookExpectation: WorktrunkHookExpectation = {
+      hookBin: incumbentLauncher,
+      observerSocketPath: join(root, "run", "observer.sock"),
+      stateDir,
+      hookSpoolDir: join(stateDir, "spool", "hooks"),
+      autoStartFromHooks: true,
+      stationConfigPath,
+    };
+    await installWorktrunkHooks({
+      expectation: { ...hookExpectation, hookBin: requesterLauncher },
+      worktrunkConfigPath,
+    });
+    const clock = { now: () => new Date(now) };
+    const stationConfig = config(stateDir);
+    const providers = new ProviderRegistry({
+      worktree: new WorktrunkProvider({
+        command: "wt",
+        configPath: worktrunkConfigPath,
+        hookExpectation,
+        clock,
+        runner: async (input) => ({
+          command: input.command,
+          args: input.args ?? [],
+          stdout: input.args?.includes("--version") ? "wt 0.68.0" : "--no-hooks --yes",
+          stderr: "",
+          exitCode: 0,
+        }),
+      }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
+    });
+    const { sqlite, persistence, core } = createTestObserverCore({
+      config: stationConfig,
+      providers,
+      clock,
+      sqlitePath: join(stateDir, "observer.sqlite"),
+    });
+    await core.reconcile("diagnostics");
+    const deps = {
+      config: stationConfig,
+      configPath: stationConfigPath,
+      core,
+      persistence,
+      persistenceHealth: persistence,
+      providers,
+      paths: { stateDir },
+      clock,
+    };
+
+    const requesterReport = await runDoctor(deps, {
+      providerHookIngressLauncher: requesterLauncher,
+    });
+    const incumbentReport = await runDoctor(deps);
+
+    expect(requesterReport.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "worktrunk-hooks", status: "ok" })]),
+    );
+    expect(incumbentReport.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "worktrunk-hooks", status: "warn" }),
+      ]),
+    );
+    sqlite.close();
+  });
+
   it("reports provider failures and missing hook setup in doctor data", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "station-wt-diag-"));
     const clock = { now: () => new Date(now) };

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
-import type { ProviderProjectConfig } from "@station/contracts";
+import type { ProviderHookRuntime, ProviderProjectConfig } from "@station/contracts";
 import type { ExternalCommandInput } from "@station/runtime";
 import { FakeHarnessProvider, FakeTerminalProvider } from "@station/testing";
 import {
@@ -17,28 +17,46 @@ import { createTestObserverCore } from "../support/testObserver";
 const now = "2026-05-21T12:00:00.000Z";
 
 describe("Worktrunk diagnostics", () => {
-  it("uses the requester hook launcher while retaining the incumbent fallback", async () => {
+  it("uses the requester hook identity while retaining the incumbent fallback", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-wt-diag-requester-"));
-    const stateDir = join(root, "state");
-    const stationConfigPath = join(root, "config.toml");
+    const incumbentStateDir = join(root, "checkout-A", "state");
+    const requesterStateDir = join(root, "checkout-B", "state");
+    const incumbentStationConfigPath = join(root, "checkout-A", "config.toml");
+    const requesterStationConfigPath = join(root, "checkout-B", "config.toml");
+    const sharedObserverSocketPath = join(root, "shared", "observer.sock");
     const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
     const incumbentLauncher = "/checkout/A/bin/stn-ingress";
     const requesterLauncher = "/checkout/B/bin/stn-ingress";
-    await mkdir(stateDir, { recursive: true });
+    await mkdir(incumbentStateDir, { recursive: true });
     const hookExpectation: WorktrunkHookExpectation = {
       hookBin: incumbentLauncher,
-      observerSocketPath: join(root, "run", "observer.sock"),
-      stateDir,
-      hookSpoolDir: join(stateDir, "spool", "hooks"),
+      observerSocketPath: sharedObserverSocketPath,
+      stateDir: incumbentStateDir,
+      hookSpoolDir: join(incumbentStateDir, "spool", "hooks"),
       autoStartFromHooks: true,
-      stationConfigPath,
+      stationConfigPath: incumbentStationConfigPath,
+    };
+    const requesterHookRuntime: ProviderHookRuntime = {
+      ingressLauncher: requesterLauncher,
+      observerSocketPath: sharedObserverSocketPath,
+      stateDir: requesterStateDir,
+      hookSpoolDir: join(requesterStateDir, "spool", "hooks"),
+      autoStartFromHooks: false,
+      stationConfigPath: requesterStationConfigPath,
     };
     await installWorktrunkHooks({
-      expectation: { ...hookExpectation, hookBin: requesterLauncher },
+      expectation: {
+        hookBin: requesterHookRuntime.ingressLauncher,
+        observerSocketPath: requesterHookRuntime.observerSocketPath,
+        stateDir: requesterHookRuntime.stateDir,
+        hookSpoolDir: requesterHookRuntime.hookSpoolDir,
+        autoStartFromHooks: requesterHookRuntime.autoStartFromHooks,
+        stationConfigPath: requesterStationConfigPath,
+      },
       worktrunkConfigPath,
     });
     const clock = { now: () => new Date(now) };
-    const stationConfig = config(stateDir);
+    const stationConfig = config(incumbentStateDir);
     const providers = new ProviderRegistry({
       worktree: new WorktrunkProvider({
         command: "wt",
@@ -60,22 +78,22 @@ describe("Worktrunk diagnostics", () => {
       config: stationConfig,
       providers,
       clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
+      sqlitePath: join(incumbentStateDir, "observer.sqlite"),
     });
     await core.reconcile("diagnostics");
     const deps = {
       config: stationConfig,
-      configPath: stationConfigPath,
+      configPath: incumbentStationConfigPath,
       core,
       persistence,
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir },
+      paths: { stateDir: incumbentStateDir },
       clock,
     };
 
     const requesterReport = await runDoctor(deps, {
-      providerHookIngressLauncher: requesterLauncher,
+      providerHookRuntime: requesterHookRuntime,
     });
     const incumbentReport = await runDoctor(deps);
 
@@ -86,6 +104,30 @@ describe("Worktrunk diagnostics", () => {
       expect.arrayContaining([
         expect.objectContaining({ name: "worktrunk-hooks", status: "warn" }),
       ]),
+    );
+
+    const requesterRuntimeWithoutConfig: ProviderHookRuntime = {
+      ingressLauncher: requesterHookRuntime.ingressLauncher,
+      observerSocketPath: requesterHookRuntime.observerSocketPath,
+      stateDir: requesterHookRuntime.stateDir,
+      hookSpoolDir: requesterHookRuntime.hookSpoolDir,
+      autoStartFromHooks: requesterHookRuntime.autoStartFromHooks,
+    };
+    await installWorktrunkHooks({
+      expectation: {
+        hookBin: requesterRuntimeWithoutConfig.ingressLauncher,
+        observerSocketPath: requesterRuntimeWithoutConfig.observerSocketPath,
+        stateDir: requesterRuntimeWithoutConfig.stateDir,
+        hookSpoolDir: requesterRuntimeWithoutConfig.hookSpoolDir,
+        autoStartFromHooks: requesterRuntimeWithoutConfig.autoStartFromHooks,
+      },
+      worktrunkConfigPath,
+    });
+    const requesterWithoutConfigReport = await runDoctor(deps, {
+      providerHookRuntime: requesterRuntimeWithoutConfig,
+    });
+    expect(requesterWithoutConfigReport.checks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "worktrunk-hooks", status: "ok" })]),
     );
     sqlite.close();
   });

--- a/apps/observer/test/tsconfig.json
+++ b/apps/observer/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "files": ["integration/worktrunk-diagnostics.test.ts"]
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -530,6 +530,7 @@ repository, then run:
 ```sh
 stn --version
 stn setup check --json
+stn hooks doctor worktrunk
 stn doctor
 stn tui
 ```
@@ -575,7 +576,9 @@ manually verify the actual user experience, not a dashboard override:
    and connects to a healthy Observer.
 4. Open a shell pane, run `sleep 30`, press Ctrl-Z, run `fg`, then press Ctrl-C.
 5. Run `stn setup` from `HOME` or Desktop. Confirm it creates a zero-project
-   config without adopting that directory. In the open TUI, press `Enter` on
+   config without adopting that directory, then verify both
+   `stn hooks doctor worktrunk` and the `worktrunk-hooks` row in full
+   `stn doctor` are `ok` without `--hook-bin`. In the open TUI, press `Enter` on
    **Add your first project**, choose a Git repository, and confirm the TUI
    reconnects and shows it after activation on the same Observer socket.
 6. Accept the compiled install's optional popup binding and confirm

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -241,7 +241,14 @@ station --config /path/to/config.toml worktrunk hooks doctor
 station --config /path/to/config.toml worktrunk hooks uninstall --yes
 ```
 
-Generated hook bodies call `stn-ingress --socket <observer.sock> --state-dir <state> --spool-dir <state>/spool/hooks --config /path/to/config.toml worktrunk <event>` by default. They do not contain lifecycle logic. The installer backs up the Worktrunk config, preserves unrelated hook commands, and removes only generated STATION entries on uninstall.
+Generated hook bodies call the resolved absolute `stn-ingress` launcher with
+`--socket <observer.sock> --state-dir <state> --spool-dir <state>/spool/hooks
+--config /path/to/config.toml worktrunk <event>`. They do not contain lifecycle
+logic. The installer backs up the Worktrunk config, preserves unrelated hook
+commands, repairs exact legacy bare-launcher entries to the canonical absolute
+form, and removes only generated STATION entries on uninstall. Standalone and
+full doctor validate that same composed expectation, so normal verification
+never requires repeating `--hook-bin`.
 
 Generic aliases are also available for the Worktrunk hook setup surface:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -383,6 +383,7 @@ pnpm smoke:release -- --keep-temp
 During development, either use the repo-local command:
 
 ```bash
+pnpm stn hooks doctor worktrunk
 pnpm stn doctor
 pnpm stn reconcile --reason manual
 pnpm stn snapshot --json
@@ -407,4 +408,8 @@ mkdir -p ~/.config/station
 cp examples/local-real-config.toml ~/.config/station/config.toml
 ```
 
-Run `stn doctor` after editing the config. Doctor should report config diagnostics, Worktrunk availability and stale registrations, effective Worktrunk automation mode, hook setup status when hooks are expected, SQLite health, provider health, local-state retention, and debug-bundle availability.
+Run `stn hooks doctor worktrunk` and `stn doctor` after editing the config.
+Both surfaces validate the same canonical Worktrunk hook commands; full doctor
+additionally reports config diagnostics, Worktrunk availability and stale
+registrations, effective automation mode, SQLite health, provider health,
+local-state retention, and debug-bundle availability.

--- a/docs/install.md
+++ b/docs/install.md
@@ -368,7 +368,7 @@ and runner self-interruption against local fake release assets. Every child and
 the overall runner have deadlines. It does not contact GitHub or modify the real
 home directory.
 
-Guided setup writes a zero-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. Add the first Git repository explicitly from Station after setup. Generated tmux and hook commands persist the resolved absolute launcher paths, whether they came from an installed runtime or the current checkout, so later processes do not depend on setup's PATH. When bare `stn` launchers are not on `PATH`, setup offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
+Guided setup writes a zero-project config, can enable Worktrunk and selected-agent hooks, and can install the tmux popup binding. Add the first Git repository explicitly from Station after setup. Generated tmux and hook commands persist the resolved absolute launcher paths, whether they came from an installed runtime or the current checkout, so later processes do not depend on setup's PATH. Hook setup validates the active `stn` runtime and its exact `stn-ingress` sibling; an unrelated launcher elsewhere on `PATH` cannot satisfy that pair. When bare `stn` launchers are not on `PATH`, setup offers `pnpm --dir <checkout> station:link` as the convenience path for bare terminal commands.
 
 Useful smoke options:
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -155,7 +155,9 @@ Observer API -> use cases and policies -> application-owned ports
 Composition is intentionally split:
 
 1. `apps/cli/src/observerProviders.ts` constructs concrete integrations,
-   assigns provider roles, and supplies a `ProviderRegistry` factory.
+   assigns provider roles, composes the canonical Worktrunk provider-hook
+   expectation from resolved runtime paths and the ingress launcher, and
+   supplies a `ProviderRegistry` factory.
 2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
    private infrastructure: SQLite, persistence, logging and project-config adapters, event bus, command
    queue, core, handlers, ingress queues, schedulers, API, and protocol server.
@@ -521,7 +523,10 @@ fall through to a second local spawn.
 
 Doctor and diagnostic collection are direct query operations over current core
 health, persistence health, durable Observer records, config diagnostics,
-provider checks, and local runtime evidence. They receive
+provider checks, and local runtime evidence. Worktrunk provider diagnostics
+validate the same composition-injected hook expectation used by CLI hook
+installation rather than reconstructing provider-hook commands inside the
+adapter. They receive
 `PersistenceHealthSource` separately from the command and event journals, so
 neither use case needs a concrete SQLite handle. Collection must remain
 read-only with respect to product state. Provider doctor calls receive an

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -155,8 +155,8 @@ Observer API -> use cases and policies -> application-owned ports
 Composition is intentionally split:
 
 1. `apps/cli/src/observerProviders.ts` constructs concrete integrations,
-   assigns provider roles, composes the canonical Worktrunk provider-hook
-   expectation from resolved runtime paths and the ingress launcher, and
+   assigns provider roles, composes the fallback Worktrunk provider-hook
+   expectation from resolved runtime paths and the Observer ingress launcher, and
    supplies a `ProviderRegistry` factory.
 2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
    private infrastructure: SQLite, persistence, logging and project-config adapters, event bus, command
@@ -523,10 +523,12 @@ fall through to a second local spawn.
 
 Doctor and diagnostic collection are direct query operations over current core
 health, persistence health, durable Observer records, config diagnostics,
-provider checks, and local runtime evidence. Worktrunk provider diagnostics
-validate the same composition-injected hook expectation used by CLI hook
-installation rather than reconstructing provider-hook commands inside the
-adapter. They receive
+provider checks, and local runtime evidence. CLI full-doctor requests carry the
+requester's composed provider-hook ingress launcher through the strict diagnostic
+contract, so Worktrunk validates the same hook expectation as standalone CLI
+doctor even when an exact-build Observer from another checkout serves the request.
+Direct API callers retain the Observer composition expectation as the fallback.
+Provider adapters receive
 `PersistenceHealthSource` separately from the command and event journals, so
 neither use case needs a concrete SQLite handle. Collection must remain
 read-only with respect to product state. Provider doctor calls receive an

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -523,11 +523,14 @@ fall through to a second local spawn.
 
 Doctor and diagnostic collection are direct query operations over current core
 health, persistence health, durable Observer records, config diagnostics,
-provider checks, and local runtime evidence. CLI full-doctor requests carry the
-requester's composed provider-hook ingress launcher through the strict diagnostic
-contract, so Worktrunk validates the same hook expectation as standalone CLI
-doctor even when an exact-build Observer from another checkout serves the request.
-Direct API callers retain the Observer composition expectation as the fallback.
+provider checks, and local runtime evidence. CLI full-doctor requests carry one
+strict provider-neutral hook-runtime context containing the requester's ingress
+launcher, socket, state and spool paths, auto-start policy, and optional Station
+config path. Provider hook adapters map the applicable fields from that context
+without mixing requester and Observer identities, so Worktrunk, Claude, Codex,
+Cursor, and OpenCode compare hook artifacts using the requester runtime identity
+even when an exact-build Observer from another checkout serves the request. Direct
+API callers retain the whole Observer composition expectation as the fallback.
 Provider adapters receive
 `PersistenceHealthSource` separately from the command and event journals, so
 neither use case needs a concrete SQLite handle. Collection must remain

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -169,8 +169,9 @@ stn (bun build --compile, per platform, no ambient env)
 - **SQLite** = `apps/observer/src/sqlite/driver.ts`, runtime-branched
   (`bun:sqlite` under bun, `node:sqlite` under Node), with the **full
   contract** below (F2).
-- **Hooks** keep the PATH-name `stn-ingress` default; every channel ships
-  the symlink.
+- **Hooks** persist the resolved absolute `stn-ingress` sibling supplied by
+  compiled composition; every channel ships that symlink, and standalone/full
+  doctor validate the same generated command expectation.
 
 ## `launchReady` vs `workflowReady` (F11 — don't weaken setup truth)
 

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -163,7 +163,7 @@ The upstream Worktrunk install docs currently recommend:
 brew install worktrunk && wt config shell install
 ```
 
-See https://worktrunk.dev/worktrunk/#install for other package managers.
+See <https://worktrunk.dev/worktrunk/#install> for other package managers.
 
 ## Resolution Order
 
@@ -211,9 +211,12 @@ configured to skip them. `worktree.worktrunk.use_lifecycle_hooks = false` makes 
 mutations use `--no-hooks`; `true` makes them use `--yes`; unset leaves Worktrunk's default prompt
 behavior in place.
 `stn setup check --json` and `stn doctor` report the effective mode and validate that the installed
-`wt` supports any required automation flag. The hook commands are generated with the resolved STATION
-config path, observer socket, state directory, spool directory, and `stn-ingress` launcher. If you
-decline hook setup but later want hook delivery, install later with:
+`wt` supports any required automation flag. The hook commands are generated from one canonical expectation containing the
+resolved STATION config path, observer socket, state directory, spool directory,
+auto-start mode, and absolute `stn-ingress` launcher. Both
+`stn hooks doctor worktrunk` and full `stn doctor` validate that same expectation
+without requiring `--hook-bin`. If you decline hook setup but later want hook
+delivery, install later with:
 
 ```bash
 stn hooks install worktrunk --yes

--- a/integrations/harness/claude/src/provider.ts
+++ b/integrations/harness/claude/src/provider.ts
@@ -93,6 +93,7 @@ function command(options: ClaudeHarnessProviderOptions): string {
 
 function hookPathOptions(
   options: ClaudeHarnessProviderOptions,
+  context?: ProviderDoctorContext,
 ): Parameters<typeof resolveClaudeSettingsArtifactPath>[0] {
   const pathOptions: Parameters<typeof resolveClaudeSettingsArtifactPath>[0] = {};
   if (options.claudeSettingsPath !== undefined) {
@@ -101,7 +102,7 @@ function hookPathOptions(
   if (options.claudeConfigDir !== undefined) {
     pathOptions.claudeConfigDir = options.claudeConfigDir;
   }
-  if (options.stateDir !== undefined) {
+  if (context?.providerHookRuntime === undefined && options.stateDir !== undefined) {
     pathOptions.stateDir = options.stateDir;
   }
   return pathOptions;
@@ -124,7 +125,7 @@ function claudeHookDoctorOptions(
   options: ClaudeHarnessProviderOptions,
   context?: ProviderDoctorContext,
 ): Parameters<typeof doctorClaudeHooks>[0] {
-  return { ...harnessHookDoctorOptions(options, context), ...hookPathOptions(options) };
+  return { ...harnessHookDoctorOptions(options, context), ...hookPathOptions(options, context) };
 }
 
 function buildLaunch(
@@ -244,6 +245,11 @@ async function hooksStatus(
   return harnessHooksStatusFrom("claude", options.installHooks === true, hookResult);
 }
 
+/**
+ * ADAPTER
+ *
+ * Supplies Claude launch, discovery, hook diagnostics, and event normalization through the harness port.
+ */
 export function createClaudeHarnessProvider(
   options: ClaudeHarnessProviderOptions = {},
 ): HarnessProvider {

--- a/integrations/harness/claude/test/unit/provider.test.ts
+++ b/integrations/harness/claude/test/unit/provider.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { BuildHarnessLaunchRequest } from "@station/contracts";
+import type { BuildHarnessLaunchRequest, ProviderHookRuntime } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import { installClaudeHooks } from "../../src/hooks";
@@ -173,6 +173,46 @@ describe("ClaudeHarnessProvider", () => {
       requested: true,
       installed: true,
     });
+  });
+
+  it("uses the requester state directory after shared hook-runtime mapping", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-claude-requester-"));
+    const incumbentStateDir = join(root, "checkout-A", "state");
+    const requesterStateDir = join(root, "checkout-B", "state");
+    const claudeConfigDir = join(root, "claude-home");
+    const requesterStationConfigPath = join(root, "checkout-B", "config.toml");
+    const providerHookRuntime: ProviderHookRuntime = {
+      ingressLauncher: "/checkout/B/bin/stn-ingress",
+      observerSocketPath: join(root, "shared", "observer.sock"),
+      stateDir: requesterStateDir,
+      hookSpoolDir: join(requesterStateDir, "spool", "hooks"),
+      autoStartFromHooks: false,
+      stationConfigPath: requesterStationConfigPath,
+    };
+    await installClaudeHooks({
+      hookBin: providerHookRuntime.ingressLauncher,
+      observerSocketPath: providerHookRuntime.observerSocketPath,
+      stateDir: providerHookRuntime.stateDir,
+      hookSpoolDir: providerHookRuntime.hookSpoolDir,
+      autoStartFromHooks: providerHookRuntime.autoStartFromHooks,
+      stationConfigPath: requesterStationConfigPath,
+      claudeConfigDir,
+    });
+    const provider = createClaudeHarnessProvider({
+      installHooks: true,
+      observerSocketPath: providerHookRuntime.observerSocketPath,
+      stateDir: incumbentStateDir,
+      hookSpoolDir: join(incumbentStateDir, "spool", "hooks"),
+      autoStartFromHooks: true,
+      claudeConfigDir,
+    });
+
+    await expect(
+      provider.hooksStatus?.({
+        stationConfigPath: join(root, "checkout-A", "config.toml"),
+        providerHookRuntime,
+      }),
+    ).resolves.toMatchObject({ installed: true });
   });
 
   it("hooksStatus reports installed:false when hooks are requested but not installed", async () => {

--- a/integrations/harness/cursor/src/provider.ts
+++ b/integrations/harness/cursor/src/provider.ts
@@ -91,7 +91,11 @@ async function doctorChecks(
 ): Promise<ProviderDoctorCheck[]> {
   try {
     const hookOptions = harnessHookDoctorOptions(options, context);
-    if (hookOptions.stationConfigPath === undefined && options.configPath !== undefined) {
+    if (
+      context?.providerHookRuntime === undefined &&
+      hookOptions.stationConfigPath === undefined &&
+      options.configPath !== undefined
+    ) {
       hookOptions.stationConfigPath = options.configPath;
     }
     const hookResult = await doctorCursorHooks(hookOptions);
@@ -119,6 +123,11 @@ async function doctorChecks(
   }
 }
 
+/**
+ * ADAPTER
+ *
+ * Supplies Cursor launch, discovery, hook diagnostics, and event normalization through the harness port.
+ */
 export function createCursorHarnessProvider(
   options: CursorHarnessProviderOptions = {},
 ): HarnessProvider {

--- a/integrations/harness/cursor/test/unit/provider.test.ts
+++ b/integrations/harness/cursor/test/unit/provider.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import type {
   BuildHarnessLaunchRequest,
   HarnessRunObservation,
+  ProviderHookRuntime,
   RawHarnessEvent,
 } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
@@ -95,6 +96,48 @@ describe("CursorHarnessProvider", () => {
           name: "cursor-hooks",
           status: "ok",
         }),
+      );
+    } finally {
+      if (previousCursorHome === undefined) {
+        delete process.env.STATION_CURSOR_HOME;
+      } else {
+        process.env.STATION_CURSOR_HOME = previousCursorHome;
+      }
+    }
+  });
+
+  it("does not re-add the incumbent config when the requester omits it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-requester-"));
+    const incumbentStateDir = join(root, "checkout-A", "state");
+    const requesterStateDir = join(root, "checkout-B", "state");
+    const providerHookRuntime: ProviderHookRuntime = {
+      ingressLauncher: "/checkout/B/bin/stn-ingress",
+      observerSocketPath: join(root, "shared", "observer.sock"),
+      stateDir: requesterStateDir,
+      hookSpoolDir: join(requesterStateDir, "spool", "hooks"),
+      autoStartFromHooks: false,
+    };
+    const previousCursorHome = process.env.STATION_CURSOR_HOME;
+    process.env.STATION_CURSOR_HOME = root;
+    try {
+      await installCursorHooks({
+        hookBin: providerHookRuntime.ingressLauncher,
+        observerSocketPath: providerHookRuntime.observerSocketPath,
+        stateDir: providerHookRuntime.stateDir,
+        hookSpoolDir: providerHookRuntime.hookSpoolDir,
+        autoStartFromHooks: providerHookRuntime.autoStartFromHooks,
+      });
+      const provider = createCursorHarnessProvider({
+        installHooks: true,
+        configPath: join(root, "checkout-A", "config.toml"),
+        observerSocketPath: providerHookRuntime.observerSocketPath,
+        stateDir: incumbentStateDir,
+        hookSpoolDir: join(incumbentStateDir, "spool", "hooks"),
+        autoStartFromHooks: true,
+      });
+
+      await expect(provider.doctorChecks?.({ providerHookRuntime })).resolves.toContainEqual(
+        expect.objectContaining({ name: "cursor-hooks", status: "ok" }),
       );
     } finally {
       if (previousCursorHome === undefined) {

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -5,6 +5,7 @@ import type {
   HarnessPermissionMode,
   HarnessProvider,
   ProviderDoctorCheck,
+  ProviderDoctorContext,
 } from "@station/contracts";
 import {
   type CommonHarnessProviderOptions,
@@ -118,6 +119,7 @@ function buildLaunch(
 
 async function doctorChecks(
   options: OpenCodeHarnessProviderOptions,
+  context?: ProviderDoctorContext,
 ): Promise<ProviderDoctorCheck[]> {
   const checks: ProviderDoctorCheck[] = [];
   const health = await harnessHealth(openCodeSpec, options);
@@ -144,14 +146,21 @@ async function doctorChecks(
       enabled: options.installHooks === true,
       env: options.env ?? process.env,
     };
-    if (options.observerSocketPath !== undefined) {
-      pluginOptions.observerSocketPath = options.observerSocketPath;
-    }
-    if (options.stateDir !== undefined) {
-      pluginOptions.stateDir = options.stateDir;
-    }
-    if (options.hookSpoolDir !== undefined) {
-      pluginOptions.hookSpoolDir = options.hookSpoolDir;
+    const requesterRuntime = context?.providerHookRuntime;
+    if (requesterRuntime !== undefined) {
+      pluginOptions.observerSocketPath = requesterRuntime.observerSocketPath;
+      pluginOptions.stateDir = requesterRuntime.stateDir;
+      pluginOptions.hookSpoolDir = requesterRuntime.hookSpoolDir;
+    } else {
+      if (options.observerSocketPath !== undefined) {
+        pluginOptions.observerSocketPath = options.observerSocketPath;
+      }
+      if (options.stateDir !== undefined) {
+        pluginOptions.stateDir = options.stateDir;
+      }
+      if (options.hookSpoolDir !== undefined) {
+        pluginOptions.hookSpoolDir = options.hookSpoolDir;
+      }
     }
     const pluginResult = await doctorOpenCodePlugin(pluginOptions);
     checks.push({
@@ -175,6 +184,11 @@ async function doctorChecks(
   return checks;
 }
 
+/**
+ * ADAPTER
+ *
+ * Supplies OpenCode launch, discovery, plugin diagnostics, and event normalization through the harness port.
+ */
 export function createOpenCodeHarnessProvider(
   options: OpenCodeHarnessProviderOptions = {},
 ): HarnessProvider {

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -251,6 +251,51 @@ describe("OpenCodeHarnessProvider", () => {
     );
   });
 
+  it("checks plugin identity against the complete requester hook runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-opencode-provider-runtime-"));
+    const opencodeConfigDir = join(root, "opencode");
+    const requesterStateDir = join(root, "requester", "state");
+    const requesterHookSpoolDir = join(requesterStateDir, "spool", "hooks");
+    const requesterObserverSocketPath = join(root, "requester", "run", "observer.sock");
+
+    await installOpenCodePlugin({
+      opencodeConfigDir,
+      observerSocketPath: requesterObserverSocketPath,
+      stateDir: requesterStateDir,
+      hookSpoolDir: requesterHookSpoolDir,
+    });
+
+    const provider = createOpenCodeHarnessProvider({
+      command: "opencode-test",
+      installHooks: true,
+      observerSocketPath: join(root, "incumbent", "run", "observer.sock"),
+      stateDir: join(root, "incumbent", "state"),
+      hookSpoolDir: join(root, "incumbent", "state", "spool", "hooks"),
+      env: { OPENCODE_CONFIG_DIR: opencodeConfigDir },
+      runner: async (input) => result(input, "1.15.12\n"),
+    });
+
+    await expect(
+      provider.doctorChecks({
+        providerHookRuntime: {
+          ingressLauncher: join(root, "requester", "bin", "stn-ingress"),
+          observerSocketPath: requesterObserverSocketPath,
+          stateDir: requesterStateDir,
+          hookSpoolDir: requesterHookSpoolDir,
+          autoStartFromHooks: false,
+          stationConfigPath: join(root, "requester", "config.toml"),
+        },
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "opencode-plugin",
+          status: "ok",
+        }),
+      ]),
+    );
+  });
+
   it("classifies and ingests OpenCode observations through provider-local parsing", async () => {
     const provider = createOpenCodeHarnessProvider({ now: () => new Date(now) });
 

--- a/integrations/worktree/worktrunk/src/hooks.ts
+++ b/integrations/worktree/worktrunk/src/hooks.ts
@@ -2,57 +2,16 @@ import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { createHookSetupFileOps, providerHookCommandLine } from "@station/runtime";
 import { parse, stringify } from "smol-toml";
-
-export const WORKTRUNK_HOOK_NAMES = [
-  "post-create",
-  "post-switch",
-  "pre-remove",
-  "post-remove",
-] as const;
-
-export type WorktrunkHookName = (typeof WORKTRUNK_HOOK_NAMES)[number];
-
-export type WorktrunkHookPlanOptions = {
-  worktrunkConfigPath?: string;
-  stationConfigPath?: string;
-  observerSocketPath?: string;
-  stateDir?: string;
-  hookSpoolDir?: string;
-  autoStartFromHooks?: boolean;
-  hookBin?: string;
-  env?: NodeJS.ProcessEnv;
-  homeDir?: string;
-};
-
-export type WorktrunkHookPlan = {
-  provider: "worktrunk";
-  configPath: string;
-  commands: Record<WorktrunkHookName, string>;
-  missing: WorktrunkHookName[];
-  changed: boolean;
-  before: string;
-  after: string;
-};
-
-export type WorktrunkHookInstallResult = WorktrunkHookPlan & {
-  installed: boolean;
-  backupPath?: string;
-};
-
-export type WorktrunkHookDoctorResult = {
-  provider: "worktrunk";
-  configPath: string;
-  status: "ok" | "warn";
-  installed: boolean;
-  missing: WorktrunkHookName[];
-  commands: Record<WorktrunkHookName, string>;
-  message: string;
-};
-
-export type WorktrunkHookSetupErrorCode =
-  | "WORKTRUNK_HOOK_CONFIG_UNREADABLE"
-  | "WORKTRUNK_HOOK_INVALID_TOML"
-  | "WORKTRUNK_HOOK_WRITE_FAILED";
+import {
+  WORKTRUNK_HOOK_NAMES,
+  type WorktrunkHookDoctorResult,
+  type WorktrunkHookExpectation,
+  type WorktrunkHookInstallResult,
+  type WorktrunkHookName,
+  type WorktrunkHookPlan,
+  type WorktrunkHookPlanOptions,
+  type WorktrunkHookSetupErrorCode,
+} from "./types.js";
 
 export class WorktrunkHookSetupError extends Error {
   readonly tag = "WorktrunkHookSetupError";
@@ -95,16 +54,19 @@ const fileOps = createHookSetupFileOps(({ operation, cause }) => {
 });
 
 export async function planWorktrunkHooks(
-  options: WorktrunkHookPlanOptions = {},
+  options: WorktrunkHookPlanOptions,
 ): Promise<WorktrunkHookPlan> {
   const configPath = resolveWorktrunkConfigPath(options);
   const before = await fileOps.readOptionalFile(configPath);
-  const commands = expectedWorktrunkHookCommands(options);
+  const commands = expectedWorktrunkHookCommands(options.expectation);
+  const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(document, hookName, commands[hookName]),
   );
-  const afterDocument = installCommands(document, commands);
+  // Bare commands from earlier builds are repair inputs, not healthy expectations.
+  const withoutLegacy = uninstallCommands(document, legacyCommands);
+  const afterDocument = installCommands(withoutLegacy, commands);
   const after = stringifyTomlDocument(afterDocument);
 
   return {
@@ -119,7 +81,7 @@ export async function planWorktrunkHooks(
 }
 
 export async function installWorktrunkHooks(
-  options: WorktrunkHookPlanOptions = {},
+  options: WorktrunkHookPlanOptions,
 ): Promise<WorktrunkHookInstallResult> {
   const plan = await planWorktrunkHooks(options);
   if (!plan.changed) {
@@ -139,13 +101,15 @@ export async function installWorktrunkHooks(
 }
 
 export async function uninstallWorktrunkHooks(
-  options: WorktrunkHookPlanOptions = {},
+  options: WorktrunkHookPlanOptions,
 ): Promise<WorktrunkHookInstallResult> {
   const configPath = resolveWorktrunkConfigPath(options);
   const before = await fileOps.readOptionalFile(configPath);
-  const commands = expectedWorktrunkHookCommands(options);
+  const commands = expectedWorktrunkHookCommands(options.expectation);
+  const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
-  const afterDocument = uninstallCommands(document, commands);
+  const withoutCanonical = uninstallCommands(document, commands);
+  const afterDocument = uninstallCommands(withoutCanonical, legacyCommands);
   const after = stringifyTomlDocument(afterDocument);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(afterDocument, hookName, commands[hookName]),
@@ -181,7 +145,7 @@ export async function uninstallWorktrunkHooks(
 }
 
 export async function doctorWorktrunkHooks(
-  options: WorktrunkHookPlanOptions & { enabled?: boolean } = {},
+  options: WorktrunkHookPlanOptions & { enabled?: boolean },
 ): Promise<WorktrunkHookDoctorResult> {
   const plan = await planWorktrunkHooks(options);
   if (options.enabled === false) {
@@ -211,7 +175,9 @@ export async function doctorWorktrunkHooks(
   };
 }
 
-export function resolveWorktrunkConfigPath(options: WorktrunkHookPlanOptions = {}): string {
+export function resolveWorktrunkConfigPath(
+  options: Pick<WorktrunkHookPlanOptions, "worktrunkConfigPath" | "env" | "homeDir"> = {},
+): string {
   if (options.worktrunkConfigPath !== undefined) {
     return resolvePath(options.worktrunkConfigPath, options.homeDir ?? homedir());
   }
@@ -222,23 +188,23 @@ export function resolveWorktrunkConfigPath(options: WorktrunkHookPlanOptions = {
 }
 
 export function expectedWorktrunkHookCommands(
-  options: Pick<
-    WorktrunkHookPlanOptions,
-    | "stationConfigPath"
-    | "observerSocketPath"
-    | "stateDir"
-    | "hookSpoolDir"
-    | "autoStartFromHooks"
-    | "hookBin"
-  > = {},
+  expectation: WorktrunkHookExpectation,
 ): Record<WorktrunkHookName, string> {
-  const hookBin = options.hookBin ?? "stn-ingress";
   return Object.fromEntries(
     WORKTRUNK_HOOK_NAMES.map((hookName) => [
       hookName,
-      providerHookCommandLine("worktrunk", { ...options, hookBin }, hookName),
+      providerHookCommandLine("worktrunk", expectation, hookName),
     ]),
   ) as Record<WorktrunkHookName, string>;
+}
+
+function legacyBareWorktrunkHookCommands(
+  expectation: WorktrunkHookExpectation,
+): Record<WorktrunkHookName, string> {
+  if (expectation.hookBin === "stn-ingress") {
+    return expectedWorktrunkHookCommands(expectation);
+  }
+  return expectedWorktrunkHookCommands({ ...expectation, hookBin: "stn-ingress" });
 }
 
 export function normalizeWorktrunkLifecycleEvent(event: string): string {

--- a/integrations/worktree/worktrunk/src/index.ts
+++ b/integrations/worktree/worktrunk/src/index.ts
@@ -6,3 +6,4 @@ export * from "./hooks.js";
 export * from "./metadata.js";
 export * from "./parse.js";
 export * from "./provider.js";
+export * from "./types.js";

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -52,16 +52,11 @@ import {
 import { doctorWorktrunkHooks } from "./hooks.js";
 import { applyRecoveryBreadcrumbMetadata } from "./metadata.js";
 import { parseWorktrunkListJson, parseWorktrunkListPayload } from "./parse.js";
-
-export type WorktrunkProviderOptions = {
-  command?: string;
-  configPath?: string;
-  useLifecycleHooks?: boolean;
-  timeoutMs?: number;
-  runner?: ExternalCommandRunner;
-  clock?: RuntimeClock;
-  resolveRegistrationIdentity?: (worktreePath: string) => Promise<string | undefined>;
-};
+import {
+  WORKTRUNK_HOOK_NAMES,
+  type WorktrunkHookExpectation,
+  type WorktrunkProviderOptions,
+} from "./types.js";
 
 type WorktrunkRunPolicy = {
   retries?: number;
@@ -82,7 +77,8 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Removal revalidates native Git registration identity, path, and branch immediately before invoking Worktrunk.
+ * Hook diagnostics validate the canonical expectation supplied by composition, while removal revalidates
+ * native Git registration identity, path, and branch immediately before invoking Worktrunk.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -90,6 +86,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #command: string;
   readonly #configPath: string | undefined;
   readonly #useLifecycleHooks: boolean | undefined;
+  readonly #hookExpectation: WorktrunkHookExpectation | undefined;
   readonly #timeoutMs: number;
   readonly #runner: ExternalCommandRunner | undefined;
   readonly #clock: RuntimeClock;
@@ -101,6 +98,7 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
     this.#configPath = options.configPath;
     this.#useLifecycleHooks = options.useLifecycleHooks;
+    this.#hookExpectation = options.hookExpectation;
     this.#timeoutMs = options.timeoutMs ?? 5000;
     this.#runner = options.runner;
     this.#clock = options.clock ?? systemClock;
@@ -158,15 +156,40 @@ export class WorktrunkProvider implements WorktreeProvider {
     return [automationCheck, ...staleChecks, hookCheck];
   }
 
-  async #hookCheck(context: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
+  async #hookCheck(_context: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
+    if (this.#useLifecycleHooks === false) {
+      return {
+        name: "worktrunk-hooks",
+        status: "ok",
+        message:
+          "Worktrunk lifecycle hooks are disabled in station config; automated mutations skip hooks.",
+      };
+    }
+    if (this.#hookExpectation === undefined) {
+      const message = `Worktrunk lifecycle hooks are missing: ${WORKTRUNK_HOOK_NAMES.join(", ")}.`;
+      const error: SafeError = {
+        tag: "WorktrunkHookSetupError",
+        code: "WORKTRUNK_HOOKS_MISSING",
+        message,
+        provider: this.id,
+      };
+      return {
+        name: "worktrunk-hooks",
+        status: "warn",
+        message,
+        error,
+      };
+    }
+
     try {
-      const result = await doctorWorktrunkHooks({
-        ...(this.#configPath === undefined ? {} : { worktrunkConfigPath: this.#configPath }),
-        ...(context.stationConfigPath === undefined
-          ? {}
-          : { stationConfigPath: context.stationConfigPath }),
-        enabled: this.#useLifecycleHooks !== false,
-      });
+      const hookOptions: Parameters<typeof doctorWorktrunkHooks>[0] = {
+        expectation: this.#hookExpectation,
+        enabled: true,
+      };
+      if (this.#configPath !== undefined) {
+        hookOptions.worktrunkConfigPath = this.#configPath;
+      }
+      const result = await doctorWorktrunkHooks(hookOptions);
       const check: ProviderDoctorCheck = {
         name: "worktrunk-hooks",
         status: result.status,

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -79,9 +79,9 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Hook diagnostics use the requester launcher when supplied and retain the Observer composition expectation
- * as a fallback. Checkout roots are validated before Worktrunk runs, and removal revalidates native Git
- * identity, path, and branch before mutation.
+ * Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition
+ * expectation as a fallback. Checkout roots are validated before Worktrunk runs, and removal revalidates
+ * native Git identity, path, and branch before mutation.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -185,9 +185,21 @@ export class WorktrunkProvider implements WorktreeProvider {
     }
 
     try {
-      const expectation: WorktrunkHookExpectation = { ...this.#hookExpectation };
-      if (context.providerHookIngressLauncher !== undefined) {
-        expectation.hookBin = context.providerHookIngressLauncher;
+      const runtime = context.providerHookRuntime;
+      let expectation: WorktrunkHookExpectation;
+      if (runtime === undefined) {
+        expectation = { ...this.#hookExpectation };
+      } else {
+        expectation = {
+          hookBin: runtime.ingressLauncher,
+          observerSocketPath: runtime.observerSocketPath,
+          stateDir: runtime.stateDir,
+          hookSpoolDir: runtime.hookSpoolDir,
+          autoStartFromHooks: runtime.autoStartFromHooks,
+        };
+        if (runtime.stationConfigPath !== undefined) {
+          expectation.stationConfigPath = runtime.stationConfigPath;
+        }
       }
       const hookOptions: Parameters<typeof doctorWorktrunkHooks>[0] = {
         expectation,

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -79,8 +79,9 @@ const defaultCapabilities: WorktreeCapabilities = {
  * ADAPTER
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
- * Hook diagnostics validate the canonical expectation supplied by composition. Checkout roots are validated
- * before Worktrunk runs, and removal revalidates native Git identity, path, and branch before mutation.
+ * Hook diagnostics use the requester launcher when supplied and retain the Observer composition expectation
+ * as a fallback. Checkout roots are validated before Worktrunk runs, and removal revalidates native Git
+ * identity, path, and branch before mutation.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -158,7 +159,7 @@ export class WorktrunkProvider implements WorktreeProvider {
     return [automationCheck, ...staleChecks, hookCheck];
   }
 
-  async #hookCheck(_context: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
+  async #hookCheck(context: ProviderDoctorContext): Promise<ProviderDoctorCheck> {
     if (this.#useLifecycleHooks === false) {
       return {
         name: "worktrunk-hooks",
@@ -184,8 +185,12 @@ export class WorktrunkProvider implements WorktreeProvider {
     }
 
     try {
+      const expectation: WorktrunkHookExpectation = { ...this.#hookExpectation };
+      if (context.providerHookIngressLauncher !== undefined) {
+        expectation.hookBin = context.providerHookIngressLauncher;
+      }
       const hookOptions: Parameters<typeof doctorWorktrunkHooks>[0] = {
-        expectation: this.#hookExpectation,
+        expectation,
         enabled: true,
       };
       if (this.#configPath !== undefined) {

--- a/integrations/worktree/worktrunk/src/types.ts
+++ b/integrations/worktree/worktrunk/src/types.ts
@@ -1,0 +1,67 @@
+import type { ExternalCommandRunner, RuntimeClock } from "@station/runtime";
+
+export const WORKTRUNK_HOOK_NAMES = [
+  "post-create",
+  "post-switch",
+  "pre-remove",
+  "post-remove",
+] as const;
+
+export type WorktrunkHookName = (typeof WORKTRUNK_HOOK_NAMES)[number];
+
+export type WorktrunkHookExpectation = {
+  hookBin: string;
+  observerSocketPath: string;
+  stateDir: string;
+  hookSpoolDir: string;
+  autoStartFromHooks: boolean;
+  stationConfigPath?: string;
+};
+
+export type WorktrunkHookPlanOptions = {
+  expectation: WorktrunkHookExpectation;
+  worktrunkConfigPath?: string;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+};
+
+export type WorktrunkHookPlan = {
+  provider: "worktrunk";
+  configPath: string;
+  commands: Record<WorktrunkHookName, string>;
+  missing: WorktrunkHookName[];
+  changed: boolean;
+  before: string;
+  after: string;
+};
+
+export type WorktrunkHookInstallResult = WorktrunkHookPlan & {
+  installed: boolean;
+  backupPath?: string;
+};
+
+export type WorktrunkHookDoctorResult = {
+  provider: "worktrunk";
+  configPath: string;
+  status: "ok" | "warn";
+  installed: boolean;
+  missing: WorktrunkHookName[];
+  commands: Record<WorktrunkHookName, string>;
+  message: string;
+};
+
+export type WorktrunkHookSetupErrorCode =
+  | "WORKTRUNK_HOOK_CONFIG_UNREADABLE"
+  | "WORKTRUNK_HOOK_INVALID_TOML"
+  | "WORKTRUNK_HOOK_WRITE_FAILED";
+
+export type WorktrunkProviderOptions = {
+  command?: string;
+  configPath?: string;
+  useLifecycleHooks?: boolean;
+  hookExpectation?: WorktrunkHookExpectation;
+  timeoutMs?: number;
+  runner?: ExternalCommandRunner;
+  clock?: RuntimeClock;
+  resolveRegistrationIdentity?: (worktreePath: string) => Promise<string | undefined>;
+};

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -16,11 +16,7 @@ describe("Worktrunk hook setup", () => {
 
     const plan = await planWorktrunkHooks({
       worktrunkConfigPath: configPath,
-      stationConfigPath: "/tmp/station/config.toml",
-      observerSocketPath: "/tmp/station/run/observer.sock",
-      stateDir: "/tmp/station/state",
-      hookSpoolDir: "/tmp/station/state/spool/hooks",
-      hookBin: "/usr/local/bin/stn-ingress",
+      expectation: hookExpectation("/usr/local/bin/stn-ingress"),
     });
 
     expect(plan.changed).toBe(true);
@@ -42,17 +38,11 @@ describe("Worktrunk hook setup", () => {
 
     const installed = await installWorktrunkHooks({
       worktrunkConfigPath: configPath,
-      stationConfigPath: "/tmp/station/config.toml",
-      observerSocketPath: "/tmp/station/run/observer.sock",
-      stateDir: "/tmp/station/state",
-      hookSpoolDir: "/tmp/station/state/spool/hooks",
+      expectation: hookExpectation(),
     });
     const second = await installWorktrunkHooks({
       worktrunkConfigPath: configPath,
-      stationConfigPath: "/tmp/station/config.toml",
-      observerSocketPath: "/tmp/station/run/observer.sock",
-      stateDir: "/tmp/station/state",
-      hookSpoolDir: "/tmp/station/state/spool/hooks",
+      expectation: hookExpectation(),
     });
     const contents = await readFile(configPath, "utf8");
 
@@ -64,10 +54,7 @@ describe("Worktrunk hook setup", () => {
     await expect(
       doctorWorktrunkHooks({
         worktrunkConfigPath: configPath,
-        stationConfigPath: "/tmp/station/config.toml",
-        observerSocketPath: "/tmp/station/run/observer.sock",
-        stateDir: "/tmp/station/state",
-        hookSpoolDir: "/tmp/station/state/spool/hooks",
+        expectation: hookExpectation(),
       }),
     ).resolves.toMatchObject({
       status: "ok",
@@ -80,18 +67,12 @@ describe("Worktrunk hook setup", () => {
     const configPath = join(root, "config.toml");
     await installWorktrunkHooks({
       worktrunkConfigPath: configPath,
-      stationConfigPath: "/tmp/station/config.toml",
-      observerSocketPath: "/tmp/station/run/observer.sock",
-      stateDir: "/tmp/station/state",
-      hookSpoolDir: "/tmp/station/state/spool/hooks",
+      expectation: hookExpectation(),
     });
 
     const removed = await uninstallWorktrunkHooks({
       worktrunkConfigPath: configPath,
-      stationConfigPath: "/tmp/station/config.toml",
-      observerSocketPath: "/tmp/station/run/observer.sock",
-      stateDir: "/tmp/station/state",
-      hookSpoolDir: "/tmp/station/state/spool/hooks",
+      expectation: hookExpectation(),
     });
     const contents = await readFile(configPath, "utf8");
 
@@ -107,7 +88,7 @@ describe("Worktrunk hook setup", () => {
     await expect(
       planWorktrunkHooks({
         worktrunkConfigPath: configPath,
-        stationConfigPath: "/tmp/station/config.toml",
+        expectation: hookExpectation(),
       }),
     ).rejects.toMatchObject({
       tag: "WorktrunkHookSetupError",
@@ -115,4 +96,45 @@ describe("Worktrunk hook setup", () => {
       provider: "worktrunk",
     });
   });
+
+  it("repairs exact legacy bare commands to the canonical absolute launcher", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-hooks-"));
+    const configPath = join(root, "config.toml");
+    await installWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation: hookExpectation(),
+    });
+
+    await expect(
+      doctorWorktrunkHooks({
+        worktrunkConfigPath: configPath,
+        expectation: hookExpectation("/opt/station/stn-ingress"),
+      }),
+    ).resolves.toMatchObject({ status: "warn", installed: false });
+
+    await installWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation: hookExpectation("/opt/station/stn-ingress"),
+    });
+    const contents = await readFile(configPath, "utf8");
+    expect(contents).toContain("/opt/station/stn-ingress");
+    expect(contents).not.toMatch(/= "stn-ingress --socket/);
+    await expect(
+      doctorWorktrunkHooks({
+        worktrunkConfigPath: configPath,
+        expectation: hookExpectation("/opt/station/stn-ingress"),
+      }),
+    ).resolves.toMatchObject({ status: "ok", installed: true });
+  });
 });
+
+function hookExpectation(hookBin = "stn-ingress") {
+  return {
+    hookBin,
+    stationConfigPath: "/tmp/station/config.toml",
+    observerSocketPath: "/tmp/station/run/observer.sock",
+    stateDir: "/tmp/station/state",
+    hookSpoolDir: "/tmp/station/state/spool/hooks",
+    autoStartFromHooks: true,
+  };
+}

--- a/packages/contracts/src/diagnostics.ts
+++ b/packages/contracts/src/diagnostics.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import { z } from "zod";
 import { CommandRecordSchema } from "./commands.js";
 import { ErrorEnvelopeSchema, SafeErrorSchema } from "./errors.js";
@@ -168,6 +169,9 @@ export const DoctorOptionsSchema = z
   .object({
     projectId: ProjectIdSchema.optional(),
     deep: z.boolean().optional(),
+    providerHookIngressLauncher: nonEmptyStringSchema
+      .refine(isAbsolute, "Provider hook ingress launcher must be an absolute path.")
+      .optional(),
   })
   .strict()
   .optional();

--- a/packages/contracts/src/diagnostics.ts
+++ b/packages/contracts/src/diagnostics.ts
@@ -1,4 +1,3 @@
-import { isAbsolute } from "node:path";
 import { z } from "zod";
 import { CommandRecordSchema } from "./commands.js";
 import { ErrorEnvelopeSchema, SafeErrorSchema } from "./errors.js";
@@ -16,7 +15,7 @@ import {
   WorktreeIdSchema,
 } from "./ids.js";
 import { ObserverHealthSchema, ObserverSqliteHealthSummarySchema } from "./observer.js";
-import { ProviderHealthSchema } from "./providers.js";
+import { ProviderHealthSchema, ProviderHookRuntimeSchema } from "./providers.js";
 import { nonEmptyStringSchema } from "./shared.js";
 import { StationSnapshotSchema } from "./snapshot.js";
 
@@ -169,9 +168,7 @@ export const DoctorOptionsSchema = z
   .object({
     projectId: ProjectIdSchema.optional(),
     deep: z.boolean().optional(),
-    providerHookIngressLauncher: nonEmptyStringSchema
-      .refine(isAbsolute, "Provider hook ingress launcher must be an absolute path.")
-      .optional(),
+    providerHookRuntime: ProviderHookRuntimeSchema.optional(),
   })
   .strict()
   .optional();

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import { z } from "zod";
 import type { TerminalFocusOrigin } from "./commands.js";
 import type { SafeError } from "./errors.js";
@@ -197,9 +198,27 @@ export type ProviderDoctorCheck = {
   error?: SafeError;
 };
 
+const providerHookAbsolutePathSchema = nonEmptyStringSchema.refine(
+  isAbsolute,
+  "Provider hook runtime paths must be absolute.",
+);
+
+export const ProviderHookRuntimeSchema = z
+  .object({
+    ingressLauncher: providerHookAbsolutePathSchema,
+    observerSocketPath: providerHookAbsolutePathSchema,
+    stateDir: providerHookAbsolutePathSchema,
+    hookSpoolDir: providerHookAbsolutePathSchema,
+    autoStartFromHooks: z.boolean(),
+    stationConfigPath: providerHookAbsolutePathSchema.optional(),
+  })
+  .strict();
+
+export type ProviderHookRuntime = z.infer<typeof ProviderHookRuntimeSchema>;
+
 export type ProviderDoctorContext = {
   stationConfigPath?: string;
-  providerHookIngressLauncher?: string;
+  providerHookRuntime?: ProviderHookRuntime;
   projects?: readonly ProviderProjectConfig[];
   signal?: AbortSignal;
   timeoutMs?: number;

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -199,6 +199,7 @@ export type ProviderDoctorCheck = {
 
 export type ProviderDoctorContext = {
   stationConfigPath?: string;
+  providerHookIngressLauncher?: string;
   projects?: readonly ProviderProjectConfig[];
   signal?: AbortSignal;
   timeoutMs?: number;

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -138,19 +138,43 @@ describe("diagnostics schemas", () => {
     );
   });
 
-  it("parses requester-scoped provider hook launchers strictly", () => {
+  it("parses requester-scoped provider hook runtimes strictly", () => {
+    const providerHookRuntime = {
+      ingressLauncher: "/checkout/station/bin/stn-ingress",
+      observerSocketPath: "/state/run/observer.sock",
+      stateDir: "/state",
+      hookSpoolDir: "/state/spool/hooks",
+      autoStartFromHooks: true,
+      stationConfigPath: "/checkout/station/config.toml",
+    };
+
+    expect(DoctorOptionsSchema.parse({ providerHookRuntime })).toEqual({ providerHookRuntime });
+    for (const field of [
+      "ingressLauncher",
+      "observerSocketPath",
+      "stateDir",
+      "hookSpoolDir",
+      "stationConfigPath",
+    ] as const) {
+      expect(
+        DoctorOptionsSchema.safeParse({
+          providerHookRuntime: { ...providerHookRuntime, [field]: "relative" },
+        }).success,
+      ).toBe(false);
+    }
     expect(
-      DoctorOptionsSchema.parse({
-        providerHookIngressLauncher: "/checkout/station/bin/stn-ingress",
-      }),
-    ).toEqual({ providerHookIngressLauncher: "/checkout/station/bin/stn-ingress" });
-    expect(
-      DoctorOptionsSchema.safeParse({ providerHookIngressLauncher: "stn-ingress" }).success,
+      DoctorOptionsSchema.safeParse({
+        providerHookRuntime: {
+          ingressLauncher: providerHookRuntime.ingressLauncher,
+          observerSocketPath: providerHookRuntime.observerSocketPath,
+          hookSpoolDir: providerHookRuntime.hookSpoolDir,
+          autoStartFromHooks: providerHookRuntime.autoStartFromHooks,
+        },
+      }).success,
     ).toBe(false);
     expect(
       DoctorOptionsSchema.safeParse({
-        providerHookIngressLauncher: "/checkout/station/bin/stn-ingress",
-        providerPrivateOption: true,
+        providerHookRuntime: { ...providerHookRuntime, providerPrivateOption: true },
       }).success,
     ).toBe(false);
   });

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -4,6 +4,7 @@ import {
   DiagnosticDetailSchema,
   DiagnosticEvidenceIndexSchema,
   DiagnosticSnapshotSchema,
+  DoctorOptionsSchema,
   DoctorReportSchema,
   LogRecordSchema,
   RedactionReportSchema,
@@ -135,6 +136,23 @@ describe("diagnostics schemas", () => {
       await loadJson("diagnostic-evidence-index.json"),
       "diagnostic evidence index",
     );
+  });
+
+  it("parses requester-scoped provider hook launchers strictly", () => {
+    expect(
+      DoctorOptionsSchema.parse({
+        providerHookIngressLauncher: "/checkout/station/bin/stn-ingress",
+      }),
+    ).toEqual({ providerHookIngressLauncher: "/checkout/station/bin/stn-ingress" });
+    expect(
+      DoctorOptionsSchema.safeParse({ providerHookIngressLauncher: "stn-ingress" }).success,
+    ).toBe(false);
+    expect(
+      DoctorOptionsSchema.safeParse({
+        providerHookIngressLauncher: "/checkout/station/bin/stn-ingress",
+        providerPrivateOption: true,
+      }).success,
+    ).toBe(false);
   });
 
   it("parses provider-neutral worktree removal refusal evidence strictly", () => {

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -237,6 +237,7 @@ export type HarnessHookDoctorOptionsInput = {
 
 export type CommonHookDoctorOptions = {
   enabled: boolean;
+  hookBin?: string;
   observerSocketPath?: string;
   stateDir?: string;
   hookSpoolDir?: string;
@@ -244,12 +245,24 @@ export type CommonHookDoctorOptions = {
   stationConfigPath?: string;
 };
 
-/** The hook-doctor option subset shared by claude/codex/cursor; adapters spread-and-extend. */
+/** Maps the whole requester hook runtime or preserves the incumbent provider options. */
 export function harnessHookDoctorOptions(
   options: HarnessHookDoctorOptionsInput,
   context?: ProviderDoctorContext,
 ): CommonHookDoctorOptions {
   const result: CommonHookDoctorOptions = { enabled: options.installHooks === true };
+  const runtime = context?.providerHookRuntime;
+  if (runtime !== undefined) {
+    result.hookBin = runtime.ingressLauncher;
+    result.observerSocketPath = runtime.observerSocketPath;
+    result.stateDir = runtime.stateDir;
+    result.hookSpoolDir = runtime.hookSpoolDir;
+    result.autoStartFromHooks = runtime.autoStartFromHooks;
+    if (runtime.stationConfigPath !== undefined) {
+      result.stationConfigPath = runtime.stationConfigPath;
+    }
+    return result;
+  }
   if (options.observerSocketPath !== undefined) {
     result.observerSocketPath = options.observerSocketPath;
   }

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -2,11 +2,13 @@ import type {
   HarnessEventObservation,
   HarnessLaunchPlan,
   HarnessStatusObservation,
+  ProviderDoctorContext,
 } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import {
   type CommonHarnessProviderOptions,
   createTerminalBoundHarnessProvider,
+  harnessHookDoctorOptions,
   type TerminalBoundHarnessProviderSpec,
 } from "../../src/provider";
 
@@ -206,5 +208,62 @@ describe("versionInfo", () => {
       },
     );
     await expect(provider.versionInfo?.()).resolves.toEqual({ installedVersion: "1.2.3" });
+  });
+});
+
+describe("harnessHookDoctorOptions", () => {
+  const incumbent = {
+    installHooks: true,
+    observerSocketPath: "/shared/observer.sock",
+    stateDir: "/checkout/A/state",
+    hookSpoolDir: "/checkout/A/state/spool/hooks",
+    autoStartFromHooks: true,
+  };
+  const requesterRuntime = {
+    ingressLauncher: "/checkout/B/bin/stn-ingress",
+    observerSocketPath: "/shared/observer.sock",
+    stateDir: "/checkout/B/state",
+    hookSpoolDir: "/checkout/B/state/spool/hooks",
+    autoStartFromHooks: false,
+    stationConfigPath: "/checkout/B/config.toml",
+  };
+
+  it("uses the whole requester hook runtime instead of mixing incumbent fields", () => {
+    const context: ProviderDoctorContext = {
+      stationConfigPath: "/checkout/A/config.toml",
+      providerHookRuntime: requesterRuntime,
+    };
+
+    expect(harnessHookDoctorOptions(incumbent, context)).toEqual({
+      enabled: true,
+      hookBin: requesterRuntime.ingressLauncher,
+      observerSocketPath: requesterRuntime.observerSocketPath,
+      stateDir: requesterRuntime.stateDir,
+      hookSpoolDir: requesterRuntime.hookSpoolDir,
+      autoStartFromHooks: requesterRuntime.autoStartFromHooks,
+      stationConfigPath: requesterRuntime.stationConfigPath,
+    });
+  });
+
+  it("does not retain the incumbent config path when the requester omits it", () => {
+    const context: ProviderDoctorContext = {
+      stationConfigPath: "/checkout/A/config.toml",
+      providerHookRuntime: {
+        ingressLauncher: requesterRuntime.ingressLauncher,
+        observerSocketPath: requesterRuntime.observerSocketPath,
+        stateDir: requesterRuntime.stateDir,
+        hookSpoolDir: requesterRuntime.hookSpoolDir,
+        autoStartFromHooks: requesterRuntime.autoStartFromHooks,
+      },
+    };
+
+    expect(harnessHookDoctorOptions(incumbent, context)).toEqual({
+      enabled: true,
+      hookBin: requesterRuntime.ingressLauncher,
+      observerSocketPath: requesterRuntime.observerSocketPath,
+      stateDir: requesterRuntime.stateDir,
+      hookSpoolDir: requesterRuntime.hookSpoolDir,
+      autoStartFromHooks: requesterRuntime.autoStartFromHooks,
+    });
   });
 });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -209,6 +209,43 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
         "compiled persisted popup command round trip",
       );
 
+      const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+      await writeWorktrunkHookSmokeConfig(configPath, stateDir, socketPath, worktrunkConfigPath);
+      const hookInstall = await run(
+        binaryPath,
+        ["--config", configPath, "hooks", "install", "worktrunk", "--yes"],
+        { env: childEnv },
+      );
+      assertEqual(JSON.parse(hookInstall.stdout).installed, true, "compiled hook install");
+      assertIncludes(
+        await readFile(worktrunkConfigPath, "utf8"),
+        join(installedRoot, "stn-ingress"),
+        "compiled hook absolute ingress launcher",
+      );
+      const standaloneHookDoctor = await run(
+        binaryPath,
+        ["--config", configPath, "hooks", "doctor", "worktrunk"],
+        { env: childEnv },
+      );
+      assertEqual(
+        JSON.parse(standaloneHookDoctor.stdout).status,
+        "ok",
+        "compiled standalone hook doctor",
+      );
+      const fullHookDoctor = await run(binaryPath, ["--config", configPath, "doctor"], {
+        env: childEnv,
+        allowedExitCodes: [0, 1],
+      });
+      const fullHookReport = JSON.parse(fullHookDoctor.stdout);
+      const fullHookCheck = fullHookReport.checks?.find(
+        (check) => check.name === "worktrunk-hooks",
+      );
+      assertEqual(fullHookCheck?.status, "ok", "compiled full hook doctor");
+      const hookObserverClient = createObserverClient({ socketPath, timeoutMs: 5000 });
+      await hookObserverClient.stop();
+      await waitForMissing(socketPath);
+      await writeSmokeConfig(configPath, stateDir, socketPath);
+
       observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
       await runObserverStart(
         binaryPath,
@@ -1128,6 +1165,33 @@ async function waitForDirectoryFileCount(directory, expected) {
     await delay(25);
   }
   fail(`directory file count did not reach ${expected}: ${directory}`);
+}
+
+async function writeWorktrunkHookSmokeConfig(path, state, socket, worktrunkConfigPath) {
+  await writeFile(
+    path,
+    [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[observer]",
+      `state_dir = ${JSON.stringify(state)}`,
+      `socket_path = ${JSON.stringify(socket)}`,
+      "",
+      "[defaults]",
+      'worktree_provider = "worktrunk"',
+      'terminal = "noop-terminal"',
+      'harness = "noop-harness"',
+      'layout = "agent-shell"',
+      "",
+      "[worktree.worktrunk]",
+      'command = "/usr/bin/true"',
+      `config_path = ${JSON.stringify(worktrunkConfigPath)}`,
+      "use_lifecycle_hooks = true",
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
 }
 
 async function writeSmokeConfig(path, state, socket, terminal = "noop-terminal") {

--- a/station/src/bin/stnMain.ts
+++ b/station/src/bin/stnMain.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { dispatchSelfExec, type SelfExecRunners } from "@station/cli/self-exec";
 import cttyHelperAsset from "../../dist/ctty-helper" with { type: "file" };
 import piExtensionAsset from "../../dist/piExtension.mjs" with { type: "file" };
@@ -19,7 +19,9 @@ function popupArgv(argv: readonly string[]): readonly string[] {
 }
 
 function compiledRunners(installedRoot: string): SelfExecRunners {
+  const providerHookIngressLauncher = join(installedRoot, "stn-ingress");
   const cliOptions = {
+    providerHookIngressLauncher,
     popupDeps: {
       checkoutRoot: installedRoot,
       preferRegisteredDevPopup: false,
@@ -34,6 +36,7 @@ function compiledRunners(installedRoot: string): SelfExecRunners {
       const { runCliObserverMain } = await import("@station/cli/observer-main");
       process.exitCode = await runCliObserverMain(argv, {
         preparePiExtension: prepareCompiledPiExtension,
+        providerHookIngressLauncher,
       });
     },
     ingress: async (argv) => (await import("@station/cli/ingress-main")).runCliIngressMain(argv),
@@ -54,8 +57,8 @@ function compiledRunners(installedRoot: string): SelfExecRunners {
 /**
  * COMPOSITION ROOT
  *
- * Binds compiled raw arguments to lazy process entries, packaged runtime assets, and
- * installed popup ownership and setup wiring.
+ * Binds compiled raw arguments to lazy process entries, packaged runtime assets,
+ * installed launcher identity, popup ownership, and setup wiring.
  */
 export async function runStationBinaryMain(): Promise<void> {
   const installedRoot = dirname(realpathSync(process.execPath));

--- a/tests/e2e/real/real-worktrunk-hooks.test.ts
+++ b/tests/e2e/real/real-worktrunk-hooks.test.ts
@@ -42,7 +42,7 @@ describeReal("real Worktrunk hook ingestion", () => {
     cleanup.defer(async () => {
       await runStationJson(env, {
         configPath: config.configPath,
-        args: ["hooks", "uninstall", "worktrunk", "--yes", "--hook-bin", env.stationIngressBin],
+        args: ["hooks", "uninstall", "worktrunk", "--yes"],
       }).catch(() => undefined);
     });
     cleanup.defer(async () => {
@@ -52,20 +52,20 @@ describeReal("real Worktrunk hook ingestion", () => {
     await expect(
       runStationJson(env, {
         configPath: config.configPath,
-        args: ["hooks", "install", "worktrunk", "--yes", "--hook-bin", env.stationIngressBin],
+        args: ["hooks", "install", "worktrunk", "--yes"],
         timeoutMs: 30_000,
       }),
     ).resolves.toMatchObject({ installed: true });
     await expect(
       runStationJson(env, {
         configPath: config.configPath,
-        args: ["hooks", "doctor", "worktrunk", "--hook-bin", env.stationIngressBin],
+        args: ["hooks", "doctor", "worktrunk"],
       }),
     ).resolves.toMatchObject({ status: "ok" });
     await expect(
       runStationJson(env, {
         configPath: config.configPath,
-        args: ["hooks", "uninstall", "worktrunk", "--yes", "--hook-bin", env.stationIngressBin],
+        args: ["hooks", "uninstall", "worktrunk", "--yes"],
       }),
     ).resolves.toMatchObject({ installed: false });
   }, 120_000);
@@ -169,6 +169,9 @@ async function runWorktrunkIngress(
       observerEntryPath: join(env.repoRoot, "apps", "cli", "dist", "observerMain.js"),
     },
   );
+  if (receipt.status === "ignored") {
+    throw new Error("Worktrunk ingress cannot ignore a lifecycle event.");
+  }
   return {
     hookId: receipt.hookId,
     status: receipt.status,

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -181,9 +181,9 @@ describe("setup guided feedback e2e", () => {
         cwd: fixture.repo,
         env: fixture.env,
         // Prompt order: install codex (y), decline cursor/opencode/pi/claude,
-        // decline Worktrunk-hooks + codex-hooks, accept Write config (y),
-        // decline shell-integration + popup.
-        answers: ["y", "n", "n", "n", "n", "n", "n", "y", "n", "n"],
+        // decline linking the fixture's non-runtime launchers, Worktrunk hooks,
+        // and Codex hooks; accept Write config; decline shell integration + popup.
+        answers: ["y", "n", "n", "n", "n", "n", "n", "n", "y", "n", "n"],
       });
 
       expect(result.timedOut).toBe(false);
@@ -207,9 +207,9 @@ describe("setup guided feedback e2e", () => {
       const result = await runStation(["--config", fixture.configPath, "setup"], {
         cwd: fixture.repo,
         env: fixture.env,
-        // Decline Worktrunk and Codex hooks, write config, decline shell integration,
-        // then accept the popup binding.
-        answers: ["n", "n", "y", "n", "y"],
+        // Decline linking the fixture's non-runtime launchers, Worktrunk and Codex
+        // hooks; write config; decline shell integration; accept the popup binding.
+        answers: ["n", "n", "n", "y", "n", "y"],
       });
 
       expect(result.timedOut).toBe(false);
@@ -217,7 +217,9 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain(
         "Tmux popup binding: tmux prefix + Space is persisted for future tmux servers; no current server was live-loaded.",
       );
-      expect(result.stdout).toContain("Direct fallback: stn popup");
+      expect(result.stdout).toContain(
+        `Direct fallback: ${join(process.cwd(), "bin", "stn")} popup`,
+      );
 
       const tmuxConfigPath = join(fixture.home, ".tmux.conf");
       const tmuxConfig = await readFile(tmuxConfigPath, "utf8");

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -2,8 +2,8 @@ import { spawn, spawnSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { createObserverClient } from "@station/protocol";
 import { describe, expect, it } from "vitest";
+import { createObserverClient } from "../../packages/protocol/src/index.js";
 import { waitForSocketClosed } from "../support/sockets";
 
 const shellIntegrationMarker = "# Worktrunk shell integration";
@@ -51,6 +51,41 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("keeps guided Worktrunk install and both doctor surfaces on one expectation", async () => {
+    const fixture = await createFixture({ harness: "codex" });
+    try {
+      const setup = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        // Decline launcher linking, accept Worktrunk hooks, decline Codex hooks,
+        // write config, then decline shell integration and popup binding.
+        answers: ["n", "y", "n", "y", "n", "n"],
+      });
+      expect(setup.exitCode).toBe(0);
+
+      const standalone = await runStation(
+        ["--config", fixture.configPath, "hooks", "doctor", "worktrunk"],
+        { cwd: fixture.repo, env: fixture.env, answers: [] },
+      );
+      expect(standalone.exitCode).toBe(0);
+      expect(JSON.parse(standalone.stdout)).toMatchObject({ status: "ok", installed: true });
+
+      const fullDoctor = await runStation(["--config", fixture.configPath, "doctor"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: [],
+      });
+      const report = JSON.parse(fullDoctor.stdout);
+      expect(report.checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "worktrunk-hooks", status: "ok" }),
+        ]),
+      );
     } finally {
       await fixture.cleanup();
     }
@@ -474,7 +509,7 @@ function runStation(
       }
     });
     child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.on("close", (exitCode) => {
+    child.on("close", (exitCode: number | null) => {
       clearTimeout(timer);
       resolve({
         exitCode,

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node", "vitest/globals"]
+  },
+  "files": [
+    "setup-guided-feedback.test.ts",
+    "worktrunk-real.test.ts",
+    "real/real-worktrunk-hooks.test.ts"
+  ]
+}

--- a/tests/e2e/worktrunk-real.test.ts
+++ b/tests/e2e/worktrunk-real.test.ts
@@ -3,6 +3,7 @@ import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { DEFAULT_WORKSPACE_CONFIG } from "@station/config";
 import { sameObservedPath } from "@station/contracts";
 import { environmentWithoutGitLocals } from "@station/runtime";
 import {
@@ -26,11 +27,13 @@ describeReal("real Worktrunk provider smoke", () => {
     const repo = join(root, "repo");
     const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
     const stationIngressBin = join(process.cwd(), "bin", "stn-ingress");
+    const stateDir = join(root, "station-state");
+    const socketPath = join(root, "run", "observer.sock");
     const stationConfigPath = await writeConfigToml(root, {
       schemaVersion: 1,
       observer: {
-        stateDir: join(root, "station-state"),
-        socketPath: join(root, "run", "observer.sock"),
+        stateDir,
+        socketPath,
         autoStartFromHooks: false,
       },
       defaults: {
@@ -40,7 +43,16 @@ describeReal("real Worktrunk provider smoke", () => {
         layout: "agent-shell",
       },
       projects: [],
+      workspace: DEFAULT_WORKSPACE_CONFIG,
     });
+    const hookExpectation = {
+      hookBin: stationIngressBin,
+      stationConfigPath,
+      observerSocketPath: socketPath,
+      stateDir,
+      hookSpoolDir: join(stateDir, "spool", "hooks"),
+      autoStartFromHooks: false,
+    };
     const branch = `station-real-${Date.now()}`;
     await mkdir(repo, { recursive: true });
     await execFileAsync("git", ["init", "-b", "main"], { cwd: repo });
@@ -52,6 +64,7 @@ describeReal("real Worktrunk provider smoke", () => {
       command: wt,
       configPath: worktrunkConfigPath,
       timeoutMs: 15000,
+      hookExpectation,
     });
     const project = {
       id: "real",
@@ -70,8 +83,7 @@ describeReal("real Worktrunk provider smoke", () => {
 
     await installWorktrunkHooks({
       worktrunkConfigPath,
-      stationConfigPath,
-      hookBin: stationIngressBin,
+      expectation: hookExpectation,
     });
 
     let createdForCleanup:
@@ -109,8 +121,7 @@ describeReal("real Worktrunk provider smoke", () => {
       }
       await uninstallWorktrunkHooks({
         worktrunkConfigPath,
-        stationConfigPath,
-        hookBin: stationIngressBin,
+        expectation: hookExpectation,
       }).catch(() => undefined);
     }
   });

--- a/tests/support/temp-projects/index.ts
+++ b/tests/support/temp-projects/index.ts
@@ -2,7 +2,7 @@ import { rmSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 
 const tempRoots = new Set<string>();
 let exitCleanupRegistered = false;
@@ -39,6 +39,7 @@ export async function createTempState(): Promise<{
         layout: "agent-shell",
       },
       projects: [],
+      workspace: DEFAULT_WORKSPACE_CONFIG,
     },
     cleanup: () => cleanupTempRoot(root),
   };
@@ -105,6 +106,10 @@ function tuiConfigToml(config: StationConfig): string[] {
           : [`time_format = ${JSON.stringify(widget.timeFormat)}`]),
         "",
       ];
+    }
+
+    if (widget.type !== "weather") {
+      return ["[[tui.widgets]]", `type = ${JSON.stringify(widget.type)}`, ""];
     }
 
     return [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "baseUrl": ".",
     "paths": {
       "@station/cli": ["apps/cli/src/index.ts"],
+      "@station/cli/ingress": ["apps/cli/src/ingress/index.ts"],
       "@station/cli/internal": ["apps/cli/src/internal.ts"],
       "@station/observer": ["apps/observer/src/index.ts"],
       "@station/observer/internal": ["apps/observer/src/internal.ts"],


### PR DESCRIPTION
## Summary

- compose one strict Worktrunk hook expectation at the CLI composition root and inject it into setup, standalone hook commands, and provider diagnostics
- persist the resolved absolute `stn-ingress` launcher in both source and compiled modes while keeping `--hook-bin` as an explicit override
- repair exact legacy bare-launcher entries without removing or duplicating unrelated Worktrunk hooks
- centralize the Worktrunk hook/provider public types and document the shared diagnostic contract

## Architecture

The CLI owns runtime path and launcher resolution. The Worktrunk adapter consumes the resulting expectation and no longer reconstructs provider-hook commands from partial defaults. This keeps provider-specific command generation behind the integration boundary while making setup and both doctor surfaces compare the same command identity.

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir station typecheck`
- `pnpm test:unit` — 1,618 passed
- `env -u STATION_PANE pnpm test:integration` — 522 passed
- `pnpm test:diagnostics` — 48 passed
- `env -u STATION_PANE pnpm test:e2e:setup` — 16 passed
- `pnpm build:binary -- --version 0.0.0-local`
- `pnpm smoke:binary -- --expected-version 0.0.0-local`

## UX

After guided setup, both `stn hooks doctor worktrunk` and the `worktrunk-hooks` row in `stn doctor` report `ok` without repeating `--hook-bin`.

Addresses the Worktrunk hook diagnostic mismatch in #231.
