### PR TITLE
fix(setup): report shell readiness accurately

### DIFF
--- a/apps/cli/src/commands/setup/checks/config.ts
+++ b/apps/cli/src/commands/setup/checks/config.ts
@@ -92,6 +92,9 @@ export async function checkSetupConfig(
     if (loaded.config.worktree?.worktrunk?.useLifecycleHooks !== undefined) {
       fact.worktrunkUseLifecycleHooks = loaded.config.worktree.worktrunk.useLifecycleHooks;
     }
+    if (loaded.config.worktree?.worktrunk?.command !== undefined) {
+      fact.worktrunkCommand = loaded.config.worktree.worktrunk.command;
+    }
     if (matchedProject !== undefined) {
       fact.matchedProject = {
         id: matchedProject.id,

--- a/apps/cli/src/commands/setup/checks/launchers.ts
+++ b/apps/cli/src/commands/setup/checks/launchers.ts
@@ -90,8 +90,7 @@ async function checkRuntimeLauncher(
   }
 
   const pathMatch = await resolveOnPath(definition.command, options.env.PATH, options.access);
-  const onPath =
-    pathMatch !== undefined && (await pathsResolveToSameLauncher(pathMatch, runtimePath));
+  const onPath = pathMatch !== undefined && (await setupLauncherPathsMatch(pathMatch, runtimePath));
   const launcher: SetupLauncherFact = {
     status: "ok",
     source: onPath ? "path" : runtimeSource,
@@ -107,7 +106,7 @@ async function checkRuntimeLauncher(
   return launcher;
 }
 
-async function pathsResolveToSameLauncher(left: string, right: string): Promise<boolean> {
+export async function setupLauncherPathsMatch(left: string, right: string): Promise<boolean> {
   if (resolve(left) === resolve(right)) return true;
   try {
     return (await realpath(left)) === (await realpath(right));

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -171,21 +171,22 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     configPromise,
     checkSetupLaunchers(launcherOptions),
   ]);
+  const worktrunkAutomationInput: Parameters<typeof checkSetupWorktrunkAutomation>[0] = {
+    worktrunk,
+    configReady: config.status === "valid",
+  };
+  if (config.status === "valid" && config.worktrunkUseLifecycleHooks !== undefined) {
+    worktrunkAutomationInput.useLifecycleHooks = config.worktrunkUseLifecycleHooks;
+  }
+  if (options.runner !== undefined) worktrunkAutomationInput.runner = options.runner;
+
+  const worktrunkShellIntegrationInput: Parameters<typeof checkSetupWorktrunkShellIntegration>[0] =
+    { worktrunk, homeDir, env };
+  if (options.runner !== undefined) worktrunkShellIntegrationInput.runner = options.runner;
+
   const [worktrunkAutomation, worktrunkShellIntegration] = await Promise.all([
-    checkSetupWorktrunkAutomation({
-      worktrunk,
-      configReady: config.status === "valid",
-      ...(config.status === "valid" && config.worktrunkUseLifecycleHooks !== undefined
-        ? { useLifecycleHooks: config.worktrunkUseLifecycleHooks }
-        : {}),
-      ...(options.runner === undefined ? {} : { runner: options.runner }),
-    }),
-    checkSetupWorktrunkShellIntegration({
-      worktrunk,
-      homeDir,
-      env,
-      ...(options.runner === undefined ? {} : { runner: options.runner }),
-    }),
+    checkSetupWorktrunkAutomation(worktrunkAutomationInput),
+    checkSetupWorktrunkShellIntegration(worktrunkShellIntegrationInput),
   ]);
   const launcherCommand =
     options.tmuxPopupOwnerRoot === undefined

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -36,11 +36,16 @@ import {
   type CheckSetupLaunchersOptions,
   checkSetupLaunchers,
   setupLauncherExecutable,
+  setupLauncherPathsMatch,
 } from "./launchers.js";
 import { checkSetupStateDir, type SetupStateDirFileSystem } from "./stateDir.js";
 import { checkSetupTmux } from "./tmux.js";
 import { checkSetupTmuxBinding, tmuxPopupRunShellCommand } from "./tmuxBinding.js";
-import { checkSetupWorktrunk, checkSetupWorktrunkAutomation } from "./worktrunk.js";
+import {
+  checkSetupWorktrunk,
+  checkSetupWorktrunkAutomation,
+  checkSetupWorktrunkShellIntegration,
+} from "./worktrunk.js";
 import { type CheckXcodeOptions, checkSetupXcode } from "./xcode.js";
 
 export type SetupDependencyCheckOptions = {
@@ -111,6 +116,14 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   const configPathOptions = setupConfigOptions(setupConfigInput);
   const configPath = setupConfigPath(configPathOptions);
   const configPromise = checkSetupConfig({ ...configPathOptions, configPath });
+  const worktrunkPromise = configPromise.then((config) =>
+    checkSetupWorktrunk({
+      ...dependencyOptions,
+      ...(config.status === "valid" && config.worktrunkCommand !== undefined
+        ? { command: config.worktrunkCommand }
+        : {}),
+    }),
+  );
   const harnessesPromise = configPromise.then((config) => {
     const harnessOptions: CheckHarnessesOptions = { ...commandOptions };
     if (config.status === "valid") {
@@ -140,7 +153,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
       ...(options.platform === undefined ? {} : { platform: options.platform }),
       ...(options.access === undefined ? {} : { access: options.access }),
     }),
-    checkSetupWorktrunk(dependencyOptions),
+    worktrunkPromise,
     checkSetupTmux(dependencyOptions),
     compiled
       ? Promise.resolve({ status: "ok" as const, command: "bun" })
@@ -158,18 +171,30 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     configPromise,
     checkSetupLaunchers(launcherOptions),
   ]);
-  const worktrunkAutomation = await checkSetupWorktrunkAutomation({
-    worktrunk,
-    configReady: config.status === "valid",
-    ...(config.status === "valid" && config.worktrunkUseLifecycleHooks !== undefined
-      ? { useLifecycleHooks: config.worktrunkUseLifecycleHooks }
-      : {}),
-    ...(options.runner === undefined ? {} : { runner: options.runner }),
-  });
+  const [worktrunkAutomation, worktrunkShellIntegration] = await Promise.all([
+    checkSetupWorktrunkAutomation({
+      worktrunk,
+      configReady: config.status === "valid",
+      ...(config.status === "valid" && config.worktrunkUseLifecycleHooks !== undefined
+        ? { useLifecycleHooks: config.worktrunkUseLifecycleHooks }
+        : {}),
+      ...(options.runner === undefined ? {} : { runner: options.runner }),
+    }),
+    checkSetupWorktrunkShellIntegration({
+      worktrunk,
+      homeDir,
+      env,
+      ...(options.runner === undefined ? {} : { runner: options.runner }),
+    }),
+  ]);
   const launcherCommand =
     options.tmuxPopupOwnerRoot === undefined
       ? setupLauncherExecutable(launchers.tmuxPopup)
       : join(options.tmuxPopupOwnerRoot, "stn-tmux-popup");
+  const popupOnPath =
+    launchers.tmuxPopup.source === "path" &&
+    launchers.tmuxPopup.resolvedPath !== undefined &&
+    (await setupLauncherPathsMatch(launchers.tmuxPopup.resolvedPath, launcherCommand));
   const resolvedLaunchers =
     options.tmuxPopupOwnerRoot === undefined
       ? launchers
@@ -178,7 +203,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
           tmuxPopup: (await canExecute(launcherCommand, options.access))
             ? {
                 status: "ok" as const,
-                source: "installed" as const,
+                source: popupOnPath ? ("path" as const) : ("installed" as const),
                 command: launchers.tmuxPopup.command,
                 resolvedPath: launcherCommand,
                 checkoutPath: launchers.tmuxPopup.checkoutPath,
@@ -245,6 +270,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     socketEvidence,
     worktrunk,
     worktrunkAutomation,
+    worktrunkShellIntegration,
     tmux,
     bun,
     stationUi,

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -16,6 +16,8 @@ import type {
   SetupConfigFact,
   SetupDependencyFact,
   SetupFacts,
+  SetupLauncherFact,
+  SetupLaunchersFact,
   SetupMode,
   SetupStationUiFact,
 } from "../model.js";
@@ -116,14 +118,15 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   const configPathOptions = setupConfigOptions(setupConfigInput);
   const configPath = setupConfigPath(configPathOptions);
   const configPromise = checkSetupConfig({ ...configPathOptions, configPath });
-  const worktrunkPromise = configPromise.then((config) =>
-    checkSetupWorktrunk({
+  const worktrunkPromise = configPromise.then((config) => {
+    const worktrunkOptions: Parameters<typeof checkSetupWorktrunk>[0] = {
       ...dependencyOptions,
-      ...(config.status === "valid" && config.worktrunkCommand !== undefined
-        ? { command: config.worktrunkCommand }
-        : {}),
-    }),
-  );
+    };
+    if (config.status === "valid" && config.worktrunkCommand !== undefined) {
+      worktrunkOptions.command = config.worktrunkCommand;
+    }
+    return checkSetupWorktrunk(worktrunkOptions);
+  });
   const harnessesPromise = configPromise.then((config) => {
     const harnessOptions: CheckHarnessesOptions = { ...commandOptions };
     if (config.status === "valid") {
@@ -192,31 +195,32 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     options.tmuxPopupOwnerRoot === undefined
       ? setupLauncherExecutable(launchers.tmuxPopup)
       : join(options.tmuxPopupOwnerRoot, "stn-tmux-popup");
-  const popupOnPath =
-    launchers.tmuxPopup.source === "path" &&
-    launchers.tmuxPopup.resolvedPath !== undefined &&
-    (await setupLauncherPathsMatch(launchers.tmuxPopup.resolvedPath, launcherCommand));
-  const resolvedLaunchers =
-    options.tmuxPopupOwnerRoot === undefined
-      ? launchers
-      : {
-          ...launchers,
-          tmuxPopup: (await canExecute(launcherCommand, options.access))
-            ? {
-                status: "ok" as const,
-                source: popupOnPath ? ("path" as const) : ("installed" as const),
-                command: launchers.tmuxPopup.command,
-                resolvedPath: launcherCommand,
-                checkoutPath: launchers.tmuxPopup.checkoutPath,
-              }
-            : {
-                status: "missing" as const,
-                source: "missing" as const,
-                command: launchers.tmuxPopup.command,
-                checkoutPath: launchers.tmuxPopup.checkoutPath,
-                message: `The installed stn-tmux-popup alias is missing or not executable at ${launcherCommand}.`,
-              },
-        };
+  let resolvedLaunchers: SetupLaunchersFact = launchers;
+  if (options.tmuxPopupOwnerRoot !== undefined) {
+    let tmuxPopup: SetupLauncherFact;
+    if (await canExecute(launcherCommand, options.access)) {
+      const popupOnPath =
+        launchers.tmuxPopup.source === "path" &&
+        launchers.tmuxPopup.resolvedPath !== undefined &&
+        (await setupLauncherPathsMatch(launchers.tmuxPopup.resolvedPath, launcherCommand));
+      tmuxPopup = {
+        status: "ok",
+        source: popupOnPath ? "path" : "installed",
+        command: launchers.tmuxPopup.command,
+        resolvedPath: launcherCommand,
+        checkoutPath: launchers.tmuxPopup.checkoutPath,
+      };
+    } else {
+      tmuxPopup = {
+        status: "missing",
+        source: "missing",
+        command: launchers.tmuxPopup.command,
+        checkoutPath: launchers.tmuxPopup.checkoutPath,
+        message: `The installed stn-tmux-popup alias is missing or not executable at ${launcherCommand}.`,
+      };
+    }
+    resolvedLaunchers = { ...launchers, tmuxPopup };
+  }
   const tmuxBindingOptions: Parameters<typeof checkSetupTmuxBinding>[0] = {
     homeDir,
     env,

--- a/apps/cli/src/commands/setup/checks/worktrunk.ts
+++ b/apps/cli/src/commands/setup/checks/worktrunk.ts
@@ -1,18 +1,24 @@
+import { basename, join } from "node:path";
+import { runExternalCommand } from "@station/runtime";
 import {
   checkWorktrunkDependency,
   missingWorktrunkAutomationFlagSupport,
   worktrunkAutomationMode,
 } from "@station/worktrunk";
-import type { SetupDependencyFact, SetupWorktrunkAutomationFact } from "../model.js";
+import type {
+  SetupDependencyFact,
+  SetupWorktrunkAutomationFact,
+  SetupWorktrunkShellIntegrationFact,
+} from "../model.js";
 import { setupProbeTimeoutMs } from "./constants.js";
-import { setupEnv } from "./env.js";
+import { commandEnv, setupEnv } from "./env.js";
 import type { SetupDependencyCheckOptions } from "./system.js";
 
 export async function checkSetupWorktrunk(
-  options: SetupDependencyCheckOptions = {},
+  options: SetupDependencyCheckOptions & { command?: string } = {},
 ): Promise<SetupDependencyFact> {
   const env = setupEnv(options.env);
-  const command = env.STATION_WORKTRUNK_BIN ?? "wt";
+  const command = options.command ?? env.STATION_WORKTRUNK_BIN ?? "wt";
   const dependencyOptions: Parameters<typeof checkWorktrunkDependency>[0] = {
     command,
     timeoutMs: setupProbeTimeoutMs,
@@ -101,6 +107,68 @@ export async function checkSetupWorktrunkAutomation(input: {
       message: `Could not verify that the installed wt supports ${mode.flag} for automated Worktrunk mutations.`,
     };
   }
+}
+
+export async function checkSetupWorktrunkShellIntegration(input: {
+  worktrunk: SetupDependencyFact;
+  homeDir: string;
+  env: SetupDependencyCheckOptions["env"];
+  runner?: SetupDependencyCheckOptions["runner"];
+}): Promise<SetupWorktrunkShellIntegrationFact> {
+  if (input.worktrunk.status !== "ok") {
+    return {
+      status: "skipped",
+      message: "Skipped until Worktrunk is available.",
+    };
+  }
+
+  const shell = activeShell(input.env?.SHELL);
+  if (shell === undefined) {
+    return {
+      status: "warning",
+      message: "Could not determine an active bash or zsh shell for Worktrunk integration.",
+    };
+  }
+
+  const rcPath = join(input.homeDir, shell === "bash" ? ".bashrc" : ".zshrc");
+  const command = input.worktrunk.resolvedPath ?? input.worktrunk.command;
+  try {
+    const result = await runExternalCommand(
+      {
+        command,
+        args: ["-y", "config", "shell", "install", "--dry-run", shell],
+        env: { ...commandEnv(input.env), HOME: input.homeDir },
+        timeoutMs: setupProbeTimeoutMs,
+      },
+      input.runner,
+    );
+    if (`${result.stdout}${result.stderr}`.trim().length === 0) {
+      return {
+        status: "ok",
+        shell,
+        rcPath,
+        message: `Worktrunk shell integration is installed for ${shell}.`,
+      };
+    }
+    return {
+      status: "warning",
+      shell,
+      rcPath,
+      message: `Worktrunk shell integration is not installed for ${shell}.`,
+    };
+  } catch {
+    return {
+      status: "warning",
+      shell,
+      rcPath,
+      message: `Could not verify Worktrunk shell integration for ${shell}.`,
+    };
+  }
+}
+
+function activeShell(shellCommand: string | undefined): "bash" | "zsh" | undefined {
+  const shell = basename(shellCommand ?? "");
+  return shell === "bash" || shell === "zsh" ? shell : undefined;
 }
 
 function setupAutomationMessage(

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -1,5 +1,4 @@
 import { access } from "node:fs/promises";
-import { basename, join } from "node:path";
 import { applySetupPlan } from "../apply.js";
 import { checkSetupTmuxBinding } from "../checks/tmuxBinding.js";
 import { planSetupConfigWrite } from "../configWriter.js";
@@ -209,7 +208,7 @@ async function runGuidedSetupWithPrompt(
   if (shellIntegration !== undefined) {
     const accepted = await prompt.confirm("Install Worktrunk shell integration?");
     if (accepted) {
-      await installWorktrunkShellIntegration(shellIntegration, plan, facts, options, deps);
+      await installWorktrunkShellIntegration(shellIntegration, plan, facts, deps);
     }
   }
 
@@ -295,21 +294,21 @@ async function installWorktrunkShellIntegration(
   action: SetupAction,
   plan: SetupPlan,
   facts: SetupFacts,
-  options: SetupCommandOptions,
   deps: SetupCommandDeps,
 ): Promise<void> {
   const baseCommand = action.command;
   if (baseCommand === undefined) return;
 
-  const shellRc = activeShellRc(facts.homeDir, (deps.env ?? options.env ?? process.env).SHELL);
-  const command = shellRc === undefined ? baseCommand : [...baseCommand, shellRc.shell];
-  if (shellRc !== undefined && !(await pathExists(shellRc.path, deps))) {
+  const integration = facts.worktrunkShellIntegration;
+  const command =
+    integration.shell === undefined ? baseCommand : [...baseCommand, integration.shell];
+  if (integration.rcPath !== undefined && !(await pathExists(integration.rcPath, deps))) {
     await write(
       deps,
       [
         "Optional Worktrunk shell integration was not installed; core setup is complete.",
-        `Active ${shellRc.shell} rc file not found: ${shellRc.path}`,
-        `Run: ${formatCommand(["touch", shellRc.path])} && ${formatCommand(command)}`,
+        `Active ${integration.shell} rc file not found: ${integration.rcPath}`,
+        `Run: ${formatCommand(["touch", integration.rcPath])} && ${formatCommand(command)}`,
         "",
       ].join("\n"),
     );
@@ -329,15 +328,6 @@ async function installWorktrunkShellIntegration(
       `Optional Worktrunk shell integration was not installed; core setup is complete.\nRun: ${formatCommand(command)}\n`,
     );
   }
-}
-
-function activeShellRc(
-  homeDir: string,
-  shellCommand: string | undefined,
-): { shell: "bash" | "zsh"; path: string } | undefined {
-  const shell = basename(shellCommand ?? "");
-  if (shell !== "bash" && shell !== "zsh") return undefined;
-  return { shell, path: join(homeDir, shell === "bash" ? ".bashrc" : ".zshrc") };
 }
 
 async function pathExists(path: string, deps: SetupCommandDeps): Promise<boolean> {

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -105,6 +105,13 @@ export type SetupWorktrunkAutomationFact = {
   missingSubcommands?: readonly string[];
 };
 
+export type SetupWorktrunkShellIntegrationFact = {
+  status: "ok" | "warning" | "skipped";
+  message: string;
+  shell?: "bash" | "zsh";
+  rcPath?: string;
+};
+
 export type SetupBrewFact = {
   status: "ok" | "missing" | "skipped";
   command: string;
@@ -204,6 +211,7 @@ export type SetupConfigFact =
       configuredHookHarnesses: readonly string[];
       defaults: SetupConfigDefaultsFact;
       tmux?: TmuxConfig;
+      worktrunkCommand?: string;
       worktrunkUseLifecycleHooks?: boolean;
       matchedProject?: SetupConfigProjectFact;
       // Non-fatal load diagnostics (broken project-local file, bad
@@ -278,6 +286,7 @@ export type SetupFacts = {
   socketEvidence: SetupDependencyFact;
   worktrunk: SetupDependencyFact;
   worktrunkAutomation: SetupWorktrunkAutomationFact;
+  worktrunkShellIntegration: SetupWorktrunkShellIntegrationFact;
   tmux: SetupDependencyFact;
   bun: SetupDependencyFact;
   stationUi: SetupStationUiFact;

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -93,16 +93,7 @@ function setupChecks(facts: SetupFacts, harnessSelection: SetupHarnessSelection)
     ...configDiagnosticsChecks(facts),
     launcherCheck(facts),
     ...(facts.compiled ? [] : [stationUiCheck(facts)]),
-    {
-      id: "worktrunk-shell-integration",
-      tier: "recommended",
-      status: facts.worktrunk.status === "ok" ? "warning" : "skipped",
-      label: "Worktrunk shell integration",
-      message:
-        facts.worktrunk.status === "ok"
-          ? "Recommended after core setup: wt config shell install."
-          : "Skipped until Worktrunk is available.",
-    },
+    worktrunkShellIntegrationCheck(facts),
     tmuxPopupBindingCheck(facts),
     worktrunkHooksCheck(facts),
     harnessHooksCheck(
@@ -220,8 +211,17 @@ function stateDirCheck(facts: SetupFacts): SetupCheck {
 function launcherCheck(facts: SetupFacts): SetupCheck {
   const launchers = [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup];
   const missing = launchers.filter((launcher) => launcher.status === "missing");
-  const checkout = launchers.filter((launcher) => launcher.source === "checkout");
-  const installed = launchers.filter((launcher) => launcher.source === "installed");
+  const launcherEntries = [
+    ["stn", facts.launchers.station],
+    ["stn-ingress", facts.launchers.ingress],
+    ["stn-tmux-popup", facts.launchers.tmuxPopup],
+  ] as const;
+  const checkoutOutsidePath = launcherEntries
+    .filter((entry) => entry[1].source === "checkout")
+    .map((entry) => entry[0]);
+  const installedOutsidePath = launcherEntries
+    .filter((entry) => entry[1].source === "installed")
+    .map((entry) => entry[0]);
   const details = {
     station: setupLauncherExecutable(facts.launchers.station),
     ingress: setupLauncherExecutable(facts.launchers.ingress),
@@ -237,24 +237,33 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
       details,
     };
   }
-  if (checkout.length > 0) {
+  if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
     return {
       id: "station-launchers",
       tier: "recommended",
       status: "warning",
       label: "STATION launchers",
-      message:
-        "Bare station launchers are not on PATH; setup will use current-checkout launcher paths.",
+      message: `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}.`,
       details,
     };
   }
-  if (installed.length > 0) {
+  if (checkoutOutsidePath.length > 0) {
     return {
       id: "station-launchers",
       tier: "recommended",
-      status: "ok",
+      status: "warning",
       label: "STATION launchers",
-      message: "STATION launchers are available from PATH or the installed artifact.",
+      message: `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`,
+      details,
+    };
+  }
+  if (installedOutsidePath.length > 0) {
+    return {
+      id: "station-launchers",
+      tier: "recommended",
+      status: "warning",
+      label: "STATION launchers",
+      message: `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}.`,
       details,
     };
   }
@@ -266,6 +275,22 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
     message: "stn, stn-ingress, and stn-tmux-popup are available on PATH.",
     details,
   };
+}
+
+function worktrunkShellIntegrationCheck(facts: SetupFacts): SetupCheck {
+  const integration = facts.worktrunkShellIntegration;
+  const details: Record<string, string> = {};
+  if (integration.shell !== undefined) details.shell = integration.shell;
+  if (integration.rcPath !== undefined) details.rcPath = integration.rcPath;
+  const check: SetupCheck = {
+    id: "worktrunk-shell-integration",
+    tier: "recommended",
+    status: integration.status,
+    label: "Worktrunk shell integration",
+    message: integration.message,
+  };
+  if (integration.shell !== undefined || integration.rcPath !== undefined) check.details = details;
+  return check;
 }
 
 function stationUiCheck(facts: SetupFacts): SetupCheck {
@@ -699,15 +724,27 @@ function setupActions(
       command: ["pnpm", "--dir", facts.launchers.packageRoot, "station:link"],
     });
   }
-  actions.push({
-    id: "worktrunk-shell-integration",
-    kind: "run-command",
-    tier: "recommended",
-    selected: false,
-    label: "Install Worktrunk shell integration",
-    message: "Run wt config shell install after core setup if you want Worktrunk shell helpers.",
-    command: [facts.worktrunk.command, "-y", "config", "shell", "install"],
-  });
+  if (
+    facts.worktrunk.status === "ok" &&
+    facts.worktrunkShellIntegration.status !== "ok" &&
+    facts.worktrunkShellIntegration.shell !== undefined
+  ) {
+    actions.push({
+      id: "worktrunk-shell-integration",
+      kind: "run-command",
+      tier: "recommended",
+      selected: false,
+      label: "Install Worktrunk shell integration",
+      message: "Run wt config shell install after core setup if you want Worktrunk shell helpers.",
+      command: [
+        facts.worktrunk.resolvedPath ?? facts.worktrunk.command,
+        "-y",
+        "config",
+        "shell",
+        "install",
+      ],
+    });
+  }
   if (
     facts.tmux.status === "ok" &&
     facts.launchers.tmuxPopup.status === "ok" &&

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -227,43 +227,23 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
     ingress: setupLauncherExecutable(facts.launchers.ingress),
     tmuxPopup: setupLauncherExecutable(facts.launchers.tmuxPopup),
   };
+  let warningMessage: string | undefined;
   if (missing.length > 0) {
-    return {
-      id: "station-launchers",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION launchers",
-      message: `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`,
-      details,
-    };
+    warningMessage = `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`;
+  } else if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
+    warningMessage = `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}.`;
+  } else if (checkoutOutsidePath.length > 0) {
+    warningMessage = `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`;
+  } else if (installedOutsidePath.length > 0) {
+    warningMessage = `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}.`;
   }
-  if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
+  if (warningMessage !== undefined) {
     return {
       id: "station-launchers",
       tier: "recommended",
       status: "warning",
       label: "STATION launchers",
-      message: `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}.`,
-      details,
-    };
-  }
-  if (checkoutOutsidePath.length > 0) {
-    return {
-      id: "station-launchers",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION launchers",
-      message: `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`,
-      details,
-    };
-  }
-  if (installedOutsidePath.length > 0) {
-    return {
-      id: "station-launchers",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION launchers",
-      message: `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}.`,
+      message: warningMessage,
       details,
     };
   }

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -24,6 +24,7 @@ import {
   tmuxPopupBindingBlock,
   tmuxPopupRunShellCommand,
 } from "../../src/commands/setup/checks/tmuxBinding.js";
+import { checkSetupWorktrunkShellIntegration } from "../../src/commands/setup/checks/worktrunk.js";
 import { checkSetupXcode } from "../../src/commands/setup/checks/xcode.js";
 import { buildSetupPlan } from "../../src/commands/setup/planner.js";
 
@@ -57,6 +58,51 @@ describe("setup dependency checks", () => {
     await expect(
       checkSetupSocketEvidence({ platform: "darwin", access: fakeAccess([]) }),
     ).resolves.toEqual({ status: "missing", command: "/usr/sbin/lsof" });
+  });
+
+  it("detects active-shell Worktrunk integration through its read-only dry run", async () => {
+    const pendingCalls: ExternalCommandInput[] = [];
+    const input = {
+      worktrunk: {
+        status: "ok" as const,
+        command: "wt",
+        resolvedPath: "/fake/bin/wt",
+      },
+      homeDir: "/tmp/home",
+      env: { PATH: "/fake/bin", SHELL: "/bin/zsh" },
+    };
+
+    await expect(
+      checkSetupWorktrunkShellIntegration({
+        ...input,
+        runner: fakeRunner(pendingCalls, {
+          "wt -y config shell install --dry-run zsh": "shell integration update pending\n",
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "warning",
+      shell: "zsh",
+      rcPath: "/tmp/home/.zshrc",
+    });
+    expect(pendingCalls).toContainEqual(
+      expect.objectContaining({
+        command: "/fake/bin/wt",
+        args: ["-y", "config", "shell", "install", "--dry-run", "zsh"],
+        env: expect.objectContaining({ HOME: "/tmp/home" }),
+      }),
+    );
+
+    await expect(
+      checkSetupWorktrunkShellIntegration({
+        ...input,
+        runner: fakeRunner([], {
+          "wt -y config shell install --dry-run zsh": "",
+        }),
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      message: "Worktrunk shell integration is installed for zsh.",
+    });
   });
 
   it("executes the compiled asset probe from the state directory", async () => {
@@ -165,7 +211,7 @@ describe("setup dependency checks", () => {
       cwd: repo,
       compiled: true,
       tmuxPopupOwnerRoot: installedRoot,
-      env: { PATH: "/fake/bin" },
+      env: { PATH: `${installedRoot}:/fake/bin` },
       runner: fakeRunner([], {
         "git rev-parse --show-toplevel": repo,
         "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
@@ -219,7 +265,7 @@ describe("setup dependency checks", () => {
 
     expect(facts.launchers.tmuxPopup).toMatchObject({
       status: "ok",
-      source: "installed",
+      source: "path",
       resolvedPath: popupAlias,
     });
     expect(facts.tmuxBinding).toMatchObject({
@@ -715,6 +761,57 @@ describe("setup dependency checks", () => {
         automationMode: "skip-hooks",
       },
     });
+  });
+
+  it("uses the configured Worktrunk command for readiness and shell checks", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const worktrunkCommand = "/custom/bin/wt";
+    const calls: ExternalCommandInput[] = [];
+    await mkdir(repo, { recursive: true });
+
+    const facts = await collectSetupFacts({
+      mode: "check",
+      cwd: repo,
+      homeDir: home,
+      env: {
+        PATH: "/fake/bin",
+        SHELL: "/bin/zsh",
+        STATION_WORKTRUNK_BIN: "/environment/bin/wt",
+      },
+      runner: fakeRunner(calls, {
+        "git rev-parse --show-toplevel": repo,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+        [`${worktrunkCommand} --version`]: "worktrunk 1.2.3\n",
+        [`${worktrunkCommand} -y config shell install --dry-run zsh`]: "",
+        "tmux -V": "tmux 3.5a\n",
+        "codex --version": "codex 0.1.0\n",
+      }),
+      access: fakeAccess([
+        worktrunkCommand,
+        "/fake/bin/tmux",
+        "/fake/bin/bun",
+        "/fake/bin/diffnav",
+        "/fake/bin/delta",
+      ]),
+      fs: readOnlyFs({
+        [join(home, ".config/station/config.toml")]: configToml(repo, {
+          worktrunkCommand,
+        }),
+      }),
+      noBrew: true,
+    });
+
+    expect(facts.worktrunk).toMatchObject({
+      status: "ok",
+      command: worktrunkCommand,
+      resolvedPath: worktrunkCommand,
+    });
+    expect(facts.worktrunkShellIntegration.status).toBe("ok");
+    expect(calls.filter((call) => call.command.includes("wt")).map((call) => call.command)).toEqual(
+      [worktrunkCommand, worktrunkCommand],
+    );
   });
 
   it("derives Worktrunk hook pre-approval mode from existing config", async () => {
@@ -1894,6 +1991,7 @@ function configToml(
     worktreeProvider?: string;
     terminal?: string;
     harness?: string;
+    worktrunkCommand?: string;
     useLifecycleHooks?: boolean;
     popupWidth?: string;
     popupHeight?: string;
@@ -1919,12 +2017,15 @@ function configToml(
     `root = ${JSON.stringify(repo)}`,
     "",
   ];
-  if (options.useLifecycleHooks !== undefined) {
-    lines.push(
-      "[worktree.worktrunk]",
-      `use_lifecycle_hooks = ${options.useLifecycleHooks ? "true" : "false"}`,
-      "",
-    );
+  if (options.worktrunkCommand !== undefined || options.useLifecycleHooks !== undefined) {
+    lines.push("[worktree.worktrunk]");
+    if (options.worktrunkCommand !== undefined) {
+      lines.push(`command = ${JSON.stringify(options.worktrunkCommand)}`);
+    }
+    if (options.useLifecycleHooks !== undefined) {
+      lines.push(`use_lifecycle_hooks = ${options.useLifecycleHooks ? "true" : "false"}`);
+    }
+    lines.push("");
   }
   if (
     options.popupWidth !== undefined ||

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -645,6 +645,12 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
       message:
         "Lifecycle hooks are enabled; automated Worktrunk mutations pass --yes to pre-approve prompts.",
     },
+    worktrunkShellIntegration: {
+      status: "warning",
+      shell: "zsh",
+      rcPath: "/tmp/home/.zshrc",
+      message: "Worktrunk shell integration is not installed for zsh.",
+    },
     tmux: { status: "ok", command: "tmux" },
     bun: { status: "ok", command: "bun" },
     stationUi: { status: "installed" },

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -40,6 +40,7 @@ describe("guided setup command", () => {
           "git rev-parse --show-toplevel": repo,
           "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
           "wt --version": "worktrunk 1.2.3\n",
+          "wt -y config shell install --dry-run zsh": "shell integration update pending\n",
           "tmux -V": "tmux 3.5a\n",
           "brew --version": "Homebrew 4.0.0\n",
           "codex --version": "codex 0.1.0\n",
@@ -94,6 +95,7 @@ describe("guided setup command", () => {
           "git rev-parse --show-toplevel": repo,
           "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
           "wt --version": "worktrunk 1.2.3\n",
+          "wt -y config shell install --dry-run zsh": "shell integration update pending\n",
           "tmux -V": "tmux 3.5a\n",
           "brew --version": "Homebrew 4.0.0\n",
           "codex --version": "codex 0.1.0\n",
@@ -357,12 +359,19 @@ describe("guided setup command", () => {
     );
 
     expect(result.code).toBe(0);
-    expect(calls.find((call) => call.command === "wt" && call.args?.[0] === "-y")).toMatchObject({
+    expect(
+      calls.find(
+        (call) =>
+          call.command === "/fake/bin/wt" &&
+          call.args?.[0] === "-y" &&
+          !call.args.includes("--dry-run"),
+      ),
+    ).toMatchObject({
       args: ["-y", "config", "shell", "install", "zsh"],
       stdio: "inherit",
     });
     expect(fs.files[zshrc]).toBe("# existing zsh config\n");
-    expect(chunks.join("")).toContain("Running: wt -y config shell install zsh");
+    expect(chunks.join("")).toContain("Running: /fake/bin/wt -y config shell install zsh");
     expect(chunks.join("")).toContain("Completed: Install Worktrunk shell integration");
   });
 
@@ -412,14 +421,21 @@ describe("guided setup command", () => {
     );
 
     expect(result.code).toBe(0);
-    expect(calls.find((call) => call.command === "wt" && call.args?.[0] === "-y")).toMatchObject({
+    expect(
+      calls.find(
+        (call) =>
+          call.command === "/fake/bin/wt" &&
+          call.args?.[0] === "-y" &&
+          !call.args.includes("--dry-run"),
+      ),
+    ).toMatchObject({
       args: ["-y", "config", "shell", "install", "zsh"],
     });
     expect(fs.files[zshrc]).toBe("# existing zsh config\n");
     expect(chunks.join("")).toContain(
       "Optional Worktrunk shell integration was not installed; core setup is complete.",
     );
-    expect(chunks.join("")).toContain("Run: wt -y config shell install zsh");
+    expect(chunks.join("")).toContain("Run: /fake/bin/wt -y config shell install zsh");
     expect(chunks.join("")).not.toContain("Failed: Install Worktrunk shell integration");
   });
 
@@ -805,7 +821,7 @@ describe("guided setup command", () => {
         ]),
         fs,
         activateObserverConfig: noopActivateObserverConfig,
-        prompt: prompt({ confirms: [false, false, true, false, true] }),
+        prompt: popupInstallPrompt,
         writeStdout: (chunk) => {
           chunks.push(chunk);
         },
@@ -868,7 +884,7 @@ describe("guided setup command", () => {
         ]),
         fs,
         activateObserverConfig: noopActivateObserverConfig,
-        prompt: prompt({ confirms: [false, false, true, false, true] }),
+        prompt: popupInstallPrompt,
         writeStdout: (chunk) => {
           chunks.push(chunk);
         },
@@ -940,7 +956,7 @@ describe("guided setup command", () => {
         ]),
         fs,
         activateObserverConfig: noopActivateObserverConfig,
-        prompt: prompt({ confirms: [false, false, true, false, true] }),
+        prompt: popupInstallPrompt,
         writeStdout: (chunk) => {
           chunks.push(chunk);
         },
@@ -1684,6 +1700,17 @@ function prompt(input: { confirms: boolean[]; multiSelects?: string[][] }): Setu
     },
   };
 }
+
+const popupInstallPrompt: SetupPromptAdapter = {
+  async confirm(message) {
+    return (
+      message === "Write core STATION config?" || message === "Install or load tmux popup binding?"
+    );
+  },
+  async selectMany() {
+    return ["codex"];
+  },
+};
 
 function readySetupDeps(repo: string) {
   return {

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -475,6 +475,39 @@ describe("setup planner", () => {
     expect(plan.actions.find((action) => action.id === "worktrunk-hooks")).toBeUndefined();
   });
 
+  it("warns when setup can use installed launchers that are not on PATH", () => {
+    const base = facts();
+    const installedRoot = "/tmp/home/.local/bin";
+    const plan = buildSetupPlan(
+      facts({
+        launchers: {
+          ...base.launchers,
+          station: {
+            ...base.launchers.station,
+            source: "installed",
+            resolvedPath: `${installedRoot}/stn`,
+          },
+          ingress: {
+            ...base.launchers.ingress,
+            source: "installed",
+            resolvedPath: `${installedRoot}/stn-ingress`,
+          },
+          tmuxPopup: {
+            ...base.launchers.tmuxPopup,
+            source: "installed",
+            resolvedPath: `${installedRoot}/stn-tmux-popup`,
+          },
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
+      status: "warning",
+      message:
+        "STATION is installed, but these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup.",
+    });
+  });
+
   it("plans the exact popup command and preserved key for a reachable tmux server", () => {
     const plan = buildSetupPlan(
       facts({
@@ -555,15 +588,41 @@ describe("setup planner", () => {
   });
 
   it("plans Worktrunk shell integration with Worktrunk's approval prompt disabled", () => {
-    const plan = buildSetupPlan(facts());
+    const plan = buildSetupPlan(
+      facts({
+        worktrunk: {
+          status: "ok",
+          command: "wt",
+          resolvedPath: "/opt/homebrew/bin/wt",
+        },
+      }),
+    );
 
     expect(
       plan.actions.find((action) => action.id === "worktrunk-shell-integration"),
     ).toMatchObject({
       kind: "run-command",
       selected: false,
-      command: ["wt", "-y", "config", "shell", "install"],
+      command: ["/opt/homebrew/bin/wt", "-y", "config", "shell", "install"],
     });
+  });
+
+  it("does not offer a broad Worktrunk shell install when the active shell is unsupported", () => {
+    const plan = buildSetupPlan(
+      facts({
+        worktrunkShellIntegration: {
+          status: "warning",
+          message: "Could not determine an active bash or zsh shell for Worktrunk integration.",
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "worktrunk-shell-integration")).toMatchObject({
+      status: "warning",
+    });
+    expect(
+      plan.actions.find((action) => action.id === "worktrunk-shell-integration"),
+    ).toBeUndefined();
   });
 
   it("installs checkout launchers through the pnpm 11-compatible package script", () => {
@@ -739,6 +798,12 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
       flag: "--yes",
       message:
         "Lifecycle hooks are enabled; automated Worktrunk mutations pass --yes to pre-approve prompts.",
+    },
+    worktrunkShellIntegration: {
+      status: "warning",
+      shell: "zsh",
+      rcPath: "/tmp/home/.zshrc",
+      message: "Worktrunk shell integration is not installed for zsh.",
     },
     tmux: {
       status: "ok",

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -31,7 +31,8 @@ describe("setup guided feedback e2e", () => {
   });
 
   it("prints config and Worktrunk shell integration feedback and exits", async () => {
-    const fixture = await createFixture({ harness: "codex" });
+    const fixture = await createFixture({ harness: "codex", shell: "zsh" });
+    await writeFile(shellRcPath(fixture.home, "zsh"), "# existing zsh config\n", "utf8");
     try {
       const result = await runStation(["--config", fixture.configPath, "setup"], {
         cwd: fixture.repo,
@@ -46,7 +47,9 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Install Codex agent hooks?");
       expect(result.stdout).toContain(`Applying: Write STATION config (${fixture.configPath})`);
       expect(result.stdout).toContain("Completed: Write STATION config");
-      expect(result.stdout).toContain("Running: wt -y config shell install");
+      expect(result.stdout).toContain(
+        `Running: ${join(fixture.bin, "wt")} -y config shell install zsh`,
+      );
       expect(result.stdout).toContain("fake shell integration installed");
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
@@ -189,7 +192,7 @@ describe("setup guided feedback e2e", () => {
         );
         expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
         expect(result.stdout).toContain(
-          `Run: touch ${rcPath} && wt -y config shell install ${shell}`,
+          `Run: touch ${rcPath} && ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
         );
         expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
         expect(result.stdout).not.toContain("fake shell integration installed");
@@ -215,13 +218,28 @@ describe("setup guided feedback e2e", () => {
         const second = await runStation(["--config", fixture.configPath, "setup"], {
           cwd: fixture.repo,
           env: fixture.env,
-          answers: ["n", "n", "y", "n"],
+          answers: ["n", "n", "n", "n"],
         });
 
         expect(first.exitCode).toBe(0);
         expect(second.exitCode).toBe(0);
-        expect(first.stdout).toContain(`Running: wt -y config shell install ${shell}`);
-        expect(second.stdout).toContain(`Running: wt -y config shell install ${shell}`);
+        expect(first.stdout).toContain(
+          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+        );
+        expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
+        expect(second.stdout).not.toContain(
+          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+        );
+        const check = await runStation(
+          ["--config", fixture.configPath, "setup", "check", "--json"],
+          { cwd: fixture.repo, env: fixture.env, answers: [] },
+        );
+        expect(check.exitCode).toBe(0);
+        expect(JSON.parse(check.stdout).checks).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
+          ]),
+        );
         const contents = await readFile(rcPath, "utf8");
         expect(contents.startsWith(original)).toBe(true);
         expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
@@ -287,9 +305,8 @@ describe("setup guided feedback e2e", () => {
       const result = await runStation(["--config", fixture.configPath, "setup"], {
         cwd: fixture.repo,
         env: fixture.env,
-        // Decline linking the fixture's non-runtime launchers, Worktrunk and Codex
-        // hooks; write config; decline shell integration; accept the popup binding.
-        answers: ["n", "n", "n", "y", "n", "y"],
+        // Decline launcher linking and hooks; write config; accept popup (no shell prompt without a supported active shell).
+        answers: ["n", "n", "n", "y", "y"],
       });
 
       expect(result.timedOut).toBe(false);
@@ -403,6 +420,17 @@ async function createFixture(input: {
     [
       'if [ "$1" = "--version" ]; then echo "worktrunk 1.2.3"; exit 0; fi',
       'if [ "$1 $2 $3 $4" = "-y config shell install" ]; then',
+      '  if [ "$5" = "--dry-run" ]; then',
+      '    case "$6" in',
+      '      zsh) rc="$HOME/.zshrc" ;;',
+      '      bash) rc="$HOME/.bashrc" ;;',
+      '      *) echo "unexpected shell $6" >&2; exit 2 ;;',
+      "    esac",
+      `    marker=${shellQuote(shellIntegrationMarker)}`,
+      '    if [ -f "$rc" ] && grep -F -x "$marker" "$rc" >/dev/null 2>&1; then exit 0; fi',
+      '    echo "shell integration update pending"',
+      "    exit 0",
+      "  fi",
       '  if [ "$#" -ge 5 ]; then',
       '    case "$5" in',
       '      zsh) rc="$HOME/.zshrc" ;;',


### PR DESCRIPTION
## Summary

- report installed or checkout launchers that do not resolve to setup's selected executables on `PATH` as warnings, including PATH-shadowed cases
- detect existing Worktrunk shell integration with its read-only dry run and suppress repeat prompts; unsupported shells remain a warning without offering a broad install
- honor Worktrunk command precedence (`config` > environment > `wt`) and use the exact resolved executable for probing, installation, and recovery guidance
- add focused collector, planner, guided-flow, and setup E2E regression coverage

This is intentionally stacked on #258 and should merge after that PR.

## Validation

- `env -u STATION_PANE pnpm test:all`
- `env -u STATION_PANE pnpm test:sqlite:bun`
- `pnpm --dir station typecheck`
- `pnpm --dir station test`
- `pnpm --dir station test:pty`
- `pnpm --dir station test:pty:bun`
- `pnpm build:binary -- --version 0.0.0-local`
- `pnpm smoke:binary -- --expected-version 0.0.0-local`
- two adversarial review rounds across three independent reviewers; final round clean

## UX verification

1. Run `stn setup check` from an installed artifact whose launchers are absent from or shadowed on `PATH`; the launcher row should be `WARN`, not `OK`.
2. Install Worktrunk shell integration for the active bash or zsh shell, then rerun `stn setup`; the integration row should be `OK` and the install prompt should not reappear.
