### PR TITLE
fix(tui): refresh visible Add Project directories

### DIFF
--- a/packages/dashboard-core/src/services/folderService.ts
+++ b/packages/dashboard-core/src/services/folderService.ts
@@ -54,19 +54,14 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 ]);
 
 export function createNodeFolderService(): TuiFolderService {
-  const cache = new Map<string, TuiFolderReadResult>();
   const home = homedir();
   return {
     cwd: () => process.cwd(),
     homeDir: () => home,
     readDirectory: async (path) => {
       const resolvedPath = resolvePath(path, home);
-      const cached = cache.get(resolvedPath);
-      if (cached !== undefined) {
-        return cached;
-      }
       const entries = await visibleDirectoryEntries(resolvedPath);
-      const result: TuiFolderReadResult = {
+      return {
         path: resolvedPath,
         entries: entries
           .map((entry) => ({
@@ -76,11 +71,6 @@ export function createNodeFolderService(): TuiFolderService {
           }))
           .sort((left, right) => left.name.localeCompare(right.name)),
       };
-      cache.set(resolvedPath, result);
-      if (cache.size > 50) {
-        cache.delete(cache.keys().next().value as string);
-      }
-      return result;
     },
     searchDirectories: async (query) => searchDirectories(query, { cwd: process.cwd(), home }),
     reviewFolder: async (path) => {

--- a/packages/dashboard-core/src/state/screens/addProjectScreen.ts
+++ b/packages/dashboard-core/src/state/screens/addProjectScreen.ts
@@ -314,6 +314,41 @@ export function applyAddProjectFolderLoaded(
   return applyAddProjectAction(state, { type: "folderLoaded", result }).state;
 }
 
+export function applyAddProjectFolderRefreshed(
+  state: TuiState,
+  result: TuiFolderReadResult,
+): TuiState {
+  if (
+    state.screen.name !== "addProject" ||
+    state.screen.flow.mode !== "choose" ||
+    state.screen.flow.currentPath !== result.path
+  ) {
+    return state;
+  }
+  const flow = state.screen.flow;
+  if (sameFolderEntries(flow.entries, result.entries)) {
+    return state;
+  }
+  const selectedIndex = addProjectSelectedIndexForFlow(flow, state.selection);
+  const selectedPath = selectedAddProjectFolderRow(state)?.path;
+  const refreshed = reconcileAddProjectSelection(
+    {
+      ...state,
+      screen: { name: "addProject", flow: { ...flow, entries: result.entries } },
+    },
+    flow,
+    false,
+  );
+  if (
+    selectedIndex === undefined ||
+    selectedPath === undefined ||
+    selectedAddProjectFolderRow(refreshed)?.path === selectedPath
+  ) {
+    return refreshed;
+  }
+  return selectAddProjectRowByIndex(refreshed, selectedIndex);
+}
+
 export function applyAddProjectFolderLoadFailed(
   state: TuiState,
   path: string,
@@ -380,4 +415,23 @@ export function applyAddProjectSubmitFailed(
     type: "submitFailed",
     error: toSafeError(error, { clientLabel }),
   }).state;
+}
+
+function sameFolderEntries(
+  left: TuiFolderReadResult["entries"],
+  right: TuiFolderReadResult["entries"],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((entry, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        entry.name === other.name &&
+        entry.path === other.path &&
+        entry.kind === other.kind &&
+        entry.displayPath === other.displayPath
+      );
+    })
+  );
 }

--- a/packages/dashboard-core/src/state/store.ts
+++ b/packages/dashboard-core/src/state/store.ts
@@ -31,8 +31,10 @@ import {
   type TuiFocusTarget,
 } from "./operations/runtimeCommands.js";
 import { createInitialTuiState, replaceSnapshot } from "./screen.js";
+import { applyAddProjectFolderRefreshed } from "./screens/addProjectScreen.js";
 import { submitQuickSession } from "./screens/quickSession.js";
 import { attachTuiSnapshotSource, type TuiSnapshotSource } from "./sourceBridge.js";
+import { ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS } from "./timing.js";
 import { addTuiToast, expireTuiToasts, refreshActiveTuiToastExpiry } from "./toasts.js";
 import { handleTuiKey, type TuiTransition } from "./transition.js";
 import type { CreateInitialTuiStateOptions, TuiState } from "./types.js";
@@ -132,15 +134,21 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
       },
     }),
     start: (): (() => void) => {
+      let stopSnapshotUpdates: () => void;
       if (source !== undefined) {
-        return attachTuiSnapshotSource(store, source);
-      }
-      if (clientRuntime === undefined) {
+        stopSnapshotUpdates = attachTuiSnapshotSource(store, source);
+      } else if (clientRuntime === undefined) {
         throw new Error("createTuiStore requires a runtime when no source is provided.");
+      } else {
+        clientRuntime.start();
+        stopSnapshotUpdates = () => {
+          void clientRuntime.stop();
+        };
       }
-      clientRuntime.start();
+      const stopDirectoryPolling = attachAddProjectDirectoryPolling(store, folderService);
       return () => {
-        void clientRuntime.stop();
+        stopDirectoryPolling();
+        stopSnapshotUpdates();
       };
     },
     handleKey: (key): TuiHandleKeyResult =>
@@ -205,6 +213,78 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
   }));
 
   return store;
+}
+
+function attachAddProjectDirectoryPolling(
+  store: StoreApi<TuiStore>,
+  folderService: TuiFolderService,
+): () => void {
+  let activePath: string | undefined;
+  let generation = 0;
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearTimer = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  const schedule = (path: string, token: number): void => {
+    timer = setTimeout(() => {
+      timer = undefined;
+      void poll(path, token);
+    }, ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+  };
+
+  const poll = async (path: string, token: number): Promise<void> => {
+    try {
+      const result = await folderService.readDirectory(path);
+      // Navigation and teardown invalidate in-flight reads before they can update the chooser.
+      if (!stopped && token === generation) {
+        store.setState(applyAddProjectFolderRefreshed(store.getState(), result));
+      }
+    } catch {
+      // A transient filesystem failure leaves the current listing intact and retries normally.
+    } finally {
+      if (
+        !stopped &&
+        token === generation &&
+        activeAddProjectDirectory(store.getState()) === path
+      ) {
+        schedule(path, token);
+      }
+    }
+  };
+
+  const sync = (): void => {
+    const nextPath = activeAddProjectDirectory(store.getState());
+    if (nextPath === activePath) {
+      return;
+    }
+    activePath = nextPath;
+    generation += 1;
+    clearTimer();
+    if (nextPath !== undefined) {
+      schedule(nextPath, generation);
+    }
+  };
+
+  const unsubscribe = store.subscribe(sync);
+  sync();
+  return () => {
+    stopped = true;
+    generation += 1;
+    clearTimer();
+    unsubscribe();
+  };
+}
+
+function activeAddProjectDirectory(state: TuiState): string | undefined {
+  return state.screen.name === "addProject" && state.screen.flow.mode === "choose"
+    ? state.screen.flow.currentPath
+    : undefined;
 }
 
 function applyDashboardFocusState(current: TuiStore, next: TuiState): TuiStore {

--- a/packages/dashboard-core/src/state/timing.ts
+++ b/packages/dashboard-core/src/state/timing.ts
@@ -2,6 +2,7 @@ import type { TuiToast } from "../services/types.js";
 
 export const FAILED_CREATE_ROW_TTL_MS = 4_000;
 export const OBSERVER_RECOVERY_TOAST_THRESHOLD_MS = 1_500;
+export const ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS = 1_000;
 
 export const TOAST_EXPIRY_MS_BY_KIND = {
   success: 2_400,

--- a/packages/dashboard-core/test/unit/services/folderService.test.ts
+++ b/packages/dashboard-core/test/unit/services/folderService.test.ts
@@ -1,0 +1,38 @@
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createNodeFolderService } from "../../../src/services/folderService.js";
+
+describe("node folder service", () => {
+  const temporaryRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(temporaryRoots.splice(0).map((path) => rm(path, { recursive: true })));
+  });
+
+  it("returns current visible directories after creation, rename, and deletion", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-folder-service-"));
+    temporaryRoots.push(root);
+    await mkdir(join(root, "alpha"));
+    const service = createNodeFolderService();
+
+    await expect(directoryNames(service, root)).resolves.toEqual(["alpha"]);
+
+    await mkdir(join(root, "beta"));
+    await mkdir(join(root, ".hidden"));
+    await writeFile(join(root, "not-a-directory"), "ignored");
+    await expect(directoryNames(service, root)).resolves.toEqual(["alpha", "beta"]);
+
+    await rename(join(root, "beta"), join(root, "gamma"));
+    await rm(join(root, "alpha"), { recursive: true });
+    await expect(directoryNames(service, root)).resolves.toEqual(["gamma"]);
+  });
+});
+
+async function directoryNames(
+  service: ReturnType<typeof createNodeFolderService>,
+  path: string,
+): Promise<string[]> {
+  return (await service.readDirectory(path)).entries.map((entry) => entry.name);
+}

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -6,13 +6,20 @@ import type {
   StationSnapshot,
   WorktreeRow,
 } from "@station/contracts";
-import type { TuiFolderService } from "@station/dashboard-core";
+import type {
+  TuiFolderEntry,
+  TuiFolderReadResult,
+  TuiFolderService,
+  TuiSnapshotSource,
+} from "@station/dashboard-core";
 import {
+  ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS,
   createTuiStore,
   openProjectDefaultAgentPicker,
+  selectedAddProjectFolderRow,
   type TuiStore,
 } from "@station/dashboard-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createCommandSnapshot,
   createDashboardSnapshot,
@@ -23,6 +30,10 @@ import {
 import { FakeTuiObserverService } from "../../support/fakeObserverService.js";
 
 describe("TUI store", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("applies semantic actions through the same transition executor as keys", () => {
     const snapshot = createNoProjectsSnapshot();
     const keyStore = createTuiStore({
@@ -468,6 +479,117 @@ describe("TUI store", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
   });
 
+  it("refreshes only the visible project directory and preserves selection by path", async () => {
+    const snapshot = createNoProjectsSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    let entries = folderEntries("alpha", "station");
+    let failNextRead = false;
+    const reads: string[] = [];
+    const folderService = mutableFolderService(
+      reads,
+      (path) => {
+        if (failNextRead) {
+          failNextRead = false;
+          throw new Error("transient directory read failure");
+        }
+        return { path, entries };
+      },
+      "/Users/example/Developer",
+    );
+    const store = createTuiStore({
+      service,
+      source: staticSnapshotSource(snapshot),
+      initialSnapshot: snapshot,
+      folderService,
+    });
+
+    store.getState().handleKey({ input: "A" });
+    store.getState().handleKey({ input: "", rightArrow: true });
+    await waitFor(() => screenMode(store.getState()) === "choose");
+    store.getState().handleKey({ input: "", downArrow: true });
+    store.getState().handleKey({ input: "", downArrow: true });
+    expect(selectedAddProjectPath(store.getState())).toBe("/Users/example/Developer/station");
+
+    vi.useFakeTimers();
+    const stop = store.getState().start();
+    entries = folderEntries("aardvark", "alpha", "station");
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+
+    expect(addProjectEntryNames(store.getState())).toEqual(["aardvark", "alpha", "station"]);
+    expect(selectedAddProjectPath(store.getState())).toBe("/Users/example/Developer/station");
+
+    let notifications = 0;
+    const unsubscribe = store.subscribe(() => {
+      notifications += 1;
+    });
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+    expect(notifications).toBe(0);
+
+    entries = folderEntries("aardvark", "renamed");
+    failNextRead = true;
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+    expect(addProjectEntryNames(store.getState())).toEqual(["aardvark", "alpha", "station"]);
+    expect(notifications).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+    expect(addProjectEntryNames(store.getState())).toEqual(["aardvark", "renamed"]);
+    expect(selectedAddProjectPath(store.getState())).toBe("/Users/example/Developer/renamed");
+
+    store.getState().handleKey({ input: "", escape: true });
+    const readsAfterClose = reads.length;
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS * 2);
+    expect(reads).toHaveLength(readsAfterClose);
+
+    unsubscribe();
+    stop();
+  });
+
+  it("does not overlap polls or apply a late result after directory navigation", async () => {
+    const snapshot = createNoProjectsSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    const rootPath = "/Users/example/Developer/station";
+    const childPath = `${rootPath}/child`;
+    const latePoll = deferred<TuiFolderReadResult>();
+    const reads: string[] = [];
+    const folderService = mutableFolderService(reads, (path) => {
+      if (path === rootPath && reads.filter((read) => read === rootPath).length > 1) {
+        return latePoll.promise;
+      }
+      return {
+        path,
+        entries: path === rootPath ? [folderEntry("child", childPath)] : [],
+      };
+    });
+    const store = createTuiStore({
+      service,
+      source: staticSnapshotSource(snapshot),
+      initialSnapshot: snapshot,
+      folderService,
+    });
+
+    store.getState().handleKey({ input: "A" });
+    store.getState().handleKey({ input: "", rightArrow: true });
+    await waitFor(() => screenMode(store.getState()) === "choose");
+
+    vi.useFakeTimers();
+    const stop = store.getState().start();
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(ADD_PROJECT_DIRECTORY_POLL_INTERVAL_MS * 4);
+    expect(reads.filter((path) => path === rootPath)).toHaveLength(2);
+
+    store.getState().handleKey({ input: "", downArrow: true });
+    store.getState().handleKey({ input: "", rightArrow: true });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(activeAddProjectPath(store.getState())).toBe(childPath);
+
+    latePoll.resolve({ path: rootPath, entries: folderEntries("stale") });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(activeAddProjectPath(store.getState())).toBe(childPath);
+    expect(addProjectEntryNames(store.getState())).toEqual([]);
+
+    stop();
+  });
+
   it("opens the explicit first-project flow with Enter on an empty dashboard", () => {
     const snapshot = createNoProjectsSnapshot();
     const service = new FakeTuiObserverService(snapshot);
@@ -729,6 +851,69 @@ function withTurnReadiness(snapshot: StationSnapshot): StationSnapshot {
         },
       };
     }),
+  };
+}
+
+function staticSnapshotSource(snapshot: StationSnapshot): TuiSnapshotSource {
+  return {
+    getState: () => ({ snapshot, connection: { state: "connected", since: Date.now() } }),
+    subscribe: () => () => {},
+  };
+}
+
+function mutableFolderService(
+  reads: string[],
+  readDirectory: (path: string) => TuiFolderReadResult | Promise<TuiFolderReadResult>,
+  cwd = "/Users/example/Developer/station",
+): TuiFolderService {
+  return {
+    cwd: () => cwd,
+    homeDir: () => "/Users/example",
+    parent: (path) => path.split("/").slice(0, -1).join("/") || "/",
+    readDirectory: async (path) => {
+      reads.push(path);
+      return readDirectory(path);
+    },
+    searchDirectories: async (query) => ({ query, entries: [], truncated: false }),
+    reviewFolder: async (path) => ({ selectedPath: path, id: "project", label: "project" }),
+  };
+}
+
+function folderEntries(...names: string[]): TuiFolderEntry[] {
+  return names.map((name) => folderEntry(name, `/Users/example/Developer/${name}`));
+}
+
+function folderEntry(name: string, path: string): TuiFolderEntry {
+  return { name, path, kind: "directory" };
+}
+
+function selectedAddProjectPath(state: TuiStore): string | undefined {
+  return selectedAddProjectFolderRow(state)?.path;
+}
+
+function activeAddProjectPath(state: TuiStore): string | undefined {
+  return state.screen.name === "addProject" && state.screen.flow.mode === "choose"
+    ? state.screen.flow.currentPath
+    : undefined;
+}
+
+function addProjectEntryNames(state: TuiStore): string[] {
+  return state.screen.name === "addProject" && state.screen.flow.mode === "choose"
+    ? state.screen.flow.entries.map((entry) => entry.name)
+    : [];
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: (value) => resolvePromise?.(value),
   };
 }
 

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -53,6 +53,10 @@ const setTimeoutAllowlist = new Map([
     "Short failed-create row expiry is local TUI operation feedback, isolated from observer command timeout plumbing.",
   ],
   [
+    "packages/dashboard-core/src/state/store.ts",
+    "Visible Add Project directory polling is a TUI-local filesystem refresh, not observer command timeout or retry plumbing.",
+  ],
+  [
     "apps/cli/src/commands/tui.ts",
     "Short popup-mode startup defer lets the TUI render a cached snapshot before requesting a nonblocking reconcile.",
   ],


### PR DESCRIPTION
## What this fixes

The persistent tmux Add Project picker could keep showing a stale directory listing after a repository was cloned or a directory was changed externally. The folder service cached each path indefinitely, so users had to close and reopen the picker before the new filesystem state appeared.

## What changed

- Reads visible directories from the current filesystem instead of a permanent path cache.
- Polls only the chooser's currently visible directory, with no overlapping reads.
- Preserves the selected path when it still exists and clamps selection safely after deletion.
- Stops polling on navigation, close, and store teardown; late reads cannot update a different screen.
- Keeps the current listing through transient read failures and retries normally.
- Skips state updates when the listing is unchanged to avoid unnecessary TUI rerenders.

## Testing

- `pnpm build`
- `pnpm typecheck` — 44/44 tasks
- `pnpm lint`
- `pnpm test:unit` — 2,059/2,059 tests
- Focused dashboard-core tests — 32/32 tests
- `env -u STATION_PANE pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/cli/test/integration/tui-command.test.ts` — 49/49 tests