### PR TITLE
feat(tui): animate merged PR button notifications

### DIFF
--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -1,7 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import { testRender } from "@opentui/react/test-utils";
+import { useState } from "react";
 import { DynamicStationButton } from "./DynamicStationButton.js";
-import { ANIM_MS, STATION_ICON, type IslandDisplayInput } from "./layout.js";
+import {
+  ANIM_MS,
+  FRAME_MS,
+  type IslandCelebration,
+  type IslandDisplayInput,
+  islandDisplay,
+  STATION_ICON,
+  targetDims,
+} from "./layout.js";
 import type { StationButtonStatus } from "./status.js";
 
 // OpenTUI's reconciler commits async layout updates outside React's act(),
@@ -33,6 +42,16 @@ async function captureFrame(node: Parameters<typeof testRender>[0]): Promise<str
   } finally {
     setup.renderer.destroy();
   }
+}
+
+function renderedButtonWidth(frame: string): number {
+  const top = frame.split("\n")[0] ?? "";
+  const left = top.indexOf("╭");
+  const right = top.indexOf("╮", left + 1);
+  if (left < 0 || right < 0) {
+    throw new Error("Station button border was not rendered.");
+  }
+  return right - left + 1;
 }
 
 describe("DynamicStationButton", () => {
@@ -103,6 +122,60 @@ describe("DynamicStationButton", () => {
     );
     expect(frame).toContain(STATION_ICON);
     expect(frame).toContain("✓ #42 merged");
+  });
+
+  it("tweens the merged notification in and out", async () => {
+    let updateCelebration: ((value: IslandCelebration | undefined) => void) | undefined;
+    function Harness() {
+      const [celebration, setCelebration] = useState<IslandCelebration>();
+      updateCelebration = setCelebration;
+      return <DynamicStationButton input={input({ idleCount: 3 }, { celebration })} />;
+    }
+
+    const restingWidth = targetDims(islandDisplay(input({ idleCount: 3 }), false)).width;
+    const notifiedWidth = targetDims(
+      islandDisplay(input({ idleCount: 3 }, { celebration: { prNumber: 42 } }), false),
+    ).width;
+    const setup = await testRender(<Harness />, SURFACE);
+    try {
+      await setup.flush();
+      const setCelebration = updateCelebration;
+      if (setCelebration === undefined) {
+        throw new Error("Celebration harness did not mount.");
+      }
+      const waitForWidth = async (predicate: (width: number) => boolean): Promise<number> => {
+        const deadline = Date.now() + ANIM_MS * 4;
+        while (Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
+          await setup.renderOnce();
+          const width = renderedButtonWidth(setup.captureCharFrame());
+          if (predicate(width)) {
+            return width;
+          }
+        }
+        throw new Error("Station button did not reach the expected animated width.");
+      };
+
+      setCelebration({ prNumber: 42 });
+      const openingWidth = await waitForWidth(
+        (width) => width > restingWidth && width < notifiedWidth,
+      );
+      expect(openingWidth).toBeGreaterThan(restingWidth);
+      await waitForWidth((width) => width === notifiedWidth);
+      expect(setup.captureCharFrame()).toContain("✓ #42 merged");
+
+      setCelebration(undefined);
+      const closingWidth = await waitForWidth(
+        (width) => width > restingWidth && width < notifiedWidth,
+      );
+      expect(closingWidth).toBeLessThan(notifiedWidth);
+      await waitForWidth((width) => width === restingWidth);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).not.toContain("#42");
+    } finally {
+      setup.renderer.destroy();
+    }
   });
 
   it("attention wins over the celebration", async () => {

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -54,6 +54,25 @@ function renderedButtonWidth(frame: string): number {
   return right - left + 1;
 }
 
+type ButtonFrame = { frame: string; width: number };
+
+async function waitForButtonFrame(
+  setup: Awaited<ReturnType<typeof testRender>>,
+  predicate: (value: ButtonFrame) => boolean,
+): Promise<ButtonFrame> {
+  const deadline = Date.now() + ANIM_MS * 6;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
+    await setup.renderOnce();
+    const frame = setup.captureCharFrame();
+    const value = { frame, width: renderedButtonWidth(frame) };
+    if (predicate(value)) {
+      return value;
+    }
+  }
+  throw new Error("Station button did not reach the expected animated frame.");
+}
+
 describe("DynamicStationButton", () => {
   it("collapsed base shows only the station icon", async () => {
     const frame = await captureFrame(
@@ -143,36 +162,173 @@ describe("DynamicStationButton", () => {
       if (setCelebration === undefined) {
         throw new Error("Celebration harness did not mount.");
       }
-      const waitForWidth = async (predicate: (width: number) => boolean): Promise<number> => {
-        const deadline = Date.now() + ANIM_MS * 4;
-        while (Date.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
-          await setup.renderOnce();
-          const width = renderedButtonWidth(setup.captureCharFrame());
-          if (predicate(width)) {
-            return width;
-          }
-        }
-        throw new Error("Station button did not reach the expected animated width.");
-      };
-
       setCelebration({ prNumber: 42 });
-      const openingWidth = await waitForWidth(
-        (width) => width > restingWidth && width < notifiedWidth,
-      );
+      const openingWidth = (
+        await waitForButtonFrame(
+          setup,
+          ({ width }) => width > restingWidth && width < notifiedWidth,
+        )
+      ).width;
       expect(openingWidth).toBeGreaterThan(restingWidth);
-      await waitForWidth((width) => width === notifiedWidth);
+      await waitForButtonFrame(setup, ({ width }) => width === notifiedWidth);
       expect(setup.captureCharFrame()).toContain("✓ #42 merged");
 
       setCelebration(undefined);
-      const closingWidth = await waitForWidth(
-        (width) => width > restingWidth && width < notifiedWidth,
-      );
+      const closingWidth = (
+        await waitForButtonFrame(
+          setup,
+          ({ width }) => width > restingWidth && width < notifiedWidth,
+        )
+      ).width;
       expect(closingWidth).toBeLessThan(notifiedWidth);
-      await waitForWidth((width) => width === restingWidth);
+      await waitForButtonFrame(setup, ({ width }) => width === restingWidth);
       await new Promise((resolve) => setTimeout(resolve, 0));
       await setup.renderOnce();
       expect(setup.captureCharFrame()).not.toContain("#42");
+    } finally {
+      setup.renderer.destroy();
+    }
+  });
+
+  it("exits the current celebration before animating its replacement", async () => {
+    const first = { prNumber: 42 };
+    const second = { prNumber: 812, title: "second title" };
+    let updateCelebration: ((value: IslandCelebration | undefined) => void) | undefined;
+    function Harness() {
+      const [celebration, setCelebration] = useState<IslandCelebration | undefined>(first);
+      updateCelebration = setCelebration;
+      return <DynamicStationButton input={input({ idleCount: 3 }, { celebration })} />;
+    }
+
+    const restingWidth = targetDims(islandDisplay(input({ idleCount: 3 }), false)).width;
+    const firstWidth = targetDims(
+      islandDisplay(input({ idleCount: 3 }, { celebration: first }), false),
+    ).width;
+    const secondWidth = targetDims(
+      islandDisplay(input({ idleCount: 3 }, { celebration: second }), false),
+    ).width;
+    const setup = await testRender(<Harness />, SURFACE);
+    try {
+      await setup.flush();
+      expect(renderedButtonWidth(setup.captureCharFrame())).toBe(firstWidth);
+      const setCelebration = updateCelebration;
+      if (setCelebration === undefined) {
+        throw new Error("Celebration replacement harness did not mount.");
+      }
+
+      setCelebration(second);
+      const exiting = await waitForButtonFrame(
+        setup,
+        ({ frame, width }) =>
+          frame.includes("#42") && width > restingWidth && width < firstWidth,
+      );
+      expect(exiting.frame).not.toContain("#812");
+      const entering = await waitForButtonFrame(
+        setup,
+        ({ frame, width }) =>
+          frame.includes("#812") && width > restingWidth && width < secondWidth,
+      );
+      expect(entering.width).toBeLessThan(secondWidth);
+      await waitForButtonFrame(
+        setup,
+        ({ frame, width }) => frame.includes("#812") && width === secondWidth,
+      );
+    } finally {
+      setup.renderer.destroy();
+    }
+  });
+
+  it("starts a hidden celebration only after attention clears", async () => {
+    const celebration = { prNumber: 99 };
+    let setAttention: ((value: boolean) => void) | undefined;
+    let setCelebration: ((value: IslandCelebration | undefined) => void) | undefined;
+    function Harness() {
+      const [attention, updateAttention] = useState(true);
+      const [currentCelebration, updateCelebration] = useState<IslandCelebration>();
+      setAttention = updateAttention;
+      setCelebration = updateCelebration;
+      return (
+        <DynamicStationButton
+          input={input(
+            {
+              attention,
+              needsYouCount: attention ? 1 : 0,
+              sessionName: attention ? "hook-scope" : undefined,
+            },
+            { celebration: currentCelebration },
+          )}
+        />
+      );
+    }
+
+    const restingWidth = targetDims(islandDisplay(input(), false)).width;
+    const notifiedWidth = targetDims(islandDisplay(input({}, { celebration }), false)).width;
+    const setup = await testRender(<Harness />, SURFACE);
+    try {
+      await setup.flush();
+      if (setAttention === undefined || setCelebration === undefined) {
+        throw new Error("Attention celebration harness did not mount.");
+      }
+      setCelebration(celebration);
+      await new Promise((resolve) => setTimeout(resolve, ANIM_MS + FRAME_MS * 2));
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).toContain("!!!!");
+
+      setAttention(false);
+      const entering = await waitForButtonFrame(
+        setup,
+        ({ width }) => width > restingWidth && width < notifiedWidth,
+      );
+      expect(entering.width).toBeLessThan(notifiedWidth);
+      await waitForButtonFrame(
+        setup,
+        ({ frame, width }) => frame.includes("#99") && width === notifiedWidth,
+      );
+    } finally {
+      setup.renderer.destroy();
+    }
+  });
+
+  it("starts a hidden celebration only after hover expansion ends", async () => {
+    const celebration = { prNumber: 44, title: "longer title" };
+    let setCelebration: ((value: IslandCelebration | undefined) => void) | undefined;
+    function Harness() {
+      const [currentCelebration, updateCelebration] = useState<IslandCelebration>();
+      setCelebration = updateCelebration;
+      return <DynamicStationButton input={input({ idleCount: 3 }, { celebration: currentCelebration })} />;
+    }
+
+    const restingWidth = targetDims(islandDisplay(input({ idleCount: 3 }), false)).width;
+    const expandedWidth = targetDims(islandDisplay(input({ idleCount: 3 }), true)).width;
+    const notifiedWidth = targetDims(
+      islandDisplay(input({ idleCount: 3 }, { celebration }), false),
+    ).width;
+    const setup = await testRender(<Harness />, SURFACE);
+    try {
+      await setup.flush();
+      await setup.mockMouse.moveTo(SURFACE.width - 1, 0);
+      await waitForButtonFrame(setup, ({ width }) => width === expandedWidth);
+      if (setCelebration === undefined) {
+        throw new Error("Hover celebration harness did not mount.");
+      }
+      setCelebration(celebration);
+      await new Promise((resolve) => setTimeout(resolve, ANIM_MS + FRAME_MS * 2));
+      await setup.renderOnce();
+      expect(setup.captureCharFrame()).toContain("sessions idle");
+      expect(setup.captureCharFrame()).not.toContain("#44");
+
+      await setup.mockMouse.moveTo(0, SURFACE.height - 1);
+      const firstClosingFrame = await waitForButtonFrame(
+        setup,
+        ({ width }) => width !== expandedWidth,
+      );
+      expect(firstClosingFrame.width).toBeGreaterThan(restingWidth);
+      expect(firstClosingFrame.width).toBeLessThan(expandedWidth);
+      expect(firstClosingFrame.frame).not.toContain("#44");
+      await waitForButtonFrame(
+        setup,
+        ({ frame, width }) => frame.includes("#44") && width === notifiedWidth,
+      );
     } finally {
       setup.renderer.destroy();
     }

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -368,6 +368,43 @@ describe("DynamicStationButton", () => {
     }
   });
 
+  it("does not acquire hover when a notification grows under a stationary pointer", async () => {
+    const celebration = { prNumber: 812, title: "1234567890123456789012345678" };
+    const hoverChanges: boolean[] = [];
+    let setCelebration: ((value: IslandCelebration | undefined) => void) | undefined;
+    function Harness() {
+      const [currentCelebration, updateCelebration] = useState<IslandCelebration>();
+      setCelebration = updateCelebration;
+      return (
+        <DynamicStationButton
+          input={input({}, { celebration: currentCelebration })}
+          onHoverChange={(hovered) => hoverChanges.push(hovered)}
+        />
+      );
+    }
+
+    const surface = { width: 100, height: 20 };
+    const notifiedWidth = targetDims(islandDisplay(input({}, { celebration }), false)).width;
+    const setup = await testRender(<Harness />, surface);
+    try {
+      await setup.flush();
+      await setup.mockMouse.moveTo(60, 1);
+      if (setCelebration === undefined) {
+        throw new Error("Stationary-pointer celebration harness did not mount.");
+      }
+      setCelebration(celebration);
+
+      const settled = await waitForButtonFrame(
+        setup,
+        ({ frame, width }) => frame.includes("#812") && width === notifiedWidth,
+      );
+      expect(settled.frame).toContain("✓ #812 merged");
+      expect(hoverChanges).toEqual([]);
+    } finally {
+      setup.renderer.destroy();
+    }
+  });
+
   it("attention wins over the celebration", async () => {
     const frame = await captureFrame(
       <DynamicStationButton

--- a/station/src/stationButton/DynamicStationButton.test.tsx
+++ b/station/src/stationButton/DynamicStationButton.test.tsx
@@ -318,17 +318,51 @@ describe("DynamicStationButton", () => {
       expect(setup.captureCharFrame()).not.toContain("#44");
 
       await setup.mockMouse.moveTo(0, SURFACE.height - 1);
-      const firstClosingFrame = await waitForButtonFrame(
-        setup,
-        ({ width }) => width !== expandedWidth,
-      );
-      expect(firstClosingFrame.width).toBeGreaterThan(restingWidth);
-      expect(firstClosingFrame.width).toBeLessThan(expandedWidth);
-      expect(firstClosingFrame.frame).not.toContain("#44");
-      await waitForButtonFrame(
-        setup,
-        ({ frame, width }) => frame.includes("#44") && width === notifiedWidth,
-      );
+      const closingWidths: number[] = [];
+      const collapseDeadline = Date.now() + ANIM_MS * 3;
+      while (Date.now() < collapseDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
+        await setup.renderOnce();
+        const frame = setup.captureCharFrame();
+        const width = renderedButtonWidth(frame);
+        closingWidths.push(width);
+        if (width === restingWidth) {
+          break;
+        }
+        expect(frame).not.toContain("✓");
+      }
+      expect(closingWidths.at(-1)).toBe(restingWidth);
+      expect(
+        closingWidths.some((width) => width > restingWidth && width < expandedWidth),
+      ).toBe(true);
+      expect(
+        closingWidths.every(
+          (width, index) => index === 0 || width <= (closingWidths[index - 1] ?? width),
+        ),
+      ).toBe(true);
+
+      const enteringWidths: number[] = [];
+      const entranceDeadline = Date.now() + ANIM_MS * 3;
+      while (Date.now() < entranceDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, FRAME_MS));
+        await setup.renderOnce();
+        const frame = setup.captureCharFrame();
+        const width = renderedButtonWidth(frame);
+        enteringWidths.push(width);
+        if (frame.includes("#44") && width === notifiedWidth) {
+          break;
+        }
+      }
+      expect(enteringWidths.at(-1)).toBe(notifiedWidth);
+      expect(
+        enteringWidths.some((width) => width > restingWidth && width < notifiedWidth),
+      ).toBe(true);
+      expect(
+        enteringWidths.every(
+          (width, index) => index === 0 || width >= (enteringWidths[index - 1] ?? width),
+        ),
+      ).toBe(true);
+      expect(setup.captureCharFrame()).toContain("#44");
     } finally {
       setup.renderer.destroy();
     }

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -63,7 +63,10 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
     setInternalHover(hovering);
     onHoverChange?.(hovering);
   };
-  const pointerProps = useHoverPointer({ onHoverChange: handleHoverChange });
+  const pointerProps = useHoverPointer({
+    acquireOnMouseOver: false,
+    onHoverChange: handleHoverChange,
+  });
 
   const { open, dims, display, textReveal, celebrationReveal } = useButtonTransition(
     input,

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -35,7 +35,8 @@ import {
   STATION_ICON,
   targetDims,
 } from "./layout.js";
-import { useTweenAmount, useTweenedOptionalValue } from "./useTweenAmount.js";
+import { useTweenAmount } from "./hooks/useTweenAmount.js";
+import { useTweenedOptionalValue } from "./hooks/useTweenedOptionalValue.js";
 
 export type DynamicStationButtonProps = {
   /** Everything the display ladder needs; islandDisplay decides what paints. */

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -1,6 +1,5 @@
 import type { MouseEvent as OpenTuiMouseEvent } from "@opentui/core";
-import { useRenderer } from "@opentui/react";
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import { type ReactNode, useState } from "react";
 import {
   isPrimaryMouseEvent,
   isRightMouseEvent,
@@ -13,7 +12,6 @@ import { Throbber } from "../station/view/Throbber.js";
 import { lerpColor, type StationButtonStateColors, stationButtonColors } from "./colors.js";
 import type { ProjectRollupEntry, ProjectRollupStatus } from "./status.js";
 import {
-  ANIM_MS,
   ATTENTION_MARK,
   attentionLines,
   celebrationText,
@@ -22,8 +20,6 @@ import {
   COLLAPSED_BASE_COLS,
   CONTENT_INDENT,
   type Dims,
-  easeInOutCubic,
-  FRAME_MS,
   GRADIENT_EDGE,
   ICON_COLS,
   ICON_PAD,
@@ -39,6 +35,7 @@ import {
   STATION_ICON,
   targetDims,
 } from "./layout.js";
+import { useTweenAmount, useTweenedOptionalValue } from "./useTweenAmount.js";
 
 export type DynamicStationButtonProps = {
   /** Everything the display ladder needs; islandDisplay decides what paints. */
@@ -67,14 +64,10 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
   };
   const pointerProps = useHoverPointer({ onHoverChange: handleHoverChange });
 
-  const open = useOpenAmount(expanded ? 1 : 0);
-  const collapsed = targetDims(islandDisplay(input, false));
-  const opened = targetDims(islandDisplay(input, true));
-  const dims: Dims = {
-    width: Math.round(lerp(collapsed.width, opened.width, open)),
-    height: Math.round(lerp(collapsed.height, opened.height, open)),
-  };
-  const display = islandDisplay(input, expanded);
+  const { open, dims, display, textReveal, celebrationReveal } = useButtonTransition(
+    input,
+    expanded,
+  );
 
   // Border/icon morph between the two state colors; expanded text fades up from
   // the background while collapsed marks/icon stay fully visible.
@@ -82,9 +75,6 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
   const to = stationButtonColors(attention, true);
   const border = lerpColor(from.border, to.border, open);
   const icon = lerpColor(from.icon, to.icon, open);
-  // Held invisible until the box has opened enough to hold it; expanded text
-  // then reveals per-character (GradientText), collapsed marks just morph color.
-  const textReveal = Math.min(1, Math.max(0, (open - 0.35) / 0.65));
   const color: StationButtonStateColors = expanded
     ? { border, icon, text: to.text }
     : { border, icon, text: lerpColor(from.text, to.text, open) };
@@ -137,6 +127,7 @@ export function DynamicStationButton(props: DynamicStationButtonProps): ReactNod
         iconPadX={iconPadX}
         iconPadY={iconPadY}
         reveal={textReveal}
+        celebrationReveal={celebrationReveal}
       />
       {/* Keeps one stable hit target above morphing text/icon children during expand/collapse. */}
       <box
@@ -158,8 +149,9 @@ function StationButtonContent(props: {
   iconPadX: number;
   iconPadY: number;
   reveal: number;
+  celebrationReveal: number;
 }): ReactNode {
-  const { display, color, iconPadX, iconPadY, reveal } = props;
+  const { display, color, iconPadX, iconPadY, reveal, celebrationReveal } = props;
   switch (display.kind) {
     case "mark":
       return <CollapsedBase color={color} iconPadX={iconPadX} iconPadY={iconPadY} />;
@@ -174,7 +166,13 @@ function StationButtonContent(props: {
         />
       );
     case "celebration":
-      return <CollapsedCelebration celebration={display.celebration} />;
+      return (
+        <CollapsedCelebration
+          celebration={display.celebration}
+          color={color}
+          reveal={celebrationReveal}
+        />
+      );
     case "alertCard":
       return (
         <ExpandedAttention
@@ -318,11 +316,23 @@ function CollapsedCounts(props: {
   );
 }
 
-function CollapsedCelebration({ celebration }: { celebration: IslandCelebration }): ReactNode {
+function CollapsedCelebration({
+  celebration,
+  color,
+  reveal,
+}: {
+  celebration: IslandCelebration;
+  color: StationButtonStateColors;
+  reveal: number;
+}): ReactNode {
   return (
     <box flexDirection="row" paddingLeft={ICON_PAD}>
-      <IconGlyph color={STATION_COLORS.green} />
-      <text fg={STATION_COLORS.green}>{` ${celebrationText(celebration)}`}</text>
+      <IconGlyph color={lerpColor(color.icon, STATION_COLORS.green, reveal)} />
+      <GradientText
+        text={` ${celebrationText(celebration)}`}
+        reveal={reveal}
+        color={STATION_COLORS.green}
+      />
     </box>
   );
 }
@@ -433,51 +443,62 @@ function ExpandedAttention(props: {
   );
 }
 
-// Manual interval tween, not OpenTUI's Timeline: nothing in Station attaches the Timeline engine
-// to the renderer, so useTimeline would never advance a frame here.
-function useOpenAmount(target: number): number {
-  const renderer = useRenderer();
-  const [open, setOpen] = useState(target);
-  const fromRef = useRef(target);
-  const mounted = useRef(false);
+type ButtonTransition = {
+  open: number;
+  dims: Dims;
+  display: IslandDisplay;
+  textReveal: number;
+  celebrationReveal: number;
+};
 
-  useEffect(() => {
-    if (!mounted.current) {
-      mounted.current = true; // first paint sits at the target, no animation
-      fromRef.current = target;
-      return;
-    }
-    const from = fromRef.current;
-    // OpenTUI is on-demand; without requesting "live" it won't paint the
-    // in-between frames of this timer-driven tween (it would snap to the end).
-    renderer.requestLive();
-    let live = true;
-    const dropLive = (): void => {
-      if (live) {
-        live = false;
-        renderer.dropLive();
-      }
-    };
-    let elapsed = 0;
-    const id = setInterval(() => {
-      elapsed += FRAME_MS;
-      const t = Math.min(1, elapsed / ANIM_MS);
-      if (t >= 1) {
-        clearInterval(id);
-        fromRef.current = target;
-        setOpen(target);
-        dropLive();
-        return;
-      }
-      const value = from + (target - from) * easeInOutCubic(t);
-      fromRef.current = value;
-      setOpen(value);
-    }, FRAME_MS);
-    return () => {
-      clearInterval(id);
-      dropLive();
-    };
-  }, [target, renderer]);
+function useButtonTransition(input: IslandDisplayInput, expanded: boolean): ButtonTransition {
+  const open = useTweenAmount(expanded ? 1 : 0);
+  const tweenedCelebration = useTweenedOptionalValue(input.celebration);
+  const collapsed = collapsedButtonState(
+    input,
+    tweenedCelebration.value,
+    tweenedCelebration.amount,
+  );
+  const opened = targetDims(islandDisplay(input, true));
+  const dims: Dims = {
+    width: Math.round(lerp(collapsed.dims.width, opened.width, open)),
+    height: Math.round(lerp(collapsed.dims.height, opened.height, open)),
+  };
+  return {
+    open,
+    dims,
+    display: expanded ? islandDisplay(input, true) : collapsed.display,
+    // Both text surfaces stay hidden until their box has enough width to hold them.
+    textReveal: contentReveal(open),
+    celebrationReveal: contentReveal(tweenedCelebration.amount),
+  };
+}
 
-  return open;
+function collapsedButtonState(
+  input: IslandDisplayInput,
+  celebration: IslandCelebration | undefined,
+  amount: number,
+): { dims: Dims; display: IslandDisplay } {
+  const restingInput: IslandDisplayInput = { status: input.status };
+  if (input.restCounts !== undefined) {
+    restingInput.restCounts = input.restCounts;
+  }
+  const collapsedInput: IslandDisplayInput = { ...restingInput };
+  if (celebration !== undefined) {
+    collapsedInput.celebration = celebration;
+  }
+  const resting = targetDims(islandDisplay(restingInput, false));
+  const display = islandDisplay(collapsedInput, false);
+  const notified = targetDims(display);
+  return {
+    dims: {
+      width: Math.round(lerp(resting.width, notified.width, amount)),
+      height: Math.round(lerp(resting.height, notified.height, amount)),
+    },
+    display,
+  };
+}
+
+function contentReveal(amount: number): number {
+  return Math.min(1, Math.max(0, (amount - 0.35) / 0.65));
 }

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -455,7 +455,8 @@ type ButtonTransition = {
 function useButtonTransition(input: IslandDisplayInput, expanded: boolean): ButtonTransition {
   const open = useTweenAmount(expanded ? 1 : 0);
   const collapsedDisplay = islandDisplay(input, false);
-  const celebrationPaintEligible = !expanded && collapsedDisplay.kind === "celebration";
+  const celebrationPaintEligible =
+    !expanded && open === 0 && collapsedDisplay.kind === "celebration";
   const tweenedCelebration = useTweenedOptionalValue(
     input.celebration,
     celebrationPaintEligible,
@@ -490,7 +491,8 @@ function collapsedButtonState(
     restingInput.restCounts = input.restCounts;
   }
   const collapsedInput: IslandDisplayInput = { ...restingInput };
-  if (celebration !== undefined) {
+  // Keep queued celebrations out of the display tree until their entrance actually starts.
+  if (celebration !== undefined && amount > 0) {
     collapsedInput.celebration = celebration;
   }
   const resting = targetDims(islandDisplay(restingInput, false));

--- a/station/src/stationButton/DynamicStationButton.tsx
+++ b/station/src/stationButton/DynamicStationButton.tsx
@@ -454,7 +454,12 @@ type ButtonTransition = {
 
 function useButtonTransition(input: IslandDisplayInput, expanded: boolean): ButtonTransition {
   const open = useTweenAmount(expanded ? 1 : 0);
-  const tweenedCelebration = useTweenedOptionalValue(input.celebration);
+  const collapsedDisplay = islandDisplay(input, false);
+  const celebrationPaintEligible = !expanded && collapsedDisplay.kind === "celebration";
+  const tweenedCelebration = useTweenedOptionalValue(
+    input.celebration,
+    celebrationPaintEligible,
+  );
   const collapsed = collapsedButtonState(
     input,
     tweenedCelebration.value,

--- a/station/src/stationButton/hooks/useTweenAmount.ts
+++ b/station/src/stationButton/hooks/useTweenAmount.ts
@@ -1,6 +1,6 @@
 import { useRenderer } from "@opentui/react";
 import { useEffect, useRef, useState } from "react";
-import { ANIM_MS, easeInOutCubic, FRAME_MS } from "./layout.js";
+import { ANIM_MS, easeInOutCubic, FRAME_MS } from "../layout.js";
 
 /**
  * Tweens a scalar target through a manual interval because Station does not attach OpenTUI's
@@ -53,23 +53,3 @@ export function useTweenAmount(target: number): number {
   return amount;
 }
 
-export type TweenedOptionalValue<T> = {
-  value: T | undefined;
-  amount: number;
-};
-
-/** Retains an outgoing optional value until its reversible tween finishes. */
-export function useTweenedOptionalValue<T>(value: T | undefined): TweenedOptionalValue<T> {
-  const [heldValue, setHeldValue] = useState(value);
-  const amount = useTweenAmount(value === undefined ? 0 : 1);
-
-  useEffect(() => {
-    if (value !== undefined) {
-      setHeldValue(value);
-    } else if (amount === 0) {
-      setHeldValue(undefined);
-    }
-  }, [amount, value]);
-
-  return { value: value === undefined ? heldValue : value, amount };
-}

--- a/station/src/stationButton/hooks/useTweenAmount.ts
+++ b/station/src/stationButton/hooks/useTweenAmount.ts
@@ -4,9 +4,9 @@ import { ANIM_MS, easeInOutCubic, FRAME_MS } from "../layout.js";
 
 /**
  * Tweens a scalar target through a manual interval because Station does not attach OpenTUI's
- * Timeline engine to the renderer.
+ * Timeline engine to the renderer. Disabled tweens release live rendering and resume in place.
  */
-export function useTweenAmount(target: number): number {
+export function useTweenAmount(target: number, enabled: boolean = true): number {
   const renderer = useRenderer();
   const [amount, setAmount] = useState(target);
   const fromRef = useRef(target);
@@ -16,6 +16,9 @@ export function useTweenAmount(target: number): number {
     if (!mounted.current) {
       mounted.current = true; // First paint sits at the target, with no entrance animation.
       fromRef.current = target;
+      return;
+    }
+    if (!enabled || fromRef.current === target) {
       return;
     }
     const from = fromRef.current;
@@ -48,8 +51,7 @@ export function useTweenAmount(target: number): number {
       clearInterval(id);
       dropLive();
     };
-  }, [target, renderer]);
+  }, [enabled, target, renderer]);
 
   return amount;
 }
-

--- a/station/src/stationButton/hooks/useTweenedOptionalValue.ts
+++ b/station/src/stationButton/hooks/useTweenedOptionalValue.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { useTweenAmount } from "./useTweenAmount.js";
+
+export type TweenedOptionalValue<T> = {
+  value: T | undefined;
+  amount: number;
+};
+
+/** Retains an outgoing optional value until its reversible tween finishes. */
+export function useTweenedOptionalValue<T>(value: T | undefined): TweenedOptionalValue<T> {
+  const [heldValue, setHeldValue] = useState(value);
+  const amount = useTweenAmount(value === undefined ? 0 : 1);
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setHeldValue(value);
+    } else if (amount === 0) {
+      setHeldValue(undefined);
+    }
+  }, [amount, value]);
+
+  return { value: value === undefined ? heldValue : value, amount };
+}

--- a/station/src/stationButton/hooks/useTweenedOptionalValue.ts
+++ b/station/src/stationButton/hooks/useTweenedOptionalValue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTweenAmount } from "./useTweenAmount.js";
 
 export type TweenedOptionalValue<T> = {
@@ -6,18 +6,46 @@ export type TweenedOptionalValue<T> = {
   amount: number;
 };
 
-/** Retains an outgoing optional value until its reversible tween finishes. */
-export function useTweenedOptionalValue<T>(value: T | undefined): TweenedOptionalValue<T> {
+/** Retains outgoing values and swaps replacements only at the tween's hidden boundary. */
+export function useTweenedOptionalValue<T>(
+  value: T | undefined,
+  entranceEnabled: boolean = true,
+): TweenedOptionalValue<T> {
+  const incomingValue = useRef(value);
   const [heldValue, setHeldValue] = useState(value);
-  const amount = useTweenAmount(value === undefined ? 0 : 1);
+  const [target, setTarget] = useState(value === undefined || !entranceEnabled ? 0 : 1);
+  const amount = useTweenAmount(target, target === 0 || entranceEnabled);
 
   useEffect(() => {
-    if (value !== undefined) {
-      setHeldValue(value);
-    } else if (amount === 0) {
-      setHeldValue(undefined);
+    if (Object.is(incomingValue.current, value)) {
+      return;
     }
-  }, [amount, value]);
+    incomingValue.current = value;
+    if (value === undefined) {
+      setTarget(0);
+    } else if (Object.is(heldValue, value)) {
+      // A value returning during its exit reverses from the current amount.
+      setTarget(1);
+    } else if (amount === 0) {
+      setHeldValue(value);
+      setTarget(1);
+    } else {
+      setTarget(0);
+    }
+  }, [amount, heldValue, value]);
 
-  return { value: value === undefined ? heldValue : value, amount };
+  useEffect(() => {
+    if (amount !== 0 || target !== 0) {
+      return;
+    }
+    const incoming = incomingValue.current;
+    if (incoming === undefined) {
+      setHeldValue(undefined);
+      return;
+    }
+    setHeldValue(incoming);
+    setTarget(1);
+  }, [amount, target]);
+
+  return { value: heldValue, amount };
 }

--- a/station/src/stationButton/useTweenAmount.ts
+++ b/station/src/stationButton/useTweenAmount.ts
@@ -1,0 +1,75 @@
+import { useRenderer } from "@opentui/react";
+import { useEffect, useRef, useState } from "react";
+import { ANIM_MS, easeInOutCubic, FRAME_MS } from "./layout.js";
+
+/**
+ * Tweens a scalar target through a manual interval because Station does not attach OpenTUI's
+ * Timeline engine to the renderer.
+ */
+export function useTweenAmount(target: number): number {
+  const renderer = useRenderer();
+  const [amount, setAmount] = useState(target);
+  const fromRef = useRef(target);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true; // First paint sits at the target, with no entrance animation.
+      fromRef.current = target;
+      return;
+    }
+    const from = fromRef.current;
+    // OpenTUI is on-demand; without requesting "live" it won't paint the
+    // in-between frames of this timer-driven tween (it would snap to the end).
+    renderer.requestLive();
+    let live = true;
+    const dropLive = (): void => {
+      if (live) {
+        live = false;
+        renderer.dropLive();
+      }
+    };
+    let elapsed = 0;
+    const id = setInterval(() => {
+      elapsed += FRAME_MS;
+      const t = Math.min(1, elapsed / ANIM_MS);
+      if (t >= 1) {
+        clearInterval(id);
+        fromRef.current = target;
+        setAmount(target);
+        dropLive();
+        return;
+      }
+      const value = from + (target - from) * easeInOutCubic(t);
+      fromRef.current = value;
+      setAmount(value);
+    }, FRAME_MS);
+    return () => {
+      clearInterval(id);
+      dropLive();
+    };
+  }, [target, renderer]);
+
+  return amount;
+}
+
+export type TweenedOptionalValue<T> = {
+  value: T | undefined;
+  amount: number;
+};
+
+/** Retains an outgoing optional value until its reversible tween finishes. */
+export function useTweenedOptionalValue<T>(value: T | undefined): TweenedOptionalValue<T> {
+  const [heldValue, setHeldValue] = useState(value);
+  const amount = useTweenAmount(value === undefined ? 0 : 1);
+
+  useEffect(() => {
+    if (value !== undefined) {
+      setHeldValue(value);
+    } else if (amount === 0) {
+      setHeldValue(undefined);
+    }
+  }, [amount, value]);
+
+  return { value: value === undefined ? heldValue : value, amount };
+}

--- a/station/src/useHoverPointer.ts
+++ b/station/src/useHoverPointer.ts
@@ -20,6 +20,7 @@ function syncPointer(renderer: ReturnType<typeof useRenderer>): void {
 
 type HoverPointerOptions = {
   enabled?: boolean | undefined;
+  acquireOnMouseOver?: boolean | undefined;
   onHoverChange?: ((hover: boolean) => void) | undefined;
 };
 
@@ -67,6 +68,15 @@ export function useHoverPointer(options: HoverPointerOptions = {}) {
     }, 0);
   }, [clearLeaveTimer, options.onHoverChange, renderer]);
 
+  const handleMouseOver = useCallback(() => {
+    // OpenTUI also emits `over` when layout moves under a stationary pointer; callers can
+    // require a real `move` while still using `over` to cancel an in-region deferred leave.
+    if (options.acquireOnMouseOver === false && !hovered.current) {
+      return;
+    }
+    activate();
+  }, [activate, options.acquireOnMouseOver]);
+
   useEffect(
     // Unmount-while-hovered (hot reload, state swap) never fires `out`; drop the
     // region so the pointer can't get stuck on for the whole terminal.
@@ -81,6 +91,6 @@ export function useHoverPointer(options: HoverPointerOptions = {}) {
   return {
     onMouseMove: activate,
     onMouseOut: deactivate,
-    onMouseOver: activate,
+    onMouseOver: handleMouseOver,
   };
 }


### PR DESCRIPTION
## Summary

- split the reusable scalar tween and optional-value retention hooks under `stationButton/hooks`
- retain notification data through its exit tween so merged-PR content does not disappear before the button collapses
- animate notification width, text reveal, and icon color in both directions while preserving hover expansion behavior
- cover intermediate opening and closing geometry with a renderer test

## Testing

- `pnpm lint`
- `pnpm test:pre-push`
- focused Station button test repeated 10 times (130/130 passing)

## UX verification

With Station visible, transition a PR from open to merged. The top-right button should smoothly expand and reveal the merged notification, then retract it after the notification TTL; hovering the button should continue to use the same smooth expansion behavior.
