### PR TITLE
fix(setup): separate Git capability from repository context

### DIFF
--- a/apps/cli/src/commands/setup/checks/git.ts
+++ b/apps/cli/src/commands/setup/checks/git.ts
@@ -1,7 +1,11 @@
 import { basename } from "node:path";
+import { findGitRoot } from "@station/config";
 import {
   type ExternalCommandInput,
   type ExternalCommandRunner,
+  environmentWithoutGitLocals,
+  externalCommandDiagnosticFromSafeError,
+  gitLocalEnvironmentVariables,
   isSafeError,
   runExternalCommand,
 } from "@station/runtime";
@@ -16,96 +20,183 @@ export type CheckGitOptions = {
   cwd?: string;
 };
 
+const defaultBranch = "main";
+const outsideRepositoryMessage = "Git is available; choose a project explicitly in STATION.";
+const gitAbsentMessage =
+  "Git is not installed. Install Git (on macOS, xcode-select --install provides it), then run stn setup check.";
+const gitUnusableMessage =
+  "Git is installed but unusable. On macOS run xcode-select --install or configure a working custom Git; otherwise repair or reinstall Git. Then run stn setup check.";
+
+type MissingGitFact = Extract<SetupGitFact, { status: "missing" }>;
+
+type GitCapabilityAssessment =
+  | { status: "available" }
+  | { status: "unavailable"; fact: MissingGitFact };
+
 export async function checkSetupGit(options: CheckGitOptions = {}): Promise<SetupGitFact> {
+  const capability = await probeGitCapability(options);
+  if (capability.status === "unavailable") return capability.fact;
+  return probeGitRepository(options, options.cwd ?? process.cwd());
+}
+
+async function probeGitCapability(options: CheckGitOptions): Promise<GitCapabilityAssessment> {
   try {
-    const rootResult = await git(options, ["rev-parse", "--show-toplevel"]);
+    const version = await git(options, ["--version"]);
+    if (!isGitVersionOutput(version.stdout)) {
+      return { status: "unavailable", fact: unusableGitFact() };
+    }
+    return { status: "available" };
+  } catch (error) {
+    if (isSafeError(error) && error.code === "ENOENT") {
+      return { status: "unavailable", fact: absentGitFact() };
+    }
+    return { status: "unavailable", fact: unusableGitFact() };
+  }
+}
+
+async function probeGitRepository(options: CheckGitOptions, cwd: string): Promise<SetupGitFact> {
+  try {
+    const rootResult = await git(options, ["rev-parse", "--show-toplevel"], cwd);
     const root = rootResult.stdout.trim();
-    const defaultBranch = await detectDefaultBranch(options);
+    if (root.length === 0) return unusableRepositoryFact(cwd);
+
+    const detectedDefaultBranch = await detectDefaultBranch(options, root);
     return {
       status: "ok",
+      repository: "present",
       root,
-      defaultBranch,
+      defaultBranch: detectedDefaultBranch,
       repoName: basename(root) || "project",
     };
   } catch (error) {
-    // runExternalCommand normalizes a missing binary to a safe error coded ENOENT;
-    // a real git that fails rev-parse (not a repository) carries a numeric exitCode
-    // instead. The two cases need different remediation.
-    // Note: on a bare macOS host /usr/bin/git is a Command Line Tools shim that
-    // exists, so spawn succeeds and rev-parse fails with a numeric exit code (not
-    // ENOENT) — that host is surfaced by the separate Command Line Tools check, so
-    // git-absent here is the genuinely-uninstalled (e.g. Linux) case.
-    if (isSafeError(error) && error.code === "ENOENT") {
+    const failureText = gitFailureText(error);
+    if (isDubiousOwnershipError(failureText)) {
       return {
         status: "missing",
-        reason: "git-absent",
-        defaultBranch: "main",
-        message:
-          "git is not installed. On macOS run xcode-select --install (or install git), then run stn setup.",
+        reason: "dubious-ownership",
+        defaultBranch,
+        message: dubiousOwnershipMessage(failureText, cwd),
       };
     }
-    return {
-      status: "missing",
-      reason: "not-a-repo",
-      defaultBranch: "main",
-      // git can run yet refuse the repo for "dubious ownership" (owned by a different
-      // UID — common with mounted volumes / containers). The user IS inside the repo,
-      // so the not-a-repo wording is wrong; point at the real fix instead.
-      message: isDubiousOwnershipError(error)
-        ? "git refused this repository for dubious ownership (it is owned by a different user, common with mounted volumes or containers). Run: git config --global --add safe.directory <repository path>, then run stn setup."
-        : "Git is available. Finish setup here, then choose a project explicitly in STATION.",
-    };
+    if (isCanonicalNotRepositoryError(gitFailureStderr(error))) {
+      // A marker means Git discovered repository intent but could not read its metadata.
+      if ((await findGitRoot(cwd)) === undefined) {
+        return {
+          status: "ok",
+          repository: "absent",
+          defaultBranch,
+          message: outsideRepositoryMessage,
+        };
+      }
+    }
+    return unusableRepositoryFact(cwd);
   }
 }
 
-function isDubiousOwnershipError(error: unknown): boolean {
-  if (!isSafeError(error)) {
-    return false;
-  }
-  const stderr =
-    error.diagnosticDetails?.find((detail) => detail.type === "external_command")?.stderrSnippet ??
-    "";
-  return /dubious ownership|safe\.directory/i.test(stderr);
+function absentGitFact(): MissingGitFact {
+  return {
+    status: "missing",
+    reason: "git-absent",
+    defaultBranch,
+    message: gitAbsentMessage,
+  };
 }
 
-async function detectDefaultBranch(options: CheckGitOptions): Promise<string> {
+function unusableGitFact(): MissingGitFact {
+  return {
+    status: "missing",
+    reason: "git-unusable",
+    defaultBranch,
+    message: gitUnusableMessage,
+  };
+}
+
+function unusableRepositoryFact(cwd: string): MissingGitFact {
+  return {
+    status: "missing",
+    reason: "repository-unusable",
+    defaultBranch,
+    message: `Git could not read repository metadata from ${cwd}. Repair its metadata, permissions, or Git configuration, then run stn setup check.`,
+  };
+}
+
+function isGitVersionOutput(stdout: string): boolean {
+  return /^git version \S+(?: [^\r\n]+)?$/.test(stdout.trim());
+}
+
+function isDubiousOwnershipError(failureText: string): boolean {
+  return /dubious ownership|safe\.directory/i.test(failureText);
+}
+
+function isCanonicalNotRepositoryError(stderr: string): boolean {
+  return /^fatal: not a git repository \(or any of the parent directories\): \.git$/m.test(stderr);
+}
+
+function dubiousOwnershipMessage(failureText: string, cwd: string): string {
+  const repository =
+    failureText.match(/dubious ownership in repository at ['"]([^'"]+)['"]/i)?.[1] ?? cwd;
+  return `Git refused this repository for dubious ownership. Review its ownership, then run git config --global --add safe.directory ${quoteCommandPart(repository)}, then run stn setup check.`;
+}
+
+function gitFailureText(error: unknown): string {
+  if (!isSafeError(error)) return "";
+  const diagnostic = externalCommandDiagnosticFromSafeError(error);
+  return [error.message, diagnostic?.stdoutSnippet, diagnostic?.stderrSnippet]
+    .filter((part) => part !== undefined)
+    .join("\n");
+}
+
+function gitFailureStderr(error: unknown): string {
+  if (!isSafeError(error)) return "";
+  return externalCommandDiagnosticFromSafeError(error)?.stderrSnippet ?? "";
+}
+
+async function detectDefaultBranch(options: CheckGitOptions, root: string): Promise<string> {
   try {
-    const originHead = await git(options, [
-      "symbolic-ref",
-      "--quiet",
-      "--short",
-      "refs/remotes/origin/HEAD",
-    ]);
+    const originHead = await git(
+      options,
+      ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"],
+      root,
+    );
     const branch = originHead.stdout.trim().replace(/^origin\//, "");
     if (branch.length > 0) {
       return branch;
     }
   } catch {
-    // fall through to current branch
+    // Fall through to the current branch because remote metadata is best-effort.
   }
 
   try {
-    const current = await git(options, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    const current = await git(options, ["rev-parse", "--abbrev-ref", "HEAD"], root);
     const branch = current.stdout.trim();
     if (branch.length > 0 && branch !== "HEAD") {
       return branch;
     }
   } catch {
-    // fall through to stable default
+    // Fall through to the stable default because branch metadata is best-effort.
   }
 
-  return "main";
+  return defaultBranch;
 }
 
-function git(options: CheckGitOptions, args: string[]) {
+function git(options: CheckGitOptions, args: string[], cwd?: string) {
+  const sanitizedEnv = environmentWithoutGitLocals(options.env ?? process.env);
   const input: ExternalCommandInput = {
     command: "git",
     args,
+    env: {
+      ...commandEnv(sanitizedEnv),
+      LANG: "C",
+      LC_ALL: "C",
+    },
+    unsetEnv: gitLocalEnvironmentVariables,
     timeoutMs: setupProbeTimeoutMs,
     maxOutputChars: 4096,
   };
-  if (options.cwd !== undefined) input.cwd = options.cwd;
-  const env = commandEnv(options.env);
-  if (env !== undefined) input.env = env;
+  if (cwd !== undefined) input.cwd = cwd;
   return runExternalCommand(input, options.runner);
+}
+
+function quoteCommandPart(part: string): string {
+  return `'${part.replaceAll("'", `'\\''`)}'`;
 }

--- a/apps/cli/src/commands/setup/checks/git.ts
+++ b/apps/cli/src/commands/setup/checks/git.ts
@@ -1,4 +1,5 @@
-import { basename } from "node:path";
+import { realpath } from "node:fs/promises";
+import { basename, delimiter, isAbsolute, relative, resolve, sep } from "node:path";
 import { findGitRoot } from "@station/config";
 import {
   type ExternalCommandInput,
@@ -78,16 +79,18 @@ async function probeGitRepository(options: CheckGitOptions, cwd: string): Promis
         message: dubiousOwnershipMessage(failureText, cwd),
       };
     }
-    if (isCanonicalNotRepositoryError(gitFailureStderr(error))) {
-      // A marker means Git discovered repository intent but could not read its metadata.
-      if ((await findGitRoot(cwd)) === undefined) {
-        return {
-          status: "ok",
-          repository: "absent",
-          defaultBranch,
-          message: outsideRepositoryMessage,
-        };
-      }
+    const stderr = gitFailureStderr(error);
+    if (
+      isFilesystemBoundaryNotRepositoryError(stderr) ||
+      (isCanonicalNotRepositoryError(stderr) &&
+        (await findDiscoverableGitRoot(cwd, options.env ?? process.env)) === undefined)
+    ) {
+      return {
+        status: "ok",
+        repository: "absent",
+        defaultBranch,
+        message: outsideRepositoryMessage,
+      };
     }
     return unusableRepositoryFact(cwd);
   }
@@ -132,10 +135,81 @@ function isCanonicalNotRepositoryError(stderr: string): boolean {
   return /^fatal: not a git repository \(or any of the parent directories\): \.git$/m.test(stderr);
 }
 
+function isFilesystemBoundaryNotRepositoryError(stderr: string): boolean {
+  return /^fatal: not a git repository \(or any parent up to mount point [^\r\n]+\)\r?\nStopping at filesystem boundary \(GIT_DISCOVERY_ACROSS_FILESYSTEM not set\)\.$/m.test(
+    stderr,
+  );
+}
+
 function dubiousOwnershipMessage(failureText: string, cwd: string): string {
   const repository =
-    failureText.match(/dubious ownership in repository at ['"]([^'"]+)['"]/i)?.[1] ?? cwd;
+    failureText.match(/^fatal: detected dubious ownership in repository at '(.*)'\r?$/im)?.[1] ??
+    cwd;
   return `Git refused this repository for dubious ownership. Review its ownership, then run git config --global --add safe.directory ${quoteCommandPart(repository)}, then run stn setup check.`;
+}
+
+async function findDiscoverableGitRoot(
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string | undefined> {
+  const root = await findGitRoot(cwd);
+  if (root === undefined) return undefined;
+
+  const ceilings = await gitCeilingDirectories(env.GIT_CEILING_DIRECTORIES);
+  if (ceilings.length === 0) return root;
+
+  const [canonicalCwd, canonicalRoot] = await Promise.all([
+    canonicalExistingPath(cwd),
+    canonicalExistingPath(root),
+  ]);
+  const blocked = ceilings.some(
+    (ceiling) =>
+      isStrictAncestor(ceiling, canonicalCwd) && isSameOrAncestor(canonicalRoot, ceiling),
+  );
+  return blocked ? undefined : root;
+}
+
+async function gitCeilingDirectories(value: string | undefined): Promise<string[]> {
+  if (value === undefined) return [];
+
+  const ceilings: string[] = [];
+  let skipCanonicalization = false;
+  for (const entry of value.split(delimiter)) {
+    if (entry.length === 0) {
+      skipCanonicalization = true;
+    } else if (isAbsolute(entry)) {
+      if (skipCanonicalization) {
+        ceilings.push(resolve(entry));
+      } else {
+        try {
+          ceilings.push(await realpath(entry));
+        } catch {
+          // Git discards ceiling entries that cannot be canonicalized.
+        }
+      }
+    }
+  }
+  return ceilings;
+}
+
+async function canonicalExistingPath(path: string): Promise<string> {
+  try {
+    return await realpath(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function isStrictAncestor(ancestor: string, path: string): boolean {
+  return ancestor !== path && isSameOrAncestor(ancestor, path);
+}
+
+function isSameOrAncestor(ancestor: string, path: string): boolean {
+  const descendant = relative(ancestor, path);
+  return (
+    descendant.length === 0 ||
+    (descendant !== ".." && !descendant.startsWith(`..${sep}`) && !isAbsolute(descendant))
+  );
 }
 
 function gitFailureText(error: unknown): string {

--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -107,7 +107,7 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
     launcherOptions.providerHookIngressLauncher = options.providerHookIngressLauncher;
   }
   const git = await checkSetupGit(commandOptions);
-  const gitRoot = git.status === "ok" ? git.root : undefined;
+  const gitRoot = git.status === "ok" && git.repository === "present" ? git.root : undefined;
   const setupConfigInput: {
     options: CollectSetupFactsOptions;
     cwd: string;

--- a/apps/cli/src/commands/setup/checks/xcode.ts
+++ b/apps/cli/src/commands/setup/checks/xcode.ts
@@ -19,10 +19,9 @@ const commandLineToolsInstallHint =
   "Command Line Tools are not installed. Run xcode-select --install, then run stn setup.";
 
 /**
- * macOS Command Line Tools probe. Homebrew, git, and node-gyp all depend on the
- * CLT, so a bare Mac fails everything downstream; this check is the one place that
- * names the `xcode-select --install` remediation. The CLT do not apply off macOS,
- * so non-darwin hosts report a not-applicable ok and add no plan noise.
+ * Source-checkout macOS Command Line Tools probe for Homebrew and native builds.
+ * Compiled setup skips this check and accepts any Git implementation that passes
+ * its own probe; non-darwin hosts report a not-applicable ok without plan noise.
  */
 export async function checkSetupXcode(options: CheckXcodeOptions = {}): Promise<SetupXcodeFact> {
   const platform = options.platform ?? process.platform;

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -165,21 +165,40 @@ export type SetupXcodeFact =
       message: string;
     };
 
+type SetupGitRepositoryFact = {
+  status: "ok";
+  repository: "present";
+  root: string;
+  defaultBranch: string;
+  repoName: string;
+};
+
+type SetupGitOutsideRepositoryFact = {
+  status: "ok";
+  repository: "absent";
+  defaultBranch: string;
+  message: string;
+};
+
+type SetupGitCapabilityFailureFact = {
+  status: "missing";
+  reason: "git-absent" | "git-unusable";
+  defaultBranch: string;
+  message: string;
+};
+
+type SetupGitRepositoryFailureFact = {
+  status: "missing";
+  reason: "repository-unusable" | "dubious-ownership";
+  defaultBranch: string;
+  message: string;
+};
+
 export type SetupGitFact =
-  | {
-      status: "ok";
-      root: string;
-      defaultBranch: string;
-      repoName: string;
-    }
-  | {
-      status: "missing";
-      // "git-absent": the git binary is not installed (bare-machine case).
-      // "not-a-repo": git works but the cwd is not inside a repository.
-      reason: "git-absent" | "not-a-repo";
-      defaultBranch: string;
-      message: string;
-    };
+  | SetupGitRepositoryFact
+  | SetupGitOutsideRepositoryFact
+  | SetupGitCapabilityFailureFact
+  | SetupGitRepositoryFailureFact;
 
 export type SetupHarnessFact = {
   id: SupportedHarnessId;

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -577,39 +577,37 @@ function gitDeltaCheck(facts: SetupFacts): SetupCheck {
   };
 }
 
+type GitCheckAssessment = Pick<SetupCheck, "status" | "message" | "details">;
+
 function gitCheck(facts: SetupFacts): SetupCheck {
-  if (facts.git.status === "ok") {
-    return {
-      id: "git-project",
-      tier: "required",
-      status: "ok",
-      label: "Git",
-      message: "Git is available; choose projects explicitly in STATION.",
-      details: {
-        root: facts.git.root,
-        defaultBranch: facts.git.defaultBranch,
-      },
-    };
-  }
-  if (facts.git.reason === "not-a-repo") {
-    return {
-      id: "git-project",
-      tier: "required",
-      status: "ok",
-      label: "Git",
-      message: "Git is available; choose a project explicitly in STATION.",
-      details: { defaultBranch: facts.git.defaultBranch },
-    };
-  }
+  const assessment = assessGit(facts.git);
   return {
     id: "git-project",
     tier: "required",
-    status: "missing",
     label: "Git",
-    message: facts.git.message,
-    details: {
-      defaultBranch: facts.git.defaultBranch,
-    },
+    ...assessment,
+  };
+}
+
+function assessGit(git: SetupFacts["git"]): GitCheckAssessment {
+  if (git.status === "missing") {
+    return {
+      status: "missing",
+      message: git.message,
+      details: { defaultBranch: git.defaultBranch },
+    };
+  }
+  if (git.repository === "absent") {
+    return {
+      status: "ok",
+      message: git.message,
+      details: { defaultBranch: git.defaultBranch },
+    };
+  }
+  return {
+    status: "ok",
+    message: "Git is available; choose projects explicitly in STATION.",
+    details: { root: git.root, defaultBranch: git.defaultBranch },
   };
 }
 
@@ -1077,7 +1075,7 @@ function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
   if (facts.bun.status === "missing") {
     return ["Install Bun (brew install bun), then run: stn setup check"];
   }
-  if (facts.git.status === "missing" && facts.git.reason === "git-absent") {
+  if (facts.git.status === "missing") {
     return [facts.git.message];
   }
   if (facts.diffnav.status === "missing" || facts.gitDelta.status === "missing") {

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -594,7 +594,7 @@ function assessGit(git: SetupFacts["git"]): GitCheckAssessment {
     return {
       status: "missing",
       message: git.message,
-      details: { defaultBranch: git.defaultBranch },
+      details: { defaultBranch: git.defaultBranch, reason: git.reason },
     };
   }
   if (git.repository === "absent") {

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -112,6 +112,9 @@ export function renderSetupApplyResult(
       theme,
     );
   }
+  if (missing?.id === "git-project") {
+    return missingResult(missing.message, "Then run:", theme);
+  }
   if (missing?.id === "harness") {
     return missingResult(missing.message, "Resolve the agent selection, then run:", theme);
   }

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -113,7 +113,7 @@ export function renderSetupApplyResult(
     );
   }
   if (missing?.id === "git-project") {
-    return missingResult(missing.message, "Then run:", theme);
+    return `${theme.bold(theme.red(missing.message))}\n`;
   }
   if (missing?.id === "harness") {
     return missingResult(missing.message, "Resolve the agent selection, then run:", theme);

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -974,7 +974,9 @@ function fakeBinOutput(
 }
 
 function defaultProbeOutput(key: string): string | undefined {
-  return key === "xcode-select -p" ? "/Library/Developer/CommandLineTools\n" : undefined;
+  if (key === "git --version") return "git version 2.50.1\n";
+  if (key === "xcode-select -p") return "/Library/Developer/CommandLineTools\n";
+  return undefined;
 }
 
 function commandResult(input: ExternalCommandInput, stdout: string): ExternalCommandResult {

--- a/apps/cli/test/integration/setup-profiles.test.ts
+++ b/apps/cli/test/integration/setup-profiles.test.ts
@@ -55,9 +55,10 @@ const harnessCommands: Record<string, string> = {
   claude: "claude",
 };
 
-// Compile a declarative profile into the real SetupCommandDeps injection surface:
-// a PATH-access set for path-resolved tools and a runner that answers the version
-// and presence probes the checks make.
+type ProfileState = MachineProfile["state"];
+type HarnessId = "codex" | "cursor" | "opencode" | "pi" | "claude";
+
+// Compile a declarative profile into the real SetupCommandDeps injection surface.
 function profileToSetupDeps(
   profile: MachineProfile,
   repo: string,
@@ -65,103 +66,150 @@ function profileToSetupDeps(
   configPath: string,
 ) {
   const state = profile.state;
-  const presentPaths = new Set<string>();
-  const addBin = (presence: string, bin: string) => {
-    if (presence === "present") presentPaths.add(`/fake/bin/${bin}`);
+  const presentPaths = profileExecutablePaths(state);
+  const files = profileConfigFiles(state, configPath, repo);
+  return {
+    cwd: repo,
+    homeDir: home,
+    env: { PATH: "/fake/bin" },
+    platform: state.platform,
+    runner: profileRunner(state, repo),
+    access: profileAccess(presentPaths),
+    fs: profileFileSystem(files),
+    probeHarnessHooksStatus: profileHarnessTrackingProbe(state),
+    now: () => new Date("2026-06-08T12:00:00.000Z"),
   };
-  addBin(state.worktrunk, "wt");
-  addBin(state.tmux, "tmux");
-  addBin(state.bun, "bun");
-  addBin(state.diffnav, "diffnav");
-  addBin(state.gitDelta, "delta");
+}
 
+function profileExecutablePaths(state: ProfileState): Set<string> {
+  const tools = [
+    [state.worktrunk, "wt"],
+    [state.tmux, "tmux"],
+    [state.bun, "bun"],
+    [state.diffnav, "diffnav"],
+    [state.gitDelta, "delta"],
+  ] as const;
+  return new Set(
+    tools.flatMap(([presence, binary]) => (presence === "present" ? [`/fake/bin/${binary}`] : [])),
+  );
+}
+
+function profileVersionOutputs(state: ProfileState): Record<string, string> {
   const versions: Record<string, string> = {};
   if (state.worktrunk === "present") versions["wt --version"] = "worktrunk 1.2.3\n";
   if (state.tmux === "present") versions["tmux -V"] = "tmux 3.5a\n";
   for (const harness of state.harnesses) {
     versions[`${harnessCommands[harness] ?? harness} --version`] = `${harness} 1.0.0\n`;
   }
+  return versions;
+}
 
-  const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
-    const bin = input.command.startsWith("/fake/bin/") ? basename(input.command) : input.command;
-    const args = input.args ?? [];
-    const key = `${bin} ${args.join(" ")}`;
-    if (input.command === "git") {
-      if (state.git === "absent") throw enoent(key);
-      if (args[0] === "rev-parse") {
-        if (!state.insideRepo) throw exitCode(key, 128);
-        return ok(input, `${repo}\n`);
-      }
-      if (args[0] === "symbolic-ref") return ok(input, "origin/main\n");
-      return ok(input, "");
-    }
-    if (bin === "brew") {
-      if (state.brew === "absent") throw enoent(key);
-      return ok(input, "Homebrew 4.0.0\n");
-    }
-    if (bin === "xcode-select") {
-      if (state.platform === "darwin" && state.xcodeClt === "present") {
-        return ok(input, "/Library/Developer/CommandLineTools\n");
-      }
-      throw exitCode(key, 1);
-    }
-    const stdout = versions[key];
-    if (stdout !== undefined) return ok(input, stdout);
-    throw enoent(key);
-  };
+function profileRunner(state: ProfileState, repo: string) {
+  const versions = profileVersionOutputs(state);
+  return (input: ExternalCommandInput): Promise<ExternalCommandResult> =>
+    Promise.resolve().then(() => profileCommandResult(state, repo, versions, input));
+}
 
-  const files: Record<string, string> = {};
-  if (state.configToml !== undefined) {
-    files[configPath] = state.configToml.replaceAll("{{REPO}}", repo);
+function profileCommandResult(
+  state: ProfileState,
+  repo: string,
+  versions: Readonly<Record<string, string>>,
+  input: ExternalCommandInput,
+): ExternalCommandResult {
+  const bin = input.command.startsWith("/fake/bin/") ? basename(input.command) : input.command;
+  const args = input.args ?? [];
+  const key = `${bin} ${args.join(" ")}`;
+  if (input.command === "git") return profileGitResult(state, repo, input, key, args);
+  if (bin === "brew") {
+    if (state.brew === "absent") throw enoent(key);
+    return ok(input, "Homebrew 4.0.0\n");
   }
+  if (bin === "xcode-select") return profileXcodeResult(state, input, key);
 
+  const stdout = versions[key];
+  if (stdout !== undefined) return ok(input, stdout);
+  throw enoent(key);
+}
+
+function profileGitResult(
+  state: ProfileState,
+  repo: string,
+  input: ExternalCommandInput,
+  key: string,
+  args: readonly string[],
+): ExternalCommandResult {
+  if (state.git === "absent") throw enoent(key);
+  if (args[0] === "--version") return ok(input, "git version 2.50.1\n");
+  if (args[0] === "rev-parse") {
+    if (!state.insideRepo) throw exitCode(key, 128);
+    return ok(input, `${repo}\n`);
+  }
+  if (args[0] === "symbolic-ref") return ok(input, "origin/main\n");
+  return ok(input, "");
+}
+
+function profileXcodeResult(
+  state: ProfileState,
+  input: ExternalCommandInput,
+  key: string,
+): ExternalCommandResult {
+  if (state.platform === "darwin" && state.xcodeClt === "present") {
+    return ok(input, "/Library/Developer/CommandLineTools\n");
+  }
+  throw exitCode(key, 1);
+}
+
+function profileAccess(presentPaths: ReadonlySet<string>) {
+  return (path: string): Promise<void> =>
+    presentPaths.has(path) ? Promise.resolve() : Promise.reject(enoent(path));
+}
+
+function profileConfigFiles(
+  state: ProfileState,
+  configPath: string,
+  repo: string,
+): Record<string, string> {
+  if (state.configToml === undefined) return {};
+  return { [configPath]: state.configToml.replaceAll("{{REPO}}", repo) };
+}
+
+function profileFileSystem(files: Record<string, string>) {
   return {
-    cwd: repo,
-    homeDir: home,
-    env: { PATH: "/fake/bin" },
-    platform: state.platform,
-    runner,
-    access: async (path: string) => {
-      if (!presentPaths.has(path)) throw enoent(path);
+    mkdir: () => Promise.resolve(),
+    readFile(path: string) {
+      const content = files[path];
+      return content === undefined ? Promise.reject(enoent(path)) : Promise.resolve(content);
     },
-    fs: {
-      async mkdir() {
-        return undefined;
-      },
-      async readFile(path: string) {
-        const content = files[path];
-        if (content === undefined) throw enoent(path);
-        return content;
-      },
-      async writeFile(path: string, content: string) {
-        files[path] = content;
-      },
-      async rename(from: string, to: string) {
-        const content = files[from];
-        if (content === undefined) throw enoent(from);
-        files[to] = content;
-        delete files[from];
-      },
-      async access(path: string) {
-        if (files[path] === undefined) throw enoent(path);
-      },
+    writeFile(path: string, content: string) {
+      files[path] = content;
+      return Promise.resolve();
     },
-    async probeHarnessHooksStatus(harnessId: "codex" | "cursor" | "opencode" | "pi" | "claude") {
-      const tracking = state.harnessTracking?.[harnessId];
-      if (tracking === "unsupported" || harnessId === "pi") return undefined;
-      if (tracking === "probe-failed") throw new Error("synthetic tracking probe failure");
-      const installed = tracking === "prepared";
-      return {
-        provider: harnessId,
-        requested: tracking !== undefined,
-        installed,
-        missing: installed ? [] : ["tracking artifact"],
-        message: installed
-          ? "Tracking artifacts are installed."
-          : "Tracking artifacts are missing.",
-      };
+    rename(from: string, to: string) {
+      const content = files[from];
+      if (content === undefined) return Promise.reject(enoent(from));
+      files[to] = content;
+      delete files[from];
+      return Promise.resolve();
     },
-    now: () => new Date("2026-06-08T12:00:00.000Z"),
+    access(path: string) {
+      return files[path] === undefined ? Promise.reject(enoent(path)) : Promise.resolve();
+    },
+  };
+}
+
+function profileHarnessTrackingProbe(state: ProfileState) {
+  return async (harnessId: HarnessId) => {
+    const tracking = state.harnessTracking?.[harnessId];
+    if (tracking === "unsupported" || harnessId === "pi") return undefined;
+    if (tracking === "probe-failed") throw new Error("synthetic tracking probe failure");
+    const installed = tracking === "prepared";
+    return {
+      provider: harnessId,
+      requested: tracking !== undefined,
+      installed,
+      missing: installed ? [] : ["tracking artifact"],
+      message: installed ? "Tracking artifacts are installed." : "Tracking artifacts are missing.",
+    };
   };
 }
 

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1,10 +1,11 @@
 import { access, chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, delimiter, join } from "node:path";
-import type {
-  ExternalCommandInput,
-  ExternalCommandResult,
-  ExternalCommandRunner,
+import {
+  type ExternalCommandInput,
+  type ExternalCommandResult,
+  type ExternalCommandRunner,
+  gitLocalEnvironmentVariables,
 } from "@station/runtime";
 import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -162,10 +163,10 @@ describe("setup dependency checks", () => {
     expect(unlinked).toEqual([join(path, ".probe")]);
   });
 
-  it("skips source renderer and Xcode probes in compiled setup", async () => {
+  it("accepts working custom Git without probing Xcode in compiled Darwin setup", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
-    await mkdir(repo, { recursive: true });
+    await mkdir(join(repo, ".git"), { recursive: true });
     const calls: ExternalCommandInput[] = [];
     const stationUiInstalled = vi.fn(async () => false);
 
@@ -175,7 +176,7 @@ describe("setup dependency checks", () => {
       homeDir: join(root, "home"),
       compiled: true,
       platform: "darwin",
-      env: { PATH: "/fake/bin" },
+      env: { PATH: "/fake/bin", GIT_DIR: "/inherited/repository" },
       runner: fakeRunner(calls, {
         "git rev-parse --show-toplevel": repo,
         "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
@@ -185,7 +186,17 @@ describe("setup dependency checks", () => {
       stationUiInstalled,
     });
     const plan = buildSetupPlan(facts);
+    const versionCall = calls.find(
+      (call) => call.command === "git" && call.args?.join(" ") === "--version",
+    );
 
+    expect(facts.git).toMatchObject({ status: "ok", repository: "present", root: repo });
+    expect(versionCall).toMatchObject({
+      env: expect.objectContaining({ LC_ALL: "C", LANG: "C" }),
+      unsetEnv: gitLocalEnvironmentVariables,
+    });
+    expect(versionCall).not.toHaveProperty("cwd");
+    expect(versionCall?.env).not.toHaveProperty("GIT_DIR");
     expect(stationUiInstalled).not.toHaveBeenCalled();
     expect(calls.some((call) => call.command === "xcode-select")).toBe(false);
     expect(plan.summary.launchReady).toBe(true);
@@ -1907,46 +1918,203 @@ describe("checkSetupXcode", () => {
 });
 
 describe("checkSetupGit", () => {
-  it("distinguishes a missing git binary from a missing repository", async () => {
+  const tempRoots: string[] = [];
+  const canonicalNotRepository =
+    "fatal: not a git repository (or any of the parent directories): .git";
+
+  afterEach(async () => {
+    await Promise.all(
+      tempRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+    );
+  });
+
+  it("reports Git absent when the version probe cannot find the binary", async () => {
+    const calls: ExternalCommandInput[] = [];
     const absent = await checkSetupGit({
       env: { PATH: "/fake/bin" },
       cwd: tmpdir(),
-      runner: fakeRunner([], {}),
-    });
-    expect(absent).toMatchObject({ status: "missing", reason: "git-absent" });
-    if (absent.status !== "missing") throw new Error("expected missing git");
-    expect(absent.message).toContain("xcode-select --install");
-
-    const notARepo = await checkSetupGit({
-      env: { PATH: "/fake/bin" },
-      cwd: tmpdir(),
-      // git resolves but rev-parse fails with a non-ENOENT exit code.
-      runner: async () => {
-        throw Object.assign(new Error("not a git repository"), { code: 128 });
+      runner: async (input) => {
+        calls.push(input);
+        throw Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" });
       },
     });
-    expect(notARepo).toMatchObject({ status: "missing", reason: "not-a-repo" });
+
+    expect(absent).toMatchObject({ status: "missing", reason: "git-absent" });
+    expect(calls.map((call) => call.args)).toEqual([["--version"]]);
   });
 
-  it("gives the safe.directory remediation when git refuses for dubious ownership", async () => {
-    const dubious = await checkSetupGit({
-      env: { PATH: "/fake/bin" },
-      cwd: "/tmp/owned-by-root",
-      // git runs but exits 128 with a dubious-ownership message; the user IS inside
-      // the repo, so the remediation must point at safe.directory, not "not a repo".
-      runner: async () => {
-        throw Object.assign(
-          new Error("fatal: detected dubious ownership in repository at '/tmp/owned-by-root'"),
-          {
-            code: 128,
-            stderr: "fatal: detected dubious ownership in repository at '/tmp/owned-by-root'",
-          },
-        );
+  it("reports an Apple shim version failure as unusable without probing a repository", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const stderr = [
+      "xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools),",
+      "missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun",
+    ].join(" ");
+    const unusable = await checkSetupGit({
+      cwd: tmpdir(),
+      runner: async (input) => {
+        calls.push(input);
+        throw Object.assign(new Error(stderr), { code: 1, stderr });
       },
     });
-    expect(dubious).toMatchObject({ status: "missing", reason: "not-a-repo" });
-    if (dubious.status !== "missing") throw new Error("expected missing git");
-    expect(dubious.message).toContain("safe.directory");
+
+    expect(unusable).toMatchObject({ status: "missing", reason: "git-unusable" });
+    if (unusable.status !== "missing") throw new Error("expected unusable Git");
+    expect(unusable.message).toContain("xcode-select --install");
+    expect(calls.map((call) => call.args)).toEqual([["--version"]]);
+  });
+
+  it("reports malformed version output as unusable without probing a repository", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const unusable = await checkSetupGit({
+      cwd: tmpdir(),
+      runner: fakeRunner(calls, { "git --version": "Apple developer tools unavailable\n" }),
+    });
+
+    expect(unusable).toMatchObject({ status: "missing", reason: "git-unusable" });
+    expect(calls.map((call) => call.args)).toEqual([["--version"]]);
+  });
+
+  it("reports working Git outside a repository as healthy when no marker exists", async () => {
+    const root = await tempRoot(tempRoots);
+    const calls: ExternalCommandInput[] = [];
+    const outside = await checkSetupGit({
+      cwd: root,
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw Object.assign(new Error(canonicalNotRepository), {
+          code: 128,
+          stderr: canonicalNotRepository,
+        });
+      },
+    });
+
+    expect(outside).toEqual({
+      status: "ok",
+      repository: "absent",
+      defaultBranch: "main",
+      message: "Git is available; choose a project explicitly in STATION.",
+    });
+  });
+
+  it("reports a healthy repository with its root and best-effort default branch", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(join(repo, ".git"), { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+
+    const healthy = await checkSetupGit({
+      cwd: repo,
+      env: { PATH: "/fake/bin", GIT_WORK_TREE: "/inherited/worktree" },
+      runner: fakeRunner(calls, {
+        "git rev-parse --show-toplevel": `${repo}\n`,
+        "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/trunk\n",
+      }),
+    });
+
+    expect(healthy).toEqual({
+      status: "ok",
+      repository: "present",
+      root: repo,
+      defaultBranch: "trunk",
+      repoName: "repo",
+    });
+    expect(calls[0]).toMatchObject({
+      command: "git",
+      args: ["--version"],
+      env: expect.objectContaining({ LC_ALL: "C", LANG: "C" }),
+      unsetEnv: gitLocalEnvironmentVariables,
+    });
+    expect(calls[0]).not.toHaveProperty("cwd");
+    expect(calls[0]?.env).not.toHaveProperty("GIT_WORK_TREE");
+  });
+
+  it("fails a canonical non-repository error when a repository marker exists", async () => {
+    const root = await tempRoot(tempRoots);
+    await mkdir(join(root, ".git"));
+    const failed = await checkSetupGit({
+      cwd: root,
+      runner: async (input) => {
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw Object.assign(new Error(canonicalNotRepository), {
+          code: 128,
+          stderr: canonicalNotRepository,
+        });
+      },
+    });
+
+    expect(failed).toMatchObject({ status: "missing", reason: "repository-unusable" });
+  });
+
+  it("gives scoped safe.directory guidance for dubious ownership", async () => {
+    const root = await tempRoot(tempRoots);
+    const repository = join(root, "owned-by-root");
+    await mkdir(repository);
+    const stderr = `fatal: detected dubious ownership in repository at '${repository}'`;
+    const dubious = await checkSetupGit({
+      cwd: repository,
+      runner: async (input) => {
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw Object.assign(new Error(stderr), { code: 128, stderr });
+      },
+    });
+
+    expect(dubious).toMatchObject({ status: "missing", reason: "dubious-ownership" });
+    if (dubious.status !== "missing") throw new Error("expected dubious repository");
+    expect(dubious.message).toContain(`git config --global --add safe.directory '${repository}'`);
+  });
+
+  it.each([
+    {
+      name: "corrupt config",
+      error: Object.assign(new Error("fatal: bad config line 1 in file .git/config"), {
+        code: 128,
+        stderr: "fatal: bad config line 1 in file .git/config",
+      }),
+    },
+    {
+      name: "permission failure",
+      error: Object.assign(new Error("permission denied"), { code: "EACCES" }),
+    },
+  ])("reports $name as an unusable repository", async ({ error }) => {
+    const root = await tempRoot(tempRoots);
+    const failed = await checkSetupGit({
+      cwd: root,
+      runner: async (input) => {
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw error;
+      },
+    });
+
+    expect(failed).toMatchObject({ status: "missing", reason: "repository-unusable" });
+  });
+
+  it("keeps remote and branch probe failures non-fatal after finding the repository root", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(join(repo, ".git"), { recursive: true });
+
+    const healthy = await checkSetupGit({
+      cwd: repo,
+      runner: fakeRunner([], {
+        "git rev-parse --show-toplevel": `${repo}\n`,
+      }),
+    });
+
+    expect(healthy).toMatchObject({
+      status: "ok",
+      repository: "present",
+      root: repo,
+      defaultBranch: "main",
+    });
   });
 });
 
@@ -1989,7 +2157,18 @@ function fakeBinOutput(
 }
 
 function defaultProbeOutput(key: string): string | undefined {
+  if (key === "git --version") return "git version 2.49.0\n";
   return key === "xcode-select -p" ? "/Library/Developer/CommandLineTools\n" : undefined;
+}
+
+function externalCommandResult(input: ExternalCommandInput, stdout: string): ExternalCommandResult {
+  return {
+    command: input.command,
+    args: input.args ?? [],
+    stdout,
+    stderr: "",
+    exitCode: 0,
+  };
 }
 
 function fakeAccess(paths: readonly string[]): (path: string) => Promise<void> {

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1999,6 +1999,48 @@ describe("checkSetupGit", () => {
     });
   });
 
+  it("reports working Git at a filesystem discovery boundary as healthy", async () => {
+    const stderr = [
+      "fatal: not a git repository (or any parent up to mount point /external)",
+      "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).",
+    ].join("\n");
+    const outside = await checkSetupGit({
+      cwd: tmpdir(),
+      runner: async (input) => {
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw Object.assign(new Error(stderr), { code: 128, stderr });
+      },
+    });
+
+    expect(outside).toMatchObject({ status: "ok", repository: "absent" });
+  });
+
+  it("honors Git's discovery ceiling when checking for repository intent", async () => {
+    const root = await tempRoot(tempRoots);
+    const repository = join(root, "repo");
+    const cwd = join(repository, "child");
+    await mkdir(join(repository, ".git"), { recursive: true });
+    await mkdir(cwd);
+
+    const outside = await checkSetupGit({
+      cwd,
+      env: { GIT_CEILING_DIRECTORIES: repository },
+      runner: async (input) => {
+        if (input.args?.[0] === "--version") {
+          return externalCommandResult(input, "git version 2.49.0\n");
+        }
+        throw Object.assign(new Error(canonicalNotRepository), {
+          code: 128,
+          stderr: canonicalNotRepository,
+        });
+      },
+    });
+
+    expect(outside).toMatchObject({ status: "ok", repository: "absent" });
+  });
+
   it("reports a healthy repository with its root and best-effort default branch", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
@@ -2050,10 +2092,10 @@ describe("checkSetupGit", () => {
     expect(failed).toMatchObject({ status: "missing", reason: "repository-unusable" });
   });
 
-  it("gives scoped safe.directory guidance for dubious ownership", async () => {
+  it("gives scoped safe.directory guidance when the repository path contains an apostrophe", async () => {
     const root = await tempRoot(tempRoots);
-    const repository = join(root, "owned-by-root");
-    await mkdir(repository);
+    const repository = join(root, "O'Brien", "repo");
+    await mkdir(repository, { recursive: true });
     const stderr = `fatal: detected dubious ownership in repository at '${repository}'`;
     const dubious = await checkSetupGit({
       cwd: repository,
@@ -2067,7 +2109,10 @@ describe("checkSetupGit", () => {
 
     expect(dubious).toMatchObject({ status: "missing", reason: "dubious-ownership" });
     if (dubious.status !== "missing") throw new Error("expected dubious repository");
-    expect(dubious.message).toContain(`git config --global --add safe.directory '${repository}'`);
+    const quotedRepository = `'${repository.replaceAll("'", `'\\''`)}'`;
+    expect(dubious.message).toContain(
+      `git config --global --add safe.directory ${quotedRepository}`,
+    );
   });
 
   it.each([

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -127,6 +127,8 @@ describe("setup config writer", () => {
       harnessSelection: {
         defaultHarness: "codex",
         selected: facts.harnesses,
+        requiredHarnessIds: ["codex", "opencode"],
+        source: "explicit",
       },
       installHarnessHooks: ["codex"],
     });
@@ -155,6 +157,7 @@ describe("setup config writer", () => {
         status: "valid",
         path: join(root, "config.toml"),
         source,
+        observerStateDir: join(root, "state"),
         hasProjectForRoot: false,
         configuredHarnesses: [],
         configuredHookHarnesses: [],
@@ -183,8 +186,8 @@ describe("setup config writer", () => {
     const root = await tempRoot(tempRoots);
     const facts = setupFacts(root, {
       git: {
-        status: "missing",
-        reason: "not-a-repo",
+        status: "ok",
+        repository: "absent",
         defaultBranch: "main",
         message: "Choose a project after setup.",
       },
@@ -218,8 +221,8 @@ describe("setup config writer", () => {
     const outsideRepo = await planSetupConfigWrite(
       setupFacts(root, {
         git: {
-          status: "missing",
-          reason: "not-a-repo",
+          status: "ok",
+          repository: "absent",
           defaultBranch: "main",
           message: "Choose a project after setup.",
         },
@@ -230,6 +233,7 @@ describe("setup config writer", () => {
       setupFacts(join(root, "ancestor"), {
         git: {
           status: "ok",
+          repository: "present",
           root: join(root, "ancestor"),
           repoName: "ancestor",
           defaultBranch: "trunk",
@@ -260,6 +264,7 @@ describe("setup config writer", () => {
         status: "valid",
         path: join(root, "config.toml"),
         source,
+        observerStateDir: join(root, "state"),
         hasProjectForRoot: true,
         configuredHarnesses: ["codex"],
         configuredHookHarnesses: [],
@@ -313,10 +318,14 @@ describe("setup config writer", () => {
       },
     });
 
+    const validConfig = facts.config;
+    if (validConfig.status !== "valid") throw new Error("expected valid config fact");
     const write = await planSetupConfigWrite(facts, {
       harnessSelection: {
         defaultHarness: "codex",
         selected: facts.harnesses,
+        requiredHarnessIds: ["codex", "opencode"],
+        source: "explicit",
       },
       installHarnessHooks: ["codex", "opencode"],
     });
@@ -343,7 +352,7 @@ describe("setup config writer", () => {
         {
           ...facts,
           config: {
-            ...facts.config,
+            ...validConfig,
             source: write.content,
             configuredHarnesses: ["codex", "opencode"],
             configuredHookHarnesses: ["codex", "opencode"],
@@ -353,6 +362,8 @@ describe("setup config writer", () => {
           harnessSelection: {
             defaultHarness: "codex",
             selected: facts.harnesses,
+            requiredHarnessIds: ["codex", "opencode"],
+            source: "explicit",
           },
           installHarnessHooks: ["opencode"],
         },
@@ -378,6 +389,7 @@ describe("setup config writer", () => {
           status: "valid",
           path: join(root, "config.toml"),
           source,
+          observerStateDir: join(root, "state"),
           hasProjectForRoot: false,
           configuredHarnesses: ["codex"],
           configuredHookHarnesses: [],
@@ -392,6 +404,8 @@ describe("setup config writer", () => {
         harnessSelection: {
           defaultHarness: "codex",
           selected: [{ id: "pi", label: "Pi", status: "ok", command: "pi" }],
+          requiredHarnessIds: ["pi", "codex"],
+          source: "explicit",
         },
       },
     );
@@ -417,6 +431,7 @@ describe("setup config writer", () => {
         status: "valid",
         path: join(root, "config.toml"),
         source,
+        observerStateDir: join(root, "state"),
         hasProjectForRoot: false,
         configuredHarnesses: ["codex"],
         configuredHookHarnesses: [],
@@ -432,6 +447,8 @@ describe("setup config writer", () => {
       harnessSelection: {
         defaultHarness: "codex",
         selected: [{ id: "pi", label: "Pi", status: "ok", command: "pi" }],
+        requiredHarnessIds: ["pi", "codex"],
+        source: "explicit",
       },
     });
 
@@ -489,6 +506,8 @@ describe("setup config writer", () => {
       harnessSelection: {
         defaultHarness: "codex",
         selected: facts.harnesses,
+        requiredHarnessIds: ["codex", "opencode"],
+        source: "explicit",
       },
       installHarnessHooks: ["codex", "opencode"],
     });
@@ -604,6 +623,7 @@ describe("setup config writer", () => {
         status: "valid",
         path: join(root, "config.toml"),
         source,
+        observerStateDir: join(root, "state"),
         hasProjectForRoot: false,
         configuredHarnesses: ["codex"],
         configuredHookHarnesses: [],
@@ -684,6 +704,7 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
     },
     git: {
       status: "ok",
+      repository: "present",
       root: repo,
       repoName: "repo",
       defaultBranch: "main",
@@ -694,6 +715,7 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
       { id: "opencode", label: "OpenCode", status: "missing", command: "opencode" },
       { id: "pi", label: "Pi", status: "missing", command: "pi" },
     ],
+    harnessTracking: [],
     config: {
       status: "missing",
       path: "/tmp/config.toml",

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -1616,6 +1616,7 @@ describe("guided setup command", () => {
             throw Object.assign(new Error("tmux not found"), { code: "ENOENT" });
           }
           const staticOutputs: Record<string, string> = {
+            "git --version": "git version 2.49.0\n",
             "git rev-parse --show-toplevel": repo,
             "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
             "codex --version": "codex 0.1.0\n",
@@ -1746,6 +1747,7 @@ describe("guided setup command", () => {
             throw Object.assign(new Error("tmux not found"), { code: "ENOENT" });
           }
           const staticOutputs: Record<string, string> = {
+            "git --version": "git version 2.49.0\n",
             "git rev-parse --show-toplevel": repo,
             "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
             "xcode-select -p": "/Library/Developer/CommandLineTools\n",
@@ -1905,6 +1907,7 @@ function fakeBinOutput(
 }
 
 function defaultProbeOutput(key: string): string | undefined {
+  if (key === "git --version") return "git version 2.49.0\n";
   return key === "xcode-select -p" ? "/Library/Developer/CommandLineTools\n" : undefined;
 }
 

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -608,6 +608,7 @@ describe("setup planner", () => {
       tier: "required",
       status: "missing",
       message,
+      details: { defaultBranch: "main", reason },
     });
     expect(plan.summary).toMatchObject({
       workflowReady: false,

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -555,32 +555,66 @@ describe("setup planner", () => {
     ]);
   });
 
-  it("treats Git outside a repository as ready for first-project selection", () => {
+  it("keeps working Git outside a repository green for first-project selection", () => {
     const config = validConfigFact({ hasProjectForRoot: false });
     delete config.matchedProject;
 
     const plan = buildSetupPlan(
       facts({
         git: {
-          status: "missing",
-          reason: "not-a-repo",
+          status: "ok",
+          repository: "absent",
           defaultBranch: "main",
-          message: "Choose a project after setup.",
+          message: "Git is available; choose a project explicitly in STATION.",
         },
         config,
       }),
     );
 
-    expect(plan.checks.find((check) => check.id === "git-project")).toMatchObject({
+    expect(plan.checks.find((check) => check.id === "git-project")).toEqual({
+      id: "git-project",
+      tier: "required",
       status: "ok",
       label: "Git",
-      message: expect.stringContaining("choose a project"),
+      message: "Git is available; choose a project explicitly in STATION.",
+      details: { defaultBranch: "main" },
     });
     expect(plan.checks.find((check) => check.id === "config")).toMatchObject({
       status: "ok",
     });
     expect(plan.summary.requiredOk).toBe(true);
     expect(plan.nextSteps).toEqual(["stn doctor", "stn"]);
+  });
+
+  it.each([
+    { name: "absent Git", reason: "git-absent" as const },
+    { name: "unusable Git", reason: "git-unusable" as const },
+    { name: "dubious ownership", reason: "dubious-ownership" as const },
+    { name: "corrupt repository metadata", reason: "repository-unusable" as const },
+  ])("keeps $name red and uses its remediation as the next step", ({ name, reason }) => {
+    const message = `${name} remediation.`;
+    const plan = buildSetupPlan(
+      facts({
+        git: {
+          status: "missing",
+          reason,
+          defaultBranch: "main",
+          message,
+        },
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "git-project")).toMatchObject({
+      tier: "required",
+      status: "missing",
+      message,
+    });
+    expect(plan.summary).toMatchObject({
+      workflowReady: false,
+      requiredOk: false,
+      requiredMissing: 1,
+    });
+    expect(plan.nextSteps).toEqual([message]);
   });
 
   it("plans the optional tmux popup binding with the preserved key and exact command", () => {
@@ -1052,6 +1086,7 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
     },
     git: {
       status: "ok",
+      repository: "present",
       root: "/tmp/repo",
       defaultBranch: "main",
       repoName: "repo",

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -137,6 +137,8 @@ describe("setup renderer", () => {
     });
 
     expect(output).toContain(message);
+    expect(output.match(/stn setup check/g)).toHaveLength(1);
+    expect(output).not.toContain("Then run:");
     expect(output).not.toContain("Core setup is incomplete.");
   });
 

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -114,6 +114,32 @@ describe("setup renderer", () => {
     expect(output).not.toContain("Worktrunk is still missing");
   });
 
+  it("preserves Git remediation in apply output", () => {
+    const message =
+      "Git is installed but unusable. Run xcode-select --install, then run stn setup check.";
+    const output = renderSetupApplyResult({
+      ...plan(),
+      checks: [
+        {
+          id: "git-project",
+          tier: "required",
+          status: "missing",
+          label: "Git",
+          message,
+        },
+      ],
+      actions: [],
+      summary: {
+        ...plan().summary,
+        requiredMissing: 1,
+        selectedActions: 0,
+      },
+    });
+
+    expect(output).toContain(message);
+    expect(output).not.toContain("Core setup is incomplete.");
+  });
+
   it("renders the effective Worktrunk automation mode", () => {
     const skipHooks = renderSetupPlan({
       ...plan(),

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -47,13 +47,21 @@ workflow, not for launch:
 - diffnav and git-delta (`delta`) — diffnav powers the "See diff (split right)" automation and renders through delta, so the two are required together
 - git (the binary); select an existing git repository explicitly after setup
 - the effective global default agent CLI, plus each CLI explicitly selected in the current guided setup: Claude Code, Codex, Cursor Agent, OpenCode, or Pi
-- current Station-owned tracking artifacts for required Claude, Codex, Cursor, and OpenCode harnesses
+- current Station-owned tracking artifacts for required Claude, Codex, Cursor,
+  and OpenCode harnesses
 
-On macOS, the Command Line Tools provide git and the compilers Homebrew needs.
-`stn setup` detects a missing-git binary distinctly from "not inside a repo". The
-latter is healthy because setup does not adopt its working directory. On macOS,
-setup reports missing Command Line Tools with the `xcode-select --install`
-remediation. `scripts/setup/bootstrap.sh` preflights both before touching Homebrew.
+Git setup first verifies that the executable itself works, then inspects
+repository metadata. Working Git outside a repository is healthy because setup
+does not adopt its working directory. An unusable Git executable, unreadable or
+corrupt repository metadata, permission failures, and dubious ownership are
+required failures with Git-specific remediation.
+
+On macOS, the Command Line Tools provide Apple Git and the compilers Homebrew
+needs. A source-checkout setup reports missing Command Line Tools with the
+`xcode-select --install` remediation. Compiled Station does not independently
+require Command Line Tools when a working custom Git is available.
+`scripts/setup/bootstrap.sh` preflights both Git and Command Line Tools before
+touching Homebrew.
 
 Recommended after setup:
 

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -159,6 +159,8 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
         allowedExitCodes: [1],
       });
       const setupPlan = JSON.parse(setup.stdout);
+      const healthyGitCheck = setupPlan.checks.find((check) => check.id === "git-project");
+      assertEqual(healthyGitCheck?.status, "ok", "compiled setup healthy Git status");
       assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
       assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
       assertEqual(setupPlan.summary.requiredOk, false, "compiled setup requiredOk alias");
@@ -1242,6 +1244,12 @@ async function verifyCompiledGitFailure({ binaryPath, installedRoot, root }) {
 
   assertEqual(result.code, 1, "compiled Git canary exit code");
   assertEqual(gitCheck?.status, "missing", "compiled Git canary git-project status");
+  assertEqual(gitCheck?.details?.reason, "git-unusable", "compiled Git canary reason");
+  assertIncludes(
+    gitCheck?.message ?? "",
+    "Git is installed but unusable.",
+    "compiled Git canary unusable message",
+  );
   assertIncludes(gitCheck?.message ?? "", "xcode-select --install", "compiled Git remediation");
   assertEqual(requiredFailures.length, 1, "compiled Git canary required failure count");
   assertEqual(plan.summary.requiredMissing, 1, "compiled Git canary requiredMissing");

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -142,6 +142,12 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
       const help = await run(binaryPath, ["--help"], { env: childEnv });
       assertIncludes(help.stdout, "Usage:", "compiled --help");
 
+      await verifyCompiledGitFailure({
+        binaryPath,
+        installedRoot,
+        root: join(root, "git-setup-canary"),
+      });
+
       const popupHelp = await run(join(dirname(binaryPath), "stn-tmux-popup"), ["--help"], {
         env: childEnv,
       });
@@ -1118,7 +1124,7 @@ async function verifyCompiledInaccessibleObserver(input) {
     { env: input.childEnv },
   );
   assertEqual(
-    JSON.parse(restoredStatus.stdout).health?.pid,
+    parseSmokeJson(restoredStatus.stdout, "compiled restored observer status").health?.pid,
     input.observerPid,
     "compiled restored observer identity",
   );
@@ -1165,6 +1171,88 @@ async function waitForDirectoryFileCount(directory, expected) {
     await delay(25);
   }
   fail(`directory file count did not reach ${expected}: ${directory}`);
+}
+
+async function verifyCompiledGitFailure({ binaryPath, installedRoot, root }) {
+  const homeDir = join(root, "home");
+  const runtimeDir = join(root, "runtime");
+  const stateDir = join(root, "state");
+  const cwd = join(root, "outside-repository");
+  const fakeBin = join(root, "fake-bin");
+  const configPath = join(root, "config.toml");
+  await Promise.all(
+    [homeDir, join(homeDir, "tmp"), runtimeDir, stateDir, cwd, fakeBin].map((path) =>
+      mkdir(path, { recursive: true, mode: 0o700 }),
+    ),
+  );
+  await Promise.all([
+    writeFile(
+      join(fakeBin, "git"),
+      [
+        "#!/bin/sh",
+        'if [ "$1" = --version ]; then',
+        "  echo 'xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun' >&2",
+        "  exit 1",
+        "fi",
+        "echo 'unexpected repository probe after failed git --version' >&2",
+        "exit 97",
+        "",
+      ].join("\n"),
+      { mode: 0o700 },
+    ),
+    writeFile(join(fakeBin, "wt"), "#!/bin/sh\necho 'worktrunk 1.2.3'\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "tmux"), "#!/bin/sh\necho 'tmux 3.5a'\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "diffnav"), "#!/bin/sh\nexit 0\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "delta"), "#!/bin/sh\nexit 0\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "pi"), "#!/bin/sh\necho 'pi 0.80.10'\n", { mode: 0o700 }),
+    writeFile(
+      configPath,
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        `state_dir = ${JSON.stringify(stateDir)}`,
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "pi"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      { mode: 0o600 },
+    ),
+  ]);
+
+  const env = {
+    ...isolatedBinaryEnv({ homeDir, runtimeDir }),
+    PATH: `${fakeBin}:${installedRoot}:/usr/bin:/bin`,
+  };
+  const result = await run(
+    binaryPath,
+    ["--config", configPath, "setup", "check", "--json", "--no-brew"],
+    { cwd, env, allowedExitCodes: [1] },
+  );
+  const plan = parseSmokeJson(result.stdout, "compiled Git canary setup plan");
+  const requiredFailures = plan.checks.filter(
+    (check) => check.tier === "required" && check.status === "missing",
+  );
+  const gitCheck = plan.checks.find((check) => check.id === "git-project");
+
+  assertEqual(result.code, 1, "compiled Git canary exit code");
+  assertEqual(gitCheck?.status, "missing", "compiled Git canary git-project status");
+  assertIncludes(gitCheck?.message ?? "", "xcode-select --install", "compiled Git remediation");
+  assertEqual(requiredFailures.length, 1, "compiled Git canary required failure count");
+  assertEqual(plan.summary.requiredMissing, 1, "compiled Git canary requiredMissing");
+  assertEqual(plan.summary.workflowReady, false, "compiled Git canary workflowReady");
+  assertEqual(plan.summary.requiredOk, false, "compiled Git canary requiredOk");
+  assertEqual(plan.summary.launchReady, true, "compiled Git canary launchReady");
+  assertEqual(
+    plan.checks.some((check) => check.id === "command-line-tools"),
+    false,
+    "compiled Git canary omits Command Line Tools",
+  );
 }
 
 async function writeWorktrunkHookSmokeConfig(path, state, socket, worktrunkConfigPath) {
@@ -2059,6 +2147,14 @@ function signalProcess(pid, signal) {
   } catch (error) {
     if (error?.code === "ESRCH") return false;
     throw error;
+  }
+}
+
+function parseSmokeJson(source, label) {
+  try {
+    return JSON.parse(source);
+  } catch {
+    fail(`${label} did not return valid JSON`);
   }
 }
 

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -399,6 +399,7 @@ async function createFixture(input: {
     bin,
     "git",
     [
+      'if [ "$1" = "--version" ]; then echo "git version 2.50.1"; exit 0; fi',
       'if [ "$1" = "-C" ]; then',
       `  exec ${shellQuote(gitPath)} "$@"`,
       "fi",


### PR DESCRIPTION
## What this fixes
STATION setup decides whether Git itself is usable before it evaluates the current project. A working Git installation could still be reported as unusable when setup started outside a repository at a filesystem or configured discovery boundary. Dubious-ownership guidance could also truncate repository paths containing apostrophes, and apply output repeated its recovery command.

## What changed
- Probe `git --version` independently with repository-local Git variables cleared and stable C-locale diagnostics.
- Treat Git's ordinary, mount-point, and `GIT_CEILING_DIRECTORIES` no-repository outcomes as healthy while retaining failures for unreadable repository metadata.
- Parse the complete dubious-ownership diagnostic path before shell-quoting the scoped `safe.directory` command.
- Preserve the Git failure reason in the setup plan and render its self-contained remediation once.
- Keep compiled setup independent of Xcode Command Line Tools when a custom Git works.
- Make the compiled smoke require an `ok` healthy Git row and the specific `git-unusable` failure reason and message.

## Testing
- `pnpm test:pre-push`
- Focused setup unit tests: 134 passed
- Focused setup integration/profile tests: 31 passed
- Real Git probes for `/System/Volumes/VM`, `GIT_CEILING_DIRECTORIES`, and a dubious-owner repository under an `O'Brien` path
- LSP/lens diagnostics and `git diff --check`
