### PR TITLE
perf(diagnostics): bound agent debugging output and log scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,10 @@ Start with the narrowest matching tool:
 - provider hook setup: `stn hooks doctor worktrunk|claude|codex|cursor|opencode` or `stn event-hooks doctor`
 - setup/tool readiness: `stn setup check --json`, `stn setup system --check`, or `pnpm setup:system:check`
 
+Use the concise default for `observer status`, `doctor`, `debug trace`, and
+`debug logs`. Add `--full` only when the default reports incomplete coverage or
+truncation, or when complete evidence was explicitly requested.
+
 If the user says "no action", treat debugging as read-only: inspect only existing logs, existing bundles, existing command/error records, and `stn debug trace` / `stn debug logs` output. Do not start/restart observer, run commands that call or auto-start the observer, retry commands, kill processes, mutate setup/hooks/config, or write a new bundle unless explicitly asked.
 
 Provider hooks are delivery hints, not runtime truth. Use hook logs and hook doctors to diagnose delivery/setup, then use observer health, reconcile output, and snapshots for current truth.

--- a/apps/cli/src/commands/debugLogs.ts
+++ b/apps/cli/src/commands/debugLogs.ts
@@ -1,8 +1,8 @@
-import { readFile } from "node:fs/promises";
 import type { StationConfig } from "@station/config";
 import type { LogRecord, SafeError } from "@station/contracts";
 import { LogRecordSchema, SafeErrorSchema } from "@station/contracts";
-import { componentLogPath } from "@station/observability";
+import { componentLogPath, readJsonlReverse } from "@station/observability";
+import { z } from "zod";
 import { resolveObserverPaths } from "../paths.js";
 
 export type DebugLogsCommandOptions = {
@@ -16,7 +16,18 @@ export type DebugLogsResult = {
   since?: string;
   limit: number;
   matched: number;
-  evidence: {
+  search: {
+    complete: boolean;
+    bytesRead: number;
+    invalidLines: number;
+    incompleteComponents: DebugLogComponent[];
+  };
+  truncation: {
+    records: boolean;
+    text: boolean;
+  };
+  retryCommand?: string;
+  evidence?: {
     filesSearched: string[];
     matchedFiles: string[];
   };
@@ -53,15 +64,11 @@ type DebugLogsArgs = {
   minLevel: DebugLogLevel;
   since?: string;
   limit: number;
+  full: boolean;
 };
 
 type DebugLogComponent = "observer" | "cli" | "tui" | "hook" | "provider" | "station-host";
 type DebugLogLevel = "debug" | "info" | "warn" | "error";
-
-type DebugLogFileMatch = {
-  path: string;
-  records: LogRecord[];
-};
 
 const defaultComponents: DebugLogComponent[] = ["observer", "cli", "tui"];
 const allComponents: DebugLogComponent[] = [
@@ -73,6 +80,19 @@ const allComponents: DebugLogComponent[] = [
   "station-host",
 ];
 const logLevels: DebugLogLevel[] = ["debug", "info", "warn", "error"];
+const defaultSearchBytes = 8 * 1024 * 1024;
+const conciseTextCodePoints = 240;
+
+const DebugLogErrorSchema = z
+  .object({
+    code: z.string().optional(),
+    message: z.string().optional(),
+    provider: z.string().optional(),
+    diagnosticId: z.string().optional(),
+    traceId: z.string().optional(),
+    commandId: z.string().optional(),
+  })
+  .passthrough();
 
 export async function runDebugLogsCommand(
   args: string[],
@@ -80,37 +100,59 @@ export async function runDebugLogsCommand(
 ): Promise<DebugLogsResult> {
   const parsed = parseDebugLogsArgs(args);
   const paths = resolveObserverPaths(options.config);
-  const filesSearched: string[] = [];
-  const matches: DebugLogFileMatch[] = [];
+  const files = parsed.components.map((component) => ({
+    component,
+    path: componentLogPath(paths.stateDir, component),
+  }));
+  const searches = await Promise.all(
+    files.map(async (file) => ({
+      ...file,
+      result: await readJsonlReverse(file.path, LogRecordSchema, {
+        ...(parsed.full ? {} : { maxBytes: defaultSearchBytes }),
+        maxRecords: parsed.limit + 1,
+        matches: (record) => logMatches(record, parsed),
+      }),
+    })),
+  );
 
-  for (const component of parsed.components) {
-    const path = componentLogPath(paths.stateDir, component);
-    filesSearched.push(path);
-    const records = (await readJsonl(path, LogRecordSchema)).filter((record) =>
-      logMatches(record, parsed),
-    );
-    if (records.length > 0) {
-      matches.push({ path, records });
-    }
-  }
-
-  const selected = matches
-    .flatMap((match) => match.records)
-    .sort((left, right) => timestamp(left) - timestamp(right))
-    .slice(-parsed.limit);
+  const matchingSearches = searches.filter((search) => search.result.records.length > 0);
+  const candidates = matchingSearches
+    .flatMap((search) => search.result.records)
+    .sort((left, right) => timestamp(left) - timestamp(right));
+  const selected = candidates.slice(-parsed.limit);
+  const summaries = selected.map((record) => logSummary(record, parsed.full));
+  const incompleteComponents = searches
+    .filter((search) => !search.result.complete)
+    .map((search) => search.component);
+  const searchComplete = incompleteComponents.length === 0;
   const result: DebugLogsResult = {
     components: parsed.components,
     minLevel: parsed.minLevel,
     limit: parsed.limit,
     matched: selected.length,
-    evidence: {
-      filesSearched,
-      matchedFiles: matches.map((match) => match.path),
+    search: {
+      complete: searchComplete,
+      bytesRead: searches.reduce((total, search) => total + search.result.bytesRead, 0),
+      invalidLines: searches.reduce((total, search) => total + search.result.invalidLines, 0),
+      incompleteComponents,
     },
-    records: selected.map(logSummary),
+    truncation: {
+      records: candidates.length > parsed.limit,
+      text: summaries.some((summary) => summary.truncated),
+    },
+    records: summaries.map((summary) => summary.record),
   };
   if (parsed.query !== undefined) result.query = parsed.query;
   if (parsed.since !== undefined) result.since = parsed.since;
+  if (parsed.full) {
+    result.evidence = {
+      filesSearched: files.map((file) => file.path),
+      matchedFiles: matchingSearches.map((search) => search.path),
+    };
+  }
+  if (!parsed.full && selected.length === 0 && !searchComplete) {
+    result.retryCommand = debugLogsFullCommand(args);
+  }
   return result;
 }
 
@@ -119,11 +161,14 @@ function parseDebugLogsArgs(args: string[]): DebugLogsArgs {
   const components: DebugLogComponent[] = [];
   let minLevel: DebugLogLevel | undefined;
   let since: string | undefined;
-  let limit = 50;
+  let explicitLimit: number | undefined;
+  let full = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    if (arg === "--json") {
+    if (arg === "--json") continue;
+    if (arg === "--full") {
+      full = true;
       continue;
     }
     if (arg === "--component") {
@@ -133,9 +178,7 @@ function parseDebugLogsArgs(args: string[]): DebugLogsArgs {
     }
     if (arg === "--all-components") {
       for (const component of allComponents) {
-        if (!components.includes(component)) {
-          components.push(component);
-        }
+        if (!components.includes(component)) components.push(component);
       }
       continue;
     }
@@ -150,13 +193,11 @@ function parseDebugLogsArgs(args: string[]): DebugLogsArgs {
       continue;
     }
     if (arg === "--limit") {
-      limit = parseLimit(requiredValue(args[index + 1], "--limit"));
+      explicitLimit = parseLimit(requiredValue(args[index + 1], "--limit"));
       index += 1;
       continue;
     }
-    if (arg?.startsWith("--")) {
-      throw new Error(`Unknown debug logs option: ${arg}`);
-    }
+    if (arg?.startsWith("--")) throw new Error(`Unknown debug logs option: ${arg}`);
     if (query === undefined && arg !== undefined) {
       query = arg;
       continue;
@@ -169,33 +210,9 @@ function parseDebugLogsArgs(args: string[]): DebugLogsArgs {
     components: components.length === 0 ? defaultComponents : components,
     minLevel: minLevel ?? (query === undefined ? "warn" : "debug"),
     ...(since === undefined ? {} : { since }),
-    limit,
+    limit: explicitLimit ?? (full ? 50 : 5),
+    full,
   };
-}
-
-async function readJsonl<T>(
-  path: string,
-  schema: { safeParse(value: unknown): { success: true; data: T } | { success: false } },
-): Promise<T[]> {
-  let source: string;
-  try {
-    source = await readFile(path, "utf8");
-  } catch {
-    return [];
-  }
-  const records: T[] = [];
-  for (const line of source.split("\n")) {
-    if (line.trim().length === 0) {
-      continue;
-    }
-    try {
-      const parsed = schema.safeParse(JSON.parse(line));
-      if (parsed.success) {
-        records.push(parsed.data);
-      }
-    } catch {}
-  }
-  return records;
 }
 
 function logMatches(record: LogRecord, args: DebugLogsArgs): boolean {
@@ -207,12 +224,16 @@ function logMatches(record: LogRecord, args: DebugLogsArgs): boolean {
   );
 }
 
-function logSummary(record: LogRecord): DebugLogRecordSummary {
+function logSummary(
+  record: LogRecord,
+  full: boolean,
+): { record: DebugLogRecordSummary; truncated: boolean } {
+  const message = boundedText(record.message, full);
   const summary: DebugLogRecordSummary = {
     timestamp: record.timestamp,
     level: record.level,
     component: record.component,
-    message: record.message,
+    message: message.value,
   };
   if (record.traceId !== undefined) summary.traceId = record.traceId;
   if (record.spanId !== undefined) summary.spanId = record.spanId;
@@ -222,54 +243,68 @@ function logSummary(record: LogRecord): DebugLogRecordSummary {
   if (record.sessionId !== undefined) summary.sessionId = record.sessionId;
   if (record.provider !== undefined) summary.provider = record.provider;
 
-  const error = errorSummary(record.attributes?.error);
-  if (error !== undefined) {
-    summary.error = error;
-  }
-  return summary;
+  const error = errorSummary(record.attributes?.error, full);
+  if (error !== undefined) summary.error = error.value;
+  return { record: summary, truncated: message.truncated || error?.truncated === true };
 }
 
-function errorSummary(value: unknown): DebugLogErrorSummary | undefined {
+function errorSummary(
+  value: unknown,
+  full: boolean,
+): { value: DebugLogErrorSummary; truncated: boolean } | undefined {
   const safeError = SafeErrorSchema.safeParse(value);
-  if (safeError.success) {
-    return safeErrorSummary(safeError.data);
-  }
-  if (!value || typeof value !== "object") {
-    return undefined;
-  }
-  const candidate = value as {
-    code?: unknown;
-    message?: unknown;
-    provider?: unknown;
-    diagnosticId?: unknown;
-    traceId?: unknown;
-    commandId?: unknown;
-  };
+  if (safeError.success) return safeErrorSummary(safeError.data, full);
+  const parsed = DebugLogErrorSchema.safeParse(value);
+  if (!parsed.success) return undefined;
   const summary: DebugLogErrorSummary = {};
-  if (typeof candidate.code === "string") summary.code = candidate.code;
-  if (typeof candidate.message === "string") summary.message = candidate.message;
-  if (typeof candidate.provider === "string") summary.provider = candidate.provider;
-  if (typeof candidate.diagnosticId === "string") summary.diagnosticId = candidate.diagnosticId;
-  if (typeof candidate.traceId === "string") summary.traceId = candidate.traceId;
-  if (typeof candidate.commandId === "string") summary.commandId = candidate.commandId;
-  return Object.keys(summary).length === 0 ? undefined : summary;
+  if (parsed.data.code !== undefined) summary.code = parsed.data.code;
+  const message =
+    parsed.data.message === undefined ? undefined : boundedText(parsed.data.message, full);
+  if (message !== undefined) summary.message = message.value;
+  if (parsed.data.provider !== undefined) summary.provider = parsed.data.provider;
+  if (parsed.data.diagnosticId !== undefined) summary.diagnosticId = parsed.data.diagnosticId;
+  if (parsed.data.traceId !== undefined) summary.traceId = parsed.data.traceId;
+  if (parsed.data.commandId !== undefined) summary.commandId = parsed.data.commandId;
+  return Object.keys(summary).length === 0
+    ? undefined
+    : { value: summary, truncated: message?.truncated === true };
 }
 
-function safeErrorSummary(error: SafeError): DebugLogErrorSummary {
-  const summary: DebugLogErrorSummary = {
-    code: error.code,
-    message: error.message,
-  };
+function safeErrorSummary(
+  error: SafeError,
+  full: boolean,
+): { value: DebugLogErrorSummary; truncated: boolean } {
+  const message = boundedText(error.message, full);
+  const summary: DebugLogErrorSummary = { code: error.code, message: message.value };
   if (error.provider !== undefined) summary.provider = error.provider;
   if (error.diagnosticId !== undefined) summary.diagnosticId = error.diagnosticId;
   if (error.traceId !== undefined) summary.traceId = error.traceId;
   if (error.commandId !== undefined) summary.commandId = error.commandId;
-  return summary;
+  return { value: summary, truncated: message.truncated };
+}
+
+function boundedText(value: string, full: boolean): { value: string; truncated: boolean } {
+  const codePoints = [...value];
+  if (full || codePoints.length <= conciseTextCodePoints) {
+    return { value, truncated: false };
+  }
+  return {
+    value: `${codePoints.slice(0, conciseTextCodePoints - 1).join("")}…`,
+    truncated: true,
+  };
+}
+
+function debugLogsFullCommand(args: readonly string[]): string {
+  const retryArgs = args.filter((arg) => arg !== "--json" && arg !== "--full");
+  return ["stn", "debug", "logs", ...retryArgs, "--full"].map(shellArg).join(" ");
+}
+
+function shellArg(value: string): string {
+  return /^[A-Za-z0-9_./:@=-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function recordContains(record: LogRecord, query: string): boolean {
-  const loweredQuery = query.toLowerCase();
-  return JSON.stringify(record).toLowerCase().includes(loweredQuery);
+  return JSON.stringify(record).toLowerCase().includes(query.toLowerCase());
 }
 
 function timestamp(record: LogRecord): number {
@@ -281,30 +316,23 @@ function levelRank(level: DebugLogLevel): number {
 }
 
 function requiredValue(value: string | undefined, option: string): string {
-  if (value === undefined || value.startsWith("--")) {
-    throw new Error(`${option} requires a value.`);
-  }
+  if (value === undefined || value.startsWith("--")) throw new Error(`${option} requires a value.`);
   return value;
 }
 
 function parseComponent(value: string): DebugLogComponent {
-  if (allComponents.includes(value as DebugLogComponent)) {
-    return value as DebugLogComponent;
-  }
+  if (allComponents.includes(value as DebugLogComponent)) return value as DebugLogComponent;
   throw new Error(`Invalid debug logs component: ${value}`);
 }
 
 function parseLevel(value: string): DebugLogLevel {
-  if (logLevels.includes(value as DebugLogLevel)) {
-    return value as DebugLogLevel;
-  }
+  if (logLevels.includes(value as DebugLogLevel)) return value as DebugLogLevel;
   throw new Error(`Invalid debug logs level: ${value}`);
 }
 
 function parseSince(value: string): string {
-  if (Number.isNaN(Date.parse(value))) {
+  if (Number.isNaN(Date.parse(value)))
     throw new Error(`Invalid debug logs --since value: ${value}`);
-  }
   return new Date(value).toISOString();
 }
 

--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -19,6 +19,7 @@ import {
   SpanIdSchema,
   TraceIdSchema,
 } from "@station/contracts";
+import { readJsonlReverse } from "@station/observability";
 import { z } from "zod";
 import { resolveObserverPaths } from "../paths.js";
 
@@ -51,7 +52,11 @@ export type DebugTraceResult = {
     diagnostics?: DiagnosticDetail[];
   };
   rootCauseCodes: string[];
-  evidence: {
+  search: {
+    complete: boolean;
+    bytesRead: number;
+  };
+  evidence?: {
     filesSearched: string[];
     matchedFiles: string[];
   };
@@ -64,6 +69,12 @@ type DebugTraceErrorSummary = NonNullable<DebugTraceResult["error"]>;
 type DebugTraceArgs = {
   query?: string;
   latestFailure: boolean;
+  full: boolean;
+};
+
+type DebugTraceSearch = {
+  bytesRead: number;
+  complete: boolean;
 };
 
 type DebugTraceMatch = {
@@ -97,6 +108,9 @@ const DebugTraceLogAttributesSchema = z
   })
   .passthrough();
 
+const defaultSearchBytes = 8 * 1024 * 1024;
+const conciseTextCodePoints = 240;
+
 export async function runDebugTraceCommand(
   args: string[],
   options: DebugTraceCommandOptions = {},
@@ -104,33 +118,39 @@ export async function runDebugTraceCommand(
   const parsed = parseDebugTraceArgs(args);
   const paths = resolveObserverPaths(options.config);
   const filesSearched: string[] = [];
-  const bundleMatches = await searchBundles(paths.diagnosticsDir, parsed, filesSearched);
-  const logMatches = await searchLogs(paths.logDir, parsed, filesSearched);
+  const search: DebugTraceSearch = { bytesRead: 0, complete: true };
+  const bundleMatches = await searchBundles(paths.diagnosticsDir, parsed, filesSearched, search);
+  const logMatches = await searchLogs(paths.logDir, parsed, filesSearched, search);
   const match = chooseMatch([...bundleMatches, ...logMatches], parsed);
   const result: DebugTraceResult = {
     latestFailure: parsed.latestFailure,
     matched: match !== undefined,
     rootCauseCodes: match?.rootCauseCodes ?? [],
-    evidence: {
-      filesSearched,
-      matchedFiles: match?.matchedFiles ?? [],
-    },
-    suggestedCommands: suggestedCommands(parsed.query, match),
+    search,
+    suggestedCommands: suggestedCommands(parsed, match, search),
   };
   if (parsed.query !== undefined) result.query = parsed.query;
   if (match?.matchedIdType !== undefined) result.matchedIdType = match.matchedIdType;
   if (match?.source !== undefined) result.source = match.source;
-  if (match?.bundlePath !== undefined) result.bundlePath = match.bundlePath;
+  if (parsed.full && match?.bundlePath !== undefined) result.bundlePath = match.bundlePath;
   if (match?.traceId !== undefined) result.traceId = match.traceId;
   if (match?.spanId !== undefined) result.spanId = match.spanId;
   if (match?.command !== undefined) result.command = match.command;
-  if (match?.error !== undefined) result.error = match.error;
+  if (match?.error !== undefined)
+    result.error = parsed.full ? match.error : conciseError(match.error);
+  if (parsed.full) {
+    result.evidence = {
+      filesSearched,
+      matchedFiles: match?.matchedFiles ?? [],
+    };
+  }
   return result;
 }
 
 function parseDebugTraceArgs(args: string[]): DebugTraceArgs {
   let query: string | undefined;
-  let latestFailure = args.length === 0;
+  let latestFailure = false;
+  let full = false;
   for (const arg of args) {
     if (arg === "--json") {
       continue;
@@ -139,6 +159,13 @@ function parseDebugTraceArgs(args: string[]): DebugTraceArgs {
       latestFailure = true;
       continue;
     }
+    if (arg === "--full") {
+      full = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      throw new Error(`Unknown debug trace option: ${arg}`);
+    }
     if (query === undefined) {
       query = arg;
       continue;
@@ -146,7 +173,8 @@ function parseDebugTraceArgs(args: string[]): DebugTraceArgs {
     throw new Error(`Unknown debug trace option: ${arg}`);
   }
   return {
-    latestFailure,
+    latestFailure: latestFailure || query === undefined,
+    full,
     ...(query === undefined ? {} : { query }),
   };
 }
@@ -155,6 +183,7 @@ async function searchBundles(
   diagnosticsDir: string,
   args: DebugTraceArgs,
   filesSearched: string[],
+  search: DebugTraceSearch,
 ): Promise<DebugTraceMatch[]> {
   const bundleDirs = await listBundleDirs(diagnosticsDir);
   const matches: DebugTraceMatch[] = [];
@@ -166,9 +195,26 @@ async function searchBundles(
     filesSearched.push(indexPath, commandsPath, errorsPath, logsPath);
 
     const index = await readJson(indexPath, DiagnosticEvidenceIndexSchema);
-    const commands = await readJsonl(commandsPath, CommandRecordSchema);
-    const errors = await readJsonl(errorsPath, ErrorEnvelopeSchema);
-    const logs = await readJsonl(logsPath, LogRecordSchema);
+    const commands = await readTraceJsonl(commandsPath, CommandRecordSchema, args, search, {
+      ...(args.latestFailure && !args.full
+        ? { maxRecords: 1, matches: (command: CommandRecord) => command.status === "failed" }
+        : {}),
+    });
+    const newestCommand = args.latestFailure ? latestFailedCommand(commands) : undefined;
+    const errors = await readTraceJsonl(errorsPath, ErrorEnvelopeSchema, args, search, {
+      ...(args.latestFailure && !args.full
+        ? {
+            maxRecords: 1,
+            matches: (error: ErrorEnvelope) =>
+              newestCommand === undefined || error.commandId === newestCommand.id,
+          }
+        : {}),
+    });
+    const logs = await readTraceJsonl(logsPath, LogRecordSchema, args, search, {
+      ...(args.latestFailure && !args.full
+        ? { maxRecords: 1, matches: (record: LogRecord) => isFailedCommandLog(record) }
+        : {}),
+    });
     const match = matchBundle({
       args,
       bundlePath,
@@ -181,6 +227,16 @@ async function searchBundles(
     if (match !== undefined) {
       matches.push(match);
     }
+    if (args.latestFailure) {
+      const failedLog = [...logs].reverse().find(isFailedCommandLog);
+      if (failedLog !== undefined) {
+        matches.push({
+          ...matchFromLog(failedLog, logsPath, undefined),
+          source: "bundle",
+          bundlePath,
+        });
+      }
+    }
   }
   return matches;
 }
@@ -189,6 +245,7 @@ async function searchLogs(
   logDir: string,
   args: DebugTraceArgs,
   filesSearched: string[],
+  search: DebugTraceSearch,
 ): Promise<DebugTraceMatch[]> {
   const paths = ["observer.jsonl", "hooks.jsonl", "cli.jsonl", "tui.jsonl"].map((name) =>
     join(logDir, name),
@@ -196,7 +253,11 @@ async function searchLogs(
   const matches: DebugTraceMatch[] = [];
   for (const path of paths) {
     filesSearched.push(path);
-    const logs = await readJsonl(path, LogRecordSchema);
+    const logs = await readTraceJsonl(path, LogRecordSchema, args, search, {
+      ...(args.latestFailure && !args.full
+        ? { maxRecords: 1, matches: (record: LogRecord) => isFailedCommandLog(record) }
+        : {}),
+    });
     const log = args.latestFailure
       ? [...logs].reverse().find(isFailedCommandLog)
       : logs.find((record) => args.query !== undefined && recordContains(record, args.query));
@@ -304,29 +365,21 @@ async function readJson<T>(
   }
 }
 
-async function readJsonl<T>(
+async function readTraceJsonl<T>(
   path: string,
   schema: { safeParse(value: unknown): { success: true; data: T } | { success: false } },
+  args: DebugTraceArgs,
+  search: DebugTraceSearch,
+  options: { maxRecords?: number; matches?: (record: T) => boolean } = {},
 ): Promise<T[]> {
-  let source: string;
-  try {
-    source = await readFile(path, "utf8");
-  } catch {
-    return [];
-  }
-  const records: T[] = [];
-  for (const line of source.split("\n")) {
-    if (line.trim().length === 0) {
-      continue;
-    }
-    try {
-      const result = schema.safeParse(JSON.parse(line));
-      if (result.success) {
-        records.push(result.data);
-      }
-    } catch {}
-  }
-  return records;
+  const result = await readJsonlReverse(path, schema, {
+    ...(args.latestFailure && !args.full ? { maxBytes: defaultSearchBytes } : {}),
+    ...(options.maxRecords === undefined ? {} : { maxRecords: options.maxRecords }),
+    ...(options.matches === undefined ? {} : { matches: options.matches }),
+  });
+  search.bytesRead += result.bytesRead;
+  search.complete &&= result.complete;
+  return result.records;
 }
 
 function latestFailedCommand(commands: readonly CommandRecord[]): CommandRecord | undefined {
@@ -523,25 +576,47 @@ function parseLogAttributeError(error: unknown): DebugTraceResult["error"] {
 }
 
 function suggestedCommands(
-  query: string | undefined,
+  args: DebugTraceArgs,
   match: DebugTraceMatch | undefined,
+  search: DebugTraceSearch,
 ): string[] {
+  if ((match?.rootCauseCodes.length ?? 0) > 0) return [];
+  const query = args.query;
   const traceId =
     match?.command?.traceId ??
     match?.traceId ??
     (query?.startsWith("trc_") === true ? query : undefined);
   const commandId = match?.command?.id ?? (query?.startsWith("cmd_") === true ? query : undefined);
-  const commands = ["stn doctor"];
-  if (traceId !== undefined) {
-    commands.push(`stn debug bundle --trace ${traceId}`);
+  const correlation = traceId ?? commandId ?? query;
+  if (match !== undefined && correlation !== undefined) {
+    return [`stn debug logs ${shellArg(correlation)} --full`];
   }
-  if (commandId !== undefined) {
-    commands.push(`stn debug bundle --command ${commandId}`);
+  if (args.latestFailure && !args.full && !search.complete) {
+    return ["stn debug trace --latest-failure --full"];
   }
-  if (traceId === undefined && commandId === undefined) {
-    commands.push("stn debug bundle --latest-failure");
-  }
-  return commands;
+  if (query !== undefined) return [`stn debug logs ${shellArg(query)} --full`];
+  return ["stn debug logs --min-level error --full"];
+}
+
+function conciseError(error: DebugTraceErrorSummary): DebugTraceErrorSummary {
+  const result: DebugTraceErrorSummary = {};
+  if (error.id !== undefined) result.id = error.id;
+  if (error.code !== undefined) result.code = error.code;
+  if (error.message !== undefined) result.message = boundedText(error.message);
+  if (error.provider !== undefined) result.provider = error.provider;
+  if (error.diagnosticId !== undefined) result.diagnosticId = error.diagnosticId;
+  return result;
+}
+
+function boundedText(value: string): string {
+  const codePoints = [...value];
+  return codePoints.length <= conciseTextCodePoints
+    ? value
+    : `${codePoints.slice(0, conciseTextCodePoints - 1).join("")}…`;
+}
+
+function shellArg(value: string): string {
+  return /^[A-Za-z0-9_./:@=-]+$/u.test(value) ? value : `'${value.replaceAll("'", `'\\''`)}'`;
 }
 
 function timestamp(match: DebugTraceMatch): number {

--- a/apps/cli/src/commands/diagnosticOutput.ts
+++ b/apps/cli/src/commands/diagnosticOutput.ts
@@ -1,0 +1,241 @@
+import type { DoctorCheck, DoctorReport, SafeError } from "@station/contracts";
+
+export type DoctorFinding = {
+  source: "check" | "config" | "provider";
+  name: string;
+  severity: "error" | "warn";
+  code?: string;
+  message: string;
+  hint?: string;
+  provider?: string;
+  traceId?: string;
+  commandId?: string;
+  diagnosticId?: string;
+};
+
+export type DoctorSummary = {
+  schemaVersion: string;
+  generatedAt: string;
+  status: DoctorReport["status"];
+  findings: DoctorFinding[];
+  counts: {
+    checks: { ok: number; warn: number; error: number };
+    providers: { healthy: number; degraded: number; unavailable: number; unknown: number };
+    projects: number;
+    sessions: number;
+    historicalErrors: number;
+  };
+  nextCommands: string[];
+  truncation: {
+    findings: boolean;
+    text: boolean;
+    totalFindings: number;
+  };
+  detailsCommand: string;
+};
+
+export type DoctorSummaryOptions = {
+  projectId?: string;
+};
+
+const maxFindings = 5;
+const maxTextCodePoints = 240;
+
+export function buildDoctorSummary(
+  report: DoctorReport,
+  options: DoctorSummaryOptions = {},
+): DoctorSummary {
+  let textTruncated = false;
+  const bound = (value: string): string => {
+    const bounded = boundText(value);
+    textTruncated ||= bounded.truncated;
+    return bounded.value;
+  };
+  const findings = collectFindings(report)
+    .sort(compareFinding)
+    .map((finding) => boundedFinding(finding, bound));
+  const retained = findings.slice(0, maxFindings);
+
+  return {
+    schemaVersion: report.schemaVersion,
+    generatedAt: report.generatedAt,
+    status: report.status,
+    findings: retained,
+    counts: {
+      checks: countChecks(report.checks),
+      providers: countProviders(report),
+      projects: report.snapshot.counts.projects,
+      sessions: report.snapshot.counts.sessions,
+      historicalErrors: report.recentErrors.length,
+    },
+    nextCommands: nextCommands(retained),
+    truncation: {
+      findings: findings.length > retained.length,
+      text: textTruncated,
+      totalFindings: findings.length,
+    },
+    detailsCommand:
+      options.projectId === undefined
+        ? "stn doctor --full"
+        : `stn doctor --project ${options.projectId} --full`,
+  };
+}
+
+function collectFindings(report: DoctorReport): DoctorFinding[] {
+  const configSeverity = report.checks.find((check) => check.name === "config")?.status ?? "warn";
+  const configFindings = report.config.diagnostics.map((error) =>
+    findingFromError("config", error.code, severity(configSeverity), error),
+  );
+  const providerFindings = Object.entries(report.providers)
+    .filter(([, health]) => health.status === "degraded" || health.status === "unavailable")
+    .map(([provider, health]) => {
+      if (health.lastError !== undefined) {
+        return findingFromError(
+          "provider",
+          provider,
+          health.status === "unavailable" ? "error" : "warn",
+          health.lastError,
+          provider,
+        );
+      }
+      return {
+        source: "provider" as const,
+        name: provider,
+        severity: health.status === "unavailable" ? ("error" as const) : ("warn" as const),
+        message: `${provider} is ${health.status}.`,
+        provider,
+      };
+    });
+  const providerIds = Object.keys(report.providers);
+  const checkFindings = report.checks
+    .filter((check) => check.status !== "ok")
+    .filter((check) => check.name !== "config" || configFindings.length === 0)
+    .filter((check) => check.name !== "providers" || providerFindings.length === 0)
+    .map((check) => findingFromCheck(check, providerIds));
+  const specificCheckFindings = checkFindings.filter((finding) => finding.name !== "observer");
+  const observerFindings = checkFindings.filter((finding) => finding.name === "observer");
+
+  return deduplicateFindings([
+    ...configFindings,
+    ...providerFindings,
+    ...specificCheckFindings,
+    ...(configFindings.length + providerFindings.length + specificCheckFindings.length === 0
+      ? observerFindings
+      : []),
+  ]);
+}
+
+function findingFromCheck(check: DoctorCheck, providerIds: readonly string[]): DoctorFinding {
+  const provider =
+    check.error?.provider ??
+    providerIds.find(
+      (candidate) =>
+        check.name === candidate ||
+        check.name.startsWith(`${candidate}.`) ||
+        check.name.startsWith(`${candidate}-`),
+    );
+  const source = provider === undefined ? "check" : "provider";
+  if (check.error !== undefined) {
+    return findingFromError(source, check.name, severity(check.status), check.error, provider);
+  }
+  return {
+    source,
+    name: check.name,
+    severity: severity(check.status),
+    message: check.message,
+    ...(provider === undefined ? {} : { provider }),
+  };
+}
+
+function findingFromError(
+  source: DoctorFinding["source"],
+  name: string,
+  findingSeverity: DoctorFinding["severity"],
+  error: SafeError,
+  providerOverride?: string,
+): DoctorFinding {
+  const finding: DoctorFinding = {
+    source,
+    name,
+    severity: findingSeverity,
+    code: error.code,
+    message: error.message,
+  };
+  if (error.hint !== undefined) finding.hint = error.hint;
+  const provider = error.provider ?? providerOverride;
+  if (provider !== undefined) finding.provider = provider;
+  if (error.traceId !== undefined) finding.traceId = error.traceId;
+  if (error.commandId !== undefined) finding.commandId = error.commandId;
+  if (error.diagnosticId !== undefined) finding.diagnosticId = error.diagnosticId;
+  return finding;
+}
+
+function boundedFinding(finding: DoctorFinding, bound: (value: string) => string): DoctorFinding {
+  return {
+    ...finding,
+    message: bound(finding.message),
+    ...(finding.hint === undefined ? {} : { hint: bound(finding.hint) }),
+  };
+}
+
+function boundText(value: string): { value: string; truncated: boolean } {
+  const codePoints = [...value];
+  if (codePoints.length <= maxTextCodePoints) return { value, truncated: false };
+  return {
+    value: `${codePoints.slice(0, maxTextCodePoints - 1).join("")}…`,
+    truncated: true,
+  };
+}
+
+function severity(status: DoctorCheck["status"]): DoctorFinding["severity"] {
+  return status === "error" ? "error" : "warn";
+}
+
+function compareFinding(left: DoctorFinding, right: DoctorFinding): number {
+  return (
+    severityRank(left.severity) - severityRank(right.severity) ||
+    left.source.localeCompare(right.source) ||
+    left.name.localeCompare(right.name) ||
+    (left.code ?? "").localeCompare(right.code ?? "") ||
+    left.message.localeCompare(right.message)
+  );
+}
+
+function severityRank(value: DoctorFinding["severity"]): number {
+  return value === "error" ? 0 : 1;
+}
+
+function deduplicateFindings(findings: readonly DoctorFinding[]): DoctorFinding[] {
+  const seen = new Set<string>();
+  return findings.filter((finding) => {
+    const key = [finding.source, finding.name, finding.code, finding.message].join("\0");
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function countChecks(checks: readonly DoctorCheck[]): DoctorSummary["counts"]["checks"] {
+  const counts = { ok: 0, warn: 0, error: 0 };
+  for (const check of checks) counts[check.status] += 1;
+  return counts;
+}
+
+function countProviders(report: DoctorReport): DoctorSummary["counts"]["providers"] {
+  const counts = { healthy: 0, degraded: 0, unavailable: 0, unknown: 0 };
+  for (const provider of Object.values(report.providers)) counts[provider.status] += 1;
+  return counts;
+}
+
+function nextCommands(findings: readonly DoctorFinding[]): string[] {
+  const commands = new Set<string>();
+  for (const finding of findings) {
+    if (finding.traceId !== undefined) commands.add(`stn debug trace ${finding.traceId}`);
+    else if (finding.commandId !== undefined) commands.add(`stn command get ${finding.commandId}`);
+    else if (finding.diagnosticId !== undefined) {
+      commands.add(`stn debug trace ${finding.diagnosticId}`);
+    }
+    if (commands.size === 3) break;
+  }
+  return [...commands];
+}

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -26,6 +26,7 @@ import {
   createProviderHookRuntime,
   type ProviderHookRuntimeOptions,
 } from "../worktrunkHookExpectation.js";
+import { buildDoctorSummary, type DoctorSummary } from "./diagnosticOutput.js";
 
 export type DoctorCommandOptions = {
   config?: StationConfig;
@@ -33,6 +34,14 @@ export type DoctorCommandOptions = {
   providerHookIngressLauncher?: string;
   providerHookArtifactOwner?: ProviderHookArtifactOwner;
   timeoutMs?: number;
+};
+
+export type DoctorCommandResult = DoctorReport | DoctorSummary;
+
+export type ParsedDoctorCommandArgs = {
+  doctorOptions: DoctorOptions;
+  full: boolean;
+  projectId?: string;
 };
 
 /**
@@ -44,8 +53,9 @@ export async function runDoctorCommand(
   args: string[],
   options: DoctorCommandOptions = {},
   deps: ObserverProcessDeps = {},
-): Promise<DoctorReport> {
-  const parsedDoctorOptions = parseDoctorOptions(args);
+): Promise<DoctorCommandResult> {
+  const parsed = parseDoctorCommandArgs(args);
+  const parsedDoctorOptions = parsed.doctorOptions;
   const hookRuntimeOptions: ProviderHookRuntimeOptions = {};
   if (options.providerHookIngressLauncher !== undefined) {
     hookRuntimeOptions.ingressLauncher = options.providerHookIngressLauncher;
@@ -123,7 +133,11 @@ export async function runDoctorCommand(
   for (const check of cliChecks) {
     report = reportWithCliCheck(report, check);
   }
-  return report;
+  return parsed.full
+    ? report
+    : buildDoctorSummary(report, {
+        ...(parsed.projectId === undefined ? {} : { projectId: parsed.projectId }),
+      });
 }
 
 /**
@@ -179,13 +193,18 @@ export async function rendererRuntimeCheck(
   return undefined;
 }
 
-function parseDoctorOptions(args: string[]): DoctorOptions {
+export function parseDoctorCommandArgs(args: string[]): ParsedDoctorCommandArgs {
   const result: {
     projectId?: string;
     deep?: true;
   } = {};
+  let full = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (arg === "--full") {
+      full = true;
+      continue;
+    }
     if (arg === "--deep") {
       result.deep = true;
       continue;
@@ -204,7 +223,11 @@ function parseDoctorOptions(args: string[]): DoctorOptions {
   if (!parsed.success) {
     throw new Error(`Invalid doctor options: ${parsed.error.message}`);
   }
-  return parsed.data;
+  return {
+    doctorOptions: parsed.data,
+    full,
+    ...(result.projectId === undefined ? {} : { projectId: result.projectId }),
+  };
 }
 
 export async function observerRuntimeFreshnessCheck(

--- a/apps/cli/src/commands/observer.ts
+++ b/apps/cli/src/commands/observer.ts
@@ -1,5 +1,5 @@
 import type { StationConfig } from "@station/config";
-import type { ObserverHealth, ObserverStopReceipt } from "@station/contracts";
+import type { ObserverHealth, ObserverStopReceipt, SafeError } from "@station/contracts";
 import { parsePositiveIntegerOption } from "../args.js";
 import {
   getObserverStatus,
@@ -88,13 +88,20 @@ export function parseObserverCommandAction(args: string[]): string {
   return parseObserverArgs(args, undefined).action;
 }
 
+export function observerCommandRequestsFull(args: string[]): boolean {
+  return parseObserverArgs(args, undefined).full;
+}
+
 function parseObserverArgs(
   args: string[],
   timeoutMs: number | undefined,
-): { action: string; timeoutMs?: number; force: boolean } {
+): { action: string; timeoutMs?: number; force: boolean; full: boolean } {
   const parsed = takeTimeoutOption(args, timeoutMs);
   const force = parsed.args.includes("--force") || parsed.args.includes("--yes");
-  const rest = parsed.args.filter((arg) => arg !== "--force" && arg !== "--yes");
+  const full = parsed.args.includes("--full");
+  const rest = parsed.args.filter(
+    (arg) => arg !== "--force" && arg !== "--yes" && arg !== "--full",
+  );
 
   const flag = rest.find((arg) => arg.startsWith("--"));
   if (flag !== undefined) {
@@ -104,9 +111,14 @@ function parseObserverArgs(
     throw new Error(`Unknown observer option: ${rest[1] ?? ""}`);
   }
 
-  const result: { action: string; timeoutMs?: number; force: boolean } = {
-    action: rest[0] ?? "status",
+  const action = rest[0] ?? "status";
+  if (full && action !== "status") {
+    throw new Error("--full is supported only for observer status.");
+  }
+  const result: { action: string; timeoutMs?: number; force: boolean; full: boolean } = {
+    action,
     force,
+    full,
   };
   if (parsed.timeoutMs !== undefined) result.timeoutMs = parsed.timeoutMs;
   return result;
@@ -130,7 +142,10 @@ function takeTimeoutOption(
   };
 }
 
-export function observerCommandSummary(result: ObserverCommandResult): unknown {
+export function observerCommandSummary(
+  result: ObserverCommandResult,
+  options: { fullStatus?: boolean } = {},
+): unknown {
   if ("plan" in result) {
     const { plan, applied } = result;
     return {
@@ -156,6 +171,20 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     };
   }
   if ("health" in result) {
+    if (options.fullStatus !== true) {
+      const health = result.health;
+      return {
+        status: result.status,
+        socketPath: result.paths.socketPath,
+        health: {
+          status: health.status,
+          ...(health.pid === undefined ? {} : { pid: health.pid }),
+          ...(health.startedAt === undefined ? {} : { startedAt: health.startedAt }),
+          ...(health.version === undefined ? {} : { version: health.version }),
+          ...(health.uptimeMs === undefined ? {} : { uptimeMs: health.uptimeMs }),
+        },
+      };
+    }
     return {
       status: result.status,
       socketPath: result.paths.socketPath,
@@ -163,6 +192,14 @@ export function observerCommandSummary(result: ObserverCommandResult): unknown {
     };
   }
   if ("paths" in result) {
+    if (options.fullStatus !== true) {
+      const summary: { status: string; socketPath: string; error?: SafeError } = {
+        status: result.status,
+        socketPath: result.paths.socketPath,
+      };
+      if ("error" in result && result.error !== undefined) summary.error = result.error;
+      return summary;
+    }
     return result;
   }
   return result satisfies ObserverStopReceipt;

--- a/apps/cli/src/commands/registry/debug.ts
+++ b/apps/cli/src/commands/registry/debug.ts
@@ -14,8 +14,8 @@ export const debugCliCommand: CliCommandNode = {
   description: "Inspect traces, logs, and shareable diagnostic bundles.",
   usage: [
     "stn debug bundle [options]",
-    "stn debug trace [query|--latest-failure] [--json]",
-    "stn debug logs [query] [options]",
+    "stn debug trace [query|--latest-failure] [--full]",
+    "stn debug logs [query] [options] [--full]",
   ],
   options: [
     { name: "--help", description: "Show debug command help." },
@@ -70,17 +70,13 @@ export const debugCliCommand: CliCommandNode = {
       description: "Resolve trace, command, diagnostic, or latest-failure evidence.",
       requiresConfig: true,
       run: runDebugTraceCliCommand,
-      usage: [
-        "stn debug trace [query]",
-        "stn debug trace --latest-failure",
-        "stn debug trace [query] --json",
-      ],
+      usage: ["stn debug trace [query]", "stn debug trace --latest-failure [--full]"],
       options: [
         {
           name: "--latest-failure",
           description: "Find the most recent failure when no query is provided.",
         },
-        { name: "--json", description: "Keep JSON output for agent-readable inspection." },
+        { name: "--full", description: "Search all history and return complete evidence." },
       ],
       examples: ["pnpm stn debug trace --latest-failure"],
     },
@@ -89,7 +85,7 @@ export const debugCliCommand: CliCommandNode = {
       description: "Search bounded STATION component logs.",
       requiresConfig: true,
       run: runDebugLogsCliCommand,
-      usage: ["stn debug logs [query] [options]"],
+      usage: ["stn debug logs [query] [options] [--full]"],
       options: [
         {
           name: "--component <name>",
@@ -105,7 +101,7 @@ export const debugCliCommand: CliCommandNode = {
           description: "Only include records at or after a timestamp.",
         },
         { name: "--limit <count>", description: "Limit returned records." },
-        { name: "--json", description: "Keep JSON output for agent-readable inspection." },
+        { name: "--full", description: "Search all history and preserve complete record text." },
       ],
       examples: [
         "pnpm stn debug logs protocol",

--- a/apps/cli/src/commands/registry/doctor.ts
+++ b/apps/cli/src/commands/registry/doctor.ts
@@ -5,7 +5,8 @@ import type {
   CliCommandRunContext,
 } from "../cliCommand/types.js";
 import { isConfigError, runInvalidConfigDoctor } from "../configDiagnostics.js";
-import { runDoctorCommand } from "../doctor.js";
+import { buildDoctorSummary } from "../diagnosticOutput.js";
+import { parseDoctorCommandArgs, runDoctorCommand } from "../doctor.js";
 
 export const doctorCliCommand: CliCommandNode = {
   name: "doctor",
@@ -13,12 +14,13 @@ export const doctorCliCommand: CliCommandNode = {
   requiresConfig: true,
   run: runDoctorCliCommand,
   handleConfigError: handleDoctorConfigError,
-  usage: ["stn doctor [--project <id>]"],
+  usage: ["stn doctor [--project <id>] [--full]"],
   options: [
     {
       name: "--project <id>",
       description: "Limit project-specific diagnostics to one project.",
     },
+    { name: "--full", description: "Return the complete diagnostic report." },
   ],
   examples: ["pnpm stn doctor", "pnpm stn --config ./config.toml doctor --help"],
   notes: [
@@ -44,5 +46,13 @@ async function handleDoctorConfigError(error: unknown, _context: CliCommandConfi
     error,
     configPath: error.configPath,
   });
-  return { code: 1, output: result };
+  const parsed = parseDoctorCommandArgs(_context.args);
+  return {
+    code: 1,
+    output: parsed.full
+      ? result
+      : buildDoctorSummary(result, {
+          ...(parsed.projectId === undefined ? {} : { projectId: parsed.projectId }),
+        }),
+  };
 }

--- a/apps/cli/src/commands/registry/observer.ts
+++ b/apps/cli/src/commands/registry/observer.ts
@@ -1,6 +1,7 @@
 import { loadedCommandOptions } from "../cliCommand/helpers.js";
 import type { CliCommandNode, CliCommandRunContext } from "../cliCommand/types.js";
 import {
+  observerCommandRequestsFull,
   observerCommandSummary,
   parseObserverCommandAction,
   runObserverCommand,
@@ -13,7 +14,7 @@ export const observerCliCommand: CliCommandNode = {
   run: runObserverCliCommand,
   usage: [
     "stn observer start",
-    "stn observer status",
+    "stn observer status [--full]",
     "stn observer stop",
     "stn observer reap [--force]",
   ],
@@ -35,7 +36,8 @@ export const observerCliCommand: CliCommandNode = {
     {
       name: "status",
       description: "Report observer process availability.",
-      usage: ["stn observer status"],
+      usage: ["stn observer status [--full]"],
+      options: [{ name: "--full", description: "Return the complete observer health payload." }],
       examples: ["pnpm stn observer status"],
     },
     {
@@ -71,5 +73,10 @@ async function runObserverCliCommand(context: CliCommandRunContext) {
     (action === "start" || action === "restart") &&
     "status" in result &&
     result.status !== "running";
-  return { code: failedStart ? 1 : 0, output: observerCommandSummary(result) };
+  return {
+    code: failedStart ? 1 : 0,
+    output: observerCommandSummary(result, {
+      fullStatus: action !== "status" || observerCommandRequestsFull(context.args),
+    }),
+  };
 }

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -22,6 +22,10 @@ describe("CLI diagnostic commands", () => {
     const configPath = await writeConfigToml(fixture.root, fixture.config);
     const providerHookIngressLauncher = "/checkout/requester/bin/stn-ingress";
     let requestedDoctorOptions: DoctorOptions;
+    const runDoctor = vi.fn(async (options?: DoctorOptions) => {
+      requestedDoctorOptions = options;
+      return doctorReport(fixture.stateDir);
+    });
     const deps = {
       buildVersion: observerBuildVersion,
       clientFactory: () =>
@@ -33,10 +37,7 @@ describe("CLI diagnostic commands", () => {
             startedAt: now,
             version: observerBuildVersion,
           }),
-          runDoctor: async (options?: DoctorOptions) => {
-            requestedDoctorOptions = options;
-            return doctorReport(fixture.stateDir);
-          },
+          runDoctor,
         }) as never,
       sleep: async () => undefined,
     };
@@ -51,11 +52,16 @@ describe("CLI diagnostic commands", () => {
       output: {
         schemaVersion: "0.9.0",
         status: "healthy",
-        debugBundle: {
-          available: true,
+        findings: [],
+        counts: {
+          historicalErrors: 0,
+          projects: 0,
+          sessions: 0,
         },
+        detailsCommand: "stn doctor --full",
       },
     });
+    expect(runDoctor).toHaveBeenCalledTimes(1);
     expect(requestedDoctorOptions).toEqual({
       providerHookRuntime: {
         ingressLauncher: providerHookIngressLauncher,
@@ -66,6 +72,90 @@ describe("CLI diagnostic commands", () => {
         stationConfigPath: configPath,
       },
     });
+
+    await expect(
+      runCli(["--config", configPath, "doctor", "--full"], {
+        observerDeps: deps,
+        providerHookIngressLauncher,
+      }),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: {
+        debugBundle: { available: true },
+        snapshot: { counts: { projects: 0, sessions: 0 } },
+      },
+    });
+    expect(runDoctor).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns deterministic current findings while counting historical errors only", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    const report = doctorReport(fixture.stateDir);
+    report.status = "degraded";
+    report.checks.push(
+      {
+        name: "provider-current",
+        status: "warn",
+        message: "generic",
+        error: {
+          tag: "ProviderError",
+          code: "PROVIDER_CURRENT",
+          message: `${"🧭".repeat(260)} current`,
+          traceId: "trc_current",
+          commandId: "cmd_current",
+          diagnosticId: "diag_current",
+        },
+      },
+      { name: "secondary", status: "error", message: "Immediate failure." },
+    );
+    report.recentErrors.push({
+      tag: "HistoricalError",
+      code: "HISTORICAL_ONLY",
+      message: "Old failure.",
+      traceId: "trc_old",
+    });
+    const runDoctor = vi.fn(async () => report);
+
+    const result = await runCli(["--config", configPath, "doctor", "--project", "demo"], {
+      observerDeps: {
+        buildVersion: observerBuildVersion,
+        clientFactory: () =>
+          ({
+            health: async () => report.observer,
+            runDoctor,
+          }) as never,
+        sleep: async () => undefined,
+      },
+    });
+
+    expect(runDoctor).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      code: 0,
+      output: {
+        status: "degraded",
+        findings: [
+          { name: "secondary", severity: "error", message: "Immediate failure." },
+          {
+            name: "provider-current",
+            severity: "warn",
+            code: "PROVIDER_CURRENT",
+            traceId: "trc_current",
+            commandId: "cmd_current",
+            diagnosticId: "diag_current",
+          },
+        ],
+        counts: { historicalErrors: 1 },
+        nextCommands: ["stn debug trace trc_current"],
+        truncation: { text: true },
+        detailsCommand: "stn doctor --project demo --full",
+      },
+    });
+    const output = result.output as { findings: Array<{ message: string }> };
+    expect([...(output.findings[1]?.message ?? "")]).toHaveLength(240);
+    expect(JSON.stringify(result.output)).not.toContain("HISTORICAL_ONLY");
+    expect(result.output).not.toHaveProperty("snapshot");
+    expect(result.output).not.toHaveProperty("logs");
   });
 
   it("reports stale local observer runtime evidence without restarting anything", async () => {
@@ -356,13 +446,16 @@ describe("CLI diagnostic commands", () => {
     await runCli(["--config", configPath, "debug", "bundle"], {
       observerDeps: deps,
     });
-    const traced = await runCli(["--config", configPath, "debug", "trace", "cmd_worktrunk"], {
-      observerDeps: {
-        clientFactory: () => {
-          throw new Error("debug trace should not contact observer");
+    const traced = await runCli(
+      ["--config", configPath, "debug", "trace", "cmd_worktrunk", "--full"],
+      {
+        observerDeps: {
+          clientFactory: () => {
+            throw new Error("debug trace should not contact observer");
+          },
         },
       },
-    });
+    );
 
     expect(traced).toMatchObject({
       code: 0,
@@ -502,7 +595,7 @@ describe("CLI diagnostic commands", () => {
         error: {
           code: "OBSERVER_START_FAILED",
         },
-        suggestedCommands: expect.arrayContaining(["stn debug bundle --trace trc_lifecycle"]),
+        suggestedCommands: [],
       },
     });
   });
@@ -571,9 +664,7 @@ describe("CLI diagnostic commands", () => {
         ],
       },
     });
-    const filesSearched = (result.output as { evidence: { filesSearched: string[] } }).evidence
-      .filesSearched;
-    expect(filesSearched).not.toContain(join(fixture.stateDir, "logs", "hooks.jsonl"));
+    expect(result.output).not.toHaveProperty("evidence");
   });
 
   it("can opt into hook log filtering", async () => {
@@ -608,6 +699,97 @@ describe("CLI diagnostic commands", () => {
     });
   });
 
+  it("reports incomplete bounded log coverage and finds old evidence with --full", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    const old = {
+      timestamp: "2026-05-20T11:00:00.000Z",
+      level: "warn",
+      component: "observer",
+      message: "old-window-marker",
+    };
+    const padding = {
+      timestamp: "2026-05-20T12:00:00.000Z",
+      level: "info",
+      component: "observer",
+      message: "x".repeat(8 * 1024 * 1024 + 1024),
+    };
+    await writeFile(
+      join(fixture.stateDir, "logs", "observer.jsonl"),
+      `${JSON.stringify(old)}\n${JSON.stringify(padding)}\n`,
+    );
+
+    const bounded = await runCli(["--config", configPath, "debug", "logs", "old-window-marker"]);
+    expect(bounded).toMatchObject({
+      code: 1,
+      output: {
+        matched: 0,
+        search: {
+          complete: false,
+          bytesRead: 8 * 1024 * 1024,
+          incompleteComponents: ["observer"],
+        },
+        retryCommand: "stn debug logs old-window-marker --full",
+      },
+    });
+
+    const exhaustive = await runCli([
+      "--config",
+      configPath,
+      "debug",
+      "logs",
+      "old-window-marker",
+      "--full",
+    ]);
+    expect(exhaustive).toMatchObject({
+      code: 0,
+      output: {
+        matched: 1,
+        search: { complete: true },
+        records: [{ message: "old-window-marker" }],
+        evidence: { matchedFiles: [join(fixture.stateDir, "logs", "observer.jsonl")] },
+      },
+    });
+  });
+
+  it("caps default log text and keeps complete text with --full", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    const message = "🧭".repeat(300);
+    await writeFile(
+      join(fixture.stateDir, "logs", "observer.jsonl"),
+      `${JSON.stringify({
+        timestamp: now,
+        level: "warn",
+        component: "observer",
+        message,
+        attributes: {
+          error: { code: "LONG_ERROR", message },
+        },
+      })}\n`,
+    );
+
+    const concise = await runCli(["--config", configPath, "debug", "logs", "LONG_ERROR"]);
+    const conciseOutput = concise.output as {
+      records: Array<{ message: string; error?: { message?: string } }>;
+      truncation: { text: boolean };
+    };
+    expect(conciseOutput.truncation.text).toBe(true);
+    expect([...(conciseOutput.records[0]?.message ?? "")]).toHaveLength(240);
+    expect([...(conciseOutput.records[0]?.error?.message ?? "")]).toHaveLength(240);
+
+    const full = await runCli(["--config", configPath, "debug", "logs", "LONG_ERROR", "--full"]);
+    expect(full).toMatchObject({
+      code: 0,
+      output: {
+        truncation: { text: false },
+        records: [{ message, error: { message } }],
+      },
+    });
+  });
+
   it("returns doctor diagnostics for an invalid config without starting the observer", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-invalid-config-"));
     const configPath = join(root, "config.toml");
@@ -638,15 +820,14 @@ describe("CLI diagnostic commands", () => {
       code: 1,
       output: {
         status: "unavailable",
-        config: {
-          configPath,
-          diagnostics: [
-            expect.objectContaining({
-              code: "CONFIG_VALIDATION_FAILED",
-              diagnosticId: "config-load",
-            }),
-          ],
-        },
+        findings: [
+          expect.objectContaining({
+            source: "config",
+            code: "CONFIG_VALIDATION_FAILED",
+            diagnosticId: "config-load",
+          }),
+        ],
+        detailsCommand: "stn doctor --full",
       },
     });
   });

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -148,7 +148,7 @@ describe("CLI manual-smoke commands", () => {
     ]);
 
     expect(result).toMatchObject({ code: 0, outputFormat: "text" });
-    expect(textOutput(result)).toContain("Usage:\n  stn doctor [--project <id>]");
+    expect(textOutput(result)).toContain("Usage:\n  stn doctor [--project <id>] [--full]");
   });
 
   it("ignores command options and operands when resolving help topics", async () => {
@@ -169,7 +169,7 @@ describe("CLI manual-smoke commands", () => {
     expect(setupCheck).toMatchObject({ code: 0, outputFormat: "text" });
     expect(textOutput(setupCheck)).toContain("Usage:\n  stn setup check [--json] [--no-brew]");
     expect(doctor).toMatchObject({ code: 0, outputFormat: "text" });
-    expect(textOutput(doctor)).toContain("Usage:\n  stn doctor [--project <id>]");
+    expect(textOutput(doctor)).toContain("Usage:\n  stn doctor [--project <id>] [--full]");
     expect(hookInstall).toMatchObject({ code: 0, outputFormat: "text" });
     expect(textOutput(hookInstall)).toContain(
       "Usage:\n  stn hooks install <target> --yes [options]",
@@ -185,6 +185,20 @@ describe("CLI manual-smoke commands", () => {
     expect(projectAdd).toMatchObject({ code: 0, outputFormat: "text" });
     expect(textOutput(projectAdd)).toContain("Usage:\n  stn project add <path>");
     expect(textOutput(projectAdd)).toContain("Behavior Notes:");
+  });
+
+  it("documents concise/full diagnostic grammar without promoting legacy --json", async () => {
+    const [trace, logs, status] = await Promise.all([
+      runCli(["debug", "trace", "--help"]),
+      runCli(["debug", "logs", "--help"]),
+      runCli(["observer", "status", "--help"]),
+    ]);
+
+    expect(textOutput(trace)).toContain("stn debug trace --latest-failure [--full]");
+    expect(textOutput(logs)).toContain("stn debug logs [query] [options]");
+    expect(textOutput(status)).toContain("stn observer status [--full]");
+    expect(textOutput(trace)).not.toContain("--json");
+    expect(textOutput(logs)).not.toContain("--json");
   });
 
   it("resolves hook action target help without running hook commands", async () => {

--- a/apps/cli/test/integration/observer-commands.test.ts
+++ b/apps/cli/test/integration/observer-commands.test.ts
@@ -11,6 +11,28 @@ const requestedBuildIdentity = "a".repeat(64);
 const requestedBuildVersion = `1.2.3+station.${requestedBuildIdentity}`;
 
 describe("CLI observer commands", () => {
+  it("keeps non-running status concise unless full detail is requested", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+
+    const concise = await runCli(["--config", configPath, "observer", "status"]);
+    expect(concise).toMatchObject({
+      code: 0,
+      output: {
+        status: "stopped",
+        socketPath: fixture.socketPath,
+        error: { code: "PROTOCOL_CONNECT_FAILED" },
+      },
+    });
+    expect(concise.output).not.toHaveProperty("paths");
+    await expect(
+      runCli(["--config", configPath, "observer", "status", "--full"]),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: { status: "stopped", paths: { stateDir: fixture.stateDir } },
+    });
+  });
+
   it("starts, reports status, stops, and restarts through injected process/protocol boundaries", async () => {
     const fixture = await createTempState();
     let running = false;
@@ -33,6 +55,15 @@ describe("CLI observer commands", () => {
               startedAt: now,
               version: zeroBuildVersion,
               socketPath: fixture.socketPath,
+              uptimeMs: 42_000,
+              hookSpoolDepth: 3,
+              providerHealth: {},
+              lastReconcile: {
+                reason: "test",
+                startedAt: now,
+                finishedAt: now,
+                durationMs: 1,
+              },
             };
           },
           stop: async () => {
@@ -80,6 +111,15 @@ describe("CLI observer commands", () => {
               startedAt: now,
               version: zeroBuildVersion,
               socketPath: fixture.socketPath,
+              uptimeMs: 42_000,
+              hookSpoolDepth: 3,
+              providerHealth: {},
+              lastReconcile: {
+                reason: "test",
+                startedAt: now,
+                finishedAt: now,
+                durationMs: 1,
+              },
             };
           },
           stop: async () => {
@@ -102,11 +142,33 @@ describe("CLI observer commands", () => {
     });
     await expect(
       runCli(["--config", configPath, "observer", "status"], { observerDeps: deps }),
-    ).resolves.toMatchObject({
+    ).resolves.toEqual({
       code: 0,
       output: {
         status: "running",
         socketPath: fixture.socketPath,
+        health: {
+          status: "healthy",
+          pid: 1234,
+          startedAt: now,
+          version: zeroBuildVersion,
+          uptimeMs: 42_000,
+        },
+      },
+    });
+    await expect(
+      runCli(["--config", configPath, "observer", "status", "--full"], {
+        observerDeps: deps,
+      }),
+    ).resolves.toMatchObject({
+      code: 0,
+      output: {
+        health: {
+          schemaVersion: "0.9.0",
+          hookSpoolDepth: 3,
+          providerHealth: {},
+          lastReconcile: { reason: "test" },
+        },
       },
     });
     await expect(

--- a/apps/cli/test/integration/release-hardening-doctor.test.ts
+++ b/apps/cli/test/integration/release-hardening-doctor.test.ts
@@ -28,10 +28,26 @@ describe("CLI release doctor", () => {
     const configPath = await writeReleaseDoctorConfig(root);
 
     const result = await runCli(["--config", configPath, "doctor"]);
-    const report = result.output as DoctorReport;
+    const summary = result.output as {
+      status: string;
+      findings: Array<{ name: string; code?: string }>;
+      detailsCommand: string;
+    };
 
     expect(result.code).toBe(0);
-    expect(report.status).toBe("degraded");
+    expect(summary.status).toBe("degraded");
+    expect(summary.findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "CONFIG_LOCAL_CONFIG_PARSE_FAILED" }),
+        expect.objectContaining({ code: "WORKTRUNK_UNAVAILABLE" }),
+        expect.objectContaining({ code: "WORKTRUNK_HOOKS_MISSING" }),
+      ]),
+    );
+    expect(summary.detailsCommand).toBe("stn doctor --full");
+    expect(result.output).not.toHaveProperty("snapshot");
+
+    const fullResult = await runCli(["--config", configPath, "doctor", "--full"]);
+    const report = fullResult.output as DoctorReport;
     expect(report.config.diagnostics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -86,15 +102,17 @@ describe("CLI release doctor", () => {
     delete process.env.STATION_DASHBOARD_COMMAND;
     try {
       const result = await runCli(["--config", configPath, "doctor"]);
-      const report = result.output as DoctorReport;
+      const summary = result.output as {
+        status: string;
+        findings: Array<{ name: string; code?: string }>;
+      };
 
-      expect(report.status).toBe("degraded");
-      expect(report.checks).toEqual(
+      expect(summary.status).toBe("degraded");
+      expect(summary.findings).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             name: "renderer-runtime",
-            status: "warn",
-            error: expect.objectContaining({ code: "BUN_RUNTIME_MISSING" }),
+            code: "BUN_RUNTIME_MISSING",
           }),
         ]),
       );

--- a/apps/cli/test/unit/ingress-command.test.ts
+++ b/apps/cli/test/unit/ingress-command.test.ts
@@ -34,7 +34,7 @@ describe("provider hook ingress command", () => {
         "--observer-entry",
         observerEntry,
         "--startup-timeout-ms",
-        "2000",
+        "5000",
         "worktrunk",
         "post-create",
       ],

--- a/apps/observer/test/integration/protocol-server.test.ts
+++ b/apps/observer/test/integration/protocol-server.test.ts
@@ -88,7 +88,7 @@ describe("observer protocol server", () => {
       };
       await expect(
         runObserverMain(
-          ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "1000"],
+          ["--socket", socketPath, "--state-dir", stateDir, "--startup-timeout-ms", "5000"],
           { providerRegistryFactory, buildVersion: observerBuildVersion, incumbentLifecycle },
         ),
       ).resolves.toBe(0);

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -44,6 +44,26 @@ Use the narrowest tool that can answer the question:
 | Observer event hook setup | `stn event-hooks doctor` |
 | Setup and tool readiness | `stn setup check --json`, `stn setup system --check`, or `pnpm setup:system:check` |
 
+## Concise-first contract
+
+The diagnostic commands answer one narrow question by default. Use `--full`
+only when the concise result reports incomplete coverage or truncation, or when
+complete detail is explicitly required.
+
+| Question | Command | Effect | Default bound | Escalation |
+| --- | --- | --- | --- | --- |
+| Which process and exact build owns Station? | `stn observer status` | Live, read-only health probe | Process status, socket, health, PID, start time, build version, and uptime only | `stn observer status --full` |
+| Is current health actionable? | `stn doctor [--project <id>]` | May auto-start the observer; performs one doctor RPC | Five current findings; messages and hints are 240 Unicode code points | Use the returned `detailsCommand` |
+| Why did the latest command fail? | `stn debug trace --latest-failure` | Reads existing bundles and logs only | Recent-first reverse scan, at most 8 MiB per log component | Use the returned exact `--full` retry only when unresolved |
+| What evidence matches a known ID? | `stn debug trace <id>` | Reads existing bundles and logs only | Exhaustive in one call; output stays concise | Add `--full` only for complete diagnostic details and paths |
+| Which recent warning or error explains a symptom? | `stn debug logs [query]` | Reads existing logs only | Five records and at most 8 MiB per selected component; text is 240 code points | Use the returned exact `--full` retry when coverage is incomplete |
+
+`--full` removes the log byte ceiling. For `debug logs`, it restores the prior
+50-record default unless `--limit` is explicit and preserves complete messages
+and evidence paths. A conclusive trace with a root-cause code recommends no
+follow-up command. Bundle creation remains an explicit capture operation and is
+never an automatic escalation.
+
 Use `stn debug logs [query]` for bounded historical log inspection when there is no
 trace, command, or diagnostic ID yet. It reads structured JSONL logs from the
 configured state directory without contacting the observer. By default it searches

--- a/docs/development.md
+++ b/docs/development.md
@@ -176,6 +176,37 @@ diagnostics tests, the scripted-agent lane, setup and Observer lifecycle E2E
 coverage, and a production Observer SQLite restart smoke. It intentionally
 excludes real provider lanes.
 
+### Agent debugging performance gate
+
+Run the explicit concise-diagnostics PR gate on the same machine used for the
+reported comparison:
+
+```bash
+pnpm gate:agent-debugging
+```
+
+The command builds once, enables `STATION_AGENT_DEBUG_PERF=1`, and runs the
+A1-A10 correctness, context, call-count, read-budget, and timing matrix. The
+fixture is isolated and exactly 96 MiB: 64 MiB of observer logs, 16 MiB of CLI
+logs, and 16 MiB of TUI logs. It places a recent failure in the final 64 KiB and
+an old query match more than 8 MiB from EOF.
+
+The gate runs one untimed warm-up followed by seven measured iterations. It
+alternates the legacy and reverse-reader order to reduce cache-order bias. The
+test-only legacy reference reproduces `readFile`, split, parse, filter, sort,
+and slice. Median is the middle sorted sample; p95 is the nearest-rank 95th
+percentile. Approximate tokens are always `ceil(output bytes / 4)`, not a
+tokenizer measurement. Every matrix item prints one JSON row with calls,
+correctness, median and p95 elapsed time, bytes, lines, approximate tokens, and
+bytes read.
+
+A diagnostics PR is a go only when every A1-A10 row passes, the command exits
+zero, recent logs and latest-failure medians are at most 400 ms, all context and
+call-count ceilings hold, the seven diagnosis fixtures remain correct, resolved
+traces recommend no extra command, and `pnpm test:all` is green. Any missing
+measurement, changed fixture/method, byte or line overage, automatic doctor or
+bundle suggestion, or deferred performance miss is a no-go.
+
 After root `pnpm install`, Lefthook runs lint before commits and pushes:
 
 ```bash

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -17,7 +17,7 @@ Live observer checks:
 
 ```bash
 stn observer status
-stn doctor [--project <projectId>] [--deep]
+stn doctor [--project <projectId>] [--deep] [--full]
 stn snapshot --json [--include-debug]
 stn observe --include-snapshot --duration 3s
 stn observe --json --include-snapshot --duration 3s
@@ -59,6 +59,13 @@ When a command error envelope includes external-command diagnostics, trace outpu
 can show the command, cwd, exit code, duration, and bounded stdout/stderr
 snippets after redaction.
 
+Latest-failure lookup is recent-first and reads at most 8 MiB per log component
+by default. Known trace, command, and diagnostic IDs remain exhaustive in one
+call. `--full` makes latest-failure coverage exhaustive and restores complete
+diagnostic details and evidence paths. A result with a root-cause code has no
+automatic follow-up; unresolved results suggest only an exact exhaustive retry
+or the narrowest existing-state log query.
+
 `stn debug logs` reads structured JSONL logs from the configured state
 directory without contacting the observer. By default it searches `observer`,
 `cli`, and `tui` logs, excludes noisy hook logs, returns recent `warn`/`error`
@@ -66,11 +73,34 @@ records when no query is supplied, and searches all levels when a query is
 supplied. Use `--component hook` or `--all-components` only when hook delivery
 or provider-ingress noise is relevant.
 
-`stn observer status` checks the configured observer process/socket state. It is
-non-mutating, but it is still a live status check rather than an existing-state
-log read.
+The default returns at most five records, reads at most 8 MiB per selected
+component, and caps record and nested error messages at 240 Unicode code points.
+`search.complete`, `search.bytesRead`, and `search.incompleteComponents` state
+the inspected coverage; `truncation` distinguishes collection and text bounds.
+If an incomplete search finds nothing, `retryCommand` is the exact `--full`
+command. `--full` removes the byte ceiling, defaults to 50 records, and retains
+complete text and evidence paths.
 
-`stn doctor` connects to the observer, asks the observer for runtime health, and reports config, SQLite, provider health, hook spool, snapshot, logs, local state usage, and retention status. If the config cannot be loaded, `doctor` does not start the observer; it returns a local SafeError report with diagnostic id `config-load`.
+`stn observer status` checks the configured observer process/socket state. Its
+default is the process status, socket, health, PID, start time, exact build
+version, and uptime. `--full` returns the complete health payload. The command
+is non-mutating, but it is still a live status check rather than an
+existing-state log read.
+
+`stn doctor` connects to the observer and performs one doctor RPC after its
+existing observer auto-start check. The concise default contains current status,
+at most five sorted current findings, compact counts, correlation-driven next
+commands, truncation metadata, and an exact scoped `detailsCommand`. It omits
+healthy checks, snapshots, recent logs, capabilities, migrations, retention
+internals, and filesystem paths. `--full` returns the complete existing report
+with config, SQLite, providers, hook spool, snapshot, logs, local state, and
+retention. If config cannot be loaded, doctor does not start the observer and
+uses the same concise/full projection with diagnostic id `config-load`.
+
+Concise findings are current check, config, or provider failures. Their messages
+and hints are capped at 240 Unicode code points, errors sort before warnings,
+and specific config/provider findings replace generic aggregates. Historical
+`recentErrors` contributes only a count and never becomes a current finding.
 
 ### Doctor health semantics
 

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:e2e:pi:real": "vitest run --config config/vitest/vitest.pi-real.config.ts",
     "test:e2e:opencode:real": "vitest run --config config/vitest/vitest.opencode-real.config.ts",
     "test:agent:scripted": "vitest run --config config/vitest/vitest.agent-scripted.config.ts",
+    "gate:agent-debugging": "pnpm build && STATION_AGENT_DEBUG_PERF=1 vitest run --config config/vitest/vitest.agent-scripted.config.ts tests/agent/scenarios/diagnosis/cli-debug-efficiency.test.ts",
     "test:agent:real": "pnpm test:e2e:codex:real",
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",

--- a/packages/observability/src/logger.ts
+++ b/packages/observability/src/logger.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { type FileHandle, mkdir, open, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { type LogRecord, LogRecordSchema } from "@station/contracts";
 import { redact } from "./redaction.js";
@@ -19,6 +19,25 @@ export type CreateJsonlLoggerOptions = {
   path: string;
   clock?: { now(): Date };
 };
+
+type JsonlSchema<T> = {
+  safeParse(value: unknown): { success: true; data: T } | { success: false };
+};
+
+export type ReverseJsonlReadOptions<T> = {
+  maxBytes?: number;
+  maxRecords?: number;
+  matches?: (record: T) => boolean;
+};
+
+export type ReverseJsonlReadResult<T> = {
+  records: T[];
+  bytesRead: number;
+  complete: boolean;
+  invalidLines: number;
+};
+
+const jsonlChunkBytes = 64 * 1024;
 
 export function componentLogPath(stateDir: string, component: LogRecord["component"]): string {
   const fileName = component === "hook" ? "hooks.jsonl" : `${component}.jsonl`;
@@ -74,17 +93,95 @@ export async function appendJsonl(path: string, record: LogRecord): Promise<void
 }
 
 export async function readJsonlLog(path: string, maxRecords = 500): Promise<LogRecord[]> {
-  let source: string;
+  const result = await readJsonlReverse(path, LogRecordSchema, { maxRecords });
+  if (result.invalidLines > 0) throw new Error("Invalid JSONL log record.");
+  return result.records;
+}
+
+export async function readJsonlReverse<T>(
+  path: string,
+  schema: JsonlSchema<T>,
+  options: ReverseJsonlReadOptions<T> = {},
+): Promise<ReverseJsonlReadResult<T>> {
+  let file: FileHandle;
   try {
-    source = await readFile(path, "utf8");
+    file = await open(path, "r");
   } catch {
-    return [];
+    return { records: [], bytesRead: 0, complete: true, invalidLines: 0 };
   }
 
-  const records = source
-    .split("\n")
-    .filter((line) => line.trim().length > 0)
-    .map((line) => LogRecordSchema.parse(JSON.parse(line)));
+  const records: T[] = [];
+  let bytesRead = 0;
+  let invalidLines = 0;
+  let stopped = false;
+  let pending = Buffer.alloc(0);
+  let hasRightBoundary = false;
+  const maxBytes = options.maxBytes ?? Number.POSITIVE_INFINITY;
+  const maxRecords = options.maxRecords ?? Number.POSITIVE_INFINITY;
 
-  return records.slice(Math.max(0, records.length - maxRecords));
+  try {
+    // Positional reads stop at the opened file's high-water mark, so concurrent appends wait for the next call.
+    const highWater = (await file.stat()).size;
+    let position = highWater;
+
+    while (position > 0 && bytesRead < maxBytes && !stopped) {
+      const length = Math.min(jsonlChunkBytes, position, maxBytes - bytesRead);
+      const start = position - length;
+      const chunk = Buffer.allocUnsafe(length);
+      const read = await file.read(chunk, 0, length, start);
+      position = start;
+      bytesRead += read.bytesRead;
+      const data = Buffer.concat([chunk.subarray(0, read.bytesRead), pending]);
+      let right = data.length;
+
+      let index = data.lastIndexOf(0x0a);
+      while (index >= 0) {
+        if (!hasRightBoundary) {
+          hasRightBoundary = true;
+          right = index;
+        } else {
+          const parsed = parseJsonlLine(data.subarray(index + 1, right), schema);
+          if (parsed.invalid) invalidLines += 1;
+          if (parsed.record !== undefined && (options.matches?.(parsed.record) ?? true)) {
+            records.push(parsed.record);
+            if (records.length >= maxRecords) {
+              stopped = true;
+              break;
+            }
+          }
+          right = index;
+        }
+        index = index === 0 ? -1 : data.lastIndexOf(0x0a, index - 1);
+      }
+
+      pending = data.subarray(0, right);
+      if (position === 0 && !stopped && hasRightBoundary) {
+        const parsed = parseJsonlLine(pending, schema);
+        if (parsed.invalid) invalidLines += 1;
+        if (parsed.record !== undefined && (options.matches?.(parsed.record) ?? true)) {
+          records.push(parsed.record);
+        }
+      }
+    }
+
+    return {
+      records: records.slice(0, maxRecords).reverse(),
+      bytesRead,
+      complete: position === 0 && !stopped,
+      invalidLines,
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+function parseJsonlLine<T>(line: Buffer, schema: JsonlSchema<T>): { record?: T; invalid: boolean } {
+  const source = line.toString("utf8");
+  if (source.trim().length === 0) return { invalid: false };
+  try {
+    const parsed = schema.safeParse(JSON.parse(source));
+    return parsed.success ? { record: parsed.data, invalid: false } : { invalid: true };
+  } catch {
+    return { invalid: true };
+  }
 }

--- a/packages/observability/test/unit/observability.test.ts
+++ b/packages/observability/test/unit/observability.test.ts
@@ -1,13 +1,15 @@
-import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DiagnosticEvidenceIndex, DiagnosticSnapshot } from "@station/contracts";
+import { LogRecordSchema } from "@station/contracts";
 import {
   createErrorEnvelope,
   createJsonlLogger,
   DEFAULT_RETENTION_POLICY,
   mergeRetentionPolicy,
   readJsonlLog,
+  readJsonlReverse,
   redact,
   scanLocalStateUsage,
   toSafeError,
@@ -58,6 +60,100 @@ describe("observability helpers", () => {
         }),
       }),
     ]);
+  });
+
+  it("reads newest JSONL records in chronological order without reading the whole file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-jsonl-reverse-"));
+    const path = join(dir, "observer.jsonl");
+    const records = Array.from({ length: 2_000 }, (_, index) => logRecord(index));
+    await writeFile(path, `${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+
+    const result = await readJsonlReverse(path, LogRecordSchema, { maxRecords: 3 });
+
+    expect(result.records.map((record) => record.message)).toEqual([
+      "record-1997",
+      "record-1998",
+      "record-1999",
+    ]);
+    expect(result.bytesRead).toBeLessThan((await readFile(path)).byteLength);
+    expect(result.complete).toBe(false);
+    expect(result.invalidLines).toBe(0);
+    await expect(readJsonlLog(path, 3)).resolves.toEqual(result.records);
+  });
+
+  it("preserves UTF-8 characters split across reverse chunks", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-jsonl-utf8-"));
+    const path = join(dir, "observer.jsonl");
+    const longMessage = `${"a".repeat(64 * 1024 - 120)}🧭tail`;
+    await writeFile(
+      path,
+      `${JSON.stringify(logRecord(1, longMessage))}\n${JSON.stringify(logRecord(2))}\n`,
+    );
+
+    const result = await readJsonlReverse(path, LogRecordSchema);
+
+    expect(result.records[0]?.message).toBe(longMessage);
+    expect(result.complete).toBe(true);
+  });
+
+  it("counts malformed complete lines and ignores an unterminated trailing write", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-jsonl-partial-"));
+    const path = join(dir, "observer.jsonl");
+    await writeFile(
+      path,
+      `${JSON.stringify(logRecord(1))}\nnot-json\n${JSON.stringify(logRecord(2))}\n{"partial":`,
+    );
+
+    const result = await readJsonlReverse(path, LogRecordSchema);
+
+    expect(result.records.map((record) => record.message)).toEqual(["record-1", "record-2"]);
+    expect(result.invalidLines).toBe(1);
+    expect(result.complete).toBe(true);
+    await expect(readJsonlLog(path)).rejects.toThrow("Invalid JSONL log record.");
+  });
+
+  it("enforces a byte ceiling and removes it in exhaustive mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-jsonl-cap-"));
+    const path = join(dir, "observer.jsonl");
+    const old = logRecord(1, `old-${"x".repeat(80 * 1024)}`);
+    const recent = logRecord(2, "recent");
+    await writeFile(path, `${JSON.stringify(old)}\n${JSON.stringify(recent)}\n`);
+
+    const bounded = await readJsonlReverse(path, LogRecordSchema, { maxBytes: 64 * 1024 });
+    const exhaustive = await readJsonlReverse(path, LogRecordSchema);
+
+    expect(bounded).toMatchObject({ bytesRead: 64 * 1024, complete: false });
+    expect(bounded.records.map((record) => record.message)).toEqual(["recent"]);
+    expect(exhaustive.records.map((record) => record.message)).toEqual([
+      expect.stringMatching(/^old-/u),
+      "recent",
+    ]);
+    expect(exhaustive.complete).toBe(true);
+  });
+
+  it("defers records appended after the opened file high-water mark", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "station-jsonl-high-water-"));
+    const path = join(dir, "observer.jsonl");
+    await writeFile(path, `${JSON.stringify(logRecord(1))}\n`);
+    let appended: Promise<void> | undefined;
+    const appendingSchema = {
+      safeParse(value: unknown) {
+        appended ??= appendFile(path, `${JSON.stringify(logRecord(2))}\n`);
+        return LogRecordSchema.safeParse(value);
+      },
+    };
+
+    const first = await readJsonlReverse(path, appendingSchema);
+    await appended;
+    const second = await readJsonlReverse(path, LogRecordSchema);
+
+    expect(first.records.map((record) => record.message)).toEqual(["record-1"]);
+    expect(second.records.map((record) => record.message)).toEqual(["record-1", "record-2"]);
+  });
+
+  it("returns an empty complete result for a missing JSONL file", async () => {
+    const result = await readJsonlReverse("/definitely/missing/station.jsonl", LogRecordSchema);
+    expect(result).toEqual({ records: [], bytesRead: 0, complete: true, invalidLines: 0 });
   });
 
   it("keeps SafeError output safe while storing redacted internal envelopes", () => {
@@ -209,6 +305,15 @@ describe("observability helpers", () => {
     expect(index.rootCauses.map((cause) => cause.code)).toContain("COMMAND_FAILED");
   });
 });
+
+function logRecord(index: number, message = `record-${index}`) {
+  return {
+    timestamp: new Date(Date.parse(now) + index).toISOString(),
+    level: "info" as const,
+    component: "observer" as const,
+    message,
+  };
+}
 
 function minimalSnapshot(): DiagnosticSnapshot {
   return {

--- a/tests/agent/scenarios/diagnosis/cli-debug-efficiency.test.ts
+++ b/tests/agent/scenarios/diagnosis/cli-debug-efficiency.test.ts
@@ -1,0 +1,658 @@
+import { mkdir, mkdtemp, open, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { runCli } from "@station/cli";
+import type { DoctorReport, LogRecord } from "@station/contracts";
+import { LogRecordSchema } from "@station/contracts";
+import { readJsonlReverse } from "@station/observability";
+import { describe, expect, it, vi } from "vitest";
+import { createTempState, writeConfigToml } from "../../../support/temp-projects";
+import { classifyDiagnosticEvidenceIndex } from "../../oracles/diagnosticOracle";
+
+const now = "2026-05-20T12:00:00.000Z";
+const buildVersion = `0.7.0+station.${"a".repeat(64)}`;
+const maxSearchBytes = 8 * 1024 * 1024;
+const timed = process.env.STATION_AGENT_DEBUG_PERF === "1";
+
+type MatrixRow = {
+  id: `A${number}`;
+  calls: number;
+  correctness: "pass";
+  elapsedMedianMs: number;
+  elapsedP95Ms: number;
+  bytes: number;
+  lines: number;
+  approximateTokens: number;
+  bytesRead: number;
+};
+
+describe("agent debugging acceptance matrix", () => {
+  it(
+    "passes A1-A10 and emits one machine-readable row per item",
+    async () => {
+      const fixture = await createTempState();
+      const configPath = await writeConfigToml(fixture.root, fixture.config);
+      const health = {
+        schemaVersion: "0.9.0",
+        status: "healthy" as const,
+        pid: 1234,
+        startedAt: now,
+        version: buildVersion,
+        socketPath: fixture.socketPath,
+        uptimeMs: 42_000,
+        hookSpoolDepth: 7,
+        providerHealth: {},
+      };
+
+      const a1 = await measure(async () =>
+        runCli(["--config", configPath, "observer", "status"], {
+          observerDeps: { clientFactory: () => ({ health: async () => health }) as never },
+        }),
+      );
+      expect(a1.value).toMatchObject({
+        code: 0,
+        output: {
+          status: "running",
+          socketPath: fixture.socketPath,
+          health: {
+            status: "healthy",
+            pid: 1234,
+            startedAt: now,
+            version: buildVersion,
+            uptimeMs: 42_000,
+          },
+        },
+      });
+      expect(a1.value.output).not.toHaveProperty("health.providerHealth");
+      emit(assertRow("A1", 1, a1.value.output, a1.samples, 0, { bytes: 1_500, lines: 40 }));
+
+      const actionableReport = doctorReport(fixture.stateDir, "degraded");
+      actionableReport.checks.push({
+        name: "provider-current",
+        status: "warn",
+        message: "Provider failed.",
+        error: {
+          tag: "ProviderError",
+          code: "PROVIDER_CURRENT",
+          message: "Provider failed with current evidence.",
+          traceId: "trc_current",
+          commandId: "cmd_current",
+          diagnosticId: "diag_current",
+        },
+      });
+      actionableReport.recentErrors.push({
+        tag: "HistoricalError",
+        code: "HISTORICAL_ONLY",
+        message: "Historical error.",
+      });
+      actionableReport.logs.recent = Array.from({ length: 20 }, (_, index) => ({
+        timestamp: new Date(Date.parse(now) + index).toISOString(),
+        level: "info",
+        component: "observer",
+        message: `full-only-${index}-${"x".repeat(200)}`,
+      }));
+      const doctorRpc = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return actionableReport;
+      });
+      const doctorDeps = {
+        buildVersion,
+        clientFactory: () =>
+          ({
+            health: async () => health,
+            runDoctor: doctorRpc,
+          }) as never,
+      };
+      const a2 = await measure(async () =>
+        runCli(["--config", configPath, "doctor"], { observerDeps: doctorDeps }),
+      );
+      const a2Full = await measure(async () =>
+        runCli(["--config", configPath, "doctor", "--full"], { observerDeps: doctorDeps }),
+      );
+      expect(a2.value.output).toMatchObject({
+        findings: [
+          expect.objectContaining({
+            severity: "warn",
+            message: "Provider failed with current evidence.",
+            code: "PROVIDER_CURRENT",
+            traceId: "trc_current",
+            commandId: "cmd_current",
+            diagnosticId: "diag_current",
+          }),
+        ],
+        counts: { historicalErrors: 1 },
+      });
+      expect(JSON.stringify(a2.value.output)).not.toContain("HISTORICAL_ONLY");
+      expect(doctorRpc).toHaveBeenCalledTimes(a2.samples.length + a2Full.samples.length + 2);
+      const a2Metrics = outputMetrics(a2.value.output);
+      const a2FullMetrics = outputMetrics(a2Full.value.output);
+      expect(a2Metrics.bytes).toBeLessThanOrEqual(Math.floor(a2FullMetrics.bytes * 0.25));
+      if (timed) {
+        expect(median(a2.samples)).toBeLessThanOrEqual(median(a2Full.samples) * 1.1);
+      }
+      emit(assertRow("A2", 1, a2.value.output, a2.samples, 0, { bytes: 4_096, lines: 80 }));
+
+      await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+      await writeFile(
+        join(fixture.stateDir, "logs", "observer.jsonl"),
+        `${JSON.stringify(failureRecord("RECENT_ROOT_CAUSE", "cmd_recent", "trc_recent"))}\n`,
+      );
+      const a3 = await measure(async () =>
+        runCli(["--config", configPath, "debug", "trace", "--latest-failure"]),
+      );
+      expect(a3.value).toMatchObject({
+        code: 0,
+        output: {
+          command: { id: "cmd_recent", traceId: "trc_recent" },
+          rootCauseCodes: ["RECENT_ROOT_CAUSE"],
+          suggestedCommands: [],
+        },
+      });
+      emit(
+        assertRow("A3", 1, a3.value.output, a3.samples, a3.value.output.search.bytesRead, {
+          bytes: 2_048,
+          lines: 60,
+        }),
+      );
+
+      const recentWarnings = Array.from({ length: 7 }, (_, index) => ({
+        timestamp: new Date(Date.parse(now) + index).toISOString(),
+        level: "warn",
+        component: "observer",
+        message: `warning-${index}`,
+        attributes: {
+          error: { code: `WARNING_${index}`, message: `warning-${index}` },
+        },
+      }));
+      await writeFile(
+        join(fixture.stateDir, "logs", "observer.jsonl"),
+        `${recentWarnings.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      );
+      const a4 = await measure(async () => runCli(["--config", configPath, "debug", "logs"]));
+      expect(a4.value.output.records).toHaveLength(5);
+      expect(a4.value.output.records.at(-1)).toMatchObject({
+        message: "warning-6",
+        error: { code: "WARNING_6" },
+      });
+      emit(
+        assertRow("A4", 1, a4.value.output, a4.samples, a4.value.output.search.bytesRead, {
+          bytes: 4_096,
+          lines: 100,
+        }),
+      );
+
+      const oldRecord = {
+        timestamp: "2026-05-20T10:00:00.000Z",
+        level: "warn",
+        component: "observer",
+        message: "old-query-marker",
+      };
+      const paddingRecord = {
+        timestamp: now,
+        level: "info",
+        component: "observer",
+        message: "x".repeat(maxSearchBytes + 1024),
+      };
+      await writeFile(
+        join(fixture.stateDir, "logs", "observer.jsonl"),
+        `${JSON.stringify(oldRecord)}\n${JSON.stringify(paddingRecord)}\n`,
+      );
+      const a5First = await measure(async () =>
+        runCli(["--config", configPath, "debug", "logs", "old-query-marker"]),
+      );
+      expect(a5First.value).toMatchObject({
+        code: 1,
+        output: {
+          matched: 0,
+          search: { complete: false },
+          retryCommand: "stn debug logs old-query-marker --full",
+        },
+      });
+      const a5Second = await runCli([
+        "--config",
+        configPath,
+        "debug",
+        "logs",
+        "old-query-marker",
+        "--full",
+      ]);
+      expect(a5Second).toMatchObject({
+        code: 0,
+        output: { records: [{ message: "old-query-marker" }] },
+      });
+      expect(a5First.value.output.search.bytesRead).toBeLessThanOrEqual(maxSearchBytes * 3);
+      emit(
+        assertRow(
+          "A5",
+          2,
+          a5First.value.output,
+          a5First.samples,
+          a5First.value.output.search.bytesRead,
+          { bytes: 2_048 },
+        ),
+      );
+
+      const healthyReport = doctorReport(fixture.stateDir, "healthy");
+      const a6 = await measure(async () =>
+        runCli(["--config", configPath, "doctor"], {
+          observerDeps: {
+            buildVersion,
+            clientFactory: () =>
+              ({ health: async () => health, runDoctor: async () => healthyReport }) as never,
+          },
+        }),
+      );
+      expect(a6.value.output).toMatchObject({
+        status: "healthy",
+        findings: [],
+        detailsCommand: "stn doctor --full",
+      });
+      expect(a6.value.output).not.toHaveProperty("snapshot");
+      emit(assertRow("A6", 1, a6.value.output, a6.samples, 0, { bytes: 1_500 }));
+
+      const invalidConfigPath = join(
+        await mkdtemp(join(tmpdir(), "station-agent-invalid-")),
+        "config.toml",
+      );
+      await writeFile(
+        invalidConfigPath,
+        "schema_version = 1\nprojects = []\n[defaults]\nterminal = 42\n",
+      );
+      const spawnObserver = vi.fn(async () => {
+        throw new Error("invalid config must not start the observer");
+      });
+      const a7 = await measure(async () =>
+        runCli(["--config", invalidConfigPath, "doctor"], {
+          observerDeps: { spawnObserver },
+        }),
+      );
+      expect(a7.value).toMatchObject({
+        code: 1,
+        output: {
+          findings: [
+            expect.objectContaining({
+              code: "CONFIG_VALIDATION_FAILED",
+              diagnosticId: "config-load",
+            }),
+          ],
+        },
+      });
+      expect(spawnObserver).not.toHaveBeenCalled();
+      emit(assertRow("A7", 1, a7.value.output, a7.samples, 0, { bytes: 2_048 }));
+
+      const scenarioDir = new URL(".", import.meta.url);
+      const scenarioFiles = (await readdir(scenarioDir))
+        .filter((file) => file.endsWith(".json"))
+        .sort();
+      const classifications = await Promise.all(
+        scenarioFiles.map(async (file) => {
+          const scenario = JSON.parse(await readFile(new URL(file, scenarioDir), "utf8")) as {
+            name: string;
+            expectedRootCause: string;
+            evidenceIndex: unknown;
+          };
+          return {
+            name: scenario.name,
+            expected: scenario.expectedRootCause,
+            actual: classifyDiagnosticEvidenceIndex(scenario.evidenceIndex).rootCause,
+          };
+        }),
+      );
+      expect(classifications).toHaveLength(7);
+      expect(classifications.every((result) => result.actual === result.expected)).toBe(true);
+      emit(assertRow("A8", 1, classifications, [0], 0));
+
+      const perfRoot = await mkdtemp(join(tmpdir(), "station-agent-debug-perf-"));
+      const logPaths = [
+        { path: join(perfRoot, "observer.jsonl"), bytes: timed ? 64 : 12 },
+        { path: join(perfRoot, "cli.jsonl"), bytes: timed ? 16 : 1 },
+        { path: join(perfRoot, "tui.jsonl"), bytes: timed ? 16 : 1 },
+      ];
+      for (const [index, entry] of logPaths.entries()) {
+        await writeSizedLog(entry.path, entry.bytes * 1024 * 1024, index === 0);
+      }
+      const benchmark = await benchmarkReaders(logPaths.map((entry) => entry.path));
+      expect(benchmark.newRecords).toEqual(benchmark.legacyRecords);
+      expect(benchmark.bytesRead).toBeLessThanOrEqual(maxSearchBytes * 3);
+      if (timed) {
+        expect(median(benchmark.newSamples)).toBeLessThanOrEqual(
+          median(benchmark.legacySamples) * 0.35,
+        );
+        expect(p95(benchmark.newSamples)).toBeLessThanOrEqual(p95(benchmark.legacySamples) * 0.5);
+      }
+      emit(
+        assertRow(
+          "A9",
+          0,
+          { records: benchmark.newRecords },
+          benchmark.newSamples,
+          benchmark.bytesRead,
+        ),
+      );
+
+      const defaultSuggestions = [
+        ...a3.value.output.suggestedCommands,
+        ...(a5First.value.output.retryCommand === undefined
+          ? []
+          : [a5First.value.output.retryCommand]),
+      ];
+      expect(defaultSuggestions).not.toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(
+            /\b(?:bundle|doctor|reconcile|dispatch|install|remove|stop|start)\b/u,
+          ),
+        ]),
+      );
+      expect(defaultSuggestions.filter((command) => command.includes("--full"))).toEqual([
+        "stn debug logs old-query-marker --full",
+      ]);
+      emit(assertRow("A10", 0, { commands: defaultSuggestions }, [0], 0));
+    },
+    timed ? 180_000 : 60_000,
+  );
+});
+
+async function measure<T>(run: () => Promise<T>): Promise<{ value: T; samples: number[] }> {
+  const warm = await run();
+  if (!timed) {
+    const started = performance.now();
+    return { value: await run(), samples: [performance.now() - started] };
+  }
+  const samples: number[] = [];
+  let value = warm;
+  for (let index = 0; index < 7; index += 1) {
+    const started = performance.now();
+    value = await run();
+    samples.push(performance.now() - started);
+  }
+  return { value, samples };
+}
+
+function assertRow(
+  id: MatrixRow["id"],
+  calls: number,
+  output: unknown,
+  elapsed: readonly number[],
+  bytesRead: number,
+  limits: { bytes?: number; lines?: number } = {},
+): MatrixRow {
+  const metrics = outputMetrics(output);
+  if (limits.bytes !== undefined)
+    expect(metrics.bytes, `${id} bytes`).toBeLessThanOrEqual(limits.bytes);
+  if (limits.lines !== undefined)
+    expect(metrics.lines, `${id} lines`).toBeLessThanOrEqual(limits.lines);
+  const elapsedMedianMs = median(elapsed);
+  const elapsedP95Ms = p95(elapsed);
+  if (timed) {
+    const threshold: readonly [number, number] | undefined =
+      id === "A1"
+        ? [300, 450]
+        : id === "A2" || id === "A6"
+          ? [750, 750]
+          : id === "A3" || id === "A4"
+            ? [400, 550]
+            : undefined;
+    if (threshold !== undefined) {
+      expect(elapsedMedianMs, `${id} median`).toBeLessThanOrEqual(threshold[0]);
+      expect(elapsedP95Ms, `${id} p95`).toBeLessThanOrEqual(threshold[1]);
+    }
+  }
+  return {
+    id,
+    calls,
+    correctness: "pass",
+    elapsedMedianMs: round(elapsedMedianMs),
+    elapsedP95Ms: round(elapsedP95Ms),
+    bytes: metrics.bytes,
+    lines: metrics.lines,
+    approximateTokens: Math.ceil(metrics.bytes / 4),
+    bytesRead,
+  };
+}
+
+function emit(row: MatrixRow): void {
+  console.log(JSON.stringify(row));
+}
+
+function outputMetrics(output: unknown): { bytes: number; lines: number } {
+  const rendered = `${JSON.stringify(output, null, 2)}\n`;
+  return { bytes: Buffer.byteLength(rendered), lines: rendered.split("\n").length - 1 };
+}
+
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.floor(sorted.length / 2)] ?? 0;
+}
+
+function p95(values: readonly number[]): number {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.max(0, Math.ceil(sorted.length * 0.95) - 1)] ?? 0;
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function failureRecord(code: string, commandId: string, traceId: string): LogRecord {
+  return LogRecordSchema.parse({
+    timestamp: now,
+    level: "error",
+    component: "observer",
+    message: "Command failed.",
+    traceId,
+    commandId,
+    attributes: {
+      commandId,
+      traceId,
+      error: { tag: "CommandError", code, message: "Command failed." },
+    },
+  });
+}
+
+function doctorReport(stateDir: string, status: DoctorReport["status"]): DoctorReport {
+  return {
+    schemaVersion: "0.9.0",
+    generatedAt: now,
+    status,
+    checks: [{ name: "observer", status: "ok", message: "Observer is healthy." }],
+    observer: {
+      schemaVersion: "0.9.0",
+      status: "healthy",
+      pid: 1234,
+      startedAt: now,
+      version: buildVersion,
+    },
+    config: { projectCount: 0, diagnostics: [] },
+    providers: {},
+    snapshot: {
+      schemaVersion: "0.9.0",
+      generatedAt: now,
+      observer: { pid: 1234, startedAt: now, version: buildVersion, healthy: true },
+      providerHealth: {},
+      projects: [],
+      rows: [],
+      sessions: [],
+      counts: {
+        projects: 0,
+        sessions: 0,
+        worktrees: 0,
+        agents: 0,
+        working: 0,
+        idle: 0,
+        attention: 0,
+        unknown: 0,
+      },
+      alerts: [],
+    },
+    logs: { paths: [], recent: [] },
+    localState: {
+      stateDir,
+      totalBytes: 0,
+      limitBytes: 262_144_000,
+      overLimit: false,
+      entries: [],
+    },
+    retention: {
+      maxDays: 14,
+      maxTotalMb: 250,
+      maxFileMb: 25,
+      maxFilesPerComponent: 4,
+      components: {
+        observerMaxMb: 64,
+        cliMaxMb: 16,
+        tuiMaxMb: 16,
+        hookRunnerMaxMb: 16,
+        providerMaxMb: 32,
+      },
+      sqlite: {
+        eventsMaxDays: 14,
+        commandsMaxDays: 30,
+        errorsMaxDays: 30,
+        providerObservationsMaxDays: 14,
+      },
+      debugBundles: { maxBundles: 20, maxDays: 14 },
+      hookSpool: { deliveredDeleteImmediately: true, failedMaxDays: 7, failedMaxItems: 1000 },
+    },
+    recentErrors: [],
+    debugBundle: { available: true, diagnosticsDir: join(stateDir, "diagnostics") },
+  };
+}
+
+async function writeSizedLog(path: string, targetBytes: number, includeRecentFailure: boolean) {
+  const file = await open(path, "w");
+  const recent = includeRecentFailure
+    ? Buffer.from(
+        `${JSON.stringify(failureRecord("PERF_RECENT_FAILURE", "cmd_perf", "trc_perf"))}\n`,
+      )
+    : Buffer.alloc(0);
+  const old = includeRecentFailure
+    ? Buffer.from(
+        `${JSON.stringify({
+          timestamp: "2026-05-20T10:00:00.000Z",
+          level: "warn",
+          component: "observer",
+          message: "perf-old-query-marker",
+        })}\n`,
+      )
+    : Buffer.alloc(0);
+  const template = Buffer.from(
+    `${JSON.stringify({
+      timestamp: now,
+      level: "info",
+      component: "observer",
+      message: "x".repeat(900),
+    })}\n`,
+  );
+  const block = Buffer.concat(Array.from({ length: 1024 }, () => template));
+  let written = 0;
+  try {
+    if (old.length > 0) {
+      await file.write(old);
+      written += old.length;
+    }
+    const minimumFinalLine = exactPaddingLine(256).length;
+    while (targetBytes - written - recent.length > block.length + minimumFinalLine) {
+      await file.write(block);
+      written += block.length;
+    }
+    while (targetBytes - written - recent.length > template.length + minimumFinalLine) {
+      await file.write(template);
+      written += template.length;
+    }
+    const finalBytes = targetBytes - written - recent.length;
+    const final = exactPaddingLine(finalBytes);
+    await file.write(final);
+    if (recent.length > 0) await file.write(recent);
+  } finally {
+    await file.close();
+  }
+  expect((await readFile(path)).byteLength).toBe(targetBytes);
+}
+
+function exactPaddingLine(bytes: number): Buffer {
+  const empty = `${JSON.stringify({
+    timestamp: now,
+    level: "info",
+    component: "observer",
+    message: "",
+  })}\n`;
+  const overhead = Buffer.byteLength(empty);
+  if (bytes < overhead) throw new Error(`Cannot fill ${bytes} bytes with a valid JSONL record.`);
+  return Buffer.from(
+    `${JSON.stringify({
+      timestamp: now,
+      level: "info",
+      component: "observer",
+      message: "x".repeat(bytes - overhead),
+    })}\n`,
+  );
+}
+
+async function benchmarkReaders(paths: readonly string[]) {
+  const legacy = async () => legacySearch(paths, "PERF_RECENT_FAILURE");
+  const current = async () => boundedSearch(paths, "PERF_RECENT_FAILURE");
+  await legacy();
+  await current();
+  const legacySamples: number[] = [];
+  const newSamples: number[] = [];
+  let legacyRecords: LogRecord[] = [];
+  let newResult = { records: [] as LogRecord[], bytesRead: 0 };
+  const iterations = timed ? 7 : 1;
+  for (let index = 0; index < iterations; index += 1) {
+    if (index % 2 === 0) {
+      ({ value: legacyRecords, elapsed: legacySamples[index] } = await timedCall(legacy));
+      ({ value: newResult, elapsed: newSamples[index] } = await timedCall(current));
+    } else {
+      ({ value: newResult, elapsed: newSamples[index] } = await timedCall(current));
+      ({ value: legacyRecords, elapsed: legacySamples[index] } = await timedCall(legacy));
+    }
+  }
+  return {
+    legacyRecords,
+    newRecords: newResult.records,
+    bytesRead: newResult.bytesRead,
+    legacySamples,
+    newSamples,
+  };
+}
+
+async function timedCall<T>(run: () => Promise<T>): Promise<{ value: T; elapsed: number }> {
+  const started = performance.now();
+  const value = await run();
+  return { value, elapsed: performance.now() - started };
+}
+
+async function boundedSearch(paths: readonly string[], query: string) {
+  const searches = await Promise.all(
+    paths.map((path) =>
+      readJsonlReverse(path, LogRecordSchema, {
+        maxBytes: maxSearchBytes,
+        maxRecords: 5,
+        matches: (record) => JSON.stringify(record).includes(query),
+      }),
+    ),
+  );
+  const results = searches.flatMap((result) => result.records);
+  return {
+    records: results
+      .sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+      .slice(-5),
+    bytesRead: searches.reduce((total, result) => total + result.bytesRead, 0),
+  };
+}
+
+async function legacySearch(paths: readonly string[], query: string): Promise<LogRecord[]> {
+  const records: LogRecord[] = [];
+  for (const path of paths) {
+    const source = await readFile(path, "utf8");
+    for (const line of source.split("\n")) {
+      if (line.trim().length === 0) continue;
+      const parsed = LogRecordSchema.safeParse(JSON.parse(line));
+      if (parsed.success && JSON.stringify(parsed.data).includes(query)) records.push(parsed.data);
+    }
+  }
+  return records
+    .sort((left, right) => Date.parse(left.timestamp) - Date.parse(right.timestamp))
+    .slice(-5);
+}

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -278,7 +278,7 @@ describe("setup guided feedback e2e", () => {
       expect(standalone.exitCode).toBe(0);
       expect(JSON.parse(standalone.stdout)).toMatchObject({ status: "ok", installed: true });
 
-      const fullDoctor = await runStation(["--config", fixture.configPath, "doctor"], {
+      const fullDoctor = await runStation(["--config", fixture.configPath, "doctor", "--full"], {
         cwd: fixture.repo,
         env: fixture.env,
         answers: [],


### PR DESCRIPTION
## What this fixes

Station's routine diagnostic commands returned exhaustive health and log payloads and read entire JSONL files even when the newest few records answered the question. Agent debugging therefore spent unnecessary wall time and context on status, doctor, latest-failure, and recent-log lookups, while unresolved bounded searches lacked an exact escalation path.

## What changed

- Make `observer status`, `doctor`, `debug trace`, and `debug logs` concise by default, with `--full` preserving exhaustive output.
- Add a fixed-high-water reverse JSONL reader using 64 KiB chunks; bounded log and latest-failure searches read at most 8 MiB per component while explicit-ID trace lookup remains exhaustive.
- Preserve correlation IDs and root-cause codes in concise results, expose coverage and truncation metadata, and emit an exact `--full` retry only when bounded evidence is incomplete.
- Stop recommending additional doctor or bundle calls after a root cause is resolved.
- Add the A1-A10 agent-debugging gate covering correctness, call count, output size, read budgets, escalation safety, and a 96 MiB performance fixture.
- Raise two test-only real-socket startup fixture budgets from 1-2 seconds to 5 seconds to keep the full suite stable under parallel local load; production timeouts are unchanged.

## Testing

- `env -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:all` — passed before the clean rebase onto current `main`.
- `pnpm gate:agent-debugging` — passed A1-A10 before rebase, including 7/7 diagnosis classification and the 96 MiB bounded-read comparison.
- `pnpm build:binary -- --version 0.0.0-pre-alpha.4` — passed.
- Post-rebase pre-push `pnpm lint` and Observer architecture validation — passed.

## Safety and scope

Defaults remain read-only where they were already read-only, and exhaustive evidence remains available through explicit `--full`. No protocol, provider boundary, schema, or production timeout changes are included. One earlier A9 p95 sample exceeded its threshold during a host-wide latency spike; the fixture and threshold were not changed, and subsequent exact reruns passed.