### PR TITLE
docs(install): distinguish agent setup execution contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ If GitHub CLI is already authenticated, skip the login command. The repository
 check should print `jeremy0dell/station`; a not-found response means the active
 account cannot read the private repository. The commands below use the existing
 authentication, so do not paste credentials into the install command.
+On macOS, a failure observed only inside a restricted agent sandbox may mean
+that sandbox cannot read Keychain-backed credentials. Retry the checks from a
+normal Terminal or with scoped host/Keychain access, and keep the later
+authenticated `gh api` calls in that same context; do not move the token into
+the sandbox or reauthenticate solely because of a sandbox-only failure.
 
 ### 2. Install the current preview candidate
 
@@ -103,6 +108,10 @@ stn doctor
 stn
 ```
 
+This PATH assignment affects only the shell where it runs. An agent tool shell
+does not update your Terminal or future login shells; use the installer's
+absolute `stn` fallback for agent-side continuation, and keep future-shell PATH
+as an unfinished manual step until a new shell resolves all three launchers.
 The installer never edits shell startup files or adds the current directory as
 a project. See [Install](docs/install.md) for supported platforms, exact-version
 installs, custom install directories, and recovery. Then follow the
@@ -120,9 +129,15 @@ Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
 Safety and scope:
 - First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. Never ask me to paste,
-  extract, or print credentials. If authentication or repository access fails,
-  stop and ask me to run `gh auth login --hostname github.com` myself.
+  access with `gh repo view jeremy0dell/station`. On macOS, a failure inside a
+  restricted agent sandbox is inconclusive because GitHub CLI credentials may
+  be stored in the Keychain. Retry both checks with scoped host/Keychain access
+  before asking me to authenticate, and run every later authenticated `gh repo`
+  or `gh api` command in that same access context. Never ask me to paste,
+  extract, print, request, or export a GitHub token. If scoped host access is
+  unavailable, ask me to run the auth checks and exact tagged temporary-file
+  installer block from the page that supplied this prompt in my Terminal, then
+  resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
   `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
@@ -130,22 +145,31 @@ Safety and scope:
 - Never fetch installer code from `main` and never pipe network output directly
   into a shell.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
-  shell startup file. Apply PATH changes only to the current shell and show me
-  the exact export I can add later.
+  shell startup file. If the installer reports a PATH mismatch, do not assume
+  an export persists across agent tool calls or reaches my Terminal. Use the
+  absolute installed `stn` path for every remaining agent command, show me the
+  exact future-shell export, and treat it as an unfinished manual step until I
+  verify all three launchers in a new shell.
 - Do not infer or add the current directory as a Station project.
 
 Validation:
-1. Verify `command -v stn`, `command -v stn-ingress`, and
-   `command -v stn-tmux-popup`, then run `stn --version`.
-2. Run `stn setup plan --json`, summarize every proposed install or write, and
-   ask for approval before applying it.
-3. Run the guided `stn setup` and let me answer its choices. If you cannot pass
-   through an interactive prompt, ask me to run it, then continue afterward.
-4. Run `stn setup check --json` and `stn doctor`.
+1. Verify all three absolute installed launcher paths and run `stn --version`
+   through the absolute installed path. Record `command -v stn`,
+   `command -v stn-ingress`, and `command -v stn-tmux-popup` only as evidence
+   about the current agent execution context.
+2. Run `stn setup plan --json` through the absolute installed `stn` path,
+   summarize every proposed install or write, and ask for approval before
+   applying it.
+3. Run the guided `stn setup` through the absolute installed path and let me
+   answer its choices. If you cannot pass through an interactive prompt, ask me
+   to run it, then continue afterward.
+4. Run `stn setup check --json` and `stn doctor` through the absolute installed
+   path.
 5. Report the installed path and version, whether setup reports
-   `summary.requiredOk: true`, doctor health, and any remaining manual steps.
-   A valid zero-project config is acceptable. Do not claim success while a
-   required check is failing.
+   `summary.requiredOk: true`, doctor health, future-shell verification state,
+   and any remaining manual steps. A valid zero-project config is acceptable.
+   Do not claim success while a required check is failing or future-shell PATH
+   remains unverified.
 ```
 
 ## How it works

--- a/docs/development.md
+++ b/docs/development.md
@@ -427,6 +427,15 @@ gh auth status --hostname github.com
 gh repo view jeremy0dell/station
 ```
 
+When validating the agent-led install prompt on macOS, start the agent in its
+normal sandbox after these host-Terminal checks succeed. A sandbox-only auth
+failure must remain inconclusive until the agent retries with scoped
+host/Keychain access; all later authenticated `gh repo` and `gh api` operations
+must use that same access context without reading, printing, requesting, or
+exporting a token. If scoped host access is unavailable, run the exact tagged
+temporary-file installer in the host Terminal and let the agent resume through
+the absolute installed `stn` path.
+
 Start the selected agent CLI once and complete its normal sign-in. Then create
 a disposable Git project for the acceptance run:
 
@@ -553,7 +562,10 @@ edit shell startup files. Copy the one future-shell export it printed into a
 shell configuration you choose,
 open a new login shell, and verify all three physical launcher resolutions and
 `stn --version`. The installer, not the user-facing PATH text alone, must have
-verified those launchers after installation.
+verified those launchers after installation. An agent must use the absolute
+installed `stn` path for continuation and report future-shell PATH as unverified
+until this new-shell check passes; its own `command -v` result is not user-shell
+evidence.
 Preserve the exact command and output at the first failure; for a runtime
 failure with no known trace ID, start with `stn debug trace --latest-failure`.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,9 +39,15 @@ Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
 Safety and scope:
 - First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. Never ask me to paste,
-  extract, or print credentials. If authentication or repository access fails,
-  stop and ask me to run `gh auth login --hostname github.com` myself.
+  access with `gh repo view jeremy0dell/station`. On macOS, a failure inside a
+  restricted agent sandbox is inconclusive because GitHub CLI credentials may
+  be stored in the Keychain. Retry both checks with scoped host/Keychain access
+  before asking me to authenticate, and run every later authenticated `gh repo`
+  or `gh api` command in that same access context. Never ask me to paste,
+  extract, print, request, or export a GitHub token. If scoped host access is
+  unavailable, ask me to run the auth checks and exact tagged temporary-file
+  installer block from the page that supplied this prompt in my Terminal, then
+  resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
   `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
@@ -49,22 +55,31 @@ Safety and scope:
 - Never fetch installer code from `main` and never pipe network output directly
   into a shell.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
-  shell startup file. Apply PATH changes only to the current shell and show me
-  the exact export I can add later.
+  shell startup file. If the installer reports a PATH mismatch, do not assume
+  an export persists across agent tool calls or reaches my Terminal. Use the
+  absolute installed `stn` path for every remaining agent command, show me the
+  exact future-shell export, and treat it as an unfinished manual step until I
+  verify all three launchers in a new shell.
 - Do not infer or add the current directory as a Station project.
 
 Validation:
-1. Verify `command -v stn`, `command -v stn-ingress`, and
-   `command -v stn-tmux-popup`, then run `stn --version`.
-2. Run `stn setup plan --json`, summarize every proposed install or write, and
-   ask for approval before applying it.
-3. Run the guided `stn setup` and let me answer its choices. If you cannot pass
-   through an interactive prompt, ask me to run it, then continue afterward.
-4. Run `stn setup check --json` and `stn doctor`.
+1. Verify all three absolute installed launcher paths and run `stn --version`
+   through the absolute installed path. Record `command -v stn`,
+   `command -v stn-ingress`, and `command -v stn-tmux-popup` only as evidence
+   about the current agent execution context.
+2. Run `stn setup plan --json` through the absolute installed `stn` path,
+   summarize every proposed install or write, and ask for approval before
+   applying it.
+3. Run the guided `stn setup` through the absolute installed path and let me
+   answer its choices. If you cannot pass through an interactive prompt, ask me
+   to run it, then continue afterward.
+4. Run `stn setup check --json` and `stn doctor` through the absolute installed
+   path.
 5. Report the installed path and version, whether setup reports
-   `summary.requiredOk: true`, doctor health, and any remaining manual steps.
-   A valid zero-project config is acceptable. Do not claim success while a
-   required check is failing.
+   `summary.requiredOk: true`, doctor health, future-shell verification state,
+   and any remaining manual steps. A valid zero-project config is acceptable.
+   Do not claim success while a required check is failing or future-shell PATH
+   remains unverified.
 ```
 
 The agent should stop at authentication or approval boundaries rather than
@@ -84,6 +99,11 @@ If GitHub CLI is already authenticated, skip the login command. The repository
 check should print `jeremy0dell/station`; a not-found response means the active
 account cannot read the private repository. GitHub CLI supplies its stored
 authentication to the API calls below, so do not add credentials to the recipe.
+On macOS, a failure observed only inside a restricted agent sandbox may mean
+that sandbox cannot read Keychain-backed credentials. Retry the checks from a
+normal Terminal or with scoped host/Keychain access, and keep the later
+authenticated `gh api` calls in that same context; do not move the token into
+the sandbox or reauthenticate solely because of a sandbox-only failure.
 
 ## 2. Install the Current Preview Candidate
 
@@ -156,7 +176,11 @@ use the exact PATH block or the `Absolute fallback` printed by the installer.
 
 The PATH assignment affects only the current shell. Copy the installer's exact
 export into the chosen shell configuration if you want it applied in future
-shells. The installer does not read, create, or edit shell startup files.
+shells. If an agent runs the assignment, it does not change your Terminal or a
+later login shell; the agent should continue through the absolute installed
+`stn` path and report future-shell PATH as unverified until you check all three
+launchers in a new shell. The installer does not read, create, or edit shell
+startup files.
 
 ## Install an Exact Version
 

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -52,22 +52,54 @@ describe("release readiness docs", () => {
   });
 
   it("provides an agent-led binary install and setup validation prompt", async () => {
-    const documents = await Promise.all(["README.md", "docs/install.md"].map(read));
+    const [readme, install, development] = await Promise.all(
+      ["README.md", "docs/install.md", "docs/development.md"].map(read),
+    );
 
-    for (const document of documents) {
-      const normalized = document.replace(/\s+/g, " ").toLowerCase();
-      expect(normalized).toContain("let your agent install and validate station");
-      expect(document).toContain("gh auth status --hostname github.com");
-      expect(document).toContain("gh repo view jeremy0dell/station");
-      expect(document).toContain("docs/install.md");
-      expect(document).toContain("stn setup plan --json");
-      expect(document).toContain("stn setup check --json");
-      expect(document).toContain("stn doctor");
-      expect(document).toContain("summary.requiredOk: true");
-      expect(normalized).toContain("do not clone the repository or build from source");
-      expect(normalized).toContain("do not edit any shell startup file");
-      expect(normalized).toContain("do not claim success");
+    for (const document of [readme, install]) {
+      const prompt = agentInstallPrompt(document);
+      const normalizedPrompt = prompt.replace(/\s+/g, " ").toLowerCase();
+      expect(document.replace(/\s+/g, " ").toLowerCase()).toContain(
+        "let your agent install and validate station",
+      );
+      expect(prompt).toContain("gh auth status --hostname github.com");
+      expect(prompt).toContain("gh repo view jeremy0dell/station");
+      expect(prompt).toContain("docs/install.md");
+      expect(prompt).toContain("stn setup plan --json");
+      expect(prompt).toContain("stn setup check --json");
+      expect(prompt).toContain("stn doctor");
+      expect(prompt).toContain("summary.requiredOk: true");
+      expect(normalizedPrompt).toContain("do not clone the repository or build from source");
+      expect(normalizedPrompt).toContain("do not edit any shell startup file");
+      expect(normalizedPrompt).toContain("scoped host/keychain access");
+      expect(normalizedPrompt).toContain("same access context");
+      expect(normalizedPrompt).toContain(
+        "retry both checks with scoped host/keychain access before asking me to authenticate",
+      );
+      expect(normalizedPrompt).toContain(
+        "if scoped host access is unavailable, ask me to run the auth checks and exact tagged temporary-file installer block from the page that supplied this prompt in my terminal",
+      );
+      expect(prompt).not.toContain("gh auth login");
+      expect(normalizedPrompt).toContain(
+        "never ask me to paste, extract, print, request, or export a github token",
+      );
+      expect(normalizedPrompt).toContain("absolute installed `stn` path");
+      expect(normalizedPrompt).toContain(
+        "only as evidence about the current agent execution context",
+      );
+      expect(normalizedPrompt).toContain("unfinished manual step");
+      expect(normalizedPrompt).toContain("verify all three launchers in a new shell");
+      expect(normalizedPrompt).toContain("do not claim success");
     }
+    expect(agentInstallPrompt(readme)).toBe(agentInstallPrompt(install));
+
+    const normalizedDevelopment = virtualBuddyCleanMacSection(development)
+      .replace(/\s+/g, " ")
+      .toLowerCase();
+    expect(normalizedDevelopment).toContain("sandbox-only auth failure");
+    expect(normalizedDevelopment).toContain("scoped host/keychain access");
+    expect(normalizedDevelopment).toContain("absolute installed `stn` path");
+    expect(normalizedDevelopment).toContain("future-shell path as unverified");
   });
 
   it("keeps the Node.js 24.2+ development requirement consistent", async () => {
@@ -294,7 +326,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("hash -r");
 
     expect(install).not.toContain(removedPersistenceOption);
-    expect(install).toMatch(/does not (?:read, create, or )?edit shell startup files/);
+    expect(install).toMatch(/does not (?:read, create, or )?edit shell\s+startup files/);
     expect(install).toContain("chosen shell configuration");
     expect(install).toContain("future shells");
     expect(install).toContain("Absolute fallback");
@@ -327,13 +359,9 @@ describe("release readiness docs", () => {
 
   it("keeps the VirtualBuddy lane aligned with zero-project onboarding", async () => {
     const development = await read("docs/development.md");
-    const start = development.indexOf("### VirtualBuddy clean-mac preparation");
-    const end = development.indexOf("\nFor each target", start);
-    const virtualBuddy = development.slice(start, end);
+    const virtualBuddy = virtualBuddyCleanMacSection(development);
     const normalizedVirtualBuddy = virtualBuddy.replace(/\s+/g, " ");
 
-    expect(start).toBeGreaterThanOrEqual(0);
-    expect(end).toBeGreaterThan(start);
     expect(normalizedVirtualBuddy).toContain("zero-project config");
     expect(virtualBuddy).toContain("**Add your first project**");
     expect(virtualBuddy.indexOf("**Add your first project**")).toBeLessThan(
@@ -372,6 +400,21 @@ async function readPackageManifest(): Promise<PackageManifest> {
   } catch (cause) {
     throw new Error("package.json must contain valid JSON", { cause });
   }
+}
+
+function agentInstallPrompt(document: string): string {
+  const heading = document.search(/let your agent install and validate station/i);
+  if (heading < 0) throw new Error("agent install prompt heading is missing");
+  const match = document.slice(heading).match(/```text\r?\n([\s\S]*?)```/);
+  if (match?.[1] === undefined) throw new Error("agent install prompt is missing");
+  return match[1];
+}
+
+function virtualBuddyCleanMacSection(document: string): string {
+  const start = document.indexOf("### VirtualBuddy clean-mac preparation");
+  const end = document.indexOf("\nFor each target", start);
+  if (start < 0 || end <= start) throw new Error("VirtualBuddy clean-mac section is missing");
+  return document.slice(start, end);
 }
 
 function continuedShellCommands(document: string): string[] {


### PR DESCRIPTION
Closes #254

## Summary
- distinguish an agent sandbox from the host terminal when validating GitHub authentication and private-repository access
- document scoped host/Keychain retry behavior without exposing or copying credentials
- make future-shell PATH readiness explicit for all three Station launchers while preserving the no-profile-mutation policy
- add release-readiness assertions for the documented agent-led setup contract

## Verification
- full local pre-push gate passed after rebasing onto `fix/setup-no-tmux`
- documentation diagnostics and release-readiness tests pass
- compiled single-binary smoke passes with no tmux server

## UX implication
Agent-led installs now explain when a failed `gh auth status` is only sandbox isolation, how to retry safely in the host context, and when setup is not yet complete for a fresh user shell.

## Manual verification
Run the tagged installer from an agent context without Keychain access, confirm the docs direct the operator to a scoped host retry or exact Terminal fallback, then open a fresh shell and verify `stn`, `stn-ingress`, and `stn-tmux-popup` all resolve.