### PR TITLE
fix(terminal): preserve OSC 8 hyperlinks through native rendering

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -549,8 +549,10 @@ hashing source from the UI. The CLI sets `STATION_TUI_PERSISTENT=1` when the
 renderer requires its lifecycle-control IPC channel; it is not a standalone
 launch mode. Native Station child PTYs also receive standard terminal values
 `TERM=xterm-256color`, `COLORTERM=truecolor`, and `TERM_PROGRAM=Station` after
-inherited and per-launch environment merging. Outer-renderer identity and
-feature hints are removed at that boundary, while ordinary locale,
+inherited and per-launch environment merging. Outer-renderer identity and feature
+hints, including inherited hyperlink overrides, are removed at that boundary.
+Station does not advertise OSC 8 until both a coordinated child detector and an
+outer-terminal capability gate are available, while ordinary locale,
 authentication, provider, project, worktree, and user environment passes
 through. This includes functional values such as Git askpass configuration.
 Local PTYs preserve inherited `NO_COLOR` / `FORCE_COLOR` preferences, while

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -94,11 +94,12 @@ continues to pass through, including functional Git askpass and provider context
 Local PTYs preserve inherited `NO_COLOR` / `FORCE_COLOR` preferences. A
 persistent Host may inherit those values from a headless provider hook rather
 than a user terminal, so Host PTYs discard daemon-inherited copies and preserve
-only values carried by the explicit launch request. Until Station supports a
-feature end to end, children must not infer it from Ghostty, Kitty, WezTerm,
-iTerm2, Windows Terminal, Warp, or another outer renderer; native Station
-currently advertises true color but neither an image protocol nor OSC 8
-hyperlinks.
+only values carried by the explicit launch request. Until Station can establish a
+feature end to end for the current outer renderer, children must not infer it from
+Ghostty, Kitty, WezTerm, iTerm2, Windows Terminal, Warp, or another outer renderer;
+native Station currently advertises true color but neither an image protocol nor
+OSC 8 hyperlinks. `TERM_PROGRAM=Station` preserves the renderer identity without
+impersonating an outer emulator.
 
 Outer-renderer variables are application conventions, not an exhaustive standard
 registry. Station therefore maintains a curated set of known identity and capability
@@ -121,6 +122,48 @@ do not pass through this native PTY policy.
 The policy applies only when a local bridge, Bun, or Station Host PTY is created.
 Existing live PTYs keep the environment captured at spawn and are never torn down to
 adopt a capability-policy update.
+
+The pinned Pi 0.80.10 detector fixture does not yet recognize Station or
+`FORCE_HYPERLINK`; it intentionally remains `hyperlinks: false`. Inherited
+hyperlink overrides are scrubbed and Station does not replace them. Capability
+advertisement remains disabled until a coordinated Pi release and an
+outer-terminal capability gate can land atomically; do not impersonate another
+emulator or patch the fixture to claim behavior the published Pi executable does
+not have.
+
+## Native OSC 8 Hyperlinks
+
+Native panes preserve hyperlink identity through the Station-owned terminal
+pipeline: xterm resolves each active buffer cell's OSC 8 link to its URI,
+link-aware VT spans preserve that URI across viewport and scrollback projection,
+and OpenTUI attaches a native link ID to only the cells actually drawn inside
+the pane. Adjacent same-style links remain distinct, and xterm owns overwrite,
+erase, reset, reflow, scrollback eviction, and alternate-buffer lifetime.
+
+Before handing a URI to OpenTUI, Station requires parseable absolute-URI syntax,
+rejects invalid percent escapes, disallowed URI characters, terminal controls,
+and malformed surrogate data, and enforces OpenTUI 0.4.1's 512-byte UTF-8 limit
+without normalizing accepted values. A constant-time code-unit length gate bounds
+all parsing and encoding work. Invalid links remain ordinary visible text.
+OpenTUI emits OSC 8 only when its outer-terminal capability is enabled; the
+outer terminal owns activation and URI policy. Station does not open or
+shell-execute child-provided URIs, and terminal drag selection,
+right-click, multi-click, wheel, and child mouse reporting remain unchanged.
+
+Station Host records and replays raw PTY data events, so a complete replay feeds
+the original OSC 8 open/close bytes back through xterm and restores link
+metadata without a Host protocol change. A replay whose required bytes were
+already truncated cannot reconstruct that state and remains owned by #216.
+
+Manual validation in a hyperlink-capable outer terminal:
+
+```sh
+printf '\033[4m\033]8;;https://github.com/jeremy0dell/station/issues/196\033\\#196\033]8;;\033\\\033[24m\n'
+```
+
+The `#196` label should expose the exact issue URI. Repeat with adjacent links,
+`file:` and `mailto:` targets, selection, scrollback, resize, and complete Host
+reattach; pane borders and neighboring panes must remain unlinked.
 
 ## Boundaries
 

--- a/station/src/host/ptyTable.smoke.test.ts
+++ b/station/src/host/ptyTable.smoke.test.ts
@@ -85,6 +85,7 @@ if (SMOKE) {
           "TERM=xterm-256color",
           "COLORTERM=truecolor",
           "TERM_PROGRAM=Station",
+          "FORCE_HYPERLINK=unset",
           "GHOSTTY=unset",
           "KITTY=unset",
           "WEZTERM=unset",

--- a/station/src/host/reattach.integration.test.ts
+++ b/station/src/host/reattach.integration.test.ts
@@ -43,6 +43,47 @@ function screenText(screen: ReturnType<typeof createStationVtScreen>): string {
 }
 
 describe("data-plane reattach (host PTY → host-attached terminal → VT screen)", () => {
+  it("restores an OSC 8 URI by replaying the complete pre-attach PTY data event", async () => {
+    const scripted = createScriptedTerminal({ cols: 80, rows: 24 });
+    const socketPath = await startHostWith(scripted);
+    const control = createStationHostClient({ socketPath });
+    const { ptyId } = await control.spawn({
+      ...identity,
+      command: "claude",
+      args: [],
+      cwd: "/repo/wt-1",
+      cols: 80,
+      rows: 24,
+    });
+    const uri = "https://example.com/complete-host-replay";
+    scripted.helpers.emitData(`\x1b]8;;${uri}\x1b\\reattached\x1b]8;;\x1b\\`);
+
+    const terminal = createHostAttachedTerminal({
+      hostSocketPath: socketPath,
+      ptyId,
+      size: { cols: 80, rows: 24 },
+    });
+    const screen = createStationVtScreen({ size: { cols: 80, rows: 24 } });
+    terminal.onData((data) => screen.feed(data));
+
+    try {
+      await waitFor(() =>
+        screen
+          .buildRows({ cursorVisible: false })
+          .some((row) => row.spans.some((span) => span.link === uri)),
+      );
+      expect(
+        screen
+          .buildRows({ cursorVisible: false })
+          .some((row) => row.spans.some((span) => span.text === "reattached" && span.link === uri)),
+      ).toBe(true);
+    } finally {
+      terminal.dispose();
+      screen.dispose();
+      control.dispose();
+    }
+  });
+
   it("replays scrollback then streams live output into a fresh screen, and detach keeps the PTY", async () => {
     const scripted = createScriptedTerminal({ cols: 80, rows: 24 });
     const socketPath = await startHostWith(scripted);

--- a/station/src/terminal/TerminalPane.test.tsx
+++ b/station/src/terminal/TerminalPane.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { rgbToHex, TextAttributes } from "@opentui/core";
+import { getLinkId, rgbToHex, TextAttributes } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
 import { MAIN_PANE_ID } from "../state/types.js";
 import { PaneRegistryProvider } from "./registry/paneTerminalContext.js";
@@ -129,6 +129,20 @@ describe("TerminalPane frame rendering", () => {
     expect((errSpan?.attributes ?? 0) & TextAttributes.BOLD).toBe(TextAttributes.BOLD);
     const okSpan = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 4);
     expect(rgbToHex(okSpan?.fg as Parameters<typeof rgbToHex>[0])).toBe("#010203");
+  });
+
+  it("projects an OSC 8 URI through the production registry, screen, and pane", async () => {
+    const pane = await renderPane();
+    const uri = "https://example.com/registry-projection";
+    await feedAndFlush(pane, `\x1b]8;;${uri}\x1b\\label\x1b]8;;\x1b\\`);
+    await waitForPaneFrame(pane, (frame) => frame.includes("label"));
+
+    const screen = pane.registry.get(MAIN_PANE_ID)?.screen;
+    expect(screen?.buildRows({ cursorVisible: false })[0]?.spans[0]?.link).toBe(uri);
+    const frameIndex = ORIGIN.y * SURFACE.width + ORIGIN.x;
+    expect(
+      getLinkId(pane.setup.renderer.currentRenderBuffer.buffers.attributes[frameIndex] ?? 0),
+    ).toBeGreaterThan(0);
   });
 
   it("shows the cursor as an inverse cell and hides it on dectcem", async () => {

--- a/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
@@ -4,6 +4,7 @@
 // scissor at the pane edge, so those tails escaped into the pane border and
 // neighboring panes; renderSelf now clips all paint to its own bounds.
 import { afterEach, describe, expect, it } from "bun:test";
+import { getLinkId } from "@opentui/core";
 import { createElement } from "react";
 import { testRender } from "@opentui/react/test-utils";
 import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
@@ -75,6 +76,16 @@ describe("renderSelf scissors paint to the pane bounds", () => {
     const { setup } = await mountNarrowPane("ABCDEFGHIJ");
     expect(setup.captureCharFrame().split("\n")[0] ?? "").toContain("ABCDEFGHIJ");
     expect(paintedExtent(setup)).toBe(PANE_COLS);
+  });
+
+  it("does not carry a final-column link into the neighboring frame cell", async () => {
+    const uri = "https://example.com/final-column";
+    const { setup } = await mountNarrowPane(
+      `\x1b]8;;${uri}\x1b\\ABCDEFGHIJ\x1b]8;;\x1b\\`,
+    );
+    const attributes = setup.renderer.currentRenderBuffer.buffers.attributes;
+    expect(getLinkId(attributes[PANE_COLS - 1] ?? 0)).toBeGreaterThan(0);
+    expect(getLinkId(attributes[PANE_COLS] ?? 0)).toBe(0);
   });
 
   it("control: a CJK row filling the pane paints exactly to the pane edge", async () => {

--- a/station/src/terminal/TerminalScreenRenderable.osc8.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.osc8.test.tsx
@@ -1,0 +1,200 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Writable } from "node:stream";
+import { testRender } from "@opentui/react/test-utils";
+import { waitFor } from "./testing/waitFor.js";
+import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
+import "./TerminalScreenRenderable.js";
+
+class CapturingStdout extends Writable {
+  readonly isTTY = true;
+  readonly columns: number;
+  readonly rows: number;
+  readonly #chunks: Buffer[] = [];
+
+  constructor(columns: number, rows: number) {
+    super();
+    this.columns = columns;
+    this.rows = rows;
+  }
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.#chunks.push(Buffer.isBuffer(chunk) ? Buffer.from(chunk) : Buffer.from(chunk));
+    callback();
+  }
+
+  getColorDepth(): number {
+    return 24;
+  }
+
+  take(): string {
+    const output = Buffer.concat(this.#chunks).toString("utf8");
+    this.#chunks.length = 0;
+    return output;
+  }
+}
+
+type Mounted = {
+  setup: Awaited<ReturnType<typeof testRender>>;
+  screen: StationVtScreen;
+  stdout: CapturingStdout;
+};
+
+const teardowns: Array<() => void> = [];
+
+afterEach(() => {
+  for (const teardown of teardowns.splice(0)) {
+    teardown();
+  }
+});
+
+async function mount(hyperlinks: boolean, width = 30): Promise<Mounted> {
+  const rows = 3;
+  const screen = createStationVtScreen({ size: { cols: width, rows } });
+  const stdout = new CapturingStdout(width, rows);
+  const previousTerm = process.env.TERM;
+  process.env.TERM = hyperlinks ? "xterm-ghostty" : "xterm-256color";
+  let setup: Awaited<ReturnType<typeof testRender>>;
+  try {
+    setup = await testRender(
+      <terminalScreen screen={screen} width="100%" height="100%" />,
+      {
+        width,
+        height: rows,
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        bufferedOutput: "stdout",
+        forwardEnvKeys: ["TERM"],
+      },
+    );
+  } finally {
+    if (previousTerm === undefined) {
+      delete process.env.TERM;
+    } else {
+      process.env.TERM = previousTerm;
+    }
+  }
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  await setup.flush();
+  stdout.take();
+  teardowns.push(() => {
+    setup.renderer.destroy();
+    screen.dispose();
+  });
+  return { setup, screen, stdout };
+}
+
+async function feedAndCapture(mounted: Mounted, data: string): Promise<string> {
+  const before = mounted.screen.getVersion();
+  mounted.screen.feed(`\x1b[?25l${data}`);
+  await mounted.screen.whenIdle();
+  await waitFor(() => mounted.screen.getVersion() > before);
+  await mounted.setup.flush();
+  return mounted.stdout.take();
+}
+
+function oscOpen(output: string, uri: string): string {
+  const prefix = "\x1b]8;id=";
+  const suffix = `;${uri}\x1b\\`;
+  const suffixIndex = output.indexOf(suffix);
+  const prefixIndex = output.lastIndexOf(prefix, suffixIndex);
+  expect(suffixIndex).toBeGreaterThanOrEqual(0);
+  expect(prefixIndex).toBeGreaterThanOrEqual(0);
+  const linkId = output.slice(prefixIndex + prefix.length, suffixIndex);
+  expect(linkId).toMatch(/^\d+$/u);
+  return `${prefix}${linkId}${suffix}`;
+}
+
+const OSC_CLOSE = "\x1b]8;;\x1b\\";
+
+describe("TerminalScreenRenderable OSC 8 output", () => {
+  it("emits the exact native OSC 8 open and close bytes around a label", async () => {
+    const mounted = await mount(true);
+    const uri = "https://example.com/issues/247?exact=yes#output";
+    const output = await feedAndCapture(
+      mounted,
+      `\x1b]8;;${uri}\x1b\\#247\x1b]8;;\x1b\\ plain`,
+    );
+
+    const open = oscOpen(output, uri);
+    expect(output).toContain(open);
+    expect(output).toContain(OSC_CLOSE);
+    expect(output.indexOf(open)).toBeLessThan(output.indexOf("#247"));
+    expect(output.indexOf(OSC_CLOSE)).toBeGreaterThan(output.indexOf("#247"));
+    expect(output.indexOf(OSC_CLOSE)).toBeLessThan(output.indexOf(" plain"));
+  });
+
+  it("closes and reopens adjacent links without URI bleed", async () => {
+    const mounted = await mount(true);
+    const first = "https://example.com/first";
+    const second = "mailto:second@example.com";
+    const output = await feedAndCapture(
+      mounted,
+      `\x1b]8;;${first}\x1b\\A\x1b]8;;\x1b\\` +
+        `\x1b]8;;${second}\x1b\\B\x1b]8;;\x1b\\C`,
+    );
+
+    const firstOpen = oscOpen(output, first);
+    const secondOpen = oscOpen(output, second);
+    const firstClose = output.indexOf(OSC_CLOSE, output.indexOf(firstOpen));
+    const secondClose = output.indexOf(OSC_CLOSE, output.indexOf(secondOpen));
+    expect(output.indexOf(firstOpen)).toBeLessThan(output.indexOf("A"));
+    expect(firstClose).toBeGreaterThan(output.indexOf("A"));
+    expect(firstClose).toBeLessThan(output.indexOf(secondOpen));
+    expect(output.indexOf(secondOpen)).toBeLessThan(output.indexOf("B"));
+    expect(secondClose).toBeGreaterThan(output.indexOf("B"));
+    expect(secondClose).toBeLessThan(output.indexOf("C"));
+  });
+
+  it("encloses every colored row of a wrapped link with the exact URI", async () => {
+    const mounted = await mount(true, 4);
+    const uri = "https://example.com/wrapped";
+    const output = await feedAndCapture(
+      mounted,
+      `\x1b[38;2;12;34;56m\x1b]8;;${uri}\x1b\\ABCDEFGH\x1b]8;;\x1b\\\x1b[0m`,
+    );
+
+    const open = oscOpen(output, uri);
+    const openIndex = output.indexOf(open);
+    const closeIndex = output.indexOf(OSC_CLOSE, openIndex + open.length);
+    let previousTextIndex = openIndex;
+    for (const [rowIndex, rowText] of ["ABCD", "EFGH"].entries()) {
+      const cursorIndex = output.indexOf(`\x1b[${rowIndex + 1};1H`, previousTextIndex);
+      const colorIndex = output.indexOf("\x1b[38;2;12;34;56m", cursorIndex);
+      const textIndex = output.indexOf(rowText, colorIndex);
+      expect(cursorIndex).toBeGreaterThan(previousTextIndex);
+      expect(colorIndex).toBeGreaterThan(cursorIndex);
+      expect(textIndex).toBeGreaterThan(colorIndex);
+      expect(textIndex).toBeLessThan(closeIndex);
+      previousTextIndex = textIndex;
+    }
+    expect(closeIndex).toBeGreaterThan(previousTextIndex);
+  });
+
+  it("emits no OSC 8 bytes when the outer capability is disabled", async () => {
+    const mounted = await mount(false);
+    const output = await feedAndCapture(
+      mounted,
+      "\x1b]8;;https://example.com/disabled\x1b\\visible\x1b]8;;\x1b\\",
+    );
+    expect(output).toContain("visible");
+    expect(output).not.toContain("\x1b]8;");
+  });
+
+  it("renders invalid and oversized URIs as ordinary visible text", async () => {
+    const mounted = await mount(true, 20);
+    const invalid = "not-a-valid-scheme/path";
+    const oversized = `x:${"a".repeat(511)}`;
+    const output = await feedAndCapture(
+      mounted,
+      `\x1b]8;;${invalid}\x1b\\bad\x1b]8;;\x1b\\` +
+        `\x1b]8;;${oversized}\x1b\\large\x1b]8;;\x1b\\`,
+    );
+    expect(output).toContain("badlarge");
+    expect(output).not.toContain("\x1b]8;");
+    expect(output).not.toContain(invalid);
+    expect(output).not.toContain(oversized);
+  });
+});

--- a/station/src/terminal/TerminalScreenRenderable.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { getLinkId } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
 import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
 import "./TerminalScreenRenderable.js";
@@ -30,6 +31,25 @@ async function teardown(setup: { renderer: { destroy(): void } }, screen: Statio
 }
 
 describe("TerminalScreenRenderable selection", () => {
+  it("retains native hyperlink attributes while highlighting a selection", async () => {
+    const uri = "https://example.com/selected";
+    const { setup, screen } = await renderPane(
+      `\x1b]8;;${uri}\x1b\\hello\x1b]8;;\x1b\\`,
+    );
+    try {
+      expect(getLinkId(setup.renderer.currentRenderBuffer.buffers.attributes[0] ?? 0)).toBeGreaterThan(
+        0,
+      );
+      await setup.mockMouse.drag(0, 0, 4, 0);
+      await setup.renderOnce();
+      expect(getLinkId(setup.renderer.currentRenderBuffer.buffers.attributes[0] ?? 0)).toBeGreaterThan(
+        0,
+      );
+    } finally {
+      await teardown(setup, screen);
+    }
+  });
+
   it("copies the dragged range on release", async () => {
     const { setup, screen, copied } = await renderPane("hello world");
     try {

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -7,6 +7,7 @@ import {
   RGBA,
 } from "@opentui/core";
 import { extend } from "@opentui/react";
+import { attributesWithOpenTuiHyperlink } from "./openTuiHyperlinks.js";
 import type { StationTerminalSize } from "./types.js";
 import { buildMouseReportSequence } from "./input/mouseReport.js";
 import { type MouseButtonName, MouseTracking } from "./protocol/mouse.js";
@@ -488,13 +489,17 @@ export class TerminalScreenRenderable extends Renderable {
           // Highlight the selected sub-range of this span via drawText's selection
           // arg (columns are char indices here; exact for single-width cells).
           const selection = selectionForSpan(selectedCols, col, span.width, selectionBg);
+          const attributes =
+            span.link === undefined
+              ? span.attributes
+              : attributesWithOpenTuiHyperlink(buffer, span.attributes, span.link);
           buffer.drawText(
             text,
             this.x + col,
             this.y + rowIndex,
             span.fg === undefined ? defaultFg : rgbaForHex(span.fg),
             span.bg === undefined ? undefined : rgbaForHex(span.bg),
-            span.attributes,
+            attributes,
             selection,
           );
           col += span.width;

--- a/station/src/terminal/openTuiHyperlinks.test.ts
+++ b/station/src/terminal/openTuiHyperlinks.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { getLinkId, OptimizedBuffer, RGBA, TextAttributes } from "@opentui/core";
+import { attributesWithOpenTuiHyperlink } from "./openTuiHyperlinks.js";
+
+const buffers: OptimizedBuffer[] = [];
+
+afterEach(() => {
+  for (const buffer of buffers.splice(0)) {
+    buffer.destroy();
+  }
+});
+
+function allocatingBuffer(allocated: string[], linkId = 42): OptimizedBuffer {
+  return {
+    lib: {
+      linkAlloc: (uri: string) => {
+        allocated.push(uri);
+        return linkId;
+      },
+    },
+  } as unknown as OptimizedBuffer;
+}
+
+describe("attributesWithOpenTuiHyperlink", () => {
+  it("preserves accepted hierarchical and opaque URIs exactly", () => {
+    const allocated: string[] = [];
+    const buffer = allocatingBuffer(allocated);
+    const uris = [
+      "https://example.com/A%2Fb?q=One%20Two#Exact",
+      "file:///tmp/Station%20Link",
+      "mailto:Person+Station@example.com?subject=Exact%20Case",
+      "custom+opaque:Value/That?Must=Remain#Exact",
+    ];
+
+    for (const uri of uris) {
+      const attributes = attributesWithOpenTuiHyperlink(buffer, TextAttributes.BOLD, uri);
+      expect(getLinkId(attributes)).toBe(42);
+      expect(attributes & TextAttributes.BOLD).toBe(TextAttributes.BOLD);
+    }
+    expect(allocated).toEqual(uris);
+  });
+
+  it("accepts exactly 512 UTF-8 bytes and rejects larger values", () => {
+    const allocated: string[] = [];
+    const buffer = allocatingBuffer(allocated);
+    const asciiBoundary = `x:${"a".repeat(510)}`;
+    const unicodeBoundary = `x:${"é".repeat(255)}`;
+
+    expect(getLinkId(attributesWithOpenTuiHyperlink(buffer, 0, asciiBoundary))).toBe(42);
+    expect(getLinkId(attributesWithOpenTuiHyperlink(buffer, 0, unicodeBoundary))).toBe(42);
+    expect(attributesWithOpenTuiHyperlink(buffer, TextAttributes.ITALIC, `${asciiBoundary}a`)).toBe(
+      TextAttributes.ITALIC,
+    );
+    expect(attributesWithOpenTuiHyperlink(buffer, TextAttributes.ITALIC, `${unicodeBoundary}é`)).toBe(
+      TextAttributes.ITALIC,
+    );
+    expect(allocated).toEqual([asciiBoundary, unicodeBoundary]);
+  });
+
+  it("rejects malformed absolute URIs", () => {
+    const allocated: string[] = [];
+    const buffer = allocatingBuffer(allocated);
+    const invalidUris = [
+      "https:",
+      "https://exa mple.com/path",
+      "https://example.com/%ZZ",
+      "https://example.com/percent%",
+      "x:{not-a-uri}",
+      "x:pipe|tail",
+      "x:fragment#one#two",
+      "https://example.com/bell\u0007tail",
+      "https://example.com/escape\u001btail",
+      "https://example.com/del\u007ftail",
+      "https://example.com/c1\u0085tail",
+      "https://example.com/high\ud800tail",
+      "https://example.com/low\udc00tail",
+      "//example.com/no-scheme",
+      "1invalid:scheme",
+      ":empty",
+    ];
+
+    for (const uri of invalidUris) {
+      expect(attributesWithOpenTuiHyperlink(buffer, TextAttributes.UNDERLINE, uri)).toBe(
+        TextAttributes.UNDERLINE,
+      );
+    }
+    expect(allocated).toEqual([]);
+  });
+
+  it("pins OpenTUI 0.4.1 native allocation, reuse, and refcount-owned generation", async () => {
+    const packageJson = JSON.parse(
+      await readFile(
+        new URL("../../node_modules/@opentui/core/package.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { version?: string };
+    expect(packageJson.version).toBe("0.4.1");
+
+    const buffer = OptimizedBuffer.create(4, 1, "unicode");
+    buffers.push(buffer);
+    const uri = "https://example.com/native-lifetime";
+    const firstAttributes = attributesWithOpenTuiHyperlink(buffer, TextAttributes.BOLD, uri);
+    const firstId = getLinkId(firstAttributes);
+    expect(firstId).toBeGreaterThan(0);
+
+    buffer.drawText("A", 0, 0, RGBA.fromValues(1, 1, 1, 1), undefined, firstAttributes);
+    const reusedId = getLinkId(attributesWithOpenTuiHyperlink(buffer, 0, uri));
+    expect(reusedId).toBe(firstId);
+    const nativeLib = buffer.lib as unknown as { linkGetUrl(linkId: number): string };
+    expect(nativeLib.linkGetUrl(firstId)).toBe(uri);
+
+    buffer.clear();
+    const nextGenerationId = getLinkId(attributesWithOpenTuiHyperlink(buffer, 0, uri));
+    expect(nextGenerationId).toBeGreaterThan(0);
+    expect(nextGenerationId).not.toBe(firstId);
+    expect(nativeLib.linkGetUrl(nextGenerationId)).toBe(uri);
+  });
+
+  it("fails closed when the pinned runtime allocator is unavailable", () => {
+    const buffer = { lib: {} } as OptimizedBuffer;
+    expect(attributesWithOpenTuiHyperlink(buffer, TextAttributes.DIM, "https://example.com")).toBe(
+      TextAttributes.DIM,
+    );
+  });
+});

--- a/station/src/terminal/openTuiHyperlinks.ts
+++ b/station/src/terminal/openTuiHyperlinks.ts
@@ -1,0 +1,78 @@
+import { attributesWithLink, type OptimizedBuffer } from "@opentui/core";
+
+const OPEN_TUI_LINK_URI_MAX_BYTES = 512;
+const OPEN_TUI_LINK_ID_MAX = 0xffffff;
+const ABSOLUTE_URI_STRUCTURE =
+  /^[A-Za-z][A-Za-z0-9+.-]*:[^?#]*(?:\?[^#]*)?(?:#[^#]*)?$/u;
+const INVALID_URI_CHARACTER =
+  /[^A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%+\-\u00a0-\u{10ffff}]/u;
+const INVALID_PERCENT_ESCAPE = /%(?![A-Fa-f0-9]{2})/u;
+const UTF8_ENCODER = new TextEncoder();
+
+type OpenTuiLinkAllocator = {
+  linkAlloc?(uri: string): number;
+};
+
+/**
+ * Validates an exact URI and packs a native OpenTUI 0.4.1 link ID into SGR attributes.
+ * OpenTUI accepts at most 512 UTF-8 bytes; IDs are allocated for each draw and never cached in
+ * TypeScript so the native generation and per-buffer refcount lifecycle owns reuse and cleanup.
+ */
+export function attributesWithOpenTuiHyperlink(
+  buffer: OptimizedBuffer,
+  attributes: number,
+  uri: string,
+): number {
+  if (!isValidOpenTuiHyperlink(uri)) {
+    return attributes;
+  }
+
+  try {
+    // `OptimizedBuffer.lib.linkAlloc` exists in OpenTUI 0.4.1 at runtime but is
+    // omitted from its RenderLib declaration; keep that pinned cast at this adapter.
+    const linkId = (buffer.lib as OpenTuiLinkAllocator).linkAlloc?.(uri);
+    if (
+      linkId === undefined ||
+      !Number.isInteger(linkId) ||
+      linkId <= 0 ||
+      linkId > OPEN_TUI_LINK_ID_MAX
+    ) {
+      return attributes;
+    }
+    return attributesWithLink(attributes, linkId);
+  } catch {
+    return attributes;
+  }
+}
+
+function isValidOpenTuiHyperlink(uri: string): boolean {
+  if (uri.length > OPEN_TUI_LINK_URI_MAX_BYTES) {
+    return false;
+  }
+  if (
+    !ABSOLUTE_URI_STRUCTURE.test(uri) ||
+    INVALID_URI_CHARACTER.test(uri) ||
+    INVALID_PERCENT_ESCAPE.test(uri) ||
+    hasMalformedSurrogate(uri) ||
+    !URL.canParse(uri)
+  ) {
+    return false;
+  }
+  return UTF8_ENCODER.encode(uri).byteLength <= OPEN_TUI_LINK_URI_MAX_BYTES;
+}
+
+function hasMalformedSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const nextCodeUnit = value.charCodeAt(index + 1);
+      if (nextCodeUnit < 0xdc00 || nextCodeUnit > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/station/src/terminal/pty/bunTerminalProcess.test.ts
+++ b/station/src/terminal/pty/bunTerminalProcess.test.ts
@@ -287,6 +287,7 @@ if (RUN_REAL_BUN_PTY) {
         "TERM=xterm-256color",
         "COLORTERM=truecolor",
         "TERM_PROGRAM=Station",
+        "FORCE_HYPERLINK=unset",
         "GHOSTTY=unset",
         "KITTY=unset",
         "WEZTERM=unset",

--- a/station/src/terminal/pty/childPtyEnvironment.test.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.test.ts
@@ -136,7 +136,7 @@ describe("createStationChildPtyEnvironment", () => {
     });
   });
 
-  it("makes the real Pi detector fail closed for the reported outer-terminal environment", () => {
+  it("keeps the pinned Pi detector and hyperlink override fail closed", () => {
     const reportedEnvironment = {
       TERM: "xterm-256color",
       COLORTERM: "truecolor",
@@ -153,9 +153,11 @@ describe("createStationChildPtyEnvironment", () => {
       KITTY_WINDOW_ID: "7",
       WEZTERM_PANE: "4",
     });
-    expect(runPiCapabilitiesProbe(childEnvironment)).toContain(
+    const output = runPiCapabilitiesProbe(childEnvironment);
+    expect(output).toContain(
       'CAPABILITIES={"images":null,"trueColor":true,"hyperlinks":false}',
     );
+    expect(output).toContain("FORCE_HYPERLINK=unset");
   });
 
   it("removes direct tmux identity while preserving explicit outer-server access", () => {

--- a/station/src/terminal/pty/childPtyEnvironment.ts
+++ b/station/src/terminal/pty/childPtyEnvironment.ts
@@ -59,7 +59,7 @@ type Environment = Readonly<Record<string, string | undefined>>;
  * Builds the environment for a Station-rendered child PTY without mutating the
  * outer renderer environment; ordinary launch values, including authentication,
  * provider context, and color preferences, pass through. Station-owned terminal
- * identity is applied after known outer-only hints are removed.
+ * identity is applied after inherited outer-only hints are removed.
  */
 export function createStationChildPtyEnvironment(
   inheritedEnvironment: Environment,

--- a/station/src/terminal/pty/fixtures/piCapabilitiesProbe.ts
+++ b/station/src/terminal/pty/fixtures/piCapabilitiesProbe.ts
@@ -8,6 +8,7 @@ process.stdout.write(
     `TERM=${value("TERM")}`,
     `COLORTERM=${value("COLORTERM")}`,
     `TERM_PROGRAM=${value("TERM_PROGRAM")}`,
+    `FORCE_HYPERLINK=${value("FORCE_HYPERLINK")}`,
     `GHOSTTY=${value("GHOSTTY_RESOURCES_DIR")}`,
     `KITTY=${value("KITTY_WINDOW_ID")}`,
     `WEZTERM=${value("WEZTERM_PANE")}`,

--- a/station/src/terminal/ptyPipeline.smoke.test.ts
+++ b/station/src/terminal/ptyPipeline.smoke.test.ts
@@ -88,6 +88,23 @@ describe("pty pipeline smoke", () => {
     }
   });
 
+  it("real shell OSC 8 output lands linked in the vt screen", async () => {
+    if (gated()) return;
+    const pipeline = startPipeline(
+      "printf '\\033]8;;https://example.com/pty-smoke\\033\\\\PTY-LINK\\033]8;;\\033\\\\\\n'",
+    );
+    try {
+      await waitFor(() => someRowIncludes(pipeline.screen, "PTY-LINK") >= 0, 5_000);
+      const row = someRowIncludes(pipeline.screen, "PTY-LINK");
+      const col = visibleRowText(pipeline.screen, row).indexOf("PTY-LINK");
+      expect(spanAtColumn(pipeline.screen, row, col)?.link).toBe(
+        "https://example.com/pty-smoke",
+      );
+    } finally {
+      pipeline.dispose();
+    }
+  });
+
   it("the real Pi detector sees only Station-owned terminal capabilities", async () => {
     if (gated()) return;
     const pipeline = startArgvPipeline(
@@ -118,6 +135,7 @@ describe("pty pipeline smoke", () => {
         "TERM=xterm-256color",
         "COLORTERM=truecolor",
         "TERM_PROGRAM=Station",
+        "FORCE_HYPERLINK=unset",
         "GHOSTTY=unset",
         "KITTY=unset",
         "WEZTERM=unset",

--- a/station/src/terminal/vt/rows.test.ts
+++ b/station/src/terminal/vt/rows.test.ts
@@ -86,6 +86,46 @@ describe("buildVisibleRows", () => {
     expect(spans[0]?.width).toBe(3);
   });
 
+  it("carries a labeled OSC 8 URI on its span", async () => {
+    const uri = "https://example.com/issues/247?exact=yes#label";
+    const screen = await screenWith(`\x1b]8;;${uri}\x1b\\#247\x1b]8;;\x1b\\`);
+    const span = buildVisibleRows(screen.unsafeEngine, { cursorVisible: false })[0]?.spans[0];
+    expect(span).toMatchObject({ text: "#247", width: 4, link: uri });
+  });
+
+  it("splits adjacent same-style cells when their URIs differ", async () => {
+    const first = "https://example.com/first";
+    const second = "mailto:second@example.com";
+    const screen = await screenWith(
+      `\x1b]8;;${first}\x1b\\A\x1b]8;;\x1b\\` +
+        `\x1b]8;;${second}\x1b\\B\x1b]8;;\x1b\\`,
+    );
+    const spans = buildVisibleRows(screen.unsafeEngine, { cursorVisible: false })[0]?.spans ?? [];
+    expect(spans.map(({ text, link }) => ({ text, link }))).toEqual([
+      { text: "A", link: first },
+      { text: "B", link: second },
+    ]);
+  });
+
+  it("preserves linked trailing spaces while trimming the unlinked row remainder", async () => {
+    const uri = "file:///tmp/station%20link";
+    const screen = await screenWith(`\x1b]8;;${uri}\x1b\\label  \x1b]8;;\x1b\\   `);
+    const spans = buildVisibleRows(screen.unsafeEngine, { cursorVisible: false })[0]?.spans ?? [];
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toMatchObject({ text: "label  ", width: 7, link: uri });
+  });
+
+  it("keeps one URI across wide cells and soft-wrapped rows", async () => {
+    const uri = "custom+opaque:wide/wrapped";
+    const screen = await screenWith(`\x1b]8;;${uri}\x1b\\漢ABCD\x1b]8;;\x1b\\`, {
+      cols: 4,
+      rows: 3,
+    });
+    const rows = buildVisibleRows(screen.unsafeEngine, { cursorVisible: false });
+    expect(rows[0]?.spans[0]).toMatchObject({ text: "漢AB", width: 4, link: uri });
+    expect(rows[1]?.spans[0]).toMatchObject({ text: "CD", width: 2, link: uri });
+  });
+
   it("trims trailing plain whitespace but keeps styled whitespace", async () => {
     const screen = await screenWith("\x1b[44m  \x1b[0m   ");
     const rows = buildVisibleRows(screen.unsafeEngine, { cursorVisible: false });

--- a/station/src/terminal/vt/rows.ts
+++ b/station/src/terminal/vt/rows.ts
@@ -1,6 +1,7 @@
 import { TextAttributes } from "@opentui/core";
 import type { IBufferCell, Terminal } from "@xterm/headless";
 import { rgbToHexColor, stationVtPalette256 } from "./theme.js";
+import { resolveXtermCellHyperlink } from "./xtermHyperlinks.js";
 
 export type VtSpan = {
   text: string;
@@ -8,6 +9,8 @@ export type VtSpan = {
   width: number;
   fg?: string;
   bg?: string;
+  /** Exact OSC 8 URI owned by every cell in the span; absent means ordinary unlinked text. */
+  link?: string;
   attributes: number;
 };
 
@@ -25,8 +28,10 @@ export type BuildVisibleRowsOptions = {
 /**
  * Converts the terminal's viewport into rows of style-merged spans. With
  * `offset === 0` this is the live bottom page; a positive offset renders that
- * many lines up into scrollback. The cursor is composited only at the bottom —
- * a live cursor drawn over historical rows would be misleading.
+ * many lines up into scrollback. Runs merge only when visual style and OSC 8
+ * URI identity match, so links follow the selected active-buffer lines through
+ * xterm's scrollback. The cursor is composited only at the bottom — a live
+ * cursor drawn over historical rows would be misleading.
  */
 export function buildVisibleRows(
   terminal: Terminal,
@@ -59,6 +64,7 @@ export function buildVisibleRows(
     let runWidth = 0;
     let runFg: string | undefined;
     let runBg: string | undefined;
+    let runLink: string | undefined;
     let runAttributes = 0;
 
     const flushRun = (): void => {
@@ -71,6 +77,9 @@ export function buildVisibleRows(
       }
       if (runBg !== undefined) {
         span.bg = runBg;
+      }
+      if (runLink !== undefined) {
+        span.link = runLink;
       }
       spans.push(span);
       runText = "";
@@ -87,6 +96,7 @@ export function buildVisibleRows(
 
         const fg = cellForeground(cell, palette);
         const bg = cellBackground(cell, palette);
+        const link = resolveXtermCellHyperlink(terminal, cell);
         let attributes = cellAttributes(cell);
         if (cursorVisible && rowIndex === cursorRow && colIndex === cursorCol) {
           // XOR so a cursor over already-inverse content flips back to normal.
@@ -94,10 +104,16 @@ export function buildVisibleRows(
         }
 
         const text = cell.getChars() || " ";
-        if (fg !== runFg || bg !== runBg || attributes !== runAttributes) {
+        if (
+          fg !== runFg ||
+          bg !== runBg ||
+          link !== runLink ||
+          attributes !== runAttributes
+        ) {
           flushRun();
           runFg = fg;
           runBg = bg;
+          runLink = link;
           runAttributes = attributes;
         }
         runText += text;
@@ -170,6 +186,7 @@ function trimTrailingPlainWhitespace(spans: VtSpan[]): void {
       last === undefined ||
       last.fg !== undefined ||
       last.bg !== undefined ||
+      last.link !== undefined ||
       last.attributes !== 0
     ) {
       return;

--- a/station/src/terminal/vt/screen.test.ts
+++ b/station/src/terminal/vt/screen.test.ts
@@ -186,6 +186,107 @@ describe("createStationVtScreen", () => {
       .join("");
   // 10 single-line rows in a 4-row viewport → 6 lines of scrollback (baseY 6).
   const tenLines = Array.from({ length: 10 }, (_, index) => `L${index}`).join("\r\n");
+  const rowLinks = (screen: StationVtScreen, row = 0): string[] =>
+    (screen.buildRows({ cursorVisible: false })[row]?.spans ?? [])
+      .map((span) => span.link)
+      .filter((link): link is string => link !== undefined);
+
+  it("parses OSC 8 opens and closes split across feed chunks", async () => {
+    const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));
+    screen.feed("\x1b]8;;https://example.com/chunk");
+    screen.feed("-split\x1b\\linked");
+    screen.feed("\x1b]8;;");
+    screen.feed("\x1b\\ plain");
+    await screen.whenIdle();
+
+    const spans = screen.buildRows({ cursorVisible: false })[0]?.spans ?? [];
+    expect(spans.map(({ text, link }) => ({ text, link }))).toEqual([
+      { text: "linked", link: "https://example.com/chunk-split" },
+      { text: " plain", link: undefined },
+    ]);
+  });
+
+  it("lets overwrite, erase, and RIS remove xterm-owned link metadata", async () => {
+    const uri = "https://example.com/lifecycle";
+    const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));
+    await feedAndFlush(screen, `\x1b]8;;${uri}\x1b\\ABC\x1b]8;;\x1b\\`);
+
+    await feedAndFlush(screen, "\r\x1b[1CX");
+    const overwritten = screen.buildRows({ cursorVisible: false })[0]?.spans ?? [];
+    expect(overwritten.map(({ text, link }) => ({ text, link }))).toEqual([
+      { text: "A", link: uri },
+      { text: "X", link: undefined },
+      { text: "C", link: uri },
+    ]);
+
+    await feedAndFlush(screen, "\r\x1b[2K");
+    expect(rowLinks(screen)).toEqual([]);
+
+    await feedAndFlush(screen, `\x1b]8;;${uri}\x1b\\Z\x1b]8;;\x1b\\\x1bc`);
+    expect(screen.buildRows({ cursorVisible: false }).flatMap((row) => row.spans)).toEqual([]);
+  });
+
+  it("keeps normal and alternate-buffer links isolated", async () => {
+    const normalUri = "https://example.com/normal";
+    const alternateUri = "file:///tmp/alternate";
+    const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));
+    await feedAndFlush(screen, `\x1b]8;;${normalUri}\x1b\\normal\x1b]8;;\x1b\\`);
+
+    await feedAndFlush(
+      screen,
+      `\x1b[?1049h\x1b]8;;${alternateUri}\x1b\\alternate\x1b]8;;\x1b\\`,
+    );
+    expect(rowLinks(screen)).toEqual([alternateUri]);
+
+    await feedAndFlush(screen, "\x1b[?1049l");
+    expect(rowLinks(screen)).toEqual([normalUri]);
+  });
+
+  it("preserves link ownership through resize reflow and retained scrollback", async () => {
+    const uri = "custom:reflow";
+    const screen = track(
+      createStationVtScreen({ size: { cols: 6, rows: 2 }, scrollback: 4 }),
+    );
+    await feedAndFlush(screen, `\x1b]8;;${uri}\x1b\\abcdefghij\x1b]8;;\x1b\\`);
+    screen.resize({ cols: 4, rows: 3 });
+    await screen.whenIdle();
+    expect(
+      screen
+        .buildRows({ cursorVisible: false })
+        .flatMap((row) => row.spans)
+        .filter((span) => span.text.trim().length > 0)
+        .every((span) => span.link === uri),
+    ).toBe(true);
+
+    await feedAndFlush(
+      screen,
+      Array.from(
+        { length: 12 },
+        (_, index) => `\r\n\x1b]8;;https://example.com/${index}\x1b\\L${index}\x1b]8;;\x1b\\`,
+      ).join(""),
+    );
+    screen.scrollBy(99);
+    const retained = screen.buildRows({ cursorVisible: false }).flatMap((row) => row.spans);
+    expect(retained.some((span) => span.link !== undefined)).toBe(true);
+    expect(retained.every((span) => span.link !== "https://example.com/0")).toBe(true);
+  });
+
+  it("resolves repeated OSC ids by both id and URI without bleeding", async () => {
+    const first = "https://example.com/reused";
+    const second = "mailto:changed@example.com";
+    const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));
+    await feedAndFlush(
+      screen,
+      `\x1b]8;id=same;${first}\x1b\\A\x1b]8;;\x1b\\` +
+        `\x1b]8;id=same;${first}\x1b\\B\x1b]8;;\x1b\\` +
+        `\x1b]8;id=same;${second}\x1b\\C\x1b]8;;\x1b\\`,
+    );
+    const spans = screen.buildRows({ cursorVisible: false })[0]?.spans ?? [];
+    expect(spans.map(({ text, link }) => ({ text, link }))).toEqual([
+      { text: "AB", link: first },
+      { text: "C", link: second },
+    ]);
+  });
 
   it("scrolls scrollback up and clamps at the oldest line", async () => {
     const screen = track(createStationVtScreen({ size: { cols: 20, rows: 4 } }));

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -113,8 +113,10 @@ export type StationVtScreen = {
   resize(size: StationTerminalSize): void;
   /**
    * Style-merged spans for the rows currently in view (the live viewport, or
-   * scrolled-back history when `getScrollOffset() > 0`). The cursor is only
-   * composited at the live bottom.
+   * scrolled-back history when `getScrollOffset() > 0`). OSC 8 URIs follow the
+   * active xterm buffer and selected viewport lines, including xterm-owned
+   * overwrite, erase, reflow, scrollback eviction, reset, and alternate-buffer
+   * lifecycles. The cursor is only composited at the live bottom.
    */
   buildRows(options?: { cursorVisible?: boolean }): VtRow[];
   /**

--- a/station/src/terminal/vt/xtermHyperlinks.test.ts
+++ b/station/src/terminal/vt/xtermHyperlinks.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { Terminal, type IBufferCell } from "@xterm/headless";
+import { resolveXtermCellHyperlink } from "./xtermHyperlinks.js";
+
+const terminals: Terminal[] = [];
+
+afterEach(() => {
+  for (const terminal of terminals.splice(0)) {
+    terminal.dispose();
+  }
+});
+
+async function write(terminal: Terminal, data: string): Promise<void> {
+  await new Promise<void>((resolve) => {
+    terminal.write(data, resolve);
+  });
+}
+
+describe("resolveXtermCellHyperlink", () => {
+  it("pins the @xterm/headless 6.0.0 private hyperlink invariant", async () => {
+    const packageJson = JSON.parse(
+      await readFile(
+        new URL("../../../node_modules/@xterm/headless/package.json", import.meta.url),
+        "utf8",
+      ),
+    ) as { version?: string };
+    expect(packageJson.version).toBe("6.0.0");
+
+    const terminal = new Terminal({ cols: 20, rows: 2, allowProposedApi: true });
+    terminals.push(terminal);
+    const uri = "https://example.com/exact?x=1#fragment";
+    await write(terminal, `\x1b]8;id=contract;${uri}\x1b\\label\x1b]8;;\x1b\\`);
+
+    const cell = terminal.buffer.active.getLine(0)?.getCell(0);
+    expect(cell).toBeDefined();
+    expect(resolveXtermCellHyperlink(terminal, cell as IBufferCell)).toBe(uri);
+  });
+
+  it("does not read stale extended attributes from a reused cell", async () => {
+    const terminal = new Terminal({ cols: 20, rows: 2, allowProposedApi: true });
+    terminals.push(terminal);
+    await write(terminal, "\x1b]8;;https://example.com/linked\x1b\\A\x1b]8;;\x1b\\B");
+
+    const line = terminal.buffer.active.getLine(0);
+    const workCell = terminal.buffer.active.getNullCell();
+    expect(resolveXtermCellHyperlink(terminal, line?.getCell(0, workCell) as IBufferCell)).toBe(
+      "https://example.com/linked",
+    );
+    expect(resolveXtermCellHyperlink(terminal, line?.getCell(1, workCell) as IBufferCell)).toBeUndefined();
+  });
+
+  it("fails closed when the pinned private service is unavailable", () => {
+    const cell = {
+      hasExtendedAttrs: () => 1,
+      extended: { urlId: 1 },
+    } as unknown as IBufferCell;
+    expect(resolveXtermCellHyperlink({} as Terminal, cell)).toBeUndefined();
+  });
+});

--- a/station/src/terminal/vt/xtermHyperlinks.ts
+++ b/station/src/terminal/vt/xtermHyperlinks.ts
@@ -1,0 +1,43 @@
+import type { IBufferCell, Terminal } from "@xterm/headless";
+
+type XtermCellInternals = IBufferCell & {
+  hasExtendedAttrs?: () => number;
+  extended?: { urlId?: number };
+};
+
+type XtermTerminalInternals = Terminal & {
+  _core?: {
+    _oscLinkService?: {
+      getLinkData?(linkId: number): { uri?: string } | undefined;
+    };
+  };
+};
+
+/**
+ * Resolves an OSC 8 URI through @xterm/headless 6.0.0's private cell and link-service shape.
+ * BufferLine.loadCell leaves a reused cell's `extended` object untouched for ordinary cells, so
+ * `hasExtendedAttrs()` must gate `extended.urlId`; any missing or changed private shape fails closed.
+ */
+export function resolveXtermCellHyperlink(
+  terminal: Terminal,
+  cell: IBufferCell,
+): string | undefined {
+  try {
+    const cellInternals = cell as XtermCellInternals;
+    if (!cellInternals.hasExtendedAttrs?.()) {
+      return undefined;
+    }
+    const linkId = cellInternals.extended?.urlId;
+    if (linkId === undefined || !Number.isInteger(linkId) || linkId <= 0) {
+      return undefined;
+    }
+    const linkData = (terminal as XtermTerminalInternals)._core?._oscLinkService?.getLinkData?.(
+      linkId,
+    );
+    return typeof linkData?.uri === "string" && linkData.uri.length > 0
+      ? linkData.uri
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
## What this fixes

Native Station parsed OSC 8 hyperlinks in xterm but discarded their destination while projecting cells into OpenTUI. Labels such as `#196` therefore retained underline styling but could not expose the URI to the outer terminal.

Closes #247.

## What changed

- Resolve xterm cell hyperlink metadata behind a version-pinned VT adapter and carry exact URI identity through viewport, scrollback, resize/reflow, alternate-buffer, and complete Host replay projection.
- Split otherwise-identical spans by URI and attach native OpenTUI link IDs only to cells drawn inside the pane, preserving clipping, selection, and native link lifetimes.
- Bound URI validation with an immediate 512-code-unit gate, then require parseable absolute syntax, valid percent escapes and characters, valid surrogate data, and OpenTUI's exact 512-byte UTF-8 limit without normalizing accepted values.
- Keep child capability advertisement fail closed: inherited hyperlink overrides are scrubbed and Station does not set `FORCE_HYPERLINK` until Pi recognition and an outer-terminal capability gate can land atomically.
- Cover wrapped colored links at the final OSC 8 output boundary, including hyperlink-disabled outer terminals.

## Testing

- `pnpm build`
- `pnpm lint`
- `cd station && bun run typecheck`
- `cd station && bun run test` (1,135 passing)
- `cd station && bun run test:vt` (328 passing)
- `cd station && bun run test:pty` (42 passing)
- `cd station && bun run test:pty:bun` (32 passing)

## User-visible behavior

OSC 8 emitted by applications now remains clickable through native Station panes, including wrapped rows, scrollback, resize, and complete Host replay. Pi 0.80.10 still sees `hyperlinks: false`, so Station does not induce compact label-only output when the outer terminal cannot emit links. Selection and child mouse behavior are unchanged.

Manual check:

```sh
printf '\033[4m\033]8;;https://github.com/jeremy0dell/station/issues/196\033\\#196\033]8;;\033\\\033[24m\n'
```

In a hyperlink-capable outer terminal, the `#196` label should expose the exact issue URI. Repeat after narrowing the pane until the colored label wraps.
