### PR TITLE
test(harness): make real ingress lanes production-faithful

### DIFF
--- a/apps/cli/test/unit/real-station-env-support.test.ts
+++ b/apps/cli/test/unit/real-station-env-support.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { realHarnessChildEnv } from "../../../../tests/support/real-station/env.js";
+
+const inheritedStationValue = process.env.STATION_PARENT_TEST;
+
+describe("real Station environment support", () => {
+  afterEach(() => {
+    if (inheritedStationValue === undefined) {
+      delete process.env.STATION_PARENT_TEST;
+    } else {
+      process.env.STATION_PARENT_TEST = inheritedStationValue;
+    }
+  });
+
+  it("removes inherited Station state and keeps fixture overrides", () => {
+    process.env.STATION_PARENT_TEST = "leaked";
+
+    const env = realHarnessChildEnv({ STATION_SESSION_ID: "ses_fixture" });
+
+    expect(env.STATION_PARENT_TEST).toBeUndefined();
+    expect(env.STATION_SESSION_ID).toBe("ses_fixture");
+    expect(env.PATH).toBe(process.env.PATH);
+  });
+});

--- a/tests/agent/real/cursor/README.md
+++ b/tests/agent/real/cursor/README.md
@@ -15,8 +15,8 @@ STATION_TMUX_BIN="$(command -v tmux)" \
 pnpm test:e2e:cursor:real
 ```
 
-The test creates a temporary git worktree, starts a unique tmux session, launches Cursor through a temporary shim that logs argv/env and then `exec`s the real Cursor Agent binary, reconciles observer state, and cleans up the tmux/temp state afterward.
+The launch test creates a temporary git worktree, starts a unique tmux session, launches Cursor through a temporary shim that logs argv/env and then `exec`s the real Cursor Agent binary, reconciles observer state, and cleans up the tmux/temp state afterward.
 
-The assertion is intentionally conservative: station must observe a provider-neutral Cursor harness run with `unknown` low-confidence status. The shim log and tmux pane/process evidence prove the Cursor launch happened without asserting on Cursor screen text.
+The launch assertion is intentionally conservative: station must observe a provider-neutral Cursor harness run with `unknown` low-confidence status. The shim log and tmux pane/process evidence prove the Cursor launch happened without asserting on Cursor screen text.
 
-This lane does not install or exercise Cursor hooks. Hook-driven state promotion requires manually configuring Cursor to call `stn-ingress cursor` from `.cursor/hooks.json` or `~/.cursor/hooks.json`.
+The hook assertion installs the generated Cursor hook, routes an active-to-stop sequence through the checkout's `stn-ingress`, and requires high-confidence idle state from the matching Observer build.

--- a/tests/agent/real/cursor/cursor-session-create.test.ts
+++ b/tests/agent/real/cursor/cursor-session-create.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import type { StationConfig } from "@station/config";
-import { createCursorHarnessProvider, installCursorHooks } from "@station/cursor";
+import {
+  createCursorHarnessProvider,
+  cursorHookAdapter,
+  installCursorHooks,
+} from "@station/cursor";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
@@ -18,6 +22,7 @@ import {
   registerObserverCommandHandlers,
   startObserverServer,
 } from "@station/observer/internal";
+import { stationObserverBuildVersion } from "@station/runtime";
 import {
   createFakeTerminalTarget,
   createFakeWorktree,
@@ -27,6 +32,7 @@ import {
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
 import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
+import { realHarnessChildEnv } from "../../../support/real-station/env.js";
 
 const execFileAsync = promisify(execFile);
 const realCursorEnabled = process.env.STATION_REAL_CURSOR === "1";
@@ -268,6 +274,7 @@ describeRealCursor("real Cursor session.create launch lane", () => {
         ],
       }),
       harnesses: [createCursorHarnessProvider({ command: cursorBin, now: () => new Date(now) })],
+      hookAdapters: [cursorHookAdapter],
     });
     const core = createObserverCore({
       config: testConfig,
@@ -286,6 +293,7 @@ describeRealCursor("real Cursor session.create launch lane", () => {
       clock,
       config: testConfig,
       socketPath,
+      observerBuildVersion: stationObserverBuildVersion(),
       stateDir,
       hookSpoolDir,
       hookReconcileDebounceMs: 0,
@@ -297,7 +305,30 @@ describeRealCursor("real Cursor session.create launch lane", () => {
 
     try {
       await core.reconcile("real-cursor-hook-initial");
-      const result = await runHookScript(
+      const hookEnv = {
+        STATION_PROJECT_ID: "web",
+        STATION_WORKTREE_ID: "wt_real_cursor_hook",
+        STATION_WORKTREE_PATH: worktreePath,
+        STATION_SESSION_ID: "ses_real_cursor_hook",
+        STATION_HARNESS_PROVIDER: "cursor",
+        STATION_TERMINAL_PROVIDER: "tmux",
+        STATION_TERMINAL_TARGET_ID: "real-cursor-hook-target",
+        STATION_CONFIG_PATH: configPath,
+        STATION_OBSERVER_SOCKET_PATH: socketPath,
+        STATION_HOOK_SPOOL_DIR: hookSpoolDir,
+      };
+      const activeResult = await runHookScript(
+        hookScriptPath,
+        JSON.stringify({
+          hook_event_name: "preToolUse",
+          cwd: worktreePath,
+          session_id: "cursor_session_real",
+          tool_name: "Shell",
+          tool_use_id: "tool_real",
+        }),
+        hookEnv,
+      );
+      const stopResult = await runHookScript(
         hookScriptPath,
         JSON.stringify({
           hook_event_name: "stop",
@@ -305,21 +336,11 @@ describeRealCursor("real Cursor session.create launch lane", () => {
           cwd: worktreePath,
           session_id: "cursor_session_real",
         }),
-        {
-          STATION_PROJECT_ID: "web",
-          STATION_WORKTREE_ID: "wt_real_cursor_hook",
-          STATION_WORKTREE_PATH: worktreePath,
-          STATION_SESSION_ID: "ses_real_cursor_hook",
-          STATION_HARNESS_PROVIDER: "cursor",
-          STATION_TERMINAL_PROVIDER: "tmux",
-          STATION_TERMINAL_TARGET_ID: "real-cursor-hook-target",
-          STATION_CONFIG_PATH: configPath,
-          STATION_OBSERVER_SOCKET_PATH: socketPath,
-          STATION_HOOK_SPOOL_DIR: hookSpoolDir,
-        },
+        hookEnv,
       );
 
-      expect(result).toEqual({ code: 0, stdout: "", stderr: "" });
+      expect(activeResult).toEqual({ code: 0, stdout: "", stderr: "" });
+      expect(stopResult).toEqual({ code: 0, stdout: "", stderr: "" });
       const snapshot = await core.reconcile("real-cursor-hook-observed");
       expect(snapshot.rows[0]?.agent).toMatchObject({
         harness: "cursor",
@@ -434,10 +455,7 @@ async function runHookScript(
 ): Promise<HookScriptResult> {
   return new Promise((resolve) => {
     const child = spawn(scriptPath, [], {
-      env: {
-        ...process.env,
-        ...env,
-      },
+      env: realHarnessChildEnv(env),
       stdio: ["pipe", "pipe", "pipe"],
     });
     const stdout: Buffer[] = [];

--- a/tests/agent/real/opencode/opencode-event-capture.test.ts
+++ b/tests/agent/real/opencode/opencode-event-capture.test.ts
@@ -15,7 +15,12 @@ import {
   ProviderRegistry,
   startObserverServer,
 } from "@station/observer/internal";
-import { createOpenCodeHarnessProvider, installOpenCodePlugin } from "@station/opencode";
+import {
+  createOpenCodeHarnessProvider,
+  installOpenCodePlugin,
+  openCodeHookAdapter,
+} from "@station/opencode";
+import { stationObserverBuildVersion } from "@station/runtime";
 import {
   createFakeTerminalTarget,
   createFakeWorktree,
@@ -23,7 +28,11 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { afterEach, describe, expect, it } from "vitest";
-import { requireRealE2eEnvironment, requireToolPath } from "../../../support/real-station/env";
+import {
+  realHarnessChildEnv,
+  requireRealE2eEnvironment,
+  requireToolPath,
+} from "../../../support/real-station/env";
 
 const realOpenCodeEnabled = process.env.STATION_REAL_OPENCODE === "1";
 const describeRealOpenCode = realOpenCodeEnabled ? describe : describe.skip;
@@ -108,6 +117,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
       harnesses: [
         createOpenCodeHarnessProvider({ command: opencodeBin, now: () => new Date(now) }),
       ],
+      hookAdapters: [openCodeHookAdapter],
     });
     const testConfig = config({ root, stateDir, socketPath, worktreePath });
     const core = createObserverCore({
@@ -128,6 +138,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
       clock,
       config: testConfig,
       socketPath,
+      observerBuildVersion: stationObserverBuildVersion(),
       stateDir,
       hookSpoolDir,
       hookReconcileDebounceMs: 0,
@@ -154,6 +165,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
           STATION_HARNESS_PROVIDER: "opencode",
           STATION_TERMINAL_PROVIDER: "tmux",
           STATION_TERMINAL_TARGET_ID: "real-opencode-target",
+          STATION_INGRESS_BIN: env.stationIngressBin,
           STATION_OBSERVER_SOCKET_PATH: socketPath,
           STATION_OBSERVER_STATE_DIR: stateDir,
           STATION_HOOK_SPOOL_DIR: hookSpoolDir,
@@ -225,10 +237,7 @@ async function runOpenCode(input: {
       ],
       {
         cwd: input.cwd,
-        env: {
-          ...process.env,
-          ...input.env,
-        },
+        env: realHarnessChildEnv(input.env),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );

--- a/tests/agent/real/pi/pi-session-create.test.ts
+++ b/tests/agent/real/pi/pi-session-create.test.ts
@@ -17,7 +17,7 @@ import {
   registerObserverCommandHandlers,
   startObserverServer,
 } from "@station/observer/internal";
-import { createPiHarnessProvider } from "@station/pi";
+import { createPiHarnessProvider, piHookAdapter } from "@station/pi";
 import { stationObserverBuildVersion } from "@station/runtime";
 import {
   createFakeTerminalTarget,
@@ -28,7 +28,7 @@ import {
 import { TmuxProvider } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
 import { createUnexpectedProjectConfigWriter } from "../../../../apps/observer/test/support/projectConfigWriter.js";
-import type { RealE2eEnvironment } from "../../../support/real-station/env";
+import { type RealE2eEnvironment, realHarnessChildEnv } from "../../../support/real-station/env";
 import { createPiLaunchLoggingWrapper, waitForPiLaunchLog } from "../../../support/real-station/pi";
 
 const execFileAsync = promisify(execFile);
@@ -285,6 +285,7 @@ describeRealPi("real Pi session.create launch lane", () => {
         ],
       }),
       harnesses: [createPiHarnessProvider({ command: piBin, now: () => new Date(now) })],
+      hookAdapters: [piHookAdapter],
     });
     const core = createObserverCore({
       config: testConfig,
@@ -459,10 +460,7 @@ async function runPi(input: {
       ],
       {
         cwd: input.cwd,
-        env: {
-          ...process.env,
-          ...input.env,
-        },
+        env: realHarnessChildEnv(input.env),
         stdio: ["ignore", "pipe", "pipe"],
       },
     );

--- a/tests/support/real-station/env.ts
+++ b/tests/support/real-station/env.ts
@@ -30,6 +30,15 @@ export function realE2eEnabled(): boolean {
   return process.env.STATION_REAL_E2E === "1";
 }
 
+/** Removes the caller's Station session identity before applying fixture-owned values. */
+export function realHarnessChildEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const name of Object.keys(env)) {
+    if (name.startsWith("STATION_")) delete env[name];
+  }
+  return { ...env, ...overrides };
+}
+
 export async function requireRealE2eEnvironment(
   requirements: RealE2eRequirements = {},
 ): Promise<RealE2eEnvironment> {


### PR DESCRIPTION
## What

- isolate real harness child processes from inherited `STATION_*` state, then apply only fixture-owned Station values
- compose the Cursor, OpenCode, and Pi ingress fixtures with their production hook adapters and matching Observer build identity
- pin OpenCode to the checkout's `stn-ingress` and exercise Cursor's supported active-to-stop lifecycle
- update the Cursor real-lane documentation and add a focused environment-sanitization regression

## Why

RC7 acceptance exposed false failures in the real provider lanes when they ran from an active Station session or alongside an older installed binary. The fixtures had drifted from production composition: parent Station identity leaked into provider children, OpenCode could resolve a global ingress binary, hook adapters/build identity were missing, and Cursor sent a completion event before any bindable active event.

This keeps the acceptance lanes provider-neutral while making their ingress boundary match the shipped runtime.

## Verification

- `pnpm test:all` from a clean Station environment
- `pnpm lint`
- `pnpm typecheck`
- real Cursor suite with deliberately leaked parent session, managed-root, and ingress variables: 2 passed
- real Pi suite with the same contamination: 5 passed
- real OpenCode suite with the same contamination: 2 passed
- `pnpm smoke:binary -- --expected-version 0.0.0-local`

The aggregate pre-push run also cleared the root and Station/Bun suites. Its first binary-smoke attempt hit a transient alternate-build handoff mismatch; the isolated binary-smoke rerun passed.
