### PR TITLE
fix(hooks): preserve artifact ownership in launch checks

### DIFF
--- a/apps/cli/src/observerProviders.ts
+++ b/apps/cli/src/observerProviders.ts
@@ -303,6 +303,9 @@ function buildClaudeHarnessProvider({
   if (registryOptions.providerHookIngressLauncher !== undefined) {
     options.hookBin = registryOptions.providerHookIngressLauncher;
   }
+  if (registryOptions.providerHookArtifactOwner !== undefined) {
+    options.artifactOwner = registryOptions.providerHookArtifactOwner;
+  }
   applyObserverPaths(options, config, true);
   return createClaudeHarnessProvider(options);
 }
@@ -338,6 +341,9 @@ function buildCodexHarnessProvider({
   if (registryOptions.providerHookIngressLauncher !== undefined) {
     options.hookBin = registryOptions.providerHookIngressLauncher;
   }
+  if (registryOptions.providerHookArtifactOwner !== undefined) {
+    options.artifactOwner = registryOptions.providerHookArtifactOwner;
+  }
   applyObserverPaths(options, config, true);
   return createCodexHarnessProvider(options);
 }
@@ -362,6 +368,9 @@ function buildCursorHarnessProvider({
   }
   if (registryOptions.providerHookIngressLauncher !== undefined) {
     options.hookBin = registryOptions.providerHookIngressLauncher;
+  }
+  if (registryOptions.providerHookArtifactOwner !== undefined) {
+    options.artifactOwner = registryOptions.providerHookArtifactOwner;
   }
   applyObserverPaths(options, config, true);
   return createCursorHarnessProvider(options);
@@ -397,6 +406,9 @@ function buildOpenCodeHarnessProvider({
   }
   if (registryOptions.configPath !== undefined) {
     options.configPath = registryOptions.configPath;
+  }
+  if (registryOptions.providerHookArtifactOwner !== undefined) {
+    options.artifactOwner = registryOptions.providerHookArtifactOwner;
   }
   applyObserverPaths(options, config, false);
   return createOpenCodeHarnessProvider(options);

--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -337,6 +337,13 @@ describe("observer providers", () => {
     const observerSocketPath = "/tmp/station/provider-table-observer.sock";
     const configPath = "/tmp/station/provider-table-config.toml";
     const ingressLauncher = "/tmp/station/bin/stn-ingress";
+    const artifactOwner: contracts.ProviderHookArtifactOwner = {
+      schemaVersion: 1,
+      launcher: ingressLauncher,
+      runtimeKind: "source",
+      version: "0.0.0-test",
+      buildIdentity: "a".repeat(64),
+    };
     const piExtensionPath = "/tmp/station/assets/pi-extension.mjs";
     const providerConfig: StationConfig = {
       ...config,
@@ -394,6 +401,7 @@ describe("observer providers", () => {
       configPath,
       piExtensionPath,
       providerHookIngressLauncher: ingressLauncher,
+      providerHookArtifactOwner: artifactOwner,
     });
     const observerPaths = resolveObserverPaths(providerConfig);
     expect(vi.mocked(createClaudeHarnessProvider).mock.calls.at(-1)?.[0]).toEqual({
@@ -405,6 +413,7 @@ describe("observer providers", () => {
       installHooks: true,
       resume: true,
       hookBin: ingressLauncher,
+      artifactOwner,
       observerSocketPath: observerPaths.socketPath,
       stateDir: observerPaths.stateDir,
       hookSpoolDir: observerPaths.hookSpoolDir,
@@ -419,6 +428,7 @@ describe("observer providers", () => {
       installHooks: true,
       resume: true,
       hookBin: ingressLauncher,
+      artifactOwner,
       observerSocketPath: observerPaths.socketPath,
       stateDir: observerPaths.stateDir,
       hookSpoolDir: observerPaths.hookSpoolDir,
@@ -430,6 +440,7 @@ describe("observer providers", () => {
       resume: true,
       configPath,
       hookBin: ingressLauncher,
+      artifactOwner,
       observerSocketPath: observerPaths.socketPath,
       stateDir: observerPaths.stateDir,
       hookSpoolDir: observerPaths.hookSpoolDir,
@@ -444,6 +455,7 @@ describe("observer providers", () => {
       installHooks: true,
       resume: true,
       configPath,
+      artifactOwner,
       observerSocketPath: observerPaths.socketPath,
       stateDir: observerPaths.stateDir,
       hookSpoolDir: observerPaths.hookSpoolDir,

--- a/integrations/harness/codex/test/unit/provider.test.ts
+++ b/integrations/harness/codex/test/unit/provider.test.ts
@@ -5,6 +5,7 @@ import type {
   BuildHarnessLaunchRequest,
   HarnessEventObservation,
   HarnessRunObservation,
+  ProviderHookArtifactOwner,
   RawHarnessEvent,
 } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
@@ -195,6 +196,13 @@ describe("CodexHarnessProvider", () => {
     const observerSocketPath = join(root, "run", "observer.sock");
     const stateDir = join(root, "state");
     const hookSpoolDir = join(stateDir, "spool", "hooks");
+    const artifactOwner: ProviderHookArtifactOwner = {
+      schemaVersion: 1,
+      launcher: "/checkout/bin/stn-ingress",
+      runtimeKind: "source",
+      version: "0.0.0-test",
+      buildIdentity: "a".repeat(64),
+    };
 
     await installCodexHooks({
       hookScriptPath,
@@ -203,6 +211,7 @@ describe("CodexHarnessProvider", () => {
       stateDir,
       hookSpoolDir,
       autoStartFromHooks: false,
+      artifactOwner,
       env: { CODEX_HOME: codexHome },
     });
 
@@ -216,6 +225,7 @@ describe("CodexHarnessProvider", () => {
         stateDir,
         hookSpoolDir,
         autoStartFromHooks: false,
+        artifactOwner,
         runner: async (input) => result(input, "Logged in with ChatGPT\n"),
       });
 
@@ -225,6 +235,10 @@ describe("CodexHarnessProvider", () => {
           status: "ok",
         }),
       );
+      await expect(provider.hooksStatus({ stationConfigPath })).resolves.toMatchObject({
+        installed: true,
+        requested: true,
+      });
     } finally {
       if (previousCodexHome === undefined) {
         delete process.env.CODEX_HOME;

--- a/integrations/harness/opencode/src/provider.ts
+++ b/integrations/harness/opencode/src/provider.ts
@@ -192,6 +192,9 @@ function openCodePluginDoctorOptions(
     if (options.hookSpoolDir !== undefined) {
       pluginOptions.hookSpoolDir = options.hookSpoolDir;
     }
+    if (options.artifactOwner !== undefined) {
+      pluginOptions.artifactOwner = options.artifactOwner;
+    }
   }
   return pluginOptions;
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -319,6 +319,19 @@ describe("OpenCodeHarnessProvider", () => {
       artifactOwner: requesterOwner,
     });
 
+    const matchingProvider = createOpenCodeHarnessProvider({
+      installHooks: true,
+      observerSocketPath: requesterObserverSocketPath,
+      stateDir: requesterStateDir,
+      hookSpoolDir: requesterHookSpoolDir,
+      artifactOwner: requesterOwner,
+      env: { OPENCODE_CONFIG_DIR: opencodeConfigDir },
+    });
+    await expect(matchingProvider.hooksStatus?.()).resolves.toMatchObject({
+      installed: true,
+      ownership: { status: "same-owner", requested: requesterOwner },
+    });
+
     const provider = createOpenCodeHarnessProvider({
       command: "opencode-test",
       installHooks: true,

--- a/packages/harness-shared/src/provider.ts
+++ b/packages/harness-shared/src/provider.ts
@@ -33,6 +33,7 @@ import {
 export type CommonHarnessProviderOptions = {
   command?: string;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
   now?: () => Date | string;
   timeoutMs?: number;
   runner?: ExternalCommandRunner;
@@ -233,6 +234,7 @@ export async function harnessHealth<TOpts extends CommonHarnessProviderOptions>(
 export type HarnessHookDoctorOptionsInput = {
   installHooks?: boolean;
   hookBin?: string;
+  artifactOwner?: ProviderHookArtifactOwner;
   observerSocketPath?: string;
   stateDir?: string;
   hookSpoolDir?: string;
@@ -276,6 +278,9 @@ export function harnessHookDoctorOptions(
   }
   if (options.hookBin !== undefined) {
     result.hookBin = options.hookBin;
+  }
+  if (options.artifactOwner !== undefined) {
+    result.artifactOwner = options.artifactOwner;
   }
   if (options.stateDir !== undefined) {
     result.stateDir = options.stateDir;

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -242,12 +242,20 @@ describe("harnessHookDoctorOptions", () => {
     stateDir: "/checkout/A/state",
     hookSpoolDir: "/checkout/A/state/spool/hooks",
     autoStartFromHooks: true,
+    artifactOwner: {
+      schemaVersion: 1 as const,
+      launcher: "/checkout/A/bin/stn-ingress",
+      runtimeKind: "source" as const,
+      version: "0.0.0-test",
+      buildIdentity: "a".repeat(64),
+    },
   };
 
   it("preserves the incumbent hook launcher without a requester runtime", () => {
     expect(harnessHookDoctorOptions(incumbent)).toMatchObject({
       enabled: true,
       hookBin: incumbent.hookBin,
+      artifactOwner: incumbent.artifactOwner,
     });
   });
   const requesterRuntime = {


### PR DESCRIPTION
## What this fixes

Station's isolated devbox prepares provider tracking artifacts before opening its UI, and the Observer rechecks those artifacts before every managed agent launch so it does not start a session it cannot track. The CLI had already resolved the current artifact owner's launcher and build identity, but provider-registry composition dropped that identity when constructing the Claude, Codex, Cursor, and OpenCode harness providers.

As a result, a devbox could complete hook installation and report `installed: true`, `missing: []`, and `same-owner` through `stn hooks doctor codex`, while Quick Session still failed closed with `HARNESS_HOOKS_NOT_INSTALLED`. This was an internal launch-readiness mismatch, not interference between concurrent devboxes: each checkout retained separate provider homes, state, and sockets.

`pnpm station:devbox start` and `pnpm station:devbox dev` use the same readiness path. Both build the current checkout, generate the worktree-local `.dev-state` config and provider homes, start the isolated Observer, and complete all four hook-install commands before opening Station. Only the final UI command differs: `start` runs the normal renderer, while `dev` runs that renderer with hot reload for `station/src/**`. Because this fix is in the shared Observer provider composition, it applies to Quick Session from either command.

## What changed

- Forward the CLI-resolved `providerHookArtifactOwner` into the Claude, Codex, Cursor, and OpenCode provider option builders used by both devbox modes.
- Preserve artifact ownership through the shared harness hook-doctor options.
- Carry that ownership into OpenCode's provider-local plugin doctor path.
- Add composition and provider tests proving matching Codex and OpenCode artifacts remain launch-ready.
- Leave installation locations, provider trust prompts, and fail-closed ownership checks unchanged.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm architecture:observer:check`
- `pnpm test:unit` — 1,892 tests passed
- Focused provider/composition tests — 88 tests passed
- `pnpm station:devbox:smoke` on this PR's exact commit — exercised the normal `start` bootstrap, required Codex, Claude, Cursor, and OpenCode hook doctors to report healthy installed artifacts, restarted the isolated Observer, verified Codex hook delivery, and stopped the disposable devbox.
- Manual `dev` acceptance — ran `pnpm station:devbox stop`, then `pnpm station:devbox dev` from a disposable Git worktree and clicked Quick Session with the mouse. Worktree creation succeeded, Codex launched, hook doctor reported the current same-owner artifact, and Observer logs contained no `HARNESS_HOOKS_NOT_INSTALLED` failure.

## User-visible behavior

- Use `pnpm station:devbox start` for normal manual testing.
- Use `pnpm station:devbox dev` when editing `station/src/**` and you want UI hot reload.
- Both commands finish the same isolated hook setup before opening the UI; a nonzero hook-install command stops startup instead of opening a devbox that is known to be unprepared.
- Quick Session then rechecks the installed artifacts with the same owner identity that created them, so either UI mode accepts the prepared hooks rather than falsely reporting them missing.

A fresh Codex provider home may still show Codex's separate hook-review prompt. That approval is a provider trust boundary, not missing Station setup.

## Safety and scope

This change only preserves identity that CLI composition already computes and hook installers already stamp into artifacts. It does not install or trust hooks implicitly, weaken foreign-owner detection, share state between devboxes, or bypass Codex's separate hook-review prompt.