### PR TITLE
fix(setup): preserve unresolved launcher PATH steps

### DIFF
--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -230,11 +230,11 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
   if (missing.length > 0) {
     warningMessage = `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`;
   } else if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
-    warningMessage = `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}.`;
+    warningMessage = `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}. Use the installer's PATH guidance for installed launchers; setup can link checkout launchers separately.`;
   } else if (checkoutOutsidePath.length > 0) {
     warningMessage = `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`;
   } else if (installedOutsidePath.length > 0) {
-    warningMessage = `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}.`;
+    warningMessage = `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}. Use the installer's PATH guidance to repair bare launcher resolution.`;
   }
   if (warningMessage !== undefined) {
     return {
@@ -906,7 +906,7 @@ function setupActions(
 
 function stationLaunchersNeedLink(facts: SetupFacts): boolean {
   return [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup].some(
-    (launcher) => launcher.source !== "path" && launcher.source !== "installed",
+    (launcher) => launcher.source === "checkout",
   );
 }
 

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path";
 import { stationUiInstallHint } from "../../stationWorkspace.js";
 import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
@@ -221,11 +222,21 @@ function launcherCheck(facts: SetupFacts): SetupCheck {
   const installedOutsidePath = launcherEntries.flatMap((entry) =>
     entry[1].source === "installed" ? [entry[0]] : [],
   );
-  const details = {
-    station: setupLauncherExecutable(facts.launchers.station),
-    ingress: setupLauncherExecutable(facts.launchers.ingress),
-    tmuxPopup: setupLauncherExecutable(facts.launchers.tmuxPopup),
+  const stationExecutable = setupLauncherExecutable(facts.launchers.station);
+  const ingressExecutable = setupLauncherExecutable(facts.launchers.ingress);
+  const tmuxPopupExecutable = setupLauncherExecutable(facts.launchers.tmuxPopup);
+  const stationDirectory = dirname(stationExecutable);
+  const launchersShareDirectory = [ingressExecutable, tmuxPopupExecutable].every(
+    (executable) => dirname(executable) === stationDirectory,
+  );
+  const details: Record<string, string> = {
+    station: stationExecutable,
+    ingress: ingressExecutable,
+    tmuxPopup: tmuxPopupExecutable,
   };
+  if (missing.length === 0 && installedOutsidePath.length > 0 && launchersShareDirectory) {
+    details.pathDirectory = stationDirectory;
+  }
   let warningMessage: string | undefined;
   if (missing.length > 0) {
     warningMessage = `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`;

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -116,11 +116,9 @@ export function renderSetupApplyResult(
           `  ${theme.cyan("hash -r")}`,
         );
       }
-      const futureShellGuidance =
-        pathDirectory === undefined
-          ? "Future login shell launcher resolution remains unverified."
-          : "Future login shell launcher resolution remains unverified; use the installer's future-shell export in a shell configuration you choose, then verify all three launchers in a new login shell.";
-      remainingLines.push("", `  ${theme.dim(futureShellGuidance)}`);
+      remainingLines.push(
+        ...bareLauncherConvenienceLines(pathDirectory, launcherLinkAction, theme),
+      );
     }
     return [
       theme.bold(theme.green(completionMessage)),
@@ -184,6 +182,42 @@ export function formatCommand(command: readonly string[]): string {
 
 function formatSelectedLauncherCommand(executable: string, args: readonly string[] = []): string {
   return [quoteShellPart(executable), ...args.map((part) => quoteCommandPart(part))].join(" ");
+}
+
+function bareLauncherConvenienceLines(
+  pathDirectory: string | undefined,
+  launcherLinkAction: SetupAction | undefined,
+  theme: SetupTheme,
+): string[] {
+  if (pathDirectory === undefined && launcherLinkAction === undefined) {
+    return ["", `  ${theme.dim("Future login shell launcher resolution remains unverified.")}`];
+  }
+
+  const lines = [
+    "",
+    theme.bold("Use stn instead of the absolute path (optional):"),
+    `  The absolute commands under ${theme.bold("Next")} already work; these steps only enable the shorter launcher names.`,
+  ];
+  if (pathDirectory !== undefined) {
+    lines.push(
+      "  To use stn in this shell, run the current-shell PATH block above.",
+      `  For future shells, add ${theme.cyan(quoteShellPart(pathDirectory))} to PATH in a shell configuration you choose.`,
+      "  Use PATH rather than an alias so all three STATION launcher names resolve together.",
+    );
+  }
+  if (launcherLinkAction !== undefined) {
+    lines.push(
+      "  To use stn from this checkout, run the link command above; it exposes all three launcher names together.",
+    );
+  }
+  lines.push(
+    "  Then verify:",
+    `    ${theme.cyan("command -v stn")}`,
+    `    ${theme.cyan("command -v stn-ingress")}`,
+    `    ${theme.cyan("command -v stn-tmux-popup")}`,
+    `  ${theme.dim("Future login shell launcher resolution remains unverified until those checks pass in a new login shell.")}`,
+  );
+  return lines;
 }
 
 export function renderActionStart(action: SetupAction, options: SetupRenderOptions = {}): string {

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -77,15 +77,33 @@ export function renderSetupApplyResult(
     );
   }
   if (plan.summary.requiredOk) {
-    // plan.nextSteps is computed before apply, so on a freshly-completed setup it
-    // can still read "resolve the missing items". Show the completion steps here.
+    // Pre-apply next steps can be stale, but the final re-probed launcher warning and its checkout recovery must remain visible.
     const nextSteps = ["stn doctor", "stn"];
     const prepared = preparedHarnesses(plan);
     const completionMessage = setupCompletionMessage(prepared);
     const completionNotices = setupCompletionNotices(prepared);
+    const launcherWarning = plan.checks.find(
+      (check) => check.id === "station-launchers" && check.status === "warning",
+    );
+    const launcherLinkAction = plan.actions.find(
+      (action) => action.id === "link-station-launchers",
+    );
+    const remainingLines: string[] = [];
+    if (launcherWarning !== undefined) {
+      remainingLines.push(
+        "",
+        sectionHeading("Remaining", theme),
+        "",
+        ...renderCheck(launcherWarning, theme),
+      );
+      if (launcherLinkAction !== undefined) {
+        remainingLines.push(...renderAction(launcherLinkAction, theme));
+      }
+    }
     return [
       theme.bold(theme.green(completionMessage)),
       ...completionNotices,
+      ...remainingLines,
       "",
       sectionHeading("Next", theme),
       "",

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -77,14 +77,21 @@ export function renderSetupApplyResult(
     );
   }
   if (plan.summary.requiredOk) {
-    // Pre-apply next steps can be stale, but the final re-probed launcher warning and its checkout recovery must remain visible.
-    const nextSteps = ["stn doctor", "stn"];
+    // Pre-apply next steps can be stale; final launcher mismatches must retain runnable absolute commands and current evidence.
     const prepared = preparedHarnesses(plan);
     const completionMessage = setupCompletionMessage(prepared);
     const completionNotices = setupCompletionNotices(prepared);
     const launcherWarning = plan.checks.find(
       (check) => check.id === "station-launchers" && check.status === "warning",
     );
+    const launcherExecutable = launcherWarning?.details?.station;
+    const nextSteps =
+      launcherExecutable === undefined
+        ? ["stn doctor", "stn"]
+        : [
+            formatSelectedLauncherCommand(launcherExecutable, ["doctor"]),
+            formatSelectedLauncherCommand(launcherExecutable),
+          ];
     const launcherLinkAction = plan.actions.find(
       (action) => action.id === "link-station-launchers",
     );
@@ -99,6 +106,21 @@ export function renderSetupApplyResult(
       if (launcherLinkAction !== undefined) {
         remainingLines.push(...renderAction(launcherLinkAction, theme));
       }
+      const pathDirectory = launcherWarning.details?.pathDirectory;
+      if (pathDirectory !== undefined) {
+        remainingLines.push(
+          "",
+          theme.bold("Current shell PATH recovery (does not edit startup files):"),
+          `  ${theme.cyan(`PATH=${quoteShellPart(pathDirectory)}\${PATH:+":$PATH"}`)}`,
+          `  ${theme.cyan("export PATH")}`,
+          `  ${theme.cyan("hash -r")}`,
+        );
+      }
+      const futureShellGuidance =
+        pathDirectory === undefined
+          ? "Future login shell launcher resolution remains unverified."
+          : "Future login shell launcher resolution remains unverified; use the installer's future-shell export in a shell configuration you choose, then verify all three launchers in a new login shell.";
+      remainingLines.push("", `  ${theme.dim(futureShellGuidance)}`);
     }
     return [
       theme.bold(theme.green(completionMessage)),
@@ -158,6 +180,10 @@ export function renderSetupApplyResult(
 
 export function formatCommand(command: readonly string[]): string {
   return command.map((part) => quoteCommandPart(part)).join(" ");
+}
+
+function formatSelectedLauncherCommand(executable: string, args: readonly string[] = []): string {
+  return [quoteShellPart(executable), ...args.map((part) => quoteCommandPart(part))].join(" ");
 }
 
 export function renderActionStart(action: SetupAction, options: SetupRenderOptions = {}): string {
@@ -325,5 +351,9 @@ function quoteCommandPart(part: string): string {
   if (/^[A-Za-z0-9_./:=@%+-]+$/.test(part)) {
     return part;
   }
+  return quoteShellPart(part);
+}
+
+function quoteShellPart(part: string): string {
   return `'${part.replaceAll("'", "'\\''")}'`;
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -369,6 +369,75 @@ describe("CLI setup command", () => {
     expect(plan.actions.find((action) => action.id === "worktrunk-hooks")).toBeUndefined();
   });
 
+  it("preserves installed launcher PATH evidence after successful noninteractive apply", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const home = join(root, "home");
+    const configPath = join(root, "config.toml");
+    const installedRoot = join(root, "installed bin");
+    const providerHookIngressLauncher = join(installedRoot, "stn-ingress");
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({});
+    const chunks: string[] = [];
+    const setupDeps = {
+      compiled: true,
+      tmuxPopupOwnerRoot: installedRoot,
+      providerHookIngressLauncher,
+      cwd: repo,
+      homeDir: home,
+      env: { PATH: "/fake/bin" },
+      runner: readySetupRunner(repo),
+      access: fakeAccess([
+        "/fake/bin/wt",
+        "/fake/bin/tmux",
+        "/fake/bin/bun",
+        "/fake/bin/diffnav",
+        "/fake/bin/delta",
+        join(installedRoot, "stn"),
+        providerHookIngressLauncher,
+        join(installedRoot, "stn-tmux-popup"),
+      ]),
+      fs,
+      activateObserverConfig: async () => undefined,
+      writeStdout: (chunk: string) => {
+        chunks.push(chunk);
+      },
+    };
+
+    const apply = await runCli(["--config", configPath, "setup", "apply", "--yes"], {
+      setupDeps,
+    });
+    const check = await runCli(["--config", configPath, "setup", "check", "--json"], {
+      setupDeps,
+    });
+    const finalPlan = check.output as {
+      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+      summary: { requiredOk: boolean };
+    };
+    const output = chunks.join("");
+
+    expect(apply.code).toBe(0);
+    expect(check.code).toBe(0);
+    expect(finalPlan.summary.requiredOk).toBe(true);
+    expect(finalPlan.checks.find((item) => item.id === "station-launchers")).toMatchObject({
+      status: "warning",
+      details: {
+        station: join(installedRoot, "stn"),
+        ingress: providerHookIngressLauncher,
+        tmuxPopup: join(installedRoot, "stn-tmux-popup"),
+      },
+    });
+    expect(output).toContain("Core setup complete.");
+    expect(output).toContain("Remaining");
+    expect(output).toContain(
+      "these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup",
+    );
+    expect(output).toContain(`station ${join(installedRoot, "stn")}`);
+    expect(output).toContain(`ingress ${providerHookIngressLauncher}`);
+    expect(output).toContain(`tmuxPopup ${join(installedRoot, "stn-tmux-popup")}`);
+    expect(output).not.toContain("station:link");
+  });
+
   it("generates the compiled binding from installed ownership while preserving its key", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -443,6 +443,14 @@ describe("CLI setup command", () => {
     expect(output).toContain(`PATH=${shellQuotedRoot}\${PATH:+":$PATH"}`);
     expect(output).toContain(`${shellQuotedStation} doctor`);
     expect(output).toContain(`  ${shellQuotedStation}\n`);
+    expect(output).toContain("Use stn instead of the absolute path (optional):");
+    expect(output).toContain(
+      `For future shells, add ${shellQuotedRoot} to PATH in a shell configuration you choose.`,
+    );
+    expect(output).toContain(
+      "Use PATH rather than an alias so all three STATION launcher names resolve together.",
+    );
+    expect(output).toContain("command -v stn-tmux-popup");
     expect(output).toContain("Future login shell launcher resolution remains unverified");
     expect(output).not.toContain("\n  stn doctor\n");
     expect(output).not.toContain("\n  stn\n");

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -374,8 +374,12 @@ describe("CLI setup command", () => {
     const repo = join(root, "repo");
     const home = join(root, "home");
     const configPath = join(root, "config.toml");
-    const installedRoot = join(root, "installed bin");
+    const installedRoot = join(root, "installed path's bin");
+    const stationLauncher = join(installedRoot, "stn");
     const providerHookIngressLauncher = join(installedRoot, "stn-ingress");
+    const popupLauncher = join(installedRoot, "stn-tmux-popup");
+    const shellQuotedRoot = `'${installedRoot.replaceAll("'", "'\\''")}'`;
+    const shellQuotedStation = `'${stationLauncher.replaceAll("'", "'\\''")}'`;
     await mkdir(repo, { recursive: true });
     const fs = fakeFs({});
     const chunks: string[] = [];
@@ -393,9 +397,9 @@ describe("CLI setup command", () => {
         "/fake/bin/bun",
         "/fake/bin/diffnav",
         "/fake/bin/delta",
-        join(installedRoot, "stn"),
+        stationLauncher,
         providerHookIngressLauncher,
-        join(installedRoot, "stn-tmux-popup"),
+        popupLauncher,
       ]),
       fs,
       activateObserverConfig: async () => undefined,
@@ -422,9 +426,10 @@ describe("CLI setup command", () => {
     expect(finalPlan.checks.find((item) => item.id === "station-launchers")).toMatchObject({
       status: "warning",
       details: {
-        station: join(installedRoot, "stn"),
+        station: stationLauncher,
         ingress: providerHookIngressLauncher,
-        tmuxPopup: join(installedRoot, "stn-tmux-popup"),
+        tmuxPopup: popupLauncher,
+        pathDirectory: installedRoot,
       },
     });
     expect(output).toContain("Core setup complete.");
@@ -432,9 +437,15 @@ describe("CLI setup command", () => {
     expect(output).toContain(
       "these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup",
     );
-    expect(output).toContain(`station ${join(installedRoot, "stn")}`);
+    expect(output).toContain(`station ${stationLauncher}`);
     expect(output).toContain(`ingress ${providerHookIngressLauncher}`);
-    expect(output).toContain(`tmuxPopup ${join(installedRoot, "stn-tmux-popup")}`);
+    expect(output).toContain(`tmuxPopup ${popupLauncher}`);
+    expect(output).toContain(`PATH=${shellQuotedRoot}\${PATH:+":$PATH"}`);
+    expect(output).toContain(`${shellQuotedStation} doctor`);
+    expect(output).toContain(`  ${shellQuotedStation}\n`);
+    expect(output).toContain("Future login shell launcher resolution remains unverified");
+    expect(output).not.toContain("\n  stn doctor\n");
+    expect(output).not.toContain("\n  stn\n");
     expect(output).not.toContain("station:link");
   });
 

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -697,6 +697,7 @@ describe("setup planner", () => {
     expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
       status: "warning",
     });
+    expect(plan.actions.find((action) => action.id === "link-station-launchers")).toBeUndefined();
     expect(plan.actions.find((action) => action.id === "worktrunk-hooks")).toBeUndefined();
   });
 
@@ -727,10 +728,18 @@ describe("setup planner", () => {
     );
 
     expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
+      tier: "recommended",
       status: "warning",
       message:
-        "STATION is installed, but these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup.",
+        "STATION is installed, but these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup. Use the installer's PATH guidance to repair bare launcher resolution.",
+      details: {
+        station: `${installedRoot}/stn`,
+        ingress: `${installedRoot}/stn-ingress`,
+        tmuxPopup: `${installedRoot}/stn-tmux-popup`,
+      },
     });
+    expect(plan.summary).toMatchObject({ workflowReady: true, requiredOk: true });
+    expect(plan.actions.find((action) => action.id === "link-station-launchers")).toBeUndefined();
   });
 
   it("plans the exact popup command and preserved key for a reachable tmux server", () => {

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -736,6 +736,7 @@ describe("setup planner", () => {
         station: `${installedRoot}/stn`,
         ingress: `${installedRoot}/stn-ingress`,
         tmuxPopup: `${installedRoot}/stn-tmux-popup`,
+        pathDirectory: installedRoot,
       },
     });
     expect(plan.summary).toMatchObject({ workflowReady: true, requiredOk: true });

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -131,7 +131,55 @@ describe("setup renderer", () => {
     expect(output).toContain("tmuxPopup /tmp/station checkout/bin/stn-tmux-popup");
     expect(output).toContain("SKIP      Link STATION launchers");
     expect(output).toContain("command pnpm --dir '/tmp/station checkout' station:link");
+    expect(output).toContain("'/tmp/station checkout/bin/stn' doctor");
+    expect(output).toContain("'/tmp/station checkout/bin/stn'");
+    expect(output).toContain("Future login shell launcher resolution remains unverified");
+    expect(output).not.toContain("\n  stn doctor\n");
+    expect(output).not.toContain("\n  stn\n");
     expect(output).not.toContain("Doctor reminder");
+  });
+
+  it("renders installed current-shell PATH recovery and runnable absolute next steps", () => {
+    const base = plan();
+    const output = renderSetupApplyResult({
+      ...base,
+      checks: [
+        {
+          id: "station-launchers",
+          tier: "recommended",
+          status: "warning",
+          label: "STATION launchers",
+          message:
+            "STATION is installed, but these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup.",
+          details: {
+            station: "/tmp/installed path's bin/stn",
+            ingress: "/tmp/installed path's bin/stn-ingress",
+            tmuxPopup: "/tmp/installed path's bin/stn-tmux-popup",
+            pathDirectory: "/tmp/installed path's bin",
+          },
+        },
+      ],
+      actions: [],
+      summary: {
+        ...base.summary,
+        workflowReady: true,
+        requiredOk: true,
+        requiredMissing: 0,
+        warnings: 1,
+        selectedActions: 0,
+      },
+    });
+
+    expect(output).toContain("Current shell PATH recovery (does not edit startup files):");
+    expect(output).toContain(`PATH='/tmp/installed path'\\''s bin'\${PATH:+":$PATH"}`);
+    expect(output).toContain("export PATH");
+    expect(output).toContain("hash -r");
+    expect(output).toContain("'/tmp/installed path'\\''s bin/stn' doctor");
+    expect(output).toContain("'/tmp/installed path'\\''s bin/stn'");
+    expect(output).toContain("Future login shell launcher resolution remains unverified");
+    expect(output).not.toContain("\n  stn doctor\n");
+    expect(output).not.toContain("\n  stn\n");
+    expect(output).not.toContain("station:link");
   });
 
   it("keeps all-correct successful apply output concise", () => {

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -133,6 +133,14 @@ describe("setup renderer", () => {
     expect(output).toContain("command pnpm --dir '/tmp/station checkout' station:link");
     expect(output).toContain("'/tmp/station checkout/bin/stn' doctor");
     expect(output).toContain("'/tmp/station checkout/bin/stn'");
+    expect(output).toContain("Use stn instead of the absolute path (optional):");
+    expect(output).toContain("The absolute commands under Next already work");
+    expect(output).toContain(
+      "To use stn from this checkout, run the link command above; it exposes all three launcher names together.",
+    );
+    expect(output).toContain("command -v stn");
+    expect(output).toContain("command -v stn-ingress");
+    expect(output).toContain("command -v stn-tmux-popup");
     expect(output).toContain("Future login shell launcher resolution remains unverified");
     expect(output).not.toContain("\n  stn doctor\n");
     expect(output).not.toContain("\n  stn\n");
@@ -176,6 +184,17 @@ describe("setup renderer", () => {
     expect(output).toContain("hash -r");
     expect(output).toContain("'/tmp/installed path'\\''s bin/stn' doctor");
     expect(output).toContain("'/tmp/installed path'\\''s bin/stn'");
+    expect(output).toContain("Use stn instead of the absolute path (optional):");
+    expect(output).toContain("To use stn in this shell, run the current-shell PATH block above.");
+    expect(output).toContain(
+      "For future shells, add '/tmp/installed path'\\''s bin' to PATH in a shell configuration you choose.",
+    );
+    expect(output).toContain(
+      "Use PATH rather than an alias so all three STATION launcher names resolve together.",
+    );
+    expect(output).toContain("command -v stn");
+    expect(output).toContain("command -v stn-ingress");
+    expect(output).toContain("command -v stn-tmux-popup");
     expect(output).toContain("Future login shell launcher resolution remains unverified");
     expect(output).not.toContain("\n  stn doctor\n");
     expect(output).not.toContain("\n  stn\n");
@@ -208,6 +227,7 @@ describe("setup renderer", () => {
     expect(output).toBe("Core setup complete.\n\nNext\n\n  stn doctor\n  stn\n");
     expect(output).not.toContain("Remaining");
     expect(output).not.toContain("STATION launchers");
+    expect(output).not.toContain("Use stn instead of the absolute path");
   });
 
   it("prioritizes unresolved harness selection in apply recovery output", () => {

--- a/apps/cli/test/unit/setup-render.test.ts
+++ b/apps/cli/test/unit/setup-render.test.ts
@@ -76,6 +76,92 @@ describe("setup renderer", () => {
     expect(output).not.toContain("runtime Ready");
   });
 
+  it("preserves a final launcher warning and checkout link command after successful apply", () => {
+    const base = plan();
+    const output = renderSetupApplyResult({
+      ...base,
+      checks: [
+        {
+          id: "station-launchers",
+          tier: "recommended",
+          status: "warning",
+          label: "STATION launchers",
+          message:
+            "These bare launchers do not resolve to this checkout on PATH: stn, stn-ingress, stn-tmux-popup; setup will use their current-checkout paths.",
+          details: {
+            station: "/tmp/station checkout/bin/stn",
+            ingress: "/tmp/station checkout/bin/stn-ingress",
+            tmuxPopup: "/tmp/station checkout/bin/stn-tmux-popup",
+          },
+        },
+        {
+          id: "doctor-reminder",
+          tier: "recommended",
+          status: "warning",
+          label: "Doctor reminder",
+          message: "Run doctor later.",
+        },
+      ],
+      actions: [
+        {
+          id: "link-station-launchers",
+          kind: "run-command",
+          tier: "recommended",
+          selected: false,
+          label: "Link STATION launchers",
+          message: "Link launchers globally.",
+          command: ["pnpm", "--dir", "/tmp/station checkout", "station:link"],
+        },
+      ],
+      summary: {
+        ...base.summary,
+        workflowReady: true,
+        requiredOk: true,
+        requiredMissing: 0,
+        warnings: 2,
+        selectedActions: 0,
+      },
+    });
+
+    expect(output).toContain("Core setup complete.");
+    expect(output).toContain("Remaining\n\n");
+    expect(output).toContain("WARN      STATION launchers");
+    expect(output).toContain("station /tmp/station checkout/bin/stn");
+    expect(output).toContain("ingress /tmp/station checkout/bin/stn-ingress");
+    expect(output).toContain("tmuxPopup /tmp/station checkout/bin/stn-tmux-popup");
+    expect(output).toContain("SKIP      Link STATION launchers");
+    expect(output).toContain("command pnpm --dir '/tmp/station checkout' station:link");
+    expect(output).not.toContain("Doctor reminder");
+  });
+
+  it("keeps all-correct successful apply output concise", () => {
+    const base = plan();
+    const output = renderSetupApplyResult({
+      ...base,
+      checks: [
+        {
+          id: "station-launchers",
+          tier: "recommended",
+          status: "ok",
+          label: "STATION launchers",
+          message: "stn, stn-ingress, and stn-tmux-popup are available on PATH.",
+        },
+      ],
+      actions: [],
+      summary: {
+        ...base.summary,
+        workflowReady: true,
+        requiredOk: true,
+        requiredMissing: 0,
+        selectedActions: 0,
+      },
+    });
+
+    expect(output).toBe("Core setup complete.\n\nNext\n\n  stn doctor\n  stn\n");
+    expect(output).not.toContain("Remaining");
+    expect(output).not.toContain("STATION launchers");
+  });
+
   it("prioritizes unresolved harness selection in apply recovery output", () => {
     const output = renderSetupApplyResult(
       {

--- a/docs/development.md
+++ b/docs/development.md
@@ -333,10 +333,11 @@ For every release candidate, retain the complete installer output and
 distinguish two successful setup lanes. Running setup through the absolute
 installed fallback while its directory is absent from `PATH` must exit
 successfully and preserve the all-three launcher warning, exact installed
-paths, a safely quoted current-shell PATH block, and absolute doctor and launch
-commands. That mismatch output must not recommend bare `stn` commands. Running
-the installer's current-shell block first must make setup's final
-current-process probe clean and keep completion concise.
+paths, a safely quoted current-shell PATH block, optional PATH-not-alias
+convenience guidance with all-three `command -v` checks, and absolute doctor and
+launch commands. That mismatch output must not recommend executing bare `stn`
+commands. Running the installer's current-shell block first must make setup's
+final current-process probe clean and keep completion concise.
 
 Neither lane proves future-login behavior. Setup must not emit a future-shell
 export or modify a startup file. Copy the installer's future-shell export into

--- a/docs/development.md
+++ b/docs/development.md
@@ -333,13 +333,14 @@ For every release candidate, retain the complete installer output and
 distinguish two successful setup lanes. Running setup through the absolute
 installed fallback while its directory is absent from `PATH` must exit
 successfully and preserve the all-three launcher warning, exact installed
-paths, and installer-owned remediation reference. Running the installer's
-current-shell block first must make setup's final current-process probe clean
-and keep completion concise.
+paths, a safely quoted current-shell PATH block, and absolute doctor and launch
+commands. That mismatch output must not recommend bare `stn` commands. Running
+the installer's current-shell block first must make setup's final
+current-process probe clean and keep completion concise.
 
-Neither lane proves future-login behavior. Setup must not emit an export or
-modify a startup file. Copy the installer's future-shell export into a
-user-chosen configuration, open a genuinely new login shell, and physically
+Neither lane proves future-login behavior. Setup must not emit a future-shell
+export or modify a startup file. Copy the installer's future-shell export into
+a user-chosen configuration, open a genuinely new login shell, and physically
 verify all three aliases with `test ... -ef` before accepting the release.
 Repeat the mismatch lane with one shadowed alias and an install directory
 containing spaces and apostrophes. Source-checkout acceptance separately

--- a/docs/development.md
+++ b/docs/development.md
@@ -327,6 +327,25 @@ identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
 workflow never publishes the draft automatically.
 
+### Launcher PATH release acceptance
+
+For every release candidate, retain the complete installer output and
+distinguish two successful setup lanes. Running setup through the absolute
+installed fallback while its directory is absent from `PATH` must exit
+successfully and preserve the all-three launcher warning, exact installed
+paths, and installer-owned remediation reference. Running the installer's
+current-shell block first must make setup's final current-process probe clean
+and keep completion concise.
+
+Neither lane proves future-login behavior. Setup must not emit an export or
+modify a startup file. Copy the installer's future-shell export into a
+user-chosen configuration, open a genuinely new login shell, and physically
+verify all three aliases with `test ... -ef` before accepting the release.
+Repeat the mismatch lane with one shadowed alias and an install directory
+containing spaces and apostrophes. Source-checkout acceptance separately
+requires the preserved `pnpm --dir <checkout> station:link` command when
+linking is declined.
+
 The current immutable binary candidate is `v0.7.1-rc.6`. `v0.7.1-rc.5` is the
 prior published binary, and `v0.7.1-rc.2`, `v0.7.1-rc.3`, and `v0.7.1-rc.4`
 remain older published rollbacks; the earlier `v0.7.0` and `v0.7.1-rc.1`

--- a/docs/install.md
+++ b/docs/install.md
@@ -186,10 +186,15 @@ Successful setup preserves the final probe's current-process launcher
 mismatch under **Remaining**, including the selected absolute launcher paths.
 When installed launchers share one directory, setup also repeats a safely
 quoted current-shell PATH block and uses the absolute selected `stn` executable
-for its immediate doctor and launch commands. It does not edit a startup file
-or generate a future-shell export. If the installer current-shell block repaired
-PATH before setup, the final probe is clean and setup stays concise, but a
-future login shell remains unverified until you test it separately.
+for its immediate doctor and launch commands. It explains that the absolute
+commands already work and that configuring the shorter `stn` name is optional.
+For that convenience, use PATH rather than a `stn` alias so all three launcher
+names resolve together; setup names the directory, leaves shell-configuration
+selection to the user, and prints `command -v` checks for all three names. It
+does not edit a startup file or generate a future-shell export. If the installer
+current-shell block repaired PATH before setup, the final probe is clean and
+setup stays concise, but a future login shell remains unverified until you test
+it separately.
 
 ## Install an Exact Version
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -182,6 +182,14 @@ later login shell; the agent should continue through the absolute installed
 launchers in a new shell. The installer does not read, create, or edit shell
 startup files.
 
+Successful setup preserves the final probe's current-process launcher
+mismatch under **Remaining**, including the selected absolute launcher paths.
+For an installed runtime, that warning points back to the installer's PATH
+guidance; setup does not invent another export or choose a startup file. If the
+installer current-shell block repaired PATH before setup, the final probe is
+clean and setup stays concise, but a future login shell remains unverified
+until you test it separately.
+
 ## Install an Exact Version
 
 To install an exact release or return to published `v0.7.1-rc.5`, use the same
@@ -258,6 +266,7 @@ The installer and setup have separate ownership:
 | Download, verify, and install the binary artifacts | Station installer |
 | Verify all three launcher paths physically | Station installer |
 | Print current-shell, future-shell, and absolute recovery commands | Station installer |
+| Preserve final current-process launcher mismatch evidence | `stn setup` |
 | Choose or edit a shell configuration | User |
 | Write Station configuration and install integrations | `stn setup` |
 | Choose the first Git project | User in Station |

--- a/docs/install.md
+++ b/docs/install.md
@@ -184,11 +184,12 @@ startup files.
 
 Successful setup preserves the final probe's current-process launcher
 mismatch under **Remaining**, including the selected absolute launcher paths.
-For an installed runtime, that warning points back to the installer's PATH
-guidance; setup does not invent another export or choose a startup file. If the
-installer current-shell block repaired PATH before setup, the final probe is
-clean and setup stays concise, but a future login shell remains unverified
-until you test it separately.
+When installed launchers share one directory, setup also repeats a safely
+quoted current-shell PATH block and uses the absolute selected `stn` executable
+for its immediate doctor and launch commands. It does not edit a startup file
+or generate a future-shell export. If the installer current-shell block repaired
+PATH before setup, the final probe is clean and setup stays concise, but a
+future login shell remains unverified until you test it separately.
 
 ## Install an Exact Version
 
@@ -265,8 +266,8 @@ The installer and setup have separate ownership:
 | --- | --- |
 | Download, verify, and install the binary artifacts | Station installer |
 | Verify all three launcher paths physically | Station installer |
-| Print current-shell, future-shell, and absolute recovery commands | Station installer |
-| Preserve final current-process launcher mismatch evidence | `stn setup` |
+| Print install-time current-shell, future-shell, and absolute recovery | Station installer |
+| Repeat final current-shell recovery and absolute next commands | `stn setup` |
 | Choose or edit a shell configuration | User |
 | Write Station configuration and install integrations | `stn setup` |
 | Choose the first Git project | User in Station |

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -37,17 +37,20 @@ checkout launchers, its existing link action.
 | Final state | Successful apply output |
 | --- | --- |
 | All three launchers on PATH | Concise; no **Remaining** section |
-| Installed aliases outside PATH | Warning + exact paths; no checkout link |
-| One installed name shadowed | Warning names only that bare launcher |
-| Compiled sibling missing | Missing warning; never `pnpm station:link` |
-| Checkout names absent | Warning + existing `station:link` command |
+| Installed aliases outside PATH | Warning, current-shell block, absolute next commands |
+| One installed name shadowed | Warning names only it; same runnable recovery |
+| Compiled sibling missing | Missing warning + absolute next; no checkout link |
+| Checkout names absent | Warning, absolute next, existing `station:link` command |
 | Current PATH repaired | Concise; login shell remains unverified |
-| Spaces or apostrophes | Exact paths; installer owns safe quoting |
+| Spaces or apostrophes | Current-shell block and commands remain safely quoted |
 
-Other recommended warnings, including doctor reminders and optional
-integrations, stay out of successful apply output. Installer tests own shell
-commands and startup-file non-interaction; release acceptance owns proof in a
-genuinely new login shell.
+Every successful mismatch rendering must keep future-login verification
+unresolved and must not recommend bare `stn` commands that the same probe found
+missing or shadowed. Compiled smoke runs a successful apply, not only a JSON
+check, and asserts the rendered recovery and absolute commands. Other
+recommended warnings, including doctor reminders and optional integrations,
+stay out of successful apply output. Installer tests own startup-file
+non-interaction; release acceptance owns proof in a genuinely new login shell.
 
 ## Tier 1 — in-process synthetic profiles (every PR, ~zero cost)
 

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -26,6 +26,29 @@ profile { name, state: { platform, xcodeClt, git, insideRepo, brew, worktrunk,
           expect: { exitCode, requiredOk, checks: { <id>: <status> } } }
 ```
 
+## Launcher success-rendering invariant
+
+Launcher PATH acceptance is deliberately outside the shared machine-profile
+contract. `station-launchers` is recommended and does not change
+`workflowReady` or `requiredOk`. Apply tests instead assert that successful
+output preserves only a final re-probed `station-launchers` warning and, for
+checkout launchers, its existing link action.
+
+| Final state | Successful apply output |
+| --- | --- |
+| All three launchers on PATH | Concise; no **Remaining** section |
+| Installed aliases outside PATH | Warning + exact paths; no checkout link |
+| One installed name shadowed | Warning names only that bare launcher |
+| Compiled sibling missing | Missing warning; never `pnpm station:link` |
+| Checkout names absent | Warning + existing `station:link` command |
+| Current PATH repaired | Concise; login shell remains unverified |
+| Spaces or apostrophes | Exact paths; installer owns safe quoting |
+
+Other recommended warnings, including doctor reminders and optional
+integrations, stay out of successful apply output. Installer tests own shell
+commands and startup-file non-interaction; release acceptance owns proof in a
+genuinely new login shell.
+
 ## Tier 1 — in-process synthetic profiles (every PR, ~zero cost)
 
 `apps/cli/test/integration/setup-profiles.test.ts` compiles each profile into the

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -37,17 +37,21 @@ checkout launchers, its existing link action.
 | Final state | Successful apply output |
 | --- | --- |
 | All three launchers on PATH | Concise; no **Remaining** section |
-| Installed aliases outside PATH | Warning, current-shell block, absolute next commands |
-| One installed name shadowed | Warning names only it; same runnable recovery |
-| Compiled sibling missing | Missing warning + absolute next; no checkout link |
-| Checkout names absent | Warning, absolute next, existing `station:link` command |
+| Installed aliases outside PATH | Warning, PATH guidance, absolute commands |
+| One installed name shadowed | Warning names it; same recovery |
+| Compiled sibling missing | Missing warning, absolute commands; no link |
+| Checkout names absent | Warning, absolute commands, contextual `station:link` |
 | Current PATH repaired | Concise; login shell remains unverified |
 | Spaces or apostrophes | Current-shell block and commands remain safely quoted |
 
 Every successful mismatch rendering must keep future-login verification
-unresolved and must not recommend bare `stn` commands that the same probe found
-missing or shadowed. Compiled smoke runs a successful apply, not only a JSON
-check, and asserts the rendered recovery and absolute commands. Other
+unresolved and must not recommend executing bare `stn` commands that the same
+probe found missing or shadowed. When a supported convenience remedy applies,
+output explains that absolute commands already work, tells installed users to
+prefer PATH over a one-name alias or checkout users to run `station:link`, and
+uses `command -v` only to verify all three names after remediation. Compiled
+smoke runs a successful apply, not only a JSON check, and asserts the rendered
+recovery, optional convenience guidance, and absolute commands. Other
 recommended warnings, including doctor reminders and optional integrations,
 stay out of successful apply output. Installer tests own startup-file
 non-interaction; release acceptance owns proof in a genuinely new login shell.

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -700,9 +700,16 @@ flow:
    OpenTUI renderer draws, observer connects, first-run screen shows.
 3. Open a shell pane → **Ctrl-Z suspends, `fg` resumes** (real job control).
 4. From `HOME` or `Desktop`, run `stn setup` → zero-project config is written
-   and the observer restarts on the **same socket**. Open the TUI, explicitly
-   add an existing Git repository, and verify the observer reflects it
-   immediately (B-config); an open TUI reconnects without a manual restart.
+   and the observer restarts on the **same socket**. First invoke setup through
+   the absolute installed fallback while the install directory is absent from
+   `PATH`: successful completion must retain the final all-three launcher
+   warning and exact installed paths. Repeat after the installer's current-shell
+   block: the current-process warning must disappear, while future-login PATH
+   remains unverified until the installer export is placed manually and tested
+   in a new login shell. Setup never emits that export or edits a startup file.
+   Open the TUI, explicitly add an existing Git repository, and verify the
+   observer reflects it immediately (B-config); an open TUI reconnects without
+   a manual restart.
 5. Build and install the compiled artifact with default popup geometry, then
    accept setup's optional popup binding. The marked block contains the
    installed-root fast command and exact sibling `stn-tmux-popup` fallback, and

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -704,9 +704,11 @@ flow:
    the absolute installed fallback while the install directory is absent from
    `PATH`: successful completion must retain the final all-three launcher
    warning and exact installed paths, print a safely quoted current-shell PATH
-   block, and use the absolute selected executable for doctor and launch next
-   steps. It must not recommend the bare commands it found unusable. Repeat
-   after the installer's current-shell block: the current-process warning must
+   block, explain that using the shorter names is optional, prefer PATH over a
+   one-name alias, print all-three `command -v` checks, and use the absolute
+   selected executable for doctor and launch next steps. It must not recommend
+   executing the bare commands it found unusable. Repeat after the installer's
+   current-shell block: the current-process warning must
    disappear, while future-login PATH remains unverified until the installer
    export is placed manually and tested in a new login shell. Setup never emits
    that future-shell export or edits a startup file. Open the TUI, explicitly

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -703,11 +703,14 @@ flow:
    and the observer restarts on the **same socket**. First invoke setup through
    the absolute installed fallback while the install directory is absent from
    `PATH`: successful completion must retain the final all-three launcher
-   warning and exact installed paths. Repeat after the installer's current-shell
-   block: the current-process warning must disappear, while future-login PATH
-   remains unverified until the installer export is placed manually and tested
-   in a new login shell. Setup never emits that export or edits a startup file.
-   Open the TUI, explicitly add an existing Git repository, and verify the
+   warning and exact installed paths, print a safely quoted current-shell PATH
+   block, and use the absolute selected executable for doctor and launch next
+   steps. It must not recommend the bare commands it found unusable. Repeat
+   after the installer's current-shell block: the current-process warning must
+   disappear, while future-login PATH remains unverified until the installer
+   export is placed manually and tested in a new login shell. Setup never emits
+   that future-shell export or edits a startup file. Open the TUI, explicitly
+   add an existing Git repository, and verify the
    observer reflects it immediately (B-config); an open TUI reconnects without
    a manual restart.
 5. Build and install the compiled artifact with default popup geometry, then

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1364,6 +1364,26 @@ async function verifyCompiledSetupApplyLauncherWarning({ binaryPath, installedRo
   );
   assertIncludes(
     result.stdout,
+    "Use stn instead of the absolute path (optional):",
+    "compiled setup apply optional bare launcher guidance",
+  );
+  assertIncludes(
+    result.stdout,
+    `For future shells, add ${quoteShellWord(installedRoot)} to PATH in a shell configuration you choose.`,
+    "compiled setup apply future-shell PATH guidance",
+  );
+  assertIncludes(
+    result.stdout,
+    "Use PATH rather than an alias so all three STATION launcher names resolve together.",
+    "compiled setup apply PATH over alias guidance",
+  );
+  assertIncludes(
+    result.stdout,
+    "command -v stn-tmux-popup",
+    "compiled setup apply all-launcher verification",
+  );
+  assertIncludes(
+    result.stdout,
     "Future login shell launcher resolution remains unverified",
     "compiled setup apply future-shell status",
   );

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -164,6 +164,23 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
       assertEqual(setupPlan.summary.launchReady, true, "compiled setup launchReady");
       assertEqual(setupPlan.summary.workflowReady, false, "compiled setup workflowReady");
       assertEqual(setupPlan.summary.requiredOk, false, "compiled setup requiredOk alias");
+      const launcherCheck = setupPlan.checks.find((check) => check.id === "station-launchers");
+      assertEqual(launcherCheck?.tier, "recommended", "compiled launcher PATH warning tier");
+      assertEqual(launcherCheck?.status, "warning", "compiled launcher PATH warning status");
+      assertEqual(
+        launcherCheck?.message,
+        "STATION is installed, but these bare launchers do not resolve to this installation on PATH: stn, stn-ingress, stn-tmux-popup. Use the installer's PATH guidance to repair bare launcher resolution.",
+        "compiled launcher PATH warning message",
+      );
+      assertDeepEqual(
+        launcherCheck?.details,
+        {
+          station: join(installedRoot, "stn"),
+          ingress: join(installedRoot, "stn-ingress"),
+          tmuxPopup: join(installedRoot, "stn-tmux-popup"),
+        },
+        "compiled launcher PATH warning paths",
+      );
       const persistedBindingAction = requiredSetupAction(setupPlan, "tmux-popup-binding");
       const liveBindingAction = requiredSetupAction(setupPlan, "tmux-live-popup-binding");
       assertEqual(persistedBindingAction.tier, "recommended", "compiled popup binding tier");

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -147,6 +147,11 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
         installedRoot,
         root: join(root, "git-setup-canary"),
       });
+      await verifyCompiledSetupApplyLauncherWarning({
+        binaryPath,
+        installedRoot,
+        root: join(root, "setup-apply-canary"),
+      });
 
       const popupHelp = await run(join(dirname(binaryPath), "stn-tmux-popup"), ["--help"], {
         env: childEnv,
@@ -178,6 +183,7 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
           station: join(installedRoot, "stn"),
           ingress: join(installedRoot, "stn-ingress"),
           tmuxPopup: join(installedRoot, "stn-tmux-popup"),
+          pathDirectory: installedRoot,
         },
         "compiled launcher PATH warning paths",
       );
@@ -1280,6 +1286,92 @@ async function verifyCompiledGitFailure({ binaryPath, installedRoot, root }) {
   );
 }
 
+async function verifyCompiledSetupApplyLauncherWarning({ binaryPath, installedRoot, root }) {
+  const homeDir = join(root, "home");
+  const runtimeDir = join(root, "runtime");
+  const stateDir = join(root, "state");
+  const cwd = join(root, "outside-repository");
+  const fakeBin = join(root, "fake-bin");
+  const configPath = join(root, "config.toml");
+  await Promise.all(
+    [homeDir, join(homeDir, "tmp"), runtimeDir, stateDir, cwd, fakeBin].map((path) =>
+      mkdir(path, { recursive: true, mode: 0o700 }),
+    ),
+  );
+  await Promise.all([
+    writeFile(
+      join(fakeBin, "wt"),
+      "#!/bin/sh\nif [ \"$1\" = --version ]; then echo 'worktrunk 1.2.3'; exit 0; fi\nexit 1\n",
+      { mode: 0o700 },
+    ),
+    writeFile(
+      join(fakeBin, "tmux"),
+      "#!/bin/sh\nif [ \"$1\" = -V ]; then echo 'tmux 3.5a'; exit 0; fi\nexit 1\n",
+      { mode: 0o700 },
+    ),
+    writeFile(join(fakeBin, "diffnav"), "#!/bin/sh\nexit 0\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "delta"), "#!/bin/sh\nexit 0\n", { mode: 0o700 }),
+    writeFile(join(fakeBin, "pi"), "#!/bin/sh\necho 'pi 0.80.10'\n", { mode: 0o700 }),
+    writeFile(
+      configPath,
+      [
+        "schema_version = 1",
+        "projects = []",
+        "",
+        "[observer]",
+        `state_dir = ${JSON.stringify(stateDir)}`,
+        `socket_path = ${JSON.stringify(join(runtimeDir, "observer.sock"))}`,
+        "",
+        "[defaults]",
+        'worktree_provider = "worktrunk"',
+        'terminal = "tmux"',
+        'harness = "pi"',
+        'layout = "agent-shell"',
+        "",
+      ].join("\n"),
+      { mode: 0o600 },
+    ),
+  ]);
+
+  const env = {
+    ...isolatedBinaryEnv({ homeDir, runtimeDir }),
+    PATH: `${fakeBin}:/usr/bin:/bin`,
+  };
+  const result = await run(
+    binaryPath,
+    ["--config", configPath, "setup", "apply", "--yes", "--no-brew"],
+    { cwd, env },
+  );
+  const stationLauncher = join(installedRoot, "stn");
+
+  assertEqual(result.code, 0, "compiled successful setup apply exit code");
+  assertIncludes(result.stdout, "Core setup complete.", "compiled setup apply completion");
+  assertIncludes(result.stdout, "Remaining", "compiled setup apply remaining section");
+  assertIncludes(
+    result.stdout,
+    `PATH=${quoteShellWord(installedRoot)}\${PATH:+":$PATH"}`,
+    "compiled setup apply current-shell PATH recovery",
+  );
+  assertIncludes(
+    result.stdout,
+    `  ${quoteShellWord(stationLauncher)} doctor`,
+    "compiled setup apply absolute doctor command",
+  );
+  assertIncludes(
+    result.stdout,
+    `  ${quoteShellWord(stationLauncher)}\n`,
+    "compiled setup apply absolute launch command",
+  );
+  assertIncludes(
+    result.stdout,
+    "Future login shell launcher resolution remains unverified",
+    "compiled setup apply future-shell status",
+  );
+  assertExcludes(result.stdout, "\n  stn doctor\n", "compiled setup apply bare doctor command");
+  assertExcludes(result.stdout, "\n  stn\n", "compiled setup apply bare launch command");
+  assertExcludes(result.stdout, "station:link", "compiled setup apply checkout link command");
+}
+
 async function writeWorktrunkHookSmokeConfig(path, state, socket, worktrunkConfigPath) {
   await writeFile(
     path,
@@ -2198,6 +2290,12 @@ function assertDeepEqual(actual, expected, label) {
 function assertIncludes(value, expected, label) {
   if (!value.includes(expected)) {
     fail(`${label}: expected ${JSON.stringify(value)} to include ${JSON.stringify(expected)}`);
+  }
+}
+
+function assertExcludes(value, unexpected, label) {
+  if (value.includes(unexpected)) {
+    fail(`${label}: expected ${JSON.stringify(value)} to exclude ${JSON.stringify(unexpected)}`);
   }
 }
 

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -53,6 +53,11 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("fake shell integration installed");
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
+      expect(result.stdout).toContain("Remaining");
+      expect(result.stdout).toContain(
+        "These bare launchers do not resolve to this checkout on PATH: stn, stn-ingress, stn-tmux-popup",
+      );
+      expect(result.stdout).toContain(`command pnpm --dir ${process.cwd()} station:link`);
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
     } finally {
       await fixture.cleanup();

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -59,6 +59,11 @@ describe("setup guided feedback e2e", () => {
       );
       expect(result.stdout).toContain(`command pnpm --dir ${process.cwd()} station:link`);
       expect(result.stdout).toContain(`'${join(process.cwd(), "bin", "stn")}' doctor`);
+      expect(result.stdout).toContain("Use stn instead of the absolute path (optional):");
+      expect(result.stdout).toContain(
+        "To use stn from this checkout, run the link command above; it exposes all three launcher names together.",
+      );
+      expect(result.stdout).toContain("command -v stn-tmux-popup");
       expect(result.stdout).toContain("Future login shell launcher resolution remains unverified");
       expect(result.stdout).not.toContain("\n  stn doctor\n");
       expect(result.stdout).not.toContain("\n  stn\n");

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -58,6 +58,10 @@ describe("setup guided feedback e2e", () => {
         "These bare launchers do not resolve to this checkout on PATH: stn, stn-ingress, stn-tmux-popup",
       );
       expect(result.stdout).toContain(`command pnpm --dir ${process.cwd()} station:link`);
+      expect(result.stdout).toContain(`'${join(process.cwd(), "bin", "stn")}' doctor`);
+      expect(result.stdout).toContain("Future login shell launcher resolution remains unverified");
+      expect(result.stdout).not.toContain("\n  stn doctor\n");
+      expect(result.stdout).not.toContain("\n  stn\n");
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
     } finally {
       await fixture.cleanup();


### PR DESCRIPTION
## What this fixes

`stn setup apply` performs a final readiness probe, but successful rendering discarded an actionable `station-launchers` warning whenever core workflow readiness was satisfied. Even after preserving that warning, the completion output still recommended bare `stn` commands that the same probe had found missing or shadowed, without explaining whether configuring the shorter launcher names was necessary.

## What changed

- Preserve only the final launcher warning under a concise **Remaining** section, including the selected absolute launcher paths.
- Use the safely quoted absolute selected `stn` executable for immediate doctor and launch next steps whenever launcher resolution is unresolved.
- Print a reusable current-shell PATH block when installed launchers share one directory, without choosing or editing a startup file, and keep future-login verification explicitly unresolved.
- Explain that absolute next commands already work and that enabling shorter launcher names is optional; installed users get PATH-over-alias guidance plus all-three `command -v` checks.
- Keep the existing checkout-only `pnpm --dir <checkout> station:link` recovery command, explain that it exposes all three names, and ensure a missing compiled alias never suggests source-checkout remediation.
- Assert that mismatch output contains no unusable bare next commands, including in a successful compiled `setup apply` binary-smoke fixture.

## Testing

- `pnpm test:pre-push` (via sanitized pre-push hook)
- `pnpm build:binary -- --version 0.7.1-rc.7-local`
- `pnpm smoke:binary -- --expected-version 0.7.1-rc.7-local`
- Focused setup unit, integration, and guided E2E tests
- `pnpm typecheck`
- `pnpm lint`

## Safety and scope

Launcher readiness remains recommended: workflow readiness, `requiredOk`, exit codes, final re-probing, and installer behavior are unchanged. Setup prints current-shell recovery and general future-shell guidance only; future-shell exports and startup-file selection remain installer/user-owned.
