### PR TITLE
diagnostics(observer): log hook launch rejections

### DIFF
--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -19,7 +19,12 @@ import type {
   StationEvent,
 } from "@station/contracts";
 import { STARTUP_RECONCILE_REASONS, STATION_SCHEMA_VERSION } from "@station/contracts";
-import { type RuntimeClock, systemClock, toIsoTimestamp } from "@station/runtime";
+import {
+  type RuntimeClock,
+  safeErrorFromUnknown,
+  systemClock,
+  toIsoTimestamp,
+} from "@station/runtime";
 import type { CommandQueue } from "../commands/queue.js";
 import { commandRecordFromPersisted } from "../commands/record.js";
 import {
@@ -253,7 +258,31 @@ async function prepareExternalLaunchSafe(
   params: Parameters<ObserverApi["prepareExternalLaunch"]>[0],
 ): ReturnType<ObserverApi["prepareExternalLaunch"]> {
   const deps = assertProvidersAvailable(options);
-  const { outcome, reconcile } = await prepareExternalLaunch(deps, params);
+  let result: Awaited<ReturnType<typeof prepareExternalLaunch>>;
+  try {
+    result = await prepareExternalLaunch(deps, params);
+  } catch (cause) {
+    const error = safeErrorFromUnknown(cause, {
+      tag: "ExternalLaunchError",
+      code: "EXTERNAL_LAUNCH_PREPARE_FAILED",
+      message: "External agent launch preparation failed.",
+    });
+    if (error.code === "HARNESS_HOOKS_NOT_INSTALLED") {
+      const attributes: Record<string, unknown> = {
+        error,
+        projectId: params.projectId,
+        worktreeId: params.worktreeId,
+      };
+      if (params.harness !== undefined) {
+        attributes.harnessProvider = params.harness;
+      }
+      await options.logger
+        ?.warn("External agent launch rejected because harness hooks are unavailable.", attributes)
+        .catch(() => undefined);
+    }
+    throw cause;
+  }
+  const { outcome, reconcile } = result;
   if (reconcile) {
     reconcileAfterExternalLaunch(
       reconcileDeps,

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { StationConfig } from "@station/config";
+import type { HarnessHooksStatus } from "@station/contracts";
 import { StationTerminalProvider } from "@station/terminal";
 import {
   createFakeWorktree,
@@ -21,6 +22,7 @@ import {
   ProviderRegistry,
   providerIngressSpoolDir,
 } from "../../src/internal";
+import type { StationLogger } from "../../src/stationLogger";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -74,9 +76,43 @@ describe("observer external-launch reconcile", () => {
 
     fixture.sqlite.close();
   });
+
+  it("logs hook readiness rejections with their diagnostic code", async () => {
+    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-ext-"));
+    const records: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
+    const logger: StationLogger = {
+      info: async () => {},
+      warn: async (message, attributes) => {
+        records.push({ message, ...(attributes === undefined ? {} : { attributes }) });
+      },
+      error: async () => {},
+    };
+    const fixture = createFixture(providerIngressSpoolDir(stateDir), {
+      harness: new MissingHooksHarness(),
+      logger,
+    });
+    await fixture.api.reconcile("seed");
+
+    await expect(
+      fixture.api.prepareExternalLaunch({ projectId: "web", worktreeId: "wt_web_feature" }),
+    ).rejects.toMatchObject({ code: "HARNESS_HOOKS_NOT_INSTALLED" });
+    expect(records).toContainEqual({
+      message: "External agent launch rejected because harness hooks are unavailable.",
+      attributes: {
+        error: expect.objectContaining({ code: "HARNESS_HOOKS_NOT_INSTALLED" }),
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+      },
+    });
+
+    fixture.sqlite.close();
+  });
 });
 
-function createFixture(spoolDir: string) {
+function createFixture(
+  spoolDir: string,
+  options: { harness?: FakeHarnessProvider; logger?: StationLogger } = {},
+) {
   const clock = { now: () => new Date(now) };
   const sqlite = openObserverSqlite({ clock });
   const persistence = createSqliteObserverPersistence({ sqlite, clock, idFactory: ids() });
@@ -99,7 +135,7 @@ function createFixture(spoolDir: string) {
     }),
     terminal: new FakeTerminalProvider({ now }),
     managedTerminal: station,
-    harnesses: [new FakeHarnessProvider({ now })],
+    harnesses: [options.harness ?? new FakeHarnessProvider({ now })],
   });
   const core = createObserverCore({ config, providers, persistence, clock });
   const queue = createCommandQueue({ persistence, clock, idFactory: ids(), eventBus });
@@ -112,8 +148,21 @@ function createFixture(spoolDir: string) {
     eventBus,
     hookSpoolDir: spoolDir,
     clock,
+    ...(options.logger === undefined ? {} : { logger: options.logger }),
   });
   return { api, sqlite };
+}
+
+class MissingHooksHarness extends FakeHarnessProvider {
+  async hooksStatus(): Promise<HarnessHooksStatus> {
+    return {
+      provider: this.id,
+      installed: false,
+      requested: true,
+      missing: ["SessionStart"],
+      message: "Hooks are not installed.",
+    };
+  }
 }
 
 function ids() {


### PR DESCRIPTION
## What this fixes

Issue #281 also exposed an observability gap: a native harness launch rejected for missing or drifted hooks returned an actionable error to the caller but left no structured Observer log record. This PR is stacked on #282.

## What changed

- Log `HARNESS_HOOKS_NOT_INSTALLED` launch rejections at the Observer API boundary.
- Preserve the original SafeError returned to the caller.
- Include safe project, worktree, and optional harness context.
- Keep logging failure from changing command behavior.
- Cover the real API integration path and diagnostic code.

## Testing

- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/observer/test/integration/external-launch-reconcile.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `env -u STATION_PANE pnpm test:pre-push`