### PR TITLE
fix(session-title): preserve custom names across fresh agent launches

### DIFF
--- a/apps/cli/test/integration/command-command.test.ts
+++ b/apps/cli/test/integration/command-command.test.ts
@@ -229,9 +229,9 @@ describe("CLI command dispatch/get", () => {
             ({
               health: async () =>
                 spawned
-                  ? { schemaVersion: "0.8.0", status: "healthy" }
+                  ? { schemaVersion: "0.9.0", status: "healthy" }
                   : {
-                      schemaVersion: "0.8.0",
+                      schemaVersion: "0.9.0",
                       status: "healthy",
                       pid: 1234,
                       startedAt: now,
@@ -263,7 +263,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -27,7 +27,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -49,7 +49,7 @@ describe("CLI diagnostic commands", () => {
     ).resolves.toMatchObject({
       code: 0,
       output: {
-        schemaVersion: "0.8.0",
+        schemaVersion: "0.9.0",
         status: "healthy",
         debugBundle: {
           available: true,
@@ -166,7 +166,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -201,7 +201,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -238,7 +238,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -301,7 +301,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -342,7 +342,7 @@ describe("CLI diagnostic commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -692,12 +692,12 @@ describe("CLI diagnostic commands", () => {
 
 function doctorReport(stateDir: string): DoctorReport {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     generatedAt: now,
     status: "healthy",
     checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
     observer: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
@@ -725,17 +725,17 @@ function doctorReport(stateDir: string): DoctorReport {
 
 function diagnosticSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: observerBuildVersion,
     },
     snapshot: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -56,7 +56,7 @@ describe("CLI manual-smoke commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const reconciles: Array<string | undefined> = [];
     const receipt: ReconcileReceipt = {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       reason: "manual-smoke",
       reconciledAt: now,
       snapshot: snapshotFixture(),
@@ -294,7 +294,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -305,7 +305,7 @@ function runningObserverDeps(options: {
         reconcile:
           options.reconcile ??
           (async (reason?: string) => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             reason: reason ?? "manual",
             reconciledAt: now,
             snapshot: options.snapshot ?? snapshotFixture(),
@@ -317,7 +317,7 @@ function runningObserverDeps(options: {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observe-command.test.ts
+++ b/apps/cli/test/integration/observe-command.test.ts
@@ -265,7 +265,7 @@ describe("CLI observe command", () => {
                       tag: "ProtocolError",
                       code: "PROTOCOL_SCHEMA_MISMATCH",
                       message:
-                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
+                        "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
                       hint: "A different STATION checkout may own the observer socket.",
                     };
                   },
@@ -280,7 +280,7 @@ describe("CLI observe command", () => {
         ),
       ).rejects.toThrow(
         [
-          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
           "Hint: A different STATION checkout may own the observer socket.",
           "Code: PROTOCOL_SCHEMA_MISMATCH",
         ].join("\n"),
@@ -304,7 +304,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -317,7 +317,7 @@ function runningObserverDeps(options: {
           return options.events;
         },
         reconcile: async (reason?: string): Promise<ReconcileReceipt> => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           reason: reason ?? "manual",
           reconciledAt: now,
           snapshot: options.snapshot ?? snapshotFixture(),
@@ -391,7 +391,7 @@ async function sleep(ms: number): Promise<void> {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
     providerHealth: {},

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -27,7 +27,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -37,7 +37,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.8.0", stopped: true, at: now };
+            return { schemaVersion: "0.9.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -74,7 +74,7 @@ describe("CLI observer commands", () => {
               throw new Error("stopped");
             }
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -84,7 +84,7 @@ describe("CLI observer commands", () => {
           },
           stop: async () => {
             running = false;
-            return { schemaVersion: "0.8.0", stopped: true, at: now };
+            return { schemaVersion: "0.9.0", stopped: true, at: now };
           },
         }) as never,
       sleep: async () => undefined,
@@ -143,7 +143,7 @@ describe("CLI observer commands", () => {
       clientFactory: () =>
         ({
           health: async () => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -38,7 +38,7 @@ describe("CLI popup command", () => {
           health: async () => {
             if (!running) throw new Error("stopped");
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -111,7 +111,7 @@ describe("CLI popup command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.8.0",
+                    schemaVersion: "0.9.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -181,7 +181,7 @@ describe("CLI popup command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.8.0",
+                    schemaVersion: "0.9.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -641,7 +641,7 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,
@@ -658,11 +658,11 @@ function runningObserverDeps(reconciles: string[]): ObserverProcessDeps {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -705,7 +705,7 @@ function nonCompletingReconcileObserverDeps(reconciles: string[]): ObserverProce
     clientFactory: () =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/project-command.test.ts
+++ b/apps/cli/test/integration/project-command.test.ts
@@ -144,7 +144,7 @@ function runningObserverDeps(options: {
     clientFactory: (socketPath: string) =>
       ({
         health: async () => ({
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "healthy",
           pid: 1234,
           startedAt: now,

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -42,11 +42,11 @@ const tuiConfig: TuiConfig = {
 
 function emptySnapshot(reason: string) {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     reason,
     reconciledAt: now,
     snapshot: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       generatedAt: now,
       observer: { pid: 1234, startedAt: now, version: "0.7.0", healthy: true },
       providerHealth: {},
@@ -94,7 +94,7 @@ function runningObserverDeps(
         health: async () => {
           if (!running) throw new Error("stopped");
           return {
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             status: "healthy",
             pid: 1234,
             startedAt: now,
@@ -298,7 +298,7 @@ describe("CLI tui command", () => {
                   if (!spawned) throw new Error("stopped");
                   await healthReady;
                   return {
-                    schemaVersion: "0.8.0",
+                    schemaVersion: "0.9.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,
@@ -364,7 +364,7 @@ describe("CLI tui command", () => {
               clientFactory: () =>
                 ({
                   health: async () => ({
-                    schemaVersion: "0.8.0",
+                    schemaVersion: "0.9.0",
                     status: "healthy",
                     pid: 1234,
                     startedAt: now,

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -51,7 +51,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!running) throw new Error("offline");
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 hookId: event.hookId ?? "hook_final_command",
                 provider: event.provider,
                 event: event.event,
@@ -121,7 +121,7 @@ describe("provider hook ingress command", () => {
             ingestProviderHookEvent: async (event: ProviderHookEvent) => {
               if (!(await fileExists(argvPath))) throw new Error("offline");
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 hookId: event.hookId ?? "hook_child_timeout",
                 provider: event.provider,
                 event: event.event,
@@ -167,7 +167,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedPayload = event.payload;
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               hookId: event.hookId ?? "hook_worktrunk_1",
               provider: event.provider,
               event: event.event,
@@ -222,7 +222,7 @@ describe("provider hook ingress command", () => {
         writeSpool: async ({ spoolDir, event, error, clock }) => {
           observedSpoolDir = spoolDir;
           return {
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             hookId: event.hookId ?? "hook_worktrunk_config_only",
             provider: event.provider,
             event: event.event,
@@ -286,7 +286,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -350,7 +350,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -410,7 +410,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               hookId: event.hookId ?? "hook_1",
               provider: event.provider,
               event: event.event,
@@ -446,7 +446,7 @@ describe("provider hook ingress command", () => {
   it("delivers compact OpenCode payloads through build-aware provider ingress", async () => {
     const fixture = await createTempState();
     const configPath = await writeConfigToml(fixture.root, fixture.config);
-    const buildVersion = `0.8.0+station.${"a".repeat(64)}`;
+    const buildVersion = `0.9.0+station.${"a".repeat(64)}`;
     let observedEvent: ProviderHookEvent | undefined;
 
     const receipt = await runProviderIngressCommand(
@@ -476,7 +476,7 @@ describe("provider hook ingress command", () => {
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => {
             observedEvent = event;
             return {
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               hookId: event.hookId ?? "hook_opencode_1",
               provider: event.provider,
               event: event.event,
@@ -488,7 +488,7 @@ describe("provider hook ingress command", () => {
           };
           return {
             health: async () => ({
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 12345,
               startedAt: now,
@@ -523,7 +523,7 @@ describe("provider hook ingress command", () => {
 
   it("returns online provider payload rejections without retrying, starting, or spooling", async () => {
     const fixture = await createTempState();
-    const buildVersion = `0.8.0+station.${"b".repeat(64)}`;
+    const buildVersion = `0.9.0+station.${"b".repeat(64)}`;
     let healthCalls = 0;
     let deliveryCalls = 0;
     let startCalls = 0;
@@ -544,7 +544,7 @@ describe("provider hook ingress command", () => {
             health: async () => {
               healthCalls += 1;
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 12345,
                 startedAt: now,
@@ -558,7 +558,7 @@ describe("provider hook ingress command", () => {
             ): Promise<ProviderHookReceipt> => {
               deliveryCalls += 1;
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 hookId: event.hookId ?? "hook_pi_invalid",
                 provider: event.provider,
                 event: event.event,
@@ -627,7 +627,7 @@ describe("provider hook ingress command", () => {
             observedBuildVersion = options.expectedBuildVersion;
           }
           const ingest = async (event: ProviderHookEvent): Promise<ProviderHookReceipt> => ({
-            schemaVersion: "0.8.0",
+            schemaVersion: "0.9.0",
             hookId: event.hookId ?? "hook_timeout_1",
             provider: event.provider,
             event: event.event,
@@ -795,7 +795,7 @@ function stationEnv(): Record<string, string> {
 
 function healthyObserver(paths: { socketPath: string; stateDir: string }): ObserverHealth {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     status: "healthy",
     pid: 12345,
     startedAt: now,

--- a/apps/cli/test/unit/ingress-correlation.test.ts
+++ b/apps/cli/test/unit/ingress-correlation.test.ts
@@ -238,7 +238,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       hookId,
       provider,
       event: expectedEvent,
@@ -352,7 +352,7 @@ describe("provider hook ingress correlation", () => {
     );
 
     expect(receipt).toEqual({
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       hookId: "hook_logging_failure",
       provider: "cursor",
       event: "beforeShellExecution",

--- a/apps/cli/test/unit/observe-formatters.test.ts
+++ b/apps/cli/test/unit/observe-formatters.test.ts
@@ -108,7 +108,7 @@ describe("observe snapshot context", () => {
 
 function snapshotFixture(): StationSnapshot {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     generatedAt: now,
     observer: { pid: 1234, startedAt: now, version: "0.0.0", healthy: true },
     providerHealth: {},
@@ -160,6 +160,7 @@ function rowFixture(): WorktreeRow {
     id: "wt_api",
     projectId: "api",
     projectLabel: "api",
+    title: "feature/cache",
     branch: "feature/cache",
     path: "/tmp/api/feature-cache",
     worktree: {
@@ -213,7 +214,7 @@ function sessionFixture(): SessionView {
     },
     terminal: {
       provider: "tmux",
-      exists: true,
+      state: "open",
     },
     status: {
       value: "working",

--- a/apps/cli/test/unit/observer-process/lifecycle.test.ts
+++ b/apps/cli/test/unit/observer-process/lifecycle.test.ts
@@ -59,7 +59,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not yet");
               }
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -109,7 +109,7 @@ describe("CLI observer process lifecycle", () => {
                 throw new Error("not running");
               }
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -221,7 +221,7 @@ describe("CLI observer process lifecycle", () => {
                   tag: "ProtocolError",
                   code: "PROTOCOL_SCHEMA_MISMATCH",
                   message:
-                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.8.0.",
+                    "Observer protocol schema mismatch: the observer responded with schema 0.3.0, but this CLI expects schema 0.9.0.",
                   hint: "A different STATION checkout may own the observer socket.",
                 };
               },
@@ -301,7 +301,7 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -332,7 +332,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -370,7 +370,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid: 1234,
               startedAt: now,
@@ -379,7 +379,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.8.0", stopped: true, at: now };
+              return { schemaVersion: "0.9.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -419,7 +419,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 1234,
                 startedAt: now,
@@ -430,7 +430,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.8.0", stopped: true, at: now };
+              return { schemaVersion: "0.9.0", stopped: true, at: now };
             },
           } as never;
         },
@@ -473,7 +473,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!stopping) {
                 return {
-                  schemaVersion: "0.8.0",
+                  schemaVersion: "0.9.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -491,7 +491,7 @@ describe("CLI observer process lifecycle", () => {
             },
             stop: async () => {
               stopping = true;
-              return { schemaVersion: "0.8.0", stopped: true, at: now };
+              return { schemaVersion: "0.9.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -530,7 +530,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.8.0",
+                  schemaVersion: "0.9.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -541,7 +541,7 @@ describe("CLI observer process lifecycle", () => {
               stop: async () => {
                 await new Promise((resolve) => setTimeout(resolve, 700));
                 running = false;
-                return { schemaVersion: "0.8.0", stopped: true, at: now };
+                return { schemaVersion: "0.9.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -570,7 +570,7 @@ describe("CLI observer process lifecycle", () => {
               health: async () => {
                 if (!running) throw new Error("stopped");
                 return {
-                  schemaVersion: "0.8.0",
+                  schemaVersion: "0.9.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -578,7 +578,7 @@ describe("CLI observer process lifecycle", () => {
               },
               stop: async () => {
                 running = false;
-                return { schemaVersion: "0.8.0", stopped: true, at: now };
+                return { schemaVersion: "0.9.0", stopped: true, at: now };
               },
             } as never;
           },
@@ -614,7 +614,7 @@ describe("CLI observer process lifecycle", () => {
             health: async () => {
               if (!running) throw new Error("stopped");
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: version === exactOneBuildVersion ? 5678 : 1234,
                 startedAt: now,
@@ -624,7 +624,7 @@ describe("CLI observer process lifecycle", () => {
             stop: async () => {
               stops += 1;
               running = false;
-              return { schemaVersion: "0.8.0", stopped: true, at: now };
+              return { schemaVersion: "0.9.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -649,14 +649,14 @@ describe("CLI observer process lifecycle", () => {
           clientFactory: () =>
             ({
               health: async () => ({
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 startedAt: now,
                 version: "1.0.0",
               }),
               stop: async () => {
                 stops += 1;
-                return { schemaVersion: "0.8.0", stopped: true, at: now };
+                return { schemaVersion: "0.9.0", stopped: true, at: now };
               },
             }) as never,
         },
@@ -687,7 +687,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               pid,
               startedAt: now,
@@ -696,7 +696,7 @@ describe("CLI observer process lifecycle", () => {
             }),
             stop: async () => {
               stops += 1;
-              return { schemaVersion: "0.8.0", stopped: true, at: now };
+              return { schemaVersion: "0.9.0", stopped: true, at: now };
             },
           }) as never,
       },
@@ -729,7 +729,7 @@ describe("CLI observer process lifecycle", () => {
               healthAttempts += 1;
               if (!spawned || healthAttempts < 3) {
                 return {
-                  schemaVersion: "0.8.0",
+                  schemaVersion: "0.9.0",
                   status: "healthy",
                   pid: 1234,
                   startedAt: now,
@@ -738,7 +738,7 @@ describe("CLI observer process lifecycle", () => {
                 };
               }
               return {
-                schemaVersion: "0.8.0",
+                schemaVersion: "0.9.0",
                 status: "healthy",
                 pid: 5678,
                 startedAt: now,
@@ -780,7 +780,7 @@ describe("CLI observer process lifecycle", () => {
         clientFactory: () =>
           ({
             health: async () => ({
-              schemaVersion: "0.8.0",
+              schemaVersion: "0.9.0",
               status: "healthy",
               ...identity,
             }),

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -11,7 +11,7 @@ const higherBuildVersion = `2.0.0+station.${"a".repeat(64)}`;
 
 const healthyObserver = (pid = 1234, version = stationObserverBuildVersion()) =>
   ({
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     status: "healthy",
     pid,
     startedAt: now,

--- a/apps/observer/package.json
+++ b/apps/observer/package.json
@@ -26,6 +26,11 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
-    "@station/testing": "workspace:*"
+    "@station/cursor": "workspace:*",
+    "@station/pi": "workspace:*",
+    "@station/terminal": "workspace:*",
+    "@station/testing": "workspace:*",
+    "@station/worktrunk": "workspace:*",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/observer/src/commands/session/create.ts
+++ b/apps/observer/src/commands/session/create.ts
@@ -12,7 +12,7 @@ import type { TerminalIntentRunner } from "../terminalIntentRunner.js";
 import {
   buildEnsureAgentWorkspaceIntent,
   defaultSessionCommandIdFactory,
-  deleteSessionTitleSeedBestEffort,
+  discardSessionSeedBestEffort,
   findProjectOrThrow,
   publishSessionCreated,
   removeWorktreeBestEffort,
@@ -20,7 +20,7 @@ import {
   resolveTerminalProviderOrThrow,
   runProviderMutation,
   type SessionCommandIdFactory,
-  seedSessionTitle,
+  seedSession,
   throwIfAborted,
 } from "./shared.js";
 
@@ -40,8 +40,8 @@ export type CreateSessionCreateHandlerOptions = {
 /**
  * USE CASE
  *
- * Create a session worktree on its generated branch, persist its independent
- * user-facing title, and launch its primary agent workspace.
+ * Creates a session worktree on its generated branch, durably seeds its independent title,
+ * and launches its primary agent; cleanup retires title authority only after verified rollback.
  */
 export function createSessionCreateHandler(
   options: CreateSessionCreateHandlerOptions,
@@ -67,7 +67,7 @@ export function createSessionCreateHandler(
       trace: context.trace,
     };
     let createdWorktree: WorktreeObservation | undefined;
-    let seededSessionTitle = false;
+    let sessionSeeded = false;
 
     try {
       const worktree = await runProviderMutation(
@@ -91,15 +91,15 @@ export function createSessionCreateHandler(
       createdWorktree = worktree;
       throwIfAborted(context.signal);
 
-      await seedSessionTitle({
+      await seedSession({
         persistence: options.persistence,
         sessionId,
         projectId: project.id,
         worktreeId: worktree.id,
-        title: payload.title ?? payload.branch,
+        initialTitle: payload.title ?? payload.branch,
         clock: options.clock,
       });
-      seededSessionTitle = true;
+      sessionSeeded = true;
       throwIfAborted(context.signal);
 
       const receipt = await options.terminalIntentRunner.submitIntent(
@@ -127,26 +127,30 @@ export function createSessionCreateHandler(
       }
       throwIfAborted(context.signal);
     } catch (error) {
-      if (seededSessionTitle) {
-        await deleteSessionTitleSeedBestEffort({
+      const worktreeRemoved =
+        createdWorktree === undefined
+          ? false
+          : await removeWorktreeBestEffort({
+              providers: options.providers,
+              projectId: project.id,
+              worktreeId: createdWorktree.id,
+              expectedPath: createdWorktree.path,
+              expectedBranch: createdWorktree.branch,
+              expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+              context,
+              logger: options.logger,
+              clock: options.clock,
+              commandTimeoutMs: options.commandTimeoutMs,
+            });
+      if (sessionSeeded) {
+        await discardSessionSeedBestEffort({
           persistence: options.persistence,
           sessionId,
+          ...(worktreeRemoved && createdWorktree !== undefined
+            ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
+            : {}),
           context,
           logger: options.logger,
-        });
-      }
-      if (createdWorktree !== undefined) {
-        await removeWorktreeBestEffort({
-          providers: options.providers,
-          projectId: project.id,
-          worktreeId: createdWorktree.id,
-          expectedPath: createdWorktree.path,
-          expectedBranch: createdWorktree.branch,
-          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-          context,
-          logger: options.logger,
-          clock: options.clock,
-          commandTimeoutMs: options.commandTimeoutMs,
         });
       }
       throw error;

--- a/apps/observer/src/commands/session/fork.ts
+++ b/apps/observer/src/commands/session/fork.ts
@@ -13,7 +13,7 @@ import {
   buildEnsureAgentWorkspaceIntent,
   commandValidationError,
   defaultSessionCommandIdFactory,
-  deleteSessionTitleSeedBestEffort,
+  discardSessionSeedBestEffort,
   findProjectOrThrow,
   publishSessionCreated,
   rememberedHarnessProviderForWorktree,
@@ -22,7 +22,7 @@ import {
   resolveTerminalProviderOrThrow,
   runProviderMutation,
   type SessionCommandIdFactory,
-  seedSessionTitle,
+  seedSession,
   throwIfAborted,
   validateSnapshotRow,
 } from "./shared.js";
@@ -43,9 +43,8 @@ export type CreateSessionForkHandlerOptions = {
 /**
  * USE CASE
  *
- * Fork an existing worktree onto an internal branch, persist an independent
- * user-facing title, optionally copy dirty state, and launch a fresh agent.
- * The source agent remains live and its remembered harness is inherited.
+ * Forks an existing worktree onto an internal branch, durably seeds its independent title,
+ * and launches a fresh agent; cleanup retires title authority only after verified rollback.
  */
 export function createSessionForkHandler(options: CreateSessionForkHandlerOptions): CommandHandler {
   const idFactory = {
@@ -98,7 +97,7 @@ export function createSessionForkHandler(options: CreateSessionForkHandlerOption
     const base = payload.base ?? sourceRow.branch;
 
     let createdWorktree: WorktreeObservation | undefined;
-    let seededSessionTitle = false;
+    let sessionSeeded = false;
 
     try {
       const worktree = await runProviderMutation(
@@ -123,15 +122,15 @@ export function createSessionForkHandler(options: CreateSessionForkHandlerOption
       createdWorktree = worktree;
       throwIfAborted(context.signal);
 
-      await seedSessionTitle({
+      await seedSession({
         persistence: options.persistence,
         sessionId,
         projectId: project.id,
         worktreeId: worktree.id,
-        title: payload.title ?? payload.branch,
+        initialTitle: payload.title ?? payload.branch,
         clock: options.clock,
       });
-      seededSessionTitle = true;
+      sessionSeeded = true;
       throwIfAborted(context.signal);
 
       const receipt = await options.terminalIntentRunner.submitIntent(
@@ -159,26 +158,30 @@ export function createSessionForkHandler(options: CreateSessionForkHandlerOption
       }
       throwIfAborted(context.signal);
     } catch (error) {
-      if (seededSessionTitle) {
-        await deleteSessionTitleSeedBestEffort({
+      const worktreeRemoved =
+        createdWorktree === undefined
+          ? false
+          : await removeWorktreeBestEffort({
+              providers: options.providers,
+              projectId: project.id,
+              worktreeId: createdWorktree.id,
+              expectedPath: createdWorktree.path,
+              expectedBranch: createdWorktree.branch,
+              expectedRegistrationIdentity: createdWorktree.registrationIdentity,
+              context,
+              logger: options.logger,
+              clock: options.clock,
+              commandTimeoutMs: options.commandTimeoutMs,
+            });
+      if (sessionSeeded) {
+        await discardSessionSeedBestEffort({
           persistence: options.persistence,
           sessionId,
+          ...(worktreeRemoved && createdWorktree !== undefined
+            ? { removedWorktree: { projectId: project.id, worktreeId: createdWorktree.id } }
+            : {}),
           context,
           logger: options.logger,
-        });
-      }
-      if (createdWorktree !== undefined) {
-        await removeWorktreeBestEffort({
-          providers: options.providers,
-          projectId: project.id,
-          worktreeId: createdWorktree.id,
-          expectedPath: createdWorktree.path,
-          expectedBranch: createdWorktree.branch,
-          expectedRegistrationIdentity: createdWorktree.registrationIdentity,
-          context,
-          logger: options.logger,
-          clock: options.clock,
-          commandTimeoutMs: options.commandTimeoutMs,
         });
       }
       throw error;

--- a/apps/observer/src/commands/session/rename.ts
+++ b/apps/observer/src/commands/session/rename.ts
@@ -15,6 +15,11 @@ export type CreateSessionRenameHandlerOptions = {
   clock?: RuntimeClock | undefined;
 };
 
+/**
+ * USE CASE
+ *
+ * Renames the canonical worktree title and its session projections before publishing convergence.
+ */
 export function createSessionRenameHandler(
   options: CreateSessionRenameHandlerOptions,
 ): CommandHandler {
@@ -40,7 +45,8 @@ export function createSessionRenameHandler(
       throw sessionMissingError(sessionId);
     }
 
-    const updated = await options.persistence.renameSession({ sessionId, title });
+    const renamedAt = nowIso(options.clock);
+    const updated = await options.persistence.renameSession({ sessionId, title, renamedAt });
     if (updated === undefined) {
       throw sessionMissingError(sessionId);
     }
@@ -63,7 +69,7 @@ export function createSessionRenameHandler(
       commandId: context.commandId,
       traceId: context.trace.traceId,
       spanId: context.trace.spanId,
-      createdAt: nowIso(options.clock),
+      createdAt: renamedAt,
     });
     options.eventBus?.publish(event);
   };

--- a/apps/observer/src/commands/session/resumeAgent.ts
+++ b/apps/observer/src/commands/session/resumeAgent.ts
@@ -15,6 +15,7 @@ import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import type { StationLogger } from "../../stationLogger.js";
 import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
@@ -24,13 +25,14 @@ import {
   buildEnsureAgentWorkspaceIntent,
   commandValidationError,
   defaultSessionCommandIdFactory,
+  discardSessionSeedBestEffort,
   findProjectOrThrow,
   lookupWorktree,
   publishSessionCreated,
   resolveHarnessProviderOrThrow,
   resolveTerminalProviderOrThrow,
   type SessionCommandIdFactory,
-  seedSessionTitle,
+  seedSession,
   throwIfAborted,
   validateSnapshotRow,
   worktreeObservationFromRow,
@@ -46,9 +48,16 @@ export type CreateSessionResumeAgentHandlerOptions = {
   eventBus?: ObserverEventBus | undefined;
   clock?: RuntimeClock | undefined;
   idFactory?: Partial<SessionCommandIdFactory> | undefined;
+  logger?: StationLogger | undefined;
   commandTimeoutMs?: number | undefined;
 };
 
+/**
+ * USE CASE
+ *
+ * Resumes provider-native recovery into an existing Station identity or a fresh titled session.
+ * Failed launch cleanup discards only a newly minted session projection.
+ */
 export function createSessionResumeAgentHandler(
   options: CreateSessionResumeAgentHandlerOptions,
 ): CommandHandler {
@@ -112,55 +121,67 @@ export function createSessionResumeAgentHandler(
     const harnessProvider = resolveHarnessProviderOrThrow(options.providers, handle.provider);
     assertHarnessCanResume(harnessProvider, handle);
 
+    const sessionIdIsFresh = handle.sessionId === undefined;
     const sessionId = handle.sessionId ?? idFactory.sessionId();
-    // Resume may reuse an existing session row, so failed launch cleanup must
-    // not delete metadata. A stray new seed is cheaper than deleting the user's
-    // known title/session record after a provider launch failure.
-    await seedSessionTitle({
-      persistence: options.persistence,
-      sessionId,
-      projectId: project.id,
-      worktreeId: worktree.id,
-      title: worktree.branch,
-      clock: options.clock,
-    });
-    throwIfAborted(context.signal);
-
-    // The terminal runner stays provider-neutral: it opens/focuses the pane, and
-    // the harness adapter alone translates this resume target into CLI args.
-    const resume: HarnessResumeOptions = {
-      target: handle.target,
-      recoveryHandleId: handle.id,
-    };
-    if (handle.sessionId !== undefined) {
-      resume.previousSessionId = handle.sessionId;
-    }
-    const receipt = await options.terminalIntentRunner.submitIntent(
-      buildEnsureAgentWorkspaceIntent({
-        commandId: context.commandId,
-        project,
-        worktree,
+    let sessionSeeded = false;
+    try {
+      await seedSession({
+        persistence: options.persistence,
         sessionId,
-        terminalProvider: terminalProviderId,
-        harnessProvider: handle.provider,
-        harness: { mode: "interactive" },
-        layout: payload.terminal?.layout ?? project.defaults.layout,
-        focus: payload.terminal?.focus,
-        origin: payload.terminal?.origin,
-        initialPrompt: payload.initialPrompt,
-        resume,
-      }),
-      {
-        trace: context.trace,
-        signal: context.signal,
-        commandTimeoutMs: options.commandTimeoutMs,
-      },
-    );
-    if (receipt.status === "rejected") {
-      throw receipt.error;
+        projectId: project.id,
+        worktreeId: worktree.id,
+        initialTitle: row?.title ?? worktree.branch,
+        clock: options.clock,
+      });
+      sessionSeeded = true;
+      throwIfAborted(context.signal);
+
+      // The terminal runner stays provider-neutral: it opens/focuses the pane, and
+      // the harness adapter alone translates this resume target into CLI args.
+      const resume: HarnessResumeOptions = {
+        target: handle.target,
+        recoveryHandleId: handle.id,
+      };
+      if (handle.sessionId !== undefined) {
+        resume.previousSessionId = handle.sessionId;
+      }
+      const receipt = await options.terminalIntentRunner.submitIntent(
+        buildEnsureAgentWorkspaceIntent({
+          commandId: context.commandId,
+          project,
+          worktree,
+          sessionId,
+          terminalProvider: terminalProviderId,
+          harnessProvider: handle.provider,
+          harness: { mode: "interactive" },
+          layout: payload.terminal?.layout ?? project.defaults.layout,
+          focus: payload.terminal?.focus,
+          origin: payload.terminal?.origin,
+          initialPrompt: payload.initialPrompt,
+          resume,
+        }),
+        {
+          trace: context.trace,
+          signal: context.signal,
+          commandTimeoutMs: options.commandTimeoutMs,
+        },
+      );
+      if (receipt.status === "rejected") {
+        throw receipt.error;
+      }
+      throwIfAborted(context.signal);
+      await options.persistence.reopenSession(sessionId);
+    } catch (error) {
+      if (sessionIdIsFresh && sessionSeeded) {
+        await discardSessionSeedBestEffort({
+          persistence: options.persistence,
+          sessionId,
+          context,
+          logger: options.logger,
+        });
+      }
+      throw error;
     }
-    throwIfAborted(context.signal);
-    await options.persistence.reopenSession(sessionId);
 
     const nextSnapshot = await reconcileAndPublish({
       core: options.core,

--- a/apps/observer/src/commands/session/shared.ts
+++ b/apps/observer/src/commands/session/shared.ts
@@ -289,35 +289,39 @@ export async function rememberedHarnessProviderForWorktree(input: {
   });
 }
 
-export async function seedSessionTitle(input: {
+export async function seedSession(input: {
   persistence: SessionStore;
   sessionId: SessionId;
   projectId: string;
   worktreeId: string;
-  title: string;
+  initialTitle: string;
   clock?: RuntimeClock | undefined;
 }): Promise<void> {
   const seededAt = toIsoTimestamp((input.clock ?? systemClock).now());
-  await input.persistence.seedSessionTitle({
+  await input.persistence.seedSession({
     sessionId: input.sessionId,
     projectId: input.projectId,
     worktreeId: input.worktreeId,
-    title: input.title.trim(),
+    initialTitle: input.initialTitle.trim(),
     createdAt: seededAt,
     lastSeenAt: seededAt,
   });
 }
 
-export async function deleteSessionTitleSeedBestEffort(input: {
+export async function discardSessionSeedBestEffort(input: {
   persistence: SessionStore;
   sessionId: SessionId;
+  removedWorktree?: { projectId: string; worktreeId: string };
   context: CommandHandlerContext;
   logger?: StationLogger | undefined;
 }): Promise<void> {
   try {
-    await input.persistence.deleteSessionTitleSeed(input.sessionId);
+    await input.persistence.discardSessionSeed({
+      sessionId: input.sessionId,
+      ...(input.removedWorktree === undefined ? {} : { removedWorktree: input.removedWorktree }),
+    });
   } catch (error) {
-    await input.logger?.warn("Session cleanup failed to delete a pre-launch title seed.", {
+    await input.logger?.warn("Session cleanup failed to discard a pre-launch seed.", {
       commandId: input.context.commandId,
       traceId: input.context.trace.traceId,
       sessionId: input.sessionId,
@@ -439,7 +443,7 @@ export async function removeWorktreeBestEffort(input: {
   logger?: StationLogger | undefined;
   clock?: RuntimeClock | undefined;
   commandTimeoutMs?: number | undefined;
-}): Promise<void> {
+}): Promise<boolean> {
   if (input.expectedRegistrationIdentity === undefined) {
     await input.logger?.warn("Session cleanup skipped an unverified worktree removal.", {
       commandId: input.context.commandId,
@@ -450,7 +454,7 @@ export async function removeWorktreeBestEffort(input: {
       worktreeId: input.worktreeId,
       refusalReason: "registration_unverified",
     });
-    return;
+    return false;
   }
   const expectedRegistrationIdentity = input.expectedRegistrationIdentity;
   try {
@@ -477,6 +481,7 @@ export async function removeWorktreeBestEffort(input: {
           force: true,
         }),
     );
+    return true;
   } catch (error) {
     await input.logger?.warn("Session cleanup failed to remove worktree.", {
       commandId: input.context.commandId,
@@ -487,6 +492,7 @@ export async function removeWorktreeBestEffort(input: {
       worktreeId: input.worktreeId,
       error,
     });
+    return false;
   }
 }
 

--- a/apps/observer/src/commands/session/startAgent.ts
+++ b/apps/observer/src/commands/session/startAgent.ts
@@ -14,7 +14,7 @@ import {
   assertNoCurrentAgent,
   buildEnsureAgentWorkspaceIntent,
   defaultSessionCommandIdFactory,
-  deleteSessionTitleSeedBestEffort,
+  discardSessionSeedBestEffort,
   findProjectOrThrow,
   lookupWorktree,
   publishSessionCreated,
@@ -22,7 +22,7 @@ import {
   resolveHarnessProviderOrThrow,
   resolveTerminalProviderOrThrow,
   type SessionCommandIdFactory,
-  seedSessionTitle,
+  seedSession,
   throwIfAborted,
   validateSnapshotRow,
   worktreeObservationFromRow,
@@ -41,6 +41,12 @@ export type CreateSessionStartAgentHandlerOptions = {
   commandTimeoutMs?: number | undefined;
 };
 
+/**
+ * USE CASE
+ *
+ * Starts a fresh agent lifecycle while inheriting the worktree's canonical display title.
+ * Failed launches discard only the fresh session projection.
+ */
 export function createSessionStartAgentHandler(
   options: CreateSessionStartAgentHandlerOptions,
 ): CommandHandler {
@@ -89,18 +95,18 @@ export function createSessionStartAgentHandler(
       project.defaults.harness;
     resolveHarnessProviderOrThrow(options.providers, harnessProviderId);
 
-    let seededSessionTitle = false;
+    let sessionSeeded = false;
 
     try {
-      await seedSessionTitle({
+      await seedSession({
         persistence: options.persistence,
         sessionId,
         projectId: project.id,
         worktreeId: worktree.id,
-        title: worktree.branch,
+        initialTitle: row?.title ?? worktree.branch,
         clock: options.clock,
       });
-      seededSessionTitle = true;
+      sessionSeeded = true;
       throwIfAborted(context.signal);
 
       const receipt = await options.terminalIntentRunner.submitIntent(
@@ -128,8 +134,8 @@ export function createSessionStartAgentHandler(
       }
       throwIfAborted(context.signal);
     } catch (error) {
-      if (seededSessionTitle) {
-        await deleteSessionTitleSeedBestEffort({
+      if (sessionSeeded) {
+        await discardSessionSeedBestEffort({
           persistence: options.persistence,
           sessionId,
           context,

--- a/apps/observer/src/commands/worktree/remove.ts
+++ b/apps/observer/src/commands/worktree/remove.ts
@@ -43,7 +43,7 @@ export type CreateWorktreeRemoveHandlerOptions = {
  * USE CASE
  *
  * Revalidates selected checkout and Git registration identity before coordinating removal.
- * Provider-side race refusals retain command-correlated evidence for diagnostics.
+ * Provider-confirmed removal atomically ends sessions and retires canonical title authority.
  */
 export function createWorktreeRemoveHandler(
   options: CreateWorktreeRemoveHandlerOptions,
@@ -146,8 +146,9 @@ export function createWorktreeRemoveHandler(
       throw error;
     }
     throwIfAborted(context.signal);
-    await options.persistence.markSessionsEnded({
-      subject: { kind: "worktree", projectId: row.projectId, worktreeId: row.id },
+    await options.persistence.retireRemovedWorktreeSessionState({
+      projectId: row.projectId,
+      worktreeId: row.id,
       endedAt: nowIso(options.clock),
     });
 

--- a/apps/observer/src/migrations/016_worktree_display_titles.ts
+++ b/apps/observer/src/migrations/016_worktree_display_titles.ts
@@ -1,0 +1,16 @@
+import type { ObserverSqliteMigration } from "./index.js";
+
+export const worktreeDisplayTitlesMigration: ObserverSqliteMigration = {
+  version: 16,
+  name: "worktree_display_titles",
+  sql: `
+    CREATE TABLE worktree_display_titles (
+      project_id TEXT NOT NULL,
+      worktree_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (project_id, worktree_id)
+    );
+  `,
+};

--- a/apps/observer/src/migrations/016_worktree_display_titles.ts
+++ b/apps/observer/src/migrations/016_worktree_display_titles.ts
@@ -1,4 +1,4 @@
-import type { ObserverSqliteMigration } from "./index.js";
+import type { ObserverSqliteMigration } from "./migration.js";
 
 export const worktreeDisplayTitlesMigration: ObserverSqliteMigration = {
   version: 16,

--- a/apps/observer/src/migrations/index.ts
+++ b/apps/observer/src/migrations/index.ts
@@ -13,6 +13,7 @@ import { sessionLifecycleMigration } from "./012_session_lifecycle.js";
 import { sessionHarnessExecutionsMigration } from "./013_session_harness_executions.js";
 import { nativeBindingIngressClaimsMigration } from "./014_native_binding_ingress_claims.js";
 import { dropRecoveryBreadcrumbsMigration } from "./015_drop_recovery_breadcrumbs.js";
+import { worktreeDisplayTitlesMigration } from "./016_worktree_display_titles.js";
 
 /** @knipignore Retains the historical migration type import surface. */
 export type { ObserverSqliteMigration } from "./migration.js";
@@ -33,6 +34,7 @@ export const migrations = [
   sessionHarnessExecutionsMigration,
   nativeBindingIngressClaimsMigration,
   dropRecoveryBreadcrumbsMigration,
+  worktreeDisplayTitlesMigration,
 ] as const;
 
 export const latestSchemaVersion = migrations[migrations.length - 1]?.version ?? 0;

--- a/apps/observer/src/persistence/correlations.ts
+++ b/apps/observer/src/persistence/correlations.ts
@@ -13,12 +13,27 @@ import {
 } from "@station/contracts";
 import { harnessRunCanActivateSession, terminalCanActivateSession } from "../sessionActivation.js";
 import type { SqlDatabase } from "../sqlite/driver.js";
+import { resolveWorktreeDisplayTitle } from "../worktreeDisplayTitle.js";
 import { maxIso, optionalJson } from "./json.js";
 import { insertProviderObservation } from "./observations.js";
 import { providerObservationExpiresAt } from "./retention.js";
 import { type SqliteSessionRow, sessionFromRow } from "./rows.js";
 import { stripTerminalProviderData } from "./terminalObservations.js";
-import type { ObserverIdFactory, PersistedSession, PersistReconcileResultInput } from "./types.js";
+import type {
+  ObserverIdFactory,
+  PersistedSession,
+  PersistedWorktreeDisplayTitle,
+  PersistReconcileResultInput,
+  ReconcileWorktreeDisplayTitleInput,
+} from "./types.js";
+import {
+  deleteWorktreeDisplayTitle,
+  insertMissingWorktreeDisplayTitles,
+  listWorktreeDisplayTitles,
+  readWorktreeDisplayTitle,
+  synchronizeSessionTitleProjections,
+  upsertWorktreeDisplayTitle,
+} from "./worktreeDisplayTitles.js";
 
 type ProjectPersistenceInput = {
   id: string;
@@ -94,7 +109,17 @@ export function persistReconcileResult(
       });
     }
   }
-  upsertSessions(database, input.terminalTargets, input.harnessRuns, input.worktrees);
+  const resolvedTitles = resolveReconcileWorktreeDisplayTitles(database, input, options.observedAt);
+  insertMissingWorktreeDisplayTitles(database, resolvedTitles);
+  const persistedTitles = resolvedTitles.map((title) => {
+    const persisted = readWorktreeDisplayTitle(database, title);
+    if (persisted === undefined) {
+      throw new Error(`Failed to initialize worktree display title for ${title.worktreeId}.`);
+    }
+    synchronizeSessionTitleProjections(database, persisted);
+    return persisted;
+  });
+  upsertSessions(database, input.terminalTargets, input.harnessRuns, persistedTitles);
 }
 
 function expiresAtFor(input: PersistReconcileResultInput, observedAt: string): string | undefined {
@@ -155,9 +180,21 @@ export function findRememberedHarnessProviderForWorktree(
 
 export function renameSession(
   database: SqlDatabase,
-  input: { sessionId: string; title: string },
+  input: { sessionId: string; title: string; renamedAt: string },
 ): PersistedSession | undefined {
-  database.prepare("UPDATE sessions SET title = ? WHERE id = ?").run(input.title, input.sessionId);
+  const existing = database.prepare("SELECT * FROM sessions WHERE id = ?").get(input.sessionId) as
+    | SqliteSessionRow
+    | undefined;
+  if (existing === undefined) return undefined;
+
+  const canonical = upsertWorktreeDisplayTitle(database, {
+    projectId: existing.project_id,
+    worktreeId: existing.worktree_id,
+    title: input.title,
+    createdAt: input.renamedAt,
+    updatedAt: input.renamedAt,
+  });
+  synchronizeSessionTitleProjections(database, canonical);
   const row = database.prepare("SELECT * FROM sessions WHERE id = ?").get(input.sessionId) as
     | SqliteSessionRow
     | undefined;
@@ -210,17 +247,39 @@ export function reopenSession(
   return row === undefined ? undefined : sessionFromRow(row);
 }
 
-export function seedSessionTitle(
+export function seedSession(
   database: SqlDatabase,
   input: {
     sessionId: string;
     projectId: string;
     worktreeId: string;
-    title: string;
+    initialTitle: string;
     createdAt: string;
     lastSeenAt: string;
   },
 ): PersistedSession {
+  const title = resolveWorktreeDisplayTitle({
+    projectId: input.projectId,
+    worktreeId: input.worktreeId,
+    branch: input.initialTitle,
+    canonicalTitles: listCanonicalTitle(database, input),
+    sessions: listSessions(database),
+  });
+  insertMissingWorktreeDisplayTitles(database, [
+    {
+      projectId: input.projectId,
+      worktreeId: input.worktreeId,
+      title,
+      createdAt: input.createdAt,
+      updatedAt: input.createdAt,
+    },
+  ]);
+  const canonical = readWorktreeDisplayTitle(database, input);
+  if (canonical === undefined) {
+    throw new Error(`Failed to seed worktree display title for ${input.worktreeId}.`);
+  }
+  synchronizeSessionTitleProjections(database, canonical);
+
   database
     .prepare(
       `
@@ -230,7 +289,7 @@ export function seedSessionTitle(
         ON CONFLICT(id) DO UPDATE SET
           project_id = excluded.project_id,
           worktree_id = excluded.worktree_id,
-          title = COALESCE(sessions.title, excluded.title),
+          title = excluded.title,
           last_seen_at = excluded.last_seen_at,
           lifecycle = CASE
             WHEN sessions.lifecycle = 'ended' THEN 'ended'
@@ -242,7 +301,7 @@ export function seedSessionTitle(
       input.sessionId,
       input.projectId,
       input.worktreeId,
-      input.title,
+      canonical.title,
       input.createdAt,
       input.lastSeenAt,
     );
@@ -251,14 +310,79 @@ export function seedSessionTitle(
     | SqliteSessionRow
     | undefined;
   if (row === undefined) {
-    throw new Error(`Failed to seed session title for ${input.sessionId}.`);
+    throw new Error(`Failed to seed session for ${input.sessionId}.`);
   }
   return sessionFromRow(row);
 }
 
-export function deleteSessionTitleSeed(database: SqlDatabase, sessionId: string): number {
-  const result = database.prepare("DELETE FROM sessions WHERE id = ?").run(sessionId);
-  return Number(result.changes);
+export function discardSessionSeed(
+  database: SqlDatabase,
+  input: {
+    sessionId: string;
+    removedWorktree?: { projectId: string; worktreeId: string };
+  },
+): { discardedSessions: number; discardedWorktreeTitles: number } {
+  const sessionResult = database.prepare("DELETE FROM sessions WHERE id = ?").run(input.sessionId);
+  const discardedWorktreeTitles =
+    input.removedWorktree === undefined
+      ? 0
+      : deleteWorktreeDisplayTitle(database, input.removedWorktree);
+  return {
+    discardedSessions: Number(sessionResult.changes),
+    discardedWorktreeTitles,
+  };
+}
+
+export function retireRemovedWorktreeSessionState(
+  database: SqlDatabase,
+  input: { projectId: string; worktreeId: string; endedAt: string },
+): { endedSessions: number; deletedWorktreeTitles: number } {
+  const endedSessions = markSessionsEnded(database, {
+    subject: { kind: "worktree", projectId: input.projectId, worktreeId: input.worktreeId },
+    endedAt: input.endedAt,
+  });
+  const deletedWorktreeTitles = deleteWorktreeDisplayTitle(database, input);
+  return { endedSessions, deletedWorktreeTitles };
+}
+
+function resolveReconcileWorktreeDisplayTitles(
+  database: SqlDatabase,
+  input: PersistReconcileResultInput,
+  observedAt: string,
+): ReconcileWorktreeDisplayTitleInput[] {
+  if (input.worktreeDisplayTitles !== undefined) return input.worktreeDisplayTitles;
+
+  const canonicalTitles = listWorktreeDisplayTitles(database);
+  const sessions = listSessions(database);
+  return input.worktrees
+    .filter((worktree) => worktree.state === "exists")
+    .map((worktree) => {
+      const existing = canonicalTitles.find(
+        (title) => title.projectId === worktree.projectId && title.worktreeId === worktree.id,
+      );
+      if (existing !== undefined) return existing;
+      return {
+        projectId: worktree.projectId,
+        worktreeId: worktree.id,
+        title: resolveWorktreeDisplayTitle({
+          projectId: worktree.projectId,
+          worktreeId: worktree.id,
+          branch: worktree.branch,
+          canonicalTitles,
+          sessions,
+        }),
+        createdAt: observedAt,
+        updatedAt: observedAt,
+      };
+    });
+}
+
+function listCanonicalTitle(
+  database: SqlDatabase,
+  input: { projectId: string; worktreeId: string },
+): PersistedWorktreeDisplayTitle[] {
+  const title = readWorktreeDisplayTitle(database, input);
+  return title === undefined ? [] : [title];
 }
 
 function upsertProject(
@@ -396,11 +520,16 @@ function upsertSessions(
   database: SqlDatabase,
   terminalTargets: TerminalTargetObservation[],
   harnessRuns: HarnessRunObservation[],
-  worktrees: WorktreeObservation[],
+  worktreeDisplayTitles: readonly PersistedWorktreeDisplayTitle[],
 ): void {
   // Sessions are reconstructed from two partial truths: terminal bindings identify
   // the workspace, while harness runs supply agent state.
-  const worktreesById = new Map(worktrees.map((worktree) => [worktree.id, worktree]));
+  const titlesByWorktree = new Map(
+    worktreeDisplayTitles.map((title) => [
+      worktreeTitleKey(title.projectId, title.worktreeId),
+      title,
+    ]),
+  );
   const sessions = new Map<string, PersistedSession>();
 
   for (const target of terminalTargets) {
@@ -423,9 +552,9 @@ function upsertSessions(
       createdAt: existing?.createdAt ?? target.observedAt,
       lastSeenAt: maxIso(existing?.lastSeenAt, target.observedAt),
     };
-    const title = sessionTitleForWorktree(worktreesById, target.worktreeId);
+    const title = titlesByWorktree.get(worktreeTitleKey(target.projectId, target.worktreeId));
     if (title !== undefined) {
-      session.title = title;
+      session.title = title.title;
     } else if (existing?.title !== undefined) {
       session.title = existing.title;
     }
@@ -459,9 +588,9 @@ function upsertSessions(
       createdAt: existing?.createdAt ?? run.observedAt,
       lastSeenAt: maxIso(existing?.lastSeenAt, run.observedAt),
     };
-    const title = sessionTitleForWorktree(worktreesById, run.worktreeId);
+    const title = titlesByWorktree.get(worktreeTitleKey(run.projectId, run.worktreeId));
     if (title !== undefined) {
-      session.title = title;
+      session.title = title.title;
     } else if (existing?.title !== undefined) {
       session.title = existing.title;
     }
@@ -481,7 +610,7 @@ function upsertSessions(
           ON CONFLICT(id) DO UPDATE SET
             project_id = excluded.project_id,
             worktree_id = excluded.worktree_id,
-            title = COALESCE(sessions.title, excluded.title),
+            title = COALESCE(excluded.title, sessions.title),
             harness = COALESCE(excluded.harness, sessions.harness),
             terminal_provider = COALESCE(excluded.terminal_provider, sessions.terminal_provider),
             state = excluded.state,
@@ -508,9 +637,6 @@ function upsertSessions(
   }
 }
 
-function sessionTitleForWorktree(
-  worktreesById: ReadonlyMap<string, WorktreeObservation>,
-  worktreeId: string,
-): string | undefined {
-  return worktreesById.get(worktreeId)?.branch;
+function worktreeTitleKey(projectId: string, worktreeId: string): string {
+  return `${projectId}\u0000${worktreeId}`;
 }

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -23,6 +23,7 @@ import type {
   PersistedSession,
   PersistedSessionHarnessExecution,
   PersistedSessionTurnReadiness,
+  PersistedWorktreeDisplayTitle,
   PersistedWorktreeMetadataCurrent,
   PersistReconcileResultInput,
   ProviderObservationKind,
@@ -128,6 +129,7 @@ export interface ObservationStore {
  * DRIVEN PORT
  *
  * Persists the Observer's correlated reconcile projection as one atomic capability.
+ * Missing canonical worktree titles initialize insert-only before session projections synchronize.
  */
 export interface ReconcileStore {
   persistReconcileResult(input: PersistReconcileResultInput): Promise<void>;
@@ -136,11 +138,12 @@ export interface ReconcileStore {
 /**
  * DRIVEN PORT
  *
- * Maintains Observer-owned session lifecycle, provider-native execution bindings, titles,
- * remembered harness selection, recovery handles, and turn readiness.
+ * Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical
+ * worktree-scoped title authority, synchronized session projections, recovery, and readiness.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;
+  listWorktreeDisplayTitles(): Promise<PersistedWorktreeDisplayTitle[]>;
   getSessionHarnessExecution(input: {
     provider: ProviderId;
     sessionId: string;
@@ -155,15 +158,18 @@ export interface SessionStore {
     worktreeId: string;
     worktreePath: string;
   }): Promise<ProviderId | undefined>;
-  seedSessionTitle(input: {
+  seedSession(input: {
     sessionId: string;
     projectId: string;
     worktreeId: string;
-    title: string;
+    initialTitle: string;
     createdAt: string;
     lastSeenAt: string;
   }): Promise<PersistedSession>;
-  deleteSessionTitleSeed(sessionId: string): Promise<number>;
+  discardSessionSeed(input: {
+    sessionId: string;
+    removedWorktree?: { projectId: string; worktreeId: string };
+  }): Promise<{ discardedSessions: number; discardedWorktreeTitles: number }>;
   markSessionsEnded(input: {
     subject:
       | { kind: "session"; sessionId: string }
@@ -171,7 +177,16 @@ export interface SessionStore {
     endedAt: string;
   }): Promise<number>;
   reopenSession(sessionId: string): Promise<PersistedSession | undefined>;
-  renameSession(input: { sessionId: string; title: string }): Promise<PersistedSession | undefined>;
+  renameSession(input: {
+    sessionId: string;
+    title: string;
+    renamedAt: string;
+  }): Promise<PersistedSession | undefined>;
+  retireRemovedWorktreeSessionState(input: {
+    projectId: string;
+    worktreeId: string;
+    endedAt: string;
+  }): Promise<{ endedSessions: number; deletedWorktreeTitles: number }>;
   upsertSessionRecoveryHandle(input: SessionRecoveryHandle): Promise<SessionRecoveryHandle>;
   getSessionRecoveryHandle(handleId: string): Promise<SessionRecoveryHandle | undefined>;
   listSessionRecoveryHandles(

--- a/apps/observer/src/persistence/rows.ts
+++ b/apps/observer/src/persistence/rows.ts
@@ -14,6 +14,7 @@ import type {
   PersistedEvent,
   PersistedProviderObservation,
   PersistedSession,
+  PersistedWorktreeDisplayTitle,
   ProviderObservationType,
 } from "./types.js";
 
@@ -57,6 +58,14 @@ export type SqliteProviderObservationRow = {
   payload_json: string;
   observed_at: string;
   expires_at: string | null;
+};
+
+export type SqliteWorktreeDisplayTitleRow = {
+  project_id: string;
+  worktree_id: string;
+  title: string;
+  created_at: string;
+  updated_at: string;
 };
 
 export type SqliteSessionRow = {
@@ -133,6 +142,18 @@ export function providerObservationFromRow(
   };
   if (expiresAt !== undefined) observation.expiresAt = expiresAt;
   return observation;
+}
+
+export function worktreeDisplayTitleFromRow(
+  row: SqliteWorktreeDisplayTitleRow,
+): PersistedWorktreeDisplayTitle {
+  return {
+    projectId: row.project_id,
+    worktreeId: row.worktree_id,
+    title: row.title,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
 }
 
 export function sessionFromRow(row: SqliteSessionRow): PersistedSession {

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -24,6 +24,7 @@ import type {
   ObserverIdFactory,
   SessionTurnReadinessMutation,
 } from "./types.js";
+import * as worktreeDisplayTitleStore from "./worktreeDisplayTitles.js";
 import * as worktreeMetadataCurrentStore from "./worktreeMetadataCurrent.js";
 
 export type CreateSqliteObserverPersistenceOptions = {
@@ -271,6 +272,9 @@ export function createSqliteObserverPersistence(
 
     listSessions: () => transaction(correlationStore.listSessions),
 
+    listWorktreeDisplayTitles: () =>
+      transaction(worktreeDisplayTitleStore.listWorktreeDisplayTitles),
+
     getSessionHarnessExecution: (input) =>
       transaction((database) =>
         sessionHarnessExecutionStore.getSessionHarnessExecution(database, input),
@@ -321,11 +325,11 @@ export function createSqliteObserverPersistence(
         correlationStore.findRememberedHarnessProviderForWorktree(database, input),
       ),
 
-    seedSessionTitle: (input) =>
-      transaction((database) => correlationStore.seedSessionTitle(database, input)),
+    seedSession: (input) =>
+      transaction((database) => correlationStore.seedSession(database, input)),
 
-    deleteSessionTitleSeed: (sessionId) =>
-      transaction((database) => correlationStore.deleteSessionTitleSeed(database, sessionId)),
+    discardSessionSeed: (input) =>
+      transaction((database) => correlationStore.discardSessionSeed(database, input)),
 
     markSessionsEnded: (input) =>
       transaction((database) => correlationStore.markSessionsEnded(database, input)),
@@ -335,6 +339,11 @@ export function createSqliteObserverPersistence(
 
     renameSession: (input) =>
       transaction((database) => correlationStore.renameSession(database, input)),
+
+    retireRemovedWorktreeSessionState: (input) =>
+      transaction((database) =>
+        correlationStore.retireRemovedWorktreeSessionState(database, input),
+      ),
 
     upsertSessionRecoveryHandle: (input) =>
       transaction((database) =>

--- a/apps/observer/src/persistence/types.ts
+++ b/apps/observer/src/persistence/types.ts
@@ -199,6 +199,16 @@ export type PersistedWorktreeMetadataCurrent<
 
 export type PersistedSessionLifecycle = "legacy" | "open" | "ended";
 
+export type PersistedWorktreeDisplayTitle = {
+  projectId: string;
+  worktreeId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ReconcileWorktreeDisplayTitleInput = PersistedWorktreeDisplayTitle;
+
 export type PersistedSession = {
   id: string;
   projectId: string;
@@ -241,6 +251,7 @@ export type PersistReconcileResultInput = {
   worktrees: WorktreeObservation[];
   terminalTargets: TerminalTargetObservation[];
   harnessRuns: HarnessRunObservation[];
+  worktreeDisplayTitles?: ReconcileWorktreeDisplayTitleInput[];
   providerHealth?: Record<string, ProviderHealth>;
   observedAt?: string;
   expiresAt?: string | undefined;

--- a/apps/observer/src/persistence/worktreeDisplayTitles.ts
+++ b/apps/observer/src/persistence/worktreeDisplayTitles.ts
@@ -1,0 +1,102 @@
+import type { SqlDatabase } from "../sqlite/driver.js";
+import { type SqliteWorktreeDisplayTitleRow, worktreeDisplayTitleFromRow } from "./rows.js";
+import type { PersistedWorktreeDisplayTitle, ReconcileWorktreeDisplayTitleInput } from "./types.js";
+
+export function listWorktreeDisplayTitles(database: SqlDatabase): PersistedWorktreeDisplayTitle[] {
+  const rows = database
+    .prepare(
+      `
+        SELECT project_id, worktree_id, title, created_at, updated_at
+        FROM worktree_display_titles
+        ORDER BY project_id ASC, worktree_id ASC
+      `,
+    )
+    .all() as SqliteWorktreeDisplayTitleRow[];
+  return rows.map(worktreeDisplayTitleFromRow);
+}
+
+export function readWorktreeDisplayTitle(
+  database: SqlDatabase,
+  input: { projectId: string; worktreeId: string },
+): PersistedWorktreeDisplayTitle | undefined {
+  const row = database
+    .prepare(
+      `
+        SELECT project_id, worktree_id, title, created_at, updated_at
+        FROM worktree_display_titles
+        WHERE project_id = ? AND worktree_id = ?
+      `,
+    )
+    .get(input.projectId, input.worktreeId) as SqliteWorktreeDisplayTitleRow | undefined;
+  return row === undefined ? undefined : worktreeDisplayTitleFromRow(row);
+}
+
+export function insertMissingWorktreeDisplayTitles(
+  database: SqlDatabase,
+  titles: readonly ReconcileWorktreeDisplayTitleInput[],
+): void {
+  const insert = database.prepare(
+    `
+      INSERT INTO worktree_display_titles
+        (project_id, worktree_id, title, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT(project_id, worktree_id) DO NOTHING
+    `,
+  );
+  for (const title of titles) {
+    insert.run(title.projectId, title.worktreeId, title.title, title.createdAt, title.updatedAt);
+  }
+}
+
+export function upsertWorktreeDisplayTitle(
+  database: SqlDatabase,
+  input: ReconcileWorktreeDisplayTitleInput,
+): PersistedWorktreeDisplayTitle {
+  database
+    .prepare(
+      `
+        INSERT INTO worktree_display_titles
+          (project_id, worktree_id, title, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(project_id, worktree_id) DO UPDATE SET
+          title = excluded.title,
+          updated_at = excluded.updated_at
+      `,
+    )
+    .run(input.projectId, input.worktreeId, input.title, input.createdAt, input.updatedAt);
+  const title = readWorktreeDisplayTitle(database, input);
+  if (title === undefined) {
+    throw new Error(`Failed to persist worktree display title for ${input.worktreeId}.`);
+  }
+  return title;
+}
+
+export function deleteWorktreeDisplayTitle(
+  database: SqlDatabase,
+  input: { projectId: string; worktreeId: string },
+): number {
+  const result = database
+    .prepare(
+      `
+        DELETE FROM worktree_display_titles
+        WHERE project_id = ? AND worktree_id = ?
+      `,
+    )
+    .run(input.projectId, input.worktreeId);
+  return Number(result.changes);
+}
+
+export function synchronizeSessionTitleProjections(
+  database: SqlDatabase,
+  title: PersistedWorktreeDisplayTitle,
+): void {
+  database
+    .prepare(
+      `
+        UPDATE sessions
+        SET title = ?
+        WHERE project_id = ? AND worktree_id = ?
+      `,
+    )
+    .run(title.title, title.projectId, title.worktreeId);
+}

--- a/apps/observer/src/reconcile/graph.ts
+++ b/apps/observer/src/reconcile/graph.ts
@@ -41,6 +41,7 @@ export type ObserverGraphInput = {
   terminalTargets: TerminalTargetObservation[];
   harnessRuns: ObserverHarnessRun[];
   sessionMetadata?: readonly ObserverSessionMetadata[];
+  worktreeDisplayTitles?: readonly ObserverWorktreeDisplayTitle[];
   recoveryHandles?: readonly SessionRecoveryHandle[];
   turnReadiness?: readonly ObserverTurnReadiness[];
   alerts?: StationAlert[];
@@ -59,6 +60,12 @@ export type ObserverSessionMetadata = {
   createdAt: string;
   endedAt?: string;
   lastSeenAt: string;
+};
+
+export type ObserverWorktreeDisplayTitle = {
+  projectId: string;
+  worktreeId: string;
+  title: string;
 };
 
 export type ObserverTurnReadiness = {
@@ -91,7 +98,8 @@ const confidenceRank = {
 /**
  * POLICY
  *
- * Correlates provider observations and durable session records into canonical snapshot truth.
+ * Correlates provider observations with canonical worktree title input and durable session records.
+ * Branch names remain only the defensive title fallback when persistence is unavailable.
  */
 export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot {
   const projectsById = new Map(input.projects.map((project) => [project.id, project]));
@@ -103,6 +111,12 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
   const harnessRunsById = new Map(harnessRuns.map((run) => [run.run.id, run.run]));
   const sessionMetadataById = new Map(
     input.sessionMetadata?.map((session) => [session.id, session]),
+  );
+  const titleByWorktree = new Map(
+    input.worktreeDisplayTitles?.map((title) => [
+      sessionWorktreeKey(title.projectId, title.worktreeId),
+      title.title,
+    ]),
   );
   const retainedSessionByWorktree = newestRetainedSessionByWorktree(input.sessionMetadata ?? []);
   const turnReadinessBySessionId = new Map(
@@ -123,9 +137,12 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
           terminal === undefined
             ? undefined
             : input.providerHealth[terminal.provider]?.capabilities;
+        const title =
+          titleByWorktree.get(sessionWorktreeKey(project.id, worktree.id)) ?? worktree.branch;
         const rowInput: BuildWorktreeRowInput = {
           project,
           worktree,
+          title,
         };
         if (terminal !== undefined) rowInput.terminal = terminal;
         if (harnessRun !== undefined) rowInput.harnessRun = harnessRun;
@@ -146,6 +163,7 @@ export function buildStationSnapshot(input: ObserverGraphInput): StationSnapshot
         const sessionInput: BuildSessionInput = {
           project,
           worktree,
+          title,
           harnessCapabilities: input.harnessCapabilities ?? {},
           sessionMetadataById,
         };
@@ -257,6 +275,7 @@ export function projectProviderHealthOntoSnapshot(input: {
 type BuildWorktreeRowInput = {
   project: ProviderProjectConfig;
   worktree: WorktreeObservation;
+  title: string;
   terminal?: TerminalTargetObservation;
   harnessRun?: ObserverHarnessRun;
   terminalCapabilities?: Record<string, boolean>;
@@ -294,6 +313,7 @@ function buildWorktreeRow(input: BuildWorktreeRowInput): WorktreeRow {
     id: input.worktree.id,
     projectId: input.project.id,
     projectLabel: input.project.label,
+    title: input.title,
     branch: input.worktree.branch,
     path: input.worktree.path,
     worktree,
@@ -423,6 +443,7 @@ function rowAgent(harnessRun: ObserverHarnessRun): WorktreeRow["agent"] {
 type BuildSessionInput = {
   project: ProviderProjectConfig;
   worktree: WorktreeObservation;
+  title: string;
   terminal?: TerminalTargetObservation;
   harnessRun?: ObserverHarnessRun;
   harnessCapabilities: Record<string, HarnessCapabilities>;
@@ -465,7 +486,7 @@ function buildStationSession(input: BuildSessionInput): SessionView | undefined 
     harnessProvider,
     status,
     createdAt,
-    title: identity.metadata?.title ?? input.worktree.branch,
+    title: input.title,
     ...(identity.harnessRun === undefined ? {} : { harnessRun: identity.harnessRun }),
     ...(terminal === undefined ? {} : { terminal }),
   });
@@ -491,7 +512,7 @@ function buildExternalSession(input: BuildSessionInput): SessionView | undefined
     harnessRun,
     status: harnessRun.status,
     createdAt: run.observedAt,
-    title: input.worktree.branch,
+    title: input.title,
     ...(terminal === undefined ? {} : { terminal }),
   });
 }

--- a/apps/observer/src/reconcile/run.ts
+++ b/apps/observer/src/reconcile/run.ts
@@ -37,6 +37,7 @@ import type {
   PersistedSessionHarnessExecution,
   PersistedSessionTurnReadiness,
   ReconcileStore,
+  ReconcileWorktreeDisplayTitleInput,
   SessionHarnessDerivedStateRepair,
   SessionStore,
   WorktreeMetadataStore,
@@ -44,6 +45,7 @@ import type {
 import { providerObservationRetentionDays } from "../persistence/retention.js";
 import type { ProviderRegistry } from "../providers/registry.js";
 import type { StationLogger } from "../stationLogger.js";
+import { resolveWorktreeDisplayTitle } from "../worktreeDisplayTitle.js";
 import { buildStationSnapshot, safeErrorToProviderHealth } from "./graph.js";
 import {
   applyHarnessEventStatusOverlays,
@@ -132,7 +134,8 @@ export function buildInitialSnapshot(input: {
 /**
  * USE CASE
  *
- * Rebuilds the Observer graph from provider reads and accepted durable evidence.
+ * Rebuilds the Observer graph after overlaying durable worktree titles on provider observations.
+ * The same resolved title records feed snapshot composition and atomic reconcile persistence.
  */
 export async function runReconcileOnce(input: ReconcileOnceInput): Promise<ReconcileOnceResult> {
   const started = toIsoTimestamp(input.read.clock.now());
@@ -220,12 +223,44 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     metadataInput.persistence = input.persistence;
   }
   const worktreesForSnapshot = await worktreesWithCachedMetadata(metadataInput);
-  const sessionMetadata =
-    input.persistence === undefined ? [] : await input.persistence.listSessions();
-  const recoveryHandles =
-    input.persistence === undefined ? [] : await input.persistence.listSessionRecoveryHandles();
-  const turnReadiness =
-    input.persistence === undefined ? [] : await input.persistence.listSessionTurnReadiness();
+  const [sessionMetadata, persistedWorktreeDisplayTitles, recoveryHandles, turnReadiness] =
+    input.persistence === undefined
+      ? [[], [], [], []]
+      : await Promise.all([
+          input.persistence.listSessions(),
+          input.persistence.listWorktreeDisplayTitles(),
+          input.persistence.listSessionRecoveryHandles(),
+          input.persistence.listSessionTurnReadiness(),
+        ]);
+  const configuredProjectIds = new Set(input.projects.map((project) => project.id));
+  const titleSessionEvidence = reattachSessionTitleEvidence({
+    sessions: sessionMetadata,
+    harnessRuns,
+    terminalTargets,
+  });
+  const worktreeDisplayTitles: ReconcileWorktreeDisplayTitleInput[] = worktreesForSnapshot
+    .filter(
+      (worktree) => worktree.state === "exists" && configuredProjectIds.has(worktree.projectId),
+    )
+    .map((worktree) => {
+      const existing = persistedWorktreeDisplayTitles.find(
+        (title) => title.projectId === worktree.projectId && title.worktreeId === worktree.id,
+      );
+      if (existing !== undefined) return existing;
+      return {
+        projectId: worktree.projectId,
+        worktreeId: worktree.id,
+        title: resolveWorktreeDisplayTitle({
+          projectId: worktree.projectId,
+          worktreeId: worktree.id,
+          branch: worktree.branch,
+          canonicalTitles: persistedWorktreeDisplayTitles,
+          sessions: titleSessionEvidence,
+        }),
+        createdAt: finishedAt,
+        updatedAt: finishedAt,
+      };
+    });
   const lastReconcile: ReconcileTiming = {
     reason: input.reason,
     startedAt: started,
@@ -250,6 +285,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     terminalTargets,
     harnessRuns,
     sessionMetadata,
+    worktreeDisplayTitles,
     recoveryHandles,
     turnReadiness,
     ...(input.featureFlags === undefined ? {} : { featureFlags: input.featureFlags }),
@@ -261,6 +297,7 @@ export async function runReconcileOnce(input: ReconcileOnceInput): Promise<Recon
     worktrees: worktreeResult.worktrees,
     terminalTargets,
     harnessRuns: harnessRuns.map((harnessRun) => harnessRun.run),
+    worktreeDisplayTitles,
     providerHealth,
     observedAt: finishedAt,
     providerObservationRetentionDays: retentionDays,
@@ -297,6 +334,37 @@ export function harnessesFromRegistry(providers: ProviderRegistry): SnapshotHarn
       harness.updateAvailable = harness.installedVersion !== harness.latestVersion;
     }
     return harness;
+  });
+}
+
+function reattachSessionTitleEvidence(input: {
+  sessions: Awaited<ReturnType<SessionStore["listSessions"]>>;
+  harnessRuns: readonly ObserverHarnessRun[];
+  terminalTargets: readonly TerminalTargetObservation[];
+}): Awaited<ReturnType<SessionStore["listSessions"]>> {
+  return input.sessions.map((session) => {
+    const currentWorktreeIds = new Set<string>();
+    for (const harnessRun of input.harnessRuns) {
+      if (
+        harnessRun.run.sessionId === session.id &&
+        harnessRun.run.projectId === session.projectId &&
+        harnessRun.run.worktreeId !== undefined
+      ) {
+        currentWorktreeIds.add(harnessRun.run.worktreeId);
+      }
+    }
+    for (const terminal of input.terminalTargets) {
+      if (
+        terminal.sessionId === session.id &&
+        terminal.projectId === session.projectId &&
+        terminal.worktreeId !== undefined
+      ) {
+        currentWorktreeIds.add(terminal.worktreeId);
+      }
+    }
+    if (currentWorktreeIds.size !== 1) return session;
+    const [worktreeId] = currentWorktreeIds;
+    return worktreeId === undefined ? session : { ...session, worktreeId };
   });
 }
 
@@ -915,6 +983,7 @@ async function persistReconcileResult(input: {
   worktrees: WorktreeObservation[];
   terminalTargets: TerminalTargetObservation[];
   harnessRuns: HarnessRunObservation[];
+  worktreeDisplayTitles: ReconcileWorktreeDisplayTitleInput[];
   providerHealth: Record<string, ProviderHealth>;
   observedAt: string;
   providerObservationRetentionDays: number;
@@ -928,6 +997,7 @@ async function persistReconcileResult(input: {
     worktrees: input.worktrees,
     terminalTargets: input.terminalTargets,
     harnessRuns: input.harnessRuns,
+    worktreeDisplayTitles: input.worktreeDisplayTitles,
     providerHealth: input.providerHealth,
     observedAt: input.observedAt,
     providerObservationRetentionDays: input.providerObservationRetentionDays,

--- a/apps/observer/src/reconcile/statusProjection.ts
+++ b/apps/observer/src/reconcile/statusProjection.ts
@@ -292,18 +292,11 @@ function projectAgent(agent: WorktreeAgent, status: ObservedStatus): WorktreeAge
 }
 
 function projectRow(row: WorktreeRow, agent: WorktreeAgent, status: ObservedStatus): WorktreeRow {
-  const nextRow: WorktreeRow = {
-    id: row.id,
-    projectId: row.projectId,
-    projectLabel: row.projectLabel,
-    branch: row.branch,
-    path: row.path,
-    worktree: row.worktree,
+  return {
+    ...row,
     display: displayForStatus(status),
     agent,
   };
-  if (row.terminal !== undefined) nextRow.terminal = row.terminal;
-  return nextRow;
 }
 
 function displayForStatus(status: ObservedStatus): WorktreeRow["display"] {

--- a/apps/observer/src/runtime/externalLaunch.ts
+++ b/apps/observer/src/runtime/externalLaunch.ts
@@ -17,7 +17,6 @@ import {
   defaultSessionCommandIdFactory,
   findProjectOrThrow,
   rememberedHarnessProviderForWorktree,
-  seedSessionTitle,
   worktreeObservationFromRow,
 } from "../commands/session/shared.js";
 import type { SessionStore } from "../persistence/index.js";
@@ -44,10 +43,8 @@ export type ExternalLaunchOutcome<T> = {
 /**
  * USE CASE
  *
- * Prepare Station-hosted agent identity, persist an optional title before reconcile
- * can expose it, and return a launch plan plus opaque managed attachment. Failed
- * terminal preparation or process launch releases the managed target before removing
- * its title seed, retaining the title whenever target cleanup cannot be confirmed.
+ * Prepares Station-hosted identity by durably seeding its canonical title before target registration.
+ * Failed launch cleanup independently releases its target and discards only the fresh session projection.
  */
 export async function prepareExternalLaunch(
   deps: ExternalLaunchDeps,
@@ -158,21 +155,26 @@ export async function prepareExternalLaunch(
   // which reconcile later reaps) rather than two targets. A single UI is already
   // covered by Station's `launchesInFlight` guard; a server-side lock is out of scope.
   const sessionId = defaultSessionCommandIdFactory.sessionId();
-
+  const seededAt = nowIso(deps.clock);
   let openedTargetId: TerminalTargetId | undefined;
-  let seededSessionTitle = false;
+  let sessionSeeded = false;
   try {
-    if (params.title !== undefined) {
-      // The title must be durable before a managed target lets reconcile publish the new session.
-      await seedSessionTitle({
-        persistence: deps.persistence,
+    await deps.persistence.seedSession({
+      sessionId,
+      projectId: project.id,
+      worktreeId: worktree.id,
+      initialTitle: params.title ?? row.title,
+      createdAt: seededAt,
+      lastSeenAt: seededAt,
+    });
+    sessionSeeded = true;
+    if (params.title !== undefined && params.title !== row.title) {
+      // New-session intent may replace reconcile's branch fallback before the target becomes visible.
+      await deps.persistence.renameSession({
         sessionId,
-        projectId: project.id,
-        worktreeId: worktree.id,
         title: params.title,
-        clock: deps.clock,
+        renamedAt: seededAt,
       });
-      seededSessionTitle = true;
     }
 
     const opened = await managedTerminal.openWorkspace({
@@ -217,13 +219,10 @@ export async function prepareExternalLaunch(
       reconcile: true,
     };
   } catch (error) {
-    // Keep metadata while a target may still exist; reconcile must never expose a
-    // dangling managed session under a branch fallback after losing its chosen title.
-    let targetReleaseConfirmed = openedTargetId === undefined;
+    // Cleanup attempts stay independent so one failure cannot suppress the other or replace the launch error.
     if (openedTargetId !== undefined) {
       try {
         await managedTerminal.releaseTarget(openedTargetId);
-        targetReleaseConfirmed = true;
       } catch (cleanupError) {
         await deps.logger
           ?.warn("External launch cleanup could not release its managed target.", {
@@ -234,12 +233,12 @@ export async function prepareExternalLaunch(
           .catch(() => undefined);
       }
     }
-    if (seededSessionTitle && targetReleaseConfirmed) {
+    if (sessionSeeded) {
       try {
-        await deps.persistence.deleteSessionTitleSeed(sessionId);
+        await deps.persistence.discardSessionSeed({ sessionId });
       } catch (cleanupError) {
         await deps.logger
-          ?.warn("External launch cleanup could not delete its title seed.", {
+          ?.warn("External launch cleanup could not discard its session seed.", {
             sessionId,
             error: cleanupError,
           })

--- a/apps/observer/src/worktreeDisplayTitle.ts
+++ b/apps/observer/src/worktreeDisplayTitle.ts
@@ -1,0 +1,44 @@
+import type { PersistedSession, PersistedWorktreeDisplayTitle } from "./persistence/types.js";
+
+export type ResolveWorktreeDisplayTitleInput = {
+  projectId: string;
+  worktreeId: string;
+  branch: string;
+  canonicalTitles: readonly PersistedWorktreeDisplayTitle[];
+  sessions: readonly PersistedSession[];
+};
+
+/**
+ * POLICY
+ *
+ * Resolves one durable display title from worktree authority and deterministic legacy session evidence.
+ */
+export function resolveWorktreeDisplayTitle(input: ResolveWorktreeDisplayTitleInput): string {
+  const canonical = input.canonicalTitles.find(
+    (title) => title.projectId === input.projectId && title.worktreeId === input.worktreeId,
+  );
+  if (canonical !== undefined) {
+    return canonical.title;
+  }
+
+  const evidence = input.sessions
+    .filter(
+      (session) =>
+        session.projectId === input.projectId &&
+        session.worktreeId === input.worktreeId &&
+        session.lifecycle !== "ended" &&
+        session.title !== undefined &&
+        session.title.trim().length > 0,
+    )
+    .sort(compareSessionTitleEvidence);
+  const custom = evidence.find((session) => session.title !== input.branch);
+  return custom?.title ?? evidence[0]?.title ?? input.branch;
+}
+
+function compareSessionTitleEvidence(left: PersistedSession, right: PersistedSession): number {
+  return (
+    right.lastSeenAt.localeCompare(left.lastSeenAt) ||
+    right.createdAt.localeCompare(left.createdAt) ||
+    right.id.localeCompare(left.id)
+  );
+}

--- a/apps/observer/test/integration/cleanup-commands.test.ts
+++ b/apps/observer/test/integration/cleanup-commands.test.ts
@@ -373,11 +373,11 @@ describe("cleanup command handlers", () => {
 
   it("force-removes an active worktree after stopping harness and closing terminal", async () => {
     const fixture = createFixture({ dirty: true, state: "working" });
-    await fixture.persistence.seedSessionTitle({
+    await fixture.persistence.seedSession({
       sessionId: "ses_web_cleanup_older",
       projectId: "web",
       worktreeId: "wt_web_cleanup",
-      title: "older cleanup session",
+      initialTitle: "older cleanup session",
       createdAt: "2026-05-21T11:00:00.000Z",
       lastSeenAt: "2026-05-21T11:00:00.000Z",
     });
@@ -431,6 +431,11 @@ describe("cleanup command handlers", () => {
       { id: "ses_web_cleanup", lifecycle: "ended" },
       { id: "ses_web_cleanup_older", lifecycle: "ended" },
     ]);
+    expect(
+      (await fixture.persistence.listWorktreeDisplayTitles()).some(
+        (title) => title.projectId === "web" && title.worktreeId === "wt_web_cleanup",
+      ),
+    ).toBe(false);
     fixture.sqlite.close();
   });
 

--- a/apps/observer/test/integration/diagnostics-collector.test.ts
+++ b/apps/observer/test/integration/diagnostics-collector.test.ts
@@ -39,7 +39,7 @@ describe("observer diagnostics collector", () => {
       };
 
       await expect(collectDiagnosticSnapshot(deps)).resolves.toMatchObject({
-        schemaVersion: "0.8.0",
+        schemaVersion: "0.9.0",
         observerHealth: {
           stateDir: "memory://state",
           socketPath: "memory://observer-socket",

--- a/apps/observer/test/integration/persistence.test.ts
+++ b/apps/observer/test/integration/persistence.test.ts
@@ -702,6 +702,7 @@ describe("observer persistence", () => {
     await persistence.renameSession({
       sessionId: "ses_web_feature",
       title: "Readable feature task",
+      renamedAt: now,
     });
     await persistence.persistReconcileResult({
       projects: [project],
@@ -754,19 +755,19 @@ describe("observer persistence", () => {
       now: later,
     });
 
-    await persistence.seedSessionTitle({
+    await persistence.seedSession({
       sessionId: "ses_web_seeded",
       projectId: "web",
       worktreeId: "wt_web_seeded",
-      title: "original-session-title",
+      initialTitle: "original-session-title",
       createdAt: now,
       lastSeenAt: now,
     });
-    await persistence.seedSessionTitle({
+    await persistence.seedSession({
       sessionId: "ses_web_seeded",
       projectId: "web",
       worktreeId: "wt_web_seeded",
-      title: "agent-created-branch",
+      initialTitle: "agent-created-branch",
       createdAt: later,
       lastSeenAt: later,
     });
@@ -798,12 +799,13 @@ describe("observer persistence", () => {
     await persistence.renameSession({
       sessionId: "ses_web_seeded",
       title: "user renamed session",
+      renamedAt: later,
     });
-    await persistence.seedSessionTitle({
+    await persistence.seedSession({
       sessionId: "ses_web_seeded",
       projectId: "web",
       worktreeId: "wt_web_seeded",
-      title: "ignored later seed",
+      initialTitle: "ignored later seed",
       createdAt: later,
       lastSeenAt: later,
     });
@@ -825,16 +827,25 @@ describe("observer persistence", () => {
       idFactory: ids(),
     });
 
-    await persistence.seedSessionTitle({
+    await persistence.seedSession({
       sessionId: "ses_cleanup_seed",
       projectId: "web",
       worktreeId: "wt_web_cleanup_seed",
-      title: "cleanup-seed",
+      initialTitle: "cleanup-seed",
       createdAt: now,
       lastSeenAt: now,
     });
-    await expect(persistence.deleteSessionTitleSeed("ses_cleanup_seed")).resolves.toBe(1);
+    await expect(
+      persistence.discardSessionSeed({ sessionId: "ses_cleanup_seed" }),
+    ).resolves.toEqual({ discardedSessions: 1, discardedWorktreeTitles: 0 });
     await expect(persistence.listSessions()).resolves.toEqual([]);
+    await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "web",
+        worktreeId: "wt_web_cleanup_seed",
+        title: "cleanup-seed",
+      }),
+    ]);
     sqlite.close();
   });
 

--- a/apps/observer/test/integration/reconcile-fake-providers.test.ts
+++ b/apps/observer/test/integration/reconcile-fake-providers.test.ts
@@ -1,4 +1,4 @@
-import type { StationConfig } from "@station/config";
+import { DEFAULT_WORKSPACE_CONFIG, type StationConfig } from "@station/config";
 import { StationSnapshotSchema } from "@station/contracts";
 import {
   createFakeHarnessRun,
@@ -16,6 +16,7 @@ const now = "2026-05-20T12:00:00.000Z";
 
 const config: StationConfig = {
   schemaVersion: 1,
+  workspace: DEFAULT_WORKSPACE_CONFIG,
   defaults: {
     worktreeProvider: "fake-worktree",
     terminal: "fake-terminal",
@@ -296,11 +297,11 @@ describe("observer reconcile with fake providers", () => {
       providers,
       clock: { now: () => new Date(now) },
     });
-    await persistence.seedSessionTitle({
+    await persistence.seedSession({
       sessionId,
       projectId: "web",
       worktreeId: oldWorktreeId,
-      title: "Branch Fix too",
+      initialTitle: "Branch Fix too",
       createdAt: now,
       lastSeenAt: now,
     });

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -642,6 +642,8 @@ describe("session command vertical slice", () => {
       },
     ]);
     expect(worktree.snapshot().worktrees).toEqual([]);
+    await expect(fixture.persistence.listSessions()).resolves.toEqual([]);
+    await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toEqual([]);
     fixture.sqlite.close();
   });
 
@@ -859,8 +861,17 @@ describe("session command vertical slice", () => {
     });
     expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
       id: "wt_web_feature",
+      title: "Readable feature task",
       branch: "feature",
+      path: "/tmp/station/web/feature",
     });
+    await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        title: "Readable feature task",
+      }),
+    ]);
     expect(
       (await fixture.persistence.listEvents({ commandId: receipt.commandId })).map(
         (event) => event.type,
@@ -917,6 +928,24 @@ describe("session command vertical slice", () => {
       sessionIds: ["ses_existing"],
     });
     await fixture.core.reconcile("pre-start-agent");
+    await fixture.persistence.seedSession({
+      sessionId: "ses_previous_title",
+      projectId: "web",
+      worktreeId: "wt_web_existing",
+      initialTitle: "existing",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.persistence.renameSession({
+      sessionId: "ses_previous_title",
+      title: "Durable existing workspace",
+      renamedAt: now,
+    });
+    await fixture.persistence.markSessionsEnded({
+      subject: { kind: "session", sessionId: "ses_previous_title" },
+      endedAt: now,
+    });
+    await fixture.core.reconcile("pre-start-agent-renamed");
 
     await fixture.queue.dispatch({
       type: "session.startAgent",
@@ -941,10 +970,20 @@ describe("session command vertical slice", () => {
     expect(terminal.snapshot().focusContexts).toEqual([
       { origin: { provider: "tmux", clientId: "client_1" } },
     ]);
-    expect(fixture.core.getSnapshot().rows[0]?.agent).toMatchObject({
-      sessionId: "ses_existing",
-      state: "working",
+    expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
+      title: "Durable existing workspace",
+      branch: "existing",
+      agent: {
+        sessionId: "ses_existing",
+        state: "working",
+      },
     });
+    expect(fixture.core.getSnapshot().sessions).toEqual([
+      expect.objectContaining({
+        id: "ses_existing",
+        title: "Durable existing workspace",
+      }),
+    ]);
     fixture.sqlite.close();
   });
 
@@ -1236,6 +1275,98 @@ describe("session command vertical slice", () => {
     ).not.toHaveProperty("endedAt");
     expect(fixture.core.getSnapshot().sessions).toEqual([
       expect.objectContaining({ id: "ses_previous", origin: "station" }),
+    ]);
+    fixture.sqlite.close();
+  });
+
+  it("mints a fresh resume identity while preserving the canonical worktree title", async () => {
+    const harness = new FakeHarnessProvider({ now });
+    const terminal = new FakeTerminalProvider({
+      now,
+      onLaunch: async ({ launchPlan }) => {
+        harness.addRun(
+          createFakeHarnessRun({
+            id: "run_resume_fresh",
+            projectId: "web",
+            worktreeId: "wt_web_resume_fresh",
+            sessionId: launchPlan.env?.STATION_SESSION_ID,
+            state: "working",
+            now,
+          }),
+        );
+      },
+    });
+    const fixture = createFixture({
+      terminal,
+      harness,
+      featureFlags: { sessionResumeAgent: true },
+      sessionIds: ["ses_resume_fresh"],
+      worktree: new FakeWorktreeProvider({
+        now,
+        worktrees: [
+          createFakeWorktree({
+            id: "wt_web_resume_fresh",
+            projectId: "web",
+            branch: "resume-fresh",
+            now,
+          }),
+        ],
+      }),
+    });
+    await fixture.core.reconcile("pre-resume-fresh");
+    await fixture.persistence.seedSession({
+      sessionId: "ses_resume_history",
+      projectId: "web",
+      worktreeId: "wt_web_resume_fresh",
+      initialTitle: "resume-fresh",
+      createdAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.persistence.renameSession({
+      sessionId: "ses_resume_history",
+      title: "Durable resumed workspace",
+      renamedAt: now,
+    });
+    await fixture.persistence.markSessionsEnded({
+      subject: { kind: "session", sessionId: "ses_resume_history" },
+      endedAt: now,
+    });
+    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
+      id: "report_resume_fresh",
+      provider: "fake-harness",
+      projectId: "web",
+      worktreeId: "wt_web_resume_fresh",
+      target: { kind: "native-session", id: "native_resume_fresh" },
+      cwd: "/tmp/station/web/resume-fresh",
+      observedAt: now,
+      lastSeenAt: now,
+    });
+    await fixture.core.reconcile("pre-resume-fresh-command");
+
+    const receipt = await fixture.queue.dispatch({
+      type: "session.resumeAgent",
+      payload: {
+        projectId: "web",
+        worktreeId: "wt_web_resume_fresh",
+        recoveryHandleId: handle.id,
+        terminal: { provider: "fake-terminal", focus: false },
+      },
+    });
+    await fixture.queue.drain();
+
+    await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
+      title: "Durable resumed workspace",
+      branch: "resume-fresh",
+      agent: { sessionId: "ses_resume_fresh", state: "working" },
+    });
+    expect(fixture.core.getSnapshot().sessions).toEqual([
+      expect.objectContaining({
+        id: "ses_resume_fresh",
+        title: "Durable resumed workspace",
+      }),
     ]);
     fixture.sqlite.close();
   });
@@ -1592,6 +1723,13 @@ describe("session command vertical slice", () => {
     expect(terminal.snapshot().closed).toEqual(["term_fake"]);
     expect(worktree.snapshot().removed).toEqual([]);
     expect(await fixture.persistence.listSessions()).toEqual([]);
+    await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "web",
+        worktreeId: "wt_web_cleanup_start",
+        title: "cleanup-start",
+      }),
+    ]);
     fixture.sqlite.close();
   });
 

--- a/apps/observer/test/integration/sqlite-persistence-ports.test.ts
+++ b/apps/observer/test/integration/sqlite-persistence-ports.test.ts
@@ -179,6 +179,82 @@ describe("SQLite-only Observer persistence behavior", () => {
     }
   });
 
+  it("backfills an earlier custom title ahead of a later branch-default seed", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "station-worktree-title-migration-"));
+    const path = join(directory, "observer.sqlite");
+    const legacyDatabase = openSqlDatabase(path);
+    try {
+      for (const migration of migrations.filter(({ version }) => version < 16)) {
+        legacyDatabase.exec(migration.sql);
+        legacyDatabase
+          .prepare("INSERT INTO observer_migrations (version, name, applied_at) VALUES (?, ?, ?)")
+          .run(migration.version, migration.name, now);
+      }
+      const insert = legacyDatabase.prepare(`
+        INSERT INTO sessions
+          (id, project_id, worktree_id, title, created_at, last_seen_at, lifecycle)
+        VALUES (?, 'web', 'wt_title_migration', ?, ?, ?, 'open')
+      `);
+      insert.run(
+        "ses_custom",
+        "Readable migration title",
+        "2026-05-20T11:58:00.000Z",
+        "2026-05-20T11:59:00.000Z",
+      );
+      insert.run("ses_branch", "feature/current", now, now);
+    } finally {
+      legacyDatabase.close();
+    }
+
+    const sqlite = openObserverSqlite({ path, clock: { now: () => new Date(now) } });
+    try {
+      const persistence = createSqliteObserverPersistence({
+        sqlite,
+        clock: { now: () => new Date(now) },
+      });
+      await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual([]);
+      await persistence.persistReconcileResult({
+        projects: [
+          {
+            id: "web",
+            label: "web",
+            root: "/tmp/station/web",
+            defaults: { harness: "codex", terminal: "tmux", layout: "agent-shell" },
+            worktrunk: { enabled: true },
+          },
+        ],
+        worktrees: [
+          createFakeWorktree({
+            id: "wt_title_migration",
+            projectId: "web",
+            branch: "feature/current",
+            now,
+          }),
+        ],
+        terminalTargets: [],
+        harnessRuns: [],
+        observedAt: now,
+      });
+
+      await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+        {
+          projectId: "web",
+          worktreeId: "wt_title_migration",
+          title: "Readable migration title",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]);
+      expect((await persistence.listSessions()).map((session) => session.title)).toEqual([
+        "Readable migration title",
+        "Readable migration title",
+      ]);
+    } finally {
+      sqlite.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("drops obsolete recovery breadcrumb storage from fresh and version-14 databases", async () => {
     const directory = await mkdtemp(join(tmpdir(), "station-recovery-breadcrumb-migration-"));
     const path = join(directory, "observer.sqlite");
@@ -295,6 +371,7 @@ describe("SQLite-only Observer persistence behavior", () => {
         [13, "session_harness_executions"],
         [14, "native_binding_ingress_claims"],
         [15, "drop_recovery_breadcrumbs"],
+        [16, "worktree_display_titles"],
       ]);
       await expect(persistence.listSessions()).resolves.toEqual([
         expect.objectContaining({

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -64,6 +64,7 @@ import type {
   PersistedSession,
   PersistedSessionHarnessExecution,
   PersistedSessionTurnReadiness,
+  PersistedWorktreeDisplayTitle,
   PersistedWorktreeMetadataCurrent,
   PersistReconcileResultInput,
   ProviderObservationKind,
@@ -78,6 +79,7 @@ import {
   harnessRunCanActivateSession,
   terminalCanActivateSession,
 } from "../../src/sessionActivation.js";
+import { resolveWorktreeDisplayTitle } from "../../src/worktreeDisplayTitle.js";
 
 type CreateInMemoryObserverPersistenceOptions = {
   clock?: RuntimeClock;
@@ -102,6 +104,7 @@ type InMemoryObserverPersistenceState = {
   terminalTargets: Map<string, TerminalTargetObservation>;
   harnessRuns: Map<string, HarnessRunObservation>;
   sessions: Map<string, PersistedSession>;
+  worktreeDisplayTitles: Map<string, PersistedWorktreeDisplayTitle>;
   sessionHarnessExecutions: Map<string, PersistedSessionHarnessExecution>;
   recoveryHandles: Map<string, SessionRecoveryHandle>;
   turnReadiness: Map<string, PersistedSessionTurnReadiness>;
@@ -357,6 +360,15 @@ export function createInMemoryObserverPersistence(
         [...draft.sessions.values()].sort((left, right) => compareAsc(left.id, right.id)),
       ),
 
+    listWorktreeDisplayTitles: () =>
+      transaction((draft) =>
+        [...draft.worktreeDisplayTitles.values()].sort(
+          (left, right) =>
+            compareAsc(left.projectId, right.projectId) ||
+            compareAsc(left.worktreeId, right.worktreeId),
+        ),
+      ),
+
     getSessionHarnessExecution: (input) =>
       transaction((draft) => draft.sessionHarnessExecutions.get(sessionHarnessExecutionKey(input))),
 
@@ -399,8 +411,29 @@ export function createInMemoryObserverPersistence(
     findRememberedHarnessProviderForWorktree: (input) =>
       transaction((draft) => findRememberedHarnessProviderForWorktree(draft, input)),
 
-    seedSessionTitle: (input) =>
+    seedSession: (input) =>
       transaction((draft) => {
+        const key = worktreeDisplayTitleKey(input.projectId, input.worktreeId);
+        const title = resolveWorktreeDisplayTitle({
+          projectId: input.projectId,
+          worktreeId: input.worktreeId,
+          branch: input.initialTitle,
+          canonicalTitles: [...draft.worktreeDisplayTitles.values()],
+          sessions: [...draft.sessions.values()],
+        });
+        let canonical = draft.worktreeDisplayTitles.get(key);
+        if (canonical === undefined) {
+          canonical = {
+            projectId: input.projectId,
+            worktreeId: input.worktreeId,
+            title,
+            createdAt: input.createdAt,
+            updatedAt: input.createdAt,
+          };
+          draft.worktreeDisplayTitles.set(key, canonical);
+        }
+        synchronizeInMemorySessionTitleProjections(draft, canonical);
+
         const existing = draft.sessions.get(input.sessionId);
         if (existing === undefined) {
           const session: PersistedSession = {
@@ -408,7 +441,7 @@ export function createInMemoryObserverPersistence(
             projectId: input.projectId,
             worktreeId: input.worktreeId,
             lifecycle: "open",
-            title: input.title,
+            title: canonical.title,
             createdAt: input.createdAt,
             lastSeenAt: input.lastSeenAt,
           };
@@ -417,14 +450,28 @@ export function createInMemoryObserverPersistence(
         }
         existing.projectId = input.projectId;
         existing.worktreeId = input.worktreeId;
-        if (existing.title === undefined) existing.title = input.title;
+        existing.title = canonical.title;
         existing.lastSeenAt = input.lastSeenAt;
         if (existing.lifecycle !== "ended") existing.lifecycle = "open";
         return existing;
       }),
 
-    deleteSessionTitleSeed: (sessionId) =>
-      transaction((draft) => (draft.sessions.delete(sessionId) ? 1 : 0)),
+    discardSessionSeed: (input) =>
+      transaction((draft) => {
+        const discardedSessions = draft.sessions.delete(input.sessionId) ? 1 : 0;
+        const discardedWorktreeTitles =
+          input.removedWorktree === undefined
+            ? 0
+            : draft.worktreeDisplayTitles.delete(
+                  worktreeDisplayTitleKey(
+                    input.removedWorktree.projectId,
+                    input.removedWorktree.worktreeId,
+                  ),
+                )
+              ? 1
+              : 0;
+        return { discardedSessions, discardedWorktreeTitles };
+      }),
 
     markSessionsEnded: (input) =>
       transaction((draft) => {
@@ -456,8 +503,41 @@ export function createInMemoryObserverPersistence(
       transaction((draft) => {
         const session = draft.sessions.get(input.sessionId);
         if (session === undefined) return undefined;
-        session.title = input.title;
+        const key = worktreeDisplayTitleKey(session.projectId, session.worktreeId);
+        const current = draft.worktreeDisplayTitles.get(key);
+        const canonical: PersistedWorktreeDisplayTitle = {
+          projectId: session.projectId,
+          worktreeId: session.worktreeId,
+          title: input.title,
+          createdAt: current?.createdAt ?? input.renamedAt,
+          updatedAt: input.renamedAt,
+        };
+        draft.worktreeDisplayTitles.set(key, canonical);
+        synchronizeInMemorySessionTitleProjections(draft, canonical);
         return session;
+      }),
+
+    retireRemovedWorktreeSessionState: (input) =>
+      transaction((draft) => {
+        let endedSessions = 0;
+        for (const session of draft.sessions.values()) {
+          if (
+            session.projectId !== input.projectId ||
+            session.worktreeId !== input.worktreeId ||
+            session.lifecycle === "ended"
+          ) {
+            continue;
+          }
+          session.lifecycle = "ended";
+          session.endedAt = input.endedAt;
+          endedSessions += 1;
+        }
+        const deletedWorktreeTitles = draft.worktreeDisplayTitles.delete(
+          worktreeDisplayTitleKey(input.projectId, input.worktreeId),
+        )
+          ? 1
+          : 0;
+        return { endedSessions, deletedWorktreeTitles };
       }),
 
     upsertSessionRecoveryHandle: (input) =>
@@ -554,11 +634,27 @@ function emptyState(): InMemoryObserverPersistenceState {
     terminalTargets: new Map(),
     harnessRuns: new Map(),
     sessions: new Map(),
+    worktreeDisplayTitles: new Map(),
     sessionHarnessExecutions: new Map(),
     recoveryHandles: new Map(),
     turnReadiness: new Map(),
     worktreeMetadata: new Map(),
   };
+}
+
+function worktreeDisplayTitleKey(projectId: string, worktreeId: string): string {
+  return `${projectId}\u0000${worktreeId}`;
+}
+
+function synchronizeInMemorySessionTitleProjections(
+  state: InMemoryObserverPersistenceState,
+  title: PersistedWorktreeDisplayTitle,
+): void {
+  for (const session of state.sessions.values()) {
+    if (session.projectId === title.projectId && session.worktreeId === title.worktreeId) {
+      session.title = title.title;
+    }
+  }
 }
 
 function applySessionHarnessExecutionEvidence(
@@ -966,7 +1062,47 @@ function persistReconcileResult(
       });
     }
   }
-  upsertSessions(state, terminalTargets, harnessRuns, worktrees);
+  const canonicalTitles = [...state.worktreeDisplayTitles.values()];
+  const worktreeDisplayTitles =
+    input.worktreeDisplayTitles ??
+    worktrees
+      .filter((worktree) => worktree.state === "exists")
+      .map((worktree) => {
+        const existing = canonicalTitles.find(
+          (title) => title.projectId === worktree.projectId && title.worktreeId === worktree.id,
+        );
+        if (existing !== undefined) return existing;
+        return {
+          projectId: worktree.projectId,
+          worktreeId: worktree.id,
+          title: resolveWorktreeDisplayTitle({
+            projectId: worktree.projectId,
+            worktreeId: worktree.id,
+            branch: worktree.branch,
+            canonicalTitles,
+            sessions: [...state.sessions.values()],
+          }),
+          createdAt: options.observedAt,
+          updatedAt: options.observedAt,
+        };
+      });
+  for (const title of worktreeDisplayTitles) {
+    const key = worktreeDisplayTitleKey(title.projectId, title.worktreeId);
+    if (!state.worktreeDisplayTitles.has(key)) {
+      state.worktreeDisplayTitles.set(key, title);
+    }
+  }
+  const persistedTitles = worktreeDisplayTitles.map((title) => {
+    const persisted = state.worktreeDisplayTitles.get(
+      worktreeDisplayTitleKey(title.projectId, title.worktreeId),
+    );
+    if (persisted === undefined) {
+      throw new Error(`Failed to initialize worktree display title for ${title.worktreeId}.`);
+    }
+    synchronizeInMemorySessionTitleProjections(state, persisted);
+    return persisted;
+  });
+  upsertSessions(state, terminalTargets, harnessRuns, persistedTitles);
 }
 
 function reconcileObservationExpiresAt(
@@ -983,9 +1119,14 @@ function upsertSessions(
   state: InMemoryObserverPersistenceState,
   terminalTargets: readonly TerminalTargetObservation[],
   harnessRuns: readonly HarnessRunObservation[],
-  worktrees: readonly WorktreeObservation[],
+  worktreeDisplayTitles: readonly PersistedWorktreeDisplayTitle[],
 ): void {
-  const worktreesById = new Map(worktrees.map((worktree) => [worktree.id, worktree]));
+  const titlesByWorktree = new Map(
+    worktreeDisplayTitles.map((title) => [
+      worktreeDisplayTitleKey(title.projectId, title.worktreeId),
+      title,
+    ]),
+  );
   const sessions = new Map<string, PersistedSession>();
 
   for (const target of terminalTargets) {
@@ -1008,8 +1149,10 @@ function upsertSessions(
       createdAt: existing?.createdAt ?? target.observedAt,
       lastSeenAt: maxIso(existing?.lastSeenAt, target.observedAt),
     };
-    const title = worktreesById.get(target.worktreeId)?.branch;
-    if (title !== undefined) session.title = title;
+    const title = titlesByWorktree.get(
+      worktreeDisplayTitleKey(target.projectId, target.worktreeId),
+    );
+    if (title !== undefined) session.title = title.title;
     else if (existing?.title !== undefined) session.title = existing.title;
     if (existing?.harness !== undefined) session.harness = existing.harness;
     sessions.set(target.sessionId, session);
@@ -1039,8 +1182,8 @@ function upsertSessions(
       createdAt: existing?.createdAt ?? run.observedAt,
       lastSeenAt: maxIso(existing?.lastSeenAt, run.observedAt),
     };
-    const title = worktreesById.get(run.worktreeId)?.branch;
-    if (title !== undefined) session.title = title;
+    const title = titlesByWorktree.get(worktreeDisplayTitleKey(run.projectId, run.worktreeId));
+    if (title !== undefined) session.title = title.title;
     else if (existing?.title !== undefined) session.title = existing.title;
     if (existing?.terminalProvider !== undefined) {
       session.terminalProvider = existing.terminalProvider;
@@ -1056,7 +1199,7 @@ function upsertSessions(
     }
     existing.projectId = session.projectId;
     existing.worktreeId = session.worktreeId;
-    if (existing.title === undefined && session.title !== undefined) existing.title = session.title;
+    if (session.title !== undefined) existing.title = session.title;
     if (session.harness !== undefined) existing.harness = session.harness;
     if (session.terminalProvider !== undefined) {
       existing.terminalProvider = session.terminalProvider;

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -780,10 +780,14 @@ export function observerPersistenceContract(
             includeExpired: true,
             now: latest,
           });
-          expect(observations.map((observation) => observation.payload.status)).toEqual([
-            "healthy",
-            "degraded",
-          ]);
+          expect(
+            observations.map((observation) => {
+              if (observation.entityKind !== "provider_health") {
+                throw new Error("Expected only provider health observations.");
+              }
+              return observation.payload.status;
+            }),
+          ).toEqual(["healthy", "degraded"]);
         });
       });
 
@@ -1631,19 +1635,19 @@ export function observerPersistenceContract(
 
       it("orders sessions by ID and preserves seeded and renamed titles", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
-          await persistence.seedSessionTitle({
+          await persistence.seedSession({
             sessionId: "ses_z",
             projectId: "web",
             worktreeId: "wt_z",
-            title: "z title",
+            initialTitle: "z title",
             createdAt: now,
             lastSeenAt: now,
           });
-          await persistence.seedSessionTitle({
+          await persistence.seedSession({
             sessionId: "ses_a",
             projectId: "web",
             worktreeId: "wt_a",
-            title: "a title",
+            initialTitle: "a title",
             createdAt: now,
             lastSeenAt: now,
           });
@@ -1652,19 +1656,19 @@ export function observerPersistenceContract(
             "ses_z",
           ]);
 
-          await persistence.seedSessionTitle({
+          await persistence.seedSession({
             sessionId: "ses_seeded",
             projectId: "web",
             worktreeId: "wt_seeded",
-            title: "original title",
+            initialTitle: "original title",
             createdAt: earlier,
             lastSeenAt: earlier,
           });
-          const reseeded = await persistence.seedSessionTitle({
+          const reseeded = await persistence.seedSession({
             sessionId: "ses_seeded",
             projectId: "web",
             worktreeId: "wt_seeded",
-            title: "ignored replacement",
+            initialTitle: "ignored replacement",
             createdAt: later,
             lastSeenAt: later,
           });
@@ -1701,7 +1705,11 @@ export function observerPersistenceContract(
           ).toMatchObject({ title: "original title" });
 
           await expect(
-            persistence.renameSession({ sessionId: "ses_seeded", title: "user title" }),
+            persistence.renameSession({
+              sessionId: "ses_seeded",
+              title: "user title",
+              renamedAt: latest,
+            }),
           ).resolves.toMatchObject({ title: "user title" });
           await persistence.persistReconcileResult({
             projects: [project],
@@ -1721,20 +1729,52 @@ export function observerPersistenceContract(
           expect(
             (await persistence.listSessions()).find((session) => session.id === "ses_seeded"),
           ).toMatchObject({ title: "user title" });
+          await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                projectId: "web",
+                worktreeId: "wt_seeded",
+                title: "user title",
+                createdAt: earlier,
+                updatedAt: latest,
+              }),
+            ]),
+          );
           await expect(
-            persistence.renameSession({ sessionId: "ses_missing", title: "missing" }),
+            persistence.renameSession({
+              sessionId: "ses_missing",
+              title: "missing",
+              renamedAt: latest,
+            }),
           ).resolves.toBeUndefined();
 
-          await persistence.seedSessionTitle({
+          await persistence.seedSession({
             sessionId: "ses_delete",
             projectId: "web",
             worktreeId: "wt_delete",
-            title: "delete me",
+            initialTitle: "delete me",
             createdAt: now,
             lastSeenAt: now,
           });
-          await expect(persistence.deleteSessionTitleSeed("ses_delete")).resolves.toBe(1);
-          await expect(persistence.deleteSessionTitleSeed("ses_delete")).resolves.toBe(0);
+          await expect(
+            persistence.discardSessionSeed({ sessionId: "ses_delete" }),
+          ).resolves.toEqual({ discardedSessions: 1, discardedWorktreeTitles: 0 });
+          await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ worktreeId: "wt_delete", title: "delete me" }),
+            ]),
+          );
+          await expect(
+            persistence.discardSessionSeed({
+              sessionId: "ses_delete",
+              removedWorktree: { projectId: "web", worktreeId: "wt_delete" },
+            }),
+          ).resolves.toEqual({ discardedSessions: 0, discardedWorktreeTitles: 1 });
+          expect(
+            (await persistence.listWorktreeDisplayTitles()).some(
+              (title) => title.worktreeId === "wt_delete",
+            ),
+          ).toBe(false);
         });
       });
 
@@ -2282,11 +2322,11 @@ export function observerPersistenceContract(
           });
           expect(observation).not.toHaveProperty("expiresAt");
 
-          const session = await persistence.seedSessionTitle({
+          const session = await persistence.seedSession({
             sessionId: "ses_optional",
             projectId: "web",
             worktreeId: "wt_optional",
-            title: "optional",
+            initialTitle: "optional",
             createdAt: now,
             lastSeenAt: now,
           });
@@ -2575,6 +2615,13 @@ function harnessIngressInput(input: {
   observedAt: string;
 }): Parameters<ObserverPersistenceBundle["recordEventAndProviderObservationWithIngressDedupe"]>[0] {
   const eventType = input.state === "idle" ? "Stop" : "PreToolUse";
+  const status: NonNullable<HarnessEventObservation["status"]> = {
+    value: input.state,
+    confidence: "high",
+    reason: input.state,
+    source: "harness_event",
+    updatedAt: input.observedAt,
+  };
   const payload: HarnessEventObservation = {
     provider: "codex",
     reportId: input.reportId,
@@ -2583,13 +2630,7 @@ function harnessIngressInput(input: {
     worktreeId: "wt_execution",
     sessionId: "ses_execution",
     nativeSessionId: input.nativeSessionId,
-    status: {
-      value: input.state,
-      confidence: "high",
-      reason: input.state,
-      source: "harness_event",
-      updatedAt: input.observedAt,
-    },
+    status,
     observedAt: input.observedAt,
   };
   if (input.state === "idle") payload.turn = { kind: "turn_completed" };
@@ -2609,7 +2650,7 @@ function harnessIngressInput(input: {
       provider: "codex",
       sessionId: "ses_execution",
       nativeSessionId: input.nativeSessionId,
-      status: payload.status,
+      status,
     },
     recoveryHandle,
     turnReadiness:

--- a/apps/observer/test/unit/external-launch.test.ts
+++ b/apps/observer/test/unit/external-launch.test.ts
@@ -29,6 +29,7 @@ import type { SessionStore } from "../../src/persistence/index";
 import { ProviderRegistry } from "../../src/providers/registry";
 import type { ObserverCore } from "../../src/reconcile/core";
 import { prepareExternalLaunch, reportExternalExit } from "../../src/runtime/externalLaunch";
+import { createInMemoryObserverPersistence } from "../support/inMemoryObserverPersistence";
 
 const now = "2026-05-21T12:00:00.000Z";
 
@@ -205,6 +206,7 @@ function row(
     id: "wt_web_feature",
     projectId: "web",
     projectLabel: "Web",
+    title: "Readable login task",
     branch: "feature/login",
     path: "/tmp/station/web/feature",
     worktree: { state: "exists", source: "worktrunk" },
@@ -244,20 +246,25 @@ function fakeCore(rows: WorktreeRow[]): ObserverCore {
 }
 
 function trackingPersistence() {
-  const seeded: Array<Parameters<SessionStore["seedSessionTitle"]>[0]> = [];
-  const deleted: string[] = [];
+  const seeded: Array<Parameters<SessionStore["seedSession"]>[0]> = [];
+  const renamed: Array<Parameters<SessionStore["renameSession"]>[0]> = [];
+  const discarded: Array<Parameters<SessionStore["discardSessionSeed"]>[0]> = [];
   const store = {
     findRememberedHarnessProviderForWorktree: async () => undefined,
-    seedSessionTitle: async (input: Parameters<SessionStore["seedSessionTitle"]>[0]) => {
+    seedSession: async (input: Parameters<SessionStore["seedSession"]>[0]) => {
       seeded.push(input);
-      return {} as Awaited<ReturnType<SessionStore["seedSessionTitle"]>>;
+      return {} as Awaited<ReturnType<SessionStore["seedSession"]>>;
     },
-    deleteSessionTitleSeed: async (sessionId: string) => {
-      deleted.push(sessionId);
-      return 1;
+    renameSession: async (input: Parameters<SessionStore["renameSession"]>[0]) => {
+      renamed.push(input);
+      return {} as Awaited<ReturnType<SessionStore["renameSession"]>>;
+    },
+    discardSessionSeed: async (input: Parameters<SessionStore["discardSessionSeed"]>[0]) => {
+      discarded.push(input);
+      return { discardedSessions: 1, discardedWorktreeTitles: 0 };
     },
   } as unknown as SessionStore;
-  return { store, seeded, deleted };
+  return { store, seeded, renamed, discarded };
 }
 
 const fakePersistence = trackingPersistence().store;
@@ -302,7 +309,9 @@ function deps(
   rows: WorktreeRow[],
   managedTerminal: ManagedTerminalLifecycle,
   harnesses?: Harnesses,
-  persistence: SessionStore = fakePersistence,
+  persistence: SessionStore = createInMemoryObserverPersistence({
+    clock: { now: () => new Date(now) },
+  }),
 ) {
   return {
     core: fakeCore(rows),
@@ -345,7 +354,8 @@ describe("ProviderRegistry managed terminal role", () => {
 describe("prepareExternalLaunch", () => {
   it("mints one session + one managed target + a launch plan", async () => {
     const station = new FakeManagedTerminalLifecycle();
-    const result = await prepareExternalLaunch(deps([row()], station), prepareParams);
+    const launchDeps = deps([row()], station);
+    const result = await prepareExternalLaunch(launchDeps, prepareParams);
 
     expect(result.reconcile).toBe(true);
     expect(result.outcome.kind).toBe("prepared");
@@ -359,6 +369,19 @@ describe("prepareExternalLaunch", () => {
     const targets = await station.listTargets();
     expect(targets).toHaveLength(1);
     expect(targets[0]?.harnessBinding?.role).toBe("main-agent");
+    await expect(launchDeps.persistence.listSessions()).resolves.toEqual([
+      expect.objectContaining({
+        id: result.outcome.sessionId,
+        title: "Readable login task",
+      }),
+    ]);
+    await expect(launchDeps.persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+      expect.objectContaining({
+        projectId: "web",
+        worktreeId: "wt_web_feature",
+        title: "Readable login task",
+      }),
+    ]);
   });
 
   it("persists a custom title before exposing a newly prepared session", async () => {
@@ -377,10 +400,16 @@ describe("prepareExternalLaunch", () => {
         sessionId: result.outcome.sessionId,
         projectId: "web",
         worktreeId: "wt_web_feature",
+        initialTitle: "Hexagonal PT 12",
+      }),
+    ]);
+    expect(persistence.renamed).toEqual([
+      expect.objectContaining({
+        sessionId: result.outcome.sessionId,
         title: "Hexagonal PT 12",
       }),
     ]);
-    expect(persistence.deleted).toEqual([]);
+    expect(persistence.discarded).toEqual([]);
   });
 
   it("rejects when the harness's status hooks are not installed", async () => {
@@ -440,7 +469,8 @@ describe("prepareExternalLaunch", () => {
     // The fake core never reconciles, so row.agent is still undefined — but the
     // station provider already holds a target, so a second prepare must not mint
     // a second identity.
-    const second = await prepareExternalLaunch(deps([row()], station), prepareParams);
+    const secondDeps = deps([row()], station);
+    const second = await prepareExternalLaunch(secondDeps, prepareParams);
     expect(second).toEqual({
       outcome: {
         kind: "existing-session",
@@ -451,6 +481,7 @@ describe("prepareExternalLaunch", () => {
       reconcile: false,
     });
     expect(await station.listTargets()).toHaveLength(1);
+    await expect(secondDeps.persistence.listWorktreeDisplayTitles()).resolves.toEqual([]);
   });
 
   it("returns the existing session id without applying a requested title", async () => {
@@ -470,7 +501,8 @@ describe("prepareExternalLaunch", () => {
     });
     // No title or target is created when an agent already exists.
     expect(persistence.seeded).toEqual([]);
-    expect(persistence.deleted).toEqual([]);
+    expect(persistence.renamed).toEqual([]);
+    expect(persistence.discarded).toEqual([]);
     expect(await station.listTargets()).toEqual([]);
   });
 
@@ -640,7 +672,7 @@ describe("prepareExternalLaunch", () => {
     expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
   });
 
-  it("releases the opened target and deletes its title seed when process launch fails", async () => {
+  it("releases the opened target and discards only the failed session projection", async () => {
     const station = new FakeManagedTerminalLifecycle({
       launchFailure: {
         tag: "TerminalProviderError",
@@ -648,20 +680,23 @@ describe("prepareExternalLaunch", () => {
         message: "launch failed",
       },
     });
-    const persistence = trackingPersistence();
+    const launchDeps = deps([row()], station);
 
-    await expect(
-      prepareExternalLaunch(deps([row()], station, undefined, persistence.store), {
-        ...prepareParams,
-        title: "Hexagonal PT 12",
-      }),
-    ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_FAILED" });
+    await expect(prepareExternalLaunch(launchDeps, prepareParams)).rejects.toMatchObject({
+      code: "MANAGED_LAUNCH_FAILED",
+    });
     expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
-    expect(persistence.deleted).toEqual([persistence.seeded[0]?.sessionId]);
     expect(await station.listTargets()).toEqual([]);
+    await expect(launchDeps.persistence.listSessions()).resolves.toEqual([]);
+    await expect(launchDeps.persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+      expect.objectContaining({
+        worktreeId: "wt_web_feature",
+        title: "Readable login task",
+      }),
+    ]);
   });
 
-  it("preserves the launch failure and title seed when rollback release also fails", async () => {
+  it("preserves the launch failure while independently discarding its session seed", async () => {
     const station = new FakeManagedTerminalLifecycle({
       launchFailure: {
         tag: "TerminalProviderError",
@@ -683,7 +718,7 @@ describe("prepareExternalLaunch", () => {
       }),
     ).rejects.toMatchObject({ code: "MANAGED_LAUNCH_FAILED" });
     expect(station.released).toEqual([managedTargetId("wt_web_feature")]);
-    expect(persistence.deleted).toEqual([]);
+    expect(persistence.discarded).toEqual([{ sessionId: persistence.seeded[0]?.sessionId }]);
     expect(await station.listTargets()).toHaveLength(1);
   });
 });

--- a/apps/observer/test/unit/graph.test.ts
+++ b/apps/observer/test/unit/graph.test.ts
@@ -11,6 +11,7 @@ import {
   buildStationSnapshot,
   type ObserverSessionMetadata,
   type ObserverTurnReadiness,
+  type ObserverWorktreeDisplayTitle,
   projectProviderHealthOntoSnapshot,
 } from "../../src/reconcile/graph";
 import type { ObserverHarnessRun } from "../../src/reconcile/harnessEventStatus";
@@ -149,6 +150,7 @@ function build(overrides: {
   terminals?: TerminalTargetObservation[];
   harnessRuns?: ObserverHarnessRun[];
   sessionMetadata?: ObserverSessionMetadata[];
+  worktreeDisplayTitles?: ObserverWorktreeDisplayTitle[];
   turnReadiness?: ObserverTurnReadiness[];
   providerHealth?: Record<string, ProviderHealth>;
 }) {
@@ -164,6 +166,7 @@ function build(overrides: {
     terminalTargets: overrides.terminals ?? [],
     harnessRuns: overrides.harnessRuns ?? [],
     sessionMetadata: overrides.sessionMetadata ?? [],
+    worktreeDisplayTitles: overrides.worktreeDisplayTitles ?? [],
     turnReadiness: overrides.turnReadiness ?? [],
   });
 }
@@ -256,6 +259,9 @@ describe("observer graph derivation", () => {
     const snapshot = build({
       projects: projects.slice(0, 1),
       worktrees: [retained],
+      worktreeDisplayTitles: [
+        { projectId: "web", worktreeId: retained.id, title: "retained title" },
+      ],
       sessionMetadata: [
         {
           id: "ses_older",
@@ -279,7 +285,8 @@ describe("observer graph derivation", () => {
       ],
     });
 
-    expect(snapshot.rows[0]?.agent).toBeUndefined();
+    expect(snapshot.rows[0]?.title).toBe("retained title");
+    expect(snapshot.rows[0]).not.toHaveProperty("agent");
     expect(snapshot.sessions).toEqual([
       expect.objectContaining({
         id: "ses_retained",
@@ -352,6 +359,9 @@ describe("observer graph derivation", () => {
       observedAt: generatedAt,
     });
     const observedTerminal = terminal("term_mixed", mixed.id, externalRun.run.id);
+    const worktreeDisplayTitles = [
+      { projectId: "web", worktreeId: mixed.id, title: "Canonical mixed workspace" },
+    ];
 
     const active = build({
       projects: projects.slice(0, 1),
@@ -359,6 +369,7 @@ describe("observer graph derivation", () => {
       terminals: [observedTerminal],
       harnessRuns: [externalRun],
       sessionMetadata: [retained],
+      worktreeDisplayTitles,
     });
     const inactive = build({
       projects: projects.slice(0, 1),
@@ -372,8 +383,11 @@ describe("observer graph derivation", () => {
         },
       ],
       sessionMetadata: [retained],
+      worktreeDisplayTitles,
     });
 
+    expect(active.rows[0]?.title).toBe("Canonical mixed workspace");
+    expect(active.sessions.every((session) => session.title === active.rows[0]?.title)).toBe(true);
     expect(active.sessions).toEqual([
       expect.objectContaining({ id: retained.id, origin: "station" }),
       expect.objectContaining({ id: externalRun.run.id, origin: "external" }),

--- a/apps/observer/test/unit/observerEventHooks.test.ts
+++ b/apps/observer/test/unit/observerEventHooks.test.ts
@@ -158,7 +158,9 @@ function notifyCodexStopHook(): ObserverEventHookConfig {
   };
 }
 
-function agentEvent(state: "idle" | "working"): StationEvent {
+type AgentStateChangedEvent = Extract<StationEvent, { type: "worktree.agentStateChanged" }>;
+
+function agentEvent(state: "idle" | "working"): AgentStateChangedEvent {
   return {
     type: "worktree.agentStateChanged",
     worktreeId: "wt_web_task",
@@ -172,7 +174,7 @@ function agentEvent(state: "idle" | "working"): StationEvent {
   };
 }
 
-function hookReportedStopEvent(): StationEvent {
+function hookReportedStopEvent(): AgentStateChangedEvent {
   return {
     ...agentEvent("idle"),
     changeSource: "harness_event_report",
@@ -218,6 +220,7 @@ function row(
     id: "wt_web_task",
     projectId: "web",
     projectLabel: "web",
+    title: "task",
     branch: "task",
     path: "/tmp/station/web/task",
     worktree: {

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -210,7 +210,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.8.0" as const,
+        schemaVersion: "0.9.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -338,7 +338,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.listening = false;
       return {
-        schemaVersion: "0.8.0" as const,
+        schemaVersion: "0.9.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -357,7 +357,7 @@ describe("negotiateObserverIncumbent", () => {
     fixture.stop.mockImplementation(async () => {
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.8.0" as const,
+        schemaVersion: "0.9.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -387,7 +387,7 @@ describe("negotiateObserverIncumbent", () => {
       fixture.listening = false;
       fixture.startToken = undefined;
       return {
-        schemaVersion: "0.8.0" as const,
+        schemaVersion: "0.9.0" as const,
         stopped: true,
         at: "2026-07-12T12:00:00.000Z",
       };
@@ -429,7 +429,7 @@ function observerBuildVersion(version: string, buildIdentity: string): string {
 
 function handoffFixture() {
   const incumbentHealth: ObserverHealth = {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     status: "healthy",
     pid: 100,
     startedAt: "2026-07-12T11:00:00.000Z",
@@ -450,7 +450,7 @@ function handoffFixture() {
     incumbentHealth,
     health: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => incumbentHealth),
     stop: vi.fn(async (_socketPath: string, _request: { timeoutMs: number }) => ({
-      schemaVersion: "0.8.0" as const,
+      schemaVersion: "0.9.0" as const,
       stopped: true,
       at: "2026-07-12T12:00:00.000Z",
     })),

--- a/apps/observer/test/unit/statusProjection.test.ts
+++ b/apps/observer/test/unit/statusProjection.test.ts
@@ -70,6 +70,30 @@ describe("live harness status projection", () => {
     ]);
   });
 
+  it("preserves the canonical row title while applying a harness status patch", () => {
+    const base = snapshotFor();
+    const snapshot = {
+      ...base,
+      rows: base.rows.map((row) => ({ ...row, title: "Durable task workspace" })),
+      sessions: base.sessions.map((session) => ({
+        ...session,
+        title: "Durable task workspace",
+      })),
+    };
+
+    const result = projectHarnessEventReportOntoSnapshot({
+      snapshot,
+      report: report({
+        status: status("working", "high", "Codex is working."),
+        correlation: { sessionId: "ses_web_task" },
+      }),
+      projectedAt: eventAt,
+    });
+
+    expect(result.snapshot.rows[0]?.title).toBe("Durable task workspace");
+    expect(result.snapshot.sessions[0]?.title).toBe("Durable task workspace");
+  });
+
   it("projects attention and idle reports through weaker unique correlations", () => {
     const attention = projectHarnessEventReportOntoSnapshot({
       snapshot: snapshotFor(),

--- a/apps/observer/test/unit/worktreeDisplayTitle.test.ts
+++ b/apps/observer/test/unit/worktreeDisplayTitle.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { PersistedSession, PersistedWorktreeDisplayTitle } from "../../src/persistence/types";
+import { resolveWorktreeDisplayTitle } from "../../src/worktreeDisplayTitle";
+
+const branch = "feature/current";
+const projectId = "web";
+const worktreeId = "shared-worktree-id";
+
+function session(
+  id: string,
+  title: string,
+  overrides: Partial<PersistedSession> = {},
+): PersistedSession {
+  return {
+    id,
+    projectId,
+    worktreeId,
+    lifecycle: "open",
+    title,
+    createdAt: "2026-05-20T12:00:00.000Z",
+    lastSeenAt: "2026-05-20T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function canonical(
+  title: string,
+  overrides: Partial<PersistedWorktreeDisplayTitle> = {},
+): PersistedWorktreeDisplayTitle {
+  return {
+    projectId,
+    worktreeId,
+    title,
+    createdAt: "2026-05-20T12:00:00.000Z",
+    updatedAt: "2026-05-20T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function resolve(input: {
+  branch?: string;
+  canonicalTitles?: readonly PersistedWorktreeDisplayTitle[];
+  sessions?: readonly PersistedSession[];
+}): string {
+  return resolveWorktreeDisplayTitle({
+    projectId,
+    worktreeId,
+    branch: input.branch ?? branch,
+    canonicalTitles: input.canonicalTitles ?? [],
+    sessions: input.sessions ?? [],
+  });
+}
+
+describe("worktree display title policy", () => {
+  it("always prefers canonical worktree title authority", () => {
+    expect(
+      resolve({
+        canonicalTitles: [canonical("Canonical workspace")],
+        sessions: [session("ses_new", "Newer custom", { lastSeenAt: "2026-05-22T12:00:00.000Z" })],
+      }),
+    ).toBe("Canonical workspace");
+  });
+
+  it("prefers an earlier custom title over a later branch-default seed", () => {
+    expect(
+      resolve({
+        sessions: [
+          session("ses_custom", "Readable task", { lastSeenAt: "2026-05-20T12:00:00.000Z" }),
+          session("ses_branch", branch, { lastSeenAt: "2026-05-21T12:00:00.000Z" }),
+        ],
+      }),
+    ).toBe("Readable task");
+  });
+
+  it("chooses the newest custom title among multiple custom titles", () => {
+    expect(
+      resolve({
+        sessions: [
+          session("ses_old", "Old title"),
+          session("ses_new", "New title", { lastSeenAt: "2026-05-21T12:00:00.000Z" }),
+        ],
+      }),
+    ).toBe("New title");
+  });
+
+  it("excludes ended sessions when a worktree identity is recreated", () => {
+    expect(
+      resolve({
+        sessions: [session("ses_ended", "Retired title", { lifecycle: "ended" })],
+      }),
+    ).toBe(branch);
+  });
+
+  it.each([
+    "open",
+    "legacy",
+  ] as const)("allows %s session evidence to seed migration", (lifecycle) => {
+    expect(
+      resolve({ sessions: [session(`ses_${lifecycle}`, "Migrated title", { lifecycle })] }),
+    ).toBe("Migrated title");
+  });
+
+  it("ignores blank legacy title evidence", () => {
+    expect(resolve({ sessions: [session("ses_blank", "   ")] })).toBe(branch);
+  });
+
+  it("falls back to the current branch without title evidence", () => {
+    expect(resolve({})).toBe(branch);
+  });
+
+  it("preserves an established canonical title after the branch changes", () => {
+    expect(
+      resolve({
+        branch: "feature/renamed",
+        canonicalTitles: [canonical("Stable workspace")],
+      }),
+    ).toBe("Stable workspace");
+  });
+
+  it("scopes title evidence by project and worktree composite identity", () => {
+    expect(
+      resolve({
+        canonicalTitles: [canonical("Other project", { projectId: "api" })],
+        sessions: [session("ses_other", "Other project session", { projectId: "api" })],
+      }),
+    ).toBe(branch);
+  });
+
+  it("uses created time and descending session ID as deterministic recency ties", () => {
+    expect(
+      resolve({
+        sessions: [
+          session("ses_a", "Older creation", { createdAt: "2026-05-19T12:00:00.000Z" }),
+          session("ses_b", "Later creation"),
+        ],
+      }),
+    ).toBe("Later creation");
+
+    expect(
+      resolve({
+        sessions: [session("ses_a", "Lower ID"), session("ses_z", "Higher ID")],
+      }),
+    ).toBe("Higher ID");
+  });
+});

--- a/apps/observer/tsconfig.test-support.json
+++ b/apps/observer/tsconfig.test-support.json
@@ -8,6 +8,7 @@
     "test/support/diagnosticEvidenceSources.ts",
     "test/support/harnessRuns.ts",
     "test/support/inMemoryObserverPersistence.ts",
+    "test/support/observerPersistenceContract.ts",
     "test/support/projectConfigWriter.ts",
     "test/support/worktreeMetadataSources.ts"
   ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,10 +47,11 @@ No single layer owns all truth.
 - Terminal providers are authoritative for terminal topology and provider-owned target identity.
 - Harness providers are authoritative for agent launch, discovery, event ingestion, and status signals they can prove.
 - Repository providers are authoritative only for code-host metadata they fetch or cache through their integration boundary.
-- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, provider observations, and current metadata cache rows.
+- Observer SQLite is durable observer memory for commands, events, correlations, explicit Station-session lifecycle, canonical worktree display titles keyed by project and worktree, provider observations, and current metadata cache rows.
 - Observer snapshots are the normalized current graph exposed to clients. `rows` is configured
-  worktree inventory; `sessions` is canonical session membership. Session and activity counts
-  derive from `sessions`, while worktree counts derive from `rows`.
+  worktree inventory; `sessions` is canonical session membership. `WorktreeRow.title` is the
+  display authority, while `SessionView.title` is its lifecycle projection. Session and activity
+  counts derive from `sessions`, while worktree counts derive from `rows`.
 - JSONL logs and debug bundles are diagnostic evidence, not runtime truth.
 
 When these disagree, reconcile from config, providers, and current observer state first. Treat stale logs, old bundles, and historical plans as evidence to inspect, not as authority.

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -1186,7 +1186,7 @@
           "name": "createSessionCreateHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Create a session worktree on its generated branch, persist its independent user-facing title, and launch its primary agent workspace."
+          "purpose": "Creates a session worktree on its generated branch, durably seeds its independent title, and launches its primary agent; cleanup retires title authority only after verified rollback."
         },
         {
           "name": "CreateSessionCreateHandlerOptions",
@@ -1221,14 +1221,14 @@
           "bindings": [
             "buildEnsureAgentWorkspaceIntent",
             "defaultSessionCommandIdFactory",
-            "deleteSessionTitleSeedBestEffort",
+            "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "publishSessionCreated",
             "removeWorktreeBestEffort",
             "resolveHarnessProviderOrThrow",
             "resolveTerminalProviderOrThrow",
             "runProviderMutation",
-            "seedSessionTitle",
+            "seedSession",
             "throwIfAborted"
           ]
         },
@@ -1295,7 +1295,7 @@
           "name": "createSessionForkHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Fork an existing worktree onto an internal branch, persist an independent user-facing title, optionally copy dirty state, and launch a fresh agent. The source agent remains live and its remembered harness is inherited."
+          "purpose": "Forks an existing worktree onto an internal branch, durably seeds its independent title, and launches a fresh agent; cleanup retires title authority only after verified rollback."
         },
         {
           "name": "CreateSessionForkHandlerOptions",
@@ -1331,7 +1331,7 @@
             "buildEnsureAgentWorkspaceIntent",
             "commandValidationError",
             "defaultSessionCommandIdFactory",
-            "deleteSessionTitleSeedBestEffort",
+            "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "publishSessionCreated",
             "rememberedHarnessProviderForWorktree",
@@ -1339,7 +1339,7 @@
             "resolveHarnessProviderOrThrow",
             "resolveTerminalProviderOrThrow",
             "runProviderMutation",
-            "seedSessionTitle",
+            "seedSession",
             "throwIfAborted",
             "validateSnapshotRow"
           ]
@@ -1449,7 +1449,7 @@
           "name": "createSessionCreateHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Create a session worktree on its generated branch, persist its independent user-facing title, and launch its primary agent workspace."
+          "purpose": "Creates a session worktree on its generated branch, durably seeds its independent title, and launches its primary agent; cleanup retires title authority only after verified rollback."
         },
         {
           "name": "CreateSessionCreateHandlerOptions",
@@ -1460,8 +1460,8 @@
         {
           "name": "createSessionResumeAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Resumes provider-native recovery into an existing Station identity or a fresh titled session. Failed launch cleanup discards only a newly minted session projection."
         },
         {
           "name": "CreateSessionResumeAgentHandlerOptions",
@@ -1472,8 +1472,8 @@
         {
           "name": "createSessionStartAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Starts a fresh agent lifecycle while inheriting the worktree's canonical display title. Failed launches discard only the fresh session projection."
         },
         {
           "name": "CreateSessionStartAgentHandlerOptions",
@@ -1488,7 +1488,7 @@
           "purpose": null
         },
         {
-          "name": "deleteSessionTitleSeedBestEffort",
+          "name": "discardSessionSeedBestEffort",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -1548,7 +1548,7 @@
           "purpose": null
         },
         {
-          "name": "seedSessionTitle",
+          "name": "seedSession",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -1635,8 +1635,8 @@
         {
           "name": "createSessionRenameHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Renames the canonical worktree title and its session projections before publishing convergence."
         },
         {
           "name": "CreateSessionRenameHandlerOptions",
@@ -1708,8 +1708,8 @@
         {
           "name": "createSessionResumeAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Resumes provider-native recovery into an existing Station identity or a fresh titled session. Failed launch cleanup discards only a newly minted session projection."
         },
         {
           "name": "CreateSessionResumeAgentHandlerOptions",
@@ -1745,12 +1745,13 @@
             "buildEnsureAgentWorkspaceIntent",
             "commandValidationError",
             "defaultSessionCommandIdFactory",
+            "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "lookupWorktree",
             "publishSessionCreated",
             "resolveHarnessProviderOrThrow",
             "resolveTerminalProviderOrThrow",
-            "seedSessionTitle",
+            "seedSession",
             "throwIfAborted",
             "validateSnapshotRow",
             "worktreeObservationFromRow"
@@ -1797,6 +1798,12 @@
           "resolvedPath": "apps/observer/src/runtime/eventBus.ts",
           "edgeKind": "type-only",
           "bindings": ["ObserverEventBus"]
+        },
+        {
+          "specifier": "../../stationLogger.js",
+          "resolvedPath": "apps/observer/src/stationLogger.ts",
+          "edgeKind": "type-only",
+          "bindings": ["StationLogger"]
         },
         {
           "specifier": "../../utils/time.js",
@@ -1866,7 +1873,7 @@
           "purpose": null
         },
         {
-          "name": "deleteSessionTitleSeedBestEffort",
+          "name": "discardSessionSeedBestEffort",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -1926,7 +1933,7 @@
           "purpose": null
         },
         {
-          "name": "seedSessionTitle",
+          "name": "seedSession",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -2069,8 +2076,8 @@
         {
           "name": "createSessionStartAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Starts a fresh agent lifecycle while inheriting the worktree's canonical display title. Failed launches discard only the fresh session projection."
         },
         {
           "name": "CreateSessionStartAgentHandlerOptions",
@@ -2106,14 +2113,14 @@
             "assertNoCurrentAgent",
             "buildEnsureAgentWorkspaceIntent",
             "defaultSessionCommandIdFactory",
-            "deleteSessionTitleSeedBestEffort",
+            "discardSessionSeedBestEffort",
             "findProjectOrThrow",
             "lookupWorktree",
             "publishSessionCreated",
             "rememberedHarnessProviderForWorktree",
             "resolveHarnessProviderOrThrow",
             "resolveTerminalProviderOrThrow",
-            "seedSessionTitle",
+            "seedSession",
             "throwIfAborted",
             "validateSnapshotRow",
             "worktreeObservationFromRow"
@@ -2678,7 +2685,7 @@
           "name": "createWorktreeRemoveHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-side race refusals retain command-correlated evidence for diagnostics."
+          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal atomically ends sessions and retires canonical title authority."
         },
         {
           "name": "CreateWorktreeRemoveHandlerOptions",
@@ -2703,7 +2710,7 @@
           "name": "createWorktreeRemoveHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-side race refusals retain command-correlated evidence for diagnostics."
+          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal atomically ends sessions and retires canonical title authority."
         },
         {
           "name": "CreateWorktreeRemoveHandlerOptions",
@@ -3940,7 +3947,7 @@
           "name": "buildStationSnapshot",
           "kind": "function",
           "role": "POLICY",
-          "purpose": "Correlates provider observations and durable session records into canonical snapshot truth."
+          "purpose": "Correlates provider observations with canonical worktree title input and durable session records. Branch names remain only the defensive title fallback when persistence is unavailable."
         },
         {
           "name": "canUseTerminalCloseFallbackForWorktree",
@@ -4246,7 +4253,7 @@
           "name": "createSessionCreateHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Create a session worktree on its generated branch, persist its independent user-facing title, and launch its primary agent workspace."
+          "purpose": "Creates a session worktree on its generated branch, durably seeds its independent title, and launches its primary agent; cleanup retires title authority only after verified rollback."
         },
         {
           "name": "CreateSessionCreateHandlerOptions",
@@ -4257,8 +4264,8 @@
         {
           "name": "createSessionResumeAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Resumes provider-native recovery into an existing Station identity or a fresh titled session. Failed launch cleanup discards only a newly minted session projection."
         },
         {
           "name": "CreateSessionResumeAgentHandlerOptions",
@@ -4269,8 +4276,8 @@
         {
           "name": "createSessionStartAgentHandler",
           "kind": "function",
-          "role": null,
-          "purpose": null
+          "role": "USE CASE",
+          "purpose": "Starts a fresh agent lifecycle while inheriting the worktree's canonical display title. Failed launches discard only the fresh session projection."
         },
         {
           "name": "CreateSessionStartAgentHandlerOptions",
@@ -4336,7 +4343,7 @@
           "name": "createWorktreeRemoveHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-side race refusals retain command-correlated evidence for diagnostics."
+          "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal atomically ends sessions and retires canonical title authority."
         },
         {
           "name": "CreateWorktreeRemoveHandlerOptions",
@@ -4363,12 +4370,6 @@
           "purpose": null
         },
         {
-          "name": "deleteSessionTitleSeedBestEffort",
-          "kind": "function",
-          "role": null,
-          "purpose": null
-        },
-        {
           "name": "DiagnosticEvidenceSource",
           "kind": "interface",
           "role": "DRIVEN PORT",
@@ -4389,6 +4390,12 @@
         {
           "name": "DiagnosticRecentLogEvidence",
           "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "discardSessionSeedBestEffort",
+          "kind": "function",
           "role": null,
           "purpose": null
         },
@@ -4759,6 +4766,12 @@
           "purpose": null
         },
         {
+          "name": "ObserverWorktreeDisplayTitle",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "openObserverSqlite",
           "kind": "function",
           "role": null,
@@ -4838,6 +4851,12 @@
         },
         {
           "name": "PersistedSessionTurnReadiness",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "PersistedWorktreeDisplayTitle",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -5068,10 +5087,16 @@
           "name": "ReconcileStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability."
+          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize."
         },
         {
           "name": "ReconcileTiming",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "ReconcileWorktreeDisplayTitleInput",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -5203,7 +5228,7 @@
           "purpose": null
         },
         {
-          "name": "seedSessionTitle",
+          "name": "seedSession",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -5242,7 +5267,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, titles, remembered harness selection, recovery handles, and turn readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -6545,6 +6570,25 @@
       ]
     },
     {
+      "path": "apps/observer/src/migrations/016_worktree_display_titles.ts",
+      "exports": [
+        {
+          "name": "worktreeDisplayTitlesMigration",
+          "kind": "const",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./migration.js",
+          "resolvedPath": "apps/observer/src/migrations/migration.ts",
+          "edgeKind": "type-only",
+          "bindings": ["ObserverSqliteMigration"]
+        }
+      ]
+    },
+    {
       "path": "apps/observer/src/migrations/index.ts",
       "exports": [
         {
@@ -6656,6 +6700,12 @@
           "resolvedPath": "apps/observer/src/migrations/015_drop_recovery_breadcrumbs.ts",
           "edgeKind": "runtime",
           "bindings": ["dropRecoveryBreadcrumbsMigration"]
+        },
+        {
+          "specifier": "./016_worktree_display_titles.js",
+          "resolvedPath": "apps/observer/src/migrations/016_worktree_display_titles.ts",
+          "edgeKind": "runtime",
+          "bindings": ["worktreeDisplayTitlesMigration"]
         },
         {
           "specifier": "./migration.js",
@@ -6778,7 +6828,7 @@
       "path": "apps/observer/src/persistence/correlations.ts",
       "exports": [
         {
-          "name": "deleteSessionTitleSeed",
+          "name": "discardSessionSeed",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -6820,7 +6870,13 @@
           "purpose": null
         },
         {
-          "name": "seedSessionTitle",
+          "name": "retireRemovedWorktreeSessionState",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "seedSession",
           "kind": "function",
           "role": null,
           "purpose": null
@@ -6867,7 +6923,26 @@
           "specifier": "./types.js",
           "resolvedPath": "apps/observer/src/persistence/types.ts",
           "edgeKind": "type-only",
-          "bindings": ["ObserverIdFactory", "PersistReconcileResultInput", "PersistedSession"]
+          "bindings": [
+            "ObserverIdFactory",
+            "PersistReconcileResultInput",
+            "PersistedSession",
+            "PersistedWorktreeDisplayTitle",
+            "ReconcileWorktreeDisplayTitleInput"
+          ]
+        },
+        {
+          "specifier": "./worktreeDisplayTitles.js",
+          "resolvedPath": "apps/observer/src/persistence/worktreeDisplayTitles.ts",
+          "edgeKind": "runtime",
+          "bindings": [
+            "deleteWorktreeDisplayTitle",
+            "insertMissingWorktreeDisplayTitles",
+            "listWorktreeDisplayTitles",
+            "readWorktreeDisplayTitle",
+            "synchronizeSessionTitleProjections",
+            "upsertWorktreeDisplayTitle"
+          ]
         },
         {
           "specifier": "../sessionActivation.js",
@@ -6880,6 +6955,12 @@
           "resolvedPath": "apps/observer/src/sqlite/driver.ts",
           "edgeKind": "type-only",
           "bindings": ["SqlDatabase"]
+        },
+        {
+          "specifier": "../worktreeDisplayTitle.js",
+          "resolvedPath": "apps/observer/src/worktreeDisplayTitle.ts",
+          "edgeKind": "runtime",
+          "bindings": ["resolveWorktreeDisplayTitle"]
         },
         {
           "specifier": "@station/contracts",
@@ -7158,6 +7239,12 @@
           "purpose": null
         },
         {
+          "name": "PersistedWorktreeDisplayTitle",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "PersistedWorktreeMetadataCurrent",
           "kind": "type",
           "role": null,
@@ -7209,7 +7296,13 @@
           "name": "ReconcileStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability."
+          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize."
+        },
+        {
+          "name": "ReconcileWorktreeDisplayTitleInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
         },
         {
           "name": "RecordProviderObservationInput",
@@ -7233,7 +7326,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, titles, remembered harness selection, recovery handles, and turn readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -7531,13 +7624,13 @@
           "name": "ReconcileStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability."
+          "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize."
         },
         {
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, titles, remembered harness selection, recovery handles, and turn readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
         },
         {
           "name": "WorktreeMetadataStore",
@@ -7567,6 +7660,7 @@
             "PersistedSession",
             "PersistedSessionHarnessExecution",
             "PersistedSessionTurnReadiness",
+            "PersistedWorktreeDisplayTitle",
             "PersistedWorktreeMetadataCurrent",
             "ProviderObservationKind",
             "ProviderObservationsIngressDedupeResult",
@@ -7693,6 +7787,18 @@
           "kind": "type",
           "role": null,
           "purpose": null
+        },
+        {
+          "name": "SqliteWorktreeDisplayTitleRow",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "worktreeDisplayTitleFromRow",
+          "kind": "function",
+          "role": null,
+          "purpose": null
         }
       ],
       "imports": [
@@ -7719,6 +7825,7 @@
             "PersistedEvent",
             "PersistedProviderObservation",
             "PersistedSession",
+            "PersistedWorktreeDisplayTitle",
             "ProviderObservationType"
           ]
         },
@@ -8034,6 +8141,12 @@
           ]
         },
         {
+          "specifier": "./worktreeDisplayTitles.js",
+          "resolvedPath": "apps/observer/src/persistence/worktreeDisplayTitles.ts",
+          "edgeKind": "runtime",
+          "bindings": ["* as worktreeDisplayTitleStore"]
+        },
+        {
           "specifier": "./worktreeMetadataCurrent.js",
           "resolvedPath": "apps/observer/src/persistence/worktreeMetadataCurrent.ts",
           "edgeKind": "runtime",
@@ -8208,6 +8321,12 @@
           "purpose": null
         },
         {
+          "name": "PersistedWorktreeDisplayTitle",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
           "name": "PersistedWorktreeMetadataCurrent",
           "kind": "type",
           "role": null,
@@ -8245,6 +8364,12 @@
         },
         {
           "name": "ProviderObservationType",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "ReconcileWorktreeDisplayTitleInput",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -8312,6 +8437,73 @@
             "WorktreeObservation",
             "WorktreePullRequest"
           ]
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/persistence/worktreeDisplayTitles.ts",
+      "exports": [
+        {
+          "name": "deleteWorktreeDisplayTitle",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "insertMissingWorktreeDisplayTitles",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "listWorktreeDisplayTitles",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "readWorktreeDisplayTitle",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "synchronizeSessionTitleProjections",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "upsertWorktreeDisplayTitle",
+          "kind": "function",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./rows.js",
+          "resolvedPath": "apps/observer/src/persistence/rows.ts",
+          "edgeKind": "runtime",
+          "bindings": ["worktreeDisplayTitleFromRow"]
+        },
+        {
+          "specifier": "./rows.js",
+          "resolvedPath": "apps/observer/src/persistence/rows.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SqliteWorktreeDisplayTitleRow"]
+        },
+        {
+          "specifier": "./types.js",
+          "resolvedPath": "apps/observer/src/persistence/types.ts",
+          "edgeKind": "type-only",
+          "bindings": ["PersistedWorktreeDisplayTitle", "ReconcileWorktreeDisplayTitleInput"]
+        },
+        {
+          "specifier": "../sqlite/driver.js",
+          "resolvedPath": "apps/observer/src/sqlite/driver.ts",
+          "edgeKind": "type-only",
+          "bindings": ["SqlDatabase"]
         }
       ]
     },
@@ -8652,7 +8844,7 @@
           "name": "buildStationSnapshot",
           "kind": "function",
           "role": "POLICY",
-          "purpose": "Correlates provider observations and durable session records into canonical snapshot truth."
+          "purpose": "Correlates provider observations with canonical worktree title input and durable session records. Branch names remain only the defensive title fallback when persistence is unavailable."
         },
         {
           "name": "ObserverGraphInput",
@@ -8668,6 +8860,12 @@
         },
         {
           "name": "ObserverTurnReadiness",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        },
+        {
+          "name": "ObserverWorktreeDisplayTitle",
           "kind": "type",
           "role": null,
           "purpose": null
@@ -8841,7 +9039,7 @@
           "name": "runReconcileOnce",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Rebuilds the Observer graph from provider reads and accepted durable evidence."
+          "purpose": "Rebuilds the Observer graph after overlaying durable worktree titles on provider observations. The same resolved title records feed snapshot composition and atomic reconcile persistence."
         }
       ],
       "imports": [
@@ -8878,6 +9076,7 @@
             "PersistedSessionHarnessExecution",
             "PersistedSessionTurnReadiness",
             "ReconcileStore",
+            "ReconcileWorktreeDisplayTitleInput",
             "SessionHarnessDerivedStateRepair",
             "SessionStore",
             "WorktreeMetadataStore"
@@ -8922,6 +9121,12 @@
           "resolvedPath": "apps/observer/src/stationLogger.ts",
           "edgeKind": "type-only",
           "bindings": ["StationLogger"]
+        },
+        {
+          "specifier": "../worktreeDisplayTitle.js",
+          "resolvedPath": "apps/observer/src/worktreeDisplayTitle.ts",
+          "edgeKind": "runtime",
+          "bindings": ["resolveWorktreeDisplayTitle"]
         },
         {
           "specifier": "@station/contracts",
@@ -9412,7 +9617,7 @@
           "name": "prepareExternalLaunch",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Prepare Station-hosted agent identity, persist an optional title before reconcile can expose it, and return a launch plan plus opaque managed attachment. Failed terminal preparation or process launch releases the managed target before removing its title seed, retaining the title whenever target cleanup cannot be confirmed."
+          "purpose": "Prepares Station-hosted identity by durably seeding its canonical title before target registration. Failed launch cleanup independently releases its target and discards only the fresh session projection."
         },
         {
           "name": "reportExternalExit",
@@ -9442,7 +9647,6 @@
             "defaultSessionCommandIdFactory",
             "findProjectOrThrow",
             "rememberedHarnessProviderForWorktree",
-            "seedSessionTitle",
             "worktreeObservationFromRow"
           ]
         },
@@ -10936,6 +11140,31 @@
           "bindings": ["RuntimeClock"]
         }
       ]
+    },
+    {
+      "path": "apps/observer/src/worktreeDisplayTitle.ts",
+      "exports": [
+        {
+          "name": "resolveWorktreeDisplayTitle",
+          "kind": "function",
+          "role": "POLICY",
+          "purpose": "Resolves one durable display title from worktree authority and deterministic legacy session evidence."
+        },
+        {
+          "name": "ResolveWorktreeDisplayTitleInput",
+          "kind": "type",
+          "role": null,
+          "purpose": null
+        }
+      ],
+      "imports": [
+        {
+          "specifier": "./persistence/types.js",
+          "resolvedPath": "apps/observer/src/persistence/types.ts",
+          "edgeKind": "type-only",
+          "bindings": ["PersistedSession", "PersistedWorktreeDisplayTitle"]
+        }
+      ]
     }
   ],
   "controlledDeclarations": [
@@ -11537,6 +11766,27 @@
           "edgeKind": "runtime"
         },
         {
+          "path": "apps/observer/src/commands/session/rename.ts",
+          "declaration": "createSessionRenameHandler",
+          "kind": "function",
+          "role": "USE CASE",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/commands/session/resumeAgent.ts",
+          "declaration": "createSessionResumeAgentHandler",
+          "kind": "function",
+          "role": "USE CASE",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/observer/src/commands/session/startAgent.ts",
+          "declaration": "createSessionStartAgentHandler",
+          "kind": "function",
+          "role": "USE CASE",
+          "edgeKind": "runtime"
+        },
+        {
           "path": "apps/observer/src/commands/worktree/remove.ts",
           "declaration": "createWorktreeRemoveHandler",
           "kind": "function",
@@ -11550,7 +11800,7 @@
       "declaration": "createSessionCreateHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Create a session worktree on its generated branch, persist its independent user-facing title, and launch its primary agent workspace.",
+      "purpose": "Creates a session worktree on its generated branch, durably seeds its independent title, and launches its primary agent; cleanup retires title authority only after verified rollback.",
       "dependencies": []
     },
     {
@@ -11558,7 +11808,46 @@
       "declaration": "createSessionForkHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Fork an existing worktree onto an internal branch, persist an independent user-facing title, optionally copy dirty state, and launch a fresh agent. The source agent remains live and its remembered harness is inherited.",
+      "purpose": "Forks an existing worktree onto an internal branch, durably seeds its independent title, and launches a fresh agent; cleanup retires title authority only after verified rollback.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/commands/session/rename.ts",
+      "declaration": "createSessionRenameHandler",
+      "kind": "function",
+      "role": "USE CASE",
+      "purpose": "Renames the canonical worktree title and its session projections before publishing convergence.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/commands/session/resumeAgent.ts",
+      "declaration": "createSessionResumeAgentHandler",
+      "kind": "function",
+      "role": "USE CASE",
+      "purpose": "Resumes provider-native recovery into an existing Station identity or a fresh titled session. Failed launch cleanup discards only a newly minted session projection.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/persistence/ports.ts",
+          "declaration": "SessionStore",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        },
+        {
+          "path": "packages/contracts/src/providers.ts",
+          "declaration": "HarnessProvider",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
+      "path": "apps/observer/src/commands/session/startAgent.ts",
+      "declaration": "createSessionStartAgentHandler",
+      "kind": "function",
+      "role": "USE CASE",
+      "purpose": "Starts a fresh agent lifecycle while inheriting the worktree's canonical display title. Failed launches discard only the fresh session projection.",
       "dependencies": []
     },
     {
@@ -11574,7 +11863,7 @@
       "declaration": "createWorktreeRemoveHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-side race refusals retain command-correlated evidence for diagnostics.",
+      "purpose": "Revalidates selected checkout and Git registration identity before coordinating removal. Provider-confirmed removal atomically ends sessions and retires canonical title authority.",
       "dependencies": []
     },
     {
@@ -11867,7 +12156,7 @@
       "declaration": "ReconcileStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability.",
+      "purpose": "Persists the Observer's correlated reconcile projection as one atomic capability. Missing canonical worktree titles initialize insert-only before session projections synchronize.",
       "dependencies": []
     },
     {
@@ -11875,7 +12164,7 @@
       "declaration": "SessionStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, titles, remembered harness selection, recovery handles, and turn readiness.",
+      "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness.",
       "dependencies": []
     },
     {
@@ -11907,7 +12196,7 @@
       "declaration": "buildStationSnapshot",
       "kind": "function",
       "role": "POLICY",
-      "purpose": "Correlates provider observations and durable session records into canonical snapshot truth.",
+      "purpose": "Correlates provider observations with canonical worktree title input and durable session records. Branch names remain only the defensive title fallback when persistence is unavailable.",
       "dependencies": [
         {
           "path": "apps/observer/src/reconcile/statusPolicy.ts",
@@ -11923,7 +12212,7 @@
       "declaration": "runReconcileOnce",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Rebuilds the Observer graph from provider reads and accepted durable evidence.",
+      "purpose": "Rebuilds the Observer graph after overlaying durable worktree titles on provider observations. The same resolved title records feed snapshot composition and atomic reconcile persistence.",
       "dependencies": [
         {
           "path": "apps/observer/src/harnessExecutionIdentity.ts",
@@ -11994,6 +12283,13 @@
           "kind": "interface",
           "role": "DRIVEN PORT",
           "edgeKind": "type-only"
+        },
+        {
+          "path": "apps/observer/src/worktreeDisplayTitle.ts",
+          "declaration": "resolveWorktreeDisplayTitle",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
         },
         {
           "path": "packages/contracts/src/providers.ts",
@@ -12155,7 +12451,7 @@
       "declaration": "prepareExternalLaunch",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Prepare Station-hosted agent identity, persist an optional title before reconcile can expose it, and return a launch plan plus opaque managed attachment. Failed terminal preparation or process launch releases the managed target before removing its title seed, retaining the title whenever target cleanup cannot be confirmed.",
+      "purpose": "Prepares Station-hosted identity by durably seeding its canonical title before target registration. Failed launch cleanup independently releases its target and discards only the fresh session projection.",
       "dependencies": []
     },
     {
@@ -12484,6 +12780,14 @@
       "kind": "interface",
       "role": "DRIVEN PORT",
       "purpose": "Records Observer operational events without exposing their storage representation or destination.",
+      "dependencies": []
+    },
+    {
+      "path": "apps/observer/src/worktreeDisplayTitle.ts",
+      "declaration": "resolveWorktreeDisplayTitle",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Resolves one durable display title from worktree authority and deterministic legacy session evidence.",
       "dependencies": []
     },
     {

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -176,9 +176,11 @@ and panes intact.
 
 There is no deletable "session" unit and no `session.remove` command. The durable, deletable unit is the worktree.
 
+The UX calls the display value a **session name**, but its durable authority is the worktree-scoped title keyed by `(projectId, worktreeId)`. `WorktreeRow.title` and every `SessionView.title` for that worktree project the same value. Agent session IDs remain lifecycle-specific: a fresh agent can receive a new `ses_<uuid>` while inheriting the worktree title. Branch supplies only the initial fallback when no canonical or historical non-ended title exists; later branch changes do not rename the workspace.
+
 ### Worktree
 
-A worktree is the durable, deletable unit: the git worktree, its branch, and its checkout. Worktree ids are **provider-supplied** (e.g. Worktrunk), not minted by the observer, so code must not parse or validate the `wt_` prefix. Removing a worktree also tears down its session and panes.
+A worktree is the durable, deletable unit: the git worktree, its branch, its checkout, and its Observer-owned display title. Worktree ids are **provider-supplied** (e.g. Worktrunk), not minted by the observer, so code must not parse or validate the `wt_` prefix. Removing a worktree also tears down its session and panes.
 
 ### Pane Tree
 

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -243,7 +243,7 @@ No single layer owns all truth.
 | Provider observations | Each provider is authoritative only for external facts it can prove. Live reads and normalized ingress observations may be persisted with retention, but cached evidence does not outrank a newer provider read. |
 | Provider-owned identity | Worktree, target, harness-run, native execution, and external endpoint identity stays owned by the provider that minted it. Application code may carry opaque IDs but must not reconstruct their format. |
 | Observer-minted state | Command, event, error, report, session, correlation, readiness, and recovery identities are legitimate internal facts minted by the observer. The observer does not invent external facts. |
-| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, native-execution bindings, metadata caches, recovery handles, and readiness. It is not an external provider's source of truth. |
+| Observer SQLite | Durable observer memory for commands, events, ingress dedupe, observations, correlations, sessions, canonical worktree display titles, native-execution bindings, metadata caches, recovery handles, and readiness. Display-title authority is keyed by `(projectId, worktreeId)` and survives transient provider observation gaps; it is not branch or provider identity. |
 | Local Git metadata evidence | Local Git is authoritative only for checkout-local `HEAD`, refs, merge-base, and numstat at read time. Command failures retain cached evidence through the TTL and mark it stale, while a matching checkout reported unavailable clears its local-change row; superseded identities cannot mutate either row. Ref-watch notifications are hints that request reconcile, never metadata or UI mutations themselves. |
 | Observer boot claim | `dirname(resolvedSocket)/observer.claim.sqlite` is a persistent private transport-lifecycle file. Only its active SQLite write transaction owns boot exclusion; file or sidecar existence is never authority. It has no Observer migrations or application persistence role. |
 | Observer process identity | `<resolved socketPath>.pid` is the strict, socket-specific `{pid, osStartTime, version, socketPath}` identity published by the process that successfully bound the socket. Its `version` is the Observer selector: display SemVer plus reserved `station.<sha256>` build metadata. It corroborates process and immutable-build identity for later handoff and diagnostics; `lsof` remains primary socket-ownership evidence, and the file alone is never liveness authority. |
@@ -417,8 +417,11 @@ trace-correlated diagnostic evidence.
 ### Reconciliation
 
 Reconcile reads worktree and terminal actors, derives the worktree context for
-harness reads, applies cached metadata and durable overlays, correlates the
-graph, persists the result, and replaces the in-memory snapshot. It then
+harness reads, applies cached metadata and durable overlays, resolves one effective display title
+per current worktree, correlates the graph, persists the same title records with the result, and
+replaces the in-memory snapshot. Existing canonical titles win; missing authority initializes from
+the best non-ended custom session evidence before branch fallback, using insert-only reconcile
+persistence so stale evidence cannot overwrite a concurrent rename. It then
 publishes state-change and reconcile events and schedules metadata refresh.
 
 Session reconciliation keeps the newest explicitly open Station-owned durable
@@ -550,7 +553,9 @@ composition-supplied `ManagedTerminalLifecycle`, carry provider-owned target IDs
 opaquely, and request reconcile after relevant lifecycle changes. Before a new
 managed harness session is launched, the use case calls the provider-neutral
 optional `hooksStatus()` capability and fails closed when requested Station
-tracking artifacts are absent or drifted. Claude, Codex, Cursor, and OpenCode —
+tracking artifacts are absent or drifted. After validation and identity minting, it durably seeds
+the session from canonical worktree title authority before target registration and process launch;
+failed launch cleanup releases any opened target and discards only the fresh session projection. Claude, Codex, Cursor, and OpenCode —
 the four providers whose external artifacts setup installs — implement this
 capability. Providers without an equivalent managed external artifact retain
 the deliberate fail-open behavior; Pi is not forced through this gate. Focusing
@@ -647,10 +652,12 @@ when it changes several tables:
   hook-processing completion across observations/native bindings/readiness.
 - `ObservationStore` owns typed provider observations, current-observation
   queries, and expiry.
-- `ReconcileStore` owns the complete atomic `persistReconcileResult` operation.
-- `SessionStore` owns explicit session lifecycle, durable provider-native
-  execution bindings, titles, recovery handles, turn readiness, and
-  purpose-specific remembered-harness lookup.
+- `ReconcileStore` owns the complete atomic `persistReconcileResult` operation, including
+  insert-only initialization of missing canonical worktree titles before session projection sync.
+- `SessionStore` owns explicit session lifecycle, canonical worktree-scoped title authority,
+  synchronized per-session title projections, durable provider-native execution bindings,
+  recovery handles, turn readiness, and purpose-specific remembered-harness lookup. Rename,
+  fresh-session seeding, and confirmed worktree retirement keep their multi-table changes atomic.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -2911,6 +2911,7 @@ function deterministicDashboardSnapshot(projectRoot: string): StationSnapshot {
       id: worktreeId,
       projectId: "popup-real",
       projectLabel: "POPUP ACCEPTANCE",
+      title: `popup-${sequence}`,
       branch: `popup-${sequence}`,
       path: join(projectRoot, `popup-${sequence}`),
       worktree,

--- a/packages/client/src/snapshotReducer.ts
+++ b/packages/client/src/snapshotReducer.ts
@@ -121,6 +121,7 @@ function mergeRowPatch(row: WorktreeRow, patch: OptionalPatch<WorktreeRow>): Wor
     id: patch.id ?? row.id,
     projectId: patch.projectId ?? row.projectId,
     projectLabel: patch.projectLabel ?? row.projectLabel,
+    title: patch.title ?? row.title,
     branch: patch.branch ?? row.branch,
     path: patch.path ?? row.path,
     worktree: row.worktree,

--- a/packages/client/test/support/snapshots.ts
+++ b/packages/client/test/support/snapshots.ts
@@ -46,7 +46,8 @@ export function row(input: {
   id: string;
   projectId: "web" | "api";
   branch: string;
-  state: WorktreeRow["agent"] extends { state: infer T } ? T | "none" : never;
+  title?: string;
+  state: NonNullable<WorktreeRow["agent"]>["state"] | "none";
   dirty?: boolean;
 }): WorktreeRow {
   const display = displayForState(input.state);
@@ -54,6 +55,7 @@ export function row(input: {
     id: input.id,
     projectId: input.projectId,
     projectLabel: input.projectId,
+    title: input.title ?? input.branch,
     branch: input.branch,
     path: `/tmp/station/${input.projectId}/worktrees/${input.branch.replaceAll("/", "-")}`,
     worktree: {

--- a/packages/client/test/unit/snapshotReducer.test.ts
+++ b/packages/client/test/unit/snapshotReducer.test.ts
@@ -6,6 +6,9 @@ import { createCommandSnapshot, fixtureNow, row } from "../support/snapshots.js"
 describe("client snapshot reducer", () => {
   it("applies direct worktree row updates without requesting a snapshot refresh", () => {
     const snapshot = createCommandSnapshot("idle");
+    const firstRow = snapshot.rows[0];
+    if (firstRow === undefined) throw new Error("Expected an idle fixture row.");
+    snapshot.rows[0] = { ...firstRow, title: "Durable workspace" };
     const event: StationEvent = {
       type: "worktree.updated",
       worktreeId: "wt_web_idle",
@@ -22,6 +25,27 @@ describe("client snapshot reducer", () => {
     const result = applyStationEvent(snapshot, event);
     expect(result.needsSnapshotRefresh).toBe(false);
     expect(result.snapshot.rows[0]?.display.statusLabel).toBe("working");
+    expect(result.snapshot.rows[0]?.title).toBe("Durable workspace");
+  });
+
+  it("applies direct title patches without dropping row state", () => {
+    const snapshot = createCommandSnapshot("idle");
+    const before = snapshot.rows[0];
+    if (before === undefined) throw new Error("Expected an idle fixture row.");
+
+    const result = applyStationEvent(snapshot, {
+      type: "worktree.updated",
+      worktreeId: before.id,
+      patch: { title: "Renamed workspace" },
+    });
+
+    expect(result.needsSnapshotRefresh).toBe(false);
+    expect(result.snapshot.rows[0]).toMatchObject({
+      title: "Renamed workspace",
+      branch: before.branch,
+      agent: before.agent,
+      display: before.display,
+    });
   });
 
   it("applies readiness-only worktree row updates", () => {

--- a/packages/contracts/src/ids.ts
+++ b/packages/contracts/src/ids.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { nonEmptyStringSchema } from "./shared.js";
 
-export const STATION_SCHEMA_VERSION = "0.8.0" as const;
+export const STATION_SCHEMA_VERSION = "0.9.0" as const;
 
 const timestampSchema = z.string().datetime({ offset: true });
 declare const stationIdKind: unique symbol;

--- a/packages/contracts/src/snapshot.ts
+++ b/packages/contracts/src/snapshot.ts
@@ -151,6 +151,7 @@ export const WorktreeRowSchema = z
     id: WorktreeIdSchema,
     projectId: ProjectIdSchema,
     projectLabel: nonEmptyStringSchema,
+    title: nonEmptyStringSchema,
     branch: nonEmptyStringSchema,
     path: nonEmptyStringSchema,
     registrationIdentity: nonEmptyStringSchema.optional(),

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -63,6 +63,7 @@ import {
   WorktreeChecksStateSchema,
   type WorktreeId,
   WorktreeObservationSchema,
+  WorktreeRowSchema,
 } from "@station/contracts";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import type { ZodType } from "zod";
@@ -153,7 +154,7 @@ describe("contract schemas", () => {
   });
 
   it("exports the shared schema version used by snapshot fixtures", async () => {
-    expect(STATION_SCHEMA_VERSION).toBe("0.8.0");
+    expect(STATION_SCHEMA_VERSION).toBe("0.9.0");
 
     const snapshots = (await loadJson("snapshots/snapshot-scenarios.json")) as Record<
       string,
@@ -687,6 +688,7 @@ describe("contract schemas", () => {
       id: "wt_web_feature_auth",
       projectId: "web",
       projectLabel: "web",
+      title: "Readable feature task",
       branch: "feature/auth",
       path: "/tmp/station-fixtures/web/worktrees/feature-auth",
       worktree: {
@@ -730,6 +732,11 @@ describe("contract schemas", () => {
     };
 
     expectParses(StationSnapshotSchema, snapshot, "snapshot with normalized branch metadata");
+    expectFails(
+      WorktreeRowSchema,
+      { ...row, title: undefined },
+      "worktree row without canonical title",
+    );
     expectFails(
       StationSnapshotSchema,
       {

--- a/packages/dashboard-core/src/selectors/selectors.ts
+++ b/packages/dashboard-core/src/selectors/selectors.ts
@@ -234,10 +234,10 @@ export function sessionForWorktreeRow(
 }
 
 export function sessionRowDisplayTitle(
-  row: Pick<DashboardSessionRow, "session">,
+  row: Pick<DashboardSessionRow, "session" | "worktree">,
   localRows: TuiLocalRows,
 ): string {
-  return pendingRenameTitles(localRows)[row.session.id]?.title ?? row.session.title;
+  return pendingRenameTitles(localRows)[row.session.id]?.title ?? row.worktree.title;
 }
 
 /**

--- a/packages/dashboard-core/test/fixtures/snapshots.ts
+++ b/packages/dashboard-core/test/fixtures/snapshots.ts
@@ -158,7 +158,8 @@ export function row(input: {
   id: string;
   projectId: "web" | "api";
   branch: string;
-  state: WorktreeRow["agent"] extends { state: infer T } ? T | "none" : never;
+  title?: string;
+  state: NonNullable<WorktreeRow["agent"]>["state"] | "none";
   dirty?: boolean;
 }): WorktreeRow {
   const display = displayForState(input.state);
@@ -166,6 +167,7 @@ export function row(input: {
     id: input.id,
     projectId: input.projectId,
     projectLabel: input.projectId,
+    title: input.title ?? input.branch,
     branch: input.branch,
     path: `/tmp/station/${input.projectId}/worktrees/${input.branch.replaceAll("/", "-")}`,
     registrationIdentity: `git-registration:${input.id}`,

--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -192,8 +192,8 @@ describe("dashboard viewport selector", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {
       ...snapshot,
-      sessions: snapshot.sessions.map((session) =>
-        session.id === "ses_wt_web_stuck" ? { ...session, title: "aaa stable task" } : session,
+      rows: snapshot.rows.map((row) =>
+        row.id === "wt_web_stuck" ? { ...row, title: "aaa stable task" } : row,
       ),
     };
     const viewport = selectDashboardViewport(
@@ -369,8 +369,8 @@ describe("dashboard viewport selector", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {
       ...snapshot,
-      sessions: snapshot.sessions.map((session) =>
-        session.id === "ses_wt_web_idle" ? { ...session, title: "Readable feature task" } : session,
+      rows: snapshot.rows.map((row) =>
+        row.id === "wt_web_idle" ? { ...row, title: "Readable feature task" } : row,
       ),
     };
     const viewport = selectDashboardViewport(titled, createInitialTuiState());

--- a/packages/dashboard-core/test/unit/selectors/selectors.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/selectors.test.ts
@@ -130,8 +130,10 @@ describe("TUI selectors", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {
       ...snapshot,
-      sessions: snapshot.sessions.map((session) =>
-        session.id === "ses_wt_web_idle" ? { ...session, title: "middle stable session" } : session,
+      rows: snapshot.rows.map((candidate) =>
+        candidate.id === "wt_web_idle"
+          ? { ...candidate, title: "middle stable session" }
+          : candidate,
       ),
     };
     const branchChanged = {
@@ -183,15 +185,20 @@ describe("TUI selectors", () => {
   it("resolves session labels with pending overrides", () => {
     const snapshot = createDashboardSnapshot();
     const session = snapshot.sessions.find((candidate) => candidate.id === "ses_wt_web_idle");
-    if (session === undefined) throw new Error("missing fixture session");
-    const titled = { ...session, title: "Readable feature task" };
+    const worktree = snapshot.rows.find((candidate) => candidate.id === "wt_web_idle");
+    if (session === undefined || worktree === undefined) throw new Error("missing fixture session");
+    const titledWorktree = { ...worktree, title: "Readable feature task" };
+    const staleSession = { ...session, title: "Stale session projection" };
 
-    expect(sessionRowDisplayTitle({ session: titled }, createInitialTuiState().localRows)).toBe(
-      "Readable feature task",
-    );
     expect(
       sessionRowDisplayTitle(
-        { session: titled },
+        { session: staleSession, worktree: titledWorktree },
+        createInitialTuiState().localRows,
+      ),
+    ).toBe("Readable feature task");
+    expect(
+      sessionRowDisplayTitle(
+        { session: staleSession, worktree: titledWorktree },
         {
           pendingCreate: [],
           failedCreate: [],
@@ -207,6 +214,41 @@ describe("TUI selectors", () => {
         },
       ),
     ).toBe("Optimistic readable title");
+  });
+
+  it("renders a retained no-agent session from canonical row title through pending launch state", () => {
+    const snapshot = createDashboardSnapshot();
+    const bareWorktree = snapshot.rows.find((candidate) => candidate.id === "wt_web_no_agent");
+    const sourceSession = snapshot.sessions[0];
+    if (bareWorktree === undefined || sourceSession === undefined) {
+      throw new Error("missing retained no-agent fixture inputs");
+    }
+    const worktree = { ...bareWorktree, title: "Durable no-agent workspace" };
+    const session = {
+      ...sourceSession,
+      id: "ses_retained_no_agent",
+      worktreeId: worktree.id,
+      title: "Stale branch-derived projection",
+    };
+    const localRows = {
+      pendingCreate: [],
+      failedCreate: [],
+      pendingRemove: [],
+      pendingStart: [
+        {
+          localId: "start-retained",
+          operation: "resumeAgent" as const,
+          projectId: worktree.projectId,
+          worktreeId: worktree.id,
+          branch: worktree.branch,
+          createdAt: "2026-05-31T12:00:00.000Z",
+        },
+      ],
+    };
+
+    expect(sessionRowDisplayTitle({ session, worktree }, localRows)).toBe(
+      "Durable no-agent workspace",
+    );
   });
 
   it("resolves an external row by run identity before retained Station membership", () => {
@@ -273,10 +315,10 @@ describe("TUI selectors", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {
       ...snapshot,
-      sessions: snapshot.sessions.map((session) =>
-        session.id === "ses_wt_web_stuck"
-          ? { ...session, title: "aaa readable feature task" }
-          : session,
+      rows: snapshot.rows.map((candidate) =>
+        candidate.id === "wt_web_stuck"
+          ? { ...candidate, title: "aaa readable feature task" }
+          : candidate,
       ),
     };
     const searched: TuiViewState = {

--- a/packages/observability/test/unit/diagnostic-evidence.test.ts
+++ b/packages/observability/test/unit/diagnostic-evidence.test.ts
@@ -75,7 +75,7 @@ describe("diagnostic evidence index", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,
@@ -114,6 +114,7 @@ describe("diagnostic evidence index", () => {
               id: "wt_web_stale",
               projectId: "web",
               projectLabel: "web",
+              title: "feature/stale",
               branch: "feature/stale",
               path: "/tmp/station/web/feature-stale",
               worktree: { state: "exists", source: "worktrunk" },

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -212,17 +212,17 @@ describe("observability helpers", () => {
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     collectedAt: now,
     observerHealth: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       status: "healthy",
       pid: 1234,
       startedAt: now,
       version: "0.0.0",
     },
     snapshot: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       generatedAt: now,
       observer: {
         pid: 1234,

--- a/packages/protocol/test/fixtures/protocol-messages.json
+++ b/packages/protocol/test/fixtures/protocol-messages.json
@@ -1,16 +1,16 @@
 {
   "request": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "method": "observer.health"
   },
   "successResponse": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "result": {
-      "schemaVersion": "0.8.0",
+      "schemaVersion": "0.9.0",
       "status": "healthy",
       "pid": 1234,
       "startedAt": "2026-05-20T12:00:00.000Z",
@@ -18,7 +18,7 @@
     }
   },
   "errorResponse": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "jsonrpc": "2.0",
     "id": "req_1",
     "error": {
@@ -28,7 +28,7 @@
     }
   },
   "eventEnvelope": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "event": {
       "type": "providerHook.ingested",
       "at": "2026-05-20T12:02:00.000Z",
@@ -38,7 +38,7 @@
     }
   },
   "doctorRequest": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "jsonrpc": "2.0",
     "id": "req_doctor",
     "method": "doctor.run",
@@ -47,7 +47,7 @@
     }
   },
   "diagnosticsRequest": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "jsonrpc": "2.0",
     "id": "req_diag",
     "method": "diagnostics.collect",

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -556,7 +556,7 @@ describe("protocol client/server", () => {
         tag: "ProtocolError",
         code: "PROTOCOL_SCHEMA_MISMATCH",
         message:
-          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.8.0.",
+          "Observer protocol schema mismatch: the observer responded with schema 9.9.9, but this CLI expects schema 0.9.0.",
         hint: expect.stringContaining("A different STATION checkout"),
       });
     } finally {

--- a/packages/protocol/test/unit/messages.test.ts
+++ b/packages/protocol/test/unit/messages.test.ts
@@ -27,7 +27,7 @@ describe("protocol message envelopes", () => {
   it("rejects unknown protocol methods", () => {
     expect(
       ProtocolRequestSchema.safeParse({
-        schemaVersion: "0.8.0",
+        schemaVersion: "0.9.0",
         jsonrpc: "2.0",
         id: "req_bad",
         method: "provider.rawCall",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,9 +112,24 @@ importers:
         specifier: ^4.1.12
         version: 4.4.3
     devDependencies:
+      '@station/cursor':
+        specifier: workspace:*
+        version: link:../../integrations/harness/cursor
+      '@station/pi':
+        specifier: workspace:*
+        version: link:../../integrations/harness/pi
+      '@station/terminal':
+        specifier: workspace:*
+        version: link:../../integrations/terminal/station
       '@station/testing':
         specifier: workspace:*
         version: link:../../packages/testing
+      '@station/worktrunk':
+        specifier: workspace:*
+        version: link:../../integrations/worktree/worktrunk
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0)
 
   integrations/harness/claude:
     dependencies:

--- a/station/src/sources/fixtures/mockObserverSnapshot.ts
+++ b/station/src/sources/fixtures/mockObserverSnapshot.ts
@@ -16,7 +16,7 @@ const harnessCapabilities = {
 };
 
 export const mockObserverSnapshot = {
-  schemaVersion: "0.8.0",
+  schemaVersion: "0.9.0",
   generatedAt: fixtureNow,
   observer: {
     pid: 4242,
@@ -80,6 +80,7 @@ export const mockObserverSnapshot = {
       id: "wt_station_design",
       projectId: "station",
       projectLabel: "STATION",
+      title: "station-design",
       branch: "station-design",
       path: "/Users/example/.worktrees/station/station-design",
       worktree: {
@@ -134,6 +135,7 @@ export const mockObserverSnapshot = {
       id: "wt_notify_cleanup",
       projectId: "station",
       projectLabel: "STATION",
+      title: "notify-cleanup",
       branch: "notify-cleanup",
       path: "/Users/example/.worktrees/station/notify-cleanup",
       worktree: {
@@ -174,6 +176,7 @@ export const mockObserverSnapshot = {
       id: "wt_docs_only",
       projectId: "station",
       projectLabel: "STATION",
+      title: "docs-only",
       branch: "docs-only",
       path: "/Users/example/.worktrees/station/docs-only",
       worktree: {

--- a/station/src/station/fixtures/scenarios.ts
+++ b/station/src/station/fixtures/scenarios.ts
@@ -262,6 +262,7 @@ function scenarioRow(input: ScenarioRowInput): WorktreeRow {
     id: input.id,
     projectId: input.project.id,
     projectLabel: input.project.label,
+    title: input.branch,
     branch: input.branch,
     path: `/Users/example/.worktrees/${input.project.id}/${input.branch.replaceAll("/", "-")}`,
     registrationIdentity: `git-registration:${input.id}`,

--- a/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
+++ b/tests/agent/scenarios/diagnosis/harness-unexpected-exit.json
@@ -2,7 +2,7 @@
   "name": "harness-unexpected-exit",
   "expectedRootCause": "HARNESS_UNEXPECTED_EXIT",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
+++ b/tests/agent/scenarios/diagnosis/hook-spool-fallback.json
@@ -2,7 +2,7 @@
   "name": "hook-spool-fallback",
   "expectedRootCause": "HOOK_SPOOL_FALLBACK",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/invalid-config.json
+++ b/tests/agent/scenarios/diagnosis/invalid-config.json
@@ -2,7 +2,7 @@
   "name": "invalid-config",
   "expectedRootCause": "INVALID_CONFIG",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "unavailable",

--- a/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
+++ b/tests/agent/scenarios/diagnosis/missing-worktrunk-binary.json
@@ -2,7 +2,7 @@
   "name": "missing-worktrunk-binary",
   "expectedRootCause": "MISSING_WORKTRUNK_BINARY",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/provider-timeout.json
+++ b/tests/agent/scenarios/diagnosis/provider-timeout.json
@@ -2,7 +2,7 @@
   "name": "provider-timeout",
   "expectedRootCause": "PROVIDER_TIMEOUT",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
+++ b/tests/agent/scenarios/diagnosis/sqlite-write-failure.json
@@ -2,7 +2,7 @@
   "name": "sqlite-write-failure",
   "expectedRootCause": "SQLITE_WRITE_FAILURE",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/agent/scenarios/diagnosis/stale-terminal-target.json
+++ b/tests/agent/scenarios/diagnosis/stale-terminal-target.json
@@ -2,7 +2,7 @@
   "name": "stale-terminal-target",
   "expectedRootCause": "STALE_TERMINAL_TARGET",
   "evidenceIndex": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-22T12:00:00.000Z",
     "summary": {
       "status": "degraded",

--- a/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
+++ b/tests/contract-fixtures/diagnostics/debug-bundle-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "bundleId": "diag_2026-05-20T120000Z",
   "createdAt": "2026-05-20T12:00:00.000Z",
   "bundlePath": "/tmp/station/diagnostics/diag_2026-05-20T120000Z",

--- a/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
+++ b/tests/contract-fixtures/diagnostics/diagnostic-evidence-index.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "generatedAt": "2026-05-22T12:00:00.000Z",
   "source": {
     "collectedAt": "2026-05-22T11:59:59.000Z",

--- a/tests/contract-fixtures/diagnostics/doctor-report.json
+++ b/tests/contract-fixtures/diagnostics/doctor-report.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "generatedAt": "2026-05-20T12:00:00.000Z",
   "status": "degraded",
   "checks": [
@@ -15,7 +15,7 @@
     }
   ],
   "observer": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "status": "healthy",
     "pid": 1234,
     "startedAt": "2026-05-20T12:00:00.000Z",
@@ -68,7 +68,7 @@
     }
   },
   "snapshot": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 1234,

--- a/tests/contract-fixtures/events/events.json
+++ b/tests/contract-fixtures/events/events.json
@@ -18,6 +18,7 @@
       "id": "wt_web_feature_auth",
       "projectId": "web",
       "projectLabel": "web",
+      "title": "feature/auth",
       "branch": "feature/auth",
       "path": "/tmp/station-fixtures/web/worktrees/feature-auth",
       "worktree": {

--- a/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
+++ b/tests/contract-fixtures/hooks/invalid-provider-hook-event.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "provider": "",
   "kind": "harness",
   "event": "",

--- a/tests/contract-fixtures/hooks/provider-hook-events.json
+++ b/tests/contract-fixtures/hooks/provider-hook-events.json
@@ -1,6 +1,6 @@
 {
   "worktrunkWorktreeCreated": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "hookId": "hook_worktrunk_1",
     "provider": "worktrunk",
     "kind": "worktree",
@@ -13,7 +13,7 @@
     }
   },
   "codexRunUpdated": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "hookId": "hook_codex_1",
     "provider": "codex",
     "kind": "harness",

--- a/tests/contract-fixtures/snapshots/invalid-snapshot.json
+++ b/tests/contract-fixtures/snapshots/invalid-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "generatedAt": "not-a-date",
   "observer": {
     "pid": 0,

--- a/tests/contract-fixtures/snapshots/snapshot-scenarios.json
+++ b/tests/contract-fixtures/snapshots/snapshot-scenarios.json
@@ -1,6 +1,6 @@
 {
   "noProjects": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -25,7 +25,7 @@
     "alerts": []
   },
   "multipleProjects": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -113,7 +113,7 @@
     "alerts": []
   },
   "zeroWorktreeProject": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -164,7 +164,7 @@
     "alerts": []
   },
   "noAgentWorktree": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -205,6 +205,7 @@
         "id": "wt_web_feature_auth",
         "projectId": "web",
         "projectLabel": "web",
+        "title": "feature/auth",
         "branch": "feature/auth",
         "path": "/tmp/station-fixtures/web/worktrees/feature-auth",
         "worktree": {
@@ -236,7 +237,7 @@
     "alerts": []
   },
   "idleAgent": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -277,6 +278,7 @@
         "id": "wt_web_idle",
         "projectId": "web",
         "projectLabel": "web",
+        "title": "idle-agent",
         "branch": "idle-agent",
         "path": "/tmp/station-fixtures/web/worktrees/idle-agent",
         "worktree": {
@@ -366,7 +368,7 @@
     "alerts": []
   },
   "workingAgent": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -407,6 +409,7 @@
         "id": "wt_api_cache",
         "projectId": "api",
         "projectLabel": "api",
+        "title": "feature/cache",
         "branch": "feature/cache",
         "path": "/tmp/station-fixtures/api/worktrees/feature-cache",
         "worktree": {
@@ -453,7 +456,7 @@
     "alerts": []
   },
   "needsAttentionAgent": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -494,6 +497,7 @@
         "id": "wt_web_payments",
         "projectId": "web",
         "projectLabel": "web",
+        "title": "feature/payments",
         "branch": "feature/payments",
         "path": "/tmp/station-fixtures/web/worktrees/feature-payments",
         "worktree": {
@@ -539,7 +543,7 @@
     "alerts": []
   },
   "stuckAgent": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -580,6 +584,7 @@
         "id": "wt_api_stuck",
         "projectId": "api",
         "projectLabel": "api",
+        "title": "debug/stuck-agent",
         "branch": "debug/stuck-agent",
         "path": "/tmp/station-fixtures/api/worktrees/debug-stuck-agent",
         "worktree": {
@@ -626,7 +631,7 @@
     "alerts": []
   },
   "exitedAgent": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -667,6 +672,7 @@
         "id": "wt_web_exited",
         "projectId": "web",
         "projectLabel": "web",
+        "title": "bugfix/exited-agent",
         "branch": "bugfix/exited-agent",
         "path": "/tmp/station-fixtures/web/worktrees/bugfix-exited-agent",
         "worktree": {
@@ -710,7 +716,7 @@
     "alerts": []
   },
   "unknownLowConfidence": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -751,6 +757,7 @@
         "id": "wt_mobile_unknown",
         "projectId": "mobile",
         "projectLabel": "mobile",
+        "title": "feature/offline-mode",
         "branch": "feature/offline-mode",
         "path": "/tmp/station-fixtures/mobile/worktrees/feature-offline-mode",
         "worktree": {
@@ -796,7 +803,7 @@
     "alerts": []
   },
   "orphanedTerminalTarget": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,
@@ -831,7 +838,7 @@
     ]
   },
   "providerFailure": {
-    "schemaVersion": "0.8.0",
+    "schemaVersion": "0.9.0",
     "generatedAt": "2026-05-20T12:00:00.000Z",
     "observer": {
       "pid": 4242,

--- a/tests/diagnostics/debug-bundle/row-provider-questions.test.ts
+++ b/tests/diagnostics/debug-bundle/row-provider-questions.test.ts
@@ -25,6 +25,7 @@ describe("row-level provider diagnostics from debug bundles", () => {
               id: "wt_web_debug",
               projectId: "web",
               projectLabel: "web",
+              title: "feature/debug",
               branch: "feature/debug",
               path: "/tmp/station/web/debug",
               worktree: { state: "exists", source: "worktrunk", dirty: true },

--- a/tests/diagnostics/injected-failures/harness-unexpected-exit.test.ts
+++ b/tests/diagnostics/injected-failures/harness-unexpected-exit.test.ts
@@ -16,6 +16,7 @@ describe("harness unexpected exit diagnostic", () => {
               id: "wt_web_exit",
               projectId: "web",
               projectLabel: "web",
+              title: "feature/exit",
               branch: "feature/exit",
               path: "/tmp/station/web/exit",
               worktree: { state: "exists", source: "worktrunk" },

--- a/tests/diagnostics/injected-failures/provider-timeout.test.ts
+++ b/tests/diagnostics/injected-failures/provider-timeout.test.ts
@@ -7,7 +7,7 @@ describe("provider timeout diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
+++ b/tests/diagnostics/injected-failures/sqlite-write-failure.test.ts
@@ -7,7 +7,7 @@ describe("SQLite write failure diagnostic", () => {
     const index = buildDiagnosticEvidenceIndex(
       baseDiagnosticSnapshot({
         observerHealth: {
-          schemaVersion: "0.8.0",
+          schemaVersion: "0.9.0",
           status: "degraded",
           pid: 1234,
           startedAt: diagnosticNow,

--- a/tests/diagnostics/injected-failures/stale-terminal-target.test.ts
+++ b/tests/diagnostics/injected-failures/stale-terminal-target.test.ts
@@ -16,6 +16,7 @@ describe("stale terminal target diagnostic", () => {
               id: "wt_web_stale",
               projectId: "web",
               projectLabel: "web",
+              title: "feature/stale-terminal",
               branch: "feature/stale-terminal",
               path: "/tmp/station/web/stale-terminal",
               worktree: { state: "exists", source: "worktrunk" },

--- a/tests/e2e/observer-lifecycle.test.ts
+++ b/tests/e2e/observer-lifecycle.test.ts
@@ -78,7 +78,7 @@ describe("observer lifecycle e2e", () => {
         code: "ENOENT",
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.8.0",
+        schemaVersion: "0.9.0",
         observer: { version: build.version },
         counts: { projects: 0 },
       });
@@ -858,7 +858,7 @@ describe("observer lifecycle e2e", () => {
         stateDir: fixture.stateDir,
       });
       await expect(client.getSnapshot()).resolves.toMatchObject({
-        schemaVersion: "0.8.0",
+        schemaVersion: "0.9.0",
         counts: { projects: 0 },
       });
     } finally {

--- a/tests/support/diagnostics/index.ts
+++ b/tests/support/diagnostics/index.ts
@@ -44,10 +44,10 @@ export function baseDiagnosticSnapshot(
   overrides: Partial<DiagnosticSnapshot> = {},
 ): DiagnosticSnapshot {
   const snapshot: DiagnosticSnapshot = {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     collectedAt: diagnosticNow,
     observerHealth: {
-      schemaVersion: "0.8.0",
+      schemaVersion: "0.9.0",
       status: "healthy",
       pid: 1234,
       startedAt: diagnosticNow,
@@ -65,7 +65,7 @@ export function baseDiagnosticSnapshot(
 
 export function baseStationSnapshot(overrides: Partial<StationSnapshot> = {}): StationSnapshot {
   const snapshot: StationSnapshot = {
-    schemaVersion: "0.8.0",
+    schemaVersion: "0.9.0",
     generatedAt: diagnosticNow,
     observer: {
       pid: 1234,


### PR DESCRIPTION
## What this fixes

Station treated the user-facing session name as lifecycle-specific session metadata, even though the worktree can outlive an agent session. Starting or resuming a fresh agent could therefore mint the correct new session ID while resetting the visible name to the branch.

This makes the display name durable for the worktree while keeping agent session identity lifecycle-specific. Closes #306.

## What changed

- Added canonical worktree display-title persistence keyed by `(projectId, worktreeId)`, including migration and deterministic legacy-title initialization.
- Made rename, reconcile initialization, session projection synchronization, and confirmed worktree retirement transactional and single-authority.
- Seeded create, fork, start, resume, and native external launches from canonical title authority before launch, with cleanup that preserves established names.
- Exposed `WorktreeRow.title` as snapshot authority and synchronized every active `SessionView.title` projection.
- Updated dashboard optimistic rename, sorting, filtering, client patches, fixtures, and schema version `0.9.0`.
- Documented the worktree-scoped naming model and refreshed generated Observer architecture evidence.

## Testing

- Focused title, launch, graph, projection, reducer, selector, contract, persistence, command, cleanup, and protocol suites: 279 tests passed.
- `pnpm --dir station typecheck` and `pnpm --dir station test`: 1,093 Station tests passed.
- Sanitized `pnpm test:all`: build, typecheck, lint, 1,841 unit tests, 52 contract tests, 573 integration tests (9 skipped), 73 diagnostics tests, 3 scripted-agent tests, 17 setup E2E tests, 19 Observer E2E tests, and installer smoke passed.
- `pnpm test:sqlite:bun`: Node/Bun migration compatibility, 50 alternating boot-claim races, 10 three-contender races, killed-owner recovery, and socket safety passed.
- `pnpm architecture:observer:check` and `git diff --check` passed.

## User-visible behavior

A renamed worktree keeps its session name while no agent is running and across a fresh agent launch, even though the new agent receives a new session ID.

## Safety and scope

This does not rename Git branches, paths, worktree IDs, session IDs, terminal targets, or provider recovery identities. Removing a confirmed worktree retires its title so a recreated identity starts from current evidence rather than stale authority.
