### PR TITLE
feat(release): add exact-tag public pre-alpha installs

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           public_path="$RUNNER_TEMP/public-path"
           mkdir -p "$public_path"
-          for command in awk cat chmod cp curl grep ln ls mkdir mktemp mv paste readlink rm rmdir sleep sort tar tr uname; do
+          for command in awk cat chmod cp curl grep gzip ln ls mkdir mktemp mv paste readlink rm rmdir sleep sort tar tr uname; do
             command_path="$(command -v "$command")"
             test -n "$command_path"
             ln -s "$command_path" "$public_path/$command"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -103,6 +103,7 @@ jobs:
 
           expected=(
             SHA256SUMS
+            install.sh
             "stn-v$version-darwin-arm64.tar.gz"
             "stn-v$version-darwin-x64.tar.gz"
             "stn-v$version-linux-arm64.tar.gz"
@@ -147,3 +148,71 @@ jobs:
             jq -r '.assets | sort_by(.name) | .[] | "\(.name)=\(.id)"' <<<"$published_release_json"
           )" = "$current_ids"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)" = "$commit"
+
+  verify-public-install:
+    name: verify public install (${{ matrix.target }})
+    needs: promote
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: linux-x64
+          - runner: ubuntu-24.04-arm
+            target: linux-arm64
+          - runner: macos-15-intel
+            target: darwin-x64
+          - runner: macos-15
+            target: darwin-arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Download exact-tag public installer
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          installer="$RUNNER_TEMP/station-install.sh"
+          env -u GH_TOKEN -u GITHUB_TOKEN -u GH_ENTERPRISE_TOKEN -u GITHUB_ENTERPRISE_TOKEN \
+            curl --fail --silent --show-error --location \
+              --proto '=https' --proto-redir '=https' --tlsv1.2 \
+              --output "$installer" \
+              "https://github.com/$GITHUB_REPOSITORY/releases/download/$TAG/install.sh"
+          test -s "$installer"
+          /bin/sh -n "$installer"
+          grep -Fx "embedded_version=\"$TAG\"" "$installer"
+          chmod 0700 "$installer"
+      - name: Install without GitHub credentials or gh
+        env:
+          EXPECTED_VERSION: ${{ inputs.tag }}
+        run: |
+          public_path="$RUNNER_TEMP/public-path"
+          mkdir -p "$public_path"
+          for command in awk cat chmod cp curl grep ln ls mkdir mktemp mv paste readlink rm rmdir sleep sort tar tr uname; do
+            command_path="$(command -v "$command")"
+            test -n "$command_path"
+            ln -s "$command_path" "$public_path/$command"
+          done
+          if command -v sha256sum >/dev/null 2>&1; then
+            ln -s "$(command -v sha256sum)" "$public_path/sha256sum"
+          else
+            ln -s "$(command -v shasum)" "$public_path/shasum"
+          fi
+          test ! -e "$public_path/gh"
+
+          install_home="$RUNNER_TEMP/public-install-home"
+          bin_dir="$install_home/.local/bin"
+          data_home="$install_home/.local/share"
+          mkdir -p "$install_home"
+          env -i \
+            HOME="$install_home" \
+            XDG_DATA_HOME="$data_home" \
+            PATH="$public_path" \
+            /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
+
+          version="${EXPECTED_VERSION#v}"
+          test "$(env -i HOME="$install_home" XDG_DATA_HOME="$data_home" \
+            PATH="$bin_dir:$public_path" stn --version)" = "$version"
+          test "$(readlink "$bin_dir/stn-ingress")" = stn
+          test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
+          test -f "$data_home/station/LICENSE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,11 +189,25 @@ jobs:
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
       - uses: actions/download-artifact@v4
         with:
           pattern: native-*
           path: release
           merge-multiple: true
+      - name: Stamp release installer
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          test "$(grep -Fxc 'embedded_version=""' scripts/install.sh)" = 1
+          sed "s/^embedded_version=\"\"$/embedded_version=\"$TAG\"/" \
+            scripts/install.sh > release/install.sh
+          chmod 0755 release/install.sh
+          /bin/sh -n release/install.sh
+          grep -Fx "embedded_version=\"$TAG\"" release/install.sh
       - name: Verify assets and checksums
         env:
           VERSION: ${{ needs.validate.outputs.version }}
@@ -211,10 +225,11 @@ jobs:
             printf 'Actual archives: %s\n' "${actual[*]}" >&2
             exit 1
           fi
+          test -x install.sh
 
           : > SHA256SUMS
-          for archive in "${expected[@]}"; do
-            sha256sum "$archive" >> SHA256SUMS
+          for asset in "${expected[@]}" install.sh; do
+            sha256sum "$asset" >> SHA256SUMS
           done
 
           mapfile -t metadata < <(find . -maxdepth 1 -type f -name 'platform-metadata-*.txt' -printf '%f\n' | sort)
@@ -231,7 +246,7 @@ jobs:
             echo "Station $TAG native binaries."
             printf 'Build commit: `%s`.\n' "$GITHUB_SHA"
             echo
-            echo "Install through the authenticated installer documented in the repository."
+            echo "Install from the exact tagged public installer asset."
             echo
             echo "## Native platform floors"
             echo
@@ -266,6 +281,7 @@ jobs:
             "stn-v$VERSION-darwin-x64.tar.gz"
             "stn-v$VERSION-linux-arm64.tar.gz"
             "stn-v$VERSION-linux-x64.tar.gz"
+            install.sh
             SHA256SUMS
           )
           args=(
@@ -356,22 +372,23 @@ jobs:
         env:
           GH_HOST: github.com
           GH_TOKEN: ${{ github.token }}
-          COMMIT: ${{ needs.validate.outputs.commit }}
+          RELEASE_ID: ${{ needs['create-draft'].outputs.release_id }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          remote_commit="$(gh api "repos/$GITHUB_REPOSITORY/commits/$TAG" --jq .sha)"
-          if [[ "$remote_commit" != "$COMMIT" ]]; then
-            echo "Release tag $TAG moved from validated commit $COMMIT to $remote_commit." >&2
-            exit 1
-          fi
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID")"
+          test "$(jq -r .draft <<<"$release_json")" = true
+          test "$(jq -r .tag_name <<<"$release_json")" = "$TAG"
+          installer_asset_id="$(
+            jq -r '[.assets[] | select(.name == "install.sh") | .id] |
+              if length == 1 then .[0] else empty end' <<<"$release_json"
+          )"
+          [[ "$installer_asset_id" =~ ^[0-9]+$ ]]
           installer="$RUNNER_TEMP/station-install.sh"
-          gh api --method GET \
-            -f ref="$COMMIT" \
-            -H "Accept: application/vnd.github.raw+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/$GITHUB_REPOSITORY/contents/scripts/install.sh" > "$installer"
+          gh api -H "Accept: application/octet-stream" \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$installer_asset_id" > "$installer"
           test -s "$installer"
           /bin/sh -n "$installer"
+          grep -Fx "embedded_version=\"$TAG\"" "$installer"
           chmod 0700 "$installer"
       - name: Seed existing installation
         run: |
@@ -383,7 +400,7 @@ jobs:
 
           cat > "$bin_dir/stn" <<'EOF'
           #!/bin/sh
-          printf '%s\n' 0.0.0-old-fixture
+          printf '%s\n' 0.7.1-rc.8
           EOF
           chmod 0755 "$bin_dir/stn"
           ln -s stn "$bin_dir/stn-ingress"
@@ -392,7 +409,7 @@ jobs:
           chmod 0644 "$license_dir/LICENSE"
           cp "$bin_dir/stn" "$RUNNER_TEMP/old-stn-fixture"
 
-          test "$("$bin_dir/stn" --version)" = 0.0.0-old-fixture
+          test "$("$bin_dir/stn" --version)" = 0.7.1-rc.8
           test "$(readlink "$bin_dir/stn-ingress")" = stn
           test "$(readlink "$bin_dir/stn-tmux-popup")" = stn
       - name: Install from draft release
@@ -407,7 +424,7 @@ jobs:
           umask 0777
           HOME="$install_home" \
             XDG_DATA_HOME="$data_home" \
-            /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+            /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
       - name: Verify installed artifact
         env:
           EXPECTED_VERSION: ${{ needs.validate.outputs.version }}
@@ -474,7 +491,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
           ) > "$RUNNER_TEMP/locked-install.stdout" 2> "$lock_stderr"; then
             echo "Installer unexpectedly succeeded while $lock_dir was owned." >&2
             exit 1
@@ -496,7 +513,7 @@ jobs:
             umask 0777
             HOME="$install_home" \
               XDG_DATA_HOME="$data_home" \
-              /bin/sh "$RUNNER_TEMP/station-install.sh" --version "$TAG" --install-dir "$bin_dir"
+              /bin/sh "$RUNNER_TEMP/station-install.sh" --install-dir "$bin_dir"
           )
 
           test ! -e "$lock_dir"
@@ -534,6 +551,7 @@ jobs:
         run: |
           expected=(
             SHA256SUMS
+            install.sh
             "stn-v$VERSION-darwin-arm64.tar.gz"
             "stn-v$VERSION-darwin-x64.tar.gz"
             "stn-v$VERSION-linux-arm64.tar.gz"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 
 Station gives every agent an isolated Git worktree, keeps its terminal session alive, and shows all active projects and sessions in one terminal workspace. Bring Claude Code, Codex, Cursor, OpenCode, or Pi; Station coordinates the surrounding work without replacing the harness.
 
+## Install
+
+Station is experimental pre-alpha software. Install the current public version,
+`v0.0.0-pre-alpha.1`, with one command:
+
+```sh
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh | sh
+```
+
+See the [installation guide](docs/install.md) for supported platforms, runtime
+floors, verification, custom directories, and recovery.
+
 <p align="center">
   <img width="1728" height="1048" alt="Station terminal workspace showing multiple agent panes and a toggleable dashboard" src="https://github.com/user-attachments/assets/358c6c52-800f-496a-ada0-c8c291c8c33f" />
   <br>
@@ -32,66 +44,21 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
   <em>Follow an agent and review its changes without leaving the terminal.</em>
 </p>
 
-## Install the binary
+## Installation details
 
-This procedure installs Station from authenticated GitHub release assets and
-assumes your GitHub account can read the private `jeremy0dell/station`
-repository. Install the [GitHub CLI](https://cli.github.com/) first. The binary
-does not require Node.js, pnpm, Bun, or a source checkout.
+The version-stamped installer downloads only that tag's archive and
+`SHA256SUMS`, verifies the checksum and archive manifest, and atomically installs
+`stn`, `stn-ingress`, and `stn-tmux-popup` in `~/.local/bin`. It needs `curl`
+and either `sha256sum` or `shasum`; it does not need a GitHub account, GitHub
+CLI, Node.js, pnpm, Bun, or a source checkout.
 
-### 1. Authenticate GitHub CLI
+Supported native targets and runtime floors:
 
-```sh
-gh auth login --hostname github.com
-gh auth status --hostname github.com
-gh repo view jeremy0dell/station --json nameWithOwner --jq '.nameWithOwner'
-```
+- macOS 13 or newer on Apple silicon (`darwin-arm64`) or Intel (`darwin-x64`)
+- glibc 2.39 or newer Linux on arm64 (`linux-arm64`) or x64 (`linux-x64`)
+- Windows and musl Linux are not supported
 
-If GitHub CLI is already authenticated, skip the login command. The repository
-check should print `jeremy0dell/station`; a not-found response means the active
-account cannot read the private repository. The commands below use the existing
-authentication, so do not paste credentials into the install command.
-On macOS, a failure observed only inside a restricted agent sandbox may mean
-that sandbox cannot read Keychain-backed credentials. Retry the checks from a
-normal Terminal or with scoped host/Keychain access, and keep the later
-authenticated `gh api` calls in that same context; do not move the token into
-the sandbox or reauthenticate solely because of a sandbox-only failure.
-
-### 2. Install the current preview candidate
-
-Run this from any directory:
-
-```sh
-(
-  set -eu
-  umask 077
-  export GH_HOST=github.com
-  tag=v0.7.1-rc.8
-  # After the first stable release, use:
-  # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
-  installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  gh api --method GET \
-    -H 'Accept: application/vnd.github.raw+json' \
-    -f ref="$tag" \
-    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
-  test -s "$installer"
-  sh -n "$installer"
-  sh "$installer" --version "$tag"
-)
-```
-
-`v0.7.1-rc.8` is the current private-binary candidate. `v0.7.1-rc.7` remains
-published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`,
-`v0.7.1-rc.4`, `v0.7.1-rc.5`, and `v0.7.1-rc.6` are older published binaries,
-while the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
-Run the recipe after the candidate is published. It fetches the installer and
-binary from the same immutable release tag, verifies the release checksum, and
-installs `stn`, `stn-ingress`, and `stn-tmux-popup` in `~/.local/bin` by
-default. It does not expose or print your GitHub credentials. After the first
-stable release, the commented assignment resolves the latest stable tag.
-
-### 3. Verify and start Station
+### Verify and start Station
 
 The installer prints an exact PATH command if `~/.local/bin` is not visible in
 the current shell. For the default install directory, run:
@@ -104,6 +71,7 @@ hash -r
 command -v stn
 stn --version
 stn setup
+stn setup check --json
 stn doctor
 stn
 ```
@@ -123,27 +91,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.8 and validate setup on this machine.
-
-Use the private GitHub repository jeremy0dell/station through GitHub CLI.
+Install experimental Station v0.0.0-pre-alpha.1 and validate setup on this machine.
 
 Safety and scope:
-- First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. On macOS, a failure inside a
-  restricted agent sandbox is inconclusive because GitHub CLI credentials may
-  be stored in the Keychain. Retry both checks with scoped host/Keychain access
-  before asking me to authenticate, and run every later authenticated `gh repo`
-  or `gh api` command in that same access context. Never ask me to paste,
-  extract, print, request, or export a GitHub token. If scoped host access is
-  unavailable, ask me to run the auth checks and exact tagged temporary-file
-  installer block from the page that supplied this prompt in my Terminal, then
-  resume using the absolute installed `stn` path.
-- Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.8`, read `docs/install.md` from that same tag with authenticated
-  `gh api`, and follow its temporary-file installer procedure. If that release
-  is not published yet, stop instead of falling back to another ref.
-- Never fetch installer code from `main` and never pipe network output directly
-  into a shell.
+- Do not clone the repository or build from source. Use only
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -157,15 +109,12 @@ Validation:
    through the absolute installed path. Record `command -v stn`,
    `command -v stn-ingress`, and `command -v stn-tmux-popup` only as evidence
    about the current agent execution context.
-2. Run `stn setup plan --json` through the absolute installed `stn` path,
-   summarize every proposed install or write, and ask for approval before
-   applying it.
-3. Run the guided `stn setup` through the absolute installed path and let me
+2. Run the guided `stn setup` through the absolute installed path and let me
    answer its choices. If you cannot pass through an interactive prompt, ask me
    to run it, then continue afterward.
-4. Run `stn setup check --json` and `stn doctor` through the absolute installed
+3. Run `stn setup check --json` and `stn doctor` through the absolute installed
    path.
-5. Report the installed path and version, whether setup reports
+4. Report the installed path and version, whether setup reports
    `summary.requiredOk: true`, doctor health, future-shell verification state,
    and any remaining manual steps. A valid zero-project config is acceptable.
    Do not claim success while a required check is failing or future-shell PATH
@@ -222,6 +171,8 @@ or real-agent lanes.
 
 ## Release status
 
-Station v0.7 is a private preview for local daily use. The authenticated
-binary supports macOS and Linux on arm64 and x64. User-facing commands and
-configuration may change between preview releases.
+Station `v0.0.0-pre-alpha.1` is an experimental pre-alpha. User-facing commands,
+configuration, state, and release packaging may change without compatibility.
+The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
+public version line. Report feedback and bugs through
+[GitHub Issues](https://github.com/jeremy0dell/station/issues).

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -116,7 +116,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.7.1-rc.8", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.1", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/observer/src/runtime/observerHandoff.ts
+++ b/apps/observer/src/runtime/observerHandoff.ts
@@ -16,6 +16,8 @@ import { observerProcessIdentitiesMatch } from "./observerPidfile.js";
 const GRACEFUL_HANDOFF_BUDGET_RATIO = 0.5;
 const DEFAULT_HANDOFF_POLL_INTERVAL_MS = 50;
 const MIN_HANDOFF_TIMEOUT_MS = 1;
+const INTERNAL_PREVIEW_VERSION_PATTERN = /^0\.7\.1-rc\.(?:0|[1-9]\d*)$/u;
+const PUBLIC_PRE_ALPHA_VERSION_PATTERN = /^0\.0\.0-pre-alpha\.(?:0|[1-9]\d*)$/u;
 
 const SemVerSchema = z
   .string()
@@ -186,7 +188,11 @@ export function classifyObserverIncumbent(input: {
       };
     }
   }
-  const precedence = compareSemVer(candidateVersion.data, incumbentVersion.data);
+  const resetPrecedence = comparePublicVersionLineReset(
+    candidateBuild.version,
+    incumbentBuild.version,
+  );
+  const precedence = resetPrecedence ?? compareSemVer(candidateVersion.data, incumbentVersion.data);
   if (precedence < 0) return { action: "attach", reason: "incumbent-wins" };
   if (precedence === 0) {
     // Display-version strings are stable across the CLI parent and Observer child;
@@ -205,6 +211,22 @@ export function classifyObserverIncumbent(input: {
     };
   }
   return { action: "replace", reason: "candidate-wins" };
+}
+
+function comparePublicVersionLineReset(candidate: string, incumbent: string): -1 | 1 | undefined {
+  if (
+    PUBLIC_PRE_ALPHA_VERSION_PATTERN.test(candidate) &&
+    INTERNAL_PREVIEW_VERSION_PATTERN.test(incumbent)
+  ) {
+    return 1;
+  }
+  if (
+    INTERNAL_PREVIEW_VERSION_PATTERN.test(candidate) &&
+    PUBLIC_PRE_ALPHA_VERSION_PATTERN.test(incumbent)
+  ) {
+    return -1;
+  }
+  return undefined;
 }
 
 /**

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -88,6 +88,20 @@ describe("classifyObserverIncumbent", () => {
     });
   });
 
+  it("orders the public pre-alpha after the internal preview version line", () => {
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.1", higherBuildIdentity);
+    const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
+
+    expect(decisionFor(publicPreAlpha, internalPreview)).toEqual({
+      action: "replace",
+      reason: "candidate-wins",
+    });
+    expect(decisionFor(internalPreview, publicPreAlpha)).toEqual({
+      action: "attach",
+      reason: "incumbent-wins",
+    });
+  });
+
   it("attaches to a valid higher incumbent without mutation-only identity fields", () => {
     expect(
       classifyObserverIncumbent({

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,7 +188,8 @@ pnpm smoke:install
 ```
 
 `pnpm test:all` includes `pnpm smoke:install`. The installer smoke uses fake
-authenticated GitHub responses and temporary homes, including startup-file
+public `curl` downloads and authenticated draft responses in temporary homes,
+including startup-file
 non-interaction, safely evaluated minimal-PATH guidance, physical launcher
 resolution, and normalized-colon preflight coverage. It is deterministic, does
 not download a real release, and does not read or modify real shell startup
@@ -304,7 +305,7 @@ must show B's build and protocol versions. Legacy or different-protocol hosts
 refuse automatic replacement and must be stopped explicitly only after their
 sessions are accounted for.
 
-## Private Binary Release
+## Experimental Pre-Alpha Release
 
 Before tagging, an administrator must enable GitHub immutable releases; the
 workflow token cannot read that administration setting. The workflow validates
@@ -314,18 +315,21 @@ and have no existing GitHub release. Pushing a `v*` tag runs the callable
 standard CI workflow, `pnpm smoke:release`, native binary build and smoke jobs
 for all four supported targets, archive/checksum assembly, and an authenticated
 installer smoke against the resulting GitHub release draft. The four native
-release builds use one archive-packaging helper, and the draft-install jobs
-consume those exact uploaded archives. Draft acceptance revalidates the tag but
-fetches `scripts/install.sh` by the validated commit SHA, then passes the tag
-with `--version`; a moved tag cannot substitute different installer code. After
-all four native installs pass, the workflow re-downloads the five draft assets,
+release builds use one archive-packaging helper. Assembly stamps the validated
+tag into the existing `embedded_version=""` marker and publishes that
+`install.sh` beside the archives. Draft-install jobs download and run the actual
+stamped draft asset with the captured numeric release ID and no version
+argument. After all four native installs pass, the workflow re-downloads the
+six draft assets,
 verifies them against the build checksum, and uploads an immutable
 `accepted-release-candidate-*` Actions artifact containing the commit, release
 ID, asset IDs, and checksums. Draft install and candidate-recording jobs use
 contents write permission because GitHub exposes draft releases only to
 identities with push access, but their steps only read release metadata and
 assets. Only draft creation and manual promotion mutate releases. The tag
-workflow never publishes the draft automatically.
+workflow never publishes the draft automatically. Promotion publishes the
+accepted draft, then four native jobs download the exact-tag public installer
+without GitHub credentials or a `gh` executable and run it end to end.
 
 ### Launcher PATH release acceptance
 
@@ -348,32 +352,34 @@ containing spaces and apostrophes. Source-checkout acceptance separately
 requires the preserved `pnpm --dir <checkout> station:link` command when
 linking is declined.
 
-The current immutable binary candidate is `v0.7.1-rc.8`. `v0.7.1-rc.7` is the
-prior published binary, and `v0.7.1-rc.2`, `v0.7.1-rc.3`, `v0.7.1-rc.4`,
-`v0.7.1-rc.5`, and `v0.7.1-rc.6` remain older published rollbacks; the earlier
-`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished:
+The public candidate is experimental pre-alpha `v0.0.0-pre-alpha.1`. The old
+`v0.7.1-rc.*` releases were internal previews, not predecessors in the public
+version line. `v0.7.1-rc.8` is retained as the installed-version fixture that
+proves the intentional version-number reset:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.7.1-rc.8`, then create and
-   push `v0.7.1-rc.8`.
+   with `package.json` and runtime reporting at `0.0.0-pre-alpha.1`, then create
+   and push `v0.0.0-pre-alpha.1`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.7.1-rc.8-attempt-*` artifact.
+   `accepted-release-candidate-0.0.0-pre-alpha.1-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
-4. Install `v0.7.1-rc.7`, upgrade to the accepted candidate, explicitly
-   reinstall `v0.7.1-rc.7`, then reinstall the candidate. Confirm the complete
+4. Install `v0.7.1-rc.8`, upgrade to the accepted candidate, and confirm the
+   lower public version number does not block replacement. Confirm the complete
    version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.7.1-rc.8`, and the manual-acceptance confirmation. It rechecks the
+   `v0.0.0-pre-alpha.1`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
-   asset IDs, and all archive hashes immediately before publishing that exact
-   draft.
+   asset IDs, the stamped installer, and all hashes immediately before
+   publishing that exact draft. Its four public-install jobs must then pass.
+6. Mark the historical assetless `v0.1.0` release as a prerelease before the
+   announcement so the repository does not present a stable channel. Leave the
+   Homebrew tap untouched; Homebrew is not currently supported.
 
 Published tags and assets are immutable. Once two binary releases exist,
 recovery may explicitly reinstall the prior version, but the release line moves
 forward with a superseding patch; it never deletes, retags, or overwrites a
-published release. The source Homebrew formula is a separate manually
-dispatched workflow and is not part of this binary release gate.
+published release.
 
 If a transient workflow failure leaves an unpublished draft, delete only that
 draft and rerun the unchanged tag workflow. If the source needs a fix, leave
@@ -384,7 +390,7 @@ Installer acceptance uses both `<install-dir>/.station-install.lock` and
 `<data-home>/station/.station-install.lock`. Their sole corresponding
 `<install-dir>/.station-install.lock/owner-*` and
 `<data-home>/station/.station-install.lock/owner-*` files record the PID,
-requested tag or `latest`, and the token embedded in each filename. The command
+requested tag and the token embedded in each filename. The command
 lock is acquired first and the license lock second, with the duplicate path
 skipped, and they are released in reverse order. Cleanup removes only its
 token-specific owner file and revalidates the directory inode so it cannot
@@ -392,7 +398,7 @@ remove a replacement owner's lock. Either refusal must name the lock and
 readable owner PID, state that the existing
 Station installation was unchanged, and tell the user to wait and retry; a
 license-lock refusal also releases the command lock without making a release
-API request. The installer never auto-removes an uncertain lock. Only after
+request. The installer never auto-removes an uncertain lock. Only after
 confirming that no installer with the recorded PID is alive may an operator
 remove the affected lock directory manually and retry.
 
@@ -400,8 +406,9 @@ The staged binary's `--version` probe must finish within 10 seconds. Its
 watchdog returns 124 for timeout and 125 for timer failure, bounds output at the
 filesystem level, TERM/KILLs and reaps the probe, removes common GitHub and
 Actions token variables from the child environment, and shows at most 4096
-sanitized bytes of compatibility stderr. Every potentially blocking `gh`
-operation is a tracked file-backed child; HUP, INT, and TERM forward to that
+sanitized bytes of compatibility stderr. Every potentially blocking public
+`curl` or draft-only `gh` operation is a tracked file-backed child; HUP, INT,
+and TERM forward to that
 child, use the same TERM/KILL/reap cleanup, and exit 129, 130, and 143.
 
 The verified `stn` rename is the sole runtime commit point. Immediately before
@@ -486,7 +493,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.7.1-rc.8
+  tag=v0.0.0-pre-alpha.1
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -515,7 +522,9 @@ promotion will verify:
     --name "accepted-release-candidate-$version-attempt-$run_attempt" \
     --dir "$candidate_dir"
   manifest="$candidate_dir/manifest.json"
+  asset_ids="$candidate_dir/asset-ids.txt"
   test -f "$manifest"
+  test -f "$asset_ids"
   manifest_field() {
     node -e '
       const { readFileSync } = require("node:fs");
@@ -539,13 +548,16 @@ promotion will verify:
     ''|*[!0-9]*) echo "candidate release ID must be numeric" >&2; exit 1 ;;
   esac
   test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq '.sha')" = "$commit"
-  gh api --method GET \
-    -H 'Accept: application/vnd.github.raw+json' \
-    -f ref="$commit" \
-    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
+  installer_asset_id="$(awk -F= '$1 == "install.sh" { print $2 }' "$asset_ids")"
+  case "$installer_asset_id" in
+    ''|*[!0-9]*) echo "candidate installer asset ID must be numeric" >&2; exit 1 ;;
+  esac
+  gh api -H 'Accept: application/octet-stream' \
+    "repos/jeremy0dell/station/releases/assets/$installer_asset_id" > "$installer"
   test -s "$installer"
   sh -n "$installer"
-  STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer" --version "$tag"
+  grep -Fx "embedded_version=\"$tag\"" "$installer"
+  STATION_INSTALL_RELEASE_ID="$release_id" sh "$installer"
 )
 ```
 
@@ -605,7 +617,7 @@ produce a Station event.
 Preserve the exact command and output at the first failure; for a runtime
 failure with no known trace ID, start with `stn debug trace --latest-failure`.
 
-For each target, install through the authenticated script into a clean home and
+For each target, install through the authenticated stamped draft asset into a clean home and
 manually verify the actual user experience, not a dashboard override:
 
 1. Install into a clean default `HOME` with `XDG_DATA_HOME` unset and an install
@@ -619,7 +631,7 @@ manually verify the actual user experience, not a dashboard override:
    Confirm two installs leave every startup file, inode, mode, symlink, and
    target unchanged. Copy the printed export manually into the file you choose,
    open a new login shell, and physically verify all three launchers. Also
-   confirm a normalized install path containing `:` fails before any GitHub
+   confirm a normalized install path containing `:` fails before any release
    request or installer-created path. With all three launchers already resolving
    physically to the install directory, confirm the short `Next: run stn setup`
    success message.
@@ -646,11 +658,12 @@ manually verify the actual user experience, not a dashboard override:
    live hosted PTY and confirm `HOST_UPGRADE_BLOCKED` preserves its terminal and
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
-   B, repeatedly reinstall the draft. Terminal A may print only `0.7.1-rc.8`:
+   B, repeatedly reinstall the draft. Terminal A may print only
+   `0.0.0-pre-alpha.1`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft
-   with published `v0.7.1-rc.7` in both directions.
+   with published internal preview `v0.7.1-rc.8` in both directions.
 10. In an isolated home, test abandoned locks separately at
     `<install-dir>/.station-install.lock` and
     `<data-home>/station/.station-install.lock` with representative owner
@@ -666,9 +679,10 @@ manually verify the actual user experience, not a dashboard override:
     replacing any asset.
 
 Record the oldest supported macOS version or built-against glibc version in the
-release notes. Signing and notarization are not part of the initial private
-binary release; integrity is the authenticated GitHub asset plus `SHA256SUMS`
-verification and immutable publication.
+release notes. The current documented floors are macOS 13 and glibc 2.39.
+Signing and notarization are not part of the initial public pre-alpha; integrity
+is the exact-tag GitHub asset plus `SHA256SUMS` verification and immutable
+publication.
 
 For CI install parity, use:
 

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -1,133 +1,24 @@
-# Homebrew Packaging
+# Homebrew
 
-Status: live, internal/team **source formula** at
-[`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station).
-Station is not ready for `homebrew/core` yet: the `station` repo itself is
-private, uses Node.js 24.2+ (and below 25) plus a separate Bun workspace, and requires explicit
-first-run setup. v0.1.0 is the first source-formula baseline.
+Homebrew installation is not currently supported for Station.
 
-The authenticated compiled binary is the primary private user channel. The tap
-remains a separate source-build option for development and internal packaging
-validation; it does not consume A5 binary archives and is not updated when a
-binary release is published. A binary Homebrew formula remains deferred until
-private release-asset downloads have a tested Homebrew authentication strategy.
+The public installation path for experimental pre-alpha
+`v0.0.0-pre-alpha.1` is the exact-tag native installer documented in
+[Install Station](install.md). Do not use the historical tap for public
+onboarding, and do not update it as part of pre-alpha publication.
 
-Because `jeremy0dell/station` is a private GitHub repo, this tap is for
-internal/team use, not public onboarding. There is no built-in Homebrew
-download strategy for private-repo archive tarballs (verified against
-Homebrew 6.x source -- no such strategy exists), so the formula clones via
-git+https instead (`url "...git", tag:, revision:`). This authenticates
-transparently using whatever git credentials the installing user already has
-for github.com (SSH key, or `gh auth login`'s git credential helper) -- no
-extra token/env var needed at install time. Revisit this once `station` goes
-public.
+The old `v0.1.0` source-formula release and `v0.7.1-rc.*` binary releases
+were internal packaging previews, not predecessors in the public version line.
 
-## Source-formula user flow
+Source development still uses Node.js 24.2+ (and below 25), pnpm 11, and Bun
+1.3.14 as documented in [Development](development.md). After a supported native
+install, run:
 
-```bash
-brew tap jeremy0dell/station
-brew trust jeremy0dell/station
-brew install station
+```sh
 stn setup
+stn setup check --json
 stn doctor
-stn
 ```
 
-Setup is independent of the current directory. On first launch, choose **Add
-your first project** and select an existing Git repository.
-
-Homebrew should install Station and its machine-level dependencies. It should not
-write `~/.config/station/config.toml`, install provider hooks, install the tmux
-popup binding, start the observer, or run `stn doctor` during formula install.
-Those steps are user and runtime aware and belong to `stn setup`; explicit
-project selection belongs to the first-project flow in Station.
-
-## Formula shape
-
-The formula lives in the
-[`jeremy0dell/homebrew-station`](https://github.com/jeremy0dell/homebrew-station)
-tap as `Formula/station.rb`, kept in sync with
-[`packaging/homebrew/station.rb.template`](../packaging/homebrew/station.rb.template)
-in this repo.
-
-The current install is source-tree based, not a single binary. The formula must
-preserve the repository-relative layout because:
-
-- `bin/stn` resolves `apps/cli/dist/main.js` relative to the launcher.
-- `bin/stn-ingress` resolves `apps/cli/dist/ingressMain.js`.
-- The CLI resolves the Bun TUI workspace at `station/`.
-- `station/` needs its own Bun `node_modules` and linked built `@station/*`
-  packages.
-
-The formula template builds with:
-
-```bash
-pnpm install --frozen-lockfile
-pnpm build
-cd station
-bun install --frozen-lockfile
-bun run link:station
-bun run repair:node-pty
-```
-
-Runtime launchers should wrap the installed tree and prepend Homebrew's
-`node@24` path because `node@24` is keg-only.
-
-## Release checklist
-
-Binary publication never updates the source formula. When a published Station
-source tag should be packaged separately:
-
-1. Confirm the tag contains the source checkout version intended for the
-   formula and that its normal CI is green.
-2. Manually dispatch the source-formula workflow with the exact published tag:
-
-   ```bash
-   gh workflow run homebrew-bump.yml -f tag=vX.Y.Z
-   ```
-
-   `.github/workflows/homebrew-bump.yml` is `workflow_dispatch` only; it does
-   not listen to `release: published`. The workflow updates
-   `Formula/station.rb`'s `tag` and revision in the tap and commits directly to
-   the tap's default branch.
-3. `COMMITTER_TOKEN` remains intentionally unconfigured for A5. A future
-   source-formula dispatch needs a PAT with cross-repository contents write
-   access on `jeremy0dell/homebrew-station`; the default `GITHUB_TOKEN` cannot
-   push to that repository. Until then, update the tap formula manually.
-4. Test locally:
-
-   ```bash
-   brew untap jeremy0dell/station; brew tap jeremy0dell/station
-   brew trust jeremy0dell/station
-   brew install --build-from-source station
-   brew audit --strict station
-   brew test station
-   stn setup check --json
-   stn doctor
-   stn
-   ```
-
-5. Publish bottles from the tap once the formula is reviewed and the tap CI is
-   green.
-
-## Known issues
-
-- `brew install` prints a non-fatal warning: `Failed changing dylib ID of
-  .../node_modules/@opentui/core-darwin-arm64/libopentui.dylib`. Homebrew's
-  automatic post-install relinking pass scans every Mach-O file in the keg,
-  including vendored prebuilt native node_modules binaries, and this
-  particular upstream binary doesn't have enough Mach-O header padding to be
-  rewritten. The CLI still works (`stn`, `stn setup check --json`, `brew
-  test` all pass) -- Node loads the addon by direct path, not via dyld
-  rpath resolution -- but expect the warning on every install/upgrade until
-  `@opentui/core` ships a binary built with `-headerpad_max_install_names`.
-
-## Core-readiness blockers
-
-- `station` itself must go public (private repos cannot be in `homebrew/core`).
-- Public, stable tagged releases with real version numbers.
-- A formula test that proves more than `--help`.
-- A cleaner installed-mode TUI smoke for the Bun/native PTY path.
-- License metadata acceptable to Homebrew core (FSL-1.1-ALv2 is a valid SPDX
-  id but is not DFSG-compliant, which `homebrew/core` requires).
-- Runtime compatibility with Homebrew-supported macOS and Linux targets.
+Report packaging feedback through
+[GitHub Issues](https://github.com/jeremy0dell/station/issues).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,21 @@
 # Station Documentation
 
-Station is a terminal workspace for running AI coding agents in isolated Git worktrees. It is currently available as a private preview for macOS and Linux on arm64 and x64.
+Station is a terminal workspace for running AI coding agents in isolated Git
+worktrees. It is experimental pre-alpha software; the current public version is
+`v0.0.0-pre-alpha.1`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+on arm64 and x64.
+
+```sh
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh | sh
+```
+
+Then run `stn setup`, `stn setup check --json`, and `stn doctor`. See
+[Install Station](install.md) for the complete installation and verification
+guide.
 
 ## Start Here
 
-- [Install Station](install.md) — install and verify the authenticated binary.
+- [Install Station](install.md) — install the exact public pre-alpha and verify setup.
 - [Agent-led install prompt](install.md#let-your-agent-install-and-validate-station) — let a coding agent install the binary and validate `stn setup` safely.
 - [Quick start](quick-start.md) — add a project and create your first agent session.
 - [Overview](overview.md) — understand projects, worktrees, sessions, providers, and the observer.
@@ -28,3 +39,5 @@ Station is a terminal workspace for running AI coding agents in isolated Git wor
 - [System dependencies](system-dependencies.md) — understand external tools and setup checks.
 
 Contributor references describe the current implementation and its invariants. Historical design records and release-planning files remain in the repository but are not part of this documentation path.
+
+Report feedback through [GitHub Issues](https://github.com/jeremy0dell/station/issues).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,23 +1,22 @@
 # Install Station
 
-Station is distributed through authenticated GitHub release assets in the
-private `jeremy0dell/station` repository. This procedure assumes your GitHub
-account already has read access; it does not require or display a personal
-access token.
+Station is experimental pre-alpha software. The current public version is
+`v0.0.0-pre-alpha.1`.
 
 ## Binary Requirements
 
 The compiled binary supports these targets:
 
-- macOS on Apple silicon (`darwin-arm64`)
-- macOS on Intel (`darwin-x64`)
-- Linux on arm64 (`linux-arm64`)
-- Linux on x64 (`linux-x64`)
+- macOS 13 or newer on Apple silicon (`darwin-arm64`)
+- macOS 13 or newer on Intel (`darwin-x64`)
+- glibc 2.39 or newer Linux on arm64 (`linux-arm64`)
+- glibc 2.39 or newer Linux on x64 (`linux-x64`)
 
-Install the [GitHub CLI](https://cli.github.com/) before continuing. The binary
-install itself does not require a source checkout, Node.js, pnpm, Bun, Xcode, or
-Homebrew. `stn setup` handles the separate tools needed for the complete agent
-workflow after Station is installed.
+Windows and musl Linux are not supported. The binary install needs `curl` and
+either `sha256sum` or `shasum`; it does not require a GitHub account, GitHub CLI,
+a source checkout, Node.js, pnpm, or Bun. `stn setup` handles the separate tools
+needed for the complete agent workflow after Station is installed. Report
+feedback through [GitHub Issues](https://github.com/jeremy0dell/station/issues).
 
 Station uses the platform `lsof` executable (`/usr/sbin/lsof` on macOS,
 `/usr/bin/lsof` on Linux) to prove that an unreachable Unix socket has no live
@@ -33,27 +32,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install Station private preview candidate v0.7.1-rc.8 and validate setup on this machine.
-
-Use the private GitHub repository jeremy0dell/station through GitHub CLI.
+Install experimental Station v0.0.0-pre-alpha.1 and validate setup on this machine.
 
 Safety and scope:
-- First run `gh auth status --hostname github.com`, then verify repository
-  access with `gh repo view jeremy0dell/station`. On macOS, a failure inside a
-  restricted agent sandbox is inconclusive because GitHub CLI credentials may
-  be stored in the Keychain. Retry both checks with scoped host/Keychain access
-  before asking me to authenticate, and run every later authenticated `gh repo`
-  or `gh api` command in that same access context. Never ask me to paste,
-  extract, print, request, or export a GitHub token. If scoped host access is
-  unavailable, ask me to run the auth checks and exact tagged temporary-file
-  installer block from the page that supplied this prompt in my Terminal, then
-  resume using the absolute installed `stn` path.
-- Do not clone the repository or build from source. Use release tag
-  `v0.7.1-rc.8`, read `docs/install.md` from that same tag with authenticated
-  `gh api`, and follow its temporary-file installer procedure. If that release
-  is not published yet, stop instead of falling back to another ref.
-- Never fetch installer code from `main` and never pipe network output directly
-  into a shell.
+- Do not clone the repository or build from source. Use only
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -67,78 +50,33 @@ Validation:
    through the absolute installed path. Record `command -v stn`,
    `command -v stn-ingress`, and `command -v stn-tmux-popup` only as evidence
    about the current agent execution context.
-2. Run `stn setup plan --json` through the absolute installed `stn` path,
-   summarize every proposed install or write, and ask for approval before
-   applying it.
-3. Run the guided `stn setup` through the absolute installed path and let me
+2. Run the guided `stn setup` through the absolute installed path and let me
    answer its choices. If you cannot pass through an interactive prompt, ask me
    to run it, then continue afterward.
-4. Run `stn setup check --json` and `stn doctor` through the absolute installed
+3. Run `stn setup check --json` and `stn doctor` through the absolute installed
    path.
-5. Report the installed path and version, whether setup reports
+4. Report the installed path and version, whether setup reports
    `summary.requiredOk: true`, doctor health, future-shell verification state,
    and any remaining manual steps. A valid zero-project config is acceptable.
    Do not claim success while a required check is failing or future-shell PATH
    remains unverified.
 ```
 
-The agent should stop at authentication or approval boundaries rather than
-inventing credentials or setup choices.
+The agent should stop at approval boundaries rather than inventing setup
+choices.
 
-## 1. Authenticate GitHub CLI
-
-Sign in with the GitHub account that can read `jeremy0dell/station`:
-
-```bash
-gh auth login --hostname github.com
-gh auth status --hostname github.com
-gh repo view jeremy0dell/station --json nameWithOwner --jq '.nameWithOwner'
-```
-
-If GitHub CLI is already authenticated, skip the login command. The repository
-check should print `jeremy0dell/station`; a not-found response means the active
-account cannot read the private repository. GitHub CLI supplies its stored
-authentication to the API calls below, so do not add credentials to the recipe.
-On macOS, a failure observed only inside a restricted agent sandbox may mean
-that sandbox cannot read Keychain-backed credentials. Retry the checks from a
-normal Terminal or with scoped host/Keychain access, and keep the later
-authenticated `gh api` calls in that same context; do not move the token into
-the sandbox or reauthenticate solely because of a sandbox-only failure.
-
-## 2. Install the Current Preview Candidate
+## Install the Exact Public Pre-Alpha
 
 From any directory, run:
 
 ```bash
-(
-  set -eu
-  umask 077
-  export GH_HOST=github.com
-  tag=v0.7.1-rc.8
-  # After the first stable release, use:
-  # tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest --jq '.tag_name')"
-  installer="$(mktemp)"
-  trap 'rm -f "$installer"' EXIT
-  gh api --method GET \
-    -H 'Accept: application/vnd.github.raw+json' \
-    -f ref="$tag" \
-    repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"
-  test -s "$installer"
-  sh -n "$installer"
-  sh "$installer" --version "$tag"
-)
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh | sh
 ```
 
-`v0.7.1-rc.8` is the current private-binary candidate. `v0.7.1-rc.7` remains
-published as its immutable rollback; `v0.7.1-rc.2`, `v0.7.1-rc.3`,
-`v0.7.1-rc.4`, `v0.7.1-rc.5`, and `v0.7.1-rc.6` are older published binaries,
-while the earlier `v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
-Run this recipe after the candidate is published. Keep the fixed assignment for
-an exact prerelease install. After the first stable release, use the commented
-assignment to resolve the latest stable tag while still fetching installer code
-and artifacts from that same immutable tag. The recipe never falls back to
-`main`, never prints GitHub credentials, and never pipes network output directly
-into a shell.
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.1`. With no
+arguments it downloads only that tag's matching native archive and
+`SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
+internal previews, not predecessors in the public version line.
 
 The installer selects the matching platform archive, verifies it against
 `SHA256SUMS`, and installs these launchers in `~/.local/bin` by default:
@@ -152,10 +90,7 @@ stn-tmux-popup
 It also installs the redistributed license under
 `${XDG_DATA_HOME:-$HOME/.local/share}/station/`.
 
-After this candidate is published, immutable rollback to `v0.7.1-rc.7` uses the
-same exact-version procedure below.
-
-## 3. Verify the Install
+## Verify the Install
 
 The installer physically verifies all three launchers. If the install directory
 is not visible in the current shell, it prints an exact current-shell recovery
@@ -197,38 +132,27 @@ current-shell block repaired PATH before setup, the final probe is clean and
 setup stays concise, but a future login shell remains unverified until you test
 it separately.
 
-## Install an Exact Version
-
-To install an exact release or return to published `v0.7.1-rc.7`, use the same
-recipe with this assignment instead of the latest-release lookup:
-
-```bash
-tag=v0.7.1-rc.7
-```
-
-The installer code and artifacts still come from that same tag. The earlier
-`v0.7.0` and `v0.7.1-rc.1` candidates remained unpublished.
-
 ## Use a Custom Install Directory
 
-Change the final installer invocation to pass an absolute or home-relative
-path:
+Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-sh "$installer" --version "$tag" --install-dir "$HOME/bin"
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh | \
+  sh -s -- --install-dir "$HOME/bin"
 ```
 
 Use the PATH and absolute commands printed by that install rather than the
 default `~/.local/bin` examples. The normalized install directory cannot
 contain `:` because PATH uses `:` to separate entries. This validation happens
-before GitHub requests, temporary-directory creation, or destination mutation.
+before network requests, temporary-directory creation, or destination mutation.
 
-## 4. Complete First-Run Setup
+## Complete First-Run Setup
 
 Run setup only after `stn --version` succeeds:
 
 ```bash
 stn setup
+stn setup check --json
 stn doctor
 stn tui
 ```
@@ -281,7 +205,7 @@ The installer and setup have separate ownership:
 The installer:
 
 - accepts only `darwin-arm64`, `darwin-x64`, `linux-arm64`, and `linux-x64`;
-- downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` through authenticated `gh api` calls (`{version}` excludes the tag's leading `v`);
+- downloads the exact `stn-v{version}-{os}-{arch}.tar.gz` asset and `SHA256SUMS` from the stamped public tag with unauthenticated `curl` (`{version}` excludes the tag's leading `v`);
 - verifies the matching SHA-256 before extraction and rejects an unexpected archive manifest;
 - stages the verified binary on the destination filesystem and requires its `--version` to match within 10 seconds, so a hung or incompatible OS/libc/CPU artifact and an embedded-version mismatch fail without replacing an existing command; compatibility failures include at most 4096 sanitized bytes of probe stderr;
 - keeps `stn-ingress` and `stn-tmux-popup` as stable symlinks to `stn`, installs the redistributed `LICENSE` under `${XDG_DATA_HOME:-$HOME/.local/share}/station/`, then atomically renames the verified `stn` last as the sole runtime commit point;
@@ -297,16 +221,16 @@ Every install serializes both mutated resources with these locks:
 - `<data-home>/station/.station-install.lock` (by default
   `~/.local/share/station/.station-install.lock`) for `LICENSE`.
 
-Each lock's sole `owner-*` file records the installer PID, requested tag or
-`latest`, and the unique ownership token embedded in its filename. Cleanup
+Each lock's sole `owner-*` file records the installer PID, requested tag, and
+the unique ownership token embedded in its filename. Cleanup
 removes only that token-specific file and revalidates the lock inode, so an
 earlier installer cannot remove a replacement lock. The installer acquires
 the command lock first and the license lock second, skips the second acquisition
 if both paths coincide, and releases them in reverse order. A refusal happens
-before release lookup or download, names
+before a release download, names
 the lock and readable owner PID, states that the existing Station installation
 was unchanged, and tells the user to wait and retry. A license-lock refusal
-releases the command lock and performs no release API request.
+releases the command lock and performs no release request.
 
 The installer never guesses that either lock is stale. For an abandoned lock,
 read its sole `<install-dir>/.station-install.lock/owner-*` or
@@ -347,10 +271,10 @@ retrying after a machine loss.
 
 The compiled binary launches the native TUI and Observer without Node.js, pnpm, Bun, `node_modules`, or a source checkout. External programs are installed separately and gate only the features that use them: Git and Worktrunk for managed worktrees, tmux for popup/provider behavior, diffnav and git-delta for diff automation, and a supported agent CLI for agent sessions.
 
-Rollback is the same authenticated explicit-version install. Published tags and
-assets are immutable; do not delete, move, or overwrite them. If a published
-binary is bad, reinstall the prior published version and ship a higher version
-containing the revert or fix.
+Every public version carries its own exact-tag stamped installer asset.
+Published tags and assets are immutable; do not delete, move, or overwrite
+them. If a published binary is bad, reinstall a known-good published version
+and ship a higher version containing the revert or fix.
 
 ## Development Checkout
 
@@ -412,8 +336,9 @@ Optional integrations can be added later.
 
 `pnpm smoke:release` builds by default, creates an isolated temporary config, runs `bin/stn doctor`, `reconcile`, `snapshot --json`, `debug bundle`, and the scripted-agent lane, then stops the observer and removes the temp state.
 
-`pnpm smoke:install` exercises latest, explicit, and draft selection; strict
-authenticated API arguments; all four platform mappings; startup-file
+`pnpm smoke:install` exercises stamped and explicit public selection plus
+release-ID-scoped authenticated draft acceptance; strict download arguments;
+all four platform mappings; startup-file
 non-interaction, safely evaluated PATH guidance for spaces and apostrophes,
 normalized-colon preflight, and physical PATH shadow behavior;
 checksum/archive/probe failures; dual-lock concurrency and stale recovery;

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,12 +1,20 @@
 # Limitations and Workarounds
 
-Station v0.7 is a private preview. This page lists user-visible constraints and the available operational workaround for each one.
+Station `v0.0.0-pre-alpha.1` is experimental pre-alpha software. This page
+lists user-visible constraints and the available operational workaround for
+each one.
 
 ## Availability
 
-Station is distributed through authenticated release assets in the private `jeremy0dell/station` repository. It is not available from a public package registry or public download page. The compiled binary supports macOS and Linux on arm64 and x64; Windows is not supported.
+Station is distributed through an exact-tag public GitHub installer. The
+compiled binary supports macOS 13+ and glibc 2.39+ Linux on arm64 and x64;
+Windows and musl Linux are not supported. Homebrew is not currently supported.
 
-Use the authenticated installation procedure in [Install](install.md).
+Use the public installation procedure in [Install](install.md), then run
+`stn setup`, `stn setup check --json`, and `stn doctor`. The old
+`v0.7.1-rc.*` releases were internal previews, not predecessors in the public
+version line. Report feedback through
+[GitHub Issues](https://github.com/jeremy0dell/station/issues).
 
 ## Agent Status Can Be Conservative
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -279,9 +279,11 @@ Current startup proceeds in this order:
    `absent`, `listening`, `stale`, and `inaccessible`. Absent or proven-stale
    keeps the claim for owned startup; bind performs a fresh zero-holder and path-
    identity check before its only unlink attempt. Listening reads incumbent health and applies the
-   strict SemVer selector policy: exact builds or higher-version incumbents
-   attach; a deterministically elected same-version build or higher-version
-   candidate may replace an incumbent only after complete process attribution.
+   strict selector policy: exact builds or higher-version incumbents attach; a
+   deterministically elected same-version build or higher-version candidate may
+   replace an incumbent only after complete process attribution. The declared
+   public version-line reset orders `0.0.0-pre-alpha.*` after the internal
+   `0.7.1-rc.*` previews despite ordinary SemVer precedence.
    A losing or legacy same-version candidate refuses rather than attaching.
    Inaccessible paths, missing or malformed `lsof` evidence, path replacement,
    and non-socket collisions fail before provider construction, main SQLite,
@@ -567,7 +569,7 @@ from the diagnostic use case.
 | --- | --- |
 | Observer boot ownership | The resolved socket defines singleton identity. One persistent claim per socket directory serializes probe, incumbent handoff, stale reclaim, bind, pidfile publication, and ready commitment; different sockets in that directory wait on the same transaction but retain separate listeners and pidfiles. Claim existence is not ownership, process death releases the OS lock, and the claim path is never stale-reclaimed. |
 | Socket ownership evidence | Connect success proves listening. Only `ECONNREFUSED`, or Bun's existing-path `ENOENT`, plus strict zero-holder `lsof` evidence proves stale. Permission failures, timeouts, live holders, evidence failure, path replacement, and non-socket collisions are inaccessible and authorize no spawn, unlink, stop, or signal. |
-| Observer build ordering | Health and pidfile `version` carry display SemVer plus reserved `station.<sha256>` build metadata derived from both repository inputs and production package outputs. Exact identified selectors attach. At one display version, the lexicographically greater immutable build identity is the only candidate allowed to replace; the loser and any missing legacy identity refuse, so neither silently delegates to different code. Each source process verifies the published identity once before adopting it and reuses that selector without further Git or hash I/O for its lifetime. Different display versions retain SemVer precedence and the existing exact-string equal-precedence tiebreak. Missing, invalid, or stale identities refuse. Replacement requires complete corroborating identity and never uses automatic SIGKILL. |
+| Observer build ordering | Health and pidfile `version` carry display SemVer plus reserved `station.<sha256>` build metadata derived from both repository inputs and production package outputs. Exact identified selectors attach. At one display version, the lexicographically greater immutable build identity is the only candidate allowed to replace; the loser and any missing legacy identity refuse, so neither silently delegates to different code. Each source process verifies the published identity once before adopting it and reuses that selector without further Git or hash I/O for its lifetime. Different display versions retain SemVer precedence and the existing exact-string equal-precedence tiebreak, except that the declared public reset orders `0.0.0-pre-alpha.*` after internal `0.7.1-rc.*` previews. Missing, invalid, or stale identities refuse. Replacement requires complete corroborating identity and never uses automatic SIGKILL. |
 | Command ordering | Commands serialize by session, worktree, project, terminal target, or command-specific fallback scope. Different scopes can execute concurrently. |
 | Command timeout and cancellation | Handlers receive a signal combining the runtime timeout and queue shutdown. Cancellation is cooperative; the process shutdown backstop handles ignored signals. |
 | Snapshot writer ordering | Full reconciles and harness-report authorization plus base projection share a non-poisoning promise chain. Readiness persistence revalidates the live snapshot after its write. Scheduled reconcile requests coalesce; queued work after a run receives a later flush. |

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -1,7 +1,7 @@
 # Single-binary Station
 
-> **Status: v1.1 (current).** v1 was feasibility evidence, not an
-> implementation-ready roadmap; an adversarial audit of commit `e0d4307`
+> **Status: implemented; distribution updated for `v0.0.0-pre-alpha.1`.** v1
+> was feasibility evidence, not an implementation-ready roadmap; an adversarial audit of commit `e0d4307`
 > found 11 blocking issues, all reproduced and confirmed (see
 > [Audit findings](#audit-findings-all-confirmed)). v1.1 is subtractive:
 > it corrects the SQLite contract and dispatch boundary, removes the
@@ -28,11 +28,8 @@ agent CLIs) gates *features*, never launch — captured precisely by the
 
 Non-goals:
 
-- **Public distribution.** The repo is private; binaries ship as private
-  GitHub release assets fetched by an authenticated install script. A
-  binary Homebrew formula is **deferred** until a tested private-asset
-  download strategy exists (see A5); the authenticated script is the only
-  binary channel meanwhile.
+- **Homebrew distribution.** The supported public channel is the exact-tag
+  installer described in A5. Homebrew is not currently supported.
 - **Windows targets.**
 - **Any observer replacement / eviction in this roadmap.** Coordinated
   single-observer behavior is owned entirely by
@@ -51,8 +48,8 @@ Pinned so the release job, install script, and acceptance suite agree.
 | ------ | -------- |
 | Targets | `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. No Windows. |
 | Build runners | Native per target (no cross-compile — only the host-matching `@opentui/core-*` optional dep installs). Use *currently available* GitHub-hosted labels resolved at implementation time; do **not** hard-code `macos-13` (F9 — Intel macOS labels are being retired). Pin exact labels in the workflow with a comment naming the check date. |
-| macOS floor | Match the oldest OS the chosen Intel/arm runners image supports; state it in release notes. |
-| Linux floor | glibc only for v1.1 (bun's default). Declare the built-against glibc version (the runner's) as the floor; musl is a later target, not silently implied. |
+| macOS floor | macOS 13.0 or newer on Apple silicon or Intel. |
+| Linux floor | glibc 2.39 or newer on x64 or arm64. musl is not supported. |
 | CPU | x64 uses Bun's explicit `-baseline` targets for older SSE4.2-era CPUs; arm64 = Apple/ARMv8. |
 | Artifact | `stn-v{ver}-{platform}-{arch}.tar.gz`, using the target values above. **Manifest below is exhaustive.** |
 
@@ -148,7 +145,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.7.1-rc.8", compiled: false }` display semantics.
+  retaining `{ version: "0.0.0-pre-alpha.1", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -373,7 +370,7 @@ PID, inode, pidfile, and holder set, spool exactly one hook, then reconnect to t
 same process and drain it after mode `0600` is restored. `observerReap.ts` and the same-TTY UI
 reaper recognize the exact compiled process shapes.
 
-### A5 — release pipeline (private, deterministic, verifiable)
+### A5 — release pipeline (public, exact-tagged, verifiable)
 
 **Status: implemented.** `.github/workflows/release.yml` runs on `v*` tags.
 It requires release SemVer without `+` build metadata, exact agreement between
@@ -394,26 +391,25 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.7.1-rc.8-darwin-arm64.tar.gz`.
+example `stn-v0.0.0-pre-alpha.1-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
 duplicate targets, emits a stably sorted `SHA256SUMS`, and creates a GitHub
-release **draft** without clobbering an existing release. A second native
-matrix revalidates the tag, fetches the installer by the validated commit SHA
-through the authenticated Contents API, invokes it with the explicit tag against
-that real draft, and verifies the binary version, both argv0 aliases, license,
-and launch without Node or Bun on the runtime PATH. The four native builds use
-one archive-packaging helper, and the draft-install matrix consumes those exact
-uploaded archives. Publication remains a manual decision after the real-TTY
-acceptance below. GitHub's tag endpoint
-exposes published releases only, so the workflow captures the new draft's
-numeric release ID from the authenticated release list and passes it only to
-these acceptance jobs; normal installs keep using the latest/published-tag
-endpoints.
+release **draft** without clobbering an existing release. The aggregate job also
+stamps the exact tag into the installer's existing `embedded_version=""` marker,
+includes that executable `install.sh` in `SHA256SUMS`, and uploads six assets:
+the four archives, `install.sh`, and `SHA256SUMS`. A second native matrix
+revalidates the tag, downloads the actual stamped installer asset from the draft
+by its captured release and asset IDs, invokes it without a version argument,
+and verifies the binary version, both argv0 aliases, license, and launch without
+Node or Bun on the runtime PATH. The four native builds use one archive-packaging
+helper, and the draft-install matrix consumes those exact uploaded archives.
+Publication remains a manual decision after the real-TTY acceptance below.
 
 After all native acceptance jobs pass, the release workflow re-downloads the
-five draft assets, checks them against the build-generated `SHA256SUMS`, and
+six draft assets, checks the five checksummed assets against the build-generated
+`SHA256SUMS`, and
 uploads an immutable `accepted-release-candidate-*` Actions artifact containing
 the validated commit, workflow run/attempt, release ID, asset IDs, and checksums.
 The manually dispatched `promote-release.yml` downloads that exact artifact,
@@ -422,28 +418,26 @@ then publishes the unchanged draft. Draft assets cannot drift between acceptance
 and promotion without failing that workflow.
 
 `SHA256SUMS` is unsigned in A5 because no signing-key infrastructure exists;
-the trust chain is authenticated GitHub access plus immutable release assets.
+the public trust chain is the exact tagged GitHub release URL, checksum
+validation, archive-manifest validation, and immutable release assets.
 The pipeline pins inputs, gates, targets, names, and manifest, but does not
 claim bit-for-bit reproducible Bun executables or archives.
 
-`scripts/install.sh` supports latest stable, explicit `--version`, and
-`--install-dir` (default `~/.local/bin`). The supported binary-install baseline
-starts at `v0.7.1-rc.2`; the earlier `v0.7.0` and `v0.7.1-rc.1` candidates
-remained unpublished.
-Explicit installs set a tag, fetch
-`scripts/install.sh` from that tag through the authenticated Contents API, and
-invoke it with `--version` set to the same tag. Latest install first resolves
-the latest stable tag, then performs the same tagged fetch and explicit invoke.
-There is no silent `main` fallback, so installer code and release artifacts are
-always paired. `v0.7.1-rc.2` is the first published binary,
-`v0.7.1-rc.7` is the latest published binary, and publishing `v0.7.1-rc.8`
-makes immutable rollback to `v0.7.1-rc.7` available.
+The released `scripts/install.sh` is self-versioned for one exact public tag and
+supports an explicit `--version` override and `--install-dir` (default
+`~/.local/bin`). Its public path uses unauthenticated `curl` only for the exact
+tagged archive and `SHA256SUMS`; it has no `latest` or source-branch fallback.
+The source installer is intentionally unstamped and therefore requires an exact
+version. Draft-release CI preserves authenticated `STATION_INSTALL_RELEASE_ID`
+handling so it can download mutable draft assets by their captured IDs without
+changing public behavior. The earlier `v0.7.1-rc.*` releases were internal
+previews, not predecessors in the public version line.
 
-The installer uses authenticated `gh api` release endpoints, accepts only the
-four supported targets, verifies the one matching `SHA256SUMS` entry and exact
-archive manifest before touching an existing install, and stages replacement
-on each destination filesystem. Every potentially blocking `gh` operation is a
-tracked file-backed child rather than a command substitution.
+The installer accepts only the four supported targets, verifies the one matching
+`SHA256SUMS` entry and exact archive manifest before touching an existing
+install, and stages replacement on each destination filesystem. Every
+potentially blocking public `curl` or draft `gh` operation is a tracked
+file-backed child rather than a command substitution.
 
 The staged binary's `--version` probe has a 10-second supervised deadline and
 a POSIX file-size limit on stdout/stderr. Watchdog exit 124 reports timeout;
@@ -457,7 +451,7 @@ The command lock is `<install-dir>/.station-install.lock`; the license lock is
 `<data-home>/station/.station-install.lock`. Their sole owner files—
 `<install-dir>/.station-install.lock/owner-*` and
 `<data-home>/station/.station-install.lock/owner-*`—record the PID, requested
-tag or `latest`, and the token embedded in each filename. Cleanup removes only
+tag, and the token embedded in each filename. Cleanup removes only
 its token-specific owner file and revalidates the lock-directory inode so it
 cannot remove a replacement owner's lock. The installer acquires the
 command lock first and the license lock second, skips a duplicate path, and
@@ -493,8 +487,8 @@ still gives coherent process-level visibility to continuous readers. Power loss
 is not equivalent: the installer does not fsync files or containing directories
 and therefore makes no post-power-loss durability guarantee; old/new
 cross-filesystem `LICENSE` metadata may also remain. The deterministic
-`smoke:install` suite exercises this boundary with fake authenticated release
-assets and is part of `test:all`.
+`smoke:install` suite exercises this boundary with fake exact-tag public
+downloads and authenticated draft assets and is part of `test:all`.
 
 After success, all three bare launchers are resolved physically. If every one
 points into the new install directory, the installer prints only
@@ -506,10 +500,12 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.7.1-rc.8` promotes only after all four native targets pass
-automated and manual acceptance, including upgrade and rollback against
-published `v0.7.1-rc.7`. Published tags and assets are never deleted, moved, or
-overwritten; a bad release rolls back explicitly and rolls forward to a higher
+Candidate `v0.0.0-pre-alpha.1` promotes only after all four native targets pass
+automated and manual acceptance, including installation over an existing
+`v0.7.1-rc.8` internal preview despite the intentional public version reset.
+After promotion, all four targets test the unauthenticated public exact-tag URL
+without GitHub credentials or a `gh` executable. Published tags and assets are
+never deleted, moved, or overwritten; a bad release rolls forward with a new
 version containing the revert or fix.
 
 Drafts are still mutable. Release notes record the workflow commit, while the
@@ -521,10 +517,7 @@ An unpublished draft left by a transient workflow failure may be deleted and
 the unchanged tag workflow rerun; a source fix uses a new prerelease tag, while
 published releases are never deleted or mutated.
 
-The source-based Homebrew formula remains separate and manually dispatched.
-The default release `GITHUB_TOKEN` cannot trigger another workflow, and the tap
-`COMMITTER_TOKEN` is intentionally not configured for A5; no binary Homebrew
-formula is claimed until private asset authentication is proven there.
+Homebrew is not currently supported and the tap is outside this release path.
 
 Implementation sources: the target and manifest policy above; the existing
 [`build:binary` staging](../scripts/build-binary.mjs),
@@ -733,16 +726,19 @@ flow:
    build (B-host).
 8. Manual promotion selects the successful run's immutable
    `accepted-release-candidate-*` artifact, rechecks the exact tag, release,
-   asset IDs, and hashes, then publishes only that draft.
+   asset IDs, and hashes, then publishes only that draft. After publication,
+   the four native targets install through the public exact-tag URL without
+   GitHub credentials or a `gh` executable.
 9. With terminal A continuously running installed `stn --version`, terminal B
-   repeatedly installs the draft → only complete `0.7.1-rc.8` output appears,
-   never command-not-found or malformed output; both aliases remain links to
-   `stn`, so entrypoints never mix. Alternate the draft with published
-   `v0.7.1-rc.7` in both directions to prove upgrade and rollback.
+   repeatedly installs the draft → only complete `0.7.1-rc.8` or
+   `0.0.0-pre-alpha.1` output appears, never command-not-found or malformed
+   output; both aliases remain links to `stn`, so entrypoints never mix. Install
+   the reset public version over the internal preview to prove the intentional
+   lower SemVer is accepted.
 10. Abandoned command and license `.station-install.lock` directories each
     refuse the install until their recorded PID is confirmed dead, the lock is
     manually removed, and the same install is retried successfully.
-11. Ctrl-C during a real authenticated upgrade exits 130, preserves the prior
+11. Ctrl-C during a real draft upgrade exits 130, preserves the prior
     launchable TUI, cleans its owned stages and both locks, and permits a
     successful retry.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.7.1-rc.8",
+  "version": "0.0.0-pre-alpha.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -27,7 +27,8 @@ export type StationBuildInfo = {
  */
 export function stationBuildInfo(): StationBuildInfo {
   return {
-    version: typeof STATION_BUILD_VERSION === "undefined" ? "0.7.1-rc.8" : STATION_BUILD_VERSION,
+    version:
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.1" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.8",
+      version: "0.0.0-pre-alpha.1",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.8+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.7.1-rc.8+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.1+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.1+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.7.1-rc.8",
+      version: "0.0.0-pre-alpha.1",
       compiled: false,
       buildIdentity,
     });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,7 @@ github_host="github.com"
 export GH_HOST=$github_host
 requested_version=""
 requested_version_set=0
+embedded_version=""
 install_dir=""
 release_id=${STATION_INSTALL_RELEASE_ID:-}
 temp_dir=""
@@ -52,7 +53,7 @@ usage() {
   cat <<'EOF'
 Usage: install.sh [--version vX.Y.Z[-prerelease]] [--install-dir PATH]
 
-Install the latest stable private Station release, or an explicit version.
+Install the exact public Station release stamped into this script, or an explicit version.
 
 Options:
   --version VERSION   Install an immutable v-prefixed release version.
@@ -314,6 +315,24 @@ run_gh() {
   return "$tracked_status"
 }
 
+run_curl() {
+  curl_output=$1
+  curl_error=$2
+  shift 2
+  child_starting=1
+  curl "$@" > "$curl_output" 2> "$curl_error" &
+  tracked_child_pid=$!
+  child_starting=0
+  finish_pending_signal
+  if wait "$tracked_child_pid"; then
+    tracked_status=0
+  else
+    tracked_status=$?
+  fi
+  tracked_child_pid=""
+  return "$tracked_status"
+}
+
 read_file_value() {
   value_file=$1
   if ! file_value=$(
@@ -461,6 +480,13 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+if [ "$requested_version_set" -eq 0 ] && [ -n "$embedded_version" ]; then
+  requested_version=$embedded_version
+  requested_version_set=1
+fi
+if [ "$requested_version_set" -eq 0 ]; then
+  fail "this installer is not version-stamped; pass --version with an exact release tag."
+fi
 if [ "$requested_version_set" -eq 1 ] && ! valid_version "$requested_version"; then
   fail "version must be valid v-prefixed SemVer, for example v0.7.0 or v0.7.1-rc.1."
 fi
@@ -468,7 +494,7 @@ if [ -n "$release_id" ]; then
   case "$release_id" in
     *[!0-9]*) fail "STATION_INSTALL_RELEASE_ID must be a numeric GitHub release ID." ;;
   esac
-  [ "$requested_version_set" -eq 1 ] || fail "STATION_INSTALL_RELEASE_ID requires --version."
+  [ "$requested_version_set" -eq 1 ] || fail "STATION_INSTALL_RELEASE_ID requires an exact version."
 fi
 
 if ! raw_current_dir=$(
@@ -516,19 +542,19 @@ case "$(uname -s 2>/dev/null || true):$(uname -m 2>/dev/null || true)" in
   *) fail "unsupported platform; Station binaries support macOS and glibc Linux on arm64 or x64." ;;
 esac
 
-command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required; install 'gh', then run 'gh auth login --hostname github.com'."
+if [ -n "$release_id" ]; then
+  command -v gh >/dev/null 2>&1 || fail "GitHub CLI is required for draft release acceptance; install 'gh', then run 'gh auth login --hostname github.com'."
+else
+  command -v curl >/dev/null 2>&1 || fail "curl is required to download the public Station release."
+fi
 temp_dir=$(mktemp -d "$tmp_base/station-install.XXXXXX") || fail "could not create a temporary directory."
 install_lock_token=$$-${temp_dir##*/}
-if ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
-  fail "GitHub authentication is required for this private release; run 'gh auth login --hostname github.com', then retry."
+if [ -n "$release_id" ] && ! run_gh "$temp_dir/auth.stdout" "$temp_dir/auth.stderr" auth status --hostname "$github_host"; then
+  fail "GitHub authentication is required for draft release acceptance; run 'gh auth login --hostname github.com', then retry."
 fi
 
 mkdir -p "$install_dir" || fail "could not create Station install directory '$install_dir'."
-if [ "$requested_version_set" -eq 1 ]; then
-  owner_request=$requested_version
-else
-  owner_request=latest
-fi
+owner_request=$requested_version
 command_lock_dir=$install_dir/.station-install.lock
 acquire_lock "$command_lock_dir" command
 
@@ -603,21 +629,8 @@ if [ -n "$release_id" ]; then
   archive_id=$asset_result
   lookup_draft_asset SHA256SUMS draft-checksums
   checksums_id=$asset_result
-elif [ "$requested_version_set" -eq 1 ]; then
-  tag=$requested_version
-  release_endpoint="repos/$repository/releases/tags/$tag"
 else
-  if ! run_gh "$temp_dir/latest.stdout" "$temp_dir/latest.stderr" api "repos/$repository/releases/latest" --jq '.tag_name'; then
-    fail "could not resolve the latest stable Station release; check 'gh auth status' and repository access."
-  fi
-  if ! read_file_value "$temp_dir/latest.stdout"; then
-    fail "could not read the latest stable Station release tag."
-  fi
-  tag=$file_value
-  if ! valid_version "$tag"; then
-    fail "the latest Station release returned an invalid tag."
-  fi
-  release_endpoint="repos/$repository/releases/tags/$tag"
+  tag=$requested_version
 fi
 
 if [ -z "$release_id" ]; then
@@ -625,30 +638,30 @@ if [ -z "$release_id" ]; then
   archive_name="stn-v${version}-${target}.tar.gz"
 fi
 
-lookup_asset() {
-  asset_name=$1
-  asset_slug=$2
-  if ! run_gh "$temp_dir/$asset_slug.stdout" "$temp_dir/$asset_slug.stderr" api "$release_endpoint" --jq ".assets[] | select(.name == \"$asset_name\") | .id"; then
-    fail "could not read release $tag; check that the release exists and your account can access it."
-  fi
-  read_numeric_result "$temp_dir/$asset_slug.stdout" "release $tag must contain exactly one '$asset_name' asset."
-  asset_result=$numeric_result
-}
-
-if [ -z "$release_id" ]; then
-  lookup_asset "$archive_name" release-archive
-  archive_id=$asset_result
-  lookup_asset SHA256SUMS release-checksums
-  checksums_id=$asset_result
-fi
 archive_path=$temp_dir/$archive_name
 checksums_path=$temp_dir/SHA256SUMS
 
-if ! run_gh "$archive_path" "$temp_dir/archive-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id"; then
-  fail "could not download $archive_name from release $tag."
-fi
-if ! run_gh "$checksums_path" "$temp_dir/checksums-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id"; then
-  fail "could not download SHA256SUMS from release $tag."
+if [ -n "$release_id" ]; then
+  if ! run_gh "$archive_path" "$temp_dir/archive-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$archive_id"; then
+    fail "could not download $archive_name from draft release $tag."
+  fi
+  if ! run_gh "$checksums_path" "$temp_dir/checksums-download.stderr" api -H "Accept: application/octet-stream" "repos/$repository/releases/assets/$checksums_id"; then
+    fail "could not download SHA256SUMS from draft release $tag."
+  fi
+else
+  release_url="https://github.com/$repository/releases/download/$tag"
+  if ! run_curl "$archive_path" "$temp_dir/archive-download.stderr" \
+    --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 \
+    "$release_url/$archive_name"; then
+    fail "could not download $archive_name from public release $tag."
+  fi
+  if ! run_curl "$checksums_path" "$temp_dir/checksums-download.stderr" \
+    --fail --silent --show-error --location \
+    --proto '=https' --proto-redir '=https' --tlsv1.2 \
+    "$release_url/SHA256SUMS"; then
+    fail "could not download SHA256SUMS from public release $tag."
+  fi
 fi
 
 expected_hashes=$(awk -v name="$archive_name" '$2 == name || $2 == "*" name { print $1 }' "$checksums_path")

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -1059,7 +1059,7 @@ function environmentWithoutGitLocals(source) {
 function parseExpectedVersion(args) {
   const normalized = args[0] === "--" ? args.slice(1) : args;
   if (normalized.length === 0) {
-    return "0.7.1-rc.8";
+    return "0.0.0-pre-alpha.1";
   }
   if (
     normalized.length === 2 &&

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -32,14 +32,16 @@ if (!/^(?:[1-9]|10)$/.test(timeoutScaleText)) {
 }
 const timeoutScale = Number(timeoutScaleText);
 const root = mkdtempSync(join(tmpdir(), "station-install-smoke-"));
+const stampedInstaller = join(root, "stamped-install.sh");
 const releasesDir = join(root, "releases");
 const fakeBinDir = join(root, "bin");
 const homeDir = join(root, "home");
 const dataDir = join(root, "data");
 const tempDir = join(root, "tmp");
 const ghLogsDir = join(root, "gh-logs");
-const stableTag = "v1.2.3";
-const rollbackTag = "v1.2.3-rc.1";
+const curlLogsDir = join(root, "curl-logs");
+const releaseTag = "v0.0.0-pre-alpha.1";
+const rollbackTag = "v0.7.1-rc.8";
 const removedPersistenceOption = ["--persist", "path"].join("-");
 const activeChildren = new Set();
 const childTimeoutMs = 30_000 * timeoutScale;
@@ -85,9 +87,9 @@ try {
     await scenarioDefaultHomeAndPathResolution();
     await scenarioPathGuidanceAndStartupFileNonOwnership();
     await scenarioExplicitRollbackAndDraft();
-    await scenarioStrictGhFlows();
+    await scenarioStrictDownloadFlows();
     await scenarioAuthenticatedReleaseValidation();
-    await scenarioGhFailuresAndRetries();
+    await scenarioDownloadFailuresAndRetries();
     await scenarioArtifactValidation();
     await scenarioStrictVersionValidation();
     await scenarioCliParsing();
@@ -104,7 +106,7 @@ try {
     await scenarioManagedPathReplacement();
     await scenarioContinuousReaders();
     await scenarioCaughtSignals();
-    await scenarioGhSignalSupervision();
+    await scenarioDownloadSignalSupervision();
     await scenarioRepeatedSignalCleanup();
     await scenarioAliasCreationSignal();
     await scenarioSignalDuringLockAcquisition();
@@ -121,13 +123,14 @@ try {
 }
 
 function prepareFixtures() {
-  for (const path of [releasesDir, fakeBinDir, homeDir, dataDir, tempDir, ghLogsDir]) {
+  for (const path of [releasesDir, fakeBinDir, homeDir, dataDir, tempDir, ghLogsDir, curlLogsDir]) {
     makeDirectory(path);
   }
   writeFakeCommands();
+  stampInstaller(installer, stampedInstaller, releaseTag);
 
   createRelease(
-    stableTag,
+    releaseTag,
     platforms.map(({ target }) => target),
   );
   createRelease(rollbackTag, ["linux-x64"]);
@@ -192,8 +195,8 @@ function scenarioPlatformInstalls() {
   for (const platform of platforms) {
     const installDir = join(root, `install-${platform.target}`);
     const result = runInstaller({ installDir, platform });
-    assertSuccess(result, `${platform.target} latest install`);
-    assertInstalled({ installDir, tag: stableTag, target: platform.target });
+    assertSuccess(result, `${platform.target} stamped install`);
+    assertInstalled({ installDir, tag: releaseTag, target: platform.target });
     assertPathRecovery(result, installDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
     assertNoInstallerResidue(installDir, dataDir);
   }
@@ -214,7 +217,7 @@ function scenarioDefaultHomeAndPathResolution() {
   assertInstalled({
     installDir: defaultInstallDir,
     dataHome: defaultDataHome,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
   assertPathRecovery(defaultInstall, defaultInstallDir, ["stn", "stn-ingress", "stn-tmux-popup"]);
@@ -385,6 +388,7 @@ function scenarioPathGuidanceAndStartupFileNonOwnership() {
   assertFailure(colon, "install directory cannot contain ':'", "normalized colon preflight");
   assertIncludes(colon.stderr, "PATH uses ':' to separate entries", "normalized colon rationale");
   assertEqual(ghCalls(colon), [], "normalized colon preflight makes no gh calls");
+  assertEqual(curlCalls(colon), [], "normalized colon preflight makes no curl calls");
   assert(
     !existsSync(colonInstallDir),
     "normalized colon preflight does not create install directory",
@@ -428,23 +432,35 @@ function expectedShellWord(value) {
 
 function scenarioExplicitRollbackAndDraft() {
   const rollbackDir = join(root, "rollback-bin");
-  assertSuccess(
-    runInstaller({
-      installDir: rollbackDir,
-      platform: linuxX64(),
-      version: stableTag,
-      includeInstallDirOnPath: true,
-    }),
-    "explicit stable install",
-  );
+  const rollbackData = join(root, "rollback-data");
+  seedInstallation({ installDir: rollbackDir, dataHome: rollbackData, tag: rollbackTag });
+  const resetUpgrade = runInstaller({
+    installDir: rollbackDir,
+    platform: linuxX64(),
+    dataHome: rollbackData,
+    includeInstallDirOnPath: true,
+  });
+  assertSuccess(resetUpgrade, "version reset upgrade");
+  assertInstalled({
+    installDir: rollbackDir,
+    dataHome: rollbackData,
+    tag: releaseTag,
+    target: "linux-x64",
+  });
   const rollback = runInstaller({
     installDir: rollbackDir,
     platform: linuxX64(),
+    dataHome: rollbackData,
     version: rollbackTag,
     includeInstallDirOnPath: true,
   });
   assertSuccess(rollback, "explicit prerelease rollback");
-  assertInstalled({ installDir: rollbackDir, tag: rollbackTag, target: "linux-x64" });
+  assertInstalled({
+    installDir: rollbackDir,
+    dataHome: rollbackData,
+    tag: rollbackTag,
+    target: "linux-x64",
+  });
   assertIncludes(rollback.stdout, "Next: run stn setup", "rollback PATH next step");
   assertNotIncludes(rollback.stdout, "hash -r", "rollback PATH recovery omission");
 
@@ -452,37 +468,47 @@ function scenarioExplicitRollbackAndDraft() {
   const draft = runInstaller({
     installDir: draftDir,
     platform: linuxX64(),
-    version: rollbackTag,
     releaseId: "42",
   });
-  assertSuccess(draft, "draft release ID install");
-  assertInstalled({ installDir: draftDir, tag: rollbackTag, target: "linux-x64" });
+  assertSuccess(draft, "stamped draft release ID install");
+  assertInstalled({ installDir: draftDir, tag: releaseTag, target: "linux-x64" });
 }
 
-function scenarioStrictGhFlows() {
-  const latest = runInstaller({
-    installDir: join(root, "strict-gh-latest-bin"),
+function scenarioStrictDownloadFlows() {
+  const publicBin = makePublicBin();
+  const stamped = runInstaller({
+    installDir: join(root, "strict-public-stamped-bin"),
     platform: linuxX64(),
+    pathEntries: [publicBin],
   });
-  assertSuccess(latest, "strict gh latest flow");
-  assertStrictGhFlow(latest, { tag: stableTag, target: "linux-x64", latest: true });
+  assertSuccess(stamped, "strict stamped public flow without gh");
+  assertStrictPublicFlow(stamped, { tag: releaseTag, target: "linux-x64" });
 
   const explicit = runInstaller({
-    installDir: join(root, "strict-gh-explicit-bin"),
+    installDir: join(root, "strict-public-explicit-bin"),
     platform: linuxX64(),
+    pathEntries: [publicBin],
     version: rollbackTag,
   });
-  assertSuccess(explicit, "strict gh explicit flow");
-  assertStrictGhFlow(explicit, { tag: rollbackTag, target: "linux-x64" });
+  assertSuccess(explicit, "strict explicit public flow without gh");
+  assertStrictPublicFlow(explicit, { tag: rollbackTag, target: "linux-x64" });
 
   const draft = runInstaller({
     installDir: join(root, "strict-gh-draft-bin"),
     platform: linuxX64(),
-    version: rollbackTag,
     releaseId: "42",
   });
-  assertSuccess(draft, "strict gh draft flow");
-  assertStrictGhFlow(draft, { draftId: "42", tag: rollbackTag, target: "linux-x64" });
+  assertSuccess(draft, "strict stamped gh draft flow");
+  assertStrictGhFlow(draft, { draftId: "42", tag: releaseTag, target: "linux-x64" });
+
+  const unstamped = runInstaller({
+    installDir: join(root, "unstamped-no-version-bin"),
+    installerPath: installer,
+    platform: linuxX64(),
+  });
+  assertFailure(unstamped, "not version-stamped", "unstamped installer without version");
+  assertEqual(ghCalls(unstamped), [], "unstamped installer makes no gh calls");
+  assertEqual(curlCalls(unstamped), [], "unstamped installer makes no curl calls");
 }
 
 function scenarioAuthenticatedReleaseValidation() {
@@ -508,15 +534,10 @@ function scenarioAuthenticatedReleaseValidation() {
       options: { version: "v1.2.6" },
     },
     {
-      label: "duplicate asset rejection",
-      expected: "exactly one",
-      options: { version: stableTag, duplicateArchiveAsset: true },
-    },
-    {
       label: "duplicate draft asset rejection",
       expected: "exactly one",
       options: {
-        version: stableTag,
+        version: releaseTag,
         releaseId: "42",
         duplicateArchiveAsset: true,
       },
@@ -524,22 +545,22 @@ function scenarioAuthenticatedReleaseValidation() {
     {
       label: "draft tag mismatch",
       expected: "no single draft matched",
-      options: { version: stableTag, releaseId: "42", releaseIdTag: rollbackTag },
+      options: { version: releaseTag, releaseId: "42", releaseIdTag: rollbackTag },
     },
     {
       label: "published release ID refusal",
       expected: "no single draft matched",
-      options: { version: stableTag, releaseId: "42", releaseDraft: false },
+      options: { version: releaseTag, releaseId: "42", releaseDraft: false },
     },
     {
       label: "invalid draft release ID",
       expected: "must be a numeric",
-      options: { version: stableTag, releaseId: "draft-42" },
+      options: { version: releaseTag, releaseId: "draft-42" },
     },
     {
       label: "authentication failure",
       expected: "gh auth login",
-      options: { auth: false },
+      options: { auth: false, releaseId: "42" },
     },
     {
       label: "unsupported platform",
@@ -558,29 +579,42 @@ function scenarioAuthenticatedReleaseValidation() {
   }
 }
 
-function scenarioGhFailuresAndRetries() {
+function scenarioDownloadFailuresAndRetries() {
+  const noDownloadBin = join(root, "no-download-bin");
+  makeDirectory(noDownloadBin);
+  symlinkSync(resolveCommand("grep"), join(noDownloadBin, "grep"));
+  symlinkSync(join(fakeBinDir, "uname"), join(noDownloadBin, "uname"));
+  const missingCurl = runInstaller({
+    installDir: join(root, "missing-curl-install"),
+    platform: linuxX64(),
+    pathEntries: [noDownloadBin],
+  });
+  assertFailure(missingCurl, "curl is required", "missing curl");
+  assertEqual(curlCalls(missingCurl), [], "missing curl makes no curl calls");
+
   const noGhBin = join(root, "no-gh-bin");
   makeDirectory(noGhBin);
+  symlinkSync(join(fakeBinDir, "curl"), join(noGhBin, "curl"));
+  symlinkSync(resolveCommand("grep"), join(noGhBin, "grep"));
   symlinkSync(join(fakeBinDir, "uname"), join(noGhBin, "uname"));
   const missingGh = runInstaller({
     installDir: join(root, "missing-gh-install"),
     platform: linuxX64(),
     pathEntries: [noGhBin],
+    releaseId: "42",
   });
-  assertFailure(missingGh, "GitHub CLI is required", "missing gh");
-  assertEqual(ghCalls(missingGh), [], "missing gh makes no gh calls");
+  assertFailure(missingGh, "GitHub CLI is required", "missing draft gh");
+  assertEqual(ghCalls(missingGh), [], "missing draft gh makes no gh calls");
 
-  const installDir = join(root, "gh-failure-bin");
-  const dataHome = join(root, "gh-failure-data");
+  const installDir = join(root, "download-failure-bin");
+  const dataHome = join(root, "download-failure-data");
   seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
   const failures = [
-    ["latest", {}, "latest release API failure"],
-    ["release", { version: stableTag }, "release asset API failure"],
-    ["release", { version: stableTag, releaseId: "42" }, "draft release API failure"],
-    ["archive-download", { version: stableTag }, "archive download failure"],
-    ["checksums-download", { version: stableTag }, "checksum download failure"],
-    ["partial-archive", { version: stableTag }, "partial archive download"],
-    ["partial-checksums", { version: stableTag }, "partial checksum download"],
+    ["release", { releaseId: "42" }, "draft release API failure"],
+    ["archive-download", { version: releaseTag }, "archive download failure"],
+    ["checksums-download", { version: releaseTag }, "checksum download failure"],
+    ["partial-archive", { version: releaseTag }, "partial archive download"],
+    ["partial-checksums", { version: releaseTag }, "partial checksum download"],
   ];
 
   for (const [phase, options, label] of failures) {
@@ -606,7 +640,7 @@ function scenarioGhFailuresAndRetries() {
     const result = runInstaller({
       installDir,
       platform: linuxX64(),
-      version: stableTag,
+      releaseId: "42",
       dataHome,
       environment,
     });
@@ -616,9 +650,9 @@ function scenarioGhFailuresAndRetries() {
     assertNoInstallerResidue(installDir, dataHome);
   }
 
-  const retry = runInstaller({ installDir, platform: linuxX64(), version: stableTag, dataHome });
-  assertSuccess(retry, "retry after gh failures");
-  assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+  const retry = runInstaller({ installDir, platform: linuxX64(), dataHome });
+  assertSuccess(retry, "retry after download failures");
+  assertInstalled({ installDir, dataHome, tag: releaseTag, target: "linux-x64" });
 }
 
 function scenarioArtifactValidation() {
@@ -657,7 +691,7 @@ function scenarioArtifactValidation() {
   const noChecksum = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     pathEntries: [noChecksumBin],
   });
@@ -674,6 +708,7 @@ function scenarioStrictVersionValidation() {
     "1.2.3",
     "v01.2.3",
     "v1.2.3+build.1",
+    "v1.2.3-01",
     "v1.2.3 ",
     "v1.2.3\r",
     "v1.2.3\nv9.9.9",
@@ -683,30 +718,26 @@ function scenarioStrictVersionValidation() {
     const result = runInstaller({ installDir, platform: linuxX64(), version });
     assertFailure(result, "v-prefixed SemVer", `invalid version ${JSON.stringify(version)}`);
     assertEqual(ghCalls(result).length, 0, `invalid version ${JSON.stringify(version)} gh calls`);
+    assertEqual(
+      curlCalls(result).length,
+      0,
+      `invalid version ${JSON.stringify(version)} curl calls`,
+    );
   }
 
   const duplicateEmpty = runInstaller({
     installDir,
     platform: linuxX64(),
     version: "",
-    extraArguments: ["--version", stableTag],
+    extraArguments: ["--version", releaseTag],
   });
   assertFailure(duplicateEmpty, "only once", "duplicate version after empty value");
   assertEqual(ghCalls(duplicateEmpty).length, 0, "duplicate version after empty value gh calls");
-
-  for (const apiTag of ["v1.2.3\nv9.9.9", "v1.2.3\n"]) {
-    const apiResult = runInstaller({
-      installDir,
-      platform: linuxX64(),
-      environment: { FAKE_LATEST_TAG: apiTag },
-    });
-    assertFailure(apiResult, "invalid tag", `invalid latest API tag ${JSON.stringify(apiTag)}`);
-    assertEqual(
-      ghCalls(apiResult).filter((call) => call.startsWith("api ")).length,
-      1,
-      `invalid latest API tag ${JSON.stringify(apiTag)} stops after lookup`,
-    );
-  }
+  assertEqual(
+    curlCalls(duplicateEmpty).length,
+    0,
+    "duplicate version after empty value curl calls",
+  );
 }
 
 function scenarioCliParsing() {
@@ -715,7 +746,7 @@ function scenarioCliParsing() {
     [["--version"], "--version requires a value", "missing version value"],
     [["--install-dir"], "--install-dir requires a path", "missing install-dir value"],
     [
-      ["--version", stableTag, "--version", rollbackTag],
+      ["--version", releaseTag, "--version", rollbackTag],
       "--version may be specified only once",
       "duplicate version flag",
     ],
@@ -737,6 +768,7 @@ function scenarioCliParsing() {
     });
     assertFailure(result, expected, label);
     assertEqual(ghCalls(result), [], `${label} makes no gh calls`);
+    assertEqual(curlCalls(result), [], `${label} makes no curl calls`);
   }
   assert(!existsSync(installDir), "CLI parsing failures do not create the install directory");
 }
@@ -744,7 +776,7 @@ function scenarioCliParsing() {
 function scenarioHostileUmaskModes() {
   const installDir = join(root, "hostile-umask-bin");
   const dataHome = join(root, "hostile-umask-data");
-  for (const version of [stableTag, rollbackTag]) {
+  for (const version of [releaseTag, rollbackTag]) {
     const result = runInstaller({
       installDir,
       platform: linuxX64(),
@@ -773,7 +805,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
   assertInstalled({
     installDir: noHomeBin,
     dataHome: noHomeData,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
 
@@ -790,7 +822,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
   assertInstalled({
     installDir: join(relativeCwd, "-station-bin"),
     dataHome: join(relativeCwd, "-station-data"),
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
 
@@ -809,7 +841,7 @@ function scenarioPathResolutionAndFilesystemFailures() {
   assertInstalled({
     installDir: unusualInstall,
     dataHome: unusualData,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
   assertPathRecovery(unusual, unusualInstall, ["stn", "stn-ingress", "stn-tmux-popup"]);
@@ -876,7 +908,7 @@ async function scenarioProbeDeadline() {
       "",
     ].join("\n"),
   );
-  seedInstallation({ installDir, dataHome, tag: stableTag });
+  seedInstallation({ installDir, dataHome, tag: releaseTag });
 
   const startedAt = Date.now();
   const running = runInstaller({
@@ -893,8 +925,8 @@ async function scenarioProbeDeadline() {
   assertIncludes(result.stderr, "10 seconds", "probe timeout duration");
   assertIncludes(result.stderr, "unchanged", "probe timeout preservation UX");
   assert(Date.now() - startedAt < 5_000, "probe timeout was bounded by the clock shim");
-  assertRuntimeVersion(installDir, stableTag, "probe timeout runtime preservation");
-  assertLicense(dataHome, stableTag, "probe timeout license preservation");
+  assertRuntimeVersion(installDir, releaseTag, "probe timeout runtime preservation");
+  assertLicense(dataHome, releaseTag, "probe timeout license preservation");
   assertProcessGone(Number(readFileSync(pidFile, "utf8")), "timed-out probe child");
   assertNoInstallerResidue(installDir, dataHome);
 }
@@ -1047,7 +1079,7 @@ async function scenarioDestinationLock() {
   const dataHome = join(root, "concurrent-data");
   const probePid = join(root, "concurrent-probe.pid");
   const releaseFile = join(root, "concurrent-probe.release");
-  seedInstallation({ installDir, dataHome, tag: stableTag });
+  seedInstallation({ installDir, dataHome, tag: releaseTag });
 
   const first = runInstaller({
     installDir,
@@ -1080,7 +1112,7 @@ async function scenarioDestinationLock() {
   assertIncludes(second.stderr, String(first.child.pid), "concurrent lock owner PID");
   assertIncludes(second.stderr, "unchanged", "concurrent lock preservation UX");
   assertNoGhApiCalls(second, "concurrent installer lock refusal");
-  assertRuntimeVersion(installDir, stableTag, "runtime while installer is locked");
+  assertRuntimeVersion(installDir, releaseTag, "runtime while installer is locked");
 
   writeText(releaseFile, "release\n", 0o600);
   const firstResult = await settleWithin(first, 5_000, "first concurrent installer");
@@ -1164,14 +1196,14 @@ async function scenarioSharedLicenseLock() {
   const coincident = runInstaller({
     installDir: coincidentInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: coincidentDataHome,
   });
   assertSuccess(coincident, "coincident command and license lock");
   assertInstalled({
     installDir: coincidentInstallDir,
     dataHome: coincidentDataHome,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
   assertNoInstallerResidue(coincidentInstallDir, coincidentDataHome);
@@ -1183,7 +1215,7 @@ async function scenarioSharedLicenseLock() {
   const ordered = runInstaller({
     installDir: orderInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: orderDataHome,
     commandBinDirs: [orderShim.directory],
     environment: orderShim.environment,
@@ -1317,7 +1349,7 @@ function scenarioCommitFailures() {
     const failed = runInstaller({
       installDir,
       platform: linuxX64(),
-      version: stableTag,
+      version: releaseTag,
       dataHome,
       commandBinDirs: [shim.directory],
       environment: shim.environment,
@@ -1335,11 +1367,11 @@ function scenarioCommitFailures() {
     const retry = runInstaller({
       installDir,
       platform: linuxX64(),
-      version: stableTag,
+      version: releaseTag,
       dataHome,
     });
     assertSuccess(retry, `${testCase.label} retry`);
-    assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+    assertInstalled({ installDir, dataHome, tag: releaseTag, target: "linux-x64" });
   }
 
   for (const testCase of cases) {
@@ -1354,7 +1386,7 @@ function scenarioCommitFailures() {
     const failed = runInstaller({
       installDir,
       platform: linuxX64(),
-      version: stableTag,
+      version: releaseTag,
       dataHome,
       commandBinDirs: [shim.directory],
       environment: shim.environment,
@@ -1382,13 +1414,13 @@ function scenarioAmbiguousRuntimeCommit() {
   const ambiguous = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     commandBinDirs: [shim.directory],
     environment: shim.environment,
   });
   assertNonzero(ambiguous, "rename-performed-then-error");
-  assertInstalled({ installDir, dataHome, tag: stableTag, target: "linux-x64" });
+  assertInstalled({ installDir, dataHome, tag: releaseTag, target: "linux-x64" });
   assertIncludes(ambiguous.stderr, join(installDir, "stn"), "ambiguous activation inspection path");
   assertIncludes(ambiguous.stderr, "--version", "ambiguous activation inspection command");
   assertNotIncludes(ambiguous.stderr, "was unchanged", "ambiguous activation truthfulness");
@@ -1400,7 +1432,7 @@ function scenarioAmbiguousRuntimeCommit() {
   const aliasFailure = runInstaller({
     installDir: aliasInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: aliasDataHome,
     commandBinDirs: [aliasShim.directory],
     environment: aliasShim.environment,
@@ -1424,7 +1456,7 @@ function scenarioAmbiguousRuntimeCommit() {
   const warning = runInstaller({
     installDir: warningInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: warningDataHome,
     commandBinDirs: [warningShim.directory],
     environment: warningShim.environment,
@@ -1434,7 +1466,7 @@ function scenarioAmbiguousRuntimeCommit() {
   assertInstalled({
     installDir: warningInstallDir,
     dataHome: warningDataHome,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
   for (const name of readdirSync(tempDir)) {
@@ -1452,7 +1484,7 @@ async function scenarioManagedPathReplacement() {
   const running = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     asynchronous: true,
     environment: {
@@ -1493,7 +1525,7 @@ async function scenarioManagedPathReplacement() {
     const replacementRunning = runInstaller({
       installDir: replacementInstallDir,
       platform: linuxX64(),
-      version: stableTag,
+      version: releaseTag,
       dataHome: replacementDataHome,
       asynchronous: true,
       environment: {
@@ -1574,7 +1606,7 @@ async function scenarioManagedPathReplacement() {
   const cleanupRunning = runInstaller({
     installDir: cleanupInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: cleanupDataHome,
     asynchronous: true,
     commandBinDirs: [blocking.directory],
@@ -1664,25 +1696,30 @@ async function scenarioCaughtSignals() {
   }
 }
 
-async function scenarioGhSignalSupervision() {
+async function scenarioDownloadSignalSupervision() {
   const phases = [
-    { name: "auth", version: stableTag },
-    { name: "latest" },
-    { name: "published-archive-asset", version: stableTag },
-    { name: "published-checksum-asset", version: stableTag },
-    { name: "archive-download", version: stableTag },
-    { name: "checksum-download", version: stableTag },
-    { draft: true, name: "draft-release", version: rollbackTag },
-    { draft: true, name: "draft-archive-asset", version: rollbackTag },
-    { draft: true, name: "draft-checksum-asset", version: rollbackTag },
+    { name: "archive-download", version: releaseTag },
+    { name: "checksum-download", version: releaseTag },
+    { draft: true, label: "draft-auth", name: "auth", version: releaseTag },
+    { draft: true, name: "draft-release", version: releaseTag },
+    { draft: true, name: "draft-archive-asset", version: releaseTag },
+    { draft: true, name: "draft-checksum-asset", version: releaseTag },
+    { draft: true, label: "draft-archive-download", name: "archive-download", version: releaseTag },
+    {
+      draft: true,
+      label: "draft-checksum-download",
+      name: "checksum-download",
+      version: releaseTag,
+    },
   ];
 
   for (const phase of phases) {
-    const installDir = join(root, `gh-${phase.name}-signal-bin`);
-    const dataHome = join(root, `gh-${phase.name}-signal-data`);
-    const marker = join(root, `gh-${phase.name}-signal.ready`);
-    const childPidFile = join(root, `gh-${phase.name}-signal.pid`);
-    const releaseFile = join(root, `gh-${phase.name}-signal.release`);
+    const label = phase.label ?? phase.name;
+    const installDir = join(root, `${label}-signal-bin`);
+    const dataHome = join(root, `${label}-signal-data`);
+    const marker = join(root, `${label}-signal.ready`);
+    const childPidFile = join(root, `${label}-signal.pid`);
+    const releaseFile = join(root, `${label}-signal.release`);
     seedInstallation({ installDir, dataHome, tag: "v0.9.0" });
     const running = runInstaller({
       installDir,
@@ -1698,14 +1735,14 @@ async function scenarioGhSignalSupervision() {
         FAKE_BLOCK_RELEASE: releaseFile,
       },
     });
-    await waitForPath(marker, `${phase.name} signal injection point`);
-    await waitForPath(childPidFile, `${phase.name} child PID`);
+    await waitForPath(marker, `${label} signal injection point`);
+    await waitForPath(childPidFile, `${label} child PID`);
     running.child.kill("SIGTERM");
-    const result = await settleWithin(running, 5_000, `${phase.name} signal cleanup`);
-    assertExactStatus(result, 143, `${phase.name} parent-only SIGTERM`);
-    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${phase.name} gh child`);
-    assertRuntimeVersion(installDir, "v0.9.0", `${phase.name} runtime preservation`);
-    assertLicense(dataHome, "v0.9.0", `${phase.name} license preservation`);
+    const result = await settleWithin(running, 5_000, `${label} signal cleanup`);
+    assertExactStatus(result, 143, `${label} parent-only SIGTERM`);
+    assertProcessGone(Number(readFileSync(childPidFile, "utf8")), `${label} download child`);
+    assertRuntimeVersion(installDir, "v0.9.0", `${label} runtime preservation`);
+    assertLicense(dataHome, "v0.9.0", `${label} license preservation`);
     assertNoInstallerResidue(installDir, dataHome);
   }
 }
@@ -1720,7 +1757,7 @@ async function scenarioRepeatedSignalCleanup() {
   const running = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     asynchronous: true,
     environment: {
@@ -1752,7 +1789,7 @@ async function scenarioAliasCreationSignal() {
   const running = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     asynchronous: true,
     commandBinDirs: [shim.directory],
@@ -1782,7 +1819,7 @@ async function scenarioAliasCreationSignal() {
   const replacedRunning = runInstaller({
     installDir: replacedInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: replacedDataHome,
     asynchronous: true,
     commandBinDirs: [replacedShim.directory],
@@ -1825,7 +1862,7 @@ async function runSignalScenario(phase, signal, delivery) {
   const options = {
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     asynchronous: true,
     environment: {},
@@ -1883,7 +1920,7 @@ async function scenarioSignalDuringLockAcquisition() {
   const running = runInstaller({
     installDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome,
     asynchronous: true,
     commandBinDirs: [shim.directory],
@@ -1974,7 +2011,7 @@ async function scenarioSigkillLeavesActionableLocks() {
   const committed = runInstaller({
     installDir: committedInstallDir,
     platform: linuxX64(),
-    version: stableTag,
+    version: releaseTag,
     dataHome: committedDataHome,
     asynchronous: true,
     commandBinDirs: [committedShim.directory],
@@ -1991,7 +2028,7 @@ async function scenarioSigkillLeavesActionableLocks() {
   assertInstalled({
     installDir: committedInstallDir,
     dataHome: committedDataHome,
-    tag: stableTag,
+    tag: releaseTag,
     target: "linux-x64",
   });
   assert(existsSync(committedLock), "SIGKILL after commit leaves command lock");
@@ -2103,6 +2140,13 @@ function scenarioHelp() {
 
 function linuxX64() {
   return platforms.find(({ target }) => target === "linux-x64");
+}
+
+function stampInstaller(source, destination, tag) {
+  const marker = 'embedded_version=""';
+  const contents = readFileSync(source, "utf8");
+  assertEqual(contents.split(marker).length, 2, "installer has one version stamp marker");
+  writeText(destination, contents.replace(marker, `embedded_version="${tag}"`), 0o700);
 }
 
 function createRelease(tag, targets, options = {}) {
@@ -2346,31 +2390,6 @@ function writeFakeCommands() {
       "  esac",
       "done",
       'case "$endpoint" in',
-      '  "repos/jeremy0dell/station/releases/latest")',
-      '    [ "$paginate" -eq 0 ] && [ -z "$accept_header" ]',
-      '    [ "$jq_filter" = .tag_name ] || exit 2',
-      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != latest ] || exit 74`,
-      "    block_phase latest",
-      "    printf '%s\\n' \"$FAKE_LATEST_TAG\"",
-      "    ;;",
-      '  "repos/jeremy0dell/station/releases/tags/$FAKE_TAG")',
-      '    [ "$paginate" -eq 0 ] && [ -z "$accept_header" ]',
-      `    [ "\${FAKE_GH_FAIL_PHASE:-}" != release ] || exit 74`,
-      '    archive_filter=".assets[] | select(.name == \\"$FAKE_ARCHIVE\\") | .id"',
-      '    checksum_filter=".assets[] | select(.name == \\"SHA256SUMS\\") | .id"',
-      '    if [ "$jq_filter" = "$archive_filter" ]; then',
-      "      block_phase published-archive-asset",
-      `      count=\${FAKE_ARCHIVE_ASSET_COUNT:-1}`,
-      `      [ "\${FAKE_DUPLICATE_ARCHIVE:-0}" = 0 ] || count=2`,
-      '      case "$count" in 0) ;; 1) printf "1\\n" ;; 2) printf "1\\n3\\n" ;; *) exit 2 ;; esac',
-      '    elif [ "$jq_filter" = "$checksum_filter" ]; then',
-      "      block_phase published-checksum-asset",
-      `      count=\${FAKE_CHECKSUM_ASSET_COUNT:-1}`,
-      '      case "$count" in 0) ;; 1) printf "2\\n" ;; 2) printf "2\\n4\\n" ;; *) exit 2 ;; esac',
-      "    else",
-      "      exit 2",
-      "    fi",
-      "    ;;",
       '  "repos/jeremy0dell/station/releases/$FAKE_RELEASE_ID")',
       '    [ "$paginate" -eq 0 ]',
       '    [ "$accept_header" = "X-GitHub-Api-Version: 2022-11-28" ]',
@@ -2419,12 +2438,69 @@ function writeFakeCommands() {
       "",
     ].join("\n"),
   );
+  writeExecutable(
+    join(fakeBinDir, "curl"),
+    [
+      "#!/bin/sh",
+      "set -eu",
+      'printf \'%s\\n\' "$*" >> "$FAKE_CURL_LOG"',
+      "{",
+      "  printf 'CALL\\n'",
+      "  for argument do printf 'ARG=%s\\n' \"$argument\"; done",
+      "  printf 'END\\n'",
+      '} >> "$FAKE_CURL_ARGV_LOG"',
+      'chmod 600 "$FAKE_CURL_LOG" "$FAKE_CURL_ARGV_LOG"',
+      "block_phase() {",
+      "  phase=$1",
+      `  if [ "\${FAKE_GH_BLOCK_PHASE:-}" != "$phase" ]; then`,
+      `    if [ "$phase" != archive-download ] || [ "\${FAKE_GH_BLOCK_DOWNLOAD:-0}" != 1 ]; then return 0; fi`,
+      "  fi",
+      '  : > "$FAKE_BLOCK_MARKER"',
+      '  chmod 600 "$FAKE_BLOCK_MARKER"',
+      `  if [ -n "\${FAKE_BLOCK_PID_FILE:-}" ]; then printf "%s\\n" "$$" > "$FAKE_BLOCK_PID_FILE"; chmod 600 "$FAKE_BLOCK_PID_FILE"; fi`,
+      "  trap 'exit 129' HUP",
+      "  trap 'exit 130' INT",
+      "  trap 'exit 143' TERM",
+      '  while [ ! -e "$FAKE_BLOCK_RELEASE" ]; do /bin/sleep 0.02; done',
+      "}",
+      'url=""',
+      'while [ "$#" -gt 0 ]; do',
+      '  case "$1" in',
+      "    --fail|--silent|--show-error|--location|--tlsv1.2) shift ;;",
+      '    --proto|--proto-redir) [ "$#" -ge 2 ]; shift 2 ;;',
+      '    https://*) [ -z "$url" ]; url=$1; shift ;;',
+      "    *) exit 2 ;;",
+      "  esac",
+      "done",
+      'case "$url" in',
+      '  "https://github.com/jeremy0dell/station/releases/download/$FAKE_TAG/$FAKE_ARCHIVE")',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      archive-download) exit 74 ;;",
+      "      partial-archive) printf 'partial archive'; exit 74 ;;",
+      "    esac",
+      "    block_phase archive-download",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/$FAKE_ARCHIVE"',
+      "    ;;",
+      '  "https://github.com/jeremy0dell/station/releases/download/$FAKE_TAG/SHA256SUMS")',
+      `    case "\${FAKE_GH_FAIL_PHASE:-}" in`,
+      "      checksums-download) exit 74 ;;",
+      "      partial-checksums) printf 'partial checksum'; exit 74 ;;",
+      "    esac",
+      "    block_phase checksum-download",
+      '    cat "$FAKE_RELEASES/$FAKE_TAG/SHA256SUMS"',
+      "    ;;",
+      "  *) exit 2 ;;",
+      "esac",
+      "",
+    ].join("\n"),
+  );
 }
 
 function runInstaller({
   installDir,
   platform,
   version,
+  installerPath = selfInterruptChild ? installer : stampedInstaller,
   auth = true,
   duplicateArchiveAsset = false,
   includeInstallDirOnPath = false,
@@ -2445,7 +2521,7 @@ function runInstaller({
   extraArguments = [],
   argumentsOverride,
 }) {
-  const tag = version ?? stableTag;
+  const tag = version ?? releaseTag;
   const archive = `stn-${tag}-${platform.target}.tar.gz`;
   const commandPath = pathEntries ?? [...commandBinDirs, fakeBinDir, "/usr/bin", "/bin"];
   if (includeInstallDirOnPath) commandPath.push(absolutePath(installDir, cwd));
@@ -2457,6 +2533,8 @@ function runInstaller({
   }
   const ghLog = join(ghLogsDir, `${++invocationCount}.log`);
   const ghArgvLog = join(ghLogsDir, `${invocationCount}.argv.log`);
+  const curlLog = join(curlLogsDir, `${invocationCount}.log`);
+  const curlArgvLog = join(curlLogsDir, `${invocationCount}.argv.log`);
   const env = applyEnvironmentOverrides(
     {
       HOME: home,
@@ -2466,10 +2544,11 @@ function runInstaller({
       XDG_DATA_HOME: unsetXdgDataHome ? undefined : dataHome,
       FAKE_ARCHIVE: archive,
       FAKE_DUPLICATE_ARCHIVE: duplicateArchiveAsset ? "1" : "0",
+      FAKE_CURL_ARGV_LOG: curlArgvLog,
+      FAKE_CURL_LOG: curlLog,
       FAKE_GH_AUTH: auth ? "1" : "0",
       FAKE_GH_ARGV_LOG: ghArgvLog,
       FAKE_GH_LOG: ghLog,
-      FAKE_LATEST_TAG: stableTag,
       FAKE_RELEASE_ID: releaseId ?? "42",
       FAKE_RELEASE_DRAFT: releaseDraft ? "1" : "0",
       FAKE_RELEASE_ID_TAG: releaseIdTag ?? tag,
@@ -2481,7 +2560,7 @@ function runInstaller({
     environment,
   );
   if (releaseId !== undefined) env.STATION_INSTALL_RELEASE_ID = releaseId;
-  const invocation = buildShellInvocation(childShell, args, umask);
+  const invocation = buildShellInvocation(childShell, installerPath, args, umask);
   const options = { cwd, env };
 
   if (!asynchronous) {
@@ -2523,7 +2602,7 @@ function runInstaller({
       );
     }
     for (const path of [supervisorPidFile, stdoutFile, stderrFile]) rmSync(path, { force: true });
-    return { ...result, ghArgvLog, ghLog, stderr, stdout };
+    return { ...result, curlArgvLog, curlLog, ghArgvLog, ghLog, stderr, stdout };
   }
 
   const child = spawn(invocation.command, invocation.args, {
@@ -2531,10 +2610,16 @@ function runInstaller({
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
   });
-  return trackChild(child, { ghArgvLog, ghLog, label: `installer ${tag}` });
+  return trackChild(child, {
+    curlArgvLog,
+    curlLog,
+    ghArgvLog,
+    ghLog,
+    label: `installer ${tag}`,
+  });
 }
 
-function trackChild(child, { ghArgvLog, ghLog, label }) {
+function trackChild(child, { curlArgvLog, curlLog, ghArgvLog, ghLog, label }) {
   activeChildren.add(child);
   let stdout = "";
   let stderr = "";
@@ -2558,7 +2643,7 @@ function trackChild(child, { ghArgvLog, ghLog, label }) {
     dumpHarnessState(`${label} exceeded ${timeoutMs}ms`);
     signalProcessGroup(child, "SIGKILL");
   }, timeoutMs);
-  const running = { child, ghArgvLog, ghLog, label, settled: false };
+  const running = { child, curlArgvLog, curlLog, ghArgvLog, ghLog, label, settled: false };
   running.completion = new Promise((resolveCompletion) => {
     child.on("close", (status, signal) => {
       clearTimeout(timeout);
@@ -2570,6 +2655,8 @@ function trackChild(child, { ghArgvLog, ghLog, label }) {
         });
       }
       resolveCompletion({
+        curlArgvLog,
+        curlLog,
         error: spawnError,
         ghArgvLog,
         ghLog,
@@ -2600,9 +2687,9 @@ function remainingOverallTime() {
   return remaining;
 }
 
-function buildShellInvocation(childShell, installerArgs, umask) {
+function buildShellInvocation(childShell, installerPath, installerArgs, umask) {
   if (umask === undefined) {
-    return { command: childShell, args: [installer, ...installerArgs] };
+    return { command: childShell, args: [installerPath, ...installerArgs] };
   }
   return {
     command: childShell,
@@ -2612,7 +2699,7 @@ function buildShellInvocation(childShell, installerArgs, umask) {
       "station-install",
       umask,
       childShell,
-      installer,
+      installerPath,
       ...installerArgs,
     ],
   };
@@ -2855,7 +2942,39 @@ function makeNoChecksumBin() {
   ]) {
     symlinkSync(resolveCommand(command), join(directory, command));
   }
+  symlinkSync(join(fakeBinDir, "curl"), join(directory, "curl"));
   symlinkSync(join(fakeBinDir, "gh"), join(directory, "gh"));
+  symlinkSync(join(fakeBinDir, "uname"), join(directory, "uname"));
+  return directory;
+}
+
+function makePublicBin() {
+  const directory = join(root, "public-no-gh-bin");
+  makeDirectory(directory);
+  for (const command of [
+    "awk",
+    "cat",
+    "chmod",
+    "cp",
+    "grep",
+    "ln",
+    "ls",
+    "mkdir",
+    "mktemp",
+    "mv",
+    "paste",
+    "readlink",
+    "rm",
+    "rmdir",
+    "sleep",
+    "sort",
+    "tar",
+    "tr",
+    process.platform === "darwin" ? "shasum" : "sha256sum",
+  ]) {
+    symlinkSync(resolveCommand(command), join(directory, command));
+  }
+  symlinkSync(join(fakeBinDir, "curl"), join(directory, "curl"));
   symlinkSync(join(fakeBinDir, "uname"), join(directory, "uname"));
   return directory;
 }
@@ -3152,48 +3271,78 @@ function ghCalls(result) {
   return readFileSync(result.ghLog, "utf8").trimEnd().split("\n");
 }
 
+function curlCalls(result) {
+  if (!existsSync(result.curlLog)) return [];
+  return readFileSync(result.curlLog, "utf8").trimEnd().split("\n");
+}
+
+function curlInvocations(result) {
+  if (!result.curlArgvLog || !existsSync(result.curlArgvLog)) return [];
+  return parseInvocationLog(result.curlArgvLog, "curl");
+}
+
 function ghInvocations(result) {
   if (!result.ghArgvLog || !existsSync(result.ghArgvLog)) return [];
+  return parseInvocationLog(result.ghArgvLog, "gh");
+}
+
+function parseInvocationLog(path, command) {
   const invocations = [];
   let current;
-  for (const line of readFileSync(result.ghArgvLog, "utf8").trimEnd().split("\n")) {
+  for (const line of readFileSync(path, "utf8").trimEnd().split("\n")) {
     if (line === "CALL") {
-      assert(current === undefined, "fake gh argv log does not nest calls");
+      assert(current === undefined, `fake ${command} argv log does not nest calls`);
       current = [];
     } else if (line === "END") {
-      assert(current !== undefined, "fake gh argv log ends a call after CALL");
+      assert(current !== undefined, `fake ${command} argv log ends a call after CALL`);
       invocations.push(current);
       current = undefined;
     } else if (line.startsWith("ARG=")) {
-      assert(current !== undefined, "fake gh argv log records arguments inside a call");
+      assert(current !== undefined, `fake ${command} argv log records arguments inside a call`);
       current.push(line.slice(4));
     } else if (line !== "") {
-      throw new Error(`unexpected fake gh argv log line: ${line}`);
+      throw new Error(`unexpected fake ${command} argv log line: ${line}`);
     }
   }
-  assert(current === undefined, "fake gh argv log closes every call");
+  assert(current === undefined, `fake ${command} argv log closes every call`);
   return invocations;
 }
 
-function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
+function assertStrictPublicFlow(result, { tag, target }) {
+  const baseUrl = "https://github.com/jeremy0dell/station/releases";
+  const archiveName = `stn-${tag}-${target}.tar.gz`;
+  const common = [
+    "--fail",
+    "--silent",
+    "--show-error",
+    "--location",
+    "--proto",
+    "=https",
+    "--proto-redir",
+    "=https",
+    "--tlsv1.2",
+  ];
+  assertEqual(
+    curlInvocations(result),
+    [
+      [...common, `${baseUrl}/download/${tag}/${archiveName}`],
+      [...common, `${baseUrl}/download/${tag}/SHA256SUMS`],
+    ],
+    `${tag} strict public curl argv flow`,
+  );
+  assertEqual(ghInvocations(result), [], `${tag} public flow makes no gh calls`);
+}
+
+function assertStrictGhFlow(result, { draftId, tag, target }) {
   const repository = "repos/jeremy0dell/station";
   const archiveName = `stn-${tag}-${target}.tar.gz`;
-  const tagEndpoint = `${repository}/releases/tags/${tag}`;
-  const archiveFilter = `.assets[] | select(.name == "${archiveName}") | .id`;
-  const checksumFilter = '.assets[] | select(.name == "SHA256SUMS") | .id';
   const expected = [["auth", "status", "--hostname", "github.com"]];
-  if (latest) expected.push(["api", `${repository}/releases/latest`, "--jq", ".tag_name"]);
-  if (draftId === undefined) {
-    expected.push(["api", tagEndpoint, "--jq", archiveFilter]);
-    expected.push(["api", tagEndpoint, "--jq", checksumFilter]);
-  } else {
-    const endpoint = `${repository}/releases/${draftId}`;
-    const match = `select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
-    const prefix = ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--jq"];
-    expected.push([...prefix, `${match} | .id`]);
-    expected.push([...prefix, `${match} | .assets[] | select(.name == "${archiveName}") | .id`]);
-    expected.push([...prefix, `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`]);
-  }
+  const endpoint = `${repository}/releases/${draftId}`;
+  const match = `select(.draft == true and .id == ${draftId} and .tag_name == "${tag}")`;
+  const prefix = ["api", "-H", "X-GitHub-Api-Version: 2022-11-28", endpoint, "--jq"];
+  expected.push([...prefix, `${match} | .id`]);
+  expected.push([...prefix, `${match} | .assets[] | select(.name == "${archiveName}") | .id`]);
+  expected.push([...prefix, `${match} | .assets[] | select(.name == "SHA256SUMS") | .id`]);
   expected.push([
     "api",
     "-H",
@@ -3207,6 +3356,7 @@ function assertStrictGhFlow(result, { draftId, latest = false, tag, target }) {
     `${repository}/releases/assets/2`,
   ]);
   assertEqual(ghInvocations(result), expected, `${tag} strict gh argv flow`);
+  assertEqual(curlInvocations(result), [], `${tag} draft flow makes no curl calls`);
 }
 
 function assertNoGhApiCalls(result, label) {
@@ -3215,6 +3365,7 @@ function assertNoGhApiCalls(result, label) {
     [],
     `${label} release API calls`,
   );
+  assertEqual(curlCalls(result), [], `${label} public release requests`);
 }
 
 function spawnChecked(command, args, label) {

--- a/scripts/test-runners/run-install-smoke.mjs
+++ b/scripts/test-runners/run-install-smoke.mjs
@@ -2956,6 +2956,7 @@ function makePublicBin() {
     "cat",
     "chmod",
     "cp",
+    "gzip",
     "grep",
     "ln",
     "ls",

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -62,27 +62,21 @@ describe("release readiness docs", () => {
       expect(document.replace(/\s+/g, " ").toLowerCase()).toContain(
         "let your agent install and validate station",
       );
-      expect(prompt).toContain("gh auth status --hostname github.com");
-      expect(prompt).toContain("gh repo view jeremy0dell/station");
-      expect(prompt).toContain("docs/install.md");
-      expect(prompt).toContain("stn setup plan --json");
+      expect(prompt).toContain(
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh",
+      );
+      expect(prompt).toContain("v0.0.0-pre-alpha.1");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
       expect(normalizedPrompt).toContain("do not clone the repository or build from source");
       expect(normalizedPrompt).toContain("do not edit any shell startup file");
-      expect(normalizedPrompt).toContain("scoped host/keychain access");
-      expect(normalizedPrompt).toContain("same access context");
-      expect(normalizedPrompt).toContain(
-        "retry both checks with scoped host/keychain access before asking me to authenticate",
-      );
-      expect(normalizedPrompt).toContain(
-        "if scoped host access is unavailable, ask me to run the auth checks and exact tagged temporary-file installer block from the page that supplied this prompt in my terminal",
-      );
-      expect(prompt).not.toContain("gh auth login");
-      expect(normalizedPrompt).toContain(
-        "never ask me to paste, extract, print, request, or export a github token",
-      );
+      expect(normalizedPrompt).not.toContain("github token");
+      expect(normalizedPrompt).not.toContain("gh auth");
+      expect(normalizedPrompt).not.toContain("latest");
+      expect(normalizedPrompt).not.toContain("homebrew");
+      expect(normalizedPrompt).not.toContain("ref=main");
+      expect(normalizedPrompt).not.toContain("/main/");
       expect(normalizedPrompt).toContain("absolute installed `stn` path");
       expect(normalizedPrompt).toContain(
         "only as evidence about the current agent execution context",
@@ -121,142 +115,138 @@ describe("release readiness docs", () => {
     expect(packageManifest.engines.node).toBe(">=24.2 <25");
   });
 
-  it("documents the authenticated private binary release contract", async () => {
-    const [readme, install, development, singleBinary, homebrew, release, promote] =
-      await Promise.all(
-        [
-          "README.md",
-          "docs/install.md",
-          "docs/development.md",
-          "docs/single-binary.md",
-          "docs/homebrew.md",
-          ".github/workflows/release.yml",
-          ".github/workflows/promote-release.yml",
-        ].map(read),
-      );
+  it("documents and enforces the public exact-tag binary release contract", async () => {
+    const [
+      readme,
+      install,
+      docsIndex,
+      limitations,
+      development,
+      singleBinary,
+      homebrew,
+      release,
+      promote,
+      installer,
+      installSmoke,
+    ] = await Promise.all(
+      [
+        "README.md",
+        "docs/install.md",
+        "docs/index.md",
+        "docs/limitations.md",
+        "docs/development.md",
+        "docs/single-binary.md",
+        "docs/homebrew.md",
+        ".github/workflows/release.yml",
+        ".github/workflows/promote-release.yml",
+        "scripts/install.sh",
+        "scripts/test-runners/run-install-smoke.mjs",
+      ].map(read),
+    );
     const packageJson = await readPackageManifest();
+    const exactVersion = "v0.0.0-pre-alpha.1";
+    const exactInstallerUrl =
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.1/install.sh";
 
-    expect(readme).toContain("authenticated GitHub release assets");
-    expect(readme).toContain("does not require Node.js, pnpm, Bun");
-    expect(install.replace(/\s+/g, " ")).toContain("latest stable tag");
-    expect(install).toContain("tag=v0.7.1-rc.8");
     for (const [path, document] of [
       ["README.md", readme],
       ["docs/install.md", install],
+      ["docs/index.md", docsIndex],
+      ["docs/limitations.md", limitations],
     ] as const) {
+      const normalized = document.replace(/\s+/g, " ");
+      expect(normalized, path).toMatch(/experimental pre-alpha/i);
+      expect(document, path).toContain(exactVersion);
+      expect(document, path).toContain("GitHub Issues");
+      expect(document, path).toContain("stn setup");
+      expect(document, path).toContain("stn setup check --json");
+      expect(document, path).toContain("stn doctor");
+      expect(document, path).toMatch(/macOS 13(?:\.0)?(?:\+| or newer)/);
+      expect(document, path).toContain("glibc 2.39");
+      expect(document, path).not.toContain("/releases/latest");
       expect(document, path).not.toContain("ref=main");
-      expect(document, path).not.toContain("gh auth token");
-      expect(document, path).not.toContain("Authorization: Bearer");
-      expect(document, path).not.toContain("curl");
-      const recipes = shellBlocks(document).filter((block) =>
-        block.includes("repos/jeremy0dell/station/contents/scripts/install.sh"),
-      );
-      expect(recipes, path).toHaveLength(1);
-      for (const recipe of recipes) {
-        expect(recipe, path).not.toContain("cd /path/to/your/git-project");
-        expect(recipe, path).toContain("umask 077");
-        expect(recipe, path).toContain("export GH_HOST=github.com");
-        expect(recipe, path).toContain("releases/latest");
-        expect(recipe.indexOf("export GH_HOST=github.com"), path).toBeLessThan(
-          recipe.indexOf("gh api --method GET"),
-        );
-        expect(recipe, path).toContain('installer="$(mktemp)"');
-        expect(recipe, path).toContain("trap 'rm -f \"$installer\"' EXIT");
-        expect(recipe, path).toContain('test -s "$installer"');
-        expect(recipe, path).toContain('sh -n "$installer"');
-        expect(recipe, path).toContain('sh "$installer" --version "$tag"');
+      expect(document, path).not.toMatch(/gh auth (?:login|status)/);
+      expect(document, path).not.toMatch(/^\s*brew install[^\n]*station/im);
+    }
 
-        const installerFetches = continuedShellCommands(recipe).filter((command) =>
-          command.includes("contents/scripts/install.sh"),
-        );
-        expect(installerFetches, path).toHaveLength(1);
-        const command = installerFetches[0] ?? "";
-        expect(command, path).toContain("gh api --method GET");
-        expect(command, path).toContain("Accept: application/vnd.github.raw+json");
-        expect(command, path).toContain('-f ref="$tag"');
-        expect(command, path).toContain(
-          'repos/jeremy0dell/station/contents/scripts/install.sh > "$installer"',
-        );
-        expect(command, path).not.toMatch(/\|\s*(?:\/bin\/)?sh\b/);
-      }
-    }
-    expect(install).toContain(
-      'tag="$(GH_HOST=github.com gh api repos/jeremy0dell/station/releases/latest',
+    expect(readme).toContain(exactInstallerUrl);
+    expect(readme.indexOf(exactInstallerUrl)).toBeLessThan(readme.indexOf("## Why Station"));
+    expect(readme).toContain("[installation guide](docs/install.md)");
+    expect(install).toContain(exactInstallerUrl);
+    expect(install).toContain("does not require a GitHub account");
+    expect(install.replace(/\s+/g, " ")).toContain(
+      "The old `v0.7.1-rc.*` releases were internal previews",
     );
-    expect(install.replace(/\s+/g, " ")).toContain("installer code and artifacts");
-    expect(install).toContain("SHA256SUMS");
-    expect(install).toContain("stn-tmux-popup");
-    for (const target of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]) {
-      expect(singleBinary).toContain(target);
-    }
-    expect(singleBinary).toContain("**Status: implemented.**");
     expect(singleBinary).toContain("release **draft**");
-    expect(singleBinary).toContain("GitHub immutable");
+    expect(singleBinary).toContain("six assets");
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
-    expect(singleBinary).toContain("without `+` build metadata");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.7.1-rc.8");
-    const acceptanceRecipes = shellBlocks(development).filter((block) =>
-      block.includes('STATION_INSTALL_RELEASE_ID="$release_id"'),
-    );
-    expect(acceptanceRecipes).toHaveLength(1);
-    const acceptanceRecipe = acceptanceRecipes[0] ?? "";
-    expect(acceptanceRecipe).toContain("export GH_HOST=github.com");
-    expect(acceptanceRecipe).toContain("release_run_id=123456789");
-    expect(acceptanceRecipe).toContain("--json workflowName --jq '.workflowName'");
-    expect(acceptanceRecipe).toContain("accepted-release-candidate-$version-attempt-$run_attempt");
-    expect(acceptanceRecipe).toContain("manifest_field workflowRunId");
-    expect(acceptanceRecipe).toContain("manifest_field workflowRunAttempt");
-    expect(acceptanceRecipe).toContain('commit="$(manifest_field commit)"');
-    expect(acceptanceRecipe).toContain('release_id="$(manifest_field releaseId)"');
-    expect(acceptanceRecipe).toContain(
-      'test "$(gh api "repos/jeremy0dell/station/commits/$tag" --jq \'.sha\')" = "$commit"',
-    );
-    expect(acceptanceRecipe).toContain('-f ref="$commit"');
-    expect(acceptanceRecipe).not.toContain(
-      'commit="$(gh api "repos/jeremy0dell/station/commits/$tag"',
-    );
-    expect(release).toContain('-f ref="$COMMIT"');
-    expect(release).toContain("persist-credentials: false");
-    const validateRelease = release.slice(
-      release.indexOf("      - name: Validate release tag"),
-      release.indexOf("\n  standard-ci:"),
-    );
-    expect(validateRelease).toMatch(/GH_TOKEN: \$\{\{ github\.token \}\}/);
-    expect(validateRelease).toContain("compare/$GITHUB_SHA...main");
-    expect(validateRelease).toContain("ahead|identical");
-    expect(validateRelease).not.toContain("git fetch --no-tags origin");
-    const createDraftStart = release.indexOf("      - name: Create draft release");
-    const createDraft = release.slice(
-      createDraftStart,
-      release.indexOf("      - uses: actions/upload-artifact@v4", createDraftStart),
-    );
-    expect(createDraft).toContain("for _ in {1..12}");
-    expect(createDraft).toContain('gh release view "$TAG" --json databaseId,isDraft');
-    expect(createDraft).toContain("'select(.isDraft == true) | .databaseId'");
-    expect(createDraft).toContain('[[ "$release_id" =~ ^[0-9]+$ ]] && break');
-    expect(createDraft).not.toContain("releases?per_page=100");
-    expect(createDraft).toContain('--argjson releaseId "$release_id"');
+    expect(development).toContain("accepted-release-candidate-0.0.0-pre-alpha.1");
+    expect(development).toContain("v0.7.1-rc.8");
+    expect(homebrew).toContain("Homebrew installation is not currently supported");
+    expect(homebrew).not.toMatch(/^\s*brew install[^\n]*station/im);
+
+    expect(installer).toContain('embedded_version=""');
+    expect(installer).toContain("releases/download/$tag");
+    expect(installer).toContain("run_curl");
+    expect(installer).toContain("STATION_INSTALL_RELEASE_ID");
+    expect(installer).not.toContain("releases/latest");
+    expect(installer).not.toContain("contents/scripts/install.sh");
+    expect(installSmoke).toContain('const releaseTag = "v0.0.0-pre-alpha.1"');
+    expect(installSmoke).toContain('const rollbackTag = "v0.7.1-rc.8"');
+    expect(installSmoke).toContain("makePublicBin()");
+    expect(installSmoke).toContain("assertStrictPublicFlow");
+    expect(installSmoke).toContain("strict stamped public flow without gh");
+    expect(installSmoke).toContain("STATION_INSTALL_RELEASE_ID");
+
+    expect(release).toContain("Stamp release installer");
+    expect(release).toContain(['embedded_version=\\"$', 'TAG\\"'].join(""));
+    expect(release).toContain(['for asset in "$', '{expected[@]}" install.sh'].join(""));
+    expect(release).toContain("install.sh");
+    expect(release).toContain("SHA256SUMS");
     expect(release).toContain("accepted-release-candidate-");
+    expect(release).not.toContain("render-installer");
+    const createDraft = release.slice(
+      release.indexOf("      - name: Create draft release"),
+      release.indexOf("\n  install-draft:"),
+    );
+    for (const asset of [
+      "stn-v$VERSION-darwin-arm64.tar.gz",
+      "stn-v$VERSION-darwin-x64.tar.gz",
+      "stn-v$VERSION-linux-arm64.tar.gz",
+      "stn-v$VERSION-linux-x64.tar.gz",
+      "install.sh",
+      "SHA256SUMS",
+    ]) {
+      expect(createDraft).toContain(asset);
+    }
     const installDraft = release.slice(
       release.indexOf("  install-draft:"),
       release.indexOf("  record-accepted-candidate:"),
     );
+    expect(installDraft).toContain("releases/assets/$installer_asset_id");
+    expect(installDraft).toContain('grep -Fx "embedded_version=\\"$TAG\\""');
+    expect(installDraft).toContain("STATION_INSTALL_RELEASE_ID");
+    expect(installDraft).not.toContain('--version "$TAG"');
+    expect(installDraft).toContain("0.7.1-rc.8");
     const recordCandidate = release.slice(release.indexOf("  record-accepted-candidate:"));
-    for (const job of [installDraft, recordCandidate]) {
-      expect(job).toContain("contents: write");
-      expect(job).not.toContain("contents: read");
+    expect(recordCandidate).toContain("asset-ids.txt");
+    expect(recordCandidate).toContain("releaseId");
+
+    expect(promote).toContain("verify-public-install:");
+    expect(promote).toContain("Download exact-tag public installer");
+    expect(promote).toContain("Install without GitHub credentials or gh");
+    expect(promote).toContain("releases/download/$TAG/install.sh");
+    expect(promote).toContain('test ! -e "$public_path/gh"');
+    expect(promote).toContain("env -u GH_TOKEN -u GITHUB_TOKEN");
+    expect(promote).toContain("install.sh");
+    for (const target of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"]) {
+      expect(release).toContain(target);
+      expect(promote).toContain(target);
+      expect(singleBinary).toContain(target);
     }
-    expect(promote).toContain("workflow_dispatch");
-    expect(promote).toContain("manual_acceptance");
-    expect(promote).toContain("asset-ids.txt");
-    expect(promote).toContain("actions/workflows/$workflow_id");
-    expect(promote).toContain("compare/$commit...main");
-    expect(promote).toContain('prerelease="$expected_prerelease"');
-    expect(packageJson.version).toBe("0.7.1-rc.8");
-    expect(development).toContain("HOST_UPGRADE_BLOCKED");
-    expect(homebrew).toContain("`workflow_dispatch` only");
-    expect(homebrew).toContain("`COMMITTER_TOKEN` remains intentionally unconfigured");
+
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.1");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );
@@ -276,7 +266,8 @@ describe("release readiness docs", () => {
       expect(document, path).toContain("<install-dir>/.station-install.lock/owner-*");
       expect(document, path).toContain("<data-home>/station/.station-install.lock");
       expect(document, path).toContain("<data-home>/station/.station-install.lock/owner-*");
-      expect(normalized, path).toContain("requested tag or `latest`");
+      expect(normalized, path).toContain("requested tag");
+      expect(normalized, path).not.toContain("requested tag or `latest`");
       expect(document, path).toContain("token");
       expect(document, path).toMatch(/10(?:-second| seconds)/);
       expect(document, path).toMatch(/existing\s+Station\s+installation\s+was\s+unchanged/);
@@ -306,7 +297,7 @@ describe("release readiness docs", () => {
       "stn-ingress",
       "HOST_UPGRADE_BLOCKED",
       "same Observer socket",
-      "prior published binary",
+      "internal preview",
     ]) {
       expect(normalizedDevelopment).toContain(acceptance);
     }
@@ -343,7 +334,7 @@ describe("release readiness docs", () => {
     expect(install).toContain("~/.config/station/config.toml");
     expect(install).toContain("PATH uses `:` to separate entries");
     expect(install).toMatch(
-      /before GitHub requests[^.]*temporary-directory creation[^.]*destination mutation/,
+      /before network requests[^.]*temporary-directory creation[^.]*destination mutation/,
     );
 
     expect(quickStart).not.toContain(removedPersistenceOption);
@@ -415,18 +406,6 @@ function virtualBuddyCleanMacSection(document: string): string {
   const end = document.indexOf("\nFor each target", start);
   if (start < 0 || end <= start) throw new Error("VirtualBuddy clean-mac section is missing");
   return document.slice(start, end);
-}
-
-function continuedShellCommands(document: string): string[] {
-  return document
-    .replace(/\\\r?\n\s*/g, " ")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => /^(?:[A-Z_]+=[^ ]+\s+)*(?:curl|gh)\s/.test(line));
-}
-
-function shellBlocks(document: string): string[] {
-  return [...document.matchAll(/```(?:sh|bash)\r?\n([\s\S]*?)```/g)].map((match) => match[1] ?? "");
 }
 
 async function markdownFiles(root: string): Promise<string[]> {

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -234,12 +234,12 @@ describe("observer lifecycle e2e", () => {
     }
   });
 
-  it("replaces a lower build only after its process and socket have closed", async () => {
+  it("replaces an internal preview only after its process and socket have closed", async () => {
     const fixture = await createTempState();
     const incumbent = await startIncumbentFixture({
       stateDir: fixture.stateDir,
       socketPath: fixture.socketPath,
-      version: "0.6.0",
+      version: "0.7.1-rc.8",
       stopDelayMs: 400,
     });
     const config = observerConfig(fixture.stateDir, fixture.socketPath);
@@ -384,12 +384,12 @@ describe("observer lifecycle e2e", () => {
     }
   });
 
-  it("refuses a wedged lower build without automatic SIGKILL", async () => {
+  it("refuses a wedged internal preview without automatic SIGKILL", async () => {
     const fixture = await createTempState();
     const incumbent = await startIncumbentFixture({
       stateDir: fixture.stateDir,
       socketPath: fixture.socketPath,
-      version: "0.6.0",
+      version: "0.7.1-rc.8",
       mode: "wedged",
     });
 
@@ -405,13 +405,13 @@ describe("observer lifecycle e2e", () => {
       expect(processIsAlive(incumbent.child.pid)).toBe(true);
       await expect(incumbent.client.health()).resolves.toMatchObject({
         pid: incumbent.child.pid,
-        version: "0.6.0",
+        version: "0.7.1-rc.8",
       });
       expect(
         ObserverProcessIdentitySchema.parse(
           JSON.parse(await readFile(`${fixture.socketPath}.pid`, "utf8")),
         ),
-      ).toMatchObject({ pid: incumbent.child.pid, version: "0.6.0" });
+      ).toMatchObject({ pid: incumbent.child.pid, version: "0.7.1-rc.8" });
     } finally {
       await terminateFixture(incumbent.child);
       await waitForSocketClosed(fixture.socketPath).catch(() => undefined);
@@ -423,8 +423,8 @@ describe("observer lifecycle e2e", () => {
     const incumbent = await startIncumbentFixture({
       stateDir: fixture.stateDir,
       socketPath: fixture.socketPath,
-      version: "0.6.0",
-      pidfileVersion: "0.5.0",
+      version: "0.7.1-rc.8",
+      pidfileVersion: "0.7.1-rc.7",
     });
 
     try {


### PR DESCRIPTION
## What this fixes

Station's public native installer was source-fetched, authentication-dependent, and not self-versioned, so the documented one-command install could not consume one immutable published release asset without extra arguments. The public version and onboarding docs also still described internal preview packaging as the supported release line.

## What changed

- stamps the exact tag into the released `install.sh`, publishes six assets, and binds the installer plus all four archives into `SHA256SUMS`
- uses unauthenticated `curl` only for the exact public tag's archive and checksum file while preserving release-ID-bound, authenticated draft acceptance
- installs the actual stamped draft asset on all four native targets, then repeats the exact public URL install without credentials or a `gh` executable after promotion
- resets the product version to `0.0.0-pre-alpha.1` and narrowly orders that public line after the internal `0.7.1-rc.*` Observer previews during handoff
- puts the one-command exact-tag install at the top of the README and aligns public docs on pre-alpha status, platform floors, setup verification, GitHub Issues, and unsupported Homebrew

## Testing

- `git diff --check`
- `/bin/sh -n scripts/install.sh`
- `pnpm smoke:install`
- `pnpm exec vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/release-readiness-docs.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm smoke:release`
- `pnpm test:pre-push`

## Safety and scope

The installer's existing checksum, archive-manifest, lock, interruption, atomic activation, launcher, and PATH guarantees remain in place. This adds no `latest` behavior or Homebrew distribution and does not touch the Homebrew tap.