### PR TITLE
fix(observer): publish provider health probe results

### DIFF
--- a/apps/observer/src/persistence/observations.ts
+++ b/apps/observer/src/persistence/observations.ts
@@ -17,7 +17,6 @@ import type {
 type InsertProviderObservationInput = RecordProviderObservationInput & {
   id: string;
   observedAt: string;
-  coalesceUnchanged?: boolean;
 };
 
 export function insertProviderObservation(

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -120,6 +120,8 @@ type RecordProviderObservationFields = {
   entityKey: string;
   observedAt?: string;
   expiresAt?: string | undefined;
+  /** Refresh the latest row when only top-level observation timestamps or latency changed. */
+  coalesceUnchanged?: boolean;
 };
 
 export type RecordProviderObservationInput = RecordProviderObservationFields & ProviderObservation;

--- a/apps/observer/src/providers/healthCache.ts
+++ b/apps/observer/src/providers/healthCache.ts
@@ -19,6 +19,8 @@ export type ProviderHealthCacheOptions = ProviderHealthCacheTuning & {
   targets: readonly ProviderHealthProbeTarget[];
 };
 
+export type ProviderHealthProbeCompletedListener = (health: ProviderHealth) => Promise<void> | void;
+
 type CacheEntry = {
   health: ProviderHealth;
   refreshedAtMs: number;
@@ -26,8 +28,8 @@ type CacheEntry = {
 
 /**
  * Out-of-band provider health cache: reconcile reads synchronously and never
- * awaits a health probe. Probes run at boot, on TTL expiry
- * (stale-while-revalidate), and eagerly after a provider read failure.
+ * awaits a health probe. Each unique probe notifies completion listeners before
+ * its in-flight slot clears, including boot, stale, and eager refreshes.
  * `stn doctor` keeps probing providers live, bypassing this cache.
  */
 export class ProviderHealthCache {
@@ -37,6 +39,7 @@ export class ProviderHealthCache {
   readonly #clock: RuntimeClock;
   readonly #entries = new Map<string, CacheEntry>();
   readonly #inFlight = new Map<string, Promise<void>>();
+  readonly #probeCompletedListeners = new Set<ProviderHealthProbeCompletedListener>();
 
   constructor(options: ProviderHealthCacheOptions) {
     this.#targets = new Map(options.targets.map((target) => [target.providerId, target]));
@@ -69,6 +72,13 @@ export class ProviderHealthCache {
     });
     this.#inFlight.set(providerId, probe);
     return probe;
+  }
+
+  onProbeCompleted(listener: ProviderHealthProbeCompletedListener): () => void {
+    this.#probeCompletedListeners.add(listener);
+    return () => {
+      this.#probeCompletedListeners.delete(listener);
+    };
   }
 
   async refreshAll(): Promise<void> {
@@ -112,6 +122,10 @@ export class ProviderHealthCache {
           capabilities: target.capabilities(),
         };
     this.#entries.set(target.providerId, { health, refreshedAtMs: this.#nowMs() });
+    const notifications = Array.from(this.#probeCompletedListeners, (listener) =>
+      Promise.resolve().then(() => listener(health)),
+    );
+    await Promise.allSettled(notifications);
   }
 
   #nowMs(): number {

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -22,10 +22,14 @@ import type {
   SessionStore,
   WorktreeMetadataStore,
 } from "../persistence/index.js";
-import { providerObservationRetentionDays } from "../persistence/retention.js";
+import {
+  providerObservationExpiresAt,
+  providerObservationRetentionDays,
+} from "../persistence/retention.js";
 import type { PersistedSessionTurnReadiness } from "../persistence/types.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { StationLogger } from "../stationLogger.js";
+import { projectProviderHealthOntoSnapshot } from "./graph.js";
 import {
   buildInitialSnapshot,
   harnessesFromRegistry,
@@ -59,6 +63,7 @@ export type ObserverCoreHealth = {
 
 export type ObserverCore = {
   reconcile(reason?: string): Promise<StationSnapshot>;
+  commitProviderHealthProbe(health: ProviderHealth): Promise<StationEvent | undefined>;
   projectHarnessEventStatus(report: HarnessEventReport): Promise<StatusProjectionResult>;
   clearTurnReadiness(input: { sessionId: string; token: string }): StationEvent | undefined;
   updateConfig(config: StationConfig): void;
@@ -147,6 +152,45 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
 
       return enqueueSnapshotWrite(run);
     },
+    commitProviderHealthProbe: (health) =>
+      enqueueSnapshotWrite(async (): Promise<StationEvent | undefined> => {
+        const current = providerHealth[health.providerId];
+        if (
+          current !== undefined &&
+          Date.parse(current.lastCheckedAt) > Date.parse(health.lastCheckedAt)
+        ) {
+          return undefined;
+        }
+        const event: StationEvent = {
+          type: "provider.healthChanged",
+          provider: health.providerId,
+          health,
+        };
+        // A reconcile can consume this exact cache object while its completion
+        // callback waits on the snapshot writer; it already persisted and projected it.
+        if (current === health) {
+          return event;
+        }
+        if (input.persistence !== undefined) {
+          const retentionDays = providerObservationRetentionDays(config.observability?.retention);
+          await input.persistence.recordProviderObservation({
+            provider: health.providerId,
+            providerType: "observer",
+            entityKind: "provider_health",
+            entityKey: health.providerId,
+            payload: health,
+            observedAt: health.lastCheckedAt,
+            expiresAt: providerObservationExpiresAt(health.lastCheckedAt, retentionDays),
+          });
+        }
+        snapshot = projectProviderHealthOntoSnapshot({
+          snapshot,
+          health,
+          projectedAt: toIsoTimestamp(clock.now()),
+        });
+        providerHealth = snapshot.providerHealth;
+        return event;
+      }),
     projectHarnessEventStatus: async (report) => {
       const result = await enqueueSnapshotWrite(async (): Promise<StatusProjectionResult> => {
         const sessionId = report.correlation?.sessionId;

--- a/apps/observer/src/reconcile/core.ts
+++ b/apps/observer/src/reconcile/core.ts
@@ -181,6 +181,7 @@ export function createObserverCore(input: CreateObserverCoreInput): ObserverCore
             payload: health,
             observedAt: health.lastCheckedAt,
             expiresAt: providerObservationExpiresAt(health.lastCheckedAt, retentionDays),
+            coalesceUnchanged: true,
           });
         }
         snapshot = projectProviderHealthOntoSnapshot({

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -216,6 +216,44 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
   return snapshot;
 }
 
+export function projectProviderHealthOntoSnapshot(input: {
+  snapshot: StationSnapshot;
+  health: ProviderHealth;
+  projectedAt: string;
+}): StationSnapshot {
+  const providerHealth: Record<string, ProviderHealth> = {
+    ...input.snapshot.providerHealth,
+    [input.health.providerId]: input.health,
+  };
+  const providerAlertIds = new Set([
+    providerHealthAlertId(input.health.providerId, "degraded"),
+    providerHealthAlertId(input.health.providerId, "unavailable"),
+  ]);
+  const alerts = [
+    ...input.snapshot.alerts.filter((alert) => !providerAlertIds.has(alert.id)),
+    ...alertsFromProviderHealth({ [input.health.providerId]: input.health }, input.projectedAt),
+  ];
+  const healthy =
+    !alerts.some((alert) => alert.severity === "error") &&
+    Object.values(providerHealth).every((health) => health.status !== "unavailable");
+
+  return {
+    ...input.snapshot,
+    generatedAt: input.projectedAt,
+    observer: {
+      ...input.snapshot.observer,
+      healthy,
+    },
+    providerHealth,
+    projects: input.snapshot.projects.map((project) =>
+      project.health.providerId === input.health.providerId
+        ? { ...project, health: input.health }
+        : project,
+    ),
+    alerts,
+  };
+}
+
 type BuildWorktreeRowInput = {
   project: ProviderProjectConfig;
   worktree: WorktreeObservation;
@@ -785,7 +823,7 @@ function alertsFromProviderHealth(
     .filter((health) => health.status === "unavailable" || health.status === "degraded")
     .map((health) => {
       const alert: StationAlert = {
-        id: `alert_${health.providerId}_${health.status}`,
+        id: providerHealthAlertId(health.providerId, health.status),
         severity: health.status === "unavailable" ? "error" : "warn",
         message:
           health.lastError?.message ??
@@ -798,6 +836,10 @@ function alertsFromProviderHealth(
       }
       return alert;
     });
+}
+
+function providerHealthAlertId(providerId: string, status: ProviderHealth["status"]): string {
+  return `alert_${providerId}_${status}`;
 }
 
 function orphans(

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -12,6 +12,7 @@ import type {
   ObserverApi,
   ObserverHealth,
   ObserverStopReceipt,
+  ProviderHealth,
   ProviderHookEvent,
   ProviderHookReceipt,
   ReconcileReceipt,
@@ -110,25 +111,28 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
   const providerHealthCache = options.providers?.healthCache;
   const pendingProviderHealthPublications = new Set<Promise<void>>();
   let acceptingProviderHealthPublications = true;
+
+  const publishProviderHealthProbe = async (health: ProviderHealth): Promise<void> => {
+    try {
+      const event = await options.core.commitProviderHealthProbe(health);
+      if (event !== undefined) {
+        options.eventBus.publish(event);
+      }
+    } catch (error) {
+      await options.logger
+        ?.error("Completed provider health probe could not be published.", {
+          provider: health.providerId,
+          error,
+        })
+        .catch(() => undefined);
+    }
+  };
+
   const unsubscribeProviderHealth = providerHealthCache?.onProbeCompleted((health) => {
     if (!acceptingProviderHealthPublications) {
       return;
     }
-    const publication = options.core
-      .commitProviderHealthProbe(health)
-      .then((event) => {
-        if (event !== undefined) {
-          options.eventBus.publish(event);
-        }
-      })
-      .catch(async (error) => {
-        await options.logger
-          ?.error("Completed provider health probe could not be published.", {
-            provider: health.providerId,
-            error,
-          })
-          .catch(() => undefined);
-      });
+    const publication = publishProviderHealthProbe(health);
     pendingProviderHealthPublications.add(publication);
     void publication.finally(() => pendingProviderHealthPublications.delete(publication));
     return publication;

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -101,12 +101,43 @@ export type CreateObserverApiOptions = {
 /**
  * COMPOSITION ROOT
  *
- * Wires Observer use cases, durable adapters, ingress workers, scheduling, and
- * exact build publication behind the application API.
+ * Wires Observer use cases, durable adapters, ingress workers, provider-health
+ * publication lifecycle, scheduling, and exact build publication behind the application API.
  */
 export function createObserverApi(options: CreateObserverApiOptions): ObserverApi {
   const clock = options.clock ?? systemClock;
   const reconciling = { reconciling: false };
+  const providerHealthCache = options.providers?.healthCache;
+  const pendingProviderHealthPublications = new Set<Promise<void>>();
+  let acceptingProviderHealthPublications = true;
+  const unsubscribeProviderHealth = providerHealthCache?.onProbeCompleted((health) => {
+    if (!acceptingProviderHealthPublications) {
+      return;
+    }
+    const publication = options.core
+      .commitProviderHealthProbe(health)
+      .then((event) => {
+        if (event !== undefined) {
+          options.eventBus.publish(event);
+        }
+      })
+      .catch(async (error) => {
+        await options.logger
+          ?.error("Completed provider health probe could not be published.", {
+            provider: health.providerId,
+            error,
+          })
+          .catch(() => undefined);
+      });
+    pendingProviderHealthPublications.add(publication);
+    void publication.finally(() => pendingProviderHealthPublications.delete(publication));
+    return publication;
+  });
+  const stopProviderHealthPublication = async (): Promise<void> => {
+    acceptingProviderHealthPublications = false;
+    unsubscribeProviderHealth?.();
+    await Promise.all(pendingProviderHealthPublications);
+  };
 
   // Assigned after metadataRefresh + the drainer (which need the scheduler); the
   // scheduler/launch closures only read it once a reconcile actually runs.
@@ -155,6 +186,10 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
     clock,
     ...(options.logger === undefined ? {} : { logger: options.logger }),
   };
+  if (providerHealthCache !== undefined) {
+    harnessReportDeps.refreshProviderHealth = (providerId) =>
+      providerHealthCache.refresh(providerId);
+  }
 
   const harnessIngressQueue = buildHarnessIngressQueue(
     options,
@@ -214,7 +249,14 @@ export function createObserverApi(options: CreateObserverApiOptions): ObserverAp
 
   const api: ObserverApi = {
     health: () => buildHealth(options, clock, harnessIngressQueue),
-    stop: () => buildStop(options, harnessIngressQueue, metadataRefresh, clock),
+    stop: () =>
+      buildStop(
+        options,
+        harnessIngressQueue,
+        metadataRefresh,
+        stopProviderHealthPublication,
+        clock,
+      ),
     getSnapshot: async () => options.core.getSnapshot(),
     subscribe: (filter?: EventFilter): AsyncIterable<StationEvent> =>
       options.eventBus.subscribe(filter),
@@ -444,10 +486,13 @@ async function buildStop(
   options: CreateObserverApiOptions,
   harnessIngressQueue: HarnessIngressQueue,
   metadataRefresh: WorktreeMetadataRefreshService | undefined,
+  stopProviderHealthPublication: () => Promise<void>,
   clock: RuntimeClock,
 ): Promise<ObserverStopReceipt> {
+  const providerHealthStopped = stopProviderHealthPublication();
   await harnessIngressQueue.shutdown();
   await metadataRefresh?.shutdown?.();
+  await providerHealthStopped;
   await options.onStop?.();
   return {
     schemaVersion: STATION_SCHEMA_VERSION,

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -114,13 +114,14 @@ export async function processHarnessIngressReport(
   for (const event of projection.value.events) {
     deps.eventBus.publish(event);
   }
-  if (
+  const refreshProviderHealth = deps.refreshProviderHealth;
+  const shouldRevalidateProviderHealth =
     projection.value.projected &&
     report.status?.value === "starting" &&
     projection.value.snapshot.providerHealth[report.provider]?.status === "unavailable" &&
-    deps.refreshProviderHealth !== undefined
-  ) {
-    void deps.refreshProviderHealth(report.provider).catch((error) =>
+    refreshProviderHealth !== undefined;
+  if (shouldRevalidateProviderHealth) {
+    void refreshProviderHealth(report.provider).catch((error) =>
       deps.logger
         ?.error("Provider health revalidation after harness startup failed.", {
           provider: report.provider,

--- a/apps/observer/src/runtime/harnessReportProcessor.ts
+++ b/apps/observer/src/runtime/harnessReportProcessor.ts
@@ -15,6 +15,7 @@ export type HarnessReportProcessorDeps = {
   core: ObserverCore;
   eventBus: ObserverEventBus;
   clock: RuntimeClock;
+  refreshProviderHealth?: (providerId: string) => Promise<void>;
   logger?: StationLogger;
 };
 
@@ -47,8 +48,8 @@ function reportDecisionFields(report: HarnessEventReport): Record<string, unknow
 /**
  * USE CASE
  *
- * Persists one normalized report, projects authorized live status, publishes derived events, and
- * returns the required reconcile reason.
+ * Persists one normalized report, projects authorized live status, publishes derived events,
+ * revalidates contradictory provider health, and returns the required reconcile reason.
  */
 export async function processHarnessIngressReport(
   deps: HarnessReportProcessorDeps,
@@ -112,6 +113,22 @@ export async function processHarnessIngressReport(
   });
   for (const event of projection.value.events) {
     deps.eventBus.publish(event);
+  }
+  if (
+    projection.value.projected &&
+    report.status?.value === "starting" &&
+    projection.value.snapshot.providerHealth[report.provider]?.status === "unavailable" &&
+    deps.refreshProviderHealth !== undefined
+  ) {
+    void deps.refreshProviderHealth(report.provider).catch((error) =>
+      deps.logger
+        ?.error("Provider health revalidation after harness startup failed.", {
+          provider: report.provider,
+          reportId: report.reportId,
+          error,
+        })
+        .catch(() => undefined),
+    );
   }
   return {
     receipt: HarnessEventReportReceiptSchema.parse({

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -230,9 +230,8 @@ async function runClaimedObserverRuntime(input: {
   const pruneAt = toIsoTimestamp(systemClock.now());
   await persistence.pruneExpiredProviderObservations(pruneAt);
   const commandQueue = createCommandQueue({ persistence, clock: systemClock, eventBus, logger });
-  // Fire-and-forget boot probes: snapshots read cached results and fill in as they land.
+  // Fire-and-forget version probes only populate provider-owned cache state.
   void providers.refreshHarnessVersions();
-  void providers.healthCache.refreshAll();
   const featureFlags = createFeatureFlagEvaluator({
     ...(config.featureFlags === undefined ? {} : { overrides: config.featureFlags }),
     revisionSeed: loadedConfig.configPath,
@@ -376,6 +375,8 @@ async function runClaimedObserverRuntime(input: {
     clock: systemClock,
     logger,
   });
+  // Register health publication before boot probes so every completed result reaches the snapshot.
+  void providers.healthCache.refreshAll();
   const api: ObserverApi = {
     ...observerApi,
     health: () => startupGate.runHealth(observerApi.health),

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -8,7 +8,7 @@ import {
   FakeTerminalProvider,
   FakeWorktreeProvider,
 } from "@station/testing";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createCommandQueue } from "../../src/commands/queue";
 import { registerObserverCommandHandlers } from "../../src/commands/router";
 import type { PersistenceHealthSource } from "../../src/persistence/ports";
@@ -155,6 +155,61 @@ describe("Observer API with in-memory persistence", () => {
     await expect(api.stop()).resolves.toMatchObject({ stopped: true, at: now });
     expect(metadataStopped).toBe(true);
     await expect(commandQueue.drain()).resolves.toBeUndefined();
+  });
+
+  it("waits for an in-flight provider health publication before stopping", async () => {
+    const clock = { now: () => new Date(now) };
+    const idFactory = observerIds();
+    const persistence = createInMemoryObserverPersistence({ clock, idFactory });
+    const eventBus = createObserverEventBus();
+    const commandQueue = createCommandQueue({ persistence, clock, idFactory, eventBus });
+    const providers = fakeProviders();
+    const core = createObserverCore({ config, providers, persistence, clock });
+    const commitProviderHealthProbe = core.commitProviderHealthProbe.bind(core);
+    let releaseCommit: () => void = () => undefined;
+    const commitBlocked = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let markCommitStarted: () => void = () => undefined;
+    const commitStarted = new Promise<void>((resolve) => {
+      markCommitStarted = resolve;
+    });
+    vi.spyOn(core, "commitProviderHealthProbe").mockImplementation(async (health) => {
+      markCommitStarted();
+      await commitBlocked;
+      return commitProviderHealthProbe(health);
+    });
+    let markMetadataStopped: () => void = () => undefined;
+    const metadataStopped = new Promise<void>((resolve) => {
+      markMetadataStopped = resolve;
+    });
+    const onStop = vi.fn(async () => undefined);
+    const api = createObserverApi({
+      core,
+      providers,
+      persistence,
+      persistenceHealth: { health: () => healthStub },
+      commandQueue,
+      eventBus,
+      clock,
+      config,
+      metadataRefresh: {
+        refresh: async () => undefined,
+        shutdown: async () => markMetadataStopped(),
+      },
+      onStop,
+    });
+
+    const refresh = providers.healthCache.refresh(providers.worktree.id);
+    await commitStarted;
+    const stop = api.stop();
+    await metadataStopped;
+
+    expect(onStop).not.toHaveBeenCalled();
+    releaseCommit();
+    await expect(stop).resolves.toMatchObject({ stopped: true });
+    await expect(refresh).resolves.toBeUndefined();
+    expect(onStop).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -11,11 +11,11 @@ import {
   FakeTerminalProvider,
   FakeWorktreeProvider,
 } from "@station/testing";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createObserverCore, ProviderRegistry } from "../../src/internal";
 import { createSqliteObserverPersistence } from "../../src/persistence";
 import { openObserverSqlite } from "../../src/sqlite";
-import { createTestObserverCore } from "../support/testObserver";
+import { createTestObserver, createTestObserverCore } from "../support/testObserver";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -185,6 +185,129 @@ describe("observer reconcile persistence", () => {
     const observations = await persistence.listProviderObservations();
     const healthRows = observations.filter((item) => item.entityKind === "provider_health");
     expect(healthRows.map((row) => row.payload.status)).toEqual(["unknown", "unknown", "unknown"]);
+    sqlite.close();
+  });
+
+  it("publishes completed provider probes without another reconcile", async () => {
+    let currentTime = now;
+    let healthStatus: "healthy" | "unavailable" = "unavailable";
+    const providers = providersWithOneSession();
+    vi.spyOn(providers.worktree, "health").mockImplementation(async () => ({
+      providerId: providers.worktree.id,
+      providerType: "worktree",
+      status: healthStatus,
+      lastCheckedAt: currentTime,
+      capabilities: providers.worktree.capabilities(),
+    }));
+    const clock = { now: () => new Date(currentTime) };
+    const { sqlite, persistence, eventBus, core, api } = createTestObserver({
+      config,
+      providers,
+      clock,
+    });
+    const events = eventBus.subscribe({ type: "provider.healthChanged" })[Symbol.asyncIterator]();
+
+    const unavailableEvent = events.next();
+    await providers.healthCache.refresh(providers.worktree.id);
+
+    expect(await unavailableEvent).toMatchObject({
+      done: false,
+      value: {
+        type: "provider.healthChanged",
+        provider: "fake-worktree",
+        health: { status: "unavailable" },
+      },
+    });
+    expect(core.getSnapshot()).toMatchObject({
+      observer: { healthy: false },
+      providerHealth: { "fake-worktree": { status: "unavailable" } },
+      projects: [{ health: { providerId: "fake-worktree", status: "unavailable" } }],
+      alerts: [{ provider: "fake-worktree", severity: "error" }],
+    });
+
+    currentTime = "2026-05-20T12:01:00.000Z";
+    healthStatus = "healthy";
+    const healthyEvent = events.next();
+    await providers.healthCache.refresh(providers.worktree.id);
+
+    expect(await healthyEvent).toMatchObject({
+      done: false,
+      value: {
+        type: "provider.healthChanged",
+        provider: "fake-worktree",
+        health: { status: "healthy" },
+      },
+    });
+    expect(core.getSnapshot()).toMatchObject({
+      observer: { healthy: true },
+      providerHealth: { "fake-worktree": { status: "healthy" } },
+      projects: [{ health: { providerId: "fake-worktree", status: "healthy" } }],
+      alerts: [],
+    });
+    expect(core.getHealth().providerHealth["fake-worktree"]?.status).toBe("healthy");
+    await expect(
+      core.commitProviderHealthProbe({
+        providerId: "fake-worktree",
+        providerType: "worktree",
+        status: "unavailable",
+        lastCheckedAt: now,
+      }),
+    ).resolves.toBeUndefined();
+    expect(core.getSnapshot().providerHealth["fake-worktree"]?.status).toBe("healthy");
+    const healthRows = await persistence.listProviderObservations({
+      entityKind: "provider_health",
+    });
+    expect(healthRows.map((row) => row.payload.status)).toEqual(["unavailable", "healthy"]);
+
+    await events.return?.();
+    await api.stop();
+    sqlite.close();
+  });
+
+  it("publishes once when reconcile consumes the completed cache object first", async () => {
+    const providers = providersWithOneSession();
+    const project = config.projects[0];
+    if (project === undefined) {
+      throw new Error("Expected the test project fixture.");
+    }
+    const worktrees = await providers.worktree.listWorktrees(project);
+    let releaseWorktreeRead: () => void = () => undefined;
+    const listWorktrees = vi.spyOn(providers.worktree, "listWorktrees").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseWorktreeRead = () => resolve(worktrees);
+        }),
+    );
+    const clock = { now: () => new Date(now) };
+    const { sqlite, persistence, eventBus, core, api } = createTestObserver({
+      config,
+      providers,
+      clock,
+    });
+    const publish = vi.spyOn(eventBus, "publish");
+
+    const reconcile = core.reconcile("health-publication-race");
+    await vi.waitFor(() => expect(listWorktrees).toHaveBeenCalledOnce());
+    const refresh = providers.healthCache.refresh("fake-harness");
+    await vi.waitFor(() =>
+      expect(providers.healthCache.read("fake-harness")?.status).toBe("healthy"),
+    );
+    releaseWorktreeRead();
+    await reconcile;
+    await refresh;
+
+    const harnessHealthEvents = publish.mock.calls
+      .map(([event]) => event)
+      .filter(
+        (event) => event.type === "provider.healthChanged" && event.provider === "fake-harness",
+      );
+    expect(harnessHealthEvents).toHaveLength(1);
+    const healthRows = await persistence.listProviderObservations({
+      entityKind: "provider_health",
+    });
+    expect(healthRows.filter((row) => row.provider === "fake-harness")).toHaveLength(1);
+
+    await api.stop();
     sqlite.close();
   });
 

--- a/apps/observer/test/integration/reconcile-persistence.test.ts
+++ b/apps/observer/test/integration/reconcile-persistence.test.ts
@@ -245,6 +245,19 @@ describe("observer reconcile persistence", () => {
       alerts: [],
     });
     expect(core.getHealth().providerHealth["fake-worktree"]?.status).toBe("healthy");
+
+    currentTime = "2026-05-20T12:02:00.000Z";
+    const repeatedHealthyEvent = events.next();
+    await providers.healthCache.refresh(providers.worktree.id);
+    expect(await repeatedHealthyEvent).toMatchObject({
+      done: false,
+      value: {
+        type: "provider.healthChanged",
+        provider: "fake-worktree",
+        health: { status: "healthy", lastCheckedAt: currentTime },
+      },
+    });
+
     await expect(
       core.commitProviderHealthProbe({
         providerId: "fake-worktree",
@@ -258,6 +271,7 @@ describe("observer reconcile persistence", () => {
       entityKind: "provider_health",
     });
     expect(healthRows.map((row) => row.payload.status)).toEqual(["unavailable", "healthy"]);
+    expect(healthRows[1]?.observedAt).toBe(currentTime);
 
     await events.return?.();
     await api.stop();

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -111,7 +111,6 @@ type InMemoryObserverPersistenceState = {
 type InsertProviderObservationInput = RecordProviderObservationInput & {
   id: string;
   observedAt: string;
-  coalesceUnchanged?: boolean;
 };
 
 export function createInMemoryObserverPersistence(

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -745,6 +745,48 @@ export function observerPersistenceContract(
         });
       });
 
+      it("optionally coalesces unchanged direct observations", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.recordProviderObservation({
+            ...healthObservation("healthy", now),
+            expiresAt: later,
+            coalesceUnchanged: true,
+          });
+          await persistence.recordProviderObservation({
+            ...healthObservation("healthy", later),
+            expiresAt: latest,
+            coalesceUnchanged: true,
+          });
+
+          let observations = await persistence.listProviderObservations({
+            entityKind: "provider_health",
+            includeExpired: true,
+            now: later,
+          });
+          expect(observations).toEqual([
+            expect.objectContaining({
+              observedAt: later,
+              expiresAt: latest,
+              payload: expect.objectContaining({ lastCheckedAt: later, status: "healthy" }),
+            }),
+          ]);
+
+          await persistence.recordProviderObservation({
+            ...healthObservation("degraded", latest),
+            coalesceUnchanged: true,
+          });
+          observations = await persistence.listProviderObservations({
+            entityKind: "provider_health",
+            includeExpired: true,
+            now: latest,
+          });
+          expect(observations.map((observation) => observation.payload.status)).toEqual([
+            "healthy",
+            "degraded",
+          ]);
+        });
+      });
+
       it("selects the latest observation by timestamp and then generated ID", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           const first = createFakeWorktree({
@@ -2507,7 +2549,10 @@ function providerHookEvent(hookId: string): StationEvent {
   };
 }
 
-function healthObservation(status: "healthy" | "degraded"): RecordProviderObservationInput {
+function healthObservation(
+  status: "healthy" | "degraded",
+  observedAt = now,
+): RecordProviderObservationInput {
   return {
     provider: "fake-harness",
     providerType: "harness",
@@ -2517,9 +2562,9 @@ function healthObservation(status: "healthy" | "degraded"): RecordProviderObserv
       providerId: "fake-harness",
       providerType: "harness",
       status,
-      lastCheckedAt: now,
+      lastCheckedAt: observedAt,
     },
-    observedAt: now,
+    observedAt,
   };
 }
 

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -11,6 +11,7 @@ import {
   buildStationSnapshot,
   type ObserverSessionMetadata,
   type ObserverTurnReadiness,
+  projectProviderHealthOntoSnapshot,
 } from "../../src/reconcile/graph";
 import type { ObserverHarnessRun } from "../../src/reconcile/harnessEventStatus";
 import { observerHarnessRunFromRun } from "../support/harnessRuns";
@@ -168,6 +169,53 @@ function build(overrides: {
 }
 
 describe("observer graph derivation", () => {
+  it("projects one provider health result without rebuilding unrelated alerts", () => {
+    const worktreeHealth: ProviderHealth = {
+      ...worktreeProviderHealth,
+      status: "unavailable",
+    };
+    const harnessHealth: ProviderHealth = {
+      providerId: "fake-harness",
+      providerType: "harness",
+      status: "unavailable",
+      lastCheckedAt: generatedAt,
+    };
+    const snapshot = build({
+      projects: projects.slice(0, 1),
+      providerHealth: {
+        "fake-worktree": worktreeHealth,
+        "fake-harness": harnessHealth,
+      },
+    });
+    const harnessAlert = snapshot.alerts.find((alert) => alert.provider === "fake-harness");
+    if (harnessAlert === undefined) {
+      throw new Error("Expected a harness health alert.");
+    }
+    const unrelatedAlert = {
+      id: "alert_unrelated",
+      severity: "warn" as const,
+      message: "Unrelated warning.",
+      createdAt: observerStartedAt,
+    };
+    snapshot.alerts.push(unrelatedAlert);
+    const projectedAt = "2026-05-20T12:01:00.000Z";
+
+    const projected = projectProviderHealthOntoSnapshot({
+      snapshot,
+      health: { ...worktreeProviderHealth, lastCheckedAt: projectedAt },
+      projectedAt,
+    });
+
+    expect(projected.generatedAt).toBe(projectedAt);
+    expect(projected.providerHealth["fake-worktree"]?.status).toBe("healthy");
+    expect(projected.projects[0]?.health.status).toBe("healthy");
+    expect(projected.alerts).toEqual([harnessAlert, unrelatedAlert]);
+    expect(projected.alerts[0]).toBe(harnessAlert);
+    expect(projected.alerts[1]).toBe(unrelatedAlert);
+    expect(projected.observer.healthy).toBe(false);
+    expect(snapshot.providerHealth["fake-worktree"]?.status).toBe("unavailable");
+  });
+
   it("counts one canonical session alongside ten unattached worktrees", () => {
     const attached = worktree("wt_web_session", "web", "session");
     const unattached = Array.from({ length: 10 }, (_, index) =>

--- a/apps/observer/test/unit/harnessReportProcessor.test.ts
+++ b/apps/observer/test/unit/harnessReportProcessor.test.ts
@@ -1,6 +1,6 @@
 import type { HarnessEventReport, HarnessEventReportReceipt } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { HarnessEventReportIngestion } from "../../src/hooks/ingestion";
 import type { ObserverCore } from "../../src/reconcile/core";
 import type { ObserverEventBus } from "../../src/runtime/eventBus";
@@ -47,6 +47,7 @@ describe("harness report processor logging", () => {
     };
     const core: ObserverCore = {
       reconcile: () => Promise.resolve(snapshot),
+      commitProviderHealthProbe: () => Promise.resolve(undefined),
       getSnapshot: () => snapshot,
       projectHarnessEventStatus: () =>
         Promise.resolve({
@@ -118,22 +119,142 @@ describe("harness report processor logging", () => {
   });
 });
 
+describe("harness report provider health revalidation", () => {
+  it("re-probes unavailable health after an accepted starting report projects", async () => {
+    const { deps, refreshProviderHealth } = healthRevalidationDeps({
+      healthStatus: "unavailable",
+    });
+
+    await processHarnessIngressReport(
+      deps,
+      report({
+        reportId: "report_start",
+        nativeSessionId: "native_start",
+        cwd: "/tmp/station/web",
+        status: "starting",
+      }),
+    );
+
+    expect(refreshProviderHealth).toHaveBeenCalledOnce();
+    expect(refreshProviderHealth).toHaveBeenCalledWith("codex");
+  });
+
+  it.each([
+    { name: "healthy health", healthStatus: "healthy" as const },
+    { name: "unknown health", healthStatus: "unknown" as const },
+    { name: "missing health", healthStatus: undefined },
+    {
+      name: "a non-starting report",
+      healthStatus: "unavailable" as const,
+      status: "working" as const,
+    },
+    { name: "an unprojected report", healthStatus: "unavailable" as const, projected: false },
+    { name: "a deduplicated report", healthStatus: "unavailable" as const, deduped: true },
+    { name: "a rejected report", healthStatus: "unavailable" as const, accepted: false },
+  ])("does not re-probe for $name", async (testCase) => {
+    const { deps, refreshProviderHealth } = healthRevalidationDeps(testCase);
+
+    await processHarnessIngressReport(
+      deps,
+      report({
+        reportId: `report_${testCase.name.replaceAll(" ", "_")}`,
+        nativeSessionId: "native_non_trigger",
+        cwd: "/tmp/station/web",
+        status: testCase.status ?? "starting",
+      }),
+    );
+
+    expect(refreshProviderHealth).not.toHaveBeenCalled();
+  });
+});
+
+function healthRevalidationDeps(input: {
+  healthStatus?: "healthy" | "unavailable" | "unknown";
+  projected?: boolean;
+  accepted?: boolean;
+  deduped?: boolean;
+}) {
+  const snapshot = emptyStationSnapshot(now);
+  if (input.healthStatus !== undefined) {
+    snapshot.providerHealth.codex = {
+      providerId: "codex",
+      providerType: "harness",
+      status: input.healthStatus,
+      lastCheckedAt: now,
+    };
+  }
+  const accepted = input.accepted ?? true;
+  const refreshProviderHealth = vi.fn(async () => undefined);
+  const harnessEventReportIngestion: HarnessEventReportIngestion = {
+    ingest: (ingestedReport): Promise<HarnessEventReportReceipt> =>
+      Promise.resolve({
+        schemaVersion: STATION_SCHEMA_VERSION,
+        reportId: ingestedReport.reportId,
+        provider: ingestedReport.provider,
+        eventType: ingestedReport.eventType,
+        accepted,
+        status: accepted ? "accepted" : "rejected",
+        receivedAt: now,
+        projected: false,
+        scheduledReconcile: false,
+        deduped: input.deduped ?? false,
+      }),
+  };
+  const core: ObserverCore = {
+    reconcile: () => Promise.resolve(snapshot),
+    commitProviderHealthProbe: () => Promise.resolve(undefined),
+    getSnapshot: () => snapshot,
+    projectHarnessEventStatus: () =>
+      Promise.resolve({
+        projected: input.projected ?? true,
+        snapshot,
+        events: [],
+      }),
+    clearTurnReadiness: () => undefined,
+    updateConfig: () => undefined,
+    getProjects: () => [],
+    getHealth: () => ({
+      status: "healthy",
+      startedAt: now,
+      providerHealth: snapshot.providerHealth,
+    }),
+  };
+  const eventBus: ObserverEventBus = {
+    publish: () => undefined,
+    subscribe: () => ({
+      [Symbol.asyncIterator]: () => ({
+        next: () => Promise.resolve({ done: true as const, value: undefined as never }),
+      }),
+    }),
+  };
+  const deps: HarnessReportProcessorDeps = {
+    harnessEventReportIngestion,
+    core,
+    eventBus,
+    clock: { now: () => new Date(now) },
+    refreshProviderHealth,
+  };
+  return { deps, refreshProviderHealth };
+}
+
 function report(input: {
   reportId: string;
   nativeSessionId: string;
   sessionId?: string;
   cwd: string;
   correlationIssue?: "station_identity_cwd_mismatch";
+  status?: "starting" | "working";
 }): HarnessEventReport {
+  const status = input.status ?? "working";
   const result: HarnessEventReport = {
     schemaVersion: STATION_SCHEMA_VERSION,
     reportId: input.reportId,
     provider: "codex",
     kind: "harness",
-    eventType: "PreToolUse",
+    eventType: status === "starting" ? "SessionStart" : "PreToolUse",
     observedAt: now,
     status: {
-      value: "working",
+      value: status,
       confidence: "medium",
       reason: "Codex is about to use Bash.",
       source: "harness_event",

--- a/apps/observer/test/unit/providerHealthCache.test.ts
+++ b/apps/observer/test/unit/providerHealthCache.test.ts
@@ -66,6 +66,41 @@ describe("provider health cache", () => {
     expect(second).toHaveBeenCalledTimes(1);
   });
 
+  it("notifies once when callers join the same probe", async () => {
+    let resolveProbe: (health: ProviderHealth) => void = () => undefined;
+    const probe = vi.fn(
+      () =>
+        new Promise<ProviderHealth>((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+    const listener = vi.fn(async () => undefined);
+    const cache = new ProviderHealthCache({ targets: [target("fake", probe)] });
+    cache.onProbeCompleted(listener);
+
+    const first = cache.refresh("fake");
+    const second = cache.refresh("fake");
+    await vi.waitFor(() => expect(probe).toHaveBeenCalledOnce());
+    resolveProbe(healthyResult("fake"));
+    await Promise.all([first, second]);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(healthyResult("fake"));
+  });
+
+  it("keeps refresh non-rejecting when a completion listener fails", async () => {
+    const cache = new ProviderHealthCache({
+      targets: [target("fake", async () => healthyResult("fake"))],
+    });
+    cache.onProbeCompleted(async () => {
+      throw new Error("publication failed");
+    });
+
+    await expect(cache.refresh("fake")).resolves.toBeUndefined();
+    expect(cache.read("fake")?.status).toBe("healthy");
+  });
+
   it("serves stale entries past the TTL while revalidating once in the background", async () => {
     const { clock, advance } = testClock();
     let resolveRevalidation: (value: ProviderHealth) => void = () => undefined;

--- a/apps/observer/test/unit/reconcileStartupJoin.test.ts
+++ b/apps/observer/test/unit/reconcileStartupJoin.test.ts
@@ -88,6 +88,7 @@ function controllableCore(): { core: ObserverCore; scans: ControlledScan[] } {
       new Promise<StationSnapshot>((resolve) => {
         scans.push({ reason, snapshot: emptyStationSnapshot(now), resolve });
       }),
+    commitProviderHealthProbe: () => Promise.resolve(undefined),
     projectHarnessEventStatus: async () => ({ projected: false, events: [] }),
     clearTurnReadiness: () => undefined,
     updateConfig: () => undefined,

--- a/docs/harness-signals.md
+++ b/docs/harness-signals.md
@@ -112,6 +112,11 @@ Normalized events are `HarnessEventReport` / `HarnessEventObservation`
     edge may mark the completed turn `idle` and ready. Markerless legacy
     producers retain their historical low-level completion semantics during a
     rolling upgrade.
+11. **Startup evidence revalidates health; it does not define it.** After an
+    accepted, projected report with normalized status `starting`, Observer
+    eagerly re-probes that provider only when current health is `unavailable`.
+    The authoritative probe result updates health; startup traffic never assigns
+    `healthy`, `idle`, or turn readiness directly.
 
 ## Target Taxonomy (HarnessSignal)
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -302,7 +302,8 @@ Current startup proceeds in this order:
    Observer core, command handlers, and configured event hooks around the awaited
    provider registry. Only the two application ports pass inward.
 7. The API constructs ingress queues, reconcile scheduling, metadata refresh,
-   diagnostics dependencies, and spool draining.
+   diagnostics dependencies, spool draining, and the provider-health completion
+   listener whose commits drain before persistence shutdown.
 8. The runtime constructs a private startup-and-health gate, then the protocol
    server binds the resolved socket before startup reconcile. Only the
    successful socket binder may publish process identity.
@@ -315,7 +316,8 @@ Current startup proceeds in this order:
 10. The startup gate marks the runtime ready, synchronously rolls back and closes
     the boot claim, then unblocks health responses. Startup reconcile follows
     outside the claim and establishes the first provider-backed snapshot;
-    provider health and harness-version probes fill caches in the background. A
+    provider-health probes commit into the current snapshot as they land, while
+    harness-version probes fill their cache in the background. A
     stop requested before readiness is terminal: health remains gated, socket
     and pidfile cleanup finish while the claim is held, and the outer lifecycle
     `finally` releases it before exit.
@@ -425,9 +427,12 @@ sessions. Terminal attachment requires matching session or run identity. Session
 and activity totals derive from canonical sessions; only worktree totals derive
 from rows.
 
-Observer core serializes full reconciles and harness-report authorization plus
-base snapshot projection on one non-poisoning writer chain. Readiness persistence
-and application happen after that base commit and revalidate the live snapshot.
+Observer core serializes full reconciles, completed provider-health commits, and
+harness-report authorization plus base snapshot projection on one non-poisoning
+writer chain. A health commit persists one observation, coherently updates the
+current health projection, and then publishes `provider.healthChanged` without a
+full provider scan. Readiness persistence and application happen after its base
+commit and revalidate the live snapshot.
 The scheduler debounces and coalesces reasons while ensuring only one scheduled
 run is active. Startup-compatible requests may join the startup flight; other
 direct requests retain the rule that their scan starts at or after the request.
@@ -579,7 +584,7 @@ from the diagnostic use case.
 | Spool drain | One configured drain runs at a time and processes stable filename order through direct durable ingress. Stable spool IDs survive legacy records without hook IDs; completion is idempotent after primary dedupe, and failed records remain on disk with attempt/error evidence. |
 | Hook auto-start throttle | `hook-autostart.lock` limits provider-hook spawn attempts only. It is never Observer ownership; each child still enters the socket-relative SQLite boot claim. |
 | Event delivery | Each subscriber currently has an unbounded in-memory queue. There is no replay or publisher backpressure; slow-subscriber growth is therefore a known operating characteristic. |
-| Background refresh | Provider probes and metadata refresh are best-effort and must report failure without blocking the primary reconcile result. |
+| Background refresh | Each unique provider probe publishes its completed result through the serialized snapshot writer before its in-flight slot clears. Joined refresh callers do not duplicate publication; shutdown unsubscribes first and drains commits already in progress. Probe and metadata-refresh failures remain best-effort and do not block the primary reconcile result. |
 
 Retry belongs at an adapter or runtime boundary whose owner can state why the
 operation is safe to repeat. Do not retry a mutation without an idempotency key,


### PR DESCRIPTION
## What this fixes

The Observer caches provider health probes outside reconcile, but completed probes did not update the current snapshot, persistence, or subscribers until an unrelated reconcile happened. A provider that recovered could therefore remain visibly unavailable even though its latest probe was healthy.

## What changed

- publish each unique completed probe through the Observer's serialized snapshot writer and existing `provider.healthChanged` event
- keep provider observations, snapshot health, affected project health, alerts, and Observer health coherent while preserving unrelated alerts
- preserve existing observation coalescing so timestamp-only probe refreshes do not grow provider history
- re-probe an unavailable provider after accepted, projected normalized `starting` evidence without inferring health from harness traffic
- register boot probes after publication wiring and drain in-flight health commits during shutdown
- document the provider-health lifecycle and keep startup idle/readiness UX separate in #292

## Testing

- `env -u STATION_PANE -u STATION_TUI_POPUP -u STATION_OUTER_TMUX_PANE pnpm test:pre-push`
- focused unit coverage for graph projection, unique-probe publication, listener isolation, and eager re-probe conditions
- SQLite and in-memory persistence contract coverage for coalesced direct observations
- focused integration coverage for unavailable-to-healthy publication, stale suppression, persistence, subscriber events, reconcile/probe races, and shutdown draining

Closes #291