### PR TITLE
ci(gates): parallelize required validation and shorten pushes

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -1,0 +1,50 @@
+name: Set up Station CI
+
+description: Install the pinned runtimes, workspace dependencies, and optional Station dependencies.
+
+inputs:
+  bun:
+    description: Install the pinned Bun runtime.
+    required: false
+    default: "false"
+  station-dependencies:
+    description: Install the Station renderer's Bun dependencies.
+    required: false
+    default: "false"
+  restore-turbo-cache:
+    description: Restore and save the pull request Turbo cache.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: 24.x
+    - name: Enable pnpm 11
+      shell: bash
+      run: |
+        corepack enable
+        corepack prepare pnpm@11.0.0 --activate
+    - name: Restore Turbo cache
+      if: inputs.restore-turbo-cache == 'true'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-
+    - name: Set up Bun
+      if: inputs.bun == 'true' || inputs.station-dependencies == 'true'
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      with:
+        bun-version: 1.3.14
+    - name: Install pnpm workspace
+      shell: bash
+      run: pnpm install --frozen-lockfile
+    - name: Install Station workspace
+      if: inputs.station-dependencies == 'true'
+      shell: bash
+      working-directory: station
+      run: bun install --frozen-lockfile

--- a/.github/workflows/nightly-observer-claim.yml
+++ b/.github/workflows/nightly-observer-claim.yml
@@ -1,0 +1,27 @@
+# Exhaustive probabilistic coverage stays off the normal PR critical path while
+# still detecting low-frequency Node/Bun Observer boot-claim races on main.
+name: nightly-observer-claim
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  claim-stress:
+    if: github.repository_owner == 'jeremy0dell'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          bun: "true"
+      - run: pnpm build
+      - name: Exhaustive Node/Bun Observer claim stress
+        run: pnpm test:observer-claim:cross-runtime

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -16,43 +16,257 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  standard-ci:
-    # Reusable release calls retain the caller's tag context and must keep the full gate.
+  classify:
     if: >-
       github.ref_type == 'tag' ||
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 2
+    outputs:
+      docs_only: ${{ steps.paths.outputs.docs_only }}
+      installer: ${{ steps.paths.outputs.installer }}
+      binary: ${{ steps.paths.outputs.binary }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify validation paths
+        id: paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+            {
+              echo "docs_only=false"
+              echo "installer=true"
+              echo "binary=true"
+            } >> "$GITHUB_OUTPUT"
+          else
+            git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" |
+              node scripts/ci/classify-standard-ci.mjs >> "$GITHUB_OUTPUT"
+          fi
+
+  static:
+    needs: classify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: ./.github/actions/setup-ci
         with:
-          node-version: 24.x
-      - name: Enable pnpm 11
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - name: Documentation validation
+        if: needs.classify.outputs.docs_only == 'true'
         run: |
-          corepack enable
-          corepack prepare pnpm@11.0.0 --activate
-      # Release acceptance stays cold so branch caches cannot enter candidate validation.
-      - name: Restore Turbo cache
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+          pnpm lint
+          pnpm test:diagnostics:policy
+      - name: Production static validation
+        if: needs.classify.outputs.docs_only != 'true'
+        run: |
+          pnpm build
+          pnpm typecheck
+          pnpm lint
+
+  fast_tests:
+    name: fast-tests
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-${{ runner.arch }}-node24-pnpm11-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
         with:
-          bun-version: 1.3.14
-      - name: Install (pnpm)
-        run: pnpm install --frozen-lockfile
-      - name: Install (bun)
-        run: bun install --frozen-lockfile
-        working-directory: station
-      - name: Test
-        run: pnpm test:pre-push
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm test:ci:fast
+
+  integration_tests:
+    name: integration-tests
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm test:integration
+
+  setup_e2e:
+    name: setup-e2e (${{ matrix.lane }})
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: guided
+            script: test:e2e:setup:guided
+          - lane: core
+            script: test:e2e:setup:core
+          - lane: sqlite
+            script: test:e2e:setup:sqlite
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm build
+      - run: pnpm ${{ matrix.script }}
+
+  observer_e2e:
+    name: observer-e2e
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm build
+      - run: pnpm test:e2e:observer
+
+  installer_smoke:
+    name: installer-smoke
+    needs: [classify, static]
+    if: >-
+      needs.classify.outputs.docs_only != 'true' &&
+      needs.classify.outputs.installer == 'true' &&
+      needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+      - run: pnpm smoke:install
+
+  sqlite_cross_runtime:
+    name: sqlite-cross-runtime
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          bun: "true"
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm build
+      - name: Cross-runtime SQLite and claim checks
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+            pnpm test:sqlite:bun
+          else
+            pnpm test:sqlite:bun:pr
+          fi
+
+  station_tests:
+    name: station-tests
+    needs: [classify, static]
+    if: needs.classify.outputs.docs_only != 'true' && needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          station-dependencies: "true"
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm build
+      - run: pnpm test:ci:station
+
+  binary_smoke:
+    name: binary-smoke
+    needs: [classify, static]
+    if: >-
+      needs.classify.outputs.docs_only != 'true' &&
+      needs.classify.outputs.binary == 'true' &&
+      needs.static.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          station-dependencies: "true"
+          restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
+      - run: pnpm test:ci:binary
+
+  standard-ci:
+    name: standard-ci
+    needs:
+      - classify
+      - static
+      - fast_tests
+      - integration_tests
+      - setup_e2e
+      - observer_e2e
+      - installer_smoke
+      - sqlite_cross_runtime
+      - station_tests
+      - binary_smoke
+    if: >-
+      always() &&
+      (github.ref_type == 'tag' ||
+       (github.event_name == 'pull_request' && github.event.pull_request.draft == false))
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Require every selected lane
+        env:
+          CLASSIFY: ${{ needs.classify.result }}
+          STATIC: ${{ needs.static.result }}
+          FAST_TESTS: ${{ needs.fast_tests.result }}
+          INTEGRATION_TESTS: ${{ needs.integration_tests.result }}
+          SETUP_E2E: ${{ needs.setup_e2e.result }}
+          OBSERVER_E2E: ${{ needs.observer_e2e.result }}
+          INSTALLER_SMOKE: ${{ needs.installer_smoke.result }}
+          SQLITE_CROSS_RUNTIME: ${{ needs.sqlite_cross_runtime.result }}
+          STATION_TESTS: ${{ needs.station_tests.result }}
+          BINARY_SMOKE: ${{ needs.binary_smoke.result }}
+        run: |
+          test "$CLASSIFY" = success
+          test "$STATIC" = success
+          for result in \
+            "$FAST_TESTS" \
+            "$INTEGRATION_TESTS" \
+            "$SETUP_E2E" \
+            "$OBSERVER_E2E" \
+            "$INSTALLER_SMOKE" \
+            "$SQLITE_CROSS_RUNTIME" \
+            "$STATION_TESTS" \
+            "$BINARY_SMOKE"; do
+            case "$result" in
+              success|skipped) ;;
+              *) echo "Required CI lane ended with $result." >&2; exit 1 ;;
+            esac
+          done
 
   main-smoke:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -62,7 +276,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -26,6 +26,8 @@ jobs:
       docs_only: ${{ steps.paths.outputs.docs_only }}
       installer: ${{ steps.paths.outputs.installer }}
       binary: ${{ steps.paths.outputs.binary }}
+      claim_stress: ${{ steps.paths.outputs.claim_stress }}
+      shell_matrix: ${{ steps.paths.outputs.shell_matrix }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -42,6 +44,8 @@ jobs:
               echo "docs_only=false"
               echo "installer=true"
               echo "binary=true"
+              echo "claim_stress=true"
+              echo "shell_matrix=true"
             } >> "$GITHUB_OUTPUT"
           else
             git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" |
@@ -125,7 +129,10 @@ jobs:
         with:
           restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
       - run: pnpm build
-      - run: pnpm ${{ matrix.script }}
+      - name: Run setup E2E shard
+        env:
+          STATION_SETUP_E2E_ALL_SHELLS: ${{ needs.classify.outputs.shell_matrix }}
+        run: pnpm ${{ matrix.script }}
 
   observer_e2e:
     name: observer-e2e
@@ -175,8 +182,10 @@ jobs:
           restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
       - run: pnpm build
       - name: Cross-runtime SQLite and claim checks
+        env:
+          CLAIM_STRESS: ${{ needs.classify.outputs.claim_stress }}
         run: |
-          if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+          if [[ "$GITHUB_REF_TYPE" == tag || "$CLAIM_STRESS" == true ]]; then
             pnpm test:sqlite:bun
           else
             pnpm test:sqlite:bun:pr
@@ -238,8 +247,16 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Require every selected lane
         env:
+          DOCS_ONLY: ${{ needs.classify.outputs.docs_only }}
+          INSTALLER_SELECTED: ${{ needs.classify.outputs.installer }}
+          BINARY_SELECTED: ${{ needs.classify.outputs.binary }}
+          CLAIM_STRESS_SELECTED: ${{ needs.classify.outputs.claim_stress }}
+          SHELL_MATRIX_SELECTED: ${{ needs.classify.outputs.shell_matrix }}
           CLASSIFY: ${{ needs.classify.result }}
           STATIC: ${{ needs.static.result }}
           FAST_TESTS: ${{ needs.fast_tests.result }}
@@ -250,23 +267,7 @@ jobs:
           SQLITE_CROSS_RUNTIME: ${{ needs.sqlite_cross_runtime.result }}
           STATION_TESTS: ${{ needs.station_tests.result }}
           BINARY_SMOKE: ${{ needs.binary_smoke.result }}
-        run: |
-          test "$CLASSIFY" = success
-          test "$STATIC" = success
-          for result in \
-            "$FAST_TESTS" \
-            "$INTEGRATION_TESTS" \
-            "$SETUP_E2E" \
-            "$OBSERVER_E2E" \
-            "$INSTALLER_SMOKE" \
-            "$SQLITE_CROSS_RUNTIME" \
-            "$STATION_TESTS" \
-            "$BINARY_SMOKE"; do
-            case "$result" in
-              success|skipped) ;;
-              *) echo "Required CI lane ended with $result." >&2; exit 1 ;;
-            esac
-          done
+        run: sh scripts/ci/require-standard-ci-results.sh
 
   main-smoke:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -61,8 +61,15 @@ describe("setup dependency checks", () => {
     ).resolves.toEqual({ status: "missing", command: "/usr/sbin/lsof" });
   });
 
-  it("detects active-shell Worktrunk integration through its read-only dry run", async () => {
+  it.each([
+    { shell: "zsh", rcFile: ".zshrc" },
+    { shell: "bash", rcFile: ".bashrc" },
+  ] as const)("detects $shell Worktrunk integration through its read-only dry run", async ({
+    shell,
+    rcFile,
+  }) => {
     const pendingCalls: ExternalCommandInput[] = [];
+    const command = `wt -y config shell install --dry-run ${shell}`;
     const input = {
       worktrunk: {
         status: "ok" as const,
@@ -70,25 +77,25 @@ describe("setup dependency checks", () => {
         resolvedPath: "/fake/bin/wt",
       },
       homeDir: "/tmp/home",
-      env: { PATH: "/fake/bin", SHELL: "/bin/zsh" },
+      env: { PATH: "/fake/bin", SHELL: `/bin/${shell}` },
     };
 
     await expect(
       checkSetupWorktrunkShellIntegration({
         ...input,
         runner: fakeRunner(pendingCalls, {
-          "wt -y config shell install --dry-run zsh": "shell integration update pending\n",
+          [command]: "shell integration update pending\n",
         }),
       }),
     ).resolves.toMatchObject({
       status: "warning",
-      shell: "zsh",
-      rcPath: "/tmp/home/.zshrc",
+      shell,
+      rcPath: `/tmp/home/${rcFile}`,
     });
     expect(pendingCalls).toContainEqual(
       expect.objectContaining({
         command: "/fake/bin/wt",
-        args: ["-y", "config", "shell", "install", "--dry-run", "zsh"],
+        args: ["-y", "config", "shell", "install", "--dry-run", shell],
         env: expect.objectContaining({ HOME: "/tmp/home" }),
       }),
     );
@@ -96,13 +103,11 @@ describe("setup dependency checks", () => {
     await expect(
       checkSetupWorktrunkShellIntegration({
         ...input,
-        runner: fakeRunner([], {
-          "wt -y config shell install --dry-run zsh": "",
-        }),
+        runner: fakeRunner([], { [command]: "" }),
       }),
     ).resolves.toMatchObject({
       status: "ok",
-      message: "Worktrunk shell integration is installed for zsh.",
+      message: `Worktrunk shell integration is installed for ${shell}.`,
     });
   });
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -147,27 +147,30 @@ diagnostics tests, the scripted-agent lane, setup and Observer lifecycle E2E
 coverage, and a production Observer SQLite restart smoke. It intentionally
 excludes real provider lanes.
 
-After root `pnpm install`, Lefthook runs the broader local gate before pushes:
+After root `pnpm install`, Lefthook runs lint before commits and pushes:
 
 ```bash
 pnpm test:pre-push
 ```
 
-In addition to `test:all`, it checks cross-runtime SQLite compatibility, the
-Station renderer, the native PTY implementation, and the compiled binary on
-the developer's current platform. Install both the root pnpm dependencies and
-the `station/` Bun dependencies before pushing.
+The pre-push hook is intentionally lint-only so pushing does not repeat the hosted deterministic
+gate. Use `pnpm test:all` or the focused commands below when local behavior needs validation.
+Install the `station/` Bun dependencies only for Station renderer, PTY, or compiled-binary work.
 
-Ready, non-draft pull requests run `pnpm test:pre-push` once on
-`ubuntu-24.04`; release tags call that same full gate before adding the four
-native build and draft-install targets. Both that gate and `smoke:release` must
-pass before any native release build starts.
-Draft pull request activity allocates no
-runner, including synchronization before `ready_for_review`.
-Pushes to `main` run only build, typecheck, and lint as a cheap post-merge
-smoke. The repository ruleset must require the pull-request `standard-ci` check
-and block direct `main` pushes; the cheap smoke is a post-merge backstop, not a
-substitute for the full required gate.
+Ready, non-draft pull requests fan out static validation, root tests, setup E2E, Observer E2E,
+cross-runtime SQLite, Station renderer and PTY tests, and selected installer and binary smokes on
+independent `ubuntu-24.04` jobs. Documentation-only changes run lint and diagnostics policy tests.
+Installer smoke runs when installer, release, dependency, or CI infrastructure changes; binary
+smoke runs when production, binary, dependency, or CI infrastructure changes. One aggregate job
+named `standard-ci` preserves the repository ruleset contract.
+
+Release tags select every lane, use the exhaustive claim-race counts, and call that parallel gate
+before adding the four native build and draft-install targets. Both `standard-ci` and
+`smoke:release` must pass before any native release build starts. Draft pull request activity
+allocates no runner, including synchronization before `ready_for_review`. Pushes to `main`
+run only build, typecheck, and lint as a cheap post-merge smoke. The repository ruleset must
+require the pull-request `standard-ci` check and block direct `main` pushes; the cheap smoke is a
+post-merge backstop, not a substitute for the full required gate.
 
 Useful focused commands:
 
@@ -193,7 +196,7 @@ including startup-file
 non-interaction, safely evaluated minimal-PATH guidance, physical launcher
 resolution, and normalized-colon preflight coverage. It is deterministic, does
 not download a real release, and does not read or modify real shell startup
-files. The single Ubuntu CI gate runs it once. On a heavily contended local host, run
+files. The path-selected installer CI job runs it once. On a heavily contended local host, run
 `STATION_INSTALL_SMOKE_TIMEOUT_SCALE=4 pnpm smoke:install` to scale only the
 harness deadlines; the default and hosted gate remain strict.
 The release workflow builds and smokes the compiled binary on all four native
@@ -202,12 +205,12 @@ targets, then installs each actual draft asset with real platform utilities.
 Run `pnpm test:sqlite:bun` after `pnpm build` with Bun 1.3.14 available. It
 creates observer databases under Node and Bun, then reopens each database under
 the other runtime to verify the shared SQLite contract and migrations. It also
-runs the permanent boot-claim race: 50 alternating Node/Bun two-process rounds,
-three-contender rounds, and killed-owner recovery with stable inode and
-`integrity_check=ok`. That runner also checks Node/Bun inaccessible and stale
-classification plus displaced-listener abandonment; the claim gate makes no
-fairness claim. Both the local pre-push
-gate and the hosted `standard-ci` job run these checks.
+runs the exhaustive boot-claim stress: 50 alternating Node/Bun two-process rounds,
+10 three-contender rounds, and killed-owner recovery with stable inode and
+`integrity_check=ok`. Pull-request CI uses `pnpm test:sqlite:bun:pr` for five two-process and two
+three-contender rounds; release tags retain the exhaustive counts. Both commands also check
+Node/Bun inaccessible and stale classification plus displaced-listener abandonment; the claim
+gate makes no fairness claim.
 
 `pnpm test:e2e:observer` drives the built production Observer through cold and
 real stale-socket races, XDG/state divergence, explicit paths with spaces,
@@ -236,7 +239,8 @@ bun run test:pty:bun             # Bun.Terminal + controlling-terminal helper
 Both PTY lanes include the pinned Pi 0.80.10 capability detector in real local
 and Station Host-backed child processes. They prove equivalent Station-owned
 capabilities while requiring persistent Host spawns to fail closed on tmux
-provenance. Both lanes are part of `test:pre-push`.
+provenance. Both lanes are part of hosted `standard-ci` and remain available as focused local
+commands.
 
 To daily-drive the Bun implementation in the isolated devbox, return to the
 repo root and start a fresh host with the selector in its environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -161,11 +161,13 @@ Ready, non-draft pull requests fan out static validation, root tests, setup E2E,
 cross-runtime SQLite, Station renderer and PTY tests, and selected installer and binary smokes on
 independent `ubuntu-24.04` jobs. Documentation-only changes run lint and diagnostics policy tests.
 Installer smoke runs when installer, release, dependency, or CI infrastructure changes; binary
-smoke runs when production, binary, dependency, or CI infrastructure changes. One aggregate job
-named `standard-ci` preserves the repository ruleset contract.
+smoke runs when production, binary, dependency, or CI infrastructure changes. Observer-sensitive
+changes use the exhaustive claim-race counts, while setup- and Worktrunk-sensitive changes retain
+both bash and zsh process-level setup coverage. One aggregate job named `standard-ci` preserves the
+repository ruleset contract and fails if a mandatory or path-selected lane is unexpectedly skipped.
 
-Release tags select every lane, use the exhaustive claim-race counts, and call that parallel gate
-before adding the four native build and draft-install targets. Both `standard-ci` and
+Release tags select every lane, use the exhaustive claim-race counts and both setup shell paths, and
+call that parallel gate before adding the four native build and draft-install targets. Both `standard-ci` and
 `smoke:release` must pass before any native release build starts. Draft pull request activity
 allocates no runner, including synchronization before `ready_for_review`. Pushes to `main`
 run only build, typecheck, and lint as a cheap post-merge smoke. The repository ruleset must
@@ -182,6 +184,7 @@ pnpm test:unit
 pnpm test:contracts
 pnpm test:integration
 pnpm test:e2e:observer
+pnpm test:e2e:setup:guided:all-shells
 pnpm test:observer-claim:cross-runtime
 pnpm test:sqlite:bun
 pnpm test:diagnostics
@@ -208,9 +211,11 @@ the other runtime to verify the shared SQLite contract and migrations. It also
 runs the exhaustive boot-claim stress: 50 alternating Node/Bun two-process rounds,
 10 three-contender rounds, and killed-owner recovery with stable inode and
 `integrity_check=ok`. Pull-request CI uses `pnpm test:sqlite:bun:pr` for five two-process and two
-three-contender rounds; release tags retain the exhaustive counts. Both commands also check
-Node/Bun inaccessible and stale classification plus displaced-listener abandonment; the claim
-gate makes no fairness claim.
+three-contender rounds; Observer-sensitive pull requests and release tags retain the exhaustive
+counts. The scheduled `nightly-observer-claim` workflow runs the same exhaustive command against
+`main` each day so a low-frequency race cannot remain latent until a release. Both commands also
+check Node/Bun inaccessible and stale classification plus displaced-listener abandonment; the
+claim gate makes no fairness claim.
 
 `pnpm test:e2e:observer` drives the built production Observer through cold and
 real stale-socket races, XDG/state divergence, explicit paths with spaces,

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -72,6 +72,11 @@ or unsupported results and never inspect a developer's real provider homes.
 pnpm test:integration   # includes setup-profiles
 ```
 
+Hosted setup E2E uses zsh as the representative process path for unrelated changes. Changes to the
+setup engine or Worktrunk integration, plus release tags, exercise both bash and zsh recovery and
+idempotency paths. Run that focused matrix locally with
+`pnpm test:e2e:setup:guided:all-shells`.
+
 ## Tier 2 — Linux containers (medium fidelity, nightly/manual)
 
 `tests/env/docker/Dockerfile` is one multi-stage build whose per-profile

--- a/docs/setup-testing.md
+++ b/docs/setup-testing.md
@@ -19,7 +19,7 @@ exits `0` when `summary.requiredOk`, else `1` (the `2` exit code is reserved for
 bad args). Output is deterministic via `--json` + an injected clock, so
 comparisons are structural diffs, not log scraping.
 
-```
+```text
 profile { name, state: { platform, xcodeClt, git, insideRepo, brew, worktrunk,
                          tmux, bun, diffnav, gitDelta, harnesses[],
                          harnessTracking?, configToml? },
@@ -61,9 +61,10 @@ non-interaction; release acceptance owns proof in a genuinely new login shell.
 `apps/cli/test/integration/setup-profiles.test.ts` compiles each profile into the
 real `SetupCommandDeps` seam and runs `runCli([... "setup","check","--json"])`,
 asserting exit code + `requiredOk` + per-check status. Runs in the existing
-`pnpm test:integration` lane (so it is already in `pnpm test:all`, the
-pre-push gate, and hosted CI). This is the backbone and the canonical contract; it covers every
-profile, including the darwin `no-xcode-clt` case via an injected `platform`.
+`pnpm test:integration` lane (so it is already in `pnpm test:all` and hosted CI).
+The local pre-push hook is lint-only. This integration lane is the backbone and
+canonical contract; it covers every profile, including the darwin `no-xcode-clt`
+case via an injected `platform`.
 Hook-status fixtures return deterministic prepared, missing/drifted, probe-failed,
 or unsupported results and never inspect a developer's real provider homes.
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -205,8 +205,10 @@ remains their authority.
 
 ### A1 — foundation: buildInfo + SQLite driver + real observer version
 
-**Status: implemented.** The mandatory `pnpm test:sqlite:bun` gate covers the
-SQLite driver contract and Node-to-Bun and Bun-to-Node database compatibility.
+**Status: implemented.** The hosted cross-runtime lane and focused
+`pnpm test:sqlite:bun` command cover the SQLite driver contract and Node-to-Bun and Bun-to-Node
+database compatibility. Pull requests use reduced race repetitions; release tags and the focused
+command retain the exhaustive stress counts.
 
 `packages/runtime/src/buildInfo.ts` (dev-safe `typeof`-guarded defines;
 exported from the package index).
@@ -267,9 +269,9 @@ through a **ctty helper** (S2, F6): `setsid()`,
 A2a checks in one portable POSIX C source. `bun run build:ctty-helper` uses the
 target's native `cc` to write the ignored development executable at
 `station/dist/ctty-helper`; no built helper is committed. Platform headers
-supply `TIOCSCTTY`, so TypeScript contains no platform ioctl constants. The
-pre-push gate compiles and tests that source natively on the developer's current
-platform, while hosted CI covers Linux and macOS across x64 and arm64.
+supply `TIOCSCTTY`, so TypeScript contains no platform ioctl constants. Focused local commands
+compile and test that source natively on the developer's current platform, while standard CI
+covers Linux and native release CI covers macOS and Linux across x64 and arm64.
 The helper stays C because it is a small direct wrapper over POSIX `setsid`,
 `ioctl`, and `execvp`; Zig or Rust would add a build toolchain without improving
 that boundary.
@@ -347,7 +349,7 @@ A4 owns the packaged helper lifecycle that A2a deliberately leaves out:
   may reload its extension path. Pi pruning waits for provider-process lifetime
   ownership rather than risking a live session.
 
-Local pre-push and hosted `standard-ci` binary smoke checks: `--version`,
+Focused local and path-selected hosted `standard-ci` binary smoke checks: `--version`,
 `--help`, exact popup alias symlinks, popup argv0 fallback routing, compiled
 setup binding generation, and `setup check --json`
 (asserting the `launchReady`/`workflowReady` split), compiled Codex hook
@@ -662,9 +664,10 @@ B-host → A5 → A6. B3's version half is supplied by the singleton roadmap.
 
 ## Verification (F11 — prove the headline UX, not a proxy)
 
-CI (every PR and `main`): the full pre-push gate on `ubuntu-24.04`, including
-vitest, the Bun renderer, cross-runtime SQLite, real PTY, installer, and compiled
-binary smoke coverage.
+CI (every ready PR): parallel `ubuntu-24.04` lanes cover Vitest, the Bun renderer,
+cross-runtime SQLite, real PTY, and path-selected installer and compiled-binary smoke coverage.
+Documentation-only pull requests run lint and diagnostics policy checks; `main` runs the static
+post-merge smoke.
 
 Native release CI: build, smoke, and draft-install the compiled binary on
 `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15-intel`, and `macos-15`.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,5 +5,5 @@ pre-commit:
 
 pre-push:
   commands:
-    test:
+    lint:
       run: node scripts/run-without-git-locals.mjs pnpm test:pre-push

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:diagnostics:policy": "vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-classification.test.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
     "test:e2e:setup:guided": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-guided-feedback.test.ts",
+    "test:e2e:setup:guided:all-shells": "STATION_SETUP_E2E_ALL_SHELLS=true pnpm test:e2e:setup:guided",
     "test:e2e:setup:core": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-core-flow.test.ts",
     "test:e2e:setup:sqlite": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/observer-sqlite-smoke.test.ts",
     "test:e2e:observer": "vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,15 @@
     "test:contracts": "vitest run --config config/vitest/vitest.contracts.config.ts",
     "test:integration": "pnpm build && vitest run --config config/vitest/vitest.integration.config.ts",
     "test:observer-claim:cross-runtime": "node scripts/test-runners/run-observer-claim-cross-runtime.mjs",
+    "test:observer-claim:cross-runtime:pr": "node scripts/test-runners/run-observer-claim-cross-runtime.mjs --rounds 5 --three-contender-rounds 2",
     "test:sqlite:bun": "node scripts/test-runners/run-sqlite-cross-runtime.mjs && pnpm test:observer-claim:cross-runtime",
+    "test:sqlite:bun:pr": "node scripts/test-runners/run-sqlite-cross-runtime.mjs && pnpm test:observer-claim:cross-runtime:pr",
     "test:diagnostics": "vitest run --config config/vitest/vitest.diagnostics.config.ts",
+    "test:diagnostics:policy": "vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-classification.test.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
+    "test:e2e:setup:guided": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-guided-feedback.test.ts",
+    "test:e2e:setup:core": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-core-flow.test.ts",
+    "test:e2e:setup:sqlite": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/observer-sqlite-smoke.test.ts",
     "test:e2e:observer": "vitest run --config config/vitest/vitest.e2e.config.ts tests/e2e/observer-lifecycle.test.ts",
     "test:e2e": "vitest run --config config/vitest/vitest.e2e.config.ts",
     "test:e2e:real": "vitest run --config config/vitest/vitest.real-e2e.config.ts",
@@ -65,8 +71,11 @@
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
+    "test:ci:fast": "pnpm build && pnpm test:unit && pnpm test:contracts && pnpm test:diagnostics && pnpm test:agent:scripted",
+    "test:ci:station": "pnpm --dir station typecheck && pnpm --dir station test && pnpm --dir station test:pty && pnpm --dir station test:pty:bun",
+    "test:ci:binary": "pnpm build:binary -- --version 0.0.0-local && pnpm smoke:binary -- --expected-version 0.0.0-local",
     "test:all": "pnpm build && pnpm typecheck && pnpm lint && pnpm test:unit && pnpm test:contracts && pnpm test:integration && pnpm test:diagnostics && pnpm test:agent:scripted && pnpm test:e2e:setup && pnpm test:e2e:observer && pnpm smoke:install",
-    "test:pre-push": "pnpm test:all && pnpm test:sqlite:bun && pnpm --dir station typecheck && pnpm --dir station test && pnpm --dir station test:pty && pnpm --dir station test:pty:bun && pnpm build:binary -- --version 0.0.0-local && pnpm smoke:binary -- --expected-version 0.0.0-local"
+    "test:pre-push": "pnpm lint"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",

--- a/scripts/ci/classify-standard-ci.mjs
+++ b/scripts/ci/classify-standard-ci.mjs
@@ -12,10 +12,14 @@ const docsOnly = !conservativeFallback && paths.every(isDocumentationPath);
 const ciInfrastructure = paths.some(isCiInfrastructurePath);
 const installer = conservativeFallback || ciInfrastructure || paths.some(isInstallerValidationPath);
 const binary = conservativeFallback || ciInfrastructure || paths.some(isBinaryValidationPath);
+const claimStress = conservativeFallback || ciInfrastructure || paths.some(isClaimStressPath);
+const shellMatrix = conservativeFallback || ciInfrastructure || paths.some(isShellMatrixPath);
 
 process.stdout.write(`docs_only=${docsOnly}\n`);
 process.stdout.write(`installer=${installer}\n`);
 process.stdout.write(`binary=${binary}\n`);
+process.stdout.write(`claim_stress=${claimStress}\n`);
+process.stdout.write(`shell_matrix=${shellMatrix}\n`);
 
 function isDocumentationPath(path) {
   return path.startsWith("docs/") || path.endsWith(".md");
@@ -24,8 +28,10 @@ function isDocumentationPath(path) {
 function isCiInfrastructurePath(path) {
   return (
     path === ".github/workflows/standard-ci.yml" ||
+    path === ".github/workflows/nightly-observer-claim.yml" ||
     path.startsWith(".github/actions/setup-ci/") ||
     path === "scripts/ci/classify-standard-ci.mjs" ||
+    path === "scripts/ci/require-standard-ci-results.sh" ||
     path === "tests/diagnostics/ci-classification.test.ts" ||
     path === "tests/diagnostics/ci-workflow-policy.test.ts"
   );
@@ -42,6 +48,26 @@ function isInstallerValidationPath(path) {
     path === "scripts/test-runners/run-release-smoke.mjs" ||
     path === ".github/workflows/release.yml" ||
     path === ".github/workflows/promote-release.yml"
+  );
+}
+
+function isClaimStressPath(path) {
+  return (
+    path === "package.json" ||
+    path === "pnpm-lock.yaml" ||
+    path.startsWith("apps/observer/") ||
+    path.startsWith("apps/cli/src/observerProcess/") ||
+    path === "apps/cli/src/ingress/observerStartup.ts" ||
+    path === "scripts/test-runners/run-observer-claim-cross-runtime.mjs"
+  );
+}
+
+function isShellMatrixPath(path) {
+  return (
+    path.startsWith("apps/cli/src/commands/setup/") ||
+    path === "apps/cli/test/unit/setup-checks.test.ts" ||
+    path.startsWith("integrations/worktree/worktrunk/") ||
+    path === "tests/e2e/setup-guided-feedback.test.ts"
   );
 }
 

--- a/scripts/ci/classify-standard-ci.mjs
+++ b/scripts/ci/classify-standard-ci.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+
+const paths = readFileSync(0)
+  .toString("utf8")
+  .split("\0")
+  .filter((path) => path.length > 0);
+
+const conservativeFallback = paths.length === 0;
+const docsOnly = !conservativeFallback && paths.every(isDocumentationPath);
+const ciInfrastructure = paths.some(isCiInfrastructurePath);
+const installer = conservativeFallback || ciInfrastructure || paths.some(isInstallerValidationPath);
+const binary = conservativeFallback || ciInfrastructure || paths.some(isBinaryValidationPath);
+
+process.stdout.write(`docs_only=${docsOnly}\n`);
+process.stdout.write(`installer=${installer}\n`);
+process.stdout.write(`binary=${binary}\n`);
+
+function isDocumentationPath(path) {
+  return path.startsWith("docs/") || path.endsWith(".md");
+}
+
+function isCiInfrastructurePath(path) {
+  return (
+    path === ".github/workflows/standard-ci.yml" ||
+    path.startsWith(".github/actions/setup-ci/") ||
+    path === "scripts/ci/classify-standard-ci.mjs" ||
+    path === "tests/diagnostics/ci-classification.test.ts" ||
+    path === "tests/diagnostics/ci-workflow-policy.test.ts"
+  );
+}
+
+function isInstallerValidationPath(path) {
+  return (
+    path === "package.json" ||
+    path === "pnpm-lock.yaml" ||
+    path === "LICENSE" ||
+    path === "scripts/install.sh" ||
+    path.startsWith("scripts/release/") ||
+    path === "scripts/test-runners/run-install-smoke.mjs" ||
+    path === "scripts/test-runners/run-release-smoke.mjs" ||
+    path === ".github/workflows/release.yml" ||
+    path === ".github/workflows/promote-release.yml"
+  );
+}
+
+function isBinaryValidationPath(path) {
+  if (isDocumentationPath(path) || isInstallerOnlyPath(path)) return false;
+  if (path.startsWith(".github/")) return false;
+  if (path.startsWith("config/vitest/")) return false;
+  if (path.startsWith("tests/")) return false;
+  if (path.startsWith("tools/")) return false;
+  if (path === "lefthook.yml" || path === "biome.json") return false;
+  if (path.includes("/__tests__/")) return false;
+  if (path.includes("/test/") || path.includes("/tests/")) return false;
+  if (/\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(path)) return false;
+  if (path.startsWith("scripts/test-runners/")) {
+    return path === "scripts/test-runners/run-binary-smoke.mjs";
+  }
+  return true;
+}
+
+function isInstallerOnlyPath(path) {
+  return (
+    path === "scripts/install.sh" ||
+    path.startsWith("scripts/release/") ||
+    path === "scripts/test-runners/run-install-smoke.mjs" ||
+    path === "scripts/test-runners/run-release-smoke.mjs" ||
+    path === ".github/workflows/release.yml" ||
+    path === ".github/workflows/promote-release.yml"
+  );
+}

--- a/scripts/ci/require-standard-ci-results.sh
+++ b/scripts/ci/require-standard-ci-results.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+set -eu
+
+require_result() {
+  lane=$1
+  actual=$2
+  expected=$3
+  if [ "$actual" != "$expected" ]; then
+    printf '%s must end with %s, received %s.\n' "$lane" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+require_boolean() {
+  selector=$1
+  value=$2
+  case "$value" in
+    true|false) ;;
+    *)
+      printf '%s must be true or false, received %s.\n' "$selector" "$value" >&2
+      exit 1
+      ;;
+  esac
+}
+
+require_selected_result() {
+  lane=$1
+  selected=$2
+  actual=$3
+  if [ "$selected" = true ]; then
+    require_result "$lane" "$actual" success
+  else
+    require_result "$lane" "$actual" skipped
+  fi
+}
+
+require_boolean docs_only "$DOCS_ONLY"
+require_boolean installer "$INSTALLER_SELECTED"
+require_boolean binary "$BINARY_SELECTED"
+require_boolean claim_stress "$CLAIM_STRESS_SELECTED"
+require_boolean shell_matrix "$SHELL_MATRIX_SELECTED"
+require_result classify "$CLASSIFY" success
+require_result static "$STATIC" success
+
+if [ "$DOCS_ONLY" = true ]; then
+  require_result fast-tests "$FAST_TESTS" skipped
+  require_result integration-tests "$INTEGRATION_TESTS" skipped
+  require_result setup-e2e "$SETUP_E2E" skipped
+  require_result observer-e2e "$OBSERVER_E2E" skipped
+  require_result sqlite-cross-runtime "$SQLITE_CROSS_RUNTIME" skipped
+  require_result station-tests "$STATION_TESTS" skipped
+  require_result installer-smoke "$INSTALLER_SMOKE" skipped
+  require_result binary-smoke "$BINARY_SMOKE" skipped
+  require_result installer-selector "$INSTALLER_SELECTED" false
+  require_result binary-selector "$BINARY_SELECTED" false
+  require_result claim-stress-selector "$CLAIM_STRESS_SELECTED" false
+  require_result shell-matrix-selector "$SHELL_MATRIX_SELECTED" false
+  exit 0
+fi
+
+require_result fast-tests "$FAST_TESTS" success
+require_result integration-tests "$INTEGRATION_TESTS" success
+require_result setup-e2e "$SETUP_E2E" success
+require_result observer-e2e "$OBSERVER_E2E" success
+require_result sqlite-cross-runtime "$SQLITE_CROSS_RUNTIME" success
+require_result station-tests "$STATION_TESTS" success
+require_selected_result installer-smoke "$INSTALLER_SELECTED" "$INSTALLER_SMOKE"
+require_selected_result binary-smoke "$BINARY_SELECTED" "$BINARY_SMOKE"

--- a/scripts/test-runners/run-observer-claim-cross-runtime.mjs
+++ b/scripts/test-runners/run-observer-claim-cross-runtime.mjs
@@ -38,7 +38,7 @@ if (process.argv[2] === "--socket-server-child") {
   await runController(parseControllerArgs(process.argv.slice(2)));
 }
 
-async function runController({ rounds }) {
+async function runController({ rounds, threeContenderRounds }) {
   const { observerBootClaimPath } = await import(observerInternalUrl);
   assert.equal(typeof observerBootClaimPath, "function");
 
@@ -49,7 +49,6 @@ async function runController({ rounds }) {
 
   let initialClaimIdentity;
   let maximumCriticalSectionConcurrency = 0;
-  const threeContenderRounds = 10;
 
   try {
     for (let round = 0; round < rounds; round += 1) {
@@ -491,12 +490,26 @@ async function runChild(flags) {
 
 function parseControllerArgs(args) {
   if (args[0] === "--") args = args.slice(1);
-  if (args.length === 0) return { rounds: 50 };
-  assert.deepEqual(args.slice(0, 1), ["--rounds"], "Usage: --rounds <positive integer>");
-  assert.equal(args.length, 2, "Usage: --rounds <positive integer>");
-  const rounds = Number(args[1]);
-  assert.ok(Number.isSafeInteger(rounds) && rounds > 0, "--rounds must be a positive integer.");
-  return { rounds };
+  assert.equal(
+    args.length % 2,
+    0,
+    "Usage: [--rounds <positive integer>] [--three-contender-rounds <positive integer>]",
+  );
+
+  const options = { rounds: 50, threeContenderRounds: 10 };
+  const seen = new Set();
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = Number(args[index + 1]);
+    assert.equal(seen.has(flag), false, `Duplicate controller flag ${flag}.`);
+    assert.ok(Number.isSafeInteger(value) && value > 0, `${flag} must be a positive integer.`);
+    seen.add(flag);
+
+    if (flag === "--rounds") options.rounds = value;
+    else if (flag === "--three-contender-rounds") options.threeContenderRounds = value;
+    else throw new Error(`Unsupported controller flag ${flag}.`);
+  }
+  return options;
 }
 
 function parseFlags(args) {

--- a/tests/diagnostics/ci-classification.test.ts
+++ b/tests/diagnostics/ci-classification.test.ts
@@ -1,0 +1,79 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const classifier = fileURLToPath(
+  new URL("../../scripts/ci/classify-standard-ci.mjs", import.meta.url),
+);
+
+type Classification = {
+  docs_only: boolean;
+  installer: boolean;
+  binary: boolean;
+};
+
+type ClassificationCase = {
+  name: string;
+  paths: readonly string[];
+  expected: Classification;
+};
+
+describe("standard CI path classification", () => {
+  it.each([
+    {
+      name: "documentation only",
+      paths: ["README.md", "docs/development.md"],
+      expected: { docs_only: true, installer: false, binary: false },
+    },
+    {
+      name: "production source",
+      paths: ["apps/observer/src/runtime/main.ts"],
+      expected: { docs_only: false, installer: false, binary: true },
+    },
+    {
+      name: "installer only",
+      paths: ["scripts/install.sh", "scripts/test-runners/run-install-smoke.mjs"],
+      expected: { docs_only: false, installer: true, binary: false },
+    },
+    {
+      name: "tests only",
+      paths: ["apps/cli/test/unit/setup-checks.test.ts", "config/vitest/vitest.unit.config.ts"],
+      expected: { docs_only: false, installer: false, binary: false },
+    },
+    {
+      name: "CI infrastructure",
+      paths: [".github/workflows/standard-ci.yml"],
+      expected: { docs_only: false, installer: true, binary: true },
+    },
+    {
+      name: "packaged dependency state",
+      paths: ["package.json", "pnpm-lock.yaml", "LICENSE"],
+      expected: { docs_only: false, installer: true, binary: true },
+    },
+  ] as const)("classifies $name changes", ({ paths, expected }: ClassificationCase) => {
+    expect(classify(paths)).toEqual(expected);
+  });
+
+  it("falls back to every specialized lane when Git reports no paths", () => {
+    expect(classify([])).toEqual({ docs_only: false, installer: true, binary: true });
+  });
+});
+
+function classify(paths: readonly string[]): Classification {
+  const input = paths.length === 0 ? Buffer.alloc(0) : Buffer.from(`${paths.join("\0")}\0`);
+  const result = spawnSync(process.execPath, [classifier], {
+    encoding: "utf8",
+    input,
+  });
+  expect(result.status, result.stderr).toBe(0);
+  return Object.fromEntries(
+    result.stdout
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1) === "true"];
+      }),
+  ) as Classification;
+}

--- a/tests/diagnostics/ci-classification.test.ts
+++ b/tests/diagnostics/ci-classification.test.ts
@@ -10,6 +10,8 @@ type Classification = {
   docs_only: boolean;
   installer: boolean;
   binary: boolean;
+  claim_stress: boolean;
+  shell_matrix: boolean;
 };
 
 type ClassificationCase = {
@@ -23,39 +25,106 @@ describe("standard CI path classification", () => {
     {
       name: "documentation only",
       paths: ["README.md", "docs/development.md"],
-      expected: { docs_only: true, installer: false, binary: false },
+      expected: {
+        docs_only: true,
+        installer: false,
+        binary: false,
+        claim_stress: false,
+        shell_matrix: false,
+      },
     },
     {
       name: "production source",
-      paths: ["apps/observer/src/runtime/main.ts"],
-      expected: { docs_only: false, installer: false, binary: true },
+      paths: ["packages/protocol/src/index.ts"],
+      expected: {
+        docs_only: false,
+        installer: false,
+        binary: true,
+        claim_stress: false,
+        shell_matrix: false,
+      },
+    },
+    {
+      name: "Observer claim-sensitive source",
+      paths: ["apps/observer/src/runtime/observerBootClaim.ts"],
+      expected: {
+        docs_only: false,
+        installer: false,
+        binary: true,
+        claim_stress: true,
+        shell_matrix: false,
+      },
+    },
+    {
+      name: "shell-sensitive setup source",
+      paths: ["apps/cli/src/commands/setup/checks/worktrunk.ts"],
+      expected: {
+        docs_only: false,
+        installer: false,
+        binary: true,
+        claim_stress: false,
+        shell_matrix: true,
+      },
     },
     {
       name: "installer only",
       paths: ["scripts/install.sh", "scripts/test-runners/run-install-smoke.mjs"],
-      expected: { docs_only: false, installer: true, binary: false },
+      expected: {
+        docs_only: false,
+        installer: true,
+        binary: false,
+        claim_stress: false,
+        shell_matrix: false,
+      },
     },
     {
       name: "tests only",
-      paths: ["apps/cli/test/unit/setup-checks.test.ts", "config/vitest/vitest.unit.config.ts"],
-      expected: { docs_only: false, installer: false, binary: false },
+      paths: [
+        "station/src/station/input/stationMouse.test.ts",
+        "config/vitest/vitest.unit.config.ts",
+      ],
+      expected: {
+        docs_only: false,
+        installer: false,
+        binary: false,
+        claim_stress: false,
+        shell_matrix: false,
+      },
     },
     {
       name: "CI infrastructure",
       paths: [".github/workflows/standard-ci.yml"],
-      expected: { docs_only: false, installer: true, binary: true },
+      expected: {
+        docs_only: false,
+        installer: true,
+        binary: true,
+        claim_stress: true,
+        shell_matrix: true,
+      },
     },
     {
       name: "packaged dependency state",
       paths: ["package.json", "pnpm-lock.yaml", "LICENSE"],
-      expected: { docs_only: false, installer: true, binary: true },
+      expected: {
+        docs_only: false,
+        installer: true,
+        binary: true,
+        claim_stress: true,
+        shell_matrix: false,
+      },
     },
   ] as const)("classifies $name changes", ({ paths, expected }: ClassificationCase) => {
     expect(classify(paths)).toEqual(expected);
   });
 
   it("falls back to every specialized lane when Git reports no paths", () => {
-    expect(classify([])).toEqual({ docs_only: false, installer: true, binary: true });
+    expect(classify([])).toEqual({
+      docs_only: false,
+      installer: true,
+      binary: true,
+      claim_stress: true,
+      shell_matrix: true,
+    });
   });
 });
 

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -1,7 +1,12 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const root = new URL("../../", import.meta.url);
+const aggregatePolicy = fileURLToPath(
+  new URL("../../scripts/ci/require-standard-ci-results.sh", import.meta.url),
+);
 
 function read(path: string): string {
   return readFileSync(new URL(path, root), "utf8");
@@ -17,6 +22,48 @@ function between(document: string, start: string, end?: string): string {
   const endIndex = end === undefined ? document.length : document.indexOf(end, startIndex + 1);
   expect(endIndex, `missing section end: ${end}`).toBeGreaterThan(startIndex);
   return document.slice(startIndex, endIndex);
+}
+
+const successfulCiEnvironment = {
+  DOCS_ONLY: "false",
+  INSTALLER_SELECTED: "true",
+  BINARY_SELECTED: "true",
+  CLAIM_STRESS_SELECTED: "false",
+  SHELL_MATRIX_SELECTED: "false",
+  CLASSIFY: "success",
+  STATIC: "success",
+  FAST_TESTS: "success",
+  INTEGRATION_TESTS: "success",
+  SETUP_E2E: "success",
+  OBSERVER_E2E: "success",
+  INSTALLER_SMOKE: "success",
+  SQLITE_CROSS_RUNTIME: "success",
+  STATION_TESTS: "success",
+  BINARY_SMOKE: "success",
+} as const;
+
+const documentationCiEnvironment = {
+  ...successfulCiEnvironment,
+  DOCS_ONLY: "true",
+  INSTALLER_SELECTED: "false",
+  BINARY_SELECTED: "false",
+  CLAIM_STRESS_SELECTED: "false",
+  SHELL_MATRIX_SELECTED: "false",
+  FAST_TESTS: "skipped",
+  INTEGRATION_TESTS: "skipped",
+  SETUP_E2E: "skipped",
+  OBSERVER_E2E: "skipped",
+  INSTALLER_SMOKE: "skipped",
+  SQLITE_CROSS_RUNTIME: "skipped",
+  STATION_TESTS: "skipped",
+  BINARY_SMOKE: "skipped",
+} as const;
+
+function runAggregatePolicy(environment: Readonly<Record<string, string>>) {
+  return spawnSync("/bin/sh", [aggregatePolicy], {
+    encoding: "utf8",
+    env: { ...environment },
+  });
 }
 
 describe("hosted CI policy", () => {
@@ -46,6 +93,9 @@ describe("hosted CI policy", () => {
     expect(standardCi).toContain("needs.classify.outputs.docs_only != 'true'");
     expect(standardCi).toContain("needs.classify.outputs.installer == 'true'");
     expect(standardCi).toContain("needs.classify.outputs.binary == 'true'");
+    expect(standardCi).toContain("needs.classify.outputs.claim_stress");
+    expect(standardCi).toContain("needs.classify.outputs.shell_matrix");
+    expect(standardCi).toContain("STATION_SETUP_E2E_ALL_SHELLS");
     expect(standardCi).toContain("pnpm test:sqlite:bun:pr");
     expect(standardCi).toContain("pnpm test:sqlite:bun");
     expect(standardCi).not.toContain("pnpm test:pre-push");
@@ -53,7 +103,7 @@ describe("hosted CI policy", () => {
     const aggregate = between(standardCi, "  standard-ci:", "  main-smoke:");
     expect(aggregate).toContain("name: standard-ci");
     expect(aggregate).toContain("always()");
-    expect(aggregate).toContain("success|skipped");
+    expect(aggregate).toContain("sh scripts/ci/require-standard-ci-results.sh");
     expect(aggregate).toContain("- binary_smoke");
 
     const releaseStandardCi = between(release, "  standard-ci:", "  release-smoke:");
@@ -67,6 +117,67 @@ describe("hosted CI policy", () => {
     expect(development).toMatch(/Pushes to `main`\s+run only build, typecheck, and lint/);
   });
 
+  it("fails closed when a required or selected lane is unexpectedly skipped", () => {
+    for (const testCase of [
+      {
+        name: "all selected",
+        environment: successfulCiEnvironment,
+      },
+      {
+        name: "specialized lanes not selected",
+        environment: {
+          ...successfulCiEnvironment,
+          INSTALLER_SELECTED: "false",
+          BINARY_SELECTED: "false",
+          INSTALLER_SMOKE: "skipped",
+          BINARY_SMOKE: "skipped",
+        },
+      },
+      {
+        name: "documentation only",
+        environment: documentationCiEnvironment,
+      },
+    ]) {
+      const result = runAggregatePolicy(testCase.environment);
+      expect(result.status, `${testCase.name}: ${result.stderr}`).toBe(0);
+    }
+
+    for (const testCase of [
+      {
+        name: "required lane skipped",
+        environment: { ...successfulCiEnvironment, FAST_TESTS: "skipped" },
+      },
+      {
+        name: "selected lane skipped",
+        environment: { ...successfulCiEnvironment, INSTALLER_SMOKE: "skipped" },
+      },
+      {
+        name: "unselected lane unexpectedly ran",
+        environment: { ...successfulCiEnvironment, BINARY_SELECTED: "false" },
+      },
+      {
+        name: "contradictory documentation selectors",
+        environment: { ...documentationCiEnvironment, SHELL_MATRIX_SELECTED: "true" },
+      },
+    ]) {
+      const result = runAggregatePolicy(testCase.environment);
+      expect(result.status, testCase.name).toBe(1);
+      expect(result.stderr, testCase.name).toContain("must end with");
+    }
+  });
+
+  it("keeps exhaustive claim stress scheduled without extending every pull request", () => {
+    const nightly = read(".github/workflows/nightly-observer-claim.yml");
+    const development = read("docs/development.md");
+
+    expect(nightly).toContain('cron: "17 7 * * *"');
+    expect(nightly).toContain("workflow_dispatch:");
+    expect(nightly).toContain('bun: "true"');
+    expect(nightly).toContain("pnpm test:observer-claim:cross-runtime");
+    expect(nightly).not.toContain("test:observer-claim:cross-runtime:pr");
+    expect(development).toContain("nightly-observer-claim");
+  });
+
   it("keeps pre-push local and fast while preserving explicit comprehensive commands", () => {
     const packageJson = JSON.parse(read("package.json")) as {
       scripts: Record<string, string>;
@@ -78,6 +189,9 @@ describe("hosted CI policy", () => {
     expect(packageJson.scripts["test:all"]).toContain("pnpm smoke:install");
     expect(packageJson.scripts["test:diagnostics:policy"]).toContain(
       "release-readiness-docs.test.ts",
+    );
+    expect(packageJson.scripts["test:e2e:setup:guided:all-shells"]).toContain(
+      "STATION_SETUP_E2E_ALL_SHELLS=true",
     );
     expect(packageJson.scripts["test:ci:binary"]).toContain("pnpm smoke:binary");
     expect(packageJson.scripts["test:ci:station"]).toContain("test:pty:bun");

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -7,6 +7,10 @@ function read(path: string): string {
   return readFileSync(new URL(path, root), "utf8");
 }
 
+function actionsExpression(value: string): string {
+  return `\${{ ${value} }}`;
+}
+
 function between(document: string, start: string, end?: string): string {
   const startIndex = document.indexOf(start);
   expect(startIndex, `missing section start: ${start}`).toBeGreaterThanOrEqual(0);
@@ -16,53 +20,95 @@ function between(document: string, start: string, end?: string): string {
 }
 
 describe("hosted CI policy", () => {
-  it("runs the full gate for ready pull requests and release calls but not main pushes", () => {
+  it("fans ready pull requests and release calls into independently reported validation lanes", () => {
     const standardCi = read(".github/workflows/standard-ci.yml");
     const release = read(".github/workflows/release.yml");
     const development = read("docs/development.md");
 
     expect(standardCi).toContain("types: [opened, synchronize, reopened, ready_for_review]");
+    expect(standardCi).toContain("github.ref_type == 'tag'");
+    expect(standardCi).toContain("github.event.pull_request.draft == false");
 
-    const fullGate = between(standardCi, "  standard-ci:", "  main-smoke:");
-    expect(fullGate).toContain("github.ref_type == 'tag'");
-    expect(fullGate).toContain("github.event.pull_request.draft == false");
-    expect(fullGate).toContain("run: pnpm test:pre-push");
+    for (const job of [
+      "fast_tests",
+      "integration_tests",
+      "setup_e2e",
+      "observer_e2e",
+      "installer_smoke",
+      "sqlite_cross_runtime",
+      "station_tests",
+      "binary_smoke",
+    ]) {
+      expect(standardCi).toContain(`  ${job}:`);
+    }
+    expect(standardCi).toContain(`name: setup-e2e (${actionsExpression("matrix.lane")})`);
+    expect(standardCi).toContain("needs: [classify, static]");
+    expect(standardCi).toContain("needs.classify.outputs.docs_only != 'true'");
+    expect(standardCi).toContain("needs.classify.outputs.installer == 'true'");
+    expect(standardCi).toContain("needs.classify.outputs.binary == 'true'");
+    expect(standardCi).toContain("pnpm test:sqlite:bun:pr");
+    expect(standardCi).toContain("pnpm test:sqlite:bun");
+    expect(standardCi).not.toContain("pnpm test:pre-push");
 
-    const mainSmoke = between(standardCi, "  main-smoke:");
-    expect(mainSmoke).toContain("github.ref == 'refs/heads/main'");
-    expect(mainSmoke).toContain("pnpm build");
-    expect(mainSmoke).toContain("pnpm typecheck");
-    expect(mainSmoke).toContain("pnpm lint");
-    expect(mainSmoke).not.toContain("test:pre-push");
-    expect(mainSmoke).not.toContain("setup-bun");
+    const aggregate = between(standardCi, "  standard-ci:", "  main-smoke:");
+    expect(aggregate).toContain("name: standard-ci");
+    expect(aggregate).toContain("always()");
+    expect(aggregate).toContain("success|skipped");
+    expect(aggregate).toContain("- binary_smoke");
 
     const releaseStandardCi = between(release, "  standard-ci:", "  release-smoke:");
     expect(releaseStandardCi).toContain("uses: ./.github/workflows/standard-ci.yml");
     const nativeBuilds = between(release, "  build-native:", "  create-draft:");
     expect(nativeBuilds).toMatch(/needs:\s+- validate\s+- standard-ci\s+- release-smoke/);
 
-    expect(development).toContain("Ready, non-draft pull requests run `pnpm test:pre-push`");
+    expect(development).toContain("Ready, non-draft pull requests fan out");
     expect(development).toContain("before any native release build starts");
-    expect(development).toMatch(/Draft pull request activity allocates no\s+runner/);
+    expect(development).toMatch(/Draft pull request activity\s+allocates no runner/);
     expect(development).toMatch(/Pushes to `main`\s+run only build, typecheck, and lint/);
   });
 
-  it("scopes the local Turbo cache to the runner and dependency state", () => {
+  it("keeps pre-push local and fast while preserving explicit comprehensive commands", () => {
+    const packageJson = JSON.parse(read("package.json")) as {
+      scripts: Record<string, string>;
+    };
+    const lefthook = read("lefthook.yml");
+    const development = read("docs/development.md");
+
+    expect(packageJson.scripts["test:pre-push"]).toBe("pnpm lint");
+    expect(packageJson.scripts["test:all"]).toContain("pnpm smoke:install");
+    expect(packageJson.scripts["test:diagnostics:policy"]).toContain(
+      "release-readiness-docs.test.ts",
+    );
+    expect(packageJson.scripts["test:ci:binary"]).toContain("pnpm smoke:binary");
+    expect(packageJson.scripts["test:ci:station"]).toContain("test:pty:bun");
+    expect(lefthook).toContain("run: node scripts/run-without-git-locals.mjs pnpm test:pre-push");
+    expect(development).toContain("The pre-push hook is intentionally lint-only");
+  });
+
+  it("scopes the shared Turbo cache to pull requests, runners, and dependency state", () => {
     const standardCi = read(".github/workflows/standard-ci.yml");
-    const fullGate = between(standardCi, "  standard-ci:", "  main-smoke:");
+    const setupAction = read(".github/actions/setup-ci/action.yml");
     const mainSmoke = between(standardCi, "  main-smoke:");
 
-    for (const job of [fullGate, mainSmoke]) {
-      expect(job).toMatch(/uses: actions\/cache@[0-9a-f]{40}/);
-      expect(job).toContain("path: .turbo");
-      expect(job).toContain("runner.os");
-      expect(job).toContain("runner.arch");
-      expect(job).toContain("hashFiles('pnpm-lock.yaml', 'turbo.json')");
-      expect(job).toContain("github.sha");
-      expect(job).toContain("restore-keys:");
-    }
+    expect(setupAction).toMatch(/uses: actions\/cache@[0-9a-f]{40}/);
+    expect(setupAction).toContain("if: inputs.restore-turbo-cache == 'true'");
+    expect(setupAction).toContain("path: .turbo");
+    expect(setupAction).toContain("runner.os");
+    expect(setupAction).toContain("runner.arch");
+    expect(setupAction).toContain("hashFiles('pnpm-lock.yaml', 'turbo.json')");
+    expect(setupAction).toContain("github.sha");
+    expect(setupAction).toContain("restore-keys:");
+    expect(standardCi).toContain(
+      `restore-turbo-cache: ${actionsExpression("github.event_name == 'pull_request'")}`,
+    );
 
-    expect(fullGate).toContain("if: github.event_name == 'pull_request'");
+    expect(mainSmoke).toContain("github.ref == 'refs/heads/main'");
+    expect(mainSmoke).toContain("pnpm build");
+    expect(mainSmoke).toContain("pnpm typecheck");
+    expect(mainSmoke).toContain("pnpm lint");
+    expect(mainSmoke).not.toContain("test:pre-push");
+    expect(mainSmoke).not.toContain("setup-bun");
+    expect(mainSmoke).toMatch(/uses: actions\/cache@[0-9a-f]{40}/);
     expect(standardCi).not.toMatch(/path:\s+.*station-build-id/);
   });
 });

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -7,8 +7,7 @@ import { createObserverClient } from "../../packages/protocol/src/index.js";
 import { waitForSocketClosed } from "../support/sockets";
 
 const shellIntegrationMarker = "# Worktrunk shell integration";
-const supportedShells = ["zsh", "bash"] as const;
-type SupportedShell = (typeof supportedShells)[number];
+type SupportedShell = "bash" | "zsh";
 
 describe("setup guided feedback e2e", () => {
   it("exits instead of hanging when every agent install choice is declined", async () => {
@@ -188,81 +187,83 @@ describe("setup guided feedback e2e", () => {
     }
   });
 
-  for (const shell of supportedShells) {
-    it(`gives one optional recovery command when the active ${shell} rc file is missing`, async () => {
-      const fixture = await createFixture({ harness: "codex", shell });
-      const rcPath = shellRcPath(fixture.home, shell);
-      try {
-        const result = await runStation(["--config", fixture.configPath, "setup"], {
-          cwd: fixture.repo,
-          env: fixture.env,
-          answers: ["n", "n", "y", "y", "y", "n"],
-        });
+  const representativeShell: SupportedShell = "zsh";
+  it(`gives one optional recovery command when the active ${representativeShell} rc file is missing`, async () => {
+    const shell = representativeShell;
+    const fixture = await createFixture({ harness: "codex", shell });
+    const rcPath = shellRcPath(fixture.home, shell);
+    try {
+      const result = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["n", "n", "y", "y", "y", "n"],
+      });
 
-        expect(result.timedOut).toBe(false);
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain(
-          "Optional Worktrunk shell integration was not installed; core setup is complete.",
-        );
-        expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
-        expect(result.stdout).toContain(
-          `Run: touch ${rcPath} && ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-        );
-        expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
-        expect(result.stdout).not.toContain("fake shell integration installed");
-        expect(result.stdout).toContain("Core setup complete.");
-        await expect(readFile(rcPath, "utf8")).rejects.toThrow();
-        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
-      } finally {
-        await fixture.cleanup();
-      }
-    });
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        "Optional Worktrunk shell integration was not installed; core setup is complete.",
+      );
+      expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
+      expect(result.stdout).toContain(
+        `Run: touch ${rcPath} && ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+      );
+      expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
+      expect(result.stdout).not.toContain("fake shell integration installed");
+      expect(result.stdout).toContain("Core setup complete.");
+      await expect(readFile(rcPath, "utf8")).rejects.toThrow();
+      await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 
-    it(`preserves an existing ${shell} rc file and does not duplicate integration`, async () => {
-      const fixture = await createFixture({ harness: "codex", shell });
-      const rcPath = shellRcPath(fixture.home, shell);
-      const original = "# user shell config\nexport USER_SETTING=preserved\n";
-      await writeFile(rcPath, original, "utf8");
-      try {
-        const first = await runStation(["--config", fixture.configPath, "setup"], {
-          cwd: fixture.repo,
-          env: fixture.env,
-          answers: ["n", "n", "y", "y", "y", "n"],
-        });
-        const second = await runStation(["--config", fixture.configPath, "setup"], {
-          cwd: fixture.repo,
-          env: fixture.env,
-          answers: ["n", "n", "n", "n"],
-        });
+  it(`preserves an existing ${representativeShell} rc file and does not duplicate integration`, async () => {
+    const shell = representativeShell;
+    const fixture = await createFixture({ harness: "codex", shell });
+    const rcPath = shellRcPath(fixture.home, shell);
+    const original = "# user shell config\nexport USER_SETTING=preserved\n";
+    await writeFile(rcPath, original, "utf8");
+    try {
+      const first = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["n", "n", "y", "y", "y", "n"],
+      });
+      const second = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["n", "n", "n", "n"],
+      });
 
-        expect(first.exitCode).toBe(0);
-        expect(second.exitCode).toBe(0);
-        expect(first.stdout).toContain(
-          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-        );
-        expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
-        expect(second.stdout).not.toContain(
-          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-        );
-        const check = await runStation(
-          ["--config", fixture.configPath, "setup", "check", "--json"],
-          { cwd: fixture.repo, env: fixture.env, answers: [] },
-        );
-        expect(check.exitCode).toBe(0);
-        expect(JSON.parse(check.stdout).checks).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
-          ]),
-        );
-        const contents = await readFile(rcPath, "utf8");
-        expect(contents.startsWith(original)).toBe(true);
-        expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
-        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
-      } finally {
-        await fixture.cleanup();
-      }
-    });
-  }
+      expect(first.exitCode).toBe(0);
+      expect(second.exitCode).toBe(0);
+      expect(first.stdout).toContain(
+        `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+      );
+      expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
+      expect(second.stdout).not.toContain(
+        `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+      );
+      const check = await runStation(["--config", fixture.configPath, "setup", "check", "--json"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: [],
+      });
+      expect(check.exitCode).toBe(0);
+      expect(JSON.parse(check.stdout).checks).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
+        ]),
+      );
+      const contents = await readFile(rcPath, "utf8");
+      expect(contents.startsWith(original)).toBe(true);
+      expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
+      await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 
   it("does not create or modify shell files when integration is declined", async () => {
     const fixture = await createFixture({ harness: "codex", shell: "zsh" });

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -187,83 +187,88 @@ describe("setup guided feedback e2e", () => {
     }
   });
 
-  const representativeShell: SupportedShell = "zsh";
-  it(`gives one optional recovery command when the active ${representativeShell} rc file is missing`, async () => {
-    const shell = representativeShell;
-    const fixture = await createFixture({ harness: "codex", shell });
-    const rcPath = shellRcPath(fixture.home, shell);
-    try {
-      const result = await runStation(["--config", fixture.configPath, "setup"], {
-        cwd: fixture.repo,
-        env: fixture.env,
-        answers: ["n", "n", "y", "y", "y", "n"],
-      });
+  // Normal PRs use zsh; shell-sensitive and release CI retain both process-level paths.
+  const shellsUnderTest: readonly SupportedShell[] =
+    process.env.STATION_SETUP_E2E_ALL_SHELLS === "true" ? ["zsh", "bash"] : ["zsh"];
+  for (const shell of shellsUnderTest) {
+    it(`gives one optional recovery command when the active ${shell} rc file is missing`, async () => {
+      const fixture = await createFixture({ harness: "codex", shell });
+      const rcPath = shellRcPath(fixture.home, shell);
+      try {
+        const result = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "n", "y", "y", "y", "n"],
+        });
 
-      expect(result.timedOut).toBe(false);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain(
-        "Optional Worktrunk shell integration was not installed; core setup is complete.",
-      );
-      expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
-      expect(result.stdout).toContain(
-        `Run: touch ${rcPath} && ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-      );
-      expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
-      expect(result.stdout).not.toContain("fake shell integration installed");
-      expect(result.stdout).toContain("Core setup complete.");
-      await expect(readFile(rcPath, "utf8")).rejects.toThrow();
-      await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
-    } finally {
-      await fixture.cleanup();
-    }
-  });
+        expect(result.timedOut).toBe(false);
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain(
+          "Optional Worktrunk shell integration was not installed; core setup is complete.",
+        );
+        expect(result.stdout).toContain(`Active ${shell} rc file not found: ${rcPath}`);
+        expect(result.stdout).toContain(
+          `Run: touch ${rcPath} && ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+        );
+        expect(result.stdout).not.toContain("Failed: Install Worktrunk shell integration");
+        expect(result.stdout).not.toContain("fake shell integration installed");
+        expect(result.stdout).toContain("Core setup complete.");
+        await expect(readFile(rcPath, "utf8")).rejects.toThrow();
+        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+      } finally {
+        await fixture.cleanup();
+      }
+    });
 
-  it(`preserves an existing ${representativeShell} rc file and does not duplicate integration`, async () => {
-    const shell = representativeShell;
-    const fixture = await createFixture({ harness: "codex", shell });
-    const rcPath = shellRcPath(fixture.home, shell);
-    const original = "# user shell config\nexport USER_SETTING=preserved\n";
-    await writeFile(rcPath, original, "utf8");
-    try {
-      const first = await runStation(["--config", fixture.configPath, "setup"], {
-        cwd: fixture.repo,
-        env: fixture.env,
-        answers: ["n", "n", "y", "y", "y", "n"],
-      });
-      const second = await runStation(["--config", fixture.configPath, "setup"], {
-        cwd: fixture.repo,
-        env: fixture.env,
-        answers: ["n", "n", "n", "n"],
-      });
+    it(`preserves an existing ${shell} rc file and does not duplicate integration`, async () => {
+      const fixture = await createFixture({ harness: "codex", shell });
+      const rcPath = shellRcPath(fixture.home, shell);
+      const original = "# user shell config\nexport USER_SETTING=preserved\n";
+      await writeFile(rcPath, original, "utf8");
+      try {
+        const first = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "n", "y", "y", "y", "n"],
+        });
+        const second = await runStation(["--config", fixture.configPath, "setup"], {
+          cwd: fixture.repo,
+          env: fixture.env,
+          answers: ["n", "n", "n", "n"],
+        });
 
-      expect(first.exitCode).toBe(0);
-      expect(second.exitCode).toBe(0);
-      expect(first.stdout).toContain(
-        `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-      );
-      expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
-      expect(second.stdout).not.toContain(
-        `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-      );
-      const check = await runStation(["--config", fixture.configPath, "setup", "check", "--json"], {
-        cwd: fixture.repo,
-        env: fixture.env,
-        answers: [],
-      });
-      expect(check.exitCode).toBe(0);
-      expect(JSON.parse(check.stdout).checks).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
-        ]),
-      );
-      const contents = await readFile(rcPath, "utf8");
-      expect(contents.startsWith(original)).toBe(true);
-      expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
-      await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
-    } finally {
-      await fixture.cleanup();
-    }
-  });
+        expect(first.exitCode).toBe(0);
+        expect(second.exitCode).toBe(0);
+        expect(first.stdout).toContain(
+          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+        );
+        expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
+        expect(second.stdout).not.toContain(
+          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
+        );
+        const check = await runStation(
+          ["--config", fixture.configPath, "setup", "check", "--json"],
+          {
+            cwd: fixture.repo,
+            env: fixture.env,
+            answers: [],
+          },
+        );
+        expect(check.exitCode).toBe(0);
+        expect(JSON.parse(check.stdout).checks).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
+          ]),
+        );
+        const contents = await readFile(rcPath, "utf8");
+        expect(contents.startsWith(original)).toBe(true);
+        expect(contents.split(shellIntegrationMarker)).toHaveLength(2);
+        await expect(readFile(otherShellRcPath(fixture.home, shell), "utf8")).rejects.toThrow();
+      } finally {
+        await fixture.cleanup();
+      }
+    });
+  }
 
   it("does not create or modify shell files when integration is declined", async () => {
     const fixture = await createFixture({ harness: "codex", shell: "zsh" });


### PR DESCRIPTION
## What this fixes

Station's deterministic validation was running as a five-minute local pre-push hook and then repeating as one seven-to-eight-minute serial GitHub Actions job. That made every push block on hosted-grade process, PTY, installer, and binary acceptance before the required PR check even started.

## What changed

- makes local pre-push lint-only while retaining `test:all` and focused comprehensive commands
- fans ready-PR validation into independent static, root-test, setup, Observer, SQLite, Station, installer, and binary jobs behind the existing required `standard-ci` aggregate
- keeps release-tag validation exhaustive and cold while documentation-only PRs run lint plus diagnostics policy checks
- makes the required aggregate fail closed when a mandatory or selected lane is unexpectedly skipped
- path-selects installer and binary smokes so unrelated and test-only changes do not pay for those mega-smokes
- uses five two-process and two three-contender claim rounds for unrelated PRs, but restores exhaustive 50/10 stress for Observer-sensitive changes, releases, and a daily scheduled workflow
- shards setup E2E by file, using representative zsh process coverage normally and both bash/zsh paths for setup-sensitive changes and releases
- centralizes pinned runtime, dependency, and Turbo-cache setup in a composite action

## Testing

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:diagnostics:policy`
- `pnpm test:ci:fast`
- `pnpm test:integration`
- `pnpm test:e2e:setup:guided`
- `pnpm test:e2e:setup:guided:all-shells`
- `pnpm test:e2e:setup:core`
- `pnpm test:e2e:setup:sqlite`
- `pnpm test:e2e:observer`
- `pnpm smoke:install`
- `pnpm test:sqlite:bun:pr`
- `pnpm test:observer-claim:cross-runtime`
- `pnpm test:ci:station`
- `pnpm test:ci:binary`
- parsed the changed workflow YAML with Ruby Psych
- hosted expanded gate: every lane passed; an initial known `OBSERVER_HANDOFF_REFUSED` binary-smoke flake correctly failed the aggregate and passed an isolated rerun

## User-visible behavior

A normal push now pauses for approximately 1.5 seconds of lint instead of roughly 5 minutes 25 seconds. The required hosted check retains the same aggregate name. The safety-expanded hosted attempt reached its fail-closed aggregate in 2m04s, down from the audited 7m33s median and 8m07s latest serial run.


