### PR TITLE
chore(release): prepare v0.7.1-rc.6 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run this from any directory:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.5
+  tag=v0.7.1-rc.6
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -81,12 +81,12 @@ Run this from any directory:
 )
 ```
 
-`v0.7.1-rc.5` is the current private-binary candidate. `v0.7.1-rc.4` remains
-published as its immutable rollback; `v0.7.1-rc.2` and `v0.7.1-rc.3` are older
-published binaries, while the earlier `v0.7.0` and `v0.7.1-rc.1`
-candidates remained unpublished. Run the recipe after the candidate is
-published. It fetches the installer and binary from the same immutable release
-tag, verifies the release checksum, and installs `stn`, `stn-ingress`, and
+`v0.7.1-rc.6` is the current private-binary candidate. `v0.7.1-rc.5` remains
+published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`, and
+`v0.7.1-rc.4` are older published binaries, while the earlier `v0.7.0` and
+`v0.7.1-rc.1` candidates remained unpublished. Run the recipe after the
+candidate is published. It fetches the installer and binary from the same
+immutable release tag, verifies the release checksum, and installs `stn`, `stn-ingress`, and
 `stn-tmux-popup` in `~/.local/bin` by default. It does not expose or print your
 GitHub credentials. After the first stable release, the commented assignment
 resolves the latest stable tag.
@@ -123,7 +123,7 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.5 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.6 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -139,7 +139,7 @@ Safety and scope:
   installer block from the page that supplied this prompt in my Terminal, then
   resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.6`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.5", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.6", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -327,23 +327,23 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
-The current immutable binary candidate is `v0.7.1-rc.5`. `v0.7.1-rc.4` is the
-prior published binary, and `v0.7.1-rc.2` and `v0.7.1-rc.3` remain older
-published rollbacks; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained
-unpublished:
+The current immutable binary candidate is `v0.7.1-rc.6`. `v0.7.1-rc.5` is the
+prior published binary, and `v0.7.1-rc.2`, `v0.7.1-rc.3`, and `v0.7.1-rc.4`
+remain older published rollbacks; the earlier `v0.7.0` and `v0.7.1-rc.1`
+candidates remained unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.5`, then create and
-   push `v0.7.1-rc.5`.
+   with `package.json` and runtime reporting at `0.7.1-rc.6`, then create and
+   push `v0.7.1-rc.6`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.5-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.6-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
-4. Install `v0.7.1-rc.4`, upgrade to the accepted candidate, explicitly
-   reinstall `v0.7.1-rc.4`, then reinstall the candidate. Confirm the complete
+4. Install `v0.7.1-rc.5`, upgrade to the accepted candidate, explicitly
+   reinstall `v0.7.1-rc.5`, then reinstall the candidate. Confirm the complete
    version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.5`, and the manual-acceptance confirmation. It rechecks the
+   `v0.7.1-rc.6`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
    asset IDs, and all archive hashes immediately before publishing that exact
    draft.
@@ -465,7 +465,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.5
+  tag=v0.7.1-rc.6
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -613,11 +613,11 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.5`:
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.6`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft
-   with published `v0.7.1-rc.4` in both directions.
+   with published `v0.7.1-rc.5` in both directions.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.5 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.6 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -49,7 +49,7 @@ Safety and scope:
   installer block from the page that supplied this prompt in my Terminal, then
   resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.5`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.6`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly
@@ -114,7 +114,7 @@ From any directory, run:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.5
+  tag=v0.7.1-rc.6
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -129,12 +129,12 @@ From any directory, run:
 )
 ```
 
-`v0.7.1-rc.5` is the current private-binary candidate. `v0.7.1-rc.4` remains
-published as its immutable rollback; `v0.7.1-rc.2` and `v0.7.1-rc.3` are older
-published binaries, while the earlier `v0.7.0` and `v0.7.1-rc.1`
-candidates remained unpublished. Run this recipe after the candidate is
-published. Keep the fixed assignment for an exact prerelease install. After the
-first stable release, use the commented assignment to resolve the latest stable
+`v0.7.1-rc.6` is the current private-binary candidate. `v0.7.1-rc.5` remains
+published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`, and
+`v0.7.1-rc.4` are older published binaries, while the earlier `v0.7.0` and
+`v0.7.1-rc.1` candidates remained unpublished. Run this recipe after the
+candidate is published. Keep the fixed assignment for an exact prerelease
+install. After the first stable release, use the commented assignment to resolve the latest stable
 tag while still fetching installer code and artifacts from that same immutable
 tag. The recipe never falls back to `main`, never prints GitHub credentials, and
 never pipes network output directly into a shell.
@@ -151,7 +151,7 @@ stn-tmux-popup
 It also installs the redistributed license under
 `${XDG_DATA_HOME:-$HOME/.local/share}/station/`.
 
-After this candidate is published, immutable rollback to `v0.7.1-rc.4` uses the
+After this candidate is published, immutable rollback to `v0.7.1-rc.5` uses the
 same exact-version procedure below.
 
 ## 3. Verify the Install
@@ -184,11 +184,11 @@ startup files.
 
 ## Install an Exact Version
 
-To install an exact release or return to published `v0.7.1-rc.4`, use the same
+To install an exact release or return to published `v0.7.1-rc.5`, use the same
 recipe with this assignment instead of the latest-release lookup:
 
 ```bash
-tag=v0.7.1-rc.4
+tag=v0.7.1-rc.5
 ```
 
 The installer code and artifacts still come from that same tag. The earlier

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.5", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.6", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -385,7 +385,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.5-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.6-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -427,8 +427,8 @@ invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
 always paired. `v0.7.1-rc.2` is the first published binary,
-`v0.7.1-rc.4` is the latest published binary, and publishing `v0.7.1-rc.5`
-makes immutable rollback to `v0.7.1-rc.4` available.
+`v0.7.1-rc.5` is the latest published binary, and publishing `v0.7.1-rc.6`
+makes immutable rollback to `v0.7.1-rc.5` available.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -497,9 +497,9 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.7.1-rc.5` promotes only after all four native targets pass
+Candidate `v0.7.1-rc.6` promotes only after all four native targets pass
 automated and manual acceptance, including upgrade and rollback against
-published `v0.7.1-rc.4`. Published tags and assets are never deleted, moved, or
+published `v0.7.1-rc.5`. Published tags and assets are never deleted, moved, or
 overwritten; a bad release rolls back explicitly and rolls forward to a higher
 version containing the revert or fix.
 
@@ -714,10 +714,10 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.5` output appears,
+   repeatedly installs the draft → only complete `0.7.1-rc.6` output appears,
    never command-not-found or malformed output; both aliases remain links to
    `stn`, so entrypoints never mix. Alternate the draft with published
-   `v0.7.1-rc.4` in both directions to prove upgrade and rollback.
+   `v0.7.1-rc.5` in both directions to prove upgrade and rollback.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.5",
+  "version": "0.7.1-rc.6",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.5" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.6" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.5",
+      version: "0.7.1-rc.6",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.5+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.5+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.6+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.6+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.5",
+      version: "0.7.1-rc.6",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -981,7 +981,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.5";
+    return "0.7.1-rc.6";
   }
   if (
     normalized.length === 2 &&

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -139,7 +139,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated GitHub release assets");
     expect(readme).toContain("does not require Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.5");
+    expect(install).toContain("tag=v0.7.1-rc.6");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -195,7 +195,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.5");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.6");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -253,7 +253,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.5");
+    expect(packageJson.version).toBe("0.7.1-rc.6");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");


### PR DESCRIPTION
## Summary

- advance the package and source runtime fallback to `0.7.1-rc.6`
- make RC6 the current candidate and RC5 the immutable rollback across install, release, and acceptance docs
- update release-readiness, runtime-version, manual-smoke, and binary-smoke expectations
- leave `STATION_SCHEMA_VERSION` and architecture boundaries unchanged

## Validation

- `pnpm build`
- `pnpm test:diagnostics`
- `pnpm test:unit`
- `env -u STATION_PANE pnpm test:pre-push`
- `pnpm build:binary -- --version 0.7.1-rc.6`
- `pnpm smoke:binary -- --expected-version 0.7.1-rc.6`
- `pnpm smoke:release`
- `git diff --check`

Full validation and the repository pre-push hook passed on commit `e42b77b951dc187e778a21be28facd15b05cb244`.