### PR TITLE
feat(setup): enable multiple agent CLIs

### DIFF
--- a/apps/cli/src/commands/setup/checks/config.ts
+++ b/apps/cli/src/commands/setup/checks/config.ts
@@ -50,6 +50,12 @@ export async function checkSetupConfig(
       gitRoot === undefined
         ? undefined
         : loaded.config.projects.find((project) => pathIsSame(project.root, gitRoot));
+    const configuredHarnessCommands: Record<string, string> = {};
+    for (const [id, providerConfig] of Object.entries(loaded.config.harness ?? {})) {
+      if (providerConfig?.command !== undefined) {
+        configuredHarnessCommands[id] = providerConfig.command;
+      }
+    }
     const fact: SetupConfigFact = {
       status: "valid",
       path,
@@ -66,6 +72,9 @@ export async function checkSetupConfig(
         harness: loaded.config.defaults.harness,
       },
     };
+    if (Object.keys(configuredHarnessCommands).length > 0) {
+      fact.configuredHarnessCommands = configuredHarnessCommands;
+    }
     if (loaded.config.terminal?.tmux !== undefined) {
       fact.tmux = loaded.config.terminal.tmux;
     }

--- a/apps/cli/src/commands/setup/checks/harnesses.ts
+++ b/apps/cli/src/commands/setup/checks/harnesses.ts
@@ -33,6 +33,8 @@ export type CheckHarnessesOptions = {
   env?: CliEnv;
   cwd?: string;
   homeDir?: string;
+  configuredHarnesses?: readonly string[];
+  configuredCommands?: Readonly<Partial<Record<SupportedHarnessId, string>>>;
 };
 
 export async function checkSetupHarnesses(
@@ -46,17 +48,21 @@ export async function checkSetupHarnesses(
   return facts;
 }
 
-function harnessCommand(definition: HarnessDefinition, env: CliEnv): string {
-  return env[definition.envKey] ?? definition.defaultCommand;
-}
-
 async function checkHarness(
   definition: HarnessDefinition,
   env: CliEnv,
   options: CheckHarnessesOptions,
 ): Promise<SetupHarnessFact> {
-  const command = harnessCommand(definition, env);
-  for (const candidate of harnessCommandCandidates(command, options.homeDir)) {
+  const configuredCommand = options.configuredCommands?.[definition.id];
+  const environmentCommand = env[definition.envKey];
+  const command = configuredCommand ?? environmentCommand ?? definition.defaultCommand;
+  const defaultCommandHomeDir =
+    options.configuredHarnesses?.includes(definition.id) !== true &&
+    configuredCommand === undefined &&
+    environmentCommand === undefined
+      ? options.homeDir
+      : undefined;
+  for (const candidate of harnessCommandCandidates(command, defaultCommandHomeDir)) {
     try {
       const input: ExternalCommandInput = {
         command: candidate,

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -110,6 +110,17 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   if (gitRoot !== undefined) setupConfigInput.gitRoot = gitRoot;
   const configPathOptions = setupConfigOptions(setupConfigInput);
   const configPath = setupConfigPath(configPathOptions);
+  const configPromise = checkSetupConfig({ ...configPathOptions, configPath });
+  const harnessesPromise = configPromise.then((config) => {
+    const harnessOptions: CheckHarnessesOptions = { ...commandOptions };
+    if (config.status === "valid") {
+      harnessOptions.configuredHarnesses = [config.defaults.harness, ...config.configuredHarnesses];
+      if (config.configuredHarnessCommands !== undefined) {
+        harnessOptions.configuredCommands = config.configuredHarnessCommands;
+      }
+    }
+    return checkSetupHarnesses(harnessOptions);
+  });
   const xcodeOptions: CheckXcodeOptions = { ...commandOptions };
   if (options.platform !== undefined) xcodeOptions.platform = options.platform;
   const [
@@ -143,8 +154,8 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     compiled
       ? Promise.resolve({ status: "ok" as const, applicable: false })
       : checkSetupXcode(xcodeOptions),
-    checkSetupHarnesses(commandOptions),
-    checkSetupConfig({ ...configPathOptions, configPath }),
+    harnessesPromise,
+    configPromise,
     checkSetupLaunchers(launcherOptions),
   ]);
   const worktrunkAutomation = await checkSetupWorktrunkAutomation({

--- a/apps/cli/src/commands/setup/configWriter.ts
+++ b/apps/cli/src/commands/setup/configWriter.ts
@@ -1,5 +1,10 @@
 import { setHarnessInstallHooksInToml } from "@station/config";
-import { isSupportedHarnessId, selectSetupHarnesses } from "./harnessSelection.js";
+import {
+  harnessSupportsSetupHooks,
+  isSupportedHarnessId,
+  resolveSetupHarnessSelection,
+  type SetupHarnessSelection,
+} from "./harnessSelection.js";
 import type {
   ConfigWritePlan,
   SetupConfigFact,
@@ -9,18 +14,17 @@ import type {
 } from "./model.js";
 
 export type PlanSetupConfigWriteOptions = {
-  selectedHarness?: SetupHarnessFact;
+  harnessSelection?: SetupHarnessSelection;
   installWorktrunkHooks?: boolean;
-  installHarnessHooks?: boolean | readonly SupportedHarnessId[];
+  installHarnessHooks?: readonly SupportedHarnessId[];
 };
 
 export async function planSetupConfigWrite(
   facts: SetupFacts,
   options: PlanSetupConfigWriteOptions = {},
 ): Promise<ConfigWritePlan> {
-  const selectedHarnesses = resolveConfigWriteHarnesses(facts, options.selectedHarness);
-  const defaultHarness = selectedHarnesses[0];
-  if (defaultHarness === undefined) {
+  const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
+  if (harnessSelection.selected.length === 0) {
     return {
       operation: "blocked",
       path: facts.configPath,
@@ -31,7 +35,7 @@ export async function planSetupConfigWrite(
     return {
       operation: "create",
       path: facts.configPath,
-      content: renderNewSetupConfig(defaultHarness, facts, options, selectedHarnesses),
+      content: renderNewSetupConfig(harnessSelection.selected, facts, options),
     };
   }
 
@@ -43,15 +47,16 @@ export async function planSetupConfigWrite(
     };
   }
 
-  return planExistingConfigAppend(facts.config, selectedHarnesses, options, facts.homeDir);
+  return planExistingConfigUpdate(facts.config, harnessSelection.selected, options, facts.homeDir);
 }
 
 export function renderNewSetupConfig(
-  harness: SetupHarnessFact,
+  harnesses: readonly SetupHarnessFact[],
   facts?: Pick<SetupFacts, "worktrunk" | "tmux">,
   options: Pick<PlanSetupConfigWriteOptions, "installWorktrunkHooks" | "installHarnessHooks"> = {},
-  harnesses: readonly SetupHarnessFact[] = [harness],
 ): string {
+  const defaultHarness = harnesses[0];
+  if (defaultHarness === undefined) throw new Error("New setup config requires an agent CLI.");
   const worktrunkCommand =
     facts?.worktrunk === undefined ? "wt" : detectedCommand(facts.worktrunk, "wt");
   const tmuxCommand =
@@ -67,7 +72,7 @@ export function renderNewSetupConfig(
     "[defaults]",
     'worktree_provider = "worktrunk"',
     'terminal = "tmux"',
-    `harness = ${tomlString(harness.id)}`,
+    `harness = ${tomlString(defaultHarness.id)}`,
     'layout = "agent-shell"',
     "",
     "[worktree.worktrunk]",
@@ -89,38 +94,20 @@ export function renderNewSetupConfig(
     ...harnesses.flatMap((selectedHarness) => [
       ...renderHarnessBlock(
         selectedHarness,
-        installHarnessHookRequested(options.installHarnessHooks, selectedHarness.id, harness.id),
+        options.installHarnessHooks?.includes(selectedHarness.id) === true,
       ).split("\n"),
       "",
     ]),
   ].join("\n");
 }
 
-function resolveConfigWriteHarnesses(
-  facts: SetupFacts,
-  fallback: SetupHarnessFact | undefined,
-): SetupHarnessFact[] {
-  const configuredHarnesses =
-    facts.config.status === "valid"
-      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
-          .filter(isSupportedHarnessId)
-          .filter((harness, index, all) => all.indexOf(harness) === index)
-      : undefined;
-  const selectedHarnesses = selectSetupHarnesses(
-    facts.harnesses,
-    facts.selectedHarnesses ?? configuredHarnesses,
-    facts.selectedHarness ?? fallback?.id,
-  );
-  return selectedHarnesses;
-}
-
-async function planExistingConfigAppend(
+async function planExistingConfigUpdate(
   config: Extract<SetupConfigFact, { status: "valid" }>,
   harnesses: readonly SetupHarnessFact[],
   options: Pick<PlanSetupConfigWriteOptions, "installHarnessHooks">,
   homeDir: string,
 ): Promise<ConfigWritePlan> {
-  const coreProblem = existingConfigAppendCoreProblem(config);
+  const coreProblem = existingConfigUpdateCoreProblem(config);
   if (coreProblem !== undefined) {
     return {
       operation: "blocked",
@@ -134,7 +121,7 @@ async function planExistingConfigAppend(
     if (
       config.configuredHarnesses.includes(harness.id) &&
       !config.configuredHookHarnesses.includes(harness.id) &&
-      installHarnessHookRequested(options.installHarnessHooks, harness.id, harnesses[0]?.id)
+      options.installHarnessHooks?.includes(harness.id) === true
     ) {
       content = await setHarnessInstallHooksInToml(content, {
         harness: harness.id,
@@ -148,7 +135,6 @@ async function planExistingConfigAppend(
   const appendedText = renderAppendText(
     harnesses.filter((harness) => !config.configuredHarnesses.includes(harness.id)),
     options.installHarnessHooks,
-    harnesses[0]?.id,
     preferredNewline(config.source),
   );
   if (appendedText.length > 0) {
@@ -164,14 +150,13 @@ async function planExistingConfigAppend(
     };
   }
   return {
-    operation: "append",
+    operation: "update",
     path: config.path,
     content,
-    appendedText,
   };
 }
 
-function existingConfigAppendCoreProblem(
+function existingConfigUpdateCoreProblem(
   config: Extract<SetupConfigFact, { status: "valid" }>,
 ): string | undefined {
   if (config.defaults.worktreeProvider !== "worktrunk") {
@@ -188,16 +173,15 @@ function existingConfigAppendCoreProblem(
 
 function renderAppendText(
   harnesses: readonly SetupHarnessFact[],
-  installHarnessHooks: boolean | readonly SupportedHarnessId[] | undefined,
-  defaultHarness: SupportedHarnessId | undefined,
+  installHarnessHooks: readonly SupportedHarnessId[] | undefined,
   newline = "\n",
 ): string {
   if (harnesses.length === 0) return "";
   const blocks = harnesses.map((harness) =>
-    renderHarnessBlock(
-      harness,
-      installHarnessHookRequested(installHarnessHooks, harness.id, defaultHarness),
-    ).replaceAll("\n", newline),
+    renderHarnessBlock(harness, installHarnessHooks?.includes(harness.id) === true).replaceAll(
+      "\n",
+      newline,
+    ),
   );
   return `${newline}${blocks.join(`${newline}${newline}`)}${newline}`;
 }
@@ -207,18 +191,8 @@ function renderHarnessBlock(harness: SetupHarnessFact, installHooks: boolean): s
     `[harness.${harness.id}]`,
     "enabled = true",
     `command = ${tomlString(harness.command)}`,
-    ...(installHooks && harnessSupportsHooks(harness.id) ? ["install_hooks = true"] : []),
+    ...(installHooks && harnessSupportsSetupHooks(harness.id) ? ["install_hooks = true"] : []),
   ].join("\n");
-}
-
-function installHarnessHookRequested(
-  requested: boolean | readonly SupportedHarnessId[] | undefined,
-  harness: SupportedHarnessId,
-  defaultHarness: SupportedHarnessId | undefined,
-): boolean {
-  return Array.isArray(requested)
-    ? requested.includes(harness)
-    : requested === true && harness === defaultHarness;
 }
 
 function tomlString(value: string): string {
@@ -227,12 +201,6 @@ function tomlString(value: string): string {
 
 function preferredNewline(source: string): "\n" | "\r\n" {
   return source.includes("\r\n") ? "\r\n" : "\n";
-}
-
-function harnessSupportsHooks(harness: string): boolean {
-  return (
-    harness === "claude" || harness === "codex" || harness === "cursor" || harness === "opencode"
-  );
 }
 
 function detectedCommand(

--- a/apps/cli/src/commands/setup/configWriter.ts
+++ b/apps/cli/src/commands/setup/configWriter.ts
@@ -1,21 +1,26 @@
-import { selectSetupHarness } from "./harnessSelection.js";
-import type { ConfigWritePlan, SetupConfigFact, SetupFacts, SetupHarnessFact } from "./model.js";
+import { setHarnessInstallHooksInToml } from "@station/config";
+import { isSupportedHarnessId, selectSetupHarnesses } from "./harnessSelection.js";
+import type {
+  ConfigWritePlan,
+  SetupConfigFact,
+  SetupFacts,
+  SetupHarnessFact,
+  SupportedHarnessId,
+} from "./model.js";
 
 export type PlanSetupConfigWriteOptions = {
   selectedHarness?: SetupHarnessFact;
   installWorktrunkHooks?: boolean;
-  installHarnessHooks?: boolean;
+  installHarnessHooks?: boolean | readonly SupportedHarnessId[];
 };
 
 export async function planSetupConfigWrite(
   facts: SetupFacts,
   options: PlanSetupConfigWriteOptions = {},
 ): Promise<ConfigWritePlan> {
-  const selectedHarness = resolveConfigWriteHarness(
-    facts,
-    options.selectedHarness ?? selectSetupHarness(facts.harnesses, facts.selectedHarness),
-  );
-  if (selectedHarness === undefined) {
+  const selectedHarnesses = resolveConfigWriteHarnesses(facts, options.selectedHarness);
+  const defaultHarness = selectedHarnesses[0];
+  if (defaultHarness === undefined) {
     return {
       operation: "blocked",
       path: facts.configPath,
@@ -26,7 +31,7 @@ export async function planSetupConfigWrite(
     return {
       operation: "create",
       path: facts.configPath,
-      content: renderNewSetupConfig(selectedHarness, facts, options),
+      content: renderNewSetupConfig(defaultHarness, facts, options, selectedHarnesses),
     };
   }
 
@@ -38,13 +43,14 @@ export async function planSetupConfigWrite(
     };
   }
 
-  return planExistingConfigAppend(facts.config, selectedHarness, options);
+  return planExistingConfigAppend(facts.config, selectedHarnesses, options, facts.homeDir);
 }
 
 export function renderNewSetupConfig(
   harness: SetupHarnessFact,
   facts?: Pick<SetupFacts, "worktrunk" | "tmux">,
   options: Pick<PlanSetupConfigWriteOptions, "installWorktrunkHooks" | "installHarnessHooks"> = {},
+  harnesses: readonly SetupHarnessFact[] = [harness],
 ): string {
   const worktrunkCommand =
     facts?.worktrunk === undefined ? "wt" : detectedCommand(facts.worktrunk, "wt");
@@ -80,37 +86,41 @@ export function renderNewSetupConfig(
     'window_naming = "project-branch"',
     "primary_agent_pane = true",
     "",
-    `[harness.${harness.id}]`,
-    "enabled = true",
-    `command = ${tomlString(harness.command)}`,
-    ...(options.installHarnessHooks === true && harnessSupportsHooks(harness.id)
-      ? ["install_hooks = true"]
-      : []),
-    "",
+    ...harnesses.flatMap((selectedHarness) => [
+      ...renderHarnessBlock(
+        selectedHarness,
+        installHarnessHookRequested(options.installHarnessHooks, selectedHarness.id, harness.id),
+      ).split("\n"),
+      "",
+    ]),
   ].join("\n");
 }
 
-function resolveConfigWriteHarness(
+function resolveConfigWriteHarnesses(
   facts: SetupFacts,
   fallback: SetupHarnessFact | undefined,
-): SetupHarnessFact | undefined {
-  if (facts.config.status !== "valid") {
-    return fallback;
-  }
-  const configuredHarness = facts.config.defaults.harness;
-  return (
-    facts.harnesses.find(
-      (harness) => harness.id === configuredHarness && harness.status === "ok",
-    ) ?? fallback
+): SetupHarnessFact[] {
+  const configuredHarnesses =
+    facts.config.status === "valid"
+      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
+          .filter(isSupportedHarnessId)
+          .filter((harness, index, all) => all.indexOf(harness) === index)
+      : undefined;
+  const selectedHarnesses = selectSetupHarnesses(
+    facts.harnesses,
+    facts.selectedHarnesses ?? configuredHarnesses,
+    facts.selectedHarness ?? fallback?.id,
   );
+  return selectedHarnesses;
 }
 
-function planExistingConfigAppend(
+async function planExistingConfigAppend(
   config: Extract<SetupConfigFact, { status: "valid" }>,
-  harness: SetupHarnessFact,
+  harnesses: readonly SetupHarnessFact[],
   options: Pick<PlanSetupConfigWriteOptions, "installHarnessHooks">,
-): ConfigWritePlan {
-  const coreProblem = existingConfigAppendCoreProblem(config, harness);
+  homeDir: string,
+): Promise<ConfigWritePlan> {
+  const coreProblem = existingConfigAppendCoreProblem(config);
   if (coreProblem !== undefined) {
     return {
       operation: "blocked",
@@ -118,28 +128,51 @@ function planExistingConfigAppend(
       reason: coreProblem,
     };
   }
-  const appendedText = renderAppendText({
-    harness,
-    addHarness: !config.configuredHarnesses.includes(harness.id),
-    installHarnessHooks: options.installHarnessHooks === true,
-  });
-  if (appendedText.length === 0) {
+
+  let content = config.source;
+  for (const harness of harnesses) {
+    if (
+      config.configuredHarnesses.includes(harness.id) &&
+      !config.configuredHookHarnesses.includes(harness.id) &&
+      installHarnessHookRequested(options.installHarnessHooks, harness.id, harnesses[0]?.id)
+    ) {
+      content = await setHarnessInstallHooksInToml(content, {
+        harness: harness.id,
+        installHooks: true,
+        configPath: config.path,
+        homeDir,
+      });
+    }
+  }
+
+  const appendedText = renderAppendText(
+    harnesses.filter((harness) => !config.configuredHarnesses.includes(harness.id)),
+    options.installHarnessHooks,
+    harnesses[0]?.id,
+    preferredNewline(config.source),
+  );
+  if (appendedText.length > 0) {
+    content = `${content}${content.endsWith("\n") ? "" : preferredNewline(content)}${appendedText}`;
+  }
+  if (content === config.source) {
     return {
       operation: "none",
-      reason: "Config already includes the selected harness and core defaults.",
+      reason:
+        harnesses.length === 1
+          ? "Config already includes the selected harness and core defaults."
+          : "Config already includes the selected harnesses and core defaults.",
     };
   }
   return {
     operation: "append",
     path: config.path,
-    content: `${config.source.trimEnd()}\n${appendedText}`,
+    content,
     appendedText,
   };
 }
 
 function existingConfigAppendCoreProblem(
   config: Extract<SetupConfigFact, { status: "valid" }>,
-  harness: SetupHarnessFact,
 ): string | undefined {
   if (config.defaults.worktreeProvider !== "worktrunk") {
     return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; setup will not rewrite existing defaults.`;
@@ -147,35 +180,53 @@ function existingConfigAppendCoreProblem(
   if (config.defaults.terminal !== "tmux") {
     return `Config defaults use terminal ${config.defaults.terminal}; setup will not rewrite existing defaults.`;
   }
-  if (config.defaults.harness !== harness.id) {
-    return `Config defaults use harness ${config.defaults.harness}; setup will not rewrite existing defaults.`;
+  if (!isSupportedHarnessId(config.defaults.harness)) {
+    return `Config defaults use unsupported harness ${config.defaults.harness}; setup will not rewrite existing defaults.`;
   }
   return undefined;
 }
 
-function renderAppendText(input: {
-  harness: SetupHarnessFact;
-  addHarness: boolean;
-  installHarnessHooks: boolean;
-}): string {
-  const blocks: string[] = [];
-  if (input.addHarness) {
-    blocks.push(
-      [
-        `[harness.${input.harness.id}]`,
-        "enabled = true",
-        `command = ${tomlString(input.harness.command)}`,
-        ...(input.installHarnessHooks && harnessSupportsHooks(input.harness.id)
-          ? ["install_hooks = true"]
-          : []),
-      ].join("\n"),
-    );
-  }
-  return blocks.length === 0 ? "" : `\n${blocks.join("\n\n")}\n`;
+function renderAppendText(
+  harnesses: readonly SetupHarnessFact[],
+  installHarnessHooks: boolean | readonly SupportedHarnessId[] | undefined,
+  defaultHarness: SupportedHarnessId | undefined,
+  newline = "\n",
+): string {
+  if (harnesses.length === 0) return "";
+  const blocks = harnesses.map((harness) =>
+    renderHarnessBlock(
+      harness,
+      installHarnessHookRequested(installHarnessHooks, harness.id, defaultHarness),
+    ).replaceAll("\n", newline),
+  );
+  return `${newline}${blocks.join(`${newline}${newline}`)}${newline}`;
+}
+
+function renderHarnessBlock(harness: SetupHarnessFact, installHooks: boolean): string {
+  return [
+    `[harness.${harness.id}]`,
+    "enabled = true",
+    `command = ${tomlString(harness.command)}`,
+    ...(installHooks && harnessSupportsHooks(harness.id) ? ["install_hooks = true"] : []),
+  ].join("\n");
+}
+
+function installHarnessHookRequested(
+  requested: boolean | readonly SupportedHarnessId[] | undefined,
+  harness: SupportedHarnessId,
+  defaultHarness: SupportedHarnessId | undefined,
+): boolean {
+  return Array.isArray(requested)
+    ? requested.includes(harness)
+    : requested === true && harness === defaultHarness;
 }
 
 function tomlString(value: string): string {
   return JSON.stringify(value);
+}
+
+function preferredNewline(source: string): "\n" | "\r\n" {
+  return source.includes("\r\n") ? "\r\n" : "\n";
 }
 
 function harnessSupportsHooks(harness: string): boolean {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -19,7 +19,12 @@ import {
   isHarnessInstallAction,
   missingHarnessInstallActions,
 } from "../harnessInstall.js";
-import { isSupportedHarnessId, selectSetupHarnesses } from "../harnessSelection.js";
+import {
+  harnessSupportsSetupHooks,
+  isSupportedHarnessId,
+  resolveSetupHarnessSelection,
+  type SetupHarnessSelection,
+} from "../harnessSelection.js";
 import { defaultPrompt, renderOptions, write } from "../io.js";
 import type { SetupAction, SetupFacts, SetupPlan, SupportedHarnessId } from "../model.js";
 import { buildSetupPlan } from "../planner.js";
@@ -105,41 +110,41 @@ async function runGuidedSetupWithPrompt(
     await write(deps, renderSetupApplyResult(noHarnessPlan, renderOptions(deps)));
     return { code: 1 };
   }
-  let selectedHarnesses: SupportedHarnessId[];
-  if (availableHarnesses.length > 1) {
-    const choices = availableHarnesses.map((harness) => ({
-      value: harness.id,
-      label: harness.label,
-    }));
-    const selected =
-      prompt.selectMany === undefined
-        ? [await prompt.select("Select the agent CLI to enable.", choices)]
-        : await prompt.selectMany(
+  const selectedIds =
+    availableHarnesses.length > 1
+      ? (
+          await prompt.selectMany(
             "Select agent CLIs to enable (comma-separated; first is the default for new configs).",
-            choices,
-          );
-    selectedHarnesses = selected.filter(isSupportedHarnessId);
-  } else {
-    selectedHarnesses = availableHarnesses.map((harness) => harness.id);
-  }
-  const configuredDefault =
-    facts.config.status === "valid" && isSupportedHarnessId(facts.config.defaults.harness)
-      ? facts.config.defaults.harness
-      : undefined;
-  const defaultHarness = configuredDefault ?? selectedHarnesses[0];
-  if (defaultHarness !== undefined) {
-    facts = {
-      ...facts,
-      selectedHarness: defaultHarness,
-      selectedHarnesses,
-    };
+            availableHarnesses.map((harness) => ({
+              value: harness.id,
+              label: harness.label,
+            })),
+          )
+        ).filter(isSupportedHarnessId)
+      : availableHarnesses.map((harness) => harness.id);
+  if (selectedIds.length === 0) {
+    await write(deps, "Select at least one available agent CLI.\n");
+    return { code: 1 };
   }
 
   facts = await maybeLinkStationLaunchers(facts, options, deps, prompt);
+  const harnessSelection = resolveSetupHarnessSelection(facts, selectedIds);
+  const refreshedIds = new Set(harnessSelection.selected.map((harness) => harness.id));
+  const unavailableIds = [...new Set(selectedIds)].filter((id) => !refreshedIds.has(id));
+  if (unavailableIds.length > 0) {
+    await write(
+      deps,
+      `Selected agent CLIs are no longer available: ${unavailableIds.join(", ")}.\n`,
+    );
+    return { code: 1 };
+  }
 
-  const hookPreferences = await promptHookPreferences(facts, prompt);
-  const configWrite = await planSetupConfigWrite(facts, hookPreferences);
-  plan = buildSetupPlan(facts, { configWrite, ...hookPreferences });
+  const hookPreferences = await promptHookPreferences(facts, prompt, harnessSelection);
+  const configWrite = await planSetupConfigWrite(facts, {
+    harnessSelection,
+    ...hookPreferences,
+  });
+  plan = buildSetupPlan(facts, { configWrite, harnessSelection, ...hookPreferences });
   if (!coreReadyForConfigWrite(plan)) {
     await write(deps, renderSetupApplyResult(plan, renderOptions(deps)));
     return { code: 1 };
@@ -514,13 +519,9 @@ async function maybeLinkStationLaunchers(
 async function promptHookPreferences(
   facts: SetupFacts,
   prompt: SetupPromptAdapter,
+  harnessSelection: SetupHarnessSelection,
 ): Promise<HookPreferences> {
   const preferences: HookPreferences = {};
-  const selectedHarnesses = selectSetupHarnesses(
-    facts.harnesses,
-    facts.selectedHarnesses,
-    facts.selectedHarness,
-  );
   if (
     facts.worktrunk.status === "ok" &&
     (facts.config.status === "missing" ||
@@ -529,8 +530,8 @@ async function promptHookPreferences(
     preferences.installWorktrunkHooks = await prompt.confirm("Install Worktrunk lifecycle hooks?");
   }
   const installHarnessHooks: SupportedHarnessId[] = [];
-  for (const harness of selectedHarnesses) {
-    if (!harnessSupportsHooks(harness.id) || !canInstallHarnessHooks(facts)) {
+  for (const harness of harnessSelection.selected) {
+    if (!harnessSupportsSetupHooks(harness.id) || facts.config.status === "invalid") {
       continue;
     }
     if (await prompt.confirm(`Install ${harness.label} agent hooks?`)) {
@@ -541,16 +542,6 @@ async function promptHookPreferences(
     preferences.installHarnessHooks = installHarnessHooks;
   }
   return preferences;
-}
-
-function canInstallHarnessHooks(facts: SetupFacts): boolean {
-  return facts.config.status === "missing" || facts.config.status === "valid";
-}
-
-function harnessSupportsHooks(harness: string): boolean {
-  return (
-    harness === "claude" || harness === "codex" || harness === "cursor" || harness === "opencode"
-  );
 }
 
 function shouldPromptLauncherLink(facts: SetupFacts): boolean {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -19,9 +19,9 @@ import {
   isHarnessInstallAction,
   missingHarnessInstallActions,
 } from "../harnessInstall.js";
-import { isSupportedHarnessId, selectSetupHarness } from "../harnessSelection.js";
+import { isSupportedHarnessId, selectSetupHarnesses } from "../harnessSelection.js";
 import { defaultPrompt, renderOptions, write } from "../io.js";
-import type { SetupAction, SetupFacts, SetupPlan } from "../model.js";
+import type { SetupAction, SetupFacts, SetupPlan, SupportedHarnessId } from "../model.js";
 import { buildSetupPlan } from "../planner.js";
 import { formatCommand, renderSetupApplyResult, renderSetupPlan } from "../render.js";
 import type {
@@ -50,7 +50,7 @@ async function runGuidedSetupWithPrompt(
 ): Promise<SetupCommandResult> {
   await write(
     deps,
-    "Core setup: required tools and one agent. Add your first project in STATION.\n\n",
+    "Core setup: required tools and one or more agents. Add your first project in STATION.\n\n",
   );
   let facts = await collectForCommand("apply", options, deps, {});
 
@@ -105,14 +105,34 @@ async function runGuidedSetupWithPrompt(
     await write(deps, renderSetupApplyResult(noHarnessPlan, renderOptions(deps)));
     return { code: 1 };
   }
+  let selectedHarnesses: SupportedHarnessId[];
   if (availableHarnesses.length > 1) {
-    const selected = await prompt.select(
-      "Select the agent CLI to enable.",
-      availableHarnesses.map((harness) => ({ value: harness.id, label: harness.label })),
-    );
-    if (isSupportedHarnessId(selected)) {
-      facts = { ...facts, selectedHarness: selected };
-    }
+    const choices = availableHarnesses.map((harness) => ({
+      value: harness.id,
+      label: harness.label,
+    }));
+    const selected =
+      prompt.selectMany === undefined
+        ? [await prompt.select("Select the agent CLI to enable.", choices)]
+        : await prompt.selectMany(
+            "Select agent CLIs to enable (comma-separated; first is the default for new configs).",
+            choices,
+          );
+    selectedHarnesses = selected.filter(isSupportedHarnessId);
+  } else {
+    selectedHarnesses = availableHarnesses.map((harness) => harness.id);
+  }
+  const configuredDefault =
+    facts.config.status === "valid" && isSupportedHarnessId(facts.config.defaults.harness)
+      ? facts.config.defaults.harness
+      : undefined;
+  const defaultHarness = configuredDefault ?? selectedHarnesses[0];
+  if (defaultHarness !== undefined) {
+    facts = {
+      ...facts,
+      selectedHarness: defaultHarness,
+      selectedHarnesses,
+    };
   }
 
   facts = await maybeLinkStationLaunchers(facts, options, deps, prompt);
@@ -146,19 +166,21 @@ async function runGuidedSetupWithPrompt(
 
   const hookActions = plan.actions.filter(isHookSetupAction).filter((action) => action.selected);
   let hookInstallFailed = false;
-  if (hookActions.length > 0) {
+  // Hook providers are independent; one failed installer must not suppress the rest.
+  for (const action of hookActions) {
     const hookResult = await applySetupPlan(
-      plan,
+      { ...plan, actions: [action] },
       applyOptions(deps, {
-        actionFilter: isHookSetupAction,
         announceActions: true,
         showCommandOutput: true,
       }),
     );
     if (hookResult.failedAction !== undefined) {
-      await write(deps, "Hook install failed. Fix the install error, then run: stn setup\n");
       hookInstallFailed = true;
     }
+  }
+  if (hookInstallFailed) {
+    await write(deps, "Hook install failed. Fix the install error, then run: stn setup\n");
   }
 
   const activationError =
@@ -349,7 +371,7 @@ function renderTmuxPopupFeedback(
 
 type HookPreferences = {
   installWorktrunkHooks?: boolean;
-  installHarnessHooks?: boolean;
+  installHarnessHooks?: readonly SupportedHarnessId[];
 };
 
 // Kicks the macOS bootstrap installers (Command Line Tools, then Homebrew) behind
@@ -494,27 +516,35 @@ async function promptHookPreferences(
   prompt: SetupPromptAdapter,
 ): Promise<HookPreferences> {
   const preferences: HookPreferences = {};
-  const selectedHarness = selectSetupHarness(facts.harnesses, facts.selectedHarness);
-  if (facts.config.status === "missing" && facts.worktrunk.status === "ok") {
+  const selectedHarnesses = selectSetupHarnesses(
+    facts.harnesses,
+    facts.selectedHarnesses,
+    facts.selectedHarness,
+  );
+  if (
+    facts.worktrunk.status === "ok" &&
+    (facts.config.status === "missing" ||
+      (facts.config.status === "valid" && facts.config.worktrunkUseLifecycleHooks === true))
+  ) {
     preferences.installWorktrunkHooks = await prompt.confirm("Install Worktrunk lifecycle hooks?");
   }
-  if (
-    selectedHarness !== undefined &&
-    harnessSupportsHooks(selectedHarness.id) &&
-    canWriteHarnessHookFlag(facts, selectedHarness.id)
-  ) {
-    preferences.installHarnessHooks = await prompt.confirm(
-      `Install ${selectedHarness.label} agent hooks?`,
-    );
+  const installHarnessHooks: SupportedHarnessId[] = [];
+  for (const harness of selectedHarnesses) {
+    if (!harnessSupportsHooks(harness.id) || !canInstallHarnessHooks(facts)) {
+      continue;
+    }
+    if (await prompt.confirm(`Install ${harness.label} agent hooks?`)) {
+      installHarnessHooks.push(harness.id);
+    }
+  }
+  if (installHarnessHooks.length > 0) {
+    preferences.installHarnessHooks = installHarnessHooks;
   }
   return preferences;
 }
 
-function canWriteHarnessHookFlag(facts: SetupFacts, harnessId: string): boolean {
-  return (
-    facts.config.status === "missing" ||
-    (facts.config.status === "valid" && !facts.config.configuredHarnesses.includes(harnessId))
-  );
+function canInstallHarnessHooks(facts: SetupFacts): boolean {
+  return facts.config.status === "missing" || facts.config.status === "valid";
 }
 
 function harnessSupportsHooks(harness: string): boolean {

--- a/apps/cli/src/commands/setup/harnessSelection.ts
+++ b/apps/cli/src/commands/setup/harnessSelection.ts
@@ -17,6 +17,24 @@ export function selectSetupHarness(
   return undefined;
 }
 
+export function selectSetupHarnesses(
+  harnesses: readonly SetupHarnessFact[],
+  selectedHarnesses?: readonly SupportedHarnessId[],
+  selectedHarness?: SupportedHarnessId,
+): SetupHarnessFact[] {
+  const selected: SetupHarnessFact[] = [];
+  for (const id of selectedHarnesses ?? (selectedHarness === undefined ? [] : [selectedHarness])) {
+    const harness = harnesses.find((candidate) => candidate.id === id && candidate.status === "ok");
+    if (harness !== undefined && !selected.some((candidate) => candidate.id === harness.id)) {
+      selected.push(harness);
+    }
+  }
+  if (selected.length > 0) return selected;
+  if (selectedHarnesses !== undefined || selectedHarness !== undefined) return [];
+  const fallback = selectSetupHarness(harnesses, selectedHarness);
+  return fallback === undefined ? [] : [fallback];
+}
+
 export function isSupportedHarnessId(value: string): value is SupportedHarnessId {
   return supportedHarnessIds.some((id) => id === value);
 }

--- a/apps/cli/src/commands/setup/harnessSelection.ts
+++ b/apps/cli/src/commands/setup/harnessSelection.ts
@@ -1,40 +1,58 @@
-import type { SetupHarnessFact, SupportedHarnessId } from "./model.js";
+import type { SetupFacts, SetupHarnessFact, SupportedHarnessId } from "./model.js";
 import { supportedHarnessIds } from "./model.js";
 
-export function selectSetupHarness(
-  harnesses: readonly SetupHarnessFact[],
-  selectedHarness?: SupportedHarnessId,
-): SetupHarnessFact | undefined {
-  if (selectedHarness !== undefined) {
-    return harnesses.find((harness) => harness.id === selectedHarness && harness.status === "ok");
-  }
-  for (const id of supportedHarnessIds) {
-    const harness = harnesses.find((candidate) => candidate.id === id && candidate.status === "ok");
-    if (harness !== undefined) {
-      return harness;
-    }
-  }
-  return undefined;
-}
+export type SetupHarnessSelection = {
+  selected: readonly SetupHarnessFact[];
+  defaultHarness: SupportedHarnessId | undefined;
+};
 
-export function selectSetupHarnesses(
-  harnesses: readonly SetupHarnessFact[],
-  selectedHarnesses?: readonly SupportedHarnessId[],
-  selectedHarness?: SupportedHarnessId,
-): SetupHarnessFact[] {
-  const selected: SetupHarnessFact[] = [];
-  for (const id of selectedHarnesses ?? (selectedHarness === undefined ? [] : [selectedHarness])) {
-    const harness = harnesses.find((candidate) => candidate.id === id && candidate.status === "ok");
-    if (harness !== undefined && !selected.some((candidate) => candidate.id === harness.id)) {
-      selected.push(harness);
-    }
-  }
-  if (selected.length > 0) return selected;
-  if (selectedHarnesses !== undefined || selectedHarness !== undefined) return [];
-  const fallback = selectSetupHarness(harnesses, selectedHarness);
-  return fallback === undefined ? [] : [fallback];
+export function resolveSetupHarnessSelection(
+  facts: Pick<SetupFacts, "config" | "harnesses">,
+  selectedIds?: readonly SupportedHarnessId[],
+): SetupHarnessSelection {
+  const configuredIds =
+    facts.config.status === "valid"
+      ? uniqueSupportedIds([facts.config.defaults.harness, ...facts.config.configuredHarnesses])
+      : undefined;
+  const requestedIds =
+    selectedIds === undefined
+      ? (configuredIds ?? firstAvailableId(facts.harnesses))
+      : uniqueSupportedIds(selectedIds);
+  const selected = requestedIds.flatMap((id) => {
+    const harness = facts.harnesses.find(
+      (candidate) => candidate.id === id && candidate.status === "ok",
+    );
+    return harness === undefined ? [] : [harness];
+  });
+  const configuredDefault =
+    facts.config.status === "valid" && isSupportedHarnessId(facts.config.defaults.harness)
+      ? facts.config.defaults.harness
+      : undefined;
+  return {
+    selected,
+    defaultHarness: configuredDefault ?? selected[0]?.id,
+  };
 }
 
 export function isSupportedHarnessId(value: string): value is SupportedHarnessId {
   return supportedHarnessIds.some((id) => id === value);
+}
+
+export function harnessSupportsSetupHooks(
+  harness: string,
+): harness is "claude" | "codex" | "cursor" | "opencode" {
+  return (
+    harness === "claude" || harness === "codex" || harness === "cursor" || harness === "opencode"
+  );
+}
+
+function uniqueSupportedIds(ids: readonly string[]): SupportedHarnessId[] {
+  return ids.filter(isSupportedHarnessId).filter((id, index, all) => all.indexOf(id) === index);
+}
+
+function firstAvailableId(harnesses: readonly SetupHarnessFact[]): SupportedHarnessId[] {
+  for (const id of supportedHarnessIds) {
+    if (harnesses.some((harness) => harness.id === id && harness.status === "ok")) return [id];
+  }
+  return [];
 }

--- a/apps/cli/src/commands/setup/io.ts
+++ b/apps/cli/src/commands/setup/io.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline/promises";
 import type { SetupRenderOptions } from "./theme.js";
-import type { SetupCommandDeps, SetupPromptAdapter } from "./types.js";
+import type { SetupCommandDeps, SetupPromptAdapter, SetupPromptChoice } from "./types.js";
 
 export async function write(deps: SetupCommandDeps, chunk: string): Promise<void> {
   const writer = deps.writeStdout ?? defaultWriteStdout;
@@ -36,8 +36,29 @@ export function defaultPrompt(): SetupPromptAdapter {
       const index = Number(answer.trim()) - 1;
       return choices[index]?.value ?? choices[0]?.value ?? "";
     },
+    async selectMany(message, choices) {
+      const labels = choices.map((choice, index) => `${index + 1}. ${choice.label}`).join("\n");
+      const answer = await readline.question(`${message}\n${labels}\n> `);
+      return parseMultiSelectAnswer(answer, choices);
+    },
     close() {
       readline.close();
     },
   };
+}
+
+export function parseMultiSelectAnswer(
+  answer: string,
+  choices: readonly SetupPromptChoice[],
+): string[] {
+  const selected: string[] = [];
+  for (const token of answer.split(",")) {
+    const trimmed = token.trim();
+    const index = /^\d+$/.test(trimmed) ? Number(trimmed) - 1 : -1;
+    const value = Number.isInteger(index) ? choices[index]?.value : undefined;
+    if (value !== undefined && !selected.includes(value)) selected.push(value);
+  }
+  if (selected.length > 0) return selected;
+  const fallback = choices[0]?.value;
+  return fallback === undefined ? [] : [fallback];
 }

--- a/apps/cli/src/commands/setup/io.ts
+++ b/apps/cli/src/commands/setup/io.ts
@@ -30,12 +30,6 @@ export function defaultPrompt(): SetupPromptAdapter {
       const answer = await readline.question(`${message} [y/N] `);
       return answer.trim().toLowerCase() === "y" || answer.trim().toLowerCase() === "yes";
     },
-    async select(message, choices) {
-      const labels = choices.map((choice, index) => `${index + 1}. ${choice.label}`).join("\n");
-      const answer = await readline.question(`${message}\n${labels}\n> `);
-      const index = Number(answer.trim()) - 1;
-      return choices[index]?.value ?? choices[0]?.value ?? "";
-    },
     async selectMany(message, choices) {
       const labels = choices.map((choice, index) => `${index + 1}. ${choice.label}`).join("\n");
       const answer = await readline.question(`${message}\n${labels}\n> `);

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -200,6 +200,7 @@ export type SetupConfigFact =
       observerStateDir: string;
       hasProjectForRoot: boolean;
       configuredHarnesses: readonly string[];
+      configuredHarnessCommands?: Readonly<Record<string, string>>;
       configuredHookHarnesses: readonly string[];
       defaults: SetupConfigDefaultsFact;
       tmux?: TmuxConfig;
@@ -289,8 +290,6 @@ export type SetupFacts = {
   harnesses: readonly SetupHarnessFact[];
   config: SetupConfigFact;
   tmuxBinding: SetupTmuxBindingFact;
-  selectedHarness?: SupportedHarnessId;
-  selectedHarnesses?: readonly SupportedHarnessId[];
 };
 
 export type ConfigWritePlan =
@@ -305,10 +304,9 @@ export type ConfigWritePlan =
       backupPath?: string;
     }
   | {
-      operation: "append";
+      operation: "update";
       path: string;
       content: string;
-      appendedText: string;
       backupPath?: string;
     }
   | {

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -290,6 +290,7 @@ export type SetupFacts = {
   config: SetupConfigFact;
   tmuxBinding: SetupTmuxBindingFact;
   selectedHarness?: SupportedHarnessId;
+  selectedHarnesses?: readonly SupportedHarnessId[];
 };
 
 export type ConfigWritePlan =

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,7 +1,12 @@
 import { stationUiInstallHint } from "../../stationWorkspace.js";
 import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
-import { isSupportedHarnessId, selectSetupHarnesses } from "./harnessSelection.js";
+import {
+  harnessSupportsSetupHooks,
+  isSupportedHarnessId,
+  resolveSetupHarnessSelection,
+  type SetupHarnessSelection,
+} from "./harnessSelection.js";
 import type {
   ConfigWritePlan,
   SetupAction,
@@ -15,33 +20,15 @@ import { SetupPlanSchema } from "./model.js";
 
 export type BuildSetupPlanOptions = {
   configWrite?: ConfigWritePlan;
+  harnessSelection?: SetupHarnessSelection;
   installWorktrunkHooks?: boolean;
-  installHarnessHooks?: boolean | readonly SupportedHarnessId[];
+  installHarnessHooks?: readonly SupportedHarnessId[];
 };
 
 export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions = {}): SetupPlan {
-  const configuredHarnesses =
-    facts.config.status === "valid"
-      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
-          .filter(isSupportedHarnessId)
-          .filter((harness, index, all) => all.indexOf(harness) === index)
-      : undefined;
-  const selectedHarnesses = selectSetupHarnesses(
-    facts.harnesses,
-    facts.selectedHarnesses ??
-      (facts.selectedHarness === undefined ? configuredHarnesses : undefined),
-    facts.selectedHarness,
-  );
-  const persistedDefaultHarness =
-    facts.config.status === "valid" && isSupportedHarnessId(facts.config.defaults.harness)
-      ? facts.config.defaults.harness
-      : undefined;
-  const selectedHarness = persistedDefaultHarness ?? selectedHarnesses[0]?.id;
-  const checks = setupChecks(
-    facts,
-    selectedHarnesses.map((harness) => harness.id),
-  );
-  const actions = setupActions(facts, selectedHarnesses, options.configWrite, options);
+  const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
+  const checks = setupChecks(facts, harnessSelection);
+  const actions = setupActions(facts, harnessSelection.selected, options.configWrite, options);
   const requiredMissing = checks.filter(
     (check) => check.tier === "required" && check.status !== "ok",
   ).length;
@@ -57,7 +44,9 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
     warnings,
     selectedActions: actions.filter((action) => action.selected).length,
     configPath: facts.configPath,
-    ...(selectedHarness === undefined ? {} : { selectedHarness }),
+    ...(harnessSelection.defaultHarness === undefined
+      ? {}
+      : { selectedHarness: harnessSelection.defaultHarness }),
   };
   const plan = {
     generatedAt: facts.generatedAt,
@@ -70,10 +59,7 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
   return SetupPlanSchema.parse(plan);
 }
 
-function setupChecks(
-  facts: SetupFacts,
-  selectedHarnesses: readonly SupportedHarnessId[],
-): SetupCheck[] {
+function setupChecks(facts: SetupFacts, harnessSelection: SetupHarnessSelection): SetupCheck[] {
   return [
     stateDirCheck(facts),
     socketEvidenceCheck(facts),
@@ -102,7 +88,7 @@ function setupChecks(
           }),
         ]),
     gitCheck(facts),
-    harnessCheck(facts, selectedHarnesses),
+    harnessCheck(facts, harnessSelection),
     configCheck(facts),
     ...configDiagnosticsChecks(facts),
     launcherCheck(facts),
@@ -119,7 +105,10 @@ function setupChecks(
     },
     tmuxPopupBindingCheck(facts),
     worktrunkHooksCheck(facts),
-    harnessHooksCheck(facts, selectedHarnesses),
+    harnessHooksCheck(
+      facts,
+      harnessSelection.selected.map((harness) => harness.id),
+    ),
     diffnavCheck(facts),
     gitDeltaCheck(facts),
     {
@@ -363,7 +352,7 @@ function harnessHooksCheck(
   facts: SetupFacts,
   selectedHarnesses: readonly SupportedHarnessId[],
 ): SetupCheck {
-  const hookHarnesses = selectedHarnesses.filter(harnessSupportsHooks);
+  const hookHarnesses = selectedHarnesses.filter(harnessSupportsSetupHooks);
   if (hookHarnesses.length === 0) {
     return {
       id: "harness-hooks",
@@ -531,10 +520,7 @@ function gitCheck(facts: SetupFacts): SetupCheck {
   };
 }
 
-function harnessCheck(
-  facts: SetupFacts,
-  selectedHarnesses: readonly SupportedHarnessId[],
-): SetupCheck {
+function harnessCheck(facts: SetupFacts, harnessSelection: SetupHarnessSelection): SetupCheck {
   const available = facts.harnesses.filter((harness) => harness.status === "ok");
   if (available.length === 0) {
     return {
@@ -547,21 +533,23 @@ function harnessCheck(
   }
   const configuredHarnesses =
     facts.config.status === "valid"
-      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
-          .filter(isSupportedHarnessId)
-          .filter((harness, index, all) => all.indexOf(harness) === index)
+      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses].filter(
+          (harness, index, all) => all.indexOf(harness) === index,
+        )
       : [];
-  const enabledHarnesses = [...configuredHarnesses, ...selectedHarnesses].filter(
-    (harness, index, all) => all.indexOf(harness) === index,
-  );
-  const selectedId = configuredHarnesses[0] ?? selectedHarnesses[0] ?? available[0]?.id;
-  const selected = available.find((harness) => harness.id === selectedId);
+  const enabledHarnesses = [
+    ...configuredHarnesses,
+    ...harnessSelection.selected.map((harness) => harness.id),
+  ].filter((harness, index, all) => all.indexOf(harness) === index);
+  const defaultHarness = harnessSelection.defaultHarness;
+  const selected = available.find((harness) => harness.id === defaultHarness);
+  const usableHarness = selected ?? harnessSelection.selected[0];
   const details: Record<string, string> = {
     available: available.map((harness) => harness.id).join(","),
   };
-  if (selectedId !== undefined) {
-    details.selected = selectedId;
-    details.selectedStatus = selected === undefined ? "unavailable" : "available";
+  if (defaultHarness !== undefined) {
+    details.default = defaultHarness;
+    details.defaultStatus = selected === undefined ? "unavailable" : "available";
     details.enabled = enabledHarnesses.join(",");
   }
   if (selected !== undefined) {
@@ -570,13 +558,15 @@ function harnessCheck(
   return {
     id: "harness",
     tier: "required",
-    status: "ok",
+    status: usableHarness === undefined ? "missing" : "ok",
     label: "Agent CLI",
     message:
-      selectedId === undefined
+      defaultHarness === undefined
         ? "A supported harness CLI is available."
         : selected === undefined
-          ? `${selectedId} remains configured as the default agent CLI, but it is unavailable; another supported agent CLI is available.`
+          ? usableHarness === undefined
+            ? `${defaultHarness} remains configured as the default agent CLI, but no configured agent CLI is available.`
+            : `${defaultHarness} remains configured as the default agent CLI, but it is unavailable; another supported agent CLI is available.`
           : `${selected.label} is selected as the default agent CLI.`,
     details,
   };
@@ -768,7 +758,7 @@ function setupActions(
 
   actions.push(...hookSetupActions(facts, selectedHarnesses, options));
 
-  const configActions = configWriteActions(selectedHarnesses[0], configWrite);
+  const configActions = configWriteActions(configWrite, selectedHarnesses.length > 0);
   actions.push(...configActions);
   return actions;
 }
@@ -809,16 +799,12 @@ function hookSetupActions(
     });
   }
   for (const selectedHarness of selectedHarnesses) {
-    if (!harnessSupportsHooks(selectedHarness.id)) continue;
+    if (!harnessSupportsSetupHooks(selectedHarness.id)) continue;
     actions.push({
       id: `${selectedHarness.id}-hooks`,
       kind: "run-command",
       tier: "recommended",
-      selected: harnessHookSelected(
-        options.installHarnessHooks,
-        selectedHarness.id,
-        selectedHarnesses[0]?.id,
-      ),
+      selected: options.installHarnessHooks?.includes(selectedHarness.id) === true,
       label: `Install ${selectedHarness.label} hooks`,
       message: `Install ${selectedHarness.label} hooks that report agent activity to STATION.`,
       command: harnessHookInstallCommand(facts, selectedHarness.id),
@@ -826,16 +812,6 @@ function hookSetupActions(
     });
   }
   return actions;
-}
-
-function harnessHookSelected(
-  selected: boolean | readonly SupportedHarnessId[] | undefined,
-  harness: SupportedHarnessId,
-  defaultHarness: SupportedHarnessId | undefined,
-): boolean {
-  return Array.isArray(selected)
-    ? selected.includes(harness)
-    : selected === true && harness === defaultHarness;
 }
 
 function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {
@@ -852,14 +828,6 @@ function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessI
     command.push("--hook-bin", setupLauncherExecutable(facts.launchers.ingress));
   }
   return command;
-}
-
-function harnessSupportsHooks(
-  harness: string,
-): harness is "claude" | "codex" | "cursor" | "opencode" {
-  return (
-    harness === "claude" || harness === "codex" || harness === "cursor" || harness === "opencode"
-  );
 }
 
 function installAction(
@@ -885,12 +853,10 @@ function installAction(
 }
 
 function configWriteActions(
-  selectedHarness: SetupHarnessFact | undefined,
   configWrite: ConfigWritePlan | undefined,
+  hasSelectedHarness: boolean,
 ): SetupAction[] {
-  if (selectedHarness === undefined) {
-    return [];
-  }
+  if (!hasSelectedHarness) return [];
   if (configWrite === undefined || configWrite.operation === "none") {
     return [];
   }
@@ -917,7 +883,7 @@ function configWriteActions(
     path: configWrite.path,
   };
   const writeAction: SetupAction = {
-    id: configWrite.operation === "create" ? "write-config" : "append-config",
+    id: configWrite.operation === "create" ? "write-config" : "update-config",
     kind: "write-config",
     tier: "required",
     selected: true,
@@ -930,7 +896,6 @@ function configWriteActions(
     data: {
       operation: configWrite.operation,
       content: configWrite.content,
-      ...(configWrite.operation === "append" ? { appendedText: configWrite.appendedText } : {}),
       ...(configWrite.backupPath === undefined ? {} : { backupPath: configWrite.backupPath }),
     },
   };

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,7 +1,7 @@
 import { stationUiInstallHint } from "../../stationWorkspace.js";
 import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
-import { selectSetupHarness } from "./harnessSelection.js";
+import { isSupportedHarnessId, selectSetupHarnesses } from "./harnessSelection.js";
 import type {
   ConfigWritePlan,
   SetupAction,
@@ -16,13 +16,32 @@ import { SetupPlanSchema } from "./model.js";
 export type BuildSetupPlanOptions = {
   configWrite?: ConfigWritePlan;
   installWorktrunkHooks?: boolean;
-  installHarnessHooks?: boolean;
+  installHarnessHooks?: boolean | readonly SupportedHarnessId[];
 };
 
 export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions = {}): SetupPlan {
-  const selectedHarness = selectSetupHarness(facts.harnesses, facts.selectedHarness);
-  const checks = setupChecks(facts, selectedHarness?.id);
-  const actions = setupActions(facts, selectedHarness, options.configWrite, options);
+  const configuredHarnesses =
+    facts.config.status === "valid"
+      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
+          .filter(isSupportedHarnessId)
+          .filter((harness, index, all) => all.indexOf(harness) === index)
+      : undefined;
+  const selectedHarnesses = selectSetupHarnesses(
+    facts.harnesses,
+    facts.selectedHarnesses ??
+      (facts.selectedHarness === undefined ? configuredHarnesses : undefined),
+    facts.selectedHarness,
+  );
+  const persistedDefaultHarness =
+    facts.config.status === "valid" && isSupportedHarnessId(facts.config.defaults.harness)
+      ? facts.config.defaults.harness
+      : undefined;
+  const selectedHarness = persistedDefaultHarness ?? selectedHarnesses[0]?.id;
+  const checks = setupChecks(
+    facts,
+    selectedHarnesses.map((harness) => harness.id),
+  );
+  const actions = setupActions(facts, selectedHarnesses, options.configWrite, options);
   const requiredMissing = checks.filter(
     (check) => check.tier === "required" && check.status !== "ok",
   ).length;
@@ -38,7 +57,7 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
     warnings,
     selectedActions: actions.filter((action) => action.selected).length,
     configPath: facts.configPath,
-    ...(selectedHarness === undefined ? {} : { selectedHarness: selectedHarness.id }),
+    ...(selectedHarness === undefined ? {} : { selectedHarness }),
   };
   const plan = {
     generatedAt: facts.generatedAt,
@@ -53,7 +72,7 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
 
 function setupChecks(
   facts: SetupFacts,
-  selectedHarness: SupportedHarnessId | undefined,
+  selectedHarnesses: readonly SupportedHarnessId[],
 ): SetupCheck[] {
   return [
     stateDirCheck(facts),
@@ -83,7 +102,7 @@ function setupChecks(
           }),
         ]),
     gitCheck(facts),
-    harnessCheck(facts, selectedHarness),
+    harnessCheck(facts, selectedHarnesses),
     configCheck(facts),
     ...configDiagnosticsChecks(facts),
     launcherCheck(facts),
@@ -100,7 +119,7 @@ function setupChecks(
     },
     tmuxPopupBindingCheck(facts),
     worktrunkHooksCheck(facts),
-    harnessHooksCheck(facts, selectedHarness),
+    harnessHooksCheck(facts, selectedHarnesses),
     diffnavCheck(facts),
     gitDeltaCheck(facts),
     {
@@ -342,15 +361,16 @@ function worktrunkAutomationDetails(
 
 function harnessHooksCheck(
   facts: SetupFacts,
-  selectedHarness: SupportedHarnessId | undefined,
+  selectedHarnesses: readonly SupportedHarnessId[],
 ): SetupCheck {
-  if (selectedHarness === undefined || !harnessSupportsHooks(selectedHarness)) {
+  const hookHarnesses = selectedHarnesses.filter(harnessSupportsHooks);
+  if (hookHarnesses.length === 0) {
     return {
       id: "harness-hooks",
       tier: "recommended",
       status: "skipped",
       label: "Agent hooks",
-      message: "Selected agent does not have guided hook setup.",
+      message: "Selected agents do not have guided hook setup.",
     };
   }
   if (facts.config.status !== "valid") {
@@ -359,16 +379,22 @@ function harnessHooksCheck(
       tier: "recommended",
       status: "warning",
       label: "Agent hooks",
-      message: `Recommended: install ${selectedHarness} hooks during setup.`,
+      message: `Recommended: install hooks for ${hookHarnesses.join(", ")} during setup.`,
+      details: { harnesses: hookHarnesses.join(",") },
     };
   }
-  if (facts.config.configuredHookHarnesses.includes(selectedHarness)) {
+  const config = facts.config;
+  const missing = hookHarnesses.filter(
+    (harness) => !config.configuredHookHarnesses.includes(harness),
+  );
+  if (missing.length === 0) {
     return {
       id: "harness-hooks",
       tier: "recommended",
       status: "ok",
       label: "Agent hooks",
-      message: `${selectedHarness} hooks are requested; station doctor verifies installed files.`,
+      message: `${hookHarnesses.join(", ")} hooks are requested; station doctor verifies installed files.`,
+      details: { harnesses: hookHarnesses.join(",") },
     };
   }
   return {
@@ -376,7 +402,8 @@ function harnessHooksCheck(
     tier: "recommended",
     status: "warning",
     label: "Agent hooks",
-    message: `${selectedHarness} hooks are not enabled in STATION config.`,
+    message: `${missing.join(", ")} hooks are not enabled in STATION config.`,
+    details: { harnesses: hookHarnesses.join(","), missing: missing.join(",") },
   };
 }
 
@@ -506,7 +533,7 @@ function gitCheck(facts: SetupFacts): SetupCheck {
 
 function harnessCheck(
   facts: SetupFacts,
-  selectedHarness: SupportedHarnessId | undefined,
+  selectedHarnesses: readonly SupportedHarnessId[],
 ): SetupCheck {
   const available = facts.harnesses.filter((harness) => harness.status === "ok");
   if (available.length === 0) {
@@ -518,12 +545,26 @@ function harnessCheck(
       message: "Install one supported harness CLI: claude, codex, cursor agent, opencode, or pi.",
     };
   }
-  const selected = available.find((harness) => harness.id === selectedHarness) ?? available[0];
+  const configuredHarnesses =
+    facts.config.status === "valid"
+      ? [facts.config.defaults.harness, ...facts.config.configuredHarnesses]
+          .filter(isSupportedHarnessId)
+          .filter((harness, index, all) => all.indexOf(harness) === index)
+      : [];
+  const enabledHarnesses = [...configuredHarnesses, ...selectedHarnesses].filter(
+    (harness, index, all) => all.indexOf(harness) === index,
+  );
+  const selectedId = configuredHarnesses[0] ?? selectedHarnesses[0] ?? available[0]?.id;
+  const selected = available.find((harness) => harness.id === selectedId);
   const details: Record<string, string> = {
     available: available.map((harness) => harness.id).join(","),
   };
+  if (selectedId !== undefined) {
+    details.selected = selectedId;
+    details.selectedStatus = selected === undefined ? "unavailable" : "available";
+    details.enabled = enabledHarnesses.join(",");
+  }
   if (selected !== undefined) {
-    details.selected = selected.id;
     details.command = selected.command;
   }
   return {
@@ -532,9 +573,11 @@ function harnessCheck(
     status: "ok",
     label: "Agent CLI",
     message:
-      selected === undefined
+      selectedId === undefined
         ? "A supported harness CLI is available."
-        : `${selected.label} is selected for first-run config.`,
+        : selected === undefined
+          ? `${selectedId} remains configured as the default agent CLI, but it is unavailable; another supported agent CLI is available.`
+          : `${selected.label} is selected as the default agent CLI.`,
     details,
   };
 }
@@ -560,10 +603,7 @@ function configCheck(facts: SetupFacts): SetupCheck {
       details: { path: facts.config.path },
     };
   }
-  const supportedHarnesses = new Set(
-    facts.harnesses.filter((harness) => harness.status === "ok").map((harness) => harness.id),
-  );
-  const defaultCoreProblem = defaultConfigCoreProblem(facts.config, supportedHarnesses);
+  const defaultCoreProblem = defaultConfigCoreProblem(facts.config);
   if (defaultCoreProblem !== undefined) {
     return {
       id: "config",
@@ -585,7 +625,11 @@ function configCheck(facts: SetupFacts): SetupCheck {
     status: "ok",
     label: "STATION config",
     message: "Core STATION config is ready; projects are added explicitly in STATION.",
-    details: { path: facts.config.path },
+    details: {
+      path: facts.config.path,
+      harness: facts.config.defaults.harness,
+      configuredHarnesses: facts.config.configuredHarnesses.join(","),
+    },
   };
 }
 
@@ -617,7 +661,6 @@ function configDiagnosticsChecks(facts: SetupFacts): SetupCheck[] {
 
 function defaultConfigCoreProblem(
   config: Extract<SetupFacts["config"], { status: "valid" }>,
-  supportedHarnesses: ReadonlySet<string>,
 ): string | undefined {
   if (config.defaults.worktreeProvider !== "worktrunk") {
     return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; set defaults.worktree_provider to "worktrunk" for the setup core path.`;
@@ -625,15 +668,15 @@ function defaultConfigCoreProblem(
   if (config.defaults.terminal !== "tmux") {
     return `Config defaults use terminal ${config.defaults.terminal}; set defaults.terminal to "tmux" for the setup core path.`;
   }
-  if (!supportedHarnesses.has(config.defaults.harness)) {
-    return `Config defaults use harness ${config.defaults.harness}, but setup did not detect that supported harness CLI.`;
+  if (!isSupportedHarnessId(config.defaults.harness)) {
+    return `Config defaults use unsupported harness ${config.defaults.harness}; choose claude, codex, cursor, opencode, or pi for the setup core path.`;
   }
   return undefined;
 }
 
 function setupActions(
   facts: SetupFacts,
-  selectedHarness: SetupHarnessFact | undefined,
+  selectedHarnesses: readonly SetupHarnessFact[],
   configWrite: ConfigWritePlan | undefined,
   options: BuildSetupPlanOptions,
 ): SetupAction[] {
@@ -723,9 +766,9 @@ function setupActions(
     });
   }
 
-  actions.push(...hookSetupActions(facts, selectedHarness, options));
+  actions.push(...hookSetupActions(facts, selectedHarnesses, options));
 
-  const configActions = configWriteActions(selectedHarness, configWrite);
+  const configActions = configWriteActions(selectedHarnesses[0], configWrite);
   actions.push(...configActions);
   return actions;
 }
@@ -738,7 +781,7 @@ function stationLaunchersNeedLink(facts: SetupFacts): boolean {
 
 function hookSetupActions(
   facts: SetupFacts,
-  selectedHarness: SetupHarnessFact | undefined,
+  selectedHarnesses: readonly SetupHarnessFact[],
   options: BuildSetupPlanOptions,
 ): SetupAction[] {
   if (facts.launchers.station.status !== "ok" || facts.launchers.ingress.status !== "ok") {
@@ -765,12 +808,17 @@ function hookSetupActions(
       data: { setupRole: "hook" },
     });
   }
-  if (selectedHarness !== undefined && harnessSupportsHooks(selectedHarness.id)) {
+  for (const selectedHarness of selectedHarnesses) {
+    if (!harnessSupportsHooks(selectedHarness.id)) continue;
     actions.push({
       id: `${selectedHarness.id}-hooks`,
       kind: "run-command",
       tier: "recommended",
-      selected: options.installHarnessHooks === true,
+      selected: harnessHookSelected(
+        options.installHarnessHooks,
+        selectedHarness.id,
+        selectedHarnesses[0]?.id,
+      ),
       label: `Install ${selectedHarness.label} hooks`,
       message: `Install ${selectedHarness.label} hooks that report agent activity to STATION.`,
       command: harnessHookInstallCommand(facts, selectedHarness.id),
@@ -778,6 +826,16 @@ function hookSetupActions(
     });
   }
   return actions;
+}
+
+function harnessHookSelected(
+  selected: boolean | readonly SupportedHarnessId[] | undefined,
+  harness: SupportedHarnessId,
+  defaultHarness: SupportedHarnessId | undefined,
+): boolean {
+  return Array.isArray(selected)
+    ? selected.includes(harness)
+    : selected === true && harness === defaultHarness;
 }
 
 function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {
@@ -863,11 +921,11 @@ function configWriteActions(
     kind: "write-config",
     tier: "required",
     selected: true,
-    label: configWrite.operation === "create" ? "Write STATION config" : "Append STATION config",
+    label: configWrite.operation === "create" ? "Write STATION config" : "Update STATION config",
     message:
       configWrite.operation === "create"
         ? "Create the core STATION config; add your first project in STATION."
-        : "Append safe missing setup blocks to the existing STATION config.",
+        : "Update selected harness settings and append safe missing setup blocks.",
     path: configWrite.path,
     data: {
       operation: configWrite.operation,

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -11,8 +11,7 @@ export type SetupPromptChoice = {
 
 export type SetupPromptAdapter = {
   confirm(message: string): Promise<boolean>;
-  select(message: string, choices: readonly SetupPromptChoice[]): Promise<string>;
-  selectMany?(message: string, choices: readonly SetupPromptChoice[]): Promise<readonly string[]>;
+  selectMany(message: string, choices: readonly SetupPromptChoice[]): Promise<readonly string[]>;
   close?(): void | Promise<void>;
 };
 

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -12,6 +12,7 @@ export type SetupPromptChoice = {
 export type SetupPromptAdapter = {
   confirm(message: string): Promise<boolean>;
   select(message: string, choices: readonly SetupPromptChoice[]): Promise<string>;
+  selectMany?(message: string, choices: readonly SetupPromptChoice[]): Promise<readonly string[]>;
   close?(): void | Promise<void>;
 };
 

--- a/apps/cli/test/integration/first-project-default-branch.test.ts
+++ b/apps/cli/test/integration/first-project-default-branch.test.ts
@@ -239,12 +239,14 @@ async function withFreshConfig(
   try {
     await writeFile(
       configPath,
-      renderNewSetupConfig({
-        id: "codex",
-        label: "Codex",
-        status: "ok",
-        command: "codex",
-      }),
+      renderNewSetupConfig([
+        {
+          id: "codex",
+          label: "Codex",
+          status: "ok",
+          command: "codex",
+        },
+      ]),
       "utf8",
     );
     await run({ root, configPath, repo });

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -103,7 +103,7 @@ describe("CLI setup command", () => {
       checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
     };
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
-      selected: "codex",
+      default: "codex",
       enabled: "codex,opencode",
     });
     expect(plan.checks.find((check) => check.id === "harness-hooks")).toMatchObject({
@@ -149,13 +149,55 @@ describe("CLI setup command", () => {
       summary: { selectedHarness?: string };
       checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
     };
+    expect(result.code).toBe(0);
     expect(plan.summary.selectedHarness).toBe("codex");
     expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
       status: "ok",
       details: {
-        selected: "codex",
-        selectedStatus: "unavailable",
+        default: "codex",
+        defaultStatus: "unavailable",
         enabled: "codex,opencode",
+        available: "opencode",
+      },
+    });
+  });
+
+  it("does not count an unconfigured installed CLI as workflow ready", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const source = setupConfigToml(repo, { includeHarness: true });
+
+    const result = await runCli(["--config", configPath, "setup", "check", "--json"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "opencode --version": "opencode 1.0.0\n",
+        }),
+        access: readySetupAccess(),
+        fs: readOnlyFs({ [configPath]: source }),
+      },
+    });
+
+    const plan = result.output as {
+      summary: { requiredOk: boolean };
+      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+    };
+    expect(result.code).toBe(1);
+    expect(plan.summary.requiredOk).toBe(false);
+    expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
+      status: "missing",
+      details: {
+        default: "codex",
+        defaultStatus: "unavailable",
+        enabled: "codex",
         available: "opencode",
       },
     });

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -62,6 +62,105 @@ describe("CLI setup command", () => {
     expect(calls.map((call) => call.command)).not.toContain("gh");
   });
 
+  it("reports every configured harness and hook on a later setup check", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const source = setupConfigToml(repo, { includeHarness: true }).replace(
+      "[[projects]]",
+      [
+        "install_hooks = true",
+        "",
+        "[harness.opencode]",
+        "enabled = true",
+        'command = "opencode"',
+        "install_hooks = true",
+        "",
+        "[[projects]]",
+      ].join("\n"),
+    );
+
+    const result = await runCli(["--config", configPath, "setup", "check", "--json"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+          "opencode --version": "opencode 1.0.0\n",
+        }),
+        access: readySetupAccess(),
+        fs: readOnlyFs({ [configPath]: source }),
+      },
+    });
+
+    const plan = result.output as {
+      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+    };
+    expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
+      selected: "codex",
+      enabled: "codex,opencode",
+    });
+    expect(plan.checks.find((check) => check.id === "harness-hooks")).toMatchObject({
+      status: "ok",
+      details: { harnesses: "codex,opencode" },
+    });
+  });
+
+  it("keeps the persisted default visible when only a secondary configured CLI is available", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const source = setupConfigToml(repo, { includeHarness: true }).replace(
+      "[[projects]]",
+      ["[harness.opencode]", "enabled = true", 'command = "opencode"', "", "[[projects]]"].join(
+        "\n",
+      ),
+    );
+
+    const result = await runCli(["--config", configPath, "setup", "check", "--json"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: {
+          PATH: "/fake/bin",
+          STATION_CODEX_BIN: "/missing/codex",
+          STATION_OPENCODE_BIN: "opencode",
+        },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "opencode --version": "opencode 1.0.0\n",
+        }),
+        access: readySetupAccess(),
+        fs: readOnlyFs({ [configPath]: source }),
+      },
+    });
+
+    const plan = result.output as {
+      summary: { selectedHarness?: string };
+      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+    };
+    expect(plan.summary.selectedHarness).toBe("codex");
+    expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
+      status: "ok",
+      details: {
+        selected: "codex",
+        selectedStatus: "unavailable",
+        enabled: "codex,opencode",
+        available: "opencode",
+      },
+    });
+  });
+
   it("reports compiled launch readiness independently from workflow readiness", async () => {
     const root = await tempRoot(tempRoots);
     const result = await runCli(["setup", "check", "--json"], {

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -491,6 +491,113 @@ describe("setup dependency checks", () => {
     expect(plan.summary.selectedHarness).toBe("cursor");
   });
 
+  it.each([
+    {
+      name: "does not substitute a global binary for a missing configured command",
+      configuredCommand: "/missing/opencode",
+      outputs: { "opencode --version": "opencode 1.0.0\n" },
+      expectedStatus: "missing" as const,
+    },
+    {
+      name: "detects a configured custom command when the global binary is missing",
+      configuredCommand: "/custom/opencode",
+      outputs: { "/custom/opencode --version": "opencode 1.0.0\n" },
+      expectedStatus: "ok" as const,
+    },
+  ])("$name", async ({ configuredCommand, outputs, expectedStatus }) => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const config = [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[defaults]",
+      'worktree_provider = "worktrunk"',
+      'terminal = "tmux"',
+      'harness = "codex"',
+      'layout = "agent-shell"',
+      "",
+      "[harness.opencode]",
+      "enabled = true",
+      `command = ${JSON.stringify(configuredCommand)}`,
+      "",
+    ].join("\n");
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: join(root, "home"),
+      configPath,
+      compiled: true,
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner(calls, {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+        ...outputs,
+      }),
+      access: fakeAccess([]),
+      fs: readOnlyFs({ [configPath]: config }),
+    });
+
+    expect(facts.harnesses.find((harness) => harness.id === "opencode")).toMatchObject({
+      status: expectedStatus,
+      command: configuredCommand,
+    });
+    expect(calls.some((call) => call.command === "opencode")).toBe(false);
+  });
+
+  it.each([
+    { name: "an implicit built-in command", harnessBlock: [] },
+    {
+      name: "an explicit bare command",
+      harnessBlock: ["[harness.cursor]", "enabled = true", 'command = "agent"', ""],
+    },
+  ])("probes $name exactly as runtime will execute it", async ({ harnessBlock }) => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const config = [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[defaults]",
+      'worktree_provider = "worktrunk"',
+      'terminal = "tmux"',
+      'harness = "cursor"',
+      'layout = "agent-shell"',
+      "",
+      ...harnessBlock,
+    ].join("\n");
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: home,
+      configPath,
+      compiled: true,
+      env: { PATH: "/fake/bin" },
+      runner: fakeRunner(calls, {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+        [`${home}/.local/bin/agent --version`]: "cursor-agent 1.0.0\n",
+      }),
+      access: fakeAccess([]),
+      fs: readOnlyFs({ [configPath]: config }),
+    });
+
+    expect(facts.harnesses.find((harness) => harness.id === "cursor")).toMatchObject({
+      status: "missing",
+      command: "agent",
+    });
+    expect(calls.some((call) => call.command === `${home}/.local/bin/agent`)).toBe(false);
+  });
+
   it("ignores Crush when choosing a supported harness", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -97,7 +97,7 @@ describe("setup config writer", () => {
 
     const write = await planSetupConfigWrite(facts, {
       installWorktrunkHooks: true,
-      installHarnessHooks: true,
+      installHarnessHooks: ["codex"],
     });
 
     expect(write.operation).toBe("create");
@@ -112,8 +112,6 @@ describe("setup config writer", () => {
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
     const facts = setupFacts(repo, {
-      selectedHarness: "codex",
-      selectedHarnesses: ["codex", "opencode"],
       harnesses: [
         { id: "codex", label: "Codex", status: "ok", command: "codex" },
         { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
@@ -126,6 +124,10 @@ describe("setup config writer", () => {
     });
 
     const write = await planSetupConfigWrite(facts, {
+      harnessSelection: {
+        defaultHarness: "codex",
+        selected: facts.harnesses,
+      },
       installHarnessHooks: ["codex"],
     });
 
@@ -167,14 +169,14 @@ describe("setup config writer", () => {
     const write = await planSetupConfigWrite(facts);
 
     expect(write).toMatchObject({
-      operation: "append",
+      operation: "update",
       path: join(root, "config.toml"),
     });
-    if (write.operation !== "append") throw new Error("expected append plan");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content.startsWith(source.trimEnd())).toBe(true);
-    expect(write.appendedText).toContain("[harness.codex]");
-    expect(write.appendedText).not.toContain("[[projects]]");
-    expect(write.appendedText).not.toContain("[defaults]");
+    expect(write.content).toContain("[harness.codex]");
+    expect(write.content.match(/\[\[projects\]\]/g)).toHaveLength(1);
+    expect(write.content.match(/\[defaults\]/g)).toHaveLength(1);
   });
 
   it("creates a zero-project config when setup is run outside a repository", async () => {
@@ -291,8 +293,6 @@ describe("setup config writer", () => {
       'command = "codex"\ninstall_hooks = false # enable during setup\n',
     );
     const facts = setupFacts(repo, {
-      selectedHarness: "codex",
-      selectedHarnesses: ["codex", "opencode"],
       harnesses: [
         { id: "codex", label: "Codex", status: "ok", command: "codex" },
         { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
@@ -314,18 +314,20 @@ describe("setup config writer", () => {
     });
 
     const write = await planSetupConfigWrite(facts, {
+      harnessSelection: {
+        defaultHarness: "codex",
+        selected: facts.harnesses,
+      },
       installHarnessHooks: ["codex", "opencode"],
     });
 
-    expect(write.operation).toBe("append");
-    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.operation).toBe("update");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
     expect(write.content.match(/\[harness\.opencode\]/g)).toHaveLength(1);
     expect(write.content.match(/install_hooks = true/g)).toHaveLength(2);
     expect(write.content).toContain("install_hooks = true # enable during setup");
     expect(write.content).not.toContain("install_hooks = false # enable during setup");
-    expect(write.appendedText).toContain("[harness.opencode]");
-    expect(write.appendedText).toContain("install_hooks = true");
     expect(write.content).toContain(
       '[defaults]\nworktree_provider = "worktrunk"\nterminal = "tmux"\nharness = "codex"',
     );
@@ -347,7 +349,13 @@ describe("setup config writer", () => {
             configuredHookHarnesses: ["codex", "opencode"],
           },
         },
-        { installHarnessHooks: ["opencode"] },
+        {
+          harnessSelection: {
+            defaultHarness: "codex",
+            selected: facts.harnesses,
+          },
+          installHarnessHooks: ["opencode"],
+        },
       ),
     ).resolves.toEqual({
       operation: "none",
@@ -362,8 +370,6 @@ describe("setup config writer", () => {
     const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true });
     const write = await planSetupConfigWrite(
       setupFacts(repo, {
-        selectedHarness: "pi",
-        selectedHarnesses: ["pi"],
         harnesses: [
           { id: "codex", label: "Codex", status: "ok", command: "codex" },
           { id: "pi", label: "Pi", status: "ok", command: "pi" },
@@ -382,10 +388,16 @@ describe("setup config writer", () => {
           },
         },
       }),
+      {
+        harnessSelection: {
+          defaultHarness: "codex",
+          selected: [{ id: "pi", label: "Pi", status: "ok", command: "pi" }],
+        },
+      },
     );
 
-    expect(write.operation).toBe("append");
-    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.operation).toBe("update");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content).toContain('harness = "codex"');
     expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
     expect(write.content.match(/\[harness\.pi\]/g)).toHaveLength(1);
@@ -397,8 +409,6 @@ describe("setup config writer", () => {
     await mkdir(repo, { recursive: true });
     const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true });
     const facts = setupFacts(repo, {
-      selectedHarness: "pi",
-      selectedHarnesses: ["pi"],
       harnesses: [
         { id: "codex", label: "Codex", status: "missing", command: "codex" },
         { id: "pi", label: "Pi", status: "ok", command: "pi" },
@@ -418,10 +428,15 @@ describe("setup config writer", () => {
       },
     });
 
-    const write = await planSetupConfigWrite(facts);
+    const write = await planSetupConfigWrite(facts, {
+      harnessSelection: {
+        defaultHarness: "codex",
+        selected: [{ id: "pi", label: "Pi", status: "ok", command: "pi" }],
+      },
+    });
 
-    expect(write.operation).toBe("append");
-    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.operation).toBe("update");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content.startsWith(source.trimEnd())).toBe(true);
     expect(write.content).toContain('harness = "codex"');
     expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
@@ -450,8 +465,6 @@ describe("setup config writer", () => {
       "",
     ].join("\n");
     const facts = setupFacts(repo, {
-      selectedHarness: "codex",
-      selectedHarnesses: ["codex", "opencode"],
       harnesses: [
         { id: "codex", label: "Codex", status: "ok", command: "codex" },
         { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
@@ -473,19 +486,21 @@ describe("setup config writer", () => {
     });
 
     const write = await planSetupConfigWrite(facts, {
+      harnessSelection: {
+        defaultHarness: "codex",
+        selected: facts.harnesses,
+      },
       installHarnessHooks: ["codex", "opencode"],
     });
 
-    expect(write.operation).toBe("append");
-    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.operation).toBe("update");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content.match(/\["harness"\."codex"\]/g)).toHaveLength(1);
     expect(write.content).toContain(
       '["harness"."codex"]\ninstall_hooks = true\nenabled = true\ncommand = """codex\n[harness.opencode]\ninstall_hooks = false"""',
     );
     expect(write.content.match(/install_hooks = true/g)).toHaveLength(2);
     expect(write.content.match(/install_hooks = false/g)).toHaveLength(1);
-    expect(write.appendedText).toContain("[harness.opencode]");
-    expect(write.appendedText).toContain("install_hooks = true");
     await expect(
       loadConfigFromToml(write.content, { configPath: write.path, homeDir: root }),
     ).resolves.toBeDefined();
@@ -515,9 +530,8 @@ describe("setup config writer", () => {
 
     const write = await planSetupConfigWrite(facts, { installHarnessHooks: ["codex"] });
 
-    expect(write.operation).toBe("append");
-    if (write.operation !== "append") throw new Error("expected append plan");
-    expect(write.appendedText).toBe("");
+    expect(write.operation).toBe("update");
+    if (write.operation !== "update") throw new Error("expected update plan");
     expect(write.content).toContain(
       '[harness.codex]\ninstall_hooks = true\nenabled = true\ncommand = "codex"',
     );

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -107,6 +107,40 @@ describe("setup config writer", () => {
     expect(write.content).toContain("install_hooks = true");
   });
 
+  it("writes every selected harness while preserving the first as the default", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const facts = setupFacts(repo, {
+      selectedHarness: "codex",
+      selectedHarnesses: ["codex", "opencode"],
+      harnesses: [
+        { id: "codex", label: "Codex", status: "ok", command: "codex" },
+        { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
+      ],
+      config: {
+        status: "missing",
+        path: join(root, "config.toml"),
+        message: "missing",
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts, {
+      installHarnessHooks: ["codex"],
+    });
+
+    expect(write.operation).toBe("create");
+    if (write.operation !== "create") throw new Error("expected create plan");
+    const loaded = await loadConfigFromToml(write.content, {
+      configPath: write.path,
+      homeDir: root,
+    });
+    expect(loaded.config.defaults.harness).toBe("codex");
+    expect(Object.keys(loaded.config.harness ?? {})).toEqual(["codex", "opencode"]);
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+    expect(loaded.config.harness?.opencode?.installHooks).toBeUndefined();
+  });
+
   it("appends only a missing harness block to a valid existing config", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
@@ -245,6 +279,252 @@ describe("setup config writer", () => {
     await expect(planSetupConfigWrite(facts)).resolves.toEqual({
       operation: "none",
       reason: "Config already includes the selected harness and core defaults.",
+    });
+  });
+
+  it("enables hooks in an existing harness while appending another hook-enabled provider", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true }).replace(
+      'command = "codex"\n',
+      'command = "codex"\ninstall_hooks = false # enable during setup\n',
+    );
+    const facts = setupFacts(repo, {
+      selectedHarness: "codex",
+      selectedHarnesses: ["codex", "opencode"],
+      harnesses: [
+        { id: "codex", label: "Codex", status: "ok", command: "codex" },
+        { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
+      ],
+      config: {
+        status: "valid",
+        path: join(root, "config.toml"),
+        source,
+        observerStateDir: join(root, "state"),
+        hasProjectForRoot: false,
+        configuredHarnesses: ["codex"],
+        configuredHookHarnesses: [],
+        defaults: {
+          worktreeProvider: "worktrunk",
+          terminal: "tmux",
+          harness: "codex",
+        },
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts, {
+      installHarnessHooks: ["codex", "opencode"],
+    });
+
+    expect(write.operation).toBe("append");
+    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
+    expect(write.content.match(/\[harness\.opencode\]/g)).toHaveLength(1);
+    expect(write.content.match(/install_hooks = true/g)).toHaveLength(2);
+    expect(write.content).toContain("install_hooks = true # enable during setup");
+    expect(write.content).not.toContain("install_hooks = false # enable during setup");
+    expect(write.appendedText).toContain("[harness.opencode]");
+    expect(write.appendedText).toContain("install_hooks = true");
+    expect(write.content).toContain(
+      '[defaults]\nworktree_provider = "worktrunk"\nterminal = "tmux"\nharness = "codex"',
+    );
+    const loaded = await loadConfigFromToml(write.content, {
+      configPath: write.path,
+      homeDir: root,
+    });
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+    expect(loaded.config.harness?.opencode?.installHooks).toBe(true);
+
+    await expect(
+      planSetupConfigWrite(
+        {
+          ...facts,
+          config: {
+            ...facts.config,
+            source: write.content,
+            configuredHarnesses: ["codex", "opencode"],
+            configuredHookHarnesses: ["codex", "opencode"],
+          },
+        },
+        { installHarnessHooks: ["opencode"] },
+      ),
+    ).resolves.toEqual({
+      operation: "none",
+      reason: "Config already includes the selected harnesses and core defaults.",
+    });
+  });
+
+  it("preserves an existing available default that was not selected", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true });
+    const write = await planSetupConfigWrite(
+      setupFacts(repo, {
+        selectedHarness: "pi",
+        selectedHarnesses: ["pi"],
+        harnesses: [
+          { id: "codex", label: "Codex", status: "ok", command: "codex" },
+          { id: "pi", label: "Pi", status: "ok", command: "pi" },
+        ],
+        config: {
+          status: "valid",
+          path: join(root, "config.toml"),
+          source,
+          hasProjectForRoot: false,
+          configuredHarnesses: ["codex"],
+          configuredHookHarnesses: [],
+          defaults: {
+            worktreeProvider: "worktrunk",
+            terminal: "tmux",
+            harness: "codex",
+          },
+        },
+      }),
+    );
+
+    expect(write.operation).toBe("append");
+    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.content).toContain('harness = "codex"');
+    expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
+    expect(write.content.match(/\[harness\.pi\]/g)).toHaveLength(1);
+  });
+
+  it("preserves an unavailable existing default while appending an available provider", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true });
+    const facts = setupFacts(repo, {
+      selectedHarness: "pi",
+      selectedHarnesses: ["pi"],
+      harnesses: [
+        { id: "codex", label: "Codex", status: "missing", command: "codex" },
+        { id: "pi", label: "Pi", status: "ok", command: "pi" },
+      ],
+      config: {
+        status: "valid",
+        path: join(root, "config.toml"),
+        source,
+        hasProjectForRoot: false,
+        configuredHarnesses: ["codex"],
+        configuredHookHarnesses: [],
+        defaults: {
+          worktreeProvider: "worktrunk",
+          terminal: "tmux",
+          harness: "codex",
+        },
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts);
+
+    expect(write.operation).toBe("append");
+    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.content.startsWith(source.trimEnd())).toBe(true);
+    expect(write.content).toContain('harness = "codex"');
+    expect(write.content.match(/\[harness\.codex\]/g)).toHaveLength(1);
+    expect(write.content.match(/\[harness\.pi\]/g)).toHaveLength(1);
+  });
+
+  it("updates a quoted table while ignoring fake tables in multiline TOML strings", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const source = [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[defaults]",
+      'worktree_provider = "worktrunk"',
+      'terminal = "tmux"',
+      "harness = 'codex'",
+      'layout = "agent-shell"',
+      "",
+      '["harness"."codex"]',
+      "enabled = true",
+      'command = """codex',
+      "[harness.opencode]",
+      'install_hooks = false"""',
+      "",
+    ].join("\n");
+    const facts = setupFacts(repo, {
+      selectedHarness: "codex",
+      selectedHarnesses: ["codex", "opencode"],
+      harnesses: [
+        { id: "codex", label: "Codex", status: "ok", command: "codex" },
+        { id: "opencode", label: "OpenCode", status: "ok", command: "opencode" },
+      ],
+      config: {
+        status: "valid",
+        path: join(root, "config.toml"),
+        source,
+        observerStateDir: join(root, "state"),
+        hasProjectForRoot: false,
+        configuredHarnesses: ["codex"],
+        configuredHookHarnesses: [],
+        defaults: {
+          worktreeProvider: "worktrunk",
+          terminal: "tmux",
+          harness: "codex",
+        },
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts, {
+      installHarnessHooks: ["codex", "opencode"],
+    });
+
+    expect(write.operation).toBe("append");
+    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.content.match(/\["harness"\."codex"\]/g)).toHaveLength(1);
+    expect(write.content).toContain(
+      '["harness"."codex"]\ninstall_hooks = true\nenabled = true\ncommand = """codex\n[harness.opencode]\ninstall_hooks = false"""',
+    );
+    expect(write.content.match(/install_hooks = true/g)).toHaveLength(2);
+    expect(write.content.match(/install_hooks = false/g)).toHaveLength(1);
+    expect(write.appendedText).toContain("[harness.opencode]");
+    expect(write.appendedText).toContain("install_hooks = true");
+    await expect(
+      loadConfigFromToml(write.content, { configPath: write.path, homeDir: root }),
+    ).resolves.toBeDefined();
+  });
+
+  it("adds hook intent to an existing harness block", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const source = existingConfigToml(root, { projectRoot: repo, includeHarness: true });
+    const facts = setupFacts(repo, {
+      config: {
+        status: "valid",
+        path: join(root, "config.toml"),
+        source,
+        observerStateDir: join(root, "state"),
+        hasProjectForRoot: false,
+        configuredHarnesses: ["codex"],
+        configuredHookHarnesses: [],
+        defaults: {
+          worktreeProvider: "worktrunk",
+          terminal: "tmux",
+          harness: "codex",
+        },
+      },
+    });
+
+    const write = await planSetupConfigWrite(facts, { installHarnessHooks: ["codex"] });
+
+    expect(write.operation).toBe("append");
+    if (write.operation !== "append") throw new Error("expected append plan");
+    expect(write.appendedText).toBe("");
+    expect(write.content).toContain(
+      '[harness.codex]\ninstall_hooks = true\nenabled = true\ncommand = "codex"',
+    );
+    await expect(
+      loadConfigFromToml(write.content, { configPath: write.path, homeDir: root }),
+    ).resolves.toMatchObject({
+      config: { harness: { codex: { installHooks: true } } },
     });
   });
 

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -321,6 +321,155 @@ describe("guided setup command", () => {
     expect(fs.files[configPath]).toBe(configuredProjectToml(repo));
   });
 
+  it("enables and installs hooks for an already-configured harness", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [configPath]: configuredProjectToml(repo) });
+    const calls: ExternalCommandInput[] = [];
+    let activations = 0;
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+          [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]:
+            "",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
+        ]),
+        fs,
+        activateObserverConfig: async () => {
+          activations += 1;
+        },
+        prompt: {
+          async confirm(message) {
+            return (
+              message.includes("Codex agent hooks") || message.includes("Write core STATION config")
+            );
+          },
+          async select() {
+            return "codex";
+          },
+        },
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(activations).toBe(1);
+    expect(fs.files[configPath]).toContain(
+      '[harness.codex]\ninstall_hooks = true\nenabled = true\ncommand = "codex"',
+    );
+    expect(calls).toContainEqual(
+      expect.objectContaining({
+        command: "/fake/bin/stn",
+        args: [
+          "--config",
+          configPath,
+          "hooks",
+          "install",
+          "codex",
+          "--yes",
+          "--hook-bin",
+          "/fake/bin/stn-ingress",
+        ],
+      }),
+    );
+  });
+
+  it("scopes hook prompts and actions to current selections while preserving the configured default", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [configPath]: configuredProjectToml(repo) });
+    const calls: ExternalCommandInput[] = [];
+    const prompts: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+          "opencode --version": "opencode 1.0.0\n",
+          [`stn --config ${configPath} hooks install opencode --yes`]: "",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: {
+          async confirm(message) {
+            prompts.push(message);
+            return (
+              message.includes("OpenCode agent hooks") ||
+              message.includes("Write core STATION config")
+            );
+          },
+          async select() {
+            return "opencode";
+          },
+          async selectMany() {
+            return ["opencode"];
+          },
+        },
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(prompts).toContain("Install OpenCode agent hooks?");
+    expect(prompts).not.toContain("Install Codex agent hooks?");
+    expect(
+      calls
+        .filter((call) => call.command === "/fake/bin/stn" && call.args?.[2] === "hooks")
+        .map((call) => call.args?.[4]),
+    ).toEqual(["opencode"]);
+    expect(fs.files[configPath].match(/^harness = "codex"$/gm)).toHaveLength(1);
+    expect(fs.files[configPath].match(/^\[harness\.codex\]$/gm)).toHaveLength(1);
+    expect(fs.files[configPath].match(/^\[harness\.opencode\]$/gm)).toHaveLength(1);
+    expect(fs.files[configPath]).toContain(
+      '[harness.opencode]\nenabled = true\ncommand = "opencode"\ninstall_hooks = true',
+    );
+  });
+
   it("does not activate when the config write fails", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
@@ -404,7 +553,7 @@ describe("guided setup command", () => {
     expect(output).not.toContain("Core setup complete.");
   });
 
-  it("selects among multiple available harnesses", async () => {
+  it("writes every selected harness and keeps the first as the new-config default", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     await mkdir(repo, { recursive: true });
@@ -434,14 +583,18 @@ describe("guided setup command", () => {
         ]),
         fs,
         activateObserverConfig: noopActivateObserverConfig,
-        prompt: prompt({ confirms: [false, false, true, false, false], selects: ["opencode"] }),
+        prompt: prompt({
+          confirms: [false, false, false, true, false, false],
+          multiSelects: [["opencode", "codex"]],
+        }),
         writeStdout: () => undefined,
       },
     );
 
-    expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain(
-      "[harness.opencode]",
-    );
+    const config = fs.files[join(root, "home/.config/station/config.toml")];
+    expect(config).toContain('harness = "opencode"');
+    expect(config).toContain("[harness.opencode]");
+    expect(config).toContain("[harness.codex]");
   });
 
   it("installs the optional tmux popup binding when accepted", async () => {
@@ -647,8 +800,10 @@ describe("guided setup command", () => {
       "wt --version": "worktrunk 1.2.3\n",
       "tmux -V": "tmux 3.5a\n",
       "codex --version": "codex 0.1.0\n",
+      "opencode --version": "opencode 1.0.0\n",
       [`stn --config ${configPath} hooks install worktrunk --yes`]: "",
       [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]: "",
+      [`stn --config ${configPath} hooks install opencode --yes`]: "",
     });
 
     const result = await runSetupCommand(
@@ -679,15 +834,18 @@ describe("guided setup command", () => {
         activateObserverConfig: async () => {
           order.push("activate");
         },
-        prompt: prompt({ confirms: [true, true, true, false, false] }),
+        prompt: prompt({
+          confirms: [true, true, true, true, false, false],
+          multiSelects: [["codex", "opencode"]],
+        }),
         writeStdout: () => undefined,
       },
     );
 
     expect(result.code).toBe(0);
-    expect(order).toEqual(["hook:worktrunk", "hook:codex", "activate"]);
+    expect(order).toEqual(["hook:worktrunk", "hook:codex", "hook:opencode", "activate"]);
     expect(fs.files[configPath]).toContain("use_lifecycle_hooks = true");
-    expect(fs.files[configPath]).toContain("install_hooks = true");
+    expect(fs.files[configPath].match(/install_hooks = true/g)).toHaveLength(2);
     expect(calls).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -707,6 +865,11 @@ describe("guided setup command", () => {
             "--hook-bin",
             "/fake/bin/stn-ingress",
           ],
+          stdio: "inherit",
+        }),
+        expect.objectContaining({
+          command: "/fake/bin/stn",
+          args: ["--config", configPath, "hooks", "install", "opencode", "--yes"],
           stdio: "inherit",
         }),
       ]),
@@ -764,6 +927,86 @@ describe("guided setup command", () => {
     expect(output).toContain("Hook install failed.");
     expect(output).toContain("Observer configuration active.");
     expect(output).not.toContain("Core setup complete.");
+  });
+
+  it("continues after one agent hook fails and retries enabled hooks on the next run", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    const calls: ExternalCommandInput[] = [];
+    let codexHookAttempts = 0;
+    const baseRunner = fakeRunner(calls, {
+      "git rev-parse --show-toplevel": repo,
+      "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      "wt --version": "worktrunk 1.2.3\n",
+      "tmux -V": "tmux 3.5a\n",
+      "codex --version": "codex 0.1.0\n",
+      "opencode --version": "opencode 1.0.0\n",
+      [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]: "",
+      [`stn --config ${configPath} hooks install opencode --yes`]: "",
+    });
+    const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
+      if (input.command === "/fake/bin/stn" && input.args?.[4] === "codex") {
+        calls.push(input);
+        codexHookAttempts += 1;
+        if (codexHookAttempts === 1) {
+          throw new Error("synthetic Codex hook failure");
+        }
+        return commandResult(input, "");
+      }
+      return baseRunner(input);
+    };
+    const promptAdapter: SetupPromptAdapter = {
+      async confirm(message) {
+        return (
+          message.includes("Codex agent hooks") ||
+          message.includes("OpenCode agent hooks") ||
+          message.includes("Write core STATION config")
+        );
+      },
+      async select() {
+        return "codex";
+      },
+      async selectMany() {
+        return ["codex", "opencode"];
+      },
+    };
+    const deps = {
+      cwd: repo,
+      homeDir,
+      env: { PATH: "/fake/bin" },
+      runner,
+      access: fakeAccess([
+        "/fake/bin/wt",
+        "/fake/bin/tmux",
+        "/fake/bin/bun",
+        "/fake/bin/diffnav",
+        "/fake/bin/delta",
+        "/fake/bin/stn",
+        "/fake/bin/stn-ingress",
+        "/fake/bin/stn-tmux-popup",
+      ]),
+      fs,
+      activateObserverConfig: noopActivateObserverConfig,
+      prompt: promptAdapter,
+      writeStdout: () => undefined,
+    };
+
+    const first = await runSetupCommand([], {}, deps);
+    const second = await runSetupCommand([], {}, deps);
+
+    expect(first.code).toBe(1);
+    expect(second.code).toBe(0);
+    expect(fs.files[configPath].match(/install_hooks = true/g)).toHaveLength(2);
+    expect(
+      calls.filter((call) => call.command === "/fake/bin/stn" && call.args?.[4] === "codex"),
+    ).toHaveLength(2);
+    expect(
+      calls.filter((call) => call.command === "/fake/bin/stn" && call.args?.[4] === "opencode"),
+    ).toHaveLength(2);
   });
 
   it("installs a selected agent CLI when no harness is available, then continues", async () => {
@@ -1260,15 +1503,23 @@ async function tempRoot(tempRoots: string[]): Promise<string> {
   return root;
 }
 
-function prompt(input: { confirms: boolean[]; selects?: string[] }): SetupPromptAdapter {
+function prompt(input: {
+  confirms: boolean[];
+  selects?: string[];
+  multiSelects?: string[][];
+}): SetupPromptAdapter {
   const confirms = [...input.confirms];
   const selects = [...(input.selects ?? [])];
+  const multiSelects = [...(input.multiSelects ?? [])];
   return {
     async confirm() {
       return confirms.shift() ?? false;
     },
     async select() {
       return selects.shift() ?? "codex";
+    },
+    async selectMany() {
+      return multiSelects.shift() ?? [selects.shift() ?? "codex"];
     },
   };
 }

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -118,8 +118,8 @@ describe("guided setup command", () => {
               message.includes("Install or load tmux popup binding")
             );
           },
-          async select() {
-            return "codex";
+          async selectMany() {
+            return ["codex"];
           },
         },
         writeStdout: (chunk) => {
@@ -138,6 +138,181 @@ describe("guided setup command", () => {
     );
     expect(chunks.join("")).toContain(`Direct fallback: ${join(packageRoot, "bin/stn")} popup`);
     expect(fs.files[join(root, "home/.config/station/config.toml")]).toContain("projects = []");
+  });
+
+  it("preserves every selected harness after linking checkout launchers", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({});
+    const packageRoot = setupPackageRoot();
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+          "opencode --version": "opencode 1.0.0\n",
+          [`pnpm --dir ${packageRoot} station:link`]: "",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          join(packageRoot, "bin/stn"),
+          join(packageRoot, "bin/stn-ingress"),
+          join(packageRoot, "integrations/terminal/tmux/bin/stn-popup"),
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: {
+          async confirm(message) {
+            return (
+              message.includes("Link STATION launchers") ||
+              message.includes("Write core STATION config")
+            );
+          },
+          async selectMany() {
+            return ["codex", "opencode"];
+          },
+        },
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(calls.find((call) => call.command === "pnpm")).toMatchObject({
+      args: ["--dir", packageRoot, "station:link"],
+      stdio: "inherit",
+    });
+    expect(fs.files[configPath].match(/^\[harness\.(codex|opencode)\]$/gm)).toHaveLength(2);
+  });
+
+  it("does not silently drop a selected harness after linking checkout launchers", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({});
+    const packageRoot = setupPackageRoot();
+    let codexProbes = 0;
+    const baseRunner = fakeRunner(calls, {
+      "git rev-parse --show-toplevel": repo,
+      "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+      "wt --version": "worktrunk 1.2.3\n",
+      "tmux -V": "tmux 3.5a\n",
+      "opencode --version": "opencode 1.0.0\n",
+      [`pnpm --dir ${packageRoot} station:link`]: "",
+    });
+    const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
+      if (input.command === "codex" && input.args?.[0] === "--version") {
+        calls.push(input);
+        codexProbes += 1;
+        if (codexProbes === 1) return commandResult(input, "codex 0.1.0\n");
+        throw Object.assign(new Error("Codex disappeared"), { code: "ENOENT" });
+      }
+      return baseRunner(input);
+    };
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner,
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          join(packageRoot, "bin/stn"),
+          join(packageRoot, "bin/stn-ingress"),
+          join(packageRoot, "integrations/terminal/tmux/bin/stn-popup"),
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: {
+          async confirm(message) {
+            return message.includes("Link STATION launchers");
+          },
+          async selectMany() {
+            return ["codex", "opencode"];
+          },
+        },
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(1);
+    expect(codexProbes).toBe(2);
+    expect(fs.files[configPath]).toBeUndefined();
+  });
+
+  it("adds an available harness while preserving an unavailable existing default", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({ [configPath]: configuredProjectToml(repo) });
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "pi --version": "pi 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: {
+          async confirm(message) {
+            return message.includes("Write core STATION config");
+          },
+          async selectMany() {
+            return ["pi"];
+          },
+        },
+        writeStdout: () => undefined,
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(fs.files[configPath]).toContain('harness = "codex"');
+    expect(fs.files[configPath].match(/^\[harness\.(codex|pi)\]$/gm)).toHaveLength(2);
   });
 
   it("runs Worktrunk shell integration non-interactively after the STATION prompt", async () => {
@@ -367,8 +542,8 @@ describe("guided setup command", () => {
               message.includes("Codex agent hooks") || message.includes("Write core STATION config")
             );
           },
-          async select() {
-            return "codex";
+          async selectMany() {
+            return ["codex"];
           },
         },
         writeStdout: () => undefined,
@@ -442,9 +617,6 @@ describe("guided setup command", () => {
               message.includes("OpenCode agent hooks") ||
               message.includes("Write core STATION config")
             );
-          },
-          async select() {
-            return "opencode";
           },
           async selectMany() {
             return ["opencode"];
@@ -967,9 +1139,6 @@ describe("guided setup command", () => {
           message.includes("Write core STATION config")
         );
       },
-      async select() {
-        return "codex";
-      },
       async selectMany() {
         return ["codex", "opencode"];
       },
@@ -1060,8 +1229,8 @@ describe("guided setup command", () => {
               message.includes("Install Codex?") || message.includes("Write core STATION config")
             );
           },
-          async select() {
-            return "codex";
+          async selectMany() {
+            return ["codex"];
           },
         },
         writeStdout: (chunk) => {
@@ -1357,8 +1526,8 @@ describe("guided setup command", () => {
               message.includes("Write core STATION config")
             );
           },
-          async select() {
-            return "codex";
+          async selectMany() {
+            return ["codex"];
           },
         },
         writeStdout: () => undefined,
@@ -1481,8 +1650,8 @@ describe("guided setup command", () => {
               message.includes("Write core STATION config")
             );
           },
-          async select() {
-            return "codex";
+          async selectMany() {
+            return ["codex"];
           },
         },
         writeStdout: () => undefined,
@@ -1503,23 +1672,15 @@ async function tempRoot(tempRoots: string[]): Promise<string> {
   return root;
 }
 
-function prompt(input: {
-  confirms: boolean[];
-  selects?: string[];
-  multiSelects?: string[][];
-}): SetupPromptAdapter {
+function prompt(input: { confirms: boolean[]; multiSelects?: string[][] }): SetupPromptAdapter {
   const confirms = [...input.confirms];
-  const selects = [...(input.selects ?? [])];
   const multiSelects = [...(input.multiSelects ?? [])];
   return {
     async confirm() {
       return confirms.shift() ?? false;
     },
-    async select() {
-      return selects.shift() ?? "codex";
-    },
     async selectMany() {
-      return multiSelects.shift() ?? [selects.shift() ?? "codex"];
+      return multiSelects.shift() ?? ["codex"];
     },
   };
 }

--- a/apps/cli/test/unit/setup-io.test.ts
+++ b/apps/cli/test/unit/setup-io.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseMultiSelectAnswer } from "../../src/commands/setup/io.js";
+
+describe("setup prompt input", () => {
+  const choices = [
+    { value: "codex", label: "Codex" },
+    { value: "opencode", label: "OpenCode" },
+    { value: "pi", label: "Pi" },
+  ];
+
+  it("preserves comma-separated selection order while ignoring duplicates and invalid slots", () => {
+    expect(parseMultiSelectAnswer("3, 1,3,99,nope", choices)).toEqual(["pi", "codex"]);
+  });
+
+  it("falls back to the first choice when no valid slot was selected", () => {
+    expect(parseMultiSelectAnswer("", choices)).toEqual(["codex"]);
+    expect(parseMultiSelectAnswer("99", choices)).toEqual(["codex"]);
+  });
+});

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -210,6 +210,11 @@ describe("setup planner", () => {
     const plan = buildSetupPlan(
       facts({
         harnesses: harnesses(["cursor", "opencode", "pi"]),
+        config: {
+          status: "missing",
+          path: "/tmp/config.toml",
+          message: "Config missing.",
+        },
       }),
     );
 
@@ -221,6 +226,11 @@ describe("setup planner", () => {
       facts({
         selectedHarness: "opencode",
         harnesses: harnesses(["codex", "opencode"]),
+        config: {
+          status: "missing",
+          path: "/tmp/config.toml",
+          message: "Config missing.",
+        },
       }),
     );
 
@@ -228,6 +238,116 @@ describe("setup planner", () => {
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
       selected: "opencode",
     });
+  });
+
+  it("keeps the first selected harness as default while planning each supported hook", () => {
+    const plan = buildSetupPlan(
+      facts({
+        selectedHarness: "codex",
+        selectedHarnesses: ["codex", "opencode", "pi"],
+        harnesses: harnesses(["codex", "opencode", "pi"]),
+      }),
+      { installHarnessHooks: ["codex", "opencode"] },
+    );
+
+    expect(plan.summary.selectedHarness).toBe("codex");
+    expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
+      selected: "codex",
+      enabled: "codex,opencode,pi",
+    });
+    expect(
+      plan.actions
+        .filter((action) => action.data?.setupRole === "hook" && action.data.harness !== undefined)
+        .map((action) => [action.id, action.selected]),
+    ).toEqual([
+      ["codex-hooks", true],
+      ["opencode-hooks", true],
+    ]);
+    expect(plan.actions.some((action) => action.id === "pi-hooks")).toBe(false);
+  });
+
+  it("derives every configured harness and hook after setup selection facts are gone", () => {
+    const plan = buildSetupPlan(
+      facts({
+        harnesses: harnesses(["codex", "opencode", "pi"]),
+        config: validConfigFact({
+          configuredHarnesses: ["codex", "opencode", "pi"],
+          configuredHookHarnesses: ["codex", "opencode"],
+        }),
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
+      selected: "codex",
+      enabled: "codex,opencode,pi",
+    });
+    expect(plan.checks.find((check) => check.id === "harness-hooks")).toMatchObject({
+      status: "ok",
+      details: { harnesses: "codex,opencode" },
+    });
+    expect(
+      plan.actions
+        .filter((action) => action.data?.harness !== undefined)
+        .map((action) => action.id),
+    ).toEqual(["codex-hooks", "opencode-hooks"]);
+  });
+
+  it("reports an unavailable persisted default without substituting an available provider", () => {
+    const plan = buildSetupPlan(
+      facts({
+        selectedHarness: "codex",
+        selectedHarnesses: ["codex", "opencode"],
+        harnesses: harnesses(["opencode"]),
+        config: validConfigFact({
+          configuredHarnesses: ["codex", "opencode"],
+          configuredHookHarnesses: ["opencode"],
+        }),
+      }),
+    );
+
+    expect(plan.summary.selectedHarness).toBe("codex");
+    expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
+      status: "ok",
+      message: expect.stringContaining("codex remains configured as the default"),
+      details: {
+        selected: "codex",
+        selectedStatus: "unavailable",
+        enabled: "codex,opencode",
+        available: "opencode",
+      },
+    });
+    expect(plan.checks.find((check) => check.id === "config")).toMatchObject({
+      status: "ok",
+      details: {
+        harness: "codex",
+        configuredHarnesses: "codex,opencode",
+      },
+    });
+  });
+
+  it("does not report an unconfigured available CLI as enabled", () => {
+    const plan = buildSetupPlan(
+      facts({
+        harnesses: harnesses(["opencode"]),
+        config: validConfigFact({
+          configuredHarnesses: ["codex"],
+          configuredHookHarnesses: [],
+        }),
+      }),
+    );
+
+    expect(plan.summary.selectedHarness).toBe("codex");
+    expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
+      status: "ok",
+      message: expect.stringContaining("another supported agent CLI is available"),
+      details: {
+        selected: "codex",
+        selectedStatus: "unavailable",
+        enabled: "codex",
+        available: "opencode",
+      },
+    });
+    expect(plan.checks.find((check) => check.id === "harness-hooks")?.status).toBe("skipped");
   });
 
   it("plans config creation for a new config", () => {

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -17,7 +17,6 @@ describe("setup planner", () => {
       requiredOk: true,
       requiredMissing: 0,
       selectedActions: 0,
-      selectedHarness: "codex",
     });
     expect(plan.checks.map((check) => [check.id, check.status])).toEqual([
       ["state-dir", "ok"],
@@ -222,37 +221,42 @@ describe("setup planner", () => {
   });
 
   it("respects an explicit selected harness when multiple are available", () => {
-    const plan = buildSetupPlan(
-      facts({
-        selectedHarness: "opencode",
-        harnesses: harnesses(["codex", "opencode"]),
-        config: {
-          status: "missing",
-          path: "/tmp/config.toml",
-          message: "Config missing.",
-        },
-      }),
-    );
+    const input = facts({
+      harnesses: harnesses(["codex", "opencode"]),
+      config: {
+        status: "missing",
+        path: "/tmp/config.toml",
+        message: "Config missing.",
+      },
+    });
+    const plan = buildSetupPlan(input, {
+      harnessSelection: {
+        defaultHarness: "opencode",
+        selected: input.harnesses.filter((harness) => harness.id === "opencode"),
+      },
+    });
 
     expect(plan.summary.selectedHarness).toBe("opencode");
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
-      selected: "opencode",
+      default: "opencode",
     });
   });
 
   it("keeps the first selected harness as default while planning each supported hook", () => {
-    const plan = buildSetupPlan(
-      facts({
-        selectedHarness: "codex",
-        selectedHarnesses: ["codex", "opencode", "pi"],
-        harnesses: harnesses(["codex", "opencode", "pi"]),
-      }),
-      { installHarnessHooks: ["codex", "opencode"] },
-    );
+    const input = facts({
+      harnesses: harnesses(["codex", "opencode", "pi"]),
+    });
+    const plan = buildSetupPlan(input, {
+      harnessSelection: {
+        defaultHarness: "codex",
+        selected: input.harnesses.filter((harness) => harness.status === "ok"),
+      },
+      installHarnessHooks: ["codex", "opencode"],
+    });
 
     expect(plan.summary.selectedHarness).toBe("codex");
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
-      selected: "codex",
+      default: "codex",
       enabled: "codex,opencode,pi",
     });
     expect(
@@ -278,7 +282,7 @@ describe("setup planner", () => {
     );
 
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
-      selected: "codex",
+      default: "codex",
       enabled: "codex,opencode,pi",
     });
     expect(plan.checks.find((check) => check.id === "harness-hooks")).toMatchObject({
@@ -295,8 +299,6 @@ describe("setup planner", () => {
   it("reports an unavailable persisted default without substituting an available provider", () => {
     const plan = buildSetupPlan(
       facts({
-        selectedHarness: "codex",
-        selectedHarnesses: ["codex", "opencode"],
         harnesses: harnesses(["opencode"]),
         config: validConfigFact({
           configuredHarnesses: ["codex", "opencode"],
@@ -310,8 +312,8 @@ describe("setup planner", () => {
       status: "ok",
       message: expect.stringContaining("codex remains configured as the default"),
       details: {
-        selected: "codex",
-        selectedStatus: "unavailable",
+        default: "codex",
+        defaultStatus: "unavailable",
         enabled: "codex,opencode",
         available: "opencode",
       },
@@ -338,16 +340,17 @@ describe("setup planner", () => {
 
     expect(plan.summary.selectedHarness).toBe("codex");
     expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
-      status: "ok",
-      message: expect.stringContaining("another supported agent CLI is available"),
+      status: "missing",
+      message: expect.stringContaining("no configured agent CLI is available"),
       details: {
-        selected: "codex",
-        selectedStatus: "unavailable",
+        default: "codex",
+        defaultStatus: "unavailable",
         enabled: "codex",
         available: "opencode",
       },
     });
     expect(plan.checks.find((check) => check.id === "harness-hooks")?.status).toBe("skipped");
+    expect(plan.summary.requiredOk).toBe(false);
   });
 
   it("plans config creation for a new config", () => {
@@ -606,22 +609,20 @@ describe("setup planner", () => {
     });
   });
 
-  it("plans a safe append for an existing config", () => {
+  it("plans a safe update for an existing config", () => {
     const plan = buildSetupPlan(facts(), {
       configWrite: {
-        operation: "append",
+        operation: "update",
         path: "/tmp/config.toml",
         content: "schema_version = 1\n",
-        appendedText: "\n[[projects]]\n",
       },
     });
 
-    expect(plan.actions.find((action) => action.id === "append-config")).toMatchObject({
+    expect(plan.actions.find((action) => action.id === "update-config")).toMatchObject({
       kind: "write-config",
       selected: true,
       data: {
-        operation: "append",
-        appendedText: "\n[[projects]]\n",
+        operation: "update",
       },
     });
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,6 +135,10 @@ The only loosely-typed provider table: `[harness.claude]` is known, and any othe
 (`codex`, `opencode`, …) is accepted via a catchall — so a **misspelled harness id
 is silently accepted** as an unused harness.
 
+Multiple `[harness.<id>]` tables may be configured at once. `[defaults].harness`
+remains the single default used when a project does not override it; the other
+configured harnesses remain available for explicit selection.
+
 | Key | Type | Notes |
 | --- | --- | --- |
 | `enabled` | bool | |

--- a/docs/development.md
+++ b/docs/development.md
@@ -436,7 +436,7 @@ exporting a token. If scoped host access is unavailable, run the exact tagged
 temporary-file installer in the host Terminal and let the agent resume through
 the absolute installed `stn` path.
 
-Start the selected agent CLI once and complete its normal sign-in. Then create
+Start each agent CLI you plan to select once and complete its normal sign-in. Then create
 a disposable Git project for the acceptance run:
 
 ```sh
@@ -535,8 +535,11 @@ For the primary VirtualBuddy user-flow pass, start with `XDG_DATA_HOME` unset
 and `~/.local/bin` absent from `PATH`, and retain the complete installer output.
 Follow the installer's printed current-shell block exactly; on this clean lane
 it must name all three missing launchers and end by running `stn setup`. Allow
-guided setup to install Worktrunk, tmux, diffnav, and git-delta, select the
-authenticated agent, and enable the desired provider hooks and tmux binding.
+guided setup to install Worktrunk, tmux, diffnav, and git-delta, select one or
+more authenticated agents, and enable the desired provider hooks and tmux binding.
+Confirm the first selection becomes the default while every selection receives
+its own harness block and every hook-capable selection receives its own prompt
+when setup can safely persist or reuse that hook intent.
 Confirm setup writes a zero-project config without adopting the disposable
 repository, then run:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -219,10 +219,10 @@ stn tui
 ```
 
 Setup checks or offers to install Worktrunk, tmux, diffnav, and git-delta;
-requires one supported agent CLI; writes a valid zero-project
+requires at least one supported agent CLI; lets you enable one or more detected CLIs; writes a valid zero-project
 `~/.config/station/config.toml`; starts or restarts the Observer; and offers to
-install provider hooks, Worktrunk shell integration, and the `Ctrl-b Space`
-tmux popup binding. Complete the selected agent CLI's own sign-in before
+install provider-specific hooks, Worktrunk shell integration, and the `Ctrl-b Space`
+tmux popup binding. The first selection is the default in a new config; an existing config keeps its current default while setup adds missing selected providers. Complete each enabled agent CLI's own sign-in before
 starting a real session.
 
 If setup writes the config but cannot activate it, it leaves the config and the

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,9 +8,9 @@ This guide starts with an installed Station binary. If `stn --version` does not 
 stn setup
 ```
 
-Setup checks the tools Station uses, requires at least one supported agent CLI, writes `~/.config/station/config.toml`, starts the observer, and offers to install provider hooks and the tmux popup binding. It does not add a project automatically.
+Setup checks the tools Station uses, requires at least one supported agent CLI, and lets you enable one or more detected CLIs. For a new config, the first selection becomes the default. Setup writes `~/.config/station/config.toml`, starts the observer, and offers provider-specific hooks and the tmux popup binding. It does not add a project automatically.
 
-Complete the agent CLI's own sign-in before starting a real session. Confirm the environment is ready:
+Complete each enabled agent CLI's own sign-in before using it for a real session. Confirm the environment is ready:
 
 ```sh
 stn doctor

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -6,7 +6,7 @@ Station integrates with Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, and Ope
 stn setup
 ```
 
-This configures the core local workflow: the required tools, an agent CLI, and a zero-project config. Add the first project explicitly in Station. Optional integrations can be added later.
+This configures the core local workflow: the required tools, one or more detected agent CLIs, and a zero-project config. The first CLI selected for a new config becomes its default. Add the first project explicitly in Station. Optional integrations can be added later.
 
 The compiled `stn` launches its TUI and Observer without Node.js, pnpm, or Bun. A local source checkout expects Node.js 24.2+ (and below 25), pnpm 11, and Bun 1.3.14 for development. Real-provider test lanes remain opt-in.
 `stn setup system --check` reports those versions, but it does not change the active Node or pnpm
@@ -46,7 +46,7 @@ workflow, not for launch:
 - Bun — only a source-checkout launcher shells out to `bun run`; the compiled binary embeds the renderer
 - diffnav and git-delta (`delta`) — diffnav powers the "See diff (split right)" automation and renders through delta, so the two are required together
 - git (the binary); select an existing git repository explicitly after setup
-- one supported agent CLI: Claude Code, Codex, Cursor Agent, OpenCode, or Pi
+- at least one supported agent CLI: Claude Code, Codex, Cursor Agent, OpenCode, or Pi; guided setup can enable several
 
 On macOS, the Command Line Tools provide git and the compilers Homebrew needs.
 `stn setup` detects a missing-git binary distinctly from "not inside a repo". The
@@ -205,11 +205,16 @@ the renderer and does not require that runtime.
 
 ## Hooks
 
-Guided `stn setup` can enable and install Worktrunk lifecycle hooks plus the selected Claude, Codex,
-Cursor, or OpenCode agent hooks. Worktrunk lifecycle hooks are optional when automation is
+Guided `stn setup` can enable and install Worktrunk lifecycle hooks plus hooks for each selected
+Claude, Codex, Cursor, or OpenCode agent. Worktrunk lifecycle hooks are optional when automation is
 configured to skip them. `worktree.worktrunk.use_lifecycle_hooks = false` makes automated Worktrunk
 mutations use `--no-hooks`; `true` makes them use `--yes`; unset leaves Worktrunk's default prompt
 behavior in place.
+
+Setup adds or enables `install_hooks` in each selected harness block while preserving unrelated TOML
+source, then validates the candidate through the canonical config loader before writing it. If a hook
+installer fails, that persisted intent lets a later setup run retry the provider without suppressing
+the other selected providers.
 `stn setup check --json` and `stn doctor` report the effective mode and validate that the installed
 `wt` supports any required automation flag. The hook commands are generated from one canonical expectation containing the
 resolved STATION config path, observer socket, state directory, spool directory,

--- a/packages/config/src/harnesses/index.ts
+++ b/packages/config/src/harnesses/index.ts
@@ -1,0 +1,5 @@
+export {
+  type HarnessConfigMutationError,
+  type SetHarnessInstallHooksInTomlOptions,
+  setHarnessInstallHooksInToml,
+} from "./installHooks.js";

--- a/packages/config/src/harnesses/installHooks.ts
+++ b/packages/config/src/harnesses/installHooks.ts
@@ -1,0 +1,279 @@
+import { parse } from "smol-toml";
+import { z } from "zod";
+import { loadConfigFromToml } from "../load/index.js";
+
+export type SetHarnessInstallHooksInTomlOptions = {
+  harness: string;
+  installHooks: boolean;
+  configPath?: string;
+  homeDir?: string;
+};
+
+type StringState = "normal" | "basic" | "literal" | "multiline-basic" | "multiline-literal";
+
+type TomlLine = {
+  start: number;
+  contentEnd: number;
+  end: number;
+  code?: string;
+};
+
+const HEADER_SENTINEL = "__station_setup_install_hooks_table__";
+const InstallHooksAssignmentSchema = z.object({ install_hooks: z.boolean() }).strict();
+
+export type HarnessConfigMutationError = Error & {
+  tag: "HarnessConfigMutationError";
+  code: "HARNESS_CONFIG_BLOCK_NOT_FOUND" | "HARNESS_CONFIG_MUTATION_INVALID";
+};
+
+/**
+ * Updates one harness hook flag without reserializing TOML or changing unrelated source.
+ * The candidate is accepted only when the canonical config loader observes the requested value.
+ */
+export async function setHarnessInstallHooksInToml(
+  source: string,
+  options: SetHarnessInstallHooksInTomlOptions,
+): Promise<string> {
+  const lines = scanTomlLines(source);
+  const tableStart = lines.findIndex((line) => {
+    return line.code !== undefined && isHarnessTableHeader(line.code, options.harness);
+  });
+  if (tableStart === -1) {
+    throw harnessConfigMutationError(
+      "HARNESS_CONFIG_BLOCK_NOT_FOUND",
+      `Could not find the harness.${options.harness} table in config.toml.`,
+    );
+  }
+
+  const tableEnd = nextTableLine(lines, tableStart + 1);
+  let candidate = source;
+  const assignment = findInstallHooksAssignment(lines, tableStart + 1, tableEnd);
+  if (assignment !== undefined) {
+    candidate = `${source.slice(0, assignment.valueStart)}${options.installHooks ? "true" : "false"}${source.slice(assignment.valueEnd)}`;
+  } else {
+    const header = lines[tableStart];
+    if (header === undefined) {
+      throw harnessConfigMutationError(
+        "HARNESS_CONFIG_BLOCK_NOT_FOUND",
+        `Could not find the harness.${options.harness} table in config.toml.`,
+      );
+    }
+    const headerHasNewline = header.end > header.contentEnd;
+    const newline = headerHasNewline
+      ? source.slice(header.contentEnd, header.end)
+      : preferredNewline(source);
+    const insertion = headerHasNewline
+      ? `install_hooks = ${options.installHooks ? "true" : "false"}${newline}`
+      : `${newline}install_hooks = ${options.installHooks ? "true" : "false"}`;
+    candidate = `${source.slice(0, header.end)}${insertion}${source.slice(header.end)}`;
+  }
+
+  const loadOptions: { configPath?: string; homeDir?: string } = {};
+  if (options.configPath !== undefined) loadOptions.configPath = options.configPath;
+  if (options.homeDir !== undefined) loadOptions.homeDir = options.homeDir;
+  const loaded = await loadConfigFromToml(candidate, loadOptions);
+  if (loaded.config.harness?.[options.harness]?.installHooks !== options.installHooks) {
+    throw harnessConfigMutationError(
+      "HARNESS_CONFIG_MUTATION_INVALID",
+      `Could not set install_hooks in the harness.${options.harness} table.`,
+    );
+  }
+  return candidate;
+}
+
+function scanTomlLines(source: string): TomlLine[] {
+  const lines: TomlLine[] = [];
+  let offset = 0;
+  let state: StringState = "normal";
+  while (offset < source.length) {
+    const newlineIndex = source.indexOf("\n", offset);
+    const end = newlineIndex === -1 ? source.length : newlineIndex + 1;
+    const contentEnd =
+      newlineIndex === -1
+        ? end
+        : source[newlineIndex - 1] === "\r"
+          ? newlineIndex - 1
+          : newlineIndex;
+    const content = source.slice(offset, contentEnd);
+    const scanned = scanTomlLine(content, state);
+    const line: TomlLine = { start: offset, contentEnd, end };
+    if (scanned.code !== undefined) line.code = scanned.code;
+    lines.push(line);
+    state = scanned.state;
+    offset = end;
+  }
+  return lines;
+}
+
+function scanTomlLine(
+  line: string,
+  initialState: StringState,
+): { state: StringState; code?: string } {
+  let state = initialState;
+  const startsInMultiline = state === "multiline-basic" || state === "multiline-literal";
+  let commentStart: number | undefined;
+  for (let index = 0; index < line.length; index += 1) {
+    if (state === "normal") {
+      if (line[index] === "#") {
+        commentStart = index;
+        break;
+      }
+      if (line.startsWith('"""', index)) {
+        state = "multiline-basic";
+        index += 2;
+      } else if (line.startsWith("'''", index)) {
+        state = "multiline-literal";
+        index += 2;
+      } else if (line[index] === '"') {
+        state = "basic";
+      } else if (line[index] === "'") {
+        state = "literal";
+      }
+      continue;
+    }
+    if (state === "basic") {
+      if (line[index] === "\\") index += 1;
+      else if (line[index] === '"') state = "normal";
+      continue;
+    }
+    if (state === "literal") {
+      if (line[index] === "'") state = "normal";
+      continue;
+    }
+    if (state === "multiline-basic") {
+      if (line[index] === "\\") index += 1;
+      else if (line.startsWith('"""', index)) {
+        index = endQuoteRun(line, index, '"') - 1;
+        state = "normal";
+      }
+      continue;
+    }
+    if (line.startsWith("'''", index)) {
+      index = endQuoteRun(line, index, "'") - 1;
+      state = "normal";
+    }
+  }
+  if (startsInMultiline) return { state };
+  return { state, code: line.slice(0, commentStart) };
+}
+
+function nextTableLine(lines: readonly TomlLine[], start: number): number {
+  for (let index = start; index < lines.length; index += 1) {
+    const code = lines[index]?.code;
+    if (code !== undefined && parseAnyTableHeader(code)) return index;
+  }
+  return lines.length;
+}
+
+function findInstallHooksAssignment(
+  lines: readonly TomlLine[],
+  start: number,
+  end: number,
+): { valueStart: number; valueEnd: number } | undefined {
+  for (let index = start; index < end; index += 1) {
+    const line = lines[index];
+    if (line?.code === undefined) continue;
+    const equals = topLevelEquals(line.code);
+    if (equals === -1) continue;
+    try {
+      if (!InstallHooksAssignmentSchema.safeParse(parse(line.code)).success) continue;
+    } catch {
+      continue;
+    }
+    const value = booleanValueRange(line.code, equals + 1);
+    if (value === undefined) continue;
+    return {
+      valueStart: line.start + value.start,
+      valueEnd: line.start + value.end,
+    };
+  }
+  return undefined;
+}
+
+function parseAnyTableHeader(code: string): boolean {
+  const trimmed = code.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return false;
+  try {
+    parse(`${trimmed}\n${HEADER_SENTINEL} = true`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isHarnessTableHeader(code: string, harness: string): boolean {
+  const trimmed = code.trim();
+  if (!trimmed.startsWith("[") || trimmed.startsWith("[[") || !trimmed.endsWith("]")) {
+    return false;
+  }
+  try {
+    const schema = z
+      .object({
+        harness: z
+          .object({
+            [harness]: z.object({ [HEADER_SENTINEL]: z.literal(true) }).passthrough(),
+          })
+          .passthrough(),
+      })
+      .passthrough();
+    return schema.safeParse(parse(`${trimmed}\n${HEADER_SENTINEL} = true`)).success;
+  } catch {
+    return false;
+  }
+}
+
+function topLevelEquals(input: string): number {
+  let state: "normal" | "basic" | "literal" = "normal";
+  for (let index = 0; index < input.length; index += 1) {
+    if (state === "normal") {
+      if (input[index] === "=") return index;
+      if (input[index] === '"') state = "basic";
+      else if (input[index] === "'") state = "literal";
+    } else if (state === "basic") {
+      if (input[index] === "\\") index += 1;
+      else if (input[index] === '"') state = "normal";
+    } else if (input[index] === "'") {
+      state = "normal";
+    }
+  }
+  return -1;
+}
+
+function booleanValueRange(
+  input: string,
+  start: number,
+): { start: number; end: number } | undefined {
+  let valueStart = start;
+  while (input[valueStart] === " " || input[valueStart] === "\t") valueStart += 1;
+  const value = input.startsWith("true", valueStart)
+    ? "true"
+    : input.startsWith("false", valueStart)
+      ? "false"
+      : undefined;
+  if (value === undefined) return undefined;
+  const valueEnd = valueStart + value.length;
+  return input.slice(valueEnd).trim().length === 0
+    ? { start: valueStart, end: valueEnd }
+    : undefined;
+}
+
+function endQuoteRun(input: string, start: number, quote: '"' | "'"): number {
+  let end = start;
+  while (input[end] === quote) end += 1;
+  return end;
+}
+
+function preferredNewline(source: string): "\n" | "\r\n" {
+  return source.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function harnessConfigMutationError(
+  code: "HARNESS_CONFIG_BLOCK_NOT_FOUND" | "HARNESS_CONFIG_MUTATION_INVALID",
+  message: string,
+): HarnessConfigMutationError {
+  const error = new Error(message) as HarnessConfigMutationError;
+  error.name = "HarnessConfigMutationError";
+  error.tag = "HarnessConfigMutationError";
+  error.code = code;
+  return error;
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./firstRun.js";
+export * from "./harnesses/index.js";
 export * from "./hooks/index.js";
 export * from "./loadConfig.js";
 export * from "./observerPaths.js";

--- a/packages/config/test/unit/harness-install-hooks-toml.test.ts
+++ b/packages/config/test/unit/harness-install-hooks-toml.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { loadConfigFromToml, setHarnessInstallHooksInToml } from "../../src/index.js";
+
+describe("harness install_hooks TOML mutation", () => {
+  it("updates a quoted harness table and preserves its comments and unrelated source", async () => {
+    const source = configToml([
+      "[\"harness\" . 'codex'] # provider table",
+      "enabled = true",
+      'command = "codex"',
+      "install_hooks = false # keep this explanation",
+      "",
+      "[harness.opencode]",
+      'command = "opencode"',
+    ]);
+
+    const updated = await setHarnessInstallHooksInToml(source, {
+      harness: "codex",
+      installHooks: true,
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    });
+
+    expect(updated).toBe(
+      source.replace(
+        "install_hooks = false # keep this explanation",
+        "install_hooks = true # keep this explanation",
+      ),
+    );
+    const loaded = await loadConfigFromToml(updated, {
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    });
+    expect(loaded.config.harness?.codex?.installHooks).toBe(true);
+  });
+
+  it.each([
+    {
+      label: "basic",
+      open: 'command = """codex',
+      close: '"""',
+    },
+    {
+      label: "literal",
+      open: "command = '''codex",
+      close: "'''",
+    },
+    {
+      label: "basic with a trailing quote",
+      open: 'command = """codex',
+      close: '""""',
+    },
+    {
+      label: "literal with a trailing quote",
+      open: "command = '''codex",
+      close: "''''",
+    },
+  ])("ignores fake tables inside $label multiline strings", async ({ open, close }) => {
+    const fakeTable = "[harness.opencode]\ninstall_hooks = false";
+    const source = configToml([
+      "[harness.codex]",
+      open,
+      fakeTable,
+      close,
+      "",
+      "# [harness.opencode] is only a comment",
+      "[ 'harness' . \"opencode\" ] # real table",
+      'command = "opencode"',
+      "",
+    ]);
+
+    const updated = await setHarnessInstallHooksInToml(source, {
+      harness: "opencode",
+      installHooks: true,
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    });
+
+    expect(updated).toContain(`${open}\n${fakeTable}\n${close}`);
+    expect(updated).toContain(
+      '[ \'harness\' . "opencode" ] # real table\ninstall_hooks = true\ncommand = "opencode"',
+    );
+    expect(updated.match(/install_hooks = true/g)).toHaveLength(1);
+    expect(updated.match(/install_hooks = false/g)).toHaveLength(1);
+  });
+
+  it("adds the flag idempotently when the harness table does not contain it", async () => {
+    const source = configToml(["[harness.codex]", 'command = "codex"', ""]);
+    const options = {
+      harness: "codex",
+      installHooks: true,
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    } as const;
+
+    const updated = await setHarnessInstallHooksInToml(source, options);
+    const second = await setHarnessInstallHooksInToml(updated, options);
+
+    expect(updated).toContain('[harness.codex]\ninstall_hooks = true\ncommand = "codex"');
+    expect(second).toBe(updated);
+  });
+
+  it("preserves CRLF and EOF while updating escaped keys", async () => {
+    const source = configToml([
+      '["har\\u006eess".codex]',
+      'command = "codex"',
+      '"install_hooks" = false',
+    ]).replaceAll("\n", "\r\n");
+
+    const updated = await setHarnessInstallHooksInToml(source, {
+      harness: "codex",
+      installHooks: true,
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    });
+
+    expect(updated).toBe(source.replace('"install_hooks" = false', '"install_hooks" = true'));
+    expect(updated.endsWith("\r\n")).toBe(false);
+    expect(updated.replaceAll("\r\n", "")).not.toContain("\n");
+  });
+
+  it("preserves a missing final newline when adding the flag at EOF", async () => {
+    const source = configToml(["[harness.codex]"]);
+
+    const updated = await setHarnessInstallHooksInToml(source, {
+      harness: "codex",
+      installHooks: true,
+      configPath: "/tmp/config.toml",
+      homeDir: "/tmp",
+    });
+
+    expect(updated).toBe(`${source}\ninstall_hooks = true`);
+  });
+
+  it("fails without changing a different harness table", async () => {
+    const source = configToml(["[harness.codex]", 'command = "codex"', ""]);
+
+    await expect(
+      setHarnessInstallHooksInToml(source, {
+        harness: "opencode",
+        installHooks: true,
+        configPath: "/tmp/config.toml",
+        homeDir: "/tmp",
+      }),
+    ).rejects.toMatchObject({
+      tag: "HarnessConfigMutationError",
+      code: "HARNESS_CONFIG_BLOCK_NOT_FOUND",
+    });
+  });
+});
+
+function configToml(harnessLines: readonly string[]): string {
+  return [
+    "schema_version = 1",
+    "projects = []",
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    'harness = "codex"',
+    'layout = "agent-shell"',
+    "",
+    ...harnessLines,
+  ].join("\n");
+}

--- a/packages/dashboard-core/test/unit/selectors/selectors.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/selectors.test.ts
@@ -316,8 +316,7 @@ describe("TUI selectors", () => {
       ...createDashboardSnapshot(),
       harnesses: [
         { id: "codex", label: "codex" },
-        { id: "opencode", label: "opencode" },
-        { id: "scripted", label: "scripted" },
+        { id: "pi", label: "pi" },
       ],
     };
     const api = snapshot.projects.find((project) => project.id === "api");
@@ -333,8 +332,7 @@ describe("TUI selectors", () => {
       selectNewSessionHarnessChoices(snapshot, api).map((choice) => [choice.key, choice.value.id]),
     ).toEqual([
       ["1", "codex"],
-      ["2", "opencode"],
-      ["3", "scripted"],
+      ["2", "pi"],
     ]);
   });
 });

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -174,6 +174,11 @@ describe("observer lifecycle e2e", () => {
     const originalSocket = await stat(fixture.socketPath);
     const originalPidfile = await stat(pidfilePath);
     const originalPidfileBytes = await readFile(pidfilePath);
+    // Health can become ready before the listener is visible to the Linux socket scan.
+    await waitFor(
+      async () => (await socketHolders(fixture.socketPath)).includes(originalPid),
+      3000,
+    );
     const originalHolders = await socketHolders(fixture.socketPath);
     let restored = false;
     const spawnObserver = vi.fn(async () => {

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -40,7 +40,7 @@ describe("setup guided feedback e2e", () => {
       });
 
       expect(result.timedOut).toBe(false);
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
       expect(result.stdout).toContain("Link STATION launchers globally?");
       expect(result.stdout).toContain("Install Worktrunk lifecycle hooks?");
       expect(result.stdout).toContain("Install Codex agent hooks?");
@@ -51,6 +51,86 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("writes multiple selected agent CLIs, installs both hooks, and passes both doctors", async () => {
+    const fixture = await createFixture({ harness: "codex-opencode" });
+    try {
+      const result = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["1,2", "n", "n", "y", "y", "y", "n", "n"],
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "Select agent CLIs to enable (comma-separated; first is the default for new configs).",
+      );
+      expect(result.stdout).toContain("Install Codex agent hooks?");
+      expect(result.stdout).toContain("Install OpenCode agent hooks?");
+      expect(result.stdout).toContain("Completed: Install Codex hooks");
+      expect(result.stdout).toContain("Completed: Install OpenCode hooks");
+      const config = await readFile(fixture.configPath, "utf8");
+      expect(config).toContain('harness = "codex"');
+      expect(config).toContain("[harness.codex]");
+      expect(config).toContain("[harness.opencode]");
+      expect(config.match(/install_hooks = true/g)).toHaveLength(2);
+
+      for (const provider of ["codex", "opencode"]) {
+        const doctorArgs = ["--config", fixture.configPath, "hooks", "doctor", provider];
+        if (provider === "codex") {
+          doctorArgs.push("--hook-bin", join(process.cwd(), "bin", "stn-ingress"));
+        }
+        const doctor = await runStation(doctorArgs, {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: [],
+        });
+        expect(doctor.exitCode, `${doctor.stdout}\n${doctor.stderr}`).toBe(0);
+        expect(JSON.parse(doctor.stdout)).toMatchObject({ provider, status: "ok" });
+      }
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("keeps a clean Codex and Pi setup idempotent and visible in the Observer snapshot", async () => {
+    const fixture = await createFixture({ harness: "codex-pi" });
+    try {
+      const first = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["1,2", "n", "n", "y", "y", "n", "n"],
+      });
+      expect(first.exitCode, `${first.stdout}\n${first.stderr}`).toBe(0);
+      const firstConfig = await readFile(fixture.configPath, "utf8");
+
+      const second = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["1,2", "n", "n", "n", "n"],
+      });
+      expect(second.exitCode, `${second.stdout}\n${second.stderr}`).toBe(0);
+      const secondConfig = await readFile(fixture.configPath, "utf8");
+
+      expect(secondConfig).toBe(firstConfig);
+      expect(secondConfig.match(/^harness = "codex"$/gm)).toHaveLength(1);
+      expect(secondConfig.match(/^\[harness\.codex\]$/gm)).toHaveLength(1);
+      expect(secondConfig.match(/^\[harness\.pi\]$/gm)).toHaveLength(1);
+
+      const snapshotResult = await runStation(
+        ["--config", fixture.configPath, "snapshot", "--json"],
+        { cwd: fixture.repo, env: fixture.env, answers: [] },
+      );
+      expect(snapshotResult.exitCode, `${snapshotResult.stdout}\n${snapshotResult.stderr}`).toBe(0);
+      const snapshot = JSON.parse(snapshotResult.stdout) as {
+        harnesses?: Array<{ id: string }>;
+      };
+      expect(snapshot.harnesses?.map((harness) => harness.id)).toEqual(["codex", "pi"]);
     } finally {
       await fixture.cleanup();
     }
@@ -135,7 +215,7 @@ describe("setup guided feedback e2e", () => {
         const second = await runStation(["--config", fixture.configPath, "setup"], {
           cwd: fixture.repo,
           env: fixture.env,
-          answers: ["n", "y", "n"],
+          answers: ["n", "n", "y", "n"],
         });
 
         expect(first.exitCode).toBe(0);
@@ -264,7 +344,7 @@ describe("setup guided feedback e2e", () => {
   });
 });
 
-type HarnessMode = "codex" | "installable-codex" | "missing";
+type HarnessMode = "codex" | "codex-opencode" | "codex-pi" | "installable-codex" | "missing";
 
 type Fixture = {
   root: string;
@@ -352,8 +432,26 @@ async function createFixture(input: {
   await writeShim(bin, "delta", "exit 0\n");
   await writeShim(bin, "bun", "exit 0\n");
   await writeShim(bin, "npm", "echo 0.1.0\n");
-  if (input.harness === "codex") {
+  if (
+    input.harness === "codex" ||
+    input.harness === "codex-opencode" ||
+    input.harness === "codex-pi"
+  ) {
     await writeCodexShim(bin);
+  }
+  if (input.harness === "codex-opencode") {
+    await writeShim(
+      bin,
+      "opencode",
+      'if [ "$1" = "--version" ]; then echo "opencode 1.0.0"; exit 0; fi\nexit 0\n',
+    );
+  }
+  if (input.harness === "codex-pi") {
+    await writeShim(
+      bin,
+      "pi",
+      'if [ "$1" = "--version" ]; then echo "pi 0.80.5"; exit 0; fi\nexit 0\n',
+    );
   }
   if (input.launchers === "complex") {
     await writeShim(launcherBin, "stn", "exit 0\n");
@@ -406,8 +504,8 @@ async function createFixture(input: {
     // searches the brew prefix) can't pick up a real one from the dev machine.
     STATION_CODEX_BIN: input.harness === "missing" ? "/missing/codex" : "codex",
     STATION_CURSOR_AGENT_BIN: "/missing/agent",
-    STATION_OPENCODE_BIN: "/missing/opencode",
-    STATION_PI_BIN: "/missing/pi",
+    STATION_OPENCODE_BIN: input.harness === "codex-opencode" ? "opencode" : "/missing/opencode",
+    STATION_PI_BIN: input.harness === "codex-pi" ? "pi" : "/missing/pi",
     STATION_CLAUDE_BIN: "/missing/claude",
   };
   if (input.shell !== undefined) env.SHELL = `/bin/${input.shell}`;


### PR DESCRIPTION
Closes #255

## Summary
- model guided agent choice as one ordered selection of one or more CLIs instead of parallel single- and multi-selection state
- use that same selection for launcher recovery, hook prompts, config updates, and readiness planning
- make the first selection the default for new configs while preserving an existing configured default
- require every selected CLI to survive the post-linker re-probe before setup mutates hooks or config
- resolve harness commands with runtime authority order: config, environment, then built-in default
- count only configured or currently selected runnable harnesses toward workflow readiness

## Stack
- depends on #257 for the agent-led installation documentation contract
- #257 depends on #256 for healthy zero-project startup with no tmux server

## Verification
- three independent adversarial review passes; each reported no remaining findings after fixes
- full repository `test:all` passed on the final code content with `STATION_PANE` removed
- clean-checkout unit suite passed serially: 184 files, 1,700 tests
- contracts, integration, diagnostics, scripted-agent, 18 setup E2E, and 19 Observer lifecycle tests passed
- Node/Bun SQLite compatibility and Observer-claim race tests passed
- Station renderer, PTY, install smoke, compiled binary build, and binary smoke passed
- production portion of the normalization commit is net 41 lines smaller

## UX implication
`stn setup` presents one multi-select prompt where choosing one agent is the ordinary case and choosing more extends the same selection. New configs use the first choice as default; existing defaults remain unchanged while all selected providers are configured.

## Manual verification
Install or expose Codex and Pi, run `stn setup`, select both, and confirm one prompt accepts the two choices, both `[harness.*]` blocks are present, and the first choice is the default in a new config. Rerun against an existing config with the other provider as default and confirm that default is preserved. Then run `stn setup check --json` and confirm readiness requires a configured or selected command that is actually runnable.