### PR TITLE
chore(release): prepare v0.7.1-rc.5 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run this from any directory:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.4
+  tag=v0.7.1-rc.5
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -76,8 +76,9 @@ Run this from any directory:
 )
 ```
 
-`v0.7.1-rc.4` is the current private-binary candidate. `v0.7.1-rc.3` remains
-published as its immutable rollback; the earlier `v0.7.0` and `v0.7.1-rc.1`
+`v0.7.1-rc.5` is the current private-binary candidate. `v0.7.1-rc.4` remains
+published as its immutable rollback; `v0.7.1-rc.2` and `v0.7.1-rc.3` are older
+published binaries, while the earlier `v0.7.0` and `v0.7.1-rc.1`
 candidates remained unpublished. Run the recipe after the candidate is
 published. It fetches the installer and binary from the same immutable release
 tag, verifies the release checksum, and installs `stn`, `stn-ingress`, and
@@ -113,7 +114,7 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.5 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -123,7 +124,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.4", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.5", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -327,22 +327,23 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
-The current immutable binary candidate is `v0.7.1-rc.4`. `v0.7.1-rc.3` is the
-prior published binary, and `v0.7.1-rc.2` remains an older published rollback;
-the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished:
+The current immutable binary candidate is `v0.7.1-rc.5`. `v0.7.1-rc.4` is the
+prior published binary, and `v0.7.1-rc.2` and `v0.7.1-rc.3` remain older
+published rollbacks; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained
+unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.4`, then create and
-   push `v0.7.1-rc.4`.
+   with `package.json` and runtime reporting at `0.7.1-rc.5`, then create and
+   push `v0.7.1-rc.5`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.4-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.5-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
-4. Install `v0.7.1-rc.3`, upgrade to the accepted candidate, explicitly
-   reinstall `v0.7.1-rc.3`, then reinstall the candidate. Confirm the complete
+4. Install `v0.7.1-rc.4`, upgrade to the accepted candidate, explicitly
+   reinstall `v0.7.1-rc.4`, then reinstall the candidate. Confirm the complete
    version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.4`, and the manual-acceptance confirmation. It rechecks the
+   `v0.7.1-rc.5`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
    asset IDs, and all archive hashes immediately before publishing that exact
    draft.
@@ -455,7 +456,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.4
+  tag=v0.7.1-rc.5
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -597,11 +598,11 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.4`:
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.5`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft
-   with published `v0.7.1-rc.3` in both directions.
+   with published `v0.7.1-rc.4` in both directions.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.4 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.5 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -43,7 +43,7 @@ Safety and scope:
   extract, or print credentials. If authentication or repository access fails,
   stop and ask me to run `gh auth login --hostname github.com` myself.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.4`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly
@@ -94,7 +94,7 @@ From any directory, run:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.4
+  tag=v0.7.1-rc.5
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -109,8 +109,9 @@ From any directory, run:
 )
 ```
 
-`v0.7.1-rc.4` is the current private-binary candidate. `v0.7.1-rc.3` remains
-published as its immutable rollback; the earlier `v0.7.0` and `v0.7.1-rc.1`
+`v0.7.1-rc.5` is the current private-binary candidate. `v0.7.1-rc.4` remains
+published as its immutable rollback; `v0.7.1-rc.2` and `v0.7.1-rc.3` are older
+published binaries, while the earlier `v0.7.0` and `v0.7.1-rc.1`
 candidates remained unpublished. Run this recipe after the candidate is
 published. Keep the fixed assignment for an exact prerelease install. After the
 first stable release, use the commented assignment to resolve the latest stable
@@ -130,7 +131,7 @@ stn-tmux-popup
 It also installs the redistributed license under
 `${XDG_DATA_HOME:-$HOME/.local/share}/station/`.
 
-After this candidate is published, immutable rollback to `v0.7.1-rc.3` uses the
+After this candidate is published, immutable rollback to `v0.7.1-rc.4` uses the
 same exact-version procedure below.
 
 ## 3. Verify the Install
@@ -159,11 +160,11 @@ shells. The installer does not read, create, or edit shell startup files.
 
 ## Install an Exact Version
 
-To install an exact release or return to published `v0.7.1-rc.3`, use the same
+To install an exact release or return to published `v0.7.1-rc.4`, use the same
 recipe with this assignment instead of the latest-release lookup:
 
 ```bash
-tag=v0.7.1-rc.3
+tag=v0.7.1-rc.4
 ```
 
 The installer code and artifacts still come from that same tag. The earlier

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.4", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.5", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -385,7 +385,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.4-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.5-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -427,8 +427,8 @@ invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
 always paired. `v0.7.1-rc.2` is the first published binary,
-`v0.7.1-rc.3` is the latest published binary, and publishing `v0.7.1-rc.4`
-makes immutable rollback to `v0.7.1-rc.3` available.
+`v0.7.1-rc.4` is the latest published binary, and publishing `v0.7.1-rc.5`
+makes immutable rollback to `v0.7.1-rc.4` available.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -497,9 +497,9 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.7.1-rc.4` promotes only after all four native targets pass
+Candidate `v0.7.1-rc.5` promotes only after all four native targets pass
 automated and manual acceptance, including upgrade and rollback against
-published `v0.7.1-rc.3`. Published tags and assets are never deleted, moved, or
+published `v0.7.1-rc.4`. Published tags and assets are never deleted, moved, or
 overwritten; a bad release rolls back explicitly and rolls forward to a higher
 version containing the revert or fix.
 
@@ -714,10 +714,10 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.4` output appears,
+   repeatedly installs the draft → only complete `0.7.1-rc.5` output appears,
    never command-not-found or malformed output; both aliases remain links to
    `stn`, so entrypoints never mix. Alternate the draft with published
-   `v0.7.1-rc.3` in both directions to prove upgrade and rollback.
+   `v0.7.1-rc.4` in both directions to prove upgrade and rollback.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.4",
+  "version": "0.7.1-rc.5",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.4" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.5" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.4",
+      version: "0.7.1-rc.5",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.4+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.4+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.5+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.5+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.4",
+      version: "0.7.1-rc.5",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -981,7 +981,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.4";
+    return "0.7.1-rc.5";
   }
   if (
     normalized.length === 2 &&

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -107,7 +107,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated GitHub release assets");
     expect(readme).toContain("does not require Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.4");
+    expect(install).toContain("tag=v0.7.1-rc.5");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -163,7 +163,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.4");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.5");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -221,7 +221,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.4");
+    expect(packageJson.version).toBe("0.7.1-rc.5");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");


### PR DESCRIPTION
## Summary

- bump Station runtime and package version to 0.7.1-rc.5
- advance private-binary candidate and rollback documentation from rc.4 to rc.5
- update release-readiness and source-version expectations

PR #242 remains separate and is not included in this candidate.

## Verification

- focused runtime build-info, CLI version, and release-readiness tests
- full `pnpm test:pre-push` with Station nesting markers sanitized
- exact committed `0.7.1-rc.5` binary build and standalone binary smoke
- mandatory pre-push hook repeated the complete gate in 287.37 seconds

## UX implication

The published candidate will report `0.7.1-rc.5`; manually verify install, launch, upgrade from rc.4, rollback to rc.4, and reinstall rc.5 before promotion.