### PR TITLE
fix(release): pin workflow dependencies and narrow credentials

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/nightly-agent-smoke.yaml
+++ b/.github/workflows/nightly-agent-smoke.yaml
@@ -14,12 +14,22 @@ jobs:
   claude-real:
     if: github.repository_owner == 'jeremy0dell'
     runs-on: ubuntu-24.04
+    environment: nightly-agent-smoke
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - name: Verify checkout removed GitHub credentials
+        run: |
+          if git config --local --get-regexp '^http\..*\.extraheader$'; then
+            echo "::error::Checkout credentials remained in repository Git configuration."
+            exit 1
+          fi
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11
@@ -38,20 +48,52 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends tmux
-          npm install -g @anthropic-ai/claude-code
+
+          claude_version="$(npm view @anthropic-ai/claude-code@latest version)"
+          node -e '
+            const version = process.argv[1];
+            const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+            if (!semver.test(version)) throw new Error(`Invalid Claude Code version: ${version}`);
+          ' "$claude_version"
+          claude_integrity="$(
+            npm view "@anthropic-ai/claude-code@$claude_version" dist.integrity
+          )"
+          case "$claude_integrity" in
+            sha512-*) ;;
+            *) echo "::error::Claude Code registry metadata has no SHA-512 integrity value."; exit 1 ;;
+          esac
+
+          npm install -g "@anthropic-ai/claude-code@$claude_version"
+          npm list -g "@anthropic-ai/claude-code@$claude_version" --depth=0
+          installed_version="$(
+            npm list -g @anthropic-ai/claude-code --depth=0 --json |
+              node -e '
+                let input = "";
+                process.stdin.setEncoding("utf8");
+                process.stdin.on("data", (chunk) => { input += chunk; });
+                process.stdin.on("end", () => {
+                  process.stdout.write(
+                    JSON.parse(input).dependencies["@anthropic-ai/claude-code"].version,
+                  );
+                });
+              '
+          )"
+          test "$installed_version" = "$claude_version"
+          {
+            echo "### Nightly Claude Code"
+            echo
+            echo "- Resolved latest version: \`$claude_version\`"
+            echo "- Registry-reported integrity: \`$claude_integrity\`"
+            echo "- Installed version: \`$installed_version\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Real Claude launch + hook-capture smoke
-        # Non-interactive Claude auth. Either secret is enough. Scoped to this step
-        # only so the secrets are never in scope for `pnpm install`/`pnpm build`/`npm
-        # install -g` third-party lifecycle scripts.
+        # This environment-scoped key belongs only to the limited nightly service account.
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN}" ] && [ -z "${ANTHROPIC_API_KEY}" ]; then
-            # Surface as an annotation so a deleted/never-configured secret silently
-            # disabling this version-skew tripwire is visible in the run summary.
-            echo "::warning::No Claude auth secret (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY) configured; skipping the real-agent version-skew smoke."
-            exit 0
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::The dedicated nightly ANTHROPIC_API_KEY is not configured."
+            exit 1
           fi
           pnpm test:agent:nightly

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -16,9 +16,7 @@ on:
         required: true
         type: boolean
 
-permissions:
-  actions: read
-  contents: write
+permissions: {}
 
 concurrency:
   group: promote-release-${{ inputs.tag }}
@@ -28,6 +26,9 @@ jobs:
   promote:
     if: inputs.manual_acceptance
     runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Verify accepted candidate and publish its draft
         env:
@@ -152,8 +153,7 @@ jobs:
   verify-public-install:
     name: verify public install (${{ matrix.target }})
     needs: promote
-    permissions:
-      contents: read
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Validate release tag
@@ -82,11 +82,11 @@ jobs:
     needs: validate
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11
@@ -119,11 +119,11 @@ jobs:
             target: darwin-arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24.x
       - name: Enable pnpm 11
@@ -168,7 +168,7 @@ jobs:
             echo "runner=$RUNNER_LABEL"
             echo "floor=$floor"
           } > "platform-metadata-$TARGET.txt"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: native-${{ matrix.target }}
           path: |
@@ -189,11 +189,11 @@ jobs:
     outputs:
       release_id: ${{ steps.release.outputs.release_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: native-*
           path: release
@@ -335,7 +335,7 @@ jobs:
               releaseId: $releaseId,
               checksumFileSha256: $checksumFileSha256
             }' > candidate/manifest.json
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: release/candidate
@@ -364,7 +364,7 @@ jobs:
             target: darwin-arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
           ref: ${{ needs.validate.outputs.commit }}
@@ -537,7 +537,7 @@ jobs:
       # GitHub exposes draft releases only to identities with push access.
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: release-candidate-input-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: candidate
@@ -601,7 +601,7 @@ jobs:
           done
           cmp candidate/SHA256SUMS downloaded/SHA256SUMS
           (cd downloaded && sha256sum -c SHA256SUMS)
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: accepted-release-candidate-${{ needs.validate.outputs.version }}-attempt-${{ github.run_attempt }}
           path: candidate

--- a/docs/development.md
+++ b/docs/development.md
@@ -357,6 +357,16 @@ must show B's build and protocol versions. Legacy or different-protocol hosts
 refuse automatic replacement and must be stopped explicitly only after their
 sessions are accounted for.
 
+## Hosted Workflow Security
+
+External GitHub Actions must use reviewed full commit SHAs with human-readable version comments. Repository-local actions and reusable workflows are tied to the checked-out commit and are exempt from external pinning. Every checkout disables persisted credentials.
+
+Dependabot proposes individual action-pin updates each week. Reviewers must verify official repository ownership, release notes, changed runtime and permissions, and the tag-to-SHA correspondence before merging; Dependabot is an update mechanism, not an approval mechanism.
+
+The nightly Claude compatibility lane intentionally resolves npm's current `latest` release once, validates and installs that exact version, and records the resolved version, installed version, and registry-reported integrity in the run summary. That integrity value is run evidence, not an independent trust root. Authentication uses a dedicated, limited, environment-scoped credential available only to the real-Claude execution step.
+
+Release write access is limited to jobs that create, inspect, or publish draft releases. Public-install verification is tokenless. `tests/diagnostics/ci-workflow-policy.test.ts` enforces action pins, checkout credential handling, release permissions, and nightly secret scope.
+
 ## Experimental Pre-Alpha Release
 
 Before tagging, an administrator must enable GitHub immutable releases; the

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
@@ -22,6 +22,63 @@ function between(document: string, start: string, end?: string): string {
   const endIndex = end === undefined ? document.length : document.indexOf(end, startIndex + 1);
   expect(endIndex, `missing section end: ${end}`).toBeGreaterThan(startIndex);
   return document.slice(startIndex, endIndex);
+}
+
+interface WorkflowFile {
+  readonly path: string;
+  readonly document: string;
+  readonly lines: readonly string[];
+}
+
+interface WorkflowStep {
+  readonly line: number;
+  readonly text: string;
+}
+
+function workflowFiles(): readonly WorkflowFile[] {
+  return [".github/workflows", ".github/actions"].flatMap((directory) =>
+    readdirSync(new URL(directory, root), { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+      .map((entry) => {
+        const path = `${directory}/${entry.parentPath.slice(
+          fileURLToPath(new URL(directory, root)).length + 1,
+        )}/${entry.name}`.replace("//", "/");
+        const document = read(path);
+        return { path, document, lines: document.split("\n") };
+      }),
+  );
+}
+
+function workflowSteps(file: WorkflowFile): readonly WorkflowStep[] {
+  const stepStarts = file.lines.flatMap((line, index) =>
+    /^\s*- (?:name|uses|run):/.test(line) ? [{ index, indent: line.search(/\S/) }] : [],
+  );
+
+  return stepStarts.map(({ index, indent }, stepIndex) => {
+    const next = stepStarts
+      .slice(stepIndex + 1)
+      .find((candidate) => candidate.indent === indent && candidate.index > index);
+    return {
+      line: index + 1,
+      text: file.lines.slice(index, next?.index ?? file.lines.length).join("\n"),
+    };
+  });
+}
+
+function workflowJobNames(document: string): readonly string[] {
+  const lines = document.slice(document.indexOf("jobs:")).split("\n");
+  return lines.flatMap((line) => {
+    const name = line.match(/^ {2}([\w-]+):$/)?.[1];
+    return name === undefined ? [] : [name];
+  });
+}
+
+function workflowJob(document: string, name: string): string {
+  const lines = document.split("\n");
+  const start = lines.indexOf(`  ${name}:`);
+  expect(start, `missing workflow job: ${name}`).toBeGreaterThanOrEqual(0);
+  const end = lines.findIndex((line, index) => index > start && /^ {2}[\w-]+:/.test(line));
+  return lines.slice(start, end === -1 ? undefined : end).join("\n");
 }
 
 const successfulCiEnvironment = {
@@ -65,6 +122,99 @@ function runAggregatePolicy(environment: Readonly<Record<string, string>>) {
     env: { ...environment },
   });
 }
+
+describe("workflow security policy", () => {
+  it("pins every external action to a full commit SHA", () => {
+    const externalAction = /^[^/\s]+\/[^@\s]+@([0-9a-f]{40})$/;
+
+    for (const file of workflowFiles()) {
+      file.lines.forEach((line, index) => {
+        const reference = line.match(/^\s*(?:-\s*)?uses:\s*([^\s#]+)/)?.[1];
+        if (
+          reference === undefined ||
+          reference.startsWith("./") ||
+          reference.startsWith("docker://")
+        ) {
+          return;
+        }
+        expect.soft(reference, `${file.path}:${index + 1}: ${line.trim()}`).toMatch(externalAction);
+      });
+    }
+  });
+
+  it("disables credential persistence in every checkout step", () => {
+    for (const file of workflowFiles()) {
+      for (const step of workflowSteps(file)) {
+        if (!/uses:\s*actions\/checkout@[0-9a-f]{40}/.test(step.text)) {
+          continue;
+        }
+        expect
+          .soft(step.text, `${file.path}:${step.line}: checkout must not persist credentials`)
+          .toMatch(/\n\s+with:\s*(?:\n\s+[^\n]+)*\n\s+persist-credentials:\s*false(?:\s|$)/);
+      }
+    }
+  });
+
+  it("limits release and promotion permissions to the jobs that need them", () => {
+    const promotion = read(".github/workflows/promote-release.yml");
+    const promotionHeader = promotion.slice(0, promotion.indexOf("jobs:"));
+    expect(promotionHeader).toMatch(/^permissions: \{\}$/m);
+    expect(promotionHeader).not.toContain("contents: write");
+
+    const promote = workflowJob(promotion, "promote");
+    expect(promote).toMatch(/\n {4}permissions:\n {6}actions: read\n {6}contents: write\n/);
+    expect(workflowJob(promotion, "verify-public-install")).toMatch(/\n {4}permissions: \{\}\n/);
+
+    const release = read(".github/workflows/release.yml");
+    const writeJobs = workflowJobNames(release).filter((job) =>
+      workflowJob(release, job).includes("contents: write"),
+    );
+    expect(writeJobs).toEqual(["create-draft", "install-draft", "record-accepted-candidate"]);
+  });
+
+  it("scopes dedicated Claude authentication to the real-agent execution step", () => {
+    const file = workflowFiles().find(
+      (candidate) => candidate.path === ".github/workflows/nightly-agent-smoke.yaml",
+    );
+    expect(file).toBeDefined();
+    if (file === undefined) {
+      return;
+    }
+
+    expect(file.document).toContain("environment: nightly-agent-smoke");
+    expect(file.document).toContain("npm view @anthropic-ai/claude-code@latest version");
+    expect(file.document).toContain(
+      'npm view "@anthropic-ai/claude-code@$claude_version" dist.integrity',
+    );
+    expect(file.document).toContain('npm install -g "@anthropic-ai/claude-code@$claude_version"');
+    expect(file.document).toContain("Resolved latest version:");
+    expect(file.document).toContain("Registry-reported integrity:");
+    expect(file.document).toContain("Installed version:");
+
+    const authentication = /ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN/;
+    const authenticatedSteps = workflowSteps(file).filter((step) => authentication.test(step.text));
+    expect(authenticatedSteps).toHaveLength(1);
+    expect(file.document.match(/ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN/g)).toHaveLength(
+      authenticatedSteps[0]?.text.match(/ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN/g)?.length ?? 0,
+    );
+    expect(authenticatedSteps[0]?.text).toContain("name: Real Claude launch + hook-capture smoke");
+    expect(authenticatedSteps[0]?.text).toContain(
+      `ANTHROPIC_API_KEY: ${actionsExpression("secrets.ANTHROPIC_API_KEY")}`,
+    );
+    expect(authenticatedSteps[0]?.text).not.toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(authenticatedSteps[0]?.text).toContain('echo "::error::');
+    expect(authenticatedSteps[0]?.text).toContain("exit 1");
+    expect(authenticatedSteps[0]?.text).not.toContain("exit 0");
+
+    for (const stepName of ["Install workspace", "Install tmux and the Claude Code CLI"]) {
+      const step = workflowSteps(file).find((candidate) =>
+        candidate.text.startsWith(`      - name: ${stepName}`),
+      );
+      expect(step, `missing nightly step: ${stepName}`).toBeDefined();
+      expect(step?.text).not.toMatch(/ANTHROPIC_API_KEY|CLAUDE_CODE_OAUTH_TOKEN/);
+    }
+  });
+});
 
 describe("hosted CI policy", () => {
   it("fans ready pull requests and release calls into independently reported validation lanes", () => {


### PR DESCRIPTION
## What this fixes

Station's release workflows depended on floating action tags and granted broader credential and publication access than their jobs required. That allowed upstream action changes to enter release runs without repository review and exposed credentials beyond the narrow steps that consume them.

## What changed

- Pin every external action under `.github/workflows` and `.github/actions` to a reviewed full commit SHA, while preserving local workflow references.
- Disable persisted checkout credentials and enforce the repository-wide pin and checkout policy in diagnostics tests.
- Move promotion write authority to the `promote` job and make public-install verification tokenless.
- Resolve npm's current Claude release once per nightly run, validate and install that exact version, and record its registry integrity and installed version.
- Scope one dedicated environment credential to the real-Claude step and fail the lane when it is missing.
- Add individual weekly Dependabot updates for GitHub Actions and document the review policy.

## Testing

- `pnpm test:diagnostics:policy`
- `pnpm lint`
- `pnpm test:unit` with inherited harness-home variables removed (1,808 tests passed)
- Verified the four official action tag-to-SHA mappings with `git ls-remote` and reviewed their official release notes and `action.yml` changes.
- Verified no floating external action references remain with the repository inventory command.
- `pnpm test:all` was attempted, but local retries encountered unrelated inherited Station environment interference and existing 5-second process-test timeouts under host contention; hosted `standard-ci` remains required.

## Safety and scope

This does not create or promote a release tag and does not change release candidate, checksum, draft-install, or promotion checks. Before manually dispatching the nightly lane, provision the `nightly-agent-smoke` GitHub environment with its dedicated limited `ANTHROPIC_API_KEY`.
