### PR TITLE
fix(ci): restore pinned setup-node ref in main smoke

### DIFF
--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -277,7 +277,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288ca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -204,6 +204,9 @@ describe("hosted CI policy", () => {
     const setupAction = read(".github/actions/setup-ci/action.yml");
     const mainSmoke = between(standardCi, "  main-smoke:");
 
+    const setupNodePin = setupAction.match(/uses: (actions\/setup-node@[0-9a-f]{40})/)?.[1];
+    expect(setupNodePin).toBeDefined();
+    expect(mainSmoke).toContain(`uses: ${setupNodePin}`);
     expect(setupAction).toMatch(/uses: actions\/cache@[0-9a-f]{40}/);
     expect(setupAction).toContain("if: inputs.restore-turbo-cache == 'true'");
     expect(setupAction).toContain("path: .turbo");


### PR DESCRIPTION
## What this fixes

The post-merge `main-smoke` job could not resolve its abbreviated `actions/setup-node` reference, so the first main run after #297 failed before checkout completed. PR lanes use the correctly pinned composite action and were unaffected.

## What changed

- restores the full 40-character setup-node v4.4.0 commit used by the shared CI setup action
- requires the standalone main smoke and shared setup action to use the same full setup-node pin

## Testing

- `pnpm test:diagnostics:policy`
- `pnpm lint`
- parsed `.github/workflows/standard-ci.yml` with Ruby Psych
