### PR TITLE
fix(worktree): make managed roots authoritative

### DIFF
--- a/apps/cli/test/integration/first-project-default-branch.test.ts
+++ b/apps/cli/test/integration/first-project-default-branch.test.ts
@@ -45,6 +45,12 @@ describe("first-project default branch", () => {
             return result(input, "false\n");
           }
           calls.push(input);
+          if (input.args?.[0] === "list") {
+            return result(
+              input,
+              JSON.stringify([{ path: repo, branch: defaultBranch, is_main: true }]),
+            );
+          }
           await mkdir(dirname(worktreePath), { recursive: true });
           await git(repo, "worktree", "add", "-b", "feature", worktreePath, defaultBranch);
           return result(input, JSON.stringify([{ path: worktreePath, branch: "feature" }]));
@@ -59,8 +65,11 @@ describe("first-project default branch", () => {
           path: worktreePath,
           registrationIdentity: `git-registration:${worktreePath}`,
         });
-        expect(calls).toHaveLength(1);
-        expect(calls[0]?.args).toEqual([
+        expect(calls).toHaveLength(2);
+        expect(calls[0]?.args).toEqual(["list", "--format=json"]);
+        expect(calls[1]?.args).toEqual([
+          "--config-set",
+          `projects.${JSON.stringify(repo)}.worktree-path=${JSON.stringify(worktreePath)}`,
           "switch",
           "--no-hooks",
           "--create",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,13 +111,18 @@ accepted by config validation but become unavailable providers at runtime.
 | --- | --- | --- |
 | `command` | string | Worktrunk CLI, e.g. `"wt"`. Overrides `STATION_WORKTRUNK_BIN`; fallback is `wt`. |
 | `config_path` | string | Path to worktrunk's own config. `~` expands at load time. |
-| `managed_root` | string | Root for managed worktrees, e.g. `~/.worktrees`; `~` expands at load time. |
+| `managed_root` | string | Authoritative root for Station-created worktrees, e.g. `~/.worktrees`; `~` expands at load time. Station overrides Worktrunk global and project-specific path templates for managed creates without rewriting Worktrunk's config. |
 | `base` | string (optional) | Default base branch for Worktrunk project listings and new worktrees. Project entries inherit this unless `[projects.worktrunk].base` is set; when neither is configured, Station omits `--base`. |
 | `include_main` | bool | Default include-main policy for Worktrunk project listings. Project entries inherit this unless overridden. |
 | `include_external` | bool | Default include-external policy for Worktrunk project listings. Project entries inherit this unless overridden. |
 | `use_lifecycle_hooks` | bool | Worktrunk automation mode. `false` makes automated mutations pass `--no-hooks`; `true` passes `--yes`; unset uses Worktrunk defaults. |
 | `hook_mode` | `required-for-mvp` \| `disabled` | Worktrunk lifecycle hook setup expectation. |
 | `breadcrumb_location` | `external` \| `worktree` \| `provider-native` \| `disabled` | Default recovery breadcrumb location. |
+
+Changing `managed_root` affects future Station creates only. Existing linked
+worktrees stay at their registered paths; do not move or delete a worktree that
+still owns a session. Close its sessions, remove it through Station or
+Worktrunk, and recreate it under the managed root.
 
 ### `[terminal.tmux]` — terminal provider (optional)
 
@@ -255,7 +260,7 @@ Nested project tables:
 | `[projects.display]` | `sort_order` | int | Optional sort order. |
 | `[projects.worktrunk]` | `enabled` | bool | Defaults to `true` when omitted. |
 | `[projects.worktrunk]` | `base` | string | Overrides `[worktree.worktrunk].base` for this project. |
-| `[projects.worktrunk]` | `managed_root` | string | Per-project Worktrunk managed root; relative paths resolve against `project.root`. If omitted and global `managed_root` is set, STATION derives a unique project child directory. |
+| `[projects.worktrunk]` | `managed_root` | string | Per-project authoritative managed root; relative paths resolve against `project.root`. If omitted and global `managed_root` is set, STATION derives a unique project child directory. |
 | `[projects.worktrunk]` | `include_main` | bool | Overrides global `include_main`. |
 | `[projects.worktrunk]` | `include_external` | bool | Overrides global `include_external`. |
 | `[projects.recovery_breadcrumbs]` | `location` | `external` \| `worktree` \| `provider-native` \| `disabled` | Overrides global breadcrumb location. |

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -13185,7 +13185,7 @@
       "declaration": "WorktrunkProvider",
       "kind": "class",
       "role": "ADAPTER",
-      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. Checkout roots are validated before Worktrunk runs, and removal revalidates native Git identity, path, and branch before mutation.",
+      "purpose": "Translates Worktrunk lifecycle output and commands into Station worktree contracts. Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition expectation as a fallback. Checkout roots are validated before Worktrunk runs, managed roots override Worktrunk's project-specific path templates, and removal revalidates native Git identity, path, and branch before mutation.",
       "dependencies": [
         {
           "path": "packages/contracts/src/providers.ts",

--- a/integrations/worktree/worktrunk/src/provider.ts
+++ b/integrations/worktree/worktrunk/src/provider.ts
@@ -73,8 +73,9 @@ const defaultCapabilities: WorktreeCapabilities = {
  *
  * Translates Worktrunk lifecycle output and commands into Station worktree contracts.
  * Hook diagnostics use an atomic requester runtime when supplied and retain the whole Observer composition
- * expectation as a fallback. Checkout roots are validated before Worktrunk runs, and removal revalidates
- * native Git identity, path, and branch before mutation.
+ * expectation as a fallback. Checkout roots are validated before Worktrunk runs, managed roots override
+ * Worktrunk's project-specific path templates, and removal revalidates native Git identity, path, and
+ * branch before mutation.
  */
 export class WorktrunkProvider implements WorktreeProvider {
   readonly id: ProviderId = "worktrunk";
@@ -89,6 +90,7 @@ export class WorktrunkProvider implements WorktreeProvider {
   readonly #resolveRegistrationIdentity: (worktreePath: string) => Promise<string | undefined>;
   readonly #observations = new Map<string, WorktreeObservation>();
   readonly #projects = new Map<string, ProviderProjectConfig>();
+  readonly #projectConfigIdentifiers = new Map<string, string | null>();
 
   constructor(options: WorktrunkProviderOptions = {}) {
     this.#command = options.command ?? process.env.STATION_WORKTRUNK_BIN ?? "wt";
@@ -299,6 +301,7 @@ export class WorktrunkProvider implements WorktreeProvider {
       providerId: this.id,
       observedAt: toIsoTimestamp(this.#clock.now()),
     });
+    this.#projectConfigIdentifiers.set(project.id, worktrunkProjectConfigIdentifier(observations));
     return Promise.all(
       observations.map((observation) => this.#withRegistrationIdentity(observation)),
     );
@@ -308,8 +311,11 @@ export class WorktrunkProvider implements WorktreeProvider {
     this.#projects.set(request.project.id, request.project);
     await this.#assertProjectRootUsable(request.project);
     const base = request.base ?? request.project.worktrunk.base;
+    const pathEnv = worktreePathEnv(request.project, request.branch, request.path);
+    const managedPathArgs = await this.#managedWorktreePathArgs(request.project, pathEnv);
     const output = await this.#run(
       this.#args([
+        ...managedPathArgs,
         "switch",
         ...this.#automationHookArgs(),
         "--create",
@@ -325,7 +331,7 @@ export class WorktrunkProvider implements WorktreeProvider {
         ...(base === undefined ? {} : { unresolvedBase: base }),
       },
       {},
-      worktreePathEnv(request.project, request.branch, request.path),
+      pathEnv,
     );
 
     const commandObservations = parseCommandObservation(output.stdout, {
@@ -582,6 +588,25 @@ export class WorktrunkProvider implements WorktreeProvider {
 
   #args(args: string[]): string[] {
     return this.#configPath === undefined ? args : ["--config", this.#configPath, ...args];
+  }
+
+  async #managedWorktreePathArgs(
+    project: ProviderProjectConfig,
+    env: Record<string, string> | undefined,
+  ): Promise<string[]> {
+    const worktreePath = env?.WORKTRUNK_WORKTREE_PATH;
+    if (worktreePath === undefined) {
+      return [];
+    }
+    if (!this.#projectConfigIdentifiers.has(project.id)) {
+      await this.#readWorktrees(project, { retries: 0 });
+    }
+    const identifier = this.#projectConfigIdentifiers.get(project.id);
+    if (identifier === undefined || identifier === null) {
+      return [];
+    }
+    // Worktrunk applies a user [projects.<id>] path after the environment, so use its higher-precedence command config too.
+    return ["--config-set", worktrunkProjectPathOverride(identifier, worktreePath)];
   }
 
   #automationHookArgs(): string[] {
@@ -893,7 +918,7 @@ function worktrunkSubcommand(args: readonly string[]): string {
     if (arg === undefined) {
       continue;
     }
-    if (arg === "--config" || arg === "-C") {
+    if (arg === "--config" || arg === "--config-set" || arg === "-C") {
       index += 1;
       continue;
     }
@@ -953,6 +978,33 @@ function isMainWorktree(project: ProviderProjectConfig, observation: WorktreeObs
     samePath(observation.path, project.root) ||
     (defaultBranch !== undefined && observation.branch === defaultBranch)
   );
+}
+
+function worktrunkProjectConfigIdentifier(
+  observations: readonly WorktreeObservation[],
+): string | null {
+  const remoteIdentifiers = new Set<string>();
+  for (const observation of observations) {
+    if (observation.remote !== undefined) {
+      remoteIdentifiers.add(
+        `${observation.remote.host}/${observation.remote.owner}/${observation.remote.repo}`,
+      );
+    }
+  }
+  if (remoteIdentifiers.size > 0) {
+    return remoteIdentifiers.size === 1 ? ([...remoteIdentifiers][0] ?? null) : null;
+  }
+
+  const primaryCheckoutPaths = new Set(
+    observations
+      .filter((observation) => observation.isPrimaryCheckout === true)
+      .map((observation) => observation.path),
+  );
+  return primaryCheckoutPaths.size === 1 ? ([...primaryCheckoutPaths][0] ?? null) : null;
+}
+
+function worktrunkProjectPathOverride(identifier: string, worktreePath: string): string {
+  return `projects.${JSON.stringify(identifier)}.worktree-path=${JSON.stringify(worktreePath)}`;
 }
 
 function worktreePathEnv(

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -165,6 +165,120 @@ describe("WorktrunkProvider", () => {
     ]);
   });
 
+  it("keeps managed roots authoritative over Worktrunk project path templates", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const managedProject = {
+      ...project,
+      worktrunk: {
+        ...project.worktrunk,
+        managedRoot: "/tmp/home/.worktrees/web",
+        includeMain: false,
+        includeExternal: false,
+      },
+    };
+    const provider = testProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.[0] === "list") {
+          return result(
+            input,
+            JSON.stringify([
+              {
+                path: "/tmp/station/web",
+                branch: "main",
+                is_main: true,
+                repo: { host: "github.com", owner: "acme", name: "web" },
+              },
+            ]),
+          );
+        }
+        return result(
+          input,
+          JSON.stringify([{ path: "/tmp/home/.worktrees/web/feature", branch: "feature" }]),
+        );
+      },
+    });
+
+    await expect(
+      provider.createWorktree({ project: managedProject, branch: "feature" }),
+    ).resolves.toMatchObject({
+      path: "/tmp/home/.worktrees/web/feature",
+    });
+    expect(calls.map((call) => call.args)).toEqual([
+      ["list", "--format=json"],
+      [
+        "--config-set",
+        'projects."github.com/acme/web".worktree-path="/tmp/home/.worktrees/web/feature"',
+        "switch",
+        "--create",
+        "feature",
+        "--base",
+        "main",
+        "--no-cd",
+        "--format=json",
+      ],
+    ]);
+    expect(calls[1]?.env).toEqual({
+      WORKTRUNK_WORKTREE_PATH: "/tmp/home/.worktrees/web/feature",
+    });
+  });
+
+  it("overrides path-keyed Worktrunk project templates for repositories without remotes", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const managedProject = {
+      ...project,
+      root: "/tmp/station/web-linked",
+      worktrunk: {
+        ...project.worktrunk,
+        managedRoot: "/tmp/home/.worktrees/web",
+        includeMain: false,
+        includeExternal: false,
+      },
+    };
+    const provider = testProvider({
+      command: "wt",
+      clock: { now: () => new Date(now) },
+      runner: async (input) => {
+        calls.push(input);
+        if (input.args?.[0] === "list") {
+          return result(
+            input,
+            JSON.stringify([
+              {
+                path: "/tmp/station/web",
+                branch: "main",
+                is_main: true,
+              },
+            ]),
+          );
+        }
+        return result(
+          input,
+          JSON.stringify([{ path: "/tmp/home/.worktrees/web/feature", branch: "feature" }]),
+        );
+      },
+    });
+
+    await expect(
+      provider.createWorktree({ project: managedProject, branch: "feature" }),
+    ).resolves.toMatchObject({
+      path: "/tmp/home/.worktrees/web/feature",
+    });
+    expect(calls[1]?.args).toEqual([
+      "--config-set",
+      'projects."/tmp/station/web".worktree-path="/tmp/home/.worktrees/web/feature"',
+      "switch",
+      "--create",
+      "feature",
+      "--base",
+      "main",
+      "--no-cd",
+      "--format=json",
+    ]);
+  });
+
   it("directs created worktrees into the managed root through Worktrunk config env", async () => {
     const calls: ExternalCommandInput[] = [];
     const managedProject = {
@@ -194,7 +308,7 @@ describe("WorktrunkProvider", () => {
       id: expect.stringMatching(/^wt_web_feature_[a-f0-9]{10}$/),
       path: "/tmp/station/web/.worktrees/feature",
     });
-    expect(calls[0]?.env).toEqual({
+    expect(calls[1]?.env).toEqual({
       WORKTRUNK_WORKTREE_PATH: "/tmp/station/web/.worktrees/feature",
     });
   });
@@ -228,7 +342,7 @@ describe("WorktrunkProvider", () => {
       id: expect.stringMatching(/^wt_web_feature_[a-f0-9]{10}$/),
       path: "/tmp/home/.worktrees/web/feature",
     });
-    expect(calls[0]?.env).toEqual({
+    expect(calls[1]?.env).toEqual({
       WORKTRUNK_WORKTREE_PATH: "/tmp/home/.worktrees/web/feature",
     });
   });
@@ -262,7 +376,7 @@ describe("WorktrunkProvider", () => {
       id: expect.stringMatching(/^wt_web_feature-auth-[a-f0-9]{10}_[a-f0-9]{10}$/),
       path: expect.stringMatching(/^\/tmp\/station\/web\/\.worktrees\/feature-auth-[a-f0-9]{10}$/),
     });
-    expect(calls[0]?.env).toEqual({
+    expect(calls[1]?.env).toEqual({
       WORKTRUNK_WORKTREE_PATH: expect.stringMatching(
         /^\/tmp\/station\/web\/\.worktrees\/feature-auth-[a-f0-9]{10}$/,
       ),
@@ -678,10 +792,30 @@ describe("WorktrunkProvider", () => {
   });
 
   it("classifies duplicate branch failures and preserves external command diagnostics", async () => {
+    const managedProject = {
+      ...project,
+      worktrunk: {
+        ...project.worktrunk,
+        managedRoot: "/tmp/home/.worktrees/web",
+      },
+    };
     const provider = testProvider({
       command: "wt",
       clock: { now: () => new Date(now) },
-      runner: async () => {
+      runner: async (input) => {
+        if (input.args?.[0] === "list") {
+          return result(
+            input,
+            JSON.stringify([
+              {
+                path: "/tmp/station/web",
+                branch: "main",
+                is_main: true,
+                repo: { host: "github.com", owner: "acme", name: "web" },
+              },
+            ]),
+          );
+        }
         throw Object.assign(new Error("wt failed"), {
           code: 128,
           stderr: "fatal: a branch named 'feature' already exists",
@@ -690,7 +824,9 @@ describe("WorktrunkProvider", () => {
       },
     });
 
-    await expect(provider.createWorktree({ project, branch: "feature" })).rejects.toMatchObject({
+    await expect(
+      provider.createWorktree({ project: managedProject, branch: "feature" }),
+    ).rejects.toMatchObject({
       tag: "WorktreeProviderError",
       code: "WORKTRUNK_BRANCH_EXISTS",
       hint: expect.stringContaining("different branch"),
@@ -699,7 +835,8 @@ describe("WorktrunkProvider", () => {
           type: "external_command",
           provider: "worktrunk",
           operation: "provider.worktrunk.switch",
-          command: "wt switch --create feature --base main --no-cd --format=json",
+          command:
+            'wt --config-set projects."github.com/acme/web".worktree-path="/tmp/home/.worktrees/web/feature" switch --create feature --base main --no-cd --format=json',
           cwd: "/tmp/station/web",
           exitCode: 128,
           stderrSnippet: "fatal: a branch named 'feature' already exists",


### PR DESCRIPTION
## What this fixes

Station's Worktrunk adapter is responsible for creating project worktrees. `[worktree.worktrunk].managed_root` promises that Station-created worktrees live beneath the configured root, but Station previously supplied the managed path only through `WORKTRUNK_WORKTREE_PATH`. Worktrunk applies a project's configured `worktree-path` later, so that setting could win and place new worktrees beside the checkout instead (for example, directly under `~/Developer`).

## What changed

- Resolve the Worktrunk project identifier from the canonical remote, with the primary checkout path as the no-remote fallback.
- Apply the managed path through invocation-local `--config-set` arguments while retaining the existing environment value.
- Keep external-command diagnostics classified as `provider.worktrunk.switch` when the inline override is present.
- Leave the user's Worktrunk configuration and existing worktrees unchanged; the override applies only to future creates initiated by Station.
- Cover remote-keyed and local-path-keyed project configurations, including managed-create failure diagnostics and the first-project integration flow.
- Clarify the precedence guarantee in Station's configuration documentation.

## Testing

- `pnpm build`
- `pnpm --filter @station/worktrunk typecheck`
- `pnpm lint`
- `env -u STATION_PANE -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:unit` (191 files, 1,859 tests)
- `env -u STATION_PANE -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:integration` (55 files, 579 tests; 1 file skipped)
- `env -u STATION_PANE -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:ci:binary`
- Isolated real Worktrunk 0.64 smoke with conflicting global and per-project templates: create landed under `managed_root`, then removal completed cleanly.

## User-visible behavior

New worktrees created through Station stay under `managed_root` even when Worktrunk has a conflicting per-project path template. Existing worktrees are not moved.