### PR TITLE
feat(tmux): add configurable client-scoped popup ownership

### DIFF
--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -231,8 +231,8 @@ export async function collectSetupFacts(options: CollectSetupFactsOptions): Prom
   };
   const resolvedTmuxCommand =
     tmux.resolvedPath ?? (isAbsolute(tmux.command) ? tmux.command : undefined);
-  const defaultPopupGeometry = usesDefaultPopupGeometry(config);
-  const configAwarePopup = options.configPath !== undefined || !defaultPopupGeometry;
+  const managedFastPopup = usesManagedFastPopupDefaults(config);
+  const configAwarePopup = options.configPath !== undefined || !managedFastPopup;
   if (options.tmuxPopupOwnerRoot !== undefined && configAwarePopup) {
     tmuxBindingOptions.runShellCommand = tmuxPopupRunShellCommand(launcherCommand, config.path);
   } else if (options.tmuxPopupOwnerRoot !== undefined && resolvedTmuxCommand !== undefined) {
@@ -303,11 +303,12 @@ export async function checkSetupSocketEvidence(
   };
 }
 
-function usesDefaultPopupGeometry(config: SetupConfigFact): boolean {
+function usesManagedFastPopupDefaults(config: SetupConfigFact): boolean {
   if (config.status === "missing") return true;
   if (config.status !== "valid") return false;
   const tmux = resolveTmuxWorkbenchConfig(config.tmux);
   return (
+    tmux.popupScope === "server" &&
     tmux.popupWidth === defaultTmuxWorkbenchConfig.popupWidth &&
     tmux.popupHeight === defaultTmuxWorkbenchConfig.popupHeight &&
     tmux.popupPosition === defaultTmuxWorkbenchConfig.popupPosition

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { type ExternalCommandRunner, runExternalCommand } from "@station/runtime";
+import { persistentUiOwnerClientOption } from "@station/tmux";
 import type { SetupTmuxBindingFact } from "../model.js";
 import type { SetupFileSystemReader } from "./config.js";
 import { setupProbeTimeoutMs } from "./constants.js";
@@ -12,6 +13,8 @@ const bindingEditComment = "# Change Space to any tmux key; stn setup preserves 
 const supportedBindingKeyPattern =
   /^(?:[A-Za-z0-9]|Space|F(?:[1-9]|1[0-2])|[CM]-(?:[A-Za-z0-9]|Space|F(?:[1-9]|1[0-2])))$/;
 const quotedShellValuePattern = /^'[^']*'(?:\\''[^']*')*$/;
+// A popup binding runs through a nested tmux client, so prefer the renderer session's outer owner.
+const popupFocusClientFormat = `#{?#{${persistentUiOwnerClientOption}},#{q:${persistentUiOwnerClientOption}},#{q:client_name}}`;
 
 export type CheckSetupTmuxBindingOptions = {
   homeDir: string;
@@ -141,7 +144,7 @@ export function tmuxPopupRunShellCommand(
   }
   command.push(
     "STATION_FOCUS_PROVIDER=tmux",
-    "STATION_FOCUS_CLIENT_ID=#{q:client_name}",
+    `STATION_FOCUS_CLIENT_ID=${popupFocusClientFormat}`,
     quoteShellValue(escapeTmuxFormat(launcherCommand)),
   );
   if (configPath !== undefined) {

--- a/apps/cli/src/commands/tui.ts
+++ b/apps/cli/src/commands/tui.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import type { StationConfig } from "@station/config";
+import type { StationConfig, TmuxConfig } from "@station/config";
 import { TUI_STARTUP_RECONCILE_REASON } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import {
@@ -114,7 +114,7 @@ export async function runTuiCommand(
       buildRendererEnv(parsed, { STATION_SOURCE: "mock" }, options.configPath),
       "dashboard",
       parsed.persistentPopup,
-      options.config?.terminal?.tmux?.command,
+      options.config?.terminal?.tmux,
     );
   }
 
@@ -181,7 +181,7 @@ export async function runTuiCommand(
     ),
     parsed.popupMode ? "dashboard" : "station",
     parsed.persistentPopup,
-    options.config?.terminal?.tmux?.command,
+    options.config?.terminal?.tmux,
   );
 }
 
@@ -211,11 +211,11 @@ function runRenderer(
   env: Record<string, string>,
   entry: RendererEntry,
   persistentPopup: boolean,
-  popupCommand: string | undefined,
+  popupConfig: TmuxConfig | undefined,
 ): Promise<TuiRunResult> {
   return (
     deps.spawnRenderer?.({ env, entry }) ??
-    spawnRenderer({ env, entry }, deps, persistentPopup, popupCommand)
+    spawnRenderer({ env, entry }, deps, persistentPopup, popupConfig)
   );
 }
 
@@ -223,7 +223,7 @@ async function spawnRenderer(
   { env, entry }: RendererSpawnOptions,
   deps: TuiCommandDeps,
   persistentPopup: boolean,
-  popupCommand: string | undefined,
+  popupConfig: TmuxConfig | undefined,
 ): Promise<TuiRunResult> {
   const childEnv = { ...process.env, ...env, STATION_QUIET_PRELAUNCH: "1" };
   const override = process.env.STATION_DASHBOARD_COMMAND;
@@ -273,7 +273,7 @@ async function spawnRenderer(
   const control = popupRenderer
     ? attachTuiRendererControl(
         child,
-        deps.popupControl ?? defaultPopupControl(deps.env, popupCommand),
+        deps.popupControl ?? defaultPopupControl(deps.env, popupConfig),
       )
     : undefined;
   return new Promise<TuiRunResult>((resolve) => {
@@ -311,14 +311,17 @@ async function runStationLink(
 
 function defaultPopupControl(
   env: CliEnv | undefined,
-  command: string | undefined,
+  config: TmuxConfig | undefined,
 ): TuiRendererControlAdapters {
   const popupEnv = { ...(env ?? process.env) };
-  // The startup client is a delivery hint; runtime requests must follow the current popup claim.
-  delete popupEnv.STATION_FOCUS_CLIENT_ID;
+  if ((config?.popupScope ?? "server") === "server") {
+    // A server-scoped renderer follows the current claim rather than its startup client.
+    delete popupEnv.STATION_FOCUS_CLIENT_ID;
+  }
   const popupOptions = {
     env: popupEnv,
-    command: resolvePopupTmuxCommand(command, popupEnv),
+    command: resolvePopupTmuxCommand(config?.command, popupEnv),
+    ...(config === undefined ? {} : { config }),
   };
   return {
     dismissPopup: () => dismissTmuxPopup(popupOptions),

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -289,6 +289,7 @@ describe("CLI popup command", () => {
         popupWidth: "90%",
         popupHeight: "80%",
         popupPosition: "C",
+        popupScope: "client",
       },
     };
     const calls: TmuxPopupOptions[] = [];
@@ -322,6 +323,7 @@ describe("CLI popup command", () => {
           popupWidth: "90%",
           popupHeight: "80%",
           popupPosition: "C",
+          popupScope: "client",
         },
         env: {
           TMUX: "/tmp/tmux-501/default,123,0",

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -321,7 +321,16 @@ describe("setup dependency checks", () => {
     );
   }, 15_000);
 
-  it("uses the config-aware popup alias for compiled bindings with custom geometry", async () => {
+  it.each([
+    {
+      label: "custom geometry",
+      popup: { popupWidth: "80", popupHeight: "24", popupPosition: "C" },
+    },
+    {
+      label: "client popup scope",
+      popup: { popupScope: "client" as const },
+    },
+  ])("uses the config-aware popup alias for compiled bindings with $label", async ({ popup }) => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     const home = join(root, "home");
@@ -355,11 +364,7 @@ describe("setup dependency checks", () => {
         popupAlias,
       ]),
       fs: readOnlyFs({
-        [configPath]: configToml(repo, {
-          popupWidth: "80",
-          popupHeight: "24",
-          popupPosition: "C",
-        }),
+        [configPath]: configToml(repo, popup),
       }),
     });
 
@@ -2287,6 +2292,7 @@ function configToml(
     popupWidth?: string;
     popupHeight?: string;
     popupPosition?: string;
+    popupScope?: "server" | "client";
   } = {},
 ): string {
   const lines = [
@@ -2321,7 +2327,8 @@ function configToml(
   if (
     options.popupWidth !== undefined ||
     options.popupHeight !== undefined ||
-    options.popupPosition !== undefined
+    options.popupPosition !== undefined ||
+    options.popupScope !== undefined
   ) {
     lines.push("[terminal.tmux]");
     if (options.popupWidth !== undefined) {
@@ -2332,6 +2339,9 @@ function configToml(
     }
     if (options.popupPosition !== undefined) {
       lines.push(`popup_position = ${JSON.stringify(options.popupPosition)}`);
+    }
+    if (options.popupScope !== undefined) {
+      lines.push(`popup_scope = ${JSON.stringify(options.popupScope)}`);
     }
     lines.push("");
   }

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -1190,7 +1190,9 @@ scroll_on_output = "teleport"
     const binding = tmuxPopupBindingBlock();
     const clientNames = ["client one", "client'quote", "client;rm -rf", "client$(touch nope)"];
 
-    expect(binding).toContain("STATION_FOCUS_CLIENT_ID=#{q:client_name}");
+    expect(binding).toContain(
+      "STATION_FOCUS_CLIENT_ID=#{?#{@station_popup_ui_owner_client},#{q:@station_popup_ui_owner_client},#{q:client_name}}",
+    );
     expect(binding).not.toContain('STATION_FOCUS_CLIENT_ID="#{client_name}"');
     for (const clientName of clientNames) {
       expect(binding).not.toContain(clientName);
@@ -1468,10 +1470,10 @@ scroll_on_output = "teleport"
     const calls: ExternalCommandInput[] = [];
 
     expect(runShellCommand).toBe(
-      "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/station-##{session_name}/stn-tmux-popup'",
+      "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{?#{@station_popup_ui_owner_client},#{q:@station_popup_ui_owner_client},#{q:client_name}} '/tmp/station-##{session_name}/stn-tmux-popup'",
     );
     expect(tmuxPopupBindingBlock(launcherCommand)).toContain(
-      "STATION_FOCUS_CLIENT_ID=#{q:client_name}",
+      "STATION_FOCUS_CLIENT_ID=#{?#{@station_popup_ui_owner_client},#{q:@station_popup_ui_owner_client},#{q:client_name}}",
     );
 
     await checkSetupTmuxBinding({

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -727,7 +727,7 @@ function setupFacts(repo: string, overrides: Partial<SetupFacts>): SetupFacts {
       marker: "# >>> station popup binding >>>",
       launcherCommand: "stn-tmux-popup",
       runShellCommand:
-        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} 'stn-tmux-popup'",
+        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{?#{@station_popup_ui_owner_client},#{q:@station_popup_ui_owner_client},#{q:client_name}} 'stn-tmux-popup'",
       bindingKey: "Space",
       insideTmux: false,
       liveStatus: "unknown",

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -1121,7 +1121,7 @@ function facts(overrides: Partial<SetupFacts> = {}): SetupFacts {
       marker: "# >>> station popup binding >>>",
       launcherCommand: "/tmp/bin/stn-tmux-popup",
       runShellCommand:
-        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{q:client_name} '/tmp/bin/stn-tmux-popup'",
+        "env STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=#{?#{@station_popup_ui_owner_client},#{q:@station_popup_ui_owner_client},#{q:client_name}} '/tmp/bin/stn-tmux-popup'",
       bindingKey: "Space",
       insideTmux: false,
       liveStatus: "unknown",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,6 +130,7 @@ accepted by config validation but become unavailable providers at runtime.
 | `window_naming` | `project-branch` | Single-value enum. |
 | `primary_agent_pane` | bool | |
 | `popup_width` / `popup_height` / `popup_position` | string | Free-form, e.g. `"50%"`, `"C"`. |
+| `popup_scope` | `server` \| `client` | Popup ownership scope. Defaults to `server`, preserving one popup and warm renderer per tmux server and transferring it between clients. `client` creates an independent popup and warm renderer for each tmux client. Close existing popups before changing this value, then rerun `stn setup` to refresh an installed popup binding; an open renderer retains the scope it started with until dismissed. |
 
 ### `[harness.<id>]` — agent harnesses (optional)
 

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -120,9 +120,11 @@ uses the canonical installed directory, the exact sibling `stn-tmux-popup`
 alias, and the resolved tmux executable. First use can invoke that full CLI
 fallback to initialize the hidden UI; a valid warm use directly attaches or
 toggles it without loading config or starting Bun or the Observer. Configured
-custom geometry uses the config-aware sibling alias instead so every open reads
-the requested size and position; setup with an explicit `--config` path also
-uses that alias so an existing hidden UI cannot mask a config change. Controlled
+custom geometry and `popup_scope = "client"` use the config-aware sibling alias
+instead so every open reads its geometry and ownership scope; setup with an
+explicit `--config` path also uses that alias so an existing hidden UI cannot
+mask a config change. Rerun `stn setup` after changing either setting so the
+managed binding is regenerated. Controlled
 binding failures are silent, return success to tmux, and show at most a
 temporary status-line message. Run `stn popup` directly for ordinary diagnostic
 output.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -36,6 +36,7 @@ primary_agent_pane = true
 popup_width = "50%"
 popup_height = "50%"
 popup_position = "C"
+popup_scope = "server"           # "server" moves one popup between clients; "client" isolates one per client
 
 [harness.claude]
 enabled = true

--- a/examples/local-real-config.toml
+++ b/examples/local-real-config.toml
@@ -35,6 +35,7 @@ primary_agent_pane = true
 popup_width = "50%"
 popup_height = "50%"
 popup_position = "C"
+popup_scope = "server"           # "server" moves one popup between clients; "client" isolates one per client
 
 [harness.claude]
 enabled = true

--- a/integrations/terminal/tmux/src/popup/args.ts
+++ b/integrations/terminal/tmux/src/popup/args.ts
@@ -84,8 +84,12 @@ function transientPopupCommandOptions(options: BuildTmuxPopupArgsOptions): {
   return input;
 }
 
-export function buildPersistentPopupTuiCommand(tuiCommand: string): string {
-  return ["env", "STATION_TUI_POPUP=1", "STATION_FOCUS_PROVIDER=tmux", tuiCommand].join(" ");
+export function buildPersistentPopupTuiCommand(tuiCommand: string, focusClientId?: string): string {
+  const envAssignments = ["STATION_TUI_POPUP=1", "STATION_FOCUS_PROVIDER=tmux"];
+  if (focusClientId !== undefined && focusClientId.length > 0) {
+    envAssignments.push(`STATION_FOCUS_CLIENT_ID=${quoteShellValue(focusClientId)}`);
+  }
+  return ["env", ...envAssignments, tuiCommand].join(" ");
 }
 
 export function buildTmuxPopupArgs(options: BuildTmuxPopupArgsOptions = {}): string[] {

--- a/integrations/terminal/tmux/src/popup/constants.ts
+++ b/integrations/terminal/tmux/src/popup/constants.ts
@@ -2,6 +2,7 @@ export const activePopupClientOption = "@station_popup_client";
 export const activePopupClaimOption = "@station_popup_active_claim";
 export const focusPopupClientOption = "@station_popup_focus_client";
 export const persistentUiLeaseOption = "@station_popup_ui_lease";
+export const persistentUiOwnerClientOption = "@station_popup_ui_owner_client";
 export const persistentUiRouteOption = "@station_popup_ui_route";
 export const persistentUiSignatureOption = "@station_popup_ui_signature";
 export const registeredPopupExpectedSignatureOption = "@station_popup_ui_expected_signature";

--- a/integrations/terminal/tmux/src/popup/display.ts
+++ b/integrations/terminal/tmux/src/popup/display.ts
@@ -1,0 +1,156 @@
+import {
+  type ExternalCommandRunner,
+  runExternalCommand,
+  runRuntimeBoundaryWithRetry,
+} from "@station/runtime";
+import { tmuxProviderErrorFromUnknown } from "../errors.js";
+import { shellQuote } from "../shell.js";
+import { isSafePopupClientName } from "./fastProtocol.js";
+import type { TmuxPopupStateKeys } from "./scope.js";
+
+export type PopupDisplayResult = "opened" | "dismissed";
+export type ClaimedPopupActionResult = PopupDisplayResult | "contended";
+
+export type PopupDisplayInput = {
+  args: string[];
+  command: string;
+  runner?: ExternalCommandRunner;
+};
+
+export type ClaimedPopupActionInput = PopupDisplayInput & {
+  claim: string;
+  clientId: string;
+  previousClientId?: string;
+  state: TmuxPopupStateKeys;
+};
+
+type GuardedPopupActionInput = PopupDisplayInput & {
+  clientId: string;
+  condition: string;
+  previousClientId?: string;
+  state: TmuxPopupStateKeys;
+};
+
+const popupCasMiss = "STATION_POPUP_CAS_MISS";
+const safeTmuxCommandTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;
+
+function tmuxFormatLiteral(value: string): string {
+  return value.replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
+}
+
+function nestedTmuxCommand(args: readonly string[]): string {
+  return args
+    .map((arg) => {
+      const escaped = arg.replaceAll("#", "##");
+      return safeTmuxCommandTokenPattern.test(escaped) ? escaped : shellQuote(escaped);
+    })
+    .join(" ");
+}
+
+async function runGuardedPopupAction(
+  input: GuardedPopupActionInput,
+): Promise<ClaimedPopupActionResult> {
+  if (
+    !isSafePopupClientName(input.clientId) ||
+    (input.previousClientId !== undefined && !isSafePopupClientName(input.previousClientId))
+  ) {
+    throw tmuxProviderErrorFromUnknown(new Error("unsafe tmux popup client"), {
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to open the station popup.",
+    });
+  }
+  const action = [
+    nestedTmuxCommand(["set-option", "-gq", input.state.activeClientOption, input.clientId]),
+    nestedTmuxCommand(["set-option", "-gq", input.state.focusClientOption, input.clientId]),
+    ...(input.previousClientId === undefined || input.previousClientId === input.clientId
+      ? []
+      : [nestedTmuxCommand(["display-popup", "-c", input.previousClientId, "-C"])]),
+    nestedTmuxCommand(input.args),
+  ].join(" ; ");
+  const result = await runRuntimeBoundaryWithRetry(
+    {
+      operation: "provider.tmux.popup.guardedAction",
+      error: {
+        tag: "TerminalProviderError",
+        code: "TERMINAL_POPUP_FAILED",
+        message: "tmux failed to open the station popup.",
+        provider: "tmux",
+      },
+      retry: { retries: 0 },
+    },
+    ({ signal }) =>
+      runExternalCommand(
+        {
+          command: input.command,
+          args: ["if-shell", "-F", input.condition, action, `display-message -p ${popupCasMiss}`],
+          signal,
+          maxOutputChars: 64 * 1024,
+          allowedExitCodes: [0, 129],
+        },
+        input.runner,
+      ),
+  );
+  if (!result.ok) {
+    throw tmuxProviderErrorFromUnknown(result.error, {
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to open the station popup.",
+    });
+  }
+  if (result.value.stdout.trim() === popupCasMiss) {
+    return "contended";
+  }
+  return result.value.exitCode === 129 ? "dismissed" : "opened";
+}
+
+export async function runPopupDisplay(input: PopupDisplayInput): Promise<PopupDisplayResult> {
+  const result = await runRuntimeBoundaryWithRetry(
+    {
+      operation: "provider.tmux.popup",
+      error: {
+        tag: "TerminalProviderError",
+        code: "TERMINAL_POPUP_FAILED",
+        message: "tmux failed to open the station popup.",
+        provider: "tmux",
+      },
+      retry: { retries: 0 },
+    },
+    ({ signal }) =>
+      runExternalCommand(
+        {
+          command: input.command,
+          args: input.args,
+          signal,
+          maxOutputChars: 64 * 1024,
+          allowedExitCodes: [0, 129],
+        },
+        input.runner,
+      ),
+  );
+
+  if (!result.ok) {
+    throw tmuxProviderErrorFromUnknown(result.error, {
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to open the station popup.",
+    });
+  }
+
+  return result.value.exitCode === 129 ? "dismissed" : "opened";
+}
+
+export function runClaimedPopupAction(
+  input: ClaimedPopupActionInput,
+): Promise<ClaimedPopupActionResult> {
+  return runGuardedPopupAction({
+    ...input,
+    condition: `#{==:#{${input.state.activeClaimOption}},${tmuxFormatLiteral(input.claim)}}`,
+  });
+}
+
+export function runUnclaimedPopupAction(
+  input: Omit<GuardedPopupActionInput, "condition">,
+): Promise<ClaimedPopupActionResult> {
+  return runGuardedPopupAction({
+    ...input,
+    condition: `#{&&:#{==:#{${input.state.activeClaimOption}},},#{==:#{${input.state.activeClientOption}},${tmuxFormatLiteral(input.previousClientId ?? "")}}}`,
+  });
+}

--- a/integrations/terminal/tmux/src/popup/fastBinding.ts
+++ b/integrations/terminal/tmux/src/popup/fastBinding.ts
@@ -102,8 +102,8 @@ function expectedPersistentPopupSignature(options: {
 /**
  * ADAPTER
  *
- * Translates an installed popup owner into a silent tmux warm-path command that falls back to
- * the exact compiled alias whenever its versioned route cannot be acted on safely.
+ * Translates the server-scoped installed popup owner into a silent tmux warm-path command that
+ * falls back to the exact compiled alias whenever its versioned route cannot be acted on safely.
  */
 export function buildManagedFastPopupRunShellCommand(
   options: BuildManagedFastPopupRunShellCommandOptions,

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -1,12 +1,6 @@
 import type { TmuxConfig } from "@station/config";
-import {
-  type ExternalCommandRunner,
-  runExternalCommand,
-  runRuntimeBoundaryWithRetry,
-} from "@station/runtime";
 import type { TmuxCommandInput } from "../command.js";
 import { tmuxProviderErrorFromUnknown } from "../errors.js";
-import { shellQuote } from "../shell.js";
 import { buildTmuxPopupArgs } from "./args.js";
 import {
   popupCommandInput,
@@ -14,33 +8,40 @@ import {
   resolveCurrentTmuxClientId,
 } from "./command.js";
 import {
-  activePopupClaimOption,
-  activePopupClientOption,
-  focusPopupClientOption,
-} from "./constants.js";
+  type PopupDisplayInput,
+  type PopupDisplayResult,
+  runClaimedPopupAction,
+  runPopupDisplay,
+  runUnclaimedPopupAction,
+} from "./display.js";
 import {
-  buildPopupActiveClaim,
-  createPopupProtocolNonce,
-  isSafePopupClientName,
-} from "./fastProtocol.js";
+  type AcquirePopupOwnershipInput,
+  acquirePopupOwnership,
+  type DismissPopupOwnershipInput,
+  dismissPopupOwnership,
+  type PopupOwnershipAcquisition,
+} from "./ownership.js";
 import {
   ensurePersistentPopupSession,
   registerFastPopupUi,
   resolvePersistentPopupUi,
 } from "./persistentUi.js";
+import {
+  resolveTmuxPopupScopeDescriptor,
+  type TmuxPopupScopeDescriptor,
+  type TmuxPopupStateKeys,
+} from "./scope.js";
 import { openPopupShellForClient } from "./shell.js";
 import {
   clearActivePopupClaimIfCurrent,
-  clearLegacyFocusIfUnclaimed,
   clearLegacyPopupStateIfUnclaimed,
-  compareAndSetActivePopupClaim,
   dismissLegacyPopupIfUnclaimed,
   resolveActivePopupClaimState,
-  resolveActivePopupClient,
   resolveFocusPopupClient,
 } from "./state.js";
 import type {
   BuildTmuxPopupArgsOptions,
+  ResolvePersistentPopupUiOptions,
   TmuxClientIdentity,
   TmuxCurrentClientInput,
   TmuxPersistentPopupSessionOptions,
@@ -64,27 +65,6 @@ export type {
   TmuxPopupResult,
 } from "./types.js";
 
-type PopupDisplayResult = "opened" | "dismissed";
-type ClaimedPopupActionResult = PopupDisplayResult | "contended";
-
-type PopupDisplayInput = {
-  args: string[];
-  command: string;
-  runner?: ExternalCommandRunner;
-};
-
-type ClaimedPopupActionInput = PopupDisplayInput & {
-  claim: string;
-  clientId: string;
-  previousClientId?: string;
-};
-
-type GuardedPopupActionInput = PopupDisplayInput & {
-  clientId: string;
-  condition: string;
-  previousClientId?: string;
-};
-
 type PopupArgsInput = {
   claim?: string;
   command: string;
@@ -92,11 +72,23 @@ type PopupArgsInput = {
   focusClientId?: string;
   persistent: boolean;
   persistentUi?: TmuxPersistentPopupUi;
+  state: TmuxPopupStateKeys;
   tuiCommand?: string;
 };
 
-const popupCasMiss = "STATION_POPUP_CAS_MISS";
-const safeTmuxCommandTokenPattern = /^[A-Za-z0-9_@%+=,./:-]+$/;
+type OpenPopupContext = {
+  command: string;
+  currentClient?: TmuxClientIdentity;
+  focusClientId?: string;
+  scope: TmuxPopupScopeDescriptor;
+  tmuxCommand: TmuxCommandInput;
+};
+
+type PreparedPersistentPopup = {
+  persistent: boolean;
+  registrationNonce?: string;
+  ui?: TmuxPersistentPopupUi;
+};
 
 function defaultTmuxCommand(command: string | undefined, env: NodeJS.ProcessEnv): string {
   return command ?? env.STATION_TMUX_BIN ?? "tmux";
@@ -116,34 +108,20 @@ function currentClientInput(options: TmuxPopupOptions, command: string): TmuxCur
   return input;
 }
 
-function dismissOptions(
-  options: TmuxPopupOptions,
-  command: string,
-  focusClientId: string,
-): TmuxPopupDismissOptions {
-  const input: TmuxPopupDismissOptions = {
-    command,
-    focusClientId,
-  };
-  if (options.runner !== undefined) {
-    input.runner = options.runner;
-  }
-  if (options.timeoutMs !== undefined) {
-    input.timeoutMs = options.timeoutMs;
-  }
-  return input;
-}
-
 function persistentSessionOptions(
   options: TmuxPopupOptions,
   command: string,
   persistentUi: TmuxPersistentPopupUi,
+  focusClientId: string | undefined,
 ): TmuxPersistentPopupSessionOptions {
   const input: TmuxPersistentPopupSessionOptions = {
     command,
     tuiCommand: persistentUi.command,
     uiSessionName: persistentUi.sessionName,
   };
+  if (focusClientId !== undefined) {
+    input.focusClientId = focusClientId;
+  }
   if (options.runner !== undefined) {
     input.runner = options.runner;
   }
@@ -153,16 +131,21 @@ function persistentSessionOptions(
   return input;
 }
 
-function popupState(command: string, clientId: string, claim: string | undefined): TmuxPopupState {
+function popupState(
+  command: string,
+  clientId: string,
+  claim: string | undefined,
+  keys: TmuxPopupStateKeys,
+): TmuxPopupState {
   const state: TmuxPopupState = {
     clientId,
-    optionName: activePopupClientOption,
-    focusOptionName: focusPopupClientOption,
+    optionName: keys.activeClientOption,
+    focusOptionName: keys.focusClientOption,
     tmuxCommand: command,
   };
   if (claim !== undefined) {
     state.claim = claim;
-    state.claimOptionName = activePopupClaimOption;
+    state.claimOptionName = keys.activeClaimOption;
   }
   return state;
 }
@@ -177,7 +160,12 @@ function popupArgsOptions(options: PopupArgsInput): BuildTmuxPopupArgsOptions {
   }
   if (options.focusClientId !== undefined) {
     input.focusClientId = options.focusClientId;
-    input.popupState = popupState(options.command, options.focusClientId, options.claim);
+    input.popupState = popupState(
+      options.command,
+      options.focusClientId,
+      options.claim,
+      options.state,
+    );
   }
   if (options.persistentUi !== undefined) {
     input.tuiCommand = options.persistentUi.command;
@@ -197,10 +185,12 @@ function popupArgsInput(
   persistent: boolean,
   persistentUi: TmuxPersistentPopupUi | undefined,
   claim: string | undefined,
+  state: TmuxPopupStateKeys,
 ): PopupArgsInput {
   const input: PopupArgsInput = {
     command,
     persistent,
+    state,
   };
   if (claim !== undefined) {
     input.claim = claim;
@@ -223,154 +213,52 @@ function popupArgsInput(
 async function clearPopupState(
   input: TmuxCommandInput,
   clientId: string | undefined,
+  state: TmuxPopupStateKeys,
 ): Promise<void> {
   if (clientId === undefined || clientId.length === 0) {
     return;
   }
-  await clearLegacyPopupStateIfUnclaimed({ ...input, clientId }).catch(() => undefined);
-}
-
-async function runPopupDisplay(input: PopupDisplayInput): Promise<PopupDisplayResult> {
-  const result = await runRuntimeBoundaryWithRetry(
-    {
-      operation: "provider.tmux.popup",
-      error: {
-        tag: "TerminalProviderError",
-        code: "TERMINAL_POPUP_FAILED",
-        message: "tmux failed to open the station popup.",
-        provider: "tmux",
-      },
-      retry: {
-        retries: 0,
-      },
-    },
-    ({ signal }) =>
-      runExternalCommand(
-        {
-          command: input.command,
-          args: input.args,
-          signal,
-          maxOutputChars: 64 * 1024,
-          allowedExitCodes: [0, 129],
-        },
-        input.runner,
-      ),
-  );
-
-  if (!result.ok) {
-    throw tmuxProviderErrorFromUnknown(result.error, {
-      code: "TERMINAL_OPEN_FAILED",
-      message: "tmux failed to open the station popup.",
-    });
-  }
-
-  return result.value.exitCode === 129 ? "dismissed" : "opened";
-}
-
-function tmuxFormatLiteral(value: string): string {
-  return value.replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
-}
-
-function nestedTmuxCommand(args: readonly string[]): string {
-  return args
-    .map((arg) => {
-      const escaped = arg.replaceAll("#", "##");
-      return safeTmuxCommandTokenPattern.test(escaped) ? escaped : shellQuote(escaped);
-    })
-    .join(" ");
-}
-
-async function runGuardedPopupAction(
-  input: GuardedPopupActionInput,
-): Promise<ClaimedPopupActionResult> {
-  if (
-    !isSafePopupClientName(input.clientId) ||
-    (input.previousClientId !== undefined && !isSafePopupClientName(input.previousClientId))
-  ) {
-    throw tmuxProviderErrorFromUnknown(new Error("unsafe tmux popup client"), {
-      code: "TERMINAL_OPEN_FAILED",
-      message: "tmux failed to open the station popup.",
-    });
-  }
-  const action = [
-    nestedTmuxCommand(["set-option", "-gq", activePopupClientOption, input.clientId]),
-    nestedTmuxCommand(["set-option", "-gq", focusPopupClientOption, input.clientId]),
-    ...(input.previousClientId === undefined || input.previousClientId === input.clientId
-      ? []
-      : [nestedTmuxCommand(["display-popup", "-c", input.previousClientId, "-C"])]),
-    nestedTmuxCommand(input.args),
-  ].join(" ; ");
-  const result = await runRuntimeBoundaryWithRetry(
-    {
-      operation: "provider.tmux.popup.guardedAction",
-      error: {
-        tag: "TerminalProviderError",
-        code: "TERMINAL_POPUP_FAILED",
-        message: "tmux failed to open the station popup.",
-        provider: "tmux",
-      },
-      retry: { retries: 0 },
-    },
-    ({ signal }) =>
-      runExternalCommand(
-        {
-          command: input.command,
-          args: ["if-shell", "-F", input.condition, action, `display-message -p ${popupCasMiss}`],
-          signal,
-          maxOutputChars: 64 * 1024,
-          allowedExitCodes: [0, 129],
-        },
-        input.runner,
-      ),
-  );
-  if (!result.ok) {
-    throw tmuxProviderErrorFromUnknown(result.error, {
-      code: "TERMINAL_OPEN_FAILED",
-      message: "tmux failed to open the station popup.",
-    });
-  }
-  if (result.value.stdout.trim() === popupCasMiss) {
-    return "contended";
-  }
-  return result.value.exitCode === 129 ? "dismissed" : "opened";
-}
-
-function runClaimedPopupAction(input: ClaimedPopupActionInput): Promise<ClaimedPopupActionResult> {
-  return runGuardedPopupAction({
-    ...input,
-    condition: `#{==:#{${activePopupClaimOption}},${tmuxFormatLiteral(input.claim)}}`,
-  });
-}
-
-function runUnclaimedPopupAction(
-  input: Omit<GuardedPopupActionInput, "condition">,
-): Promise<ClaimedPopupActionResult> {
-  return runGuardedPopupAction({
-    ...input,
-    condition: `#{&&:#{==:#{${activePopupClaimOption}},},#{==:#{${activePopupClientOption}},${tmuxFormatLiteral(input.previousClientId ?? "")}}}`,
-  });
+  await clearLegacyPopupStateIfUnclaimed({ ...input, clientId }, state).catch(() => undefined);
 }
 
 async function dismissLegacyTmuxPopupForClient(
   options: TmuxPopupDismissOptions,
   clientId: string,
+  scope: TmuxPopupScopeDescriptor,
 ): Promise<TmuxPopupDismissResult> {
   const command = defaultTmuxCommand(options.command, options.env ?? process.env);
   const input = popupCommandInput(options, command);
-  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
+  return {
+    dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }, scope.state),
+  };
 }
 
 function popupDismissOptions(
   options: TmuxPopupFocusOriginOptions,
   command: string,
+  focusClientId?: string,
 ): TmuxPopupDismissOptions {
   const result: TmuxPopupDismissOptions = {
     command,
     env: options.env ?? process.env,
   };
+  if (options.config !== undefined) result.config = options.config;
+  if (focusClientId !== undefined) result.focusClientId = focusClientId;
   if (options.runner !== undefined) result.runner = options.runner;
   if (options.timeoutMs !== undefined) result.timeoutMs = options.timeoutMs;
   return result;
+}
+
+function configuredFocusClientId(
+  options: { focusClientId?: string },
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  if (options.focusClientId !== undefined && options.focusClientId.length > 0) {
+    return options.focusClientId;
+  }
+  return env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
+    ? env.STATION_FOCUS_CLIENT_ID
+    : undefined;
 }
 
 async function dismissTmuxPopupWithExpectedClaim(
@@ -378,347 +266,239 @@ async function dismissTmuxPopupWithExpectedClaim(
   expectedClaim?: string,
 ): Promise<TmuxPopupDismissResult> {
   const env = options.env ?? process.env;
-  const command = defaultTmuxCommand(options.command, env);
-  const input = popupCommandInput(options, command);
-  const requestedFocusClientId =
-    options.focusClientId !== undefined && options.focusClientId.length > 0
-      ? options.focusClientId
-      : undefined;
-  const envFocusClientId =
-    env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
-      ? env.STATION_FOCUS_CLIENT_ID
-      : undefined;
-  let boundClaim = expectedClaim;
-  let claimContended = false;
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    const claimState = await resolveActivePopupClaimState(input);
-    if (
-      claimState.kind === "malformed" ||
-      (claimState.kind === "valid" && claimState.claim.state !== "open")
-    ) {
-      return { dismissed: false };
-    }
-    if (boundClaim !== undefined) {
-      if (claimState.kind !== "valid" || claimState.raw !== boundClaim) {
-        return { dismissed: false };
-      }
-    } else if (claimState.kind === "valid") {
-      boundClaim = claimState.raw;
-    }
-    if (claimState.kind === "absent") {
-      break;
-    }
-    const closingClaim = buildPopupActiveClaim({
-      clientName: claimState.claim.clientName,
-      clientPid: claimState.claim.clientPid,
-      registrationNonce: claimState.claim.registrationNonce,
-      state: "closing",
-    });
-    if (
-      !(await compareAndSetActivePopupClaim(input, {
-        expected: claimState.raw,
-        replacement: closingClaim,
-      }))
-    ) {
-      claimContended = true;
-      continue;
-    }
-    let actionResult: ClaimedPopupActionResult | undefined;
-    try {
-      actionResult = await runClaimedPopupAction({
-        args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
-        claim: closingClaim,
-        clientId: claimState.claim.clientName,
-        command,
-        ...(options.runner === undefined ? {} : { runner: options.runner }),
-      });
-    } finally {
-      if (actionResult !== "contended") {
-        await clearActivePopupClaimIfCurrent(input, {
-          claim: closingClaim,
-          clientId: claimState.claim.clientName,
-        }).catch(() => undefined);
-      }
-    }
-    if (actionResult === "contended") {
-      claimContended = true;
-      continue;
-    }
-    return { dismissed: true };
-  }
-  if (claimContended) {
-    return { dismissed: false };
-  }
-  if (boundClaim !== undefined) {
-    return { dismissed: false };
-  }
-  const clientId =
-    requestedFocusClientId ??
-    envFocusClientId ??
-    (await resolveFocusPopupClient(input)) ??
-    (await resolveActivePopupClient(input));
-  if (clientId === undefined) {
-    return { dismissed: false };
-  }
-  return { dismissed: await dismissLegacyPopupIfUnclaimed({ ...input, clientId }) };
+  const command = defaultTmuxCommand(options.command ?? options.config?.command, env);
+  const focusClientId = configuredFocusClientId(options, env);
+  const scope = resolveTmuxPopupScopeDescriptor({
+    ...(options.config === undefined ? {} : { config: options.config }),
+    ...(focusClientId === undefined ? {} : { focusClientId }),
+  });
+  if (scope === undefined) return { dismissed: false };
+
+  const input: DismissPopupOwnershipInput = {
+    command,
+    scope,
+    tmuxCommand: popupCommandInput(options, command),
+  };
+  if (expectedClaim !== undefined) input.expectedClaim = expectedClaim;
+  if (focusClientId !== undefined) input.focusClientId = focusClientId;
+  if (options.runner !== undefined) input.runner = options.runner;
+  return { dismissed: await dismissPopupOwnership(input) };
 }
 
-export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<TmuxPopupResult> {
-  const command = defaultTmuxCommand(
-    options.command ?? options.config?.command,
-    options.env ?? process.env,
-  );
-  const persistent = options.persistent !== false;
+function popupClaimContention(): never {
+  throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+    code: "TERMINAL_OPEN_FAILED",
+    message: "tmux failed to claim the station popup.",
+  });
+}
+
+async function clearAcquiredPopupState(input: {
+  acquisition: PopupOwnershipAcquisition;
+  focusClientId: string | undefined;
+  scope: TmuxPopupScopeDescriptor;
+  tmuxCommand: TmuxCommandInput;
+}): Promise<void> {
+  if (input.acquisition.kind === "claimed" && input.focusClientId !== undefined) {
+    await clearActivePopupClaimIfCurrent(
+      input.tmuxCommand,
+      { claim: input.acquisition.claim, clientId: input.focusClientId },
+      input.scope.state,
+    ).catch(() => undefined);
+    return;
+  }
+  if (input.acquisition.kind === "legacy") {
+    await clearPopupState(input.tmuxCommand, input.focusClientId, input.scope.state);
+  }
+}
+
+async function displayAcquiredPopup(input: {
+  acquisition: PopupOwnershipAcquisition;
+  display: PopupDisplayInput;
+  focusClientId: string | undefined;
+  scope: TmuxPopupScopeDescriptor;
+}): Promise<PopupDisplayResult> {
+  if (input.acquisition.kind === "claimed" && input.focusClientId !== undefined) {
+    const result = await runClaimedPopupAction({
+      ...input.display,
+      claim: input.acquisition.claim,
+      clientId: input.focusClientId,
+      state: input.scope.state,
+      ...(input.acquisition.previousClientId === undefined
+        ? {}
+        : { previousClientId: input.acquisition.previousClientId }),
+    });
+    return result === "contended" ? popupClaimContention() : result;
+  }
+  if (input.acquisition.kind === "legacy" && input.focusClientId !== undefined) {
+    const result = await runUnclaimedPopupAction({
+      ...input.display,
+      clientId: input.focusClientId,
+      state: input.scope.state,
+      ...(input.acquisition.previousClientId === undefined
+        ? {}
+        : { previousClientId: input.acquisition.previousClientId }),
+    });
+    return result === "contended" ? popupClaimContention() : result;
+  }
+  return runPopupDisplay(input.display);
+}
+
+function popupScopeForOpen(
+  options: TmuxPopupOptions,
+  focusClientId: string | undefined,
+): TmuxPopupScopeDescriptor | undefined {
+  const input: {
+    config?: TmuxConfig;
+    focusClientId?: string;
+    uiSessionName?: string;
+  } = {};
+  if (options.config !== undefined) input.config = options.config;
+  if (focusClientId !== undefined) input.focusClientId = focusClientId;
+  if (options.uiSessionName !== undefined) input.uiSessionName = options.uiSessionName;
+  return resolveTmuxPopupScopeDescriptor(input);
+}
+
+async function resolveOpenPopupContext(options: TmuxPopupOptions): Promise<OpenPopupContext> {
+  const env = options.env ?? process.env;
+  const command = defaultTmuxCommand(options.command ?? options.config?.command, env);
   const clientInput = currentClientInput(options, command);
   const currentClient = await resolveCurrentTmuxClient(clientInput);
-  const requestedFocusClientId =
-    options.focusClientId !== undefined && options.focusClientId.length > 0
-      ? options.focusClientId
-      : undefined;
-  const envFocusClientId =
-    clientInput.env.STATION_FOCUS_CLIENT_ID !== undefined &&
-    clientInput.env.STATION_FOCUS_CLIENT_ID.length > 0
-      ? clientInput.env.STATION_FOCUS_CLIENT_ID
-      : undefined;
   const focusClientId =
-    requestedFocusClientId ??
-    envFocusClientId ??
+    configuredFocusClientId(options, clientInput.env) ??
     currentClient?.name ??
     (await resolveCurrentTmuxClientId(clientInput));
-  const tmuxCommand = popupCommandInput(options, command);
-
-  const persistentUi = persistent
-    ? await resolvePersistentPopupUi(options, tmuxCommand)
-    : undefined;
-  let registeredRoute: Awaited<ReturnType<typeof registerFastPopupUi>> | undefined;
-
-  if (persistentUi !== undefined) {
-    await ensurePersistentPopupSession(persistentSessionOptions(options, command, persistentUi));
-    if (persistentUi.registerFastPopup) {
-      registeredRoute = await registerFastPopupUi(tmuxCommand, persistentUi).catch(() => undefined);
-    }
+  const scope = popupScopeForOpen(options, focusClientId);
+  if (scope === undefined) {
+    return popupClaimContention();
   }
+  const context: OpenPopupContext = {
+    command,
+    scope,
+    tmuxCommand: popupCommandInput(options, command),
+  };
+  if (currentClient !== undefined) context.currentClient = currentClient;
+  if (focusClientId !== undefined) context.focusClientId = focusClientId;
+  return context;
+}
 
-  let activeClaim: string | undefined;
-  let legacyPopupAction = false;
-  let previousPopupClientId: string | undefined;
-  if (focusClientId !== undefined && focusClientId.length > 0 && currentClient !== undefined) {
-    const claimClient: TmuxClientIdentity = {
-      ...currentClient,
-      name: focusClientId,
-    };
-    const fallbackRegistrationNonce = createPopupProtocolNonce();
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const claimState = await resolveActivePopupClaimState(tmuxCommand);
-      if (claimState.kind === "malformed" && claimState.raw.length > 4096) {
-        break;
-      }
-
-      if (claimState.kind === "valid") {
-        const sameClient =
-          claimState.claim.clientName === focusClientId &&
-          claimState.claim.clientPid === claimClient.pid;
-        const nestedClient =
-          persistentUi !== undefined && claimClient.sessionName === persistentUi.sessionName;
-        if (sameClient || nestedClient) {
-          const closingClaim = buildPopupActiveClaim({
-            clientName: claimState.claim.clientName,
-            clientPid: claimState.claim.clientPid,
-            registrationNonce: claimState.claim.registrationNonce,
-            state: "closing",
-          });
-          if (
-            !(await compareAndSetActivePopupClaim(tmuxCommand, {
-              expected: claimState.raw,
-              replacement: closingClaim,
-            }))
-          ) {
-            continue;
-          }
-          let actionResult: ClaimedPopupActionResult | undefined;
-          try {
-            actionResult = await runClaimedPopupAction({
-              args: ["display-popup", "-c", claimState.claim.clientName, "-C"],
-              claim: closingClaim,
-              clientId: claimState.claim.clientName,
-              command,
-              ...(options.runner === undefined ? {} : { runner: options.runner }),
-            });
-          } finally {
-            if (actionResult !== "contended") {
-              await clearActivePopupClaimIfCurrent(tmuxCommand, {
-                claim: closingClaim,
-                clientId: claimState.claim.clientName,
-              }).catch(() => undefined);
-            }
-          }
-          if (actionResult === "contended") {
-            continue;
-          }
-          return { opened: false, closed: true };
-        }
-      }
-
-      const activeClientId = await resolveActivePopupClient(tmuxCommand);
-      if (claimState.kind === "absent" && activeClientId === focusClientId) {
-        const closingClaim = buildPopupActiveClaim({
-          clientName: claimClient.name,
-          clientPid: claimClient.pid,
-          registrationNonce: registeredRoute?.registrationNonce ?? fallbackRegistrationNonce,
-          state: "closing",
-        });
-        if (
-          !(await compareAndSetActivePopupClaim(tmuxCommand, {
-            replacement: closingClaim,
-          }))
-        ) {
-          continue;
-        }
-        let actionResult: ClaimedPopupActionResult | undefined;
-        try {
-          actionResult = await runClaimedPopupAction({
-            args: ["display-popup", "-c", focusClientId, "-C"],
-            claim: closingClaim,
-            clientId: focusClientId,
-            command,
-            ...(options.runner === undefined ? {} : { runner: options.runner }),
-          });
-        } finally {
-          if (actionResult !== "contended") {
-            await clearActivePopupClaimIfCurrent(tmuxCommand, {
-              claim: closingClaim,
-              clientId: focusClientId,
-            }).catch(() => undefined);
-          }
-        }
-        if (actionResult === "contended") {
-          continue;
-        }
-        return { opened: false, closed: true };
-      }
-
-      const registrationNonce =
-        registeredRoute?.registrationNonce ??
-        (claimState.kind === "valid"
-          ? claimState.claim.registrationNonce
-          : fallbackRegistrationNonce);
-      const nextClaim = buildPopupActiveClaim({
-        clientName: claimClient.name,
-        clientPid: claimClient.pid,
-        registrationNonce,
-        state: "open",
-      });
-      const replaced = await compareAndSetActivePopupClaim(tmuxCommand, {
-        ...(claimState.kind === "absent" ? {} : { expected: claimState.raw }),
-        replacement: nextClaim,
-      });
-      if (!replaced) {
-        continue;
-      }
-      activeClaim = nextClaim;
-      previousPopupClientId =
-        claimState.kind === "valid" ? claimState.claim.clientName : activeClientId;
-      break;
-    }
-    if (activeClaim === undefined) {
-      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
-        code: "TERMINAL_OPEN_FAILED",
-        message: "tmux failed to claim the station popup.",
-      });
-    }
-  } else if (focusClientId !== undefined && focusClientId.length > 0) {
-    const claimState = await resolveActivePopupClaimState(tmuxCommand);
-    if (claimState.kind !== "absent") {
-      throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
-        code: "TERMINAL_OPEN_FAILED",
-        message: "tmux failed to claim the station popup.",
-      });
-    }
-    const activeClientId = await resolveActivePopupClient(tmuxCommand);
-    if (activeClientId === focusClientId) {
-      await dismissTmuxPopup(dismissOptions(options, command, focusClientId));
-      return { opened: false, closed: true };
-    }
-    legacyPopupAction = true;
-    previousPopupClientId = activeClientId;
-  } else {
-    const legacyFocusClientId = await resolveFocusPopupClient(tmuxCommand);
-    if (legacyFocusClientId !== undefined) {
-      await clearLegacyFocusIfUnclaimed({
-        ...tmuxCommand,
-        clientId: legacyFocusClientId,
-      }).catch(() => undefined);
-    }
+function persistentUiOptions(
+  options: TmuxPopupOptions,
+  scope: TmuxPopupScopeDescriptor,
+): ResolvePersistentPopupUiOptions {
+  const input: ResolvePersistentPopupUiOptions = { uiSessionName: scope.uiSessionName };
+  if (options.checkoutRoot !== undefined) input.checkoutRoot = options.checkoutRoot;
+  if (options.registeredDevPopupRoot !== undefined) {
+    input.registeredDevPopupRoot = options.registeredDevPopupRoot;
   }
+  if (options.tuiCommand !== undefined) input.tuiCommand = options.tuiCommand;
+  if (scope.kind === "server" && options.preferRegisteredDevPopup === true) {
+    input.preferRegisteredDevPopup = true;
+  }
+  return input;
+}
 
+async function preparePersistentPopup(
+  options: TmuxPopupOptions,
+  context: OpenPopupContext,
+): Promise<PreparedPersistentPopup> {
+  if (options.persistent === false) {
+    return { persistent: false };
+  }
+  const ui = await resolvePersistentPopupUi(
+    persistentUiOptions(options, context.scope),
+    context.tmuxCommand,
+  );
+  const fixedFocusClientId = context.scope.kind === "client" ? context.focusClientId : undefined;
+  await ensurePersistentPopupSession(
+    persistentSessionOptions(options, context.command, ui, fixedFocusClientId),
+  );
+  const prepared: PreparedPersistentPopup = { persistent: true, ui };
+  if (context.scope.registerFastPopup && ui.registerFastPopup) {
+    const route = await registerFastPopupUi(context.tmuxCommand, ui).catch(() => undefined);
+    if (route !== undefined) prepared.registrationNonce = route.registrationNonce;
+  }
+  return prepared;
+}
+
+function popupOwnershipInput(
+  options: TmuxPopupOptions,
+  context: OpenPopupContext,
+  prepared: PreparedPersistentPopup,
+): AcquirePopupOwnershipInput {
+  const input: AcquirePopupOwnershipInput = {
+    command: context.command,
+    scope: context.scope,
+    tmuxCommand: context.tmuxCommand,
+  };
+  if (context.currentClient !== undefined) input.currentClient = context.currentClient;
+  if (context.focusClientId !== undefined) input.focusClientId = context.focusClientId;
+  if (prepared.ui !== undefined) input.persistentUi = prepared.ui;
+  if (prepared.registrationNonce !== undefined) {
+    input.registrationNonce = prepared.registrationNonce;
+  }
+  if (options.runner !== undefined) input.runner = options.runner;
+  return input;
+}
+
+function popupDisplayInput(
+  options: TmuxPopupOptions,
+  context: OpenPopupContext,
+  prepared: PreparedPersistentPopup,
+  acquisition: PopupOwnershipAcquisition,
+): PopupDisplayInput {
+  const activeClaim = acquisition.kind === "claimed" ? acquisition.claim : undefined;
   const args = buildTmuxPopupArgs(
     popupArgsOptions(
-      popupArgsInput(options, command, focusClientId, persistent, persistentUi, activeClaim),
+      popupArgsInput(
+        options,
+        context.command,
+        context.focusClientId,
+        prepared.persistent,
+        prepared.ui,
+        activeClaim,
+        context.scope.state,
+      ),
     ),
   );
+  const input: PopupDisplayInput = { args, command: context.command };
+  if (options.runner !== undefined) input.runner = options.runner;
+  return input;
+}
 
-  const displayInput: PopupDisplayInput = {
-    args,
-    command,
-  };
-  if (options.runner !== undefined) {
-    displayInput.runner = options.runner;
+/**
+ * ADAPTER
+ *
+ * Coordinates the configured ownership scope and persistent renderer through tmux.
+ */
+export async function openTmuxPopup(options: TmuxPopupOptions = {}): Promise<TmuxPopupResult> {
+  const context = await resolveOpenPopupContext(options);
+  const prepared = await preparePersistentPopup(options, context);
+  const acquisition = await acquirePopupOwnership(popupOwnershipInput(options, context, prepared));
+  if (acquisition.kind === "closed") {
+    return { opened: false, closed: true };
   }
 
+  const cleanupInput = {
+    acquisition,
+    focusClientId: context.focusClientId,
+    scope: context.scope,
+    tmuxCommand: context.tmuxCommand,
+  };
   let displayResult: PopupDisplayResult;
   try {
-    if (activeClaim !== undefined && focusClientId !== undefined) {
-      const claimedResult = await runClaimedPopupAction({
-        ...displayInput,
-        claim: activeClaim,
-        clientId: focusClientId,
-        ...(previousPopupClientId === undefined ? {} : { previousClientId: previousPopupClientId }),
-      });
-      if (claimedResult === "contended") {
-        throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
-          code: "TERMINAL_OPEN_FAILED",
-          message: "tmux failed to claim the station popup.",
-        });
-      }
-      displayResult = claimedResult;
-    } else if (legacyPopupAction && focusClientId !== undefined) {
-      const guardedResult = await runUnclaimedPopupAction({
-        ...displayInput,
-        clientId: focusClientId,
-        ...(previousPopupClientId === undefined ? {} : { previousClientId: previousPopupClientId }),
-      });
-      if (guardedResult === "contended") {
-        throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
-          code: "TERMINAL_OPEN_FAILED",
-          message: "tmux failed to claim the station popup.",
-        });
-      }
-      displayResult = guardedResult;
-    } else {
-      displayResult = await runPopupDisplay(displayInput);
-    }
+    displayResult = await displayAcquiredPopup({
+      acquisition,
+      display: popupDisplayInput(options, context, prepared, acquisition),
+      focusClientId: context.focusClientId,
+      scope: context.scope,
+    });
   } catch (error) {
-    if (activeClaim !== undefined && focusClientId !== undefined) {
-      await clearActivePopupClaimIfCurrent(tmuxCommand, {
-        claim: activeClaim,
-        clientId: focusClientId,
-      }).catch(() => undefined);
-    } else {
-      await clearPopupState(tmuxCommand, focusClientId);
-    }
+    await clearAcquiredPopupState(cleanupInput);
     throw error;
   }
   if (displayResult === "dismissed") {
-    if (activeClaim !== undefined && focusClientId !== undefined) {
-      await clearActivePopupClaimIfCurrent(tmuxCommand, {
-        claim: activeClaim,
-        clientId: focusClientId,
-      }).catch(() => undefined);
-    } else {
-      await clearPopupState(tmuxCommand, focusClientId);
-    }
+    await clearAcquiredPopupState(cleanupInput);
   }
-
   return { opened: true };
 }
 
@@ -726,17 +506,18 @@ export async function resolveTmuxPopupFocusTarget(
   options: TmuxPopupFocusOriginOptions = {},
 ): Promise<TmuxPopupFocusTarget | undefined> {
   const env = options.env ?? process.env;
-  const command = defaultTmuxCommand(options.command, env);
-  const requestedFocusClientId =
-    options.focusClientId !== undefined && options.focusClientId.length > 0
-      ? options.focusClientId
-      : undefined;
-  const envFocusClientId =
-    env.STATION_FOCUS_CLIENT_ID !== undefined && env.STATION_FOCUS_CLIENT_ID.length > 0
-      ? env.STATION_FOCUS_CLIENT_ID
-      : undefined;
+  const command = defaultTmuxCommand(options.command ?? options.config?.command, env);
+  const focusClientId = configuredFocusClientId(options, env);
+  const scope = resolveTmuxPopupScopeDescriptor({
+    ...(options.config === undefined ? {} : { config: options.config }),
+    ...(focusClientId === undefined ? {} : { focusClientId }),
+  });
+  if (scope === undefined) {
+    return undefined;
+  }
+
   const input = popupCommandInput(options, command);
-  const claimState = await resolveActivePopupClaimState(input);
+  const claimState = await resolveActivePopupClaimState(input, scope.state);
   if (claimState.kind === "malformed") {
     return undefined;
   }
@@ -744,7 +525,7 @@ export async function resolveTmuxPopupFocusTarget(
     if (claimState.claim.state !== "open") {
       return undefined;
     }
-    const exactDismissOptions = popupDismissOptions(options, command);
+    const exactDismissOptions = popupDismissOptions(options, command, claimState.claim.clientName);
     return {
       origin: {
         provider: "tmux",
@@ -755,16 +536,19 @@ export async function resolveTmuxPopupFocusTarget(
       dismissExact: () => dismissTmuxPopupWithExpectedClaim(exactDismissOptions, claimState.raw),
     };
   }
-  const clientId =
-    requestedFocusClientId ?? envFocusClientId ?? (await resolveFocusPopupClient(input));
+  if (!scope.allowLegacyState) {
+    return undefined;
+  }
+
+  const clientId = focusClientId ?? (await resolveFocusPopupClient(input, scope.state));
   if (clientId === undefined) {
     return undefined;
   }
-  const legacyDismissOptions = popupDismissOptions(options, command);
+  const legacyDismissOptions = popupDismissOptions(options, command, clientId);
   return {
     origin: { provider: "tmux", clientId },
     openShell: (cwd) => openPopupShellForClient(options, command, clientId, cwd),
-    dismissExact: () => dismissLegacyTmuxPopupForClient(legacyDismissOptions, clientId),
+    dismissExact: () => dismissLegacyTmuxPopupForClient(legacyDismissOptions, clientId, scope),
   };
 }
 

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -56,6 +56,7 @@ import type {
 } from "./types.js";
 
 export { buildTmuxPopupArgs } from "./args.js";
+export { persistentUiOwnerClientOption } from "./constants.js";
 export { buildManagedFastPopupRunShellCommand } from "./fastBinding.js";
 export { ensurePersistentPopupSession, resolveRegisteredDevPopupUi } from "./persistentUi.js";
 export type {

--- a/integrations/terminal/tmux/src/popup/ownership.ts
+++ b/integrations/terminal/tmux/src/popup/ownership.ts
@@ -1,0 +1,414 @@
+import type { ExternalCommandRunner } from "@station/runtime";
+import type { TmuxCommandInput } from "../command.js";
+import { tmuxProviderErrorFromUnknown } from "../errors.js";
+import { type ClaimedPopupActionResult, runClaimedPopupAction } from "./display.js";
+import {
+  buildPopupActiveClaim,
+  createPopupProtocolNonce,
+  type PopupActiveClaim,
+} from "./fastProtocol.js";
+import type { TmuxPopupScopeDescriptor } from "./scope.js";
+import {
+  clearActivePopupClaimIfCurrent,
+  clearLegacyFocusIfUnclaimed,
+  compareAndSetActivePopupClaim,
+  dismissLegacyPopupIfUnclaimed,
+  resolveActivePopupClaimState,
+  resolveActivePopupClient,
+  resolveFocusPopupClient,
+  type TmuxActivePopupClaimState,
+} from "./state.js";
+import type { TmuxClientIdentity, TmuxPersistentPopupUi } from "./types.js";
+
+export type PopupOwnershipAcquisition =
+  | { kind: "closed" }
+  | { claim: string; kind: "claimed"; previousClientId?: string }
+  | { kind: "legacy"; previousClientId?: string }
+  | { kind: "untracked" };
+
+export type AcquirePopupOwnershipInput = {
+  command: string;
+  currentClient?: TmuxClientIdentity;
+  focusClientId?: string;
+  persistentUi?: TmuxPersistentPopupUi;
+  registrationNonce?: string;
+  runner?: ExternalCommandRunner;
+  scope: TmuxPopupScopeDescriptor;
+  tmuxCommand: TmuxCommandInput;
+};
+
+export type CloseClaimedPopupInput = Pick<
+  AcquirePopupOwnershipInput,
+  "command" | "runner" | "scope" | "tmuxCommand"
+> & {
+  claim: PopupActiveClaim;
+  expectedClaim: string;
+};
+
+export type DismissPopupOwnershipInput = Pick<
+  AcquirePopupOwnershipInput,
+  "command" | "runner" | "scope" | "tmuxCommand"
+> & {
+  expectedClaim?: string;
+  focusClientId?: string;
+};
+
+type ClaimPopupOwnershipInput = AcquirePopupOwnershipInput & {
+  currentClient: TmuxClientIdentity;
+  focusClientId: string;
+};
+
+type ClaimAttemptResult =
+  | Extract<PopupOwnershipAcquisition, { kind: "claimed" | "closed" }>
+  | { kind: "failed" | "retry" };
+
+type CloseClaimedPopupResult = "closed" | "contended";
+
+type DismissClaimAttemptResult =
+  | { kind: "absent" }
+  | { kind: "dismissed" }
+  | { boundClaim: string; kind: "retry" }
+  | { kind: "unavailable" };
+
+function popupClaimContention(): never {
+  throw tmuxProviderErrorFromUnknown(new Error("tmux popup claim contention"), {
+    code: "TERMINAL_OPEN_FAILED",
+    message: "tmux failed to claim the station popup.",
+  });
+}
+
+function claimClientIdentity(input: ClaimPopupOwnershipInput): TmuxClientIdentity {
+  return {
+    ...input.currentClient,
+    name: input.focusClientId,
+  };
+}
+
+function isCurrentPopupOwner(
+  input: ClaimPopupOwnershipInput,
+  claimState: Extract<TmuxActivePopupClaimState, { kind: "valid" }>,
+  claimClient: TmuxClientIdentity,
+): boolean {
+  const sameClient =
+    claimState.claim.clientName === input.focusClientId &&
+    claimState.claim.clientPid === claimClient.pid;
+  const nestedClient =
+    input.persistentUi !== undefined && claimClient.sessionName === input.persistentUi.sessionName;
+  return sameClient || nestedClient;
+}
+
+async function closeUnclaimedPopupForCurrentClient(
+  input: ClaimPopupOwnershipInput,
+  claimClient: TmuxClientIdentity,
+  registrationNonce: string,
+): Promise<CloseClaimedPopupResult> {
+  const closingClaim = buildPopupActiveClaim({
+    clientName: claimClient.name,
+    clientPid: claimClient.pid,
+    registrationNonce,
+    state: "closing",
+  });
+  const claimed = await compareAndSetActivePopupClaim(
+    input.tmuxCommand,
+    { replacement: closingClaim },
+    input.scope.state,
+  );
+  if (!claimed) {
+    return "contended";
+  }
+  return closeClaimedPopupAction(input, closingClaim, claimClient);
+}
+
+async function closeClaimedPopupAction(
+  input: ClaimPopupOwnershipInput,
+  closingClaim: string,
+  claimClient: TmuxClientIdentity,
+): Promise<CloseClaimedPopupResult> {
+  let actionResult: ClaimedPopupActionResult | undefined;
+  try {
+    actionResult = await runClaimedPopupAction({
+      args: ["display-popup", "-c", claimClient.name, "-C"],
+      claim: closingClaim,
+      clientId: claimClient.name,
+      command: input.command,
+      state: input.scope.state,
+      ...(input.runner === undefined ? {} : { runner: input.runner }),
+    });
+  } finally {
+    if (actionResult !== "contended") {
+      await clearActivePopupClaimIfCurrent(
+        input.tmuxCommand,
+        { claim: closingClaim, clientId: claimClient.name },
+        input.scope.state,
+      ).catch(() => undefined);
+    }
+  }
+  return actionResult === "contended" ? "contended" : "closed";
+}
+
+function nextOpenClaim(input: {
+  claimClient: TmuxClientIdentity;
+  claimState: TmuxActivePopupClaimState;
+  fallbackRegistrationNonce: string;
+  registrationNonce?: string;
+}): string {
+  const registrationNonce =
+    input.registrationNonce ??
+    (input.claimState.kind === "valid"
+      ? input.claimState.claim.registrationNonce
+      : input.fallbackRegistrationNonce);
+  return buildPopupActiveClaim({
+    clientName: input.claimClient.name,
+    clientPid: input.claimClient.pid,
+    registrationNonce,
+    state: "open",
+  });
+}
+
+async function closeCurrentOwnedClaim(
+  input: ClaimPopupOwnershipInput,
+  claimClient: TmuxClientIdentity,
+  claimState: TmuxActivePopupClaimState,
+): Promise<ClaimAttemptResult | undefined> {
+  if (claimState.kind !== "valid" || !isCurrentPopupOwner(input, claimState, claimClient)) {
+    return undefined;
+  }
+  const closeInput: CloseClaimedPopupInput = {
+    command: input.command,
+    claim: claimState.claim,
+    expectedClaim: claimState.raw,
+    scope: input.scope,
+    tmuxCommand: input.tmuxCommand,
+  };
+  if (input.runner !== undefined) closeInput.runner = input.runner;
+  const result = await closeClaimedPopup(closeInput);
+  return { kind: result === "contended" ? "retry" : "closed" };
+}
+
+async function replacePopupClaim(input: {
+  activeClientId?: string;
+  claimClient: TmuxClientIdentity;
+  claimInput: ClaimPopupOwnershipInput;
+  claimState: TmuxActivePopupClaimState;
+  fallbackRegistrationNonce: string;
+}): Promise<ClaimAttemptResult> {
+  const claimOptions: Parameters<typeof nextOpenClaim>[0] = {
+    claimClient: input.claimClient,
+    claimState: input.claimState,
+    fallbackRegistrationNonce: input.fallbackRegistrationNonce,
+  };
+  if (input.claimInput.registrationNonce !== undefined) {
+    claimOptions.registrationNonce = input.claimInput.registrationNonce;
+  }
+  const claim = nextOpenClaim(claimOptions);
+  const replacement: { expected?: string; replacement: string } = { replacement: claim };
+  if (input.claimState.kind !== "absent") replacement.expected = input.claimState.raw;
+  const replaced = await compareAndSetActivePopupClaim(
+    input.claimInput.tmuxCommand,
+    replacement,
+    input.claimInput.scope.state,
+  );
+  if (!replaced) return { kind: "retry" };
+
+  const previousClientId =
+    input.claimState.kind === "valid" ? input.claimState.claim.clientName : input.activeClientId;
+  const acquired: Extract<PopupOwnershipAcquisition, { kind: "claimed" }> = {
+    claim,
+    kind: "claimed",
+  };
+  if (previousClientId !== undefined) acquired.previousClientId = previousClientId;
+  return acquired;
+}
+
+async function attemptPopupClaim(
+  input: ClaimPopupOwnershipInput,
+  claimClient: TmuxClientIdentity,
+  fallbackRegistrationNonce: string,
+): Promise<ClaimAttemptResult> {
+  const claimState = await resolveActivePopupClaimState(input.tmuxCommand, input.scope.state);
+  if (claimState.kind === "malformed" && claimState.raw.length > 4096) {
+    return { kind: "failed" };
+  }
+
+  const currentClose = await closeCurrentOwnedClaim(input, claimClient, claimState);
+  if (currentClose !== undefined) return currentClose;
+
+  const activeClientId = await resolveActivePopupClient(input.tmuxCommand, input.scope.state);
+  if (claimState.kind === "absent" && activeClientId === input.focusClientId) {
+    const result = await closeUnclaimedPopupForCurrentClient(
+      input,
+      claimClient,
+      input.registrationNonce ?? fallbackRegistrationNonce,
+    );
+    return { kind: result === "contended" ? "retry" : "closed" };
+  }
+  return replacePopupClaim({
+    claimClient,
+    claimInput: input,
+    claimState,
+    fallbackRegistrationNonce,
+    ...(activeClientId === undefined ? {} : { activeClientId }),
+  });
+}
+
+async function acquireClaimedPopupOwnership(
+  input: ClaimPopupOwnershipInput,
+): Promise<PopupOwnershipAcquisition> {
+  const claimClient = claimClientIdentity(input);
+  const fallbackRegistrationNonce = createPopupProtocolNonce();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = await attemptPopupClaim(input, claimClient, fallbackRegistrationNonce);
+    if (result.kind === "claimed" || result.kind === "closed") return result;
+    if (result.kind === "failed") break;
+  }
+  return popupClaimContention();
+}
+
+async function attemptClaimedPopupDismissal(
+  input: DismissPopupOwnershipInput,
+  boundClaim: string | undefined,
+): Promise<DismissClaimAttemptResult> {
+  const claimState = await resolveActivePopupClaimState(input.tmuxCommand, input.scope.state);
+  if (
+    claimState.kind === "malformed" ||
+    (claimState.kind === "valid" && claimState.claim.state !== "open")
+  ) {
+    return { kind: "unavailable" };
+  }
+  if (boundClaim !== undefined && (claimState.kind !== "valid" || claimState.raw !== boundClaim)) {
+    return { kind: "unavailable" };
+  }
+  if (claimState.kind === "absent") {
+    return { kind: "absent" };
+  }
+
+  const closeInput: CloseClaimedPopupInput = {
+    command: input.command,
+    claim: claimState.claim,
+    expectedClaim: claimState.raw,
+    scope: input.scope,
+    tmuxCommand: input.tmuxCommand,
+  };
+  if (input.runner !== undefined) closeInput.runner = input.runner;
+  const result = await closeClaimedPopup(closeInput);
+  return result === "contended"
+    ? { boundClaim: claimState.raw, kind: "retry" }
+    : { kind: "dismissed" };
+}
+
+async function acquireLegacyPopupOwnership(
+  input: AcquirePopupOwnershipInput & { focusClientId: string },
+): Promise<PopupOwnershipAcquisition> {
+  const claimState = await resolveActivePopupClaimState(input.tmuxCommand, input.scope.state);
+  if (claimState.kind !== "absent") {
+    return popupClaimContention();
+  }
+  const activeClientId = await resolveActivePopupClient(input.tmuxCommand, input.scope.state);
+  if (activeClientId === input.focusClientId) {
+    await dismissLegacyPopupIfUnclaimed(
+      { ...input.tmuxCommand, clientId: input.focusClientId },
+      input.scope.state,
+    );
+    return { kind: "closed" };
+  }
+  return {
+    kind: "legacy",
+    ...(activeClientId === undefined ? {} : { previousClientId: activeClientId }),
+  };
+}
+
+export async function closeClaimedPopup(
+  input: CloseClaimedPopupInput,
+): Promise<CloseClaimedPopupResult> {
+  const closingClaim = buildPopupActiveClaim({
+    clientName: input.claim.clientName,
+    clientPid: input.claim.clientPid,
+    registrationNonce: input.claim.registrationNonce,
+    state: "closing",
+  });
+  const claimed = await compareAndSetActivePopupClaim(
+    input.tmuxCommand,
+    {
+      expected: input.expectedClaim,
+      replacement: closingClaim,
+    },
+    input.scope.state,
+  );
+  if (!claimed) {
+    return "contended";
+  }
+
+  let actionResult: ClaimedPopupActionResult | undefined;
+  try {
+    actionResult = await runClaimedPopupAction({
+      args: ["display-popup", "-c", input.claim.clientName, "-C"],
+      claim: closingClaim,
+      clientId: input.claim.clientName,
+      command: input.command,
+      state: input.scope.state,
+      ...(input.runner === undefined ? {} : { runner: input.runner }),
+    });
+  } finally {
+    if (actionResult !== "contended") {
+      await clearActivePopupClaimIfCurrent(
+        input.tmuxCommand,
+        {
+          claim: closingClaim,
+          clientId: input.claim.clientName,
+        },
+        input.scope.state,
+      ).catch(() => undefined);
+    }
+  }
+  return actionResult === "contended" ? "contended" : "closed";
+}
+
+export async function dismissPopupOwnership(input: DismissPopupOwnershipInput): Promise<boolean> {
+  let boundClaim = input.expectedClaim;
+  let contended = false;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = await attemptClaimedPopupDismissal(input, boundClaim);
+    if (result.kind === "dismissed") return true;
+    if (result.kind === "unavailable") return false;
+    if (result.kind === "absent") break;
+    boundClaim = result.boundClaim;
+    contended = true;
+  }
+  if (contended || boundClaim !== undefined || !input.scope.allowLegacyState) {
+    return false;
+  }
+  const clientId =
+    input.focusClientId ??
+    (await resolveFocusPopupClient(input.tmuxCommand, input.scope.state)) ??
+    (await resolveActivePopupClient(input.tmuxCommand, input.scope.state));
+  if (clientId === undefined) return false;
+  return dismissLegacyPopupIfUnclaimed({ ...input.tmuxCommand, clientId }, input.scope.state);
+}
+
+export async function acquirePopupOwnership(
+  input: AcquirePopupOwnershipInput,
+): Promise<PopupOwnershipAcquisition> {
+  if (input.focusClientId !== undefined && input.currentClient !== undefined) {
+    return acquireClaimedPopupOwnership({
+      ...input,
+      currentClient: input.currentClient,
+      focusClientId: input.focusClientId,
+    });
+  }
+  if (input.focusClientId !== undefined) {
+    if (!input.scope.allowLegacyState) {
+      return popupClaimContention();
+    }
+    return acquireLegacyPopupOwnership({ ...input, focusClientId: input.focusClientId });
+  }
+  if (input.scope.allowLegacyState) {
+    const legacyFocusClientId = await resolveFocusPopupClient(input.tmuxCommand, input.scope.state);
+    if (legacyFocusClientId !== undefined) {
+      await clearLegacyFocusIfUnclaimed(
+        { ...input.tmuxCommand, clientId: legacyFocusClientId },
+        input.scope.state,
+      ).catch(() => undefined);
+    }
+  }
+  return { kind: "untracked" };
+}

--- a/integrations/terminal/tmux/src/popup/persistentUi.ts
+++ b/integrations/terminal/tmux/src/popup/persistentUi.ts
@@ -15,6 +15,7 @@ import {
   defaultPersistentPopupSessionName,
   defaultPersistentPopupTuiCommand,
   persistentUiLeaseOption,
+  persistentUiOwnerClientOption,
   persistentUiRouteOption,
   persistentUiSignatureOption,
   registeredDevPopupCommandOption,
@@ -145,6 +146,25 @@ async function setPersistentPopupSessionLease(
   });
 }
 
+async function setPersistentPopupSessionOwnerClient(
+  input: TmuxCommandInput,
+  options: { clientId: string; sessionName: string },
+): Promise<void> {
+  await runTmuxPopupCommand(input, {
+    args: [
+      "set-option",
+      "-t",
+      options.sessionName,
+      "-q",
+      persistentUiOwnerClientOption,
+      options.clientId,
+    ],
+    operation: "provider.tmux.popup.setPersistentUiOwnerClient",
+    message: "tmux failed to record the persistent station popup owner client.",
+    timeoutMessage: "tmux persistent station popup owner client update timed out.",
+  });
+}
+
 function globalOptionEqualsFormat(optionName: string, value: string | undefined): string {
   const literal = (value ?? "").replaceAll("#", "##").replaceAll(",", "#,").replaceAll("}", "#}");
   return `#{==:#{${optionName}},${literal}}`;
@@ -229,6 +249,20 @@ async function enablePersistentPopupSessionMouse(
   });
 }
 
+async function configurePersistentPopupSession(
+  input: TmuxCommandInput,
+  sessionName: string,
+  focusClientId: string | undefined,
+): Promise<void> {
+  await enablePersistentPopupSessionMouse(input, sessionName);
+  if (focusClientId !== undefined) {
+    await setPersistentPopupSessionOwnerClient(input, {
+      clientId: focusClientId,
+      sessionName,
+    });
+  }
+}
+
 /** Identifies the exact renderer command and build allowed to own the persistent session. */
 export function persistentPopupSignature(
   tuiCommand: string,
@@ -254,7 +288,7 @@ export async function ensurePersistentPopupSession(
   if (await hasTmuxSession(input, sessionName)) {
     const currentSignature = await resolvePersistentPopupSessionSignature(input, sessionName);
     if (currentSignature === signature) {
-      await enablePersistentPopupSessionMouse(input, sessionName);
+      await configurePersistentPopupSession(input, sessionName, options.focusClientId);
       return { sessionName, created: false };
     }
     if (currentSignature !== undefined) {
@@ -264,7 +298,7 @@ export async function ensurePersistentPopupSession(
         // only its exact signature is reusable.
         const contenderSignature = await resolvePersistentPopupSessionSignature(input, sessionName);
         if (contenderSignature === signature) {
-          await enablePersistentPopupSessionMouse(input, sessionName);
+          await configurePersistentPopupSession(input, sessionName, options.focusClientId);
           return { sessionName, created: false };
         }
         throw persistentPopupOwnershipError(
@@ -300,7 +334,7 @@ export async function ensurePersistentPopupSession(
     sessionName,
     signature,
   });
-  await enablePersistentPopupSessionMouse(input, sessionName);
+  await configurePersistentPopupSession(input, sessionName, options.focusClientId);
   return { sessionName, created: true };
 }
 

--- a/integrations/terminal/tmux/src/popup/persistentUi.ts
+++ b/integrations/terminal/tmux/src/popup/persistentUi.ts
@@ -233,8 +233,10 @@ async function enablePersistentPopupSessionMouse(
 export function persistentPopupSignature(
   tuiCommand: string,
   buildVersion = stationObserverBuildVersion(),
+  focusClientId?: string,
 ): string {
-  return `v2:${buildVersion}:${tuiCommand}`;
+  const focusIdentity = focusClientId === undefined ? "" : `:client=${focusClientId}`;
+  return `v2:${buildVersion}:${tuiCommand}${focusIdentity}`;
 }
 
 export async function ensurePersistentPopupSession(
@@ -244,7 +246,11 @@ export async function ensurePersistentPopupSession(
   const input = persistentSessionOptions(options, command);
   const sessionName = options.uiSessionName ?? defaultPersistentPopupSessionName;
   const tuiCommand = options.tuiCommand ?? defaultPersistentPopupTuiCommand;
-  const signature = persistentPopupSignature(tuiCommand);
+  const signature = persistentPopupSignature(
+    tuiCommand,
+    stationObserverBuildVersion(),
+    options.focusClientId,
+  );
   if (await hasTmuxSession(input, sessionName)) {
     const currentSignature = await resolvePersistentPopupSessionSignature(input, sessionName);
     if (currentSignature === signature) {
@@ -284,7 +290,7 @@ export async function ensurePersistentPopupSession(
       sessionName,
       "-n",
       "station-ui",
-      buildPersistentPopupTuiCommand(tuiCommand),
+      buildPersistentPopupTuiCommand(tuiCommand, options.focusClientId),
     ],
     operation: "provider.tmux.popup.createPersistentUi",
     message: "tmux failed to create the persistent station popup UI.",

--- a/integrations/terminal/tmux/src/popup/scope.ts
+++ b/integrations/terminal/tmux/src/popup/scope.ts
@@ -1,0 +1,66 @@
+import { createHash } from "node:crypto";
+import type { TmuxConfig, TmuxPopupScope } from "@station/config";
+import {
+  activePopupClaimOption,
+  activePopupClientOption,
+  defaultPersistentPopupSessionName,
+  focusPopupClientOption,
+} from "./constants.js";
+
+export type TmuxPopupStateKeys = {
+  activeClaimOption: string;
+  activeClientOption: string;
+  focusClientOption: string;
+};
+
+export type TmuxPopupScopeDescriptor = {
+  kind: TmuxPopupScope;
+  allowLegacyState: boolean;
+  registerFastPopup: boolean;
+  state: TmuxPopupStateKeys;
+  uiSessionName: string;
+};
+
+export const serverPopupStateKeys: TmuxPopupStateKeys = {
+  activeClaimOption: activePopupClaimOption,
+  activeClientOption: activePopupClientOption,
+  focusClientOption: focusPopupClientOption,
+};
+
+export function resolveTmuxPopupScope(config: TmuxConfig | undefined): TmuxPopupScope {
+  return config?.popupScope ?? "server";
+}
+
+export function resolveTmuxPopupScopeDescriptor(input: {
+  config?: TmuxConfig;
+  focusClientId?: string;
+  uiSessionName?: string;
+}): TmuxPopupScopeDescriptor | undefined {
+  const kind = resolveTmuxPopupScope(input.config);
+  const baseSessionName = input.uiSessionName ?? defaultPersistentPopupSessionName;
+  if (kind === "server") {
+    return {
+      kind,
+      allowLegacyState: true,
+      registerFastPopup: true,
+      state: serverPopupStateKeys,
+      uiSessionName: baseSessionName,
+    };
+  }
+  if (input.focusClientId === undefined || input.focusClientId.length === 0) {
+    return undefined;
+  }
+  // The deterministic hash keeps arbitrary tmux client names out of option and session identifiers.
+  const namespace = createHash("sha256").update(input.focusClientId).digest("hex").slice(0, 16);
+  return {
+    kind,
+    allowLegacyState: false,
+    registerFastPopup: false,
+    state: {
+      activeClaimOption: `${activePopupClaimOption}_c_${namespace}`,
+      activeClientOption: `${activePopupClientOption}_c_${namespace}`,
+      focusClientOption: `${focusPopupClientOption}_c_${namespace}`,
+    },
+    uiSessionName: `${baseSessionName}-c-${namespace}`,
+  };
+}

--- a/integrations/terminal/tmux/src/popup/state.ts
+++ b/integrations/terminal/tmux/src/popup/state.ts
@@ -1,15 +1,11 @@
 import type { TmuxCommandInput } from "../command.js";
 import { resolveTmuxGlobalOption, runTmuxPopupCommand, runTmuxPopupQuery } from "./command.js";
 import {
-  activePopupClaimOption,
-  activePopupClientOption,
-  focusPopupClientOption,
-} from "./constants.js";
-import {
   isSafePopupClientName,
   type PopupActiveClaim,
   parsePopupActiveClaim,
 } from "./fastProtocol.js";
+import { serverPopupStateKeys, type TmuxPopupStateKeys } from "./scope.js";
 
 export type TmuxActivePopupClaimState =
   | { kind: "absent" }
@@ -24,24 +20,25 @@ function optionEqualsFormat(optionName: string, value: string | undefined): stri
   return `#{==:#{${optionName}},${formatLiteral(value ?? "")}}`;
 }
 
-function claimEqualsFormat(value: string | undefined): string {
-  return optionEqualsFormat(activePopupClaimOption, value);
+function claimEqualsFormat(value: string | undefined, state: TmuxPopupStateKeys): string {
+  return optionEqualsFormat(state.activeClaimOption, value);
 }
 
-function legacyPopupCondition(clientId: string): string {
-  return `#{&&:${claimEqualsFormat(undefined)},#{||:${optionEqualsFormat(activePopupClientOption, clientId)},${optionEqualsFormat(focusPopupClientOption, clientId)}}}`;
+function legacyPopupCondition(clientId: string, state: TmuxPopupStateKeys): string {
+  return `#{&&:${claimEqualsFormat(undefined, state)},#{||:${optionEqualsFormat(state.activeClientOption, clientId)},${optionEqualsFormat(state.focusClientOption, clientId)}}}`;
 }
 
-function legacyPopupClearCommands(clientId: string): string {
+function legacyPopupClearCommands(clientId: string, state: TmuxPopupStateKeys): string {
   return [
-    `if-shell -F "${optionEqualsFormat(activePopupClientOption, clientId)}" "set-option -gq -u ${activePopupClientOption}"`,
-    `if-shell -F "${optionEqualsFormat(focusPopupClientOption, clientId)}" "set-option -gq -u ${focusPopupClientOption}"`,
+    `if-shell -F "${optionEqualsFormat(state.activeClientOption, clientId)}" "set-option -gq -u ${state.activeClientOption}"`,
+    `if-shell -F "${optionEqualsFormat(state.focusClientOption, clientId)}" "set-option -gq -u ${state.focusClientOption}"`,
   ].join(" ; ");
 }
 
 async function runLegacyPopupActionIfUnclaimed(
   input: TmuxCommandInput & { clientId: string },
   close: boolean,
+  state: TmuxPopupStateKeys,
 ): Promise<boolean> {
   if (!isSafePopupClientName(input.clientId)) {
     return false;
@@ -49,13 +46,13 @@ async function runLegacyPopupActionIfUnclaimed(
   const miss = "STATION_POPUP_CAS_MISS";
   const commands = [
     ...(close ? [`display-popup -c ${input.clientId} -C`] : []),
-    legacyPopupClearCommands(input.clientId),
+    legacyPopupClearCommands(input.clientId, state),
   ].join(" ; ");
   const result = await runTmuxPopupQuery(input, {
     args: [
       "if-shell",
       "-F",
-      legacyPopupCondition(input.clientId),
+      legacyPopupCondition(input.clientId, state),
       commands,
       `display-message -p ${miss}`,
     ],
@@ -68,8 +65,9 @@ async function runLegacyPopupActionIfUnclaimed(
 
 export async function resolveActivePopupClaimState(
   input: TmuxCommandInput,
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<TmuxActivePopupClaimState> {
-  const raw = await resolveTmuxGlobalOption(input, activePopupClaimOption, {
+  const raw = await resolveTmuxGlobalOption(input, state.activeClaimOption, {
     operation: "provider.tmux.popup.activeClaim",
     message: "tmux failed to resolve the active station popup claim.",
     timeoutMessage: "tmux active popup claim lookup timed out.",
@@ -84,32 +82,34 @@ export async function resolveActivePopupClaimState(
 export async function compareAndSetActivePopupClaim(
   input: TmuxCommandInput,
   options: { expected?: string; replacement: string },
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<boolean> {
   await runTmuxPopupCommand(input, {
     args: [
       "if-shell",
       "-F",
-      claimEqualsFormat(options.expected),
-      `set-option -gq ${activePopupClaimOption} ${options.replacement}`,
+      claimEqualsFormat(options.expected, state),
+      `set-option -gq ${state.activeClaimOption} ${options.replacement}`,
     ],
     operation: "provider.tmux.popup.replaceActiveClaim",
     message: "tmux failed to claim the active station popup.",
     timeoutMessage: "tmux active popup claim update timed out.",
   });
-  return (await resolveTmuxGlobalOption(input, activePopupClaimOption)) === options.replacement;
+  return (await resolveTmuxGlobalOption(input, state.activeClaimOption)) === options.replacement;
 }
 
 export async function clearActivePopupClaimIfCurrent(
   input: TmuxCommandInput,
   options: { claim: string; clientId: string },
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<void> {
   const clearCommands = [
-    `set-option -gq -u ${activePopupClaimOption}`,
-    `if-shell -F "#{==:#{${activePopupClientOption}},${options.clientId}}" "set-option -gq -u ${activePopupClientOption}"`,
-    `if-shell -F "#{==:#{${focusPopupClientOption}},${options.clientId}}" "set-option -gq -u ${focusPopupClientOption}"`,
+    `set-option -gq -u ${state.activeClaimOption}`,
+    `if-shell -F "#{==:#{${state.activeClientOption}},${options.clientId}}" "set-option -gq -u ${state.activeClientOption}"`,
+    `if-shell -F "#{==:#{${state.focusClientOption}},${options.clientId}}" "set-option -gq -u ${state.focusClientOption}"`,
   ].join(" ; ");
   await runTmuxPopupCommand(input, {
-    args: ["if-shell", "-F", claimEqualsFormat(options.claim), clearCommands],
+    args: ["if-shell", "-F", claimEqualsFormat(options.claim, state), clearCommands],
     operation: "provider.tmux.popup.clearActiveClaim",
     message: "tmux failed to clear the active station popup claim.",
     timeoutMessage: "tmux active popup claim cleanup timed out.",
@@ -118,24 +118,26 @@ export async function clearActivePopupClaimIfCurrent(
 
 export async function clearLegacyPopupStateIfUnclaimed(
   input: TmuxCommandInput & { clientId: string },
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<boolean> {
-  return runLegacyPopupActionIfUnclaimed(input, false);
+  return runLegacyPopupActionIfUnclaimed(input, false, state);
 }
 
 export async function clearLegacyFocusIfUnclaimed(
   input: TmuxCommandInput & { clientId: string },
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<boolean> {
   if (!isSafePopupClientName(input.clientId)) {
     return false;
   }
   const miss = "STATION_POPUP_CAS_MISS";
-  const condition = `#{&&:${claimEqualsFormat(undefined)},${optionEqualsFormat(focusPopupClientOption, input.clientId)}}`;
+  const condition = `#{&&:${claimEqualsFormat(undefined, state)},${optionEqualsFormat(state.focusClientOption, input.clientId)}}`;
   const result = await runTmuxPopupQuery(input, {
     args: [
       "if-shell",
       "-F",
       condition,
-      `set-option -gq -u ${focusPopupClientOption}`,
+      `set-option -gq -u ${state.focusClientOption}`,
       `display-message -p ${miss}`,
     ],
     operation: "provider.tmux.popup.clearLegacyFocus",
@@ -147,14 +149,16 @@ export async function clearLegacyFocusIfUnclaimed(
 
 export async function dismissLegacyPopupIfUnclaimed(
   input: TmuxCommandInput & { clientId: string },
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<boolean> {
-  return runLegacyPopupActionIfUnclaimed(input, true);
+  return runLegacyPopupActionIfUnclaimed(input, true, state);
 }
 
 export async function resolveActivePopupClient(
   input: TmuxCommandInput,
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<string | undefined> {
-  return resolveTmuxGlobalOption(input, activePopupClientOption, {
+  return resolveTmuxGlobalOption(input, state.activeClientOption, {
     operation: "provider.tmux.popup.activeClient",
     message: "tmux failed to resolve the active station popup.",
     timeoutMessage: "tmux active popup lookup timed out.",
@@ -163,8 +167,9 @@ export async function resolveActivePopupClient(
 
 export async function resolveFocusPopupClient(
   input: TmuxCommandInput,
+  state: TmuxPopupStateKeys = serverPopupStateKeys,
 ): Promise<string | undefined> {
-  return resolveTmuxGlobalOption(input, focusPopupClientOption, {
+  return resolveTmuxGlobalOption(input, state.focusClientOption, {
     operation: "provider.tmux.popup.focusClient",
     message: "tmux failed to resolve the station popup focus client.",
     timeoutMessage: "tmux popup focus client lookup timed out.",

--- a/integrations/terminal/tmux/src/popup/types.ts
+++ b/integrations/terminal/tmux/src/popup/types.ts
@@ -52,6 +52,7 @@ export type TmuxClientIdentity = {
 
 export type TmuxPersistentPopupSessionOptions = {
   command?: string;
+  focusClientId?: string;
   runner?: ExternalCommandRunner;
   timeoutMs?: number;
   tuiCommand?: string;
@@ -65,6 +66,7 @@ export type TmuxPopupCommandInputOptions = {
 
 export type TmuxPopupDismissOptions = {
   command?: string;
+  config?: TmuxConfig;
   env?: NodeJS.ProcessEnv;
   focusClientId?: string;
   runner?: ExternalCommandRunner;
@@ -82,6 +84,7 @@ export type TmuxPopupFocusTarget = {
 
 export type TmuxPopupFocusOriginOptions = {
   command?: string;
+  config?: TmuxConfig;
   env?: NodeJS.ProcessEnv;
   focusClientId?: string;
   runner?: ExternalCommandRunner;

--- a/integrations/terminal/tmux/src/topology.ts
+++ b/integrations/terminal/tmux/src/topology.ts
@@ -1,4 +1,4 @@
-import type { TmuxConfig } from "@station/config";
+import type { TmuxConfig, TmuxPopupScope } from "@station/config";
 import { normalizeObservedPath } from "@station/contracts";
 import { stableName } from "@station/runtime";
 
@@ -10,6 +10,7 @@ export type TmuxWorkbenchConfig = {
   popupWidth: string;
   popupHeight: string;
   popupPosition: string;
+  popupScope: TmuxPopupScope;
 };
 
 export type TmuxSessionOption = {
@@ -25,6 +26,7 @@ export const defaultTmuxWorkbenchConfig: TmuxWorkbenchConfig = {
   popupWidth: "50%",
   popupHeight: "50%",
   popupPosition: "C",
+  popupScope: "server",
 };
 
 export const defaultTmuxWorkbenchSessionOptions: readonly TmuxSessionOption[] = [
@@ -42,6 +44,7 @@ export function resolveTmuxWorkbenchConfig(config: TmuxConfig = {}): TmuxWorkben
     popupWidth: config.popupWidth ?? defaultTmuxWorkbenchConfig.popupWidth,
     popupHeight: config.popupHeight ?? defaultTmuxWorkbenchConfig.popupHeight,
     popupPosition: config.popupPosition ?? defaultTmuxWorkbenchConfig.popupPosition,
+    popupScope: config.popupScope ?? defaultTmuxWorkbenchConfig.popupScope,
   };
 }
 

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -23,6 +23,7 @@ import {
 } from "@station/runtime";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
+import { tmuxPopupRunShellCommand } from "../../../../../apps/cli/src/commands/setup/checks/tmuxBinding.js";
 import { mockObserverSnapshot } from "../../../../../station/src/sources/fixtures/mockObserverSnapshot.js";
 import { buildManagedFastPopupRunShellCommand, openTmuxPopup } from "../../src/popup";
 import { parsePopupActiveClaim } from "../../src/popup/fastProtocol";
@@ -1013,6 +1014,80 @@ describeRealTmux("real tmux dev popup routing", () => {
       },
     });
     await assertWrapperAudit(fixture);
+  }, 120_000);
+
+  it("client-scoped bindings keep two owners independent and toggle through nested clients", async () => {
+    const fixture = await createDashboardFixture(tmux, {
+      height: "50%",
+      position: "C",
+      width: "50%",
+    });
+    const validConfig = await readFile(fixture.configPath, "utf8");
+    await writeFile(
+      fixture.configPath,
+      validConfig.replace('popup_position = "C"', 'popup_position = "C"\npopup_scope = "client"'),
+      "utf8",
+    );
+    cleanup = () => cleanupDashboardFixture(fixture);
+
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base", "-c", fixture.projectRoot, "sleep 300"],
+      fixture.env,
+    );
+    fixture.ptyClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base",
+      env: fixture.env,
+    });
+    await tmuxExec(
+      fixture.wrapper,
+      ["new-session", "-d", "-s", "base-cross", "-c", fixture.projectRoot, "sleep 300"],
+      fixture.env,
+    );
+    const secondClient = await startTmuxPtyClient({
+      tmux: fixture.wrapper,
+      sessionName: "base-cross",
+      env: fixture.env,
+    });
+    fixture.otherPtyClients.push(secondClient);
+
+    const fallbackAlias = join(dirname(await realpath(builtBinaryPath)), "stn-tmux-popup");
+    const runShellCommand = tmuxPopupRunShellCommand(fallbackAlias, fixture.configPath);
+    await tmuxExec(
+      fixture.wrapper,
+      ["bind-key", "Space", "run-shell", "-b", runShellCommand],
+      fixture.env,
+    );
+
+    await triggerPopupBinding(fixture.ptyClient);
+    const [firstSession] = await waitForClientScopedPopupSessions(fixture, 1);
+    if (firstSession === undefined) throw new Error("first client-scoped popup session missing");
+    await waitForTmuxSessionClientCount(fixture, firstSession, 1);
+    const firstPanePid = await panePid(fixture.wrapper, firstSession);
+
+    await triggerPopupBinding(secondClient);
+    const sessions = await waitForClientScopedPopupSessions(fixture, 2);
+    const secondSession = sessions.find((sessionName) => sessionName !== firstSession);
+    if (secondSession === undefined) throw new Error("second client-scoped popup session missing");
+    await waitForTmuxSessionClientCount(fixture, secondSession, 1);
+
+    await triggerPopupBinding(fixture.ptyClient);
+    await waitForTmuxSessionClientCount(fixture, firstSession, 0);
+    await waitForTmuxSessionClientCount(fixture, secondSession, 1);
+
+    await triggerPopupBinding(fixture.ptyClient);
+    await waitForTmuxSessionClientCount(fixture, firstSession, 1);
+    expect(await panePid(fixture.wrapper, firstSession)).toBe(firstPanePid);
+    expect(await clientScopedPopupSessions(fixture)).toEqual(sessions);
+
+    await fixture.ptyClient.write(Buffer.from([0x1b]));
+    await waitForTmuxSessionClientCount(fixture, firstSession, 0);
+    await waitForTmuxSessionClientCount(fixture, secondSession, 1);
+
+    await triggerPopupBinding(secondClient);
+    await waitForTmuxSessionClientCount(fixture, secondSession, 0);
+    expect(await clientScopedPopupSessions(fixture)).toEqual(sessions);
   }, 120_000);
 
   it("compiled managed binding honors dashboard dismissal, reuses the warm UI, and fails without entering view mode", async () => {
@@ -3199,6 +3274,53 @@ async function makeCheckoutTempRoot(): Promise<string> {
     .replaceAll(/[^A-Za-z0-9_-]/g, "-")
     .slice(0, 24);
   return mkdtemp(join("/tmp", `stn-${checkout}-`));
+}
+
+async function clientScopedPopupSessions(fixture: DashboardFixture): Promise<string[]> {
+  const output = await tmuxExec(
+    fixture.wrapper,
+    ["list-sessions", "-F", "#{session_name}"],
+    fixture.env,
+  );
+  return nonEmptyLines(output).filter((sessionName) => sessionName.startsWith("_station-ui-c-"));
+}
+
+async function waitForClientScopedPopupSessions(
+  fixture: DashboardFixture,
+  expected: number,
+): Promise<string[]> {
+  const deadline = Date.now() + 10_000;
+  let sessions: string[] = [];
+  while (Date.now() < deadline) {
+    sessions = await clientScopedPopupSessions(fixture);
+    if (sessions.length === expected) return sessions;
+    await delay(100);
+  }
+  throw new Error(
+    `found ${sessions.length} client-scoped popup sessions instead of ${expected}: ${sessions.join(", ")}`,
+  );
+}
+
+async function waitForTmuxSessionClientCount(
+  fixture: DashboardFixture,
+  sessionName: string,
+  expected: number,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  let clients: string[] = [];
+  while (Date.now() < deadline) {
+    const output = await tmuxExec(
+      fixture.wrapper,
+      ["list-clients", "-t", sessionName, "-F", "#{client_name}"],
+      fixture.env,
+    );
+    clients = nonEmptyLines(output);
+    if (clients.length === expected) return;
+    await delay(100);
+  }
+  throw new Error(
+    `tmux session ${sessionName} had ${clients.length} clients instead of ${expected}; scoped sessions: ${(await clientScopedPopupSessions(fixture)).join(", ")}`,
+  );
 }
 
 async function waitForTmuxSession(tmux: string, sessionName: string): Promise<void> {

--- a/integrations/terminal/tmux/test/unit/popup-scope.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-scope.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTmuxPopupScope,
+  resolveTmuxPopupScopeDescriptor,
+  serverPopupStateKeys,
+} from "../../src/popup/scope";
+
+describe("tmux popup scope", () => {
+  it("preserves the existing server-owned popup defaults", () => {
+    expect(resolveTmuxPopupScope(undefined)).toBe("server");
+    expect(resolveTmuxPopupScopeDescriptor({})).toEqual({
+      kind: "server",
+      allowLegacyState: true,
+      registerFastPopup: true,
+      state: serverPopupStateKeys,
+      uiSessionName: "_station-ui",
+    });
+  });
+
+  it("derives stable isolated state and renderer names for each client", () => {
+    const first = resolveTmuxPopupScopeDescriptor({
+      config: { popupScope: "client" },
+      focusClientId: "/dev/ttys001",
+    });
+    const repeated = resolveTmuxPopupScopeDescriptor({
+      config: { popupScope: "client" },
+      focusClientId: "/dev/ttys001",
+    });
+    const second = resolveTmuxPopupScopeDescriptor({
+      config: { popupScope: "client" },
+      focusClientId: "/dev/ttys002",
+    });
+
+    expect(first).toEqual(repeated);
+    expect(first).toMatchObject({
+      kind: "client",
+      allowLegacyState: false,
+      registerFastPopup: false,
+      state: {
+        activeClaimOption: expect.stringMatching(/^@station_popup_active_claim_c_[a-f0-9]{16}$/),
+        activeClientOption: expect.stringMatching(/^@station_popup_client_c_[a-f0-9]{16}$/),
+        focusClientOption: expect.stringMatching(/^@station_popup_focus_client_c_[a-f0-9]{16}$/),
+      },
+      uiSessionName: expect.stringMatching(/^_station-ui-c-[a-f0-9]{16}$/),
+    });
+    expect(second?.state).not.toEqual(first?.state);
+    expect(second?.uiSessionName).not.toBe(first?.uiSessionName);
+  });
+
+  it("requires a concrete client before selecting client scope", () => {
+    expect(resolveTmuxPopupScopeDescriptor({ config: { popupScope: "client" } })).toBeUndefined();
+  });
+});

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -6,6 +6,7 @@ import {
   dismissTmuxPopup,
   ensurePersistentPopupSession,
   openTmuxPopup,
+  persistentUiOwnerClientOption,
   resolveRegisteredDevPopupUi,
   resolveTmuxPopupFocusTarget,
 } from "../../src/popup";
@@ -147,6 +148,14 @@ describe("tmux popup", () => {
     expect(
       calls.find((call) => call.args?.includes("@station_popup_ui_signature"))?.args?.at(-1),
     ).toContain(":client=/dev/ttys001");
+    expect(calls.map((call) => call.args)).toContainEqual([
+      "set-option",
+      "-t",
+      "_station-ui-client",
+      "-q",
+      persistentUiOwnerClientOption,
+      "/dev/ttys001",
+    ]);
   });
 
   it("refuses to replace an unsigned session without ownership evidence", async () => {

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -125,6 +125,30 @@ describe("tmux popup", () => {
     ]);
   });
 
+  it("pins a client-scoped persistent renderer to its owning client", async () => {
+    const calls: ExternalCommandInput[] = [];
+    await expect(
+      ensurePersistentPopupSession({
+        focusClientId: "/dev/ttys001",
+        uiSessionName: "_station-ui-client",
+        runner: async (input) => {
+          calls.push(input);
+          if (input.args?.[0] === "has-session") {
+            throw Object.assign(new Error("missing"), { code: 1 });
+          }
+          return tmuxCommandResult(input);
+        },
+      }),
+    ).resolves.toEqual({ created: true, sessionName: "_station-ui-client" });
+
+    expect(calls.find((call) => call.args?.[0] === "new-session")?.args?.at(-1)).toBe(
+      "env STATION_TUI_POPUP=1 STATION_FOCUS_PROVIDER=tmux STATION_FOCUS_CLIENT_ID=/dev/ttys001 stn tui --popup --persistent",
+    );
+    expect(
+      calls.find((call) => call.args?.includes("@station_popup_ui_signature"))?.args?.at(-1),
+    ).toContain(":client=/dev/ttys001");
+  });
+
   it("refuses to replace an unsigned session without ownership evidence", async () => {
     const unsignedCalls: ExternalCommandInput[] = [];
     await expect(
@@ -278,6 +302,53 @@ describe("tmux popup", () => {
     );
     expect(claimWriteIndex).toBeLessThan(closeIndex);
     expect(fake.executedPopupActions.at(-1)).toContain("display-popup -c /dev/ttys001 -C");
+  });
+
+  it("keeps client-scoped claims and persistent renderers independent", async () => {
+    const fake = createPopupTmux();
+    const firstClient = { name: "/dev/ttys001", pid: 1234 };
+    const secondClient = { name: "/dev/ttys002", pid: 5678 };
+    const openForCurrentClient = () =>
+      openTmuxPopup({
+        config: { popupScope: "client" },
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
+      });
+
+    await expect(openForCurrentClient()).resolves.toEqual({ opened: true });
+    fake.setCurrentClient(secondClient);
+    await expect(openForCurrentClient()).resolves.toEqual({ opened: true });
+
+    const claimOptions = [...fake.globalOptions.keys()].filter((key) =>
+      key.startsWith("@station_popup_active_claim_c_"),
+    );
+    const clientSessions = [...fake.sessionSignatures.keys()].filter((name) =>
+      name.startsWith("_station-ui-c-"),
+    );
+    expect(claimOptions).toHaveLength(2);
+    expect(clientSessions).toHaveLength(2);
+    expect(new Set(clientSessions).size).toBe(2);
+    expect(
+      fake.executedPopupActions.some((action) =>
+        action.includes(`display-popup -c ${firstClient.name} -C`),
+      ),
+    ).toBe(false);
+
+    const firstTarget = await resolveTmuxPopupFocusTarget({
+      config: { popupScope: "client" },
+      env: { STATION_FOCUS_CLIENT_ID: firstClient.name },
+      runner: fake.runner,
+    });
+    expect(firstTarget?.origin.clientId).toBe(firstClient.name);
+    await expect(firstTarget?.dismissExact()).resolves.toEqual({ dismissed: true });
+    expect(
+      [...fake.globalOptions.keys()].filter((key) =>
+        key.startsWith("@station_popup_active_claim_c_"),
+      ),
+    ).toHaveLength(1);
+    expect(
+      [...fake.globalOptions.values()].some((value) => value.includes(secondClient.name)),
+    ).toBe(true);
   });
 
   it("uses a valid claim for focus origin and falls back to the compatibility mirror", async () => {
@@ -726,8 +797,8 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
   const calls: ExternalCommandInput[] = [];
   const executedPopupActions: string[] = [];
   const root = options.root ?? "/opt/station/bin";
-  const clientName = options.clientName ?? "/dev/ttys001";
-  const clientPid = options.clientPid ?? 1234;
+  let clientName = options.clientName ?? "/dev/ttys001";
+  let clientPid = options.clientPid ?? 1234;
   const route = buildNormalPopupRoute({
     registrationNonce,
     root,
@@ -801,7 +872,8 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
       return tmuxCommandResult(input, `${clientName}\n`);
     }
     if (args[0] === "has-session") {
-      if (killedSessions.has(args[2] ?? "")) {
+      const sessionName = args[2] ?? "";
+      if (killedSessions.has(sessionName) || !sessionSignatures.has(sessionName)) {
         throw Object.assign(new Error("no such session"), { code: 1 });
       }
       return tmuxCommandResult(input);
@@ -871,9 +943,11 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
         }
         return tmuxCommandResult(input);
       }
-      if (command.startsWith("set-option -gq @station_popup_active_claim")) {
+      const claimOptionName =
+        /^set-option -gq (@station_popup_active_claim(?:_c_[a-f0-9]+)?) /.exec(command)?.[1];
+      if (claimOptionName !== undefined) {
         if (claimCasReplacementPending !== undefined) {
-          globalOptions.set("@station_popup_active_claim", claimCasReplacementPending);
+          globalOptions.set(claimOptionName, claimCasReplacementPending);
           globalOptions.set("@station_popup_client", "/dev/ttys099");
           globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
           claimCasReplacementPending = undefined;
@@ -882,40 +956,49 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
           claimCasMisses -= 1;
           return tmuxCommandResult(input);
         }
-        const expected = extractComparedValue(condition, "@station_popup_active_claim");
-        if ((globalOptions.get("@station_popup_active_claim") ?? "") === expected) {
+        const expected = extractComparedValue(condition, claimOptionName);
+        if ((globalOptions.get(claimOptionName) ?? "") === expected) {
           setFromTmuxCommand(command, globalOptions);
         }
         return tmuxCommandResult(input);
       }
-      if (command.startsWith("set-option -gq -u @station_popup_active_claim")) {
+      const clearedClaimOptionName =
+        /^set-option -gq -u (@station_popup_active_claim(?:_c_[a-f0-9]+)?)/.exec(command)?.[1];
+      if (clearedClaimOptionName !== undefined) {
         if (replacementPending !== undefined) {
-          globalOptions.set("@station_popup_active_claim", replacementPending);
+          globalOptions.set(clearedClaimOptionName, replacementPending);
           globalOptions.set("@station_popup_client", "/dev/ttys099");
           globalOptions.set("@station_popup_focus_client", "/dev/ttys099");
           replacementPending = undefined;
         }
-        const expected = extractComparedValue(condition, "@station_popup_active_claim");
-        if (globalOptions.get("@station_popup_active_claim") === expected) {
-          globalOptions.delete("@station_popup_active_claim");
-          const client = extractComparedValue(command, "@station_popup_client");
-          if (globalOptions.get("@station_popup_client") === client) {
-            globalOptions.delete("@station_popup_client");
+        const expected = extractComparedValue(condition, clearedClaimOptionName);
+        if (globalOptions.get(clearedClaimOptionName) === expected) {
+          globalOptions.delete(clearedClaimOptionName);
+          const activeClientOption = clearedClaimOptionName.replace("active_claim", "client");
+          const focusClientOption = clearedClaimOptionName.replace("active_claim", "focus_client");
+          const client = extractComparedValue(command, activeClientOption);
+          if (globalOptions.get(activeClientOption) === client) {
+            globalOptions.delete(activeClientOption);
           }
-          if (globalOptions.get("@station_popup_focus_client") === client) {
-            globalOptions.delete("@station_popup_focus_client");
+          if (globalOptions.get(focusClientOption) === client) {
+            globalOptions.delete(focusClientOption);
           }
         }
         return tmuxCommandResult(input);
       }
-      if (condition.includes("@station_popup_active_claim") && command.includes("display-popup")) {
-        const expected = extractComparedValue(condition, "@station_popup_active_claim");
-        if ((globalOptions.get("@station_popup_active_claim") ?? "") !== expected) {
+      const guardedClaimOptionName =
+        /#\{==:#\{(@station_popup_active_claim(?:_c_[a-f0-9]+)?)\},/.exec(condition)?.[1];
+      if (guardedClaimOptionName !== undefined && command.includes("display-popup")) {
+        const expected = extractComparedValue(condition, guardedClaimOptionName);
+        if ((globalOptions.get(guardedClaimOptionName) ?? "") !== expected) {
           return tmuxCommandResult(input, "STATION_POPUP_CAS_MISS\n");
         }
-        for (const optionName of ["@station_popup_client", "@station_popup_focus_client"]) {
-          const value = new RegExp(`set-option -gq ${optionName} ([^ ;]+)`).exec(command)?.[1];
-          if (value !== undefined) globalOptions.set(optionName, value);
+        for (const match of command.matchAll(
+          /set-option -gq (@station_popup_(?:client|focus_client)(?:_c_[a-f0-9]+)?) ([^ ;]+)/g,
+        )) {
+          const optionName = match[1];
+          const value = match[2];
+          if (optionName !== undefined && value !== undefined) globalOptions.set(optionName, value);
         }
         executedPopupActions.push(command);
         if (options.displayExit !== undefined && !command.trimEnd().endsWith(" -C")) {
@@ -964,7 +1047,11 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
     }
     if (args[0] === "new-session") {
       const nameIndex = args.indexOf("-s");
-      if (nameIndex >= 0) killedSessions.delete(args[nameIndex + 1] ?? "");
+      if (nameIndex >= 0) {
+        const sessionName = args[nameIndex + 1] ?? "";
+        killedSessions.delete(sessionName);
+        sessionSignatures.set(sessionName, "");
+      }
       return tmuxCommandResult(input);
     }
     if (args[0] === "display-popup" && !args.includes("-C") && options.displayExit !== undefined) {
@@ -1003,6 +1090,10 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
     root,
     runner,
     sessionSignatures,
+    setCurrentClient: (identity: { name: string; pid: number }) => {
+      clientName = identity.name;
+      clientPid = identity.pid;
+    },
   };
 }
 
@@ -1040,7 +1131,10 @@ function applySetOption(
 }
 
 function setFromTmuxCommand(command: string, globalOptions: Map<string, string>): void {
-  const match = /set-option -gq (@station_popup_(?:ui_route|active_claim)) ([^ ;]+)/.exec(command);
+  const match =
+    /set-option -gq (@station_popup_(?:ui_route|active_claim(?:_c_[a-f0-9]+)?)) ([^ ;]+)/.exec(
+      command,
+    );
   if (match?.[1] !== undefined && match[2] !== undefined) {
     globalOptions.set(match[1], match[2]);
   }

--- a/integrations/terminal/tmux/test/unit/topology.test.ts
+++ b/integrations/terminal/tmux/test/unit/topology.test.ts
@@ -19,6 +19,7 @@ describe("tmux workbench topology", () => {
       popupWidth: "50%",
       popupHeight: "50%",
       popupPosition: "C",
+      popupScope: "server",
     });
   });
 

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -84,6 +84,7 @@ function normalizeTmuxConfig(value: unknown): unknown {
     popup_width: "popupWidth",
     popup_height: "popupHeight",
     popup_position: "popupPosition",
+    popup_scope: "popupScope",
   });
 }
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -126,6 +126,10 @@ export const WorktreeProvidersConfigSchema = z
   })
   .strict();
 
+export const TmuxPopupScopeSchema = z.enum(["server", "client"]);
+
+export type TmuxPopupScope = z.infer<typeof TmuxPopupScopeSchema>;
+
 export const TmuxConfigSchema = z
   .object({
     command: nonEmptyStringSchema.optional(),
@@ -137,6 +141,7 @@ export const TmuxConfigSchema = z
     popupWidth: nonEmptyStringSchema.optional(),
     popupHeight: nonEmptyStringSchema.optional(),
     popupPosition: nonEmptyStringSchema.optional(),
+    popupScope: TmuxPopupScopeSchema.optional(),
   })
   .strict();
 

--- a/packages/config/test/fixtures/valid-config.json
+++ b/packages/config/test/fixtures/valid-config.json
@@ -32,7 +32,8 @@
       "primaryAgentPane": true,
       "popupWidth": "50%",
       "popupHeight": "50%",
-      "popupPosition": "C"
+      "popupPosition": "C",
+      "popupScope": "server"
     }
   },
   "harness": {

--- a/packages/config/test/unit/config-schema.test.ts
+++ b/packages/config/test/unit/config-schema.test.ts
@@ -7,11 +7,14 @@ import {
   WorkspaceConfigSchema,
 } from "@station/config";
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 const fixtureUrl = (path: string) => new URL(`../fixtures/${path}`, import.meta.url);
 
-async function loadJson(path: string): Promise<unknown> {
-  return JSON.parse(await readFile(fixtureUrl(path), "utf8"));
+async function loadJson(path: string): Promise<Record<string, unknown>> {
+  return z
+    .record(z.string(), z.unknown())
+    .parse(JSON.parse(await readFile(fixtureUrl(path), "utf8")));
 }
 
 describe("config schemas", () => {
@@ -182,6 +185,21 @@ describe("config schemas", () => {
             command: "",
           },
         },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts tmux popup scopes and rejects unsupported ownership modes", async () => {
+    const config = ParsedStationConfigSchema.parse({
+      ...(await loadJson("valid-config.json")),
+      terminal: { tmux: { popupScope: "client" } },
+    });
+
+    expect(config.terminal?.tmux?.popupScope).toBe("client");
+    expect(
+      ParsedStationConfigSchema.safeParse({
+        ...config,
+        terminal: { tmux: { popupScope: "window" } },
       }).success,
     ).toBe(false);
   });

--- a/packages/config/test/unit/config-schema.test.ts
+++ b/packages/config/test/unit/config-schema.test.ts
@@ -190,14 +190,14 @@ describe("config schemas", () => {
   });
 
   it("accepts tmux popup scopes and rejects unsupported ownership modes", async () => {
-    const config = ParsedStationConfigSchema.parse({
+    const config = StationConfigSchema.parse({
       ...(await loadJson("valid-config.json")),
       terminal: { tmux: { popupScope: "client" } },
     });
 
     expect(config.terminal?.tmux?.popupScope).toBe("client");
     expect(
-      ParsedStationConfigSchema.safeParse({
+      StationConfigSchema.safeParse({
         ...config,
         terminal: { tmux: { popupScope: "window" } },
       }).success,

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -113,6 +113,17 @@ describe("config loading", () => {
     expect(loaded.diagnostics).toEqual([]);
   });
 
+  it("normalizes the configured tmux popup scope", async () => {
+    const tempDir = await makeTempDir();
+    const root = await makeProjectRoot(tempDir, "web");
+    const loaded = await loadConfigFromToml(
+      `${baseToml(projectToml("web", root))}\n[terminal.tmux]\npopup_scope = "client"\n`,
+      { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
+    );
+
+    expect(loaded.config.terminal?.tmux?.popupScope).toBe("client");
+  });
+
   it("loads TOML, applies defaults, expands paths, and keeps every configured project", async () => {
     const tempDir = await makeTempDir();
     const roots = {

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -387,9 +387,12 @@ describe("setup guided feedback e2e", () => {
       );
 
       expect(freshTmux.status, freshTmux.stderr).toBe(0);
-      expect(await readFile(fixture.popupMarker, "utf8")).toBe(
-        "/usr/bin:/bin\ntmux\n#{q:client_name}\n",
-      );
+      const popupMarker = (await readFile(fixture.popupMarker, "utf8")).trim().split("\n");
+      expect(popupMarker).toEqual([
+        "/usr/bin:/bin",
+        "tmux",
+        expect.stringContaining("client_name"),
+      ]);
     } finally {
       await fixture.cleanup();
     }


### PR DESCRIPTION
## What this fixes

Station's tmux adapter previously treated popup ownership as one server-wide singleton. That preserves a useful shared warm dashboard, but it prevents users with multiple attached tmux clients from keeping independent popup overlays and leaves the ownership protocol concentrated in one high-complexity coordinator.

## What changed

- Add `terminal.tmux.popup_scope = "server" | "client"`, defaulting to the existing server-scoped behavior.
- Centralize scope-derived session names, option keys, renderer identity, focus state, and compare-and-set ownership so the complete popup identity follows one strategy.
- Give client scope a dedicated persistent renderer and claim namespace per verified tmux client, with same-client lifecycle and no cross-client transfer or legacy global-state adoption.
- Preserve the existing server-scoped route, legacy migration, exact cleanup, cross-client transfer, and compiled warm fast path.
- Route client-scoped setup bindings through the config-aware launcher and persist the outer owner on each renderer session so toggling from its nested tmux client closes the correct popup.
- Document scope selection, binding refresh, and the no-live-migration behavior, with configuration, ownership, setup, and real two-client popup coverage.

## Testing

- `env -u STATION_PANE PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm test:all`
- `cd station && bun run typecheck && bun run test` (1,052 tests)
- `pnpm lint`
- Real tmux two-client client-scope acceptance passed, covering independent sessions, nested-client toggle dismissal, Escape dismissal, and warm renderer reuse.
- Real tmux compiled server-scope managed-binding acceptance passed after the client-scope fix.
- An earlier full real-tmux run exercised all eight pre-existing cases; six passed and two hit the existing outer PTY detach timeout during geometry/fixture cleanup.

## Safety and scope

Existing configuration remains server-scoped. Scope is selected when a popup renderer starts; changing it does not migrate an open popup. The optimized managed fast binding remains server-only, while client scope intentionally uses the config-aware launcher and still reuses its client-specific warm renderer.

## User-visible behavior

With `popup_scope = "client"`, two attached tmux clients can keep independent Station popups and use the same tmux binding to toggle only their own popup. After changing scope, close existing popups and rerun `stn setup` so an installed binding is regenerated.
