### PR TITLE
fix(opencode): accept managed worktree hook identity

### DIFF
--- a/integrations/harness/opencode/src/eventSchemas.ts
+++ b/integrations/harness/opencode/src/eventSchemas.ts
@@ -98,6 +98,7 @@ export const OpenCodeCompactEventSchema = z
     station_project_id: nonEmptyStringSchema.optional(),
     station_worktree_id: nonEmptyStringSchema.optional(),
     station_worktree_path: nonEmptyStringSchema.optional(),
+    station_worktree_managed_root: nonEmptyStringSchema.optional(),
     station_session_id: nonEmptyStringSchema.optional(),
     station_terminal_provider: nonEmptyStringSchema.optional(),
     station_terminal_target_id: nonEmptyStringSchema.optional(),

--- a/integrations/harness/opencode/test/unit/events.test.ts
+++ b/integrations/harness/opencode/test/unit/events.test.ts
@@ -350,11 +350,13 @@ describe("OpenCode event parsing", () => {
         env: {
           STATION_SESSION_ID: "ses_web_task",
           STATION_WORKTREE_ID: "wt_web_task",
+          STATION_WORKTREE_MANAGED_ROOT: "/tmp/station/web/task",
         },
       }),
     ).toMatchObject({
       station_session_id: "ses_web_task",
       station_worktree_id: "wt_web_task",
+      station_worktree_managed_root: "/tmp/station/web/task",
     });
     expect(
       openCodeHookAdapter.decideScope?.({
@@ -400,6 +402,7 @@ describe("OpenCode event parsing", () => {
         cwd: "/tmp/station/web/task",
         opencode_session_id: "opencode_session_123",
         station_worktree_id: "wt_web_task",
+        station_worktree_managed_root: "/tmp/station/web/task",
         station_session_id: "ses_web_task",
         station_terminal_target_id: "tmux:station:@1:%2",
       },


### PR DESCRIPTION
## What this fixes

OpenCode status hooks were delivered to the Observer but rejected by the provider's strict compact-event schema. Shared Station identity enrichment adds `station_worktree_managed_root`; because the OpenCode schema did not declare that field, valid launched-session events never updated the worktree row.

## What changed

- Accept the shared managed-worktree identity field in OpenCode compact hook payloads.
- Cover both shared identity enrichment and end-to-end hook report conversion with the managed root present.

## Testing

- `pnpm exec vitest run integrations/harness/opencode/test/unit/events.test.ts --config config/vitest/vitest.unit.config.ts`
- `pnpm test:all` (with inherited devbox/provider environment variables removed to match CI)
