### PR TITLE
fix(devbox): make isolated hook recovery verifiable

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -114,9 +114,10 @@ bun run station:isolated:stop     # tear down the observer + host for this workt
   `STATION_OBSERVER_SOCKET_PATH` (so Station connects to this observer);
 - sets `CODEX_HOME=.dev-state/codex-home`, seeds it with a symlink to your real
   `~/.codex/auth.json` (shared login) and a copy of `config.toml` (isolated
-  snapshot), and installs the codex status hooks **there** — so the launch guard
-  (below) is satisfied and launched agents report to **this** observer, with your
-  global `~/.codex` left untouched;
+  snapshot), enables hooks in the isolated `station` profile, and installs the
+  codex status hooks **there** — so the launch guard (below) is satisfied and
+  launched agents report to **this** observer, with your global `~/.codex` left
+  untouched;
 - installs the claude status hook for the isolated observer (its artifact + script
   land under `.dev-state/observer`, which is what the launch guard checks) so a
   claude-default worktree also clears the guard; sets

--- a/integrations/harness/codex/src/hooks/hookConfigEditor.ts
+++ b/integrations/harness/codex/src/hooks/hookConfigEditor.ts
@@ -31,6 +31,18 @@ export function stringifyTomlDocument(document: Record<string, unknown>): string
   return result.endsWith("\n") ? result : `${result}\n`;
 }
 
+/** Enables hooks only for isolated devbox profiles; normal setup preserves user feature flags. */
+export function enableCodexHooksFeature(
+  document: Record<string, unknown>,
+): Record<string, unknown> {
+  const next = cloneRecord(document);
+  const featuresRecord = recordValue(next.features);
+  const features = featuresRecord === undefined ? {} : cloneRecord(featuresRecord);
+  features.hooks = true;
+  next.features = features;
+  return next;
+}
+
 export function installCodexHookCommands(
   document: Record<string, unknown>,
   commands: Record<CodexHookEventName, string>,

--- a/integrations/harness/codex/test/unit/hooks.test.ts
+++ b/integrations/harness/codex/test/unit/hooks.test.ts
@@ -10,9 +10,30 @@ import {
   planCodexHooks,
   uninstallCodexHooks,
 } from "../../src/hooks";
-import { generatedStationHookEvents, parseTomlDocument } from "../../src/hooks/hookConfigEditor";
+import {
+  enableCodexHooksFeature,
+  generatedStationHookEvents,
+  parseTomlDocument,
+  stringifyTomlDocument,
+} from "../../src/hooks/hookConfigEditor";
 
 describe("Codex hook setup", () => {
+  it.each([
+    ["a profile without the table", ""],
+    ["a commented table", "[features] # retained comment\nhooks = false\n"],
+    ["an indented table", "  [features]\nhooks = false\n"],
+    ["a quoted table", '["features"]\nhooks = false\n'],
+    ["an inline table", "features = { hooks = false, unified_exec = true }\n"],
+  ])("enables hooks in an isolated profile from %s", (_name, source) => {
+    const enabled = enableCodexHooksFeature(parseTomlDocument(source));
+    const reparsed = parseTomlDocument(stringifyTomlDocument(enabled));
+
+    expect(reparsed).toMatchObject({ features: { hooks: true } });
+    if (source.includes("unified_exec")) {
+      expect(reparsed).toMatchObject({ features: { unified_exec: true } });
+    }
+  });
+
   it("plans hook config and generated script without writing files", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-codex-hooks-"));
     const codexHome = join(root, "codex-home");

--- a/scripts/enable-devbox-codex-hooks.mjs
+++ b/scripts/enable-devbox-codex-hooks.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { open, rename, rm, writeFile } from "node:fs/promises";
+import {
+  enableCodexHooksFeature,
+  parseTomlDocument,
+  stringifyTomlDocument,
+} from "../integrations/harness/codex/dist/hooks/hookConfigEditor.js";
+
+const [configPath] = process.argv.slice(2);
+if (configPath === undefined) {
+  throw new Error("Usage: enable-devbox-codex-hooks.mjs <config-path>");
+}
+
+const configFile = await open(configPath, "a+", 0o600);
+let before;
+try {
+  before = await configFile.readFile("utf8");
+} finally {
+  await configFile.close();
+}
+
+const after = stringifyTomlDocument(enableCodexHooksFeature(parseTomlDocument(before)));
+if (after !== before) {
+  const temporaryPath = `${configPath}.tmp.${process.pid}`;
+  try {
+    await writeFile(temporaryPath, after, { encoding: "utf8", mode: 0o600 });
+    await rename(temporaryPath, configPath);
+  } catch (error) {
+    await rm(temporaryPath, { force: true });
+    throw error;
+  }
+}

--- a/scripts/station-devbox.mjs
+++ b/scripts/station-devbox.mjs
@@ -69,7 +69,11 @@ function restart() {
   log("Rebuilding (pnpm build)…");
   run("pnpm", ["build"], { cwd: repoRoot });
   log("Recycling the isolated observer (the persistent host + agents survive and reconnect)…");
-  run("node", [CLI, "--config", CFG, "observer", "restart"], { cwd: repoRoot });
+  run("node", [CLI, "--config", CFG, "observer", "stop"], { cwd: repoRoot });
+  run("bash", [ISOLATED_SCRIPT, "start"], {
+    cwd: repoRoot,
+    env: { ...process.env, STATION_ISOLATED_NO_LAUNCH: "1" },
+  });
   log(
     "Done. If you changed the station host (hostMain.ts), run `stop` then `start` to recycle it.",
   );

--- a/scripts/test-runners/run-station-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-devbox-smoke.mjs
@@ -117,6 +117,15 @@ try {
     "restoring socket access did not reconnect to the original devbox Observer",
   );
 
+  devbox(["restart"], "restart");
+  const restartedStatus = spawnChecked("node", [cli, "--config", cfg, "observer", "status"], {
+    label: "restarted isolated observer status",
+  });
+  assert(
+    JSON.parse(restartedStatus.stdout).health?.pid !== originalPid,
+    "devbox restart did not replace the isolated Observer",
+  );
+
   // stop removes the isolated observer + host sockets (teardown scoped to .dev-state).
   devbox(["stop"], "stop");
   assert(!existsSync(observerSock), `stop did not remove ${observerSock}`);

--- a/scripts/test-runners/run-station-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-devbox-smoke.mjs
@@ -8,7 +8,7 @@
 // then STOPS the devbox, so a live devbox here will be stopped.
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, readdirSync, statSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,6 +28,9 @@ const socketDir = join(
 const observerSock = join(socketDir, "observer.sock");
 const hostSock = join(socketDir, "station-host.sock");
 const hooksDir = join(ds, "observer", "hooks");
+const hookLog = join(ds, "observer", "logs", "hooks.jsonl");
+const codexHookScript = join(hooksDir, "station-codex-hook.sh");
+const codexProfileConfig = join(ds, "codex-home", "station.config.toml");
 const globalStateFragment = join(".local", "state", "station");
 let socketRestricted = false;
 
@@ -51,15 +54,11 @@ try {
   );
   assertNoGlobalLeak(start.stdout, "start");
   assert(existsSync(observerSock), `isolated observer socket not created at ${observerSock}`);
-
-  // Claude parity: the isolated hook install must land artifacts under .dev-state.
-  const claudeArtifacts = existsSync(hooksDir)
-    ? readdirSync(hooksDir).filter((file) => file.includes("claude"))
-    : [];
   assert(
-    claudeArtifacts.length > 0,
-    `no isolated Claude hook artifacts under ${hooksDir} — claude parity install did not run`,
+    /^hooks\s*=\s*true\s*$/m.test(readFileSync(codexProfileConfig, "utf8")),
+    `isolated Codex profile does not enable hooks: ${codexProfileConfig}`,
   );
+  assertHookDoctors("initial start");
 
   // status through the wrapper reports the isolated socket; the direct isolated
   // observer status must not leak the global state dir.
@@ -125,6 +124,8 @@ try {
     JSON.parse(restartedStatus.stdout).health?.pid !== originalPid,
     "devbox restart did not replace the isolated Observer",
   );
+  assertHookDoctors("restart");
+  assertCodexHookDelivery();
 
   // stop removes the isolated observer + host sockets (teardown scoped to .dev-state).
   devbox(["stop"], "stop");
@@ -132,11 +133,7 @@ try {
   assert(!existsSync(hostSock), `stop did not remove ${hostSock}`);
 
   process.stdout.write(
-    `${JSON.stringify(
-      { status: "station:devbox smoke passed", devboxState: ds, claudeArtifacts },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify({ status: "station:devbox smoke passed", devboxState: ds }, null, 2)}\n`,
   );
 } catch (error) {
   // Best-effort teardown so a failed assertion never leaves the observer running.
@@ -177,6 +174,72 @@ function assertNoGlobalLeak(output, label) {
   );
 }
 
+function assertHookDoctors(label) {
+  for (const provider of ["codex", "claude", "cursor", "opencode"]) {
+    const result = spawnChecked("node", [cli, "--config", cfg, "hooks", "doctor", provider], {
+      label: `${label} ${provider} hook doctor`,
+      env: {
+        ...process.env,
+        CLAUDE_CONFIG_DIR: join(ds, "claude-home"),
+        CODEX_HOME: join(ds, "codex-home"),
+        OPENCODE_CONFIG_DIR: join(ds, "opencode-config"),
+        STATION_CURSOR_HOME: join(ds, "cursor-home"),
+      },
+    });
+    const doctor = JSON.parse(result.stdout);
+    assert(
+      doctor.status === "ok" && doctor.installed === true,
+      `${label} left ${provider} hooks unhealthy\n${result.stdout}`,
+    );
+  }
+}
+
+function assertCodexHookDelivery() {
+  assert(existsSync(codexHookScript), `Codex hook script missing at ${codexHookScript}`);
+  const recordsBefore = readJsonl(hookLog).length;
+  const payload = JSON.stringify({
+    session_id: `devbox-smoke-${process.pid}`,
+    transcript_path: null,
+    cwd: repoRoot,
+    hook_event_name: "SessionStart",
+    model: "gpt-5.6-sol",
+    permission_mode: "bypassPermissions",
+    source: "startup",
+  });
+  spawnChecked(codexHookScript, [], {
+    label: "restarted Codex hook delivery",
+    input: payload,
+    env: {
+      ...process.env,
+      STATION_CONFIG_PATH: cfg,
+      STATION_HOOK_SPOOL_DIR: join(ds, "observer", "spool", "hooks"),
+      STATION_OBSERVER_SOCKET_PATH: observerSock,
+      STATION_SESSION_ID: `devbox-smoke-session-${process.pid}`,
+      STATION_STATE_DIR: join(ds, "observer"),
+      STATION_WORKTREE_ID: `devbox-smoke-worktree-${process.pid}`,
+      STATION_WORKTREE_PATH: repoRoot,
+    },
+  });
+  const newRecords = readJsonl(hookLog).slice(recordsBefore);
+  assert(
+    newRecords.some(
+      (record) =>
+        record.provider === "codex" &&
+        record.attributes?.status === "ingested" &&
+        record.attributes?.event === "SessionStart",
+    ),
+    `Codex hook did not deliver to the restarted Observer\n${JSON.stringify(newRecords, null, 2)}`,
+  );
+}
+
+function readJsonl(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line));
+}
+
 function spawnChecked(command, args, options) {
   const result = spawnResult(command, args, options);
   if (result.error !== undefined) {
@@ -196,6 +259,7 @@ function spawnResult(command, args, options = {}) {
     encoding: "utf8",
     timeout: timeoutMs,
     env: options.env ?? process.env,
+    input: options.input,
   });
 }
 

--- a/station/scripts/station-isolated.sh
+++ b/station/scripts/station-isolated.sh
@@ -217,6 +217,8 @@ export CODEX_HOME="$DS/codex-home"
 mkdir -p "$CODEX_HOME"
 [ -e "$HOME/.codex/auth.json" ] && ln -sf "$HOME/.codex/auth.json" "$CODEX_HOME/auth.json"
 [ -e "$HOME/.codex/config.toml" ] && [ ! -e "$CODEX_HOME/config.toml" ] && cp "$HOME/.codex/config.toml" "$CODEX_HOME/config.toml"
+# Codex hook execution is enabled only in this worktree-local Station profile.
+node "$ROOT/scripts/enable-devbox-codex-hooks.mjs" "$CODEX_HOME/station.config.toml"
 
 # Claude isolates its config via CLAUDE_CONFIG_DIR instead of CODEX_HOME; keeps the
 # hook install below off your global ~/.claude. Auth lives in the (machine-global)
@@ -254,7 +256,7 @@ fi
 # Install status hooks against THIS observer so the launch guard lets these
 # harnesses spawn; each writes into its own isolated home/state, never globals.
 for harness in codex claude cursor opencode; do
-  node "$CLI" --config "$CFG" hooks install "$harness" --yes >/dev/null 2>&1 || true
+  node "$CLI" --config "$CFG" hooks install "$harness" --yes >/dev/null
 done
 
 echo "Isolated observer up — $STATION_OBSERVER_SOCKET_PATH"


### PR DESCRIPTION
## What this fixes

A Station devbox has four pieces that must stay aligned:

1. the freshly built CLI and TUI client;
2. the worktree-local Observer that owns the socket and runtime state;
3. the persistent Host that keeps agent PTYs alive across Observer restarts; and
4. provider hook files installed into isolated Codex, Claude, Cursor, and OpenCode homes under `.dev-state`.

Previously, `pnpm station:devbox restart` rebuilt the client and then invoked the generic Observer restart command directly. If the socket was still owned by the previous build, the rebuilt client could encounter an Observer build mismatch. Even when the Observer restarted, the devbox bootstrap that exports the isolated provider homes and installs their hooks did not run again.

Hook installation failures were also discarded with `|| true`, so the command could report that the devbox was up while an agent had no working status hooks. Codex had an additional gap: installing hook definitions is not enough when hook execution is disabled, and the isolated `station.config.toml` did not safely guarantee `features.hooks = true`.

The visible result was the behavior this PR targets: an agent process could be alive while Station showed **needs attention**, reported that hooks were not installed, received no status events, or rejected the client because the Observer had a different build identity.

## What changed

- Restart now follows an explicit **build → stop Observer → rerun isolated bootstrap** sequence. The persistent Host is left running, so existing agent PTYs survive and reconnect to the replacement Observer.
- The isolated bootstrap reinstalls Codex, Claude, Cursor, and OpenCode hooks against the replacement Observer. Installation errors now fail the command and remain visible instead of producing a false success.
- The devbox enables Codex hooks only in its worktree-local `station` profile. It parses and serializes TOML through the existing Codex boundary, preserves other feature flags, and atomically replaces the file.
- Codex profile coverage includes missing, commented, indented, quoted, and inline `features` tables, including preservation of unrelated feature values.
- The devbox smoke binds every hook doctor to the isolated provider homes, verifies all four providers before and after restart, proves the Observer PID changed, and sends a generated Codex `SessionStart` event through the hook script to the replacement Observer.

## Testing

- `node scripts/build-identity.mjs`: all 22 package builds completed successfully.
- Codex hook unit suite: 14/14 passed, including the TOML regression matrix and generated hook-script delivery.
- `node scripts/test-runners/run-station-devbox-smoke.mjs --skip-build`: passed the real start, inaccessible-socket preservation, recovery, restart, four-provider doctor, Codex delivery, and teardown sequence.
- Biome, Node syntax checks, `bash -n`, `git diff --check`, pre-commit lint, and Observer architecture checks passed.
- GitHub CI passed: static checks, fast tests, integration tests, Observer E2E, Station tests, setup E2E, SQLite cross-runtime, and binary smoke.

## User-visible behavior

After this change, normal development remains:

```bash
pnpm station:devbox restart
```

That command rebuilds current source, replaces the Observer, refreshes isolated hooks, and preserves existing agent PTYs. It does not require repeated `pnpm install`, `bun install`, manual `cd` steps, or a separate build. Dependency installation is only needed for a fresh checkout or when dependency metadata changes.

If hook setup fails, restart now stops with the provider error instead of leaving an apparently healthy but unobservable devbox.

## Safety and scope

- Global Codex, Claude, Cursor, and OpenCode configuration remains untouched; all devbox hook changes stay under the checkout's `.dev-state`.
- The persistent Host intentionally survives this restart. If `station/src/host/hostMain.ts` changed, use `pnpm station:devbox stop` followed by `pnpm station:devbox start` to replace the Host too.
- This PR verifies that the isolated OpenCode plugin is installed and healthy. The separate OpenCode payload-identity parser fix remains in #322.