### PR TITLE
refactor(setup): extract deterministic setup policies

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -56,6 +56,7 @@
     "@station/protocol": "workspace:*",
     "@station/runtime": "workspace:*",
     "@station/scripted-harness": "workspace:*",
+    "@station/setup-core": "workspace:*",
     "@station/terminal": "workspace:*",
     "@station/tmux": "workspace:*",
     "@station/worktrunk": "workspace:*",

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -214,16 +214,21 @@ async function selectGuidedHarnesses(
     if (right.id === configuredDefault) return 1;
     return 0;
   });
-  const selectedValues = await prompt.selectMany(
-    "Select agent CLIs to prepare (comma-separated; the first is the default only for a new config).",
-    orderedHarnesses.map((harness) => ({ value: harness.id, label: harness.label })),
-  );
-  const selectedHarnessIds = selectedValues.filter(isSupportedHarnessId);
-  if (selectedHarnessIds.length === 0) {
+  const choices = orderedHarnesses.map((harness) => ({
+    value: harness.id,
+    label: harness.label,
+  }));
+  while (true) {
+    const selectedValues = await prompt.selectMany(
+      "Select agent CLIs to prepare (comma-separated; the first is the default only for a new config).",
+      choices,
+    );
+    const selectedHarnessIds = selectedValues.filter(isSupportedHarnessId);
+    if (selectedHarnessIds.length > 0) {
+      return { status: "continue", selectedHarnessIds };
+    }
     await write(deps, "Select at least one available agent CLI.\n");
-    return { status: "halt" };
   }
-  return { status: "continue", selectedHarnessIds };
 }
 
 function shouldPromptHarnessSelection(facts: SetupFacts, availableCount: number): boolean {

--- a/apps/cli/src/commands/setup/harnessSelection.ts
+++ b/apps/cli/src/commands/setup/harnessSelection.ts
@@ -1,10 +1,17 @@
+import {
+  type HarnessSelectionFacts,
+  type HarnessSelectionIntent,
+  type HarnessTrackingRepairFact,
+  resolveHarnessSelection,
+  selectHarnessTrackingRepairTargets,
+  supportedHarnessIds,
+} from "@station/setup-core";
 import type {
   SetupFacts,
   SetupHarnessFact,
   SetupHarnessSelectionSource,
   SupportedHarnessId,
 } from "./model.js";
-import { supportedHarnessIds } from "./model.js";
 
 export type SetupHarnessSelection = {
   selected: readonly SetupHarnessFact[];
@@ -17,69 +24,49 @@ export function resolveSetupHarnessSelection(
   facts: Pick<SetupFacts, "config" | "harnesses">,
   selectedIds?: readonly SupportedHarnessId[],
 ): SetupHarnessSelection {
-  const configuredDefault = configuredDefaultHarness(facts);
-  if (selectedIds !== undefined) {
-    return resolveExplicitSelection(facts, selectedIds, configuredDefault);
-  }
-  if (facts.config.status === "valid") {
-    if (configuredDefault === undefined) return unresolvedSelection();
-    return {
-      selected: availableHarnesses(facts.harnesses, [configuredDefault]),
-      requiredHarnessIds: [configuredDefault],
-      source: "configured",
-      defaultHarness: configuredDefault,
-    };
-  }
-  return inferSingleAvailableHarness(facts) ?? unresolvedSelection();
-}
-
-function configuredDefaultHarness(
-  facts: Pick<SetupFacts, "config">,
-): SupportedHarnessId | undefined {
-  if (facts.config.status !== "valid") return undefined;
-  return isSupportedHarnessId(facts.config.defaults.harness)
-    ? facts.config.defaults.harness
-    : undefined;
-}
-
-function resolveExplicitSelection(
-  facts: Pick<SetupFacts, "config" | "harnesses">,
-  selectedIds: readonly SupportedHarnessId[],
-  configuredDefault: SupportedHarnessId | undefined,
-): SetupHarnessSelection {
-  if (facts.config.status === "valid" && configuredDefault === undefined) {
-    return unresolvedSelection();
-  }
-  const explicitIds = uniqueSupportedIds(selectedIds);
-  const firstExplicit = explicitIds[0];
-  if (firstExplicit === undefined) return unresolvedSelection();
-
-  // Explicit choices may extend an existing config, but cannot replace its authoritative default.
-  const requiredHarnessIds =
-    configuredDefault === undefined || explicitIds.includes(configuredDefault)
-      ? explicitIds
-      : [...explicitIds, configuredDefault];
+  const resolution = resolveHarnessSelection(
+    coreSelectionFacts(facts),
+    selectionIntent(selectedIds),
+  );
+  if (resolution.outcome !== "selected") return unresolvedSelection();
   return {
-    selected: availableHarnesses(facts.harnesses, requiredHarnessIds),
-    requiredHarnessIds,
-    source: "explicit",
-    defaultHarness: configuredDefault ?? firstExplicit,
+    selected: availableHarnesses(facts.harnesses, resolution.requiredHarnessIds),
+    requiredHarnessIds: resolution.requiredHarnessIds,
+    source: resolution.source,
+    defaultHarness: resolution.defaultHarness,
   };
 }
 
-function inferSingleAvailableHarness(
+function coreSelectionFacts(
   facts: Pick<SetupFacts, "config" | "harnesses">,
-): SetupHarnessSelection | undefined {
-  if (facts.config.status !== "missing") return undefined;
-  const available = facts.harnesses.filter((harness) => harness.status === "ok");
-  const inferred = available.length === 1 ? available[0] : undefined;
-  if (inferred === undefined) return undefined;
+): HarnessSelectionFacts {
+  let config: HarnessSelectionFacts["config"];
+  switch (facts.config.status) {
+    case "missing":
+      config = { status: "missing" };
+      break;
+    case "invalid":
+      config = { status: "invalid" };
+      break;
+    case "valid":
+      config = { status: "valid", defaultHarness: facts.config.defaults.harness };
+      break;
+  }
   return {
-    selected: [inferred],
-    requiredHarnessIds: [inferred.id],
-    source: "inferred",
-    defaultHarness: inferred.id,
+    config,
+    harnesses: facts.harnesses.map((harness) => ({
+      id: harness.id,
+      availability: harness.status === "ok" ? "available" : "unavailable",
+    })),
   };
+}
+
+function selectionIntent(
+  selectedIds: readonly SupportedHarnessId[] | undefined,
+): HarnessSelectionIntent {
+  return selectedIds === undefined
+    ? { kind: "automatic" }
+    : { kind: "explicit", harnessIds: selectedIds };
 }
 
 function unresolvedSelection(): SetupHarnessSelection {
@@ -99,15 +86,28 @@ export function harnessSupportsSetupHooks(
 }
 
 export function harnessTrackingRepairTargets(
-  facts: Pick<SetupFacts, "config" | "harnesses">,
+  facts: Pick<SetupFacts, "config" | "harnesses" | "harnessTracking">,
   harnessSelection: SetupHarnessSelection,
 ): SetupHarnessFact[] {
-  const persistedHookIds =
+  const persistedTrackingHarnessIds =
     facts.config.status === "valid" ? facts.config.configuredHookHarnesses : [];
-  const repairIds = uniqueSupportedIds([
-    ...harnessSelection.requiredHarnessIds,
-    ...persistedHookIds,
-  ]);
+  const harnesses: HarnessTrackingRepairFact[] = facts.harnesses.map((harness) => {
+    const tracking = facts.harnessTracking.find((candidate) => candidate.harnessId === harness.id);
+    return {
+      id: harness.id,
+      available: harness.status === "ok",
+      capability: harnessSupportsSetupHooks(harness.id) ? "supported" : "unsupported",
+      prepared:
+        tracking?.capability === "supported" &&
+        tracking.requested === true &&
+        tracking.installed === true,
+    };
+  });
+  const repairIds = selectHarnessTrackingRepairTargets({
+    requiredHarnessIds: harnessSelection.requiredHarnessIds,
+    persistedTrackingHarnessIds,
+    harnesses,
+  });
   return availableHarnesses(facts.harnesses, repairIds);
 }
 

--- a/apps/cli/src/commands/setup/io.ts
+++ b/apps/cli/src/commands/setup/io.ts
@@ -58,7 +58,5 @@ export function parseMultiSelectAnswer(
     const value = Number.isInteger(index) ? choices[index]?.value : undefined;
     if (value !== undefined && !selected.includes(value)) selected.push(value);
   }
-  if (selected.length > 0) return selected;
-  const fallback = choices[0]?.value;
-  return fallback === undefined ? [] : [fallback];
+  return selected;
 }

--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -1,6 +1,10 @@
 import type { TmuxConfig } from "@station/config";
 import { ProviderHookArtifactOwnershipSchema } from "@station/contracts";
+import { type SupportedHarnessId, supportedHarnessIds } from "@station/setup-core";
 import { z } from "zod";
+
+export type { SupportedHarnessId } from "@station/setup-core";
+export { supportedHarnessIds } from "@station/setup-core";
 
 export const setupTiers = ["required", "recommended", "optional"] as const;
 export const setupStatuses = ["ok", "missing", "warning", "skipped"] as const;
@@ -14,7 +18,6 @@ export const setupActionKinds = [
   "noop",
 ] as const;
 export const setupActionStatuses = ["pending", "completed", "failed", "skipped"] as const;
-export const supportedHarnessIds = ["codex", "cursor", "opencode", "pi", "claude"] as const;
 export const setupHarnessSelectionSources = [
   "configured",
   "explicit",
@@ -57,7 +60,6 @@ export const SetupHarnessTrackingFactSchema = z
 
 export type SetupTier = z.infer<typeof SetupTierSchema>;
 export type SetupMode = z.infer<typeof SetupModeSchema>;
-export type SupportedHarnessId = z.infer<typeof SupportedHarnessIdSchema>;
 export type SetupHarnessSelectionSource = z.infer<typeof SetupHarnessSelectionSourceSchema>;
 export type SetupHarnessTrackingFact = z.infer<typeof SetupHarnessTrackingFactSchema>;
 

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,5 +1,11 @@
 import { dirname } from "node:path";
 import type { ProviderHookArtifactOwnership } from "@station/contracts";
+import {
+  assessHarnessTracking,
+  deriveSetupReadiness,
+  type HarnessTrackingAssessment,
+  type HarnessTrackingFacts,
+} from "@station/setup-core";
 import { stationUiInstallHint } from "../../stationWorkspace.js";
 import { setupLauncherExecutable } from "./checks/launchers.js";
 import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
@@ -32,18 +38,25 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
   const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
   const checks = setupChecks(facts, harnessSelection);
   const actions = setupActions(facts, harnessSelection, options.configWrite, options);
-  const requiredMissing = checks.filter(
-    (check) => check.tier === "required" && check.status !== "ok",
-  ).length;
   const warnings = checks.filter((check) => check.status === "warning").length;
-  const workflowReady = checks.every((check) => check.tier !== "required" || check.status === "ok");
+  const readiness = deriveSetupReadiness({
+    stateDirectoryWritable: facts.stateDir.status === "ok",
+    runtime: facts.compiled
+      ? { kind: "compiled" }
+      : {
+          kind: "source",
+          bunAvailable: facts.bun.status === "ok",
+          stationUiUsable: facts.stationUi.status !== "missing",
+        },
+    requirements: checks.flatMap((check) =>
+      check.tier === "required" ? [check.status === "ok" ? "satisfied" : "unsatisfied"] : [],
+    ),
+  });
   const summary = {
-    launchReady:
-      facts.stateDir.status === "ok" &&
-      (facts.compiled || (facts.bun.status === "ok" && facts.stationUi.status !== "missing")),
-    workflowReady,
-    requiredOk: workflowReady,
-    requiredMissing,
+    launchReady: readiness.launchReady,
+    workflowReady: readiness.workflowReady,
+    requiredOk: readiness.workflowReady,
+    requiredMissing: readiness.requiredMissing,
     warnings,
     selectedActions: actions.filter((action) => action.selected).length,
     selectionSource: harnessSelection.source,
@@ -58,7 +71,7 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
     checks,
     actions,
     summary,
-    nextSteps: nextSteps(requiredMissing, facts),
+    nextSteps: nextSteps(readiness.requiredMissing, facts),
   };
   return SetupPlanSchema.parse(plan);
 }
@@ -375,26 +388,6 @@ function harnessTrackingChecks(
   );
 }
 
-type HarnessTrackingAssessmentResult = {
-  status: SetupCheck["status"];
-  message: string;
-};
-
-type NoExternalTrackingAssessment = HarnessTrackingAssessmentResult & {
-  capability: "unsupported";
-  state: "not-applicable";
-};
-
-type ExternalTrackingAssessment = HarnessTrackingAssessmentResult & {
-  capability: "supported";
-  state: "probe-failed" | "disabled" | "artifact-missing-or-drifted" | "prepared";
-  requested: boolean | undefined;
-  installed: boolean | undefined;
-};
-
-// The capability discriminant keeps no-artifact outcomes distinct from incomplete external evidence.
-type HarnessTrackingAssessment = NoExternalTrackingAssessment | ExternalTrackingAssessment;
-
 function harnessTrackingCheck(
   facts: SetupFacts,
   harnessId: SupportedHarnessId,
@@ -403,27 +396,107 @@ function harnessTrackingCheck(
 ): SetupCheck {
   const harnessLabel =
     facts.harnesses.find((candidate) => candidate.id === harnessId)?.label ?? harnessId;
-  const assessment = assessHarnessTracking(facts, harnessId, harnessLabel, required);
+  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
+  const trackingFacts = coreHarnessTrackingFacts(facts, harnessId, fact);
+  const assessment = assessHarnessTracking(trackingFacts);
+  const presentation = harnessTrackingPresentation(
+    assessment,
+    fact,
+    harnessId,
+    harnessLabel,
+    required,
+  );
   const details: Record<string, string> = {
     harness: harnessId,
     selectionSource,
-    capability: assessment.capability,
+    capability: trackingFacts.capability,
     state: assessment.state,
   };
-  if (assessment.capability === "supported") {
+  if (assessment.state !== "not-applicable") {
     if (assessment.requested !== undefined) details.requested = String(assessment.requested);
     if (assessment.installed !== undefined) details.installed = String(assessment.installed);
   }
-  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
   if (fact?.ownership !== undefined) addHookOwnershipDetails(details, fact.ownership);
   return {
     id: `harness-tracking:${harnessId}`,
     tier: required ? "required" : "recommended",
-    status: assessment.status,
+    status: presentation.status,
     label: `${harnessLabel} tracking`,
-    message: assessment.message,
+    message: presentation.message,
     details,
   };
+}
+
+function coreHarnessTrackingFacts(
+  facts: SetupFacts,
+  harnessId: SupportedHarnessId,
+  fact: SetupFacts["harnessTracking"][number] | undefined,
+): HarnessTrackingFacts {
+  if (!harnessSupportsSetupHooks(harnessId)) {
+    return {
+      capability: "unsupported",
+      configRequested: false,
+      evidence: { availability: "unavailable" },
+    };
+  }
+  const configRequested =
+    facts.config.status === "valid" && facts.config.configuredHookHarnesses.includes(harnessId);
+  if (fact === undefined || fact.capability !== "supported") {
+    return {
+      capability: "supported",
+      configRequested,
+      evidence: { availability: "unavailable" },
+    };
+  }
+  const evidence: {
+    availability: "available";
+    requested?: boolean;
+    installed?: boolean;
+    probeFailed: boolean;
+  } = {
+    availability: "available",
+    probeFailed: fact.probeFailed === true,
+  };
+  if (fact.requested !== undefined) evidence.requested = fact.requested;
+  if (fact.installed !== undefined) evidence.installed = fact.installed;
+  return { capability: "supported", configRequested, evidence };
+}
+
+function harnessTrackingPresentation(
+  assessment: HarnessTrackingAssessment,
+  fact: SetupFacts["harnessTracking"][number] | undefined,
+  harnessId: SupportedHarnessId,
+  harnessLabel: string,
+  required: boolean,
+): Pick<SetupCheck, "status" | "message"> {
+  const unavailableStatus = required ? "missing" : "warning";
+  switch (assessment.state) {
+    case "not-applicable":
+      return {
+        status: required ? "ok" : "skipped",
+        message: `${harnessLabel} has no Station-managed external tracking artifact.`,
+      };
+    case "probe-failed":
+      return {
+        status: unavailableStatus,
+        message: fact?.detail ?? `${harnessId} tracking status could not be inspected.`,
+      };
+    case "disabled":
+      return {
+        status: unavailableStatus,
+        message: `${harnessLabel} tracking is disabled in Station config.`,
+      };
+    case "artifact-missing-or-drifted":
+      return {
+        status: unavailableStatus,
+        message: fact?.detail ?? `${harnessId} tracking artifacts are absent or drifted.`,
+      };
+    case "prepared":
+      return {
+        status: "ok",
+        message: `${harnessLabel} Station tracking artifacts are prepared on disk.`,
+      };
+  }
 }
 
 function addHookOwnershipDetails(
@@ -443,83 +516,6 @@ function addHookOwnershipDetails(
     details.currentRuntimeVersion = ownership.current.version;
     details.currentBuildIdentity = ownership.current.buildIdentity;
   }
-}
-
-function assessHarnessTracking(
-  facts: SetupFacts,
-  harnessId: SupportedHarnessId,
-  harnessLabel: string,
-  required: boolean,
-): HarnessTrackingAssessment {
-  if (!harnessSupportsSetupHooks(harnessId)) {
-    return {
-      capability: "unsupported",
-      state: "not-applicable",
-      status: required ? "ok" : "skipped",
-      message: `${harnessLabel} has no Station-managed external tracking artifact.`,
-    };
-  }
-
-  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
-  const configRequested =
-    facts.config.status === "valid" && facts.config.configuredHookHarnesses.includes(harnessId);
-  return assessSupportedHarnessTracking({
-    fact,
-    harnessId,
-    harnessLabel,
-    configRequested,
-    required,
-  });
-}
-
-function assessSupportedHarnessTracking(input: {
-  fact: SetupFacts["harnessTracking"][number] | undefined;
-  harnessId: SupportedHarnessId;
-  harnessLabel: string;
-  configRequested: boolean;
-  required: boolean;
-}): HarnessTrackingAssessment {
-  const { fact, harnessId, harnessLabel, configRequested, required } = input;
-  const unavailableStatus = required ? "missing" : "warning";
-  if (fact === undefined || fact.capability !== "supported" || fact.probeFailed === true) {
-    const supportedFact = fact?.capability === "supported" ? fact : undefined;
-    return {
-      capability: "supported",
-      state: "probe-failed",
-      status: unavailableStatus,
-      message: fact?.detail ?? `${harnessId} tracking status could not be inspected.`,
-      requested: supportedFact?.requested,
-      installed: supportedFact?.installed,
-    };
-  }
-  if (!configRequested || fact.requested !== true) {
-    return {
-      capability: "supported",
-      state: "disabled",
-      status: unavailableStatus,
-      message: `${harnessLabel} tracking is disabled in Station config.`,
-      requested: fact.requested,
-      installed: fact.installed,
-    };
-  }
-  if (fact.installed !== true) {
-    return {
-      capability: "supported",
-      state: "artifact-missing-or-drifted",
-      status: unavailableStatus,
-      message: fact.detail ?? `${harnessId} tracking artifacts are absent or drifted.`,
-      requested: fact.requested,
-      installed: fact.installed,
-    };
-  }
-  return {
-    capability: "supported",
-    state: "prepared",
-    status: "ok",
-    message: `${harnessLabel} Station tracking artifacts are prepared on disk.`,
-    requested: fact.requested,
-    installed: fact.installed,
-  };
 }
 
 function xcodeChecks(facts: SetupFacts): SetupCheck[] {
@@ -973,12 +969,6 @@ function hookSetupActions(
     });
   }
   for (const repairTarget of harnessTrackingRepairTargets(facts, harnessSelection)) {
-    if (
-      !harnessSupportsSetupHooks(repairTarget.id) ||
-      harnessTrackingPrepared(facts, repairTarget.id)
-    ) {
-      continue;
-    }
     actions.push({
       id: `${repairTarget.id}-hooks`,
       kind: "run-command",
@@ -993,11 +983,6 @@ function hookSetupActions(
     });
   }
   return actions;
-}
-
-function harnessTrackingPrepared(facts: SetupFacts, harnessId: SupportedHarnessId): boolean {
-  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
-  return fact?.capability === "supported" && fact.requested === true && fact.installed === true;
 }
 
 function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -224,6 +224,70 @@ describe("guided setup command", () => {
     expect(fs.files[configPath].match(/^\[harness\.(codex|opencode)\]$/gm)).toHaveLength(2);
   });
 
+  it("reprompts invalid harness selection before any mutation", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const configPath = join(homeDir, ".config/station/config.toml");
+    await mkdir(repo, { recursive: true });
+    const calls: ExternalCommandInput[] = [];
+    const fs = fakeFs({});
+    const activations: string[] = [];
+    const chunks: string[] = [];
+    let selectionPrompts = 0;
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner(calls, {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+          "opencode --version": "opencode 1.0.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+        ]),
+        fs,
+        activateObserverConfig: async ({ configPath: activatedPath }) => {
+          activations.push(activatedPath);
+        },
+        prompt: {
+          async confirm(message) {
+            return message.includes("Write core STATION config");
+          },
+          async selectMany() {
+            selectionPrompts += 1;
+            expect(fs.files[configPath]).toBeUndefined();
+            expect(activations).toEqual([]);
+            expect(calls.some((call) => call.stdio === "inherit")).toBe(false);
+            return selectionPrompts === 1 ? [] : ["opencode"];
+          },
+        },
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(selectionPrompts).toBe(2);
+    expect(chunks.join("")).toContain("Select at least one available agent CLI.");
+    expect(fs.files[configPath]).toContain('harness = "opencode"');
+    expect(fs.files[configPath]).not.toContain("[harness.codex]");
+    expect(activations).toEqual([configPath]);
+  });
+
   it("does not silently drop a selected harness after linking checkout launchers", async () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");

--- a/apps/cli/test/unit/setup-io.test.ts
+++ b/apps/cli/test/unit/setup-io.test.ts
@@ -12,8 +12,9 @@ describe("setup prompt input", () => {
     expect(parseMultiSelectAnswer("3, 1,3,99,nope", choices)).toEqual(["pi", "codex"]);
   });
 
-  it("falls back to the first choice when no valid slot was selected", () => {
-    expect(parseMultiSelectAnswer("", choices)).toEqual(["codex"]);
-    expect(parseMultiSelectAnswer("99", choices)).toEqual(["codex"]);
+  it("returns no selection when no valid slot was selected", () => {
+    expect(parseMultiSelectAnswer("", choices)).toEqual([]);
+    expect(parseMultiSelectAnswer("99", choices)).toEqual([]);
+    expect(parseMultiSelectAnswer("nope", choices)).toEqual([]);
   });
 });

--- a/apps/cli/test/unit/setup-model.test.ts
+++ b/apps/cli/test/unit/setup-model.test.ts
@@ -1,3 +1,4 @@
+import { supportedHarnessIds as coreSupportedHarnessIds } from "@station/setup-core";
 import { describe, expect, it } from "vitest";
 import { harnessDefinitions } from "../../src/commands/setup/checks/harnesses.js";
 import {
@@ -9,6 +10,7 @@ import {
 
 describe("setup model", () => {
   it("keeps supported harness ids aligned with setup detection", () => {
+    expect(supportedHarnessIds).toBe(coreSupportedHarnessIds);
     expect([...supportedHarnessIds]).toEqual(harnessDefinitions.map((harness) => harness.id));
     expect([...supportedHarnessIds]).not.toContain("crush");
   });

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -18,6 +18,7 @@
       "@station/protocol": ["../../packages/protocol/dist/index.d.ts"],
       "@station/runtime": ["../../packages/runtime/dist/index.d.ts"],
       "@station/scripted-harness": ["../../integrations/harness/scripted/dist/index.d.ts"],
+      "@station/setup-core": ["../../packages/setup-core/dist/index.d.ts"],
       "@station/tmux": ["../../integrations/terminal/tmux/dist/index.d.ts"],
       "@station/worktrunk": ["../../integrations/worktree/worktrunk/dist/index.d.ts"]
     }

--- a/config/vitest/vitest.config.shared.ts
+++ b/config/vitest/vitest.config.shared.ts
@@ -58,6 +58,9 @@ export const stationAliases = {
   "@station/scripted-harness": fileURLToPath(
     new URL("../../integrations/harness/scripted/src/index.ts", import.meta.url),
   ),
+  "@station/setup-core": fileURLToPath(
+    new URL("../../packages/setup-core/src/index.ts", import.meta.url),
+  ),
   "@station/host": fileURLToPath(
     new URL("../../packages/station-host/src/index.ts", import.meta.url),
   ),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ The repo is organized around these boundaries:
 - `packages/contracts` owns shared application schemas and types, including `ObserverApi`, external-launch values, commands, events, snapshots, observations, provider ports, hooks, diagnostics, and safe errors.
 - `packages/protocol` owns the observer NDJSON transport: envelopes, method mapping, validation execution, client/server mechanics, and fail-closed Unix-socket probing and stale-owner evidence.
 - `packages/runtime` owns shared runtime boundary helpers for timeouts, retry, cancellation, external commands, typed error conversion, and atomic text replacement.
+- `packages/setup-core` owns dependency-free deterministic setup decisions over normalized harness selection, tracking, repair, and readiness facts.
 - `packages/client` owns the framework-neutral rich-client observer runtime: snapshot loading, the event subscription/reconnect loop, event-to-snapshot reduction, and command dispatch/completion-wait wrappers consumed by the Station UI.
 - `apps/cli/src/ingress` owns the tiny `stn-ingress` sender: raw provider hook delivery to the observer socket and offline spool writes. Events sent through this raw path normalize and compact observer-side via provider hook adapters; integrations that submit typed harness reports normalize in their own adapter.
 - `packages/station-host` owns the standalone `station-station-host` daemon contract and client: a process that owns PTYs and their bounded raw/semantic replay state beyond the Station UI lifetime, exposing attach/list/close over its own local socket so panes can warm-reattach. Station consumes it directly; Observer application code can reach host-backed terminal behavior only through an adapter supplied by CLI composition.
@@ -73,6 +74,7 @@ When these disagree, reconcile from config, providers, and current observer stat
   context and on daemon-inherited color controls; only color controls carried
   by the explicit launch request are authoritative.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
+- Setup IO and orchestration remain in the CLI: it validates and normalizes external facts, projects setup-core outcomes into existing plan schemas and copy, and owns config, provider, process, and persistence effects. `@station/setup-core` imports none of those concerns.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
 - The protocol validates transport messages and keeps consumer APIs simple. It should not become a provider boundary.
 - Client processes may spawn after an absent or proven-stale socket, but only the process binding the replacement may unlink it. Inaccessible ownership is preserved; pidfiles never establish liveness or authorize reclaim.

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -14010,6 +14010,38 @@
       "role": "POLICY",
       "purpose": "Uses the canonical launcher path as the durable owner key so upgrades at one installed location remain automatic. Only a valid marker establishes ownership; unmarked or malformed artifacts require explicit takeover.",
       "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/policy/assessHarnessTracking.ts",
+      "declaration": "assessHarnessTracking",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Classifies normalized tracking evidence without provider or presentation concerns.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/policy/deriveReadiness.ts",
+      "declaration": "deriveSetupReadiness",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Derives launch and workflow readiness from normalized runtime and requirement facts.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/policy/resolveHarnessSelection.ts",
+      "declaration": "resolveHarnessSelection",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Resolves configured, explicit, or discovered harness intent without choosing an ambiguous candidate.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/policy/selectRepairTargets.ts",
+      "declaration": "selectHarnessTrackingRepairTargets",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Selects available, supported, unprepared harnesses whose selected or persisted intent requires repair.",
+      "dependencies": []
     }
   ]
 }

--- a/packages/setup-core/package.json
+++ b/packages/setup-core/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@station/setup-core",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/setup-core/src/index.ts
+++ b/packages/setup-core/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  type HarnessSelectionFacts,
+  type HarnessSelectionResolution,
+  type HarnessTrackingAssessment,
+  type HarnessTrackingFacts,
+  type HarnessTrackingRepairFact,
+  type SetupReadiness,
+  type SetupReadinessFacts,
+  type SupportedHarnessId,
+  supportedHarnessIds,
+} from "./model/facts.js";
+export type { HarnessSelectionIntent } from "./model/intent.js";
+export { assessHarnessTracking } from "./policy/assessHarnessTracking.js";
+export { deriveSetupReadiness } from "./policy/deriveReadiness.js";
+export { resolveHarnessSelection } from "./policy/resolveHarnessSelection.js";
+export { selectHarnessTrackingRepairTargets } from "./policy/selectRepairTargets.js";

--- a/packages/setup-core/src/model/facts.ts
+++ b/packages/setup-core/src/model/facts.ts
@@ -1,0 +1,86 @@
+export const supportedHarnessIds = ["codex", "cursor", "opencode", "pi", "claude"] as const;
+
+export type SupportedHarnessId = (typeof supportedHarnessIds)[number];
+
+export type HarnessSelectionFacts = {
+  readonly config:
+    | { readonly status: "missing" }
+    | { readonly status: "invalid" }
+    | { readonly status: "valid"; readonly defaultHarness: string };
+  readonly harnesses: readonly {
+    readonly id: SupportedHarnessId;
+    readonly availability: "available" | "unavailable";
+  }[];
+};
+
+export type HarnessSelectionResolution =
+  | {
+      readonly outcome: "selected";
+      readonly source: "configured" | "explicit" | "inferred";
+      readonly requiredHarnessIds: readonly SupportedHarnessId[];
+      readonly defaultHarness: SupportedHarnessId;
+    }
+  | {
+      readonly outcome: "invalid";
+      readonly reason:
+        | "empty-explicit-selection"
+        | "no-available-harness"
+        | "invalid-config"
+        | "unsupported-configured-default";
+    }
+  | {
+      readonly outcome: "ambiguous";
+      readonly candidateHarnessIds: readonly SupportedHarnessId[];
+    }
+  | { readonly outcome: "cancelled" };
+
+export type HarnessTrackingFacts = {
+  readonly capability: "supported" | "unsupported";
+  readonly configRequested: boolean;
+  readonly evidence:
+    | { readonly availability: "unavailable" }
+    | {
+        readonly availability: "available";
+        readonly requested?: boolean;
+        readonly installed?: boolean;
+        readonly probeFailed: boolean;
+      };
+};
+
+export type HarnessTrackingAssessment =
+  | { readonly state: "not-applicable" }
+  | {
+      readonly state: "probe-failed" | "disabled" | "artifact-missing-or-drifted";
+      readonly requested?: boolean;
+      readonly installed?: boolean;
+    }
+  | {
+      readonly state: "prepared";
+      readonly requested: true;
+      readonly installed: true;
+    };
+
+export type HarnessTrackingRepairFact = {
+  readonly id: SupportedHarnessId;
+  readonly available: boolean;
+  readonly capability: "supported" | "unsupported";
+  readonly prepared: boolean;
+};
+
+export type SetupReadinessFacts = {
+  readonly stateDirectoryWritable: boolean;
+  readonly runtime:
+    | { readonly kind: "compiled" }
+    | {
+        readonly kind: "source";
+        readonly bunAvailable: boolean;
+        readonly stationUiUsable: boolean;
+      };
+  readonly requirements: readonly ("satisfied" | "unsatisfied")[];
+};
+
+export type SetupReadiness = {
+  readonly launchReady: boolean;
+  readonly workflowReady: boolean;
+  readonly requiredMissing: number;
+};

--- a/packages/setup-core/src/model/intent.ts
+++ b/packages/setup-core/src/model/intent.ts
@@ -1,0 +1,9 @@
+import type { SupportedHarnessId } from "./facts.js";
+
+export type HarnessSelectionIntent =
+  | { readonly kind: "automatic" }
+  | {
+      readonly kind: "explicit";
+      readonly harnessIds: readonly SupportedHarnessId[];
+    }
+  | { readonly kind: "cancelled" };

--- a/packages/setup-core/src/policy/assessHarnessTracking.ts
+++ b/packages/setup-core/src/policy/assessHarnessTracking.ts
@@ -1,0 +1,36 @@
+import type { HarnessTrackingAssessment, HarnessTrackingFacts } from "../model/facts.js";
+
+/**
+ * POLICY
+ *
+ * Classifies normalized tracking evidence without provider or presentation concerns.
+ */
+export function assessHarnessTracking(facts: HarnessTrackingFacts): HarnessTrackingAssessment {
+  if (facts.capability === "unsupported") return { state: "not-applicable" };
+  if (facts.evidence.availability === "unavailable") return { state: "probe-failed" };
+
+  if (facts.evidence.probeFailed) {
+    return incompleteAssessment("probe-failed", facts.evidence);
+  }
+  if (!facts.configRequested || facts.evidence.requested !== true) {
+    return incompleteAssessment("disabled", facts.evidence);
+  }
+  if (facts.evidence.installed !== true) {
+    return incompleteAssessment("artifact-missing-or-drifted", facts.evidence);
+  }
+  return { state: "prepared", requested: true, installed: true };
+}
+
+function incompleteAssessment(
+  state: "probe-failed" | "disabled" | "artifact-missing-or-drifted",
+  evidence: Extract<HarnessTrackingFacts["evidence"], { availability: "available" }>,
+): HarnessTrackingAssessment {
+  const assessment: {
+    state: "probe-failed" | "disabled" | "artifact-missing-or-drifted";
+    requested?: boolean;
+    installed?: boolean;
+  } = { state };
+  if (evidence.requested !== undefined) assessment.requested = evidence.requested;
+  if (evidence.installed !== undefined) assessment.installed = evidence.installed;
+  return assessment;
+}

--- a/packages/setup-core/src/policy/deriveReadiness.ts
+++ b/packages/setup-core/src/policy/deriveReadiness.ts
@@ -1,0 +1,20 @@
+import type { SetupReadiness, SetupReadinessFacts } from "../model/facts.js";
+
+/**
+ * POLICY
+ *
+ * Derives launch and workflow readiness from normalized runtime and requirement facts.
+ */
+export function deriveSetupReadiness(facts: SetupReadinessFacts): SetupReadiness {
+  const runtimeReady =
+    facts.runtime.kind === "compiled" ||
+    (facts.runtime.bunAvailable && facts.runtime.stationUiUsable);
+  const requiredMissing = facts.requirements.filter(
+    (requirement) => requirement === "unsatisfied",
+  ).length;
+  return {
+    launchReady: facts.stateDirectoryWritable && runtimeReady,
+    workflowReady: requiredMissing === 0,
+    requiredMissing,
+  };
+}

--- a/packages/setup-core/src/policy/resolveHarnessSelection.ts
+++ b/packages/setup-core/src/policy/resolveHarnessSelection.ts
@@ -1,0 +1,83 @@
+import {
+  type HarnessSelectionFacts,
+  type HarnessSelectionResolution,
+  type SupportedHarnessId,
+  supportedHarnessIds,
+} from "../model/facts.js";
+import type { HarnessSelectionIntent } from "../model/intent.js";
+
+/**
+ * POLICY
+ *
+ * Resolves configured, explicit, or discovered harness intent without choosing an ambiguous candidate.
+ */
+export function resolveHarnessSelection(
+  facts: HarnessSelectionFacts,
+  intent: HarnessSelectionIntent,
+): HarnessSelectionResolution {
+  if (intent.kind === "cancelled") return { outcome: "cancelled" };
+
+  const configuredDefault = configuredDefaultHarness(facts);
+  if (facts.config.status === "valid" && configuredDefault === undefined) {
+    return { outcome: "invalid", reason: "unsupported-configured-default" };
+  }
+
+  if (intent.kind === "explicit") {
+    const explicitHarnessIds = uniqueHarnessIds(intent.harnessIds);
+    const firstExplicitHarness = explicitHarnessIds[0];
+    if (firstExplicitHarness === undefined) {
+      return { outcome: "invalid", reason: "empty-explicit-selection" };
+    }
+    const requiredHarnessIds =
+      configuredDefault === undefined || explicitHarnessIds.includes(configuredDefault)
+        ? explicitHarnessIds
+        : [...explicitHarnessIds, configuredDefault];
+    return {
+      outcome: "selected",
+      source: "explicit",
+      requiredHarnessIds,
+      defaultHarness: configuredDefault ?? firstExplicitHarness,
+    };
+  }
+
+  if (facts.config.status === "invalid") {
+    return { outcome: "invalid", reason: "invalid-config" };
+  }
+  if (configuredDefault !== undefined) {
+    return {
+      outcome: "selected",
+      source: "configured",
+      requiredHarnessIds: [configuredDefault],
+      defaultHarness: configuredDefault,
+    };
+  }
+
+  const candidateHarnessIds = uniqueHarnessIds(
+    facts.harnesses.flatMap((harness) =>
+      harness.availability === "available" ? [harness.id] : [],
+    ),
+  );
+  const inferredHarness = candidateHarnessIds[0];
+  if (inferredHarness === undefined) {
+    return { outcome: "invalid", reason: "no-available-harness" };
+  }
+  if (candidateHarnessIds.length > 1) {
+    return { outcome: "ambiguous", candidateHarnessIds };
+  }
+  return {
+    outcome: "selected",
+    source: "inferred",
+    requiredHarnessIds: [inferredHarness],
+    defaultHarness: inferredHarness,
+  };
+}
+
+function configuredDefaultHarness(facts: HarnessSelectionFacts): SupportedHarnessId | undefined {
+  if (facts.config.status !== "valid") return undefined;
+  const defaultHarness = facts.config.defaultHarness;
+  return supportedHarnessIds.find((harnessId) => harnessId === defaultHarness);
+}
+
+function uniqueHarnessIds(ids: readonly SupportedHarnessId[]): SupportedHarnessId[] {
+  return ids.filter((id, index) => ids.indexOf(id) === index);
+}

--- a/packages/setup-core/src/policy/selectRepairTargets.ts
+++ b/packages/setup-core/src/policy/selectRepairTargets.ts
@@ -1,0 +1,32 @@
+import type { HarnessTrackingRepairFact, SupportedHarnessId } from "../model/facts.js";
+
+/**
+ * POLICY
+ *
+ * Selects available, supported, unprepared harnesses whose selected or persisted intent requires repair.
+ */
+export function selectHarnessTrackingRepairTargets(input: {
+  readonly requiredHarnessIds: readonly SupportedHarnessId[];
+  readonly persistedTrackingHarnessIds: readonly string[];
+  readonly harnesses: readonly HarnessTrackingRepairFact[];
+}): readonly SupportedHarnessId[] {
+  const targets: SupportedHarnessId[] = [];
+  const requestedIds: readonly string[] = [
+    ...input.requiredHarnessIds,
+    ...input.persistedTrackingHarnessIds,
+  ];
+  for (const requestedId of requestedIds) {
+    const harness = input.harnesses.find((candidate) => candidate.id === requestedId);
+    if (
+      harness === undefined ||
+      !harness.available ||
+      harness.capability === "unsupported" ||
+      harness.prepared ||
+      targets.includes(harness.id)
+    ) {
+      continue;
+    }
+    targets.push(harness.id);
+  }
+  return targets;
+}

--- a/packages/setup-core/test/unit/assess-harness-tracking.test.ts
+++ b/packages/setup-core/test/unit/assess-harness-tracking.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { assessHarnessTracking, type HarnessTrackingFacts } from "../../src/index.js";
+
+describe("assessHarnessTracking", () => {
+  it("classifies unsupported capability as not applicable", () => {
+    expect(
+      assessHarnessTracking({
+        capability: "unsupported",
+        configRequested: true,
+        evidence: { availability: "unavailable" },
+      }),
+    ).toEqual({ state: "not-applicable" });
+  });
+
+  it.each([
+    {
+      name: "unavailable evidence",
+      facts: supported({ availability: "unavailable" }),
+      expected: { state: "probe-failed" },
+    },
+    {
+      name: "failed probe with evidence",
+      facts: supported({
+        availability: "available",
+        requested: true,
+        installed: false,
+        probeFailed: true,
+      }),
+      expected: { state: "probe-failed", requested: true, installed: false },
+    },
+    {
+      name: "config intent disabled",
+      facts: supported(
+        { availability: "available", requested: true, installed: true, probeFailed: false },
+        false,
+      ),
+      expected: { state: "disabled", requested: true, installed: true },
+    },
+    {
+      name: "provider intent disabled",
+      facts: supported({ availability: "available", requested: false, probeFailed: false }),
+      expected: { state: "disabled", requested: false },
+    },
+    {
+      name: "artifact absent or drifted",
+      facts: supported({
+        availability: "available",
+        requested: true,
+        installed: false,
+        probeFailed: false,
+      }),
+      expected: {
+        state: "artifact-missing-or-drifted",
+        requested: true,
+        installed: false,
+      },
+    },
+    {
+      name: "prepared",
+      facts: supported({
+        availability: "available",
+        requested: true,
+        installed: true,
+        probeFailed: false,
+      }),
+      expected: { state: "prepared", requested: true, installed: true },
+    },
+  ])("classifies $name", ({ facts, expected }) => {
+    expect(assessHarnessTracking(facts)).toEqual(expected);
+  });
+
+  it("preserves absent optional evidence fields", () => {
+    const failed = assessHarnessTracking(
+      supported({ availability: "available", probeFailed: true }),
+    );
+    expect(failed).toEqual({ state: "probe-failed" });
+    expect("requested" in failed).toBe(false);
+    expect("installed" in failed).toBe(false);
+
+    const missing = assessHarnessTracking(
+      supported({ availability: "available", requested: true, probeFailed: false }),
+    );
+    expect(missing).toEqual({ state: "artifact-missing-or-drifted", requested: true });
+    expect("installed" in missing).toBe(false);
+  });
+});
+
+function supported(
+  evidence: HarnessTrackingFacts["evidence"],
+  configRequested = true,
+): HarnessTrackingFacts {
+  return { capability: "supported", configRequested, evidence };
+}

--- a/packages/setup-core/test/unit/derive-readiness.test.ts
+++ b/packages/setup-core/test/unit/derive-readiness.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { deriveSetupReadiness, type SetupReadinessFacts } from "../../src/index.js";
+
+describe("deriveSetupReadiness", () => {
+  it.each([
+    {
+      name: "compiled runtime with writable state",
+      facts: readiness({ runtime: { kind: "compiled" } }),
+      launchReady: true,
+    },
+    {
+      name: "compiled runtime with unwritable state",
+      facts: readiness({ stateDirectoryWritable: false, runtime: { kind: "compiled" } }),
+      launchReady: false,
+    },
+    {
+      name: "complete source runtime",
+      facts: readiness({
+        runtime: { kind: "source", bunAvailable: true, stationUiUsable: true },
+      }),
+      launchReady: true,
+    },
+    {
+      name: "source runtime without Bun",
+      facts: readiness({
+        runtime: { kind: "source", bunAvailable: false, stationUiUsable: true },
+      }),
+      launchReady: false,
+    },
+    {
+      name: "source runtime without a usable UI",
+      facts: readiness({
+        runtime: { kind: "source", bunAvailable: true, stationUiUsable: false },
+      }),
+      launchReady: false,
+    },
+  ])("derives launch readiness for $name", ({ facts, launchReady }) => {
+    expect(deriveSetupReadiness(facts).launchReady).toBe(launchReady);
+  });
+
+  it("derives workflow readiness and the exact missing count from requirements", () => {
+    expect(
+      deriveSetupReadiness(
+        readiness({ requirements: ["satisfied", "unsatisfied", "satisfied", "unsatisfied"] }),
+      ),
+    ).toEqual({ launchReady: true, workflowReady: false, requiredMissing: 2 });
+    expect(deriveSetupReadiness(readiness({ requirements: [] }))).toEqual({
+      launchReady: true,
+      workflowReady: true,
+      requiredMissing: 0,
+    });
+  });
+});
+
+function readiness(overrides: Partial<SetupReadinessFacts> = {}): SetupReadinessFacts {
+  return {
+    stateDirectoryWritable: true,
+    runtime: { kind: "compiled" },
+    requirements: ["satisfied"],
+    ...overrides,
+  };
+}

--- a/packages/setup-core/test/unit/resolve-harness-selection.test.ts
+++ b/packages/setup-core/test/unit/resolve-harness-selection.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  type HarnessSelectionFacts,
+  resolveHarnessSelection,
+  supportedHarnessIds,
+} from "../../src/index.js";
+
+describe("resolveHarnessSelection", () => {
+  it("preserves a supported configured default even when it is unavailable", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "codex", available: ["pi"] }), {
+        kind: "automatic",
+      }),
+    ).toEqual({
+      outcome: "selected",
+      source: "configured",
+      requiredHarnessIds: ["codex"],
+      defaultHarness: "codex",
+    });
+  });
+
+  it("deduplicates explicit choices and appends the authoritative configured default", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "codex", available: ["opencode"] }), {
+        kind: "explicit",
+        harnessIds: ["opencode", "pi", "opencode"],
+      }),
+    ).toEqual({
+      outcome: "selected",
+      source: "explicit",
+      requiredHarnessIds: ["opencode", "pi", "codex"],
+      defaultHarness: "codex",
+    });
+  });
+
+  it("uses the first explicit choice as the default only when no valid config exists", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "missing", available: ["codex"] }), {
+        kind: "explicit",
+        harnessIds: ["pi", "codex"],
+      }),
+    ).toEqual({
+      outcome: "selected",
+      source: "explicit",
+      requiredHarnessIds: ["pi", "codex"],
+      defaultHarness: "pi",
+    });
+
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "invalid", available: ["codex"] }), {
+        kind: "explicit",
+        harnessIds: ["codex"],
+      }),
+    ).toMatchObject({ outcome: "selected", defaultHarness: "codex" });
+  });
+
+  it("infers exactly one available harness", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "missing", available: ["cursor"] }), {
+        kind: "automatic",
+      }),
+    ).toEqual({
+      outcome: "selected",
+      source: "inferred",
+      requiredHarnessIds: ["cursor"],
+      defaultHarness: "cursor",
+    });
+  });
+
+  it("returns ambiguous candidates in fact order without selecting one", () => {
+    expect(
+      resolveHarnessSelection(
+        selectionFacts({
+          config: "missing",
+          available: ["opencode", "codex", "pi"],
+          order: ["pi", "codex", "opencode", "cursor", "claude"],
+        }),
+        { kind: "automatic" },
+      ),
+    ).toEqual({
+      outcome: "ambiguous",
+      candidateHarnessIds: ["pi", "codex", "opencode"],
+    });
+  });
+
+  it.each([
+    {
+      name: "empty explicit input",
+      facts: selectionFacts({ config: "missing", available: ["codex"] }),
+      intent: { kind: "explicit", harnessIds: [] } as const,
+      reason: "empty-explicit-selection",
+    },
+    {
+      name: "zero discovery candidates",
+      facts: selectionFacts({ config: "missing", available: [] }),
+      intent: { kind: "automatic" } as const,
+      reason: "no-available-harness",
+    },
+    {
+      name: "invalid automatic config",
+      facts: selectionFacts({ config: "invalid", available: ["codex"] }),
+      intent: { kind: "automatic" } as const,
+      reason: "invalid-config",
+    },
+    {
+      name: "unsupported configured default",
+      facts: selectionFacts({ config: "custom", available: ["codex"] }),
+      intent: { kind: "automatic" } as const,
+      reason: "unsupported-configured-default",
+    },
+  ])("returns a typed invalid outcome for $name", ({ facts, intent, reason }) => {
+    expect(resolveHarnessSelection(facts, intent)).toEqual({ outcome: "invalid", reason });
+  });
+
+  it("does not let explicit input replace an unsupported configured default", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "custom", available: ["codex"] }), {
+        kind: "explicit",
+        harnessIds: ["codex"],
+      }),
+    ).toEqual({ outcome: "invalid", reason: "unsupported-configured-default" });
+  });
+
+  it("preserves cancellation", () => {
+    expect(
+      resolveHarnessSelection(selectionFacts({ config: "missing", available: ["codex"] }), {
+        kind: "cancelled",
+      }),
+    ).toEqual({ outcome: "cancelled" });
+  });
+});
+
+function selectionFacts(input: {
+  config: "missing" | "invalid" | string;
+  available: readonly (typeof supportedHarnessIds)[number][];
+  order?: readonly (typeof supportedHarnessIds)[number][];
+}): HarnessSelectionFacts {
+  const order = input.order ?? supportedHarnessIds;
+  const config: HarnessSelectionFacts["config"] =
+    input.config === "missing"
+      ? { status: "missing" }
+      : input.config === "invalid"
+        ? { status: "invalid" }
+        : { status: "valid", defaultHarness: input.config };
+  return {
+    config,
+    harnesses: order.map((id) => ({
+      id,
+      availability: input.available.includes(id) ? "available" : "unavailable",
+    })),
+  };
+}

--- a/packages/setup-core/test/unit/select-repair-targets.test.ts
+++ b/packages/setup-core/test/unit/select-repair-targets.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  type HarnessTrackingRepairFact,
+  selectHarnessTrackingRepairTargets,
+} from "../../src/index.js";
+
+describe("selectHarnessTrackingRepairTargets", () => {
+  const harnesses: readonly HarnessTrackingRepairFact[] = [
+    {
+      id: "codex",
+      available: true,
+      capability: "supported",
+      prepared: false,
+    },
+    {
+      id: "cursor",
+      available: false,
+      capability: "supported",
+      prepared: false,
+    },
+    {
+      id: "opencode",
+      available: true,
+      capability: "supported",
+      prepared: false,
+    },
+    {
+      id: "pi",
+      available: true,
+      capability: "unsupported",
+      prepared: false,
+    },
+    {
+      id: "claude",
+      available: true,
+      capability: "supported",
+      prepared: true,
+    },
+  ];
+
+  it("preserves required-then-persisted order while deduplicating", () => {
+    expect(
+      selectHarnessTrackingRepairTargets({
+        requiredHarnessIds: ["opencode", "codex", "opencode"],
+        persistedTrackingHarnessIds: ["codex", "opencode"],
+        harnesses,
+      }),
+    ).toEqual(["opencode", "codex"]);
+  });
+
+  it("repairs a configured secondary harness only when persisted intent requests it", () => {
+    expect(
+      selectHarnessTrackingRepairTargets({
+        requiredHarnessIds: ["codex"],
+        persistedTrackingHarnessIds: ["opencode"],
+        harnesses,
+      }),
+    ).toEqual(["codex", "opencode"]);
+    expect(
+      selectHarnessTrackingRepairTargets({
+        requiredHarnessIds: ["codex"],
+        persistedTrackingHarnessIds: [],
+        harnesses,
+      }),
+    ).toEqual(["codex"]);
+  });
+
+  it("ignores unknown, unavailable, unsupported, and prepared targets", () => {
+    expect(
+      selectHarnessTrackingRepairTargets({
+        requiredHarnessIds: ["cursor", "pi", "claude"],
+        persistedTrackingHarnessIds: ["custom", "codex"],
+        harnesses,
+      }),
+    ).toEqual(["codex"]);
+  });
+});

--- a/packages/setup-core/tsconfig.json
+++ b/packages/setup-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@station/scripted-harness':
         specifier: workspace:*
         version: link:../../integrations/harness/scripted
+      '@station/setup-core':
+        specifier: workspace:*
+        version: link:../../packages/setup-core
       '@station/terminal':
         specifier: workspace:*
         version: link:../../integrations/terminal/station
@@ -381,6 +384,8 @@ importers:
       effect:
         specifier: ^3.21.2
         version: 3.21.2
+
+  packages/setup-core: {}
 
   packages/station-host:
     dependencies:

--- a/tests/diagnostics/setup-boundaries.test.ts
+++ b/tests/diagnostics/setup-boundaries.test.ts
@@ -1,0 +1,89 @@
+import { readdir, readFile } from "node:fs/promises";
+import { builtinModules } from "node:module";
+import { dirname, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve("packages/setup-core/src");
+const nodeBuiltins = new Set(builtinModules.flatMap((module) => [module, `node:${module}`]));
+const forbiddenPackage =
+  /^@station\/(?:cli|config|observer|observability|claude|codex|cursor|opencode|pi|tmux|terminal|worktrunk|github-repository|scripted-harness|harness-shared|setup-messages)$|^integrations\/|^@clack\/|^react(?:\/|$)|^@opentui\//;
+const controlledRoles = [
+  "DRIVING PORT",
+  "DRIVEN PORT",
+  "ADAPTER",
+  "USE CASE",
+  "POLICY",
+  "COMPOSITION ROOT",
+] as const;
+const policyNames = [
+  "resolveHarnessSelection",
+  "assessHarnessTracking",
+  "selectHarnessTrackingRepairTargets",
+  "deriveSetupReadiness",
+] as const;
+
+describe("setup core boundaries", () => {
+  it("has no runtime, CLI, provider, presentation, or package dependency", async () => {
+    const packageJson = JSON.parse(await readFile("packages/setup-core/package.json", "utf8")) as {
+      dependencies?: Record<string, string>;
+    };
+    expect(packageJson.dependencies ?? {}).toEqual({});
+
+    for (const file of await sourceFiles(sourceRoot)) {
+      const source = await readFile(file, "utf8");
+      const displayPath = relative(process.cwd(), file);
+      expect(source, displayPath).not.toMatch(/\b(?:process|Buffer|Bun|Deno)\b/);
+
+      for (const specifier of importSpecifiers(source)) {
+        expect(nodeBuiltins.has(specifier), `${displayPath}: ${specifier}`).toBe(false);
+        expect(forbiddenPackage.test(specifier), `${displayPath}: ${specifier}`).toBe(false);
+        if (!specifier.startsWith(".")) continue;
+        const target = resolve(dirname(file), specifier);
+        expect(target === sourceRoot || target.startsWith(`${sourceRoot}/`), displayPath).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("marks exactly the four public policies and no data declarations or barrels", async () => {
+    const declarations: string[] = [];
+    let markerCount = 0;
+    for (const file of await sourceFiles(sourceRoot)) {
+      const source = await readFile(file, "utf8");
+      markerCount += controlledRoles.reduce(
+        (count, role) => count + (source.match(new RegExp(`\\* ${role}`, "g"))?.length ?? 0),
+        0,
+      );
+      const policyPattern =
+        /\/\*\*\s*\n\s*\* POLICY\s*\n\s*\*\s*\n(?:\s*\* .+\n)+?\s*\*\/\s*\nexport function (\w+)/g;
+      for (const match of source.matchAll(policyPattern)) {
+        const name = match[1];
+        if (name !== undefined) declarations.push(name);
+      }
+    }
+
+    expect(markerCount).toBe(4);
+    expect(declarations.sort()).toEqual([...policyNames].sort());
+  });
+});
+
+async function sourceFiles(directory: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await sourceFiles(path)));
+    else if (entry.isFile() && path.endsWith(".ts")) files.push(path);
+  }
+  return files.sort();
+}
+
+function importSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+  const pattern = /(?:import|export)\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']/g;
+  for (const match of source.matchAll(pattern)) {
+    const specifier = match[1];
+    if (specifier !== undefined) specifiers.push(specifier);
+  }
+  return specifiers;
+}

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -221,6 +221,32 @@ describe("setup guided feedback e2e", () => {
     }
   });
 
+  it("reprompts after an out-of-range agent selection without choosing the first item", async () => {
+    const fixture = await createFixture({ harness: "codex-opencode" });
+    try {
+      const result = await runStation(["--config", fixture.configPath, "setup"], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        answers: ["99", "2", "n", "n", "y", "y", "n", "n"],
+      });
+
+      expect(result.timedOut).toBe(false);
+      expect(result.exitCode, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(
+        result.stdout.match(
+          /Select agent CLIs to prepare \(comma-separated; the first is the default only for a new config\)\./g,
+        ),
+      ).toHaveLength(2);
+      expect(result.stdout).toContain("Select at least one available agent CLI.");
+      const config = await readFile(fixture.configPath, "utf8");
+      expect(config).toContain('harness = "opencode"');
+      expect(config).toContain("[harness.opencode]");
+      expect(config).not.toContain("[harness.codex]");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   it("keeps a clean Codex and Pi setup idempotent and visible in the Observer snapshot", async () => {
     const fixture = await createFixture({ harness: "codex-pi" });
     try {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -37,6 +37,7 @@
       "@station/protocol": ["packages/protocol/src/index.ts"],
       "@station/runtime": ["packages/runtime/src/index.ts"],
       "@station/scripted-harness": ["integrations/harness/scripted/src/index.ts"],
+      "@station/setup-core": ["packages/setup-core/src/index.ts"],
       "@station/host": ["packages/station-host/src/index.ts"],
       "@station/testing": ["packages/testing/src/index.ts"],
       "@station/tmux": ["integrations/terminal/tmux/src/index.ts"],


### PR DESCRIPTION
## What this fixes

Guided setup mixed deterministic harness selection, tracking assessment, repair targeting, and readiness decisions into CLI orchestration and presentation. That made the rules harder to reuse or verify independently, and invalid multi-select input could silently choose the first available harness instead of preserving user intent.

## What changed

- Add dependency-free `@station/setup-core` policies over normalized setup facts and intent.
- Adapt the existing CLI planner and harness-selection boundary to those policies without moving config, provider, process, persistence, or presentation effects out of the CLI.
- Centralize supported harness identity and preserve absent optional tracking evidence.
- Re-prompt invalid guided harness selections before any setup mutation instead of selecting a fallback.
- Add focused policy tables, CLI unit coverage, a process-level guided setup regression, and an architecture boundary guard.

## Testing

- `env -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:all`
- Pre-commit and pre-push lint hooks
