### PR TITLE
test(observer): use neutral alternate socket path

### DIFF
--- a/apps/cli/test/unit/observer-reap.test.ts
+++ b/apps/cli/test/unit/observer-reap.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/observerReap.js";
 
 const SOCK = "/Users/u/.local/state/station/observer.sock";
-const OTHER = "/Users/u/.local/state/wosm/observer.sock";
+const OTHER = "/Users/u/.local/state/unrelated/observer.sock";
 
 function proc(
   pid: number,


### PR DESCRIPTION
## What changed

Replaced a repository-specific alternate observer socket fixture with a neutral unrelated path.

## Why

The test only needs a path distinct from the Station socket. A neutral fixture communicates that intent without carrying unrelated repository naming.

## Impact

Test-only change. Runtime and terminal UX are unchanged.

## Validation

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/observer-reap.test.ts` — 12/12 passed
- pre-commit Biome/source-order/raw-hex gate — passed
- full pre-push gate — 1,661/1,662 unit tests passed; blocked by the unrelated, reproducible `integrations/harness/cursor/test/unit/provider.test.ts` hook-diagnostics assertion