### PR TITLE
test(release): verify compiled hook identity

### DIFF
--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -353,7 +353,9 @@ A4 owns the packaged helper lifecycle that A2a deliberately leaves out:
 Local pre-push and hosted `standard-ci` binary smoke checks: `--version`,
 `--help`, exact popup alias symlinks, popup argv0 fallback routing, compiled
 setup binding generation, and `setup check --json`
-(asserting the `launchReady`/`workflowReady` split), an **observer round
+(asserting the `launchReady`/`workflowReady` split), compiled Codex hook
+installation with the absolute sibling ingress launcher plus agreement across
+plain doctor, setup check, and Observer doctor, an **observer round
 trip through the binary** in an isolated state dir, an ingress receipt via
 the `stn-ingress` symlink, the **hostile-directory RCE test** (F1), and the
 **detached self-spawn** check (folds in S5). A stateful fake tmux proves that a

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -275,6 +275,53 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
       const hookObserverClient = createObserverClient({ socketPath, timeoutMs: 5000 });
       await hookObserverClient.stop();
       await waitForMissing(socketPath);
+
+      const codexHome = join(root, "codex-home");
+      const codexHookEnv = { ...childEnv, CODEX_HOME: codexHome };
+      await writeCodexHookSmokeConfig(configPath, stateDir, socketPath);
+      const codexHookInstall = await run(
+        binaryPath,
+        ["--config", configPath, "hooks", "install", "codex", "--yes"],
+        { env: codexHookEnv },
+      );
+      const codexHookInstallReport = JSON.parse(codexHookInstall.stdout);
+      assertEqual(codexHookInstallReport.installed, true, "compiled Codex hook install");
+      assertIncludes(
+        await readFile(codexHookInstallReport.hookScriptPath, "utf8"),
+        join(installedRoot, "stn-ingress"),
+        "compiled Codex hook absolute ingress launcher",
+      );
+      const codexStandaloneDoctor = await run(
+        binaryPath,
+        ["--config", configPath, "hooks", "doctor", "codex"],
+        { env: codexHookEnv },
+      );
+      assertEqual(
+        JSON.parse(codexStandaloneDoctor.stdout).status,
+        "ok",
+        "compiled standalone Codex hook doctor",
+      );
+      const codexSetupCheck = await run(
+        binaryPath,
+        ["--config", configPath, "setup", "check", "--json", "--no-brew"],
+        { env: codexHookEnv, allowedExitCodes: [0, 1] },
+      );
+      const codexSetupPlan = JSON.parse(codexSetupCheck.stdout);
+      const codexSetupHookCheck = codexSetupPlan.checks.find(
+        (check) => check.id === "harness-tracking:codex",
+      );
+      assertEqual(codexSetupHookCheck?.status, "ok", "compiled setup Codex hook check");
+      const codexFullDoctor = await run(binaryPath, ["--config", configPath, "doctor"], {
+        env: codexHookEnv,
+        allowedExitCodes: [0, 1],
+      });
+      const codexFullHookCheck = JSON.parse(codexFullDoctor.stdout).checks?.find(
+        (check) => check.name === "codex-hooks",
+      );
+      assertEqual(codexFullHookCheck?.status, "ok", "compiled full Codex hook doctor");
+      const codexObserverClient = createObserverClient({ socketPath, timeoutMs: 5000 });
+      await codexObserverClient.stop();
+      await waitForMissing(socketPath);
       await writeSmokeConfig(configPath, stateDir, socketPath);
 
       observerClient = createObserverClient({ socketPath, timeoutMs: 5000 });
@@ -1413,6 +1460,32 @@ async function writeWorktrunkHookSmokeConfig(path, state, socket, worktrunkConfi
       'command = "/usr/bin/true"',
       `config_path = ${JSON.stringify(worktrunkConfigPath)}`,
       "use_lifecycle_hooks = true",
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+}
+
+async function writeCodexHookSmokeConfig(path, state, socket) {
+  await writeFile(
+    path,
+    [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[observer]",
+      `state_dir = ${JSON.stringify(state)}`,
+      `socket_path = ${JSON.stringify(socket)}`,
+      "",
+      "[defaults]",
+      'worktree_provider = "noop-worktree"',
+      'terminal = "noop-terminal"',
+      'harness = "codex"',
+      'layout = "agent-shell"',
+      "",
+      "[harness.codex]",
+      'command = "/usr/bin/true"',
+      "install_hooks = true",
       "",
     ].join("\n"),
     { mode: 0o600 },


### PR DESCRIPTION
## What this fixes

The RC7 defect crossed compiled setup, generated hook artifacts, plain doctor, setup check, full doctor, and native launch composition. Source-only tests could pass while those surfaces disagreed. This PR is stacked on #283.

## What changed

- Add a compiled Codex hook acceptance canary to the binary smoke runner.
- Install hooks through the actual binary without an explicit `--hook-bin`.
- Run under a restricted PATH and require the generated hook to use the absolute sibling `stn-ingress`.
- Require plain hook doctor, setup check, and full doctor to agree that the artifact is healthy.
- Restore the smoke fixture after the canary and document the release boundary.

## Testing

- `node --check scripts/test-runners/run-binary-smoke.mjs`
- `pnpm test:diagnostics`
- `pnpm build:binary -- --version 0.0.0-local`
- `pnpm smoke:binary -- --expected-version 0.0.0-local`
- `env -u STATION_PANE pnpm test:pre-push`