### PR TITLE
refactor(observer): dispatch harness providers through typed factories

### DIFF
--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -66,6 +66,23 @@ export type CreateProviderRegistryOptions = {
   providerHookIngressLauncher?: string | undefined;
 };
 
+type HarnessProviderBuilderContext = {
+  config: StationConfig;
+  providerConfig: HarnessProviderConfig | undefined;
+  registryOptions: CreateProviderRegistryOptions;
+};
+
+type HarnessProviderBuilder = (context: HarnessProviderBuilderContext) => HarnessProvider;
+type KnownHarnessProviderId =
+  | "scripted"
+  | "claude"
+  | "codex"
+  | "cursor"
+  | "opencode"
+  | "pi"
+  | "noop-harness";
+type HarnessProviderBuilderRegistry = Record<KnownHarnessProviderId, HarnessProviderBuilder>;
+
 /**
  * ADAPTER
  *
@@ -238,130 +255,200 @@ function createHarnessProviders(
   return Array.from(ids).map((id) => createHarnessProvider(id, config, options));
 }
 
+function buildScriptedHarnessProvider({
+  config,
+  providerConfig,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: ConstructorParameters<typeof ScriptedAgentHarnessProvider>[0] = {
+    stateDir: join(config.observer?.stateDir ?? process.cwd(), "scripted"),
+  };
+  if (providerConfig?.command !== undefined) {
+    options.nodeCommand = providerConfig.command;
+  }
+  return new ScriptedAgentHarnessProvider(options);
+}
+
+function buildClaudeHarnessProvider({
+  config,
+  providerConfig,
+  registryOptions,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: ClaudeHarnessProviderOptions = {};
+  if (providerConfig?.command !== undefined) {
+    options.command = providerConfig.command;
+  }
+  if (providerConfig?.profile !== undefined) {
+    options.profile = providerConfig.profile;
+  }
+  const permissionMode = resolveClaudePermissionMode(config);
+  if (permissionMode !== undefined) {
+    options.permissionMode = permissionMode;
+  }
+  if (providerConfig?.approvalPolicy !== undefined) {
+    options.approvalPolicy = providerConfig.approvalPolicy;
+  }
+  if (providerConfig?.sandboxMode !== undefined) {
+    options.sandboxMode = providerConfig.sandboxMode;
+  }
+  if (providerConfig?.installHooks !== undefined) {
+    options.installHooks = providerConfig.installHooks;
+  }
+  if (providerConfig?.resume !== undefined) {
+    options.resume = providerConfig.resume;
+  }
+  if (registryOptions.providerHookIngressLauncher !== undefined) {
+    options.hookBin = registryOptions.providerHookIngressLauncher;
+  }
+  applyObserverPaths(options, config, true);
+  return createClaudeHarnessProvider(options);
+}
+
+function buildCodexHarnessProvider({
+  config,
+  providerConfig,
+  registryOptions,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: CodexHarnessProviderOptions = {};
+  if (providerConfig?.command !== undefined) {
+    options.command = providerConfig.command;
+  }
+  const permissionMode = resolveHarnessPermissionMode(config, "codex");
+  if (permissionMode !== undefined) {
+    options.permissionMode = permissionMode;
+  }
+  if (providerConfig?.approvalPolicy !== undefined) {
+    options.approvalPolicy = providerConfig.approvalPolicy;
+  }
+  if (providerConfig?.sandboxMode !== undefined) {
+    options.sandboxMode = providerConfig.sandboxMode;
+  }
+  if (providerConfig?.installHooks !== undefined) {
+    options.installHooks = providerConfig.installHooks;
+  }
+  if (providerConfig?.profile !== undefined) {
+    options.profile = providerConfig.profile;
+  }
+  if (providerConfig?.resume !== undefined) {
+    options.resume = providerConfig.resume;
+  }
+  if (registryOptions.providerHookIngressLauncher !== undefined) {
+    options.hookBin = registryOptions.providerHookIngressLauncher;
+  }
+  applyObserverPaths(options, config, true);
+  return createCodexHarnessProvider(options);
+}
+
+function buildCursorHarnessProvider({
+  config,
+  providerConfig,
+  registryOptions,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: CursorHarnessProviderOptions = {};
+  if (providerConfig?.command !== undefined) {
+    options.command = providerConfig.command;
+  }
+  if (providerConfig?.installHooks !== undefined) {
+    options.installHooks = providerConfig.installHooks;
+  }
+  if (providerConfig?.resume !== undefined) {
+    options.resume = providerConfig.resume;
+  }
+  if (registryOptions.configPath !== undefined) {
+    options.configPath = registryOptions.configPath;
+  }
+  if (registryOptions.providerHookIngressLauncher !== undefined) {
+    options.hookBin = registryOptions.providerHookIngressLauncher;
+  }
+  applyObserverPaths(options, config, true);
+  return createCursorHarnessProvider(options);
+}
+
+function buildOpenCodeHarnessProvider({
+  config,
+  providerConfig,
+  registryOptions,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: OpenCodeHarnessProviderOptions = {};
+  if (providerConfig?.command !== undefined) {
+    options.command = providerConfig.command;
+  }
+  const permissionMode = resolveHarnessPermissionMode(config, "opencode");
+  if (permissionMode !== undefined) {
+    options.permissionMode = permissionMode;
+  }
+  if (providerConfig?.approvalPolicy !== undefined) {
+    options.approvalPolicy = providerConfig.approvalPolicy;
+  }
+  if (providerConfig?.sandboxMode !== undefined) {
+    options.sandboxMode = providerConfig.sandboxMode;
+  }
+  if (providerConfig?.installHooks !== undefined) {
+    options.installHooks = providerConfig.installHooks;
+  }
+  if (providerConfig?.profile !== undefined) {
+    options.profile = providerConfig.profile;
+  }
+  if (providerConfig?.resume !== undefined) {
+    options.resume = providerConfig.resume;
+  }
+  if (registryOptions.configPath !== undefined) {
+    options.configPath = registryOptions.configPath;
+  }
+  applyObserverPaths(options, config, false);
+  return createOpenCodeHarnessProvider(options);
+}
+
+function buildPiHarnessProvider({
+  config,
+  providerConfig,
+  registryOptions,
+}: HarnessProviderBuilderContext): HarnessProvider {
+  const options: PiHarnessProviderOptions = {};
+  if (providerConfig?.command !== undefined) {
+    options.command = providerConfig.command;
+  }
+  if (providerConfig?.resume !== undefined) {
+    options.resume = providerConfig.resume;
+  }
+  if (registryOptions.configPath !== undefined) {
+    options.configPath = registryOptions.configPath;
+  }
+  if (registryOptions.piExtensionPath !== undefined) {
+    options.extensionPath = registryOptions.piExtensionPath;
+  }
+  applyObserverPaths(options, config, false);
+  return createPiHarnessProvider(options);
+}
+
+function buildNoopHarnessProvider(): HarnessProvider {
+  return new NoopHarnessProvider("noop-harness");
+}
+
+const HARNESS_PROVIDER_BUILDERS = {
+  scripted: buildScriptedHarnessProvider,
+  claude: buildClaudeHarnessProvider,
+  codex: buildCodexHarnessProvider,
+  cursor: buildCursorHarnessProvider,
+  opencode: buildOpenCodeHarnessProvider,
+  pi: buildPiHarnessProvider,
+  "noop-harness": buildNoopHarnessProvider,
+} satisfies HarnessProviderBuilderRegistry;
+
 function createHarnessProvider(
   id: string,
   config: StationConfig,
   registryOptions: CreateProviderRegistryOptions,
 ): HarnessProvider {
-  const providerConfig = harnessProviderConfig(config, id);
-
-  if (id === "scripted") {
-    const options: ConstructorParameters<typeof ScriptedAgentHarnessProvider>[0] = {
-      stateDir: join(config.observer?.stateDir ?? process.cwd(), "scripted"),
-    };
-    if (providerConfig?.command !== undefined) {
-      options.nodeCommand = providerConfig.command;
-    }
-    return new ScriptedAgentHarnessProvider(options);
+  const builders = HARNESS_PROVIDER_BUILDERS as Partial<Record<string, HarnessProviderBuilder>>;
+  const builder = builders[id];
+  if (builder === undefined) {
+    return new UnavailableHarnessProvider(id);
   }
-
-  if (id === "claude") {
-    const options: ClaudeHarnessProviderOptions = {};
-    if (providerConfig?.command !== undefined) {
-      options.command = providerConfig.command;
-    }
-    if (providerConfig?.profile !== undefined) {
-      options.profile = providerConfig.profile;
-    }
-    const permissionMode = resolveClaudePermissionMode(config);
-    if (permissionMode !== undefined) {
-      options.permissionMode = permissionMode;
-    }
-    if (providerConfig?.approvalPolicy !== undefined) {
-      options.approvalPolicy = providerConfig.approvalPolicy;
-    }
-    if (providerConfig?.sandboxMode !== undefined) {
-      options.sandboxMode = providerConfig.sandboxMode;
-    }
-    if (providerConfig?.installHooks !== undefined) {
-      options.installHooks = providerConfig.installHooks;
-    }
-    if (providerConfig?.resume !== undefined) {
-      options.resume = providerConfig.resume;
-    }
-    if (registryOptions.providerHookIngressLauncher !== undefined) {
-      options.hookBin = registryOptions.providerHookIngressLauncher;
-    }
-    applyObserverPaths(options, config, true);
-    return createClaudeHarnessProvider(options);
-  }
-
-  if (id === "codex") {
-    const options: CodexHarnessProviderOptions = {};
-    applyHarnessAgentOptions(options, providerConfig, resolveHarnessPermissionMode(config, id));
-    if (providerConfig?.profile !== undefined) {
-      options.profile = providerConfig.profile;
-    }
-    if (providerConfig?.resume !== undefined) {
-      options.resume = providerConfig.resume;
-    }
-    if (registryOptions.providerHookIngressLauncher !== undefined) {
-      options.hookBin = registryOptions.providerHookIngressLauncher;
-    }
-    applyObserverPaths(options, config, true);
-    return createCodexHarnessProvider(options);
-  }
-
-  if (id === "cursor") {
-    const options: CursorHarnessProviderOptions = {};
-    if (providerConfig?.command !== undefined) {
-      options.command = providerConfig.command;
-    }
-    if (providerConfig?.installHooks !== undefined) {
-      options.installHooks = providerConfig.installHooks;
-    }
-    if (providerConfig?.resume !== undefined) {
-      options.resume = providerConfig.resume;
-    }
-    if (registryOptions.configPath !== undefined) {
-      options.configPath = registryOptions.configPath;
-    }
-    if (registryOptions.providerHookIngressLauncher !== undefined) {
-      options.hookBin = registryOptions.providerHookIngressLauncher;
-    }
-    applyObserverPaths(options, config, true);
-    return createCursorHarnessProvider(options);
-  }
-
-  if (id === "opencode") {
-    const options: OpenCodeHarnessProviderOptions = {};
-    applyHarnessAgentOptions(options, providerConfig, resolveHarnessPermissionMode(config, id));
-    if (providerConfig?.profile !== undefined) {
-      options.profile = providerConfig.profile;
-    }
-    if (providerConfig?.resume !== undefined) {
-      options.resume = providerConfig.resume;
-    }
-    if (registryOptions.configPath !== undefined) {
-      options.configPath = registryOptions.configPath;
-    }
-    applyObserverPaths(options, config, false);
-    return createOpenCodeHarnessProvider(options);
-  }
-
-  if (id === "pi") {
-    const options: PiHarnessProviderOptions = {};
-    if (providerConfig?.command !== undefined) {
-      options.command = providerConfig.command;
-    }
-    if (providerConfig?.resume !== undefined) {
-      options.resume = providerConfig.resume;
-    }
-    if (registryOptions.configPath !== undefined) {
-      options.configPath = registryOptions.configPath;
-    }
-    if (registryOptions.piExtensionPath !== undefined) {
-      options.extensionPath = registryOptions.piExtensionPath;
-    }
-    applyObserverPaths(options, config, false);
-    return createPiHarnessProvider(options);
-  }
-
-  if (id === "noop-harness") {
-    return new NoopHarnessProvider(id);
-  }
-
-  return new UnavailableHarnessProvider(id);
+  return builder({
+    config,
+    providerConfig: harnessProviderConfig(config, id),
+    registryOptions,
+  });
 }
 
 function createRepositoryProviders(config: StationConfig): RepositoryProvider[] {
@@ -431,28 +518,6 @@ function applyObserverPaths(
   if (withAutoStart) {
     options.autoStartFromHooks = config.observer?.autoStartFromHooks !== false;
   }
-}
-
-/** Permission/approval/sandbox/hook fields shared by the codex and opencode adapters. */
-function applyHarnessAgentOptions(
-  options: {
-    command?: string;
-    permissionMode?: HarnessPermissionMode;
-    approvalPolicy?: string;
-    sandboxMode?: string;
-    installHooks?: boolean;
-  },
-  providerConfig: HarnessProviderConfig | undefined,
-  permissionMode: HarnessPermissionMode | undefined,
-): void {
-  if (providerConfig?.command !== undefined) options.command = providerConfig.command;
-  if (permissionMode !== undefined) options.permissionMode = permissionMode;
-  if (providerConfig?.approvalPolicy !== undefined) {
-    options.approvalPolicy = providerConfig.approvalPolicy;
-  }
-  if (providerConfig?.sandboxMode !== undefined) options.sandboxMode = providerConfig.sandboxMode;
-  if (providerConfig?.installHooks !== undefined)
-    options.installHooks = providerConfig.installHooks;
 }
 
 function health(providerId: string, providerType: ProviderHealth["providerType"]): ProviderHealth {

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -1,19 +1,55 @@
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createClaudeHarnessProvider } from "@station/claude";
+import { createCodexHarnessProvider } from "@station/codex";
 import {
   DEFAULT_WORKSPACE_CONFIG,
   HarnessProvidersConfigSchema,
   loadConfig,
+  resolveObserverPaths,
   type StationConfig,
 } from "@station/config";
 import * as contracts from "@station/contracts";
-import { installCursorHooks } from "@station/cursor";
-import { openCodeHookAdapter } from "@station/opencode";
+import { createCursorHarnessProvider, installCursorHooks } from "@station/cursor";
+import { createOpenCodeHarnessProvider, openCodeHookAdapter } from "@station/opencode";
 import { createPiHarnessProvider } from "@station/pi";
+import { ScriptedAgentHarnessProvider } from "@station/scripted-harness";
 import { createStationHostController } from "@station/terminal";
 import { describe, expect, it, vi } from "vitest";
 import { createProviderRegistry, probeHarnessHooksStatus } from "../../src/observerProviders";
+
+vi.mock("@station/claude", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@station/claude")>();
+  return {
+    ...actual,
+    createClaudeHarnessProvider: vi.fn(actual.createClaudeHarnessProvider),
+  };
+});
+
+vi.mock("@station/codex", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@station/codex")>();
+  return {
+    ...actual,
+    createCodexHarnessProvider: vi.fn(actual.createCodexHarnessProvider),
+  };
+});
+
+vi.mock("@station/cursor", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@station/cursor")>();
+  return {
+    ...actual,
+    createCursorHarnessProvider: vi.fn(actual.createCursorHarnessProvider),
+  };
+});
+
+vi.mock("@station/opencode", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@station/opencode")>();
+  return {
+    ...actual,
+    createOpenCodeHarnessProvider: vi.fn(actual.createOpenCodeHarnessProvider),
+  };
+});
 
 vi.mock("@station/terminal", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@station/terminal")>();
@@ -242,6 +278,199 @@ describe("observer providers", () => {
     });
 
     expect([...allBuiltIns.harnesses.keys()]).toEqual(["codex", "cursor", "pi", "opencode"]);
+  });
+
+  it("dispatches every known harness id through its registered provider builder", async () => {
+    vi.mocked(createClaudeHarnessProvider).mockClear();
+    vi.mocked(createCodexHarnessProvider).mockClear();
+    vi.mocked(createCursorHarnessProvider).mockClear();
+    vi.mocked(createOpenCodeHarnessProvider).mockClear();
+    vi.mocked(createPiHarnessProvider).mockClear();
+    const registry = createProviderRegistry({
+      ...config,
+      defaults: { ...config.defaults, harness: "claude" },
+      projects: [
+        {
+          ...firstProject(),
+          defaults: { ...firstProject().defaults, harness: "codex" },
+        },
+      ],
+      harness: {
+        scripted: {},
+        claude: {},
+        codex: {},
+        cursor: {},
+        opencode: {},
+        pi: {},
+        "noop-harness": {},
+      },
+    });
+
+    expect([...registry.harnesses.keys()]).toEqual([
+      "claude",
+      "codex",
+      "scripted",
+      "cursor",
+      "opencode",
+      "pi",
+      "noop-harness",
+    ]);
+    expect(createClaudeHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(createCodexHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(createCursorHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(createOpenCodeHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(createPiHarnessProvider).toHaveBeenCalledTimes(1);
+    expect(registry.harnesses.get("scripted")).toBeInstanceOf(ScriptedAgentHarnessProvider);
+    await expect(registry.harnesses.get("noop-harness")?.health()).resolves.toMatchObject({
+      providerId: "noop-harness",
+      status: "healthy",
+    });
+  });
+
+  it("constructs only provider-supported runtime options", async () => {
+    vi.mocked(createClaudeHarnessProvider).mockClear();
+    vi.mocked(createCodexHarnessProvider).mockClear();
+    vi.mocked(createCursorHarnessProvider).mockClear();
+    vi.mocked(createOpenCodeHarnessProvider).mockClear();
+    vi.mocked(createPiHarnessProvider).mockClear();
+    const stateDir = "/tmp/station/provider-table-state";
+    const observerSocketPath = "/tmp/station/provider-table-observer.sock";
+    const configPath = "/tmp/station/provider-table-config.toml";
+    const ingressLauncher = "/tmp/station/bin/stn-ingress";
+    const piExtensionPath = "/tmp/station/assets/pi-extension.mjs";
+    const providerConfig: StationConfig = {
+      ...config,
+      observer: {
+        stateDir,
+        socketPath: observerSocketPath,
+        autoStartFromHooks: false,
+      },
+      defaults: {
+        ...config.defaults,
+        harness: "claude",
+        harnessPermissionMode: "yolo",
+      },
+      projects: [
+        {
+          ...firstProject(),
+          defaults: { ...firstProject().defaults, harness: "codex" },
+        },
+      ],
+      harness: {
+        scripted: { command: "node-scripted" },
+        claude: {
+          command: "claude-custom",
+          profile: "claude-profile",
+          permissionMode: "standard",
+          approvalPolicy: "claude-approval",
+          sandboxMode: "claude-sandbox",
+          installHooks: true,
+          resume: true,
+        },
+        codex: {
+          command: "codex-custom",
+          profile: "codex-profile",
+          permissionMode: "standard",
+          approvalPolicy: "codex-approval",
+          sandboxMode: "codex-sandbox",
+          installHooks: true,
+          resume: true,
+        },
+        cursor: { command: "cursor-custom", installHooks: true, resume: true },
+        opencode: {
+          command: "opencode-custom",
+          profile: "opencode-profile",
+          permissionMode: "standard",
+          approvalPolicy: "opencode-approval",
+          sandboxMode: "opencode-sandbox",
+          installHooks: true,
+          resume: true,
+        },
+        pi: { command: "pi-custom", resume: true },
+      },
+    };
+
+    const registry = createProviderRegistry(providerConfig, {
+      configPath,
+      piExtensionPath,
+      providerHookIngressLauncher: ingressLauncher,
+    });
+    const observerPaths = resolveObserverPaths(providerConfig);
+    expect(vi.mocked(createClaudeHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
+      command: "claude-custom",
+      profile: "claude-profile",
+      permissionMode: "standard",
+      approvalPolicy: "claude-approval",
+      sandboxMode: "claude-sandbox",
+      installHooks: true,
+      resume: true,
+      hookBin: ingressLauncher,
+      observerSocketPath: observerPaths.socketPath,
+      stateDir: observerPaths.stateDir,
+      hookSpoolDir: observerPaths.hookSpoolDir,
+      autoStartFromHooks: false,
+    });
+    expect(vi.mocked(createCodexHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
+      command: "codex-custom",
+      profile: "codex-profile",
+      permissionMode: "standard",
+      approvalPolicy: "codex-approval",
+      sandboxMode: "codex-sandbox",
+      installHooks: true,
+      resume: true,
+      hookBin: ingressLauncher,
+      observerSocketPath: observerPaths.socketPath,
+      stateDir: observerPaths.stateDir,
+      hookSpoolDir: observerPaths.hookSpoolDir,
+      autoStartFromHooks: false,
+    });
+    expect(vi.mocked(createCursorHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
+      command: "cursor-custom",
+      installHooks: true,
+      resume: true,
+      configPath,
+      hookBin: ingressLauncher,
+      observerSocketPath: observerPaths.socketPath,
+      stateDir: observerPaths.stateDir,
+      hookSpoolDir: observerPaths.hookSpoolDir,
+      autoStartFromHooks: false,
+    });
+    expect(vi.mocked(createOpenCodeHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
+      command: "opencode-custom",
+      profile: "opencode-profile",
+      permissionMode: "standard",
+      approvalPolicy: "opencode-approval",
+      sandboxMode: "opencode-sandbox",
+      installHooks: true,
+      resume: true,
+      configPath,
+      observerSocketPath: observerPaths.socketPath,
+      stateDir: observerPaths.stateDir,
+      hookSpoolDir: observerPaths.hookSpoolDir,
+    });
+    expect(vi.mocked(createPiHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
+      command: "pi-custom",
+      resume: true,
+      configPath,
+      extensionPath: piExtensionPath,
+      observerSocketPath: observerPaths.socketPath,
+      stateDir: observerPaths.stateDir,
+      hookSpoolDir: observerPaths.hookSpoolDir,
+    });
+
+    const scripted = registry.harnesses.get("scripted");
+    await expect(scripted?.buildLaunch(launchRequest("scripted"))).resolves.toMatchObject({
+      provider: "scripted",
+      command: "node-scripted",
+      env: { STATION_SCRIPTED_STATE_DIR: join(stateDir, "scripted") },
+      providerData: { stateDir: join(stateDir, "scripted") },
+    });
+    await expect(
+      registry.harnesses.get("opencode")?.buildLaunch(launchRequest("opencode")),
+    ).resolves.toMatchObject({
+      provider: "opencode",
+      command: "opencode-custom",
+    });
   });
 
   it("forwards a prepared extension path only to the Pi provider", () => {
@@ -969,6 +1198,27 @@ const config: StationConfig = {
     },
   ],
 };
+
+function launchRequest(harness: string): Parameters<contracts.HarnessProvider["buildLaunch"]>[0] {
+  const project = firstProject();
+  return {
+    project: {
+      ...project,
+      defaults: { ...project.defaults, harness },
+    },
+    worktree: {
+      id: "wt_web_task",
+      provider: "worktrunk",
+      projectId: project.id,
+      branch: "task",
+      path: "/tmp/station/web/task",
+      state: "exists",
+      source: "worktrunk",
+      observedAt: now,
+    },
+    mode: "interactive",
+  };
+}
 
 function firstProject(): StationConfig["projects"][number] {
   const project = config.projects[0];


### PR DESCRIPTION
## What this fixes

The CLI composition root selected harness adapters through a growing provider-name conditional. That mixed dispatch with provider-specific construction and made it easy to pass unsupported runtime options as integrations evolved.

## What changed

- Added a typed harness-builder context and one builder per supported provider.
- Replaced provider selection with the typed `HARNESS_PROVIDER_BUILDERS` table and a lookup/invoke/fallback dispatcher.
- Kept provider-specific runtime options explicit, including permission precedence, executable paths, auto-start behavior, and Pi extension injection.
- Preserved the free-form fallback for unknown provider names.
- Expanded composition tests to characterize known-provider dispatch and the exact options supported by each adapter.

## Testing

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/observerProviders.test.ts` (26 passed)
- `pnpm --filter @station/cli typecheck`
- Biome cognitive-complexity gate at 15 for the changed production file
- `pnpm lint` via pre-commit and pre-push hooks
