### PR TITLE
refactor(diagnostics): isolate local evidence collection

### DIFF
--- a/apps/observer/src/diagnostics/collector.ts
+++ b/apps/observer/src/diagnostics/collector.ts
@@ -1,5 +1,3 @@
-import { readdir, stat } from "node:fs/promises";
-import { join } from "node:path";
 import type { ConfigDiagnostic, StationConfig } from "@station/config";
 import type {
   DiagnosticCollectionOptions,
@@ -22,12 +20,7 @@ import {
   DoctorReportSchema,
   STATION_SCHEMA_VERSION,
 } from "@station/contracts";
-import {
-  componentLogPath,
-  mergeRetentionPolicy,
-  readJsonlLog,
-  scanLocalStateUsage,
-} from "@station/observability";
+import { mergeRetentionPolicy } from "@station/observability";
 import type { RuntimeClock } from "@station/runtime";
 import { runRuntimeBoundaryWithTimeout, systemClock, toIsoTimestamp } from "@station/runtime";
 import { commandRecordFromPersisted } from "../commands/record.js";
@@ -42,50 +35,58 @@ import type {
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { ObserverCore } from "../reconcile/core.js";
 import { buildSessionEnvironmentCheck } from "./environmentCheck.js";
-
-export type DiagnosticRuntimePaths = {
-  stateDir: string;
-  socketPath?: string;
-  hookSpoolDir?: string;
-  diagnosticsDir?: string;
-  logPaths?: string[];
-};
+import type {
+  DiagnosticEvidenceSource,
+  DiagnosticLocalStateEvidence,
+  DiagnosticRecentLogEvidence,
+} from "./evidenceSource.js";
 
 export type ObserverDiagnosticsDeps = {
   config: StationConfig;
   configPath?: string;
   configDiagnostics?: ConfigDiagnostic[];
   core: ObserverCore;
-  persistence: CommandJournal & EventJournal;
+  commandJournal: CommandJournal;
+  eventJournal: EventJournal;
   persistenceHealth: PersistenceHealthSource;
+  evidenceSource: DiagnosticEvidenceSource;
   providers?: ProviderRegistry;
-  paths: DiagnosticRuntimePaths;
   clock?: RuntimeClock;
   providerDoctorTimeoutMs?: number;
 };
 
+type DiagnosticCollectionResult = {
+  snapshot: DiagnosticSnapshot;
+  localStateEvidence: DiagnosticLocalStateEvidence;
+  recentLogEvidence?: DiagnosticRecentLogEvidence;
+};
+
+/**
+ * USE CASE
+ *
+ * Aggregates current core health, purpose-specific journals, persistence health,
+ * configuration, and typed local evidence into a bounded read-only diagnostic snapshot.
+ */
 export async function collectDiagnosticSnapshot(
   deps: ObserverDiagnosticsDeps,
   options: DiagnosticCollectionOptions = {},
 ): Promise<DiagnosticSnapshot> {
+  return (await collectDiagnosticResult(deps, options ?? {})).snapshot;
+}
+
+async function collectDiagnosticResult(
+  deps: ObserverDiagnosticsDeps,
+  options: NonNullable<DiagnosticCollectionOptions>,
+): Promise<DiagnosticCollectionResult> {
   const clock = deps.clock ?? systemClock;
   const collectedAt = toIsoTimestamp(clock.now());
-  const observerHealth: DiagnosticSnapshot["observerHealth"] = {
-    schemaVersion: STATION_SCHEMA_VERSION,
-    ...deps.core.getHealth(),
-    pid: deps.core.getSnapshot().observer.pid,
-    version: deps.core.getSnapshot().observer.version,
-    stateDir: deps.paths.stateDir,
-    sqlite: deps.persistenceHealth.health(),
-  };
-  if (deps.paths.socketPath !== undefined) {
-    observerHealth.socketPath = deps.paths.socketPath;
-  }
+  const coreHealth = deps.core.getHealth();
   const snapshot = deps.core.getSnapshot();
-  const commands = await deps.persistence.listCommands();
-  const latestFailure = options?.latestFailure === true ? latestFailedCommand(commands) : undefined;
-  const commandIdFilter = options?.commandId ?? latestFailure?.id;
-  const traceIdFilter = options?.traceId ?? latestFailure?.traceId;
+  const sqliteHealth = deps.persistenceHealth.health();
+  const commands = await deps.commandJournal.listCommands();
+  const latestFailure = options.latestFailure === true ? latestFailedCommand(commands) : undefined;
+  const commandIdFilter = options.commandId ?? latestFailure?.id;
+  const traceIdFilter = options.traceId ?? latestFailure?.traceId;
   const hasCommandFilter = commandIdFilter !== undefined || traceIdFilter !== undefined;
   const filteredCommands = filterCommands(commands, {
     commandId: commandIdFilter,
@@ -105,26 +106,36 @@ export async function collectDiagnosticSnapshot(
   if (commandIdFilter !== undefined) {
     eventFilter.commandId = commandIdFilter;
   }
-  const events = (await deps.persistence.listEvents(eventFilter)).filter((event) =>
+  const events = (await deps.eventJournal.listEvents(eventFilter)).filter((event) =>
     persistedEventMatches(event, { commandIds, traceIds }),
   );
-  const commandErrors = (await deps.persistence.listCommandErrors(commandIdFilter)).filter(
+  const commandErrors = (await deps.commandJournal.listCommandErrors(commandIdFilter)).filter(
     (error) => commandErrorMatches(error, { commandIds, traceIds }),
   );
   const policy = mergeRetentionPolicy(deps.config.observability?.retention);
-  const localState = await scanLocalStateUsage(deps.paths.stateDir, policy);
-  const rawLogs =
-    options?.includeLogs === false
-      ? []
-      : await readLogs(
-          deps.paths.logPaths ?? [componentLogPath(deps.paths.stateDir, "observer")],
-          options?.maxLogRecords ?? 500,
-        );
-  const logs = prioritizeLogs(rawLogs, { commandIds, traceIds }, options?.maxLogRecords ?? 500);
-  const hookSpool =
-    deps.paths.hookSpoolDir === undefined
+  const localStateEvidence = await deps.evidenceSource.scanLocalState(policy);
+  const maxLogRecords = options.maxLogRecords ?? 500;
+  const recentLogEvidence =
+    options.includeLogs === false
       ? undefined
-      : await summarizeHookSpool(deps.paths.hookSpoolDir);
+      : await deps.evidenceSource.readRecentLogs(maxLogRecords);
+  const logs = prioritizeLogs(
+    recentLogEvidence?.records ?? [],
+    { commandIds, traceIds },
+    maxLogRecords,
+  );
+  const hookSpool = await deps.evidenceSource.summarizeHookSpool();
+  const observerHealth: DiagnosticSnapshot["observerHealth"] = {
+    schemaVersion: STATION_SCHEMA_VERSION,
+    ...coreHealth,
+    pid: snapshot.observer.pid,
+    version: snapshot.observer.version,
+    stateDir: localStateEvidence.usage.stateDir,
+    sqlite: sqliteHealth,
+  };
+  if (localStateEvidence.socketPath !== undefined) {
+    observerHealth.socketPath = localStateEvidence.socketPath;
+  }
 
   const diagnosticSnapshot: DiagnosticSnapshot = {
     schemaVersion: STATION_SCHEMA_VERSION,
@@ -137,32 +148,41 @@ export async function collectDiagnosticSnapshot(
     errors: commandErrors.map((error) => error.envelope),
     logs,
     configSummary: configSummary(deps),
-    localState,
+    localState: localStateEvidence.usage,
     retention: policy,
   };
   if (hookSpool !== undefined) {
     diagnosticSnapshot.hookSpool = hookSpool;
   }
 
-  return DiagnosticSnapshotSchema.parse(diagnosticSnapshot);
+  const result: DiagnosticCollectionResult = {
+    snapshot: DiagnosticSnapshotSchema.parse(diagnosticSnapshot),
+    localStateEvidence,
+  };
+  if (recentLogEvidence !== undefined) {
+    result.recentLogEvidence = recentLogEvidence;
+  }
+  return result;
 }
 
 /**
  * USE CASE
  *
- * Aggregates current runtime, persistence, and provider evidence into the read-only health report.
- * Top-level health comes from current checks; persisted command errors remain historical evidence.
+ * Aggregates current runtime, persistence, provider, and typed local evidence into
+ * the read-only health report. Top-level health comes from current checks; persisted
+ * command errors remain historical evidence.
  */
 export async function runDoctor(
   deps: ObserverDiagnosticsDeps,
   options: DoctorOptions = {},
 ): Promise<DoctorReport> {
   const clock = deps.clock ?? systemClock;
-  const snapshot = await collectDiagnosticSnapshot(deps, {
+  const collection = await collectDiagnosticResult(deps, {
     includeLogs: true,
     maxLogRecords: 50,
   });
-  const doctorSnapshot = requireDoctorSnapshotState(snapshot);
+  const doctorSnapshot = requireDoctorSnapshotState(collection.snapshot);
+  const recentLogEvidence = requireDoctorRecentLogs(collection);
   const providerHealth = await collectProviderHealth(deps);
   const providers = {
     ...doctorSnapshot.providerHealth,
@@ -220,7 +240,7 @@ export async function runDoctor(
     providers,
     snapshot: doctorSnapshot.snapshot,
     logs: {
-      paths: deps.paths.logPaths ?? [componentLogPath(deps.paths.stateDir, "observer")],
+      paths: recentLogEvidence.paths,
       recent: doctorSnapshot.logs,
     },
     localState: doctorSnapshot.localState,
@@ -228,7 +248,7 @@ export async function runDoctor(
     recentErrors,
     debugBundle: {
       available: true,
-      diagnosticsDir: deps.paths.diagnosticsDir ?? join(deps.paths.stateDir, "diagnostics"),
+      diagnosticsDir: collection.localStateEvidence.diagnosticsDir,
     },
   };
   if (doctorSnapshot.observerHealth.sqlite !== undefined) {
@@ -239,11 +259,6 @@ export async function runDoctor(
   }
 
   return DoctorReportSchema.parse(report);
-}
-
-async function readLogs(paths: readonly string[], maxRecords: number): Promise<LogRecord[]> {
-  const logs = await Promise.all(paths.map((path) => readJsonlLog(path, maxRecords)));
-  return logs.flat().slice(-maxRecords);
 }
 
 function latestFailedCommand(commands: readonly PersistedCommand[]): PersistedCommand | undefined {
@@ -354,42 +369,6 @@ function configSummary(
   return summary;
 }
 
-async function summarizeHookSpool(
-  path: string,
-): Promise<NonNullable<DiagnosticSnapshot["hookSpool"]>> {
-  const entries = await listFileStats(path);
-  const created = entries.map((entry) => entry.mtime.toISOString()).sort();
-  const summary: NonNullable<DiagnosticSnapshot["hookSpool"]> = {
-    path,
-    pending: entries.length,
-  };
-  const oldestCreatedAt = created[0];
-  const newestCreatedAt = created.at(-1);
-  if (oldestCreatedAt !== undefined) {
-    summary.oldestCreatedAt = oldestCreatedAt;
-  }
-  if (newestCreatedAt !== undefined) {
-    summary.newestCreatedAt = newestCreatedAt;
-  }
-  return summary;
-}
-
-async function listFileStats(path: string): Promise<Array<{ mtime: Date }>> {
-  try {
-    const entries = await readdir(path, { withFileTypes: true });
-    return Promise.all(
-      entries
-        .filter((entry) => entry.isFile())
-        .map(async (entry) => {
-          const fileStat = await stat(join(path, entry.name));
-          return { mtime: fileStat.mtime };
-        }),
-    );
-  } catch {
-    return [];
-  }
-}
-
 function providerStatus(providers: Record<string, ProviderHealth>): "healthy" | "degraded" {
   return Object.values(providers).some(
     (health) => health.status === "degraded" || health.status === "unavailable",
@@ -431,6 +410,13 @@ function requireDoctorSnapshotState(snapshot: DiagnosticSnapshot): DoctorDiagnos
     throw missingDoctorStateError("retention");
   }
   return snapshot as DoctorDiagnosticSnapshot;
+}
+
+function requireDoctorRecentLogs(result: DiagnosticCollectionResult): DiagnosticRecentLogEvidence {
+  if (result.recentLogEvidence === undefined) {
+    throw missingDoctorStateError("recentLogs");
+  }
+  return result.recentLogEvidence;
 }
 
 function missingDoctorStateError(field: string): SafeError {

--- a/apps/observer/src/diagnostics/evidenceSource.ts
+++ b/apps/observer/src/diagnostics/evidenceSource.ts
@@ -1,0 +1,34 @@
+import type {
+  DiagnosticSnapshot,
+  LocalStateUsage,
+  LogRecord,
+  RetentionPolicy,
+} from "@station/contracts";
+
+export type DiagnosticLocalStateEvidence = {
+  usage: LocalStateUsage;
+  diagnosticsDir: string;
+  socketPath?: string;
+};
+
+export type DiagnosticRecentLogEvidence = {
+  paths: string[];
+  records: LogRecord[];
+};
+
+export type DiagnosticHookSpoolEvidence = NonNullable<DiagnosticSnapshot["hookSpool"]>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Supplies typed local diagnostic measurements and recent evidence while keeping
+ * state, log, spool paths and filesystem representations outside diagnostic use cases.
+ *
+ * Evidence is read-only and diagnostic only; the port owns no persistence,
+ * provider, core, or SQLite conversation.
+ */
+export interface DiagnosticEvidenceSource {
+  scanLocalState(retention: RetentionPolicy): Promise<DiagnosticLocalStateEvidence>;
+  readRecentLogs(maxRecords: number): Promise<DiagnosticRecentLogEvidence>;
+  summarizeHookSpool(): Promise<DiagnosticHookSpoolEvidence | undefined>;
+}

--- a/apps/observer/src/diagnostics/localEvidenceSource.ts
+++ b/apps/observer/src/diagnostics/localEvidenceSource.ts
@@ -1,0 +1,118 @@
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { readJsonlLog, scanLocalStateUsage } from "@station/observability";
+import { safeErrorFromUnknown } from "@station/runtime";
+import type {
+  DiagnosticEvidenceSource,
+  DiagnosticHookSpoolEvidence,
+  DiagnosticLocalStateEvidence,
+} from "./evidenceSource.js";
+
+export type CreateLocalDiagnosticEvidenceSourceOptions = {
+  stateDir: string;
+  diagnosticsDir: string;
+  logPaths: readonly string[];
+  socketPath?: string;
+  hookSpoolDir?: string;
+};
+
+/**
+ * ADAPTER
+ *
+ * Captures resolved Observer runtime locations and translates local state,
+ * structured JSONL logs, and hook-spool metadata into typed diagnostic evidence.
+ *
+ * Raw spool contents never cross the boundary, and local failures are normalized
+ * without exposing raw records.
+ */
+export function createLocalDiagnosticEvidenceSource(
+  options: CreateLocalDiagnosticEvidenceSourceOptions,
+): DiagnosticEvidenceSource {
+  const stateDir = options.stateDir;
+  const diagnosticsDir = options.diagnosticsDir;
+  const logPaths = [...options.logPaths];
+  const socketPath = options.socketPath;
+  const hookSpoolDir = options.hookSpoolDir;
+
+  return {
+    scanLocalState: async (retention) => {
+      try {
+        const usage = await scanLocalStateUsage(stateDir, retention);
+        const evidence: DiagnosticLocalStateEvidence = {
+          usage,
+          diagnosticsDir,
+        };
+        if (socketPath !== undefined) {
+          evidence.socketPath = socketPath;
+        }
+        return evidence;
+      } catch (error) {
+        throw localEvidenceError(error);
+      }
+    },
+    readRecentLogs: async (maxRecords) => {
+      try {
+        const logs = await Promise.all(logPaths.map((path) => readJsonlLog(path, maxRecords)));
+        return {
+          paths: [...logPaths],
+          records: logs.flat().slice(-maxRecords),
+        };
+      } catch (error) {
+        throw localEvidenceError(error);
+      }
+    },
+    summarizeHookSpool: async () => {
+      if (hookSpoolDir === undefined) {
+        return undefined;
+      }
+      try {
+        return await summarizeHookSpool(hookSpoolDir);
+      } catch (error) {
+        throw localEvidenceError(error);
+      }
+    },
+  };
+}
+
+async function summarizeHookSpool(path: string): Promise<DiagnosticHookSpoolEvidence> {
+  const entries = await listFileStats(path);
+  const created = entries.map((entry) => entry.mtime.toISOString()).sort();
+  const summary: DiagnosticHookSpoolEvidence = {
+    path,
+    pending: entries.length,
+  };
+  const oldestCreatedAt = created[0];
+  const newestCreatedAt = created.at(-1);
+  if (oldestCreatedAt !== undefined) {
+    summary.oldestCreatedAt = oldestCreatedAt;
+  }
+  if (newestCreatedAt !== undefined) {
+    summary.newestCreatedAt = newestCreatedAt;
+  }
+  return summary;
+}
+
+async function listFileStats(path: string): Promise<Array<{ mtime: Date }>> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    // Await inside the try so post-readdir file rotation remains best-effort.
+    return await Promise.all(
+      entries
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const fileStat = await stat(join(path, entry.name));
+          return { mtime: fileStat.mtime };
+        }),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function localEvidenceError(error: unknown) {
+  return safeErrorFromUnknown(error, {
+    tag: "DiagnosticEvidenceError",
+    code: "LOCAL_DIAGNOSTIC_EVIDENCE_FAILED",
+    message: "Local diagnostic evidence collection failed.",
+  });
+}

--- a/apps/observer/src/internal.ts
+++ b/apps/observer/src/internal.ts
@@ -9,6 +9,8 @@ export * from "./commands/terminalIntentRunner.js";
 export * from "./commands/worktree/index.js";
 export * from "./diagnostics/collector.js";
 export * from "./diagnostics/errors.js";
+export * from "./diagnostics/evidenceSource.js";
+export * from "./diagnostics/localEvidenceSource.js";
 export * from "./hooks/harnessIngressQueue.js";
 export * from "./hooks/ingestion.js";
 export * from "./hooks/observerEventHooks.js";

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -30,10 +30,10 @@ import type { CommandQueue } from "../commands/queue.js";
 import { commandRecordFromPersisted } from "../commands/record.js";
 import {
   collectDiagnosticSnapshot,
-  type DiagnosticRuntimePaths,
   type ObserverDiagnosticsDeps,
   runDoctor,
 } from "../diagnostics/collector.js";
+import type { DiagnosticEvidenceSource } from "../diagnostics/evidenceSource.js";
 import {
   createHarnessIngressQueue,
   type HarnessIngressQueue,
@@ -86,6 +86,7 @@ export type CreateObserverApiOptions = {
   persistenceHealth: PersistenceHealthSource;
   commandQueue: CommandQueue;
   eventBus: ObserverEventBus;
+  diagnosticEvidenceSource: DiagnosticEvidenceSource;
   clock?: RuntimeClock;
   providerHookIngress?: ProviderHookIngress;
   harnessEventReportIngestion?: HarnessEventReportIngestion;
@@ -95,8 +96,6 @@ export type CreateObserverApiOptions = {
   /** Exact handoff selector; legacy callers fall back to the core snapshot version. */
   observerBuildVersion?: string;
   stateDir?: string;
-  diagnosticsDir?: string;
-  logPaths?: string[];
   logger?: StationLogger;
   config?: StationConfig;
   configPath?: string;
@@ -111,9 +110,9 @@ export type CreateObserverApiOptions = {
 /**
  * COMPOSITION ROOT
  *
- * Wires Observer use cases, durable and local-metadata adapters, ingress workers,
- * provider-health publication, scheduling, exact build publication, and adapter
- * shutdown behind the application API.
+ * Wires Observer use cases with supplied durable, local-metadata, and diagnostic-
+ * evidence roles, ingress workers, provider-health publication, scheduling, exact
+ * build publication, and adapter shutdown behind the application API.
  */
 export function createObserverApi(options: CreateObserverApiOptions): ObserverApi {
   const clock = options.clock ?? systemClock;
@@ -567,22 +566,14 @@ async function getCommandById(
 function buildDiagnosticDeps(
   options: CreateObserverApiOptions,
   clock: RuntimeClock,
-): ObserverDiagnosticsDeps & { paths: DiagnosticRuntimePaths } {
-  const stateDir = options.stateDir ?? process.cwd();
-  const paths: DiagnosticRuntimePaths = {
-    stateDir,
-    diagnosticsDir: options.diagnosticsDir ?? `${stateDir}/diagnostics`,
-  };
-  if (options.socketPath !== undefined) paths.socketPath = options.socketPath;
-  if (options.hookSpoolDir !== undefined) paths.hookSpoolDir = options.hookSpoolDir;
-  if (options.logPaths !== undefined) paths.logPaths = options.logPaths;
-
-  const deps: ObserverDiagnosticsDeps & { paths: DiagnosticRuntimePaths } = {
+): ObserverDiagnosticsDeps {
+  const deps: ObserverDiagnosticsDeps = {
     config: options.config ?? emptyConfig(),
     core: options.core,
-    persistence: options.persistence,
+    commandJournal: options.persistence,
+    eventJournal: options.persistence,
     persistenceHealth: options.persistenceHealth,
-    paths,
+    evidenceSource: options.diagnosticEvidenceSource,
     clock,
   };
   if (options.configPath !== undefined) deps.configPath = options.configPath;

--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -23,6 +23,7 @@ import {
 } from "@station/runtime";
 import { createCommandQueue } from "../commands/queue.js";
 import { registerObserverCommandHandlers } from "../commands/router.js";
+import { createLocalDiagnosticEvidenceSource } from "../diagnostics/localEvidenceSource.js";
 import { createFeatureFlagEvaluator } from "../features/evaluator.js";
 import {
   createObserverEventHookRuntime,
@@ -100,9 +101,9 @@ export type RunObserverMainDeps = {
 /**
  * COMPOSITION ROOT
  *
- * Claims boot ownership, branches on four-state socket evidence before
- * constructing providers, and owns bind, pidfile, and ownership-aware shutdown
- * before releasing the claim and publishing exact build health.
+ * Claims boot ownership, branches on four-state socket evidence, selects
+ * Observer-private infrastructure from resolved runtime identity, and owns bind,
+ * pidfile, ownership-aware shutdown, and exact build health publication.
  */
 export async function runObserverMain(
   argv = process.argv.slice(2),
@@ -142,7 +143,8 @@ export async function runObserverMain(
   try {
     const processEvidence = deps.processEvidence ?? createLocalObserverProcessEvidence();
     const socketProbe = await probeObserverSocket(socketPath, {
-      socketHolders: (path) => processEvidence.socketHolders(path),
+      timeoutMs: DEFAULT_STARTUP_TIMEOUT_MS,
+      socketHolders: (path: string) => processEvidence.socketHolders(path),
     });
     if (socketProbe.status === "inaccessible") throw socketProbe.error;
     if (socketProbe.status === "listening") {
@@ -223,6 +225,13 @@ async function runClaimedObserverRuntime(input: {
   const persistence = createSqliteObserverPersistence({ sqlite, clock: systemClock });
   const eventBus = createObserverEventBus();
   const logger = createObserverLogger({ stateDir, clock: systemClock });
+  const diagnosticEvidenceSource = createLocalDiagnosticEvidenceSource({
+    stateDir,
+    socketPath,
+    diagnosticsDir: join(stateDir, "diagnostics"),
+    logPaths: [componentLogPath(stateDir, "observer"), componentLogPath(stateDir, "hook")],
+    hookSpoolDir: spoolDir,
+  });
   const projectConfigWriter = createProjectConfigWriter({
     homeDir,
     ...(options.configPath === undefined ? {} : { configPath: loadedConfig.configPath }),
@@ -363,12 +372,11 @@ async function runClaimedObserverRuntime(input: {
     persistenceHealth: persistence,
     commandQueue,
     eventBus,
+    diagnosticEvidenceSource,
     hookSpoolDir: spoolDir,
     socketPath,
     observerBuildVersion: buildVersion,
     stateDir,
-    diagnosticsDir: join(stateDir, "diagnostics"),
-    logPaths: [componentLogPath(stateDir, "observer"), componentLogPath(stateDir, "hook")],
     config,
     ...(options.configPath === undefined ? {} : { configPath: loadedConfig.configPath }),
     configDiagnostics: loadedConfig.diagnostics,

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -1,98 +1,125 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import type { StationConfig } from "@station/config";
-import { createCursorHarnessProvider } from "@station/cursor";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import type { LogRecord, ProviderHealth } from "@station/contracts";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
-import { collectDiagnosticSnapshot, ProviderRegistry, runDoctor } from "../../src/internal";
+import {
+  type CommandJournal,
+  collectDiagnosticSnapshot,
+  type EventJournal,
+  ProviderRegistry,
+  runDoctor,
+} from "../../src/internal";
+import {
+  FakeDiagnosticEvidenceSource,
+  memoryRecentLogEvidence,
+} from "../support/diagnosticEvidenceSources.js";
 import { createTestObserverCore } from "../support/testObserver";
 
 const now = "2026-05-20T12:00:00.000Z";
 
 describe("observer diagnostics collector", () => {
-  it("collects doctor and diagnostic snapshot data from fake providers", async () => {
-    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-diag-"));
+  it("collects doctor and diagnostic snapshot data from substitutable local evidence", async () => {
     const clock = { now: () => new Date(now) };
-    const providers = new ProviderRegistry({
-      worktree: new ProviderDiagnosticWorktreeProvider({ now }),
-      terminal: new FakeTerminalProvider({ now }),
-      harnesses: [new FakeHarnessProvider({ now })],
-    });
-    const { sqlite, persistence, core } = createTestObserverCore({
-      config,
-      providers,
-      clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
-    });
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
+    const evidenceSource = new FakeDiagnosticEvidenceSource();
+    const journals = diagnosticJournals(persistence);
 
-    await providers.healthCache.refreshAll();
-    await core.reconcile("diagnostics-test");
-    const deps = {
-      config,
-      core,
-      persistence,
-      persistenceHealth: persistence,
-      providers,
-      paths: { stateDir },
-      clock,
-    };
+    try {
+      await providers.healthCache.refreshAll();
+      await core.reconcile("diagnostics-test");
+      const deps = {
+        config,
+        core,
+        ...journals,
+        persistenceHealth: persistence,
+        providers,
+        evidenceSource,
+        clock,
+      };
 
-    await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-      schemaVersion: "0.8.0",
-      providerHealth: {
-        "fake-worktree": { status: "healthy" },
-      },
-      retention: {
-        maxDays: 14,
-      },
-    });
-    await expect(runDoctor(deps)).resolves.toMatchObject({
-      status: "healthy",
-      checks: expect.arrayContaining([
-        expect.objectContaining({
-          name: "fake-provider-check",
-          status: "ok",
-        }),
-      ]),
-      debugBundle: {
-        available: true,
-      },
-    });
-    sqlite.close();
+      await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
+        schemaVersion: "0.8.0",
+        observerHealth: {
+          stateDir: "memory://state",
+          socketPath: "memory://observer-socket",
+        },
+        providerHealth: {
+          "fake-worktree": { status: "healthy" },
+        },
+        localState: { stateDir: "memory://state" },
+        hookSpool: { path: "urn:station:hook-spool", pending: 1 },
+        retention: { maxDays: 14 },
+      });
+      await expect(runDoctor(deps)).resolves.toMatchObject({
+        status: "healthy",
+        checks: expect.arrayContaining([
+          expect.objectContaining({ name: "fake-provider-check", status: "ok" }),
+        ]),
+        logs: {
+          paths: ["queue://observer-log", "queue://hook-log"],
+          recent: [expect.objectContaining({ message: "Memory diagnostic evidence." })],
+        },
+        debugBundle: {
+          available: true,
+          diagnosticsDir: "memory://diagnostics",
+        },
+      });
+      expect(journals.commandJournal).not.toBe(journals.eventJournal);
+      expect(evidenceSource.scanLocalStateCalls).toHaveLength(2);
+      expect(evidenceSource.readRecentLogsCalls).toEqual([500, 50]);
+      expect(evidenceSource.summarizeHookSpoolCalls).toBe(2);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("does not request recent logs when collection excludes them", async () => {
+    const clock = { now: () => new Date(now) };
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
+    const evidenceSource = new FakeDiagnosticEvidenceSource();
+
+    try {
+      await collectDiagnosticSnapshot(
+        {
+          config,
+          core,
+          ...diagnosticJournals(persistence),
+          persistenceHealth: persistence,
+          providers,
+          evidenceSource,
+          clock,
+        },
+        { includeLogs: false },
+      );
+
+      expect(evidenceSource.readRecentLogsCalls).toEqual([]);
+      expect(evidenceSource.scanLocalStateCalls).toHaveLength(1);
+      expect(evidenceSource.summarizeHookSpoolCalls).toBe(1);
+    } finally {
+      sqlite.close();
+    }
   });
 
   it("derives current health from checks while retaining command error evidence", async () => {
-    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-diag-recovery-"));
     const clock = { now: () => new Date(now) };
-    const providers = new ProviderRegistry({
-      worktree: new ProviderDiagnosticWorktreeProvider({ now }),
-      terminal: new FakeTerminalProvider({ now }),
-      harnesses: [new FakeHarnessProvider({ now })],
-    });
-    const { sqlite, persistence, core } = createTestObserverCore({
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
+    const deps = {
       config,
+      core,
+      ...diagnosticJournals(persistence),
+      persistenceHealth: persistence,
       providers,
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
-    });
+    };
 
     try {
       await providers.healthCache.refreshAll();
       await core.reconcile("diagnostics-recovery-test");
-      const deps = {
-        config,
-        core,
-        persistence,
-        persistenceHealth: persistence,
-        providers,
-        paths: { stateDir },
-        clock,
-      };
-
-      const baseline = await runDoctor(deps);
-      expect(baseline.status).toBe("healthy");
-      expect(baseline.recentErrors).toEqual([]);
+      expect((await runDoctor(deps)).status).toBe("healthy");
 
       await persistence.recordCommandAccepted({
         commandId: "cmd_historical_failure",
@@ -125,16 +152,6 @@ describe("observer diagnostics collector", () => {
         finishedAt: now,
       });
 
-      const snapshot = await collectDiagnosticSnapshot(deps);
-      expect(snapshot.errors).toContainEqual(
-        expect.objectContaining({
-          id: "err_historical_failure",
-          code: "PROJECT_ROOT_NOT_GIT",
-          commandId: "cmd_historical_failure",
-          traceId: "trc_historical_failure",
-        }),
-      );
-
       const report = await runDoctor(deps);
       expect(report.checks.every((check) => check.status === "ok")).toBe(true);
       expect(report.status).toBe("healthy");
@@ -151,77 +168,10 @@ describe("observer diagnostics collector", () => {
     }
   });
 
-  it("includes Cursor hook diagnostics in doctor data", async () => {
-    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-cursor-diag-"));
-    const clock = { now: () => new Date(now) };
-    const providers = new ProviderRegistry({
-      worktree: new FakeWorktreeProvider({ now }),
-      terminal: new FakeTerminalProvider({ now }),
-      harnesses: [
-        createCursorHarnessProvider({
-          command: "agent-test",
-          installHooks: false,
-          runner: async (input) => ({
-            command: input.command,
-            args: input.args ?? [],
-            stdout: "2026.06.02-8c11d9f\n",
-            stderr: "",
-            exitCode: 0,
-          }),
-        }),
-      ],
-    });
-    const { sqlite, persistence, core } = createTestObserverCore({
-      config,
-      providers,
-      clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
-    });
-    const previousHome = process.env.HOME;
-    process.env.HOME = stateDir;
-    try {
-      const report = await runDoctor({
-        config,
-        core,
-        persistence,
-        persistenceHealth: persistence,
-        providers,
-        paths: { stateDir },
-        clock,
-      });
-
-      expect(report.checks).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            name: "cursor-hooks",
-            status: "ok",
-          }),
-        ]),
-      );
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = previousHome;
-      }
-      sqlite.close();
-    }
-  });
-
   it("filters command-specific diagnostics and prioritizes matching logs", async () => {
-    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-diag-filter-"));
     const clock = { now: () => new Date(now) };
-    const providers = new ProviderRegistry({
-      worktree: new ProviderDiagnosticWorktreeProvider({ now }),
-      terminal: new FakeTerminalProvider({ now }),
-      harnesses: [new FakeHarnessProvider({ now })],
-    });
-    const { sqlite, persistence, core } = createTestObserverCore({
-      config,
-      providers,
-      clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
-    });
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
     await persistence.recordCommandAccepted({
       commandId: "cmd_match",
       command: { type: "observer.reconcile", payload: { reason: "match" } },
@@ -254,60 +204,52 @@ describe("observer diagnostics collector", () => {
       },
       finishedAt: now,
     });
-    const logPath = join(stateDir, "observer.jsonl");
-    await writeFile(
-      logPath,
-      `${[
-        JSON.stringify({
-          timestamp: now,
-          level: "error",
-          component: "observer",
-          message: "Command failed.",
-          attributes: { commandId: "cmd_other", traceId: "trc_other" },
-        }),
-        JSON.stringify({
-          timestamp: now,
-          level: "error",
-          component: "observer",
-          message: "Command failed.",
-          attributes: { commandId: "cmd_match", traceId: "trc_match" },
-        }),
-      ].join("\n")}\n`,
-    );
-
-    const snapshot = await collectDiagnosticSnapshot(
+    const records: LogRecord[] = [
       {
-        config,
-        core,
-        persistence,
-        persistenceHealth: persistence,
-        providers,
-        paths: { stateDir, logPaths: [logPath] },
-        clock,
+        timestamp: now,
+        level: "error",
+        component: "observer",
+        message: "Other command failed.",
+        attributes: { commandId: "cmd_other", traceId: "trc_other" },
       },
-      { commandId: "cmd_match" },
-    );
+      {
+        timestamp: now,
+        level: "error",
+        component: "observer",
+        message: "Matching command failed.",
+        attributes: { commandId: "cmd_match", traceId: "trc_match" },
+      },
+    ];
+    const evidenceSource = new FakeDiagnosticEvidenceSource({
+      recentLogs: memoryRecentLogEvidence(records),
+    });
 
-    expect(snapshot.commands.map((command) => command.id)).toEqual(["cmd_match"]);
-    expect(snapshot.errors.map((error) => error.id)).toEqual(["err_match"]);
-    expect(snapshot.logs[0]?.attributes).toMatchObject({ commandId: "cmd_match" });
-    sqlite.close();
+    try {
+      const snapshot = await collectDiagnosticSnapshot(
+        {
+          config,
+          core,
+          ...diagnosticJournals(persistence),
+          persistenceHealth: persistence,
+          providers,
+          evidenceSource,
+          clock,
+        },
+        { commandId: "cmd_match" },
+      );
+
+      expect(snapshot.commands.map((command) => command.id)).toEqual(["cmd_match"]);
+      expect(snapshot.errors.map((error) => error.id)).toEqual(["err_match"]);
+      expect(snapshot.logs[0]?.attributes).toMatchObject({ commandId: "cmd_match" });
+    } finally {
+      sqlite.close();
+    }
   });
 
-  it("includes uncorrelated hook report events in unfiltered diagnostics", async () => {
-    const stateDir = await mkdtemp(join(tmpdir(), "station-observer-diag-events-"));
+  it("includes uncorrelated hook report events only in unfiltered diagnostics", async () => {
     const clock = { now: () => new Date(now) };
-    const providers = new ProviderRegistry({
-      worktree: new ProviderDiagnosticWorktreeProvider({ now }),
-      terminal: new FakeTerminalProvider({ now }),
-      harnesses: [new FakeHarnessProvider({ now })],
-    });
-    const { sqlite, persistence, core } = createTestObserverCore({
-      config,
-      providers,
-      clock,
-      sqlitePath: join(stateDir, "observer.sqlite"),
-    });
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
     await persistence.recordCommandAccepted({
       commandId: "cmd_match",
       command: { type: "observer.reconcile", payload: { reason: "match" } },
@@ -325,42 +267,149 @@ describe("observer diagnostics collector", () => {
       },
       { source: "hook", createdAt: now },
     );
-
-    const unfiltered = await collectDiagnosticSnapshot({
+    const deps = {
       config,
       core,
-      persistence,
+      ...diagnosticJournals(persistence),
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir },
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
+    };
+
+    try {
+      const unfiltered = await collectDiagnosticSnapshot(deps);
+      const commandFiltered = await collectDiagnosticSnapshot(deps, { commandId: "cmd_match" });
+
+      expect(unfiltered.events).toContainEqual(
+        expect.objectContaining({
+          type: "harness.eventReported",
+          provider: "codex",
+          eventType: "PreToolUse",
+        }),
+      );
+      expect(commandFiltered.events).not.toContainEqual(
+        expect.objectContaining({ type: "harness.eventReported" }),
+      );
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("cannot upgrade degraded core, provider, or persistence health from empty local evidence", async () => {
+    const clock = { now: () => new Date(now) };
+    const providers = new ProviderRegistry({
+      worktree: new DegradedWorktreeProvider({ now }),
+      terminal: new FakeTerminalProvider({ now }),
+      harnesses: [new FakeHarnessProvider({ now })],
     });
-    const commandFiltered = await collectDiagnosticSnapshot(
-      {
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
+    const localState = new FakeDiagnosticEvidenceSource().localStateResult;
+    localState.usage = {
+      ...localState.usage,
+      totalBytes: 0,
+      entries: [],
+    };
+    const evidenceSource = new FakeDiagnosticEvidenceSource({
+      localState,
+      recentLogs: memoryRecentLogEvidence([]),
+      hookSpool: undefined,
+    });
+    const sqliteFailure = {
+      ...persistence.health(),
+      open: false,
+      status: "unavailable" as const,
+      lastError: {
+        tag: "SqliteError",
+        code: "SQLITE_UNAVAILABLE",
+        message: "SQLite is unavailable.",
+      },
+    };
+
+    try {
+      await core.reconcile("degraded-diagnostics");
+      const report = await runDoctor({
         config,
         core,
-        persistence,
-        persistenceHealth: persistence,
+        ...diagnosticJournals(persistence),
+        persistenceHealth: { health: () => sqliteFailure },
         providers,
-        paths: { stateDir },
+        evidenceSource,
         clock,
-      },
-      { commandId: "cmd_match" },
-    );
+      });
 
-    expect(unfiltered.events).toContainEqual(
-      expect.objectContaining({
-        type: "harness.eventReported",
-        provider: "codex",
-        eventType: "PreToolUse",
-      }),
-    );
-    expect(commandFiltered.events).not.toContainEqual(
-      expect.objectContaining({ type: "harness.eventReported" }),
-    );
-    sqlite.close();
+      expect(report.status).toBe("degraded");
+      expect(report.sqlite?.status).toBe("unavailable");
+      expect(report.providers["fake-worktree"]?.status).toBe("unavailable");
+      expect(report.localState.totalBytes).toBe(0);
+    } finally {
+      sqlite.close();
+    }
+  });
+
+  it("propagates local-evidence failures instead of synthesizing a healthy snapshot", async () => {
+    const clock = { now: () => new Date(now) };
+    const providers = diagnosticProviders();
+    const { sqlite, persistence, core } = createTestObserverCore({ config, providers, clock });
+    const evidenceSource = new FakeDiagnosticEvidenceSource();
+    evidenceSource.scanLocalStateFailure = {
+      tag: "DiagnosticEvidenceError",
+      code: "LOCAL_DIAGNOSTIC_EVIDENCE_FAILED",
+      message: "Local diagnostic evidence collection failed.",
+    };
+
+    try {
+      await expect(
+        collectDiagnosticSnapshot({
+          config,
+          core,
+          ...diagnosticJournals(persistence),
+          persistenceHealth: persistence,
+          providers,
+          evidenceSource,
+          clock,
+        }),
+      ).rejects.toMatchObject({
+        code: "LOCAL_DIAGNOSTIC_EVIDENCE_FAILED",
+      });
+      expect(evidenceSource.readRecentLogsCalls).toEqual([]);
+      expect(evidenceSource.summarizeHookSpoolCalls).toBe(0);
+    } finally {
+      sqlite.close();
+    }
   });
 });
+
+function diagnosticProviders(): ProviderRegistry {
+  return new ProviderRegistry({
+    worktree: new ProviderDiagnosticWorktreeProvider({ now }),
+    terminal: new FakeTerminalProvider({ now }),
+    harnesses: [new FakeHarnessProvider({ now })],
+  });
+}
+
+function diagnosticJournals(persistence: CommandJournal & EventJournal): {
+  commandJournal: CommandJournal;
+  eventJournal: EventJournal;
+} {
+  return {
+    commandJournal: {
+      recordCommandAccepted: (input) => persistence.recordCommandAccepted(input),
+      markCommandStarted: (commandId, startedAt) =>
+        persistence.markCommandStarted(commandId, startedAt),
+      markCommandSucceeded: (commandId, finishedAt) =>
+        persistence.markCommandSucceeded(commandId, finishedAt),
+      markCommandFailed: (input) => persistence.markCommandFailed(input),
+      getCommand: (commandId) => persistence.getCommand(commandId),
+      listCommands: () => persistence.listCommands(),
+      listCommandErrors: (commandId) => persistence.listCommandErrors(commandId),
+    },
+    eventJournal: {
+      recordEvent: (event, options) => persistence.recordEvent(event, options),
+      listEvents: (filter) => persistence.listEvents(filter),
+    },
+  };
+}
 
 class ProviderDiagnosticWorktreeProvider extends FakeWorktreeProvider {
   async doctorChecks() {
@@ -374,8 +423,26 @@ class ProviderDiagnosticWorktreeProvider extends FakeWorktreeProvider {
   }
 }
 
+class DegradedWorktreeProvider extends FakeWorktreeProvider {
+  override async health(): Promise<ProviderHealth> {
+    return {
+      providerId: this.id,
+      providerType: "worktree",
+      status: "unavailable",
+      lastCheckedAt: now,
+      lastError: {
+        tag: "WorktreeProviderError",
+        code: "FAKE_WORKTREE_UNAVAILABLE",
+        message: "Fake worktree provider is unavailable.",
+        provider: this.id,
+      },
+    };
+  }
+}
+
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/apps/observer/test/integration/external-launch-reconcile.test.ts
+++ b/apps/observer/test/integration/external-launch-reconcile.test.ts
@@ -24,6 +24,7 @@ import {
   providerIngressSpoolDir,
 } from "../../src/internal";
 import type { StationLogger } from "../../src/stationLogger";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -168,6 +169,7 @@ function createFixture(
     persistenceHealth: persistence,
     commandQueue: queue,
     eventBus,
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     hookSpoolDir: spoolDir,
     clock,
     ...(options.logger === undefined ? {} : { logger: options.logger }),

--- a/apps/observer/test/integration/hook-ingestion.test.ts
+++ b/apps/observer/test/integration/hook-ingestion.test.ts
@@ -1,4 +1,4 @@
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { HarnessEventReportReceipt, ProviderHookAdapter } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
 import {
@@ -21,6 +21,7 @@ import {
   openObserverSqlite,
   ProviderRegistry,
 } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createTestObserver } from "../support/testObserver";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -313,6 +314,7 @@ describe("observer provider hook ingress", () => {
       persistenceHealth: persistence,
       commandQueue: createCommandQueue({ persistence, clock, idFactory: ids(), eventBus }),
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       harnessEventReportIngestion: {
         ingest: async (report): Promise<HarnessEventReportReceipt> => {
@@ -368,6 +370,7 @@ describe("observer provider hook ingress", () => {
       persistenceHealth: persistence,
       commandQueue: createCommandQueue({ persistence, clock, idFactory: ids(), eventBus }),
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       harnessEventReportIngestion: {
         ingest: async (report): Promise<HarnessEventReportReceipt> => {
@@ -750,6 +753,7 @@ describe("observer provider hook ingress", () => {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",
@@ -904,10 +908,10 @@ class RecordingHarnessProvider extends FakeHarnessProvider {
         sessionId: "ses_web_feature_auth",
         rawEventType: "run.updated",
         status: {
-          value: "idle",
-          confidence: "high",
+          value: "idle" as const,
+          confidence: "high" as const,
           reason: "Fake harness hook reported idle.",
-          source: "harness_event",
+          source: "harness_event" as const,
           updatedAt: now,
         },
         observedAt: now,

--- a/apps/observer/test/integration/hook-spool-drain.test.ts
+++ b/apps/observer/test/integration/hook-spool-drain.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { codexHookPayloadToHarnessEventReport, compactCodexHookPayload } from "@station/codex";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { HarnessEventReport, HarnessEventReportReceipt } from "@station/contracts";
 import { STATION_SCHEMA_VERSION } from "@station/contracts";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
@@ -33,6 +33,7 @@ import {
   providerIngressSpoolDir,
   startObserverServer,
 } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 
 const now = "2026-05-20T12:00:00.000Z";
 
@@ -462,6 +463,7 @@ function createFixture(
     persistenceHealth: persistence,
     commandQueue: queue,
     eventBus,
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     ...(options.providerHookIngress === undefined
       ? {}
       : { providerHookIngress: options.providerHookIngress }),
@@ -518,6 +520,7 @@ function codexHarnessReport(reportId: string, toolUseId: string): HarnessEventRe
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -16,6 +16,7 @@ import { ProviderRegistry } from "../../src/providers/registry";
 import { createObserverCore, type ObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
 import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 import {
@@ -48,6 +49,7 @@ describe("Observer API composition with in-memory persistence", () => {
       lifecycle.push("metadata");
     };
     const persistenceHealth: PersistenceHealthSource = { health: () => healthStub };
+    const diagnosticEvidenceSource = new FakeDiagnosticEvidenceSource();
     const api = createObserverApi({
       core,
       providers,
@@ -55,9 +57,9 @@ describe("Observer API composition with in-memory persistence", () => {
       persistenceHealth,
       commandQueue,
       eventBus,
+      diagnosticEvidenceSource,
       clock,
       config,
-      stateDir: "/tmp/station-no-sqlite-observer",
       hookReconcileDebounceMs: 0,
       worktreeChangeSource,
       worktreeMetadataInvalidationSource,
@@ -162,12 +164,23 @@ describe("Observer API composition with in-memory persistence", () => {
       sqlite: healthStub,
     });
     await expect(api.collectDiagnostics({ includeLogs: false })).resolves.toMatchObject({
-      observerHealth: { sqlite: healthStub },
+      observerHealth: {
+        sqlite: healthStub,
+        stateDir: "memory://state",
+        socketPath: "memory://observer-socket",
+      },
+      localState: { stateDir: "memory://state" },
+      hookSpool: { path: "urn:station:hook-spool" },
       commands: [expect.objectContaining({ id: command.commandId, status: "succeeded" })],
       events: expect.arrayContaining([
         expect.objectContaining({ type: "providerHook.ingested", hookId: "hook_memory_1" }),
       ]),
     });
+    await expect(api.runDoctor()).resolves.toMatchObject({
+      logs: { paths: ["queue://observer-log", "queue://hook-log"] },
+      debugBundle: { diagnosticsDir: "memory://diagnostics" },
+    });
+    expect(diagnosticEvidenceSource.readRecentLogsCalls).toEqual([50]);
 
     await expect(api.stop()).resolves.toMatchObject({ stopped: true, at: now });
     expect(worktreeMetadataInvalidationSource.shutdownCount).toBe(1);
@@ -217,6 +230,7 @@ describe("Observer API composition with in-memory persistence", () => {
       persistenceHealth: { health: () => healthStub },
       commandQueue,
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       config,
       worktreeMetadataInvalidationSource: invalidationSource,
@@ -271,6 +285,7 @@ describe("Observer API composition with in-memory persistence", () => {
       persistenceHealth: { health: () => healthStub },
       commandQueue,
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       config,
       metadataRefresh: {

--- a/apps/observer/test/integration/local-diagnostic-evidence-source.test.ts
+++ b/apps/observer/test/integration/local-diagnostic-evidence-source.test.ts
@@ -1,0 +1,270 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  symlink,
+  truncate,
+  unlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { LogRecord } from "@station/contracts";
+import {
+  createJsonlLogger,
+  DEFAULT_RETENTION_POLICY,
+  mergeRetentionPolicy,
+} from "@station/observability";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLocalDiagnosticEvidenceSource } from "../../src/diagnostics/localEvidenceSource.js";
+
+const now = "2026-05-20T12:00:00.000Z";
+const secretLogValue = "authorization=secret-value";
+
+const statRace = vi.hoisted(() => ({ path: undefined as string | undefined }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...original,
+    stat: async (...args: Parameters<typeof original.stat>) => {
+      if (args[0] === statRace.path) {
+        throw new Error("deleted secret spool payload");
+      }
+      return original.stat(...args);
+    },
+  };
+});
+
+afterEach(() => {
+  statRace.path = undefined;
+});
+
+describe("local diagnostic evidence source", () => {
+  it("translates fixed local-state entries with custom retention limits", async () => {
+    const fixture = await createFixture();
+    await writeFile(join(fixture.stateDir, "logs", "observer.jsonl"), "12345");
+    await writeFile(join(fixture.stateDir, "observer.sqlite"), "");
+    await truncate(join(fixture.stateDir, "observer.sqlite"), 3 * 1024 * 1024);
+    await writeFile(join(fixture.diagnosticsDir, "bundle.json"), "bundle");
+    await writeFile(join(fixture.spoolDir, "pending.json"), "pending");
+    const retention = mergeRetentionPolicy({
+      maxTotalMb: 1,
+      components: {
+        observerMaxMb: 1,
+        cliMaxMb: 1,
+        tuiMaxMb: 1,
+        hookRunnerMaxMb: 1,
+        providerMaxMb: 1,
+      },
+    });
+
+    const evidence = await fixture.source.scanLocalState(retention);
+
+    expect(evidence).toMatchObject({
+      diagnosticsDir: fixture.diagnosticsDir,
+      socketPath: fixture.socketPath,
+      usage: {
+        stateDir: fixture.stateDir,
+        limitBytes: 1024 * 1024,
+        overLimit: true,
+      },
+    });
+    expect(evidence.usage.entries.map((entry) => [entry.kind, entry.path])).toEqual([
+      ["logs", join(fixture.stateDir, "logs")],
+      ["database", join(fixture.stateDir, "observer.sqlite")],
+      ["debug_bundles", fixture.diagnosticsDir],
+      ["hook_spool", fixture.spoolDir],
+    ]);
+    expect(evidence.usage.entries[0]).toMatchObject({
+      limitBytes: 5 * 1024 * 1024,
+      overLimit: false,
+    });
+    expect(evidence.usage.entries[1]).toMatchObject({ sizeBytes: 3 * 1024 * 1024 });
+  });
+
+  it("preserves configured log order, per-file tails, and the final bound", async () => {
+    const fixture = await createFixture();
+    await writeLogs(fixture.observerLog, ["observer-1", "observer-2", "observer-3"]);
+    await writeLogs(fixture.hookLog, ["hook-1", "hook-2", "hook-3"]);
+
+    const evidence = await fixture.source.readRecentLogs(2);
+
+    expect(evidence.paths).toEqual([fixture.observerLog, fixture.hookLog]);
+    expect(evidence.records.map((record) => record.message)).toEqual(["hook-2", "hook-3"]);
+  });
+
+  it("treats missing and unreadable local evidence as empty", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-local-evidence-missing-"));
+    const source = createLocalDiagnosticEvidenceSource({
+      stateDir: join(root, "missing-state"),
+      diagnosticsDir: join(root, "missing-diagnostics"),
+      logPaths: [join(root, "missing-log.jsonl")],
+      hookSpoolDir: join(root, "missing-spool"),
+    });
+
+    await expect(source.scanLocalState(DEFAULT_RETENTION_POLICY)).resolves.toMatchObject({
+      usage: { totalBytes: 0 },
+    });
+    await expect(source.readRecentLogs(10)).resolves.toEqual({
+      paths: [join(root, "missing-log.jsonl")],
+      records: [],
+    });
+    await expect(source.summarizeHookSpool()).resolves.toEqual({
+      path: join(root, "missing-spool"),
+      pending: 0,
+    });
+  });
+
+  it.each([
+    ["malformed JSON", `{not-json:${secretLogValue}}`],
+    [
+      "invalid LogRecord",
+      JSON.stringify({
+        timestamp: now,
+        level: "info",
+        component: "observer",
+        message: "",
+        attributes: { authorization: secretLogValue },
+      }),
+    ],
+  ])("rejects %s without exposing its contents", async (_label, source) => {
+    const fixture = await createFixture();
+    await writeFile(fixture.observerLog, `${source}\n`);
+
+    const failure = await fixture.source.readRecentLogs(10).catch((error: unknown) => error);
+
+    expect(failure).toEqual({
+      tag: "DiagnosticEvidenceError",
+      code: "LOCAL_DIAGNOSTIC_EVIDENCE_FAILED",
+      message: "Local diagnostic evidence collection failed.",
+    });
+    expect(JSON.stringify(failure)).not.toContain(secretLogValue);
+  });
+
+  it("follows state and configured-log symlinks but ignores spool symlink entries", async () => {
+    const fixture = await createFixture();
+    const target = join(fixture.stateDir, "target.log");
+    await writeLogs(target, ["through-symlink"]);
+    await unlink(fixture.observerLog).catch(() => undefined);
+    await symlink(target, fixture.observerLog);
+    await symlink(target, join(fixture.spoolDir, "linked.json"));
+    await writeFile(join(fixture.spoolDir, "regular.json"), "metadata only");
+
+    const state = await fixture.source.scanLocalState(DEFAULT_RETENTION_POLICY);
+    const logs = await fixture.source.readRecentLogs(10);
+    const spool = await fixture.source.summarizeHookSpool();
+
+    expect(state.usage.entries.find((entry) => entry.kind === "logs")?.fileCount).toBeGreaterThan(
+      0,
+    );
+    expect(logs.records.map((record) => record.message)).toContain("through-symlink");
+    expect(spool).toMatchObject({ pending: 1 });
+  });
+
+  it("uses only file metadata for sparse and secret-bearing spool records", async () => {
+    const fixture = await createFixture();
+    const sparseDatabase = join(fixture.stateDir, "observer.sqlite");
+    const oldSpool = join(fixture.spoolDir, "old-secret.json");
+    const newSpool = join(fixture.spoolDir, "new-secret.json");
+    await writeFile(sparseDatabase, "");
+    await truncate(sparseDatabase, 64 * 1024 * 1024);
+    await writeFile(oldSpool, '{"token":"old-secret"}');
+    await writeFile(newSpool, '{"token":"new-secret"}');
+    await truncate(newSpool, 32 * 1024 * 1024);
+    await utimes(
+      oldSpool,
+      new Date("2026-05-20T10:00:00.000Z"),
+      new Date("2026-05-20T10:00:00.000Z"),
+    );
+    await utimes(
+      newSpool,
+      new Date("2026-05-20T11:00:00.000Z"),
+      new Date("2026-05-20T11:00:00.000Z"),
+    );
+
+    const state = await fixture.source.scanLocalState(DEFAULT_RETENTION_POLICY);
+    const spool = await fixture.source.summarizeHookSpool();
+
+    expect(state.usage.entries.find((entry) => entry.kind === "database")).toMatchObject({
+      sizeBytes: 64 * 1024 * 1024,
+      fileCount: 1,
+    });
+    expect(spool).toEqual({
+      path: fixture.spoolDir,
+      pending: 2,
+      oldestCreatedAt: "2026-05-20T10:00:00.000Z",
+      newestCreatedAt: "2026-05-20T11:00:00.000Z",
+    });
+    expect(JSON.stringify(spool)).not.toContain("secret");
+  });
+
+  it("preserves best-effort semantics when a spool file disappears after readdir", async () => {
+    const fixture = await createFixture();
+    const racedPath = join(fixture.spoolDir, "raced-secret.json");
+    await writeFile(racedPath, '{"token":"must-not-leak"}');
+    statRace.path = racedPath;
+
+    const spool = await fixture.source.summarizeHookSpool();
+
+    expect(spool).toEqual({ path: fixture.spoolDir, pending: 0 });
+    expect(JSON.stringify(spool)).not.toContain("must-not-leak");
+  });
+
+  it("retains logger redaction in collected log records", async () => {
+    const fixture = await createFixture();
+    const logger = createJsonlLogger({ path: fixture.observerLog, component: "observer" });
+    await logger.info("Redacted record.", {
+      authorization: "Bearer top-secret-token",
+      safe: "visible",
+    });
+
+    const evidence = await fixture.source.readRecentLogs(10);
+
+    expect(evidence.records[0]?.attributes).toMatchObject({
+      authorization: "[REDACTED]",
+      safe: "visible",
+    });
+    expect(await readFile(fixture.observerLog, "utf8")).not.toContain("top-secret-token");
+  });
+});
+
+async function createFixture() {
+  const stateDir = await mkdtemp(join(tmpdir(), "station-local-evidence-"));
+  const diagnosticsDir = join(stateDir, "diagnostics");
+  const spoolDir = join(stateDir, "spool", "hooks");
+  const logsDir = join(stateDir, "logs");
+  const observerLog = join(logsDir, "observer.jsonl");
+  const hookLog = join(logsDir, "hooks.jsonl");
+  const socketPath = join(stateDir, "run", "observer.sock");
+  await Promise.all([
+    mkdir(diagnosticsDir, { recursive: true }),
+    mkdir(spoolDir, { recursive: true }),
+    mkdir(logsDir, { recursive: true }),
+  ]);
+  return {
+    stateDir,
+    diagnosticsDir,
+    spoolDir,
+    observerLog,
+    hookLog,
+    socketPath,
+    source: createLocalDiagnosticEvidenceSource({
+      stateDir,
+      socketPath,
+      diagnosticsDir,
+      logPaths: [observerLog, hookLog],
+      hookSpoolDir: spoolDir,
+    }),
+  };
+}
+
+async function writeLogs(path: string, messages: readonly string[]): Promise<void> {
+  const records: LogRecord[] = messages.map((message) => ({
+    timestamp: now,
+    level: "info",
+    component: "observer",
+    message,
+  }));
+  await writeFile(path, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+}

--- a/apps/observer/test/integration/metadata-refresh.test.ts
+++ b/apps/observer/test/integration/metadata-refresh.test.ts
@@ -32,6 +32,7 @@ import {
   providerProjectsFromConfig,
 } from "../../src/internal";
 import { createLocalGitWorktreeChangeSource } from "../../src/metadata/localGitChangeSummary.js";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createTestObserver } from "../support/testObserver";
 import {
   FakeWorktreeChangeSource,
@@ -582,6 +583,7 @@ describe("observer worktree metadata refresh use case", () => {
         eventBus,
       }),
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock: fixture.clock,
       metadataRefresh: {
         refresh: async () => {

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -1,6 +1,8 @@
-import { access, chmod } from "node:fs/promises";
+import { access, chmod, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { componentLogPath } from "@station/observability";
 import { createObserverClient } from "@station/protocol";
 import {
   createFakeWorktree,
@@ -26,6 +28,7 @@ import {
   runObserverMain,
   startObserverServer,
 } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createUnexpectedProjectConfigWriter } from "../support/projectConfigWriter.js";
 
 const now = "2026-05-20T12:00:00.000Z";
@@ -133,6 +136,63 @@ describe("observer protocol server", () => {
       await chmod(socketPath, 0o600);
       await server.close();
       fixture.sqlite.close();
+    }
+  });
+
+  it("captures canonical runtime paths in the local diagnostic adapter", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-runtime-diagnostics-"));
+    const stateDir = join(root, "state with spaces");
+    const { socketPath } = await createTempSocketPath();
+    const providerRegistryFactory = vi.fn(
+      () =>
+        new ProviderRegistry({
+          worktree: new FakeWorktreeProvider({ now }),
+          terminal: new FakeTerminalProvider({ now }),
+          harnesses: [new FakeHarnessProvider({ now })],
+        }),
+    );
+    const runtime = runObserverMain(
+      ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "2000"],
+      { providerRegistryFactory, buildVersion: observerBuildVersion },
+    );
+    const client = createObserverClient({ socketPath, requestId: ids("runtime-path") });
+
+    try {
+      await vi.waitFor(
+        async () => {
+          await expect(client.health()).resolves.toMatchObject({ stateDir, socketPath });
+        },
+        { timeout: 2000 },
+      );
+      const snapshot = await client.collectDiagnostics({ includeLogs: false });
+      expect(snapshot.observerHealth).toMatchObject({ stateDir, socketPath });
+      expect(snapshot.localState).toMatchObject({
+        stateDir,
+        entries: [
+          { kind: "logs", path: join(stateDir, "logs") },
+          { kind: "database", path: join(stateDir, "observer.sqlite") },
+          { kind: "debug_bundles", path: join(stateDir, "diagnostics") },
+          { kind: "hook_spool", path: join(stateDir, "spool", "hooks") },
+        ],
+      });
+      expect(snapshot.hookSpool).toMatchObject({
+        path: join(stateDir, "spool", "hooks"),
+      });
+
+      const report = await client.runDoctor();
+      expect(report.observer).toMatchObject({ stateDir, socketPath });
+      expect(report.logs.paths).toEqual([
+        componentLogPath(stateDir, "observer"),
+        componentLogPath(stateDir, "hook"),
+      ]);
+      expect(report.debugBundle.diagnosticsDir).toBe(join(stateDir, "diagnostics"));
+
+      await client.stop();
+      await expect(runtime).resolves.toBe(0);
+      expect(providerRegistryFactory).toHaveBeenCalledOnce();
+    } finally {
+      await client.stop().catch(() => undefined);
+      await runtime.catch(() => undefined);
     }
   });
 
@@ -266,6 +326,7 @@ function createObserverFixture(socketPath: string) {
     persistenceHealth,
     commandQueue: queue,
     eventBus,
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     clock,
     socketPath,
     observerBuildVersion,

--- a/apps/observer/test/integration/release-doctor-boundary.test.ts
+++ b/apps/observer/test/integration/release-doctor-boundary.test.ts
@@ -1,11 +1,12 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import type { ProviderDoctorCheck } from "@station/contracts";
 import { FakeHarnessProvider, FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
 import { ProviderRegistry, runDoctor } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createTestObserverCore } from "../support/testObserver";
 
 const now = "2026-05-22T12:00:00.000Z";
@@ -29,10 +30,11 @@ describe("release doctor boundaries", () => {
     const report = await runDoctor({
       config,
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir },
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       providerDoctorTimeoutMs: 5,
     });
@@ -70,6 +72,7 @@ class SlowDoctorWorktreeProvider extends FakeWorktreeProvider {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/apps/observer/test/integration/worktrunk-diagnostics.test.ts
+++ b/apps/observer/test/integration/worktrunk-diagnostics.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 import { ProviderRegistry, runDoctor } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createTestObserverCore } from "../support/testObserver";
 
 const now = "2026-05-21T12:00:00.000Z";
@@ -85,10 +86,11 @@ describe("Worktrunk diagnostics", () => {
       config: stationConfig,
       configPath: incumbentStationConfigPath,
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir: incumbentStateDir },
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
     };
 
@@ -157,10 +159,11 @@ describe("Worktrunk diagnostics", () => {
     const report = await runDoctor({
       config: config(stateDir),
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir },
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
     });
 
@@ -241,10 +244,11 @@ describe("Worktrunk diagnostics", () => {
       {
         config: stationConfig,
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
         providers,
-        paths: { stateDir },
+        evidenceSource: new FakeDiagnosticEvidenceSource(),
         clock,
       },
       { projectId: "web" },
@@ -328,10 +332,11 @@ describe("Worktrunk diagnostics", () => {
       {
         config: stationConfig,
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
         providers,
-        paths: { stateDir },
+        evidenceSource: new FakeDiagnosticEvidenceSource(),
         clock,
       },
       { projectId: "web" },
@@ -411,10 +416,11 @@ describe("Worktrunk diagnostics", () => {
     const report = await runDoctor({
       config: stationConfig,
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
       providers,
-      paths: { stateDir },
+      evidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       providerDoctorTimeoutMs: 250,
     });

--- a/apps/observer/test/support/diagnosticEvidenceSources.ts
+++ b/apps/observer/test/support/diagnosticEvidenceSources.ts
@@ -1,0 +1,113 @@
+import type { LogRecord, RetentionPolicy } from "@station/contracts";
+import type {
+  DiagnosticEvidenceSource,
+  DiagnosticHookSpoolEvidence,
+  DiagnosticLocalStateEvidence,
+  DiagnosticRecentLogEvidence,
+} from "../../src/diagnostics/evidenceSource.js";
+
+const timestamp = "2026-05-20T12:00:00.000Z";
+
+export class FakeDiagnosticEvidenceSource implements DiagnosticEvidenceSource {
+  readonly scanLocalStateCalls: RetentionPolicy[] = [];
+  readonly readRecentLogsCalls: number[] = [];
+  summarizeHookSpoolCalls = 0;
+
+  localStateResult: DiagnosticLocalStateEvidence;
+  recentLogsResult: DiagnosticRecentLogEvidence;
+  hookSpoolResult: DiagnosticHookSpoolEvidence | undefined;
+
+  scanLocalStateFailure: unknown;
+  readRecentLogsFailure: unknown;
+  summarizeHookSpoolFailure: unknown;
+
+  constructor(
+    options: {
+      localState?: DiagnosticLocalStateEvidence;
+      recentLogs?: DiagnosticRecentLogEvidence;
+      hookSpool?: DiagnosticHookSpoolEvidence | undefined;
+    } = {},
+  ) {
+    this.localStateResult = options.localState ?? memoryLocalStateEvidence();
+    this.recentLogsResult = options.recentLogs ?? memoryRecentLogEvidence();
+    this.hookSpoolResult = "hookSpool" in options ? options.hookSpool : memoryHookSpoolEvidence();
+  }
+
+  async scanLocalState(retention: RetentionPolicy): Promise<DiagnosticLocalStateEvidence> {
+    this.scanLocalStateCalls.push(retention);
+    if (this.scanLocalStateFailure !== undefined) {
+      throw this.scanLocalStateFailure;
+    }
+    return this.localStateResult;
+  }
+
+  async readRecentLogs(maxRecords: number): Promise<DiagnosticRecentLogEvidence> {
+    this.readRecentLogsCalls.push(maxRecords);
+    if (this.readRecentLogsFailure !== undefined) {
+      throw this.readRecentLogsFailure;
+    }
+    return this.recentLogsResult;
+  }
+
+  async summarizeHookSpool(): Promise<DiagnosticHookSpoolEvidence | undefined> {
+    this.summarizeHookSpoolCalls += 1;
+    if (this.summarizeHookSpoolFailure !== undefined) {
+      throw this.summarizeHookSpoolFailure;
+    }
+    return this.hookSpoolResult;
+  }
+}
+
+export function memoryLocalStateEvidence(): DiagnosticLocalStateEvidence {
+  return {
+    usage: {
+      stateDir: "memory://state",
+      totalBytes: 48,
+      limitBytes: 1024,
+      overLimit: false,
+      entries: [
+        {
+          kind: "logs",
+          path: "queue://logs",
+          sizeBytes: 32,
+          fileCount: 2,
+          overLimit: false,
+        },
+        {
+          kind: "hook_spool",
+          path: "urn:station:hook-spool",
+          sizeBytes: 16,
+          fileCount: 1,
+          overLimit: false,
+        },
+      ],
+    },
+    diagnosticsDir: "memory://diagnostics",
+    socketPath: "memory://observer-socket",
+  };
+}
+
+export function memoryRecentLogEvidence(
+  records: LogRecord[] = [
+    {
+      timestamp,
+      level: "info",
+      component: "observer",
+      message: "Memory diagnostic evidence.",
+    },
+  ],
+): DiagnosticRecentLogEvidence {
+  return {
+    paths: ["queue://observer-log", "queue://hook-log"],
+    records,
+  };
+}
+
+export function memoryHookSpoolEvidence(): DiagnosticHookSpoolEvidence {
+  return {
+    path: "urn:station:hook-spool",
+    pending: 1,
+    oldestCreatedAt: timestamp,
+    newestCreatedAt: timestamp,
+  };
+}

--- a/apps/observer/test/support/testObserver.ts
+++ b/apps/observer/test/support/testObserver.ts
@@ -11,6 +11,7 @@ import {
   openObserverSqlite,
   type ProviderRegistry,
 } from "../../src/internal";
+import { FakeDiagnosticEvidenceSource } from "./diagnosticEvidenceSources.js";
 
 export type TestClock = { now: () => Date };
 
@@ -119,6 +120,7 @@ export function createTestObserver(input: CreateTestObserverInput) {
     persistenceHealth: persistence,
     commandQueue,
     eventBus,
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     clock,
     config,
     hookReconcileDebounceMs: input.hookReconcileDebounceMs ?? 0,

--- a/apps/observer/test/tsconfig.json
+++ b/apps/observer/test/tsconfig.json
@@ -7,11 +7,19 @@
     "types": ["node", "vitest/globals"]
   },
   "files": [
+    "integration/diagnostics-collector.test.ts",
+    "integration/external-launch-reconcile.test.ts",
+    "integration/hook-spool-drain.test.ts",
     "integration/in-memory-observer-api.test.ts",
+    "integration/local-diagnostic-evidence-source.test.ts",
     "integration/local-git-worktree-change-source.test.ts",
     "integration/metadata-refresh.test.ts",
+    "integration/protocol-server.test.ts",
+    "integration/release-doctor-boundary.test.ts",
     "integration/worktrunk-diagnostics.test.ts",
     "unit/git-ref-invalidation.test.ts",
-    "unit/localGitChangeSummary.test.ts"
+    "unit/localGitChangeSummary.test.ts",
+    "unit/reconcileProfiling.test.ts",
+    "unit/reconcileStartupJoin.test.ts"
   ]
 }

--- a/apps/observer/test/unit/reconcileProfiling.test.ts
+++ b/apps/observer/test/unit/reconcileProfiling.test.ts
@@ -4,6 +4,7 @@ import type { ObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
 import type { StationLogger } from "../../src/stationLogger";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
 import { emptyStationSnapshot, fakeObserverCommandQueue } from "../support/testObserver";
 
@@ -113,6 +114,7 @@ function createProfilingApi(input: {
     },
     commandQueue: fakeObserverCommandQueue(),
     eventBus,
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     clock,
     logger: input.logger,
     metadataRefresh: {
@@ -135,7 +137,13 @@ function fakeCore(reconcileDelayMs: number): ObserverCore {
       }
       return emptyStationSnapshot(now);
     },
-    projectHarnessEventStatus: async () => ({ projected: false, events: [] }),
+    commitProviderHealthProbe: () => Promise.resolve(undefined),
+    projectHarnessEventStatus: async () => ({
+      projected: false,
+      snapshot: emptyStationSnapshot(now),
+      events: [],
+    }),
+    clearTurnReadiness: () => undefined,
     updateConfig: () => undefined,
     getProjects: () => [],
     getSnapshot: () => emptyStationSnapshot(now),

--- a/apps/observer/test/unit/reconcileStartupJoin.test.ts
+++ b/apps/observer/test/unit/reconcileStartupJoin.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ObserverCore } from "../../src/reconcile/core";
 import { createObserverApi } from "../../src/runtime/api";
 import { createObserverEventBus } from "../../src/runtime/eventBus";
+import { FakeDiagnosticEvidenceSource } from "../support/diagnosticEvidenceSources.js";
 import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
 import { emptyStationSnapshot, fakeObserverCommandQueue } from "../support/testObserver";
 
@@ -89,7 +90,11 @@ function controllableCore(): { core: ObserverCore; scans: ControlledScan[] } {
         scans.push({ reason, snapshot: emptyStationSnapshot(now), resolve });
       }),
     commitProviderHealthProbe: () => Promise.resolve(undefined),
-    projectHarnessEventStatus: async () => ({ projected: false, events: [] }),
+    projectHarnessEventStatus: async () => ({
+      projected: false,
+      snapshot: emptyStationSnapshot(now),
+      events: [],
+    }),
     clearTurnReadiness: () => undefined,
     updateConfig: () => undefined,
     getProjects: () => [],
@@ -119,6 +124,7 @@ function createJoinApi(core: ObserverCore) {
     },
     commandQueue: fakeObserverCommandQueue(),
     eventBus: createObserverEventBus(),
+    diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
     clock,
     metadataRefresh: {
       refresh: async () => undefined,

--- a/apps/observer/tsconfig.test-support.json
+++ b/apps/observer/tsconfig.test-support.json
@@ -5,6 +5,7 @@
     "rootDir": "."
   },
   "include": [
+    "test/support/diagnosticEvidenceSources.ts",
     "test/support/harnessRuns.ts",
     "test/support/inMemoryObserverPersistence.ts",
     "test/support/projectConfigWriter.ts",

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -159,8 +159,9 @@ Composition is intentionally split:
    expectation from resolved runtime paths and the Observer ingress launcher, and
    supplies a `ProviderRegistry` factory.
 2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
-   private infrastructure: SQLite, persistence, logging and project-config adapters, event bus, command
-   queue, core, handlers, ingress queues, schedulers, API, and protocol server.
+   private infrastructure: SQLite, persistence, logging, project-config, and local
+   diagnostic-evidence adapters, event bus, command queue, core, handlers, ingress
+   queues, schedulers, API, and protocol server.
 
 The split is allowed because both pieces are outer wiring. Application modules
 must not compensate for it by selecting concrete adapters at runtime.
@@ -192,7 +193,7 @@ ownership even where current ownership is still a deviation.
 | Persistence health | Driven | `PersistenceHealthSource` | SQLite adapter created by `createSqliteObserverPersistence` | Runtime health and diagnostics read the public SQLite health projection without receiving the concrete database handle. |
 | Logging and config mutation | Driven | `StationLogger` and `ProjectConfigWriter` | `runtime/logging.ts` JSONL adapter and `runtime/projectConfigWriter.ts` config adapter | Conforming ports expose only operational logging and the three project mutations; paths and representations remain adapter-owned. |
 | Worktree metadata evidence | Driven | `WorktreeChangeSource` and `WorktreeMetadataInvalidationSource` | local Git reader and ref-watcher adapters | Conforming path-free roles: one reads typed checkout-local change evidence; the other owns full-set watcher replacement and terminal shutdown. |
-| Diagnostic evidence | Driven | target `DiagnosticEvidenceSource` | local state, log, and hook-spool adapter | Only typed local evidence traversal crosses the port; command/event persistence, providers, core, and SQLite remain separate inputs (OBS-HEX-012). |
+| Diagnostic evidence | Driven | `DiagnosticEvidenceSource` | `createLocalDiagnosticEvidenceSource` | Conforming read-only role: the adapter captures resolved local state, log, diagnostics, socket, and hook-spool locations while only typed measurements and bounded evidence cross the port; command/event journals, providers, core, and SQLite remain separate inputs. |
 | Observer incumbent lifecycle | Driven | `ObserverIncumbentLifecycle` | local protocol client adapter | Handoff may read health and request controlled stop without importing transport mechanics into policy or orchestration. |
 | Observer process evidence | Driven | `ObserverProcessEvidenceSource` | local `lsof`/`ps`/pidfile/signal adapter | `lsof` is primary socket ownership; health, strict pidfile, argv, and OS start token must corroborate before replacement or signaling. |
 
@@ -221,7 +222,7 @@ areas contain the following responsibilities:
 | `persistence/ports.ts`, `persistence/types.ts` | seven purpose-owned persistence ports, their seven-port composition bundle, the separate persistence-health port, and Observer application records and inputs | Observer-private application boundary; no SQL, SQLite handles, or SQLite row representations. The bundle is composition-only. |
 | `persistence/sqliteAdapter.ts`, SQLite implementation modules, `migrations/`, `sqlite.ts` | SQL and row translation, transactions, migrations, driver compatibility, health, and durable-handle mechanics | Production outbound adapter edge selected and lifecycle-managed by runtime composition. |
 | `test/support/inMemoryObserverPersistence.ts`, `persistence/observationParser.ts` | Process-local persistence test support plus representation-neutral observation parsing and coalescing | Test-only storage substitute and shared boundary translation used to prove substitution; production source and runtime remain SQLite-only. |
-| `diagnostics/` | doctor and diagnostic collection plus local evidence traversal | Diagnostic use cases depend on an evidence-source port (OBS-HEX-012). |
+| `diagnostics/` | doctor and diagnostic collection, the local-evidence port, and local representation translation | Diagnostic use cases aggregate core, journal, persistence-health, provider, configuration, and typed local evidence; `localEvidenceSource.ts` alone owns state, JSONL log, and hook-spool filesystem traversal. |
 | `features/` | feature-flag evaluation | Deterministic application policy. |
 | `apps/cli/src/observerProviders.ts` | concrete provider construction and role assignment | Outer composition root. |
 | `integrations/**` | external-system parsing and operations | Outbound adapters. |
@@ -302,12 +303,15 @@ Current startup proceeds in this order:
    `ProjectConfigWriter` configuration adapter, command queue, feature evaluator,
    Observer core, command handlers, and configured event hooks around the awaited
    provider registry. Only the two application ports pass inward.
-7. The API constructs ingress queues, reconcile scheduling, metadata refresh,
-   diagnostics dependencies, spool draining, and the provider-health completion
-   listener whose commits drain before persistence shutdown. Local Git readers
-   and ref invalidation are selected here; watches arm lazily on the first
-   metadata refresh, and each refresh replaces the complete watched identity set
-   before cache or metadata reads so a later ref move cannot be missed.
+7. Runtime composition captures the resolved state, socket, diagnostics, log,
+   and hook-spool locations in the local diagnostic-evidence adapter before
+   supplying it to the API. The API constructs ingress queues, reconcile
+   scheduling, metadata refresh, diagnostics dependencies, spool draining, and
+   the provider-health completion listener whose commits drain before persistence
+   shutdown. Local Git readers and ref invalidation are selected here; watches
+   arm lazily on the first metadata refresh, and each refresh replaces the
+   complete watched identity set before cache or metadata reads so a later ref
+   move cannot be missed.
 8. The runtime constructs a private startup-and-health gate, then the protocol
    server binds the resolved socket before startup reconcile. Only the
    successful socket binder may publish process identity.
@@ -576,14 +580,16 @@ without mixing requester and Observer identities, so Worktrunk, Claude, Codex,
 Cursor, and OpenCode compare hook artifacts using the requester runtime identity
 even when an exact-build Observer from another checkout serves the request. Direct
 API callers retain the whole Observer composition expectation as the fallback.
-Provider adapters receive
-`PersistenceHealthSource` separately from the command and event journals, so
-neither use case needs a concrete SQLite handle. Collection must remain
-read-only with respect to product state. Provider doctor calls receive an
+Provider adapters receive `PersistenceHealthSource` separately from the command
+and event journals, so neither use case needs a concrete SQLite handle. The
+`DiagnosticEvidenceSource` supplies measured local-state usage, bounded typed
+logs with their reported locations, and hook-spool file metadata separately from
+those inputs. Its local adapter captures canonical runtime paths at composition;
+the use cases receive no filesystem layout or traversal mechanics. Collection
+remains read-only with respect to product state. Provider doctor calls receive an
 Observer-owned total timeout and cancellation signal; adapters that fan out
 checks must bound concurrency and return completed evidence before that budget
-expires. OBS-HEX-012 tracks separation of filesystem, log, and spool traversal
-from the diagnostic use case.
+expires.
 
 ## Concurrency, Failure, And Backpressure
 
@@ -792,10 +798,11 @@ Architecture is protected by several forms of evidence:
 Current enforcement is partial. The boundary inventory catches forbidden
 package imports but cannot detect copied provider IDs, reconstructed target
 formats, or application logic that selects a concrete adapter. Marker and
-declared-seam checks begin with documented or touched seams. Persistence
-substitution is covered by shared contracts and a no-SQLite application lane;
-complete conformance still requires the remaining dependency-direction and
-local-evidence adapter remediation tracked below.
+declared-seam checks begin with documented or touched seams. Persistence substitution is covered by shared contracts and a no-SQLite
+application lane. Diagnostic-evidence substitution is covered by a deliberately
+non-local fake, local-adapter translation tests, runtime path-capture coverage,
+and import diagnostics; complete conformance still requires the remaining
+major-module dependency-direction remediation tracked below.
 
 The final architecture manifest is generated from named exported declarations,
 their controlled JSDoc markers and purpose prose, and the source/import graph.
@@ -817,7 +824,6 @@ and exit condition here.
 | ID | Current evidence and risk | Containment and exit evidence | Tracking |
 | --- | --- | --- | --- |
 | `OBS-HEX-007` | Terminal intent orchestration now belongs to `commands/`, resolving that provider/application back-edge. Unrelated type-only ownership cycles remain, so not every major module role is yet explainable without source cycles. | A dependency diagnostic prevents `providers/**` from importing `commands/**`. Exit when the remaining major-module type cycles are removed and final dependency-direction enforcement covers every major Observer module. | Internal ownership remediation. |
-| `OBS-HEX-012` | Diagnostic collection directly traverses filesystem, log, spool, and runtime path representations. The use case cannot be substituted independently of local evidence layout. | Diagnostics remain read-only. Exit when a `DiagnosticEvidenceSource` adapter owns only local-state, recent-log, and hook-spool traversal, captures its paths, and the use case runs against a fake without absorbing persistence, providers, core, or SQLite. | Diagnostic evidence isolation. |
 
 The managed-terminal lifecycle leak formerly tracked as `OBS-HEX-001` is
 resolved: application code receives `ManagedTerminalLifecycle` from composition,
@@ -846,6 +852,10 @@ configuration/home paths; static inventory and substitution tests enforce both e
 `WorktreeMetadataInvalidationSource` ports isolate local Git reads and ref-watch
 lifecycle, runtime composition selects both adapters, substitution tests replace
 both roles, and boundary diagnostics confine Git/process and filesystem mechanics.
+`OBS-HEX-012` is resolved: the typed `DiagnosticEvidenceSource` isolates local
+state, recent-log, and hook-spool reads; runtime composition captures canonical
+paths in its local adapter, while fake substitution and import diagnostics keep
+journals, persistence health, providers, core, and SQLite as separate inputs.
 `OBS-HEX-013` is resolved: normal and provider-hook clients no longer unlink
 stale sockets, the child holds the persistent SQLite boot claim through ready
 commitment, and permanent Node/Bun plus production lifecycle races cover

--- a/tests/agent/real/claude/claude-session-create.test.ts
+++ b/tests/agent/real/claude/claude-session-create.test.ts
@@ -4,11 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { createClaudeHarnessProvider } from "@station/claude";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createSqliteObserverPersistence,
@@ -226,12 +227,14 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [join(input.stateDir, "logs", "observer.jsonl")],
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({
@@ -245,6 +248,7 @@ async function writeFailureBundle(input: {
 function config(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
       socketPath: join(root, "observer.sock"),

--- a/tests/agent/real/codex/codex-session-create.test.ts
+++ b/tests/agent/real/codex/codex-session-create.test.ts
@@ -4,11 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { createCodexHarnessProvider } from "@station/codex";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createSqliteObserverPersistence,
@@ -227,12 +228,14 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [join(input.stateDir, "logs", "observer.jsonl")],
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({
@@ -246,6 +249,7 @@ async function writeFailureBundle(input: {
 function config(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
       socketPath: join(root, "observer.sock"),

--- a/tests/agent/real/cursor/cursor-session-create.test.ts
+++ b/tests/agent/real/cursor/cursor-session-create.test.ts
@@ -3,12 +3,13 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { createCursorHarnessProvider, installCursorHooks } from "@station/cursor";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverApi,
   createObserverCore,
   createObserverEventBus,
@@ -235,6 +236,9 @@ describeRealCursor("real Cursor session.create launch lane", () => {
     const eventBus = createObserverEventBus();
     const queue = createCommandQueue({ persistence, idFactory, clock, eventBus });
     const testConfig = config(root, stateDir);
+    if (testConfig.observer === undefined) {
+      throw new Error("Expected Observer configuration in the Cursor fixture.");
+    }
     testConfig.observer.socketPath = socketPath;
     const providers = new ProviderRegistry({
       worktree: new FakeWorktreeProvider({
@@ -276,6 +280,13 @@ describeRealCursor("real Cursor session.create launch lane", () => {
       clock,
       providerTimeoutMs: 20_000,
     });
+    const diagnosticEvidenceSource = createLocalDiagnosticEvidenceSource({
+      stateDir,
+      socketPath,
+      diagnosticsDir: join(stateDir, "diagnostics"),
+      logPaths: [join(stateDir, "logs", "observer.jsonl"), join(stateDir, "logs", "hooks.jsonl")],
+      hookSpoolDir,
+    });
     const api = createObserverApi({
       core,
       providers,
@@ -283,6 +294,7 @@ describeRealCursor("real Cursor session.create launch lane", () => {
       persistenceHealth: persistence,
       commandQueue: queue,
       eventBus,
+      diagnosticEvidenceSource,
       clock,
       config: testConfig,
       socketPath,
@@ -528,12 +540,18 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [
+        join(input.stateDir, "logs", "observer.jsonl"),
+        join(input.stateDir, "logs", "hooks.jsonl"),
+      ],
+      hookSpoolDir: join(input.stateDir, "spool", "hooks"),
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({
@@ -547,6 +565,7 @@ async function writeFailureBundle(input: {
 function config(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
       socketPath: join(root, "observer.sock"),

--- a/tests/agent/real/opencode/opencode-event-capture.test.ts
+++ b/tests/agent/real/opencode/opencode-event-capture.test.ts
@@ -2,11 +2,12 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverApi,
   createObserverCore,
   createObserverEventBus,
@@ -118,6 +119,13 @@ describeRealOpenCode("real OpenCode event capture", () => {
       providerTimeoutMs: 20_000,
     });
     const queue = createCommandQueue({ persistence, clock, idFactory, eventBus });
+    const diagnosticEvidenceSource = createLocalDiagnosticEvidenceSource({
+      stateDir,
+      socketPath,
+      diagnosticsDir: join(stateDir, "diagnostics"),
+      logPaths: [join(stateDir, "logs", "observer.jsonl"), join(stateDir, "logs", "hooks.jsonl")],
+      hookSpoolDir,
+    });
     const api = createObserverApi({
       core,
       providers,
@@ -125,6 +133,7 @@ describeRealOpenCode("real OpenCode event capture", () => {
       persistenceHealth: persistence,
       commandQueue: queue,
       eventBus,
+      diagnosticEvidenceSource,
       clock,
       config: testConfig,
       socketPath,
@@ -305,12 +314,18 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [
+        join(input.stateDir, "logs", "observer.jsonl"),
+        join(input.stateDir, "logs", "hooks.jsonl"),
+      ],
+      hookSpoolDir: join(input.stateDir, "spool", "hooks"),
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({
@@ -329,6 +344,7 @@ function config(input: {
 }): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir: input.stateDir,
       socketPath: input.socketPath,

--- a/tests/agent/real/opencode/opencode-session-create.test.ts
+++ b/tests/agent/real/opencode/opencode-session-create.test.ts
@@ -3,11 +3,12 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createSqliteObserverPersistence,
@@ -254,12 +255,14 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [join(input.stateDir, "logs", "observer.jsonl")],
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({
@@ -273,6 +276,7 @@ async function writeFailureBundle(input: {
 function config(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
       socketPath: join(root, "observer.sock"),

--- a/tests/agent/real/pi/pi-session-create.test.ts
+++ b/tests/agent/real/pi/pi-session-create.test.ts
@@ -8,6 +8,7 @@ import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverApi,
   createObserverCore,
   createObserverEventBus,
@@ -293,6 +294,13 @@ describeRealPi("real Pi session.create launch lane", () => {
       clock,
       providerTimeoutMs: 20_000,
     });
+    const diagnosticEvidenceSource = createLocalDiagnosticEvidenceSource({
+      stateDir,
+      socketPath,
+      diagnosticsDir: join(stateDir, "diagnostics"),
+      logPaths: [join(stateDir, "logs", "observer.jsonl"), join(stateDir, "logs", "hooks.jsonl")],
+      hookSpoolDir,
+    });
     const api = createObserverApi({
       core,
       providers,
@@ -300,6 +308,7 @@ describeRealPi("real Pi session.create launch lane", () => {
       persistenceHealth: persistence,
       commandQueue: queue,
       eventBus,
+      diagnosticEvidenceSource,
       clock,
       config: testConfig,
       socketPath,
@@ -574,12 +583,18 @@ async function writeFailureBundle(input: {
   const snapshot = await collectDiagnosticSnapshot({
     config: input.config,
     core: input.core,
-    persistence: input.persistence,
+    commandJournal: input.persistence,
+    eventJournal: input.persistence,
     persistenceHealth: input.persistence,
-    paths: {
+    evidenceSource: createLocalDiagnosticEvidenceSource({
       stateDir: input.stateDir,
       diagnosticsDir: input.diagnosticsDir,
-    },
+      logPaths: [
+        join(input.stateDir, "logs", "observer.jsonl"),
+        join(input.stateDir, "logs", "hooks.jsonl"),
+      ],
+      hookSpoolDir: join(input.stateDir, "spool", "hooks"),
+    }),
     clock: { now: () => new Date(now) },
   });
   await writeDebugBundle({

--- a/tests/agent/scripted/scripted-agent-lifecycle.test.ts
+++ b/tests/agent/scripted/scripted-agent-lifecycle.test.ts
@@ -1,11 +1,12 @@
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createSqliteObserverPersistence,
@@ -110,9 +111,14 @@ describe("scripted agent lifecycle", () => {
     const diagnostics = await collectDiagnosticSnapshot({
       config: config(root, stateDir),
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
-      paths: { stateDir, diagnosticsDir: join(stateDir, "diagnostics") },
+      evidenceSource: createLocalDiagnosticEvidenceSource({
+        stateDir,
+        diagnosticsDir: join(stateDir, "diagnostics"),
+        logPaths: [join(stateDir, "logs", "observer.jsonl")],
+      }),
       clock: { now: () => new Date(now) },
     });
     const manifest = await writeDebugBundle({
@@ -247,6 +253,7 @@ function worktree(path: string) {
 function config(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
       socketPath: join(root, "run", "observer.sock"),

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -374,6 +374,77 @@ describe("boundary inventory guard", () => {
     );
   });
 
+  it("isolates local diagnostic evidence behind an application-owned port", async () => {
+    const collectorPath = join(process.cwd(), "apps/observer/src/diagnostics/collector.ts");
+    const portPath = join(process.cwd(), "apps/observer/src/diagnostics/evidenceSource.ts");
+    const adapterPath = join(process.cwd(), "apps/observer/src/diagnostics/localEvidenceSource.ts");
+    const apiPath = join(process.cwd(), "apps/observer/src/runtime/api.ts");
+    const mainPath = join(process.cwd(), "apps/observer/src/runtime/main.ts");
+    const [collectorSource, portSource, adapterSource, apiSource, mainSource] = await Promise.all(
+      [collectorPath, portPath, adapterPath, apiPath, mainPath].map((path) =>
+        readFile(path, "utf8"),
+      ),
+    );
+
+    const collectorImports = sourceImports(collectorSource, collectorPath).map(
+      (entry) => entry.specifier,
+    );
+    expect(collectorImports).toContain("./evidenceSource.js");
+    expect(collectorImports).not.toEqual(
+      expect.arrayContaining([
+        "node:fs",
+        "node:fs/promises",
+        "node:path",
+        "@station/observability/logger",
+        "@station/observability/retention",
+      ]),
+    );
+    expect(collectorSource).not.toMatch(
+      /\b(?:readJsonlLog|scanLocalStateUsage|componentLogPath|readdir|stat)\b/,
+    );
+
+    const portImports = sourceImports(portSource, portPath).map((entry) => entry.specifier);
+    expect(portImports).toEqual(["@station/contracts"]);
+    expect(portSource).not.toMatch(
+      /\b(?:node:fs|node:path|Persistence|ProviderRegistry|ObserverCore|Sqlite|SpoolStore)\b/,
+    );
+
+    const diagnosticsFiles = (
+      await sourceFilesAt(join(process.cwd(), "apps/observer/src/diagnostics"))
+    ).filter(isProductionSourceFile);
+    const traversalOwners: string[] = [];
+    for (const file of diagnosticsFiles) {
+      const source = await readFile(file, "utf8");
+      const imports = sourceImports(source, file).map((entry) => entry.specifier);
+      if (
+        imports.some((specifier) => specifier.startsWith("node:fs")) ||
+        /\b(?:readJsonlLog|scanLocalStateUsage|readdir|stat)\b/.test(source)
+      ) {
+        traversalOwners.push(relative(process.cwd(), file));
+      }
+    }
+    expect(traversalOwners).toEqual(["apps/observer/src/diagnostics/localEvidenceSource.ts"]);
+
+    expect(sourceImports(mainSource, mainPath).map((entry) => entry.specifier)).toContain(
+      "../diagnostics/localEvidenceSource.js",
+    );
+    expect(mainSource).toContain("createLocalDiagnosticEvidenceSource({");
+    expect(sourceImports(apiSource, apiPath).map((entry) => entry.specifier)).toContain(
+      "../diagnostics/evidenceSource.js",
+    );
+    expect(apiSource).not.toContain("localEvidenceSource");
+
+    expect(portSource).toMatch(
+      /\/\*\*[\s\S]*?\* DRIVEN PORT[\s\S]*?export interface DiagnosticEvidenceSource/,
+    );
+    expect(adapterSource).toMatch(
+      /\/\*\*[\s\S]*?\* ADAPTER[\s\S]*?export function createLocalDiagnosticEvidenceSource/,
+    );
+    expect(collectorSource).toMatch(
+      /\/\*\*[\s\S]*?\* USE CASE[\s\S]*?export async function collectDiagnosticSnapshot/,
+    );
+  });
+
   it("centralizes safe-error and external-command shape inspection in runtime", async () => {
     const files = await sourceFiles();
     const violations: string[] = [];

--- a/tests/diagnostics/debug-bundle/claude-provider.test.ts
+++ b/tests/diagnostics/debug-bundle/claude-provider.test.ts
@@ -2,10 +2,11 @@ import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createClaudeHarnessProvider } from "@station/claude";
-import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createSqliteObserverPersistence,
   openObserverSqlite,
@@ -59,12 +60,14 @@ describe("Claude provider debug bundle diagnostics", () => {
       config,
       configPath: join(root, "config.toml"),
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
-      paths: {
+      evidenceSource: createLocalDiagnosticEvidenceSource({
         stateDir,
         diagnosticsDir,
-      },
+        logPaths: [componentLogPath(stateDir, "observer")],
+      }),
       clock,
     });
     const manifest = await writeDebugBundle({
@@ -92,6 +95,7 @@ describe("Claude provider debug bundle diagnostics", () => {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/tests/diagnostics/debug-bundle/cleanup-command.test.ts
+++ b/tests/diagnostics/debug-bundle/cleanup-command.test.ts
@@ -1,11 +1,12 @@
 import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createObserverLogger,
@@ -125,13 +126,14 @@ describe("cleanup command debug bundle diagnostics", () => {
         config,
         configPath: join(root, "config.toml"),
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
-        paths: {
+        evidenceSource: createLocalDiagnosticEvidenceSource({
           stateDir,
           diagnosticsDir,
           logPaths: [componentLogPath(stateDir, "observer")],
-        },
+        }),
         clock,
       },
       { includeLogs: true },
@@ -158,6 +160,7 @@ describe("cleanup command debug bundle diagnostics", () => {
 function configFor(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: { stateDir },
     defaults: {
       worktreeProvider: "fake-worktree",

--- a/tests/diagnostics/debug-bundle/codex-provider.test.ts
+++ b/tests/diagnostics/debug-bundle/codex-provider.test.ts
@@ -2,10 +2,11 @@ import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createCodexHarnessProvider } from "@station/codex";
-import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createSqliteObserverPersistence,
   openObserverSqlite,
@@ -59,12 +60,14 @@ describe("Codex provider debug bundle diagnostics", () => {
       config,
       configPath: join(root, "config.toml"),
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
-      paths: {
+      evidenceSource: createLocalDiagnosticEvidenceSource({
         stateDir,
         diagnosticsDir,
-      },
+        logPaths: [componentLogPath(stateDir, "observer")],
+      }),
       clock,
     });
     const manifest = await writeDebugBundle({
@@ -92,6 +95,7 @@ describe("Codex provider debug bundle diagnostics", () => {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/tests/diagnostics/debug-bundle/debug-bundle-operational.test.ts
+++ b/tests/diagnostics/debug-bundle/debug-bundle-operational.test.ts
@@ -1,11 +1,12 @@
 import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverLogger,
   createSqliteObserverPersistence,
@@ -78,13 +79,14 @@ describe("operational debug bundle", () => {
         config,
         configPath: join(root, "config.toml"),
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
-        paths: {
+        evidenceSource: createLocalDiagnosticEvidenceSource({
           stateDir,
           diagnosticsDir,
           logPaths: [componentLogPath(stateDir, "observer")],
-        },
+        }),
         clock,
       },
       { includeLogs: true },
@@ -113,6 +115,7 @@ describe("operational debug bundle", () => {
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",

--- a/tests/diagnostics/debug-bundle/session-create-command.test.ts
+++ b/tests/diagnostics/debug-bundle/session-create-command.test.ts
@@ -1,11 +1,12 @@
 import { mkdir, mkdtemp, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
   createCommandQueue,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createObserverEventBus,
   createObserverLogger,
@@ -89,13 +90,14 @@ describe("session.create debug bundle diagnostics", () => {
         config,
         configPath: join(root, "config.toml"),
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
-        paths: {
+        evidenceSource: createLocalDiagnosticEvidenceSource({
           stateDir,
           diagnosticsDir,
           logPaths: [componentLogPath(stateDir, "observer")],
-        },
+        }),
         clock,
       },
       { includeLogs: true, commandId: receipt.commandId },
@@ -175,13 +177,14 @@ describe("session.create debug bundle diagnostics", () => {
         config,
         configPath: join(root, "config.toml"),
         core,
-        persistence,
+        commandJournal: persistence,
+        eventJournal: persistence,
         persistenceHealth: persistence,
-        paths: {
+        evidenceSource: createLocalDiagnosticEvidenceSource({
           stateDir,
           diagnosticsDir,
           logPaths: [componentLogPath(stateDir, "observer")],
-        },
+        }),
         clock,
       },
       { includeLogs: true, commandId: receipt.commandId },
@@ -207,6 +210,7 @@ describe("session.create debug bundle diagnostics", () => {
 function configFor(root: string, stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: { stateDir },
     defaults: {
       worktreeProvider: "fake-worktree",

--- a/tests/diagnostics/debug-bundle/worktrunk-dependency.test.ts
+++ b/tests/diagnostics/debug-bundle/worktrunk-dependency.test.ts
@@ -1,10 +1,11 @@
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
-import { writeDebugBundle } from "@station/observability";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
+import { componentLogPath, writeDebugBundle } from "@station/observability";
 import {
   collectDiagnosticSnapshot,
+  createLocalDiagnosticEvidenceSource,
   createObserverCore,
   createSqliteObserverPersistence,
   openObserverSqlite,
@@ -51,9 +52,14 @@ describe("Worktrunk dependency debug bundle diagnostics", () => {
       config,
       configPath: join(root, "config.toml"),
       core,
-      persistence,
+      commandJournal: persistence,
+      eventJournal: persistence,
       persistenceHealth: persistence,
-      paths: { stateDir, diagnosticsDir },
+      evidenceSource: createLocalDiagnosticEvidenceSource({
+        stateDir,
+        diagnosticsDir,
+        logPaths: [componentLogPath(stateDir, "observer")],
+      }),
       clock,
     });
     const manifest = await writeDebugBundle({
@@ -79,6 +85,7 @@ describe("Worktrunk dependency debug bundle diagnostics", () => {
 function stationConfig(stateDir: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: {
       stateDir,
     },

--- a/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-cleanup-scripted.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import {
   createCommandQueue,
   createObserverApi,
@@ -22,6 +22,7 @@ import {
   FakeWorktreeProvider,
 } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { FakeDiagnosticEvidenceSource } from "../../../apps/observer/test/support/diagnosticEvidenceSources.js";
 import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 import { createTempSocketPath } from "../../support/sockets";
 
@@ -43,12 +44,16 @@ describe("full session cleanup e2e", () => {
     const terminal = new FakeTerminalProvider({
       now,
       onLaunch: async ({ launchPlan }) => {
+        const sessionId = launchPlan.env?.STATION_SESSION_ID;
+        if (sessionId === undefined) {
+          throw new Error("Expected Station session identity in the launch plan.");
+        }
         harness.addRun(
           createFakeHarnessRun({
             id: "run_web_cleanup",
             projectId: "web",
             worktreeId: "wt_web_cleanup",
-            sessionId: launchPlan.env?.STATION_SESSION_ID,
+            sessionId,
             state: "working",
             now,
           }),
@@ -92,6 +97,7 @@ describe("full session cleanup e2e", () => {
       persistenceHealth: persistence,
       commandQueue: queue,
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       socketPath,
       stateDir,
@@ -154,6 +160,7 @@ describe("full session cleanup e2e", () => {
 function configFor(root: string, stateDir: string, socketPath: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: { stateDir, socketPath },
     defaults: {
       worktreeProvider: "fake-worktree",

--- a/tests/e2e/full-session-lifecycle/session-create-scripted.test.ts
+++ b/tests/e2e/full-session-lifecycle/session-create-scripted.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { ObserverEventHookInvocationSchema } from "@station/contracts";
 import {
   createCommandQueue,
@@ -20,6 +20,7 @@ import type { ExternalCommandInput } from "@station/runtime";
 import { ScriptedAgentHarnessProvider } from "@station/scripted-harness";
 import { FakeTerminalProvider, FakeWorktreeProvider } from "@station/testing";
 import { describe, expect, it } from "vitest";
+import { FakeDiagnosticEvidenceSource } from "../../../apps/observer/test/support/diagnosticEvidenceSources.js";
 import { createUnexpectedProjectConfigWriter } from "../../../apps/observer/test/support/projectConfigWriter.js";
 import { runScriptedAgentLaunchPlan } from "../../support/fake-agent";
 import { createTempSocketPath } from "../../support/sockets";
@@ -104,6 +105,7 @@ describe("full session lifecycle e2e", () => {
       persistenceHealth: persistence,
       commandQueue: queue,
       eventBus,
+      diagnosticEvidenceSource: new FakeDiagnosticEvidenceSource(),
       clock,
       socketPath,
       stateDir,
@@ -169,6 +171,7 @@ describe("full session lifecycle e2e", () => {
 function configFor(root: string, stateDir: string, socketPath: string): StationConfig {
   return {
     schemaVersion: 1,
+    workspace: DEFAULT_WORKSPACE_CONFIG,
     observer: { stateDir, socketPath },
     defaults: {
       worktreeProvider: "fake-worktree",

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -7,6 +7,8 @@
     "types": ["node", "vitest/globals"]
   },
   "files": [
+    "full-session-lifecycle/session-cleanup-scripted.test.ts",
+    "full-session-lifecycle/session-create-scripted.test.ts",
     "setup-guided-feedback.test.ts",
     "worktrunk-real.test.ts",
     "real/real-worktrunk-hooks.test.ts"


### PR DESCRIPTION
## What this fixes

Observer diagnostics combined three kinds of evidence with different ownership and failure semantics: authoritative command/event history, live persistence health, and incidental local runtime artifacts. The collector also read those local artifacts itself, which leaked filesystem layout into the diagnostic use case and API and made non-local substitution impractical.

## What changed

- Treats command history, event history, and persistence health as separate capabilities. They happen to share a SQLite implementation today, but they represent different contracts: queryable application history versus the storage engine's current operational state.
- Groups state usage, recent logs, and hook-spool metadata behind one private `DiagnosticEvidenceSource`. These are coherent as one port because they share the same local-runtime ownership, path configuration, untrusted-file parsing, redaction, and best-effort filesystem semantics.
- Adds the local filesystem adapter for that port, preserving existing retention, ordering, symlink, metadata-only spool, strict parsing, and redacted failure behavior.
- Keeps canonical paths at the composition boundary, where runtime configuration is resolved, rather than allowing the API or collector to infer local layout or fall back to the current working directory.
- Adds fake-source substitution, local-adapter integration, runtime path-capture, and architecture boundary coverage, then retires `OBS-HEX-012`.

The split is by evidence authority and lifecycle, not by diagnostic output section. It avoids a broad diagnostics repository that would couple application history, storage-engine internals, and machine-local files, while also avoiding one tiny port per file category.

## Testing

- `env -u STATION_PANE pnpm test:all`
- `pnpm lint`
- `pnpm exec tsc -p apps/observer/test/tsconfig.json --noEmit`
- `pnpm exec tsc -p tests/e2e/tsconfig.json --noEmit`
- Focused local evidence adapter suite: 9 tests passed
