### PR TITLE
docs(dev): explain isolated cross-worktree testing

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,6 +23,12 @@ Status: current living doc for development, test, and documentation workflow.
 Do not use `station:dev` as a catch-all name until it truthfully owns the UI,
 CLI/package, observer, provider, protocol, and host restart boundaries.
 
+To test a different worktree without interrupting the devbox or hosted sessions
+from this checkout, open a second terminal, `cd` to the worktree under test, and
+run `pnpm station:devbox dev` there. Devbox state, sockets, Observer, Host, and
+provider homes are checkout-local. See the copy-paste recipe in
+[Local development](local-development.md#fast-path-test-another-worktree-and-keep-current-sessions).
+
 - `pnpm stn` opens the normal station popup from the current checkout's built CLI when run inside tmux.
 - `pnpm stn tui` opens the normal station TUI fullscreen from the current checkout's built CLI.
 - Source popup registrations are scoped to the canonical checkout root that

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -11,6 +11,46 @@ tmux popup — and the headless CLI).
 > [architecture.md](architecture.md); for the Station OpenTUI/React UI in
 > `station/` see [tui.md](tui.md).
 
+## Fast path: test another worktree and keep current sessions
+
+Open a second terminal, enter the worktree whose code you want to test, and run
+its checkout-local devbox:
+
+```bash
+cd /path/to/the-worktree
+git branch --show-current
+
+test -d node_modules || pnpm install --frozen-lockfile
+test -d station/node_modules || (cd station && bun install)
+pnpm station:devbox dev
+```
+
+That command builds and runs **that worktree's code** against that worktree's
+`.dev-state`, checkout-keyed socket, Observer, provider homes, and Station Host.
+A devbox running from another checkout—and every session hosted by it—keeps
+running. Quitting this Station UI also leaves this checkout's hosted sessions
+running so the same command can reattach later.
+
+If that worktree already has a devbox and you then change code outside
+`station/src/**`, run `pnpm station:devbox restart` there before reopening
+`pnpm station:devbox dev`; the restart is scoped to that worktree and preserves
+its persistent Host and agents. Do not use
+`pnpm station:link`, `pnpm station:reset`, or the global Observer while comparing
+branches.
+
+For example, to validate native OSC 8 rendering, open a shell pane in the
+isolated Station UI and run:
+
+```sh
+printf '\033]8;;https://github.com/jeremy0dell/station/issues/196\033\\#196\033]8;;\033\\ plain\n'
+```
+
+The `#196` label should expose that exact URI through the outer terminal's usual
+hyperlink gesture, while `plain` must not. OSC 8 carries the URI rather than a
+color or underline, so the terminal decides how to style the link. Repeat after
+scrolling, resizing, quitting, and reopening the isolated Station UI to cover
+viewport and Host replay behavior.
+
 ---
 
 ## 1. The one thing to understand: isolate the observer


### PR DESCRIPTION
## What this fixes

Developers did not have one clear, copy-paste path for running another worktree's Station build without replacing the devbox or hosted sessions they were already using. The existing guidance also did not explain that an OSC 8 link carries a URI while the outer terminal chooses its color and underline treatment.

## What changed

- Add a second-terminal recipe that starts the target worktree's checkout-local devbox.
- Explain which state, sockets, Observer, Host, and provider homes remain isolated per checkout.
- Document when a checkout-local restart is needed and which global or reset commands to avoid while comparing branches.
- Add a bounded OSC 8 probe with linked and plain text, plus the expected interaction and replay checks.

## Testing

- `pnpm lint`
- `git diff --check`
- `node scripts/station-devbox.mjs --help` confirmed the documented `dev` and persistence-preserving `restart` commands.
- Verified the documented OSC 8 command emits one open sequence, the `#196` label, one close sequence, and plain trailing text.

## User-visible behavior

Documentation only. Developers can test another branch while keeping current Station sessions running, and can distinguish hyperlink payload correctness from terminal-specific styling.