### PR TITLE
fix(station): settle failed managed launches

### DIFF
--- a/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
+++ b/packages/dashboard-core/test/unit/selectors/dashboardViewport.test.ts
@@ -188,6 +188,43 @@ describe("dashboard viewport selector", () => {
     expect(viewport.items.filter((item) => item.type === "createLocalRow")).toEqual([]);
   });
 
+  it("shows a failed create row when only the retained bare worktree exists", () => {
+    const snapshot = createDashboardSnapshot();
+    const viewport = selectDashboardViewport(
+      snapshot,
+      createInitialTuiState({
+        initialSnapshot: snapshot,
+        localRows: {
+          pendingCreate: [],
+          failedCreate: [
+            {
+              localId: "local_create_failed",
+              projectId: "web",
+              title: "Failed launch",
+              branch: "feature-auth",
+              error: {
+                tag: "ClientObserverError",
+                code: "PREPARE_FAILED",
+                message: "Harness preparation failed.",
+              },
+              expiresAt: Date.now() + 4_000,
+            },
+          ],
+          pendingRemove: [],
+          pendingStart: [],
+        },
+      }),
+    );
+
+    const failed = viewport.items.find(
+      (item) => item.type === "createLocalRow" && item.row.localId === "local_create_failed",
+    );
+    expect(failed).toMatchObject({ type: "createLocalRow", row: { status: "failed" } });
+    expect(viewport.rowChoices.map((choice) => choice.value.worktree.branch)).not.toContain(
+      "feature-auth",
+    );
+  });
+
   it("orders mixed local and real rows by resolved display title", () => {
     const snapshot = createDashboardSnapshot();
     const titled = {

--- a/packages/dashboard-core/test/unit/state/localRows.test.ts
+++ b/packages/dashboard-core/test/unit/state/localRows.test.ts
@@ -1,8 +1,10 @@
 import {
+  addPendingCreateSessionRow,
   addPendingStartAgentRow,
   bindPendingStartAgentRow,
   createEmptyTuiLocalRows,
   createInitialTuiState,
+  failPendingCreateSessionRow,
   pruneLocalRowsForSnapshot,
   removePendingStartAgentRow,
 } from "@station/dashboard-core";
@@ -10,6 +12,35 @@ import { describe, expect, it } from "vitest";
 import { createCommandSnapshot } from "../../fixtures/snapshots.js";
 
 describe("TUI local rows", () => {
+  it("atomically replaces the matching pending create row with a failed row", () => {
+    const pending = addPendingCreateSessionRow(createInitialTuiState(), {
+      localId: "create:web:feature-failed",
+      projectId: "web",
+      title: "Failed launch",
+      branch: "feature-failed",
+      createdAt: "2026-06-01T12:00:00.000Z",
+    });
+    const error = {
+      tag: "ClientObserverError" as const,
+      code: "PREPARE_FAILED",
+      message: "Harness preparation failed.",
+    };
+
+    const failed = failPendingCreateSessionRow(pending, "create:web:feature-failed", error, 1234);
+
+    expect(failed.localRows.pendingCreate).toEqual([]);
+    expect(failed.localRows.failedCreate).toEqual([
+      {
+        localId: "create:web:feature-failed",
+        projectId: "web",
+        title: "Failed launch",
+        branch: "feature-failed",
+        error,
+        expiresAt: 1234,
+      },
+    ]);
+  });
+
   it("adds, binds, and removes pending start-agent rows", () => {
     const state = addPendingStartAgentRow(createInitialTuiState(), {
       localId: "start:wt_web_no_agent",

--- a/station/src/input/runtime/managedLaunch.ts
+++ b/station/src/input/runtime/managedLaunch.ts
@@ -5,9 +5,11 @@ import type { StationStore } from "../../state/store.js";
 import { agentWorktreePaneId, type PaneId } from "../../state/types.js";
 import { dispatchStationKey } from "../../station/input/stationActions.js";
 import { safeErrorToNotice, toSafeError, type ObserverService } from "@station/client";
-import type { ProviderId, StationCommand } from "@station/contracts";
+import type { ProviderId, SafeError, StationCommand } from "@station/contracts";
 import {
   addPendingCreateSessionRow,
+  failPendingCreateSessionRow,
+  FAILED_CREATE_ROW_TTL_MS,
   removeCreateSessionLocalRow,
   type TuiStore,
 } from "@station/dashboard-core";
@@ -72,6 +74,21 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
     if (stationViewStore !== undefined) {
       stationViewStore.setState(removeCreateSessionLocalRow(stationViewStore.getState(), localId));
     }
+  }
+
+  function failPendingCreateRow(localId: string, error: SafeError): void {
+    if (stationViewStore === undefined) {
+      return;
+    }
+    stationViewStore.setState(
+      failPendingCreateSessionRow(
+        stationViewStore.getState(),
+        localId,
+        error,
+        Date.now() + FAILED_CREATE_ROW_TTL_MS,
+      ),
+    );
+    setTimeout(() => clearPendingCreateRow(localId), FAILED_CREATE_ROW_TTL_MS);
   }
 
   /**
@@ -162,7 +179,7 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
       pushLaunchError(completion.error);
       return;
     }
-    // The optimistic row auto-prunes when the worktree reaches the snapshot, which is also when this resolves.
+    // A bare worktree does not prune the optimistic row; only the matching canonical session does.
     const row = await waitForWorktreeByBranch(stationViewStore, spec.projectId, spec.branch);
     if (row === undefined) {
       clearPendingCreateRow(spec.localId);
@@ -179,7 +196,10 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
     if (spec.harness !== undefined) {
       launchTarget.harness = spec.harness;
     }
-    await runManagedLaunchAttempt(agentWorktreePaneId(row.id), launchTarget);
+    const result = await runManagedLaunchAttempt(agentWorktreePaneId(row.id), launchTarget);
+    if (result.kind === "preparation-failed") {
+      failPendingCreateRow(spec.localId, result.error);
+    }
   }
 
   return {

--- a/station/src/input/runtime/managedLaunchAttempt.test.ts
+++ b/station/src/input/runtime/managedLaunchAttempt.test.ts
@@ -291,10 +291,19 @@ describe("createManagedLaunchAttempt", () => {
       },
     });
 
-    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
-    await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+    const failure = await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
+    const retry = await harness.runManagedLaunchAttempt(PANE_ID, TARGET);
 
     expect(harness.prepareCalls).toHaveLength(2);
+    expect(failure).toEqual({
+      kind: "preparation-failed",
+      error: {
+        tag: "ClientObserverError",
+        code: "CLIENT_OBSERVER_OPERATION_FAILED",
+        message: "The Station could not complete the observer operation.",
+      },
+    });
+    expect(retry).toEqual({ kind: "settled" });
     expect(harness.calls).toEqual([
       `ensure:${PANE_ID}`,
       `pane:${PANE_ID}:primary-agent`,
@@ -371,9 +380,10 @@ describe("createManagedLaunchAttempt", () => {
       },
     });
 
-    await failing.runManagedLaunchAttempt(PANE_ID, TARGET);
+    const result = await failing.runManagedLaunchAttempt(PANE_ID, TARGET);
     await failing.runManagedLaunchAttempt(PANE_ID, TARGET);
 
+    expect(result).toEqual({ kind: "settled" });
     expect(failing.prepareCalls).toHaveLength(2);
     expect(failing.calls).toEqual([]);
     expect(failing.lastToast()?.message).toContain("attachment failed");

--- a/station/src/input/runtime/managedLaunchAttempt.ts
+++ b/station/src/input/runtime/managedLaunchAttempt.ts
@@ -1,5 +1,5 @@
 import { safeErrorToNotice, toSafeError, type ObserverService } from "@station/client";
-import type { ProviderId } from "@station/contracts";
+import type { ProviderId, SafeError } from "@station/contracts";
 import type { TuiStore } from "@station/dashboard-core";
 import { StationHostProviderError } from "@station/host";
 import type { StoreApi } from "zustand/vanilla";
@@ -64,6 +64,12 @@ type ManagedLaunchContext = {
 
 type PreparedLaunch = Awaited<ReturnType<ObserverService["prepareExternalLaunch"]>>;
 
+export type ManagedLaunchAttemptResult =
+  | { kind: "settled" }
+  | { kind: "preparation-failed"; error: SafeError };
+
+const SETTLED_RESULT: ManagedLaunchAttemptResult = { kind: "settled" };
+
 type ManagedLaunchAction =
   | {
       kind: "open-pane";
@@ -82,10 +88,12 @@ function pushToast(
   runtime.stationViewStore?.getState().pushToast({ kind, message });
 }
 
+function pushSafeError(runtime: ManagedLaunchRuntime, error: SafeError): void {
+  runtime.stationViewStore?.getState().pushToast(safeErrorToNotice(error));
+}
+
 function pushError(runtime: ManagedLaunchRuntime, error: unknown): void {
-  runtime.stationViewStore
-    ?.getState()
-    .pushToast(safeErrorToNotice(toSafeError(error, { clientLabel: "Station" })));
+  pushSafeError(runtime, toSafeError(error, { clientLabel: "Station" }));
 }
 
 function createContext(
@@ -184,12 +192,19 @@ async function prepareLaunch(
   runtime: ManagedLaunchRuntime,
   service: ObserverService,
   target: ManagedLaunchTarget,
-): Promise<PreparedLaunch | undefined> {
+): Promise<
+  | { kind: "prepared"; launch: PreparedLaunch }
+  | Extract<ManagedLaunchAttemptResult, { kind: "preparation-failed" }>
+> {
   try {
-    return await service.prepareExternalLaunch(buildPrepareParams(target));
+    return {
+      kind: "prepared",
+      launch: await service.prepareExternalLaunch(buildPrepareParams(target)),
+    };
   } catch (error) {
-    pushError(runtime, error);
-    return undefined;
+    const safeError = toSafeError(error, { clientLabel: "Station" });
+    pushSafeError(runtime, safeError);
+    return { kind: "preparation-failed", error: safeError };
   }
 }
 
@@ -348,21 +363,22 @@ async function runManagedLaunchAttempt(
   runtime: ManagedLaunchRuntime,
   paneId: PaneId,
   target: ManagedLaunchTarget,
-): Promise<void> {
+): Promise<ManagedLaunchAttemptResult> {
   const context = createContext(runtime, paneId, target);
   const service = await runPreflight(runtime, context);
   if (service === undefined) {
-    return;
+    return SETTLED_RESULT;
   }
   try {
-    const prepared = await prepareLaunch(runtime, service, target);
-    if (prepared === undefined) {
-      return;
+    const preparation = await prepareLaunch(runtime, service, target);
+    if (preparation.kind === "preparation-failed") {
+      return preparation;
     }
-    const action = await resolvePreparedLaunch(runtime, prepared, target);
+    const action = await resolvePreparedLaunch(runtime, preparation.launch, target);
     if (action !== undefined) {
       await performPreparedAction(runtime, context, service, action);
     }
+    return SETTLED_RESULT;
   } finally {
     runtime.launchesInFlight.delete(paneId);
   }
@@ -374,7 +390,7 @@ async function runManagedLaunchAttempt(
  */
 export function createManagedLaunchAttempt(
   deps: ManagedLaunchAttemptDeps,
-): (paneId: PaneId, target: ManagedLaunchTarget) => Promise<void> {
+): (paneId: PaneId, target: ManagedLaunchTarget) => Promise<ManagedLaunchAttemptResult> {
   const runtime: ManagedLaunchRuntime = {
     ...deps,
     launchesInFlight: new Set<PaneId>(),

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { createTuiStore, selectDashboardViewport, type TuiStore } from "@station/dashboard-core";
+import {
+  createTuiStore,
+  FAILED_CREATE_ROW_TTL_MS,
+  selectDashboardViewport,
+  type TuiStore,
+} from "@station/dashboard-core";
 import type { StoreApi } from "zustand/vanilla";
 import { selectActivePaneId, selectStationOverlayVisible } from "../state/selectors.js";
 import { createStationStore } from "../state/store.js";
@@ -2079,6 +2084,68 @@ describe("createStationInputRuntime New Session hosted launch", () => {
     ).toBe(false);
   });
 
+  it("shows then expires a failed optimistic row when New preparation rejects", async () => {
+    const harness = newSessionHarness();
+    const worktreeId = "wt_failed_new_session";
+    harness.observerService.prepareExternalLaunch = async (params) => {
+      harness.observerService.preparedLaunches.push(params);
+      throw {
+        tag: "CommandValidationError",
+        code: "HARNESS_HOOKS_NOT_INSTALLED",
+        message: "Claude hooks are not installed.",
+        hint: "Run 'stn hooks install claude'.",
+      };
+    };
+    const { branch } = openWizardAndCaptureSubmit(harness, "Failed New Session");
+    const localId = `station-create:${PROJECT_ID}:${branch}`;
+
+    expect(harness.pressKey("\r")).toBe(true);
+    await harness.settle();
+
+    const realSetTimeout = globalThis.setTimeout;
+    let expireFailedRow: (() => void) | undefined;
+    globalThis.setTimeout = ((
+      callback: (...callbackArgs: unknown[]) => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      if (ms === FAILED_CREATE_ROW_TTL_MS) {
+        expireFailedRow = () => callback(...rest);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(callback, ms, ...rest);
+    }) as typeof globalThis.setTimeout;
+    try {
+      harness.source.setSnapshot(snapshotWithWorktree(harness.snapshot, worktreeId, branch));
+      await harness.settle();
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+
+    expect(harness.stationViewStore.getState().localRows.pendingCreate).toEqual([]);
+    const failedRow = harness.stationViewStore.getState().localRows.failedCreate[0];
+    expect(harness.stationViewStore.getState().localRows.failedCreate).toHaveLength(1);
+    expect(failedRow).toMatchObject({ localId, title: "Failed New Session", branch });
+    expect(failedRow?.error).toMatchObject({
+      code: "HARNESS_HOOKS_NOT_INSTALLED",
+      message: "Claude hooks are not installed.",
+    });
+    expect(
+      harness.store
+        .getState()
+        .workspace.panes.some((pane) => pane.id === agentWorktreePaneId(worktreeId)),
+    ).toBe(false);
+    expect(harness.stationViewStore.getState().toasts.at(-1)?.toast).toMatchObject({
+      kind: "error",
+      message: "Claude hooks are not installed.",
+      hint: "Run 'stn hooks install claude'.",
+    });
+
+    expect(expireFailedRow).toBeDefined();
+    expireFailedRow?.();
+    expect(harness.stationViewStore.getState().localRows.failedCreate).toEqual([]);
+  });
+
   it("removes the optimistic row and toasts when the worktree create is rejected", async () => {
     const harness = newSessionHarness();
     harness.observerService.nextReceipt = {
@@ -2354,6 +2421,44 @@ describe("createStationInputRuntime Fork hosted launch", () => {
     );
     // Background launch: the dashboard overlay stays up.
     expect(selectStationOverlayVisible(harness.store.getState())).toBe(true);
+  });
+
+  it("shows a failed optimistic row without deleting the retained fork when preparation rejects", async () => {
+    const harness = forkHarness();
+    const worktreeId = "wt_failed_fork";
+    harness.observerService.prepareExternalLaunch = async (params) => {
+      harness.observerService.preparedLaunches.push(params);
+      throw {
+        tag: "ClientObserverError",
+        code: "HARNESS_UNAVAILABLE",
+        message: "The selected harness is unavailable.",
+      };
+    };
+    const submit = openForkAndCaptureSubmit(harness, "Failed Fork");
+    const localId = `station-fork:${submit.sourceWorktreeId}:${submit.branch}`;
+
+    expect(harness.pressKey("\r")).toBe(true);
+    await harness.settle();
+    harness.source.setSnapshot(
+      snapshotWithWorktree(harness.snapshot, submit.projectId, worktreeId, submit.branch),
+    );
+    await harness.settle();
+
+    expect(
+      harness.stationViewStore.getState().snapshot?.rows.some(
+        (row) => row.id === worktreeId && row.branch === submit.branch,
+      ),
+    ).toBe(true);
+    expect(harness.stationViewStore.getState().localRows.pendingCreate).toEqual([]);
+    const failedRow = harness.stationViewStore.getState().localRows.failedCreate[0];
+    expect(harness.stationViewStore.getState().localRows.failedCreate).toHaveLength(1);
+    expect(failedRow).toMatchObject({ localId, title: "Failed Fork", branch: submit.branch });
+    expect(failedRow?.error).toMatchObject({ code: "HARNESS_UNAVAILABLE" });
+    expect(
+      harness.store
+        .getState()
+        .workspace.panes.some((pane) => pane.id === agentWorktreePaneId(worktreeId)),
+    ).toBe(false);
   });
 
   it("removes the optimistic row and toasts when the worktree fork is rejected", async () => {


### PR DESCRIPTION
## What this fixes

Station creates the worktree before preparing a native New or Fork agent launch. If preparation then fails, the real worktree is retained but the optimistic dashboard row previously remained pending with no bounded failed state. This made a completed worktree mutation look stuck even though the actionable launch error was already available.

## What changed

- Return a small managed-launch result only for Observer preparation failures, normalizing the SafeError once.
- Convert the exact hosted New or Fork optimistic row into the existing inert failed-row presentation.
- Expire that local failed row after the existing four-second bound while preserving the created worktree and branch.
- Keep successful launches, existing-session focus, early guards, command failures, timeouts, and post-prepare attachment failures on their existing paths.
- Correct the pending-row comment: a bare worktree does not prune it; the matching canonical session does.

## Testing

- pnpm architecture:observer:generate
- pnpm architecture:observer:check
- pnpm --dir station typecheck
- pnpm --dir station test (1,095 passed)
- Focused Station managed-launch tests (113 passed)
- Focused dashboard-core local-row and viewport tests (21 passed)
- env -u STATION_PANE -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:all
- git diff --check

## User-visible behavior

When native New or Fork creates a worktree but agent preparation fails, Station now shows the actionable failed row briefly and then removes it; the real worktree and any copied fork state remain intact. Manually verify by forcing prepareExternalLaunch to reject after the bare worktree appears and observing no pane plus a four-second failed row.

Closes #300