### PR TITLE
fix(hooks): unify composed ingress identity

### DIFF
--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -112,6 +112,9 @@ export function buildCommonHookOptions(context: HookCommandContext): CommonHookO
   if (context.env !== undefined) {
     options.env = context.env;
   }
+  if (context.providerHookIngressLauncher !== undefined) {
+    options.hookBin = context.providerHookIngressLauncher;
+  }
   return options;
 }
 

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { runObserverMain } from "@station/observer";
 import { type CreateProviderRegistryOptions, createProviderRegistry } from "./observerProviders.js";
+import { resolveDefaultIngressLauncher } from "./worktrunkHookExpectation.js";
 
 export type RunCliObserverMainOptions = {
   preparePiExtension?: (stateDir: string) => string | Promise<string>;
@@ -17,6 +18,8 @@ export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),
   options: RunCliObserverMainOptions = {},
 ): Promise<number> {
+  const providerHookIngressLauncher =
+    options.providerHookIngressLauncher ?? resolveDefaultIngressLauncher();
   return runObserverMain([...argv], {
     providerRegistryFactory: async (config, providerOptions) => {
       const registryOptions: CreateProviderRegistryOptions = {};
@@ -28,9 +31,7 @@ export async function runCliObserverMain(
           providerOptions.stateDir,
         );
       }
-      if (options.providerHookIngressLauncher !== undefined) {
-        registryOptions.providerHookIngressLauncher = options.providerHookIngressLauncher;
-      }
+      registryOptions.providerHookIngressLauncher = providerHookIngressLauncher;
       return createProviderRegistry(config, registryOptions);
     },
   });

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -279,6 +279,9 @@ function createHarnessProvider(
     if (providerConfig?.resume !== undefined) {
       options.resume = providerConfig.resume;
     }
+    if (registryOptions.providerHookIngressLauncher !== undefined) {
+      options.hookBin = registryOptions.providerHookIngressLauncher;
+    }
     applyObserverPaths(options, config, true);
     return createClaudeHarnessProvider(options);
   }
@@ -291,6 +294,9 @@ function createHarnessProvider(
     }
     if (providerConfig?.resume !== undefined) {
       options.resume = providerConfig.resume;
+    }
+    if (registryOptions.providerHookIngressLauncher !== undefined) {
+      options.hookBin = registryOptions.providerHookIngressLauncher;
     }
     applyObserverPaths(options, config, true);
     return createCodexHarnessProvider(options);
@@ -309,6 +315,9 @@ function createHarnessProvider(
     }
     if (registryOptions.configPath !== undefined) {
       options.configPath = registryOptions.configPath;
+    }
+    if (registryOptions.providerHookIngressLauncher !== undefined) {
+      options.hookBin = registryOptions.providerHookIngressLauncher;
     }
     applyObserverPaths(options, config, true);
     return createCursorHarnessProvider(options);

--- a/apps/cli/test/integration/claude-hooks-command.test.ts
+++ b/apps/cli/test/integration/claude-hooks-command.test.ts
@@ -53,6 +53,22 @@ describe("CLI Claude hook commands", () => {
     );
   });
 
+  it("uses the composed ingress launcher when --hook-bin is omitted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-claude-hooks-"));
+    const configPath = await writeConfig(root, true);
+    const env = claudeEnv(root);
+    const hookScriptPath = join(root, "state", "hooks", "station-claude-hook.sh");
+    const providerHookIngressLauncher = join(root, "installed", "stn-ingress");
+    const options = { env, providerHookIngressLauncher };
+
+    await runCli(["--config", configPath, "hooks", "install", "claude", "--yes"], options);
+
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain(providerHookIngressLauncher);
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "claude"], options),
+    ).resolves.toMatchObject({ code: 0, output: { installed: true, status: "ok" } });
+  });
+
   it("installs and uninstalls through the generic hooks command", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cli-claude-hooks-"));
     const configPath = await writeConfig(root, true);

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -56,6 +56,39 @@ describe("CLI Codex hook commands", () => {
     );
   });
 
+  it("uses the composed ingress launcher when --hook-bin is omitted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-codex-hooks-"));
+    const configPath = await writeConfig(root, true);
+    const env = codexEnv(root);
+    const hookScriptPath = join(root, "state", "hooks", "station-codex-hook.sh");
+    const providerHookIngressLauncher = join(root, "installed", "stn-ingress");
+    const options = { env, providerHookIngressLauncher };
+
+    await runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], options);
+
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain(providerHookIngressLauncher);
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "codex"], options),
+    ).resolves.toMatchObject({ code: 0, output: { installed: true, status: "ok" } });
+
+    await runCli(
+      [
+        "--config",
+        configPath,
+        "hooks",
+        "install",
+        "codex",
+        "--yes",
+        "--hook-bin",
+        "/explicit/stn-ingress",
+      ],
+      options,
+    );
+    const overriddenScript = await readFile(hookScriptPath, "utf8");
+    expect(overriddenScript).toContain("/explicit/stn-ingress");
+    expect(overriddenScript).not.toContain(providerHookIngressLauncher);
+  });
+
   it("installs and uninstalls through the generic hooks command", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cli-codex-hooks-"));
     const configPath = await writeConfig(root, true);

--- a/apps/cli/test/integration/cursor-hooks-command.test.ts
+++ b/apps/cli/test/integration/cursor-hooks-command.test.ts
@@ -51,6 +51,24 @@ describe("CLI Cursor hook commands", () => {
     );
   });
 
+  it("uses the composed ingress launcher when --hook-bin is omitted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-cursor-hooks-"));
+    const configPath = await writeConfig(root, true);
+    const env = { STATION_CURSOR_HOME: root };
+    const hooksPath = join(root, ".cursor", "hooks.json");
+    const hookScriptPath = join(root, "state", "hooks", "station-cursor-hook.sh");
+    const providerHookIngressLauncher = join(root, "installed", "stn-ingress");
+    const options = { env, providerHookIngressLauncher };
+
+    await runCli(["--config", configPath, "hooks", "install", "cursor", "--yes"], options);
+
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain(providerHookIngressLauncher);
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "cursor"], options),
+    ).resolves.toMatchObject({ code: 0, output: { installed: true, status: "ok" } });
+    await expect(readFile(hooksPath, "utf8")).resolves.toContain(hookScriptPath);
+  });
+
   it("installs and uninstalls through the generic hooks command", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cli-cursor-hooks-"));
     const configPath = await writeConfig(root, true);

--- a/apps/cli/test/unit/observer-main.test.ts
+++ b/apps/cli/test/unit/observer-main.test.ts
@@ -45,6 +45,7 @@ describe("runCliObserverMain", () => {
     expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {
       configPath: "/config/station.toml",
       piExtensionPath: "/canonical/state/assets/pi/station-pi-extension.mjs",
+      providerHookIngressLauncher: expect.stringMatching(/\/bin\/stn-ingress$/),
     });
   });
 
@@ -60,6 +61,8 @@ describe("runCliObserverMain", () => {
     const config = {} as StationConfig;
     await deps.providerRegistryFactory(config, { stateDir: "/source/state" });
 
-    expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {});
+    expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {
+      providerHookIngressLauncher: expect.stringMatching(/\/bin\/stn-ingress$/),
+    });
   });
 });

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import {
   DEFAULT_WORKSPACE_CONFIG,
   HarnessProvidersConfigSchema,
+  loadConfig,
   type StationConfig,
 } from "@station/config";
 import * as contracts from "@station/contracts";
@@ -437,6 +438,18 @@ describe("observer providers", () => {
 
       await expect(
         probeHarnessHooksStatus("cursor", configPath, { ingressLauncher }),
+      ).resolves.toMatchObject({
+        provider: "cursor",
+        requested: true,
+        installed: true,
+      });
+      const loaded = await loadConfig(configPath);
+      const provider = createProviderRegistry(loaded.config, {
+        configPath: loaded.configPath,
+        providerHookIngressLauncher: ingressLauncher,
+      }).harnesses.get("cursor");
+      await expect(
+        provider?.hooksStatus?.({ stationConfigPath: loaded.configPath }),
       ).resolves.toMatchObject({
         provider: "cursor",
         requested: true,

--- a/apps/observer/src/commands/providers.ts
+++ b/apps/observer/src/commands/providers.ts
@@ -4,6 +4,7 @@ import type {
   SafeError,
   TerminalProvider,
 } from "@station/contracts";
+import { commandLine } from "@station/runtime";
 import type { ProviderRegistry } from "../providers/registry.js";
 
 export function resolveTerminalProviderOrThrow(
@@ -61,15 +62,18 @@ export async function assertHooksInstalledOrThrow(
         : { stationConfigPath: options.stationConfigPath },
     );
   } catch {
+    const doctorCommand = providerHookCommand(provider.id, "doctor", options.stationConfigPath);
     const error: SafeError = {
       tag: "HarnessProviderError",
       code: "HARNESS_HOOKS_STATUS_FAILED",
       message: `STATION could not verify whether ${provider.id} status hooks are installed.`,
-      hint: `Run 'stn hooks doctor ${provider.id}' to diagnose, then retry.`,
+      hint: `Run \`${doctorCommand}\` to diagnose, then retry.`,
       provider: provider.id,
     };
     throw error;
   }
+  const installCommand = providerHookCommand(provider.id, "install", options.stationConfigPath);
+  const doctorCommand = providerHookCommand(provider.id, "doctor", options.stationConfigPath);
   if (status.installed) {
     return;
   }
@@ -81,15 +85,31 @@ export async function assertHooksInstalledOrThrow(
         tag: "CommandValidationError",
         code: "HARNESS_HOOKS_NOT_INSTALLED",
         message: `${provider.id} status hooks are not installed, so the observer cannot track this agent.`,
-        hint: `Run 'stn hooks install ${provider.id}' (then 'stn hooks doctor ${provider.id}' to confirm) and retry.`,
+        hint: `Run \`${installCommand}\`, then \`${doctorCommand}\` to confirm, and retry.`,
         provider: provider.id,
       }
     : {
         tag: "CommandValidationError",
         code: "HARNESS_HOOKS_NOT_INSTALLED",
         message: `${provider.id} status hooks are not enabled, so the observer cannot track this agent.`,
-        hint: `Enable hooks for this harness — set 'install_hooks = true' under [harness.${provider.id}] in your station config (or run 'stn setup'), then 'stn hooks install ${provider.id}' — and retry.`,
+        hint: `Enable hooks for this harness — set 'install_hooks = true' under [harness.${provider.id}] in your station config (or run \`stn setup\`), then run \`${installCommand}\` and retry.`,
         provider: provider.id,
       };
   throw error;
+}
+
+function providerHookCommand(
+  providerId: string,
+  action: "doctor" | "install",
+  configPath: string | undefined,
+): string {
+  const args = ["stn"];
+  if (configPath !== undefined) {
+    args.push("--config", configPath);
+  }
+  args.push("hooks", action, providerId);
+  if (action === "install") {
+    args.push("--yes");
+  }
+  return commandLine(args);
 }

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -348,11 +348,18 @@ describe("prepareExternalLaunch", () => {
   it("rejects when the harness's status hooks are not installed", async () => {
     const station = new FakeManagedTerminalLifecycle();
     await expect(
-      prepareExternalLaunch(deps([row()], station, [new HookableHarness(false)]), prepareParams),
+      prepareExternalLaunch(
+        {
+          ...deps([row()], station, [new HookableHarness(false)]),
+          configPath: "/tmp/custom station/config.toml",
+        },
+        prepareParams,
+      ),
     ).rejects.toMatchObject({
       tag: "CommandValidationError",
       code: "HARNESS_HOOKS_NOT_INSTALLED",
       provider: "fake-harness",
+      hint: "Run `stn --config '/tmp/custom station/config.toml' hooks install fake-harness --yes`, then `stn --config '/tmp/custom station/config.toml' hooks doctor fake-harness` to confirm, and retry.",
     });
     // No target is left registered after a gated rejection.
     expect(await station.listTargets()).toEqual([]);

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -30,6 +30,7 @@ import {
 /** Options every terminal-bound harness adapter accepts; provider-specific options extend this. */
 export type CommonHarnessProviderOptions = {
   command?: string;
+  hookBin?: string;
   now?: () => Date | string;
   timeoutMs?: number;
   runner?: ExternalCommandRunner;
@@ -229,6 +230,7 @@ export async function harnessHealth<TOpts extends CommonHarnessProviderOptions>(
 
 export type HarnessHookDoctorOptionsInput = {
   installHooks?: boolean;
+  hookBin?: string;
   observerSocketPath?: string;
   stateDir?: string;
   hookSpoolDir?: string;
@@ -265,6 +267,9 @@ export function harnessHookDoctorOptions(
   }
   if (options.observerSocketPath !== undefined) {
     result.observerSocketPath = options.observerSocketPath;
+  }
+  if (options.hookBin !== undefined) {
+    result.hookBin = options.hookBin;
   }
   if (options.stateDir !== undefined) {
     result.stateDir = options.stateDir;

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -214,11 +214,19 @@ describe("versionInfo", () => {
 describe("harnessHookDoctorOptions", () => {
   const incumbent = {
     installHooks: true,
+    hookBin: "/checkout/A/bin/stn-ingress",
     observerSocketPath: "/shared/observer.sock",
     stateDir: "/checkout/A/state",
     hookSpoolDir: "/checkout/A/state/spool/hooks",
     autoStartFromHooks: true,
   };
+
+  it("preserves the incumbent hook launcher without a requester runtime", () => {
+    expect(harnessHookDoctorOptions(incumbent)).toMatchObject({
+      enabled: true,
+      hookBin: incumbent.hookBin,
+    });
+  });
   const requesterRuntime = {
     ingressLauncher: "/checkout/B/bin/stn-ingress",
     observerSocketPath: "/shared/observer.sock",


### PR DESCRIPTION
## What this fixes

RC7 setup installed Codex hooks with an absolute `stn-ingress` path, while plain hook doctor and native launch composed the provider with the bare command. That made a fresh setup look green and then reject the first native Codex launch; the displayed repair command also omitted the required `--yes`. Closes #281.

## What changed

- Flow one composed ingress launcher through plain CLI hook commands and Observer provider composition for Claude, Codex, and Cursor.
- Preserve an explicit `--hook-bin` override and the incumbent provider hook identity.
- Emit shell-safe, config-aware install and doctor remediation commands.
- Include `--yes` in the mutating install remediation.
- Cover CLI, shared-provider, Observer composition, and native-launch behavior.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Focused unit and hook-command integration suites
- `env -u STATION_PANE pnpm test:pre-push`