### PR TITLE
chore(release): prepare v0.7.1-rc.8 candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run this from any directory:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.7
+  tag=v0.7.1-rc.8
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -81,15 +81,15 @@ Run this from any directory:
 )
 ```
 
-`v0.7.1-rc.7` is the current private-binary candidate. `v0.7.1-rc.6` remains
+`v0.7.1-rc.8` is the current private-binary candidate. `v0.7.1-rc.7` remains
 published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`,
-`v0.7.1-rc.4`, and `v0.7.1-rc.5` are older published binaries, while the earlier
-`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished. Run the recipe
-after the candidate is published. It fetches the installer and binary from the
-same immutable release tag, verifies the release checksum, and installs `stn`,
-`stn-ingress`, and `stn-tmux-popup` in `~/.local/bin` by default. It does not
-expose or print your GitHub credentials. After the first stable release, the
-commented assignment resolves the latest stable tag.
+`v0.7.1-rc.4`, `v0.7.1-rc.5`, and `v0.7.1-rc.6` are older published binaries,
+while the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
+Run the recipe after the candidate is published. It fetches the installer and
+binary from the same immutable release tag, verifies the release checksum, and
+installs `stn`, `stn-ingress`, and `stn-tmux-popup` in `~/.local/bin` by
+default. It does not expose or print your GitHub credentials. After the first
+stable release, the commented assignment resolves the latest stable tag.
 
 ### 3. Verify and start Station
 
@@ -123,7 +123,7 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.7 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.8 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -139,7 +139,7 @@ Safety and scope:
   installer block from the page that supplied this prompt in my Terminal, then
   resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.7`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.8`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.7", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.8", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -348,23 +348,23 @@ containing spaces and apostrophes. Source-checkout acceptance separately
 requires the preserved `pnpm --dir <checkout> station:link` command when
 linking is declined.
 
-The current immutable binary candidate is `v0.7.1-rc.7`. `v0.7.1-rc.6` is the
-prior published binary, and `v0.7.1-rc.2`, `v0.7.1-rc.3`, `v0.7.1-rc.4`, and
-`v0.7.1-rc.5` remain older published rollbacks; the earlier `v0.7.0` and
-`v0.7.1-rc.1` candidates remained unpublished:
+The current immutable binary candidate is `v0.7.1-rc.8`. `v0.7.1-rc.7` is the
+prior published binary, and `v0.7.1-rc.2`, `v0.7.1-rc.3`, `v0.7.1-rc.4`,
+`v0.7.1-rc.5`, and `v0.7.1-rc.6` remain older published rollbacks; the earlier
+`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.7`, then create and
-   push `v0.7.1-rc.7`.
+   with `package.json` and runtime reporting at `0.7.1-rc.8`, then create and
+   push `v0.7.1-rc.8`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.7-attempt-*` artifact.
+   `accepted-release-candidate-0.7.1-rc.8-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
-4. Install `v0.7.1-rc.6`, upgrade to the accepted candidate, explicitly
-   reinstall `v0.7.1-rc.6`, then reinstall the candidate. Confirm the complete
+4. Install `v0.7.1-rc.7`, upgrade to the accepted candidate, explicitly
+   reinstall `v0.7.1-rc.7`, then reinstall the candidate. Confirm the complete
    version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.7`, and the manual-acceptance confirmation. It rechecks the
+   `v0.7.1-rc.8`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
    asset IDs, and all archive hashes immediately before publishing that exact
    draft.
@@ -486,7 +486,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.7
+  tag=v0.7.1-rc.8
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -646,11 +646,11 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.7`:
+   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.8`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft
-   with published `v0.7.1-rc.6` in both directions.
+   with published `v0.7.1-rc.7` in both directions.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,7 +33,7 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.7 and validate setup on this machine.
+Install Station private preview candidate v0.7.1-rc.8 and validate setup on this machine.
 
 Use the private GitHub repository jeremy0dell/station through GitHub CLI.
 
@@ -49,7 +49,7 @@ Safety and scope:
   installer block from the page that supplied this prompt in my Terminal, then
   resume using the absolute installed `stn` path.
 - Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.7`, read `docs/install.md` from that same tag with authenticated
+  `v0.7.1-rc.8`, read `docs/install.md` from that same tag with authenticated
   `gh api`, and follow its temporary-file installer procedure. If that release
   is not published yet, stop instead of falling back to another ref.
 - Never fetch installer code from `main` and never pipe network output directly
@@ -114,7 +114,7 @@ From any directory, run:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.7
+  tag=v0.7.1-rc.8
   # After the first stable release, use:
   # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
   installer="$(mktemp)"
@@ -129,16 +129,16 @@ From any directory, run:
 )
 ```
 
-`v0.7.1-rc.7` is the current private-binary candidate. `v0.7.1-rc.6` remains
+`v0.7.1-rc.8` is the current private-binary candidate. `v0.7.1-rc.7` remains
 published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`,
-`v0.7.1-rc.4`, and `v0.7.1-rc.5` are older published binaries, while the earlier
-`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished. Run this recipe
-after the candidate is published. Keep the fixed assignment for an exact
-prerelease install. After the first stable release, use the commented assignment
-to resolve the latest stable tag while still fetching installer code and
-artifacts from that same immutable tag. The recipe never falls back to `main`,
-never prints GitHub credentials, and never pipes network output directly into a
-shell.
+`v0.7.1-rc.4`, `v0.7.1-rc.5`, and `v0.7.1-rc.6` are older published binaries,
+while the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
+Run this recipe after the candidate is published. Keep the fixed assignment for
+an exact prerelease install. After the first stable release, use the commented
+assignment to resolve the latest stable tag while still fetching installer code
+and artifacts from that same immutable tag. The recipe never falls back to
+`main`, never prints GitHub credentials, and never pipes network output directly
+into a shell.
 
 The installer selects the matching platform archive, verifies it against
 `SHA256SUMS`, and installs these launchers in `~/.local/bin` by default:
@@ -152,7 +152,7 @@ stn-tmux-popup
 It also installs the redistributed license under
 `${XDG_DATA_HOME:-$HOME/.local/share}/station/`.
 
-After this candidate is published, immutable rollback to `v0.7.1-rc.6` uses the
+After this candidate is published, immutable rollback to `v0.7.1-rc.7` uses the
 same exact-version procedure below.
 
 ## 3. Verify the Install
@@ -199,11 +199,11 @@ it separately.
 
 ## Install an Exact Version
 
-To install an exact release or return to published `v0.7.1-rc.6`, use the same
+To install an exact release or return to published `v0.7.1-rc.7`, use the same
 recipe with this assignment instead of the latest-release lookup:
 
 ```bash
-tag=v0.7.1-rc.6
+tag=v0.7.1-rc.7
 ```
 
 The installer code and artifacts still come from that same tag. The earlier

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -148,7 +148,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.7", compiled: false }` display semantics.
+  retaining `{ version: "0.7.1-rc.8", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -394,7 +394,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.7-darwin-arm64.tar.gz`.
+example `stn-v0.7.1-rc.8-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -436,8 +436,8 @@ invoke it with `--version` set to the same tag. Latest install first resolves
 the latest stable tag, then performs the same tagged fetch and explicit invoke.
 There is no silent `main` fallback, so installer code and release artifacts are
 always paired. `v0.7.1-rc.2` is the first published binary,
-`v0.7.1-rc.6` is the latest published binary, and publishing `v0.7.1-rc.7`
-makes immutable rollback to `v0.7.1-rc.6` available.
+`v0.7.1-rc.7` is the latest published binary, and publishing `v0.7.1-rc.8`
+makes immutable rollback to `v0.7.1-rc.7` available.
 
 The installer uses authenticated `gh api` release endpoints, accepts only the
 four supported targets, verifies the one matching `SHA256SUMS` entry and exact
@@ -506,9 +506,9 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.7.1-rc.7` promotes only after all four native targets pass
+Candidate `v0.7.1-rc.8` promotes only after all four native targets pass
 automated and manual acceptance, including upgrade and rollback against
-published `v0.7.1-rc.6`. Published tags and assets are never deleted, moved, or
+published `v0.7.1-rc.7`. Published tags and assets are never deleted, moved, or
 overwritten; a bad release rolls back explicitly and rolls forward to a higher
 version containing the revert or fix.
 
@@ -735,10 +735,10 @@ flow:
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
    asset IDs, and hashes, then publishes only that draft.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.7` output appears,
+   repeatedly installs the draft → only complete `0.7.1-rc.8` output appears,
    never command-not-found or malformed output; both aliases remain links to
    `stn`, so entrypoints never mix. Alternate the draft with published
-   `v0.7.1-rc.6` in both directions to prove upgrade and rollback.
+   `v0.7.1-rc.7` in both directions to prove upgrade and rollback.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.7",
+  "version": "0.7.1-rc.8",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,7 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.7" : STATION_BUILD_VERSION,
+    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.8" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.7",
+      version: "0.7.1-rc.8",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.7+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.7+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.8+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.8+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.7",
+      version: "0.7.1-rc.8",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1059,7 +1059,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.7";
+    return "0.7.1-rc.8";
   }
   if (
     normalized.length === 2 &&

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -139,7 +139,7 @@ describe("release readiness docs", () => {
     expect(readme).toContain("authenticated GitHub release assets");
     expect(readme).toContain("does not require Node.js, pnpm, Bun");
     expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.7");
+    expect(install).toContain("tag=v0.7.1-rc.8");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
@@ -195,7 +195,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.7");
+    expect(development).toContain("accepted-release-candidate-0.7.1-rc.8");
     const acceptanceRecipes = shellBlocks(development).filter((block) =>
       block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
     );
@@ -253,7 +253,7 @@ describe("release readiness docs", () => {
     expect(promote).toContain("actions/workflows/$workflow_id");
     expect(promote).toContain("compare/$commit...main");
     expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.7");
+    expect(packageJson.version).toBe("0.7.1-rc.8");
     expect(development).toContain("HOST_UPGRADE_BLOCKED");
     expect(homebrew).toContain("`workflow_dispatch` only");
     expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");


### PR DESCRIPTION
## What this fixes

Prepares the next immutable release candidate containing the merged RC7 first-run hook fixes from #282, #283, and #284.

## What changed

- advances the prerelease from `0.7.1-rc.7` to `0.7.1-rc.8`
- updates release-facing documentation and exact version assertions
- keeps `0.7.1-rc.7` documented as the immutable rollback candidate

## Testing

- `env -u STATION_PANE pnpm test:pre-push`
- `pnpm build:binary -- --version 0.7.1-rc.8`
- `pnpm smoke:binary -- --expected-version 0.7.1-rc.8`
- `pnpm smoke:release`
- focused build-info, manual-smoke, and diagnostics suites

UX implication: clean setup now installs canonical absolute hook ingress paths, Observer reports rejected hook launches, and compiled release smoke verifies hook identity. Manual check: install the candidate in an isolated environment, run `stn setup`, and confirm Codex hooks work without adding `--yes` or restarting Observer.