### PR TITLE
fix(observer): preserve binary handoff failure evidence

### DIFF
--- a/.github/workflows/binary-handoff-stress.yml
+++ b/.github/workflows/binary-handoff-stress.yml
@@ -1,0 +1,57 @@
+name: binary-handoff-stress
+
+on:
+  workflow_dispatch:
+    inputs:
+      rounds:
+        description: Immutable lower-to-higher handoff rounds (1-100)
+        required: true
+        type: number
+        default: 50
+
+permissions:
+  contents: read
+
+jobs:
+  stress:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-ci
+        with:
+          station-dependencies: "true"
+      - name: Validate requested rounds
+        env:
+          ROUNDS: ${{ inputs.rounds }}
+        run: |
+          case "$ROUNDS" in
+            ''|*[!0-9]*) echo "rounds must be an integer from 1 through 100" >&2; exit 2 ;;
+          esac
+          if [ "$ROUNDS" -lt 1 ] || [ "$ROUNDS" -gt 100 ]; then
+            echo "rounds must be an integer from 1 through 100" >&2
+            exit 2
+          fi
+      - name: Build immutable current artifact
+        run: pnpm build:binary -- --version 0.0.0-local
+      - name: Run binary handoff stress
+        id: binary_handoff_stress_run
+        env:
+          ROUNDS: ${{ inputs.rounds }}
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: ${{ runner.temp }}/station-binary-smoke-evidence
+        run: >-
+          pnpm stress:binary-handoff --
+          --expected-version 0.0.0-local
+          --rounds "$ROUNDS"
+          --round-timeout-ms 30000
+      - name: Upload binary handoff failure evidence
+        if: ${{ failure() && steps.binary_handoff_stress_run.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-smoke-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/station-binary-smoke-evidence
+          if-no-files-found: warn
+          retention-days: 3
+        continue-on-error: true

--- a/.github/workflows/standard-ci.yml
+++ b/.github/workflows/standard-ci.yml
@@ -225,7 +225,20 @@ jobs:
         with:
           station-dependencies: "true"
           restore-turbo-cache: ${{ github.event_name == 'pull_request' }}
-      - run: pnpm test:ci:binary
+      - name: Run binary smoke
+        id: binary_smoke_run
+        env:
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: ${{ runner.temp }}/station-binary-smoke-evidence
+        run: pnpm test:ci:binary
+      - name: Upload binary smoke failure evidence
+        if: ${{ failure() && steps.binary_smoke_run.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-smoke-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/station-binary-smoke-evidence
+          if-no-files-found: warn
+          retention-days: 3
+        continue-on-error: true
 
   standard-ci:
     name: standard-ci

--- a/apps/cli/src/observerProcess/startup.ts
+++ b/apps/cli/src/observerProcess/startup.ts
@@ -4,11 +4,11 @@ import type { ObserverHealth, SafeError } from "@station/contracts";
 import { redactString } from "@station/observability";
 import {
   Effect,
+  publicSafeErrorFromUnknown,
   type RuntimeBoundaryResult,
   type RuntimeClock,
   type RuntimeTraceContext,
   runRuntimeBoundaryWithTimeout,
-  withTimeout,
 } from "@station/runtime";
 import {
   observerHandoffRefusedError,
@@ -173,19 +173,25 @@ async function waitForStartedObserver(
       return outcome.health;
     }
 
+    let convergenceError: unknown;
     try {
       // A losing child can exit just before the winning observer becomes healthy, so preserve its retry loop briefly.
       return await waitForIncumbentHealth(healthPromise, healthController);
-    } catch {
+    } catch (error) {
       if (input.signal.aborted) {
         throw observerHealthWaitCancelledError();
       }
+      convergenceError = error;
     }
     if (replaceableIncumbent !== undefined) {
-      throw observerHandoffRefusedError(
+      throw await observerReplacementExitedError(
         replaceableIncumbent,
         input.buildVersion,
-        "The replacement process exited before publishing compatible health.",
+        input.paths,
+        input.child,
+        outcome.exit,
+        convergenceError,
+        input.trace,
       );
     }
     throw await observerExitedOnStartError(input.paths, input.child, outcome.exit, input.trace);
@@ -195,6 +201,38 @@ async function waitForStartedObserver(
     input.child.disposeExitWait?.();
     void healthPromise.catch(() => undefined);
   }
+}
+
+async function observerReplacementExitedError(
+  incumbent: ObserverHealth,
+  requestedVersion: string,
+  paths: SpawnObserverInput["paths"],
+  child: ChildProcessLike,
+  exit: ChildExitResult,
+  convergenceFailure: unknown,
+  trace: RuntimeTraceContext,
+): Promise<SafeError> {
+  const convergence = publicSafeErrorFromUnknown(convergenceFailure, {
+    tag: "ObserverStartupError",
+    code: "OBSERVER_HEALTH_FAILED",
+    message: "Observer health check failed during startup convergence.",
+  });
+  const convergenceDescription =
+    convergence.code === "OBSERVER_INCUMBENT_HEALTH_TIMEOUT"
+      ? `${convergence.code} after ${incumbentHealthGraceMs} ms`
+      : convergence.code;
+  const bootLogHint = await observerBootLogHint(paths, child);
+  const traceHint =
+    trace.traceId === undefined ? "" : `\nRun station debug trace ${trace.traceId}.`;
+  const error = observerHandoffRefusedError(
+    incumbent,
+    requestedVersion,
+    `Replacement child: ${childExitDescription(exit)}. Health convergence: ${convergenceDescription}.\n${bootLogHint}${traceHint}`,
+  );
+  if (trace.traceId !== undefined) {
+    error.traceId = trace.traceId;
+  }
+  return error;
 }
 
 async function observerExitedOnStartError(
@@ -240,21 +278,23 @@ async function observerBootLogHint(
     const pathHint = `Latest observer boot log: ${path}`;
     try {
       const tail = await child.readBootLogTail();
-      if (tail === undefined) return pathHint;
+      if (tail === undefined) {
+        return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
+      }
       return `${pathHint}\nThis attempt's last 15 lines (redacted):\n${redactString(tail)}`;
     } catch {
-      return pathHint;
+      return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
     }
   }
   const pathHint = `Observer boot log: ${path}`;
   try {
     const tail = await readObserverBootLogTail(path);
     if (tail === undefined) {
-      return pathHint;
+      return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
     }
     return `${pathHint}\nLast 15 lines (redacted):\n${redactString(tail)}`;
   } catch {
-    return pathHint;
+    return `${pathHint}\nBoot-log tail unavailable (missing, empty, or unreadable).`;
   }
 }
 
@@ -262,30 +302,27 @@ function waitForIncumbentHealth(
   healthPromise: Promise<ObserverHealth>,
   healthController: AbortController,
 ): Promise<ObserverHealth> {
-  return withTimeout(
-    async ({ signal }) => {
-      const cancelHealth = () => healthController.abort();
-      signal.addEventListener("abort", cancelHealth, { once: true });
-      try {
-        return await healthPromise;
-      } finally {
-        signal.removeEventListener("abort", cancelHealth);
-      }
-    },
-    {
-      timeoutMs: incumbentHealthGraceMs,
-      error: {
-        tag: "ObserverStartupError",
-        code: "OBSERVER_INCUMBENT_HEALTH_FAILED",
-        message: "Competing observer health check failed.",
-      },
-      timeoutError: {
+  // Reject before aborting so grace expiry remains distinct from the health poll's cancellation error.
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject({
         tag: "ObserverStartupError",
         code: "OBSERVER_INCUMBENT_HEALTH_TIMEOUT",
         message: "Competing observer did not become healthy during startup convergence.",
+      } satisfies SafeError);
+      healthController.abort();
+    }, incumbentHealthGraceMs);
+    void healthPromise.then(
+      (health) => {
+        clearTimeout(timeout);
+        resolve(health);
       },
-    },
-  );
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
 }
 
 async function disposeObserverBootLog(child: ChildProcessLike | undefined): Promise<void> {

--- a/apps/cli/test/unit/observer-process/startup.test.ts
+++ b/apps/cli/test/unit/observer-process/startup.test.ts
@@ -8,6 +8,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const higherBuildVersion = `2.0.0+station.${"a".repeat(64)}`;
+const lowerBuildVersion = `1.0.0+station.${"b".repeat(64)}`;
 
 const healthyObserver = (pid = 1234, version = stationObserverBuildVersion()) =>
   ({
@@ -272,31 +273,153 @@ describe("CLI observer process startup", () => {
     expect(kills).toBe(0);
   });
 
-  it("maps a child exit with only lower-build health remaining to handoff refusal", async () => {
+  it.each([
+    {
+      label: "exit code",
+      exit: { type: "exit" as const, code: 17, signal: null },
+      expected: "Replacement child: exit code 17",
+    },
+    {
+      label: "signal",
+      exit: { type: "exit" as const, code: null, signal: "SIGTERM" as const },
+      expected: "Replacement child: signal SIGTERM",
+    },
+    {
+      label: "spawn error",
+      exit: {
+        type: "spawn_error" as const,
+        error: new Error("launch failed with API_TOKEN=super-secret-value"),
+      },
+      expected: "Replacement child: spawn error: launch failed with API_TOKEN=[REDACTED]",
+    },
+    {
+      label: "unknown status",
+      exit: { type: "exit" as const, code: null, signal: null },
+      expected: "Replacement child: unknown exit status",
+    },
+  ])("retains a replacement child's $label under handoff refusal", async ({ exit, expected }) => {
     const fixture = await createTempState();
     let healthCalls = 0;
 
     const result = await startObserver(
       { config: fixture.config, timeoutMs: 2_000 },
       {
-        buildVersion: "2.0.0",
+        buildVersion: higherBuildVersion,
         spawnObserver: async () =>
           fakeChild({
             pid: 5678,
-            exited: Promise.resolve({ type: "exit", code: 1, signal: null }),
+            exited: Promise.resolve(exit),
           }),
         clientFactory: fakeClientFactory(async () => {
           healthCalls += 1;
-          return healthyObserver(1234, "1.0.0");
+          return healthyObserver(1234, lowerBuildVersion);
         }),
       },
     );
 
     expect(result).toMatchObject({
       status: "unhealthy",
-      error: { code: "OBSERVER_HANDOFF_REFUSED" },
+      error: { code: "OBSERVER_HANDOFF_REFUSED", traceId: expect.any(String) },
     });
+    expect(result.error?.hint).toContain(expected);
+    expect(result.error?.hint).toContain(
+      "Health convergence: OBSERVER_INCUMBENT_HEALTH_TIMEOUT after 1000 ms",
+    );
+    expect(result.error?.hint).toContain("Boot-log tail unavailable");
+    expect(result.error?.hint).toContain("1.0.0 (build bbbbbbbbbbbb)");
+    expect(result.error?.hint).toContain("2.0.0 (build aaaaaaaaaaaa)");
+    expect(result.error?.hint).toContain(`station debug trace ${result.error?.traceId}`);
+    expect(result.error?.hint).not.toContain("super-secret-value");
     expect(healthCalls).toBeGreaterThan(1);
+  });
+
+  it.each([
+    { delayMs: 999, expectedStatus: "running", expectedCode: undefined },
+    {
+      delayMs: 1_001,
+      expectedStatus: "unhealthy",
+      expectedCode: "OBSERVER_HANDOFF_REFUSED",
+    },
+  ])("keeps the one-second convergence boundary at $delayMs ms", async ({
+    delayMs,
+    expectedStatus,
+    expectedCode,
+  }) => {
+    const fixture = await createTempState();
+    const replacementHealthObserved = deferred<void>();
+    const childExited = deferred<{ type: "exit"; code: number; signal: null }>();
+    const compatibleHealth = deferred<ReturnType<typeof healthyObserver>>();
+    let healthCalls = 0;
+
+    vi.useFakeTimers();
+    try {
+      const startup = startObserver(
+        { config: fixture.config, timeoutMs: 5_000 },
+        {
+          buildVersion: higherBuildVersion,
+          spawnObserver: async () =>
+            fakeChild({
+              pid: 5678,
+              exited: childExited.promise,
+            }),
+          clientFactory: fakeClientFactory(async () => {
+            healthCalls += 1;
+            if (healthCalls <= 2) {
+              if (healthCalls === 2) replacementHealthObserved.resolve(undefined);
+              return healthyObserver(1234, lowerBuildVersion);
+            }
+            return compatibleHealth.promise;
+          }),
+        },
+      );
+      await replacementHealthObserved.promise;
+      await vi.advanceTimersByTimeAsync(0);
+      childExited.resolve({ type: "exit", code: 0, signal: null });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(delayMs);
+      compatibleHealth.resolve(healthyObserver(9876, higherBuildVersion));
+      await vi.advanceTimersByTimeAsync(0);
+      const result = await startup;
+
+      expect(result.status).toBe(expectedStatus);
+      expect(result.error?.code).toBe(expectedCode);
+      if (delayMs === 1_001) {
+        expect(result.error?.hint).toContain(
+          "Health convergence: OBSERVER_INCUMBENT_HEALTH_TIMEOUT after 1000 ms",
+        );
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains a normalized health rejection and the child-owned boot tail", async () => {
+    const fixture = await createTempState();
+    let healthCalls = 0;
+
+    const result = await startObserver(
+      { config: fixture.config, timeoutMs: 5_000 },
+      {
+        buildVersion: higherBuildVersion,
+        spawnObserver: async () =>
+          fakeChild({
+            exited: Promise.resolve({ type: "exit", code: 1, signal: null }),
+            readBootLogTail: async () => "startup failed with API_TOKEN=super-secret-value",
+          }),
+        clientFactory: fakeClientFactory(async () => {
+          healthCalls += 1;
+          return healthCalls <= 2
+            ? healthyObserver(1234, lowerBuildVersion)
+            : healthyObserver(9876, `2.0.0+station.${"c".repeat(64)}`);
+        }),
+      },
+    );
+
+    expect(result.error?.code).toBe("OBSERVER_HANDOFF_REFUSED");
+    expect(result.error?.hint).toContain("Health convergence: OBSERVER_HANDOFF_REFUSED");
+    expect(result.error?.hint).toContain("This attempt's last 15 lines (redacted):");
+    expect(result.error?.hint).toContain("API_TOKEN=[REDACTED]");
+    expect(result.error?.hint).not.toContain("super-secret-value");
   });
 
   it("lets the outer startup timeout preempt incumbent convergence", async () => {
@@ -425,6 +548,7 @@ describe("CLI observer process startup", () => {
     );
 
     expect(result.error?.hint).toContain(`Observer boot log: ${bootLogPath}`);
+    expect(result.error?.hint).toContain("Boot-log tail unavailable");
     expect(result.error?.hint).not.toContain("Last 15 lines");
   });
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -202,13 +202,16 @@ version (`0.7.0` in this example).
 
 `OBSERVER_HANDOFF_REFUSED` means automatic build or cross-version replacement
 could not proceed safely. Read the running/requested display versions and build
-IDs in the error. A same-version legacy or losing identified build with stable
-PID/start-time health can be stopped explicitly; missing process identity
-refuses rather than risking a successor. It must not attach to different code.
-Inspect `logs/observer-boot.log`, compare `lsof -t <socket>` with the
-strict pidfile and `ps -ww -p <pid> -o lstart=,command=`, then retry only after
-resolving missing or conflicting evidence. Automatic handoff never uses
-SIGKILL.
+IDs in the error. When a replacement child exits, the error also reports its
+exit code, signal, redacted spawn error, or unknown status; the health rejection
+code or unchanged one-second convergence expiry; and that child's bounded,
+redacted boot-log tail or an explicit unavailable marker. Use the included
+trace ID against the same state directory. A same-version legacy or losing
+identified build with stable PID/start-time health can be stopped explicitly;
+missing process identity refuses rather than risking a successor. It must not
+attach to different code. Compare `lsof -t <socket>` with the strict pidfile and
+`ps -ww -p <pid> -o lstart=,command=`, then retry only after resolving missing
+or conflicting evidence. Automatic handoff never uses SIGKILL.
 
 After startup reconcile, the Observer performs one report-only duplicate
 inspection. `stn doctor` reports this as `observer-singleton`: an eligible
@@ -239,6 +242,7 @@ the client; a scoped `tsc` output is not an identified whole-repository build.
 ## Reading Evidence
 
 - `logs/observer-boot.log` is the raw, local-only record of the latest observer startup attempt. Each attempt atomically replaces it at mode `0600` with a JSON-encoded command header followed by that child's stdout/stderr. It sits outside structured `stn debug logs`; an `OBSERVER_EXITED_ON_START` error includes the latest path and, when available, a redacted final 15-line tail captured from its own failed child.
+- A failed hosted binary smoke can upload `binary-smoke-evidence-<run-id>-<attempt>` for three days. Download it with `gh run download <run-id> --name binary-smoke-evidence-<run-id>-<attempt> --dir /tmp/station-binary-smoke-evidence-<run-id>`, then read `manifest.json` before the round's `failure.json`, bounded logs, and runtime summary. The bundle is redacted, allowlisted, and capped at 1 MiB, but collaborators with Actions access can download it. Do not run `stn debug trace` against unrelated live state and treat it as evidence for the downloaded CI run.
 - `observer.claim.sqlite` is boot-exclusion evidence only. Inspect it with
   read-only SQLite tooling after confirming no startup is in progress; never
   infer ownership from the file or sidecars being present.

--- a/docs/development.md
+++ b/docs/development.md
@@ -194,6 +194,9 @@ smoke runs when production, binary, dependency, or CI infrastructure changes. Ob
 changes use the exhaustive claim-race counts, while setup- and Worktrunk-sensitive changes retain
 both bash and zsh process-level setup coverage. One aggregate job named `standard-ci` preserves the
 repository ruleset contract and fails if a mandatory or path-selected lane is unexpectedly skipped.
+A failed binary-smoke step best-effort uploads one redacted, allowlisted evidence directory capped at
+1 MiB with three-day retention; a successful step creates and uploads no evidence directory, and
+artifact upload failure cannot mask the smoke failure.
 
 Release tags select every lane, use the exhaustive claim-race counts and both setup shell paths, and
 call that parallel gate before adding the four native build and draft-install targets. Both `standard-ci` and
@@ -342,6 +345,48 @@ runs the lower identity as incumbent, replaces it with the higher identity, and
 verifies that a later mutating command from the loser is refused without
 changing the Observer, Station Host, or live PTY. It requires a committed clean
 checkout so the detached-worktree artifact has one controlled source delta.
+
+For a local failure bundle, name an absolute path that does not exist and is
+outside the smoke root:
+
+```bash
+STATION_BINARY_SMOKE_EVIDENCE_DIR=/absolute/new/path \
+  pnpm smoke:binary -- --expected-version 0.0.0-local
+```
+
+The runner creates that private directory only for failure or cancellation,
+captures evidence before teardown, records cleanup afterward, and preserves the
+original failure. Inspect `manifest.json` first. In hosted CI, use:
+
+```bash
+gh run download <run-id> \
+  --name binary-smoke-evidence-<run-id>-<attempt> \
+  --dir /tmp/station-binary-smoke-evidence-<run-id>
+```
+
+The focused handoff stress reuses immutable current and alternate binaries for
+fresh isolated rounds and stops at the first failure without rebuilding or
+retrying a handoff:
+
+```bash
+STATION_BINARY_SMOKE_EVIDENCE_DIR=/absolute/new/path \
+  pnpm stress:binary-handoff -- \
+  --expected-version 0.0.0-local \
+  --rounds 50 \
+  --round-timeout-ms 30000
+```
+
+Each round proves the logical lower-to-higher replacement, exact PID/build and
+socket/pidfile ownership, one healthy Observer, live Host PTY continuity, and
+then the reverse physical call's deterministic reuse or refusal without winner
+mutation. With one fixed artifact pair, that reverse call is not a second valid
+replacement direction. The `Binary handoff stress` workflow exposes the same
+lane through manual dispatch on Ubuntu 24.04 with at most 100 rounds; it is not a
+required PR or nightly lane. If rounds were independent at the previously
+observed 13.8% failure rate, 50 rounds would have about a 99.94% chance of a
+failure and zero failures would imply only an approximate one-sided 95% upper
+bound of 5.8% (about 3% for 100 and 1% for 300). Hosted timing can be correlated,
+so these runs increase confidence but do not prove absence.
 
 To inspect the UX manually after the smoke:
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "station:devbox:smoke": "node scripts/test-runners/run-station-devbox-smoke.mjs",
     "station:devbox:tmux:smoke": "node scripts/test-runners/run-station-tmux-devbox-smoke.mjs",
     "smoke:binary": "node scripts/test-runners/run-binary-smoke.mjs",
+    "stress:binary-handoff": "node scripts/test-runners/run-binary-smoke.mjs --mode handoff-stress",
     "smoke:install": "node scripts/test-runners/run-install-smoke.mjs",
     "typecheck": "turbo run typecheck",
     "architecture:observer:generate": "node tools/lint/check-observer-architecture.mjs --write",
@@ -91,6 +92,7 @@
     "lefthook": "^1.13.6",
     "turbo": "^2.9.15",
     "typescript": "^5.9.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "zod": "^4.1.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0)
+      zod:
+        specifier: ^4.1.12
+        version: 4.4.3
 
   apps/cli:
     dependencies:

--- a/scripts/test-runners/binary-smoke-evidence.mjs
+++ b/scripts/test-runners/binary-smoke-evidence.mjs
@@ -1,0 +1,761 @@
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, mkdir, open, readdir, readFile, rename } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+import {
+  DiagnosticEvidenceIndexSchema,
+  ErrorEnvelopeSchema,
+  LogRecordSchema,
+  ObserverProcessIdentitySchema,
+} from "../../packages/contracts/dist/index.js";
+import {
+  mergeRedactionReports,
+  REDACTION_POLICY_VERSION,
+  redact,
+} from "../../packages/observability/dist/index.js";
+import { readUnixSocketHolderPids } from "../../packages/protocol/dist/index.js";
+
+export const BINARY_SMOKE_EVIDENCE_LIMITS = Object.freeze({
+  maxTotalBytes: 1_048_576,
+  maxFileBytes: 131_072,
+  maxLogLines: 200,
+  maxBootLines: 100,
+});
+
+const manifestMaxBytes = 65_536;
+const failureMaxBytes = 32_768;
+const runtimeMaxBytes = 32_768;
+const bootMaxBytes = 65_536;
+const diagnosticErrorsMaxBytes = 65_536;
+const diagnosticErrorLines = 100;
+const outputStatusSchema = z.enum(["failed", "cancelled"]);
+const fileStatusSchema = z.enum([
+  "captured",
+  "missing",
+  "malformed",
+  "refused_symlink",
+  "read_error",
+  "budget_exhausted",
+]);
+const exitDispositionSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("code"), code: z.number().int() }).strict(),
+  z.object({ type: z.literal("signal"), signal: z.string().min(1) }).strict(),
+  z.object({ type: z.literal("spawn_error"), message: z.string() }).strict(),
+  z.object({ type: z.literal("unknown") }).strict(),
+  z.object({ type: z.literal("unavailable") }).strict(),
+]);
+const artifactSchema = z
+  .object({
+    path: z.string().min(1),
+    displayVersion: z.string().min(1),
+    buildIdentity: z.string().min(1),
+  })
+  .strict();
+const artifactLabelSchema = z.enum(["current", "alternate", "source"]);
+const capturedFileSchema = z
+  .object({
+    path: z.string().min(1),
+    source: z.string().min(1),
+    status: fileStatusSchema,
+    bytes: z.number().int().nonnegative().optional(),
+    lines: z.number().int().nonnegative().optional(),
+    truncated: z.boolean().optional(),
+  })
+  .strict();
+const cleanupSchema = z
+  .object({
+    status: z.enum(["pending", "complete", "incomplete"]),
+    observerExited: z.boolean(),
+    hostExited: z.boolean(),
+    socketRemoved: z.boolean(),
+    pidfileRemoved: z.boolean(),
+  })
+  .strict();
+const runtimeProcessSchema = z
+  .object({
+    role: z.string().min(1),
+    pid: z.number().int().positive(),
+    exists: z.boolean(),
+  })
+  .strict();
+const runtimeSocketSchema = z
+  .object({
+    status: z.enum(["socket", "missing", "non_socket", "refused_symlink", "read_error"]),
+    holderPids: z.array(z.number().int().positive()).optional(),
+  })
+  .strict();
+const runtimePidfileSchema = z
+  .object({
+    status: z.enum(["parsed", "missing", "malformed", "refused_symlink", "read_error"]),
+    pid: z.number().int().positive().optional(),
+    buildIdentity: z.string().min(12).optional(),
+  })
+  .strict();
+const manifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    kind: z.literal("station-binary-smoke-failure"),
+    status: outputStatusSchema,
+    capturedAt: z.iso.datetime(),
+    limits: z
+      .object({
+        maxTotalBytes: z.literal(BINARY_SMOKE_EVIDENCE_LIMITS.maxTotalBytes),
+        maxFileBytes: z.literal(BINARY_SMOKE_EVIDENCE_LIMITS.maxFileBytes),
+        maxLogLines: z.literal(BINARY_SMOKE_EVIDENCE_LIMITS.maxLogLines),
+        maxBootLines: z.literal(BINARY_SMOKE_EVIDENCE_LIMITS.maxBootLines),
+      })
+      .strict(),
+    rounds: z.array(
+      z
+        .object({
+          round: z.number().int().positive(),
+          elapsedMs: z.number().int().nonnegative(),
+          direction: z.object({ logical: z.string().min(1), physical: z.string().min(1) }).strict(),
+          failure: z
+            .object({
+              message: z.string(),
+              command: z
+                .object({ artifact: z.string().min(1), argv: z.array(z.string()) })
+                .strict()
+                .optional(),
+              exitDisposition: exitDispositionSchema,
+            })
+            .strict(),
+          artifacts: z
+            .object({
+              current: artifactSchema,
+              alternate: artifactSchema,
+              source: artifactSchema.optional(),
+              incumbent: artifactLabelSchema,
+              requested: artifactLabelSchema,
+            })
+            .strict(),
+          correlation: z
+            .object({ traceIds: z.array(z.string()), diagnosticIds: z.array(z.string()) })
+            .strict(),
+          runtime: z
+            .object({
+              socket: runtimeSocketSchema,
+              pidfile: runtimePidfileSchema,
+              processes: z.array(runtimeProcessSchema),
+            })
+            .strict(),
+          files: z.array(capturedFileSchema),
+          cleanup: cleanupSchema,
+        })
+        .strict(),
+    ),
+    redaction: z
+      .object({
+        policyVersion: z.literal(REDACTION_POLICY_VERSION),
+        replacements: z.number().int().nonnegative(),
+        suspiciousSecretsFound: z.number().int().nonnegative(),
+      })
+      .strict(),
+    warnings: z.array(z.string()),
+  })
+  .strict();
+
+const allowedLogAttributes = new Set([
+  "attempt",
+  "buildIdentity",
+  "candidateBuildIdentity",
+  "code",
+  "diagnosticId",
+  "durationMs",
+  "elapsedMs",
+  "healthStatus",
+  "incumbentBuildIdentity",
+  "incumbentPid",
+  "operation",
+  "pid",
+  "processRole",
+  "processToken",
+  "requestedBuildIdentity",
+  "result",
+  "sequence",
+  "signal",
+  "stage",
+  "traceId",
+  "version",
+]);
+
+export {
+  exitDispositionSchema as BinarySmokeExitDispositionSchema,
+  manifestSchema as BinarySmokeEvidenceManifestSchema,
+};
+
+export async function captureBinarySmokeEvidence(input) {
+  validateEvidenceSources(input.stateDir, input.socketPath, input.smokeRoot);
+  validateEvidenceDestination(input.evidenceDir, input.smokeRoot);
+  const capturedAt = (input.now ?? new Date()).toISOString();
+  const roundName = `${String(input.round).padStart(4, "0")}-${safeName(input.direction.physical)}`;
+  const roundRoot = `rounds/${roundName}`;
+  await createPrivateDirectory(input.evidenceDir);
+  await createPrivateDirectory(resolve(input.evidenceDir, "rounds"));
+  await createPrivateDirectory(resolve(input.evidenceDir, roundRoot));
+
+  const state = {
+    input,
+    capturedAt,
+    files: [],
+    redactionReports: [],
+    warnings: [],
+    bytesWritten: 0,
+    correlations: { traceIds: new Set(), diagnosticIds: new Set() },
+  };
+  const failure = failureRecord(input, state);
+  const runtime = await runtimeRecord(input, state);
+
+  await writePriorityJson(
+    state,
+    `${roundRoot}/failure.json`,
+    "runner/failure",
+    failure,
+    failureMaxBytes,
+  );
+  await writePriorityJson(
+    state,
+    `${roundRoot}/runtime/summary.json`,
+    "runtime/socket-pidfile-process-summary",
+    runtime,
+    runtimeMaxBytes,
+  );
+
+  if (input.status === "failed") {
+    await captureBootLog(state, roundRoot);
+    await captureLog(state, roundRoot, "observer.jsonl");
+    await captureLog(state, roundRoot, "cli.jsonl");
+    await captureDiagnostics(state, roundRoot);
+  }
+
+  const redaction = mergeRedactionReports(state.redactionReports, capturedAt);
+  const manifest = manifestSchema.parse({
+    schemaVersion: 1,
+    kind: "station-binary-smoke-failure",
+    status: input.status,
+    capturedAt,
+    limits: BINARY_SMOKE_EVIDENCE_LIMITS,
+    rounds: [
+      {
+        round: input.round,
+        elapsedMs: Math.max(0, Math.round(input.elapsedMs)),
+        direction: input.direction,
+        failure,
+        artifacts: replaceSmokeRoot(input.artifacts, input.smokeRoot),
+        correlation: {
+          traceIds: [...state.correlations.traceIds].sort(),
+          diagnosticIds: [...state.correlations.diagnosticIds].sort(),
+        },
+        runtime,
+        files: state.files,
+        cleanup: {
+          status: "pending",
+          observerExited: false,
+          hostExited: false,
+          socketRemoved: false,
+          pidfileRemoved: false,
+        },
+      },
+    ],
+    redaction: {
+      policyVersion: REDACTION_POLICY_VERSION,
+      replacements: redaction.replacements,
+      suspiciousSecretsFound: redaction.suspiciousSecretsFound,
+    },
+    warnings: state.warnings,
+  });
+  const manifestBytes = jsonBytes(manifest);
+  if (manifestBytes.length > manifestMaxBytes) {
+    throw new Error(`Binary smoke evidence manifest exceeded ${manifestMaxBytes} bytes.`);
+  }
+  if (state.bytesWritten + manifestBytes.length > BINARY_SMOKE_EVIDENCE_LIMITS.maxTotalBytes) {
+    throw new Error("Binary smoke evidence exceeded its total byte budget before manifest write.");
+  }
+  await atomicWrite(resolve(input.evidenceDir, "manifest.json"), manifestBytes);
+  return manifest;
+}
+
+function validateEvidenceSources(stateDir, socketPath, smokeRoot) {
+  const root = resolve(smokeRoot);
+  if (resolve(stateDir) !== resolve(root, "state")) {
+    throw new Error(
+      "Binary smoke evidence state directory must be the smoke root's state directory.",
+    );
+  }
+  const socket = resolve(socketPath);
+  if (socket === root || !socket.startsWith(`${root}${sep}`)) {
+    throw new Error("Binary smoke evidence socket must be beneath the smoke root.");
+  }
+}
+
+export async function finalizeBinarySmokeEvidence(input) {
+  const manifestPath = resolve(input.evidenceDir, "manifest.json");
+  const stats = await lstat(manifestPath);
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new Error("Binary smoke evidence manifest is not a regular file.");
+  }
+  const source = await readFile(manifestPath, "utf8");
+  if (Buffer.byteLength(source) > manifestMaxBytes) {
+    throw new Error("Binary smoke evidence manifest exceeds its read limit.");
+  }
+  const manifest = manifestSchema.parse(JSON.parse(source));
+  const [round] = manifest.rounds;
+  if (round === undefined) throw new Error("Binary smoke evidence manifest has no round.");
+  round.cleanup = cleanupSchema.parse(input.cleanup);
+  round.runtime.processes = input.processes.map((process) => runtimeProcessSchema.parse(process));
+  manifest.warnings.push(...input.warnings.map((warning) => boundedText(warning, 1_000)));
+  const bytes = jsonBytes(manifestSchema.parse(manifest));
+  if (bytes.length > manifestMaxBytes) {
+    throw new Error(`Binary smoke evidence manifest exceeded ${manifestMaxBytes} bytes.`);
+  }
+  await atomicWrite(manifestPath, bytes, true);
+}
+
+function validateEvidenceDestination(evidenceDir, smokeRoot) {
+  if (!isAbsolute(evidenceDir)) {
+    throw new Error("STATION_BINARY_SMOKE_EVIDENCE_DIR must be absolute.");
+  }
+  const output = resolve(evidenceDir);
+  const root = resolve(smokeRoot);
+  if (output === root || output.startsWith(`${root}${sep}`) || root.startsWith(`${output}${sep}`)) {
+    throw new Error("STATION_BINARY_SMOKE_EVIDENCE_DIR must be outside the smoke root.");
+  }
+}
+
+async function createPrivateDirectory(path) {
+  await mkdir(path, { mode: 0o700 });
+  const stats = await lstat(path);
+  if (!stats.isDirectory() || stats.isSymbolicLink() || (stats.mode & 0o077) !== 0) {
+    throw new Error(`Evidence path is not a private directory: ${path}`);
+  }
+}
+
+function failureRecord(input, state) {
+  const rawMessage = input.failure?.message ?? errorMessage(input.error);
+  const redactedMessage = redactValue(replaceSmokeRoot(rawMessage, input.smokeRoot), state);
+  collectCorrelations(redactedMessage, state.correlations);
+  const result = {
+    message: boundedText(redactedMessage, 16_384),
+    exitDisposition: exitDispositionSchema.parse(
+      redactValue(input.failure?.exitDisposition ?? { type: "unavailable" }, state),
+    ),
+  };
+  if (input.failure?.command !== undefined) {
+    result.command = redactValue(replaceSmokeRoot(input.failure.command, input.smokeRoot), state);
+  }
+  return result;
+}
+
+async function runtimeRecord(input, state) {
+  const socket = await socketSummary(input.socketPath, input.smokeRoot);
+  const pidfile = await pidfileSummary(`${input.socketPath}.pid`, input.smokeRoot);
+  const processes = input.knownProcesses.map(({ role, pid }) => ({
+    role,
+    pid,
+    exists: processExists(pid),
+  }));
+  const runtime = { socket, pidfile, processes };
+  return redactValue(runtime, state);
+}
+
+async function socketSummary(path, smokeRoot) {
+  const checked = await secureSource(path, smokeRoot, false);
+  if (checked.status !== "ready") return { status: checked.status };
+  if (!checked.stats.isSocket()) return { status: "non_socket" };
+  try {
+    return { status: "socket", holderPids: readUnixSocketHolderPids(path) };
+  } catch {
+    return { status: "socket" };
+  }
+}
+
+async function pidfileSummary(path, smokeRoot) {
+  const read = await boundedSourceRead(path, smokeRoot, BINARY_SMOKE_EVIDENCE_LIMITS.maxFileBytes);
+  if (read.status !== "ready") return { status: read.status };
+  try {
+    const identity = ObserverProcessIdentitySchema.parse(JSON.parse(read.bytes.toString("utf8")));
+    const buildIdentity = identity.version.match(/station\.([0-9a-f]{64})$/)?.[1];
+    const summary = { status: "parsed", pid: identity.pid };
+    if (buildIdentity !== undefined) summary.buildIdentity = buildIdentity.slice(0, 12);
+    return summary;
+  } catch {
+    return { status: "malformed" };
+  }
+}
+
+async function captureBootLog(state, roundRoot) {
+  const source = resolve(state.input.stateDir, "logs/observer-boot.log");
+  const read = await boundedSourceRead(source, state.input.smokeRoot, bootMaxBytes, true);
+  const output = `${roundRoot}/observer-boot.log`;
+  if (read.status !== "ready")
+    return recordUnavailable(state, output, "state/logs/observer-boot.log", read.status);
+  const lines = tailLines(
+    read.bytes.toString("utf8"),
+    BINARY_SMOKE_EVIDENCE_LIMITS.maxBootLines,
+    read.truncated,
+  );
+  const content = redactValue(replaceSmokeRoot(lines.join("\n"), state.input.smokeRoot), state);
+  collectCorrelations(content, state.correlations);
+  await writeCaptured(state, output, "state/logs/observer-boot.log", Buffer.from(`${content}\n`), {
+    lines: lines.length,
+    truncated: read.truncated || lines.length >= BINARY_SMOKE_EVIDENCE_LIMITS.maxBootLines,
+    maxBytes: bootMaxBytes,
+  });
+}
+
+async function captureLog(state, roundRoot, name) {
+  const sourceName = `state/logs/${name}`;
+  const source = resolve(state.input.stateDir, `logs/${name}`);
+  const read = await boundedSourceRead(
+    source,
+    state.input.smokeRoot,
+    BINARY_SMOKE_EVIDENCE_LIMITS.maxFileBytes,
+    true,
+  );
+  const output = `${roundRoot}/logs/${name}`;
+  if (read.status !== "ready") return recordUnavailable(state, output, sourceName, read.status);
+  const parsed = parseJsonlTail(
+    read.bytes.toString("utf8"),
+    LogRecordSchema,
+    BINARY_SMOKE_EVIDENCE_LIMITS.maxLogLines,
+    read.truncated,
+  );
+  if (parsed.status === "malformed")
+    return recordUnavailable(state, output, sourceName, "malformed");
+  const records = parsed.records.filter(relevantLogRecord).map(stripLogRecord);
+  const redacted = redactValue(replaceSmokeRoot(records, state.input.smokeRoot), state);
+  for (const record of redacted) collectCorrelations(record, state.correlations);
+  const bytes = Buffer.from(`${redacted.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  await writeCaptured(state, output, sourceName, bytes, {
+    lines: redacted.length,
+    truncated: read.truncated || parsed.truncated,
+  });
+}
+
+async function captureDiagnostics(state, roundRoot) {
+  const diagnosticsRoot = resolve(state.input.stateDir, "diagnostics");
+  const checked = await secureSource(diagnosticsRoot, state.input.smokeRoot, false);
+  if (checked.status !== "ready" || !checked.stats.isDirectory()) return;
+  let entries;
+  try {
+    entries = (await readdir(diagnosticsRoot, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory() && !entry.isSymbolicLink())
+      .map((entry) => entry.name)
+      .sort()
+      .reverse()
+      .slice(0, 2);
+  } catch (error) {
+    state.warnings.push(`Could not enumerate diagnostic evidence: ${errorMessage(error)}`);
+    return;
+  }
+  for (const [index, directory] of entries.entries()) {
+    const suffix = index === 0 ? "" : `-${index + 1}`;
+    await captureDiagnosticIndex(state, roundRoot, diagnosticsRoot, directory, suffix);
+    await captureDiagnosticErrors(state, roundRoot, diagnosticsRoot, directory, suffix);
+  }
+}
+
+async function captureDiagnosticIndex(state, roundRoot, diagnosticsRoot, directory, suffix) {
+  const sourceName = `state/diagnostics/${directory}/diagnostic-index.json`;
+  const output = `${roundRoot}/diagnostics/diagnostic-index${suffix}.json`;
+  const read = await boundedSourceRead(
+    resolve(diagnosticsRoot, directory, "diagnostic-index.json"),
+    state.input.smokeRoot,
+    BINARY_SMOKE_EVIDENCE_LIMITS.maxFileBytes,
+  );
+  if (read.status !== "ready") return recordUnavailable(state, output, sourceName, read.status);
+  try {
+    const parsed = DiagnosticEvidenceIndexSchema.parse(JSON.parse(read.bytes.toString("utf8")));
+    const redacted = redactValue(replaceSmokeRoot(parsed, state.input.smokeRoot), state);
+    collectCorrelations(redacted, state.correlations);
+    await writeCaptured(state, output, sourceName, jsonBytes(redacted), { truncated: false });
+  } catch {
+    recordUnavailable(state, output, sourceName, "malformed");
+  }
+}
+
+async function captureDiagnosticErrors(state, roundRoot, diagnosticsRoot, directory, suffix) {
+  const sourceName = `state/diagnostics/${directory}/errors.jsonl`;
+  const output = `${roundRoot}/diagnostics/errors${suffix}.jsonl`;
+  const read = await boundedSourceRead(
+    resolve(diagnosticsRoot, directory, "errors.jsonl"),
+    state.input.smokeRoot,
+    diagnosticErrorsMaxBytes,
+    true,
+  );
+  if (read.status !== "ready") return recordUnavailable(state, output, sourceName, read.status);
+  const parsed = parseJsonlTail(
+    read.bytes.toString("utf8"),
+    ErrorEnvelopeSchema,
+    diagnosticErrorLines,
+    read.truncated,
+  );
+  if (parsed.status === "malformed")
+    return recordUnavailable(state, output, sourceName, "malformed");
+  const errors = parsed.records.map(stripErrorEnvelope);
+  const redacted = redactValue(replaceSmokeRoot(errors, state.input.smokeRoot), state);
+  for (const error of redacted) collectCorrelations(error, state.correlations);
+  const bytes = Buffer.from(`${redacted.map((error) => JSON.stringify(error)).join("\n")}\n`);
+  await writeCaptured(state, output, sourceName, bytes, {
+    lines: redacted.length,
+    truncated: read.truncated || parsed.truncated,
+    maxBytes: diagnosticErrorsMaxBytes,
+  });
+}
+
+async function boundedSourceRead(path, smokeRoot, maxBytes, fromEnd = false) {
+  const checked = await secureSource(path, smokeRoot, true);
+  if (checked.status !== "ready") return checked;
+  let handle;
+  try {
+    handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.dev !== checked.stats.dev || opened.ino !== checked.stats.ino) {
+      return { status: "read_error" };
+    }
+    const length = Math.min(opened.size, maxBytes);
+    const bytes = Buffer.alloc(length);
+    const position = fromEnd ? Math.max(0, opened.size - length) : 0;
+    const result = await handle.read(bytes, 0, length, position);
+    return {
+      status: "ready",
+      bytes: bytes.subarray(0, result.bytesRead),
+      truncated: opened.size > length,
+    };
+  } catch {
+    return { status: "read_error" };
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function secureSource(path, smokeRoot, requireFile) {
+  const root = resolve(smokeRoot);
+  const target = resolve(path);
+  if (target === root || !target.startsWith(`${root}${sep}`)) return { status: "read_error" };
+  const segments = relative(root, target).split(sep);
+  let current = root;
+  try {
+    for (const [index, segment] of segments.entries()) {
+      if (segment === "" || segment === "." || segment === "..") return { status: "read_error" };
+      current = resolve(current, segment);
+      const stats = await lstat(current);
+      if (stats.isSymbolicLink()) return { status: "refused_symlink" };
+      if (index < segments.length - 1 && !stats.isDirectory()) return { status: "read_error" };
+      if (index === segments.length - 1) {
+        if (requireFile && !stats.isFile()) return { status: "read_error" };
+        return { status: "ready", stats };
+      }
+    }
+  } catch (error) {
+    return error?.code === "ENOENT" ? { status: "missing" } : { status: "read_error" };
+  }
+  return { status: "read_error" };
+}
+
+async function writePriorityJson(state, output, source, value, maxBytes) {
+  let bytes = jsonBytes(value);
+  let truncated = false;
+  if (bytes.length > maxBytes) {
+    truncated = true;
+    bytes = jsonBytes({
+      message: boundedText(value.message ?? "Evidence exceeded its file cap.", maxBytes / 2),
+    });
+    state.warnings.push(`${source} was reduced to fit its ${maxBytes}-byte cap.`);
+  }
+  await writeCaptured(state, output, source, bytes, { truncated, maxBytes });
+}
+
+async function writeCaptured(state, output, source, bytes, metadata) {
+  const { maxBytes = BINARY_SMOKE_EVIDENCE_LIMITS.maxFileBytes, ...fileMetadata } = metadata;
+  if (bytes.length > maxBytes) {
+    state.warnings.push(`${source} exceeded the per-file evidence cap.`);
+    recordUnavailable(state, output, source, "budget_exhausted");
+    return;
+  }
+  if (
+    state.bytesWritten + bytes.length + manifestMaxBytes >
+    BINARY_SMOKE_EVIDENCE_LIMITS.maxTotalBytes
+  ) {
+    recordUnavailable(state, output, source, "budget_exhausted");
+    return;
+  }
+  const path = resolve(state.input.evidenceDir, output);
+  await createParentDirectories(path, state.input.evidenceDir);
+  await atomicWrite(path, bytes);
+  state.bytesWritten += bytes.length;
+  state.files.push({
+    path: output,
+    source,
+    status: "captured",
+    bytes: bytes.length,
+    ...fileMetadata,
+  });
+}
+
+function recordUnavailable(state, output, source, status) {
+  state.files.push({ path: output, source, status: fileStatusSchema.parse(status) });
+}
+
+async function createParentDirectories(path, evidenceDir) {
+  const parent = dirname(path);
+  const relativeParent = relative(resolve(evidenceDir), parent);
+  let current = resolve(evidenceDir);
+  for (const segment of relativeParent.split(sep)) {
+    if (segment.length === 0) continue;
+    current = resolve(current, segment);
+    try {
+      await mkdir(current, { mode: 0o700 });
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+    const stats = await lstat(current);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw new Error(`Evidence output component is not a directory: ${current}`);
+    }
+  }
+}
+
+async function atomicWrite(path, bytes, replace = false) {
+  if (!replace) {
+    try {
+      await lstat(path);
+      throw new Error(`Evidence output already exists: ${path}`);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  const temporary = resolve(dirname(path), `.${randomUUID()}.tmp`);
+  const handle = await open(temporary, "wx", 0o600);
+  try {
+    await handle.chmod(0o600);
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  await rename(temporary, path);
+}
+
+function parseJsonlTail(source, schema, maxLines, truncatedBytes) {
+  const lines = source.split(/\r?\n/);
+  if (truncatedBytes) lines.shift();
+  const candidates = lines.filter((line) => line.trim().length > 0).slice(-maxLines);
+  const records = [];
+  for (const line of candidates) {
+    try {
+      const result = schema.safeParse(JSON.parse(line));
+      if (result.success) records.push(result.data);
+    } catch {
+      // A malformed record is ignored only when other strict records remain useful.
+    }
+  }
+  return records.length === 0 && candidates.length > 0
+    ? { status: "malformed" }
+    : { status: "captured", records, truncated: candidates.length >= maxLines };
+}
+
+function relevantLogRecord(record) {
+  return (
+    record.traceId !== undefined ||
+    record.commandId !== undefined ||
+    record.attributes?.diagnosticId !== undefined ||
+    /observer|handoff|startup|health|socket|pidfile|claim|bind/i.test(record.message)
+  );
+}
+
+function stripLogRecord(record) {
+  const result = {
+    timestamp: record.timestamp,
+    level: record.level,
+    component: record.component,
+    message: record.message,
+  };
+  for (const key of ["traceId", "spanId", "commandId"]) {
+    if (record[key] !== undefined) result[key] = record[key];
+  }
+  if (record.attributes !== undefined) {
+    const attributes = Object.fromEntries(
+      Object.entries(record.attributes).filter(([key]) => allowedLogAttributes.has(key)),
+    );
+    if (Object.keys(attributes).length > 0) result.attributes = attributes;
+  }
+  return result;
+}
+
+function stripErrorEnvelope(error) {
+  const result = {
+    id: error.id,
+    tag: error.tag,
+    code: error.code,
+    message: error.message,
+    severity: error.severity,
+    redacted: error.redacted,
+    createdAt: error.createdAt,
+  };
+  for (const key of ["commandId", "traceId", "spanId", "diagnosticId"]) {
+    if (error[key] !== undefined) result[key] = error[key];
+  }
+  return result;
+}
+
+function tailLines(source, maxLines, truncatedBytes) {
+  const lines = source.trimEnd().split(/\r?\n/);
+  if (truncatedBytes) lines.shift();
+  return lines.slice(-maxLines);
+}
+
+function collectCorrelations(value, correlations) {
+  const source = JSON.stringify(value);
+  for (const match of source.matchAll(/\btrc_[A-Za-z0-9-]+\b/g))
+    correlations.traceIds.add(match[0]);
+  for (const match of source.matchAll(/\bdiag_[A-Za-z0-9-]+\b/g)) {
+    correlations.diagnosticIds.add(match[0]);
+  }
+}
+
+function redactValue(value, state) {
+  const result = redact(value, new Date(state.capturedAt));
+  state.redactionReports.push(result.report);
+  return result.value;
+}
+
+function replaceSmokeRoot(value, smokeRoot) {
+  if (typeof value === "string") return value.replaceAll(resolve(smokeRoot), "$SMOKE_ROOT");
+  if (Array.isArray(value)) return value.map((entry) => replaceSmokeRoot(entry, smokeRoot));
+  if (value === null || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value).map(([key, child]) => [key, replaceSmokeRoot(child, smokeRoot)]),
+  );
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function boundedText(value, maxCharacters) {
+  return value.length <= maxCharacters ? value : value.slice(value.length - maxCharacters);
+}
+
+function jsonBytes(value) {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function safeName(value) {
+  const name = value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return name.length === 0 ? "unknown" : name.slice(0, 80);
+}

--- a/scripts/test-runners/run-binary-smoke.mjs
+++ b/scripts/test-runners/run-binary-smoke.mjs
@@ -15,9 +15,14 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, parse, resolve } from "node:path";
+import { dirname, join, parse, relative, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  ObserverHealthSchema,
+  ObserverProcessIdentitySchema,
+  SafeErrorSchema,
+} from "../../packages/contracts/dist/index.js";
 import {
   createObserverClient,
   readUnixSocketHolderPids,
@@ -27,6 +32,10 @@ import {
   stationObserverBuildVersion,
 } from "../../packages/runtime/dist/index.js";
 import { createStationHostClient } from "../../packages/station-host/dist/index.js";
+import {
+  captureBinarySmokeEvidence,
+  finalizeBinarySmokeEvidence,
+} from "./binary-smoke-evidence.mjs";
 
 const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
 const alternateProductionSource = "apps/cli/src/commandRegistry.ts";
@@ -35,10 +44,25 @@ let smokeRunSignal;
 
 class SmokeRunCancelledError extends Error {}
 
+class StressRoundTimeoutError extends Error {}
+
+class SmokeCommandError extends Error {
+  constructor(message, command, args, exitDisposition) {
+    super(message);
+    this.command = command;
+    this.args = args;
+    this.exitDisposition = exitDisposition;
+  }
+}
+
 if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
   await runObserverCancellationSelfCheck();
 } else if (process.env.STATION_BINARY_SMOKE_FAKE_TMUX === "1") {
   await runFakeTmuxProcess(process.argv.slice(2));
+} else if (
+  process.argv.some((arg, index, args) => arg === "--mode" && args[index + 1] === "handoff-stress")
+) {
+  await runHandoffStress(parseHandoffStressOptions(process.argv.slice(2)));
 } else {
   const binaryPath = resolve(process.env.STATION_BINARY_PATH ?? "station/dist/bin/stn");
   const sourceCliPath = resolve("apps/cli/dist/main.js");
@@ -53,6 +77,8 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
   });
   const ptyOnly = process.env.STATION_BINARY_SMOKE_PTY_ONLY === "1";
   const root = await mkdtemp(join(tmpdir(), "station-binary-smoke-"));
+  const rootIdentity = fileIdentity(await lstat(root));
+  const smokeStartedAt = Date.now();
   const alternateWorktreePath = join(root, "alternate-worktree");
   const homeDir = join(root, "home");
   const stateDir = join(root, "state");
@@ -89,6 +115,12 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
   let alternateBinaryPath;
   let alternateObserverVersion;
   let orderedSameVersionBuilds;
+  let sourceArtifact;
+  let evidenceDirection = { logical: "binary-smoke", physical: "current" };
+  let evidenceIncumbent = "current";
+  let evidenceRequested = "alternate";
+  let primaryFailure;
+  let evidenceCaptured = false;
   const cancellation = installSmokeCancellation();
   smokeRunSignal = cancellation.signal;
 
@@ -97,6 +129,9 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
       process.kill(process.pid, "SIGINT");
       await delay(0);
       throw runCancelledError(process.execPath, [], cancellation.signal);
+    }
+    if (process.env.STATION_BINARY_SMOKE_EVIDENCE_FAILURE_SELF_CHECK === "1") {
+      throw new Error("synthetic binary smoke evidence failure");
     }
     await access(binaryPath, constants.X_OK);
     const installedRoot = dirname(await realpath(binaryPath));
@@ -357,6 +392,12 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
         ],
         expectedVersion,
       );
+      evidenceIncumbent = orderedSameVersionBuilds[0].label;
+      evidenceRequested = orderedSameVersionBuilds[1].label;
+      evidenceDirection = {
+        logical: "lower-to-higher",
+        physical: `${evidenceIncumbent}-to-${evidenceRequested}`,
+      };
       await runObserverStart(
         binaryPath,
         ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
@@ -763,8 +804,19 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
         compiled: false,
         buildIdentity,
       });
+      sourceArtifact = {
+        path: relative(repoRoot, sourceCliPath),
+        displayVersion: sourceVersion,
+        buildIdentity,
+      };
       if (expectedVersion.startsWith("0.0.0-") && sourceVersion !== expectedVersion) {
         const previousObserverPid = observerPid;
+        evidenceIncumbent = higherBuild.label;
+        evidenceRequested = "source";
+        evidenceDirection = {
+          logical: "compiled-to-source-version",
+          physical: `${higherBuild.label}-to-source`,
+        };
         await runObserverStart(
           process.execPath,
           [sourceCliPath, "--config", configPath, "observer", "start", "--timeout-ms", "30000"],
@@ -790,6 +842,12 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
           );
         }
 
+        evidenceIncumbent = "source";
+        evidenceRequested = "current";
+        evidenceDirection = {
+          logical: "losing-caller-reuse",
+          physical: "source-to-current",
+        };
         await runObserverStart(
           binaryPath,
           ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
@@ -843,44 +901,910 @@ if (process.env.STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK === "1") {
       join(stateDir, "run", "assets", "ctty"),
       (name) => name === "station-ctty-helper",
     );
-    process.stdout.write("binary smoke passed\n");
   } catch (error) {
-    if (!(error instanceof SmokeRunCancelledError)) throw error;
-  } finally {
-    smokeRunSignal = undefined;
+    primaryFailure = error;
+  }
+
+  smokeRunSignal = undefined;
+  const cleanupWarnings = [];
+  const evidenceDir = process.env.STATION_BINARY_SMOKE_EVIDENCE_DIR;
+  if (primaryFailure !== undefined && evidenceDir !== undefined && evidenceDir.length > 0) {
     try {
-      if (observerClient !== undefined) {
-        await observerClient.stop().catch(() => undefined);
-        await waitForMissing(socketPath).catch(() => undefined);
-      }
-      if (observerPid !== undefined) {
-        await terminateProcess(observerPid);
-      }
-      hostClient?.dispose();
-      if (hostProcess !== undefined && hostProcess.exitCode === null) {
-        hostProcess.kill("SIGTERM");
-        try {
-          await waitForExit(hostProcess, 3000);
-        } catch {
-          hostProcess.kill("SIGKILL");
-          await waitForExit(hostProcess, 3000).catch(() => undefined);
-        }
-      }
-      await stopFakeTmuxProcesses(fakeTmuxStatePath);
-    } finally {
+      await captureSmokeFailureEvidence({
+        evidenceDir,
+        root,
+        stateDir,
+        socketPath,
+        primaryFailure,
+        smokeStartedAt,
+        evidenceDirection,
+        evidenceIncumbent,
+        evidenceRequested,
+        binaryPath,
+        expectedVersion,
+        buildIdentity,
+        alternateBinaryPath,
+        alternateObserverVersion,
+        sourceArtifact,
+        observerPid,
+        hostPid: hostProcess?.pid,
+      });
+      evidenceCaptured = true;
+    } catch (error) {
+      cleanupWarnings.push(`Evidence capture failed: ${errorMessage(error)}`);
+    }
+  }
+  await cleanupAction(cleanupWarnings, "cleanup self-check", async () => {
+    if (process.env.STATION_BINARY_SMOKE_CLEANUP_FAILURE_SELF_CHECK === "1") {
+      throw new Error("synthetic binary smoke cleanup failure");
+    }
+  });
+
+  await cleanupAction(cleanupWarnings, "Observer stop", async () => {
+    if (observerClient === undefined) return;
+    await observerClient.stop().catch(() => undefined);
+    await waitForMissing(socketPath).catch(() => undefined);
+  });
+  await cleanupAction(cleanupWarnings, "Observer process cleanup", async () => {
+    if (observerPid !== undefined) await terminateProcess(observerPid);
+  });
+  await cleanupAction(cleanupWarnings, "Station Host client cleanup", async () =>
+    hostClient?.dispose(),
+  );
+  await cleanupAction(cleanupWarnings, "Station Host process cleanup", async () => {
+    if (
+      hostProcess === undefined ||
+      hostProcess.exitCode !== null ||
+      hostProcess.signalCode !== null
+    ) {
+      return;
+    }
+    hostProcess.kill("SIGTERM");
+    try {
+      await waitForExit(hostProcess, 3000);
+    } catch {
+      hostProcess.kill("SIGKILL");
+      await waitForExit(hostProcess, 3000);
+    }
+  });
+  await cleanupAction(cleanupWarnings, "fake tmux cleanup", () =>
+    stopFakeTmuxProcesses(fakeTmuxStatePath),
+  );
+  await cleanupAction(cleanupWarnings, "alternate worktree cleanup", async () => {
+    if (alternateWorktreeAdded) await removeTemporaryWorktree(alternateWorktreePath);
+  });
+
+  if (primaryFailure === undefined && cleanupWarnings.length > 0) {
+    primaryFailure = new AggregateError(
+      cleanupWarnings.map((warning) => new Error(warning)),
+      "Binary smoke cleanup failed.",
+    );
+    if (evidenceDir !== undefined && evidenceDir.length > 0) {
       try {
-        if (alternateWorktreeAdded) {
-          await removeTemporaryWorktree(alternateWorktreePath);
-        }
-      } finally {
-        try {
-          await rm(root, { recursive: true, force: true });
-        } finally {
-          cancellation.dispose();
-        }
+        await captureSmokeFailureEvidence({
+          evidenceDir,
+          root,
+          stateDir,
+          socketPath,
+          primaryFailure,
+          smokeStartedAt,
+          evidenceDirection,
+          evidenceIncumbent,
+          evidenceRequested,
+          binaryPath,
+          expectedVersion,
+          buildIdentity,
+          alternateBinaryPath,
+          alternateObserverVersion,
+          sourceArtifact,
+          observerPid,
+          hostPid: hostProcess?.pid,
+        });
+        evidenceCaptured = true;
+      } catch (error) {
+        cleanupWarnings.push(`Evidence capture failed: ${errorMessage(error)}`);
       }
     }
   }
+
+  await cleanupAction(cleanupWarnings, "smoke root cleanup", () =>
+    removeExactSmokeRoot(root, rootIdentity),
+  );
+  if (primaryFailure === undefined && cleanupWarnings.length > 0) {
+    primaryFailure = new AggregateError(
+      cleanupWarnings.map((warning) => new Error(warning)),
+      "Binary smoke cleanup failed.",
+    );
+    if (!evidenceCaptured && evidenceDir !== undefined && evidenceDir.length > 0) {
+      try {
+        await captureSmokeFailureEvidence({
+          evidenceDir,
+          root,
+          stateDir,
+          socketPath,
+          primaryFailure,
+          smokeStartedAt,
+          evidenceDirection,
+          evidenceIncumbent,
+          evidenceRequested,
+          binaryPath,
+          expectedVersion,
+          buildIdentity,
+          alternateBinaryPath,
+          alternateObserverVersion,
+          sourceArtifact,
+          observerPid,
+          hostPid: hostProcess?.pid,
+        });
+        evidenceCaptured = true;
+      } catch (error) {
+        cleanupWarnings.push(`Evidence capture failed: ${errorMessage(error)}`);
+      }
+    }
+  }
+  cancellation.dispose();
+
+  if (evidenceCaptured && evidenceDir !== undefined) {
+    const cleanup = {
+      status: cleanupWarnings.length === 0 ? "complete" : "incomplete",
+      observerExited: observerPid === undefined || !processIsAlive(observerPid),
+      hostExited: hostProcess?.pid === undefined || !processIsAlive(hostProcess.pid),
+      socketRemoved: !(await pathExists(socketPath)),
+      pidfileRemoved: !(await pathExists(`${socketPath}.pid`)),
+    };
+    try {
+      await finalizeBinarySmokeEvidence({
+        evidenceDir,
+        cleanup,
+        processes: knownProcessSummaries(observerPid, hostProcess?.pid),
+        warnings: cleanupWarnings,
+      });
+    } catch (error) {
+      cleanupWarnings.push(`Evidence finalization failed: ${errorMessage(error)}`);
+    }
+  }
+
+  reportCleanupWarnings("Binary smoke", cleanupWarnings);
+  if (primaryFailure !== undefined && !(primaryFailure instanceof SmokeRunCancelledError)) {
+    throw primaryFailure;
+  }
+  if (primaryFailure === undefined) {
+    process.stdout.write("binary smoke passed\n");
+  }
+}
+
+async function runHandoffStress(options) {
+  const binaryPath = resolve(process.env.STATION_BINARY_PATH ?? "station/dist/bin/stn");
+  const baseRoot = await mkdtemp(join(tmpdir(), "stn-h-"));
+  const baseIdentity = fileIdentity(await lstat(baseRoot));
+  const alternateWorktreePath = join(baseRoot, "alternate-worktree");
+  const evidenceDir = process.env.STATION_BINARY_SMOKE_EVIDENCE_DIR;
+  const cancellation = installSmokeCancellation();
+  smokeRunSignal = cancellation.signal;
+  let alternateWorktreeAdded = false;
+  let primaryFailure;
+  const cleanupWarnings = [];
+
+  try {
+    if (
+      evidenceDir !== undefined &&
+      (resolve(evidenceDir) === baseRoot || resolve(evidenceDir).startsWith(`${baseRoot}/`))
+    ) {
+      throw new Error("STATION_BINARY_SMOKE_EVIDENCE_DIR must be outside the stress root.");
+    }
+    await access(binaryPath, constants.X_OK);
+    await requireCommittedCleanCheckout(repoRoot);
+    alternateWorktreeAdded = true;
+    await runGit(["worktree", "add", "--detach", alternateWorktreePath, "HEAD"], {
+      terminateDescendants: true,
+    });
+    const alternateBinaryPath = await buildAlternateBinary({
+      worktreePath: alternateWorktreePath,
+      expectedVersion: options.expectedVersion,
+    });
+    const currentObserverVersion = await queryBinaryObserverVersion({
+      binaryPath,
+      expectedVersion: options.expectedVersion,
+      root: join(baseRoot, "current-selector"),
+      label: "current compiled observer",
+    });
+    const alternateObserverVersion = await queryBinaryObserverVersion({
+      binaryPath: alternateBinaryPath,
+      expectedVersion: options.expectedVersion,
+      root: join(baseRoot, "alternate-selector"),
+      label: "alternate compiled observer",
+    });
+    const orderedBuilds = orderSameVersionBuilds(
+      [
+        { binaryPath, label: "current", observerVersion: currentObserverVersion },
+        {
+          binaryPath: alternateBinaryPath,
+          label: "alternate",
+          observerVersion: alternateObserverVersion,
+        },
+      ],
+      options.expectedVersion,
+    );
+
+    for (let round = 1; round <= options.rounds; round += 1) {
+      await runHandoffStressRound({
+        round,
+        baseRoot,
+        orderedBuilds,
+        expectedVersion: options.expectedVersion,
+        roundTimeoutMs: options.roundTimeoutMs,
+        evidenceDir,
+        cancellationSignal: cancellation.signal,
+      });
+    }
+  } catch (error) {
+    primaryFailure = error;
+  }
+
+  smokeRunSignal = undefined;
+  await cleanupAction(cleanupWarnings, "alternate worktree cleanup", async () => {
+    if (alternateWorktreeAdded) await removeTemporaryWorktree(alternateWorktreePath);
+  });
+  await cleanupAction(cleanupWarnings, "stress root cleanup", () =>
+    removeExactTemporaryRoot(baseRoot, baseIdentity, "stn-h-"),
+  );
+  cancellation.dispose();
+
+  if (primaryFailure === undefined && cleanupWarnings.length > 0) {
+    primaryFailure = new AggregateError(
+      cleanupWarnings.map((warning) => new Error(warning)),
+      "Binary handoff stress cleanup failed.",
+    );
+  }
+  reportCleanupWarnings("Binary handoff stress", cleanupWarnings);
+  if (primaryFailure !== undefined && !(primaryFailure instanceof SmokeRunCancelledError)) {
+    throw primaryFailure;
+  }
+}
+
+async function runHandoffStressRound(input) {
+  const roundRoot = join(input.baseRoot, `r${String(input.round).padStart(4, "0")}`);
+  await mkdir(roundRoot, { mode: 0o700 });
+  const roundIdentity = fileIdentity(await lstat(roundRoot));
+  const context = await createStressRoundContext(input, roundRoot);
+  const roundController = new AbortController();
+  const roundTimeout = setTimeout(
+    () =>
+      roundController.abort(
+        new StressRoundTimeoutError(
+          `Binary handoff stress round ${input.round} exceeded ${input.roundTimeoutMs} ms.`,
+        ),
+      ),
+    input.roundTimeoutMs,
+  );
+  smokeRunSignal = AbortSignal.any([input.cancellationSignal, roundController.signal]);
+  let primaryFailure;
+  let evidenceCaptured = false;
+  const cleanupWarnings = [];
+  const startedAt = Date.now();
+
+  try {
+    const result = await executeStressRound(context);
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (error) {
+    primaryFailure = error;
+  } finally {
+    clearTimeout(roundTimeout);
+    smokeRunSignal = input.cancellationSignal;
+  }
+
+  if (primaryFailure !== undefined && input.evidenceDir !== undefined) {
+    try {
+      await captureStressRoundEvidence(context, primaryFailure, startedAt, input.evidenceDir);
+      evidenceCaptured = true;
+    } catch (error) {
+      cleanupWarnings.push(`Evidence capture failed: ${errorMessage(error)}`);
+    }
+  }
+
+  const cleanup = await cleanupStressRound(context, cleanupWarnings);
+  if (primaryFailure === undefined && cleanupWarnings.length > 0) {
+    primaryFailure = new AggregateError(
+      cleanupWarnings.map((warning) => new Error(warning)),
+      `Binary handoff stress round ${input.round} cleanup failed.`,
+    );
+    if (input.evidenceDir !== undefined) {
+      try {
+        await captureStressRoundEvidence(context, primaryFailure, startedAt, input.evidenceDir);
+        evidenceCaptured = true;
+      } catch (error) {
+        cleanupWarnings.push(`Evidence capture failed: ${errorMessage(error)}`);
+      }
+    }
+  }
+
+  if (evidenceCaptured && input.evidenceDir !== undefined) {
+    try {
+      await finalizeBinarySmokeEvidence({
+        evidenceDir: input.evidenceDir,
+        cleanup,
+        processes: stressKnownProcessSummaries(context),
+        warnings: cleanupWarnings,
+      });
+    } catch (error) {
+      cleanupWarnings.push(`Evidence finalization failed: ${errorMessage(error)}`);
+    }
+  }
+  await cleanupAction(cleanupWarnings, "stress round root cleanup", () =>
+    removeExactDirectory(roundRoot, roundIdentity, input.baseRoot),
+  );
+
+  reportCleanupWarnings(`Binary handoff stress round ${input.round}`, cleanupWarnings);
+  if (primaryFailure !== undefined) throw primaryFailure;
+  if (cleanupWarnings.length > 0) {
+    throw new AggregateError(
+      cleanupWarnings.map((warning) => new Error(warning)),
+      `Binary handoff stress round ${input.round} cleanup failed.`,
+    );
+  }
+}
+
+async function createStressRoundContext(input, roundRoot) {
+  const homeDir = join(roundRoot, "home");
+  const stateDir = join(roundRoot, "state");
+  const runtimeDir = join(roundRoot, "runtime");
+  const socketPath = join(runtimeDir, "observer.sock");
+  const hostSocketPath = join(runtimeDir, "station-host.sock");
+  const configPath = join(roundRoot, "config.toml");
+  const releasePath = join(roundRoot, "release-host-pty");
+  for (const path of [socketPath, hostSocketPath]) {
+    if (process.platform === "darwin" && Buffer.byteLength(path) >= 104) {
+      fail(`Binary handoff stress socket path exceeds macOS's 103-byte limit: ${path}`);
+    }
+  }
+  await Promise.all(
+    [join(homeDir, "tmp"), stateDir, runtimeDir].map((path) =>
+      mkdir(path, { recursive: true, mode: 0o700 }),
+    ),
+  );
+  await writeSmokeConfig(configPath, stateDir, socketPath);
+  return {
+    ...input,
+    roundRoot,
+    homeDir,
+    stateDir,
+    runtimeDir,
+    socketPath,
+    hostSocketPath,
+    configPath,
+    releasePath,
+    env: isolatedBinaryEnv({ homeDir, runtimeDir }),
+    client: createObserverClient({ socketPath, timeoutMs: 5000 }),
+    timings: {},
+  };
+}
+
+async function executeStressRound(context) {
+  const lower = context.orderedBuilds[0];
+  const higher = context.orderedBuilds[1];
+  const startedAt = Date.now();
+  const mark = (stage) => {
+    context.timings[stage] = Date.now() - startedAt;
+  };
+
+  const lowerStartup = await runObserverStart(
+    lower.binaryPath,
+    [
+      "--config",
+      context.configPath,
+      "observer",
+      "start",
+      "--timeout-ms",
+      String(context.roundTimeoutMs),
+    ],
+    {
+      client: context.client,
+      env: context.env,
+      socketPath: context.socketPath,
+      timeoutMs: context.roundTimeoutMs,
+    },
+  );
+  context.incumbentPid = lowerStartup.health.pid;
+  context.observerPid = lowerStartup.health.pid;
+  const lowerHealth = await waitForObserverClientHealth(context.client, 5_000);
+  assertEqual(lowerHealth.pid, lowerStartup.health.pid, "stress lower startup PID");
+  mark("lowerHealthyMs");
+  await assertStressObserverOwnership(context, lowerHealth, lower.observerVersion, "lower");
+
+  context.hostProcess = spawn(
+    lower.binaryPath,
+    ["__station-host", "--socket", context.hostSocketPath, "--state-dir", context.stateDir],
+    { env: context.env, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const hostDiagnostics = collectOutput(context.hostProcess);
+  context.hostClient = createStationHostClient({
+    socketPath: context.hostSocketPath,
+    timeoutMs: 1000,
+    expectedBuildVersion: context.expectedVersion,
+  });
+  await waitForHost(context.hostClient, hostDiagnostics);
+  context.spawnedPty = await context.hostClient.spawn({
+    terminalTargetId: `native:binary-handoff-stress-${context.round}`,
+    worktreeId: `binary-handoff-stress-${context.round}`,
+    projectId: "binary-handoff-stress",
+    sessionId: `ses_binary_handoff_stress_${context.round}`,
+    worktreePath: context.roundRoot,
+    harnessProvider: "scripted",
+    command: "/bin/sh",
+    args: [
+      "-c",
+      'printf STATION_BINARY_HANDOFF_STRESS_OK; while [ ! -f "$1" ]; do sleep 1; done; exit 7',
+      "station-binary-handoff-stress",
+      context.releasePath,
+    ],
+    cwd: context.roundRoot,
+    cols: 80,
+    rows: 24,
+  });
+  context.attachment = await context.hostClient.attach(context.spawnedPty.ptyId);
+  mark("hostPtyReadyMs");
+
+  const higherStartup = await runObserverStart(
+    higher.binaryPath,
+    [
+      "--config",
+      context.configPath,
+      "observer",
+      "start",
+      "--timeout-ms",
+      String(context.roundTimeoutMs),
+    ],
+    {
+      client: context.client,
+      env: context.env,
+      socketPath: context.socketPath,
+      timeoutMs: context.roundTimeoutMs,
+    },
+  );
+  context.replacementPid = higherStartup.health.pid;
+  context.observerPid = higherStartup.health.pid;
+  const higherHealth = await waitForObserverClientHealth(context.client, 5_000);
+  assertEqual(higherHealth.pid, higherStartup.health.pid, "stress higher startup PID");
+  mark("higherHealthyMs");
+  assertEqual(higherHealth.version, higher.observerVersion, "stress higher Observer build");
+  assertEqual(higherHealth.pid === lowerHealth.pid, false, "stress replacement changes PID");
+  assertEqual(
+    await waitForProcessExit(lowerHealth.pid, 10_000),
+    true,
+    "stress lower Observer exact exit",
+  );
+  await assertStressObserverOwnership(context, higherHealth, higher.observerVersion, "higher");
+  assertEqual(processIsAlive(context.hostProcess.pid), true, "stress handoff preserves Host");
+  const livePty = (await context.hostClient.list()).find(
+    (entry) => entry.ptyId === context.spawnedPty.ptyId,
+  );
+  assertEqual(livePty?.alive, true, "stress handoff preserves live PTY");
+
+  const losingCaller = await run(
+    lower.binaryPath,
+    [
+      "--config",
+      context.configPath,
+      "observer",
+      "start",
+      "--timeout-ms",
+      String(context.roundTimeoutMs),
+    ],
+    {
+      env: context.env,
+      timeoutMs: context.roundTimeoutMs,
+      allowedExitCodes: [0, 1],
+    },
+  );
+  if (losingCaller.code === 1) {
+    assertIncludes(
+      `${losingCaller.stdout}${losingCaller.stderr}`,
+      "OBSERVER_HANDOFF_REFUSED",
+      "stress losing caller refusal",
+    );
+  }
+  const afterLosingCaller = await context.client.health();
+  assertEqual(afterLosingCaller.pid, higherHealth.pid, "stress losing caller preserves PID");
+  assertEqual(
+    afterLosingCaller.version,
+    higher.observerVersion,
+    "stress losing caller preserves build",
+  );
+  await assertStressObserverOwnership(
+    context,
+    afterLosingCaller,
+    higher.observerVersion,
+    "post-refusal",
+  );
+  mark("losingCallerVerifiedMs");
+
+  await writeFile(context.releasePath, "", { mode: 0o600 });
+  const terminal = await collectTerminalResult(context.attachment, 10_000);
+  assertIncludes(terminal.output, "STATION_BINARY_HANDOFF_STRESS_OK", "stress live PTY output");
+  assertEqual(terminal.exitCode, 7, "stress live PTY exit code");
+  mark("ptyCompletedMs");
+
+  return {
+    round: context.round,
+    direction: {
+      logical: "lower-to-higher",
+      replacementPhysical: `${lower.label}-to-${higher.label}`,
+      losingCallerPhysical: `${higher.label}-to-${lower.label}`,
+    },
+    builds: {
+      lower: lower.buildIdentity,
+      higher: higher.buildIdentity,
+    },
+    pids: { incumbent: lowerHealth.pid, requested: higherHealth.pid },
+    timings: context.timings,
+    elapsedMs: Date.now() - startedAt,
+    disposition: "passed",
+  };
+}
+
+async function assertStressObserverOwnership(context, health, version, label) {
+  assertEqual(health.status, "healthy", `${label} Observer health`);
+  assertEqual(health.version, version, `${label} Observer selector`);
+  const identity = ObserverProcessIdentitySchema.parse(
+    JSON.parse(await readFile(`${context.socketPath}.pid`, "utf8")),
+  );
+  assertEqual(identity.pid, health.pid, `${label} pidfile PID`);
+  assertEqual(identity.version, version, `${label} pidfile selector`);
+  assertEqual(identity.socketPath, context.socketPath, `${label} pidfile socket`);
+  assertDeepEqual(
+    readUnixSocketHolderPids(context.socketPath),
+    [health.pid],
+    `${label} sole socket holder`,
+  );
+  assertEqual((await lstat(context.socketPath)).isSocket(), true, `${label} socket type`);
+  assertEqual(
+    (await observerProcessInventory(context.socketPath)).length,
+    1,
+    `${label} exact Observer process count`,
+  );
+}
+
+async function captureStressRoundEvidence(context, primaryFailure, startedAt, evidenceDir) {
+  const lower = context.orderedBuilds[0];
+  const higher = context.orderedBuilds[1];
+  const failure = {
+    message: errorMessage(primaryFailure),
+    exitDisposition:
+      primaryFailure instanceof SmokeCommandError
+        ? primaryFailure.exitDisposition
+        : { type: "unavailable" },
+  };
+  if (primaryFailure instanceof SmokeCommandError) {
+    failure.command = {
+      artifact: commandArtifact(
+        primaryFailure.command,
+        context.orderedBuilds.find((build) => build.label === "current")?.binaryPath ?? "",
+        context.orderedBuilds.find((build) => build.label === "alternate")?.binaryPath,
+      ),
+      argv: primaryFailure.args,
+    };
+  }
+  await captureBinarySmokeEvidence({
+    evidenceDir,
+    smokeRoot: context.roundRoot,
+    stateDir: context.stateDir,
+    socketPath: context.socketPath,
+    status: primaryFailure instanceof SmokeRunCancelledError ? "cancelled" : "failed",
+    round: context.round,
+    elapsedMs: Date.now() - startedAt,
+    direction: {
+      logical: "lower-to-higher",
+      physical: `${lower.label}-to-${higher.label}`,
+    },
+    error: primaryFailure,
+    failure,
+    artifacts: {
+      current: stressArtifact(context, "current"),
+      alternate: stressArtifact(context, "alternate"),
+      incumbent: lower.label,
+      requested: higher.label,
+    },
+    knownProcesses: stressKnownProcesses(context),
+  });
+}
+
+function stressArtifact(context, label) {
+  const artifact = context.orderedBuilds.find((candidate) => candidate.label === label);
+  if (artifact === undefined) throw new Error(`Missing ${label} stress artifact.`);
+  return {
+    path:
+      label === "current"
+        ? relative(repoRoot, artifact.binaryPath)
+        : "alternate-worktree/station/dist/bin/stn",
+    displayVersion: context.expectedVersion,
+    buildIdentity: artifact.buildIdentity,
+  };
+}
+
+async function cleanupStressRound(context, warnings) {
+  smokeRunSignal = undefined;
+  await cleanupAction(warnings, "Observer stop", async () => {
+    await context.client.stop().catch(() => undefined);
+    await waitForMissing(context.socketPath).catch(() => undefined);
+  });
+  await cleanupAction(warnings, "Observer process cleanup", async () => {
+    for (const process of stressKnownProcesses(context)) {
+      if (process.role !== "station-host") await terminateProcess(process.pid);
+    }
+  });
+  await cleanupAction(warnings, "Station Host client cleanup", async () =>
+    context.hostClient?.dispose(),
+  );
+  await cleanupAction(warnings, "Station Host process cleanup", async () => {
+    if (
+      context.hostProcess === undefined ||
+      context.hostProcess.exitCode !== null ||
+      context.hostProcess.signalCode !== null
+    ) {
+      return;
+    }
+    context.hostProcess.kill("SIGTERM");
+    try {
+      await waitForExit(context.hostProcess, 3000);
+    } catch {
+      context.hostProcess.kill("SIGKILL");
+      await waitForExit(context.hostProcess, 3000);
+    }
+  });
+  await cleanupAction(warnings, "Observer cleanup proof", async () => {
+    const survivingObserver = stressKnownProcesses(context).find(
+      (process) => process.role !== "station-host" && processIsAlive(process.pid),
+    );
+    if (survivingObserver !== undefined) {
+      throw new Error(`Observer PID ${survivingObserver.pid} remained alive.`);
+    }
+    const observerProcesses = await observerProcessInventory(context.socketPath);
+    if (observerProcesses.length > 0) {
+      throw new Error(`Observer processes remained: ${observerProcesses.join("; ")}`);
+    }
+    if (await pathExists(context.socketPath)) throw new Error("Observer socket remained present.");
+    if (await pathExists(`${context.socketPath}.pid`))
+      throw new Error("Observer pidfile remained present.");
+  });
+  await cleanupAction(warnings, "Station Host cleanup proof", async () => {
+    if (context.hostProcess?.pid !== undefined && processIsAlive(context.hostProcess.pid)) {
+      throw new Error(`Station Host PID ${context.hostProcess.pid} remained alive.`);
+    }
+    if (await pathExists(context.hostSocketPath))
+      throw new Error("Station Host socket remained present.");
+  });
+  const observersExited = stressKnownProcesses(context)
+    .filter((process) => process.role !== "station-host")
+    .every((process) => !processIsAlive(process.pid));
+  return {
+    status: warnings.length === 0 ? "complete" : "incomplete",
+    observerExited: observersExited,
+    hostExited: context.hostProcess?.pid === undefined || !processIsAlive(context.hostProcess.pid),
+    socketRemoved: !(await pathExists(context.socketPath)),
+    pidfileRemoved: !(await pathExists(`${context.socketPath}.pid`)),
+  };
+}
+
+function parseHandoffStressOptions(args) {
+  const normalized = args.filter((arg) => arg !== "--");
+  const values = new Map();
+  for (let index = 0; index < normalized.length; index += 2) {
+    const key = normalized[index];
+    const value = normalized[index + 1];
+    if (key === undefined || value === undefined || !key.startsWith("--")) {
+      throw new Error(handoffStressUsage());
+    }
+    if (values.has(key)) throw new Error(`Duplicate handoff stress flag: ${key}`);
+    values.set(key, value);
+  }
+  if (values.get("--mode") !== "handoff-stress") throw new Error(handoffStressUsage());
+  for (const key of values.keys()) {
+    if (!["--mode", "--expected-version", "--rounds", "--round-timeout-ms"].includes(key)) {
+      throw new Error(`Unknown handoff stress flag: ${key}`);
+    }
+  }
+  const expectedVersion = values.get("--expected-version");
+  if (expectedVersion === undefined || !isSemver(expectedVersion)) {
+    throw new Error("--expected-version must be a SemVer value.");
+  }
+  return {
+    expectedVersion,
+    rounds: parsePositiveInteger(values.get("--rounds") ?? "50", "--rounds", 1000),
+    roundTimeoutMs: parsePositiveInteger(
+      values.get("--round-timeout-ms") ?? "30000",
+      "--round-timeout-ms",
+      Number.MAX_SAFE_INTEGER,
+    ),
+  };
+}
+
+function parsePositiveInteger(value, flag, maximum) {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${flag} must be a positive integer.`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed > maximum) {
+    throw new Error(`${flag} must be between 1 and ${maximum}.`);
+  }
+  return parsed;
+}
+
+function isSemver(value) {
+  return /^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(
+    value,
+  );
+}
+
+function handoffStressUsage() {
+  return "Usage: run-binary-smoke.mjs --mode handoff-stress --expected-version <semver> --rounds <1..1000> --round-timeout-ms <positive-safe-integer>";
+}
+
+async function captureSmokeFailureEvidence(input) {
+  const alternateIdentity =
+    input.alternateObserverVersion === undefined
+      ? "unavailable"
+      : (parseStationObserverBuildVersion(input.alternateObserverVersion).buildIdentity ??
+        "unavailable");
+  const command =
+    input.primaryFailure instanceof SmokeCommandError
+      ? {
+          artifact: commandArtifact(
+            input.primaryFailure.command,
+            input.binaryPath,
+            input.alternateBinaryPath,
+            input.primaryFailure.args,
+            input.sourceArtifact?.path,
+          ),
+          argv: input.primaryFailure.args,
+        }
+      : undefined;
+  const failure = {
+    message: errorMessage(input.primaryFailure),
+    exitDisposition:
+      input.primaryFailure instanceof SmokeCommandError
+        ? input.primaryFailure.exitDisposition
+        : { type: "unavailable" },
+  };
+  if (command !== undefined) failure.command = command;
+  await captureBinarySmokeEvidence({
+    evidenceDir: input.evidenceDir,
+    smokeRoot: input.root,
+    stateDir: input.stateDir,
+    socketPath: input.socketPath,
+    status: input.primaryFailure instanceof SmokeRunCancelledError ? "cancelled" : "failed",
+    round: 1,
+    elapsedMs: Date.now() - input.smokeStartedAt,
+    direction: input.evidenceDirection,
+    error: input.primaryFailure,
+    failure,
+    artifacts: {
+      current: {
+        path: relative(repoRoot, input.binaryPath),
+        displayVersion: input.expectedVersion,
+        buildIdentity: input.buildIdentity,
+      },
+      alternate: {
+        path:
+          input.alternateBinaryPath ??
+          join(input.root, "alternate-worktree", "station", "dist", "bin", "stn"),
+        displayVersion: input.expectedVersion,
+        buildIdentity: alternateIdentity,
+      },
+      ...(input.sourceArtifact === undefined ? {} : { source: input.sourceArtifact }),
+      incumbent: input.evidenceIncumbent,
+      requested: input.evidenceRequested,
+    },
+    knownProcesses: knownProcesses(input.observerPid, input.hostPid),
+  });
+}
+
+function commandArtifact(command, currentBinaryPath, alternateBinaryPath, args, sourceCliPath) {
+  if (resolve(command) === resolve(currentBinaryPath)) return "current";
+  if (alternateBinaryPath !== undefined && resolve(command) === resolve(alternateBinaryPath)) {
+    return "alternate";
+  }
+  if (
+    sourceCliPath !== undefined &&
+    (resolve(command) === resolve(sourceCliPath) ||
+      resolve(args?.[0] ?? "") === resolve(sourceCliPath))
+  ) {
+    return "source";
+  }
+  return "runner";
+}
+
+function knownProcesses(observerPid, hostPid) {
+  const processes = [];
+  if (observerPid !== undefined) processes.push({ role: "observer", pid: observerPid });
+  if (hostPid !== undefined) processes.push({ role: "station-host", pid: hostPid });
+  return processes;
+}
+
+function knownProcessSummaries(observerPid, hostPid) {
+  return knownProcesses(observerPid, hostPid).map((entry) => ({
+    ...entry,
+    exists: processIsAlive(entry.pid),
+  }));
+}
+
+function stressKnownProcesses(context) {
+  const processes = [];
+  if (context.incumbentPid !== undefined) {
+    processes.push({ role: "incumbent", pid: context.incumbentPid });
+  }
+  if (context.replacementPid !== undefined && context.replacementPid !== context.incumbentPid) {
+    processes.push({ role: "replacement", pid: context.replacementPid });
+  }
+  if (context.hostProcess?.pid !== undefined) {
+    processes.push({ role: "station-host", pid: context.hostProcess.pid });
+  }
+  return processes;
+}
+
+function stressKnownProcessSummaries(context) {
+  return stressKnownProcesses(context).map((entry) => ({
+    ...entry,
+    exists: processIsAlive(entry.pid),
+  }));
+}
+
+async function cleanupAction(warnings, label, action) {
+  try {
+    await action();
+  } catch (error) {
+    warnings.push(`${label}: ${errorMessage(error)}`);
+  }
+}
+
+function reportCleanupWarnings(scope, warnings) {
+  for (const warning of warnings) process.stderr.write(`${scope} warning: ${warning}\n`);
+}
+
+async function removeExactSmokeRoot(root, expectedIdentity) {
+  return removeExactTemporaryRoot(root, expectedIdentity, "station-binary-smoke-");
+}
+
+async function removeExactTemporaryRoot(root, expectedIdentity, prefix) {
+  const resolvedRoot = resolve(root);
+  if (
+    dirname(resolvedRoot) !== resolve(tmpdir()) ||
+    !resolvedRoot.startsWith(join(resolve(tmpdir()), prefix))
+  ) {
+    throw new Error(`Refusing unexpected temporary deletion target: ${resolvedRoot}`);
+  }
+  await removeExactDirectory(resolvedRoot, expectedIdentity, resolve(tmpdir()));
+}
+
+async function removeExactDirectory(path, expectedIdentity, expectedParent) {
+  const resolvedPath = resolve(path);
+  if (dirname(resolvedPath) !== resolve(expectedParent)) {
+    throw new Error(`Refusing unexpected deletion target: ${resolvedPath}`);
+  }
+  const stats = await lstat(resolvedPath);
+  const identity = fileIdentity(stats);
+  if (
+    !stats.isDirectory() ||
+    stats.isSymbolicLink() ||
+    identity.device !== expectedIdentity.device ||
+    identity.inode !== expectedIdentity.inode
+  ) {
+    throw new Error(`Refusing replaced deletion target: ${resolvedPath}`);
+  }
+  await rm(resolvedPath, { recursive: true, force: true });
+}
+
+async function pathExists(path) {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function errorMessage(error) {
+  if (error instanceof Error) return error.message;
+  const safeError = SafeErrorSchema.safeParse(error);
+  return safeError.success ? `${safeError.data.code}: ${safeError.data.message}` : String(error);
 }
 
 async function requireCommittedCleanCheckout(root) {
@@ -965,12 +1889,12 @@ async function queryBinaryObserverVersion({ binaryPath, expectedVersion, root, l
   try {
     const version = await run(binaryPath, ["--version"], { env });
     assertEqual(version.stdout.trim(), expectedVersion, `${label} display version`);
-    await runObserverStart(
+    const startup = await runObserverStart(
       binaryPath,
       ["--config", configPath, "observer", "start", "--timeout-ms", "30000"],
       { client, env, socketPath },
     );
-    const health = await client.health();
+    const health = startup.health;
     pid = health.pid;
     assertEqual(health.status, "healthy", `${label} health`);
     if (health.version === undefined) {
@@ -2073,7 +2997,11 @@ function run(command, args, options = {}) {
       killRunChild(child, terminateDescendants);
     };
     const timeout = setTimeout(() => {
-      terminate(new Error(`${command} ${args.join(" ")} timed out\n${stderr}`));
+      terminate(
+        new SmokeCommandError(`${command} ${args.join(" ")} timed out\n${stderr}`, command, args, {
+          type: "unknown",
+        }),
+      );
     }, options.timeoutMs ?? 30_000);
     const onAbort = () => {
       terminate(runCancelledError(command, args, cancellationSignal));
@@ -2084,7 +3012,14 @@ function run(command, args, options = {}) {
     child.stdout.on("data", (chunk) => (stdout += chunk));
     child.stderr.on("data", (chunk) => (stderr += chunk));
     child.once("error", (error) => {
-      finish(() => reject(error));
+      finish(() =>
+        reject(
+          new SmokeCommandError(error.message, command, args, {
+            type: "spawn_error",
+            message: error.message,
+          }),
+        ),
+      );
     });
     child.once("close", (code, signal) => {
       if (terminationError !== undefined) {
@@ -2093,10 +3028,19 @@ function run(command, args, options = {}) {
       }
       const allowed = options.allowedExitCodes ?? [0];
       if (code === null || !allowed.includes(code)) {
+        const exitDisposition =
+          code !== null
+            ? { type: "code", code }
+            : signal !== null
+              ? { type: "signal", signal }
+              : { type: "unknown" };
         finish(() =>
           reject(
-            new Error(
+            new SmokeCommandError(
               `${command} ${args.join(" ")} exited ${code ?? signal ?? "unknown"}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+              command,
+              args,
+              exitDisposition,
             ),
           ),
         );
@@ -2108,24 +3052,48 @@ function run(command, args, options = {}) {
   });
 }
 
-async function runObserverStart(command, args, { client, env, socketPath }) {
+async function runObserverStart(command, args, { client, env, socketPath, timeoutMs = 30_000 }) {
   const cancellationSignal = smokeRunSignal;
   if (cancellationSignal?.aborted === true) {
     throw runCancelledError(command, args, cancellationSignal);
   }
   // The launcher owns its detached child until startup resolves, so cancellation waits for that bounded handoff.
-  await run(command, args, {
+  const result = await run(command, args, {
     deferSmokeCancellation: true,
     env,
-    timeoutMs: 35_000,
+    timeoutMs: timeoutMs + 5_000,
   });
-  if (cancellationSignal?.aborted !== true) return;
+  if (cancellationSignal?.aborted !== true) {
+    const health = ObserverHealthSchema.parse(
+      parseSmokeJson(result.stdout, `${command} observer start`).health,
+    );
+    return { ...result, health };
+  }
 
-  const health = await client.health();
-  await client.stop().catch(() => undefined);
-  await waitForMissing(socketPath).catch(() => undefined);
-  await terminateProcess(health.pid);
+  const health = await client.health().catch(() => undefined);
+  if (health !== undefined) {
+    await client.stop().catch(() => undefined);
+    await waitForMissing(socketPath).catch(() => undefined);
+    await terminateProcess(health.pid);
+  }
   throw runCancelledError(command, args, cancellationSignal);
+}
+
+async function waitForObserverClientHealth(client, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+  do {
+    try {
+      return await client.health();
+    } catch (error) {
+      lastError = error;
+    }
+    if (smokeRunSignal?.aborted === true) {
+      throw smokeRunSignal.reason ?? new SmokeRunCancelledError("Observer health wait cancelled.");
+    }
+    await delay(25);
+  } while (Date.now() < deadline);
+  throw lastError ?? new Error("Observer did not become reachable.");
 }
 
 async function runObserverCancellationSelfCheck() {
@@ -2208,6 +3176,7 @@ function killRunChild(child, terminateDescendants) {
 }
 
 function runCancelledError(command, args, signal) {
+  if (signal.reason instanceof Error) return signal.reason;
   const reason = signal.reason === undefined ? "" : ` by ${String(signal.reason)}`;
   return new SmokeRunCancelledError(`${command} ${args.join(" ")} was cancelled${reason}.`);
 }

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -126,6 +126,129 @@ describe("binary smoke script", () => {
       stdio: "pipe",
     });
     expect(interrupted.status).toBe(130);
+  });
+
+  it("preserves the primary failure and cancellation while retaining external evidence", () => {
+    const scriptPath = fileURLToPath(
+      new URL("../../scripts/test-runners/run-binary-smoke.mjs", import.meta.url),
+    );
+    const parent = mkdtempSync(join(tmpdir(), "station-binary-evidence-process-"));
+    try {
+      const failedEvidence = join(parent, "failed-evidence");
+      const failed = spawnSync(process.execPath, [scriptPath], {
+        env: {
+          ...process.env,
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: failedEvidence,
+          STATION_BINARY_SMOKE_EVIDENCE_FAILURE_SELF_CHECK: "1",
+        },
+        encoding: "utf8",
+      });
+      expect(failed.status).toBe(1);
+      expect(failed.stderr).toContain("synthetic binary smoke evidence failure");
+      const failedManifest = JSON.parse(
+        readFileSync(join(failedEvidence, "manifest.json"), "utf8"),
+      );
+      expect(failedManifest.status).toBe("failed");
+      expect(failedManifest.rounds[0].cleanup.status).toBe("complete");
+      expect(failedManifest.rounds[0].failure.message).toBe(
+        "synthetic binary smoke evidence failure",
+      );
+
+      const captureFailed = spawnSync(process.execPath, [scriptPath], {
+        env: {
+          ...process.env,
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: "relative-evidence",
+          STATION_BINARY_SMOKE_EVIDENCE_FAILURE_SELF_CHECK: "1",
+        },
+        encoding: "utf8",
+      });
+      expect(captureFailed.status).toBe(1);
+      expect(captureFailed.stderr).toContain("synthetic binary smoke evidence failure");
+      expect(captureFailed.stderr).toContain(
+        "Evidence capture failed: STATION_BINARY_SMOKE_EVIDENCE_DIR must be absolute",
+      );
+
+      const cleanupFailedEvidence = join(parent, "cleanup-failed-evidence");
+      const cleanupFailed = spawnSync(process.execPath, [scriptPath], {
+        env: {
+          ...process.env,
+          STATION_BINARY_SMOKE_CLEANUP_FAILURE_SELF_CHECK: "1",
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: cleanupFailedEvidence,
+          STATION_BINARY_SMOKE_EVIDENCE_FAILURE_SELF_CHECK: "1",
+        },
+        encoding: "utf8",
+      });
+      expect(cleanupFailed.status).toBe(1);
+      expect(cleanupFailed.stderr).toContain("synthetic binary smoke evidence failure");
+      expect(cleanupFailed.stderr).toContain(
+        "Binary smoke warning: cleanup self-check: synthetic binary smoke cleanup failure",
+      );
+      const cleanupFailedManifest = JSON.parse(
+        readFileSync(join(cleanupFailedEvidence, "manifest.json"), "utf8"),
+      );
+      expect(cleanupFailedManifest.rounds[0].cleanup.status).toBe("incomplete");
+      expect(cleanupFailedManifest.warnings).toContain(
+        "cleanup self-check: synthetic binary smoke cleanup failure",
+      );
+
+      const cancelledEvidence = join(parent, "cancelled-evidence");
+      const cancelled = spawnSync(process.execPath, [scriptPath], {
+        env: {
+          ...process.env,
+          STATION_BINARY_SMOKE_CANCELLATION_EXIT_SELF_CHECK: "1",
+          STATION_BINARY_SMOKE_EVIDENCE_DIR: cancelledEvidence,
+        },
+        encoding: "utf8",
+      });
+      expect(cancelled.status).toBe(130);
+      const cancelledManifest = JSON.parse(
+        readFileSync(join(cancelledEvidence, "manifest.json"), "utf8"),
+      );
+      expect(cancelledManifest.status).toBe("cancelled");
+      expect(cancelledManifest.rounds[0].cleanup.status).toBe("complete");
+      expect(existsSync(cancelledEvidence)).toBe(true);
+    } finally {
+      rmSync(parent, { recursive: true, force: true });
+    }
+  });
+
+  it("validates the focused handoff-stress flags before building artifacts", () => {
+    const scriptPath = fileURLToPath(
+      new URL("../../scripts/test-runners/run-binary-smoke.mjs", import.meta.url),
+    );
+    const invalidVersion = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--mode",
+        "handoff-stress",
+        "--expected-version",
+        "not-semver",
+        "--rounds",
+        "50",
+        "--round-timeout-ms",
+        "30000",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(invalidVersion.status).toBe(1);
+    expect(invalidVersion.stderr).toContain("--expected-version must be a SemVer value");
+
+    const excessiveRounds = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        "--mode",
+        "handoff-stress",
+        "--expected-version",
+        "0.0.0-local",
+        "--rounds",
+        "1001",
+      ],
+      { encoding: "utf8" },
+    );
+    expect(excessiveRounds.status).toBe(1);
+    expect(excessiveRounds.stderr).toContain("--rounds must be between 1 and 1000");
   });
 });
 

--- a/tests/diagnostics/binary-smoke-evidence.test.ts
+++ b/tests/diagnostics/binary-smoke-evidence.test.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+async function loadEvidenceModule() {
+  return import("../../scripts/test-runners/binary-smoke-evidence.mjs");
+}
+
+async function fixture() {
+  const parent = await mkdtemp(join(tmpdir(), "station-evidence-test-"));
+  temporaryRoots.push(parent);
+  const smokeRoot = join(parent, "smoke");
+  const stateDir = join(smokeRoot, "state");
+  const evidenceDir = join(parent, "station-binary-smoke-evidence");
+  await mkdir(join(stateDir, "logs"), { recursive: true, mode: 0o700 });
+  return { parent, smokeRoot, stateDir, evidenceDir, socketPath: join(smokeRoot, "observer.sock") };
+}
+
+function artifact(path: string, marker: string) {
+  return {
+    path,
+    displayVersion: "0.0.0-local",
+    buildIdentity: marker.repeat(64),
+  };
+}
+
+function captureInput(input: Awaited<ReturnType<typeof fixture>>) {
+  return {
+    evidenceDir: input.evidenceDir,
+    smokeRoot: input.smokeRoot,
+    stateDir: input.stateDir,
+    socketPath: input.socketPath,
+    status: "failed",
+    round: 1,
+    elapsedMs: 1842,
+    direction: { logical: "lower-to-higher", physical: "current-to-alternate" },
+    error: new Error(`handoff failed at ${input.smokeRoot} with API_TOKEN=super-secret-value`),
+    failure: {
+      command: {
+        artifact: "alternate",
+        argv: ["observer", "start", "--timeout-ms", "30000"],
+      },
+      exitDisposition: { type: "code", code: 1 },
+    },
+    artifacts: {
+      current: artifact(join(input.smokeRoot, "station/dist/bin/stn"), "a"),
+      alternate: artifact(join(input.smokeRoot, "alternate/stn"), "b"),
+      incumbent: "current",
+      requested: "alternate",
+    },
+    knownProcesses: [{ role: "incumbent", pid: process.pid }],
+    now: new Date("2026-07-29T17:00:00.000Z"),
+  } as const;
+}
+
+function logRecord(index: number): string {
+  return JSON.stringify({
+    timestamp: "2026-07-29T17:00:00.000Z",
+    level: "error",
+    component: "observer",
+    message: `Observer handoff record ${index} trc_example`,
+    traceId: "trc_example",
+    attributes: {
+      stage: "handoff",
+      pid: 1234,
+      providerData: { API_TOKEN: "must-not-survive" },
+    },
+  });
+}
+
+async function treeBytes(path: string): Promise<number> {
+  let total = 0;
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    total += entry.isDirectory() ? await treeBytes(child) : (await lstat(child)).size;
+  }
+  return total;
+}
+
+describe("binary smoke failure evidence", () => {
+  it("writes bounded redacted evidence before cleanup and preserves it afterward", async () => {
+    const input = await fixture();
+    const module = await loadEvidenceModule();
+    const bootLines = Array.from(
+      { length: 140 },
+      (_, index) => `${"x".repeat(700)} boot-${index} API_TOKEN=super-secret-value`,
+    );
+    const logLines = Array.from({ length: 240 }, (_, index) => logRecord(index));
+    await writeFile(join(input.stateDir, "logs/observer-boot.log"), bootLines.join("\n"), {
+      mode: 0o600,
+    });
+    await writeFile(join(input.stateDir, "logs/observer.jsonl"), logLines.join("\n"), {
+      mode: 0o600,
+    });
+    await writeFile(join(input.stateDir, "logs/cli.jsonl"), `${logRecord(1)}\n`, { mode: 0o600 });
+    await writeFile(
+      `${input.socketPath}.pid`,
+      JSON.stringify({
+        pid: process.pid,
+        osStartTime: "2026-07-29T16:59:00.000Z",
+        processToken: randomUUID(),
+        version: `0.0.0-local+station.${"a".repeat(64)}`,
+        socketPath: input.socketPath,
+      }),
+      { mode: 0o600 },
+    );
+
+    const manifest = await module.captureBinarySmokeEvidence(captureInput(input));
+    expect(module.BinarySmokeEvidenceManifestSchema.parse(manifest)).toEqual(manifest);
+    expect(manifest.rounds[0].correlation.traceIds).toEqual(["trc_example"]);
+    expect(manifest.rounds[0].runtime.pidfile).toMatchObject({
+      status: "parsed",
+      pid: process.pid,
+      buildIdentity: "aaaaaaaaaaaa",
+    });
+    expect(manifest.redaction.replacements).toBeGreaterThan(0);
+    expect(manifest.redaction.suspiciousSecretsFound).toBeGreaterThan(0);
+
+    const roundDir = join(input.evidenceDir, "rounds/0001-current-to-alternate");
+    const failure = await readFile(join(roundDir, "failure.json"), "utf8");
+    const boot = await readFile(join(roundDir, "observer-boot.log"), "utf8");
+    const observer = await readFile(join(roundDir, "logs/observer.jsonl"), "utf8");
+    expect(failure).toContain("$SMOKE_ROOT");
+    expect(failure).toContain("API_TOKEN=[REDACTED]");
+    expect(failure).not.toContain(input.smokeRoot);
+    expect(boot.split("\n").filter(Boolean).length).toBeLessThanOrEqual(100);
+    expect(boot).toContain("boot-139");
+    expect(boot).not.toContain("boot-0 ");
+    expect(boot).not.toContain("super-secret-value");
+    expect(observer.split("\n").filter(Boolean)).toHaveLength(200);
+    expect(observer).not.toContain("providerData");
+    expect(observer).not.toContain("must-not-survive");
+    expect(Buffer.byteLength(boot)).toBeLessThanOrEqual(65_536);
+    expect(Buffer.byteLength(observer)).toBeLessThanOrEqual(131_072);
+    expect(await treeBytes(input.evidenceDir)).toBeLessThanOrEqual(1_048_576);
+    expect((await lstat(input.evidenceDir)).mode & 0o777).toBe(0o700);
+    expect((await lstat(join(input.evidenceDir, "manifest.json"))).mode & 0o777).toBe(0o600);
+
+    await rm(input.smokeRoot, { recursive: true, force: true });
+    await module.finalizeBinarySmokeEvidence({
+      evidenceDir: input.evidenceDir,
+      cleanup: {
+        status: "complete",
+        observerExited: true,
+        hostExited: true,
+        socketRemoved: true,
+        pidfileRemoved: true,
+      },
+      processes: [{ role: "incumbent", pid: process.pid, exists: true }],
+      warnings: [],
+    });
+    const finalized = JSON.parse(await readFile(join(input.evidenceDir, "manifest.json"), "utf8"));
+    expect(finalized.rounds[0].cleanup.status).toBe("complete");
+    expect(await readdir(input.evidenceDir)).toEqual(["manifest.json", "rounds"]);
+  }, 15_000);
+
+  it("records symlink, malformed, and missing sources without following them", async () => {
+    const input = await fixture();
+    const module = await loadEvidenceModule();
+    const outside = join(input.parent, "outside.log");
+    await writeFile(outside, "API_TOKEN=outside-secret", { mode: 0o600 });
+    await symlink(outside, join(input.stateDir, "logs/observer-boot.log"));
+    await writeFile(join(input.stateDir, "logs/observer.jsonl"), "not-json\n", { mode: 0o600 });
+
+    const manifest = await module.captureBinarySmokeEvidence(captureInput(input));
+    expect(manifest.rounds[0].files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: "state/logs/observer-boot.log",
+          status: "refused_symlink",
+        }),
+        expect.objectContaining({ source: "state/logs/observer.jsonl", status: "malformed" }),
+        expect.objectContaining({ source: "state/logs/cli.jsonl", status: "missing" }),
+      ]),
+    );
+    expect(JSON.stringify(manifest)).not.toContain("outside-secret");
+  });
+
+  it("rejects unsafe destinations and creates no directory for an uncaptured success", async () => {
+    const input = await fixture();
+    const module = await loadEvidenceModule();
+    await expect(
+      module.captureBinarySmokeEvidence({
+        ...captureInput(input),
+        evidenceDir: "relative/evidence",
+      }),
+    ).rejects.toThrow("must be absolute");
+    await expect(
+      module.captureBinarySmokeEvidence({
+        ...captureInput(input),
+        evidenceDir: join(input.smokeRoot, "evidence"),
+      }),
+    ).rejects.toThrow("outside the smoke root");
+    await expect(lstat(input.evidenceDir)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/tests/diagnostics/ci-workflow-policy.test.ts
+++ b/tests/diagnostics/ci-workflow-policy.test.ts
@@ -316,6 +316,63 @@ describe("hosted CI policy", () => {
     }
   });
 
+  it("uploads only bounded binary-smoke failure evidence without masking the lane", () => {
+    const standardCi = read(".github/workflows/standard-ci.yml");
+    const binary = workflowJob(standardCi, "binary_smoke");
+    const aggregate = workflowJob(standardCi, "standard-ci");
+
+    expect(binary).toContain("id: binary_smoke_run");
+    expect(binary).toContain(
+      `STATION_BINARY_SMOKE_EVIDENCE_DIR: ${actionsExpression("runner.temp")}/station-binary-smoke-evidence`,
+    );
+    expect(binary).toContain(
+      `if: ${actionsExpression("failure() && steps.binary_smoke_run.outcome == 'failure'")}`,
+    );
+    expect(binary).toContain(
+      "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+    );
+    expect(binary).toContain(
+      `name: binary-smoke-evidence-${actionsExpression("github.run_id")}-${actionsExpression("github.run_attempt")}`,
+    );
+    expect(binary).toContain(
+      `path: ${actionsExpression("runner.temp")}/station-binary-smoke-evidence`,
+    );
+    expect(binary).toContain("if-no-files-found: warn");
+    expect(binary).toContain("retention-days: 3");
+    expect(binary).toContain("continue-on-error: true");
+    expect(binary.indexOf("id: binary_smoke_run")).toBeLessThan(
+      binary.indexOf("uses: actions/upload-artifact@"),
+    );
+    expect(aggregate).toContain(`BINARY_SMOKE: ${actionsExpression("needs.binary_smoke.result")}`);
+  });
+
+  it("keeps binary handoff stress manual, capped, and failure-artifact-only", () => {
+    const stress = read(".github/workflows/binary-handoff-stress.yml");
+    const packageJson = JSON.parse(read("package.json")) as { scripts: Record<string, string> };
+
+    expect(stress).toContain("workflow_dispatch:");
+    expect(stress).not.toContain("schedule:");
+    expect(stress).not.toContain("pull_request:");
+    expect(stress).toContain("timeout-minutes: 20");
+    expect(stress).toContain('if [ "$ROUNDS" -lt 1 ] || [ "$ROUNDS" -gt 100 ]');
+    expect(stress).toContain("pnpm build:binary -- --version 0.0.0-local");
+    expect(stress).toContain("--round-timeout-ms 30000");
+    expect(stress).toContain(
+      `STATION_BINARY_SMOKE_EVIDENCE_DIR: ${actionsExpression("runner.temp")}/station-binary-smoke-evidence`,
+    );
+    expect(stress).toContain(
+      `if: ${actionsExpression("failure() && steps.binary_handoff_stress_run.outcome == 'failure'")}`,
+    );
+    expect(stress).toContain(
+      "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+    );
+    expect(stress).toContain("retention-days: 3");
+    expect(stress).toContain("continue-on-error: true");
+    expect(packageJson.scripts["stress:binary-handoff"]).toBe(
+      "node scripts/test-runners/run-binary-smoke.mjs --mode handoff-stress",
+    );
+  });
+
   it("keeps exhaustive claim stress scheduled without extending every pull request", () => {
     const nightly = read(".github/workflows/nightly-observer-claim.yml");
     const development = read("docs/development.md");


### PR DESCRIPTION
## What this fixes

Station's Observer launcher is responsible for either attaching to the exact running build or safely handing ownership to a replacement. When a replacement child exited before incumbent health converged, the parent reduced the attempt to a generic handoff refusal, and binary smoke cleanup removed the local state that could explain the failure. This made the existing handoff race difficult to attribute from CI.

## What changed

- Preserve the replacement child's exit code, signal, redacted spawn error, or unknown disposition alongside the one-second incumbent-health convergence outcome.
- Include the child-owned, redacted Observer boot-log tail and trace ID in the parent-side refusal without changing handoff ordering or grace behavior.
- Capture a private, allowlisted, redacted binary-smoke failure bundle before teardown, then append cleanup status while preserving the original failure.
- Best-effort upload binary-smoke failure evidence for three days without masking the lane's result.
- Add a manual Ubuntu handoff stress workflow that reuses two immutable artifacts across fresh lower-to-higher rounds and verifies exact ownership, losing-caller behavior, Host continuity, and live PTY continuity.
- Document local and hosted evidence inspection plus the statistical limits of the stress lane.

## Testing

- `env -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:all`
- `env -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:diagnostics` (84 tests)
- Two real `stress:binary-handoff` rounds with independent compiled artifacts
- Matching-version full binary smoke
- Mismatched-version binary smoke reproduction, confirming the bundle records the source artifact, exit disposition, convergence timeout, boot tail, trace, and complete cleanup
- Cross-runtime Observer claim stress

## Safety and scope

This PR does not change handoff ordering, retries, replacement authority, SIGKILL policy, or the existing one-second convergence grace. Evidence output must use a new absolute path outside the smoke root, is created with private permissions, and is capped at 1 MiB.