### PR TITLE
docs(contributing): guide reviewer-oriented PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,18 @@ When finishing a change and summarizing it, include a minimal line or section na
 
 PR titles should be semantic and reviewer-oriented, using a type/domain shape like `refactor(protocol): centralize observer command completion waits`; do not add agent tags.
 
+PR descriptions must be reviewer-oriented and understandable without prior knowledge of Station's implementation history.
+
+Every substantive PR should answer, in this order:
+
+- `## What this fixes`: briefly explain the affected Station responsibility, the concrete problem, and why it matters.
+- `## What changed`: summarize the resulting behavior and important design decisions using concise, outcome-oriented bullets.
+- `## Testing`: name the meaningful validation performed.
+
+Add `## Safety and scope` or `## User-visible behavior` only when they provide decision-relevant context.
+
+Assume the reviewer is technically capable but may not know Station's internal architecture. Define unfamiliar subsystem responsibilities on first mention, but do not include project history, a file-by-file walkthrough, implementation details already clear from the diff, or exhaustive test output. Prefer one short context paragraph and 3-7 change bullets; smaller PRs should be shorter.
+
 STATION is terminal/TUI-first. Ignore generic web, frontend, site, image, and browser guidance unless the task explicitly targets a web frontend or browser-rendered UI.
 
 ## Code Comments


### PR DESCRIPTION
## What this fixes

Station's agent guidance defines reviewer-oriented PR titles but does not define what a useful PR description must communicate. Agent-created descriptions can therefore assume creator-level context, narrate the diff, or become long enough that reviewers miss the important behavior and boundaries.

## What changed

- Substantive PRs must explain the affected Station responsibility, concrete problem, and why it matters under `What this fixes`.
- Descriptions must summarize behavioral and design outcomes under `What changed`, then name meaningful validation under `Testing`.
- `Safety and scope` and `User-visible behavior` are conditional so small PRs do not acquire empty boilerplate.
- The guidance assumes a technically capable reviewer who may not know Station internals and explicitly excludes project history, file-by-file walkthroughs, diff-obvious details, and exhaustive test output.
- A short context paragraph and 3-7 change bullets provide a default brevity target, with smaller PRs expected to be shorter.

## Testing

- `git diff --check`
- pre-commit Biome and source-order checks
- `env -u STATION_PANE pnpm test:pre-push` through the repository pre-push hook

## User-visible behavior

Station runtime behavior is unchanged. To verify the workflow change, ask an agent to open a substantive PR and confirm its description supplies the three required sections without unnecessary background or empty optional sections.
