### PR TITLE
refactor(tui): route add-project input through shared keymap

### DIFF
--- a/packages/dashboard-core/src/flows/addProject/flow.ts
+++ b/packages/dashboard-core/src/flows/addProject/flow.ts
@@ -2,12 +2,9 @@ import {
   createEditableTextInputState,
   transitionEditableTextInput,
 } from "../../components/EditableTextInput/editing.js";
-import { normalizedFilter, pastedPathCandidate, searchQueryForFilter } from "./input.js";
-import { addProjectRows } from "./rows.js";
+import { normalizedFilter, searchQueryForFilter } from "./input.js";
 import {
   chooseStateForLoadedFolder,
-  clampChooseSelection,
-  clampIndex,
   commitEditedProjectId,
   createAddProjectStartState,
   failedStateForError,
@@ -33,19 +30,14 @@ export function transitionAddProjectFlow(
   parentPath?: (path: string) => string,
 ): AddProjectTransition {
   switch (action.type) {
-    case "move":
-      return { state: moveSelection(state, action.delta) };
-    case "select":
-      return { state: selectIndex(state, action.index) };
-    case "startOpen": {
-      if (state.mode !== "start") return { state };
-      const choice = state.choices[state.selectedIndex];
-      return choice === undefined
-        ? { state }
-        : { state, effects: [{ type: "loadDirectory", path: choice.path }] };
-    }
+    case "startOpen":
+      return state.mode === "start"
+        ? { state, effects: [{ type: "loadDirectory", path: action.path }] }
+        : { state };
     case "chooseOpen":
-      return chooseOpen(state);
+      return state.mode === "choose"
+        ? { state, effects: [{ type: "loadDirectory", path: action.path }] }
+        : { state };
     case "chooseParent":
       return state.mode === "choose"
         ? {
@@ -56,7 +48,9 @@ export function transitionAddProjectFlow(
           }
         : { state };
     case "chooseSelected":
-      return chooseSelected(state);
+      return state.mode === "choose"
+        ? { state, effects: [{ type: "reviewFolder", path: action.path }] }
+        : { state };
     case "folderLoaded":
       return {
         state: chooseStateForLoadedFolder(state, action.result.path, action.result.entries),
@@ -68,14 +62,12 @@ export function transitionAddProjectFlow(
     case "folderSearchLoaded":
       return state.mode === "choose" && action.result.query === normalizedFilter(state.filter)
         ? {
-            state: clampChooseSelection(
-              withoutSearchError({
-                ...state,
-                searchEntries: action.result.entries,
-                searching: false,
-                searchTruncated: action.result.truncated,
-              }),
-            ),
+            state: withoutSearchError({
+              ...state,
+              searchEntries: action.result.entries,
+              searching: false,
+              searchTruncated: action.result.truncated,
+            }),
           }
         : { state };
     case "folderSearchFailed":
@@ -107,7 +99,6 @@ export function transitionAddProjectFlow(
               ...state,
               filter: "",
               filterMode: false,
-              selectedIndex: 0,
               searchEntries: [],
               searching: false,
               searchTruncated: false,
@@ -150,31 +141,6 @@ export function transitionAddProjectFlow(
   }
 }
 
-function chooseOpen(state: AddProjectFlowState): AddProjectTransition {
-  if (state.mode !== "choose") return { state };
-  const row = addProjectRows(state)[state.selectedIndex];
-  if (row === undefined || row.kind === "current") return { state };
-  return { state, effects: [{ type: "loadDirectory", path: row.path }] };
-}
-
-function chooseSelected(state: AddProjectFlowState): AddProjectTransition {
-  if (state.mode === "start") {
-    const choice = state.choices[state.selectedIndex];
-    return choice === undefined
-      ? { state }
-      : { state, effects: [{ type: "loadDirectory", path: choice.path }] };
-  }
-  if (state.mode !== "choose") return { state };
-  const row = addProjectRows(state)[state.selectedIndex];
-  if (row !== undefined) {
-    return { state, effects: [{ type: "reviewFolder", path: row.path }] };
-  }
-  const pastedPath = pastedPathCandidate(state.filter);
-  return pastedPath === undefined
-    ? { state }
-    : { state, effects: [{ type: "reviewFolder", path: pastedPath }] };
-}
-
 function submitReview(state: AddProjectFlowState): AddProjectTransition {
   if (state.mode !== "review" || state.editingId !== undefined || state.gitRoot === undefined) {
     return { state };
@@ -197,46 +163,18 @@ function submitReview(state: AddProjectFlowState): AddProjectTransition {
   };
 }
 
-function moveSelection(state: AddProjectFlowState, delta: number): AddProjectFlowState {
-  if (state.mode === "start") {
-    return {
-      ...state,
-      selectedIndex: clampIndex(state.selectedIndex + delta, 0, state.choices.length - 1),
-    };
-  }
-  if (state.mode === "choose") {
-    const count = addProjectRows(state).length;
-    return { ...state, selectedIndex: clampIndex(state.selectedIndex + delta, 0, count - 1) };
-  }
-  return state;
-}
-
-// Absolute-index cursor move for a mouse click; clamps into the active list so a
-// stale click past the end lands on the last row rather than out of range.
-function selectIndex(state: AddProjectFlowState, index: number): AddProjectFlowState {
-  if (state.mode === "start") {
-    return { ...state, selectedIndex: clampIndex(index, 0, state.choices.length - 1) };
-  }
-  if (state.mode === "choose") {
-    return { ...state, selectedIndex: clampIndex(index, 0, addProjectRows(state).length - 1) };
-  }
-  return state;
-}
-
 function updateFilter(state: AddProjectFlowState, filter: string): AddProjectTransition {
   if (state.mode !== "choose") {
     return { state };
   }
   const searchQuery = searchQueryForFilter(filter);
-  const nextState = clampChooseSelection(
-    withoutSearchError({
-      ...state,
-      filter,
-      searchEntries: [],
-      searching: searchQuery !== undefined,
-      searchTruncated: false,
-    }),
-  );
+  const nextState = withoutSearchError({
+    ...state,
+    filter,
+    searchEntries: [],
+    searching: searchQuery !== undefined,
+    searchTruncated: false,
+  });
   return {
     state: nextState,
     ...(searchQuery === undefined

--- a/packages/dashboard-core/src/flows/addProject/state.ts
+++ b/packages/dashboard-core/src/flows/addProject/state.ts
@@ -1,6 +1,5 @@
 import { createStepWizardState, enterWizardStep } from "../stepWizard.js";
 import { normalizeProjectId } from "./input.js";
-import { addProjectRows } from "./rows.js";
 import type {
   AddProjectChooseState,
   AddProjectFailedState,
@@ -26,7 +25,6 @@ export function createAddProjectStartState(input: CreateAddProjectFlowInput): Ad
     mode: wizard.mode,
     stepHistory: wizard.stepHistory,
     firstProject: input.firstProject === true,
-    selectedIndex: 0,
     choices: startChoices(input.cwd, input.homeDir),
   };
 }
@@ -41,7 +39,6 @@ export function chooseStateForLoadedFolder(
     ...wizardFieldsFor(state, "choose"),
     currentPath,
     entries,
-    selectedIndex: 0,
     filter: "",
     filterMode: false,
     loading: false,
@@ -112,18 +109,6 @@ export function reviewWithoutEditingId(state: AddProjectReviewState): AddProject
 export function withoutSearchError(state: AddProjectChooseState): AddProjectChooseState {
   const { searchError: _searchError, ...nextState } = state;
   return nextState;
-}
-
-export function clampChooseSelection(state: AddProjectChooseState): AddProjectChooseState {
-  const count = addProjectRows(state).length;
-  return { ...state, selectedIndex: clampIndex(state.selectedIndex, 0, count - 1) };
-}
-
-export function clampIndex(value: number, min: number, max: number): number {
-  if (max < min) {
-    return min;
-  }
-  return Math.min(max, Math.max(min, value));
 }
 
 function wizardFieldsFor<TMode extends AddProjectStep>(

--- a/packages/dashboard-core/src/flows/addProject/types.ts
+++ b/packages/dashboard-core/src/flows/addProject/types.ts
@@ -26,14 +26,12 @@ export type AddProjectStartChoice = {
 export type AddProjectStartState = AddProjectBaseState & {
   mode: "start";
   choices: AddProjectStartChoice[];
-  selectedIndex: number;
 };
 
 export type AddProjectChooseState = AddProjectBaseState & {
   mode: "choose";
   currentPath: string;
   entries: TuiFolderEntry[];
-  selectedIndex: number;
   filter: string;
   filterMode: boolean;
   loading: boolean;
@@ -80,12 +78,10 @@ export type CreateAddProjectFlowInput = {
 };
 
 export type AddProjectFlowAction =
-  | { type: "move"; delta: number }
-  | { type: "select"; index: number }
-  | { type: "startOpen" }
-  | { type: "chooseOpen" }
+  | { type: "startOpen"; path: string }
+  | { type: "chooseOpen"; path: string }
   | { type: "chooseParent" }
-  | { type: "chooseSelected" }
+  | { type: "chooseSelected"; path: string }
   | { type: "folderLoaded"; result: TuiFolderReadResult }
   | { type: "folderLoadFailed"; path: string; error: SafeError }
   | { type: "folderSearchLoaded"; result: TuiFolderSearchResult }

--- a/packages/dashboard-core/src/index.ts
+++ b/packages/dashboard-core/src/index.ts
@@ -44,4 +44,5 @@ export * from "./state/screens/quickSession.js";
 export * from "./state/screens/removeWorktree.js";
 export * from "./state/screens/sessionRows.js";
 export * from "./state/screens/widgetSettings.js";
+export * from "./state/selection/addProject.js";
 export * from "./state/selection/registry.js";

--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -21,7 +21,13 @@ export type TuiInputMode =
   | "newSessionPickAgent"
   | "projectDefaultAgent"
   | "projectSettings"
-  | "addProject"
+  | "addProjectStart"
+  | "addProjectChoose"
+  | "addProjectFilter"
+  | "addProjectReview"
+  | "addProjectEditId"
+  | "addProjectSuccess"
+  | "addProjectFailed"
   | "widgetSettings";
 
 export function deriveTuiInputMode(state: TuiState): TuiInputMode {
@@ -50,7 +56,14 @@ export function deriveTuiInputMode(state: TuiState): TuiInputMode {
       if (screen.flow.mode === "pickProject") return "newSessionPickProject";
       return "newSessionPickAgent";
     case "addProject":
-      return "addProject";
+      if (screen.flow.mode === "start") return "addProjectStart";
+      if (screen.flow.mode === "choose") {
+        return screen.flow.filterMode ? "addProjectFilter" : "addProjectChoose";
+      }
+      if (screen.flow.mode === "review") {
+        return screen.flow.editingId === undefined ? "addProjectReview" : "addProjectEditId";
+      }
+      return screen.flow.mode === "success" ? "addProjectSuccess" : "addProjectFailed";
     case "projectDefaultAgent":
       return "projectDefaultAgent";
     case "projectSettings":

--- a/packages/dashboard-core/src/state/screens/addProjectScreen.ts
+++ b/packages/dashboard-core/src/state/screens/addProjectScreen.ts
@@ -1,8 +1,12 @@
 import { dirname } from "node:path";
 import { editableTextInputIntentForInput } from "../../components/EditableTextInput/editing.js";
-import { createAddProjectFlow, transitionAddProjectFlow } from "../../flows/addProject/flow.js";
+import { createAddProjectFlow } from "../../flows/addProject/flow.js";
+import { pastedPathCandidate } from "../../flows/addProject/input.js";
 import type {
-  AddProjectFlowEffect,
+  AddProjectChooseState,
+  AddProjectFailedState,
+  AddProjectFlowAction,
+  AddProjectFlowState,
   CreateAddProjectFlowInput,
 } from "../../flows/addProject/types.js";
 import { toSafeError } from "../../services/errors/errors.js";
@@ -13,17 +17,34 @@ import type {
 } from "../../services/folderService.js";
 import type { TuiKey } from "../keys.js";
 import { isReturnKey } from "../keys.js";
+import {
+  reconcileAddProjectSelection,
+  selectAddProjectRowByIndex,
+  selectedAddProjectFolderRow,
+  selectedAddProjectStartPath,
+} from "../selection/addProject.js";
 import type { TuiTransition } from "../transition.js";
 import type { TuiState } from "../types.js";
+import { applyAddProjectAction } from "./addProjectTransition.js";
+
+type AddProjectInputIntent =
+  | { type: "none" }
+  | { type: "close" }
+  | { type: "retry"; path: string }
+  | { type: "transition"; action: AddProjectFlowAction };
 
 export function openAddProject(state: TuiState, input: CreateAddProjectFlowInput): TuiState {
-  return {
-    ...state,
-    screen: {
-      name: "addProject",
-      flow: createAddProjectFlow(input),
+  return reconcileAddProjectSelection(
+    {
+      ...state,
+      screen: {
+        name: "addProject",
+        flow: createAddProjectFlow(input),
+      },
     },
-  };
+    undefined,
+    true,
+  );
 }
 
 export function handleAddProjectKey(state: TuiState, key: TuiKey): TuiTransition {
@@ -31,101 +52,150 @@ export function handleAddProjectKey(state: TuiState, key: TuiKey): TuiTransition
     return { state };
   }
 
-  const flow = state.screen.flow;
-  if (flow.mode === "review" && flow.editingId !== undefined) {
-    if (key.escape === true) {
-      return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "editIdCancel" }));
-    }
-    if (isReturnKey(key)) {
-      return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "editIdCommit" }));
-    }
-    const intent = editableTextInputIntentForInput({ input: key.input, key });
-    return intent.type === "edit"
-      ? applyFlowTransition(
-          state,
-          transitionAddProjectFlow(flow, { type: "editIdInput", action: intent.action }),
-        )
-      : { state };
-  }
-
-  if (key.escape === true) {
-    if (flow.mode === "choose" && (flow.filterMode || flow.filter.length > 0)) {
-      return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "filterClear" }));
-    }
-    return { state: { ...state, screen: { name: "dashboard" } } };
-  }
-
-  if (flow.mode === "choose" && flow.filterMode) {
-    if (key.backspace === true || key.delete === true) {
-      return applyFlowTransition(
-        state,
-        transitionAddProjectFlow(flow, { type: "filterBackspace" }),
-      );
-    }
-    if (key.ctrl === true && key.input === "u") {
-      return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "filterClear" }));
-    }
-    if (key.input.length > 0 && !isReturnKey(key)) {
-      return applyFlowTransition(
-        state,
-        transitionAddProjectFlow(flow, { type: "filterInput", value: key.input }),
-      );
-    }
-  }
-
-  if (key.upArrow === true) {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "move", delta: -1 }));
-  }
-  if (key.downArrow === true) {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "move", delta: 1 }));
-  }
-  if (key.rightArrow === true) {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, rightArrowAction(flow.mode)));
-  }
-  if (key.leftArrow === true) {
-    return applyFlowTransition(
-      state,
-      transitionAddProjectFlow(flow, { type: "chooseParent" }, dirname),
-    );
-  }
-  if (key.input === "/") {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "filterStart" }));
-  }
-  if (key.input === "B") {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "backToChoose" }));
-  }
-  if (key.input === "N" && flow.mode === "review") {
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "editIdStart" }));
-  }
-  if (key.input === "R" && flow.mode === "failed") {
-    return {
-      state,
-      operations: [{ type: "reviewProjectFolder", path: flow.selectedPath }],
-    };
-  }
-  if (isReturnKey(key)) {
-    if (flow.mode === "review") {
-      return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "submit" }));
-    }
-    if (flow.mode === "success") {
+  const intent = addProjectIntentForInput(state, key);
+  switch (intent.type) {
+    case "none":
+      return { state };
+    case "close":
       return { state: { ...state, screen: { name: "dashboard" } } };
-    }
-    return applyFlowTransition(state, transitionAddProjectFlow(flow, { type: "chooseSelected" }));
+    case "retry":
+      return {
+        state,
+        operations: [{ type: "reviewProjectFolder", path: intent.path }],
+      };
+    case "transition":
+      return applyAddProjectAction(state, intent.action, dirname);
   }
-
-  return { state };
 }
 
-/** Mouse: click a folder/start row to move the cursor there (open/pick stay on the keyboard). */
+function addProjectIntentForInput(state: TuiState, key: TuiKey): AddProjectInputIntent {
+  if (state.screen.name !== "addProject") {
+    return { type: "none" };
+  }
+  const flow = state.screen.flow;
+  if (flow.mode === "review" && flow.editingId !== undefined) {
+    return editProjectIdIntent(key);
+  }
+  if (key.escape === true) {
+    return escapeIntent(flow);
+  }
+  switch (flow.mode) {
+    case "start":
+      return startIntent(state, key);
+    case "choose":
+      return chooseIntent(state, flow, key);
+    case "review":
+      return reviewIntent(key);
+    case "success":
+      return isReturnKey(key) ? { type: "close" } : { type: "none" };
+    case "failed":
+      return failedIntent(flow, key);
+  }
+}
+
+function editProjectIdIntent(key: TuiKey): AddProjectInputIntent {
+  if (key.escape === true) {
+    return transitionIntent({ type: "editIdCancel" });
+  }
+  if (isReturnKey(key)) {
+    return transitionIntent({ type: "editIdCommit" });
+  }
+  const intent = editableTextInputIntentForInput({ input: key.input, key });
+  return intent.type === "edit"
+    ? transitionIntent({ type: "editIdInput", action: intent.action })
+    : { type: "none" };
+}
+
+function escapeIntent(flow: AddProjectFlowState): AddProjectInputIntent {
+  return flow.mode === "choose" && (flow.filterMode || flow.filter.length > 0)
+    ? transitionIntent({ type: "filterClear" })
+    : { type: "close" };
+}
+
+function startIntent(state: TuiState, key: TuiKey): AddProjectInputIntent {
+  if (key.rightArrow !== true) {
+    return { type: "none" };
+  }
+  const path = selectedAddProjectStartPath(state);
+  return path === undefined ? { type: "none" } : transitionIntent({ type: "startOpen", path });
+}
+
+function chooseIntent(
+  state: TuiState,
+  flow: AddProjectChooseState,
+  key: TuiKey,
+): AddProjectInputIntent {
+  if (flow.filterMode) {
+    const intent = filterInputIntent(key);
+    if (intent.type !== "none") {
+      return intent;
+    }
+  }
+  if (key.rightArrow === true) {
+    const row = selectedAddProjectFolderRow(state);
+    return row === undefined || row.kind === "current"
+      ? { type: "none" }
+      : transitionIntent({ type: "chooseOpen", path: row.path });
+  }
+  if (key.leftArrow === true) {
+    return transitionIntent({ type: "chooseParent" });
+  }
+  if (key.input === "/") {
+    return transitionIntent({ type: "filterStart" });
+  }
+  if (isReturnKey(key)) {
+    const path = pastedPathCandidate(flow.filter);
+    return path === undefined
+      ? { type: "none" }
+      : transitionIntent({ type: "chooseSelected", path });
+  }
+  return { type: "none" };
+}
+
+function filterInputIntent(key: TuiKey): AddProjectInputIntent {
+  if (key.backspace === true || key.delete === true) {
+    return transitionIntent({ type: "filterBackspace" });
+  }
+  if (key.ctrl === true && key.input === "u") {
+    return transitionIntent({ type: "filterClear" });
+  }
+  if (key.input.length > 0 && !isReturnKey(key)) {
+    return transitionIntent({ type: "filterInput", value: key.input });
+  }
+  return { type: "none" };
+}
+
+function reviewIntent(key: TuiKey): AddProjectInputIntent {
+  if (key.input === "N") {
+    return transitionIntent({ type: "editIdStart" });
+  }
+  if (key.input === "B") {
+    return transitionIntent({ type: "backToChoose" });
+  }
+  return isReturnKey(key) ? transitionIntent({ type: "submit" }) : { type: "none" };
+}
+
+function failedIntent(flow: AddProjectFailedState, key: TuiKey): AddProjectInputIntent {
+  if (key.input === "R") {
+    return { type: "retry", path: flow.selectedPath };
+  }
+  return key.input === "B" ? transitionIntent({ type: "backToChoose" }) : { type: "none" };
+}
+
+function transitionIntent(action: AddProjectFlowAction): AddProjectInputIntent {
+  return { type: "transition", action };
+}
+
+/** Mouse selection writes the canonical cursor shared by arrows and Enter. */
 export function selectAddProjectRow(state: TuiState, index: number): TuiState {
-  return applyFlowTransitionState(state, { type: "select", index });
+  return selectAddProjectRowByIndex(state, index);
 }
 
 export function applyAddProjectFolderLoaded(
   state: TuiState,
   result: TuiFolderReadResult,
 ): TuiState {
-  return applyFlowTransitionState(state, { type: "folderLoaded", result });
+  return applyAddProjectAction(state, { type: "folderLoaded", result }).state;
 }
 
 export function applyAddProjectFolderLoadFailed(
@@ -134,18 +204,18 @@ export function applyAddProjectFolderLoadFailed(
   error: unknown,
   clientLabel = "TUI",
 ): TuiState {
-  return applyFlowTransitionState(state, {
+  return applyAddProjectAction(state, {
     type: "folderLoadFailed",
     path,
     error: toSafeError(error, { clientLabel }),
-  });
+  }).state;
 }
 
 export function applyAddProjectFolderSearchLoaded(
   state: TuiState,
   result: TuiFolderSearchResult,
 ): TuiState {
-  return applyFlowTransitionState(state, { type: "folderSearchLoaded", result });
+  return applyAddProjectAction(state, { type: "folderSearchLoaded", result }).state;
 }
 
 export function applyAddProjectFolderSearchFailed(
@@ -154,15 +224,15 @@ export function applyAddProjectFolderSearchFailed(
   error: unknown,
   clientLabel = "TUI",
 ): TuiState {
-  return applyFlowTransitionState(state, {
+  return applyAddProjectAction(state, {
     type: "folderSearchFailed",
     query,
     error: toSafeError(error, { clientLabel }),
-  });
+  }).state;
 }
 
 export function applyAddProjectFolderReviewed(state: TuiState, review: TuiFolderReview): TuiState {
-  return applyFlowTransitionState(state, { type: "folderReviewed", review });
+  return applyAddProjectAction(state, { type: "folderReviewed", review }).state;
 }
 
 export function applyAddProjectFolderReviewFailed(
@@ -171,18 +241,18 @@ export function applyAddProjectFolderReviewFailed(
   error: unknown,
   clientLabel = "TUI",
 ): TuiState {
-  return applyFlowTransitionState(state, {
+  return applyAddProjectAction(state, {
     type: "folderReviewFailed",
     path,
     error: toSafeError(error, { clientLabel }),
-  });
+  }).state;
 }
 
 export function applyAddProjectSubmitted(
   state: TuiState,
   input: { label: string; root: string },
 ): TuiState {
-  return applyFlowTransitionState(state, { type: "submitted", ...input });
+  return applyAddProjectAction(state, { type: "submitted", ...input }).state;
 }
 
 export function applyAddProjectSubmitFailed(
@@ -190,61 +260,8 @@ export function applyAddProjectSubmitFailed(
   error: unknown,
   clientLabel = "TUI",
 ): TuiState {
-  return applyFlowTransitionState(state, {
+  return applyAddProjectAction(state, {
     type: "submitFailed",
     error: toSafeError(error, { clientLabel }),
-  });
-}
-
-function rightArrowAction(mode: string) {
-  return mode === "start" ? ({ type: "startOpen" } as const) : ({ type: "chooseOpen" } as const);
-}
-
-function applyFlowTransition(
-  state: TuiState,
-  transition: ReturnType<typeof transitionAddProjectFlow>,
-): TuiTransition {
-  const nextState = transition.state === undefined ? state : setFlow(state, transition.state);
-  const result: TuiTransition = { state: nextState };
-  const operations = addProjectEffectsToOperations(transition.effects);
-  if (operations !== undefined) {
-    result.operations = operations;
-  }
-  return result;
-}
-
-function applyFlowTransitionState(
-  state: TuiState,
-  action: Parameters<typeof transitionAddProjectFlow>[1],
-): TuiState {
-  if (state.screen.name !== "addProject") {
-    return state;
-  }
-  const transition = transitionAddProjectFlow(state.screen.flow, action);
-  return transition.state === undefined ? state : setFlow(state, transition.state);
-}
-
-function setFlow(
-  state: TuiState,
-  flow: NonNullable<Extract<TuiState["screen"], { name: "addProject" }>["flow"]>,
-): TuiState {
-  return {
-    ...state,
-    screen: { name: "addProject", flow },
-  };
-}
-
-function addProjectEffectsToOperations(effects: readonly AddProjectFlowEffect[] | undefined) {
-  return effects?.map((effect) => {
-    if (effect.type === "loadDirectory") {
-      return { type: "loadProjectDirectory" as const, path: effect.path };
-    }
-    if (effect.type === "reviewFolder") {
-      return { type: "reviewProjectFolder" as const, path: effect.path };
-    }
-    if (effect.type === "searchDirectories") {
-      return { type: "searchProjectDirectories" as const, query: effect.query };
-    }
-    return { type: "addProject" as const, command: effect.command };
-  });
+  }).state;
 }

--- a/packages/dashboard-core/src/state/screens/addProjectTransition.ts
+++ b/packages/dashboard-core/src/state/screens/addProjectTransition.ts
@@ -1,0 +1,54 @@
+import { transitionAddProjectFlow } from "../../flows/addProject/flow.js";
+import type { AddProjectFlowAction, AddProjectFlowEffect } from "../../flows/addProject/types.js";
+import { reconcileAddProjectSelection } from "../selection/addProject.js";
+import type { TuiTransition } from "../transition.js";
+import type { TuiState } from "../types.js";
+
+export function applyAddProjectAction(
+  state: TuiState,
+  action: AddProjectFlowAction,
+  parentPath?: (path: string) => string,
+): TuiTransition {
+  if (state.screen.name !== "addProject") {
+    return { state };
+  }
+  const previousFlow = state.screen.flow;
+  const transition = transitionAddProjectFlow(previousFlow, action, parentPath);
+  const nextState =
+    transition.state === undefined
+      ? state
+      : reconcileAddProjectSelection(
+          { ...state, screen: { name: "addProject", flow: transition.state } },
+          previousFlow,
+          resetsSelection(action),
+        );
+  const result: TuiTransition = { state: nextState };
+  const operations = addProjectEffectsToOperations(transition.effects);
+  if (operations !== undefined) {
+    result.operations = operations;
+  }
+  return result;
+}
+
+function resetsSelection(action: AddProjectFlowAction): boolean {
+  return (
+    action.type === "folderLoaded" ||
+    action.type === "folderLoadFailed" ||
+    action.type === "filterClear"
+  );
+}
+
+function addProjectEffectsToOperations(effects: readonly AddProjectFlowEffect[] | undefined) {
+  return effects?.map((effect) => {
+    if (effect.type === "loadDirectory") {
+      return { type: "loadProjectDirectory" as const, path: effect.path };
+    }
+    if (effect.type === "reviewFolder") {
+      return { type: "reviewProjectFolder" as const, path: effect.path };
+    }
+    if (effect.type === "searchDirectories") {
+      return { type: "searchProjectDirectories" as const, query: effect.query };
+    }
+    return { type: "addProject" as const, command: effect.command };
+  });
+}

--- a/packages/dashboard-core/src/state/selection/addProject.ts
+++ b/packages/dashboard-core/src/state/selection/addProject.ts
@@ -1,0 +1,141 @@
+import { addProjectRows } from "../../flows/addProject/rows.js";
+import type { AddProjectFlowState } from "../../flows/addProject/types.js";
+import type { TuiState } from "../types.js";
+import type { TuiSelectionState } from "./types.js";
+
+export const ADD_PROJECT_START_LIST_ID = "addProjectStart";
+export const ADD_PROJECT_CHOOSE_LIST_ID = "addProjectChoose";
+
+function startChoiceId(index: number): string {
+  return String(index);
+}
+
+export function addProjectSelectedIndex(state: TuiState): number | undefined {
+  return state.screen.name === "addProject"
+    ? addProjectSelectedIndexForFlow(state.screen.flow, state.selection)
+    : undefined;
+}
+
+export function addProjectSelectedIndexForFlow(
+  flow: AddProjectFlowState,
+  selection: TuiSelectionState,
+): number | undefined {
+  if (flow.mode === "start") {
+    const value = selection.get(ADD_PROJECT_START_LIST_ID);
+    if (value === undefined) {
+      return undefined;
+    }
+    const index = Number(value);
+    return Number.isInteger(index) && index >= 0 && index < flow.choices.length ? index : undefined;
+  }
+  if (flow.mode === "choose") {
+    const path = selection.get(ADD_PROJECT_CHOOSE_LIST_ID);
+    if (path === undefined) {
+      return undefined;
+    }
+    const index = addProjectRows(flow).findIndex((row) => row.path === path);
+    return index < 0 ? undefined : index;
+  }
+  return undefined;
+}
+
+export function selectedAddProjectStartPath(state: TuiState): string | undefined {
+  if (state.screen.name !== "addProject" || state.screen.flow.mode !== "start") {
+    return undefined;
+  }
+  const index = addProjectSelectedIndex(state);
+  return index === undefined ? undefined : state.screen.flow.choices[index]?.path;
+}
+
+export function selectedAddProjectFolderRow(state: TuiState) {
+  if (state.screen.name !== "addProject" || state.screen.flow.mode !== "choose") {
+    return undefined;
+  }
+  const index = addProjectSelectedIndex(state);
+  return index === undefined ? undefined : addProjectRows(state.screen.flow)[index];
+}
+
+/** Reconcile the canonical list cursor whenever the wizard changes its visible rows. */
+export function reconcileAddProjectSelection(
+  state: TuiState,
+  previousFlow: AddProjectFlowState | undefined,
+  reset: boolean,
+): TuiState {
+  if (state.screen.name !== "addProject") {
+    return state;
+  }
+  const flow = state.screen.flow;
+  if (flow.mode === "start") {
+    const current = state.selection.get(ADD_PROJECT_START_LIST_ID);
+    const currentIndex = current === undefined ? -1 : Number(current);
+    const keepCurrent =
+      !reset &&
+      previousFlow?.mode === "start" &&
+      Number.isInteger(currentIndex) &&
+      currentIndex >= 0 &&
+      currentIndex < flow.choices.length;
+    return withSelection(
+      state,
+      ADD_PROJECT_START_LIST_ID,
+      keepCurrent ? current : flow.choices.length === 0 ? undefined : startChoiceId(0),
+    );
+  }
+  if (flow.mode === "choose") {
+    const rows = addProjectRows(flow);
+    const current = state.selection.get(ADD_PROJECT_CHOOSE_LIST_ID);
+    const sameFolder =
+      previousFlow?.mode === "choose" && previousFlow.currentPath === flow.currentPath;
+    const keepCurrent = !reset && sameFolder && rows.some((row) => row.path === current);
+    return withSelection(state, ADD_PROJECT_CHOOSE_LIST_ID, keepCurrent ? current : rows[0]?.path);
+  }
+  return state;
+}
+
+/** Mouse selection writes the same cursor used by arrows and Enter. */
+export function selectAddProjectRowByIndex(state: TuiState, index: number): TuiState {
+  if (state.screen.name !== "addProject") {
+    return state;
+  }
+  const flow = state.screen.flow;
+  if (flow.mode === "start") {
+    const selected = clampedItem(flow.choices, index);
+    return selected === undefined
+      ? state
+      : withSelection(state, ADD_PROJECT_START_LIST_ID, startChoiceId(selected.index));
+  }
+  if (flow.mode === "choose") {
+    const selected = clampedItem(addProjectRows(flow), index);
+    return selected === undefined
+      ? state
+      : withSelection(state, ADD_PROJECT_CHOOSE_LIST_ID, selected.value.path);
+  }
+  return state;
+}
+
+function clampedItem<T>(
+  items: readonly T[],
+  index: number,
+): { index: number; value: T } | undefined {
+  if (items.length === 0) {
+    return undefined;
+  }
+  const clampedIndex = Math.min(items.length - 1, Math.max(0, index));
+  const value = items[clampedIndex];
+  return value === undefined ? undefined : { index: clampedIndex, value };
+}
+
+function withSelection(state: TuiState, listId: string, id: string | undefined): TuiState {
+  if (id === undefined && !state.selection.has(listId)) {
+    return state;
+  }
+  if (id !== undefined && state.selection.get(listId) === id) {
+    return state;
+  }
+  const selection = new Map(state.selection);
+  if (id === undefined) {
+    selection.delete(listId);
+  } else {
+    selection.set(listId, id);
+  }
+  return { ...state, selection };
+}

--- a/packages/dashboard-core/src/state/selection/registry.ts
+++ b/packages/dashboard-core/src/state/selection/registry.ts
@@ -1,5 +1,6 @@
 import { deriveTuiInputMode, type TuiInputMode } from "../keymap.js";
 import type { TuiState } from "../types.js";
+import { addProjectChooseListSpec, addProjectStartListSpec } from "./specs/addProject.js";
 import { newSessionPickAgentListSpec, newSessionPickProjectListSpec } from "./specs/newSession.js";
 import { projectCollapseListSpec, projectSettingsPickerListSpec } from "./specs/projectChoosers.js";
 import { projectDefaultAgentListSpec } from "./specs/projectDefaultAgent.js";
@@ -11,6 +12,9 @@ import type { RegisteredListSpec } from "./types.js";
  * middleware a no-op, so a half-migrated tree runs.
  */
 export const LIST_REGISTRY: Partial<Record<TuiInputMode, RegisteredListSpec>> = {
+  addProjectStart: addProjectStartListSpec,
+  addProjectChoose: addProjectChooseListSpec,
+  addProjectFilter: addProjectChooseListSpec,
   projectDefaultAgent: projectDefaultAgentListSpec,
   newSessionPickProject: newSessionPickProjectListSpec,
   newSessionPickAgent: newSessionPickAgentListSpec,

--- a/packages/dashboard-core/src/state/selection/specs/addProject.ts
+++ b/packages/dashboard-core/src/state/selection/specs/addProject.ts
@@ -1,0 +1,53 @@
+import { addProjectRows } from "../../../flows/addProject/rows.js";
+import { applyAddProjectAction } from "../../screens/addProjectTransition.js";
+import { ADD_PROJECT_CHOOSE_LIST_ID, ADD_PROJECT_START_LIST_ID } from "../addProject.js";
+import { defineList } from "../types.js";
+
+export const addProjectStartListSpec = defineList({
+  listId: ADD_PROJECT_START_LIST_ID,
+  cursor: true,
+  rows: (state) => {
+    if (state.screen.name !== "addProject" || state.screen.flow.mode !== "start") {
+      return [];
+    }
+    return state.screen.flow.choices.map((_, index) => ({
+      selectable: true as const,
+      id: String(index),
+    }));
+  },
+  commit: (state, id) => {
+    if (state.screen.name !== "addProject" || state.screen.flow.mode !== "start") {
+      return { state };
+    }
+    const index = Number(id);
+    const choice = Number.isInteger(index) ? state.screen.flow.choices[index] : undefined;
+    return choice === undefined
+      ? { state }
+      : applyAddProjectAction(state, { type: "startOpen", path: choice.path });
+  },
+});
+
+export const addProjectChooseListSpec = defineList({
+  listId: ADD_PROJECT_CHOOSE_LIST_ID,
+  cursor: true,
+  active: (state) =>
+    state.screen.name === "addProject" &&
+    state.screen.flow.mode === "choose" &&
+    addProjectRows(state.screen.flow).length > 0,
+  rows: (state) => {
+    if (state.screen.name !== "addProject" || state.screen.flow.mode !== "choose") {
+      return [];
+    }
+    return addProjectRows(state.screen.flow).map((row) => ({
+      selectable: true as const,
+      id: row.path,
+    }));
+  },
+  commit: (state, path) => {
+    if (state.screen.name !== "addProject" || state.screen.flow.mode !== "choose") {
+      return { state };
+    }
+    const selected = addProjectRows(state.screen.flow).some((row) => row.path === path);
+    return selected ? applyAddProjectAction(state, { type: "chooseSelected", path }) : { state };
+  },
+});

--- a/packages/dashboard-core/test/unit/flows/addProject/flow.test.ts
+++ b/packages/dashboard-core/test/unit/flows/addProject/flow.test.ts
@@ -18,19 +18,18 @@ describe("add project flow", () => {
     ]);
   });
 
-  it("selects a start row by absolute index and clamps out-of-range clicks", () => {
+  it("opens an explicitly selected start path", () => {
     const started = createAddProjectFlow({
       cwd: "/Users/example/Developer/station",
       homeDir: "/Users/example",
     });
-    expect(started.selectedIndex).toBe(0);
 
-    const picked = transitionAddProjectFlow(started, { type: "select", index: 1 }).state;
-    expect(picked?.selectedIndex).toBe(1);
+    const opened = transitionAddProjectFlow(started, {
+      type: "startOpen",
+      path: "/Users/example",
+    });
 
-    // A stale click past the list clamps to the last row instead of going out of range.
-    const clamped = transitionAddProjectFlow(started, { type: "select", index: 9 }).state;
-    expect(clamped?.selectedIndex).toBe(started.choices.length - 1);
+    expect(opened.effects).toEqual([{ type: "loadDirectory", path: "/Users/example" }]);
   });
 
   it("uses wizard history and does not leak choose fields into review state", () => {

--- a/packages/dashboard-core/test/unit/state/selection/addProject.test.ts
+++ b/packages/dashboard-core/test/unit/state/selection/addProject.test.ts
@@ -1,0 +1,233 @@
+import {
+  addProjectSelectedIndex,
+  applyAddProjectFolderLoaded,
+  applyAddProjectFolderReviewed,
+  applyAddProjectFolderReviewFailed,
+  applyAddProjectFolderSearchLoaded,
+  applyAddProjectSubmitted,
+  createInitialTuiState,
+  deriveTuiInputMode,
+  handleTuiKey,
+  openAddProject,
+  selectAddProjectRow,
+  type TuiState,
+} from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+
+const KEY_CONTEXT = { cwd: "/workspace/station", homeDir: "/Users/example" };
+
+function startState(): TuiState {
+  return openAddProject(createInitialTuiState(), {
+    cwd: KEY_CONTEXT.cwd,
+    homeDir: KEY_CONTEXT.homeDir,
+  });
+}
+
+function chooseState(
+  entries = [{ name: "station", path: "/workspace/station", kind: "directory" as const }],
+) {
+  return applyAddProjectFolderLoaded(startState(), {
+    path: "/workspace",
+    entries,
+  });
+}
+
+function reviewState(): TuiState {
+  return applyAddProjectFolderReviewed(startState(), {
+    selectedPath: "/workspace/station",
+    gitRoot: "/workspace/station",
+    id: "station",
+    label: "Station",
+  });
+}
+
+describe("add-project shared selection", () => {
+  it("seeds the start cursor and routes arrows and Enter through the registered list", () => {
+    const opened = startState();
+    expect(deriveTuiInputMode(opened)).toBe("addProjectStart");
+    expect(addProjectSelectedIndex(opened)).toBe(0);
+
+    const moved = handleTuiKey(opened, { input: "", downArrow: true }, KEY_CONTEXT).state;
+    expect(addProjectSelectedIndex(moved)).toBe(1);
+
+    const committed = handleTuiKey(moved, { input: "\r", return: true }, KEY_CONTEXT);
+    expect(committed.operations).toEqual([
+      { type: "loadProjectDirectory", path: "/Users/example" },
+    ]);
+  });
+
+  it("uses the same canonical cursor for mouse selection", () => {
+    const moved = selectAddProjectRow(startState(), 99);
+    expect(addProjectSelectedIndex(moved)).toBe(1);
+  });
+
+  it("opens the selected start path with Right and closes with Escape", () => {
+    const opened = handleTuiKey(startState(), { input: "", rightArrow: true }, KEY_CONTEXT);
+    expect(opened.operations).toEqual([
+      { type: "loadProjectDirectory", path: "/workspace/station" },
+    ]);
+
+    const closed = handleTuiKey(startState(), { input: "", escape: true }, KEY_CONTEXT);
+    expect(closed.state.screen).toEqual({ name: "dashboard" });
+  });
+
+  it("registers folder selection in normal and filter modes", () => {
+    const choosing = chooseState();
+    expect(deriveTuiInputMode(choosing)).toBe("addProjectChoose");
+    expect(addProjectSelectedIndex(choosing)).toBe(0);
+
+    const moved = handleTuiKey(choosing, { input: "", downArrow: true }, KEY_CONTEXT).state;
+    expect(addProjectSelectedIndex(moved)).toBe(1);
+    expect(handleTuiKey(moved, { input: "\r", return: true }, KEY_CONTEXT).operations).toEqual([
+      { type: "reviewProjectFolder", path: "/workspace/station" },
+    ]);
+
+    const filtering = handleTuiKey(choosing, { input: "/" }, KEY_CONTEXT).state;
+    expect(deriveTuiInputMode(filtering)).toBe("addProjectFilter");
+    expect(handleTuiKey(filtering, { input: "\r", return: true }, KEY_CONTEXT).operations).toEqual([
+      { type: "reviewProjectFolder", path: "/workspace" },
+    ]);
+  });
+
+  it("opens a selected child with Right and its parent with Left", () => {
+    const choosing = chooseState();
+    expect(
+      handleTuiKey(choosing, { input: "", rightArrow: true }, KEY_CONTEXT).operations,
+    ).toBeUndefined();
+
+    const child = handleTuiKey(choosing, { input: "", downArrow: true }, KEY_CONTEXT).state;
+    expect(handleTuiKey(child, { input: "", rightArrow: true }, KEY_CONTEXT).operations).toEqual([
+      { type: "loadProjectDirectory", path: "/workspace/station" },
+    ]);
+    expect(handleTuiKey(child, { input: "", leftArrow: true }, KEY_CONTEXT).operations).toEqual([
+      { type: "loadProjectDirectory", path: "/" },
+    ]);
+  });
+
+  it("handles filter editing and reseeds the cursor when results arrive", () => {
+    let state = chooseState([]);
+    state = handleTuiKey(state, { input: "/" }, KEY_CONTEXT).state;
+    state = handleTuiKey(state, { input: "zz" }, KEY_CONTEXT).state;
+    expect(addProjectSelectedIndex(state)).toBeUndefined();
+
+    state = handleTuiKey(state, { input: "", backspace: true }, KEY_CONTEXT).state;
+    expect(state.screen).toMatchObject({ name: "addProject", flow: { filter: "z" } });
+    state = handleTuiKey(state, { input: "", delete: true }, KEY_CONTEXT).state;
+    expect(state.screen).toMatchObject({ name: "addProject", flow: { filter: "" } });
+
+    state = handleTuiKey(state, { input: "zz" }, KEY_CONTEXT).state;
+    state = applyAddProjectFolderSearchLoaded(state, {
+      query: "zz",
+      entries: [{ name: "fizz", path: "/search/fizz", kind: "directory" }],
+      truncated: false,
+    });
+    expect(addProjectSelectedIndex(state)).toBe(0);
+
+    state = handleTuiKey(state, { input: "u", ctrl: true }, KEY_CONTEXT).state;
+    expect(state.screen).toMatchObject({
+      name: "addProject",
+      flow: { filter: "", filterMode: false },
+    });
+  });
+
+  it("falls through to pasted-path review when filtering has no rows", () => {
+    let state = chooseState([]);
+    state = handleTuiKey(state, { input: "/" }, KEY_CONTEXT).state;
+    state = handleTuiKey(state, { input: "/missing/project" }, KEY_CONTEXT).state;
+
+    const submitted = handleTuiKey(state, { input: "\r", return: true }, KEY_CONTEXT);
+    expect(submitted.operations).toEqual([
+      { type: "reviewProjectFolder", path: "/missing/project" },
+    ]);
+  });
+});
+
+describe("add-project mode intents", () => {
+  it("maps review, id editing, and back actions", () => {
+    const reviewing = reviewState();
+    expect(deriveTuiInputMode(reviewing)).toBe("addProjectReview");
+
+    const editing = handleTuiKey(reviewing, { input: "N" }, KEY_CONTEXT).state;
+    expect(deriveTuiInputMode(editing)).toBe("addProjectEditId");
+
+    const changed = handleTuiKey(editing, { input: "-custom" }, KEY_CONTEXT).state;
+    const committed = handleTuiKey(changed, { input: "\r", return: true }, KEY_CONTEXT).state;
+    expect(committed.screen).toMatchObject({
+      name: "addProject",
+      flow: { mode: "review", id: "station-custom" },
+    });
+
+    expect(handleTuiKey(committed, { input: "B" }, KEY_CONTEXT).operations).toEqual([
+      { type: "loadProjectDirectory", path: "/workspace/station" },
+    ]);
+  });
+
+  it("cancels id editing without changing the project id", () => {
+    const reviewing = reviewState();
+    let state = handleTuiKey(reviewing, { input: "N" }, KEY_CONTEXT).state;
+    state = handleTuiKey(state, { input: "-discarded" }, KEY_CONTEXT).state;
+    state = handleTuiKey(state, { input: "", escape: true }, KEY_CONTEXT).state;
+
+    expect(state.screen).toMatchObject({
+      name: "addProject",
+      flow: { mode: "review", id: "station" },
+    });
+  });
+
+  it("submits review, closes success, and retries failure", () => {
+    const reviewing = reviewState();
+    expect(handleTuiKey(reviewing, { input: "\r", return: true }, KEY_CONTEXT).operations).toEqual([
+      {
+        type: "addProject",
+        command: {
+          type: "project.add",
+          payload: { path: "/workspace/station", id: "station", label: "Station" },
+        },
+      },
+    ]);
+
+    const success = applyAddProjectSubmitted(reviewing, {
+      label: "Station",
+      root: "/workspace/station",
+    });
+    expect(deriveTuiInputMode(success)).toBe("addProjectSuccess");
+    expect(handleTuiKey(success, { input: "\r", return: true }, KEY_CONTEXT).state.screen).toEqual({
+      name: "dashboard",
+    });
+
+    const failed = applyAddProjectFolderReviewFailed(
+      reviewing,
+      "/workspace/station",
+      new Error("failed"),
+    );
+    expect(deriveTuiInputMode(failed)).toBe("addProjectFailed");
+    expect(handleTuiKey(failed, { input: "R" }, KEY_CONTEXT).operations).toEqual([
+      { type: "reviewProjectFolder", path: "/workspace/station" },
+    ]);
+    expect(handleTuiKey(failed, { input: "B" }, KEY_CONTEXT).operations).toEqual([
+      { type: "loadProjectDirectory", path: "/workspace/station" },
+    ]);
+    expect(handleTuiKey(failed, { input: "", escape: true }, KEY_CONTEXT).state.screen).toEqual({
+      name: "dashboard",
+    });
+    expect(handleTuiKey(success, { input: "", escape: true }, KEY_CONTEXT).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+
+  it("clears filtering before Escape closes the wizard", () => {
+    let state = chooseState();
+    state = handleTuiKey(state, { input: "/" }, KEY_CONTEXT).state;
+    state = handleTuiKey(state, { input: "st" }, KEY_CONTEXT).state;
+
+    const cleared = handleTuiKey(state, { input: "", escape: true }, KEY_CONTEXT).state;
+    expect(cleared.screen).toMatchObject({
+      name: "addProject",
+      flow: { mode: "choose", filter: "", filterMode: false },
+    });
+
+    expect(handleTuiKey(cleared, { input: "", escape: true }, KEY_CONTEXT).state.screen).toEqual({
+      name: "dashboard",
+    });
+  });
+});

--- a/packages/dashboard-core/test/unit/state/selection/engine.test.ts
+++ b/packages/dashboard-core/test/unit/state/selection/engine.test.ts
@@ -198,6 +198,9 @@ describe("list registry — migrated modes", () => {
     // Any accidental registration in an unmigrated mode flips this red, so the
     // set is asserted whole rather than sampled.
     expect(Object.keys(LIST_REGISTRY).sort()).toEqual([
+      "addProjectChoose",
+      "addProjectFilter",
+      "addProjectStart",
       "newSessionPickAgent",
       "newSessionPickProject",
       "projectCollapse",

--- a/station/src/dashboardRenderer/dashboardMouse.test.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { StationSnapshot } from "@station/contracts";
 import {
+  addProjectSelectedIndex,
   addTuiToast,
   createEditableTextInputState,
   openProjectSettings,
@@ -168,19 +169,11 @@ describe("routeDashboardMouse", () => {
   it("routes wheel over child targets and blocks background scrolling in modal modes", () => {
     const store = makeStore();
 
-    routeDashboardMouse(
-      { kind: "row", rowId: "ses_wt_station_working" },
-      SCROLL_DOWN,
-      store,
-    );
+    routeDashboardMouse({ kind: "row", rowId: "ses_wt_station_working" }, SCROLL_DOWN, store);
     expect(store.getState().scrollOffset).toBe(1);
 
     store.getState().handleKey({ input: "H" });
-    routeDashboardMouse(
-      { kind: "row", rowId: "ses_wt_station_working" },
-      SCROLL_DOWN,
-      store,
-    );
+    routeDashboardMouse({ kind: "row", rowId: "ses_wt_station_working" }, SCROLL_DOWN, store);
     expect(store.getState().scrollOffset).toBe(1);
   });
 
@@ -232,7 +225,8 @@ describe("routeDashboardMouse", () => {
     store.getState().handleKey({ input: "A" });
     routeDashboardMouse({ kind: "addProjectRow", index: 1 }, LEFT_DOWN, store);
     const addProject = store.getState().screen;
-    expect(addProject.name === "addProject" && addProject.flow.mode === "start" && addProject.flow.selectedIndex).toBe(1);
+    expect(addProject.name === "addProject" && addProject.flow.mode === "start").toBe(true);
+    expect(addProjectSelectedIndex(store.getState())).toBe(1);
     store.getState().handleKey({ input: "", escape: true });
 
     store.setState({ widgets: [{ type: "time" }, { type: "moon" }] });
@@ -288,7 +282,9 @@ describe("routeDashboardMouse", () => {
     await waitFor(() =>
       fixture.service.dispatched.some((command) => command.type === "session.create"),
     );
-    expect(fixture.service.dispatched.find((command) => command.type === "session.create")).toMatchObject({
+    expect(
+      fixture.service.dispatched.find((command) => command.type === "session.create"),
+    ).toMatchObject({
       payload: {
         projectId: "station",
         harness: { provider: "codex" },
@@ -319,11 +315,7 @@ describe("routeDashboardMouse", () => {
     expect(store.getState().collapsedProjectIds).toEqual(before.collapsedProjectIds);
 
     store.getState().handleKey({ input: "H" });
-    routeDashboardMouse(
-      { kind: "row", rowId: "ses_wt_station_none" },
-      LEFT_DOWN,
-      store,
-    );
+    routeDashboardMouse({ kind: "row", rowId: "ses_wt_station_none" }, LEFT_DOWN, store);
     routeDashboardMouse({ kind: "projectHeader", projectId: "station" }, LEFT_DOWN, store);
     expect(store.getState().screen).toEqual({ name: "help" });
     expect(store.getState().localRows.pendingStart).toEqual([]);
@@ -352,8 +344,12 @@ describe("routeDashboardMouse", () => {
       Array.from({ length: 10 }, () => "https://github.com/example/station/pull/12"),
     );
     expect(store.getState().toasts.length).toBeLessThanOrEqual(3);
-    expect(store.getState().toasts.some((entry) =>
-      entry.toast.message === "That dashboard item is no longer available."
-    )).toBe(true);
+    expect(
+      store
+        .getState()
+        .toasts.some(
+          (entry) => entry.toast.message === "That dashboard item is no longer available.",
+        ),
+    ).toBe(true);
   });
 });

--- a/station/src/dashboardRenderer/dashboardMouse.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.ts
@@ -18,11 +18,7 @@ import {
   type TuiInputMode,
 } from "@station/dashboard-core";
 import type { StoreApi } from "zustand/vanilla";
-import {
-  isPrimaryMouseEvent,
-  wheelDirection,
-  type StationMouseEvent,
-} from "../input/mouse.js";
+import { isPrimaryMouseEvent, wheelDirection, type StationMouseEvent } from "../input/mouse.js";
 import type { StationMouseTarget } from "../station/input/stationMouse.js";
 
 export type DashboardMouseEffects = {
@@ -37,6 +33,11 @@ const ROW_INTERACTIVE_MODES: ReadonlySet<TuiInputMode> = new Set([
   "forkChooseSlot",
 ]);
 const SHEET_CHOICE_MODES: ReadonlySet<string> = new Set(Object.keys(LIST_REGISTRY));
+const ADD_PROJECT_ROW_MODES: ReadonlySet<TuiInputMode> = new Set([
+  "addProjectStart",
+  "addProjectChoose",
+  "addProjectFilter",
+]);
 const SCROLL_PAGE_ROWS = 5;
 const STALE_TARGET_MESSAGE = "That dashboard item is no longer available.";
 
@@ -113,11 +114,7 @@ function routeSurfaceClick(
   }
 }
 
-function activateRowInMode(
-  store: StoreApi<TuiStore>,
-  rowId: string,
-  mode: TuiInputMode,
-): void {
+function activateRowInMode(store: StoreApi<TuiStore>, rowId: string, mode: TuiInputMode): void {
   if (ROW_INTERACTIVE_MODES.has(mode)) {
     activateCurrentRow(store, rowId);
   }
@@ -133,11 +130,7 @@ function toggleProjectInMode(
   }
 }
 
-function openLinkInMode(
-  url: string,
-  mode: TuiInputMode,
-  effects: DashboardMouseEffects,
-): void {
+function openLinkInMode(url: string, mode: TuiInputMode, effects: DashboardMouseEffects): void {
   if (mode === "dashboard") {
     effects.openUrl(url);
   }
@@ -167,7 +160,9 @@ function openProjectShellInMode(
   effects: DashboardMouseEffects,
 ): void {
   if (mode !== "dashboard") return;
-  const project = store.getState().snapshot?.projects.find((candidate) => candidate.id === projectId);
+  const project = store
+    .getState()
+    .snapshot?.projects.find((candidate) => candidate.id === projectId);
   if (project === undefined) {
     showNotice(store, STALE_TARGET_MESSAGE);
     return;
@@ -175,11 +170,7 @@ function openProjectShellInMode(
   effects.openShell({ cwd: project.root });
 }
 
-function pageInMode(
-  store: StoreApi<TuiStore>,
-  direction: "up" | "down",
-  mode: TuiInputMode,
-): void {
+function pageInMode(store: StoreApi<TuiStore>, direction: "up" | "down", mode: TuiInputMode): void {
   if (!ROW_INTERACTIVE_MODES.has(mode)) {
     return;
   }
@@ -216,7 +207,7 @@ function routeModalClick(
       confirmProjectRemoval(store, mode);
       return true;
     case "addProjectRow":
-      if (mode === "addProject") {
+      if (ADD_PROJECT_ROW_MODES.has(mode)) {
         store.setState(selectAddProjectRow(store.getState(), target.index));
       }
       return true;

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, it } from "bun:test";
 import type { StoreApi } from "zustand/vanilla";
 import type { ProviderId, StationSnapshot } from "@station/contracts";
-import { selectDashboardViewport } from "@station/dashboard-core";
+import { addProjectSelectedIndex, selectDashboardViewport } from "@station/dashboard-core";
 import { addTuiToast } from "@station/dashboard-core";
 import {
   createEditableTextInputState,
@@ -342,7 +342,11 @@ describe("routeStationMouse", () => {
     const store = makeStore();
     const before = store.getState().screen;
 
-    const outcome = routeStationMouse({ kind: "projectHeader", projectId: "station" }, RIGHT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "projectHeader", projectId: "station" },
+      RIGHT_DOWN,
+      store,
+    );
 
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toBe(before);
@@ -382,7 +386,11 @@ describe("routeStationMouse", () => {
 
   it("opens a shell pane for a project header click at the project root", () => {
     const store = makeStore();
-    const outcome = routeStationMouse({ kind: "openShellForProject", projectId: "station" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "openShellForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
     expect(outcome).toEqual({
       kind: "open-pane",
       paneId: "pane-proj-station",
@@ -415,7 +423,13 @@ describe("routeStationMouse", () => {
     const store = makeStore();
     store.getState().handleKey({ input: "/" }); // enter search (non-dashboard) mode
 
-    expect(routeStationMouse({ kind: "openShellForRow", rowId: "ses_wt_station_idle" }, LEFT_DOWN, store)).toEqual({
+    expect(
+      routeStationMouse(
+        { kind: "openShellForRow", rowId: "ses_wt_station_idle" },
+        LEFT_DOWN,
+        store,
+      ),
+    ).toEqual({
       kind: "handled",
     });
     expect(
@@ -425,7 +439,9 @@ describe("routeStationMouse", () => {
 
   it("treats an unresolvable row or project as an inert click", () => {
     const store = makeStore();
-    expect(routeStationMouse({ kind: "openShellForRow", rowId: "wt_nope" }, LEFT_DOWN, store)).toEqual({
+    expect(
+      routeStationMouse({ kind: "openShellForRow", rowId: "wt_nope" }, LEFT_DOWN, store),
+    ).toEqual({
       kind: "handled",
     });
     expect(
@@ -435,7 +451,11 @@ describe("routeStationMouse", () => {
 
   it("creates a session immediately via [+] quick-session affordance", () => {
     const store = makeStore();
-    const outcome = routeStationMouse({ kind: "quickSessionForProject", projectId: "station" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "quickSessionForProject", projectId: "station" },
+      LEFT_DOWN,
+      store,
+    );
     expect(outcome.kind).toBe("launch-new-session");
     if (outcome.kind === "launch-new-session") {
       expect(outcome.projectId).toBe("station");
@@ -448,11 +468,7 @@ describe("routeStationMouse", () => {
     const store = makeStore(snapshotWithBareProject("station"));
 
     expect(
-      routeStationMouse(
-        { kind: "quickSessionForProject", projectId: "station" },
-        LEFT_DOWN,
-        store,
-      ),
+      routeStationMouse({ kind: "quickSessionForProject", projectId: "station" }, LEFT_DOWN, store),
     ).toEqual({ kind: "handled" });
     expect(store.getState().localRows.pendingCreate).toEqual([]);
     const toast = store.getState().toasts.at(-1)?.toast;
@@ -597,9 +613,9 @@ describe("routeStationMouse", () => {
     expect(
       routeStationMouse({ kind: "projectSettingsItem", itemId: "remove" }, LEFT_DOWN, store),
     ).toEqual({ kind: "handled" });
-    expect(
-      routeStationMouse({ kind: "projectSettingsConfirmRemove" }, LEFT_DOWN, store),
-    ).toEqual({ kind: "handled" });
+    expect(routeStationMouse({ kind: "projectSettingsConfirmRemove" }, LEFT_DOWN, store)).toEqual({
+      kind: "handled",
+    });
     expect(store.getState().screen).toEqual(before);
   });
 });
@@ -736,14 +752,14 @@ describe("routeStationMouse widget settings", () => {
     if (opened.name !== "addProject" || opened.flow.mode !== "start") {
       throw new Error("expected addProject start");
     }
-    expect(opened.flow.selectedIndex).toBe(0);
+    expect(addProjectSelectedIndex(store.getState())).toBe(0);
 
     routeStationMouse({ kind: "addProjectRow", index: 1 }, LEFT_DOWN, store);
     const moved = store.getState().screen;
     if (moved.name !== "addProject" || moved.flow.mode !== "start") {
       throw new Error("expected addProject start");
     }
-    expect(moved.flow.selectedIndex).toBe(1);
+    expect(addProjectSelectedIndex(store.getState())).toBe(1);
   });
 
   it("ignores an add-project row click outside addProject mode", () => {

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -146,6 +146,11 @@ const ROW_INTERACTIVE_MODES: ReadonlySet<TuiInputMode> = new Set([
   "renameChooseSlot",
   "forkChooseSlot",
 ]);
+const ADD_PROJECT_ROW_MODES: ReadonlySet<TuiInputMode> = new Set([
+  "addProjectStart",
+  "addProjectChoose",
+  "addProjectFilter",
+]);
 
 export function routeStationMouse(
   target: StationMouseTarget,
@@ -263,7 +268,7 @@ export function routeStationMouse(
       addWidgetSettingsPickerChoice(store, target.index);
       return { kind: "handled" };
     case "addProjectRow":
-      if (mode !== "addProject") {
+      if (!ADD_PROJECT_ROW_MODES.has(mode)) {
         return { kind: "handled" };
       }
       selectAddProjectRow(store, target.index);
@@ -306,10 +311,7 @@ export function routeStationMouse(
   }
 }
 
-function routeDashboardRow(
-  store: StoreApi<TuiStore>,
-  rowId: string,
-): StationMouseOutcome {
+function routeDashboardRow(store: StoreApi<TuiStore>, rowId: string): StationMouseOutcome {
   const target = resolveRowAgentTarget(store, rowId);
   return target.kind === "launch-managed"
     ? fromRowAgentTarget(target)

--- a/station/src/station/view/OverlayHostView.tsx
+++ b/station/src/station/view/OverlayHostView.tsx
@@ -53,7 +53,14 @@ export function OverlayHostView({
     );
   }
   if (screen.name === "addProject") {
-    return <AddProjectSheetView columns={columns} rows={rows} state={screen.flow} />;
+    return (
+      <AddProjectSheetView
+        columns={columns}
+        rows={rows}
+        state={screen.flow}
+        selection={selection}
+      />
+    );
   }
   if (screen.name === "newSession") {
     return (

--- a/station/src/station/view/sheets/AddProjectSheetView.tsx
+++ b/station/src/station/view/sheets/AddProjectSheetView.tsx
@@ -1,5 +1,5 @@
-import { addProjectRows } from "@station/dashboard-core";
-import type { AddProjectFlowState } from "@station/dashboard-core";
+import { addProjectRows, addProjectSelectedIndexForFlow } from "@station/dashboard-core";
+import type { AddProjectFlowState, TuiSelectionState } from "@station/dashboard-core";
 import { bottomSheetContentWidth } from "@station/dashboard-core";
 import { EditableTextInputView } from "../EditableTextInputView.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
@@ -17,13 +17,15 @@ import {
 
 export type AddProjectSheetViewProps = {
   state: AddProjectFlowState;
+  selection: TuiSelectionState;
   columns: number;
   rows: number;
 };
 
-export function AddProjectSheetView({ state, columns, rows }: AddProjectSheetViewProps) {
+export function AddProjectSheetView({ state, selection, columns, rows }: AddProjectSheetViewProps) {
   const targetHeight = fixedSheetHeight(rows);
   const contentWidth = bottomSheetContentWidth(columns);
+  const selectedIndex = addProjectSelectedIndexForFlow(state, selection);
   return (
     <BottomSheetFrameView
       columns={columns}
@@ -32,17 +34,36 @@ export function AddProjectSheetView({ state, columns, rows }: AddProjectSheetVie
       contentRows={Math.max(1, targetHeight - 2)}
       minHeight={targetHeight}
     >
-      {renderState(state, contentWidth, Math.max(1, targetHeight - 3))}
+      {renderState(state, selectedIndex, contentWidth, Math.max(1, targetHeight - 3))}
     </BottomSheetFrameView>
   );
 }
 
-function renderState(state: AddProjectFlowState, width: number, contentRows: number) {
+function renderState(
+  state: AddProjectFlowState,
+  selectedIndex: number | undefined,
+  width: number,
+  contentRows: number,
+) {
   if (state.mode === "start") {
-    return <StartChoices state={state} width={width} contentRows={contentRows} />;
+    return (
+      <StartChoices
+        state={state}
+        selectedIndex={selectedIndex}
+        width={width}
+        contentRows={contentRows}
+      />
+    );
   }
   if (state.mode === "choose") {
-    return <FolderPicker state={state} width={width} contentRows={contentRows} />;
+    return (
+      <FolderPicker
+        state={state}
+        selectedIndex={selectedIndex}
+        width={width}
+        contentRows={contentRows}
+      />
+    );
   }
   if (state.mode === "review") {
     return <Review state={state} width={width} />;
@@ -55,10 +76,12 @@ function renderState(state: AddProjectFlowState, width: number, contentRows: num
 
 function StartChoices({
   state,
+  selectedIndex,
   width,
   contentRows,
 }: {
   state: Extract<AddProjectFlowState, { mode: "start" }>;
+  selectedIndex: number | undefined;
   width: number;
   contentRows: number;
 }) {
@@ -71,7 +94,7 @@ function StartChoices({
         <SheetPickerLine
           key={choice.path}
           width={width}
-          selected={index === state.selectedIndex}
+          selected={index === selectedIndex}
           label={choice.label}
           detail={choice.detail}
           mouseTarget={{ kind: "addProjectRow", index }}
@@ -85,17 +108,19 @@ function StartChoices({
 
 function FolderPicker({
   state,
+  selectedIndex,
   width,
   contentRows,
 }: {
   state: Extract<AddProjectFlowState, { mode: "choose" }>;
+  selectedIndex: number | undefined;
   width: number;
   contentRows: number;
 }) {
   const rows = addProjectRows(state);
   const hasSearchPrompt = state.filterMode || state.filter.length > 0;
   const listHeight = Math.max(1, contentRows - (hasSearchPrompt ? 5 : 4));
-  const start = Math.max(0, Math.min(state.selectedIndex, rows.length - listHeight));
+  const start = Math.max(0, Math.min(selectedIndex ?? 0, rows.length - listHeight));
   const visible = rows.slice(start, start + listHeight);
   if (state.filter.length > 0 && rows.length === 0) {
     return (
@@ -147,7 +172,7 @@ function FolderPicker({
         <SheetPickerLine
           key={`${row.kind}:${row.path}`}
           width={width}
-          selected={start + index === state.selectedIndex}
+          selected={start + index === selectedIndex}
           label={rowLabel(row)}
           detail={rowDetail(row.kind)}
           mouseTarget={{ kind: "addProjectRow", index: start + index }}


### PR DESCRIPTION
## What this fixes

The Add Project wizard bypassed dashboard-core's shared selection registry, so one screen reducer owned list navigation, mode-specific shortcuts, filtering, editing, and operations while also maintaining a second cursor in the flow state. That duplication made keyboard and mouse behavior easier to drift and gave `handleAddProjectKey` a Biome cognitive-complexity score of 40.

## What changed

- Added explicit Add Project input modes and registered its start, folder, and filter lists with the shared selection middleware.
- Made `TuiState.selection` the single cursor authority, including seeding, visible-row reconciliation, rendering, and mouse clicks.
- Split screen-specific keys into small mode intents and centralized flow-to-operation translation; `handleAddProjectKey` now scores 2 at Biome's cognitive-complexity rule.
- Preserved start/folder navigation, pasted-path fallback, filter editing, project-ID editing, review/submit, retry/back, success/close, and mouse behavior.
- Added focused coverage for every wizard mode, shared cursor routing, filter result reseeding, path operations, and mouse/key parity.

## Testing

- `env -u STATION_PANE PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm test:all`
- `cd station && bun run typecheck && bun run test`
- Pre-push `pnpm test:pre-push` hook, including Station PTY lanes, binary build, and binary smoke
- Biome `noExcessiveCognitiveComplexity` at `maxAllowedComplexity: 15` on the refactored Add Project modules
- TypeScript LSP and pi-lens diagnostics: clean

## User-visible behavior

No shortcut changes are intended. Manually verify by opening **Add Project**, moving and clicking through both start locations and folders, filtering with `/`, selecting a result, editing the project ID with `N`, and completing or backing out of the wizard.
