### PR TITLE
fix(runtime): make cleanup failures safe and observable

### DIFF
--- a/apps/observer/src/runtime/main.ts
+++ b/apps/observer/src/runtime/main.ts
@@ -17,6 +17,7 @@ import type {
 import { componentLogPath } from "@station/observability";
 import {
   parseStationObserverBuildVersion,
+  safeErrorFromUnknown,
   stationObserverBuildVersion,
   systemClock,
   toIsoTimestamp,
@@ -322,11 +323,16 @@ async function runClaimedObserverRuntime(input: {
           try {
             await removeObserverProcessIdentity(processIdentity);
           } catch (error) {
+            const cleanupError = safeErrorFromUnknown(error, {
+              tag: "ObserverLifecycleError",
+              code: "OBSERVER_IDENTITY_REMOVE_FAILED",
+              message: "Observer process identity could not be removed.",
+            });
             await logger
               .warn("Observer process identity could not be removed during shutdown.", {
                 socketPath,
                 pid: processIdentity.pid,
-                error,
+                error: cleanupError,
               })
               .catch(() => undefined);
           }

--- a/apps/observer/src/runtime/observerPidfile.ts
+++ b/apps/observer/src/runtime/observerPidfile.ts
@@ -155,7 +155,21 @@ export async function removeObserverProcessIdentity(
   try {
     await unlink(claimedPath);
   } catch (error) {
-    await restoreClaimedIdentity(claimedPath, path).catch(() => undefined);
+    try {
+      await restoreClaimedIdentity(claimedPath, path);
+    } catch (restoreError) {
+      // SafeError fields keep the dual failure searchable while `errors` retains both causes.
+      throw Object.assign(
+        new AggregateError(
+          [error, restoreError],
+          "Observer process identity could not be removed or restored.",
+        ),
+        {
+          tag: "ObserverLifecycleError",
+          code: "OBSERVER_IDENTITY_REMOVE_AND_RESTORE_FAILED",
+        },
+      );
+    }
     throw error;
   }
   await syncDirectory(dirname(path));

--- a/apps/observer/test/unit/observerPidfile.test.ts
+++ b/apps/observer/test/unit/observerPidfile.test.ts
@@ -3,7 +3,8 @@ import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { ObserverProcessIdentity } from "@station/contracts";
-import { afterEach, describe, expect, it } from "vitest";
+import { safeErrorFromUnknown } from "@station/runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createObserverProcessIdentity,
   observerPidfilePath,
@@ -12,12 +13,41 @@ import {
   removeObserverProcessIdentity,
 } from "../../src/runtime/observerPidfile.js";
 
+const pidfileFailures = vi.hoisted(() => ({
+  failClaimedLink: false,
+  failClaimedUnlink: false,
+  linkError: new Error("pidfile restoration failed"),
+  unlinkError: new Error("pidfile removal failed"),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...original,
+    link: async (...args: Parameters<typeof original.link>) => {
+      if (pidfileFailures.failClaimedLink && String(args[0]).endsWith(".remove")) {
+        throw pidfileFailures.linkError;
+      }
+      return original.link(...args);
+    },
+    unlink: async (...args: Parameters<typeof original.unlink>) => {
+      if (pidfileFailures.failClaimedUnlink && String(args[0]).endsWith(".remove")) {
+        throw pidfileFailures.unlinkError;
+      }
+      return original.unlink(...args);
+    },
+  };
+});
+
 describe("observer pidfile", () => {
   let dir: string | undefined;
 
   afterEach(async () => {
+    pidfileFailures.failClaimedLink = false;
+    pidfileFailures.failClaimedUnlink = false;
     if (dir !== undefined) {
       await rm(dir, { recursive: true, force: true });
+      dir = undefined;
     }
   });
 
@@ -173,6 +203,44 @@ describe("observer pidfile", () => {
     await expect(removeObserverProcessIdentity(processIdentity(socketPath))).rejects.toThrow();
     await expect(readFile(path, "utf8")).resolves.toBe("{}\n");
     await expect(readdir(dir)).resolves.toEqual([basename(observerPidfilePath(socketPath))]);
+  });
+
+  it("preserves both failures when pidfile removal and restoration fail", async () => {
+    dir = await mkdtemp(join(tmpdir(), "stn-pidfile-"));
+    const socketPath = join(dir, "observer.sock");
+    const identity = processIdentity(socketPath);
+    await publishObserverProcessIdentity(identity);
+    pidfileFailures.failClaimedUnlink = true;
+    pidfileFailures.failClaimedLink = true;
+
+    let failure: unknown;
+    try {
+      await removeObserverProcessIdentity(identity);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      pidfileFailures.unlinkError,
+      pidfileFailures.linkError,
+    ]);
+    expect((failure as AggregateError).message).toContain("could not be removed or restored");
+    expect(
+      safeErrorFromUnknown(failure, {
+        tag: "ObserverLifecycleError",
+        code: "OBSERVER_IDENTITY_REMOVE_FAILED",
+        message: "Observer process identity could not be removed.",
+      }),
+    ).toEqual({
+      tag: "ObserverLifecycleError",
+      code: "OBSERVER_IDENTITY_REMOVE_AND_RESTORE_FAILED",
+      message: "Observer process identity could not be removed or restored.",
+    });
+    await expect(readObserverProcessIdentity(socketPath)).resolves.toBeUndefined();
+    const entries = await readdir(dir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatch(/^\.observer\.pid\..+\.remove$/);
   });
 });
 

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -9884,6 +9884,7 @@
           "edgeKind": "runtime",
           "bindings": [
             "parseStationObserverBuildVersion",
+            "safeErrorFromUnknown",
             "stationObserverBuildVersion",
             "systemClock",
             "toIsoTimestamp"

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -415,8 +415,13 @@ async function preparePersistentPopup(
   );
   const prepared: PreparedPersistentPopup = { persistent: true, ui };
   if (context.scope.registerFastPopup && ui.registerFastPopup) {
-    const route = await registerFastPopupUi(context.tmuxCommand, ui).catch(() => undefined);
-    if (route !== undefined) prepared.registrationNonce = route.registrationNonce;
+    try {
+      const route = await registerFastPopupUi(context.tmuxCommand, ui);
+      if (route !== undefined) prepared.registrationNonce = route.registrationNonce;
+    } catch {
+      // Registration only accelerates later binding opens; this popup is already usable,
+      // and a later full launch retries registration.
+    }
   }
   return prepared;
 }

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -645,6 +645,22 @@ describe("tmux popup", () => {
     expect(fake.globalOptions.get("@station_popup_ui_route")).toBe(replacementRoute);
   });
 
+  it("opens through fallback ownership when fast popup registration fails", async () => {
+    const fake = createPopupTmux({ failFastRegistration: true, root: "/opt/station/bin" });
+
+    await expect(
+      openTmuxPopup({
+        checkoutRoot: fake.root,
+        env: { TMUX: "/tmp/tmux/default,1,0" },
+        runner: fake.runner,
+      }),
+    ).resolves.toEqual({ opened: true });
+
+    expect(fake.globalOptions.has("@station_popup_ui_route")).toBe(false);
+    expect(fake.globalOptions.get("@station_popup_active_claim")).toMatch(/^v1\.open\./);
+    expect(fake.executedPopupActions.some((action) => action.includes("display-popup"))).toBe(true);
+  });
+
   it("prefers only a live same-root dev UI and rejects stale or wrong-root registrations", async () => {
     const fake = createPopupTmux({
       devCommand: "node dev-ui tui --popup --persistent",
@@ -793,6 +809,7 @@ type PopupFakeOptions = {
   devRoot?: string;
   devSession?: string;
   displayExit?: number;
+  failFastRegistration?: boolean;
   malformedRoute?: string;
   registered?: boolean;
   replaceClaimBeforeCleanup?: string;
@@ -913,6 +930,9 @@ function createPopupTmux(options: PopupFakeOptions = {}) {
       return tmuxCommandResult(input);
     }
     if (args[0] === "set-option") {
+      if (options.failFastRegistration === true && args.includes("@station_popup_ui_lease")) {
+        throw Object.assign(new Error("fast registration failed"), { code: 1 });
+      }
       applySetOption(args, globalOptions, sessionOptions, sessionSignatures);
       return tmuxCommandResult(input);
     }

--- a/station/src/bin/packagedAssets.test.ts
+++ b/station/src/bin/packagedAssets.test.ts
@@ -155,6 +155,41 @@ describe("preparePackagedPtyRuntime", () => {
     expect(await pathExists(dead)).toBe(false);
   });
 
+  it("keeps the current helper usable when stale cache removals fail", async () => {
+    const state = await stateDir();
+    const ctty = join(state, "run", "assets", "ctty");
+    const dead = join(ctty, "old-dead");
+    const deadLease = join(dead, ".leases", "2147483647-dead");
+    await mkdir(dirname(deadLease), { recursive: true });
+    await writeFile(deadLease, "");
+    const attempts: Array<{ path: string; recursive: boolean }> = [];
+
+    const runtime = await preparePty(state, {
+      removeStalePath: async (
+        path: string,
+        options: { force: true; recursive?: true },
+      ): Promise<void> => {
+        attempts.push({ path, recursive: options.recursive === true });
+        throw new Error("stale cleanup denied");
+      },
+    });
+    runtimes.push(runtime);
+
+    expect(attempts).toEqual([
+      { path: deadLease, recursive: false },
+      { path: dead, recursive: true },
+    ]);
+    expect(await pathExists(dead)).toBe(true);
+    const identityDirs = (await readdir(ctty, { withFileTypes: true })).filter(
+      (entry) => entry.isDirectory() && !entry.name.endsWith(".lock"),
+    );
+    const current = identityDirs.find((entry) => entry.name !== "old-dead");
+    expect(current).toBeDefined();
+    expect(await pathExists(join(ctty, current?.name ?? "missing", "station-ctty-helper"))).toBe(
+      true,
+    );
+  });
+
   it("reclaims an extraction lock owned by a dead process", async () => {
     const state = await stateDir();
     const first = await preparePty(state);

--- a/station/src/bin/packagedAssets.ts
+++ b/station/src/bin/packagedAssets.ts
@@ -41,11 +41,15 @@ type AssetSpec = {
   mode: number;
 };
 
-/** @internal Deterministic seams for cache contention and execution-boundary tests. */
+type StalePathRemovalOptions = { force: true; recursive?: true };
+type StalePathRemover = (path: string, options: StalePathRemovalOptions) => Promise<void>;
+
+/** @internal Deterministic seams for cache contention, stale pruning, and execution tests. */
 export type PackagedAssetDeps = {
   helperExitCode?: (path: string) => Promise<number>;
   lockTimeoutMs?: number;
   lockWaitMs?: number;
+  removeStalePath?: StalePathRemover;
 };
 
 export type PreparedPtyRuntime = {
@@ -95,7 +99,7 @@ export async function preparePackagedPtyRuntime(
     );
     await probeCttyHelper(helperPath, deps.helperExitCode ?? spawnExitCode);
     const lease = await createHelperLease(helperPath);
-    await pruneStaleHelpers(cttyDir, dirname(helperPath));
+    await pruneStaleHelpers(cttyDir, dirname(helperPath), deps.removeStalePath ?? rm);
 
     return {
       implementation,
@@ -376,7 +380,11 @@ async function createHelperLease(helperPath: string): Promise<{ dispose(): void 
   };
 }
 
-async function pruneStaleHelpers(cttyDir: string, currentDir: string): Promise<void> {
+async function pruneStaleHelpers(
+  cttyDir: string,
+  currentDir: string,
+  removeStalePath: StalePathRemover,
+): Promise<void> {
   let entries;
   try {
     entries = await readdir(cttyDir, { withFileTypes: true });
@@ -388,14 +396,21 @@ async function pruneStaleHelpers(cttyDir: string, currentDir: string): Promise<v
       continue;
     }
     const assetDir = join(cttyDir, entry.name);
-    if (assetDir === currentDir || (await hasLiveLease(assetDir))) {
+    if (assetDir === currentDir || (await hasLiveLease(assetDir, removeStalePath))) {
       continue;
     }
-    await rm(assetDir, { recursive: true, force: true }).catch(() => undefined);
+    await removeStalePathBestEffort(
+      assetDir,
+      { recursive: true, force: true },
+      removeStalePath,
+    );
   }
 }
 
-async function hasLiveLease(assetDir: string): Promise<boolean> {
+async function hasLiveLease(
+  assetDir: string,
+  removeStalePath: StalePathRemover,
+): Promise<boolean> {
   const leasesDir = join(assetDir, ".leases");
   let leases: string[];
   try {
@@ -407,12 +422,24 @@ async function hasLiveLease(assetDir: string): Promise<boolean> {
   for (const lease of leases) {
     const match = /^(\d+)-/.exec(lease);
     if (match === null || !processIsAlive(Number(match[1]))) {
-      await rm(join(leasesDir, lease), { force: true }).catch(() => undefined);
+      await removeStalePathBestEffort(join(leasesDir, lease), { force: true }, removeStalePath);
     } else {
       live = true;
     }
   }
   return live;
+}
+
+async function removeStalePathBestEffort(
+  path: string,
+  options: StalePathRemovalOptions,
+  removeStalePath: StalePathRemover,
+): Promise<void> {
+  try {
+    await removeStalePath(path, options);
+  } catch {
+    // Stale cache deletion must not block a validated, leased helper; later starts retry it.
+  }
 }
 
 function safePathComponent(value: string): string {

--- a/station/src/terminal/pty/hostAttachedTerminal.test.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.test.ts
@@ -6,6 +6,10 @@ import {
   StationHostProviderError,
 } from "@station/host";
 import { describe, expect, it } from "bun:test";
+import {
+  resetTerminalDiagnosticsForTest,
+  terminalCorruptionCounters,
+} from "../diagnostics.js";
 import { createHostAttachedTerminal, RECONNECT_REPAINT } from "./hostAttachedTerminal.js";
 
 const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -407,6 +411,45 @@ describe("createHostAttachedTerminal (Station-owned aux)", () => {
     terminal.kill();
     await flush();
     expect(tracking.closes).toEqual(["pty-reattach"]);
+  });
+
+  it("reports an owned PTY close failure after immediate pane disposal", async () => {
+    resetTerminalDiagnosticsForTest();
+    try {
+      const ctrl = controllableAttachment(ack({ ptyId: "pty-close-failure" }));
+      let clientCreations = 0;
+      let closerDisposed = false;
+      const terminal = createHostAttachedTerminal({
+        hostSocketPath: "/tmp/x.sock",
+        ptyId: "pty-close-failure",
+        owned: true,
+        size: { cols: 80, rows: 24 },
+        clientFactory: () => {
+          clientCreations += 1;
+          if (clientCreations === 1) {
+            return clientForAttach(async () => ctrl.attachment);
+          }
+          return {
+            ...clientForAttach(async () => ctrl.attachment, () => {
+              closerDisposed = true;
+            }),
+            close: async () => {
+              throw new Error("host close failed");
+            },
+          } satisfies StationHostClient;
+        },
+      });
+      await flush();
+
+      expect(() => terminal.kill()).not.toThrow();
+      terminal.dispose();
+      await flush();
+
+      expect(terminalCorruptionCounters()["terminal_diagnostic:host_close_failed"]).toBe(1);
+      expect(closerDisposed).toBe(true);
+    } finally {
+      resetTerminalDiagnosticsForTest();
+    }
   });
 
   it("kill() is a no-op for an attach-only (agent) terminal", async () => {

--- a/station/src/terminal/pty/hostAttachedTerminal.ts
+++ b/station/src/terminal/pty/hostAttachedTerminal.ts
@@ -8,6 +8,7 @@ import {
 } from "@station/host";
 import { type SafeErrorFallback, toSafeError } from "@station/observability";
 import { stationBuildInfo } from "@station/runtime";
+import { reportTerminalCorruption } from "../diagnostics.js";
 import { ControlByte } from "../protocol/controlBytes.js";
 import type {
   StationTerminalDisposable,
@@ -155,7 +156,20 @@ export function createHostAttachedTerminal(
     const closer = makeClient(options.hostSocketPath);
     closer
       .close(id)
-      .catch(() => {})
+      .catch((error) => {
+        const safeError = toSafeError(error, HOST_DATA_PLANE_FALLBACK);
+        // Pane disposal clears listeners before this settles, so process-level telemetry
+        // retains the close failure without widening the synchronous terminal contract.
+        reportTerminalCorruption({
+          kind: "terminal_diagnostic",
+          key: "host_close_failed",
+          detail: {
+            code: safeError.code,
+            message: safeError.message,
+            ptyId: id,
+          },
+        });
+      })
       .finally(() => closer.dispose());
   };
 


### PR DESCRIPTION
## What this fixes

Station has several teardown and recovery paths where optional cleanup must not break the primary runtime, but failures still need an explicit policy and usable diagnostics. Observer pidfile removal could lose the restoration failure, owned Host PTY close failures disappeared after pane disposal, and the tmux fast-route and packaged-helper cleanup fallbacks lacked regression coverage proving that the user-facing operation remains usable.

## What changed

- Preserve both Observer pidfile unlink and restoration causes in a tagged aggregate failure, then emit the normalized SafeError fields from the shutdown boundary.
- Keep stale packaged-helper pruning best-effort after the current helper is validated and leased, with deterministic coverage for denied removals.
- Keep tmux popup launch working when optional fast-route registration fails and document why the fallback is safe.
- Report asynchronous owned Host PTY close failures through process-level terminal diagnostics while always disposing the closer client.
- Refresh the generated Observer architecture manifest for the new runtime dependency.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm --dir station typecheck`
- `pnpm lint`
- `pnpm test:unit` — 1,815 tests
- `pnpm --dir station test` — 1,095 tests
- `pnpm test:e2e:observer` — 19 lifecycle tests
- Focused changed-path suites — 81 tests

## User-visible behavior

A popup can still open when fast registration fails, and a validated packaged PTY helper can still start when stale cache deletion is denied. Observer identity cleanup and owned Host PTY close failures remain non-disruptive but become searchable through structured logs or terminal diagnostics.