### PR TITLE
refactor(runtime): centralize provider error normalization

### DIFF
--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -3,7 +3,7 @@ import {
   type WorktreeRemovalRefusalDiagnosticDetail,
   WorktreeRemovalRefusalDiagnosticDetailSchema,
 } from "@station/contracts";
-import type { RuntimeClock } from "@station/runtime";
+import { isSafeError, type RuntimeClock } from "@station/runtime";
 import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
@@ -179,14 +179,10 @@ export function createWorktreeRemoveHandler(
 function worktreeRemovalRefusalDiagnostic(
   error: unknown,
 ): WorktreeRemovalRefusalDiagnosticDetail | undefined {
-  if (typeof error !== "object" || error === null) {
+  if (!isSafeError(error)) {
     return undefined;
   }
-  const details = (error as { diagnosticDetails?: unknown }).diagnosticDetails;
-  if (!Array.isArray(details)) {
-    return undefined;
-  }
-  for (const detail of details) {
+  for (const detail of error.diagnosticDetails ?? []) {
     const parsed = WorktreeRemovalRefusalDiagnosticDetailSchema.safeParse(detail);
     if (parsed.success) {
       return parsed.data;

--- a/integrations/repository/github/src/errors.ts
+++ b/integrations/repository/github/src/errors.ts
@@ -1,0 +1,161 @@
+import type { DiagnosticDetail, ProviderHealth, SafeError } from "@station/contracts";
+import { type RuntimeSafeError, safeErrorFromUnknown } from "@station/runtime";
+
+export type GithubRepositoryProviderErrorCode =
+  | "EXTERNAL_COMMAND_ABORTED"
+  | "EXTERNAL_COMMAND_FAILED"
+  | "GITHUB_AUTH_UNAVAILABLE"
+  | "GITHUB_COMMAND_FAILED"
+  | "GITHUB_COMMAND_TIMEOUT"
+  | "GITHUB_COMMAND_UNAVAILABLE"
+  | "GITHUB_NETWORK_FAILED"
+  | "GITHUB_PULL_REQUEST_AMBIGUOUS"
+  | "GITHUB_RATE_LIMITED";
+
+export class GithubRepositoryProviderError extends Error implements SafeError {
+  readonly tag = "RepositoryProviderError";
+  readonly provider = "github";
+  readonly code: GithubRepositoryProviderErrorCode;
+  readonly hint?: string;
+  readonly diagnosticDetails?: DiagnosticDetail[];
+
+  constructor(
+    code: GithubRepositoryProviderErrorCode,
+    message: string,
+    options: {
+      hint?: string;
+      cause?: unknown;
+      diagnosticDetails?: DiagnosticDetail[];
+    } = {},
+  ) {
+    super(message, { cause: options.cause });
+    Object.defineProperty(this, "name", {
+      value: this.tag,
+      enumerable: false,
+      configurable: true,
+    });
+    this.code = code;
+    if (options.hint !== undefined) this.hint = options.hint;
+    if (options.diagnosticDetails !== undefined) {
+      this.diagnosticDetails = options.diagnosticDetails;
+    }
+  }
+}
+
+export function githubRepositoryErrorFromUnknown(error: unknown): GithubRepositoryProviderError {
+  if (error instanceof GithubRepositoryProviderError) {
+    return error;
+  }
+  const normalized = safeErrorFromUnknown(error, {
+    tag: "RepositoryProviderError",
+    code: "GITHUB_COMMAND_FAILED",
+    message: "GitHub CLI command failed.",
+    provider: "github",
+  });
+  const options = providerErrorOptions(normalized);
+
+  if (normalized.code === "EXTERNAL_COMMAND_TIMEOUT") {
+    return new GithubRepositoryProviderError(
+      "GITHUB_COMMAND_TIMEOUT",
+      "GitHub CLI command timed out.",
+      options,
+    );
+  }
+  if (normalized.code === "EXTERNAL_COMMAND_ABORTED" || normalized.tag === "CancellationError") {
+    return new GithubRepositoryProviderError(
+      "EXTERNAL_COMMAND_ABORTED",
+      "External command was aborted.",
+      options,
+    );
+  }
+
+  const text = githubFailureText(normalized);
+  if (/rate limit|secondary rate limit|http 429/i.test(text)) {
+    return new GithubRepositoryProviderError(
+      "GITHUB_RATE_LIMITED",
+      "GitHub CLI request was rate limited.",
+      {
+        ...options,
+        hint: "Wait for the GitHub rate limit to reset, then refresh metadata again.",
+      },
+    );
+  }
+  if (/authentication|not logged in|gh auth login|http 401|http 403/i.test(text)) {
+    return new GithubRepositoryProviderError(
+      "GITHUB_AUTH_UNAVAILABLE",
+      "GitHub CLI authentication is unavailable.",
+      {
+        ...options,
+        hint: "Run `gh auth status` or `gh auth login` to verify GitHub authentication.",
+      },
+    );
+  }
+  if (/could not resolve|network|timed out|econnreset|enotfound|tls|http 5\d\d/i.test(text)) {
+    return new GithubRepositoryProviderError(
+      "GITHUB_NETWORK_FAILED",
+      "GitHub CLI network request failed.",
+      options,
+    );
+  }
+  if (normalized.code === "ENOENT" || /enoent|not found/i.test(text)) {
+    return new GithubRepositoryProviderError(
+      "GITHUB_COMMAND_UNAVAILABLE",
+      "GitHub CLI command is unavailable.",
+      {
+        ...options,
+        hint: "Install `gh` or configure repository.github.command.",
+      },
+    );
+  }
+
+  if (normalized.code === "EXTERNAL_COMMAND_FAILED") {
+    return new GithubRepositoryProviderError(
+      "EXTERNAL_COMMAND_FAILED",
+      normalized.message,
+      options,
+    );
+  }
+  return new GithubRepositoryProviderError("GITHUB_COMMAND_FAILED", normalized.message, options);
+}
+
+export function githubRepositoryError(
+  code: GithubRepositoryProviderErrorCode,
+  message: string,
+  hint?: string,
+): GithubRepositoryProviderError {
+  return new GithubRepositoryProviderError(code, message, {
+    ...(hint === undefined ? {} : { hint }),
+  });
+}
+
+export function githubErrorHealthStatus(error: SafeError): ProviderHealth["status"] {
+  if (error.code === "GITHUB_COMMAND_UNAVAILABLE" || error.code === "GITHUB_AUTH_UNAVAILABLE") {
+    return "unavailable";
+  }
+  return "degraded";
+}
+
+function providerErrorOptions(normalized: RuntimeSafeError): {
+  cause: RuntimeSafeError;
+  diagnosticDetails?: DiagnosticDetail[];
+} {
+  const options: {
+    cause: RuntimeSafeError;
+    diagnosticDetails?: DiagnosticDetail[];
+  } = { cause: normalized };
+  if (normalized.diagnosticDetails !== undefined) {
+    options.diagnosticDetails = normalized.diagnosticDetails;
+  }
+  return options;
+}
+
+function githubFailureText(error: RuntimeSafeError): string {
+  const text = [error.message, error.code];
+  for (const detail of error.diagnosticDetails ?? []) {
+    if (detail.type !== "external_command") continue;
+    text.push(detail.command);
+    if (detail.stdoutSnippet !== undefined) text.push(detail.stdoutSnippet);
+    if (detail.stderrSnippet !== undefined) text.push(detail.stderrSnippet);
+  }
+  return text.join("\n");
+}

--- a/integrations/repository/github/src/index.ts
+++ b/integrations/repository/github/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./errors.js";
 export type { GithubRepositoryProviderOptions } from "./provider.js";
 export { GithubRepositoryProvider } from "./provider.js";

--- a/integrations/repository/github/src/provider.ts
+++ b/integrations/repository/github/src/provider.ts
@@ -19,14 +19,19 @@ import {
 } from "@station/contracts";
 import {
   type ExternalCommandRunner,
+  externalCommandErrorFromUnknown,
+  publicSafeErrorFromUnknown,
   type RuntimeClock,
-  redactCommandOutput,
   runExternalCommand,
-  safeErrorFromUnknown,
   systemClock,
   toIsoTimestamp,
 } from "@station/runtime";
 import { z } from "zod";
+import {
+  githubErrorHealthStatus,
+  githubRepositoryError,
+  githubRepositoryErrorFromUnknown,
+} from "./errors.js";
 
 export type GithubRepositoryProviderOptions = {
   command?: string;
@@ -134,8 +139,9 @@ export class GithubRepositoryProvider implements RepositoryProvider {
         },
       ];
     } catch (error) {
-      const safeError = githubRepositoryErrorFromUnknown(error);
-      this.#recordHealth(errorHealthStatus(safeError), safeError);
+      const providerError = githubRepositoryErrorFromUnknown(error);
+      const safeError = githubPublicError(providerError);
+      this.#recordHealth(githubErrorHealthStatus(safeError), safeError);
       return [
         {
           name: "github.auth",
@@ -190,9 +196,10 @@ export class GithubRepositoryProvider implements RepositoryProvider {
             toWorktreePullRequest(selected, parsed.remote, this.#now()),
           );
     } catch (error) {
-      const safeError = githubRepositoryErrorFromUnknown(error);
-      this.#recordHealth(errorHealthStatus(safeError), safeError);
-      throw safeError;
+      const providerError = githubRepositoryErrorFromUnknown(error);
+      const safeError = githubPublicError(providerError);
+      this.#recordHealth(githubErrorHealthStatus(safeError), safeError);
+      throw providerError;
     }
   }
 
@@ -216,9 +223,10 @@ export class GithubRepositoryProvider implements RepositoryProvider {
       this.#recordHealth("healthy");
       return WorktreeChecksSummarySchema.parse(toChecksSummary(checks, this.#now()));
     } catch (error) {
-      const safeError = githubRepositoryErrorFromUnknown(error);
-      this.#recordHealth(errorHealthStatus(safeError), safeError);
-      throw safeError;
+      const providerError = githubRepositoryErrorFromUnknown(error);
+      const safeError = githubPublicError(providerError);
+      this.#recordHealth(githubErrorHealthStatus(safeError), safeError);
+      throw providerError;
     }
   }
 
@@ -233,7 +241,19 @@ export class GithubRepositoryProvider implements RepositoryProvider {
     if (options.allowedExitCodes !== undefined) {
       input.allowedExitCodes = options.allowedExitCodes;
     }
-    return runExternalCommand(input, this.#runner);
+    const result = await runExternalCommand(input, this.#runner);
+    // gh uses selected nonzero exits for check status, but stderr-only exits remain command failures.
+    if (result.exitCode !== 0 && result.stdout.trim().length === 0 && result.stderr.length > 0) {
+      throw externalCommandErrorFromUnknown(
+        {
+          code: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        },
+        { command: this.#command, args },
+      );
+    }
+    return result;
   }
 
   #now(): string {
@@ -469,98 +489,13 @@ function checksState(counts: CheckCounts): WorktreeChecksState {
   return "unknown";
 }
 
-function githubRepositoryErrorFromUnknown(error: unknown): SafeError {
-  if (isSafeError(error) && error.tag === "RepositoryProviderError") {
-    return error;
-  }
-  if (isSafeError(error) && error.code === "EXTERNAL_COMMAND_TIMEOUT") {
-    return githubRepositoryError("GITHUB_COMMAND_TIMEOUT", "GitHub CLI command timed out.");
-  }
-  if (isSafeError(error) && error.code === "EXTERNAL_COMMAND_ABORTED") {
-    return error;
-  }
-
-  const text = errorText(error);
-  if (text.match(/rate limit|secondary rate limit|http 429/i)) {
-    return githubRepositoryError(
-      "GITHUB_RATE_LIMITED",
-      "GitHub CLI request was rate limited.",
-      "Wait for the GitHub rate limit to reset, then refresh metadata again.",
-    );
-  }
-  if (text.match(/authentication|not logged in|gh auth login|http 401|http 403/i)) {
-    return githubRepositoryError(
-      "GITHUB_AUTH_UNAVAILABLE",
-      "GitHub CLI authentication is unavailable.",
-      "Run `gh auth status` or `gh auth login` to verify GitHub authentication.",
-    );
-  }
-  if (text.match(/could not resolve|network|timed out|econnreset|enotfound|tls|http 5\d\d/i)) {
-    return githubRepositoryError("GITHUB_NETWORK_FAILED", "GitHub CLI network request failed.");
-  }
-  if (text.match(/enoent|not found/i)) {
-    return githubRepositoryError(
-      "GITHUB_COMMAND_UNAVAILABLE",
-      "GitHub CLI command is unavailable.",
-      "Install `gh` or configure repository.github.command.",
-    );
-  }
-
-  const safe = safeErrorFromUnknown(error, {
+function githubPublicError(error: unknown): SafeError {
+  return publicSafeErrorFromUnknown(error, {
     tag: "RepositoryProviderError",
     code: "GITHUB_COMMAND_FAILED",
     message: "GitHub CLI command failed.",
     provider: "github",
   });
-  return {
-    tag: "RepositoryProviderError",
-    code: safe.code === "EXTERNAL_COMMAND_TIMEOUT" ? "GITHUB_COMMAND_TIMEOUT" : safe.code,
-    message: redactCommandOutput(safe.message),
-    provider: "github",
-  };
-}
-
-function githubRepositoryError(code: string, message: string, hint?: string): SafeError {
-  const error: SafeError = {
-    tag: "RepositoryProviderError",
-    code,
-    message,
-    provider: "github",
-  };
-  if (hint !== undefined) error.hint = hint;
-  return error;
-}
-
-function errorHealthStatus(error: SafeError): ProviderHealth["status"] {
-  if (error.code === "GITHUB_COMMAND_UNAVAILABLE" || error.code === "GITHUB_AUTH_UNAVAILABLE") {
-    return "unavailable";
-  }
-  return "degraded";
-}
-
-function isSafeError(value: unknown): value is SafeError {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-  const record = value as Partial<SafeError>;
-  return (
-    typeof record.tag === "string" &&
-    typeof record.code === "string" &&
-    typeof record.message === "string"
-  );
-}
-
-function errorText(error: unknown): string {
-  if (typeof error === "string") {
-    return error;
-  }
-  if (typeof error !== "object" || error === null) {
-    return "";
-  }
-  const record = error as Record<string, unknown>;
-  return [record.message, record.code, record.stderr, record.stderrSnippet, record.stdoutSnippet]
-    .filter((value): value is string => typeof value === "string")
-    .join("\n");
 }
 
 function repositoryNameWithOwner(value: unknown): {

--- a/integrations/repository/github/test/unit/provider.test.ts
+++ b/integrations/repository/github/test/unit/provider.test.ts
@@ -240,8 +240,41 @@ describe("GitHub repository provider", () => {
     await expect(
       aborted.discoverPullRequest({ remote, branch: "feature", signal: controller.signal }),
     ).rejects.toMatchObject({
+      tag: "RepositoryProviderError",
       code: "EXTERNAL_COMMAND_ABORTED",
+      provider: "github",
     });
+  });
+
+  it("throws rich typed failures while retaining only lean provider health", async () => {
+    const provider = providerWithFailure("authentication required");
+    let failure: unknown;
+    try {
+      await provider.discoverPullRequest({ remote, branch: "feature" });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toMatchObject({
+      tag: "RepositoryProviderError",
+      code: "GITHUB_AUTH_UNAVAILABLE",
+      diagnosticDetails: [
+        expect.objectContaining({
+          type: "external_command",
+          command: expect.stringContaining("gh pr list"),
+          stderrSnippet: "authentication required",
+        }),
+      ],
+    });
+    const health = await provider.health();
+    expect(health.lastError).toEqual({
+      tag: "RepositoryProviderError",
+      code: "GITHUB_AUTH_UNAVAILABLE",
+      message: "GitHub CLI authentication is unavailable.",
+      hint: "Run `gh auth status` or `gh auth login` to verify GitHub authentication.",
+      provider: "github",
+    });
+    expect(JSON.stringify(health.lastError)).not.toContain("diagnosticDetails");
   });
 });
 

--- a/integrations/terminal/tmux/src/errors.ts
+++ b/integrations/terminal/tmux/src/errors.ts
@@ -1,5 +1,9 @@
-import type { SafeError } from "@station/contracts";
-import { safeErrorFromUnknown } from "@station/runtime";
+import type { DiagnosticDetail, SafeError } from "@station/contracts";
+import {
+  isExternalCommandError,
+  type RuntimeSafeError,
+  safeErrorFromUnknown,
+} from "@station/runtime";
 
 export type TmuxTerminalProviderErrorCode =
   | "TERMINAL_CAPTURE_FAILED"
@@ -23,6 +27,7 @@ export class TmuxTerminalProviderError extends Error implements SafeError {
   readonly projectId?: string;
   readonly worktreeId?: string;
   readonly sessionId?: string;
+  readonly diagnosticDetails?: DiagnosticDetail[];
 
   constructor(
     code: TmuxTerminalProviderErrorCode,
@@ -33,6 +38,7 @@ export class TmuxTerminalProviderError extends Error implements SafeError {
       projectId?: string;
       worktreeId?: string;
       sessionId?: string;
+      diagnosticDetails?: DiagnosticDetail[];
     } = {},
   ) {
     super(message, { cause: options.cause });
@@ -42,17 +48,12 @@ export class TmuxTerminalProviderError extends Error implements SafeError {
       configurable: true,
     });
     this.code = code;
-    if (options.hint !== undefined) {
-      this.hint = options.hint;
-    }
-    if (options.projectId !== undefined) {
-      this.projectId = options.projectId;
-    }
-    if (options.worktreeId !== undefined) {
-      this.worktreeId = options.worktreeId;
-    }
-    if (options.sessionId !== undefined) {
-      this.sessionId = options.sessionId;
+    if (options.hint !== undefined) this.hint = options.hint;
+    if (options.projectId !== undefined) this.projectId = options.projectId;
+    if (options.worktreeId !== undefined) this.worktreeId = options.worktreeId;
+    if (options.sessionId !== undefined) this.sessionId = options.sessionId;
+    if (options.diagnosticDetails !== undefined) {
+      this.diagnosticDetails = options.diagnosticDetails;
     }
   }
 }
@@ -64,7 +65,7 @@ export function tmuxSafeError(
     message: string;
     hint?: string;
   },
-): SafeError {
+): RuntimeSafeError {
   return safeErrorFromUnknown(error, {
     tag: "TerminalProviderError",
     code: fallback.code,
@@ -82,82 +83,68 @@ export function tmuxProviderErrorFromUnknown(
     hint?: string;
   },
 ): TmuxTerminalProviderError {
-  if (isMissingTarget(error)) {
+  const normalized = tmuxSafeError(error, fallback);
+  const diagnosticDetails = normalized.diagnosticDetails;
+  if (isMissingTarget(normalized)) {
     return new TmuxTerminalProviderError(
       "TERMINAL_TARGET_MISSING",
       "The terminal target no longer exists.",
       {
         hint: "Refresh the dashboard or reopen the worktree.",
-        cause: error,
+        cause: normalized,
+        ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
       },
     );
   }
-  if (isMissingBinary(error)) {
+  if (normalized.code === "ENOENT") {
     return new TmuxTerminalProviderError("TERMINAL_TMUX_UNAVAILABLE", "tmux is not available.", {
       hint: "Install tmux or choose a different terminal provider.",
-      cause: error,
+      cause: normalized,
+      ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
     });
   }
-  if (isTimeout(error)) {
+  if (
+    normalized.code === "TERMINAL_TMUX_TIMEOUT" ||
+    normalized.code === "EXTERNAL_COMMAND_TIMEOUT"
+  ) {
     return new TmuxTerminalProviderError("TERMINAL_TMUX_TIMEOUT", "tmux command timed out.", {
-      cause: error,
+      cause: normalized,
+      ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
     });
   }
 
-  const safeError = tmuxSafeError(error, fallback);
-  const hint = safeError.hint ?? fallback.hint;
-  const message = isGenericExternalCommandFailure(safeError) ? fallback.message : safeError.message;
+  const hint = normalized.hint ?? fallback.hint;
+  const message = isGenericExternalCommandFailure(normalized)
+    ? fallback.message
+    : normalized.message;
   return new TmuxTerminalProviderError(fallback.code, message, {
-    cause: error,
+    cause: normalized,
     ...(hint === undefined ? {} : { hint }),
+    ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
   });
 }
 
-function isGenericExternalCommandFailure(error: SafeError): boolean {
+function isGenericExternalCommandFailure(error: RuntimeSafeError): boolean {
   return (
-    error.tag === "ExternalCommandError" &&
+    isExternalCommandError(error) &&
     (error.code === "EXTERNAL_COMMAND_FAILED" ||
       error.code === "EXTERNAL_COMMAND_TIMEOUT" ||
       error.code === "EXTERNAL_COMMAND_ABORTED")
   );
 }
 
-function isMissingBinary(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
+function isMissingTarget(error: RuntimeSafeError): boolean {
+  if (error.code === "TERMINAL_TARGET_MISSING") {
+    return true;
   }
-  const cause = error as { code?: unknown; cause?: unknown };
-  return cause.code === "ENOENT" || isMissingBinary(cause.cause);
-}
-
-function isTimeout(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "TERMINAL_TMUX_TIMEOUT"
-  );
-}
-
-function isMissingTarget(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
+  const text = [error.message];
+  for (const detail of error.diagnosticDetails ?? []) {
+    if (detail.type !== "external_command") continue;
+    text.push(detail.command);
+    if (detail.stdoutSnippet !== undefined) text.push(detail.stdoutSnippet);
+    if (detail.stderrSnippet !== undefined) text.push(detail.stderrSnippet);
   }
-  const candidate = error as {
-    code?: unknown;
-    message?: unknown;
-    stderrSnippet?: unknown;
-    stderr?: unknown;
-    cause?: unknown;
-  };
-  const message = [
-    typeof candidate.message === "string" ? candidate.message : "",
-    typeof candidate.stderrSnippet === "string" ? candidate.stderrSnippet : "",
-    typeof candidate.stderr === "string" ? candidate.stderr : "",
-  ].join("\n");
-  return (
-    candidate.code === "TERMINAL_TARGET_MISSING" ||
-    /can't find|cannot find|no such|not found|missing pane|missing window/i.test(message) ||
-    isMissingTarget(candidate.cause)
+  return /can't find|cannot find|no such|not found|missing pane|missing window/i.test(
+    text.join("\n"),
   );
 }

--- a/integrations/terminal/tmux/src/provider.ts
+++ b/integrations/terminal/tmux/src/provider.ts
@@ -64,6 +64,13 @@ const tmuxCapabilities: TerminalCapabilities = {
   canDisplayPopup: true,
 };
 
+/**
+ * ADAPTER
+ *
+ * Translates Station terminal operations into tmux-owned topology and commands.
+ *
+ * Operational failures retain diagnostic evidence while provider health exposes only the lean public projection.
+ */
 export class TmuxProvider implements TerminalProvider {
   readonly id: ProviderId = "tmux";
 

--- a/integrations/terminal/tmux/src/provider.ts
+++ b/integrations/terminal/tmux/src/provider.ts
@@ -17,6 +17,7 @@ import {
   type ExternalCommandRunner,
   pathIsSame,
   pathIsSameOrInside,
+  publicSafeErrorFromUnknown,
   type RuntimeClock,
   systemClock,
   toIsoTimestamp,
@@ -103,15 +104,21 @@ export class TmuxProvider implements TerminalProvider {
         capabilities: this.capabilities(),
       };
     } catch (cause) {
+      const error = tmuxProviderErrorFromUnknown(cause, {
+        code: "TERMINAL_TMUX_UNAVAILABLE",
+        message: "tmux is not available.",
+        hint: "Install tmux or choose a different terminal provider.",
+      });
       return {
         providerId: this.id,
         providerType: "terminal",
         status: "unavailable",
         lastCheckedAt: checkedAt,
-        lastError: tmuxProviderErrorFromUnknown(cause, {
+        lastError: publicSafeErrorFromUnknown(error, {
+          tag: "TerminalProviderError",
           code: "TERMINAL_TMUX_UNAVAILABLE",
           message: "tmux is not available.",
-          hint: "Install tmux or choose a different terminal provider.",
+          provider: this.id,
         }),
         capabilities: this.capabilities(),
       };

--- a/integrations/terminal/tmux/test/unit/errors.test.ts
+++ b/integrations/terminal/tmux/test/unit/errors.test.ts
@@ -1,0 +1,76 @@
+import { externalCommandErrorFromUnknown } from "@station/runtime";
+import { describe, expect, it } from "vitest";
+import { tmuxProviderErrorFromUnknown } from "../../src/errors.js";
+
+const fallback = {
+  code: "TERMINAL_CAPTURE_FAILED" as const,
+  message: "tmux failed to capture terminal output.",
+};
+
+describe("tmux provider error mapping", () => {
+  it("classifies missing targets from typed command evidence", () => {
+    const commandError = externalCommandErrorFromUnknown(
+      { code: 1, stderr: "can't find pane: %12" },
+      { command: "tmux", args: ["capture-pane", "-t", "%12"] },
+    );
+
+    const mapped = tmuxProviderErrorFromUnknown(commandError, fallback);
+
+    expect(mapped).toMatchObject({
+      tag: "TerminalProviderError",
+      code: "TERMINAL_TARGET_MISSING",
+      message: "The terminal target no longer exists.",
+      diagnosticDetails: [
+        expect.objectContaining({
+          type: "external_command",
+          command: "tmux capture-pane -t %12",
+          exitCode: 1,
+          stderrSnippet: "can't find pane: %12",
+        }),
+      ],
+    });
+    expect(mapped.cause).toMatchObject({
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+    });
+  });
+
+  it("classifies missing binaries and timeout by normalized code", () => {
+    expect(
+      tmuxProviderErrorFromUnknown(
+        {
+          tag: "ExternalCommandError",
+          code: "ENOENT",
+          message: "External command failed.",
+        },
+        fallback,
+      ),
+    ).toMatchObject({ code: "TERMINAL_TMUX_UNAVAILABLE", message: "tmux is not available." });
+
+    expect(
+      tmuxProviderErrorFromUnknown(
+        {
+          tag: "TimeoutError",
+          code: "TERMINAL_TMUX_TIMEOUT",
+          message: "tmux command timed out.",
+        },
+        fallback,
+      ),
+    ).toMatchObject({ code: "TERMINAL_TMUX_TIMEOUT", message: "tmux command timed out." });
+  });
+
+  it("uses the operation fallback while retaining typed diagnostics", () => {
+    const commandError = externalCommandErrorFromUnknown(
+      { code: 1, stderr: "ordinary failure" },
+      { command: "tmux", args: ["capture-pane"] },
+    );
+
+    const mapped = tmuxProviderErrorFromUnknown(commandError, fallback);
+
+    expect(mapped).toMatchObject({
+      code: "TERMINAL_CAPTURE_FAILED",
+      message: fallback.message,
+      diagnosticDetails: [expect.objectContaining({ type: "external_command", exitCode: 1 })],
+    });
+  });
+});

--- a/integrations/terminal/tmux/test/unit/errors.test.ts
+++ b/integrations/terminal/tmux/test/unit/errors.test.ts
@@ -1,6 +1,10 @@
-import { externalCommandErrorFromUnknown } from "@station/runtime";
+import { externalCommandErrorFromUnknown, publicSafeErrorFromUnknown } from "@station/runtime";
 import { describe, expect, it } from "vitest";
-import { tmuxProviderErrorFromUnknown } from "../../src/errors.js";
+import {
+  TmuxTerminalProviderError,
+  tmuxProviderErrorFromUnknown,
+  tmuxSafeError,
+} from "../../src/errors.js";
 
 const fallback = {
   code: "TERMINAL_CAPTURE_FAILED" as const,
@@ -72,5 +76,21 @@ describe("tmux provider error mapping", () => {
       message: fallback.message,
       diagnosticDetails: [expect.objectContaining({ type: "external_command", exitCode: 1 })],
     });
+  });
+
+  it("omits unset optional fields from normalized provider errors", () => {
+    const error = new TmuxTerminalProviderError("TERMINAL_CAPTURE_FAILED", "capture failed");
+    const normalized = tmuxSafeError(error, fallback);
+    const projected = publicSafeErrorFromUnknown(error, {
+      tag: "TerminalProviderError",
+      code: fallback.code,
+      message: fallback.message,
+    });
+
+    for (const safeError of [normalized, projected]) {
+      expect(Object.keys(safeError).sort()).toEqual(["code", "message", "provider", "tag"]);
+      expect(Object.hasOwn(safeError, "hint")).toBe(false);
+      expect(Object.hasOwn(safeError, "projectId")).toBe(false);
+    }
   });
 });

--- a/integrations/terminal/tmux/test/unit/provider.test.ts
+++ b/integrations/terminal/tmux/test/unit/provider.test.ts
@@ -55,6 +55,26 @@ describe("TmuxProvider", () => {
     });
   });
 
+  it("keeps provider health errors lean while command evidence stays internal", async () => {
+    const provider = new TmuxProvider({
+      clock: { now: () => new Date(now) },
+      runner: async () => {
+        throw Object.assign(new Error("failed"), { code: 1, stderr: "tmux probe failed" });
+      },
+    });
+
+    const health = await provider.health();
+
+    expect(health.lastError).toEqual({
+      tag: "TerminalProviderError",
+      code: "TERMINAL_TMUX_UNAVAILABLE",
+      message: "tmux is not available.",
+      hint: "Install tmux or choose a different terminal provider.",
+      provider: "tmux",
+    });
+    expect(JSON.stringify(health.lastError)).not.toContain("diagnosticDetails");
+  });
+
   it("opens or reuses a workbench window and binds the primary pane identity", async () => {
     const calls: ExternalCommandInput[] = [];
     const provider = new TmuxProvider({
@@ -583,12 +603,10 @@ describe("TmuxProvider", () => {
     const provider = new TmuxProvider({
       runner: async (input) => {
         calls.push(input);
+        const args = input.args ?? [];
         // The popup launcher publishes the originating client in this option;
         // the persistent popup can't pass it in the focus command directly.
-        if (
-          input.args[0] === "show-options" &&
-          input.args.includes("@station_popup_focus_client")
-        ) {
+        if (args[0] === "show-options" && args.includes("@station_popup_focus_client")) {
           return tmuxCommandResult(input, "client_live\n");
         }
         return tmuxCommandResult(input, "");

--- a/integrations/worktree/worktrunk/src/commandFailure.ts
+++ b/integrations/worktree/worktrunk/src/commandFailure.ts
@@ -1,0 +1,246 @@
+import { stripVTControlCharacters } from "node:util";
+import type {
+  DiagnosticDetail,
+  ExternalCommandDiagnosticDetail,
+  ProviderId,
+} from "@station/contracts";
+import {
+  externalCommandDiagnosticFromSafeError,
+  externalCommandErrorFromUnknown,
+  type RuntimeSafeError,
+} from "@station/runtime";
+import type { WorktrunkProviderErrorCode } from "./errors.js";
+import { ProviderUnavailableError, WorktrunkProviderError } from "./errors.js";
+
+export type WorktrunkCommandFailureFallback = {
+  code: "WORKTRUNK_COMMAND_FAILED" | "WORKTRUNK_UNAVAILABLE";
+  message: string;
+  unresolvedBase?: string;
+};
+
+export type WorktrunkCommandFailureInput = {
+  error: RuntimeSafeError;
+  provider: ProviderId;
+  operation: string;
+  command: string;
+  args: readonly string[];
+  cwd?: string | undefined;
+  durationMs: number;
+  fallback: WorktrunkCommandFailureFallback;
+  installHint: string;
+};
+
+export function worktrunkCommandFailure(
+  input: WorktrunkCommandFailureInput,
+): WorktrunkProviderError | ProviderUnavailableError {
+  const commandDiagnostic = enrichedCommandDiagnostic(input);
+  const diagnosticDetails = retainedDiagnostics(input.error, commandDiagnostic);
+
+  if (input.error.code === "ENOENT") {
+    return new ProviderUnavailableError("Worktrunk is not available.", {
+      hint: input.installHint,
+      command: input.command,
+      installHint: input.installHint,
+      cause: input.error,
+      diagnosticDetails,
+    });
+  }
+  if (input.error.code === "WORKTRUNK_TIMEOUT" || input.error.code === "EXTERNAL_COMMAND_TIMEOUT") {
+    return new WorktrunkProviderError("WORKTRUNK_TIMEOUT", "Worktrunk command timed out.", {
+      cause: input.error,
+      diagnosticDetails,
+    });
+  }
+  if (
+    input.error.code === "WORKTRUNK_CANCELLED" ||
+    input.error.code === "EXTERNAL_COMMAND_ABORTED" ||
+    input.error.tag === "CancellationError"
+  ) {
+    return new WorktrunkProviderError("WORKTRUNK_CANCELLED", "Worktrunk command was cancelled.", {
+      cause: input.error,
+      diagnosticDetails,
+    });
+  }
+
+  const classified = classifyWorktrunkFailure(input.error, input.fallback);
+  const hint = input.error.hint ?? classified.hint;
+  const message = input.error.code === classified.code ? input.error.message : classified.message;
+  if (classified.code === "WORKTRUNK_UNAVAILABLE") {
+    return new ProviderUnavailableError(message, {
+      cause: input.error,
+      diagnosticDetails,
+      ...(hint === undefined ? {} : { hint }),
+    });
+  }
+  return new WorktrunkProviderError(classified.code, message, {
+    cause: input.error,
+    diagnosticDetails,
+    ...(hint === undefined ? {} : { hint }),
+  });
+}
+
+function enrichedCommandDiagnostic(
+  input: WorktrunkCommandFailureInput,
+): ExternalCommandDiagnosticDetail {
+  const evidence =
+    externalCommandDiagnosticFromSafeError(input.error) ??
+    externalCommandDiagnosticFromSafeError(
+      externalCommandErrorFromUnknown(input.error, {
+        command: input.command,
+        args: [...input.args],
+        ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
+      }),
+    );
+  const detail: ExternalCommandDiagnosticDetail = {
+    type: "external_command",
+    provider: input.provider,
+    operation: input.operation,
+    command: evidence?.command ?? input.command,
+    durationMs: input.durationMs,
+  };
+  const cwd = evidence?.cwd ?? input.cwd;
+  if (cwd !== undefined) detail.cwd = cwd;
+  if (evidence?.exitCode !== undefined) detail.exitCode = evidence.exitCode;
+  if (evidence?.signal !== undefined) detail.signal = evidence.signal;
+  if (evidence?.stdoutSnippet !== undefined) detail.stdoutSnippet = evidence.stdoutSnippet;
+  if (evidence?.stderrSnippet !== undefined) detail.stderrSnippet = evidence.stderrSnippet;
+  return detail;
+}
+
+function retainedDiagnostics(
+  error: RuntimeSafeError,
+  commandDiagnostic: ExternalCommandDiagnosticDetail,
+): DiagnosticDetail[] {
+  const diagnostics = (error.diagnosticDetails ?? []).filter(
+    (detail) => detail.type !== "external_command",
+  );
+  return [...diagnostics, commandDiagnostic];
+}
+
+function classifyWorktrunkFailure(
+  error: RuntimeSafeError,
+  fallback: WorktrunkCommandFailureFallback,
+): { code: WorktrunkProviderErrorCode; message: string; hint?: string } {
+  if (fallback.code !== "WORKTRUNK_COMMAND_FAILED") {
+    return fallback;
+  }
+
+  const diagnostic = stripVTControlCharacters(commandFailureText(error));
+  const text = diagnostic.toLowerCase();
+  if (isUnsupportedFlagText(text)) {
+    return {
+      code: "WORKTRUNK_UNSUPPORTED_FLAG",
+      message: "Worktrunk rejected an automation flag used by STATION.",
+      hint: "Upgrade Worktrunk or adjust worktree.worktrunk.use_lifecycle_hooks in STATION config.",
+    };
+  }
+
+  if (isHookApprovalText(text)) {
+    return {
+      code: "WORKTRUNK_HOOK_APPROVAL_REQUIRED",
+      message:
+        "Worktrunk lifecycle hooks needed interactive approval during automated STATION work.",
+      hint: "Set worktree.worktrunk.use_lifecycle_hooks to false to skip hooks or true to pre-approve hook prompts.",
+    };
+  }
+
+  if (isDuplicateBranchText(text)) {
+    return {
+      code: "WORKTRUNK_BRANCH_EXISTS",
+      message: "Worktrunk could not create the worktree because the branch already exists.",
+      hint: "Choose a different branch name or start/focus the existing worktree.",
+    };
+  }
+
+  if (isDuplicateWorktreeText(text)) {
+    return {
+      code: "WORKTRUNK_WORKTREE_EXISTS",
+      message: "Worktrunk could not create the worktree because the worktree path already exists.",
+      hint: "Choose a different branch/path or remove the stale worktree path.",
+    };
+  }
+
+  if (
+    fallback.unresolvedBase !== undefined &&
+    unresolvedNamedReference(diagnostic) === fallback.unresolvedBase
+  ) {
+    return {
+      code: "WORKTRUNK_BASE_MISSING",
+      message: `Base \`${fallback.unresolvedBase}\` does not resolve to a commit.`,
+      hint: "Create its first commit or choose another base.",
+    };
+  }
+
+  if (isMissingBaseText(text)) {
+    return {
+      code: "WORKTRUNK_BASE_MISSING",
+      message: "Worktrunk could not find the requested base for the new worktree.",
+      hint: "Fetch the base branch or set a valid worktree.worktrunk.base/default branch in STATION config.",
+    };
+  }
+
+  return fallback;
+}
+
+function commandFailureText(error: RuntimeSafeError): string {
+  const parts = [error.message];
+  for (const detail of error.diagnosticDetails ?? []) {
+    if (detail.type !== "external_command") continue;
+    parts.push(detail.command);
+    if (detail.stdoutSnippet !== undefined) parts.push(detail.stdoutSnippet);
+    if (detail.stderrSnippet !== undefined) parts.push(detail.stderrSnippet);
+  }
+  return parts.join("\n");
+}
+
+function isUnsupportedFlagText(text: string): boolean {
+  return (
+    /unknown (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
+    /unrecognized (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
+    /unexpected (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
+    /found argument ['"]--(?:no-hooks|yes)['"].*(?:not expected|wasn't expected)/.test(text) ||
+    /invalid (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text)
+  );
+}
+
+function isHookApprovalText(text: string): boolean {
+  return (
+    /(?:approval|confirm|confirmation|prompt).*(?:required|needed)/.test(text) ||
+    /(?:requires|needs).*(?:approval|confirmation|interactive)/.test(text) ||
+    /(?:use|pass).*(?:--yes|-y).*(?:approve|confirm|continue)/.test(text) ||
+    /not a tty/.test(text) ||
+    /hook.*(?:cancelled|aborted|declined|refused)/.test(text)
+  );
+}
+
+function isDuplicateBranchText(text: string): boolean {
+  return (
+    /branch\b.*\balready exists/.test(text) ||
+    /\balready exists\b.*\bbranch\b/.test(text) ||
+    /refs\/heads\/[^\s]+.*\balready exists/.test(text)
+  );
+}
+
+function isDuplicateWorktreeText(text: string): boolean {
+  return (
+    /worktree\b.*\balready exists/.test(text) ||
+    /\balready exists\b.*\bworktree\b/.test(text) ||
+    /\bpath\b.*\balready exists/.test(text) ||
+    /\bdestination\b.*\balready exists/.test(text)
+  );
+}
+
+function unresolvedNamedReference(text: string): string | undefined {
+  return /no branch, tag, or commit named ['"]?([^'"\s]+)['"]?/i.exec(text)?.[1];
+}
+
+function isMissingBaseText(text: string): boolean {
+  return (
+    /base\b.*\b(?:not found|missing|does not exist|unknown)/.test(text) ||
+    /(?:not found|missing|does not exist|unknown)\b.*\bbase\b/.test(text) ||
+    /could(?:n't| not) find remote ref/.test(text) ||
+    /invalid reference/.test(text) ||
+    /not a valid object name/.test(text) ||
+    /unknown revision/.test(text)
+  );
+}

--- a/integrations/worktree/worktrunk/src/errors.ts
+++ b/integrations/worktree/worktrunk/src/errors.ts
@@ -1,5 +1,4 @@
 import type { DiagnosticDetail, SafeError } from "@station/contracts";
-import { safeErrorFromUnknown } from "@station/runtime";
 
 export type WorktrunkProviderErrorCode =
   | "WORKTRUNK_BRANCH_EXISTS"
@@ -82,52 +81,4 @@ export class ProviderUnavailableError extends Error implements SafeError {
       this.diagnosticDetails = options.diagnosticDetails;
     }
   }
-}
-
-export function worktrunkSafeError(
-  error: unknown,
-  fallback: {
-    code: WorktrunkProviderErrorCode;
-    message: string;
-    hint?: string;
-  },
-): SafeError {
-  return safeErrorFromUnknown(error, {
-    tag:
-      fallback.code === "WORKTRUNK_UNAVAILABLE"
-        ? "ProviderUnavailableError"
-        : "WorktreeProviderError",
-    code: fallback.code,
-    message: fallback.message,
-    provider: "worktrunk",
-    ...(fallback.hint === undefined ? {} : { hint: fallback.hint }),
-  });
-}
-
-export function providerErrorFromUnknown(
-  error: unknown,
-  fallback: {
-    code: WorktrunkProviderErrorCode;
-    message: string;
-    hint?: string;
-  },
-  options: { diagnosticDetails?: DiagnosticDetail[] } = {},
-): WorktrunkProviderError | ProviderUnavailableError {
-  const safeError = worktrunkSafeError(error, fallback);
-  const hint = safeError.hint ?? fallback.hint;
-  const diagnosticDetails = options.diagnosticDetails;
-  const message = safeError.code === fallback.code ? safeError.message : fallback.message;
-  if (safeError.tag === "ProviderUnavailableError" || fallback.code === "WORKTRUNK_UNAVAILABLE") {
-    return new ProviderUnavailableError(message, {
-      cause: error,
-      ...(hint === undefined ? {} : { hint }),
-      ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
-    });
-  }
-
-  return new WorktrunkProviderError(fallback.code, message, {
-    cause: error,
-    ...(hint === undefined ? {} : { hint }),
-    ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
-  });
 }

--- a/integrations/worktree/worktrunk/src/index.ts
+++ b/integrations/worktree/worktrunk/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./automation.js";
+export * from "./commandFailure.js";
 export * from "./dependency.js";
 export * from "./errors.js";
 export * from "./hookAdapter.js";

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -2,11 +2,8 @@ import { createHash } from "node:crypto";
 import { lstat, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, normalize, relative, resolve } from "node:path";
-import { stripVTControlCharacters } from "node:util";
 import type {
   CreateWorktreeRequest,
-  DiagnosticDetail,
-  ExternalCommandDiagnosticDetail,
   GetWorktreeRequest,
   ProviderDoctorCheck,
   ProviderDoctorContext,
@@ -24,10 +21,10 @@ import type {
   WorktreeRemovalRefusalDiagnosticDetail,
   WorktreeRemovalRefusalReason,
 } from "@station/contracts";
-import { ExternalCommandDiagnosticDetailSchema } from "@station/contracts";
 import {
   type ExternalCommandRunner,
   gitLocalEnvironmentVariables,
+  publicSafeErrorFromUnknown,
   type RuntimeClock,
   runExternalCommand,
   runRuntimeBoundaryWithRetryAndTimeout,
@@ -37,18 +34,14 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { missingWorktrunkAutomationFlagSupport, worktrunkAutomationMode } from "./automation.js";
+import { worktrunkCommandFailure } from "./commandFailure.js";
 import {
   type CheckWorktrunkDependencyOptions,
   checkWorktrunkDependency,
   type WorktrunkDependencyStatus,
   worktrunkInstallHint,
 } from "./dependency.js";
-import {
-  ProviderUnavailableError,
-  providerErrorFromUnknown,
-  WorktrunkProviderError,
-  type WorktrunkProviderErrorCode,
-} from "./errors.js";
+import { WorktrunkProviderError, type WorktrunkProviderErrorCode } from "./errors.js";
 import { doctorWorktrunkHooks } from "./hooks.js";
 import { applyRecoveryBreadcrumbMetadata } from "./metadata.js";
 import { parseWorktrunkListJson, parseWorktrunkListPayload } from "./parse.js";
@@ -136,7 +129,12 @@ export class WorktrunkProvider implements WorktreeProvider {
       providerType: "worktree",
       status: "unavailable",
       lastCheckedAt: checkedAt,
-      lastError: dependency.error,
+      lastError: publicSafeErrorFromUnknown(dependency.error, {
+        tag: "ProviderUnavailableError",
+        code: "WORKTRUNK_UNAVAILABLE",
+        message: "Worktrunk is not available.",
+        provider: this.id,
+      }),
       capabilities: this.capabilities(),
       diagnostics: dependencyDiagnostics(dependency),
     };
@@ -182,12 +180,13 @@ export class WorktrunkProvider implements WorktreeProvider {
       }
       return check;
     } catch (cause) {
-      const error = safeErrorFromUnknown(cause, {
+      const fallback = {
         tag: "WorktrunkHookSetupError",
         code: "WORKTRUNK_HOOK_DIAGNOSTIC_FAILED",
         message: "Worktrunk hook diagnostics failed.",
         provider: this.id,
-      });
+      };
+      const error = publicSafeErrorFromUnknown(cause, fallback);
       return {
         name: "worktrunk-hooks",
         status: "error",
@@ -573,7 +572,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         message: "Worktrunk automation capability diagnostics failed.",
         provider: this.id,
       });
-      const missingBinary = isMissingBinary(cause);
+      const missingBinary = fallback.code === "ENOENT";
       const error = {
         tag: missingBinary ? "ProviderUnavailableError" : "WorktrunkAutomationDiagnosticError",
         code: missingBinary ? "WORKTRUNK_UNAVAILABLE" : fallback.code,
@@ -750,47 +749,17 @@ export class WorktrunkProvider implements WorktreeProvider {
       return result.value;
     }
 
-    try {
-      throw result.error;
-    } catch (cause) {
-      const diagnosticDetails = worktrunkCommandDiagnostics({
-        error: cause,
-        provider: this.id,
-        operation,
-        command: this.#command,
-        args,
-        cwd,
-        durationMs: result.timing.durationMs,
-      });
-      if (isMissingBinary(cause)) {
-        throw new ProviderUnavailableError("Worktrunk is not available.", {
-          hint: worktrunkInstallHint(this.#command),
-          command: this.#command,
-          installHint: worktrunkInstallHint(this.#command),
-          cause,
-          diagnosticDetails,
-        });
-      }
-      if (isTimeout(cause)) {
-        throw new WorktrunkProviderError("WORKTRUNK_TIMEOUT", "Worktrunk command timed out.", {
-          cause,
-          diagnosticDetails,
-        });
-      }
-      if (isAbort(cause)) {
-        throw new WorktrunkProviderError(
-          "WORKTRUNK_CANCELLED",
-          "Worktrunk command was cancelled.",
-          {
-            cause,
-            diagnosticDetails,
-          },
-        );
-      }
-      throw providerErrorFromUnknown(cause, classifyWorktrunkFailure(cause, fallback), {
-        diagnosticDetails,
-      });
-    }
+    throw worktrunkCommandFailure({
+      error: result.error,
+      provider: this.id,
+      operation,
+      command: this.#command,
+      args,
+      cwd,
+      durationMs: result.timing.durationMs,
+      fallback,
+      installHint: worktrunkInstallHint(this.#command),
+    });
   }
 }
 
@@ -813,182 +782,6 @@ function doctorWorkBudgetMs(timeoutMs: number): number {
 
 function mergeAbortSignals(primary: AbortSignal, secondary: AbortSignal | undefined): AbortSignal {
   return secondary === undefined ? primary : AbortSignal.any([primary, secondary]);
-}
-
-function worktrunkCommandDiagnostics(input: {
-  error: unknown;
-  provider: ProviderId;
-  operation: string;
-  command: string;
-  args: readonly string[];
-  cwd?: string | undefined;
-  durationMs: number;
-}): DiagnosticDetail[] {
-  const detail: ExternalCommandDiagnosticDetail = {
-    type: "external_command",
-    provider: input.provider,
-    operation: input.operation,
-    command: stringFieldDeep(input.error, "command") ?? formatCommand(input.command, input.args),
-  };
-  const cwd = stringFieldDeep(input.error, "cwd") ?? input.cwd;
-  if (cwd !== undefined) detail.cwd = cwd;
-  const exitCode = numberFieldDeep(input.error, "exitCode");
-  if (exitCode !== undefined) detail.exitCode = exitCode;
-  const signal = stringFieldDeep(input.error, "signal");
-  if (signal !== undefined) detail.signal = signal;
-  const stdoutSnippet = stringFieldDeep(input.error, "stdoutSnippet");
-  if (stdoutSnippet !== undefined && stdoutSnippet.length > 0) {
-    detail.stdoutSnippet = stdoutSnippet;
-  }
-  const stderrSnippet = stringFieldDeep(input.error, "stderrSnippet");
-  if (stderrSnippet !== undefined && stderrSnippet.length > 0) {
-    detail.stderrSnippet = stderrSnippet;
-  }
-  detail.durationMs = input.durationMs;
-  const parsed = ExternalCommandDiagnosticDetailSchema.safeParse(detail);
-  return parsed.success ? [parsed.data] : [];
-}
-
-function classifyWorktrunkFailure(
-  error: unknown,
-  fallback: {
-    code: "WORKTRUNK_COMMAND_FAILED" | "WORKTRUNK_UNAVAILABLE";
-    message: string;
-    unresolvedBase?: string;
-  },
-): { code: WorktrunkProviderErrorCode; message: string; hint?: string } {
-  if (fallback.code !== "WORKTRUNK_COMMAND_FAILED") {
-    return fallback;
-  }
-
-  const diagnostic = stripVTControlCharacters(diagnosticText(error));
-  const text = diagnostic.toLowerCase();
-  if (isUnsupportedFlagText(text)) {
-    return {
-      code: "WORKTRUNK_UNSUPPORTED_FLAG",
-      message: "Worktrunk rejected an automation flag used by STATION.",
-      hint: "Upgrade Worktrunk or adjust worktree.worktrunk.use_lifecycle_hooks in STATION config.",
-    };
-  }
-
-  if (isHookApprovalText(text)) {
-    return {
-      code: "WORKTRUNK_HOOK_APPROVAL_REQUIRED",
-      message:
-        "Worktrunk lifecycle hooks needed interactive approval during automated STATION work.",
-      hint: "Set worktree.worktrunk.use_lifecycle_hooks to false to skip hooks or true to pre-approve hook prompts.",
-    };
-  }
-
-  if (isDuplicateBranchText(text)) {
-    return {
-      code: "WORKTRUNK_BRANCH_EXISTS",
-      message: "Worktrunk could not create the worktree because the branch already exists.",
-      hint: "Choose a different branch name or start/focus the existing worktree.",
-    };
-  }
-
-  if (isDuplicateWorktreeText(text)) {
-    return {
-      code: "WORKTRUNK_WORKTREE_EXISTS",
-      message: "Worktrunk could not create the worktree because the worktree path already exists.",
-      hint: "Choose a different branch/path or remove the stale worktree path.",
-    };
-  }
-
-  if (
-    fallback.unresolvedBase !== undefined &&
-    unresolvedNamedReference(diagnostic) === fallback.unresolvedBase
-  ) {
-    return {
-      code: "WORKTRUNK_BASE_MISSING",
-      message: `Base \`${fallback.unresolvedBase}\` does not resolve to a commit.`,
-      hint: "Create its first commit or choose another base.",
-    };
-  }
-
-  if (isMissingBaseText(text)) {
-    return {
-      code: "WORKTRUNK_BASE_MISSING",
-      message: "Worktrunk could not find the requested base for the new worktree.",
-      hint: "Fetch the base branch or set a valid worktree.worktrunk.base/default branch in STATION config.",
-    };
-  }
-
-  return fallback;
-}
-
-function isUnsupportedFlagText(text: string): boolean {
-  return (
-    /unknown (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
-    /unrecognized (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
-    /unexpected (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text) ||
-    /found argument ['"]--(?:no-hooks|yes)['"].*(?:not expected|wasn't expected)/.test(text) ||
-    /invalid (?:argument|flag|option).*--(?:no-hooks|yes)/.test(text)
-  );
-}
-
-function isHookApprovalText(text: string): boolean {
-  return (
-    /(?:approval|confirm|confirmation|prompt).*(?:required|needed)/.test(text) ||
-    /(?:requires|needs).*(?:approval|confirmation|interactive)/.test(text) ||
-    /(?:use|pass).*(?:--yes|-y).*(?:approve|confirm|continue)/.test(text) ||
-    /not a tty/.test(text) ||
-    /hook.*(?:cancelled|aborted|declined|refused)/.test(text)
-  );
-}
-
-function isDuplicateBranchText(text: string): boolean {
-  return (
-    /branch\b.*\balready exists/.test(text) ||
-    /\balready exists\b.*\bbranch\b/.test(text) ||
-    /refs\/heads\/[^\s]+.*\balready exists/.test(text)
-  );
-}
-
-function isDuplicateWorktreeText(text: string): boolean {
-  return (
-    /worktree\b.*\balready exists/.test(text) ||
-    /\balready exists\b.*\bworktree\b/.test(text) ||
-    /\bpath\b.*\balready exists/.test(text) ||
-    /\bdestination\b.*\balready exists/.test(text)
-  );
-}
-
-function unresolvedNamedReference(text: string): string | undefined {
-  return /no branch, tag, or commit named ['"]?([^'"\s]+)['"]?/i.exec(text)?.[1];
-}
-
-function isMissingBaseText(text: string): boolean {
-  return (
-    /base\b.*\b(?:not found|missing|does not exist|unknown)/.test(text) ||
-    /(?:not found|missing|does not exist|unknown)\b.*\bbase\b/.test(text) ||
-    /could(?:n't| not) find remote ref/.test(text) ||
-    /invalid reference/.test(text) ||
-    /not a valid object name/.test(text) ||
-    /unknown revision/.test(text)
-  );
-}
-
-function diagnosticText(error: unknown, seen = new Set<unknown>()): string {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return "";
-  }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
-  const parts: string[] = [];
-  for (const key of ["message", "stdoutSnippet", "stderrSnippet", "command"]) {
-    const value = record[key];
-    if (typeof value === "string") {
-      parts.push(value);
-    }
-  }
-  parts.push(diagnosticText(record.cause, seen));
-  return parts.join("\n");
-}
-
-function formatCommand(command: string, args: readonly string[]): string {
-  return [command, ...args].join(" ");
 }
 
 function worktrunkSubcommand(args: readonly string[]): string {
@@ -1189,67 +982,6 @@ function canonicalPathForComparison(path: string): string {
   return normalized;
 }
 
-function isMissingBinary(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) {
-    return false;
-  }
-  const cause = error as { code?: unknown; cause?: unknown };
-  if (cause.code === "EXTERNAL_COMMAND_CWD_NOT_FOUND") return false;
-  return cause.code === "ENOENT" || isMissingBinary(cause.cause);
-}
-
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
-}
-
-function stringFieldDeep(
-  error: unknown,
-  key: "command" | "cwd" | "signal" | "stdoutSnippet" | "stderrSnippet",
-  seen = new Set<unknown>(),
-): string | undefined {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return undefined;
-  }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
-  const value = record[key];
-  if (typeof value === "string") {
-    return value;
-  }
-  return stringFieldDeep(record.cause, key, seen);
-}
-
-function numberFieldDeep(
-  error: unknown,
-  key: "exitCode",
-  seen = new Set<unknown>(),
-): number | undefined {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return undefined;
-  }
-  seen.add(error);
-  const record = error as Record<string, unknown>;
-  const value = record[key];
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  return numberFieldDeep(record.cause, key, seen);
-}
-
-function isTimeout(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "WORKTRUNK_TIMEOUT"
-  );
-}
-
-function isAbort(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    (error.code === "WORKTRUNK_CANCELLED" || error.code === "EXTERNAL_COMMAND_ABORTED")
-  );
 }

--- a/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/commandFailure.test.ts
@@ -1,0 +1,117 @@
+import {
+  externalCommandErrorFromUnknown,
+  type RuntimeSafeError,
+  safeErrorFromUnknown,
+} from "@station/runtime";
+import { describe, expect, it } from "vitest";
+import { worktrunkCommandFailure } from "../../src/commandFailure.js";
+
+const fallback = {
+  code: "WORKTRUNK_COMMAND_FAILED" as const,
+  message: "Worktrunk failed to create a worktree.",
+};
+
+function mapFailure(error: RuntimeSafeError) {
+  return worktrunkCommandFailure({
+    error,
+    provider: "worktrunk",
+    operation: "provider.worktrunk.switch",
+    command: "wt",
+    args: ["switch", "--create", "feature"],
+    cwd: "/tmp/project",
+    durationMs: 12,
+    fallback,
+    installHint: "Install Worktrunk.",
+  });
+}
+
+describe("Worktrunk command failure mapping", () => {
+  it("enriches redacted typed command evidence and classifies branch conflicts", () => {
+    const normalized = safeErrorFromUnknown(
+      externalCommandErrorFromUnknown(
+        {
+          code: 128,
+          signal: "SIGTERM",
+          stdout: "progress",
+          stderr: "fatal: branch feature already exists OPENAI_TOKEN=secret-value",
+        },
+        { command: "wt", args: ["switch", "--create", "feature"], cwd: "/tmp/project" },
+      ),
+      {
+        tag: "WorktreeProviderError",
+        code: fallback.code,
+        message: fallback.message,
+        provider: "worktrunk",
+      },
+    );
+
+    const mapped = mapFailure(normalized);
+
+    expect(mapped).toMatchObject({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_BRANCH_EXISTS",
+      message: "Worktrunk could not create the worktree because the branch already exists.",
+      diagnosticDetails: [
+        {
+          type: "external_command",
+          provider: "worktrunk",
+          operation: "provider.worktrunk.switch",
+          command: "wt switch --create feature",
+          cwd: "/tmp/project",
+          exitCode: 128,
+          signal: "SIGTERM",
+          stdoutSnippet: "progress",
+          stderrSnippet: "fatal: branch feature already exists OPENAI_TOKEN=[REDACTED]",
+          durationMs: 12,
+        },
+      ],
+    });
+    expect(mapped.cause).toBe(normalized);
+    expect(JSON.stringify(mapped)).not.toContain("secret-value");
+  });
+
+  it("distinguishes a missing binary from a missing working directory", () => {
+    const missingBinary = mapFailure({
+      tag: "ExternalCommandError",
+      code: "ENOENT",
+      message: "External command failed.",
+    });
+    expect(missingBinary).toMatchObject({
+      tag: "ProviderUnavailableError",
+      code: "WORKTRUNK_UNAVAILABLE",
+      message: "Worktrunk is not available.",
+      hint: "Install Worktrunk.",
+    });
+
+    const missingCwd = mapFailure({
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_CWD_NOT_FOUND",
+      message: "External command failed.",
+    });
+    expect(missingCwd).toMatchObject({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: fallback.message,
+    });
+  });
+
+  it("maps timeout and cancellation from normalized codes", () => {
+    expect(
+      mapFailure({
+        tag: "TimeoutError",
+        code: "WORKTRUNK_TIMEOUT",
+        message: "Worktrunk command timed out.",
+      }),
+    ).toMatchObject({ code: "WORKTRUNK_TIMEOUT", message: "Worktrunk command timed out." });
+    expect(
+      mapFailure({
+        tag: "ExternalCommandError",
+        code: "EXTERNAL_COMMAND_ABORTED",
+        message: "External command was aborted.",
+      }),
+    ).toMatchObject({
+      code: "WORKTRUNK_CANCELLED",
+      message: "Worktrunk command was cancelled.",
+    });
+  });
+});

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,5 +1,5 @@
 import type { SafeError } from "@station/contracts";
-import type { RuntimeSafeErrorFallback } from "@station/runtime";
+import { publicSafeErrorFromUnknown, type RuntimeSafeErrorFallback } from "@station/runtime";
 import { isObserverConnectError, observerConnectNotice } from "./connectionState.js";
 import type { ClientNotice } from "./types.js";
 
@@ -23,18 +23,11 @@ export type ToSafeErrorOptions = {
 };
 
 export function toSafeError(error: unknown, options: ToSafeErrorOptions = {}): SafeError {
-  if (isSafeError(error)) {
-    return error;
-  }
-  const cause = safeErrorCause(error);
-  if (cause !== undefined) {
-    return cause;
-  }
-  return {
+  return publicSafeErrorFromUnknown(error, {
     tag: "ClientObserverError",
     code: "CLIENT_OBSERVER_OPERATION_FAILED",
     message: `${clientSubject(options.clientLabel)} could not complete the observer operation.`,
-  };
+  });
 }
 
 export function safeErrorToNotice(error: SafeError): ClientNotice {
@@ -69,35 +62,8 @@ export function timeoutErrorFallback(code: string, message: string): RuntimeSafe
   };
 }
 
-function isSafeError(value: unknown): value is SafeError {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as Partial<SafeError>;
-  return (
-    typeof candidate.tag === "string" &&
-    candidate.tag.length > 0 &&
-    typeof candidate.code === "string" &&
-    candidate.code.length > 0 &&
-    typeof candidate.message === "string" &&
-    candidate.message.length > 0
-  );
-}
-
 function clientSubject(clientLabel: string | undefined): string {
   return clientLabel === undefined || clientLabel.length === 0
     ? "The client"
     : `The ${clientLabel}`;
-}
-
-function safeErrorCause(error: unknown, seen = new Set<unknown>()): SafeError | undefined {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return undefined;
-  }
-  seen.add(error);
-  const cause = (error as { cause?: unknown }).cause;
-  if (isSafeError(cause)) {
-    return cause;
-  }
-  return safeErrorCause(cause, seen);
 }

--- a/packages/client/test/unit/errors.test.ts
+++ b/packages/client/test/unit/errors.test.ts
@@ -69,6 +69,33 @@ describe("client SafeError mapping", () => {
     expect(JSON.stringify(notice)).not.toContain("/tmp/station-test.sock");
   });
 
+  it("strips runtime diagnostics and raw causes from client errors and notices", () => {
+    const rich = Object.assign(new Error("The operation failed."), {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      diagnosticDetails: [
+        {
+          type: "external_command",
+          provider: "worktrunk",
+          operation: "provider.worktrunk.switch",
+          command: "wt switch feature",
+          stderrSnippet: "raw provider output",
+        },
+      ],
+      cause: new Error("raw cause"),
+    });
+
+    const safe = toSafeError(rich);
+    const notice = safeErrorToNotice(safe);
+
+    expect(safe).toEqual({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "The operation failed.",
+    });
+    expect(JSON.stringify(notice)).not.toMatch(/diagnosticDetails|raw provider output|raw cause/);
+  });
+
   it("labels unknown failures when a client label is provided", () => {
     const safe = toSafeError(new Error("raw failure"), { clientLabel: "Station" });
 

--- a/packages/observability/src/errors.ts
+++ b/packages/observability/src/errors.ts
@@ -6,6 +6,11 @@ import {
   type SafeError,
   SafeErrorSchema,
 } from "@station/contracts";
+import {
+  publicSafeErrorFromUnknown,
+  type RuntimeSafeError,
+  safeErrorFromUnknown,
+} from "@station/runtime";
 import { redact } from "./redaction.js";
 
 export type SafeErrorFallback = {
@@ -42,22 +47,20 @@ export function toSafeError(
     >
   > = {},
 ): SafeError {
-  const knownSafeError = isSafeErrorLike(error) ? error : safeErrorCause(error);
-  const known = knownSafeError ?? fallback;
-  const safeMessage = redact(known.message).value;
+  const projected = publicSafeErrorFromUnknown(error, fallback);
   const safeError: SafeError = {
-    tag: known.tag,
-    code: known.code,
-    message: safeMessage,
+    tag: projected.tag,
+    code: projected.code,
+    message: redact(projected.message).value,
   };
-  if (known.hint !== undefined) safeError.hint = redact(known.hint).value;
-  if (known.provider !== undefined) safeError.provider = known.provider;
-  if (knownSafeError?.projectId !== undefined) safeError.projectId = knownSafeError.projectId;
-  if (knownSafeError?.worktreeId !== undefined) safeError.worktreeId = knownSafeError.worktreeId;
-  if (knownSafeError?.sessionId !== undefined) safeError.sessionId = knownSafeError.sessionId;
-  if (knownSafeError?.diagnosticId !== undefined) {
-    safeError.diagnosticId = knownSafeError.diagnosticId;
-  }
+  if (projected.hint !== undefined) safeError.hint = redact(projected.hint).value;
+  if (projected.commandId !== undefined) safeError.commandId = projected.commandId;
+  if (projected.projectId !== undefined) safeError.projectId = projected.projectId;
+  if (projected.worktreeId !== undefined) safeError.worktreeId = projected.worktreeId;
+  if (projected.sessionId !== undefined) safeError.sessionId = projected.sessionId;
+  if (projected.provider !== undefined) safeError.provider = projected.provider;
+  if (projected.traceId !== undefined) safeError.traceId = projected.traceId;
+  if (projected.diagnosticId !== undefined) safeError.diagnosticId = projected.diagnosticId;
   applySafeErrorContext(safeError, context);
   return SafeErrorSchema.parse(safeError);
 }
@@ -75,14 +78,15 @@ export function createErrorEnvelope(input: ErrorEnvelopeInput): ErrorEnvelope {
   if (input.sessionId !== undefined) context.sessionId = input.sessionId;
   if (input.traceId !== undefined) context.traceId = input.traceId;
 
-  const safeError = toSafeError(input.error, input.fallback, context);
+  const normalized = safeErrorFromUnknown(input.error, input.fallback);
+  const safeError = toSafeError(normalized, input.fallback, context);
   const errorObject = input.error instanceof Error ? input.error : undefined;
   const provider = input.provider ?? safeError.provider;
   const redactedCause = redact(errorObject?.message ?? input.error).value;
   const redactedStack =
     errorObject?.stack === undefined ? undefined : redact(errorObject.stack).value;
   const redactedRaw = input.raw === undefined ? undefined : redact(input.raw).value;
-  const redactedDiagnostics = diagnosticsFromUnknown(input.error);
+  const redactedDiagnostics = diagnosticsFromRuntimeError(normalized);
 
   const envelope: ErrorEnvelope = {
     id: input.id,
@@ -108,86 +112,16 @@ export function createErrorEnvelope(input: ErrorEnvelopeInput): ErrorEnvelope {
   return ErrorEnvelopeSchema.parse(envelope);
 }
 
-function isSafeErrorLike(value: unknown): value is SafeError {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const candidate = value as Partial<SafeError>;
-  return (
-    typeof candidate.tag === "string" &&
-    typeof candidate.code === "string" &&
-    typeof candidate.message === "string"
-  );
-}
-
-function safeErrorCause(error: unknown, seen = new Set<unknown>()): SafeError | undefined {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return undefined;
-  }
-  seen.add(error);
-  const cause = (error as { cause?: unknown }).cause;
-  if (isSafeErrorLike(cause)) {
-    return cause;
-  }
-  return safeErrorCause(cause, seen);
-}
-
-function diagnosticsFromUnknown(error: unknown, seen = new Set<unknown>()): DiagnosticDetail[] {
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return [];
-  }
-  seen.add(error);
+function diagnosticsFromRuntimeError(error: RuntimeSafeError): DiagnosticDetail[] {
   const diagnostics: DiagnosticDetail[] = [];
-  const record = error as {
-    diagnosticDetails?: unknown;
-    cause?: unknown;
-  };
-
-  if (Array.isArray(record.diagnosticDetails)) {
-    for (const detail of record.diagnosticDetails) {
-      const redacted = redact(detail).value;
-      const parsed = DiagnosticDetailSchema.safeParse(redacted);
-      if (parsed.success) {
-        diagnostics.push(parsed.data);
-      }
+  for (const detail of error.diagnosticDetails ?? []) {
+    const redacted = redact(detail).value;
+    const parsed = DiagnosticDetailSchema.safeParse(redacted);
+    if (parsed.success) {
+      diagnostics.push(parsed.data);
     }
   }
-
-  const externalDetail = externalCommandDiagnosticFromUnknown(error);
-  if (externalDetail !== undefined) {
-    diagnostics.push(externalDetail);
-  }
-
-  diagnostics.push(...diagnosticsFromUnknown(record.cause, seen));
   return dedupeDiagnostics(diagnostics);
-}
-
-function externalCommandDiagnosticFromUnknown(error: unknown): DiagnosticDetail | undefined {
-  if (!error || typeof error !== "object") {
-    return undefined;
-  }
-  const record = error as Record<string, unknown>;
-  if (record.tag !== "ExternalCommandError" || typeof record.command !== "string") {
-    return undefined;
-  }
-
-  const detail: DiagnosticDetail = {
-    type: "external_command",
-    operation: `externalCommand.${record.command.split(" ")[0] ?? "command"}`,
-    command: record.command,
-  };
-  if (typeof record.provider === "string") detail.provider = record.provider;
-  if (typeof record.cwd === "string") detail.cwd = record.cwd;
-  if (typeof record.exitCode === "number") detail.exitCode = record.exitCode;
-  if (typeof record.signal === "string") detail.signal = record.signal;
-  if (typeof record.stdoutSnippet === "string" && record.stdoutSnippet.length > 0) {
-    detail.stdoutSnippet = record.stdoutSnippet;
-  }
-  if (typeof record.stderrSnippet === "string" && record.stderrSnippet.length > 0) {
-    detail.stderrSnippet = record.stderrSnippet;
-  }
-  const parsed = DiagnosticDetailSchema.safeParse(redact(detail).value);
-  return parsed.success ? parsed.data : undefined;
 }
 
 function dedupeDiagnostics(diagnostics: readonly DiagnosticDetail[]): DiagnosticDetail[] {
@@ -195,9 +129,7 @@ function dedupeDiagnostics(diagnostics: readonly DiagnosticDetail[]): Diagnostic
   const deduped: DiagnosticDetail[] = [];
   for (const diagnostic of diagnostics) {
     const key = JSON.stringify(diagnostic);
-    if (seen.has(key)) {
-      continue;
-    }
+    if (seen.has(key)) continue;
     seen.add(key);
     deduped.push(diagnostic);
   }

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -121,6 +121,60 @@ describe("observability helpers", () => {
     expect(envelope.redacted).toBe(true);
   });
 
+  it("keeps nested provider errors lean while retaining typed envelope evidence", () => {
+    const commandError = Object.assign(new Error("External command failed."), {
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+      command: "wt switch feature",
+      diagnosticDetails: [
+        {
+          type: "external_command",
+          provider: "worktrunk",
+          operation: "provider.worktrunk.switch",
+          command: "wt switch feature",
+          stderrSnippet: "OPENAI_TOKEN=secret-value branch already exists",
+        },
+      ],
+    });
+    const providerError = Object.assign(new Error("Worktrunk failed to switch worktrees."), {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      provider: "worktrunk",
+      cause: commandError,
+    });
+
+    const safeError = toSafeError(providerError, {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed to switch worktrees.",
+    });
+    const envelope = createErrorEnvelope({
+      id: "err_nested",
+      error: providerError,
+      fallback: {
+        tag: "WorktreeProviderError",
+        code: "WORKTRUNK_COMMAND_FAILED",
+        message: "Worktrunk failed to switch worktrees.",
+      },
+      createdAt: now,
+    });
+
+    expect(safeError).toEqual({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed to switch worktrees.",
+      provider: "worktrunk",
+    });
+    expect(envelope.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "external_command",
+        operation: "provider.worktrunk.switch",
+        stderrSnippet: "OPENAI_TOKEN=[REDACTED] branch already exists",
+      }),
+    ]);
+    expect(JSON.stringify(envelope)).not.toContain("secret-value");
+  });
+
   it("merges retention defaults and scans local state usage", async () => {
     const dir = await mkdtemp(join(tmpdir(), "station-retention-"));
     await mkdir(join(dir, "logs"), { recursive: true });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@station/contracts": "workspace:*",
     "effect": "^3.21.2"
   }
 }

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -1,44 +1,20 @@
-export type RuntimeSafeError = {
-  tag: string;
-  code: string;
-  message: string;
-  hint?: string;
-  commandId?: string;
-  projectId?: string;
-  worktreeId?: string;
-  sessionId?: string;
-  provider?: string;
-  traceId?: string;
-  diagnosticId?: string;
-  diagnosticDetails?: RuntimeDiagnosticDetail[];
-};
+import {
+  type DiagnosticDetail,
+  DiagnosticDetailSchema,
+  type ExternalCommandDiagnosticDetail,
+  ExternalCommandDiagnosticDetailSchema,
+  type SafeError,
+  SafeErrorSchema,
+  type WorktreeRemovalRefusalDiagnosticDetail,
+} from "@station/contracts";
 
-export type RuntimeExternalCommandDiagnosticDetail = {
-  type: "external_command";
-  provider?: string;
-  operation: string;
-  command: string;
-  cwd?: string;
-  exitCode?: number;
-  signal?: string;
-  stdoutSnippet?: string;
-  stderrSnippet?: string;
-  durationMs?: number;
-};
+export type RuntimeDiagnosticDetail = DiagnosticDetail;
+export type RuntimeExternalCommandDiagnosticDetail = ExternalCommandDiagnosticDetail;
+export type RuntimeWorktreeRemovalRefusalDiagnosticDetail = WorktreeRemovalRefusalDiagnosticDetail;
 
-export type RuntimeWorktreeRemovalRefusalDiagnosticDetail = {
-  type: "worktree_removal_refusal";
-  provider?: string;
-  projectId?: string;
-  worktreeId: string;
-  canonicalPath: string;
-  observedBranch: string;
-  refusalReason: string;
+export type RuntimeSafeError = SafeError & {
+  diagnosticDetails?: DiagnosticDetail[];
 };
-
-export type RuntimeDiagnosticDetail =
-  | RuntimeExternalCommandDiagnosticDetail
-  | RuntimeWorktreeRemovalRefusalDiagnosticDetail;
 
 export type RuntimeSafeErrorFallback = {
   tag: string;
@@ -67,119 +43,222 @@ export type ExternalCommandError = RuntimeSafeError & {
   stderrSnippet?: string;
 };
 
-export function isSafeError(value: unknown): value is RuntimeSafeError {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
+type SafeErrorChain = {
+  safeError?: SafeError;
+  externalCommand?: ExternalCommandFields;
+  diagnostics: DiagnosticDetail[];
+};
 
-  const candidate = value as Partial<RuntimeSafeError>;
-  return (
-    typeof candidate.tag === "string" &&
-    candidate.tag.length > 0 &&
-    typeof candidate.code === "string" &&
-    candidate.code.length > 0 &&
-    typeof candidate.message === "string" &&
-    candidate.message.length > 0
-  );
+type ExternalCommandFields = Pick<
+  ExternalCommandDiagnosticDetail,
+  "command" | "cwd" | "exitCode" | "signal" | "stdoutSnippet" | "stderrSnippet"
+>;
+
+const RuntimeSafeErrorViewSchema = SafeErrorSchema.strip();
+const RuntimeSafeErrorSchema = SafeErrorSchema.extend({
+  diagnosticDetails: DiagnosticDetailSchema.array().optional(),
+}).strip();
+const ExternalCommandFieldsSchema = ExternalCommandDiagnosticDetailSchema.omit({
+  type: true,
+  provider: true,
+  operation: true,
+  durationMs: true,
+}).strip();
+
+export function isSafeError(value: unknown): value is RuntimeSafeError {
+  return RuntimeSafeErrorSchema.safeParse(value).success;
 }
 
 export function safeErrorFromUnknown(
   error: unknown,
   fallback: RuntimeSafeErrorFallback,
 ): RuntimeSafeError {
-  if (isSafeError(error)) {
-    return copySafeError(error);
+  const chain = inspectSafeErrorChain(error);
+  const safeError = chain.safeError ?? safeErrorFallback(fallback);
+  const normalized: RuntimeSafeError = { ...safeError };
+
+  if (chain.diagnostics.length > 0) {
+    normalized.diagnosticDetails = chain.diagnostics;
   }
-  const cause = safeErrorCause(error);
-  if (cause !== undefined) {
-    return copySafeError(cause);
+  if (safeError.tag === "ExternalCommandError" && chain.externalCommand !== undefined) {
+    copyExternalCommandFields(normalized as ExternalCommandError, chain.externalCommand);
   }
 
-  const safeError: RuntimeSafeError = {
+  return normalized;
+}
+
+/**
+ * Projects an unknown failure onto the lean shared SafeError contract.
+ *
+ * Runtime-only diagnostic evidence, command fields, raw output, and causes are omitted.
+ */
+export function publicSafeErrorFromUnknown(
+  error: unknown,
+  fallback: RuntimeSafeErrorFallback,
+): SafeError {
+  const normalized = safeErrorFromUnknown(error, fallback);
+  return safeErrorView(normalized) ?? safeErrorFallback(fallback);
+}
+
+/** Returns whether a normalized runtime failure contains typed external-command fields. */
+export function isExternalCommandError(error: RuntimeSafeError): error is ExternalCommandError {
+  return error.tag === "ExternalCommandError" && externalCommandFields(error) !== undefined;
+}
+
+/** Extracts redacted external-command evidence without exposing process-error shapes. */
+export function externalCommandDiagnosticFromSafeError(
+  error: RuntimeSafeError,
+): ExternalCommandDiagnosticDetail | undefined {
+  if (Array.isArray(error.diagnosticDetails)) {
+    for (const detail of error.diagnosticDetails) {
+      const parsed = ExternalCommandDiagnosticDetailSchema.safeParse(detail);
+      if (parsed.success) {
+        return parsed.data;
+      }
+    }
+  }
+
+  if (!isExternalCommandError(error)) {
+    return undefined;
+  }
+  const fields = externalCommandFields(error);
+  if (fields === undefined) {
+    return undefined;
+  }
+  const detail: ExternalCommandDiagnosticDetail = {
+    type: "external_command",
+    operation: `externalCommand.${error.command.split(" ")[0] ?? "command"}`,
+    ...fields,
+  };
+  if (error.provider !== undefined) {
+    detail.provider = error.provider;
+  }
+  return ExternalCommandDiagnosticDetailSchema.parse(detail);
+}
+
+function inspectSafeErrorChain(error: unknown): SafeErrorChain {
+  const seen = new Set<unknown>();
+  const diagnostics: DiagnosticDetail[] = [];
+  let safeError: SafeError | undefined;
+  let externalCommand: ExternalCommandFields | undefined;
+  let current: unknown = error;
+
+  while (current !== null && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const parsed = safeErrorView(current);
+    if (parsed !== undefined) {
+      if (safeError === undefined) {
+        safeError = parsed;
+        if (parsed.tag === "ExternalCommandError") {
+          externalCommand = externalCommandFields(current);
+        }
+      }
+      const currentDiagnostics = diagnosticDetails(current);
+      diagnostics.push(...currentDiagnostics);
+      if (
+        parsed.tag === "ExternalCommandError" &&
+        !currentDiagnostics.some((detail) => detail.type === "external_command")
+      ) {
+        const commandDiagnostic = externalCommandDiagnostic(current, parsed);
+        if (commandDiagnostic !== undefined) {
+          diagnostics.push(commandDiagnostic);
+        }
+      }
+    }
+    current = runtimeErrorProperty(current, "cause");
+  }
+
+  const result: SafeErrorChain = {
+    diagnostics: dedupeDiagnostics(diagnostics),
+  };
+  if (safeError !== undefined) result.safeError = safeError;
+  if (externalCommand !== undefined) result.externalCommand = externalCommand;
+  return result;
+}
+
+function safeErrorView(value: unknown): SafeError | undefined {
+  const parsed = RuntimeSafeErrorViewSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function safeErrorFallback(fallback: RuntimeSafeErrorFallback): SafeError {
+  const candidate: Record<string, unknown> = {
     tag: fallback.tag,
     code: fallback.code,
     message: fallback.message,
   };
-
-  if (fallback.hint !== undefined) {
-    safeError.hint = fallback.hint;
-  }
-  if (fallback.provider !== undefined) {
-    safeError.provider = fallback.provider;
-  }
-  if (fallback.traceId !== undefined) {
-    safeError.traceId = fallback.traceId;
-  }
-
-  return safeError;
+  if (fallback.hint !== undefined) candidate.hint = fallback.hint;
+  if (fallback.provider !== undefined) candidate.provider = fallback.provider;
+  if (fallback.traceId !== undefined) candidate.traceId = fallback.traceId;
+  return SafeErrorSchema.parse(candidate);
 }
 
-function copySafeError(input: RuntimeSafeError): RuntimeSafeError {
-  const safeError: RuntimeSafeError = {
-    tag: input.tag,
-    code: input.code,
-    message: input.message,
-  };
-  if (input.hint !== undefined) safeError.hint = input.hint;
-  if (input.commandId !== undefined) safeError.commandId = input.commandId;
-  if (input.projectId !== undefined) safeError.projectId = input.projectId;
-  if (input.worktreeId !== undefined) safeError.worktreeId = input.worktreeId;
-  if (input.sessionId !== undefined) safeError.sessionId = input.sessionId;
-  if (input.provider !== undefined) safeError.provider = input.provider;
-  if (input.traceId !== undefined) safeError.traceId = input.traceId;
-  if (input.diagnosticId !== undefined) safeError.diagnosticId = input.diagnosticId;
-  if (input.diagnosticDetails !== undefined) {
-    safeError.diagnosticDetails = input.diagnosticDetails.map(copyDiagnosticDetail);
+function diagnosticDetails(value: object): DiagnosticDetail[] {
+  const details = runtimeErrorProperty(value, "diagnosticDetails");
+  if (!Array.isArray(details)) {
+    return [];
   }
-  if (input.tag === "ExternalCommandError") {
-    const source = input as Partial<ExternalCommandError>;
-    const target = safeError as ExternalCommandError;
-    if (typeof source.command === "string") target.command = source.command;
-    if (typeof source.cwd === "string") target.cwd = source.cwd;
-    if (typeof source.exitCode === "number") target.exitCode = source.exitCode;
-    if (typeof source.signal === "string") target.signal = source.signal;
-    if (typeof source.stdoutSnippet === "string") target.stdoutSnippet = source.stdoutSnippet;
-    if (typeof source.stderrSnippet === "string") target.stderrSnippet = source.stderrSnippet;
+  const parsed: DiagnosticDetail[] = [];
+  for (const detail of details) {
+    const result = DiagnosticDetailSchema.safeParse(detail);
+    if (result.success) {
+      parsed.push(result.data);
+    }
   }
-  return safeError;
+  return parsed;
 }
 
-function safeErrorCause(error: unknown, seen = new Set<unknown>()): RuntimeSafeError | undefined {
-  if (!error || typeof error !== "object" || seen.has(error)) {
+function externalCommandFields(value: unknown): ExternalCommandFields | undefined {
+  const parsed = ExternalCommandFieldsSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function externalCommandDiagnostic(
+  value: unknown,
+  safeError: SafeError,
+): ExternalCommandDiagnosticDetail | undefined {
+  const fields = externalCommandFields(value);
+  if (fields === undefined) {
     return undefined;
   }
-  seen.add(error);
-  const cause = (error as { cause?: unknown }).cause;
-  if (isSafeError(cause)) {
-    return cause;
-  }
-  return safeErrorCause(cause, seen);
+  const detail: ExternalCommandDiagnosticDetail = {
+    type: "external_command",
+    operation: `externalCommand.${fields.command.split(" ")[0] ?? "command"}`,
+    ...fields,
+  };
+  if (safeError.provider !== undefined) detail.provider = safeError.provider;
+  const parsed = ExternalCommandDiagnosticDetailSchema.safeParse(detail);
+  return parsed.success ? parsed.data : undefined;
 }
 
-function copyDiagnosticDetail(detail: RuntimeDiagnosticDetail): RuntimeDiagnosticDetail {
-  if (detail.type === "worktree_removal_refusal") {
-    const copied: RuntimeWorktreeRemovalRefusalDiagnosticDetail = {
-      type: detail.type,
-      worktreeId: detail.worktreeId,
-      canonicalPath: detail.canonicalPath,
-      observedBranch: detail.observedBranch,
-      refusalReason: detail.refusalReason,
-    };
-    if (detail.provider !== undefined) copied.provider = detail.provider;
-    if (detail.projectId !== undefined) copied.projectId = detail.projectId;
-    return copied;
+function copyExternalCommandFields(
+  target: ExternalCommandError,
+  fields: ExternalCommandFields,
+): void {
+  target.command = fields.command;
+  if (fields.cwd !== undefined) target.cwd = fields.cwd;
+  if (fields.exitCode !== undefined) target.exitCode = fields.exitCode;
+  if (fields.signal !== undefined) target.signal = fields.signal;
+  if (fields.stdoutSnippet !== undefined) target.stdoutSnippet = fields.stdoutSnippet;
+  if (fields.stderrSnippet !== undefined) target.stderrSnippet = fields.stderrSnippet;
+}
+
+function dedupeDiagnostics(diagnostics: readonly DiagnosticDetail[]): DiagnosticDetail[] {
+  const seen = new Set<string>();
+  const deduped: DiagnosticDetail[] = [];
+  for (const diagnostic of diagnostics) {
+    const key = JSON.stringify(diagnostic);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(diagnostic);
   }
-  const copied: RuntimeExternalCommandDiagnosticDetail = {
-    type: "external_command",
-    operation: detail.operation,
-    command: detail.command,
-  };
-  if (detail.provider !== undefined) copied.provider = detail.provider;
-  if (detail.cwd !== undefined) copied.cwd = detail.cwd;
-  if (detail.exitCode !== undefined) copied.exitCode = detail.exitCode;
-  if (detail.signal !== undefined) copied.signal = detail.signal;
-  if (detail.stdoutSnippet !== undefined) copied.stdoutSnippet = detail.stdoutSnippet;
-  if (detail.stderrSnippet !== undefined) copied.stderrSnippet = detail.stderrSnippet;
-  if (detail.durationMs !== undefined) copied.durationMs = detail.durationMs;
-  return copied;
+  return deduped;
+}
+
+function runtimeErrorProperty(value: object, key: string): unknown {
+  try {
+    return Reflect.get(value, key);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -113,7 +113,7 @@ export function externalCommandDiagnosticFromSafeError(
     for (const detail of error.diagnosticDetails) {
       const parsed = ExternalCommandDiagnosticDetailSchema.safeParse(detail);
       if (parsed.success) {
-        return parsed.data;
+        return copyExternalCommandDiagnosticDetail(parsed.data);
       }
     }
   }
@@ -178,7 +178,22 @@ function inspectSafeErrorChain(error: unknown): SafeErrorChain {
 
 function safeErrorView(value: unknown): SafeError | undefined {
   const parsed = RuntimeSafeErrorViewSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
+  if (!parsed.success) return undefined;
+
+  const safeError: SafeError = {
+    tag: parsed.data.tag,
+    code: parsed.data.code,
+    message: parsed.data.message,
+  };
+  if (parsed.data.hint !== undefined) safeError.hint = parsed.data.hint;
+  if (parsed.data.commandId !== undefined) safeError.commandId = parsed.data.commandId;
+  if (parsed.data.projectId !== undefined) safeError.projectId = parsed.data.projectId;
+  if (parsed.data.worktreeId !== undefined) safeError.worktreeId = parsed.data.worktreeId;
+  if (parsed.data.sessionId !== undefined) safeError.sessionId = parsed.data.sessionId;
+  if (parsed.data.provider !== undefined) safeError.provider = parsed.data.provider;
+  if (parsed.data.traceId !== undefined) safeError.traceId = parsed.data.traceId;
+  if (parsed.data.diagnosticId !== undefined) safeError.diagnosticId = parsed.data.diagnosticId;
+  return safeError;
 }
 
 function safeErrorFallback(fallback: RuntimeSafeErrorFallback): SafeError {
@@ -202,7 +217,7 @@ function diagnosticDetails(value: object): DiagnosticDetail[] {
   for (const detail of details) {
     const result = DiagnosticDetailSchema.safeParse(detail);
     if (result.success) {
-      parsed.push(result.data);
+      parsed.push(copyDiagnosticDetail(result.data));
     }
   }
   return parsed;
@@ -210,7 +225,15 @@ function diagnosticDetails(value: object): DiagnosticDetail[] {
 
 function externalCommandFields(value: unknown): ExternalCommandFields | undefined {
   const parsed = ExternalCommandFieldsSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
+  if (!parsed.success) return undefined;
+
+  const fields: ExternalCommandFields = { command: parsed.data.command };
+  if (parsed.data.cwd !== undefined) fields.cwd = parsed.data.cwd;
+  if (parsed.data.exitCode !== undefined) fields.exitCode = parsed.data.exitCode;
+  if (parsed.data.signal !== undefined) fields.signal = parsed.data.signal;
+  if (parsed.data.stdoutSnippet !== undefined) fields.stdoutSnippet = parsed.data.stdoutSnippet;
+  if (parsed.data.stderrSnippet !== undefined) fields.stderrSnippet = parsed.data.stderrSnippet;
+  return fields;
 }
 
 function externalCommandDiagnostic(
@@ -241,6 +264,41 @@ function copyExternalCommandFields(
   if (fields.signal !== undefined) target.signal = fields.signal;
   if (fields.stdoutSnippet !== undefined) target.stdoutSnippet = fields.stdoutSnippet;
   if (fields.stderrSnippet !== undefined) target.stderrSnippet = fields.stderrSnippet;
+}
+
+function copyDiagnosticDetail(detail: DiagnosticDetail): DiagnosticDetail {
+  if (detail.type === "external_command") {
+    return copyExternalCommandDiagnosticDetail(detail);
+  }
+
+  const copied: WorktreeRemovalRefusalDiagnosticDetail = {
+    type: detail.type,
+    worktreeId: detail.worktreeId,
+    canonicalPath: detail.canonicalPath,
+    observedBranch: detail.observedBranch,
+    refusalReason: detail.refusalReason,
+  };
+  if (detail.provider !== undefined) copied.provider = detail.provider;
+  if (detail.projectId !== undefined) copied.projectId = detail.projectId;
+  return copied;
+}
+
+function copyExternalCommandDiagnosticDetail(
+  detail: ExternalCommandDiagnosticDetail,
+): ExternalCommandDiagnosticDetail {
+  const copied: ExternalCommandDiagnosticDetail = {
+    type: detail.type,
+    operation: detail.operation,
+    command: detail.command,
+  };
+  if (detail.provider !== undefined) copied.provider = detail.provider;
+  if (detail.cwd !== undefined) copied.cwd = detail.cwd;
+  if (detail.exitCode !== undefined) copied.exitCode = detail.exitCode;
+  if (detail.signal !== undefined) copied.signal = detail.signal;
+  if (detail.stdoutSnippet !== undefined) copied.stdoutSnippet = detail.stdoutSnippet;
+  if (detail.stderrSnippet !== undefined) copied.stderrSnippet = detail.stderrSnippet;
+  if (detail.durationMs !== undefined) copied.durationMs = detail.durationMs;
+  return copied;
 }
 
 function dedupeDiagnostics(diagnostics: readonly DiagnosticDetail[]): DiagnosticDetail[] {

--- a/packages/runtime/src/externalCommand.ts
+++ b/packages/runtime/src/externalCommand.ts
@@ -50,15 +50,15 @@ export type ResolveExecutablePathOptions = {
   access?: (path: string) => Promise<void>;
 };
 
-type ExternalCommandErrorLike = {
-  code?: unknown;
-  exitCode?: unknown;
-  name?: unknown;
-  signal?: unknown;
-  stderr?: unknown;
-  stderrSnippet?: unknown;
-  stdout?: unknown;
-  stdoutSnippet?: unknown;
+type NormalizedProcessError = {
+  code?: string | number;
+  exitCode?: number;
+  name?: string;
+  signal?: string;
+  stderr?: string;
+  stderrSnippet?: string;
+  stdout?: string;
+  stdoutSnippet?: string;
 };
 
 export async function runExternalCommand(
@@ -271,7 +271,7 @@ export function externalCommandErrorFromUnknown(
 ): ExternalCommandError {
   const fallback = externalCommandFallback("EXTERNAL_COMMAND_FAILED", "External command failed.");
   const safeError = safeErrorFromUnknown(error, fallback);
-  const cause = externalCommandErrorLike(error);
+  const cause = normalizeProcessError(error);
   const normalized: ExternalCommandError = {
     tag: "ExternalCommandError",
     code: cwdMissing
@@ -287,22 +287,21 @@ export function externalCommandErrorFromUnknown(
     normalized.cwd = input.cwd;
   }
 
-  const exitCode = numericField(cause, "exitCode") ?? numericField(cause, "code");
+  const exitCode = cause.exitCode ?? (typeof cause.code === "number" ? cause.code : undefined);
   if (exitCode !== undefined) {
     normalized.exitCode = exitCode;
   }
 
-  const signal = externalCommandStringValue(cause, "signal");
-  if (signal !== undefined) {
-    normalized.signal = signal;
+  if (cause.signal !== undefined) {
+    normalized.signal = cause.signal;
   }
 
-  const stdoutSnippet = outputSnippet(cause, "stdout", "stdoutSnippet");
+  const stdoutSnippet = commandOutputSnippet(cause.stdout ?? cause.stdoutSnippet);
   if (stdoutSnippet !== undefined) {
     normalized.stdoutSnippet = stdoutSnippet;
   }
 
-  const stderrSnippet = outputSnippet(cause, "stderr", "stderrSnippet");
+  const stderrSnippet = commandOutputSnippet(cause.stderr ?? cause.stderrSnippet);
   if (stderrSnippet !== undefined) {
     normalized.stderrSnippet = stderrSnippet;
   }
@@ -322,17 +321,14 @@ function externalCommandEnvironment(input: Pick<ExternalCommandInput, "env" | "u
 }
 
 async function missingWorkingDirectory(error: unknown, cwd: string | undefined): Promise<boolean> {
-  if (
-    cwd === undefined ||
-    externalCommandStringValue(externalCommandErrorLike(error), "code") !== "ENOENT"
-  ) {
+  if (cwd === undefined || normalizeProcessError(error).code !== "ENOENT") {
     return false;
   }
   try {
     await defaultAccess(cwd);
     return false;
   } catch (cause) {
-    return externalCommandStringValue(externalCommandErrorLike(cause), "code") === "ENOENT";
+    return normalizeProcessError(cause).code === "ENOENT";
   }
 }
 
@@ -346,13 +342,13 @@ function externalCommandFallback(code: string, message: string): RuntimeSafeErro
 
 function externalCommandCode(
   error: unknown,
-  cause: ExternalCommandErrorLike,
+  cause: NormalizedProcessError,
   safeError: RuntimeSafeError,
 ): string {
   if (isAbortLikeError(error)) {
     return "EXTERNAL_COMMAND_ABORTED";
   }
-  return externalCommandStringValue(cause, "code") ?? safeError.code;
+  return typeof cause.code === "string" ? cause.code : safeError.code;
 }
 
 function externalCommandMessage(error: unknown, safeError: RuntimeSafeError): string {
@@ -376,29 +372,7 @@ function formatCommandForError(input: Pick<ExternalCommandInput, "command" | "ar
   return redacted.join(" ");
 }
 
-function numericField(
-  record: ExternalCommandErrorLike,
-  key: "exitCode" | "code",
-): number | undefined {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function externalCommandStringValue(
-  record: ExternalCommandErrorLike,
-  key: keyof ExternalCommandErrorLike,
-): string | undefined {
-  const value = record[key];
-  return typeof value === "string" ? value : undefined;
-}
-
-function outputSnippet(
-  cause: ExternalCommandErrorLike,
-  rawKey: "stdout" | "stderr",
-  snippetKey: "stdoutSnippet" | "stderrSnippet",
-): string | undefined {
-  const value =
-    externalCommandStringValue(cause, rawKey) ?? externalCommandStringValue(cause, snippetKey);
+function commandOutputSnippet(value: string | undefined): string | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -413,9 +387,9 @@ function allowedExitCodeResultFromUnknown(
   if (isAbortLikeError(error)) {
     return undefined;
   }
-  const cause = externalCommandErrorLike(error);
+  const cause = normalizeProcessError(error);
 
-  const exitCode = numericField(cause, "exitCode") ?? numericField(cause, "code");
+  const exitCode = cause.exitCode ?? (typeof cause.code === "number" ? cause.code : undefined);
   if (exitCode === undefined || input.allowedExitCodes?.includes(exitCode) !== true) {
     return undefined;
   }
@@ -423,8 +397,8 @@ function allowedExitCodeResultFromUnknown(
   return {
     command: input.command,
     args: input.args ?? [],
-    stdout: externalCommandStringValue(cause, "stdout") ?? "",
-    stderr: externalCommandStringValue(cause, "stderr") ?? "",
+    stdout: cause.stdout ?? "",
+    stderr: cause.stderr ?? "",
     exitCode,
   };
 }
@@ -533,7 +507,7 @@ function isAbortLikeError(error: unknown): boolean {
   if (isSafeError(error)) {
     return error.tag === "CancellationError" || error.code === "EXTERNAL_COMMAND_ABORTED";
   }
-  const cause = externalCommandErrorLike(error);
+  const cause = normalizeProcessError(error);
   return cause.name === "AbortError" || cause.code === "ABORT_ERR";
 }
 
@@ -550,6 +524,30 @@ export function redactCommandOutput(value: string): string {
     );
 }
 
-function externalCommandErrorLike(error: unknown): ExternalCommandErrorLike {
-  return error === null || error === undefined ? {} : (Object(error) as ExternalCommandErrorLike);
+function normalizeProcessError(error: unknown): NormalizedProcessError {
+  if (error === null || error === undefined) {
+    return {};
+  }
+  const source = Object(error) as Record<string, unknown>;
+  const normalized: NormalizedProcessError = {};
+  if (
+    (typeof source.code === "string" && source.code.length > 0) ||
+    (typeof source.code === "number" && Number.isFinite(source.code))
+  ) {
+    normalized.code = source.code;
+  }
+  if (typeof source.exitCode === "number" && Number.isFinite(source.exitCode)) {
+    normalized.exitCode = source.exitCode;
+  }
+  if (typeof source.name === "string") normalized.name = source.name;
+  if (typeof source.signal === "string") normalized.signal = source.signal;
+  if (typeof source.stderr === "string") normalized.stderr = source.stderr;
+  if (typeof source.stderrSnippet === "string") {
+    normalized.stderrSnippet = source.stderrSnippet;
+  }
+  if (typeof source.stdout === "string") normalized.stdout = source.stdout;
+  if (typeof source.stdoutSnippet === "string") {
+    normalized.stdoutSnippet = source.stdoutSnippet;
+  }
+  return normalized;
 }

--- a/packages/runtime/test/unit/errors.test.ts
+++ b/packages/runtime/test/unit/errors.test.ts
@@ -1,4 +1,5 @@
 import {
+  externalCommandDiagnosticFromSafeError,
   publicSafeErrorFromUnknown,
   type RuntimeSafeError,
   safeErrorFromUnknown,
@@ -120,5 +121,104 @@ describe("runtime safe error normalization", () => {
     );
 
     expect(Object.keys(normalized).sort()).toEqual(["code", "message", "tag"]);
+  });
+
+  it("omits undefined optional fields from public projections", () => {
+    const projected = publicSafeErrorFromUnknown(
+      {
+        tag: "ProviderError",
+        code: "PROVIDER_FAILED",
+        message: "Provider failed.",
+        hint: undefined,
+        projectId: undefined,
+      },
+      fallback,
+    );
+
+    expect(Object.keys(projected).sort()).toEqual(["code", "message", "tag"]);
+    expect(Object.hasOwn(projected, "hint")).toBe(false);
+    expect(Object.hasOwn(projected, "projectId")).toBe(false);
+  });
+
+  it("omits undefined optional fields from normalized diagnostic details", () => {
+    const normalized = safeErrorFromUnknown(
+      {
+        tag: "ProviderError",
+        code: "PROVIDER_FAILED",
+        message: "Provider failed.",
+        diagnosticDetails: [
+          {
+            type: "external_command",
+            operation: "provider.test",
+            command: "test",
+            provider: undefined,
+            cwd: undefined,
+            exitCode: undefined,
+            signal: undefined,
+            stdoutSnippet: undefined,
+            stderrSnippet: undefined,
+            durationMs: undefined,
+          },
+          {
+            type: "worktree_removal_refusal",
+            worktreeId: "wt_1",
+            canonicalPath: "/tmp/worktree",
+            observedBranch: "main",
+            refusalReason: "branch_changed",
+            provider: undefined,
+            projectId: undefined,
+          },
+        ],
+      },
+      fallback,
+    );
+
+    const [command, removal] = normalized.diagnosticDetails ?? [];
+    expect(Object.keys(command ?? {}).sort()).toEqual(["command", "operation", "type"]);
+    expect(Object.hasOwn(command ?? {}, "provider")).toBe(false);
+    expect(Object.hasOwn(command ?? {}, "cwd")).toBe(false);
+    expect(Object.keys(removal ?? {}).sort()).toEqual([
+      "canonicalPath",
+      "observedBranch",
+      "refusalReason",
+      "type",
+      "worktreeId",
+    ]);
+    expect(Object.hasOwn(removal ?? {}, "provider")).toBe(false);
+    expect(Object.hasOwn(removal ?? {}, "projectId")).toBe(false);
+    expect(Object.keys(externalCommandDiagnosticFromSafeError(normalized) ?? {}).sort()).toEqual([
+      "command",
+      "operation",
+      "type",
+    ]);
+  });
+
+  it("omits undefined optional fields from synthesized command diagnostics", () => {
+    const normalized = safeErrorFromUnknown(
+      {
+        tag: "ExternalCommandError",
+        code: "EXTERNAL_COMMAND_FAILED",
+        message: "External command failed.",
+        command: "test",
+        cwd: undefined,
+        exitCode: undefined,
+        signal: undefined,
+        stdoutSnippet: undefined,
+        stderrSnippet: undefined,
+      },
+      fallback,
+    );
+    const diagnostic = externalCommandDiagnosticFromSafeError(normalized);
+
+    expect(Object.keys(normalized).sort()).toEqual([
+      "code",
+      "command",
+      "diagnosticDetails",
+      "message",
+      "tag",
+    ]);
+    expect(Object.keys(diagnostic ?? {}).sort()).toEqual(["command", "operation", "type"]);
+    expect(Object.hasOwn(diagnostic ?? {}, "cwd")).toBe(false);
+    expect(Object.hasOwn(diagnostic ?? {}, "exitCode")).toBe(false);
   });
 });

--- a/packages/runtime/test/unit/errors.test.ts
+++ b/packages/runtime/test/unit/errors.test.ts
@@ -1,0 +1,124 @@
+import {
+  publicSafeErrorFromUnknown,
+  type RuntimeSafeError,
+  safeErrorFromUnknown,
+} from "@station/runtime";
+import { describe, expect, it } from "vitest";
+
+const fallback = {
+  tag: "RuntimeError",
+  code: "RUNTIME_FAILED",
+  message: "Runtime failed.",
+};
+
+const commandDiagnostic = {
+  type: "external_command" as const,
+  provider: "worktrunk",
+  operation: "provider.worktrunk.switch",
+  command: "wt switch feature",
+  cwd: "/tmp/project",
+  exitCode: 1,
+  stderrSnippet: "failed",
+};
+
+describe("runtime safe error normalization", () => {
+  it("preserves the outer safe error while inheriting nested typed diagnostics", () => {
+    const inner = Object.assign(new Error("inner"), {
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+      command: "wt switch feature",
+      diagnosticDetails: [commandDiagnostic],
+    });
+    const outer = Object.assign(new Error("Worktrunk failed to switch worktrees."), {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      cause: inner,
+    });
+
+    expect(safeErrorFromUnknown(outer, fallback)).toEqual({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed to switch worktrees.",
+      diagnosticDetails: [commandDiagnostic],
+    });
+  });
+
+  it("deduplicates typed diagnostics inherited through nested safe causes", () => {
+    const inner = {
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+      message: "External command failed.",
+      command: "wt switch feature",
+      diagnosticDetails: [commandDiagnostic],
+    };
+    const outer = {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed to switch worktrees.",
+      diagnosticDetails: [commandDiagnostic],
+      cause: inner,
+    };
+
+    expect(safeErrorFromUnknown(outer, fallback).diagnosticDetails).toEqual([commandDiagnostic]);
+  });
+
+  it("terminates cyclic cause traversal safely", () => {
+    const first: { cause?: unknown } = {};
+    const second: { cause?: unknown } = { cause: first };
+    first.cause = second;
+
+    expect(safeErrorFromUnknown(first, fallback)).toEqual(fallback);
+  });
+
+  it("rejects malformed diagnostic details without crashing normalization", () => {
+    const malformed = {
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed.",
+      diagnosticDetails: { type: "external_command" },
+    };
+
+    expect(safeErrorFromUnknown(malformed, fallback)).toEqual({
+      tag: "WorktreeProviderError",
+      code: "WORKTRUNK_COMMAND_FAILED",
+      message: "Worktrunk failed.",
+    });
+  });
+
+  it("projects only the lean public SafeError contract", () => {
+    const cause = new Error("raw cause");
+    const rich = Object.assign(new Error("External command failed."), {
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+      command: "wt switch feature",
+      cwd: "/tmp/project",
+      exitCode: 1,
+      stdoutSnippet: "raw stdout",
+      stderrSnippet: "raw stderr",
+      diagnosticDetails: [commandDiagnostic],
+      cause,
+    });
+
+    const projected = publicSafeErrorFromUnknown(rich, fallback);
+
+    expect(projected).toEqual({
+      tag: "ExternalCommandError",
+      code: "EXTERNAL_COMMAND_FAILED",
+      message: "External command failed.",
+    });
+    expect(Object.keys(projected).sort()).toEqual(["code", "message", "tag"]);
+  });
+
+  it("preserves absence for optional public fields", () => {
+    const normalized: RuntimeSafeError = safeErrorFromUnknown(
+      {
+        tag: "ProviderError",
+        code: "PROVIDER_FAILED",
+        message: "Provider failed.",
+      },
+      fallback,
+    );
+
+    expect(Object.keys(normalized).sort()).toEqual(["code", "message", "tag"]);
+  });
+});

--- a/packages/runtime/test/unit/external-command.test.ts
+++ b/packages/runtime/test/unit/external-command.test.ts
@@ -3,10 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   createFakeExternalCommandRunner,
+  externalCommandDiagnosticFromSafeError,
   externalCommandErrorFromUnknown,
+  isExternalCommandError,
   nodeExternalCommandRunner,
   resolveExecutablePath,
   runExternalCommand,
+  safeErrorFromUnknown,
 } from "@station/runtime";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -188,6 +191,42 @@ describe("runtime external command boundary", () => {
     expect(JSON.stringify(second)).not.toContain("sk-secret");
     expect(JSON.stringify(second)).not.toContain("secret-value");
     expect(JSON.stringify(second)).not.toContain("abcdefghijklmnop");
+  });
+
+  it("preserves typed command fields and evidence through runtime normalization", () => {
+    const commandError = externalCommandErrorFromUnknown(
+      {
+        code: 7,
+        signal: "SIGTERM",
+        stdout: "stdout",
+        stderr: "stderr",
+      },
+      { command: "fake", args: ["run"], cwd: "/tmp/project" },
+    );
+    const normalized = safeErrorFromUnknown(commandError, {
+      tag: "RuntimeError",
+      code: "RUNTIME_FAILED",
+      message: "Runtime failed.",
+    });
+
+    expect(isExternalCommandError(normalized)).toBe(true);
+    expect(normalized).toMatchObject({
+      command: "fake run",
+      cwd: "/tmp/project",
+      exitCode: 7,
+      signal: "SIGTERM",
+      stdoutSnippet: "stdout",
+      stderrSnippet: "stderr",
+    });
+    expect(externalCommandDiagnosticFromSafeError(normalized)).toMatchObject({
+      type: "external_command",
+      command: "fake run",
+      cwd: "/tmp/project",
+      exitCode: 7,
+      signal: "SIGTERM",
+      stdoutSnippet: "stdout",
+      stderrSnippet: "stderr",
+    });
   });
 
   it("redacts secrets from rendered command strings", () => {

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@station/contracts": ["../../packages/contracts/dist/index.d.ts"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,6 +381,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@station/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       effect:
         specifier: ^3.21.2
         version: 3.21.2

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -298,6 +298,43 @@ describe("boundary inventory guard", () => {
 
     expect([...violations].sort()).toEqual([]);
   });
+
+  it("centralizes safe-error and external-command shape inspection in runtime", async () => {
+    const files = await sourceFiles();
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      const path = relative(process.cwd(), file);
+      const isRuntimeNormalization = path === "packages/runtime/src/errors.ts";
+
+      if (!isRuntimeNormalization && /\b(?:function|const)\s+isSafeError(?:Like)?\b/.test(source)) {
+        violations.push(`${path}: local SafeError guard`);
+      }
+      if (!isRuntimeNormalization && /\bsafeErrorCause\b/.test(source)) {
+        violations.push(`${path}: local SafeError cause traversal`);
+      }
+      if (/\b(?:stringFieldDeep|numberFieldDeep)\b/.test(source)) {
+        violations.push(`${path}: recursive arbitrary-field probing`);
+      }
+      if (/try\s*\{\s*throw\s+[^;]+;?\s*\}\s*catch/s.test(source)) {
+        violations.push(`${path}: artificial throw/catch normalization`);
+      }
+      if (/diagnosticDetails\s*\?\s*:\s*unknown/.test(source)) {
+        violations.push(`${path}: untyped diagnosticDetails cast`);
+      }
+      if (
+        !path.startsWith("packages/runtime/src/") &&
+        /(?:command|cwd|exitCode|signal|stdout|stderr|stdoutSnippet|stderrSnippet)\s*\?\s*:\s*unknown/.test(
+          source,
+        )
+      ) {
+        violations.push(`${path}: arbitrary external-command field inspection`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
 });
 
 async function noSqliteImportViolations(entryPath: string): Promise<string[]> {


### PR DESCRIPTION
## Summary

- make `@station/runtime` the schema-backed authority for SafeError normalization, cause traversal, typed diagnostic merging, external-command evidence, and lean public projections
- move Worktrunk, tmux, and GitHub failure classification onto normalized codes and typed command diagnostics while preserving provider-owned messages, hints, and rich operational errors
- remove duplicate SafeError guards and recursive arbitrary-field probing from observability, client, providers, and worktree removal handling, with structural regression coverage

## Testing

- `env -u STATION_PANE pnpm test:all`
- pre-push gate, including Station renderer/PTY tests and binary smoke

## UX

User-facing error codes and messages are unchanged. Failures now retain more reliable redacted command evidence internally without leaking diagnostics into provider health or client notices.

Manual verification: trigger an intentional Worktrunk failure in a disposable project, then run `stn debug trace --latest-failure` and confirm operation, command, cwd, exit status, and stderr are present without secrets or raw stacks.
