### PR TITLE
refactor(station): extract managed launch phases

### DIFF
--- a/station/src/input/runtime/managedLaunch.ts
+++ b/station/src/input/runtime/managedLaunch.ts
@@ -1,11 +1,8 @@
-import { StationHostProviderError } from "@station/host";
 import type { ManagedTerminalAttacher } from "../../terminal/pty/managedTerminalAttacher.js";
 import type { PtyRegistry } from "../../terminal/registry/ptyRegistry.js";
-import type { StationTerminalSpawnOptions } from "../../terminal/types.js";
 import type { StoreApi } from "zustand/vanilla";
-import { selectPaneRecord } from "../../state/selectors.js";
 import type { StationStore } from "../../state/store.js";
-import { agentWorktreePaneId, type AgentIdentity, type PaneId } from "../../state/types.js";
+import { agentWorktreePaneId, type PaneId } from "../../state/types.js";
 import { dispatchStationKey } from "../../station/input/stationActions.js";
 import { safeErrorToNotice, toSafeError, type ObserverService } from "@station/client";
 import type { ProviderId, StationCommand } from "@station/contracts";
@@ -14,38 +11,13 @@ import {
   removeCreateSessionLocalRow,
   type TuiStore,
 } from "@station/dashboard-core";
+import { inheritedForkHarness, waitForWorktreeByBranch } from "./stationRows.js";
 import {
-  externalTerminalProviderForWorktree,
-  inheritedForkHarness,
-  nonFocusableStationTerminalForWorktree,
-  readinessForWorktree,
-  unreachableTerminalRow,
-  waitForWorktreeByBranch,
-} from "./stationRows.js";
+  createManagedLaunchAttempt,
+  type ManagedLaunchTarget,
+} from "./managedLaunchAttempt.js";
 
-/** What a managed primary-agent launch needs to ask the observer to prepare it. */
-export type ManagedLaunchTarget = {
-  projectId: string;
-  worktreeId: string;
-  cwd: string;
-  /**
-   * User-visible title to persist only when this preparation mints a fresh
-   * session; an existing session keeps its current title.
-   */
-  title?: string;
-  /**
-   * Harness to launch when minting a fresh session (the New Session wizard's
-   * pick). Absent for a row click, where the observer uses the worktree's
-   * remembered harness or the project default.
-   */
-  harness?: ProviderId;
-  /**
-   * Spawn the agent pane but leave the STATION overlay open and unfocused — the New
-   * Session flow stays on the dashboard instead of focusing the pane. A row click
-   * omits this and focuses the new pane.
-   */
-  background?: boolean;
-};
+export type { ManagedLaunchTarget } from "./managedLaunchAttempt.js";
 
 export type ManagedLaunch = {
   /**
@@ -85,12 +57,8 @@ type ManagedLaunchDeps = {
 };
 
 export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
-  const { store, stationViewStore, observerService, registry, managedTerminalAttacher } = deps;
-  // Guards a managed launch's async window: between a click's synchronous return
-  // and its `prepareExternalLaunch` resolving, no pane record exists yet, so a
-  // second click would otherwise fire a second prepare for the same pane and
-  // orphan an observer session/target. Keyed by the deterministic agent pane id.
-  const launchesInFlight = new Set<PaneId>();
+  const { stationViewStore, observerService } = deps;
+  const runManagedLaunchAttempt = createManagedLaunchAttempt(deps);
 
   function pushLaunchToast(message: string, kind: "info" | "error" = "error"): void {
     stationViewStore?.getState().pushToast({ kind, message });
@@ -114,204 +82,6 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
   function closeNewSessionWizard(): void {
     if (stationViewStore !== undefined && stationViewStore.getState().screen.name === "newSession") {
       dispatchStationKey(stationViewStore, { input: "", escape: true });
-    }
-  }
-
-  async function acknowledgeTurnReadiness(
-    readiness: { sessionId: string; token: string } | undefined,
-  ): Promise<void> {
-    if (readiness === undefined || observerService === undefined) {
-      return;
-    }
-    try {
-      const receipt = await observerService.dispatch({
-        type: "session.acknowledgeTurn",
-        payload: readiness,
-      });
-      if (receipt.accepted) {
-        await observerService.waitForCommandCompletion(receipt.commandId);
-      }
-    } catch {
-      // Opening the pane succeeded; a best-effort acknowledgement must not turn
-      // that successful focus into an error path.
-    }
-  }
-
-  async function focusExistingSession(sessionId: string): Promise<boolean> {
-    if (observerService === undefined) {
-      pushLaunchToast("No observer connection; cannot focus the existing agent.");
-      return false;
-    }
-    try {
-      const receipt = await observerService.dispatch({ type: "terminal.focus", payload: { sessionId } });
-      if (!receipt.accepted) {
-        pushLaunchError(
-          receipt.error ?? {
-            tag: "ClientObserverError",
-            code: "STATION_FOCUS_REJECTED",
-            message: "Station could not focus the existing agent.",
-          },
-        );
-        return false;
-      }
-      const completion = await observerService.waitForCommandCompletion(receipt.commandId);
-      if (completion.status === "failed") {
-        pushLaunchError(completion.error);
-        return false;
-      }
-      return true;
-    } catch (error: unknown) {
-      pushLaunchError(error);
-      return false;
-    }
-  }
-
-  /** Close the overlay onto the opened pane and acknowledge a ready turn (best-effort). */
-  async function landOnPane(turnReadiness: { sessionId: string; token: string } | undefined): Promise<void> {
-    store.actions.closeOverlay();
-    await acknowledgeTurnReadiness(turnReadiness);
-  }
-
-  // Seed the registry entry (observer-built command/args/env) *before* createPane, same ordering
-  // reason openPane documents, then record the STATION identity so the agent's exit can be reported.
-  async function runManagedLaunch(paneId: PaneId, target: ManagedLaunchTarget): Promise<void> {
-    // A background launch (New Session) keeps the overlay open; a row click focuses the pane.
-    const landInPane = target.background !== true;
-    const turnReadiness =
-      stationViewStore === undefined ? undefined : readinessForWorktree(stationViewStore, target.worktreeId);
-    if (selectPaneRecord(store.getState(), paneId) !== null) {
-      if (landInPane) {
-        store.actions.revealPane(paneId);
-        await landOnPane(turnReadiness);
-      }
-      return;
-    }
-    // A detached/stale terminal is running but not attached anywhere Station can render; report
-    // where it lives instead of dispatching a terminal.focus the observer accepts yet paints
-    // nothing. Open terminals fall through below.
-    const unreachable =
-      stationViewStore === undefined ? undefined : unreachableTerminalRow(stationViewStore, target.worktreeId);
-    if (unreachable !== undefined) {
-      pushLaunchToast(
-        `${unreachable.label}: agent is ${unreachable.state} under '${unreachable.provider}'; Station can't focus it here.`,
-        "info",
-      );
-      return;
-    }
-    // A launch for this pane is already underway (its pane record does not exist
-    // yet); a second click must not fire a second prepare.
-    if (launchesInFlight.has(paneId)) {
-      return;
-    }
-    if (observerService === undefined) {
-      pushLaunchToast("No observer connection; cannot launch the agent.");
-      return;
-    }
-    launchesInFlight.add(paneId);
-    try {
-      let prepared: Awaited<ReturnType<ObserverService["prepareExternalLaunch"]>>;
-      try {
-        const prepareParams: Parameters<ObserverService["prepareExternalLaunch"]>[0] = {
-          projectId: target.projectId,
-          worktreeId: target.worktreeId,
-        };
-        // Honor the New Session wizard's harness pick when minting a fresh session;
-        // a row click leaves it absent (observer uses remembered/default).
-        if (target.harness !== undefined) {
-          prepareParams.harness = target.harness;
-        }
-        if (target.title !== undefined) {
-          prepareParams.title = target.title;
-        }
-        prepared = await observerService.prepareExternalLaunch(prepareParams);
-      } catch (error) {
-        pushLaunchError(error);
-        return;
-      }
-      // Resolve an advertised attachment before touching the registry or store.
-      // Failure is terminal for this launch: falling through would double-spawn locally.
-      if (prepared.attachment !== undefined) {
-        if (managedTerminalAttacher === undefined) {
-          pushLaunchError(
-            new StationHostProviderError("HOST_UNREACHABLE", "Station host is not reachable."),
-          );
-          return;
-        }
-        let createTerminal: Awaited<ReturnType<ManagedTerminalAttacher["resolve"]>>;
-        try {
-          createTerminal = await managedTerminalAttacher.resolve(prepared.attachment);
-        } catch (error) {
-          pushLaunchError(error);
-          return;
-        }
-        registry?.ensure(paneId, { cwd: target.cwd }, createTerminal);
-        store.actions.createPane(paneId, { role: "primary-agent" });
-        const identity: AgentIdentity = {
-          sessionId: prepared.sessionId,
-          terminalTargetId: prepared.attachment.terminalTargetId,
-          harnessProvider:
-            prepared.kind === "prepared" ? prepared.launchPlan.provider : prepared.harnessProvider,
-        };
-        store.actions.setPrimaryAgent(paneId, identity);
-        if (landInPane) {
-          await landOnPane(turnReadiness);
-        }
-        return;
-      }
-
-      if (prepared.kind === "existing-session") {
-        // A live agent already holds this worktree. If it runs in an external terminal (tmux)
-        // Station can't render, say so — focusing would have no visible effect; otherwise focus it.
-        const nonFocusableStation =
-          stationViewStore !== undefined
-            ? nonFocusableStationTerminalForWorktree(stationViewStore, target.worktreeId)
-            : undefined;
-        if (nonFocusableStation !== undefined) {
-          pushLaunchToast(
-            `${nonFocusableStation.label}: Station has no attachable host PTY for this existing agent.`,
-            "info",
-          );
-          return;
-        }
-        const externalProvider =
-          stationViewStore !== undefined
-            ? externalTerminalProviderForWorktree(stationViewStore, target.worktreeId)
-            : undefined;
-        if (externalProvider !== undefined) {
-          // Keep the overlay open: this is an informational notice, not an open. Closing would flash
-          // the toast away before the user could read it.
-          pushLaunchToast(
-            `This agent runs in the "${externalProvider}" terminal, which Station can't display. Attach to it from a ${externalProvider} client.`,
-            "info",
-          );
-          return;
-        }
-        if (landInPane && (await focusExistingSession(prepared.sessionId))) {
-          await landOnPane(turnReadiness);
-        }
-        return;
-      }
-      const { launchPlan, sessionId, terminalTargetId } = prepared;
-      const spawnOptions: StationTerminalSpawnOptions = {
-        cwd: target.cwd,
-        command: launchPlan.command,
-        args: launchPlan.args,
-      };
-      if (launchPlan.env !== undefined) {
-        spawnOptions.env = launchPlan.env;
-      }
-      registry?.ensure(paneId, spawnOptions);
-      store.actions.createPane(paneId, { role: "primary-agent" });
-      store.actions.setPrimaryAgent(paneId, {
-        sessionId,
-        terminalTargetId,
-        harnessProvider: launchPlan.provider,
-      });
-      if (landInPane) {
-        await landOnPane(turnReadiness);
-      }
-    } finally {
-      launchesInFlight.delete(paneId);
     }
   }
 
@@ -359,6 +129,11 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
     });
   }
 
+  function missingWorktreeMessage(verb: HostedWorktreeLaunch["verb"]): string {
+    const completedVerb = verb === "create" ? "Created" : "Forked";
+    return `${completedVerb} the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.`;
+  }
+
   async function runHostedWorktreeLaunch(spec: HostedWorktreeLaunch): Promise<void> {
     if (observerService === undefined) {
       clearPendingCreateRow(spec.localId);
@@ -391,10 +166,7 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
     const row = await waitForWorktreeByBranch(stationViewStore, spec.projectId, spec.branch);
     if (row === undefined) {
       clearPendingCreateRow(spec.localId);
-      pushLaunchToast(
-        `${spec.verb === "create" ? "Created" : "Forked"} the worktree, but it didn't appear in time to launch the agent — open it from the dashboard.`,
-        "info",
-      );
+      pushLaunchToast(missingWorktreeMessage(spec.verb), "info");
       return;
     }
     const launchTarget: ManagedLaunchTarget = {
@@ -407,14 +179,14 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
     if (spec.harness !== undefined) {
       launchTarget.harness = spec.harness;
     }
-    await runManagedLaunch(agentWorktreePaneId(row.id), launchTarget);
+    await runManagedLaunchAttempt(agentWorktreePaneId(row.id), launchTarget);
   }
 
   return {
     launchPrimaryAgent: (paneId, target) => {
       // Fire-and-forget so executeOutcome stays synchronous; any throw becomes a toast, never an
       // unhandled rejection, so the failures-toast contract holds end to end.
-      void runManagedLaunch(paneId, target).catch((error) => {
+      void runManagedLaunchAttempt(paneId, target).catch((error) => {
         pushLaunchError(error);
       });
     },

--- a/station/src/input/runtime/managedLaunchAttempt.test.ts
+++ b/station/src/input/runtime/managedLaunchAttempt.test.ts
@@ -1,0 +1,558 @@
+import { describe, expect, it } from "bun:test";
+import type { AgentPrepareExternalLaunchParams, AgentPrepareExternalLaunchResult } from "@station/client";
+import type { StationCommand, StationSnapshot, WorktreeRow } from "@station/contracts";
+import { createTuiStore } from "@station/dashboard-core";
+import { selectStationOverlayVisible } from "../../state/selectors.js";
+import { createStationStore } from "../../state/store.js";
+import { STATION_OVERLAY_ID, type PaneId } from "../../state/types.js";
+import { manyProjectsSnapshot } from "../../station/fixtures/scenarios.js";
+import { FakeTuiObserverService } from "../../station/test/support/fakeObserverService.js";
+import { FakeStationSource } from "../../station/test/support/fakeStationSource.js";
+import type {
+  ManagedTerminalAttacher,
+  ManagedTerminalFactory,
+} from "../../terminal/pty/managedTerminalAttacher.js";
+import { createPtyRegistry, type PtyRegistry } from "../../terminal/registry/ptyRegistry.js";
+import { createScriptedTerminal } from "../../terminal/testing/scriptedTerminal.js";
+import type { StationTerminalSpawnOptions } from "../../terminal/types.js";
+import {
+  createManagedLaunchAttempt,
+  type ManagedLaunchTarget,
+} from "./managedLaunchAttempt.js";
+
+const WORKTREE_ID = "wt_station_idle";
+const ROW_ID = "ses_wt_station_idle";
+const PANE_ID = "agent:wt_station_idle" as PaneId;
+const CWD = "/Users/example/.worktrees/station/pty-buffer";
+const TERMINAL_TARGET_ID = `native:${WORKTREE_ID}`;
+const TARGET: ManagedLaunchTarget = {
+  projectId: "station",
+  worktreeId: WORKTREE_ID,
+  cwd: CWD,
+};
+
+function preparedPlan(
+  env: Record<string, string> | undefined = {
+    STATION_SESSION_ID: "ses_managed",
+    STATION_TERMINAL_TARGET_ID: TERMINAL_TARGET_ID,
+  },
+): AgentPrepareExternalLaunchResult {
+  const launchPlan: Extract<AgentPrepareExternalLaunchResult, { kind: "prepared" }>["launchPlan"] = {
+    provider: "codex",
+    command: "codex-custom",
+    args: ["--exec", "task"],
+    cwd: CWD,
+    mode: "interactive",
+  };
+  if (env !== undefined) {
+    launchPlan.env = env;
+  }
+  return {
+    kind: "prepared",
+    sessionId: "ses_managed",
+    terminalTargetId: TERMINAL_TARGET_ID,
+    launchPlan,
+  };
+}
+
+function stationHostedSnapshot(): StationSnapshot {
+  const snapshot = manyProjectsSnapshot();
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row): WorktreeRow => {
+      if (row.id !== WORKTREE_ID || row.terminal === undefined) {
+        return row;
+      }
+      return { ...row, terminal: { ...row.terminal, provider: "native", focusable: false } };
+    }),
+    sessions: snapshot.sessions.map((session) => {
+      if (session.id !== ROW_ID || session.terminal === undefined) {
+        return session;
+      }
+      return {
+        ...session,
+        terminal: { ...session.terminal, provider: "native", focusable: false },
+      };
+    }),
+  };
+}
+
+function withoutTerminal(snapshot: StationSnapshot = manyProjectsSnapshot()): StationSnapshot {
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row): WorktreeRow => {
+      if (row.id !== WORKTREE_ID) {
+        return row;
+      }
+      const next = { ...row };
+      delete next.terminal;
+      return next;
+    }),
+    sessions: snapshot.sessions.map((session) => {
+      if (session.id !== ROW_ID) {
+        return session;
+      }
+      const next = { ...session };
+      delete next.terminal;
+      return next;
+    }),
+  };
+}
+
+function withDetachedTerminal(): StationSnapshot {
+  const snapshot = manyProjectsSnapshot();
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row): WorktreeRow =>
+      row.id === WORKTREE_ID && row.terminal !== undefined
+        ? { ...row, terminal: { ...row.terminal, state: "detached" } }
+        : row,
+    ),
+    sessions: snapshot.sessions.map((session) =>
+      session.id === ROW_ID && session.terminal !== undefined
+        ? { ...session, terminal: { ...session.terminal, state: "detached" } }
+        : session,
+    ),
+  };
+}
+
+function withTurnReadiness(): StationSnapshot {
+  const snapshot = manyProjectsSnapshot();
+  return {
+    ...snapshot,
+    rows: snapshot.rows.map((row): WorktreeRow => {
+      if (row.id !== WORKTREE_ID || row.agent === undefined) {
+        return row;
+      }
+      return {
+        ...row,
+        agent: {
+          ...row.agent,
+          turnReadiness: {
+            state: "ready_to_read",
+            token: "report_station_ready",
+            completedAt: "2026-06-17T12:00:00.000Z",
+          },
+        },
+      };
+    }),
+  };
+}
+
+type AttemptHarnessOptions = {
+  prepared?: AgentPrepareExternalLaunchResult;
+  snapshot?: StationSnapshot;
+  observer?: boolean;
+  registry?: boolean;
+  attacher?: ManagedTerminalAttacher;
+  prepare?: (
+    params: AgentPrepareExternalLaunchParams,
+  ) => Promise<AgentPrepareExternalLaunchResult>;
+};
+
+function attemptHarness(options: AttemptHarnessOptions = {}) {
+  const snapshot = options.snapshot ?? manyProjectsSnapshot();
+  const observerService = new FakeTuiObserverService(snapshot);
+  observerService.nextPreparedLaunch = options.prepared ?? preparedPlan();
+  const prepareCalls: AgentPrepareExternalLaunchParams[] = [];
+  const prepare = options.prepare;
+  observerService.prepareExternalLaunch = async (params) => {
+    prepareCalls.push(params);
+    return prepare === undefined ? observerService.nextPreparedLaunch : await prepare(params);
+  };
+  const stationViewStore = createTuiStore({
+    source: new FakeStationSource(snapshot),
+    service: observerService,
+    initialSnapshot: snapshot,
+    persistentPopup: true,
+    onDismiss: async () => {},
+    initialState: { terminalRows: 12 },
+  });
+  const scripted = createScriptedTerminal();
+  const baseRegistry = createPtyRegistry({ createTerminal: () => scripted.terminal });
+  const calls: string[] = [];
+  const ensured: StationTerminalSpawnOptions[] = [];
+  const terminalFactories: ManagedTerminalFactory[] = [];
+  const registry: PtyRegistry = {
+    ...baseRegistry,
+    ensure: (paneId, spawnOptions, createTerminalOverride) => {
+      calls.push(`ensure:${paneId}`);
+      if (spawnOptions !== undefined) {
+        ensured.push(spawnOptions);
+      }
+      if (createTerminalOverride !== undefined) {
+        terminalFactories.push(createTerminalOverride);
+      }
+      return baseRegistry.ensure(paneId, spawnOptions, createTerminalOverride);
+    },
+  };
+  const store = createStationStore();
+  const createPane = store.actions.createPane;
+  store.actions.createPane = (paneId, createOptions) => {
+    calls.push(`pane:${paneId}:${createOptions?.role ?? "shell"}`);
+    createPane(paneId, createOptions);
+  };
+  const setPrimaryAgent = store.actions.setPrimaryAgent;
+  store.actions.setPrimaryAgent = (paneId, identity) => {
+    calls.push(`identity:${paneId}:${identity.sessionId}`);
+    setPrimaryAgent(paneId, identity);
+  };
+  const revealPane = store.actions.revealPane;
+  store.actions.revealPane = (paneId) => {
+    calls.push(`reveal:${paneId}`);
+    revealPane(paneId);
+  };
+  const runManagedLaunchAttempt = createManagedLaunchAttempt({
+    store,
+    stationViewStore,
+    observerService: options.observer === false ? undefined : observerService,
+    registry: options.registry === false ? undefined : registry,
+    managedTerminalAttacher: options.attacher,
+  });
+  return {
+    store,
+    stationViewStore,
+    observerService,
+    prepareCalls,
+    calls,
+    ensured,
+    terminalFactories,
+    runManagedLaunchAttempt,
+    lastToast: () => stationViewStore.getState().toasts.at(-1)?.toast,
+  };
+}
+
+function openOverlay(harness: ReturnType<typeof attemptHarness>): void {
+  harness.store.actions.openOverlay(STATION_OVERLAY_ID);
+}
+
+describe("createManagedLaunchAttempt", () => {
+  it("reveals an existing pane without preparing, while a background attempt does neither", async () => {
+    const foreground = attemptHarness();
+    foreground.store.actions.createPane(PANE_ID, { role: "primary-agent" });
+    foreground.calls.length = 0;
+    openOverlay(foreground);
+
+    await foreground.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(foreground.prepareCalls).toEqual([]);
+    expect(foreground.calls).toEqual([`reveal:${PANE_ID}`]);
+    expect(selectStationOverlayVisible(foreground.store.getState())).toBe(false);
+
+    const background = attemptHarness();
+    background.store.actions.createPane(PANE_ID, { role: "primary-agent" });
+    background.calls.length = 0;
+    openOverlay(background);
+
+    await background.runManagedLaunchAttempt(PANE_ID, { ...TARGET, background: true });
+
+    expect(background.prepareCalls).toEqual([]);
+    expect(background.calls).toEqual([]);
+    expect(selectStationOverlayVisible(background.store.getState())).toBe(true);
+  });
+
+  it("reports a detached terminal without preparing or closing the overlay", async () => {
+    const harness = attemptHarness({ snapshot: withDetachedTerminal() });
+    openOverlay(harness);
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(harness.prepareCalls).toEqual([]);
+    expect(harness.lastToast()).toMatchObject({ kind: "info" });
+    expect(harness.lastToast()?.message).toContain("detached");
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
+  });
+
+  it("deduplicates preparation while one pane launch is in flight", async () => {
+    let release!: (result: AgentPrepareExternalLaunchResult) => void;
+    const gate = new Promise<AgentPrepareExternalLaunchResult>((resolve) => {
+      release = resolve;
+    });
+    const harness = attemptHarness({ prepare: async () => await gate });
+
+    const first = harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+    const duplicate = harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+    await Promise.resolve();
+
+    expect(harness.prepareCalls).toHaveLength(1);
+    release(preparedPlan());
+    await Promise.all([first, duplicate]);
+  });
+
+  it("releases the in-flight guard after a failed preparation so retry is accepted", async () => {
+    let attempts = 0;
+    const harness = attemptHarness({
+      prepare: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error("prepare failed");
+        }
+        return preparedPlan();
+      },
+    });
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(harness.prepareCalls).toHaveLength(2);
+    expect(harness.calls).toEqual([
+      `ensure:${PANE_ID}`,
+      `pane:${PANE_ID}:primary-agent`,
+      `identity:${PANE_ID}:ses_managed`,
+    ]);
+  });
+
+  it("resolves an advertised attachment before ensure, pane, and identity publication", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-host`,
+    } as const;
+    const base = preparedPlan();
+    if (base.kind !== "prepared") {
+      throw new Error("expected a prepared launch fixture");
+    }
+    const order: string[] = [];
+    const scripted = createScriptedTerminal();
+    const factory: ManagedTerminalFactory = () => scripted.terminal;
+    const harness = attemptHarness({
+      prepared: { ...base, attachment },
+      attacher: {
+        resolve: async () => {
+          order.push("resolve");
+          return factory;
+        },
+      },
+    });
+    const originalPush = harness.calls.push.bind(harness.calls);
+    harness.calls.push = (...items) => {
+      order.push(...items);
+      return originalPush(...items);
+    };
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(order).toEqual([
+      "resolve",
+      `ensure:${PANE_ID}`,
+      `pane:${PANE_ID}:primary-agent`,
+      `identity:${PANE_ID}:ses_managed`,
+    ]);
+    expect(harness.ensured).toEqual([{ cwd: CWD }]);
+    expect(harness.terminalFactories).toEqual([factory]);
+  });
+
+  it("never falls back to local ensure when an advertised attachment is missing or fails", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-gone`,
+    } as const;
+    const base = preparedPlan();
+    if (base.kind !== "prepared") {
+      throw new Error("expected a prepared launch fixture");
+    }
+    const missing = attemptHarness({ prepared: { ...base, attachment } });
+
+    await missing.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(missing.calls).toEqual([]);
+    expect(missing.lastToast()).toMatchObject({ kind: "error" });
+
+    const failing = attemptHarness({
+      prepared: { ...base, attachment },
+      attacher: {
+        resolve: async () => {
+          throw {
+            tag: "TerminalProviderError",
+            code: "HOST_ATTACH_FAILED",
+            message: "attachment failed",
+            provider: "native",
+          };
+        },
+      },
+    });
+
+    await failing.runManagedLaunchAttempt(PANE_ID, TARGET);
+    await failing.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(failing.prepareCalls).toHaveLength(2);
+    expect(failing.calls).toEqual([]);
+    expect(failing.lastToast()?.message).toContain("attachment failed");
+  });
+
+  it("publishes a fresh spawn with command, arguments, optional environment, and ordering", async () => {
+    const harness = attemptHarness();
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(harness.calls).toEqual([
+      `ensure:${PANE_ID}`,
+      `pane:${PANE_ID}:primary-agent`,
+      `identity:${PANE_ID}:ses_managed`,
+    ]);
+    expect(harness.ensured).toEqual([
+      {
+        cwd: CWD,
+        command: "codex-custom",
+        args: ["--exec", "task"],
+        env: {
+          STATION_SESSION_ID: "ses_managed",
+          STATION_TERMINAL_TARGET_ID: TERMINAL_TARGET_ID,
+        },
+      },
+    ]);
+
+    const planWithoutEnvironment = preparedPlan();
+    if (planWithoutEnvironment.kind !== "prepared") {
+      throw new Error("expected a prepared launch fixture");
+    }
+    const launchPlanWithoutEnvironment = { ...planWithoutEnvironment.launchPlan };
+    delete launchPlanWithoutEnvironment.env;
+    const withoutEnvironment = attemptHarness({
+      prepared: { ...planWithoutEnvironment, launchPlan: launchPlanWithoutEnvironment },
+    });
+    await withoutEnvironment.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect("env" in (withoutEnvironment.ensured[0] ?? {})).toBe(false);
+  });
+
+  it("keeps external and non-attachable Station existing sessions as informational notices", async () => {
+    const existing: AgentPrepareExternalLaunchResult = {
+      kind: "existing-session",
+      sessionId: "ses_elsewhere",
+      harnessProvider: "codex",
+    };
+    const external = attemptHarness({ prepared: existing });
+    openOverlay(external);
+
+    await external.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(external.observerService.dispatched).toEqual([]);
+    expect(external.lastToast()).toMatchObject({ kind: "info" });
+    expect(external.lastToast()?.message).toContain("tmux");
+    expect(selectStationOverlayVisible(external.store.getState())).toBe(true);
+
+    const station = attemptHarness({ prepared: existing, snapshot: stationHostedSnapshot() });
+    openOverlay(station);
+
+    await station.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(station.observerService.dispatched).toEqual([]);
+    expect(station.lastToast()).toMatchObject({ kind: "info" });
+    expect(station.lastToast()?.message).toContain("no attachable host PTY");
+    expect(selectStationOverlayVisible(station.store.getState())).toBe(true);
+  });
+
+  it("focuses and lands only after a visibly actionable existing session succeeds", async () => {
+    const harness = attemptHarness({
+      prepared: {
+        kind: "existing-session",
+        sessionId: "ses_elsewhere",
+        harnessProvider: "codex",
+      },
+      snapshot: withoutTerminal(),
+    });
+    openOverlay(harness);
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(harness.observerService.dispatched).toEqual([
+      { type: "terminal.focus", payload: { sessionId: "ses_elsewhere" } },
+    ]);
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(false);
+  });
+
+  it("does not land after rejected, failed, or thrown focus operations", async () => {
+    const existing: AgentPrepareExternalLaunchResult = {
+      kind: "existing-session",
+      sessionId: "ses_elsewhere",
+      harnessProvider: "codex",
+    };
+
+    const rejected = attemptHarness({ prepared: existing, snapshot: withoutTerminal() });
+    rejected.observerService.nextReceipt = {
+      commandId: "cmd_tui_1",
+      accepted: false,
+      status: "rejected",
+    };
+    openOverlay(rejected);
+    await rejected.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect(selectStationOverlayVisible(rejected.store.getState())).toBe(true);
+
+    const failed = attemptHarness({ prepared: existing, snapshot: withoutTerminal() });
+    failed.observerService.nextCompletion = {
+      status: "failed",
+      commandId: "cmd_tui_1",
+      error: { tag: "ClientObserverError", code: "FOCUS_FAILED", message: "focus failed" },
+    };
+    openOverlay(failed);
+    await failed.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect(selectStationOverlayVisible(failed.store.getState())).toBe(true);
+
+    const thrown = attemptHarness({ prepared: existing, snapshot: withoutTerminal() });
+    thrown.observerService.dispatch = async () => {
+      throw new Error("focus threw");
+    };
+    openOverlay(thrown);
+    await thrown.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect(selectStationOverlayVisible(thrown.store.getState())).toBe(true);
+  });
+
+  it("does not focus or land an existing session for a background launch", async () => {
+    const harness = attemptHarness({
+      prepared: {
+        kind: "existing-session",
+        sessionId: "ses_elsewhere",
+        harnessProvider: "codex",
+      },
+      snapshot: withoutTerminal(),
+    });
+    openOverlay(harness);
+
+    await harness.runManagedLaunchAttempt(PANE_ID, { ...TARGET, background: true });
+
+    expect(harness.observerService.dispatched).toEqual([]);
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
+  });
+
+  it("keeps readiness acknowledgement best-effort after a successful open", async () => {
+    const harness = attemptHarness({ snapshot: withTurnReadiness() });
+    harness.observerService.dispatch = async (command: StationCommand) => {
+      if (command.type === "session.acknowledgeTurn") {
+        throw new Error("ack failed");
+      }
+      return harness.observerService.nextReceipt;
+    };
+    openOverlay(harness);
+
+    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(false);
+    expect(
+      harness.store
+        .getState()
+        .workspace.panes.some((pane) => pane.id === PANE_ID && pane.role === "primary-agent"),
+    ).toBe(true);
+    expect(harness.stationViewStore.getState().toasts).toEqual([]);
+  });
+
+  it("releases the in-flight guard after informational and focus-failure completions", async () => {
+    const existing: AgentPrepareExternalLaunchResult = {
+      kind: "existing-session",
+      sessionId: "ses_elsewhere",
+      harnessProvider: "codex",
+    };
+    const notice = attemptHarness({ prepared: existing });
+    await notice.runManagedLaunchAttempt(PANE_ID, TARGET);
+    await notice.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect(notice.prepareCalls).toHaveLength(2);
+
+    const focusFailure = attemptHarness({ prepared: existing, snapshot: withoutTerminal() });
+    focusFailure.observerService.nextCompletion = {
+      status: "failed",
+      commandId: "cmd_tui_1",
+      error: { tag: "ClientObserverError", code: "FOCUS_FAILED", message: "focus failed" },
+    };
+    await focusFailure.runManagedLaunchAttempt(PANE_ID, TARGET);
+    await focusFailure.runManagedLaunchAttempt(PANE_ID, TARGET);
+    expect(focusFailure.prepareCalls).toHaveLength(2);
+  });
+});

--- a/station/src/input/runtime/managedLaunchAttempt.ts
+++ b/station/src/input/runtime/managedLaunchAttempt.ts
@@ -1,0 +1,383 @@
+import { safeErrorToNotice, toSafeError, type ObserverService } from "@station/client";
+import type { ProviderId } from "@station/contracts";
+import type { TuiStore } from "@station/dashboard-core";
+import { StationHostProviderError } from "@station/host";
+import type { StoreApi } from "zustand/vanilla";
+import { selectPaneRecord } from "../../state/selectors.js";
+import type { StationStore } from "../../state/store.js";
+import type { AgentIdentity, PaneId } from "../../state/types.js";
+import type {
+  ManagedTerminalAttacher,
+  ManagedTerminalFactory,
+} from "../../terminal/pty/managedTerminalAttacher.js";
+import type { PtyRegistry } from "../../terminal/registry/ptyRegistry.js";
+import type { StationTerminalSpawnOptions } from "../../terminal/types.js";
+import {
+  externalTerminalProviderForWorktree,
+  nonFocusableStationTerminalForWorktree,
+  readinessForWorktree,
+  unreachableTerminalRow,
+} from "./stationRows.js";
+
+/** What a managed primary-agent launch needs to ask the observer to prepare it. */
+export type ManagedLaunchTarget = {
+  projectId: string;
+  worktreeId: string;
+  cwd: string;
+  /**
+   * User-visible title to persist only when this preparation mints a fresh
+   * session; an existing session keeps its current title.
+   */
+  title?: string;
+  /**
+   * Harness to launch when minting a fresh session (the New Session wizard's
+   * pick). Absent for a row click, where the observer uses the worktree's
+   * remembered harness or the project default.
+   */
+  harness?: ProviderId;
+  /**
+   * Spawn the agent pane but leave the STATION overlay open and unfocused — the New
+   * Session flow stays on the dashboard instead of focusing the pane. A row click
+   * omits this and focuses the new pane.
+   */
+  background?: boolean;
+};
+
+type ManagedLaunchAttemptDeps = {
+  store: StationStore;
+  stationViewStore: StoreApi<TuiStore> | undefined;
+  observerService: ObserverService | undefined;
+  registry: PtyRegistry | undefined;
+  managedTerminalAttacher: ManagedTerminalAttacher | undefined;
+};
+
+type ManagedLaunchRuntime = ManagedLaunchAttemptDeps & {
+  launchesInFlight: Set<PaneId>;
+};
+
+type ManagedLaunchContext = {
+  paneId: PaneId;
+  target: ManagedLaunchTarget;
+  landInPane: boolean;
+  turnReadiness: { sessionId: string; token: string } | undefined;
+};
+
+type PreparedLaunch = Awaited<ReturnType<ObserverService["prepareExternalLaunch"]>>;
+
+type ManagedLaunchAction =
+  | {
+      kind: "open-pane";
+      spawnOptions: StationTerminalSpawnOptions;
+      identity: AgentIdentity;
+      createTerminal?: ManagedTerminalFactory;
+    }
+  | { kind: "focus-existing"; sessionId: string }
+  | { kind: "notice"; message: string };
+
+function pushToast(
+  runtime: ManagedLaunchRuntime,
+  message: string,
+  kind: "info" | "error" = "error",
+): void {
+  runtime.stationViewStore?.getState().pushToast({ kind, message });
+}
+
+function pushError(runtime: ManagedLaunchRuntime, error: unknown): void {
+  runtime.stationViewStore
+    ?.getState()
+    .pushToast(safeErrorToNotice(toSafeError(error, { clientLabel: "Station" })));
+}
+
+function createContext(
+  runtime: ManagedLaunchRuntime,
+  paneId: PaneId,
+  target: ManagedLaunchTarget,
+): ManagedLaunchContext {
+  return {
+    paneId,
+    target,
+    landInPane: target.background !== true,
+    turnReadiness:
+      runtime.stationViewStore === undefined
+        ? undefined
+        : readinessForWorktree(runtime.stationViewStore, target.worktreeId),
+  };
+}
+
+async function landOnPane(
+  runtime: ManagedLaunchRuntime,
+  service: ObserverService | undefined,
+  readiness: ManagedLaunchContext["turnReadiness"],
+): Promise<void> {
+  runtime.store.actions.closeOverlay();
+  if (readiness === undefined || service === undefined) {
+    return;
+  }
+  try {
+    const receipt = await service.dispatch({
+      type: "session.acknowledgeTurn",
+      payload: readiness,
+    });
+    if (receipt.accepted) {
+      await service.waitForCommandCompletion(receipt.commandId);
+    }
+  } catch {
+    // Readiness acknowledgement is best-effort after the pane has opened successfully.
+  }
+}
+
+async function runPreflight(
+  runtime: ManagedLaunchRuntime,
+  context: ManagedLaunchContext,
+): Promise<ObserverService | undefined> {
+  if (selectPaneRecord(runtime.store.getState(), context.paneId) !== null) {
+    if (context.landInPane) {
+      runtime.store.actions.revealPane(context.paneId);
+      await landOnPane(runtime, runtime.observerService, context.turnReadiness);
+    }
+    return undefined;
+  }
+
+  const unreachable =
+    runtime.stationViewStore === undefined
+      ? undefined
+      : unreachableTerminalRow(runtime.stationViewStore, context.target.worktreeId);
+  if (unreachable !== undefined) {
+    pushToast(
+      runtime,
+      `${unreachable.label}: agent is ${unreachable.state} under '${unreachable.provider}'; Station can't focus it here.`,
+      "info",
+    );
+    return undefined;
+  }
+
+  // The synchronous guard prevents duplicate clicks from minting a second Observer session.
+  if (runtime.launchesInFlight.has(context.paneId)) {
+    return undefined;
+  }
+  if (runtime.observerService === undefined) {
+    pushToast(runtime, "No observer connection; cannot launch the agent.");
+    return undefined;
+  }
+
+  runtime.launchesInFlight.add(context.paneId);
+  return runtime.observerService;
+}
+
+function buildPrepareParams(
+  target: ManagedLaunchTarget,
+): Parameters<ObserverService["prepareExternalLaunch"]>[0] {
+  const params: Parameters<ObserverService["prepareExternalLaunch"]>[0] = {
+    projectId: target.projectId,
+    worktreeId: target.worktreeId,
+  };
+  if (target.harness !== undefined) {
+    params.harness = target.harness;
+  }
+  if (target.title !== undefined) {
+    params.title = target.title;
+  }
+  return params;
+}
+
+async function prepareLaunch(
+  runtime: ManagedLaunchRuntime,
+  service: ObserverService,
+  target: ManagedLaunchTarget,
+): Promise<PreparedLaunch | undefined> {
+  try {
+    return await service.prepareExternalLaunch(buildPrepareParams(target));
+  } catch (error) {
+    pushError(runtime, error);
+    return undefined;
+  }
+}
+
+function resolveExistingSession(
+  runtime: ManagedLaunchRuntime,
+  prepared: Extract<PreparedLaunch, { kind: "existing-session" }>,
+  target: ManagedLaunchTarget,
+): ManagedLaunchAction {
+  const nonFocusableStation =
+    runtime.stationViewStore === undefined
+      ? undefined
+      : nonFocusableStationTerminalForWorktree(runtime.stationViewStore, target.worktreeId);
+  if (nonFocusableStation !== undefined) {
+    return {
+      kind: "notice",
+      message: `${nonFocusableStation.label}: Station has no attachable host PTY for this existing agent.`,
+    };
+  }
+  const externalProvider =
+    runtime.stationViewStore === undefined
+      ? undefined
+      : externalTerminalProviderForWorktree(runtime.stationViewStore, target.worktreeId);
+  if (externalProvider !== undefined) {
+    return {
+      kind: "notice",
+      message: `This agent runs in the "${externalProvider}" terminal, which Station can't display. Attach to it from a ${externalProvider} client.`,
+    };
+  }
+  return { kind: "focus-existing", sessionId: prepared.sessionId };
+}
+
+async function resolvePreparedLaunch(
+  runtime: ManagedLaunchRuntime,
+  prepared: PreparedLaunch,
+  target: ManagedLaunchTarget,
+): Promise<ManagedLaunchAction | undefined> {
+  // An advertised attachment is a commitment: resolution failure must never reach local spawn.
+  if (prepared.attachment !== undefined) {
+    if (runtime.managedTerminalAttacher === undefined) {
+      pushError(
+        runtime,
+        new StationHostProviderError("HOST_UNREACHABLE", "Station host is not reachable."),
+      );
+      return undefined;
+    }
+    try {
+      const createTerminal = await runtime.managedTerminalAttacher.resolve(prepared.attachment);
+      return {
+        kind: "open-pane",
+        createTerminal,
+        spawnOptions: { cwd: target.cwd },
+        identity: {
+          sessionId: prepared.sessionId,
+          terminalTargetId: prepared.attachment.terminalTargetId,
+          harnessProvider:
+            prepared.kind === "prepared" ? prepared.launchPlan.provider : prepared.harnessProvider,
+        },
+      };
+    } catch (error) {
+      pushError(runtime, error);
+      return undefined;
+    }
+  }
+
+  if (prepared.kind === "existing-session") {
+    return resolveExistingSession(runtime, prepared, target);
+  }
+
+  const spawnOptions: StationTerminalSpawnOptions = {
+    cwd: target.cwd,
+    command: prepared.launchPlan.command,
+    args: prepared.launchPlan.args,
+  };
+  if (prepared.launchPlan.env !== undefined) {
+    spawnOptions.env = prepared.launchPlan.env;
+  }
+  return {
+    kind: "open-pane",
+    spawnOptions,
+    identity: {
+      sessionId: prepared.sessionId,
+      terminalTargetId: prepared.terminalTargetId,
+      harnessProvider: prepared.launchPlan.provider,
+    },
+  };
+}
+
+async function focusExistingSession(
+  runtime: ManagedLaunchRuntime,
+  service: ObserverService,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const receipt = await service.dispatch({
+      type: "terminal.focus",
+      payload: { sessionId },
+    });
+    if (!receipt.accepted) {
+      pushError(
+        runtime,
+        receipt.error ?? {
+          tag: "ClientObserverError",
+          code: "STATION_FOCUS_REJECTED",
+          message: "Station could not focus the existing agent.",
+        },
+      );
+      return false;
+    }
+    const completion = await service.waitForCommandCompletion(receipt.commandId);
+    if (completion.status === "failed") {
+      pushError(runtime, completion.error);
+      return false;
+    }
+    return true;
+  } catch (error) {
+    pushError(runtime, error);
+    return false;
+  }
+}
+
+async function performPreparedAction(
+  runtime: ManagedLaunchRuntime,
+  context: ManagedLaunchContext,
+  service: ObserverService,
+  action: ManagedLaunchAction,
+): Promise<void> {
+  switch (action.kind) {
+    case "open-pane":
+      // Registry seeding must precede pane publication so first render cannot spawn defaults.
+      if (action.createTerminal === undefined) {
+        runtime.registry?.ensure(context.paneId, action.spawnOptions);
+      } else {
+        runtime.registry?.ensure(context.paneId, action.spawnOptions, action.createTerminal);
+      }
+      runtime.store.actions.createPane(context.paneId, { role: "primary-agent" });
+      runtime.store.actions.setPrimaryAgent(context.paneId, action.identity);
+      if (context.landInPane) {
+        await landOnPane(runtime, service, context.turnReadiness);
+      }
+      return;
+    case "focus-existing":
+      if (
+        context.landInPane &&
+        (await focusExistingSession(runtime, service, action.sessionId))
+      ) {
+        await landOnPane(runtime, service, context.turnReadiness);
+      }
+      return;
+    case "notice":
+      pushToast(runtime, action.message, "info");
+      return;
+  }
+}
+
+async function runManagedLaunchAttempt(
+  runtime: ManagedLaunchRuntime,
+  paneId: PaneId,
+  target: ManagedLaunchTarget,
+): Promise<void> {
+  const context = createContext(runtime, paneId, target);
+  const service = await runPreflight(runtime, context);
+  if (service === undefined) {
+    return;
+  }
+  try {
+    const prepared = await prepareLaunch(runtime, service, target);
+    if (prepared === undefined) {
+      return;
+    }
+    const action = await resolvePreparedLaunch(runtime, prepared, target);
+    if (action !== undefined) {
+      await performPreparedAction(runtime, context, service, action);
+    }
+  } finally {
+    runtime.launchesInFlight.delete(paneId);
+  }
+}
+
+/**
+ * Creates one managed-launch runner whose phases preserve registry-before-pane publication and
+ * treat every advertised attachment as a no-local-fallback commitment.
+ */
+export function createManagedLaunchAttempt(
+  deps: ManagedLaunchAttemptDeps,
+): (paneId: PaneId, target: ManagedLaunchTarget) => Promise<void> {
+  const runtime: ManagedLaunchRuntime = {
+    ...deps,
+    launchesInFlight: new Set<PaneId>(),
+  };
+  return (paneId, target) => runManagedLaunchAttempt(runtime, paneId, target);
+}

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1652,6 +1652,44 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
     expect(selectStationOverlayVisible(store.getState())).toBe(true);
   });
 
+  it("retries a failed advertised attachment without taking the local-spawn fallback", async () => {
+    const attachment = {
+      kind: "managed-terminal",
+      terminalTargetId: `${TERMINAL_TARGET_ID}-gone`,
+    } as const;
+    const base = preparedPlan();
+    if (base.kind !== "prepared") {
+      throw new Error("preparedPlan must be a prepared launch");
+    }
+    let resolutions = 0;
+    const { store, calls, dispatch, settle, observerService } = agentHarness(
+      { ...base, attachment },
+      manyProjectsSnapshot(),
+      {
+        resolve: async () => {
+          resolutions += 1;
+          throw {
+            tag: "TerminalProviderError",
+            code: "HOST_ATTACH_GONE",
+            message: "The managed terminal is no longer available.",
+            provider: "native",
+          };
+        },
+      },
+    );
+    store.actions.openOverlay(STATION_OVERLAY_ID);
+
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+
+    expect(observerService.preparedLaunches).toHaveLength(2);
+    expect(resolutions).toBe(2);
+    expect(calls).toEqual([]);
+    expect(store.getState().workspace.panes.some((pane) => pane.role === "primary-agent")).toBe(false);
+  });
+
   it("toasts the observer's error when prepareExternalLaunch rejects", async () => {
     const { store, calls, dispatch, settle, observerService, stationViewStore } = agentHarness();
     observerService.prepareExternalLaunch = async () => {
@@ -1675,6 +1713,36 @@ describe("createStationInputRuntime managed primary-agent launch", () => {
       message: "Claude hooks are not installed.",
       hint: "Run 'stn hooks install claude'.",
     });
+  });
+
+  it("accepts a retry after prepareExternalLaunch fails", async () => {
+    const { store, calls, dispatch, settle, observerService } = agentHarness();
+    let attempts = 0;
+    observerService.prepareExternalLaunch = async (params) => {
+      observerService.preparedLaunches.push(params);
+      attempts += 1;
+      if (attempts === 1) {
+        throw {
+          tag: "ClientObserverError",
+          code: "PREPARE_FAILED",
+          message: "Prepare failed once.",
+        };
+      }
+      return preparedPlan();
+    };
+    store.actions.openOverlay(STATION_OVERLAY_ID);
+
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+    dispatch({ kind: "row", rowId: ROW_ID });
+    await settle();
+
+    expect(observerService.preparedLaunches).toHaveLength(2);
+    expect(calls).toEqual([
+      `ensure:${AGENT_PANE_ID}:${CWD}:codex:--exec`,
+      `createPane:${AGENT_PANE_ID}:primary-agent`,
+      `setPrimaryAgent:${AGENT_PANE_ID}:ses_managed:${TERMINAL_TARGET_ID}`,
+    ]);
   });
 
   it("toasts when launched with no observer service (no spawn)", async () => {
@@ -1975,6 +2043,40 @@ describe("createStationInputRuntime New Session hosted launch", () => {
     // into the new pane.
     expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
     expect(harness.store.getState().input.focus).not.toEqual({ kind: "pane", paneId: agentPaneId });
+  });
+
+  it("keeps a background existing-session preparation on the overlay without focusing", async () => {
+    const harness = newSessionHarness();
+    const worktreeId = "wt_existing_session";
+    harness.observerService.nextPreparedLaunch = {
+      kind: "existing-session",
+      sessionId: "ses_existing_session",
+      harnessProvider: "codex",
+    };
+    const { branch } = openWizardAndCaptureSubmit(harness, "Existing Session");
+
+    expect(harness.pressKey("\r")).toBe(true);
+    await harness.settle();
+    harness.source.setSnapshot(snapshotWithWorktree(harness.snapshot, worktreeId, branch));
+    await harness.settle();
+
+    expect(harness.observerService.preparedLaunches).toEqual([
+      {
+        projectId: PROJECT_ID,
+        worktreeId,
+        harness: "codex",
+        title: "Existing Session",
+      },
+    ]);
+    expect(
+      harness.observerService.dispatched.some((command) => command.type === "terminal.focus"),
+    ).toBe(false);
+    expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
+    expect(
+      harness.store
+        .getState()
+        .workspace.panes.some((pane) => pane.id === agentWorktreePaneId(worktreeId)),
+    ).toBe(false);
   });
 
   it("removes the optimistic row and toasts when the worktree create is rejected", async () => {


### PR DESCRIPTION
## What this fixes

Station's managed pane launch coordinator handled observer preparation, attachment resolution, pane publication, focus, readiness acknowledgement, and cleanup in one path. That made retry, no-fallback, and ordering guarantees difficult to characterize independently and risky to change.

## What changed

- Extracted managed launch attempts into explicit preflight, prepare, resolve, publish, focus/land, and cleanup phases.
- Kept `managedLaunch.ts` as the public facade and hosted create/fork coordinator.
- Preserved advertised-attachment no-fallback behavior, registry → pane → identity publication order, duplicate-launch suppression, background launches, display titles, and best-effort readiness acknowledgement.
- Added direct phase characterization tests plus input-runtime coverage for prepare retries, attachment retries without local fallback, and background existing sessions.

## Testing

- `cd station && bun test src/input/runtime/managedLaunchAttempt.test.ts src/input/stationInput.test.ts` (111 passed)
- `cd station && bun run typecheck`
- Biome cognitive-complexity gate at 15 for changed production files
- `pnpm lint` via pre-commit and pre-push hooks

## User-visible behavior

No behavior change is intended. Fresh launches, existing-session focus, informational notices, and attachment failures retain their current overlay and fallback semantics.
