### PR TITLE
fix(hooks): require explicit takeover of shared artifacts

### DIFF
--- a/apps/cli/src/cliTypes.ts
+++ b/apps/cli/src/cliTypes.ts
@@ -1,3 +1,4 @@
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import type { NotifyCommandDeps } from "./commands/notify.js";
 import type { ObserveCommandDeps } from "./commands/observe/index.js";
 import type { PopupCommandDeps } from "./commands/popup.js";
@@ -22,4 +23,5 @@ export type CliRunOptions = {
   observeDeps?: ObserveCommandDeps;
   setupDeps?: SetupCommandDeps;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
 };

--- a/apps/cli/src/commands/cliCommand/helpers.ts
+++ b/apps/cli/src/commands/cliCommand/helpers.ts
@@ -50,7 +50,3 @@ export function hookCommandExitCode(result: object): number {
 export function actionNeedsYes(action: string): boolean {
   return action === "install" || action === "uninstall";
 }
-
-export function capitalize(value: string): string {
-  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
-}

--- a/apps/cli/src/commands/cliCommand/helpers.ts
+++ b/apps/cli/src/commands/cliCommand/helpers.ts
@@ -1,11 +1,12 @@
 import type { StationConfig } from "@station/config";
-import type { SafeError } from "@station/contracts";
+import type { ProviderHookArtifactOwner, SafeError } from "@station/contracts";
 import type { CliCommandRunContext } from "./types.js";
 
 export type LoadedCommandOptions = {
   config?: StationConfig;
   configPath?: string;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
 };
 
 type LoadedConfigCommandOptions = LoadedCommandOptions & {
@@ -22,6 +23,9 @@ export function loadedCommandOptions(context: CliCommandRunContext): LoadedComma
   }
   if (context.options.providerHookIngressLauncher !== undefined) {
     options.providerHookIngressLauncher = context.options.providerHookIngressLauncher;
+  }
+  if (context.options.providerHookArtifactOwner !== undefined) {
+    options.providerHookArtifactOwner = context.options.providerHookArtifactOwner;
   }
   return options;
 }

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,6 +1,11 @@
 import { stat } from "node:fs/promises";
 import type { StationConfig } from "@station/config";
-import type { DoctorCheck, DoctorOptions, DoctorReport } from "@station/contracts";
+import type {
+  DoctorCheck,
+  DoctorOptions,
+  DoctorReport,
+  ProviderHookArtifactOwner,
+} from "@station/contracts";
 import { DoctorOptionsSchema } from "@station/contracts";
 import { createObserverClient } from "@station/protocol";
 import {
@@ -26,6 +31,7 @@ export type DoctorCommandOptions = {
   config?: StationConfig;
   configPath?: string;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
   timeoutMs?: number;
 };
 
@@ -43,6 +49,9 @@ export async function runDoctorCommand(
   const hookRuntimeOptions: ProviderHookRuntimeOptions = {};
   if (options.providerHookIngressLauncher !== undefined) {
     hookRuntimeOptions.ingressLauncher = options.providerHookIngressLauncher;
+  }
+  if (options.providerHookArtifactOwner !== undefined) {
+    hookRuntimeOptions.artifactOwner = options.providerHookArtifactOwner;
   }
   if (options.configPath !== undefined) {
     hookRuntimeOptions.stationConfigPath = options.configPath;

--- a/apps/cli/src/commands/providerHookAdapters.ts
+++ b/apps/cli/src/commands/providerHookAdapters.ts
@@ -250,6 +250,7 @@ export function runWorktrunkHooksCommand(
         const expectation = createWorktrunkHookExpectation(config, {
           stationConfigPath: context.configPath,
           ingressLauncher: context.providerHookIngressLauncher,
+          artifactOwner: context.providerHookArtifactOwner,
         });
         if (flags.hookBin !== undefined) {
           expectation.hookBin = flags.hookBin;

--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -102,7 +102,7 @@ export function parseHookFlags(
       continue;
     }
     if (arg !== undefined) {
-      throw new Error(`Unknown ${capitalize(provider)} hook option: ${arg}`);
+      throw new Error(`Unknown ${provider} hook option: ${arg}`);
     }
   }
 
@@ -139,7 +139,7 @@ export function assertHookConfirmed(
   action: "install" | "uninstall",
 ): void {
   if (!yes) {
-    throw new Error(`Refusing to ${action} ${capitalize(provider)} hooks without --yes.`);
+    throw new Error(`Refusing to ${action} ${provider} hooks without --yes.`);
   }
 }
 
@@ -204,8 +204,4 @@ async function resolveHookBinOwnership(
       launcher: flags.hookBin,
     },
   };
-}
-
-export function capitalize(value: string): string {
-  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }

--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -1,7 +1,11 @@
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { resolveObserverPaths, type StationConfig } from "@station/config";
-import type { ProviderHookArtifactOwner } from "@station/contracts";
-import { resolveExecutablePath } from "@station/runtime";
+import type { ProviderHookArtifactOwner, ProviderId, SafeError } from "@station/contracts";
+import {
+  ProviderHookArtifactOwnershipError,
+  resolveExecutablePath,
+  shellQuote,
+} from "@station/runtime";
 import type { CliEnv } from "../env.js";
 
 type CommonHookOptions = {
@@ -18,7 +22,7 @@ type CommonHookOptions = {
 };
 
 type ProviderHooksAdapter<PlanOptions extends CommonHookOptions> = {
-  provider: string;
+  provider: ProviderId;
   plan: (options: PlanOptions) => Promise<unknown>;
   install: (options: PlanOptions) => Promise<unknown>;
   uninstall: (options: PlanOptions) => Promise<unknown>;
@@ -66,7 +70,7 @@ export type ProviderHooksCommandResult = unknown;
 
 export function parseHookFlags(
   args: string[],
-  provider: string,
+  provider: ProviderId,
   spec: ProviderHookFlagSpec,
 ): ParsedHookFlags {
   const flags: ParsedHookFlags = { yes: false, takeover: false };
@@ -135,7 +139,7 @@ export function buildCommonHookOptions(context: HookCommandContext): CommonHookO
 
 export function assertHookConfirmed(
   yes: boolean,
-  provider: string,
+  provider: ProviderId,
   action: "install" | "uninstall",
 ): void {
   if (!yes) {
@@ -157,22 +161,29 @@ export function createProviderHooksRunner<PlanOptions extends CommonHookOptions>
     const hookOptions = adapter.buildOptions(flags, context);
     if (flags.takeover) hookOptions.takeover = true;
 
-    if (action === "plan") {
-      return adapter.plan(hookOptions);
-    }
-    if (action === "install") {
-      assertHookConfirmed(flags.yes, adapter.provider, "install");
-      return adapter.install(hookOptions);
-    }
-    if (action === "uninstall") {
-      assertHookConfirmed(flags.yes, adapter.provider, "uninstall");
-      return adapter.uninstall(hookOptions);
-    }
-    if (action === "doctor") {
-      return adapter.doctor({
-        ...hookOptions,
-        enabled: adapter.isEnabled(options.config),
-      });
+    try {
+      if (action === "plan") {
+        return await adapter.plan(hookOptions);
+      }
+      if (action === "install") {
+        assertHookConfirmed(flags.yes, adapter.provider, "install");
+        return await adapter.install(hookOptions);
+      }
+      if (action === "uninstall") {
+        assertHookConfirmed(flags.yes, adapter.provider, "uninstall");
+        return await adapter.uninstall(hookOptions);
+      }
+      if (action === "doctor") {
+        return await adapter.doctor({
+          ...hookOptions,
+          enabled: adapter.isEnabled(options.config),
+        });
+      }
+    } catch (error) {
+      if (error instanceof ProviderHookArtifactOwnershipError) {
+        throw providerHookOwnershipSafeError(error);
+      }
+      throw error;
     }
 
     throw new Error(
@@ -184,7 +195,7 @@ export function createProviderHooksRunner<PlanOptions extends CommonHookOptions>
 async function resolveHookBinOwnership(
   flags: ParsedHookFlags,
   context: ProviderHooksCommandOptions,
-  provider: string,
+  provider: ProviderId,
 ): Promise<ProviderHooksCommandOptions> {
   if (flags.hookBin === undefined || context.providerHookArtifactOwner === undefined) {
     return context;
@@ -203,5 +214,26 @@ async function resolveHookBinOwnership(
       ...context.providerHookArtifactOwner,
       launcher: flags.hookBin,
     },
+  };
+}
+
+function providerHookOwnershipSafeError(error: ProviderHookArtifactOwnershipError): SafeError {
+  const requested = error.ownership.requested;
+  const requestedOwner = `${requested.runtimeKind} ${requested.version} build ${requested.buildIdentity} via ${JSON.stringify(requested.launcher)}`;
+  let currentOwner = "unknown because the existing ownership marker is missing or invalid";
+  let reason = "has no valid Station ownership marker";
+  let repair = "";
+  if (error.ownership.status === "different-owner") {
+    const current = error.ownership.current;
+    currentOwner = `${current.runtimeKind} ${current.version} build ${current.buildIdentity} via ${JSON.stringify(current.launcher)}`;
+    reason = "is owned by another Station runtime";
+    repair = ` To perform this action as the current owner, run ${shellQuote(resolve(dirname(current.launcher), "stn"))} hooks ${error.action} ${error.provider} --yes.`;
+  }
+  return {
+    tag: error.tag,
+    code: error.code,
+    provider: error.provider,
+    message: `Refusing to ${error.action} ${error.provider} hooks because ${JSON.stringify(error.artifactPath)} ${reason}. Current owner: ${currentOwner}. Requested owner: ${requestedOwner}.`,
+    hint: `Run stn hooks ${error.action} ${error.provider} --yes --takeover only to transfer ownership.${repair}`,
   };
 }

--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -1,4 +1,5 @@
 import { resolveObserverPaths, type StationConfig } from "@station/config";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import type { CliEnv } from "../env.js";
 
 type CommonHookOptions = {
@@ -10,6 +11,8 @@ type CommonHookOptions = {
   env?: CliEnv;
   hookBin?: string;
   hookScriptPath?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
 };
 
 type ProviderHooksAdapter<PlanOptions extends CommonHookOptions> = {
@@ -29,10 +32,12 @@ type HookCommandContext = {
   configPath?: string;
   env?: CliEnv;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
 };
 
 type ParsedHookFlags = {
   yes: boolean;
+  takeover: boolean;
   providerConfig?: string;
   hookScriptPath?: string;
   hookBin?: string;
@@ -52,6 +57,7 @@ export type ProviderHooksCommandOptions = {
   configPath?: string;
   env?: CliEnv;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
 };
 
 export type ProviderHooksCommandResult = unknown;
@@ -61,12 +67,16 @@ export function parseHookFlags(
   provider: string,
   spec: ProviderHookFlagSpec,
 ): ParsedHookFlags {
-  const flags: ParsedHookFlags = { yes: false };
+  const flags: ParsedHookFlags = { yes: false, takeover: false };
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--yes" || arg === "-y") {
       flags.yes = true;
+      continue;
+    }
+    if (arg === "--takeover") {
+      flags.takeover = true;
       continue;
     }
     const value = args[index + 1];
@@ -115,6 +125,9 @@ export function buildCommonHookOptions(context: HookCommandContext): CommonHookO
   if (context.providerHookIngressLauncher !== undefined) {
     options.hookBin = context.providerHookIngressLauncher;
   }
+  if (context.providerHookArtifactOwner !== undefined) {
+    options.artifactOwner = context.providerHookArtifactOwner;
+  }
   return options;
 }
 
@@ -139,6 +152,7 @@ export function createProviderHooksRunner<PlanOptions extends CommonHookOptions>
     const [action] = args;
     const flags = parseHookFlags(args.slice(1), adapter.provider, flagSpec);
     const hookOptions = adapter.buildOptions(flags, options);
+    if (flags.takeover) hookOptions.takeover = true;
 
     if (action === "plan") {
       return adapter.plan(hookOptions);

--- a/apps/cli/src/commands/providerHooks.ts
+++ b/apps/cli/src/commands/providerHooks.ts
@@ -1,5 +1,7 @@
+import { resolve } from "node:path";
 import { resolveObserverPaths, type StationConfig } from "@station/config";
 import type { ProviderHookArtifactOwner } from "@station/contracts";
+import { resolveExecutablePath } from "@station/runtime";
 import type { CliEnv } from "../env.js";
 
 type CommonHookOptions = {
@@ -151,7 +153,8 @@ export function createProviderHooksRunner<PlanOptions extends CommonHookOptions>
   ): Promise<ProviderHooksCommandResult> {
     const [action] = args;
     const flags = parseHookFlags(args.slice(1), adapter.provider, flagSpec);
-    const hookOptions = adapter.buildOptions(flags, options);
+    const context = await resolveHookBinOwnership(flags, options, adapter.provider);
+    const hookOptions = adapter.buildOptions(flags, context);
     if (flags.takeover) hookOptions.takeover = true;
 
     if (action === "plan") {
@@ -175,6 +178,31 @@ export function createProviderHooksRunner<PlanOptions extends CommonHookOptions>
     throw new Error(
       `Usage: station hooks plan|install|uninstall|doctor ${adapter.provider} [--yes]`,
     );
+  };
+}
+
+async function resolveHookBinOwnership(
+  flags: ParsedHookFlags,
+  context: ProviderHooksCommandOptions,
+  provider: string,
+): Promise<ProviderHooksCommandOptions> {
+  if (flags.hookBin === undefined || context.providerHookArtifactOwner === undefined) {
+    return context;
+  }
+  const resolveOptions = context.env?.PATH === undefined ? {} : { pathEnv: context.env.PATH };
+  const launcher = await resolveExecutablePath(flags.hookBin, resolveOptions);
+  if (launcher === undefined) {
+    throw new Error(
+      `Refusing ${provider} --hook-bin ${flags.hookBin}: the executable could not be resolved.`,
+    );
+  }
+  flags.hookBin = resolve(launcher);
+  return {
+    ...context,
+    providerHookArtifactOwner: {
+      ...context.providerHookArtifactOwner,
+      launcher: flags.hookBin,
+    },
   };
 }
 

--- a/apps/cli/src/commands/registry/hooks.ts
+++ b/apps/cli/src/commands/registry/hooks.ts
@@ -33,6 +33,10 @@ export const hooksCliCommand: CliCommandNode = {
     { name: "<target>", description: `One of: ${hookTargets.join(", ")}.` },
     { name: "--yes, -y", description: "Confirm install or uninstall actions." },
     {
+      name: "--takeover",
+      description: "Transfer a shared hook artifact from another Station runtime.",
+    },
+    {
       name: "--hook-bin <command>",
       description: "Use a specific stn-ingress command for generated hooks.",
     },
@@ -117,6 +121,10 @@ function hookActionCommand(action: (typeof hookActions)[number]): CliCommandNode
     options: [
       { name: "<target>", description: `One of: ${hookTargets.join(", ")}.` },
       { name: "--yes, -y", description: "Required for install and uninstall actions." },
+      {
+        name: "--takeover",
+        description: "Transfer a shared hook artifact from another Station runtime.",
+      },
       {
         name: "--hook-bin <command>",
         description: "Use a specific stn-ingress command for generated hooks.",

--- a/apps/cli/src/commands/registry/worktrunk.ts
+++ b/apps/cli/src/commands/registry/worktrunk.ts
@@ -1,6 +1,5 @@
 import {
   actionNeedsYes,
-  capitalize,
   hookCommandExitCode,
   loadedConfigCommandOptions,
 } from "../cliCommand/helpers.js";
@@ -52,7 +51,7 @@ async function runWorktrunkHooksCliCommand(context: CliCommandRunContext) {
 function worktrunkHookActionCommand(action: string): CliCommandNode {
   return {
     name: action,
-    description: `${capitalize(action)} Worktrunk lifecycle hooks.`,
+    description: `Worktrunk lifecycle hooks: ${action}.`,
     usage: [`stn worktrunk hooks ${action}${actionNeedsYes(action) ? " --yes" : ""} [options]`],
     options: [
       { name: "--yes, -y", description: "Required for install and uninstall actions." },

--- a/apps/cli/src/commands/registry/worktrunk.ts
+++ b/apps/cli/src/commands/registry/worktrunk.ts
@@ -27,6 +27,10 @@ export const worktrunkCliCommand: CliCommandNode = {
       options: [
         { name: "--yes, -y", description: "Confirm install or uninstall actions." },
         {
+          name: "--takeover",
+          description: "Transfer shared lifecycle hooks from another Station runtime.",
+        },
+        {
           name: "--worktrunk-config <path>",
           description: "Use a specific Worktrunk config file.",
         },
@@ -52,6 +56,10 @@ function worktrunkHookActionCommand(action: string): CliCommandNode {
     usage: [`stn worktrunk hooks ${action}${actionNeedsYes(action) ? " --yes" : ""} [options]`],
     options: [
       { name: "--yes, -y", description: "Required for install and uninstall actions." },
+      {
+        name: "--takeover",
+        description: "Transfer shared lifecycle hooks from another Station runtime.",
+      },
       { name: "--worktrunk-config <path>", description: "Use a specific Worktrunk config file." },
       { name: "--hook-bin <command>", description: "Use a specific stn-ingress command." },
     ],

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -162,13 +162,15 @@ async function probeHarnessTrackingFact(
     if (status === undefined) {
       throw setupHarnessProbeUnavailable;
     }
-    return SetupHarnessTrackingFactSchema.parse({
+    const fact: SetupHarnessTrackingFact = {
       harnessId,
       capability: "supported",
       requested: status.requested,
       installed: status.installed,
       detail: status.message,
-    });
+    };
+    if (status.ownership !== undefined) fact.ownership = status.ownership;
+    return SetupHarnessTrackingFactSchema.parse(fact);
   } catch (error) {
     const safeError = safeErrorFromUnknown(error, setupHarnessProbeFailed);
     return SetupHarnessTrackingFactSchema.parse({

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -1,4 +1,5 @@
 import type { TmuxConfig } from "@station/config";
+import { ProviderHookArtifactOwnershipSchema } from "@station/contracts";
 import { z } from "zod";
 
 export const setupTiers = ["required", "recommended", "optional"] as const;
@@ -34,6 +35,7 @@ export const SetupHarnessTrackingFactSchema = z
     capability: z.enum(["supported", "unsupported"]),
     requested: z.boolean().optional(),
     installed: z.boolean().optional(),
+    ownership: ProviderHookArtifactOwnershipSchema.optional(),
     detail: z.string().min(1).optional(),
     probeFailed: z.boolean().optional(),
   })
@@ -43,6 +45,7 @@ export const SetupHarnessTrackingFactSchema = z
       fact.capability === "unsupported" &&
       (fact.requested !== undefined ||
         fact.installed !== undefined ||
+        fact.ownership !== undefined ||
         fact.probeFailed !== undefined)
     ) {
       context.addIssue({

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,4 +1,5 @@
 import { dirname } from "node:path";
+import type { ProviderHookArtifactOwnership } from "@station/contracts";
 import { stationUiInstallHint } from "../../stationWorkspace.js";
 import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
@@ -413,6 +414,8 @@ function harnessTrackingCheck(
     if (assessment.requested !== undefined) details.requested = String(assessment.requested);
     if (assessment.installed !== undefined) details.installed = String(assessment.installed);
   }
+  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
+  if (fact?.ownership !== undefined) addHookOwnershipDetails(details, fact.ownership);
   return {
     id: `harness-tracking:${harnessId}`,
     tier: required ? "required" : "recommended",
@@ -421,6 +424,25 @@ function harnessTrackingCheck(
     message: assessment.message,
     details,
   };
+}
+
+function addHookOwnershipDetails(
+  details: Record<string, string>,
+  ownership: ProviderHookArtifactOwnership,
+): void {
+  details.ownership = ownership.status;
+  details.requestedLauncher = ownership.requested.launcher;
+  details.requestedRuntimeKind = ownership.requested.runtimeKind;
+  details.requestedRuntimeVersion = ownership.requested.version;
+  details.requestedBuildIdentity = ownership.requested.buildIdentity;
+  if (ownership.status === "same-owner" || ownership.status === "different-owner") {
+    details.currentLauncher = ownership.currentLauncher;
+  }
+  if (ownership.status === "different-owner" && ownership.current !== undefined) {
+    details.currentRuntimeKind = ownership.current.runtimeKind;
+    details.currentRuntimeVersion = ownership.current.version;
+    details.currentBuildIdentity = ownership.current.buildIdentity;
+  }
 }
 
 function assessHarnessTracking(

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 import { loadConfig } from "@station/config";
-import { isSafeError, type RuntimeSafeError, stationBuildInfo } from "@station/runtime";
+import {
+  isSafeError,
+  providerHookArtifactOwner,
+  type RuntimeSafeError,
+  stationBuildInfo,
+} from "@station/runtime";
 import { parseRequiredOptionValue } from "./args.js";
 import type { CliRunOptions, CliRunResult } from "./cliTypes.js";
 import {
@@ -89,7 +94,7 @@ function defaultCommandEnv(options: CliRunOptions): CliEnv {
  * ADAPTER
  *
  * Translates process arguments, output, and exit semantics around `runCli` while composing
- * process-owned provider-hook identity.
+ * process-owned provider-hook launcher and artifact-owner identity.
  */
 export async function runCliMain(
   argv: readonly string[] = process.argv.slice(2),
@@ -126,6 +131,9 @@ function withProcessComposition(options: CliRunOptions): CliRunOptions {
   return {
     ...options,
     providerHookIngressLauncher,
+    providerHookArtifactOwner:
+      options.providerHookArtifactOwner ??
+      providerHookArtifactOwner(providerHookIngressLauncher, stationBuildInfo()),
   };
 }
 
@@ -135,13 +143,14 @@ function withProviderHookSetupComposition(options: CliRunOptions): CliRunOptions
     setupDeps.providerHookIngressLauncher = options.providerHookIngressLauncher;
   }
   setupDeps.probeHarnessHooksStatus ??= (harnessId, configPath) =>
-    probeHarnessHooksStatus(
-      harnessId,
-      configPath,
-      options.providerHookIngressLauncher === undefined
+    probeHarnessHooksStatus(harnessId, configPath, {
+      ...(options.providerHookIngressLauncher === undefined
         ? {}
-        : { ingressLauncher: options.providerHookIngressLauncher },
-    );
+        : { ingressLauncher: options.providerHookIngressLauncher }),
+      ...(options.providerHookArtifactOwner === undefined
+        ? {}
+        : { artifactOwner: options.providerHookArtifactOwner }),
+    });
   return {
     ...options,
     setupDeps,

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import { runObserverMain } from "@station/observer";
+import { providerHookArtifactOwner, stationBuildInfo } from "@station/runtime";
 import { type CreateProviderRegistryOptions, createProviderRegistry } from "./observerProviders.js";
 import { resolveDefaultIngressLauncher } from "./worktrunkHookExpectation.js";
 
 export type RunCliObserverMainOptions = {
   preparePiExtension?: (stateDir: string) => string | Promise<string>;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
 };
 
 /**
  * COMPOSITION ROOT
  *
- * Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle.
+ * Chooses CLI-owned provider composition, including requester-relative hook
+ * artifact ownership, and joins it to the Observer runtime lifecycle.
  */
 export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),
@@ -19,6 +23,9 @@ export async function runCliObserverMain(
 ): Promise<number> {
   const providerHookIngressLauncher =
     options.providerHookIngressLauncher ?? resolveDefaultIngressLauncher();
+  const artifactOwner =
+    options.providerHookArtifactOwner ??
+    providerHookArtifactOwner(providerHookIngressLauncher, stationBuildInfo());
   return runObserverMain([...argv], {
     providerRegistryFactory: async (config, providerOptions) => {
       const registryOptions: CreateProviderRegistryOptions = {};
@@ -31,6 +38,7 @@ export async function runCliObserverMain(
         );
       }
       registryOptions.providerHookIngressLauncher = providerHookIngressLauncher;
+      registryOptions.providerHookArtifactOwner = artifactOwner;
       return createProviderRegistry(config, registryOptions);
     },
   });

--- a/apps/cli/src/observerMain.ts
+++ b/apps/cli/src/observerMain.ts
@@ -14,8 +14,7 @@ export type RunCliObserverMainOptions = {
 /**
  * COMPOSITION ROOT
  *
- * Chooses CLI-owned provider composition, including requester-relative hook
- * artifact ownership, and joins it to the Observer runtime lifecycle.
+ * Chooses CLI-owned provider composition and joins it to the Observer runtime lifecycle.
  */
 export async function runCliObserverMain(
   argv: readonly string[] = process.argv.slice(2),

--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -25,6 +25,7 @@ import type {
   HarnessProvider,
   HarnessRunObservation,
   ProviderHealth,
+  ProviderHookArtifactOwner,
   RepositoryProvider,
   SafeError,
   TerminalCapabilities,
@@ -64,6 +65,7 @@ export type CreateProviderRegistryOptions = {
   configPath?: string | undefined;
   piExtensionPath?: string | undefined;
   providerHookIngressLauncher?: string | undefined;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner | undefined;
 };
 
 type HarnessProviderBuilderContext = {
@@ -103,6 +105,7 @@ export async function probeHarnessHooksStatus(
     const provider = createHarnessProvider(harnessId, loaded.config, {
       configPath: loaded.configPath,
       providerHookIngressLauncher: providerHookRuntime.ingressLauncher,
+      providerHookArtifactOwner: providerHookRuntime.artifactOwner,
     });
     if (provider.hooksStatus === undefined) {
       return undefined;
@@ -131,8 +134,8 @@ export async function probeHarnessHooksStatus(
  * COMPOSITION ROOT
  *
  * Constructs concrete provider adapters, including the packaged Pi extension
- * path and canonical provider-hook launcher supplied by compiled CLI composition,
- * and assigns their Observer roles.
+ * path plus canonical provider-hook launcher and artifact owner supplied by CLI
+ * composition, and assigns their Observer roles.
  *
  * Observer application use cases are composed by the Observer runtime, not
  * stored in the provider registry.
@@ -210,6 +213,7 @@ function createWorktreeProvider(
     options.hookExpectation = createWorktrunkHookExpectation(config, {
       stationConfigPath: registryOptions.configPath,
       ingressLauncher: registryOptions.providerHookIngressLauncher,
+      artifactOwner: registryOptions.providerHookArtifactOwner,
     });
     return new WorktrunkProvider(options);
   }

--- a/apps/cli/src/worktrunkHookExpectation.ts
+++ b/apps/cli/src/worktrunkHookExpectation.ts
@@ -1,7 +1,7 @@
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveObserverPaths, type StationConfig } from "@station/config";
-import type { ProviderHookRuntime } from "@station/contracts";
+import type { ProviderHookArtifactOwner, ProviderHookRuntime } from "@station/contracts";
 import { isCompiledBinary } from "@station/runtime";
 import type { WorktrunkHookExpectation } from "@station/worktrunk";
 
@@ -11,6 +11,7 @@ export type ProviderHookRuntimeOptions = {
   compiled?: boolean | undefined;
   execPath?: string | undefined;
   sourceRoot?: string | undefined;
+  artifactOwner?: ProviderHookArtifactOwner | undefined;
 };
 
 /** Builds the one Worktrunk hook expectation shared by CLI setup and provider diagnostics. */
@@ -29,6 +30,9 @@ export function createWorktrunkHookExpectation(
   if (runtime.stationConfigPath !== undefined) {
     expectation.stationConfigPath = runtime.stationConfigPath;
   }
+  if (runtime.artifactOwner !== undefined) {
+    expectation.artifactOwner = runtime.artifactOwner;
+  }
   return expectation;
 }
 
@@ -46,6 +50,9 @@ export function createProviderHookRuntime(
   };
   if (options.stationConfigPath !== undefined) {
     runtime.stationConfigPath = options.stationConfigPath;
+  }
+  if (options.artifactOwner !== undefined) {
+    runtime.artifactOwner = options.artifactOwner;
   }
   return runtime;
 }

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
-import { commandLine, providerHookScriptRoutesByStationEnv } from "@station/runtime";
+import {
+  commandLine,
+  providerHookOwnerMarker,
+  providerHookScriptRoutesByStationEnv,
+} from "@station/runtime";
 import { describe, expect, it } from "vitest";
 
 describe("CLI Codex hook commands", () => {
@@ -87,6 +91,92 @@ describe("CLI Codex hook commands", () => {
     const overriddenScript = await readFile(hookScriptPath, "utf8");
     expect(overriddenScript).toContain("/explicit/stn-ingress");
     expect(overriddenScript).not.toContain(providerHookIngressLauncher);
+  });
+
+  it("refuses cross-runtime overwrite until explicit takeover", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-codex-hooks-owner-"));
+    const configPath = await writeConfig(root, true);
+    const env = codexEnv(root);
+    const hookScriptPath = join(root, "state", "hooks", "station-codex-hook.sh");
+    const installedOwner = artifactOwner(join(root, "installed", "stn-ingress"), "compiled", "a");
+    const sourceOwner = artifactOwner(join(root, "source", "bin", "stn-ingress"), "source", "b");
+
+    await runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], {
+      env,
+      providerHookIngressLauncher: installedOwner.launcher,
+      providerHookArtifactOwner: installedOwner,
+    });
+    const installedScript = await readFile(hookScriptPath, "utf8");
+
+    await expect(
+      runCli(["--config", configPath, "hooks", "plan", "codex"], {
+        env,
+        providerHookIngressLauncher: sourceOwner.launcher,
+        providerHookArtifactOwner: sourceOwner,
+      }),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: {
+        ownership: {
+          status: "different-owner",
+          current: installedOwner,
+          requested: sourceOwner,
+        },
+      },
+    });
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(installedScript);
+
+    await expect(
+      runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], {
+        env,
+        providerHookIngressLauncher: sourceOwner.launcher,
+        providerHookArtifactOwner: sourceOwner,
+      }),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+      message: expect.stringContaining("stn hooks install codex --yes --takeover"),
+    });
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(installedScript);
+
+    await expect(
+      runCli(["--config", configPath, "hooks", "install", "codex", "--takeover"], {
+        env,
+        providerHookIngressLauncher: sourceOwner.launcher,
+        providerHookArtifactOwner: sourceOwner,
+      }),
+    ).rejects.toThrow("without --yes");
+
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "codex"], {
+        env,
+        providerHookIngressLauncher: sourceOwner.launcher,
+        providerHookArtifactOwner: sourceOwner,
+      }),
+    ).resolves.toMatchObject({
+      code: 1,
+      output: {
+        status: "warn",
+        installed: false,
+        ownership: { status: "different-owner" },
+        message: expect.stringContaining("--yes --takeover"),
+      },
+    });
+
+    const takeover = await runCli(
+      ["--config", configPath, "hooks", "install", "codex", "--yes", "--takeover"],
+      {
+        env,
+        providerHookIngressLauncher: sourceOwner.launcher,
+        providerHookArtifactOwner: sourceOwner,
+      },
+    );
+    expect(takeover).toMatchObject({
+      code: 0,
+      output: { ownership: { status: "same-owner", requested: sourceOwner } },
+    });
+    const sourceScript = await readFile(hookScriptPath, "utf8");
+    expect(sourceScript).toContain(sourceOwner.launcher);
+    expect(sourceScript).toContain(providerHookOwnerMarker(sourceOwner));
   });
 
   it("installs and uninstalls through the generic hooks command", async () => {
@@ -479,6 +569,16 @@ describe("CLI Codex hook commands", () => {
     });
   });
 });
+
+function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", digit: string) {
+  return {
+    schemaVersion: 1 as const,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
+}
 
 function codexEnv(root: string): Record<string, string> {
   return { CODEX_HOME: join(root, "codex-home") };

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
@@ -91,6 +91,111 @@ describe("CLI Codex hook commands", () => {
     const overriddenScript = await readFile(hookScriptPath, "utf8");
     expect(overriddenScript).toContain("/explicit/stn-ingress");
     expect(overriddenScript).not.toContain(providerHookIngressLauncher);
+  });
+
+  it("treats an explicit hook executable as the requested artifact owner", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-codex-hook-bin-owner-"));
+    const configPath = await writeConfig(root, true);
+    const env = codexEnv(root);
+    const hookScriptPath = join(root, "state", "hooks", "station-codex-hook.sh");
+    const defaultOwner = artifactOwner(join(root, "installed", "stn-ingress"), "compiled", "a");
+    const customHookBin = join(root, "custom-stn-ingress");
+    await writeFile(customHookBin, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(customHookBin, 0o700);
+    const options = {
+      env,
+      providerHookIngressLauncher: defaultOwner.launcher,
+      providerHookArtifactOwner: defaultOwner,
+    };
+
+    await runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], options);
+    const beforeConflict = await readFile(hookScriptPath, "utf8");
+
+    await expect(
+      runCli(
+        ["--config", configPath, "hooks", "install", "codex", "--yes", "--hook-bin", customHookBin],
+        options,
+      ),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(beforeConflict);
+    expect(
+      (await readdir(join(root, "state", "hooks"))).some((name) => name.includes(".bak")),
+    ).toBe(false);
+
+    const takeover = await runCli(
+      [
+        "--config",
+        configPath,
+        "hooks",
+        "install",
+        "codex",
+        "--yes",
+        "--takeover",
+        "--hook-bin",
+        customHookBin,
+      ],
+      options,
+    );
+    const customOwner = { ...defaultOwner, launcher: customHookBin };
+    expect(takeover).toMatchObject({
+      code: 0,
+      output: { ownership: { status: "same-owner", requested: customOwner } },
+    });
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain(
+      providerHookOwnerMarker(customOwner),
+    );
+    await expect(
+      runCli(
+        ["--config", configPath, "hooks", "doctor", "codex", "--hook-bin", customHookBin],
+        options,
+      ),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: { status: "ok", ownership: { status: "same-owner", requested: customOwner } },
+    });
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "codex"], options),
+    ).resolves.toMatchObject({
+      code: 1,
+      output: { status: "warn", ownership: { status: "different-owner" } },
+    });
+
+    await runCli(
+      ["--config", configPath, "hooks", "install", "codex", "--yes", "--takeover"],
+      options,
+    );
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "codex"], options),
+    ).resolves.toMatchObject({ code: 0, output: { ownership: { status: "same-owner" } } });
+  });
+
+  it("rejects an unresolved explicit hook executable before writing artifacts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-codex-missing-hook-bin-"));
+    const configPath = await writeConfig(root, true);
+    const env = codexEnv(root);
+    const hookScriptPath = join(root, "state", "hooks", "station-codex-hook.sh");
+    const owner = artifactOwner(join(root, "installed", "stn-ingress"), "compiled", "a");
+
+    await expect(
+      runCli(
+        [
+          "--config",
+          configPath,
+          "hooks",
+          "install",
+          "codex",
+          "--yes",
+          "--hook-bin",
+          join(root, "missing-stn-ingress"),
+        ],
+        {
+          env,
+          providerHookIngressLauncher: owner.launcher,
+          providerHookArtifactOwner: owner,
+        },
+      ),
+    ).rejects.toThrow("executable could not be resolved");
+    await expect(readFile(hookScriptPath, "utf8")).rejects.toThrow();
   });
 
   it("refuses cross-runtime overwrite until explicit takeover", async () => {

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -239,7 +239,7 @@ describe("CLI Codex hook commands", () => {
       }),
     ).rejects.toMatchObject({
       code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
-      message: expect.stringContaining("stn hooks install codex --yes --takeover"),
+      hint: expect.stringContaining("stn hooks install codex --yes --takeover"),
     });
     await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(installedScript);
 

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -1,0 +1,171 @@
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { runCli } from "@station/cli";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
+import { providerHookOwnerMarker } from "@station/runtime";
+import { describe, expect, it } from "vitest";
+
+describe("provider hook ownership across Station runtimes", () => {
+  it("refuses, transfers, and repairs a Codex hook between installed and source launchers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-hook-owner-runtimes-"));
+    const configPath = await writeConfig(root);
+    const hookDir = join(root, "state", "hooks");
+    const hookScriptPath = join(hookDir, "station-codex-hook.sh");
+    const installedOwner = artifactOwner("/opt/station/bin/stn-ingress", "compiled", "a");
+    const runtimeDir = join(root, "runtime");
+    const libraryOptions = {
+      env: { CODEX_HOME: join(root, "codex-home") },
+      providerHookIngressLauncher: installedOwner.launcher,
+      providerHookArtifactOwner: installedOwner,
+    };
+    const processEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: join(root, "home"),
+      CODEX_HOME: join(root, "codex-home"),
+      XDG_CONFIG_HOME: join(root, "xdg-config"),
+      XDG_RUNTIME_DIR: runtimeDir,
+      NO_COLOR: "1",
+      PATH: `${dirname(process.execPath)}:/usr/bin:/bin`,
+    };
+    await mkdir(runtimeDir, { recursive: true });
+
+    await runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], libraryOptions);
+    const installedScript = await readFile(hookScriptPath, "utf8");
+    const installedEntries = await readdir(hookDir);
+
+    const refused = await runSourceCli(
+      ["--config", configPath, "hooks", "install", "codex", "--yes"],
+      processEnv,
+    );
+    expect(refused.exitCode).toBe(1);
+    expect(`${refused.stdout}\n${refused.stderr}`).toContain(
+      "stn hooks install codex --yes --takeover",
+    );
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(installedScript);
+    expect(await readdir(hookDir)).toEqual(installedEntries);
+
+    const sourceDoctor = await runSourceCli(
+      ["--config", configPath, "hooks", "doctor", "codex"],
+      processEnv,
+    );
+    expect(sourceDoctor.exitCode).toBe(1);
+    const sourceConflict = JSON.parse(sourceDoctor.stdout) as {
+      ownership: {
+        status: string;
+        requested: ProviderHookArtifactOwner;
+        current: ProviderHookArtifactOwner;
+      };
+    };
+    expect(sourceConflict.ownership).toMatchObject({
+      status: "different-owner",
+      current: installedOwner,
+      requested: {
+        launcher: join(process.cwd(), "bin", "stn-ingress"),
+        runtimeKind: "source",
+      },
+    });
+
+    const takeover = await runSourceCli(
+      ["--config", configPath, "hooks", "install", "codex", "--yes", "--takeover"],
+      processEnv,
+    );
+    expect(takeover.exitCode, `${takeover.stdout}\n${takeover.stderr}`).toBe(0);
+    const sourceScript = await readFile(hookScriptPath, "utf8");
+    expect(sourceScript).not.toBe(installedScript);
+    expect(sourceScript).toContain(join(process.cwd(), "bin", "stn-ingress"));
+    expect(sourceScript).not.toContain(providerHookOwnerMarker(installedOwner));
+    await expect(
+      runSourceCli(["--config", configPath, "hooks", "doctor", "codex"], processEnv),
+    ).resolves.toMatchObject({ exitCode: 0 });
+
+    await expect(
+      runCli(["--config", configPath, "hooks", "install", "codex", "--yes"], libraryOptions),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(sourceScript);
+
+    await runCli(
+      ["--config", configPath, "hooks", "install", "codex", "--yes", "--takeover"],
+      libraryOptions,
+    );
+    await expect(readFile(hookScriptPath, "utf8")).resolves.toContain(
+      providerHookOwnerMarker(installedOwner),
+    );
+    await expect(
+      runCli(["--config", configPath, "hooks", "doctor", "codex"], libraryOptions),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: { ownership: { status: "same-owner", requested: installedOwner } },
+    });
+    await expect(
+      runSourceCli(["--config", configPath, "hooks", "doctor", "codex"], processEnv),
+    ).resolves.toMatchObject({ exitCode: 1 });
+  });
+});
+
+async function runSourceCli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(join(process.cwd(), "bin", "stn"), [...args], {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("close", (exitCode) => {
+      resolve({
+        exitCode,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
+}
+
+async function writeConfig(root: string): Promise<string> {
+  const configPath = join(root, "config.toml");
+  await mkdir(join(root, "state"), { recursive: true });
+  await writeFile(
+    configPath,
+    [
+      "schema_version = 1",
+      "projects = []",
+      "",
+      "[observer]",
+      `socket_path = ${JSON.stringify(join(root, "run", "observer.sock"))}`,
+      `state_dir = ${JSON.stringify(join(root, "state"))}`,
+      "",
+      "[defaults]",
+      'worktree_provider = "worktrunk"',
+      'terminal = "tmux"',
+      'harness = "codex"',
+      'layout = "agent-shell"',
+      "",
+      "[harness.codex]",
+      'command = "codex"',
+      "install_hooks = true",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return configPath;
+}
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
+}

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -136,6 +136,74 @@ describe("CLI setup command", () => {
     });
   });
 
+  it("reports conflicting hook runtime provenance in setup check JSON", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const configPath = join(root, "config.toml");
+    await mkdir(repo, { recursive: true });
+    const source = setupConfigToml(repo, { includeHarness: true }).replace(
+      "[[projects]]",
+      ["install_hooks = true", "", "[[projects]]"].join("\n"),
+    );
+    const requested = {
+      schemaVersion: 1 as const,
+      launcher: join(root, "source", "bin", "stn-ingress"),
+      runtimeKind: "source" as const,
+      version: "0.0.0-pre-alpha.4",
+      buildIdentity: "a".repeat(64),
+    };
+    const current = {
+      schemaVersion: 1 as const,
+      launcher: join(root, "installed", "stn-ingress"),
+      runtimeKind: "compiled" as const,
+      version: "0.7.1",
+      buildIdentity: "b".repeat(64),
+    };
+
+    const result = await runCli(["--config", configPath, "setup", "check", "--json"], {
+      setupDeps: {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: readySetupAccess(),
+        fs: readOnlyFs({ [configPath]: source }),
+        probeHarnessHooksStatus: async () => ({
+          provider: "codex",
+          requested: true,
+          installed: false,
+          missing: ["station-codex-hook.sh"],
+          message: "Another Station runtime owns the hook.",
+          ownership: {
+            status: "different-owner",
+            requested,
+            currentLauncher: current.launcher,
+            current,
+          },
+        }),
+      },
+    });
+
+    const plan = result.output as {
+      checks: Array<{ id: string; details?: Record<string, string> }>;
+    };
+    expect(plan.checks.find((check) => check.id === "harness-tracking:codex")?.details).toEqual(
+      expect.objectContaining({
+        ownership: "different-owner",
+        requestedLauncher: requested.launcher,
+        requestedBuildIdentity: requested.buildIdentity,
+        currentLauncher: current.launcher,
+        currentBuildIdentity: current.buildIdentity,
+      }),
+    );
+  });
+
   it("repairs persisted tracking intent for a configured secondary harness", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -207,6 +207,7 @@ describe("CLI setup command", () => {
         args: ["--config", configPath, "hooks", "install", "opencode", "--yes"],
       }),
     );
+    expect(calls.flatMap((call) => call.args ?? [])).not.toContain("--takeover");
     expect(installed).toContain("opencode");
   });
 

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@station/cli/internal";
 import { loadConfig, setTuiWidgetsInConfig, type TuiConfig } from "@station/config";
 import { TUI_RENDERER_CONTROL_PROTOCOL_VERSION } from "@station/contracts";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempState, writeConfigToml } from "../../../../tests/support/temp-projects";
 import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 
@@ -23,6 +23,7 @@ const nestedTuiDisabledError = {
   message: "Nested Station is disabled.",
   hint: "Press Ctrl-O to open Station, or use `stn tui --allow-nested` for testing.",
 } as const;
+const inheritedStationPane = process.env.STATION_PANE;
 const tuiConfig: TuiConfig = {
   widgets: [
     {
@@ -114,6 +115,15 @@ function runningObserverDeps(
 }
 
 describe("CLI tui command", () => {
+  beforeEach(() => {
+    delete process.env.STATION_PANE;
+  });
+
+  afterEach(() => {
+    if (inheritedStationPane === undefined) delete process.env.STATION_PANE;
+    else process.env.STATION_PANE = inheritedStationPane;
+  });
+
   it("prefers the configured popup command over the environment and default", () => {
     expect(resolvePopupTmuxCommand("config-tmux", { STATION_TMUX_BIN: "env-tmux" })).toBe(
       "config-tmux",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runCli } from "@station/cli";
 import { loadConfig } from "@station/config";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import { providerHookCommandLine } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import { createProviderRegistry } from "../../src/observerProviders";
@@ -155,6 +156,84 @@ describe("CLI Worktrunk hook commands", () => {
     );
   });
 
+  it("aligns an explicit hook executable with Worktrunk artifact ownership", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cli-wt-hook-bin-owner-"));
+    const configPath = await writeConfig(root);
+    const worktrunkConfigPath = join(root, "worktrunk", "config.toml");
+    const defaultOwner = artifactOwner(join(root, "installed", "stn-ingress"), "compiled", "a");
+    const customHookBin = join(root, "custom-stn-ingress");
+    await writeFile(customHookBin, "#!/bin/sh\nexit 0\n", "utf8");
+    await chmod(customHookBin, 0o700);
+    const options = {
+      providerHookIngressLauncher: defaultOwner.launcher,
+      providerHookArtifactOwner: defaultOwner,
+    };
+    const args = ["--worktrunk-config", worktrunkConfigPath];
+
+    await runCli(
+      ["--config", configPath, "hooks", "install", "worktrunk", "--yes", ...args],
+      options,
+    );
+    const beforeConflict = await readFile(worktrunkConfigPath, "utf8");
+    await expect(
+      runCli(
+        [
+          "--config",
+          configPath,
+          "hooks",
+          "install",
+          "worktrunk",
+          "--yes",
+          "--hook-bin",
+          customHookBin,
+          ...args,
+        ],
+        options,
+      ),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(worktrunkConfigPath, "utf8")).resolves.toBe(beforeConflict);
+
+    const customOwner = { ...defaultOwner, launcher: customHookBin };
+    await expect(
+      runCli(
+        [
+          "--config",
+          configPath,
+          "hooks",
+          "install",
+          "worktrunk",
+          "--yes",
+          "--takeover",
+          "--hook-bin",
+          customHookBin,
+          ...args,
+        ],
+        options,
+      ),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: { ownership: { status: "same-owner", requested: customOwner } },
+    });
+    await expect(
+      runCli(
+        [
+          "--config",
+          configPath,
+          "hooks",
+          "doctor",
+          "worktrunk",
+          "--hook-bin",
+          customHookBin,
+          ...args,
+        ],
+        options,
+      ),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: { ownership: { status: "same-owner", requested: customOwner } },
+    });
+  });
+
   it("installs through both worktrunk hooks and generic hooks aliases", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cli-wt-hooks-"));
     const configPath = await writeConfig(root);
@@ -262,4 +341,18 @@ async function writeConfig(root: string, worktrunkCommand = "wt"): Promise<strin
     ].join("\n"),
   );
   return configPath;
+}
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
 }

--- a/apps/cli/test/unit/observer-main.test.ts
+++ b/apps/cli/test/unit/observer-main.test.ts
@@ -13,6 +13,15 @@ vi.mock("../../src/observerProviders.js", () => ({
 
 import { runCliObserverMain } from "../../src/observerMain.js";
 
+const ingressLauncher = "/source/bin/stn-ingress";
+const artifactOwner = {
+  schemaVersion: 1 as const,
+  launcher: ingressLauncher,
+  runtimeKind: "source" as const,
+  version: "0.0.0-test",
+  buildIdentity: "a".repeat(64),
+};
+
 describe("runCliObserverMain", () => {
   beforeEach(() => {
     mocks.runObserverMain.mockReset();
@@ -26,7 +35,11 @@ describe("runCliObserverMain", () => {
     );
 
     await expect(
-      runCliObserverMain(["--state-dir", "/custom/state"], { preparePiExtension }),
+      runCliObserverMain(["--state-dir", "/custom/state"], {
+        preparePiExtension,
+        providerHookIngressLauncher: ingressLauncher,
+        providerHookArtifactOwner: artifactOwner,
+      }),
     ).resolves.toBe(0);
 
     const deps = mocks.runObserverMain.mock.calls[0]?.[1] as {
@@ -45,12 +58,16 @@ describe("runCliObserverMain", () => {
     expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {
       configPath: "/config/station.toml",
       piExtensionPath: "/canonical/state/assets/pi/station-pi-extension.mjs",
-      providerHookIngressLauncher: expect.stringMatching(/\/bin\/stn-ingress$/),
+      providerHookIngressLauncher: ingressLauncher,
+      providerHookArtifactOwner: artifactOwner,
     });
   });
 
   it("does not prepare or inject Pi assets in source composition", async () => {
-    await runCliObserverMain([]);
+    await runCliObserverMain([], {
+      providerHookIngressLauncher: ingressLauncher,
+      providerHookArtifactOwner: artifactOwner,
+    });
 
     const deps = mocks.runObserverMain.mock.calls[0]?.[1] as {
       providerRegistryFactory: (
@@ -62,7 +79,8 @@ describe("runCliObserverMain", () => {
     await deps.providerRegistryFactory(config, { stateDir: "/source/state" });
 
     expect(mocks.createProviderRegistry).toHaveBeenCalledWith(config, {
-      providerHookIngressLauncher: expect.stringMatching(/\/bin\/stn-ingress$/),
+      providerHookIngressLauncher: ingressLauncher,
+      providerHookArtifactOwner: artifactOwner,
     });
   });
 });

--- a/apps/cli/test/unit/setup-planner.test.ts
+++ b/apps/cli/test/unit/setup-planner.test.ts
@@ -111,6 +111,55 @@ describe("setup planner", () => {
     expect(plan.actions.some((action) => action.id === "pi-hooks")).toBe(false);
   });
 
+  it("reports hook ownership provenance in tracking details", () => {
+    const requested = {
+      schemaVersion: 1 as const,
+      launcher: "/source/bin/stn-ingress",
+      runtimeKind: "source" as const,
+      version: "0.0.0-pre-alpha.4",
+      buildIdentity: "a".repeat(64),
+    };
+    const current = {
+      schemaVersion: 1 as const,
+      launcher: "/installed/stn-ingress",
+      runtimeKind: "compiled" as const,
+      version: "0.7.1",
+      buildIdentity: "b".repeat(64),
+    };
+    const plan = buildSetupPlan(
+      facts({
+        harnessTracking: [
+          {
+            harnessId: "codex",
+            capability: "supported",
+            requested: true,
+            installed: false,
+            ownership: {
+              status: "different-owner",
+              requested,
+              currentLauncher: current.launcher,
+              current,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(plan.checks.find((check) => check.id === "harness-tracking:codex")?.details).toEqual(
+      expect.objectContaining({
+        ownership: "different-owner",
+        requestedLauncher: requested.launcher,
+        requestedRuntimeKind: requested.runtimeKind,
+        requestedRuntimeVersion: requested.version,
+        requestedBuildIdentity: requested.buildIdentity,
+        currentLauncher: current.launcher,
+        currentRuntimeKind: current.runtimeKind,
+        currentRuntimeVersion: current.version,
+        currentBuildIdentity: current.buildIdentity,
+      }),
+    );
+  });
+
   it("warns without socket evidence without blocking fresh setup", () => {
     const plan = buildSetupPlan(
       facts({

--- a/apps/cli/test/unit/worktrunkHookExpectation.test.ts
+++ b/apps/cli/test/unit/worktrunkHookExpectation.test.ts
@@ -25,10 +25,18 @@ const config: StationConfig = {
 
 describe("Worktrunk hook expectation composition", () => {
   it("collects every command input from resolved CLI composition", () => {
+    const artifactOwner = {
+      schemaVersion: 1 as const,
+      launcher: "/opt/station/stn-ingress",
+      runtimeKind: "compiled" as const,
+      version: "0.7.1",
+      buildIdentity: "a".repeat(64),
+    };
     expect(
       createWorktrunkHookExpectation(config, {
         stationConfigPath: "/tmp/station/config.toml",
         ingressLauncher: "/opt/station/stn-ingress",
+        artifactOwner,
       }),
     ).toEqual({
       hookBin: "/opt/station/stn-ingress",
@@ -37,6 +45,7 @@ describe("Worktrunk hook expectation composition", () => {
       stateDir: "/tmp/station/state",
       hookSpoolDir: "/tmp/station/state/spool/hooks",
       autoStartFromHooks: false,
+      artifactOwner,
     });
   });
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -117,27 +117,6 @@ confirms a normal mutation but does not transfer ownership; only run
 intentional. Setup apply deliberately stops on this conflict instead of choosing
 an owner.
 
-## No-Action Mode
-
-If the user says "no action", keep debugging read-only.
-
-Do not start or restart the observer, retry commands, kill processes, mutate state, or write a new bundle unless explicitly asked.
-
-In no-action mode, inspect existing state only:
-
-- `stn debug trace <id>` or `stn debug trace --latest-failure`
-- `stn debug logs [query]`
-- existing bundles under `diagnostics/`
-- existing logs under `logs/`
-- existing bundle `commands.jsonl`, `errors.jsonl`, and derived indexes
-
-Avoid live observer commands in no-action mode, including `doctor`, `snapshot`,
-`observe`, `command get`, `command dispatch`, `reconcile`, `debug bundle`,
-`project add/remove`, hook install/uninstall, setup apply, and observer
-start/stop/restart/run. `stn observer status` is non-mutating, but it is still a
-live status check rather than an existing-state log read; use it only when live
-status is allowed by the request.
-
 ## State Directory
 
 The default observer state directory is:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -106,6 +106,37 @@ uses Worktrunk's default prompt behavior. Setup and doctor checks should report
 the effective automation mode and whether the installed `wt` supports the flag
 required by that mode.
 
+Hook doctor output also reports the requester-relative artifact owner. A
+`different-owner` result means another canonical Station launcher owns the
+shared provider artifact; `legacy-unknown` means the existing generated artifact
+cannot be attributed safely. Inspect the reported current and requested
+launchers before changing anything. `--yes` confirms a normal mutation but does
+not transfer ownership; only run
+`stn hooks install <target> --yes --takeover` when replacing that owner is
+intentional. Setup apply deliberately stops on this conflict instead of choosing
+an owner.
+
+## No-Action Mode
+
+If the user says "no action", keep debugging read-only.
+
+Do not start or restart the observer, retry commands, kill processes, mutate state, or write a new bundle unless explicitly asked.
+
+In no-action mode, inspect existing state only:
+
+- `stn debug trace <id>` or `stn debug trace --latest-failure`
+- `stn debug logs [query]`
+- existing bundles under `diagnostics/`
+- existing logs under `logs/`
+- existing bundle `commands.jsonl`, `errors.jsonl`, and derived indexes
+
+Avoid live observer commands in no-action mode, including `doctor`, `snapshot`,
+`observe`, `command get`, `command dispatch`, `reconcile`, `debug bundle`,
+`project add/remove`, hook install/uninstall, setup apply, and observer
+start/stop/restart/run. `stn observer status` is non-mutating, but it is still a
+live status check rather than an existing-state log read; use it only when live
+status is allowed by the request.
+
 ## State Directory
 
 The default observer state directory is:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -106,12 +106,13 @@ uses Worktrunk's default prompt behavior. Setup and doctor checks should report
 the effective automation mode and whether the installed `wt` supports the flag
 required by that mode.
 
-Hook doctor output also reports the requester-relative artifact owner. A
-`different-owner` result means another canonical Station launcher owns the
-shared provider artifact; `legacy-unknown` means the existing generated artifact
-cannot be attributed safely. Inspect the reported current and requested
-launchers before changing anything. `--yes` confirms a normal mutation but does
-not transfer ownership; only run
+Hook doctor output and the `harness-tracking:*` details from
+`stn setup check --json` report the requester-relative artifact owner, including
+launcher and build provenance. A `different-owner` result means another
+canonical Station launcher owns the shared provider artifact; `legacy-unknown`
+means the existing generated artifact cannot be attributed safely. Inspect the
+reported current and requested launchers before changing anything. `--yes`
+confirms a normal mutation but does not transfer ownership; only run
 `stn hooks install <target> --yes --takeover` when replacing that owner is
 intentional. Setup apply deliberately stops on this conflict instead of choosing
 an owner.

--- a/docs/development.md
+++ b/docs/development.md
@@ -666,6 +666,15 @@ writes. For Codex, verify setup does not mutate trust or `[features] hooks`, the
 Prepared output names `/hooks` review, and approving the current definition can
 produce a Station event.
 
+For shared-hook ownership acceptance, use two Station launchers and one isolated
+provider home. Install each target with launcher A, then run plan, doctor, and
+install from launcher B. Plan and doctor must identify A as the current owner;
+`install --yes` must leave every provider artifact byte-for-byte unchanged and
+report the ownership conflict. `install --yes --takeover` must transfer the
+marker and generated command to B. Repeat uninstall from A to prove it cannot
+remove B's artifact. Finally run setup apply from A and confirm setup reports the
+conflict without synthesizing `--takeover`.
+
 Preserve the exact command and output at the first failure; for a runtime
 failure with no known trace ID, start with `stn debug trace --latest-failure`.
 

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -11192,7 +11192,7 @@
       "declaration": "runCliMain",
       "kind": "function",
       "role": "ADAPTER",
-      "purpose": "Translates process arguments, output, and exit semantics around `runCli` while composing process-owned provider-hook identity.",
+      "purpose": "Translates process arguments, output, and exit semantics around `runCli` while composing process-owned provider-hook launcher and artifact-owner identity.",
       "dependencies": [
         {
           "path": "apps/cli/src/main.ts",
@@ -11323,7 +11323,7 @@
       "declaration": "createProviderRegistry",
       "kind": "function",
       "role": "COMPOSITION ROOT",
-      "purpose": "Constructs concrete provider adapters, including the packaged Pi extension path and canonical provider-hook launcher supplied by compiled CLI composition, and assigns their Observer roles.",
+      "purpose": "Constructs concrete provider adapters, including the packaged Pi extension path plus canonical provider-hook launcher and artifact owner supplied by CLI composition, and assigns their Observer roles.",
       "dependencies": [
         {
           "path": "integrations/harness/claude/src/provider.ts",
@@ -12890,6 +12890,14 @@
       "kind": "function",
       "role": "ADAPTER",
       "purpose": "Reads canonical lsof holder evidence, treating only its empty status-1 result as proof that no process owns the socket.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/runtime/src/hookSetup.ts",
+      "declaration": "classifyProviderHookArtifactOwnership",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Uses the canonical launcher path as the durable owner key so upgrades at one installed location remain automatic. Only a valid marker establishes ownership; unmarked or malformed artifacts require explicit takeover.",
       "dependencies": []
     }
   ]

--- a/docs/harness-ingress.md
+++ b/docs/harness-ingress.md
@@ -45,6 +45,15 @@ drain. Raw hook payloads normalize exactly once through the selected
 Observer-side provider adapter; an already-normalized `HarnessEventReport`
 bypasses that adapter.
 
+Station-generated Codex, Claude, and Cursor scripts, the OpenCode plugin, and
+Worktrunk lifecycle commands carry a strict artifact-owner marker. The canonical
+launcher path is the durable owner key; runtime kind, display version, and build
+identity are diagnostic provenance. An upgrade at the same launcher may refresh
+the artifact, but another installed or source runtime cannot replace or remove it
+with ordinary `--yes`. Install and uninstall re-read ownership at the write
+boundary and require the explicit `--takeover` flag to transfer a different or
+unknown owner. Setup never adds that flag automatically.
+
 ## Pre-Delivery Ordering And Evidence
 
 After required JSON parsing, `stn-ingress` resolves the provider event and applies

--- a/docs/harness-ingress.md
+++ b/docs/harness-ingress.md
@@ -52,7 +52,9 @@ identity are diagnostic provenance. An upgrade at the same launcher may refresh
 the artifact, but another installed or source runtime cannot replace or remove it
 with ordinary `--yes`. Install and uninstall re-read ownership at the write
 boundary and require the explicit `--takeover` flag to transfer a different or
-unknown owner. Setup never adds that flag automatically.
+unknown owner. Only a valid marker establishes ownership; unmarked or malformed
+Station artifacts are unknown-owner and are never adopted automatically. Setup
+never adds `--takeover` automatically.
 
 ## Pre-Delivery Ordering And Evidence
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -156,8 +156,8 @@ Composition is intentionally split:
 
 1. `apps/cli/src/observerProviders.ts` constructs concrete integrations,
    assigns provider roles, composes the fallback Worktrunk provider-hook
-   expectation from resolved runtime paths and the Observer ingress launcher, and
-   supplies a `ProviderRegistry` factory.
+   expectation from resolved runtime paths plus the Observer ingress launcher
+   and artifact owner, and supplies a `ProviderRegistry` factory.
 2. `apps/observer/src/runtime/main.ts` loads config and constructs Observer-
    private infrastructure: SQLite, persistence, logging, project-config, and local
    diagnostic-evidence adapters, event bus, command queue, core, handlers, ingress
@@ -575,7 +575,9 @@ health, persistence health, durable Observer records, config diagnostics,
 provider checks, and local runtime evidence. CLI full-doctor requests carry one
 strict provider-neutral hook-runtime context containing the requester's ingress
 launcher, socket, state and spool paths, auto-start policy, and optional Station
-config path. Provider hook adapters map the applicable fields from that context
+config path. It also carries the generated-artifact owner: canonical launcher,
+source or compiled runtime kind, display version, and immutable build identity.
+Provider hook adapters map the applicable fields from that context
 without mixing requester and Observer identities, so Worktrunk, Claude, Codex,
 Cursor, and OpenCode compare hook artifacts using the requester runtime identity
 even when an exact-build Observer from another checkout serves the request. Direct

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -1,14 +1,13 @@
 // Installs/uninstalls the STATION hook into Claude Code's settings.json hooks.
 // Upstream hook contract: https://code.claude.com/docs/en/hooks-guide
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
-import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
 import {
   assertProviderHookArtifactOwnership,
   classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
   expectedProviderHookScript,
   installConfigScriptHook,
-  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
   providerHookScriptLauncher,
   providerHookScriptOptions,

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -1,11 +1,16 @@
 // Installs/uninstalls the STATION hook into Claude Code's settings.json hooks.
 // Upstream hook contract: https://code.claude.com/docs/en/hooks-guide
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import {
+  assertProviderHookArtifactOwnership,
+  classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
   expectedProviderHookScript,
   installConfigScriptHook,
+  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
+  providerHookScriptLauncher,
   providerHookScriptOptions,
 } from "@station/runtime";
 import { CLAUDE_HOOK_EVENT_NAMES, type ClaudeHookEventName } from "./hooks/hookConstants.js";
@@ -40,6 +45,8 @@ export type ClaudeHookPlanOptions = {
   autoStartFromHooks?: boolean;
   stationConfigPath?: string;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
 };
@@ -66,6 +73,7 @@ export type ClaudeHookPlan = {
   userSettingsCleanup: ClaudeUserSettingsCleanup;
   before: string;
   after: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type ClaudeHookInstallResult = ClaudeHookPlan & {
@@ -88,6 +96,7 @@ export type ClaudeHookDoctorResult = {
   artifactInvalid: boolean;
   userSettingsCleanup: ClaudeUserSettingsCleanup;
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type ClaudeHookScriptOptions = ProviderHookScriptOptions & {
@@ -167,6 +176,7 @@ function installResultFromPlan(plan: ClaudeHookPlan, installed: boolean): Claude
     before: plan.before,
     after: plan.after,
     installed,
+    ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
   };
 }
 
@@ -216,9 +226,18 @@ export async function planClaudeHooks(
   const scriptBefore = await fileOps.readOptionalFile(hookScriptPath);
   const settingsChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
+  const legacyLauncher = providerHookScriptLauncher(scriptBefore, "claude");
+  const ownership =
+    options.artifactOwner === undefined
+      ? undefined
+      : classifyProviderHookArtifactOwnership({
+          contents: scriptBefore,
+          requested: options.artifactOwner,
+          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+        });
   const { cleanup } = await buildUserSettingsCleanup(userSettingsPath);
 
-  return {
+  const result: ClaudeHookPlan = {
     provider: "claude",
     settingsPath,
     userSettingsPath,
@@ -233,6 +252,8 @@ export async function planClaudeHooks(
     before,
     after,
   };
+  if (ownership !== undefined) result.ownership = ownership;
+  return result;
 }
 
 export async function installClaudeHooks(
@@ -249,6 +270,9 @@ export async function installClaudeHooks(
     configChanged: plan.settingsChanged,
     scriptChanged: plan.scriptChanged,
     fileOps,
+    provider: "claude",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   let userSettingsBackupPath: string | undefined;
 
@@ -258,6 +282,13 @@ export async function installClaudeHooks(
   }
 
   const result = installResultFromPlan({ ...plan, missing: [], artifactInvalid: false }, true);
+  if (options.artifactOwner !== undefined) {
+    result.ownership = {
+      status: "same-owner",
+      requested: options.artifactOwner,
+      currentLauncher: options.artifactOwner.launcher,
+    };
+  }
   const backupPaths: string[] = [];
   if (backupPath !== undefined) {
     result.backupPath = backupPath;
@@ -280,6 +311,17 @@ export async function uninstallClaudeHooks(
   const userSettingsPath = resolveClaudeUserSettingsPath(options);
   const hookScriptPath = resolveClaudeHookScriptPath(options);
   const before = await fileOps.readOptionalFile(settingsPath);
+  const currentScript = await fileOps.readOptionalFile(hookScriptPath);
+  const legacyLauncher = providerHookScriptLauncher(currentScript, "claude");
+  assertProviderHookArtifactOwnership({
+    provider: "claude",
+    action: "uninstall",
+    artifactPath: hookScriptPath,
+    contents: currentScript,
+    ...(options.artifactOwner === undefined ? {} : { requested: options.artifactOwner }),
+    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
+  });
   const { cleanup, document: cleanedUserDocument } =
     await buildUserSettingsCleanup(userSettingsPath);
   let userSettingsBackupPath: string | undefined;
@@ -338,26 +380,33 @@ export async function doctorClaudeHooks(
       message: staleUserEntries
         ? "Claude hooks are not requested in station config, but generated station hooks remain in the user Claude settings."
         : "Claude hooks are not requested in station config.",
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
 
   const installed = !plan.settingsChanged && !plan.scriptChanged && !plan.artifactInvalid;
-  return {
+  const ownershipConflict =
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+  const result: ClaudeHookDoctorResult = {
     provider: "claude",
     settingsPath: plan.settingsPath,
     userSettingsPath: plan.userSettingsPath,
     hookScriptPath: plan.hookScriptPath,
-    status: installed && !staleUserEntries ? "ok" : "warn",
-    installed,
+    status: installed && !staleUserEntries && !ownershipConflict ? "ok" : "warn",
+    installed: installed && !ownershipConflict,
     missing: plan.missing,
     artifactInvalid: plan.artifactInvalid,
     userSettingsCleanup: plan.userSettingsCleanup,
-    message: doctorMessage({
-      installed,
-      artifactInvalid: plan.artifactInvalid,
-      staleUserEntries,
-      missing: plan.missing,
-      scriptChanged: plan.scriptChanged,
-    }),
+    message: ownershipConflict
+      ? "Claude hook artifact ownership conflicts with this Station runtime; run `stn hooks install claude --yes --takeover` only to transfer it."
+      : doctorMessage({
+          installed,
+          artifactInvalid: plan.artifactInvalid,
+          staleUserEntries,
+          missing: plan.missing,
+          scriptChanged: plan.scriptChanged,
+        }),
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }

--- a/integrations/harness/claude/src/hooks.ts
+++ b/integrations/harness/claude/src/hooks.ts
@@ -9,7 +9,6 @@ import {
   expectedProviderHookScript,
   installConfigScriptHook,
   type ProviderHookScriptOptions,
-  providerHookScriptLauncher,
   providerHookScriptOptions,
 } from "@station/runtime";
 import { CLAUDE_HOOK_EVENT_NAMES, type ClaudeHookEventName } from "./hooks/hookConstants.js";
@@ -225,14 +224,12 @@ export async function planClaudeHooks(
   const scriptBefore = await fileOps.readOptionalFile(hookScriptPath);
   const settingsChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== script;
-  const legacyLauncher = providerHookScriptLauncher(scriptBefore, "claude");
   const ownership =
     options.artifactOwner === undefined
       ? undefined
       : classifyProviderHookArtifactOwnership({
           contents: scriptBefore,
           requested: options.artifactOwner,
-          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
         });
   const { cleanup } = await buildUserSettingsCleanup(userSettingsPath);
 
@@ -311,14 +308,12 @@ export async function uninstallClaudeHooks(
   const hookScriptPath = resolveClaudeHookScriptPath(options);
   const before = await fileOps.readOptionalFile(settingsPath);
   const currentScript = await fileOps.readOptionalFile(hookScriptPath);
-  const legacyLauncher = providerHookScriptLauncher(currentScript, "claude");
   assertProviderHookArtifactOwnership({
     provider: "claude",
     action: "uninstall",
     artifactPath: hookScriptPath,
     contents: currentScript,
     ...(options.artifactOwner === undefined ? {} : { requested: options.artifactOwner }),
-    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
     ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   const { cleanup, document: cleanedUserDocument } =
@@ -385,7 +380,7 @@ export async function doctorClaudeHooks(
 
   const installed = !plan.settingsChanged && !plan.scriptChanged && !plan.artifactInvalid;
   const ownershipConflict =
-    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "unknown-owner";
   const result: ClaudeHookDoctorResult = {
     provider: "claude",
     settingsPath: plan.settingsPath,

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { access, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import { describe, expect, it } from "vitest";
 import {
   doctorClaudeHooks,
@@ -110,6 +111,46 @@ describe("Claude hook setup", () => {
       installed: true,
       settingsPath,
     });
+  });
+
+  it("refuses install and uninstall from another Station runtime owner", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-claude-hooks-owner-"));
+    const options = {
+      claudeSettingsPath: join(root, "state", "hooks", "station-claude-settings.json"),
+      claudeConfigDir: join(root, "claude-home"),
+      hookScriptPath: join(root, "state", "hooks", "station-claude-hook.sh"),
+      env: {},
+    };
+    const installedOwner = artifactOwner("/installed/stn-ingress", "compiled", "a");
+    const sourceOwner = artifactOwner("/source/bin/stn-ingress", "source", "b");
+    await installClaudeHooks({
+      ...options,
+      hookBin: installedOwner.launcher,
+      artifactOwner: installedOwner,
+    });
+
+    await expect(
+      doctorClaudeHooks({
+        ...options,
+        hookBin: sourceOwner.launcher,
+        artifactOwner: sourceOwner,
+        enabled: true,
+      }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "different-owner" },
+    });
+    await expect(
+      installClaudeHooks({ ...options, hookBin: sourceOwner.launcher, artifactOwner: sourceOwner }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(
+      uninstallClaudeHooks({
+        ...options,
+        hookBin: sourceOwner.launcher,
+        artifactOwner: sourceOwner,
+      }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
   });
 
   it("generated script delivers to stn-ingress even without ownership env", async () => {
@@ -259,6 +300,20 @@ describe("Claude hook setup", () => {
     expect(doctor.message).toContain("silently ignores");
   });
 });
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
+}
 
 function userSettingsWithGeneratedEntries(hookScriptPath: string): string {
   return JSON.stringify(

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -128,6 +128,8 @@ describe("Claude hook setup", () => {
       hookBin: installedOwner.launcher,
       artifactOwner: installedOwner,
     });
+    const installedSettings = await readFile(options.claudeSettingsPath, "utf8");
+    const installedScript = await readFile(options.hookScriptPath, "utf8");
 
     await expect(
       doctorClaudeHooks({
@@ -151,6 +153,48 @@ describe("Claude hook setup", () => {
         artifactOwner: sourceOwner,
       }),
     ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(options.claudeSettingsPath, "utf8")).resolves.toBe(installedSettings);
+    await expect(readFile(options.hookScriptPath, "utf8")).resolves.toBe(installedScript);
+
+    await installClaudeHooks({
+      ...options,
+      hookBin: sourceOwner.launcher,
+      artifactOwner: sourceOwner,
+      takeover: true,
+    });
+    await expect(
+      doctorClaudeHooks({
+        ...options,
+        hookBin: sourceOwner.launcher,
+        artifactOwner: sourceOwner,
+        enabled: true,
+      }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      installed: true,
+      ownership: { status: "same-owner", requested: sourceOwner },
+    });
+    await expect(
+      installClaudeHooks({
+        ...options,
+        hookBin: installedOwner.launcher,
+        artifactOwner: installedOwner,
+      }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await installClaudeHooks({
+      ...options,
+      hookBin: installedOwner.launcher,
+      artifactOwner: installedOwner,
+      takeover: true,
+    });
+    await expect(
+      doctorClaudeHooks({
+        ...options,
+        hookBin: installedOwner.launcher,
+        artifactOwner: installedOwner,
+        enabled: true,
+      }),
+    ).resolves.toMatchObject({ status: "ok", ownership: { status: "same-owner" } });
   });
 
   it("generated script delivers to stn-ingress even without ownership env", async () => {

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -1,14 +1,13 @@
 // Installs/uninstalls the STATION hook into Codex's hook config.
 // Upstream hook contract: https://developers.openai.com/codex/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
-import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
 import {
   commandLine,
   createHookSetupFileOps,
   expectedProviderHookScript,
   hookCommandsForEvents,
   installConfigScriptHook,
-  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
   providerHookScriptOptions,

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -310,7 +310,7 @@ export async function doctorCodexHooks(
 
   const installed = plan.missing.length === 0 && !plan.scriptChanged;
   const ownershipConflict =
-    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "unknown-owner";
   const result: CodexHookDoctorResult = {
     provider: "codex",
     configPath: plan.configPath,

--- a/integrations/harness/codex/src/hooks.ts
+++ b/integrations/harness/codex/src/hooks.ts
@@ -1,12 +1,14 @@
 // Installs/uninstalls the STATION hook into Codex's hook config.
 // Upstream hook contract: https://developers.openai.com/codex/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import {
   commandLine,
   createHookSetupFileOps,
   expectedProviderHookScript,
   hookCommandsForEvents,
   installConfigScriptHook,
+  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
   providerHookScriptOptions,
@@ -48,6 +50,8 @@ export type CodexHookPlanOptions = {
   autoStartFromHooks?: boolean;
   stationConfigPath?: string;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
 };
@@ -78,6 +82,7 @@ export type CodexHookPlan = {
   generatedGlobalCleanup: CodexGeneratedGlobalHookCleanup;
   before: string;
   after: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type CodexHookInstallResult = CodexHookPlan & {
@@ -102,6 +107,7 @@ export type CodexHookDoctorResult = {
   commands: Record<CodexHookEventName, string>;
   generatedGlobalCleanup: CodexGeneratedGlobalHookCleanup;
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type CodexHookScriptOptions = ProviderHookScriptOptions & {
@@ -153,9 +159,11 @@ export async function planCodexHooks(options: CodexHookPlanOptions = {}): Promis
     expectedCommands: (path) => expectedCodexHookCommands({ hookScriptPath: path }),
     expectedScript: script,
     extraChanged: generatedGlobalCleanup.changed,
+    provider: "codex",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
   });
 
-  return {
+  const result: CodexHookPlan = {
     provider: "codex",
     configPath,
     profileName: CODEX_STATION_PROFILE_NAME,
@@ -172,6 +180,8 @@ export async function planCodexHooks(options: CodexHookPlanOptions = {}): Promis
     before: plan.before,
     after: plan.after,
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }
 
 export async function installCodexHooks(
@@ -188,6 +198,9 @@ export async function installCodexHooks(
     configChanged: plan.configChanged,
     scriptChanged: plan.scriptChanged,
     fileOps,
+    provider: "codex",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   let baseBackupPath: string | undefined;
   if (plan.generatedGlobalCleanup.changed) {
@@ -196,6 +209,13 @@ export async function installCodexHooks(
   }
 
   const result = installResultFromPlan(plan, true);
+  if (options.artifactOwner !== undefined) {
+    result.ownership = {
+      status: "same-owner",
+      requested: options.artifactOwner,
+      currentLauncher: options.artifactOwner.launcher,
+    };
+  }
   assignBackupPaths(result, { profileBackupPath, baseBackupPath });
   return result;
 }
@@ -223,6 +243,9 @@ export async function uninstallCodexHooks(
     documentContainsCommand,
     expectedCommands: (path) => expectedCodexHookCommands({ hookScriptPath: path }),
     fileOps,
+    provider: "codex",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   let baseBackupPath: string | undefined;
   if (generatedGlobalCleanup.changed) {
@@ -282,30 +305,40 @@ export async function doctorCodexHooks(
       commands: plan.commands,
       generatedGlobalCleanup: plan.generatedGlobalCleanup,
       message: withObsoleteHookRemediation(message, obsoleteEvents, obsoleteRemediation),
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
 
   const installed = plan.missing.length === 0 && !plan.scriptChanged;
-  return {
+  const ownershipConflict =
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+  const result: CodexHookDoctorResult = {
     provider: "codex",
     configPath: plan.configPath,
     profileName: plan.profileName,
     profileConfigPath: plan.profileConfigPath,
     baseConfigPath: plan.baseConfigPath,
     hookScriptPath: plan.hookScriptPath,
-    status: installed && !generatedGlobalInstalled && !obsoleteGeneratedInstalled ? "ok" : "warn",
-    installed,
+    status:
+      installed && !generatedGlobalInstalled && !obsoleteGeneratedInstalled && !ownershipConflict
+        ? "ok"
+        : "warn",
+    installed: installed && !ownershipConflict,
     missing: plan.missing,
     commands: plan.commands,
     generatedGlobalCleanup: plan.generatedGlobalCleanup,
-    message: doctorMessage({
-      installed,
-      generatedGlobalInstalled,
-      obsoleteEvents,
-      obsoleteRemediation,
-      plan,
-    }),
+    message: ownershipConflict
+      ? `Codex hook artifact ownership conflicts with this Station runtime; run \`stn hooks install codex --yes --takeover\` only to transfer it.`
+      : doctorMessage({
+          installed,
+          generatedGlobalInstalled,
+          obsoleteEvents,
+          obsoleteRemediation,
+          plan,
+        }),
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }
 
 function expectedCodexHookCommands(input: {
@@ -336,6 +369,7 @@ function installResultFromPlan(plan: CodexHookPlan, installed: boolean): CodexHo
     before: plan.before,
     after: plan.after,
     installed,
+    ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
   };
 }
 

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -12,7 +12,6 @@ import {
   installConfigScriptHook,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
-  providerHookScriptLauncher,
   providerHookScriptOptions,
   providerHookScriptRoutesByStationEnv,
   uninstallConfigScriptHook,
@@ -150,17 +149,15 @@ async function sharedGeneratedHookPlan(
     return undefined;
   }
 
-  const legacyLauncher = providerHookScriptLauncher(scriptBefore, "cursor");
   const ownership =
     options.artifactOwner === undefined
       ? undefined
       : classifyProviderHookArtifactOwnership({
           contents: scriptBefore,
           requested: options.artifactOwner,
-          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
         });
   const ownershipConflict =
-    ownership?.status === "different-owner" || ownership?.status === "legacy-unknown";
+    ownership?.status === "different-owner" || ownership?.status === "unknown-owner";
 
   return {
     provider: "cursor",
@@ -214,14 +211,12 @@ async function assertConfiguredCursorHookOwnership(
     return;
   }
   const currentScript = await fileOps.readOptionalFile(currentHookScriptPath);
-  const legacyLauncher = providerHookScriptLauncher(currentScript, "cursor");
   assertProviderHookArtifactOwnership({
     provider: "cursor",
     action: "install",
     artifactPath: currentHookScriptPath,
     contents: currentScript,
     requested: options.artifactOwner,
-    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
     ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
 }
@@ -351,7 +346,7 @@ export async function doctorCursorHooks(
 
   const installed = plan.missing.length === 0 && !plan.configChanged && !plan.scriptChanged;
   const ownershipConflict =
-    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "unknown-owner";
   if (!installed) {
     const shared = await sharedGeneratedHookPlan(plan.before, options);
     if (shared !== undefined) {

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -3,6 +3,7 @@
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
 import type { ProviderHookArtifactOwner } from "@station/contracts";
 import {
+  assertProviderHookArtifactOwnership,
   assignBackupPaths,
   classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
@@ -199,6 +200,33 @@ function sharedGeneratedHookScriptPath(
   return shared;
 }
 
+/** Guards the configured Station script before install migrates Cursor to another script path. */
+async function assertConfiguredCursorHookOwnership(
+  hooksPath: string,
+  requestedHookScriptPath: string,
+  options: CursorHookPlanOptions,
+): Promise<void> {
+  if (options.artifactOwner === undefined) return;
+  const source = await fileOps.readOptionalFile(hooksPath);
+  const currentHookScriptPath = sharedGeneratedHookScriptPath(
+    generatedCursorHookCommands(parseJsonDocument(source)),
+  );
+  if (currentHookScriptPath === undefined || currentHookScriptPath === requestedHookScriptPath) {
+    return;
+  }
+  const currentScript = await fileOps.readOptionalFile(currentHookScriptPath);
+  const legacyLauncher = providerHookScriptLauncher(currentScript, "cursor");
+  assertProviderHookArtifactOwnership({
+    provider: "cursor",
+    action: "install",
+    artifactPath: currentHookScriptPath,
+    contents: currentScript,
+    requested: options.artifactOwner,
+    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
+  });
+}
+
 export async function planCursorHooks(
   options: CursorHookPlanOptions = {},
 ): Promise<CursorHookPlan> {
@@ -239,6 +267,7 @@ export async function installCursorHooks(
   options: CursorHookPlanOptions = {},
 ): Promise<CursorHookInstallResult> {
   const plan = await planCursorHooks(options);
+  await assertConfiguredCursorHookOwnership(plan.hooksPath, plan.hookScriptPath, options);
   const backupPath = await installConfigScriptHook({
     configPath: plan.hooksPath,
     hookScriptPath: plan.hookScriptPath,

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -1,7 +1,7 @@
 // Installs/uninstalls the STATION hook into Cursor's .cursor/hooks.json.
 // Upstream hook contract: https://cursor.com/docs/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
-import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
 import {
   assertProviderHookArtifactOwnership,
   assignBackupPaths,
@@ -10,7 +10,6 @@ import {
   expectedProviderHookScript,
   hookCommandsForEvents,
   installConfigScriptHook,
-  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
   providerHookScriptLauncher,

--- a/integrations/harness/cursor/src/hooks.ts
+++ b/integrations/harness/cursor/src/hooks.ts
@@ -1,14 +1,18 @@
 // Installs/uninstalls the STATION hook into Cursor's .cursor/hooks.json.
 // Upstream hook contract: https://cursor.com/docs/hooks
 // STATION ingress flow: docs/harness-ingress.md. Generated command + payload must match the ingress parser.
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import {
   assignBackupPaths,
+  classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
   expectedProviderHookScript,
   hookCommandsForEvents,
   installConfigScriptHook,
+  type ProviderHookArtifactOwnership,
   type ProviderHookScriptOptions,
   planConfigScriptHook,
+  providerHookScriptLauncher,
   providerHookScriptOptions,
   providerHookScriptRoutesByStationEnv,
   uninstallConfigScriptHook,
@@ -38,6 +42,8 @@ export type CursorHookPlanOptions = {
   autoStartFromHooks?: boolean;
   stationConfigPath?: string;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
 };
@@ -53,6 +59,7 @@ export type CursorHookPlan = {
   scriptChanged: boolean;
   before: string;
   after: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type CursorHookInstallResult = CursorHookPlan & {
@@ -71,6 +78,7 @@ export type CursorHookDoctorResult = {
   missing: CursorHookEventName[];
   commands: Record<CursorHookEventName, string>;
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type CursorHookScriptOptions = ProviderHookScriptOptions & {
@@ -142,15 +150,30 @@ async function sharedGeneratedHookPlan(
     return undefined;
   }
 
+  const legacyLauncher = providerHookScriptLauncher(scriptBefore, "cursor");
+  const ownership =
+    options.artifactOwner === undefined
+      ? undefined
+      : classifyProviderHookArtifactOwnership({
+          contents: scriptBefore,
+          requested: options.artifactOwner,
+          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+        });
+  const ownershipConflict =
+    ownership?.status === "different-owner" || ownership?.status === "legacy-unknown";
+
   return {
     provider: "cursor",
     hooksPath: resolveCursorHooksPath(options),
     hookScriptPath,
-    status: "ok",
-    installed: true,
+    status: ownershipConflict ? "warn" : "ok",
+    installed: !ownershipConflict,
     missing: [],
     commands: expectedCursorHookCommands({ hookScriptPath }),
-    message: "Cursor hooks are installed.",
+    message: ownershipConflict
+      ? "Cursor hook artifact ownership conflicts with this Station runtime; run `stn hooks install cursor --yes --takeover` only to transfer it."
+      : "Cursor hooks are installed.",
+    ...(ownership === undefined ? {} : { ownership }),
   };
 }
 
@@ -192,9 +215,11 @@ export async function planCursorHooks(
     missingEvents: missingCursorHookEvents,
     expectedCommands: (path) => expectedCursorHookCommands({ hookScriptPath: path }),
     expectedScript: script,
+    provider: "cursor",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
   });
 
-  return {
+  const result: CursorHookPlan = {
     provider: "cursor",
     hooksPath,
     hookScriptPath,
@@ -206,6 +231,8 @@ export async function planCursorHooks(
     before: plan.before,
     after: plan.after,
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }
 
 export async function installCursorHooks(
@@ -222,8 +249,18 @@ export async function installCursorHooks(
     configChanged: plan.configChanged,
     scriptChanged: plan.scriptChanged,
     fileOps,
+    provider: "cursor",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   const result: CursorHookInstallResult = { ...plan, installed: true };
+  if (options.artifactOwner !== undefined) {
+    result.ownership = {
+      status: "same-owner",
+      requested: options.artifactOwner,
+      currentLauncher: options.artifactOwner.launcher,
+    };
+  }
   assignBackupPaths(result, [backupPath]);
   return result;
 }
@@ -244,6 +281,9 @@ export async function uninstallCursorHooks(
     documentContainsCommand,
     expectedCommands: (path) => expectedCursorHookCommands({ hookScriptPath: path }),
     fileOps,
+    provider: "cursor",
+    ...(options.artifactOwner === undefined ? {} : { artifactOwner: options.artifactOwner }),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
   const result: CursorHookInstallResult = {
     provider: "cursor",
@@ -266,38 +306,44 @@ export async function uninstallCursorHooks(
 export async function doctorCursorHooks(
   options: CursorHookPlanOptions & { enabled?: boolean } = {},
 ): Promise<CursorHookDoctorResult> {
+  const plan = await planCursorHooks(options);
   if (options.enabled === false) {
-    const hookScriptPath = resolveCursorHookScriptPath(options);
     return {
       provider: "cursor",
-      hooksPath: resolveCursorHooksPath(options),
-      hookScriptPath,
+      hooksPath: plan.hooksPath,
+      hookScriptPath: plan.hookScriptPath,
       status: "ok",
       installed: false,
       missing: [],
-      commands: expectedCursorHookCommands({ hookScriptPath }),
+      commands: plan.commands,
       message: "Cursor hooks are not requested in station config.",
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
 
-  const plan = await planCursorHooks(options);
   const installed = plan.missing.length === 0 && !plan.configChanged && !plan.scriptChanged;
+  const ownershipConflict =
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
   if (!installed) {
     const shared = await sharedGeneratedHookPlan(plan.before, options);
     if (shared !== undefined) {
       return shared;
     }
   }
-  return {
+  const result: CursorHookDoctorResult = {
     provider: "cursor",
     hooksPath: plan.hooksPath,
     hookScriptPath: plan.hookScriptPath,
-    status: installed ? "ok" : "warn",
-    installed,
+    status: installed && !ownershipConflict ? "ok" : "warn",
+    installed: installed && !ownershipConflict,
     missing: plan.missing,
     commands: plan.commands,
-    message: installed
-      ? "Cursor hooks are installed."
-      : `Cursor hooks are missing or stale: ${missingDescription(plan)}.`,
+    message: ownershipConflict
+      ? "Cursor hook artifact ownership conflicts with this Station runtime; run `stn hooks install cursor --yes --takeover` only to transfer it."
+      : installed
+        ? "Cursor hooks are installed."
+        : `Cursor hooks are missing or stale: ${missingDescription(plan)}.`,
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -191,13 +191,18 @@ describe("Cursor hook setup", () => {
       hookBin: installedOwner.launcher,
       artifactOwner: installedOwner,
     });
+    const installedHooks = await readFile(hooksPath, "utf8");
+    const installedScript = await readFile(sharedHookScriptPath, "utf8");
+    const sourceOptions = {
+      cursorHooksPath: hooksPath,
+      hookScriptPath: requestedHookScriptPath,
+      hookBin: sourceOwner.launcher,
+      artifactOwner: sourceOwner,
+    };
 
     await expect(
       doctorCursorHooks({
-        cursorHooksPath: hooksPath,
-        hookScriptPath: requestedHookScriptPath,
-        hookBin: sourceOwner.launcher,
-        artifactOwner: sourceOwner,
+        ...sourceOptions,
         enabled: true,
       }),
     ).resolves.toMatchObject({
@@ -205,6 +210,37 @@ describe("Cursor hook setup", () => {
       installed: false,
       hookScriptPath: sharedHookScriptPath,
       ownership: { status: "different-owner" },
+    });
+    await expect(installCursorHooks(sourceOptions)).rejects.toMatchObject({
+      code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+    });
+    await expect(
+      uninstallCursorHooks({ ...sourceOptions, hookScriptPath: sharedHookScriptPath }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(hooksPath, "utf8")).resolves.toBe(installedHooks);
+    await expect(readFile(sharedHookScriptPath, "utf8")).resolves.toBe(installedScript);
+
+    await installCursorHooks({ ...sourceOptions, takeover: true });
+    await expect(doctorCursorHooks({ ...sourceOptions, enabled: true })).resolves.toMatchObject({
+      status: "ok",
+      installed: true,
+      hookScriptPath: requestedHookScriptPath,
+      ownership: { status: "same-owner", requested: sourceOwner },
+    });
+
+    const installedOptions = {
+      cursorHooksPath: hooksPath,
+      hookScriptPath: sharedHookScriptPath,
+      hookBin: installedOwner.launcher,
+      artifactOwner: installedOwner,
+    };
+    await expect(installCursorHooks(installedOptions)).rejects.toMatchObject({
+      code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+    });
+    await installCursorHooks({ ...installedOptions, takeover: true });
+    await expect(doctorCursorHooks({ ...installedOptions, enabled: true })).resolves.toMatchObject({
+      status: "ok",
+      ownership: { status: "same-owner", requested: installedOwner },
     });
   });
 

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { access, mkdir, mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import { providerHookScriptRoutesByStationEnv } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import {
@@ -177,6 +178,36 @@ describe("Cursor hook setup", () => {
     });
   });
 
+  it("does not accept a shared generated script owned by another Station runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-owner-"));
+    const hooksPath = join(root, "cursor", "hooks.json");
+    const sharedHookScriptPath = join(root, "default", "hooks", "station-cursor-hook.sh");
+    const requestedHookScriptPath = join(root, "requested", "hooks", "station-cursor-hook.sh");
+    const installedOwner = artifactOwner("/installed/stn-ingress", "compiled", "a");
+    const sourceOwner = artifactOwner("/source/bin/stn-ingress", "source", "b");
+    await installCursorHooks({
+      cursorHooksPath: hooksPath,
+      hookScriptPath: sharedHookScriptPath,
+      hookBin: installedOwner.launcher,
+      artifactOwner: installedOwner,
+    });
+
+    await expect(
+      doctorCursorHooks({
+        cursorHooksPath: hooksPath,
+        hookScriptPath: requestedHookScriptPath,
+        hookBin: sourceOwner.launcher,
+        artifactOwner: sourceOwner,
+        enabled: true,
+      }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      hookScriptPath: sharedHookScriptPath,
+      ownership: { status: "different-owner" },
+    });
+  });
+
   it("generated script delivers to stn-ingress even without ownership env", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cursor-hooks-"));
     const hooksPath = join(root, "cursor", "hooks.json");
@@ -342,6 +373,20 @@ describe("Cursor hook setup", () => {
     });
   });
 });
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
+}
 
 async function runHookScript(
   scriptPath: string,

--- a/integrations/harness/opencode/src/pluginInstall.ts
+++ b/integrations/harness/opencode/src/pluginInstall.ts
@@ -1,11 +1,10 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
 import {
   assertProviderHookArtifactOwnership,
   classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
-  type ProviderHookArtifactOwnership,
   providerHookOwnerMarker,
 } from "@station/runtime";
 import { openCodeForwardedEventTypes } from "./ingressRules.js";

--- a/integrations/harness/opencode/src/pluginInstall.ts
+++ b/integrations/harness/opencode/src/pluginInstall.ts
@@ -1,6 +1,13 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { createHookSetupFileOps } from "@station/runtime";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
+import {
+  assertProviderHookArtifactOwnership,
+  classifyProviderHookArtifactOwnership,
+  createHookSetupFileOps,
+  type ProviderHookArtifactOwnership,
+  providerHookOwnerMarker,
+} from "@station/runtime";
 import { openCodeForwardedEventTypes } from "./ingressRules.js";
 
 export const OPENCODE_STATION_PLUGIN_NAME = "station-agent-state.js";
@@ -14,6 +21,8 @@ export type OpenCodePluginPlanOptions = {
   hookSpoolDir?: string;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
 };
 
 export type OpenCodePluginPlan = {
@@ -24,6 +33,7 @@ export type OpenCodePluginPlan = {
   installed: boolean;
   before: string;
   after: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type OpenCodePluginInstallResult = OpenCodePluginPlan & {
@@ -40,6 +50,7 @@ export type OpenCodePluginDoctorResult = {
   installed: boolean;
   changed: boolean;
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 const fileOps = createHookSetupFileOps(({ operation, path, cause }) => {
@@ -54,7 +65,8 @@ export async function planOpenCodePlugin(
   const before = await fileOps.readOptionalFile(pluginPath);
   const after = expectedOpenCodePluginScript(options);
   const changed = before !== after;
-  return {
+  const ownership = openCodePluginOwnership(before, options);
+  const result: OpenCodePluginPlan = {
     provider: "opencode",
     configDir,
     pluginPath,
@@ -63,12 +75,16 @@ export async function planOpenCodePlugin(
     before,
     after,
   };
+  if (ownership !== undefined) result.ownership = ownership;
+  return result;
 }
 
 export async function installOpenCodePlugin(
   options: OpenCodePluginPlanOptions = {},
 ): Promise<OpenCodePluginInstallResult> {
   const plan = await planOpenCodePlugin(options);
+  const current = await fileOps.readOptionalFile(plan.pluginPath);
+  assertOpenCodePluginOwnership("install", plan.pluginPath, current, options);
   let backupPath: string | undefined;
   if (plan.changed) {
     backupPath = await fileOps.backupIfPresent(plan.pluginPath);
@@ -78,6 +94,13 @@ export async function installOpenCodePlugin(
     ...plan,
     installed: true,
   };
+  if (options.artifactOwner !== undefined) {
+    result.ownership = {
+      status: "same-owner",
+      requested: options.artifactOwner,
+      currentLauncher: options.artifactOwner.launcher,
+    };
+  }
   if (backupPath !== undefined) {
     result.backupPath = backupPath;
   }
@@ -88,6 +111,8 @@ export async function uninstallOpenCodePlugin(
   options: OpenCodePluginPlanOptions = {},
 ): Promise<OpenCodePluginInstallResult> {
   const plan = await planOpenCodePlugin(options);
+  const current = await fileOps.readOptionalFile(plan.pluginPath);
+  assertOpenCodePluginOwnership("uninstall", plan.pluginPath, current, options);
   let removed = false;
   if (plan.before.includes(OPENCODE_STATION_PLUGIN_MARKER)) {
     removed = await fileOps.removeHookFileIfPresent(plan.pluginPath);
@@ -105,26 +130,32 @@ export async function doctorOpenCodePlugin(
 ): Promise<OpenCodePluginDoctorResult> {
   const plan = await planOpenCodePlugin(options);
   const installed = plan.before.includes(OPENCODE_STATION_PLUGIN_MARKER);
+  const ownershipConflict =
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
   if (!installed && options.enabled === true) {
     return {
       provider: "opencode",
       configDir: plan.configDir,
       pluginPath: plan.pluginPath,
       status: "warn",
-      installed,
+      installed: ownershipConflict ? false : installed,
       changed: true,
       message: "OpenCode event plugin is not installed.",
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
-  if (installed && plan.changed) {
+  if (installed && (plan.changed || ownershipConflict)) {
     return {
       provider: "opencode",
       configDir: plan.configDir,
       pluginPath: plan.pluginPath,
       status: "warn",
-      installed,
+      installed: ownershipConflict ? false : installed,
       changed: true,
-      message: "OpenCode event plugin is installed but differs from the expected STATION plugin.",
+      message: ownershipConflict
+        ? "OpenCode event plugin ownership conflicts with this Station runtime; run `stn hooks install opencode --yes --takeover` only to transfer it."
+        : "OpenCode event plugin is installed but differs from the expected STATION plugin.",
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
   return {
@@ -137,6 +168,7 @@ export async function doctorOpenCodePlugin(
     message: installed
       ? "OpenCode event plugin is installed."
       : "OpenCode event plugin is not requested.",
+    ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
   };
 }
 
@@ -167,8 +199,16 @@ export function expectedOpenCodePluginScript(options: OpenCodePluginPlanOptions 
   const observerSocketPath = options.observerSocketPath ?? "";
   const stateDir = options.stateDir ?? "";
   const hookSpoolDir = options.hookSpoolDir ?? "";
-  return `// ${OPENCODE_STATION_PLUGIN_MARKER}
-// Generated by STATION. Do not edit by hand.
+  const ownerMarker =
+    options.artifactOwner === undefined
+      ? []
+      : [`// ${providerHookOwnerMarker(options.artifactOwner)}`];
+  const header = [
+    `// ${OPENCODE_STATION_PLUGIN_MARKER}`,
+    ...ownerMarker,
+    "// Generated by STATION. Do not edit by hand.",
+  ].join("\n");
+  return `${header}
 import { spawn, spawnSync } from "node:child_process";
 
 const fallbackSocketPath = ${JSON.stringify(observerSocketPath)};
@@ -350,4 +390,44 @@ function recordValue(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? value : undefined;
 }
 `;
+}
+
+function openCodePluginOwnership(
+  contents: string,
+  options: OpenCodePluginPlanOptions,
+): ProviderHookArtifactOwnership | undefined {
+  if (options.artifactOwner === undefined) return undefined;
+  const legacy = expectedOpenCodePluginScript(withoutOwnership(options));
+  return classifyProviderHookArtifactOwnership({
+    contents,
+    requested: options.artifactOwner,
+    ...(contents === legacy ? { legacyLauncher: options.artifactOwner.launcher } : {}),
+  });
+}
+
+function assertOpenCodePluginOwnership(
+  action: "install" | "uninstall",
+  pluginPath: string,
+  contents: string,
+  options: OpenCodePluginPlanOptions,
+): void {
+  const legacy = expectedOpenCodePluginScript(withoutOwnership(options));
+  assertProviderHookArtifactOwnership({
+    provider: "opencode",
+    action,
+    artifactPath: pluginPath,
+    contents,
+    ...(options.artifactOwner === undefined ? {} : { requested: options.artifactOwner }),
+    ...(contents === legacy && options.artifactOwner !== undefined
+      ? { legacyLauncher: options.artifactOwner.launcher }
+      : {}),
+    ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
+  });
+}
+
+function withoutOwnership(options: OpenCodePluginPlanOptions): OpenCodePluginPlanOptions {
+  const legacyOptions = { ...options };
+  delete legacyOptions.artifactOwner;
+  delete legacyOptions.takeover;
+  return legacyOptions;
 }

--- a/integrations/harness/opencode/src/pluginInstall.ts
+++ b/integrations/harness/opencode/src/pluginInstall.ts
@@ -130,7 +130,7 @@ export async function doctorOpenCodePlugin(
   const plan = await planOpenCodePlugin(options);
   const installed = plan.before.includes(OPENCODE_STATION_PLUGIN_MARKER);
   const ownershipConflict =
-    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "unknown-owner";
   if (!installed && options.enabled === true) {
     return {
       provider: "opencode",
@@ -396,11 +396,9 @@ function openCodePluginOwnership(
   options: OpenCodePluginPlanOptions,
 ): ProviderHookArtifactOwnership | undefined {
   if (options.artifactOwner === undefined) return undefined;
-  const legacy = expectedOpenCodePluginScript(withoutOwnership(options));
   return classifyProviderHookArtifactOwnership({
     contents,
     requested: options.artifactOwner,
-    ...(contents === legacy ? { legacyLauncher: options.artifactOwner.launcher } : {}),
   });
 }
 
@@ -410,23 +408,12 @@ function assertOpenCodePluginOwnership(
   contents: string,
   options: OpenCodePluginPlanOptions,
 ): void {
-  const legacy = expectedOpenCodePluginScript(withoutOwnership(options));
   assertProviderHookArtifactOwnership({
     provider: "opencode",
     action,
     artifactPath: pluginPath,
     contents,
     ...(options.artifactOwner === undefined ? {} : { requested: options.artifactOwner }),
-    ...(contents === legacy && options.artifactOwner !== undefined
-      ? { legacyLauncher: options.artifactOwner.launcher }
-      : {}),
     ...(options.takeover === undefined ? {} : { takeover: options.takeover }),
   });
-}
-
-function withoutOwnership(options: OpenCodePluginPlanOptions): OpenCodePluginPlanOptions {
-  const legacyOptions = { ...options };
-  delete legacyOptions.artifactOwner;
-  delete legacyOptions.takeover;
-  return legacyOptions;
 }

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -179,6 +179,9 @@ function openCodePluginDoctorOptions(
     pluginOptions.observerSocketPath = requesterRuntime.observerSocketPath;
     pluginOptions.stateDir = requesterRuntime.stateDir;
     pluginOptions.hookSpoolDir = requesterRuntime.hookSpoolDir;
+    if (requesterRuntime.artifactOwner !== undefined) {
+      pluginOptions.artifactOwner = requesterRuntime.artifactOwner;
+    }
   } else {
     if (options.observerSocketPath !== undefined) {
       pluginOptions.observerSocketPath = options.observerSocketPath;

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -203,13 +203,15 @@ async function hooksStatus(
   const pluginResult = await doctorOpenCodePlugin(openCodePluginDoctorOptions(options, context));
   const requested = options.installHooks === true;
   const installed = requested && pluginResult.installed && !pluginResult.changed;
-  return {
+  const status: HarnessHooksStatus = {
     provider: "opencode",
     requested,
     installed,
     missing: installed ? [] : [pluginResult.pluginPath],
     message: pluginResult.message,
   };
+  if (pluginResult.ownership !== undefined) status.ownership = pluginResult.ownership;
+  return status;
 }
 
 /**

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -134,7 +134,7 @@ describe("OpenCode plugin setup", () => {
     await expect(readFile(pluginPath, "utf8")).resolves.toContain("UserPlugin");
   });
 
-  it("adopts an exact legacy plugin but requires takeover across runtime owners", async () => {
+  it("requires takeover for an exact unmarked plugin and across runtime owners", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-opencode-owner-"));
     const pluginPath = join(root, "opencode", "plugins", "station-agent-state.js");
     const installedOwner = artifactOwner("/installed/stn-ingress", "compiled", "a");
@@ -142,7 +142,17 @@ describe("OpenCode plugin setup", () => {
     await mkdir(join(root, "opencode", "plugins"), { recursive: true });
     await writeFile(pluginPath, expectedOpenCodePluginScript(), "utf8");
 
-    await installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner });
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: installedOwner, enabled: true }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "unknown-owner", requested: installedOwner },
+    });
+    await expect(
+      installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner, takeover: true });
     const installedPlugin = await readFile(pluginPath, "utf8");
     await expect(
       installOpenCodePlugin({ pluginPath, artifactOwner: sourceOwner }),
@@ -181,28 +191,28 @@ describe("OpenCode plugin setup", () => {
     ).resolves.toMatchObject({ status: "ok", ownership: { status: "same-owner" } });
   });
 
-  it("requires takeover for a changed legacy Station plugin without creating a backup", async () => {
-    const root = await mkdtemp(join(tmpdir(), "station-opencode-legacy-owner-"));
+  it("requires takeover for a changed unmarked Station plugin without creating a backup", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-opencode-unknown-owner-"));
     const pluginDir = join(root, "opencode", "plugins");
     const pluginPath = join(pluginDir, "station-agent-state.js");
     const owner = artifactOwner("/source/bin/stn-ingress", "source", "a");
     await mkdir(pluginDir, { recursive: true });
-    const changedLegacy = `${expectedOpenCodePluginScript()}\n// local change\n`;
-    await writeFile(pluginPath, changedLegacy, "utf8");
+    const changedUnmarked = `${expectedOpenCodePluginScript()}\n// local change\n`;
+    await writeFile(pluginPath, changedUnmarked, "utf8");
 
     await expect(
       doctorOpenCodePlugin({ pluginPath, artifactOwner: owner, enabled: true }),
     ).resolves.toMatchObject({
       status: "warn",
       installed: false,
-      ownership: { status: "legacy-unknown", requested: owner },
+      ownership: { status: "unknown-owner", requested: owner },
     });
     await expect(installOpenCodePlugin({ pluginPath, artifactOwner: owner })).rejects.toMatchObject(
       {
         code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
       },
     );
-    await expect(readFile(pluginPath, "utf8")).resolves.toBe(changedLegacy);
+    await expect(readFile(pluginPath, "utf8")).resolves.toBe(changedUnmarked);
     expect((await readdir(pluginDir)).some((name) => name.includes(".bak"))).toBe(false);
 
     await installOpenCodePlugin({ pluginPath, artifactOwner: owner, takeover: true });

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -160,6 +160,55 @@ describe("OpenCode plugin setup", () => {
     await expect(readFile(pluginPath, "utf8")).resolves.toContain(
       providerHookOwnerMarker(sourceOwner),
     );
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: sourceOwner, enabled: true }),
+    ).resolves.toMatchObject({
+      status: "ok",
+      installed: true,
+      ownership: { status: "same-owner", requested: sourceOwner },
+    });
+    const sourcePlugin = await readFile(pluginPath, "utf8");
+    await expect(
+      uninstallOpenCodePlugin({ pluginPath, artifactOwner: installedOwner }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(pluginPath, "utf8")).resolves.toBe(sourcePlugin);
+    await expect(
+      installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner, takeover: true });
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: installedOwner, enabled: true }),
+    ).resolves.toMatchObject({ status: "ok", ownership: { status: "same-owner" } });
+  });
+
+  it("requires takeover for a changed legacy Station plugin without creating a backup", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-opencode-legacy-owner-"));
+    const pluginDir = join(root, "opencode", "plugins");
+    const pluginPath = join(pluginDir, "station-agent-state.js");
+    const owner = artifactOwner("/source/bin/stn-ingress", "source", "a");
+    await mkdir(pluginDir, { recursive: true });
+    const changedLegacy = `${expectedOpenCodePluginScript()}\n// local change\n`;
+    await writeFile(pluginPath, changedLegacy, "utf8");
+
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: owner, enabled: true }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "legacy-unknown", requested: owner },
+    });
+    await expect(installOpenCodePlugin({ pluginPath, artifactOwner: owner })).rejects.toMatchObject(
+      {
+        code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+      },
+    );
+    await expect(readFile(pluginPath, "utf8")).resolves.toBe(changedLegacy);
+    expect((await readdir(pluginDir)).some((name) => name.includes(".bak"))).toBe(false);
+
+    await installOpenCodePlugin({ pluginPath, artifactOwner: owner, takeover: true });
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: owner, enabled: true }),
+    ).resolves.toMatchObject({ status: "ok", ownership: { status: "same-owner" } });
   });
 
   it("filters streaming message events before delivery or spool", async () => {

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -2,9 +2,12 @@ import { access, mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/pr
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
+import { providerHookOwnerMarker } from "@station/runtime";
 import { describe, expect, it } from "vitest";
 import {
   doctorOpenCodePlugin,
+  expectedOpenCodePluginScript,
   installOpenCodePlugin,
   planOpenCodePlugin,
   resolveOpenCodeConfigDir,
@@ -129,6 +132,34 @@ describe("OpenCode plugin setup", () => {
       removed: false,
     });
     await expect(readFile(pluginPath, "utf8")).resolves.toContain("UserPlugin");
+  });
+
+  it("adopts an exact legacy plugin but requires takeover across runtime owners", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-opencode-owner-"));
+    const pluginPath = join(root, "opencode", "plugins", "station-agent-state.js");
+    const installedOwner = artifactOwner("/installed/stn-ingress", "compiled", "a");
+    const sourceOwner = artifactOwner("/source/bin/stn-ingress", "source", "b");
+    await mkdir(join(root, "opencode", "plugins"), { recursive: true });
+    await writeFile(pluginPath, expectedOpenCodePluginScript(), "utf8");
+
+    await installOpenCodePlugin({ pluginPath, artifactOwner: installedOwner });
+    const installedPlugin = await readFile(pluginPath, "utf8");
+    await expect(
+      installOpenCodePlugin({ pluginPath, artifactOwner: sourceOwner }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(pluginPath, "utf8")).resolves.toBe(installedPlugin);
+    await expect(
+      doctorOpenCodePlugin({ pluginPath, artifactOwner: sourceOwner, enabled: true }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "different-owner" },
+    });
+
+    await installOpenCodePlugin({ pluginPath, artifactOwner: sourceOwner, takeover: true });
+    await expect(readFile(pluginPath, "utf8")).resolves.toContain(
+      providerHookOwnerMarker(sourceOwner),
+    );
   });
 
   it("filters streaming message events before delivery or spool", async () => {
@@ -400,6 +431,20 @@ describe("OpenCode plugin setup", () => {
     });
   });
 });
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
+  };
+}
 
 async function writeIngressRecorder(root: string) {
   const ingressPath = join(root, "stn-ingress");

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -303,12 +303,20 @@ describe("OpenCodeHarnessProvider", () => {
     const requesterStateDir = join(root, "requester", "state");
     const requesterHookSpoolDir = join(requesterStateDir, "spool", "hooks");
     const requesterObserverSocketPath = join(root, "requester", "run", "observer.sock");
+    const requesterOwner = {
+      schemaVersion: 1 as const,
+      launcher: join(root, "requester", "bin", "stn-ingress"),
+      runtimeKind: "source" as const,
+      version: "0.0.0-pre-alpha.4",
+      buildIdentity: "a".repeat(64),
+    };
 
     await installOpenCodePlugin({
       opencodeConfigDir,
       observerSocketPath: requesterObserverSocketPath,
       stateDir: requesterStateDir,
       hookSpoolDir: requesterHookSpoolDir,
+      artifactOwner: requesterOwner,
     });
 
     const provider = createOpenCodeHarnessProvider({
@@ -323,18 +331,18 @@ describe("OpenCodeHarnessProvider", () => {
 
     const doctorChecks = provider.doctorChecks;
     if (doctorChecks === undefined) throw new Error("OpenCode doctor checks are unavailable.");
-    await expect(
-      doctorChecks({
-        providerHookRuntime: {
-          ingressLauncher: join(root, "requester", "bin", "stn-ingress"),
-          observerSocketPath: requesterObserverSocketPath,
-          stateDir: requesterStateDir,
-          hookSpoolDir: requesterHookSpoolDir,
-          autoStartFromHooks: false,
-          stationConfigPath: join(root, "requester", "config.toml"),
-        },
-      }),
-    ).resolves.toEqual(
+    const context = {
+      providerHookRuntime: {
+        ingressLauncher: requesterOwner.launcher,
+        observerSocketPath: requesterObserverSocketPath,
+        stateDir: requesterStateDir,
+        hookSpoolDir: requesterHookSpoolDir,
+        autoStartFromHooks: false,
+        stationConfigPath: join(root, "requester", "config.toml"),
+        artifactOwner: requesterOwner,
+      },
+    };
+    await expect(doctorChecks(context)).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: "opencode-plugin",
@@ -342,6 +350,10 @@ describe("OpenCodeHarnessProvider", () => {
         }),
       ]),
     );
+    await expect(provider.hooksStatus?.(context)).resolves.toMatchObject({
+      installed: true,
+      ownership: { status: "same-owner", requested: requesterOwner },
+    });
   });
 
   it("classifies and ingests OpenCode observations through provider-local parsing", async () => {

--- a/integrations/worktree/worktrunk/src/hooks.ts
+++ b/integrations/worktree/worktrunk/src/hooks.ts
@@ -3,9 +3,9 @@ import { isAbsolute, join, resolve } from "node:path";
 import {
   classifyProviderHookArtifactOwnership,
   createHookSetupFileOps,
+  PROVIDER_HOOK_OWNER_MARKER,
   ProviderHookArtifactOwnershipError,
   parseProviderHookOwnerMarker,
-  providerHookCommandLauncher,
   providerHookCommandLine,
   providerHookOwnerMarker,
 } from "@station/runtime";
@@ -67,19 +67,13 @@ export async function planWorktrunkHooks(
   const configPath = resolveWorktrunkConfigPath(options);
   const before = await fileOps.readOptionalFile(configPath);
   const commands = expectedWorktrunkHookCommands(options.expectation);
-  const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
-  const ownership = worktrunkArtifactOwnership(document, options.expectation);
+  const inspection = inspectWorktrunkHooks(document, options.expectation);
+  const ownership = worktrunkArtifactOwnership(inspection, options.expectation);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(document, hookName, commands[hookName]),
   );
-  // Bare commands from earlier builds are repair inputs, not healthy expectations.
-  const withoutLegacyOwner = uninstallCommands(
-    document,
-    expectedWorktrunkHookCommands(withoutArtifactOwner(options.expectation)),
-  );
-  const withoutLegacy = uninstallCommands(withoutLegacyOwner, legacyCommands);
-  const afterDocument = installCommands(withoutLegacy, commands);
+  const afterDocument = installCommands(inspection.document, commands);
   const after = stringifyTomlDocument(afterDocument);
 
   const result: WorktrunkHookPlan = {
@@ -98,7 +92,7 @@ export async function planWorktrunkHooks(
 export async function installWorktrunkHooks(
   options: WorktrunkHookPlanOptions,
 ): Promise<WorktrunkHookInstallResult> {
-  const plan = await planWorktrunkHooks(options);
+  let plan = await planWorktrunkHooks(options);
   if (!plan.changed) {
     return {
       ...plan,
@@ -106,7 +100,14 @@ export async function installWorktrunkHooks(
     };
   }
 
-  await assertWorktrunkArtifactOwnership("install", plan.configPath, options);
+  plan = await planWorktrunkHooks(options);
+  assertWorktrunkArtifactOwnership("install", plan.configPath, plan.ownership, options);
+  if (!plan.changed) {
+    return {
+      ...plan,
+      installed: true,
+    };
+  }
   const backupPath = await fileOps.backupIfPresent(plan.configPath);
   await fileOps.writeHookConfig(plan.configPath, plan.after);
   const result: WorktrunkHookInstallResult = {
@@ -130,21 +131,11 @@ export async function uninstallWorktrunkHooks(
   const configPath = resolveWorktrunkConfigPath(options);
   const before = await fileOps.readOptionalFile(configPath);
   const commands = expectedWorktrunkHookCommands(options.expectation);
-  const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
-  if (options.expectation.artifactOwner !== undefined && stationCommands(document).length > 0) {
-    await assertWorktrunkArtifactOwnership("uninstall", configPath, options);
-  }
-  const afterDocument =
-    options.expectation.artifactOwner === undefined
-      ? uninstallCommands(
-          uninstallCommands(
-            uninstallCommands(document, commands),
-            expectedWorktrunkHookCommands(withoutArtifactOwner(options.expectation)),
-          ),
-          legacyCommands,
-        )
-      : uninstallStationCommands(document);
+  const inspection = inspectWorktrunkHooks(document, options.expectation);
+  const ownership = worktrunkArtifactOwnership(inspection, options.expectation);
+  assertWorktrunkArtifactOwnership("uninstall", configPath, ownership, options);
+  const afterDocument = inspection.document;
   const after = stringifyTomlDocument(afterDocument);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(afterDocument, hookName, commands[hookName]),
@@ -199,7 +190,7 @@ export async function doctorWorktrunkHooks(
 
   const installed = plan.missing.length === 0;
   const ownershipConflict =
-    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "unknown-owner";
   const result: WorktrunkHookDoctorResult = {
     provider: "worktrunk",
     configPath: plan.configPath,
@@ -244,63 +235,41 @@ export function expectedWorktrunkHookCommands(
   ) as Record<WorktrunkHookName, string>;
 }
 
-function legacyBareWorktrunkHookCommands(
-  expectation: WorktrunkHookExpectation,
-): Record<WorktrunkHookName, string> {
-  if (expectation.hookBin === "stn-ingress") {
-    return expectedWorktrunkHookCommands(expectation);
-  }
-  return expectedWorktrunkHookCommands({
-    ...withoutArtifactOwner(expectation),
-    hookBin: "stn-ingress",
-  });
-}
-
 function worktrunkArtifactOwnership(
-  document: Record<string, unknown>,
+  inspection: WorktrunkHookInspection,
   expectation: WorktrunkHookExpectation,
 ): WorktrunkHookPlan["ownership"] {
   if (expectation.artifactOwner === undefined) return undefined;
-  const commands = stationCommands(document);
-  const contents = commands.join("\n");
-  const owners = commands.map(parseProviderHookOwnerMarker);
-  const launchers = new Set(
-    commands
-      .map((command) =>
-        isStationWorktrunkCommand(command) ? providerHookCommandLauncher(command) : undefined,
-      )
-      .filter((launcher): launcher is string => launcher !== undefined),
-  );
+  if (inspection.commands.length === 0 && !inspection.unknownOwner) {
+    return { status: "absent", requested: expectation.artifactOwner };
+  }
+  const owners = inspection.commands.map(parseProviderHookOwnerMarker);
   const markedLaunchers = new Set(
     owners.filter((owner) => owner !== undefined).map((owner) => owner.launcher),
   );
   if (
-    launchers.size > 1 ||
+    inspection.unknownOwner ||
     markedLaunchers.size > 1 ||
-    (markedLaunchers.size > 0 && owners.some((owner) => owner === undefined))
+    owners.some((owner) => owner === undefined)
   ) {
-    return { status: "legacy-unknown", requested: expectation.artifactOwner };
+    return { status: "unknown-owner", requested: expectation.artifactOwner };
   }
-  const legacyLauncher = launchers.size === 1 ? launchers.values().next().value : undefined;
   return classifyProviderHookArtifactOwnership({
-    contents,
+    contents: inspection.commands.join("\n"),
     requested: expectation.artifactOwner,
-    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
   });
 }
 
-async function assertWorktrunkArtifactOwnership(
+function assertWorktrunkArtifactOwnership(
   action: "install" | "uninstall",
   configPath: string,
+  ownership: WorktrunkHookPlan["ownership"],
   options: WorktrunkHookPlanOptions,
-): Promise<void> {
+): void {
   if (options.expectation.artifactOwner === undefined) return;
-  const current = await fileOps.readOptionalFile(configPath);
-  const document = parseTomlDocument(current);
-  const ownership = worktrunkArtifactOwnership(document, options.expectation);
   if (
     options.takeover !== true &&
-    (ownership?.status === "different-owner" || ownership?.status === "legacy-unknown")
+    (ownership?.status === "different-owner" || ownership?.status === "unknown-owner")
   ) {
     throw new ProviderHookArtifactOwnershipError({
       provider: "worktrunk",
@@ -311,30 +280,72 @@ async function assertWorktrunkArtifactOwnership(
   }
 }
 
-function stationCommands(document: Record<string, unknown>): string[] {
-  return WORKTRUNK_HOOK_NAMES.flatMap((hookName) => stationCommandsInHookValue(document[hookName]));
+type WorktrunkHookInspection = {
+  document: Record<string, unknown>;
+  commands: string[];
+  unknownOwner: boolean;
+};
+
+function inspectWorktrunkHooks(
+  document: Record<string, unknown>,
+  expectation: WorktrunkHookExpectation,
+): WorktrunkHookInspection {
+  const next = { ...document };
+  const commands: string[] = [];
+  let unknownOwner = false;
+  for (const hookName of WORKTRUNK_HOOK_NAMES) {
+    const inspected = inspectWorktrunkHookValue(
+      next[hookName],
+      providerHookCommandLine("worktrunk", expectation, hookName),
+    );
+    commands.push(...inspected.commands);
+    unknownOwner ||= inspected.unknownOwner;
+    if (inspected.value === undefined) delete next[hookName];
+    else next[hookName] = inspected.value;
+  }
+  return { document: next, commands, unknownOwner };
 }
 
-function stationCommandsInHookValue(value: unknown): string[] {
-  if (typeof value === "string") return isStationWorktrunkCommand(value) ? [value] : [];
-  if (Array.isArray(value)) return value.flatMap(stationCommandsInHookValue);
-  if (!isRecord(value)) return [];
+function inspectWorktrunkHookValue(
+  value: unknown,
+  unmarkedCommand: string,
+): { value: unknown; commands: string[]; unknownOwner: boolean } {
+  if (typeof value === "string") {
+    const stationCommand = value === unmarkedCommand || value.includes(PROVIDER_HOOK_OWNER_MARKER);
+    return stationCommand
+      ? {
+          value: undefined,
+          commands: [value],
+          unknownOwner: !value.includes(PROVIDER_HOOK_OWNER_MARKER),
+        }
+      : { value, commands: [], unknownOwner: false };
+  }
+  if (Array.isArray(value)) {
+    const commands: string[] = [];
+    let unknownOwner = false;
+    const next = value.flatMap((entry) => {
+      const inspected = inspectWorktrunkHookValue(entry, unmarkedCommand);
+      commands.push(...inspected.commands);
+      unknownOwner ||= inspected.unknownOwner;
+      return inspected.value === undefined ? [] : [inspected.value];
+    });
+    return {
+      value: next.length === 0 ? undefined : next,
+      commands,
+      unknownOwner,
+    };
+  }
+  if (!isRecord(value) || !(generatedCommandKey in value)) {
+    return { value, commands: [], unknownOwner: false };
+  }
   const command = value[generatedCommandKey];
-  return typeof command === "string" ? [command] : [];
-}
-
-function isStationWorktrunkCommand(command: string): boolean {
-  return (
-    providerHookCommandLauncher(command) !== undefined &&
-    command.includes(" worktrunk ") &&
-    WORKTRUNK_HOOK_NAMES.some((hookName) => command.includes(` ${hookName}`))
-  );
-}
-
-function withoutArtifactOwner(expectation: WorktrunkHookExpectation): WorktrunkHookExpectation {
-  const legacy = { ...expectation };
-  delete legacy.artifactOwner;
-  return legacy;
+  const next = { ...value };
+  delete next[generatedCommandKey];
+  return {
+    value: Object.keys(next).length === 0 ? undefined : next,
+    commands: typeof command === "string" ? [command] : [],
+    unknownOwner: typeof command !== "string" || !command.includes(PROVIDER_HOOK_OWNER_MARKER),
+  };
 }
 
 export function normalizeWorktrunkLifecycleEvent(event: string): string {
@@ -358,46 +369,7 @@ function installCommands(
   return next;
 }
 
-function uninstallCommands(
-  document: Record<string, unknown>,
-  commands: Record<WorktrunkHookName, string>,
-): Record<string, unknown> {
-  const next = { ...document };
-  for (const hookName of WORKTRUNK_HOOK_NAMES) {
-    const value = withoutGeneratedCommand(next[hookName], commands[hookName]);
-    if (value === undefined) {
-      delete next[hookName];
-    } else {
-      next[hookName] = value;
-    }
-  }
-  return next;
-}
-
-function uninstallStationCommands(document: Record<string, unknown>): Record<string, unknown> {
-  const next = { ...document };
-  for (const hookName of WORKTRUNK_HOOK_NAMES) {
-    const value = withoutStationCommand(next[hookName]);
-    if (value === undefined) delete next[hookName];
-    else next[hookName] = value;
-  }
-  return next;
-}
-
-function withoutStationCommand(value: unknown): unknown {
-  if (typeof value === "string") return isStationWorktrunkCommand(value) ? undefined : value;
-  if (Array.isArray(value)) {
-    const next = value.map(withoutStationCommand).filter((entry) => entry !== undefined);
-    return next.length === 0 ? undefined : next;
-  }
-  if (!isRecord(value)) return value;
-  const next = { ...value };
-  delete next[generatedCommandKey];
-  return Object.keys(next).length === 0 ? undefined : next;
-}
-
-// Worktrunk hook values may be strings, arrays, or tables. Preserve user hooks
-// and add/remove only our generated command under the stable "station" key.
+// Worktrunk hook values may be strings, arrays, or tables; "station" is our reserved table key.
 function withGeneratedCommand(value: unknown, command: string): unknown {
   if (value === undefined) {
     return { [generatedCommandKey]: command };
@@ -412,26 +384,6 @@ function withGeneratedCommand(value: unknown, command: string): unknown {
     return { ...value, [generatedCommandKey]: command };
   }
   return { existing: String(value), [generatedCommandKey]: command };
-}
-
-function withoutGeneratedCommand(value: unknown, command: string): unknown {
-  if (typeof value === "string") {
-    return value === command ? undefined : value;
-  }
-  if (Array.isArray(value)) {
-    const next = value
-      .map((entry) => withoutGeneratedCommand(entry, command))
-      .filter((entry) => entry !== undefined);
-    return next.length === 0 ? undefined : next;
-  }
-  if (isRecord(value)) {
-    const next = { ...value };
-    if (next[generatedCommandKey] === command) {
-      delete next[generatedCommandKey];
-    }
-    return Object.keys(next).length === 0 ? undefined : next;
-  }
-  return value;
 }
 
 function hookContainsCommand(

--- a/integrations/worktree/worktrunk/src/hooks.ts
+++ b/integrations/worktree/worktrunk/src/hooks.ts
@@ -1,6 +1,14 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
-import { createHookSetupFileOps, providerHookCommandLine } from "@station/runtime";
+import {
+  classifyProviderHookArtifactOwnership,
+  createHookSetupFileOps,
+  ProviderHookArtifactOwnershipError,
+  parseProviderHookOwnerMarker,
+  providerHookCommandLauncher,
+  providerHookCommandLine,
+  providerHookOwnerMarker,
+} from "@station/runtime";
 import { parse, stringify } from "smol-toml";
 import {
   WORKTRUNK_HOOK_NAMES,
@@ -61,15 +69,20 @@ export async function planWorktrunkHooks(
   const commands = expectedWorktrunkHookCommands(options.expectation);
   const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
+  const ownership = worktrunkArtifactOwnership(document, options.expectation);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(document, hookName, commands[hookName]),
   );
   // Bare commands from earlier builds are repair inputs, not healthy expectations.
-  const withoutLegacy = uninstallCommands(document, legacyCommands);
+  const withoutLegacyOwner = uninstallCommands(
+    document,
+    expectedWorktrunkHookCommands(withoutArtifactOwner(options.expectation)),
+  );
+  const withoutLegacy = uninstallCommands(withoutLegacyOwner, legacyCommands);
   const afterDocument = installCommands(withoutLegacy, commands);
   const after = stringifyTomlDocument(afterDocument);
 
-  return {
+  const result: WorktrunkHookPlan = {
     provider: "worktrunk",
     configPath,
     commands,
@@ -78,6 +91,8 @@ export async function planWorktrunkHooks(
     before,
     after,
   };
+  if (ownership !== undefined) result.ownership = ownership;
+  return result;
 }
 
 export async function installWorktrunkHooks(
@@ -91,13 +106,22 @@ export async function installWorktrunkHooks(
     };
   }
 
+  await assertWorktrunkArtifactOwnership("install", plan.configPath, options);
   const backupPath = await fileOps.backupIfPresent(plan.configPath);
   await fileOps.writeHookConfig(plan.configPath, plan.after);
-  return {
+  const result: WorktrunkHookInstallResult = {
     ...plan,
     installed: true,
     ...(backupPath === undefined ? {} : { backupPath }),
   };
+  if (options.expectation.artifactOwner !== undefined) {
+    result.ownership = {
+      status: "same-owner",
+      requested: options.expectation.artifactOwner,
+      currentLauncher: options.expectation.artifactOwner.launcher,
+    };
+  }
+  return result;
 }
 
 export async function uninstallWorktrunkHooks(
@@ -108,8 +132,19 @@ export async function uninstallWorktrunkHooks(
   const commands = expectedWorktrunkHookCommands(options.expectation);
   const legacyCommands = legacyBareWorktrunkHookCommands(options.expectation);
   const document = parseTomlDocument(before);
-  const withoutCanonical = uninstallCommands(document, commands);
-  const afterDocument = uninstallCommands(withoutCanonical, legacyCommands);
+  if (options.expectation.artifactOwner !== undefined && stationCommands(document).length > 0) {
+    await assertWorktrunkArtifactOwnership("uninstall", configPath, options);
+  }
+  const afterDocument =
+    options.expectation.artifactOwner === undefined
+      ? uninstallCommands(
+          uninstallCommands(
+            uninstallCommands(document, commands),
+            expectedWorktrunkHookCommands(withoutArtifactOwner(options.expectation)),
+          ),
+          legacyCommands,
+        )
+      : uninstallStationCommands(document);
   const after = stringifyTomlDocument(afterDocument);
   const missing = WORKTRUNK_HOOK_NAMES.filter(
     (hookName) => !hookContainsCommand(afterDocument, hookName, commands[hookName]),
@@ -158,21 +193,28 @@ export async function doctorWorktrunkHooks(
       commands: plan.commands,
       message:
         "Worktrunk lifecycle hooks are disabled in station config; automated mutations skip hooks.",
+      ...(plan.ownership === undefined ? {} : { ownership: plan.ownership }),
     };
   }
 
   const installed = plan.missing.length === 0;
-  return {
+  const ownershipConflict =
+    plan.ownership?.status === "different-owner" || plan.ownership?.status === "legacy-unknown";
+  const result: WorktrunkHookDoctorResult = {
     provider: "worktrunk",
     configPath: plan.configPath,
-    status: installed ? "ok" : "warn",
-    installed,
+    status: installed && !ownershipConflict ? "ok" : "warn",
+    installed: installed && !ownershipConflict,
     missing: plan.missing,
     commands: plan.commands,
-    message: installed
-      ? "Worktrunk lifecycle hooks are installed."
-      : `Worktrunk lifecycle hooks are missing: ${plan.missing.join(", ")}.`,
+    message: ownershipConflict
+      ? "Worktrunk lifecycle hook ownership conflicts with this Station runtime; run `stn hooks install worktrunk --yes --takeover` only to transfer it."
+      : installed
+        ? "Worktrunk lifecycle hooks are installed."
+        : `Worktrunk lifecycle hooks are missing: ${plan.missing.join(", ")}.`,
   };
+  if (plan.ownership !== undefined) result.ownership = plan.ownership;
+  return result;
 }
 
 export function resolveWorktrunkConfigPath(
@@ -193,7 +235,11 @@ export function expectedWorktrunkHookCommands(
   return Object.fromEntries(
     WORKTRUNK_HOOK_NAMES.map((hookName) => [
       hookName,
-      providerHookCommandLine("worktrunk", expectation, hookName),
+      `${providerHookCommandLine("worktrunk", expectation, hookName)}${
+        expectation.artifactOwner === undefined
+          ? ""
+          : ` # ${providerHookOwnerMarker(expectation.artifactOwner)}`
+      }`,
     ]),
   ) as Record<WorktrunkHookName, string>;
 }
@@ -204,7 +250,91 @@ function legacyBareWorktrunkHookCommands(
   if (expectation.hookBin === "stn-ingress") {
     return expectedWorktrunkHookCommands(expectation);
   }
-  return expectedWorktrunkHookCommands({ ...expectation, hookBin: "stn-ingress" });
+  return expectedWorktrunkHookCommands({
+    ...withoutArtifactOwner(expectation),
+    hookBin: "stn-ingress",
+  });
+}
+
+function worktrunkArtifactOwnership(
+  document: Record<string, unknown>,
+  expectation: WorktrunkHookExpectation,
+): WorktrunkHookPlan["ownership"] {
+  if (expectation.artifactOwner === undefined) return undefined;
+  const commands = stationCommands(document);
+  const contents = commands.join("\n");
+  const owners = commands.map(parseProviderHookOwnerMarker);
+  const launchers = new Set(
+    commands
+      .map((command) =>
+        isStationWorktrunkCommand(command) ? providerHookCommandLauncher(command) : undefined,
+      )
+      .filter((launcher): launcher is string => launcher !== undefined),
+  );
+  const markedLaunchers = new Set(
+    owners.filter((owner) => owner !== undefined).map((owner) => owner.launcher),
+  );
+  if (
+    launchers.size > 1 ||
+    markedLaunchers.size > 1 ||
+    (markedLaunchers.size > 0 && owners.some((owner) => owner === undefined))
+  ) {
+    return { status: "legacy-unknown", requested: expectation.artifactOwner };
+  }
+  const legacyLauncher = launchers.size === 1 ? launchers.values().next().value : undefined;
+  return classifyProviderHookArtifactOwnership({
+    contents,
+    requested: expectation.artifactOwner,
+    ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+  });
+}
+
+async function assertWorktrunkArtifactOwnership(
+  action: "install" | "uninstall",
+  configPath: string,
+  options: WorktrunkHookPlanOptions,
+): Promise<void> {
+  if (options.expectation.artifactOwner === undefined) return;
+  const current = await fileOps.readOptionalFile(configPath);
+  const document = parseTomlDocument(current);
+  const ownership = worktrunkArtifactOwnership(document, options.expectation);
+  if (
+    options.takeover !== true &&
+    (ownership?.status === "different-owner" || ownership?.status === "legacy-unknown")
+  ) {
+    throw new ProviderHookArtifactOwnershipError({
+      provider: "worktrunk",
+      action,
+      artifactPath: configPath,
+      ownership,
+    });
+  }
+}
+
+function stationCommands(document: Record<string, unknown>): string[] {
+  return WORKTRUNK_HOOK_NAMES.flatMap((hookName) => stationCommandsInHookValue(document[hookName]));
+}
+
+function stationCommandsInHookValue(value: unknown): string[] {
+  if (typeof value === "string") return isStationWorktrunkCommand(value) ? [value] : [];
+  if (Array.isArray(value)) return value.flatMap(stationCommandsInHookValue);
+  if (!isRecord(value)) return [];
+  const command = value[generatedCommandKey];
+  return typeof command === "string" ? [command] : [];
+}
+
+function isStationWorktrunkCommand(command: string): boolean {
+  return (
+    providerHookCommandLauncher(command) !== undefined &&
+    command.includes(" worktrunk ") &&
+    WORKTRUNK_HOOK_NAMES.some((hookName) => command.includes(` ${hookName}`))
+  );
+}
+
+function withoutArtifactOwner(expectation: WorktrunkHookExpectation): WorktrunkHookExpectation {
+  const legacy = { ...expectation };
+  delete legacy.artifactOwner;
+  return legacy;
 }
 
 export function normalizeWorktrunkLifecycleEvent(event: string): string {
@@ -242,6 +372,28 @@ function uninstallCommands(
     }
   }
   return next;
+}
+
+function uninstallStationCommands(document: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...document };
+  for (const hookName of WORKTRUNK_HOOK_NAMES) {
+    const value = withoutStationCommand(next[hookName]);
+    if (value === undefined) delete next[hookName];
+    else next[hookName] = value;
+  }
+  return next;
+}
+
+function withoutStationCommand(value: unknown): unknown {
+  if (typeof value === "string") return isStationWorktrunkCommand(value) ? undefined : value;
+  if (Array.isArray(value)) {
+    const next = value.map(withoutStationCommand).filter((entry) => entry !== undefined);
+    return next.length === 0 ? undefined : next;
+  }
+  if (!isRecord(value)) return value;
+  const next = { ...value };
+  delete next[generatedCommandKey];
+  return Object.keys(next).length === 0 ? undefined : next;
 }
 
 // Worktrunk hook values may be strings, arrays, or tables. Preserve user hooks

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -220,7 +220,7 @@ export class WorktrunkProvider implements WorktreeProvider {
           tag: "WorktrunkHookSetupError",
           code:
             result.ownership?.status === "different-owner" ||
-            result.ownership?.status === "legacy-unknown"
+            result.ownership?.status === "unknown-owner"
               ? "WORKTRUNK_HOOK_OWNERSHIP_CONFLICT"
               : "WORKTRUNK_HOOKS_MISSING",
           message: result.message,

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -198,6 +198,9 @@ export class WorktrunkProvider implements WorktreeProvider {
         if (runtime.stationConfigPath !== undefined) {
           expectation.stationConfigPath = runtime.stationConfigPath;
         }
+        if (runtime.artifactOwner !== undefined) {
+          expectation.artifactOwner = runtime.artifactOwner;
+        }
       }
       const hookOptions: Parameters<typeof doctorWorktrunkHooks>[0] = {
         expectation,
@@ -215,7 +218,11 @@ export class WorktrunkProvider implements WorktreeProvider {
       if (result.status !== "ok") {
         check.error = {
           tag: "WorktrunkHookSetupError",
-          code: "WORKTRUNK_HOOKS_MISSING",
+          code:
+            result.ownership?.status === "different-owner" ||
+            result.ownership?.status === "legacy-unknown"
+              ? "WORKTRUNK_HOOK_OWNERSHIP_CONFLICT"
+              : "WORKTRUNK_HOOKS_MISSING",
           message: result.message,
           provider: this.id,
         };

--- a/integrations/worktree/worktrunk/src/types.ts
+++ b/integrations/worktree/worktrunk/src/types.ts
@@ -1,4 +1,9 @@
-import type { ExternalCommandRunner, RuntimeClock } from "@station/runtime";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type {
+  ExternalCommandRunner,
+  ProviderHookArtifactOwnership,
+  RuntimeClock,
+} from "@station/runtime";
 
 export const WORKTRUNK_HOOK_NAMES = [
   "post-create",
@@ -16,6 +21,7 @@ export type WorktrunkHookExpectation = {
   hookSpoolDir: string;
   autoStartFromHooks: boolean;
   stationConfigPath?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
 };
 
 export type WorktrunkHookPlanOptions = {
@@ -23,6 +29,7 @@ export type WorktrunkHookPlanOptions = {
   worktrunkConfigPath?: string;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+  takeover?: boolean;
 };
 
 export type WorktrunkHookPlan = {
@@ -33,6 +40,7 @@ export type WorktrunkHookPlan = {
   changed: boolean;
   before: string;
   after: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type WorktrunkHookInstallResult = WorktrunkHookPlan & {
@@ -48,6 +56,7 @@ export type WorktrunkHookDoctorResult = {
   missing: WorktrunkHookName[];
   commands: Record<WorktrunkHookName, string>;
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type WorktrunkHookSetupErrorCode =

--- a/integrations/worktree/worktrunk/src/types.ts
+++ b/integrations/worktree/worktrunk/src/types.ts
@@ -1,9 +1,5 @@
-import type { ProviderHookArtifactOwner } from "@station/contracts";
-import type {
-  ExternalCommandRunner,
-  ProviderHookArtifactOwnership,
-  RuntimeClock,
-} from "@station/runtime";
+import type { ProviderHookArtifactOwner, ProviderHookArtifactOwnership } from "@station/contracts";
+import type { ExternalCommandRunner, RuntimeClock } from "@station/runtime";
 
 export const WORKTRUNK_HOOK_NAMES = [
   "post-create",

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -99,34 +99,69 @@ describe("Worktrunk hook setup", () => {
     });
   });
 
-  it("repairs exact legacy bare commands to the canonical absolute launcher", async () => {
+  it("requires takeover before replacing unmarked commands", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-wt-hooks-"));
     const configPath = join(root, "config.toml");
     await installWorktrunkHooks({
       worktrunkConfigPath: configPath,
       expectation: hookExpectation(),
     });
+    const owner = artifactOwner("/opt/station/stn-ingress", "compiled", "a");
+    const expectation = hookExpectation(owner.launcher, owner);
+    const unmarked = await readFile(configPath, "utf8");
 
     await expect(
       doctorWorktrunkHooks({
         worktrunkConfigPath: configPath,
-        expectation: hookExpectation("/opt/station/stn-ingress"),
+        expectation,
       }),
-    ).resolves.toMatchObject({ status: "warn", installed: false });
-
-    await installWorktrunkHooks({
-      worktrunkConfigPath: configPath,
-      expectation: hookExpectation("/opt/station/stn-ingress"),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "unknown-owner", requested: owner },
     });
+
+    await expect(
+      installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(unmarked);
+    await installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation, takeover: true });
     const contents = await readFile(configPath, "utf8");
     expect(contents).toContain("/opt/station/stn-ingress");
     expect(contents).not.toMatch(/= "stn-ingress --socket/);
     await expect(
-      doctorWorktrunkHooks({
-        worktrunkConfigPath: configPath,
-        expectation: hookExpectation("/opt/station/stn-ingress"),
-      }),
+      doctorWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
     ).resolves.toMatchObject({ status: "ok", installed: true });
+  });
+
+  it("refuses an occupied Station slot without removing unrelated Worktrunk commands", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-hooks-reserved-slot-"));
+    const configPath = join(root, "config.toml");
+    const owner = artifactOwner("/source/bin/stn-ingress", "source", "a");
+    const expectation = hookExpectation(owner.launcher, owner);
+    const before = '[post-create]\nstation = "echo user"\nkeep = "echo keep"\n';
+    await writeFile(configPath, before, "utf8");
+
+    await expect(
+      installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+      ownership: { status: "unknown-owner" },
+    });
+    await expect(
+      uninstallWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(before);
+
+    await installWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation,
+      takeover: true,
+    });
+    const after = await readFile(configPath, "utf8");
+    expect(after).toContain('keep = "echo keep"');
+    expect(after).not.toContain('station = "echo user"');
+    expect(after).toContain("station-provider-artifact-owner:v1:");
   });
 
   it("requires takeover before replacing or removing another runtime's lifecycle hooks", async () => {
@@ -191,7 +226,7 @@ describe("Worktrunk hook setup", () => {
     ).resolves.toMatchObject({
       status: "warn",
       installed: false,
-      ownership: { status: "legacy-unknown", requested: owner },
+      ownership: { status: "unknown-owner", requested: owner },
     });
     await expect(
       installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderHookArtifactOwner } from "@station/contracts";
@@ -171,6 +171,38 @@ describe("Worktrunk hook setup", () => {
       expectation: sourceExpectation,
     });
     await expect(readFile(configPath, "utf8")).resolves.not.toContain("stn-ingress");
+  });
+
+  it("requires takeover when lifecycle commands have mixed marker validity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-hooks-mixed-owner-"));
+    const configPath = join(root, "config.toml");
+    const owner = artifactOwner("/source/bin/stn-ingress", "source", "a");
+    const expectation = hookExpectation(owner.launcher, owner);
+    await installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation });
+    const installed = await readFile(configPath, "utf8");
+    const mixed = installed.replace(
+      /station-provider-artifact-owner:v1:[A-Za-z0-9_-]+/u,
+      "station-provider-artifact-owner:v1:malformed",
+    );
+    await writeFile(configPath, mixed, "utf8");
+
+    await expect(
+      doctorWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "legacy-unknown", requested: owner },
+    });
+    await expect(
+      installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(mixed);
+    expect((await readdir(root)).some((name) => name.includes(".bak"))).toBe(false);
+
+    await installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation, takeover: true });
+    await expect(
+      doctorWorktrunkHooks({ worktrunkConfigPath: configPath, expectation }),
+    ).resolves.toMatchObject({ status: "ok", ownership: { status: "same-owner" } });
   });
 });
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -1,11 +1,13 @@
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
 import {
   doctorWorktrunkHooks,
   installWorktrunkHooks,
   planWorktrunkHooks,
   uninstallWorktrunkHooks,
+  type WorktrunkHookExpectation,
 } from "@station/worktrunk";
 import { describe, expect, it } from "vitest";
 
@@ -126,15 +128,78 @@ describe("Worktrunk hook setup", () => {
       }),
     ).resolves.toMatchObject({ status: "ok", installed: true });
   });
+
+  it("requires takeover before replacing or removing another runtime's lifecycle hooks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-wt-hooks-owner-"));
+    const configPath = join(root, "config.toml");
+    const installedOwner = artifactOwner("/installed/stn-ingress", "compiled", "a");
+    const sourceOwner = artifactOwner("/source/bin/stn-ingress", "source", "b");
+    const installedExpectation = hookExpectation(installedOwner.launcher, installedOwner);
+    const sourceExpectation = hookExpectation(sourceOwner.launcher, sourceOwner);
+
+    await installWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation: installedExpectation,
+    });
+    const beforeConflict = await readFile(configPath, "utf8");
+
+    await expect(
+      installWorktrunkHooks({ worktrunkConfigPath: configPath, expectation: sourceExpectation }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await expect(readFile(configPath, "utf8")).resolves.toBe(beforeConflict);
+    await expect(
+      doctorWorktrunkHooks({ worktrunkConfigPath: configPath, expectation: sourceExpectation }),
+    ).resolves.toMatchObject({
+      status: "warn",
+      installed: false,
+      ownership: { status: "different-owner" },
+    });
+
+    await installWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation: sourceExpectation,
+      takeover: true,
+    });
+    await expect(
+      uninstallWorktrunkHooks({
+        worktrunkConfigPath: configPath,
+        expectation: installedExpectation,
+      }),
+    ).rejects.toMatchObject({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" });
+    await uninstallWorktrunkHooks({
+      worktrunkConfigPath: configPath,
+      expectation: sourceExpectation,
+    });
+    await expect(readFile(configPath, "utf8")).resolves.not.toContain("stn-ingress");
+  });
 });
 
-function hookExpectation(hookBin = "stn-ingress") {
-  return {
+function hookExpectation(
+  hookBin = "stn-ingress",
+  artifactOwner?: ProviderHookArtifactOwner,
+): WorktrunkHookExpectation {
+  const expectation: WorktrunkHookExpectation = {
     hookBin,
     stationConfigPath: "/tmp/station/config.toml",
     observerSocketPath: "/tmp/station/run/observer.sock",
     stateDir: "/tmp/station/state",
     hookSpoolDir: "/tmp/station/state/spool/hooks",
     autoStartFromHooks: true,
+  };
+  if (artifactOwner !== undefined) expectation.artifactOwner = artifactOwner;
+  return expectation;
+}
+
+function artifactOwner(
+  launcher: string,
+  runtimeKind: "compiled" | "source",
+  digit: string,
+): ProviderHookArtifactOwner {
+  return {
+    schemaVersion: 1,
+    launcher,
+    runtimeKind,
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.4",
+    buildIdentity: digit.repeat(64),
   };
 }

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -203,6 +203,18 @@ const providerHookAbsolutePathSchema = nonEmptyStringSchema.refine(
   "Provider hook runtime paths must be absolute.",
 );
 
+export const ProviderHookArtifactOwnerSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    launcher: providerHookAbsolutePathSchema,
+    runtimeKind: z.enum(["compiled", "source"]),
+    version: nonEmptyStringSchema,
+    buildIdentity: z.string().regex(/^[0-9a-f]{64}$/u),
+  })
+  .strict();
+
+export type ProviderHookArtifactOwner = z.infer<typeof ProviderHookArtifactOwnerSchema>;
+
 export const ProviderHookRuntimeSchema = z
   .object({
     ingressLauncher: providerHookAbsolutePathSchema,
@@ -211,6 +223,7 @@ export const ProviderHookRuntimeSchema = z
     hookSpoolDir: providerHookAbsolutePathSchema,
     autoStartFromHooks: z.boolean(),
     stationConfigPath: providerHookAbsolutePathSchema.optional(),
+    artifactOwner: ProviderHookArtifactOwnerSchema.optional(),
   })
   .strict();
 

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -234,12 +234,12 @@ export const ProviderHookArtifactOwnershipSchema = z.discriminatedUnion("status"
       status: z.literal("different-owner"),
       requested: ProviderHookArtifactOwnerSchema,
       currentLauncher: providerHookAbsolutePathSchema,
-      current: ProviderHookArtifactOwnerSchema.optional(),
+      current: ProviderHookArtifactOwnerSchema,
     })
     .strict(),
   z
     .object({
-      status: z.literal("legacy-unknown"),
+      status: z.literal("unknown-owner"),
       requested: ProviderHookArtifactOwnerSchema,
     })
     .strict(),

--- a/packages/contracts/src/providers.ts
+++ b/packages/contracts/src/providers.ts
@@ -215,6 +215,38 @@ export const ProviderHookArtifactOwnerSchema = z
 
 export type ProviderHookArtifactOwner = z.infer<typeof ProviderHookArtifactOwnerSchema>;
 
+export const ProviderHookArtifactOwnershipSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("absent"),
+      requested: ProviderHookArtifactOwnerSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("same-owner"),
+      requested: ProviderHookArtifactOwnerSchema,
+      currentLauncher: providerHookAbsolutePathSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("different-owner"),
+      requested: ProviderHookArtifactOwnerSchema,
+      currentLauncher: providerHookAbsolutePathSchema,
+      current: ProviderHookArtifactOwnerSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("legacy-unknown"),
+      requested: ProviderHookArtifactOwnerSchema,
+    })
+    .strict(),
+]);
+
+export type ProviderHookArtifactOwnership = z.infer<typeof ProviderHookArtifactOwnershipSchema>;
+
 export const ProviderHookRuntimeSchema = z
   .object({
     ingressLauncher: providerHookAbsolutePathSchema,
@@ -239,7 +271,8 @@ export type ProviderDoctorContext = {
 
 /**
  * Import-safe hook-install status for launch gates: `installed` is the gate,
- * `requested` separates missing hooks from config that never asked for them.
+ * `requested` separates missing hooks from config that never asked for them, and
+ * ownership preserves requester-versus-artifact provenance for setup diagnostics.
  */
 export type HarnessHooksStatus = {
   provider: ProviderId;
@@ -247,6 +280,7 @@ export type HarnessHooksStatus = {
   requested: boolean;
   missing: string[];
   message: string;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type OpenWorkspaceRequest = {

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -116,8 +116,21 @@ describe("contract schemas", () => {
     );
     expectFails(
       ProviderHookArtifactOwnershipSchema,
+      { status: "different-owner", requested, currentLauncher: current.launcher },
+      "different ownership without current owner provenance",
+    );
+    expectFails(
+      ProviderHookArtifactOwnershipSchema,
       { status: "absent", requested, extra: true },
       "ownership with an unknown field",
+    );
+    expect(
+      ProviderHookArtifactOwnershipSchema.parse({ status: "unknown-owner", requested }),
+    ).toEqual({ status: "unknown-owner", requested });
+    expectFails(
+      ProviderHookArtifactOwnershipSchema,
+      { status: "legacy-unknown", requested },
+      "removed legacy ownership status",
     );
   });
 

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -33,6 +33,7 @@ import {
   type ProjectId,
   ProjectIdSchema,
   ProviderHealthSchema,
+  ProviderHookArtifactOwnershipSchema,
   ProviderHookEventSchema,
   ProviderHookReceiptSchema,
   ProviderHookSpoolRecordSchema,
@@ -84,6 +85,42 @@ function expectFails(schema: ZodType, value: unknown, label: string) {
 }
 
 describe("contract schemas", () => {
+  it("strictly parses provider hook artifact ownership", () => {
+    const requested = {
+      schemaVersion: 1,
+      launcher: "/source/bin/stn-ingress",
+      runtimeKind: "source",
+      version: "0.0.0-pre-alpha.4",
+      buildIdentity: "a".repeat(64),
+    } as const;
+    const current = {
+      schemaVersion: 1,
+      launcher: "/installed/stn-ingress",
+      runtimeKind: "compiled",
+      version: "0.7.1",
+      buildIdentity: "b".repeat(64),
+    } as const;
+
+    expect(
+      ProviderHookArtifactOwnershipSchema.parse({
+        status: "different-owner",
+        requested,
+        currentLauncher: current.launcher,
+        current,
+      }),
+    ).toMatchObject({ status: "different-owner", requested, current });
+    expectFails(
+      ProviderHookArtifactOwnershipSchema,
+      { status: "same-owner", requested, currentLauncher: "relative/stn-ingress" },
+      "ownership with a relative current launcher",
+    );
+    expectFails(
+      ProviderHookArtifactOwnershipSchema,
+      { status: "absent", requested, extra: true },
+      "ownership with an unknown field",
+    );
+  });
+
   it("keeps provider-native execution identity on harness run observations", () => {
     expect(
       HarnessRunObservationSchema.parse({

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -127,11 +127,6 @@ describe("contract schemas", () => {
     expect(
       ProviderHookArtifactOwnershipSchema.parse({ status: "unknown-owner", requested }),
     ).toEqual({ status: "unknown-owner", requested });
-    expectFails(
-      ProviderHookArtifactOwnershipSchema,
-      { status: "legacy-unknown", requested },
-      "removed legacy ownership status",
-    );
   });
 
   it("keeps provider-native execution identity on harness run observations", () => {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -146,6 +146,13 @@ describe("diagnostics schemas", () => {
       hookSpoolDir: "/state/spool/hooks",
       autoStartFromHooks: true,
       stationConfigPath: "/checkout/station/config.toml",
+      artifactOwner: {
+        schemaVersion: 1,
+        launcher: "/checkout/station/bin/stn-ingress",
+        runtimeKind: "source",
+        version: "0.0.0-pre-alpha.4",
+        buildIdentity: "a".repeat(64),
+      },
     };
 
     expect(DoctorOptionsSchema.parse({ providerHookRuntime })).toEqual({ providerHookRuntime });
@@ -175,6 +182,14 @@ describe("diagnostics schemas", () => {
     expect(
       DoctorOptionsSchema.safeParse({
         providerHookRuntime: { ...providerHookRuntime, providerPrivateOption: true },
+      }).success,
+    ).toBe(false);
+    expect(
+      DoctorOptionsSchema.safeParse({
+        providerHookRuntime: {
+          ...providerHookRuntime,
+          artifactOwner: { ...providerHookRuntime.artifactOwner, launcher: "relative" },
+        },
       }).success,
     ).toBe(false);
   });

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -13,6 +13,7 @@ import type {
   ProviderDoctorCheck,
   ProviderDoctorContext,
   ProviderHealth,
+  ProviderHookArtifactOwner,
   ProviderId,
   RawHarnessEvent,
   SafeError,
@@ -245,6 +246,7 @@ export type CommonHookDoctorOptions = {
   hookSpoolDir?: string;
   autoStartFromHooks?: boolean;
   stationConfigPath?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
 };
 
 /** Maps the whole requester hook runtime or preserves the incumbent provider options. */
@@ -262,6 +264,9 @@ export function harnessHookDoctorOptions(
     result.autoStartFromHooks = runtime.autoStartFromHooks;
     if (runtime.stationConfigPath !== undefined) {
       result.stationConfigPath = runtime.stationConfigPath;
+    }
+    if (runtime.artifactOwner !== undefined) {
+      result.artifactOwner = runtime.artifactOwner;
     }
     return result;
   }

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -14,6 +14,7 @@ import type {
   ProviderDoctorContext,
   ProviderHealth,
   ProviderHookArtifactOwner,
+  ProviderHookArtifactOwnership,
   ProviderId,
   RawHarnessEvent,
   SafeError,
@@ -294,15 +295,22 @@ export function harnessHookDoctorOptions(
 export function harnessHooksStatusFrom(
   provider: ProviderId,
   requested: boolean,
-  result: { installed: boolean; missing: readonly unknown[]; message: string },
+  result: {
+    installed: boolean;
+    missing: readonly unknown[];
+    message: string;
+    ownership?: ProviderHookArtifactOwnership;
+  },
 ): HarnessHooksStatus {
-  return {
+  const status: HarnessHooksStatus = {
     provider,
     installed: result.installed,
     requested,
     missing: result.missing.map((name) => String(name)),
     message: result.message,
   };
+  if (result.ownership !== undefined) status.ownership = result.ownership;
+  return status;
 }
 
 function harnessCapabilities<TOpts extends CommonHarnessProviderOptions>(

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -184,11 +184,11 @@ describe("createTerminalBoundHarnessProvider", () => {
         installed: false,
         missing: ["station-codex-hook.sh"],
         message: "Another Station runtime owns the hook.",
-        ownership: { status: "legacy-unknown", requested },
+        ownership: { status: "unknown-owner", requested },
       }),
     ).toMatchObject({
       provider: "codex",
-      ownership: { status: "legacy-unknown", requested },
+      ownership: { status: "unknown-owner", requested },
     });
   });
 });

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -9,6 +9,7 @@ import {
   type CommonHarnessProviderOptions,
   createTerminalBoundHarnessProvider,
   harnessHookDoctorOptions,
+  harnessHooksStatusFrom,
   type TerminalBoundHarnessProviderSpec,
 } from "../../src/provider";
 
@@ -167,6 +168,28 @@ describe("createTerminalBoundHarnessProvider", () => {
     expect("doctorChecks" in provider).toBe(true);
     expect("hooksStatus" in provider).toBe(true);
     expect(provider.acceptsPersistedEvent?.({ provider: "test", observedAt: now })).toBe(false);
+  });
+
+  it("preserves hook artifact ownership in shared status mapping", () => {
+    const requested = {
+      schemaVersion: 1 as const,
+      launcher: "/source/bin/stn-ingress",
+      runtimeKind: "source" as const,
+      version: "0.0.0-pre-alpha.4",
+      buildIdentity: "a".repeat(64),
+    };
+
+    expect(
+      harnessHooksStatusFrom("codex", true, {
+        installed: false,
+        missing: ["station-codex-hook.sh"],
+        message: "Another Station runtime owns the hook.",
+        ownership: { status: "legacy-unknown", requested },
+      }),
+    ).toMatchObject({
+      provider: "codex",
+      ownership: { status: "legacy-unknown", requested },
+    });
   });
 });
 

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -234,6 +234,13 @@ describe("harnessHookDoctorOptions", () => {
     hookSpoolDir: "/checkout/B/state/spool/hooks",
     autoStartFromHooks: false,
     stationConfigPath: "/checkout/B/config.toml",
+    artifactOwner: {
+      schemaVersion: 1 as const,
+      launcher: "/checkout/B/bin/stn-ingress",
+      runtimeKind: "source" as const,
+      version: "0.0.0-test",
+      buildIdentity: "b".repeat(64),
+    },
   };
 
   it("uses the whole requester hook runtime instead of mixing incumbent fields", () => {
@@ -250,6 +257,7 @@ describe("harnessHookDoctorOptions", () => {
       hookSpoolDir: requesterRuntime.hookSpoolDir,
       autoStartFromHooks: requesterRuntime.autoStartFromHooks,
       stationConfigPath: requesterRuntime.stationConfigPath,
+      artifactOwner: requesterRuntime.artifactOwner,
     });
   });
 

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -6,6 +6,7 @@ import {
   type ProviderHookArtifactOwner,
   ProviderHookArtifactOwnerSchema,
   type ProviderHookArtifactOwnership,
+  type ProviderId,
 } from "@station/contracts";
 import type { StationBuildInfo } from "./buildInfo.js";
 import {
@@ -43,31 +44,41 @@ export type ProviderHookScriptOptions = {
 
 export const PROVIDER_HOOK_OWNER_MARKER = "station-provider-artifact-owner:v1:";
 
-export type { ProviderHookArtifactOwnership };
-
 export class ProviderHookArtifactOwnershipError extends Error {
+  readonly tag = "ProviderHookArtifactOwnershipError";
   readonly code = "PROVIDER_HOOK_OWNERSHIP_CONFLICT";
+  readonly provider: ProviderId;
+  readonly hint: string;
   readonly ownership: ProviderHookArtifactOwnership;
 
   constructor(input: {
-    provider: string;
+    provider: ProviderId;
     action: "install" | "uninstall";
     artifactPath: string;
-    ownership: ProviderHookArtifactOwnership;
+    ownership: Extract<
+      ProviderHookArtifactOwnership,
+      { status: "different-owner" | "legacy-unknown" }
+    >;
   }) {
-    const current =
-      "currentLauncher" in input.ownership
-        ? ` It currently belongs to ${input.ownership.currentLauncher}; the requested owner is ${input.ownership.requested.launcher}.`
-        : " Its existing Station ownership cannot be determined safely.";
+    const requested = input.ownership.requested;
+    const requestedOwner = `${requested.runtimeKind} ${requested.version} build ${requested.buildIdentity} via ${requested.launcher}`;
+    const currentOwner =
+      input.ownership.status === "legacy-unknown"
+        ? "unknown because the existing ownership marker is missing or invalid"
+        : input.ownership.current === undefined
+          ? `legacy artifact invoking ${input.ownership.currentLauncher}`
+          : `${input.ownership.current.runtimeKind} ${input.ownership.current.version} build ${input.ownership.current.buildIdentity} via ${input.ownership.current.launcher}`;
     const takeover = `stn hooks ${input.action} ${input.provider} --yes --takeover`;
     const repair =
-      "currentLauncher" in input.ownership
+      input.ownership.status === "different-owner"
         ? ` To perform this action as the current owner, run ${shellQuote(resolve(dirname(input.ownership.currentLauncher), "stn"))} hooks ${input.action} ${input.provider} --yes.`
         : "";
     super(
-      `Refusing to ${input.action} ${input.provider} hooks because ${input.artifactPath} is a shared Station artifact with a different or unknown owner.${current} Re-run ${takeover} only to transfer ownership.${repair}`,
+      `Refusing to ${input.action} ${input.provider} hooks because ${input.artifactPath} belongs to another Station runtime. Current owner: ${currentOwner}. Requested owner: ${requestedOwner}.`,
     );
-    this.name = "ProviderHookArtifactOwnershipError";
+    this.name = this.tag;
+    this.provider = input.provider;
+    this.hint = `Run ${takeover} only to transfer ownership.${repair}`;
     this.ownership = input.ownership;
   }
 }
@@ -146,7 +157,7 @@ export function classifyProviderHookArtifactOwnership(input: {
 }
 
 export function assertProviderHookArtifactOwnership(input: {
-  provider: string;
+  provider: ProviderId;
   action: "install" | "uninstall";
   artifactPath: string;
   contents: string;

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { copyFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import {
   type ProviderHookArtifactOwner,
   ProviderHookArtifactOwnerSchema,
@@ -48,8 +48,12 @@ export class ProviderHookArtifactOwnershipError extends Error {
   readonly tag = "ProviderHookArtifactOwnershipError";
   readonly code = "PROVIDER_HOOK_OWNERSHIP_CONFLICT";
   readonly provider: ProviderId;
-  readonly hint: string;
-  readonly ownership: ProviderHookArtifactOwnership;
+  readonly action: "install" | "uninstall";
+  readonly artifactPath: string;
+  readonly ownership: Extract<
+    ProviderHookArtifactOwnership,
+    { status: "different-owner" | "unknown-owner" }
+  >;
 
   constructor(input: {
     provider: ProviderId;
@@ -57,28 +61,14 @@ export class ProviderHookArtifactOwnershipError extends Error {
     artifactPath: string;
     ownership: Extract<
       ProviderHookArtifactOwnership,
-      { status: "different-owner" | "legacy-unknown" }
+      { status: "different-owner" | "unknown-owner" }
     >;
   }) {
-    const requested = input.ownership.requested;
-    const requestedOwner = `${requested.runtimeKind} ${requested.version} build ${requested.buildIdentity} via ${requested.launcher}`;
-    const currentOwner =
-      input.ownership.status === "legacy-unknown"
-        ? "unknown because the existing ownership marker is missing or invalid"
-        : input.ownership.current === undefined
-          ? `legacy artifact invoking ${input.ownership.currentLauncher}`
-          : `${input.ownership.current.runtimeKind} ${input.ownership.current.version} build ${input.ownership.current.buildIdentity} via ${input.ownership.current.launcher}`;
-    const takeover = `stn hooks ${input.action} ${input.provider} --yes --takeover`;
-    const repair =
-      input.ownership.status === "different-owner"
-        ? ` To perform this action as the current owner, run ${shellQuote(resolve(dirname(input.ownership.currentLauncher), "stn"))} hooks ${input.action} ${input.provider} --yes.`
-        : "";
-    super(
-      `Refusing to ${input.action} ${input.provider} hooks because ${input.artifactPath} belongs to another Station runtime. Current owner: ${currentOwner}. Requested owner: ${requestedOwner}.`,
-    );
+    super(`Provider hook artifact ownership conflicts at ${input.artifactPath}.`);
     this.name = this.tag;
     this.provider = input.provider;
-    this.hint = `Run ${takeover} only to transfer ownership.${repair}`;
+    this.action = input.action;
+    this.artifactPath = input.artifactPath;
     this.ownership = input.ownership;
   }
 }
@@ -126,34 +116,30 @@ export function parseProviderHookOwnerMarker(
  * POLICY
  *
  * Uses the canonical launcher path as the durable owner key so upgrades at one installed
- * location remain automatic while source and installed runtimes cannot replace each other.
+ * location remain automatic. Only a valid marker establishes ownership; unmarked or malformed
+ * artifacts require explicit takeover.
  */
 export function classifyProviderHookArtifactOwnership(input: {
   contents: string;
   requested: ProviderHookArtifactOwner;
-  legacyLauncher?: string;
 }): ProviderHookArtifactOwnership {
   if (input.contents.trim().length === 0) {
     return { status: "absent", requested: input.requested };
   }
   const current = parseProviderHookOwnerMarker(input.contents);
-  if (current === undefined && input.contents.includes(PROVIDER_HOOK_OWNER_MARKER)) {
-    return { status: "legacy-unknown", requested: input.requested };
+  if (current === undefined) {
+    return { status: "unknown-owner", requested: input.requested };
   }
-  const currentLauncher = current?.launcher ?? input.legacyLauncher;
-  if (currentLauncher === undefined) {
-    return { status: "legacy-unknown", requested: input.requested };
-  }
+  const currentLauncher = current.launcher;
   if (resolve(currentLauncher) === resolve(input.requested.launcher)) {
     return { status: "same-owner", requested: input.requested, currentLauncher };
   }
-  const ownership: ProviderHookArtifactOwnership = {
+  return {
     status: "different-owner",
     requested: input.requested,
     currentLauncher,
+    current,
   };
-  if (current !== undefined) ownership.current = current;
-  return ownership;
 }
 
 export function assertProviderHookArtifactOwnership(input: {
@@ -162,18 +148,16 @@ export function assertProviderHookArtifactOwnership(input: {
   artifactPath: string;
   contents: string;
   requested?: ProviderHookArtifactOwner;
-  legacyLauncher?: string;
   takeover?: boolean;
 }): ProviderHookArtifactOwnership | undefined {
   if (input.requested === undefined) return undefined;
   const ownership = classifyProviderHookArtifactOwnership({
     contents: input.contents,
     requested: input.requested,
-    ...(input.legacyLauncher === undefined ? {} : { legacyLauncher: input.legacyLauncher }),
   });
   if (
     input.takeover !== true &&
-    (ownership.status === "different-owner" || ownership.status === "legacy-unknown")
+    (ownership.status === "different-owner" || ownership.status === "unknown-owner")
   ) {
     throw new ProviderHookArtifactOwnershipError({
       provider: input.provider,
@@ -183,17 +167,6 @@ export function assertProviderHookArtifactOwnership(input: {
     });
   }
   return ownership;
-}
-
-export function providerHookScriptLauncher(script: string, provider: string): string | undefined {
-  const command = script
-    .split("\n")
-    .find((line) => line.includes(`${shellQuote(provider)} > /dev/null`));
-  return command === undefined ? undefined : providerHookCommandLauncher(command);
-}
-
-export function providerHookCommandLauncher(command: string): string | undefined {
-  return firstShellWord(command);
 }
 
 export type ConfigScriptHookPlan<Document, EventName extends string> = {
@@ -469,7 +442,7 @@ export async function planConfigScriptHook<Document, EventName extends string>(i
   expectedCommands: (hookScriptPath: string) => Record<EventName, string>;
   expectedScript: string;
   extraChanged?: boolean;
-  provider?: string;
+  provider?: ProviderId;
   artifactOwner?: ProviderHookArtifactOwner;
 }): Promise<ConfigScriptHookPlan<Document, EventName>> {
   const before = await input.readOptionalFile(input.configPath);
@@ -481,17 +454,12 @@ export async function planConfigScriptHook<Document, EventName extends string>(i
   const configChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== input.expectedScript;
   const changed = configChanged || scriptChanged || input.extraChanged === true;
-  const legacyLauncher =
-    input.provider === undefined
-      ? undefined
-      : providerHookScriptLauncher(scriptBefore, input.provider);
   const ownership =
     input.provider === undefined || input.artifactOwner === undefined
       ? undefined
       : classifyProviderHookArtifactOwnership({
           contents: scriptBefore,
           requested: input.artifactOwner,
-          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
         });
 
   const result: ConfigScriptHookPlan<Document, EventName> = {
@@ -516,20 +484,18 @@ export async function installConfigScriptHook(input: {
   configChanged: boolean;
   scriptChanged: boolean;
   fileOps: HookSetupFileOps;
-  provider?: string;
+  provider?: ProviderId;
   artifactOwner?: ProviderHookArtifactOwner;
   takeover?: boolean;
 }): Promise<string | undefined> {
   if (input.provider !== undefined) {
     const currentScript = await input.fileOps.readOptionalFile(input.hookScriptPath);
-    const legacyLauncher = providerHookScriptLauncher(currentScript, input.provider);
     assertProviderHookArtifactOwnership({
       provider: input.provider,
       action: "install",
       artifactPath: input.hookScriptPath,
       contents: currentScript,
       ...(input.artifactOwner === undefined ? {} : { requested: input.artifactOwner }),
-      ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
       ...(input.takeover === undefined ? {} : { takeover: input.takeover }),
     });
   }
@@ -555,20 +521,18 @@ export async function uninstallConfigScriptHook<Document, EventName extends stri
   documentContainsCommand: (document: Document, command: string) => boolean;
   expectedCommands: (hookScriptPath: string) => Record<EventName, string>;
   fileOps: HookSetupFileOps;
-  provider?: string;
+  provider?: ProviderId;
   artifactOwner?: ProviderHookArtifactOwner;
   takeover?: boolean;
 }): Promise<ConfigScriptHookUninstallPlan<Document, EventName>> {
   if (input.provider !== undefined) {
     const currentScript = await input.fileOps.readOptionalFile(input.hookScriptPath);
-    const legacyLauncher = providerHookScriptLauncher(currentScript, input.provider);
     assertProviderHookArtifactOwnership({
       provider: input.provider,
       action: "uninstall",
       artifactPath: input.hookScriptPath,
       contents: currentScript,
       ...(input.artifactOwner === undefined ? {} : { requested: input.artifactOwner }),
-      ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
       ...(input.takeover === undefined ? {} : { takeover: input.takeover }),
     });
   }
@@ -625,22 +589,4 @@ export function commandLine(args: readonly string[]): string {
 
 export function shellQuote(value: string): string {
   return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-function firstShellWord(command: string): string | undefined {
-  if (!command.startsWith("'")) return command.match(/^[^\s]+/u)?.[0];
-  let result = "";
-  let index = 1;
-  while (index < command.length) {
-    const end = command.indexOf("'", index);
-    if (end < 0) return undefined;
-    result += command.slice(index, end);
-    if (command.slice(end, end + 4) === "'\\''") {
-      result += "'";
-      index = end + 4;
-      continue;
-    }
-    return command[end + 1] === " " ? result : undefined;
-  }
-  return undefined;
 }

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import {
   type ProviderHookArtifactOwner,
   ProviderHookArtifactOwnerSchema,
+  type ProviderHookArtifactOwnership,
 } from "@station/contracts";
 import type { StationBuildInfo } from "./buildInfo.js";
 import {
@@ -42,16 +43,7 @@ export type ProviderHookScriptOptions = {
 
 export const PROVIDER_HOOK_OWNER_MARKER = "station-provider-artifact-owner:v1:";
 
-export type ProviderHookArtifactOwnership =
-  | { status: "absent"; requested: ProviderHookArtifactOwner }
-  | { status: "same-owner"; requested: ProviderHookArtifactOwner; currentLauncher: string }
-  | {
-      status: "different-owner";
-      requested: ProviderHookArtifactOwner;
-      currentLauncher: string;
-      current?: ProviderHookArtifactOwner;
-    }
-  | { status: "legacy-unknown"; requested: ProviderHookArtifactOwner };
+export type { ProviderHookArtifactOwnership };
 
 export class ProviderHookArtifactOwnershipError extends Error {
   readonly code = "PROVIDER_HOOK_OWNERSHIP_CONFLICT";

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import { copyFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+  type ProviderHookArtifactOwner,
+  ProviderHookArtifactOwnerSchema,
+} from "@station/contracts";
+import type { StationBuildInfo } from "./buildInfo.js";
 import {
   pathExists,
   readTextFileIfPresent,
@@ -30,7 +36,163 @@ export type ProviderHookScriptOptions = {
   hookSpoolDir?: string;
   autoStartFromHooks?: boolean;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
 };
+
+export const PROVIDER_HOOK_OWNER_MARKER = "station-provider-artifact-owner:v1:";
+
+export type ProviderHookArtifactOwnership =
+  | { status: "absent"; requested: ProviderHookArtifactOwner }
+  | { status: "same-owner"; requested: ProviderHookArtifactOwner; currentLauncher: string }
+  | {
+      status: "different-owner";
+      requested: ProviderHookArtifactOwner;
+      currentLauncher: string;
+      current?: ProviderHookArtifactOwner;
+    }
+  | { status: "legacy-unknown"; requested: ProviderHookArtifactOwner };
+
+export class ProviderHookArtifactOwnershipError extends Error {
+  readonly code = "PROVIDER_HOOK_OWNERSHIP_CONFLICT";
+  readonly ownership: ProviderHookArtifactOwnership;
+
+  constructor(input: {
+    provider: string;
+    action: "install" | "uninstall";
+    artifactPath: string;
+    ownership: ProviderHookArtifactOwnership;
+  }) {
+    const provider = capitalize(input.provider);
+    const current =
+      "currentLauncher" in input.ownership
+        ? ` It currently belongs to ${input.ownership.currentLauncher}; the requested owner is ${input.ownership.requested.launcher}.`
+        : " Its existing Station ownership cannot be determined safely.";
+    const takeover = `stn hooks ${input.action} ${input.provider} --yes --takeover`;
+    const repair =
+      "currentLauncher" in input.ownership
+        ? ` To perform this action as the current owner, run ${shellQuote(resolve(dirname(input.ownership.currentLauncher), "stn"))} hooks ${input.action} ${input.provider} --yes.`
+        : "";
+    super(
+      `Refusing to ${input.action} ${provider} hooks because ${input.artifactPath} is a shared Station artifact with a different or unknown owner.${current} Re-run ${takeover} only to transfer ownership.${repair}`,
+    );
+    this.name = "ProviderHookArtifactOwnershipError";
+    this.ownership = input.ownership;
+  }
+}
+
+export function providerHookArtifactOwner(
+  launcher: string,
+  buildInfo: StationBuildInfo,
+): ProviderHookArtifactOwner {
+  return ProviderHookArtifactOwnerSchema.parse({
+    schemaVersion: 1,
+    launcher: resolve(launcher),
+    runtimeKind: buildInfo.compiled ? "compiled" : "source",
+    version: buildInfo.version,
+    buildIdentity: buildInfo.buildIdentity,
+  });
+}
+
+export function providerHookOwnerMarker(owner: ProviderHookArtifactOwner): string {
+  const encoded = Buffer.from(
+    JSON.stringify(ProviderHookArtifactOwnerSchema.parse(owner)),
+    "utf8",
+  ).toString("base64url");
+  return `${PROVIDER_HOOK_OWNER_MARKER}${encoded}`;
+}
+
+export function parseProviderHookOwnerMarker(
+  contents: string,
+): ProviderHookArtifactOwner | undefined {
+  const markerIndex = contents.indexOf(PROVIDER_HOOK_OWNER_MARKER);
+  if (markerIndex < 0) return undefined;
+  const encoded = contents
+    .slice(markerIndex + PROVIDER_HOOK_OWNER_MARKER.length)
+    .match(/^[A-Za-z0-9_-]+/u)?.[0];
+  if (encoded === undefined) return undefined;
+  try {
+    return ProviderHookArtifactOwnerSchema.parse(
+      JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * POLICY
+ *
+ * Uses the canonical launcher path as the durable owner key so upgrades at one installed
+ * location remain automatic while source and installed runtimes cannot replace each other.
+ */
+export function classifyProviderHookArtifactOwnership(input: {
+  contents: string;
+  requested: ProviderHookArtifactOwner;
+  legacyLauncher?: string;
+}): ProviderHookArtifactOwnership {
+  if (input.contents.trim().length === 0) {
+    return { status: "absent", requested: input.requested };
+  }
+  const current = parseProviderHookOwnerMarker(input.contents);
+  if (current === undefined && input.contents.includes(PROVIDER_HOOK_OWNER_MARKER)) {
+    return { status: "legacy-unknown", requested: input.requested };
+  }
+  const currentLauncher = current?.launcher ?? input.legacyLauncher;
+  if (currentLauncher === undefined) {
+    return { status: "legacy-unknown", requested: input.requested };
+  }
+  if (resolve(currentLauncher) === resolve(input.requested.launcher)) {
+    return { status: "same-owner", requested: input.requested, currentLauncher };
+  }
+  const ownership: ProviderHookArtifactOwnership = {
+    status: "different-owner",
+    requested: input.requested,
+    currentLauncher,
+  };
+  if (current !== undefined) ownership.current = current;
+  return ownership;
+}
+
+export function assertProviderHookArtifactOwnership(input: {
+  provider: string;
+  action: "install" | "uninstall";
+  artifactPath: string;
+  contents: string;
+  requested?: ProviderHookArtifactOwner;
+  legacyLauncher?: string;
+  takeover?: boolean;
+}): ProviderHookArtifactOwnership | undefined {
+  if (input.requested === undefined) return undefined;
+  const ownership = classifyProviderHookArtifactOwnership({
+    contents: input.contents,
+    requested: input.requested,
+    ...(input.legacyLauncher === undefined ? {} : { legacyLauncher: input.legacyLauncher }),
+  });
+  if (
+    input.takeover !== true &&
+    (ownership.status === "different-owner" || ownership.status === "legacy-unknown")
+  ) {
+    throw new ProviderHookArtifactOwnershipError({
+      provider: input.provider,
+      action: input.action,
+      artifactPath: input.artifactPath,
+      ownership,
+    });
+  }
+  return ownership;
+}
+
+export function providerHookScriptLauncher(script: string, provider: string): string | undefined {
+  const command = script
+    .split("\n")
+    .find((line) => line.includes(`${shellQuote(provider)} > /dev/null`));
+  return command === undefined ? undefined : providerHookCommandLauncher(command);
+}
+
+export function providerHookCommandLauncher(command: string): string | undefined {
+  return firstShellWord(command);
+}
 
 export type ConfigScriptHookPlan<Document, EventName extends string> = {
   before: string;
@@ -41,6 +203,7 @@ export type ConfigScriptHookPlan<Document, EventName extends string> = {
   configChanged: boolean;
   scriptChanged: boolean;
   changed: boolean;
+  ownership?: ProviderHookArtifactOwnership;
 };
 
 export type ConfigScriptHookUninstallPlan<Document, EventName extends string> = {
@@ -224,6 +387,12 @@ export function providerHookScriptOptions(
   if (options.hookBin !== undefined) {
     input.hookBin = options.hookBin;
   }
+  if (options.artifactOwner !== undefined) {
+    input.artifactOwner = options.artifactOwner;
+  }
+  if (options.takeover !== undefined) {
+    input.takeover = options.takeover;
+  }
   return input;
 }
 
@@ -241,6 +410,9 @@ export function expectedProviderHookScript(input: {
   // scope — the observer correlates env-less events by their payload cwd.
   return [
     "#!/usr/bin/env bash",
+    ...(options.artifactOwner === undefined
+      ? []
+      : [`# ${providerHookOwnerMarker(options.artifactOwner)}`]),
     "set -euo pipefail",
     ...dynamicHookArg(
       "SOCKET_ARG",
@@ -295,6 +467,8 @@ export async function planConfigScriptHook<Document, EventName extends string>(i
   expectedCommands: (hookScriptPath: string) => Record<EventName, string>;
   expectedScript: string;
   extraChanged?: boolean;
+  provider?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
 }): Promise<ConfigScriptHookPlan<Document, EventName>> {
   const before = await input.readOptionalFile(input.configPath);
   const document = input.parseDocument(before);
@@ -305,8 +479,20 @@ export async function planConfigScriptHook<Document, EventName extends string>(i
   const configChanged = before.trim() !== after.trim();
   const scriptChanged = scriptBefore !== input.expectedScript;
   const changed = configChanged || scriptChanged || input.extraChanged === true;
+  const legacyLauncher =
+    input.provider === undefined
+      ? undefined
+      : providerHookScriptLauncher(scriptBefore, input.provider);
+  const ownership =
+    input.provider === undefined || input.artifactOwner === undefined
+      ? undefined
+      : classifyProviderHookArtifactOwnership({
+          contents: scriptBefore,
+          requested: input.artifactOwner,
+          ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+        });
 
-  return {
+  const result: ConfigScriptHookPlan<Document, EventName> = {
     before,
     after,
     document,
@@ -316,6 +502,8 @@ export async function planConfigScriptHook<Document, EventName extends string>(i
     scriptChanged,
     changed,
   };
+  if (ownership !== undefined) result.ownership = ownership;
+  return result;
 }
 
 export async function installConfigScriptHook(input: {
@@ -326,7 +514,23 @@ export async function installConfigScriptHook(input: {
   configChanged: boolean;
   scriptChanged: boolean;
   fileOps: HookSetupFileOps;
+  provider?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
 }): Promise<string | undefined> {
+  if (input.provider !== undefined) {
+    const currentScript = await input.fileOps.readOptionalFile(input.hookScriptPath);
+    const legacyLauncher = providerHookScriptLauncher(currentScript, input.provider);
+    assertProviderHookArtifactOwnership({
+      provider: input.provider,
+      action: "install",
+      artifactPath: input.hookScriptPath,
+      contents: currentScript,
+      ...(input.artifactOwner === undefined ? {} : { requested: input.artifactOwner }),
+      ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+      ...(input.takeover === undefined ? {} : { takeover: input.takeover }),
+    });
+  }
   let backupPath: string | undefined;
   if (input.configChanged) {
     backupPath = await input.fileOps.backupIfPresent(input.configPath);
@@ -349,7 +553,23 @@ export async function uninstallConfigScriptHook<Document, EventName extends stri
   documentContainsCommand: (document: Document, command: string) => boolean;
   expectedCommands: (hookScriptPath: string) => Record<EventName, string>;
   fileOps: HookSetupFileOps;
+  provider?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
+  takeover?: boolean;
 }): Promise<ConfigScriptHookUninstallPlan<Document, EventName>> {
+  if (input.provider !== undefined) {
+    const currentScript = await input.fileOps.readOptionalFile(input.hookScriptPath);
+    const legacyLauncher = providerHookScriptLauncher(currentScript, input.provider);
+    assertProviderHookArtifactOwnership({
+      provider: input.provider,
+      action: "uninstall",
+      artifactPath: input.hookScriptPath,
+      contents: currentScript,
+      ...(input.artifactOwner === undefined ? {} : { requested: input.artifactOwner }),
+      ...(legacyLauncher === undefined ? {} : { legacyLauncher }),
+      ...(input.takeover === undefined ? {} : { takeover: input.takeover }),
+    });
+  }
   const before = await input.readOptionalFile(input.configPath);
   const document = input.parseDocument(before);
   const commands = input.expectedCommands(input.hookScriptPath);
@@ -403,4 +623,26 @@ export function commandLine(args: readonly string[]): string {
 
 export function shellQuote(value: string): string {
   return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function firstShellWord(command: string): string | undefined {
+  if (!command.startsWith("'")) return command.match(/^[^\s]+/u)?.[0];
+  let result = "";
+  let index = 1;
+  while (index < command.length) {
+    const end = command.indexOf("'", index);
+    if (end < 0) return undefined;
+    result += command.slice(index, end);
+    if (command.slice(end, end + 4) === "'\\''") {
+      result += "'";
+      index = end + 4;
+      continue;
+    }
+    return command[end + 1] === " " ? result : undefined;
+  }
+  return undefined;
+}
+
+function capitalize(value: string): string {
+  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }

--- a/packages/runtime/src/hookSetup.ts
+++ b/packages/runtime/src/hookSetup.ts
@@ -55,7 +55,6 @@ export class ProviderHookArtifactOwnershipError extends Error {
     artifactPath: string;
     ownership: ProviderHookArtifactOwnership;
   }) {
-    const provider = capitalize(input.provider);
     const current =
       "currentLauncher" in input.ownership
         ? ` It currently belongs to ${input.ownership.currentLauncher}; the requested owner is ${input.ownership.requested.launcher}.`
@@ -66,7 +65,7 @@ export class ProviderHookArtifactOwnershipError extends Error {
         ? ` To perform this action as the current owner, run ${shellQuote(resolve(dirname(input.ownership.currentLauncher), "stn"))} hooks ${input.action} ${input.provider} --yes.`
         : "";
     super(
-      `Refusing to ${input.action} ${provider} hooks because ${input.artifactPath} is a shared Station artifact with a different or unknown owner.${current} Re-run ${takeover} only to transfer ownership.${repair}`,
+      `Refusing to ${input.action} ${input.provider} hooks because ${input.artifactPath} is a shared Station artifact with a different or unknown owner.${current} Re-run ${takeover} only to transfer ownership.${repair}`,
     );
     this.name = "ProviderHookArtifactOwnershipError";
     this.ownership = input.ownership;
@@ -633,8 +632,4 @@ function firstShellWord(command: string): string | undefined {
     return command[end + 1] === " " ? result : undefined;
   }
   return undefined;
-}
-
-function capitalize(value: string): string {
-  return `${value.slice(0, 1).toUpperCase()}${value.slice(1)}`;
 }

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -18,7 +18,6 @@ import {
   providerHookCommandArgs,
   providerHookCommandLine,
   providerHookOwnerMarker,
-  providerHookScriptLauncher,
   providerHookScriptOptions,
   providerHookScriptRoutesByStationEnv,
   shellQuote,
@@ -187,7 +186,7 @@ describe("runtime hookSetup", () => {
       expect(script).toContain("SPOOL_DIR_ARG=(--spool-dir /tmp/stale/spool/hooks)");
     });
 
-    it("embeds and recovers strict artifact ownership without changing the command", () => {
+    it("embeds and classifies strict artifact ownership without changing the command", () => {
       const owner = providerHookArtifactOwner("/opt/station/bin/stn-ingress", {
         version: "0.7.1",
         compiled: true,
@@ -199,7 +198,6 @@ describe("runtime hookSetup", () => {
       });
 
       expect(script).toContain(`# ${providerHookOwnerMarker(owner)}`);
-      expect(providerHookScriptLauncher(script, "codex")).toBe(owner.launcher);
       expect(classifyProviderHookArtifactOwnership({ contents: script, requested: owner })).toEqual(
         {
           status: "same-owner",
@@ -209,7 +207,7 @@ describe("runtime hookSetup", () => {
       );
     });
 
-    it("classifies absent, different, and unknown legacy artifacts", () => {
+    it("classifies absent, different, and unknown-owner artifacts", () => {
       const requested = providerHookArtifactOwner("/source/bin/stn-ingress", {
         version: "0.0.0",
         compiled: false,
@@ -232,14 +230,13 @@ describe("runtime hookSetup", () => {
       expect(
         classifyProviderHookArtifactOwnership({ contents: "# old generated hook\n", requested })
           .status,
-      ).toBe("legacy-unknown");
+      ).toBe("unknown-owner");
       expect(
         classifyProviderHookArtifactOwnership({
           contents: `# ${PROVIDER_HOOK_OWNER_MARKER}malformed\n/source/bin/stn-ingress codex`,
           requested,
-          legacyLauncher: requested.launcher,
         }).status,
-      ).toBe("legacy-unknown");
+      ).toBe("unknown-owner");
       expect(() =>
         assertProviderHookArtifactOwnership({
           provider: "codex",
@@ -250,7 +247,9 @@ describe("runtime hookSetup", () => {
         }),
       ).toThrowError(
         expect.objectContaining({
-          hint: expect.stringContaining("stn hooks install codex --yes --takeover"),
+          action: "install",
+          artifactPath: "/shared/hook.sh",
+          ownership: expect.objectContaining({ status: "different-owner" }),
         }),
       );
     });
@@ -279,7 +278,7 @@ describe("runtime hookSetup", () => {
       });
     });
 
-    it("adopts legacy generated scripts only when their launcher matches", () => {
+    it("requires takeover for an unmarked generated script", () => {
       const requested = providerHookArtifactOwner("/source path/bin/stn-ingress", {
         version: "0.0.0",
         compiled: false,
@@ -289,14 +288,21 @@ describe("runtime hookSetup", () => {
         provider: "claude",
         options: { hookBin: requested.launcher },
       });
-      expect(providerHookScriptLauncher(script, "claude")).toBe(requested.launcher);
       expect(
         classifyProviderHookArtifactOwnership({
           contents: script,
           requested,
-          legacyLauncher: providerHookScriptLauncher(script, "claude"),
         }).status,
-      ).toBe("same-owner");
+      ).toBe("unknown-owner");
+      expect(() =>
+        assertProviderHookArtifactOwnership({
+          provider: "claude",
+          action: "install",
+          artifactPath: "/shared/hook.sh",
+          contents: script,
+          requested,
+        }),
+      ).toThrowError(expect.objectContaining({ code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT" }));
     });
 
     it("recognizes generated scripts that route through runtime Station env", () => {
@@ -425,12 +431,9 @@ describe("runtime hookSetup", () => {
         tag: "ProviderHookArtifactOwnershipError",
         code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
         provider: "codex",
-        message: expect.stringContaining(
-          `Current owner: compiled 0.7.1 build ${BUILD_B} via /installed/bin/stn-ingress.`,
-        ),
-        hint: expect.stringContaining(
-          "To perform this action as the current owner, run /installed/bin/stn hooks install codex --yes.",
-        ),
+        action: "install",
+        artifactPath: scriptPath,
+        ownership: expect.objectContaining({ status: "different-owner", current }),
       });
       await expect(refusal.catch((error: unknown) => isSafeError(error))).resolves.toBe(true);
       await expect(readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -250,6 +250,30 @@ describe("runtime hookSetup", () => {
       ).toThrow(/--yes --takeover/u);
     });
 
+    it("allows version and build upgrades at the same launcher", () => {
+      const current = providerHookArtifactOwner("/opt/station/bin/stn-ingress", {
+        version: "0.7.1",
+        compiled: true,
+        buildIdentity: BUILD_A,
+      });
+      const requested = providerHookArtifactOwner(current.launcher, {
+        version: "0.7.2",
+        compiled: true,
+        buildIdentity: BUILD_B,
+      });
+
+      expect(
+        classifyProviderHookArtifactOwnership({
+          contents: `# ${providerHookOwnerMarker(current)}\n`,
+          requested,
+        }),
+      ).toEqual({
+        status: "same-owner",
+        requested,
+        currentLauncher: current.launcher,
+      });
+    });
+
     it("adopts legacy generated scripts only when their launcher matches", () => {
       const requested = providerHookArtifactOwner("/source path/bin/stn-ingress", {
         version: "0.0.0",

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -2,16 +2,22 @@ import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  assertProviderHookArtifactOwnership,
   assignBackupPaths,
+  classifyProviderHookArtifactOwnership,
   commandLine,
   createHookSetupFileOps,
   expectedProviderHookScript,
   type HookSetupErrorFactory,
   hookCommandsForEvents,
   installConfigScriptHook,
+  PROVIDER_HOOK_OWNER_MARKER,
   planConfigScriptHook,
+  providerHookArtifactOwner,
   providerHookCommandArgs,
   providerHookCommandLine,
+  providerHookOwnerMarker,
+  providerHookScriptLauncher,
   providerHookScriptOptions,
   providerHookScriptRoutesByStationEnv,
   shellQuote,
@@ -24,6 +30,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 type Doc = Record<string, string>;
 const EVENTS = ["PreToolUse", "PostToolUse"] as const;
 type Event = (typeof EVENTS)[number];
+const BUILD_A = "a".repeat(64);
+const BUILD_B = "b".repeat(64);
 
 const docSpec = (scriptPath: string) => ({
   readOptionalFile: readViaOps,
@@ -178,6 +186,90 @@ describe("runtime hookSetup", () => {
       expect(script).toContain("SPOOL_DIR_ARG=(--spool-dir /tmp/stale/spool/hooks)");
     });
 
+    it("embeds and recovers strict artifact ownership without changing the command", () => {
+      const owner = providerHookArtifactOwner("/opt/station/bin/stn-ingress", {
+        version: "0.7.1",
+        compiled: true,
+        buildIdentity: BUILD_A,
+      });
+      const script = expectedProviderHookScript({
+        provider: "codex",
+        options: { hookBin: owner.launcher, artifactOwner: owner },
+      });
+
+      expect(script).toContain(`# ${providerHookOwnerMarker(owner)}`);
+      expect(providerHookScriptLauncher(script, "codex")).toBe(owner.launcher);
+      expect(classifyProviderHookArtifactOwnership({ contents: script, requested: owner })).toEqual(
+        {
+          status: "same-owner",
+          requested: owner,
+          currentLauncher: owner.launcher,
+        },
+      );
+    });
+
+    it("classifies absent, different, and unknown legacy artifacts", () => {
+      const requested = providerHookArtifactOwner("/source/bin/stn-ingress", {
+        version: "0.0.0",
+        compiled: false,
+        buildIdentity: BUILD_A,
+      });
+      const current = providerHookArtifactOwner("/installed/bin/stn-ingress", {
+        version: "0.7.1",
+        compiled: true,
+        buildIdentity: BUILD_B,
+      });
+      expect(classifyProviderHookArtifactOwnership({ contents: "", requested }).status).toBe(
+        "absent",
+      );
+      expect(
+        classifyProviderHookArtifactOwnership({
+          contents: `# ${providerHookOwnerMarker(current)}\n`,
+          requested,
+        }),
+      ).toMatchObject({ status: "different-owner", currentLauncher: current.launcher });
+      expect(
+        classifyProviderHookArtifactOwnership({ contents: "# old generated hook\n", requested })
+          .status,
+      ).toBe("legacy-unknown");
+      expect(
+        classifyProviderHookArtifactOwnership({
+          contents: `# ${PROVIDER_HOOK_OWNER_MARKER}malformed\n/source/bin/stn-ingress codex`,
+          requested,
+          legacyLauncher: requested.launcher,
+        }).status,
+      ).toBe("legacy-unknown");
+      expect(() =>
+        assertProviderHookArtifactOwnership({
+          provider: "codex",
+          action: "install",
+          artifactPath: "/shared/hook.sh",
+          contents: `# ${providerHookOwnerMarker(current)}\n`,
+          requested,
+        }),
+      ).toThrow(/--yes --takeover/u);
+    });
+
+    it("adopts legacy generated scripts only when their launcher matches", () => {
+      const requested = providerHookArtifactOwner("/source path/bin/stn-ingress", {
+        version: "0.0.0",
+        compiled: false,
+        buildIdentity: BUILD_A,
+      });
+      const script = expectedProviderHookScript({
+        provider: "claude",
+        options: { hookBin: requested.launcher },
+      });
+      expect(providerHookScriptLauncher(script, "claude")).toBe(requested.launcher);
+      expect(
+        classifyProviderHookArtifactOwnership({
+          contents: script,
+          requested,
+          legacyLauncher: providerHookScriptLauncher(script, "claude"),
+        }).status,
+      ).toBe("same-owner");
+    });
+
     it("recognizes generated scripts that route through runtime Station env", () => {
       const script = expectedProviderHookScript({
         provider: "cursor",
@@ -257,6 +349,60 @@ describe("runtime hookSetup", () => {
       expect(replan.configChanged).toBe(false);
       expect(replan.scriptChanged).toBe(false);
       expect(replan.changed).toBe(true);
+    });
+
+    it("re-reads ownership before mutation and refuses a raced owner change", async () => {
+      const configPath = join(root, "config.json");
+      const scriptPath = join(root, "hook.sh");
+      const requested = providerHookArtifactOwner("/source/bin/stn-ingress", {
+        version: "0.0.0",
+        compiled: false,
+        buildIdentity: BUILD_A,
+      });
+      const current = providerHookArtifactOwner("/installed/bin/stn-ingress", {
+        version: "0.7.1",
+        compiled: true,
+        buildIdentity: BUILD_B,
+      });
+      const expectedScript = expectedProviderHookScript({
+        provider: "codex",
+        options: { hookBin: requested.launcher, artifactOwner: requested },
+      });
+      const plan = await planConfigScriptHook({
+        ...docSpec(scriptPath),
+        configPath,
+        expectedScript,
+      });
+      await writeFile(
+        scriptPath,
+        expectedProviderHookScript({
+          provider: "codex",
+          options: { hookBin: current.launcher, artifactOwner: current },
+        }),
+      );
+
+      await expect(
+        installConfigScriptHook({
+          configPath,
+          hookScriptPath: scriptPath,
+          after: plan.after,
+          expectedScript,
+          configChanged: plan.configChanged,
+          scriptChanged: plan.scriptChanged,
+          fileOps: ops,
+          provider: "codex",
+          artifactOwner: requested,
+        }),
+      ).rejects.toMatchObject({
+        code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+        message: expect.stringContaining(
+          "To perform this action as the current owner, run /installed/bin/stn hooks install codex --yes.",
+        ),
+      });
+      await expect(readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(readFile(scriptPath, "utf8")).resolves.toContain(
+        providerHookOwnerMarker(current),
+      );
     });
 
     it("backs up the existing config when a reinstall changes it", async () => {

--- a/packages/runtime/test/unit/hookSetup.test.ts
+++ b/packages/runtime/test/unit/hookSetup.test.ts
@@ -11,6 +11,7 @@ import {
   type HookSetupErrorFactory,
   hookCommandsForEvents,
   installConfigScriptHook,
+  isSafeError,
   PROVIDER_HOOK_OWNER_MARKER,
   planConfigScriptHook,
   providerHookArtifactOwner,
@@ -247,7 +248,11 @@ describe("runtime hookSetup", () => {
           contents: `# ${providerHookOwnerMarker(current)}\n`,
           requested,
         }),
-      ).toThrow(/--yes --takeover/u);
+      ).toThrowError(
+        expect.objectContaining({
+          hint: expect.stringContaining("stn hooks install codex --yes --takeover"),
+        }),
+      );
     });
 
     it("allows version and build upgrades at the same launcher", () => {
@@ -405,24 +410,29 @@ describe("runtime hookSetup", () => {
         }),
       );
 
-      await expect(
-        installConfigScriptHook({
-          configPath,
-          hookScriptPath: scriptPath,
-          after: plan.after,
-          expectedScript,
-          configChanged: plan.configChanged,
-          scriptChanged: plan.scriptChanged,
-          fileOps: ops,
-          provider: "codex",
-          artifactOwner: requested,
-        }),
-      ).rejects.toMatchObject({
+      const refusal = installConfigScriptHook({
+        configPath,
+        hookScriptPath: scriptPath,
+        after: plan.after,
+        expectedScript,
+        configChanged: plan.configChanged,
+        scriptChanged: plan.scriptChanged,
+        fileOps: ops,
+        provider: "codex",
+        artifactOwner: requested,
+      });
+      await expect(refusal).rejects.toMatchObject({
+        tag: "ProviderHookArtifactOwnershipError",
         code: "PROVIDER_HOOK_OWNERSHIP_CONFLICT",
+        provider: "codex",
         message: expect.stringContaining(
+          `Current owner: compiled 0.7.1 build ${BUILD_B} via /installed/bin/stn-ingress.`,
+        ),
+        hint: expect.stringContaining(
           "To perform this action as the current owner, run /installed/bin/stn hooks install codex --yes.",
         ),
       });
+      await expect(refusal.catch((error: unknown) => isSafeError(error))).resolves.toBe(true);
       await expect(readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
       await expect(readFile(scriptPath, "utf8")).resolves.toContain(
         providerHookOwnerMarker(current),

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -1,9 +1,13 @@
 import { spawn, spawnSync } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { createObserverClient } from "../../packages/protocol/src/index.js";
+import {
+  expectedProviderHookScript,
+  providerHookOwnerMarker,
+} from "../../packages/runtime/src/index.js";
 import { waitForSocketClosed } from "../support/sockets";
 
 const shellIntegrationMarker = "# Worktrunk shell integration";
@@ -67,6 +71,109 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).not.toContain("\n  stn doctor\n");
       expect(result.stdout).not.toContain("\n  stn\n");
       await expect(readFile(fixture.configPath, "utf8")).resolves.toContain("[harness.codex]");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("refuses a foreign Codex hook in guided and noninteractive setup until takeover", async () => {
+    const fixture = await createFixture({ harness: "codex", shell: "zsh" });
+    const hookDir = join(fixture.home, ".local", "state", "station", "hooks");
+    const hookScriptPath = join(hookDir, "station-codex-hook.sh");
+    const foreignOwner = {
+      schemaVersion: 1 as const,
+      launcher: "/opt/station/bin/stn-ingress",
+      runtimeKind: "compiled" as const,
+      version: "0.7.1",
+      buildIdentity: "a".repeat(64),
+    };
+    const foreignScript = expectedProviderHookScript({
+      provider: "codex",
+      options: { hookBin: foreignOwner.launcher, artifactOwner: foreignOwner },
+    });
+    await mkdir(hookDir, { recursive: true });
+    await writeFile(hookScriptPath, foreignScript, "utf8");
+    try {
+      const guided = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["n", "n", "y", "y", "n", "n"],
+      });
+
+      expect(guided.timedOut).toBe(false);
+      expect(guided.exitCode).toBe(1);
+      expect(`${guided.stdout}\n${guided.stderr}`).toContain(
+        "stn hooks install codex --yes --takeover",
+      );
+      await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(foreignScript);
+      expect((await readdir(hookDir)).some((name) => name.includes(".bak"))).toBe(false);
+
+      const check = await runStation(["--config", fixture.configPath, "setup", "check", "--json"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: [],
+      });
+      const checkPlan = JSON.parse(check.stdout) as {
+        checks: Array<{ id: string; details?: Record<string, string> }>;
+      };
+      expect(
+        checkPlan.checks.find((candidate) => candidate.id === "harness-tracking:codex")?.details,
+      ).toEqual(
+        expect.objectContaining({
+          ownership: "different-owner",
+          currentLauncher: foreignOwner.launcher,
+          currentBuildIdentity: foreignOwner.buildIdentity,
+          requestedLauncher: join(process.cwd(), "bin", "stn-ingress"),
+        }),
+      );
+
+      const noninteractive = await runStation(
+        ["--config", fixture.configPath, "setup", "apply", "--yes"],
+        { cwd: fixture.repo, env: fixture.env, answers: [] },
+      );
+      expect(noninteractive.exitCode).toBe(1);
+      expect(`${noninteractive.stdout}\n${noninteractive.stderr}`).toContain(
+        "stn hooks install codex --yes --takeover",
+      );
+      await expect(readFile(hookScriptPath, "utf8")).resolves.toBe(foreignScript);
+
+      const repaired = await runStation(
+        [
+          "--config",
+          fixture.configPath,
+          "hooks",
+          "install",
+          "codex",
+          "--yes",
+          "--takeover",
+          "--hook-bin",
+          join(process.cwd(), "bin", "stn-ingress"),
+        ],
+        { cwd: fixture.repo, env: fixture.env, answers: [] },
+      );
+      expect(repaired.exitCode, `${repaired.stdout}\n${repaired.stderr}`).toBe(0);
+      const repairedScript = await readFile(hookScriptPath, "utf8");
+      expect(repairedScript).not.toBe(foreignScript);
+      expect(repairedScript).toContain(join(process.cwd(), "bin", "stn-ingress"));
+      expect(repairedScript).toContain("station-provider-artifact-owner:v1:");
+      expect(repairedScript).not.toContain(providerHookOwnerMarker(foreignOwner));
+
+      const repairedCheck = await runStation(
+        ["--config", fixture.configPath, "setup", "check", "--json"],
+        { cwd: fixture.repo, env: fixture.env, answers: [] },
+      );
+      const repairedPlan = JSON.parse(repairedCheck.stdout) as {
+        checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
+      };
+      expect(
+        repairedPlan.checks.find((candidate) => candidate.id === "harness-tracking:codex"),
+      ).toMatchObject({
+        status: "ok",
+        details: {
+          ownership: "same-owner",
+          requestedLauncher: join(process.cwd(), "bin", "stn-ingress"),
+        },
+      });
     } finally {
       await fixture.cleanup();
     }


### PR DESCRIPTION
## What this fixes

`stn hooks install <provider>` writes small pieces of executable glue into user-level locations shared by every Station installation and source checkout on the machine. Codex, Claude, and Cursor use generated scripts in Station state; OpenCode uses a generated plugin in its user config; Worktrunk stores Station-managed lifecycle commands in its config.

Previously, one Station runtime could silently rewrite those shared artifacts to launch its own `stn-ingress`. An installed Observer would then receive events stamped by a different source build and correctly reject them as `OBSERVER_HANDOFF_REFUSED`. Provider readiness failed, so new or forked sessions could remain at `starting session...`.

The Observer rejection is intentional. The bug was treating `--yes` as enough authority for one Station runtime to replace another runtime's shared entrypoint.

Fixes #301.

## What changed

- Stamp each Station-owned shared artifact with its canonical launcher path, runtime kind, version, and build identity.
- Treat only a valid marker as ownership proof. Unmarked, malformed, mixed-marker, or hand-edited Station artifacts are `unknown-owner`; Station never guesses or silently adopts them.
- Keep absent and same-launcher upgrades automatic. Require `--yes --takeover` for `different-owner` and `unknown-owner`; setup never adds takeover itself.
- Resolve an explicit `--hook-bin` to an absolute executable and use that effective launcher as the requested owner.
- Re-read ownership at the write boundary and report current/requested provenance, the takeover command, and the current-owner repair command from the CLI boundary.
- Inspect Worktrunk's reserved `station` fragments in one traversal while preserving unrelated TOML and refusing occupied or ambiguous Station slots before backup or write.
- Propagate ownership through plan, doctor, provider readiness, and setup-check results across Codex, Claude, Cursor, OpenCode, and Worktrunk.

## Safety and scope

- Ownership refusals leave artifacts byte-for-byte unchanged and create no backup.
- Explicit takeover replaces only Station-owned files or reserved fragments; unrelated provider configuration remains intact.
- Ordinary CLI validation failures remain ordinary errors. The structured SafeError conversion applies only to artifact-ownership conflicts.
- Observer build-handoff policy is unchanged.

## Testing

- `pnpm test:all`: build, typecheck, lint, 1,820 unit tests, 52 contract tests, 571 integration tests (9 skipped), 64 diagnostics tests, 3 scripted-agent tests, 17 setup E2E tests, 19 observer E2E tests, and install smoke all passed.
- Focused ownership coverage passes for marker/schema classification, write-boundary refusal, unmarked and malformed artifacts, OpenCode content drift, Worktrunk reserved-slot preservation, explicit takeover, and installed/source repair.
- `pnpm test:ci:binary` built the local binary successfully but hit the intermittent Observer handoff failure tracked in #319 twice locally. Independent clean runs passed on this PR (2/2) and current `main` (1/1); historical CI evidence puts the unrelated failure near 10%.
- The branch was merged with current `origin/main`; post-merge lint passes.
- GitHub workflow jobs are currently classified as skipped, so the validation above was run locally.