### PR TITLE
fix(observer): tolerate empty tmux topology

### DIFF
--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -18,9 +18,9 @@ import {
   durationMs,
   forEachConcurrent,
   pathIsSameOrInside,
+  publicSafeErrorFromUnknown,
   type RuntimeClock,
   runRuntimeBoundaryWithRetryAndTimeout,
-  safeErrorFromUnknown,
   toIsoTimestamp,
 } from "@station/runtime";
 import {
@@ -1063,7 +1063,14 @@ async function recordProviderReadFailure(input: {
   errors: SafeError[];
   logger: StationLogger | undefined;
 }): Promise<void> {
-  input.errors.push(input.error);
+  input.errors.push(
+    publicSafeErrorFromUnknown(input.error, {
+      tag: input.error.tag,
+      code: input.error.code,
+      message: input.error.message,
+      provider: input.providerId,
+    }),
+  );
   await input.logger?.error(input.message, {
     provider: input.providerId,
     error: input.error,
@@ -1096,7 +1103,7 @@ function failedProviderHealth(input: {
     providerId: input.providerId,
     providerType: input.providerType,
     lastCheckedAt: input.lastCheckedAt,
-    lastError: safeErrorFromUnknown(input.lastError, {
+    lastError: publicSafeErrorFromUnknown(input.lastError, {
       tag: input.lastError.tag,
       code: input.lastError.code,
       message: input.lastError.message,

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -188,6 +188,95 @@ describe("observer reconcile persistence", () => {
     sqlite.close();
   });
 
+  it("persists lean provider health when a read failure carries command diagnostics", async () => {
+    const terminal = new FakeTerminalProvider({ now });
+    terminal.listTargets = async () => {
+      throw {
+        tag: "TerminalProviderError",
+        code: "TERMINAL_LIST_FAILED",
+        message: "tmux failed to list terminal targets.",
+        provider: "fake-terminal",
+        diagnosticDetails: [
+          {
+            type: "external_command",
+            provider: "fake-terminal",
+            operation: "provider.fake-terminal.listTargets",
+            command: "tmux list-panes -a",
+            exitCode: 1,
+            stderrSnippet: "tmux list failed",
+          },
+        ],
+      };
+    };
+    const clock = { now: () => new Date(now) };
+    const sqlite = openObserverSqlite({ clock });
+    const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
+    const logErrors: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
+    const core = createObserverCore({
+      config,
+      providers: new ProviderRegistry({
+        worktree: new FakeWorktreeProvider({ now }),
+        terminal,
+        harnesses: [new FakeHarnessProvider({ now })],
+      }),
+      persistence,
+      clock,
+      logger: {
+        info: async () => undefined,
+        warn: async () => undefined,
+        error: async (message, attributes) => {
+          logErrors.push({ message, ...(attributes === undefined ? {} : { attributes }) });
+        },
+      },
+    });
+
+    const snapshot = await core.reconcile("diagnostic-rich-provider-failure");
+
+    expect(StationSnapshotSchema.parse(snapshot)).toEqual(snapshot);
+    expect(snapshot.observer.healthy).toBe(false);
+    expect(snapshot.providerHealth["fake-terminal"]).toMatchObject({
+      status: "unavailable",
+      lastError: {
+        code: "TERMINAL_LIST_FAILED",
+        provider: "fake-terminal",
+      },
+    });
+    expect(snapshot.providerHealth["fake-terminal"]?.lastError).not.toHaveProperty(
+      "diagnosticDetails",
+    );
+    expect(core.getHealth().lastReconcile?.errors[0]).not.toHaveProperty("diagnosticDetails");
+    expect(logErrors).toEqual([
+      {
+        message: "Terminal provider list failed.",
+        attributes: expect.objectContaining({
+          error: expect.objectContaining({
+            diagnosticDetails: [
+              expect.objectContaining({
+                type: "external_command",
+                command: "tmux list-panes -a",
+                stderrSnippet: "tmux list failed",
+              }),
+            ],
+          }),
+        }),
+      },
+    ]);
+    const terminalHealth = (await persistence.listProviderObservations()).find(
+      (observation) =>
+        observation.entityKind === "provider_health" &&
+        observation.payload.providerId === "fake-terminal",
+    );
+    expect(terminalHealth).toMatchObject({
+      entityKind: "provider_health",
+      payload: {
+        status: "unavailable",
+        lastError: { code: "TERMINAL_LIST_FAILED" },
+      },
+    });
+    expect(terminalHealth?.payload.lastError).not.toHaveProperty("diagnosticDetails");
+    sqlite.close();
+  });
+
   it("does not hydrate the live graph from stale SQLite records", async () => {
     const dbPath = await tempDbPath();
     const {

--- a/integrations/terminal/tmux/src/errors.ts
+++ b/integrations/terminal/tmux/src/errors.ts
@@ -1,5 +1,6 @@
 import type { DiagnosticDetail, SafeError } from "@station/contracts";
 import {
+  externalCommandDiagnosticFromSafeError,
   isExternalCommandError,
   type RuntimeSafeError,
   safeErrorFromUnknown,
@@ -82,10 +83,11 @@ export function tmuxProviderErrorFromUnknown(
     message: string;
     hint?: string;
   },
+  options: { classifyMissingTarget?: boolean } = {},
 ): TmuxTerminalProviderError {
   const normalized = tmuxSafeError(error, fallback);
   const diagnosticDetails = normalized.diagnosticDetails;
-  if (isMissingTarget(normalized)) {
+  if (options.classifyMissingTarget !== false && isMissingTarget(normalized)) {
     return new TmuxTerminalProviderError(
       "TERMINAL_TARGET_MISSING",
       "The terminal target no longer exists.",
@@ -122,6 +124,24 @@ export function tmuxProviderErrorFromUnknown(
     ...(hint === undefined ? {} : { hint }),
     ...(diagnosticDetails === undefined ? {} : { diagnosticDetails }),
   });
+}
+
+export function isTmuxNoServerListError(error: unknown): boolean {
+  const normalized = tmuxSafeError(error, {
+    code: "TERMINAL_LIST_FAILED",
+    message: "tmux failed to list terminal targets.",
+  });
+  const diagnostic = externalCommandDiagnosticFromSafeError(normalized);
+  if (
+    diagnostic?.exitCode !== 1 ||
+    diagnostic.stderrSnippet === undefined ||
+    !/(?:^|\s)list-panes\s+-a(?:\s|$)/.test(diagnostic.command)
+  ) {
+    return false;
+  }
+  return /^(?:no server running on .+|error connecting to .+ \(No such file or directory\))$/.test(
+    diagnostic.stderrSnippet.trim(),
+  );
 }
 
 function isGenericExternalCommandFailure(error: RuntimeSafeError): boolean {

--- a/integrations/terminal/tmux/src/provider.ts
+++ b/integrations/terminal/tmux/src/provider.ts
@@ -4,6 +4,7 @@ import type {
   OpenWorkspaceResult,
   ProviderHealth,
   ProviderId,
+  SafeError,
   TerminalCapabilities,
   TerminalCapture,
   TerminalFocusContext,
@@ -23,7 +24,11 @@ import {
   toIsoTimestamp,
 } from "@station/runtime";
 import { runTmuxCommand, type TmuxCommandInput } from "./command.js";
-import { TmuxTerminalProviderError, tmuxProviderErrorFromUnknown } from "./errors.js";
+import {
+  isTmuxNoServerListError,
+  TmuxTerminalProviderError,
+  tmuxProviderErrorFromUnknown,
+} from "./errors.js";
 import { buildRespawnPaneLaunchArgs, resolveLaunchPaneTarget } from "./launch.js";
 import { parseTmuxTargetLines, tmuxListTargetsFormat } from "./parse.js";
 import { resolveFocusPopupClient } from "./popup/state.js";
@@ -69,7 +74,8 @@ const tmuxCapabilities: TerminalCapabilities = {
  *
  * Translates Station terminal operations into tmux-owned topology and commands.
  *
- * Operational failures retain diagnostic evidence while provider health exposes only the lean public projection.
+ * An absent tmux server is empty topology; other operational failures retain diagnostic evidence while
+ * provider health exposes only the lean public projection.
  */
 export class TmuxProvider implements TerminalProvider {
   readonly id: ProviderId = "tmux";
@@ -133,17 +139,26 @@ export class TmuxProvider implements TerminalProvider {
   }
 
   async listTargets(): Promise<TerminalTargetObservation[]> {
-    const output = await this.#run(["list-panes", "-a", "-F", tmuxListTargetsFormat], {
-      operation: "provider.tmux.listTargets",
-      fallback: {
-        code: "TERMINAL_LIST_FAILED",
-        message: "tmux failed to list terminal targets.",
-      },
-      retries: 1,
-    });
-    return parseTmuxTargetLines(output.stdout, {
-      observedAt: toIsoTimestamp(this.#clock.now()),
-    });
+    const fallback = {
+      code: "TERMINAL_LIST_FAILED",
+      message: "tmux failed to list terminal targets.",
+    } as const;
+    try {
+      const output = await this.#run(["list-panes", "-a", "-F", tmuxListTargetsFormat], {
+        operation: "provider.tmux.listTargets",
+        fallback,
+        retries: 1,
+        mapErrors: false,
+        shouldRetry: (error) =>
+          error.code !== "TERMINAL_TMUX_TIMEOUT" && !isTmuxNoServerListError(error),
+      });
+      return parseTmuxTargetLines(output.stdout, {
+        observedAt: toIsoTimestamp(this.#clock.now()),
+      });
+    } catch (error) {
+      if (isTmuxNoServerListError(error)) return [];
+      throw tmuxProviderErrorFromUnknown(error, fallback, { classifyMissingTarget: false });
+    }
   }
 
   async openWorkspace(request: OpenWorkspaceRequest): Promise<OpenWorkspaceResult> {
@@ -597,6 +612,7 @@ export class TmuxProvider implements TerminalProvider {
       };
       retries?: number;
       mapErrors?: boolean;
+      shouldRetry?: (error: SafeError) => boolean;
     },
   ) {
     try {
@@ -624,7 +640,7 @@ export class TmuxProvider implements TerminalProvider {
         },
         retries: options.retries ?? 0,
         delayMs: 10,
-        shouldRetry: (error) => error.code !== "TERMINAL_TMUX_TIMEOUT",
+        shouldRetry: options.shouldRetry ?? ((error) => error.code !== "TERMINAL_TMUX_TIMEOUT"),
         maxOutputChars: 512 * 1024,
       });
     } catch (error) {

--- a/integrations/terminal/tmux/test/unit/provider.test.ts
+++ b/integrations/terminal/tmux/test/unit/provider.test.ts
@@ -559,6 +559,49 @@ describe("TmuxProvider", () => {
     ]);
   });
 
+  it.each([
+    ["macOS", "error connecting to /private/tmp/tmux-501/default (No such file or directory)"],
+    ["Linux", "no server running on /tmp/tmux-1000/default"],
+  ])("treats %s no-server output as empty topology without retry", async (_platform, stderr) => {
+    let calls = 0;
+    const provider = new TmuxProvider({
+      runner: async () => {
+        calls += 1;
+        throw Object.assign(new Error("tmux has no server"), { code: 1, stderr });
+      },
+    });
+
+    await expect(provider.listTargets()).resolves.toEqual([]);
+    expect(calls).toBe(1);
+  });
+
+  it.each([
+    ["permission failure", 1, "error connecting to /tmp/tmux-1000/default (Permission denied)"],
+    ["a different exit code", 2, "no server running on /tmp/tmux-1000/default"],
+    ["target-shaped stderr", 1, "can't find pane: %12"],
+    ["additional stderr", 1, "warning: bad config\nno server running on /tmp/tmux-1000/default"],
+    [
+      "noisy macOS stderr",
+      1,
+      "warning: bad config\nerror connecting to /private/tmp/tmux-501/default (No such file or directory)",
+    ],
+  ])("does not normalize %s while listing targets", async (_case, code, stderr) => {
+    let calls = 0;
+    const provider = new TmuxProvider({
+      runner: async () => {
+        calls += 1;
+        throw Object.assign(new Error("tmux list failed"), { code, stderr });
+      },
+    });
+
+    await expect(provider.listTargets()).rejects.toMatchObject({
+      tag: "TerminalProviderError",
+      code: "TERMINAL_LIST_FAILED",
+      provider: "tmux",
+    });
+    expect(calls).toBe(2);
+  });
+
   it("maps stale target focus to a typed TerminalProviderError", async () => {
     const provider = new TmuxProvider({
       runner: async () => {

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -80,7 +80,15 @@ describe("setup core flow e2e", () => {
       await writeShim(
         bin,
         "tmux",
-        'if [ "$1" = "-V" ]; then echo "tmux 3.5a"; exit 0; fi\nexit 0\n',
+        [
+          'if [ "$1" = "-V" ]; then echo "tmux 3.5a"; exit 0; fi',
+          'if [ "$1" = "list-panes" ]; then',
+          '  echo "no server running on /tmp/tmux-1000/default" >&2',
+          "  exit 1",
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
       );
       await writeShim(
         bin,
@@ -131,9 +139,12 @@ describe("setup core flow e2e", () => {
       await expect(readFile(configPath, "utf8")).resolves.toContain("[harness.codex]");
 
       const observer = createObserverClient({ socketPath: observerSocket, timeoutMs: 1000 });
-      const health = await observer.health();
+      const health = await waitForStartupReconcile(observer);
       const snapshot = await observer.getSnapshot();
       expect(health.pid).toBeTypeOf("number");
+      expect(health.lastReconcile?.reason).toBe("observer.startup");
+      expect(health.lastReconcile?.errors).toEqual([]);
+      expect(snapshot.observer.healthy).toBe(true);
       expect(snapshot.projects).toEqual([]);
       expect(snapshot.counts.projects).toBe(0);
 
@@ -542,6 +553,16 @@ async function stopObserverCandidates(socketPaths: readonly string[]): Promise<v
     await client.stop().catch(() => undefined);
     await waitForSocketClosed(socketPath, { timeoutMs: 5000 });
   }
+}
+
+async function waitForStartupReconcile(observer: ReturnType<typeof createObserverClient>) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const health = await observer.health();
+    if (health.lastReconcile?.reason === "observer.startup") return health;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Observer startup reconcile did not finish within 5 seconds.");
 }
 
 function processIsAlive(pid: number | undefined): boolean {


### PR DESCRIPTION
## Summary

- treat tmux with no running server as an empty terminal topology
- keep other tmux list failures typed as TERMINAL_LIST_FAILED without weakening target-operation errors
- project diagnostic-rich provider failures to the strict public SafeError shape while retaining full evidence in logs
- prove a zero-project Observer finishes startup reconciliation healthy with no tmux server

Addresses the empty-tmux startup slice of #231. This intentionally does not close the broader issue.

## Verification

- full pre-push gate
- 27 tmux provider unit tests
- 11 Observer persistence integration tests
- 16 setup E2E tests
- compiled 0.0.0-local binary smoke
- independent adversarial review, followed by re-review of every finding

## UX

A fresh zero-project setup no longer requires a placeholder tmux session. With tmux installed but no server running, setup activation and Observer startup complete with an empty terminal list.

Manual check: ensure no tmux server exists, run setup or observer startup in an isolated state directory, then confirm doctor succeeds and snapshot reports zero projects.