### PR TITLE
refactor(terminal): isolate host PTY attach phases

### DIFF
--- a/station/src/terminal/pty/hostAttachedTerminal.test.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.test.ts
@@ -160,6 +160,67 @@ describe("createHostAttachedTerminal", () => {
     expect(ctrl.state.resizes).toEqual([{ cols: 100, rows: 30 }]);
   });
 
+  it("resends a resize that lands during initial geometry synchronization", async () => {
+    const initialResize = deferred<void>();
+    const initialResizeStarted = deferred<void>();
+    let blockInitialResize = true;
+    const ctrl = controllableAttachment(ack(), {
+      resize: async () => {
+        if (!blockInitialResize) {
+          return;
+        }
+        blockInitialResize = false;
+        initialResizeStarted.resolve(undefined);
+        await initialResize.promise;
+      },
+    });
+    const { terminal } = terminalFor(ctrl.attachment);
+
+    await initialResizeStarted.promise;
+    terminal.resize({ cols: 100, rows: 30 });
+    initialResize.resolve(undefined);
+    await flush();
+    await flush();
+
+    expect(ctrl.state.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 100, rows: 30 },
+    ]);
+    expect(terminal.ackedSize).toEqual({ cols: 100, rows: 30 });
+    terminal.dispose();
+  });
+
+  it("resends a resize that lands during the same-size repaint restore", async () => {
+    const restoreResize = deferred<void>();
+    const restoreResizeStarted = deferred<void>();
+    let resizeCalls = 0;
+    const ctrl = controllableAttachment(ack({ scrollback: ["history"] }), {
+      resize: async () => {
+        resizeCalls += 1;
+        if (resizeCalls === 3) {
+          restoreResizeStarted.resolve(undefined);
+          await restoreResize.promise;
+        }
+      },
+    });
+    const { terminal } = terminalFor(ctrl.attachment);
+
+    await restoreResizeStarted.promise;
+    terminal.resize({ cols: 100, rows: 30 });
+    restoreResize.resolve(undefined);
+    await flush();
+    await flush();
+
+    expect(ctrl.state.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 80, rows: 23 },
+      { cols: 80, rows: 24 },
+      { cols: 100, rows: 30 },
+    ]);
+    expect(terminal.ackedSize).toEqual({ cols: 100, rows: 30 });
+    terminal.dispose();
+  });
+
   it("surfaces an exit frame through onExit", async () => {
     const ctrl = controllableAttachment(ack());
     const { terminal } = terminalFor(ctrl.attachment);

--- a/station/src/terminal/pty/hostAttachedTerminal.test.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.test.ts
@@ -10,7 +10,23 @@ import { createHostAttachedTerminal, RECONNECT_REPAINT } from "./hostAttachedTer
 
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-function controllableAttachment(ack: HostAttachAck) {
+function deferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+type ControllableAttachmentBehavior = {
+  write?: (data: string) => Promise<void>;
+  resize?: (cols: number, rows: number) => Promise<void>;
+};
+
+function controllableAttachment(
+  ack: HostAttachAck,
+  behavior: ControllableAttachmentBehavior = {},
+) {
   const queue: HostFrame[] = [];
   const waiters: Array<(r: IteratorResult<HostFrame>) => void> = [];
   let ended = false;
@@ -45,9 +61,11 @@ function controllableAttachment(ack: HostAttachAck) {
     },
     write: async (data) => {
       writes.push(data);
+      await behavior.write?.(data);
     },
     resize: async (cols, rows) => {
       resizes.push({ cols, rows });
+      await behavior.resize?.(cols, rows);
     },
     detach: async () => {
       detached = true;
@@ -84,6 +102,24 @@ function ack(overrides: Partial<HostAttachAck> = {}): HostAttachAck {
   };
 }
 
+function clientForAttach(
+  attach: StationHostClient["attach"],
+  dispose: () => void = () => {},
+): StationHostClient {
+  return {
+    attach,
+    dispose,
+    health: async () => ({ ok: true, protocolVersion: 1 }),
+    stopIfIdle: async () => ({ stopping: true }),
+    spawn: async () => ({ ptyId: "pty-1", pid: 4242 }),
+    write: async () => undefined,
+    resize: async () => undefined,
+    list: async () => [],
+    focus: async () => undefined,
+    close: async () => ({ closed: true }),
+  };
+}
+
 function terminalFor(attachment: HostAttachment) {
   let clientDisposed = false;
   const terminal = createHostAttachedTerminal({
@@ -91,20 +127,9 @@ function terminalFor(attachment: HostAttachment) {
     ptyId: "pty-1",
     size: { cols: 80, rows: 24 },
     clientFactory: () =>
-      ({
-        attach: async () => attachment,
-        dispose: () => {
-          clientDisposed = true;
-        },
-        health: async () => ({ ok: true, protocolVersion: 1 }),
-        stopIfIdle: async () => ({ stopping: true }),
-        spawn: async () => ({ ptyId: "pty-1", pid: 4242 }),
-        write: async () => undefined,
-        resize: async () => undefined,
-        list: async () => [],
-        focus: async () => undefined,
-        close: async () => ({ closed: true }),
-      }) satisfies StationHostClient,
+      clientForAttach(async () => attachment, () => {
+        clientDisposed = true;
+      }),
   });
   return { terminal, clientDisposed: () => clientDisposed };
 }
@@ -152,6 +177,83 @@ describe("createHostAttachedTerminal", () => {
     await flush();
     terminal.dispose();
     expect(clientDisposed()).toBe(true);
+  });
+
+  it("stops before replay or activation when dispose races attach resolution", async () => {
+    const ctrl = controllableAttachment(ack({ scrollback: ["history"] }));
+    const pendingAttach = deferred<HostAttachment>();
+    let clientDisposed = false;
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () =>
+        clientForAttach(async () => pendingAttach.promise, () => {
+          clientDisposed = true;
+        }),
+    });
+    const received: string[] = [];
+    terminal.onData((data) => received.push(data));
+
+    terminal.dispose();
+    pendingAttach.resolve(ctrl.attachment);
+    await flush();
+
+    expect(clientDisposed).toBe(true);
+    expect(received).toEqual([]);
+    expect(ctrl.state.resizes).toEqual([]);
+    expect(ctrl.state.writes).toEqual([]);
+  });
+
+  it("stops activation when dispose lands during replay", async () => {
+    const replayGate = deferred<void>();
+    const ctrl = controllableAttachment(ack({ scrollback: ["history"] }));
+    const { terminal } = terminalFor(ctrl.attachment);
+    let replayStarted = false;
+    terminal.onReplay?.(async () => {
+      replayStarted = true;
+      await replayGate.promise;
+    });
+
+    await flush();
+    expect(replayStarted).toBe(true);
+    terminal.dispose();
+    replayGate.resolve(undefined);
+    await flush();
+
+    expect(ctrl.state.resizes).toEqual([]);
+    expect(ctrl.state.writes).toEqual([]);
+  });
+
+  it("treats an exited attach acknowledgement as terminal without retrying", async () => {
+    const ctrl = controllableAttachment(ack({ exited: true, scrollback: ["stale"] }));
+    let attachCalls = 0;
+    const sleeps: number[] = [];
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () =>
+        clientForAttach(async () => {
+          attachCalls += 1;
+          return ctrl.attachment;
+        }),
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+    const diagnostics: string[] = [];
+    const exits: number[] = [];
+    terminal.onDiagnostic((message) => diagnostics.push(message));
+    terminal.onExit((event) => exits.push(event.exitCode));
+
+    await flush();
+
+    expect(attachCalls).toBe(1);
+    expect(sleeps).toEqual([]);
+    expect(diagnostics).toEqual(["Station host PTY already exited."]);
+    expect(exits).toEqual([1]);
+    expect(ctrl.state.resizes).toEqual([]);
   });
 });
 
@@ -259,6 +361,195 @@ describe("createHostAttachedTerminal (Station-owned aux)", () => {
     terminal.kill();
     await flush();
     expect(tracking.closes).toEqual([]);
+  });
+
+  it("publishes only after buffered writes drain and catches a resize that arrives mid-drain", async () => {
+    const firstWrite = deferred<void>();
+    const ctrl = controllableAttachment(ack(), {
+      write: async (data) => {
+        if (data === "first") {
+          await firstWrite.promise;
+        }
+      },
+    });
+    const { terminal } = terminalFor(ctrl.attachment);
+
+    terminal.write("first");
+    await flush();
+    expect(ctrl.state.writes).toEqual(["first"]);
+
+    terminal.write("second");
+    terminal.resize({ cols: 100, rows: 30 });
+    firstWrite.resolve(undefined);
+    await flush();
+    await flush();
+
+    terminal.write("third");
+    await flush();
+
+    expect(ctrl.state.writes).toEqual(["first", "second", "third"]);
+    expect(ctrl.state.resizes).toEqual([
+      { cols: 80, rows: 24 },
+      { cols: 100, rows: 30 },
+    ]);
+    expect(terminal.ackedSize).toEqual({ cols: 100, rows: 30 });
+    terminal.dispose();
+  });
+
+  it("rejects a resize acknowledgement from an attachment after its stream drops", async () => {
+    const oldResize = deferred<void>();
+    const reconnectWait = deferred<void>();
+    const first = controllableAttachment(ack(), {
+      resize: async (cols, rows) => {
+        if (cols === 100 && rows === 30) {
+          await oldResize.promise;
+        }
+      },
+    });
+    const second = controllableAttachment(ack());
+    let clientCreations = 0;
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () => {
+        const selected = clientCreations === 0 ? first : second;
+        clientCreations += 1;
+        return clientForAttach(async () => selected.attachment);
+      },
+      sleep: async () => reconnectWait.promise,
+    });
+
+    await flush();
+    expect(terminal.ackedSize).toEqual({ cols: 80, rows: 24 });
+
+    terminal.resize({ cols: 100, rows: 30 });
+    await flush();
+    first.endStream();
+    await flush();
+    expect(terminal.ackedSize).toBeUndefined();
+
+    oldResize.resolve(undefined);
+    await flush();
+    expect(terminal.ackedSize).toBeUndefined();
+
+    reconnectWait.resolve(undefined);
+    await flush();
+    terminal.dispose();
+  });
+
+  it("retries the failed buffered-write head without duplicating successful writes", async () => {
+    const first = controllableAttachment(ack(), {
+      write: async (data) => {
+        if (data === "second") {
+          throw new Error("write transport dropped");
+        }
+      },
+    });
+    const second = controllableAttachment(ack());
+    let clientCreations = 0;
+    const sleeps: number[] = [];
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () => {
+        const selected = clientCreations === 0 ? first : second;
+        clientCreations += 1;
+        return clientForAttach(async () => selected.attachment);
+      },
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+    const exits: number[] = [];
+    terminal.onExit((event) => exits.push(event.exitCode));
+
+    terminal.write("first");
+    terminal.write("second");
+    terminal.write("third");
+    await flush();
+
+    expect(first.state.writes).toEqual(["first", "second"]);
+    expect(second.state.writes).toEqual(["second", "third"]);
+    expect(sleeps).toEqual([250]);
+    expect(exits).toEqual([]);
+    terminal.dispose();
+  });
+
+  it("uses reconnect repaint when activation fails after the initial replay", async () => {
+    const first = controllableAttachment(ack({ scrollback: ["history-"] }), {
+      resize: async () => {
+        throw new Error("resize transport dropped");
+      },
+    });
+    const second = controllableAttachment(ack({ scrollback: ["history-", "gap-"] }));
+    let clientCreations = 0;
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () => {
+        const selected = clientCreations === 0 ? first : second;
+        clientCreations += 1;
+        return clientForAttach(async () => selected.attachment);
+      },
+      sleep: async () => {},
+    });
+    const received: string[] = [];
+    terminal.onData((data) => received.push(data));
+
+    await flush();
+
+    expect(received).toEqual([
+      "history-",
+      RECONNECT_REPAINT,
+      "history-",
+      "gap-",
+    ]);
+    terminal.dispose();
+  });
+
+  it("exits once after exhausting the consecutive transient retry budget", async () => {
+    let clientCreations = 0;
+    let attachCalls = 0;
+    let clientDisposals = 0;
+    const sleeps: number[] = [];
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: "/tmp/x.sock",
+      ptyId: "pty-1",
+      size: { cols: 80, rows: 24 },
+      clientFactory: () => {
+        clientCreations += 1;
+        return clientForAttach(
+          async () => {
+            attachCalls += 1;
+            throw new Error("socket unavailable");
+          },
+          () => {
+            clientDisposals += 1;
+          },
+        );
+      },
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+    const diagnostics: string[] = [];
+    const exits: number[] = [];
+    terminal.onDiagnostic((message) => diagnostics.push(message));
+    terminal.onExit((event) => exits.push(event.exitCode));
+
+    await flush();
+
+    expect(attachCalls).toBe(6);
+    expect(clientCreations).toBe(6);
+    expect(clientDisposals).toBe(5);
+    expect(sleeps).toEqual([250, 500, 1_000, 2_000, 2_000]);
+    expect(diagnostics.filter((message) => message === "Station host reconnect failed.")).toHaveLength(
+      1,
+    );
+    expect(exits).toEqual([1]);
   });
 
   it("reconnects after a transient attach failure instead of killing the pane", async () => {
@@ -445,28 +736,21 @@ describe("createHostAttachedTerminal (Station-owned aux)", () => {
     let clock = 0;
     let attachCalls = 0;
     let current = controllableAttachment(ack());
+    const sleeps: number[] = [];
     const terminal = createHostAttachedTerminal({
       hostSocketPath: "/tmp/x.sock",
       ptyId: "pty-1",
       size: { cols: 80, rows: 24 },
       now: () => clock,
       clientFactory: () =>
-        ({
-          attach: async () => {
-            attachCalls += 1;
-            current = controllableAttachment(ack());
-            return current.attachment;
-          },
-          dispose: () => {},
-          health: async () => ({ ok: true, protocolVersion: 1 }),
-          stopIfIdle: async () => ({ stopping: true }),
-          spawn: async () => ({ ptyId: "pty-1", pid: 4242 }),
-          write: async () => undefined,
-          resize: async () => undefined,
-          list: async () => [],
-          focus: async () => undefined,
-          close: async () => ({ closed: true }),
-        }) satisfies StationHostClient,
+        clientForAttach(async () => {
+          attachCalls += 1;
+          current = controllableAttachment(ack());
+          return current.attachment;
+        }),
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
     });
     const exits: number[] = [];
     terminal.onExit((event) => exits.push(event.exitCode));
@@ -477,10 +761,13 @@ describe("createHostAttachedTerminal (Station-owned aux)", () => {
     for (let i = 0; i < 8; i += 1) {
       clock += 5_000;
       current.endStream();
-      await new Promise((resolve) => setTimeout(resolve, 300)); // past healthy backoff
+      await flush();
     }
     expect(exits).toEqual([]); // never killed despite > MAX_ATTACH_ATTEMPTS drops
-    expect(attachCalls).toBeGreaterThan(8); // it kept redialing each time
+    expect(attachCalls).toBe(9); // it kept redialing each time
+    // The fresh-budget reset computes its preserved 125 ms delay from attempt -1.
+    expect(sleeps).toEqual(Array.from({ length: 8 }, () => 125));
+    terminal.dispose();
   });
 
   for (const code of ["HOST_ATTACH_GONE", "HOST_VERSION_INCOMPATIBLE"] as const) {

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -44,6 +44,37 @@ export const RECONNECT_REPAINT = `${ControlByte.Csi}H${ControlByte.Csi}2J${Contr
 const reconnectDelayMs = (attempt: number): number =>
   Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** attempt);
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+const unreachableAttachmentState = (_value: never): never => {
+  throw new Error("Unexpected Station Host attachment state.");
+};
+
+type AttachmentFailure =
+  | { kind: "fatal"; message: string }
+  | { kind: "transient"; message: string };
+
+type AttachmentStreamOutcome =
+  | { kind: "disconnected" }
+  | { kind: "exited"; exit: StationTerminalExit };
+
+type AttachAttemptOutcome =
+  | { kind: "complete" }
+  | {
+      kind: "reconnect";
+      replayed: boolean;
+      connectedAt: number | undefined;
+    };
+
+type AttachmentPreparationState = { replayed: boolean };
+
+type ReconnectPreparationOutcome =
+  | { kind: "stop" }
+  | { kind: "exhausted" }
+  | { kind: "retry"; attempt: number };
+
+type AttachLoopStep =
+  | { kind: "complete" }
+  | { kind: "exhausted" }
+  | { kind: "retry"; attempt: number; replayed: boolean };
 
 export type HostAttachedTerminalOptions = {
   hostSocketPath: string;
@@ -65,6 +96,8 @@ export type HostAttachedTerminalOptions = {
   clientFactory?: (socketPath: string) => StationHostClient;
   /** Test seam for the reconnect-budget clock; production uses wall time. */
   now?: () => number;
+  /** Test seam for reconnect waits; production uses wall-clock timers. */
+  sleep?: (milliseconds: number) => Promise<void>;
 };
 
 /**
@@ -83,6 +116,7 @@ export function createHostAttachedTerminal(
         expectedBuildVersion: stationBuildInfo().version,
       }));
   const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? delay;
   // Reassigned on reconnect: the host client does not auto-reconnect, so a dropped
   // connection is replaced with a fresh one.
   let client = makeClient(options.hostSocketPath);
@@ -175,9 +209,10 @@ export function createHostAttachedTerminal(
     await Promise.all(
       [...replayListeners].map(async (listener) => {
         try {
-          await listener({ size: recordedSize, chunks });
+          return await listener({ size: recordedSize, chunks });
         } catch (error) {
           emitDiagnostic(toSafeError(error, HOST_DATA_PLANE_FALLBACK).message);
+          return;
         }
       }),
     );
@@ -205,137 +240,263 @@ export function createHostAttachedTerminal(
       });
   };
 
-  // Attach, replay scrollback once, then stream frames. A transient transport
-  // failure — or the stream ending with no exit frame — reconnects with backoff;
-  // only a genuinely-gone PTY (or exhausted retries) ends the pane.
-  const runAttachLoop = async (ptyId: string): Promise<void> => {
-    let replayed = false;
-    for (let attempt = 0; attempt < MAX_ATTACH_ATTEMPTS; attempt += 1) {
-      // Stamped once this attempt actually streams; a connection that outlives
-      // the backoff window earns a fresh retry budget below (see the reset).
-      let connectedAt: number | undefined;
-      try {
-        const opened = await client.attach(ptyId);
-        if (disposed) {
-          // dispose() already closed the client connection; the host detaches via
-          // socket-close. No explicit detach (it would race the closed connection).
-          return;
-        }
-        pid = opened.ack.pid;
-        // Defensive: the host deletes exited entries, so attach normally throws
-        // HOST_ATTACH_GONE rather than acking exited. Don't fabricate a clean exit
-        // and don't retry.
-        if (opened.ack.exited) {
-          emitDiagnostic("Station host PTY already exited.");
-          emitExit({ exitCode: 1 });
-          return;
-        }
-        // First successful attach: replay the snapshot into the fresh client VT.
-        // On a RECONNECT the ack snapshot is the current ring — it captured output
-        // produced while we were detached — so repaint from it (clearing first so
-        // the already-shown history isn't duplicated) rather than dropping the gap.
-        const isReconnect = replayed;
-        const recordedSize = { cols: opened.ack.cols, rows: opened.ack.rows };
-        if (!replayed) {
-          await emitReplay(opened.ack.scrollback, recordedSize);
-          replayed = true;
-        } else if (opened.ack.scrollback.length > 0) {
-          await emitReplay([RECONNECT_REPAINT, ...opened.ack.scrollback], recordedSize);
-        }
-        // else: reconnect with an empty ring — clearing would just blank the pane
-        // with nothing to replay, so leave the shown frame and rely on the nudge.
-        // Sync the host PTY to THIS client's pane size on (re)attach — the host may
-        // have spawned it at a different size — then flush input typed before attach
-        // resolved. Expose `attachment` only AFTER the flush so later writes order
-        // after the buffered ones.
-        await opened.resize(size.cols, size.rows);
-        // A same-size resize is a no-op TIOCSWINSZ — no SIGWINCH — so a child
-        // whose frame may be stale would never repaint; flap the rows to force
-        // one. Needed whenever there was history to reflow OR this is a reconnect
-        // (the child may have produced state while we were detached). A real size
-        // change above already delivers the signal.
-        if (
-          (isReconnect || opened.ack.scrollback.length > 0) &&
-          opened.ack.cols === size.cols &&
-          opened.ack.rows === size.rows
-        ) {
-          await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
-          await opened.resize(size.cols, size.rows);
-        }
-        // The size the host was just driven to; a resize arriving during the
-        // write drain below only updates `size` (resize() no-ops while detached).
-        const attachSentSize: StationTerminalSize = { cols: size.cols, rows: size.rows };
-        // Drain front-to-back so a mid-flush failure leaves only the un-sent
-        // writes to retry (no double-send on reconnect). New writes keep arriving
-        // at the back while attachment is still undefined, preserving order.
-        while (pendingWrites.length > 0) {
-          const data = pendingWrites[0];
-          if (data === undefined) {
-            break;
-          }
-          await opened.write(data);
-          pendingWrites.shift();
-        }
-        attachment = opened;
-        if (size.cols !== attachSentSize.cols || size.rows !== attachSentSize.rows) {
-          // A resize arrived during attach; resize() no-op'd then, so send it now.
-          applyHostResize(size);
-        } else {
-          // Host is at the size we just drove it to; record it as confirmed.
-          ackedSize = attachSentSize;
-        }
-        connectedAt = now();
-        for await (const frame of opened.frames) {
-          if (frame.type === "data") {
-            emitData(frame.data);
-          } else if (frame.type === "exit") {
-            emitExit({
+  // First attachment replays the initial snapshot; reconnects clear and repaint
+  // only when the fresh ring contains history that can replace the shown frame.
+  const replayAttachmentSnapshot = async (
+    opened: HostAttachment,
+    isReconnect: boolean,
+  ): Promise<void> => {
+    const recordedSize = { cols: opened.ack.cols, rows: opened.ack.rows };
+    if (!isReconnect) {
+      await emitReplay(opened.ack.scrollback, recordedSize);
+      return;
+    }
+    if (opened.ack.scrollback.length > 0) {
+      await emitReplay([RECONNECT_REPAINT, ...opened.ack.scrollback], recordedSize);
+    }
+    // An empty reconnect ring must not clear the pane with nothing to replace it;
+    // the geometry nudge below asks the child to repaint instead.
+  };
+
+  const synchronizeAttachmentGeometry = async (
+    opened: HostAttachment,
+    isReconnect: boolean,
+  ): Promise<StationTerminalSize> => {
+    await opened.resize(size.cols, size.rows);
+    if (disposed) {
+      return { cols: size.cols, rows: size.rows };
+    }
+    // A same-size TIOCSWINSZ emits no SIGWINCH, so stale same-size frames need a
+    // temporary row change whenever replay or reconnect requires a child repaint.
+    if (
+      (isReconnect || opened.ack.scrollback.length > 0) &&
+      opened.ack.cols === size.cols &&
+      opened.ack.rows === size.rows
+    ) {
+      await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
+      await opened.resize(size.cols, size.rows);
+    }
+    // A resize arriving during the write drain only updates `size` because the
+    // attachment remains unpublished until every buffered write has been sent.
+    return { cols: size.cols, rows: size.rows };
+  };
+
+  const drainPendingWrites = async (opened: HostAttachment): Promise<void> => {
+    // Shift only after a successful write so reconnect retries the failed head
+    // without duplicating writes that the prior attachment already accepted.
+    while (!disposed && pendingWrites.length > 0) {
+      const data = pendingWrites[0];
+      if (data === undefined) {
+        break;
+      }
+      await opened.write(data);
+      pendingWrites.shift();
+    }
+  };
+
+  const publishPreparedAttachment = (
+    opened: HostAttachment,
+    attachSentSize: StationTerminalSize,
+  ): void => {
+    // Publishing after the drain keeps later writes behind every buffered write.
+    attachment = opened;
+    if (size.cols !== attachSentSize.cols || size.rows !== attachSentSize.rows) {
+      // A resize arrived during attach; resize() no-op'd then, so send it now.
+      applyHostResize(size);
+      return;
+    }
+    // Host is at the size we just drove it to; record it as confirmed.
+    ackedSize = attachSentSize;
+  };
+
+  const consumeAttachmentFrames = async (
+    opened: HostAttachment,
+  ): Promise<AttachmentStreamOutcome> => {
+    for await (const frame of opened.frames) {
+      switch (frame.type) {
+        case "data":
+          emitData(frame.data);
+          break;
+        case "exit":
+          return {
+            kind: "exited",
+            exit: {
               exitCode: frame.exitCode ?? 0,
               ...(frame.signal === undefined || frame.signal === null
                 ? {}
                 : { signal: frame.signal }),
-            });
-            return;
-          }
-          // a "focus" frame is best-effort and has no terminal-output meaning here
-        }
-        // Stream ended with no exit frame: the host dropped our connection while
-        // the PTY may still be alive. Fall through to reconnect.
-      } catch (error) {
-        if (disposed) {
-          return;
-        }
-        const compatibilityFailure = isStationHostCompatibilityError(error);
-        const safe = toSafeError(error, HOST_DATA_PLANE_FALLBACK);
-        if (PTY_GONE_CODES.has(safe.code) || compatibilityFailure) {
-          emitDiagnostic(safe.message);
-          emitExit({ exitCode: 1 });
-          return;
-        }
-        emitDiagnostic(safe.message);
+            },
+          };
+        case "focus":
+          // Focus is best-effort host metadata with no terminal-output meaning.
+          break;
+        default:
+          return unreachableAttachmentState(frame);
       }
-      // Transient: clear attachment so write() re-buffers, then drop the dead
-      // client and dial a fresh one before the next attempt. Clear ackedSize so
-      // a geometry check during the reconnect window does not read a stale ack.
-      attachment = undefined;
-      ackedSize = undefined;
-      if (disposed || closeRequested) {
+    }
+    // No exit frame means the transport vanished while the host PTY may live.
+    return { kind: "disconnected" };
+  };
+
+  const classifyAttachmentFailure = (error: unknown): AttachmentFailure => {
+    const compatibilityFailure = isStationHostCompatibilityError(error);
+    const safe = toSafeError(error, HOST_DATA_PLANE_FALLBACK);
+    if (PTY_GONE_CODES.has(safe.code) || compatibilityFailure) {
+      return { kind: "fatal", message: safe.message };
+    }
+    return { kind: "transient", message: safe.message };
+  };
+
+  const acceptAttachedPty = (opened: HostAttachment): boolean => {
+    if (disposed) {
+      // dispose() closed the client; an explicit detach would race socket-close.
+      return false;
+    }
+    pid = opened.ack.pid;
+    // The host normally rejects exited entries as HOST_ATTACH_GONE; an exited
+    // acknowledgement is defensive terminal evidence and must not be retried.
+    if (opened.ack.exited) {
+      emitDiagnostic("Station host PTY already exited.");
+      emitExit({ exitCode: 1 });
+      return false;
+    }
+    return true;
+  };
+
+  const prepareAttachmentForStreaming = async (
+    opened: HostAttachment,
+    state: AttachmentPreparationState,
+  ): Promise<boolean> => {
+    const isReconnect = state.replayed;
+    await replayAttachmentSnapshot(opened, isReconnect);
+    if (disposed) {
+      return false;
+    }
+    // Failures after replay must clear before replaying the next ring snapshot.
+    state.replayed = true;
+    const attachSentSize = await synchronizeAttachmentGeometry(opened, isReconnect);
+    if (disposed) {
+      return false;
+    }
+    await drainPendingWrites(opened);
+    if (disposed) {
+      return false;
+    }
+    publishPreparedAttachment(opened, attachSentSize);
+    return true;
+  };
+
+  const resolveAttachFailure = (
+    error: unknown,
+    state: AttachmentPreparationState,
+    connectedAt: number | undefined,
+  ): AttachAttemptOutcome => {
+    if (disposed) {
+      return { kind: "complete" };
+    }
+    const failure = classifyAttachmentFailure(error);
+    emitDiagnostic(failure.message);
+    if (failure.kind === "fatal") {
+      emitExit({ exitCode: 1 });
+      return { kind: "complete" };
+    }
+    return { kind: "reconnect", replayed: state.replayed, connectedAt };
+  };
+
+  const runAttachAttempt = async (
+    ptyId: string,
+    hadReplayed: boolean,
+  ): Promise<AttachAttemptOutcome> => {
+    const state: AttachmentPreparationState = { replayed: hadReplayed };
+    // Stamped only after this attempt is ready to stream so setup failures do not
+    // earn the healthy-connection retry reset.
+    let connectedAt: number | undefined;
+    try {
+      const opened = await client.attach(ptyId);
+      if (!acceptAttachedPty(opened)) {
+        return { kind: "complete" };
+      }
+      if (!(await prepareAttachmentForStreaming(opened, state))) {
+        return { kind: "complete" };
+      }
+      connectedAt = now();
+      const stream = await consumeAttachmentFrames(opened);
+      if (stream.kind === "exited") {
+        emitExit(stream.exit);
+        return { kind: "complete" };
+      }
+    } catch (error) {
+      return resolveAttachFailure(error, state, connectedAt);
+    }
+    return { kind: "reconnect", replayed: state.replayed, connectedAt };
+  };
+
+  const prepareReconnect = async (
+    attempt: number,
+    connectedAt: number | undefined,
+  ): Promise<ReconnectPreparationOutcome> => {
+    // Invalidate pending resize acknowledgements from the detached generation
+    // before clearing its published write path and confirmed geometry.
+    resizeSeq += 1;
+    attachment = undefined;
+    ackedSize = undefined;
+    if (disposed || closeRequested) {
+      return { kind: "stop" };
+    }
+
+    let backoffAttempt = attempt;
+    // A long-lived pane reconnects indefinitely, while a tight accept/drop flap
+    // still exhausts the bounded budget instead of spinning forever.
+    if (connectedAt !== undefined && now() - connectedAt > RECONNECT_MAX_MS) {
+      backoffAttempt = -1;
+    }
+    if (backoffAttempt >= MAX_ATTACH_ATTEMPTS - 1) {
+      return { kind: "exhausted" };
+    }
+
+    client.dispose();
+    client = makeClient(options.hostSocketPath);
+    emitDiagnostic("Station host connection lost; reconnecting…");
+    await sleep(reconnectDelayMs(backoffAttempt));
+    return { kind: "retry", attempt: backoffAttempt };
+  };
+
+  const advanceAttachLoop = async (
+    ptyId: string,
+    replayed: boolean,
+    attempt: number,
+  ): Promise<AttachLoopStep> => {
+    const outcome = await runAttachAttempt(ptyId, replayed);
+    if (outcome.kind === "complete") {
+      return { kind: "complete" };
+    }
+    const reconnect = await prepareReconnect(attempt, outcome.connectedAt);
+    switch (reconnect.kind) {
+      case "stop":
+        return { kind: "complete" };
+      case "exhausted":
+        return reconnect;
+      case "retry":
+        return { kind: "retry", attempt: reconnect.attempt, replayed: outcome.replayed };
+      default:
+        return unreachableAttachmentState(reconnect);
+    }
+  };
+
+  // Retry only transient transport loss; permanent host evidence or exhaustion
+  // ends the pane, while a healthy connection earns a fresh consecutive budget.
+  const runAttachLoop = async (ptyId: string): Promise<void> => {
+    let replayed = false;
+    for (let attempt = 0; attempt < MAX_ATTACH_ATTEMPTS; attempt += 1) {
+      const step = await advanceAttachLoop(ptyId, replayed, attempt);
+      if (step.kind === "complete") {
         return;
       }
-      // Flap-safe budget reset: a connection that outlived the max backoff window
-      // was healthy, so a later drop earns a FRESH retry budget — a long-lived
-      // pane reconnects indefinitely across host restarts. A tight accept-then-
-      // drop flap (shorter than the window) does NOT reset, so it still exhausts
-      // the budget and ends the pane rather than spinning forever.
-      if (connectedAt !== undefined && now() - connectedAt > RECONNECT_MAX_MS) {
-        attempt = -1;
+      if (step.kind === "exhausted") {
+        break;
       }
-      if (attempt < MAX_ATTACH_ATTEMPTS - 1) {
-        client.dispose();
-        client = makeClient(options.hostSocketPath);
-        emitDiagnostic("Station host connection lost; reconnecting…");
-        await delay(reconnectDelayMs(attempt));
-      }
+      replayed = step.replayed;
+      attempt = step.attempt;
     }
     emitDiagnostic("Station host reconnect failed.");
     emitExit({ exitCode: 1 });

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -262,23 +262,37 @@ export function createHostAttachedTerminal(
     opened: HostAttachment,
     isReconnect: boolean,
   ): Promise<StationTerminalSize> => {
-    await opened.resize(size.cols, size.rows);
+    // Snapshot each target before awaiting so the returned acknowledgement always
+    // describes geometry the host actually applied, not a newer pane assertion.
+    const attachTarget = { cols: size.cols, rows: size.rows };
+    await opened.resize(attachTarget.cols, attachTarget.rows);
     if (disposed) {
-      return { cols: size.cols, rows: size.rows };
+      return attachTarget;
     }
     // A same-size TIOCSWINSZ emits no SIGWINCH, so stale same-size frames need a
     // temporary row change whenever replay or reconnect requires a child repaint.
+    const sizeUnchanged = size.cols === attachTarget.cols && size.rows === attachTarget.rows;
     if (
+      sizeUnchanged &&
       (isReconnect || opened.ack.scrollback.length > 0) &&
-      opened.ack.cols === size.cols &&
-      opened.ack.rows === size.rows
+      opened.ack.cols === attachTarget.cols &&
+      opened.ack.rows === attachTarget.rows
     ) {
-      await opened.resize(size.cols, size.rows > 1 ? size.rows - 1 : size.rows + 1);
-      await opened.resize(size.cols, size.rows);
+      const nudgeTarget = {
+        cols: attachTarget.cols,
+        rows: attachTarget.rows > 1 ? attachTarget.rows - 1 : attachTarget.rows + 1,
+      };
+      await opened.resize(nudgeTarget.cols, nudgeTarget.rows);
+      if (disposed) {
+        return nudgeTarget;
+      }
+      const restoreTarget = { cols: size.cols, rows: size.rows };
+      await opened.resize(restoreTarget.cols, restoreTarget.rows);
+      return restoreTarget;
     }
-    // A resize arriving during the write drain only updates `size` because the
-    // attachment remains unpublished until every buffered write has been sent.
-    return { cols: size.cols, rows: size.rows };
+    // Publication compares this exact sent size with the latest pane assertion,
+    // catching changes during geometry synchronization or the buffered-write drain.
+    return attachTarget;
   };
 
   const drainPendingWrites = async (opened: HostAttachment): Promise<void> => {


### PR DESCRIPTION
## What this fixes

The Station Host attachment loop coordinated replay, geometry synchronization, buffered input, live frames, disposal, and reconnect policy in one complexity-66 function. That made ordering-sensitive terminal behavior difficult to review and exposed lifecycle races: a detached attachment could publish a late resize acknowledgement, disposal during replay could continue activation work, and a pane resize arriving during an in-flight activation resize could be reported as acknowledged even though the Host had applied only the older geometry.

## What changed

- Split attachment work into explicit replay, geometry, buffered-write, publication, frame-consumption, failure-classification, attempt, and reconnect phases.
- Preserve the existing retry budget, backoff sequence, replay bytes, same-size repaint nudge, detach-not-kill behavior, and spawn-once boundary.
- Invalidate resize acknowledgements when their attachment generation disconnects.
- Track the exact geometry applied by each activation resize and resend the latest pane geometry when it changes during synchronization or repaint restoration.
- Stop replay, geometry, and write activation when pane disposal wins the race.
- Add deterministic coverage for retry exhaustion, healthy-budget reset timing, partial write retries, writes and resizes during activation, post-replay failure, exited acknowledgements, and disposal races.

## Testing

- `pnpm test:all`
- `pnpm build`
- `cd station && bun run typecheck`
- `cd station && bun run test` (1,062 tests)
- `cd station && bun run test:pty` (41 tests)
- `cd station && bun run test:pty:bun` (32 tests)
- Focused host attachment, replay sizing, and geometry diagnostics tests (35 tests)
- Cognitive-complexity scan at threshold 8: `runAttachLoop` and `runAttachAttempt` no longer report

## Safety and scope

No Station Host protocol, Observer boundary, config, retry count, replay format, PTY ownership, or spawn behavior changes. The intended UX remains silent warm reattachment with ordered input, correct scrollback, and current geometry; a resize that overlaps activation now converges without requiring another manual resize.
