### PR TITLE
refactor(setup): derive semantic setup plans

### DIFF
--- a/apps/cli/src/commands/setup/model.ts
+++ b/apps/cli/src/commands/setup/model.ts
@@ -1,6 +1,16 @@
 import type { TmuxConfig } from "@station/config";
-import { ProviderHookArtifactOwnershipSchema } from "@station/contracts";
-import { type SupportedHarnessId, supportedHarnessIds } from "@station/setup-core";
+import {
+  type CliSetupAction,
+  CliSetupActionSchema,
+  type CliSetupCheck,
+  CliSetupCheckSchema,
+  CliSetupHarnessIdSchema,
+  type CliSetupPlan,
+  CliSetupPlanSchema,
+  CliSetupSummarySchema,
+  ProviderHookArtifactOwnershipSchema,
+} from "@station/contracts";
+import type { SupportedHarnessId } from "@station/setup-core";
 import { z } from "zod";
 
 export type { SupportedHarnessId } from "@station/setup-core";
@@ -30,7 +40,7 @@ export const SetupStatusSchema = z.enum(setupStatuses);
 export const SetupModeSchema = z.enum(setupModes);
 export const SetupActionKindSchema = z.enum(setupActionKinds);
 export const SetupActionStatusSchema = z.enum(setupActionStatuses);
-export const SupportedHarnessIdSchema = z.enum(supportedHarnessIds);
+export const SupportedHarnessIdSchema = CliSetupHarnessIdSchema;
 export const SetupHarnessSelectionSourceSchema = z.enum(setupHarnessSelectionSources);
 export const SetupHarnessTrackingFactSchema = z
   .object({
@@ -63,64 +73,14 @@ export type SetupMode = z.infer<typeof SetupModeSchema>;
 export type SetupHarnessSelectionSource = z.infer<typeof SetupHarnessSelectionSourceSchema>;
 export type SetupHarnessTrackingFact = z.infer<typeof SetupHarnessTrackingFactSchema>;
 
-export const SetupCheckSchema = z
-  .object({
-    id: z.string().min(1),
-    tier: SetupTierSchema,
-    status: SetupStatusSchema,
-    label: z.string().min(1),
-    message: z.string().min(1),
-    details: z.record(z.string(), z.string()).optional(),
-  })
-  .strict();
+export const SetupCheckSchema = CliSetupCheckSchema;
+export const SetupActionSchema = CliSetupActionSchema;
+export const SetupSummarySchema = CliSetupSummarySchema;
+export const SetupPlanSchema = CliSetupPlanSchema;
 
-export const SetupActionSchema = z
-  .object({
-    id: z.string().min(1),
-    kind: SetupActionKindSchema,
-    tier: SetupTierSchema,
-    selected: z.boolean(),
-    label: z.string().min(1),
-    message: z.string().min(1),
-    command: z.array(z.string()).optional(),
-    path: z.string().optional(),
-    status: SetupActionStatusSchema.optional(),
-    data: z.record(z.string(), z.string()).optional(),
-  })
-  .strict();
-
-export const SetupSummarySchema = z
-  .object({
-    launchReady: z.boolean(),
-    workflowReady: z.boolean(),
-    requiredOk: z.boolean(),
-    requiredMissing: z.number().int().nonnegative(),
-    warnings: z.number().int().nonnegative(),
-    selectedActions: z.number().int().nonnegative(),
-    selectionSource: SetupHarnessSelectionSourceSchema,
-    selectedHarness: SupportedHarnessIdSchema.optional(),
-    configPath: z.string(),
-  })
-  .strict()
-  .refine((summary) => summary.requiredOk === summary.workflowReady, {
-    message: "requiredOk must match workflowReady",
-    path: ["requiredOk"],
-  });
-
-export const SetupPlanSchema = z
-  .object({
-    generatedAt: z.string().min(1),
-    mode: SetupModeSchema,
-    checks: z.array(SetupCheckSchema),
-    actions: z.array(SetupActionSchema),
-    summary: SetupSummarySchema,
-    nextSteps: z.array(z.string()),
-  })
-  .strict();
-
-export type SetupCheck = z.infer<typeof SetupCheckSchema>;
-export type SetupAction = z.infer<typeof SetupActionSchema>;
-export type SetupPlan = z.infer<typeof SetupPlanSchema>;
+export type SetupCheck = CliSetupCheck;
+export type SetupAction = CliSetupAction;
+export type SetupPlan = CliSetupPlan;
 
 export type SetupDependencyFact = {
   status: "ok" | "missing";

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -135,12 +135,15 @@ function normalizeHarnessTracking(
   selection: SetupHarnessSelection,
 ): SetupPlanningFacts["harnessTracking"] {
   const requiredHarnessIds = new Set(selection.requiredHarnessIds);
+  const persistedHarnessIds =
+    facts.config.status === "valid" ? new Set(facts.config.configuredHookHarnesses) : new Set();
   return relevantHarnessTrackingIds(facts, selection).map((harnessId) => {
     const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
     return {
       harnessId,
       assessment: assessHarnessTracking(coreHarnessTrackingFacts(facts, harnessId, fact)),
       required: requiredHarnessIds.has(harnessId),
+      persistedIntent: persistedHarnessIds.has(harnessId),
     };
   });
 }

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,31 +1,22 @@
-import { dirname } from "node:path";
-import type { ProviderHookArtifactOwnership } from "@station/contracts";
 import {
   assessHarnessTracking,
-  deriveSetupReadiness,
-  type HarnessTrackingAssessment,
+  type HarnessSelectionFacts,
+  type HarnessSelectionIntent,
   type HarnessTrackingFacts,
+  planSetup,
+  type SetupPlanningFacts,
+  type SetupPlanningIntent,
 } from "@station/setup-core";
-import { stationUiInstallHint } from "../../stationWorkspace.js";
-import { setupLauncherExecutable } from "./checks/launchers.js";
-import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "./checks/tmuxBinding.js";
 import {
   harnessSupportsSetupHooks,
-  harnessTrackingRepairTargets,
   isSupportedHarnessId,
   relevantHarnessTrackingIds,
   resolveSetupHarnessSelection,
   type SetupHarnessSelection,
 } from "./harnessSelection.js";
-import type {
-  ConfigWritePlan,
-  SetupAction,
-  SetupCheck,
-  SetupFacts,
-  SetupPlan,
-  SupportedHarnessId,
-} from "./model.js";
-import { SetupHarnessTrackingFactSchema, SetupPlanSchema } from "./model.js";
+import type { ConfigWritePlan, SetupFacts, SetupPlan, SupportedHarnessId } from "./model.js";
+import { SetupHarnessTrackingFactSchema } from "./model.js";
+import { projectCliSetupPlan } from "./presentation/projectCliSetupPlan.js";
 
 export type BuildSetupPlanOptions = {
   configWrite?: ConfigWritePlan;
@@ -36,395 +27,122 @@ export type BuildSetupPlanOptions = {
 export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions = {}): SetupPlan {
   SetupHarnessTrackingFactSchema.array().parse(facts.harnessTracking);
   const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
-  const checks = setupChecks(facts, harnessSelection);
-  const actions = setupActions(facts, harnessSelection, options.configWrite, options);
-  const warnings = checks.filter((check) => check.status === "warning").length;
-  const readiness = deriveSetupReadiness({
-    stateDirectoryWritable: facts.stateDir.status === "ok",
-    runtime: facts.compiled
-      ? { kind: "compiled" }
-      : {
-          kind: "source",
-          bunAvailable: facts.bun.status === "ok",
-          stationUiUsable: facts.stationUi.status !== "missing",
-        },
-    requirements: checks.flatMap((check) =>
-      check.tier === "required" ? [check.status === "ok" ? "satisfied" : "unsatisfied"] : [],
-    ),
-  });
-  const summary = {
-    launchReady: readiness.launchReady,
-    workflowReady: readiness.workflowReady,
-    requiredOk: readiness.workflowReady,
-    requiredMissing: readiness.requiredMissing,
-    warnings,
-    selectedActions: actions.filter((action) => action.selected).length,
-    selectionSource: harnessSelection.source,
-    configPath: facts.configPath,
-    ...(harnessSelection.defaultHarness === undefined
-      ? {}
-      : { selectedHarness: harnessSelection.defaultHarness }),
-  };
-  const plan = {
-    generatedAt: facts.generatedAt,
+  const evidence = normalizeSetupPlanningFacts(facts, harnessSelection, options.configWrite);
+  const intent: SetupPlanningIntent = {
     mode: facts.mode,
-    checks,
-    actions,
-    summary,
-    nextSteps: nextSteps(readiness.requiredMissing, facts),
+    harnessSelection: normalizeHarnessSelectionIntent(options.harnessSelection),
+    installWorktrunkHooks: options.installWorktrunkHooks === true,
   };
-  return SetupPlanSchema.parse(plan);
-}
-
-function setupChecks(facts: SetupFacts, harnessSelection: SetupHarnessSelection): SetupCheck[] {
-  return [
-    stateDirCheck(facts),
-    socketEvidenceCheck(facts),
-    ...(facts.compiled ? [] : xcodeChecks(facts)),
-    dependencyCheck({
-      id: "worktrunk",
-      label: "Worktrunk / wt",
-      missingMessage: facts.worktrunk.message ?? "Worktrunk is required for core worktree setup.",
-      dependency: facts.worktrunk,
-    }),
-    dependencyCheck({
-      id: "tmux",
-      label: "tmux",
-      missingMessage: facts.tmux.message ?? "tmux is required for the reference terminal workflow.",
-      dependency: facts.tmux,
-    }),
-    ...(facts.compiled
-      ? []
-      : [
-          dependencyCheck({
-            id: "bun",
-            label: "Bun",
-            missingMessage:
-              facts.bun.message ?? "Bun is required to run the STATION terminal UI (bare stn).",
-            dependency: facts.bun,
-          }),
-        ]),
-    gitCheck(facts),
-    harnessCheck(facts, harnessSelection),
-    configCheck(facts),
-    ...configDiagnosticsChecks(facts),
-    launcherCheck(facts),
-    ...(facts.compiled ? [] : [stationUiCheck(facts)]),
-    worktrunkShellIntegrationCheck(facts),
-    tmuxPopupBindingCheck(facts),
-    worktrunkHooksCheck(facts),
-    ...harnessTrackingChecks(facts, harnessSelection),
-    diffnavCheck(facts),
-    gitDeltaCheck(facts),
-    {
-      id: "doctor",
-      tier: "recommended",
-      status: "warning",
-      label: "stn doctor",
-      message: "Run stn doctor after setup to validate the observer runtime.",
-    },
-  ];
-}
-
-function socketEvidenceCheck(facts: SetupFacts): SetupCheck {
-  const details = { command: facts.socketEvidence.command };
-  if (facts.socketEvidence.status === "ok") {
-    return {
-      id: "observer-socket-evidence",
-      tier: "recommended",
-      status: "ok",
-      label: "Observer socket evidence",
-      message: "lsof is available for safe Observer socket recovery and build handoff.",
-      details,
-    };
-  }
-  return {
-    id: "observer-socket-evidence",
-    tier: "recommended",
-    status: "warning",
-    label: "Observer socket evidence",
-    message: `Fresh Observer startup can continue, but stale-socket recovery and build handoff are blocked until lsof is executable at ${facts.socketEvidence.command}. Install lsof, then rerun stn setup check (Debian/Ubuntu: sudo apt-get install lsof; Fedora/RHEL: sudo dnf install lsof).`,
-    details,
-  };
-}
-
-function tmuxPopupBindingCheck(facts: SetupFacts): SetupCheck {
-  const base = {
-    id: "tmux-popup-binding",
-    tier: "recommended",
-    label: "tmux popup binding",
-    details: {
-      path: facts.tmuxBinding.path,
-      launcherCommand: facts.tmuxBinding.launcherCommand,
-      liveStatus: facts.tmuxBinding.liveStatus,
-      ...(facts.tmuxBinding.status === "conflict"
-        ? {}
-        : { bindingKey: facts.tmuxBinding.bindingKey }),
-    },
-  } as const;
-  if (facts.tmuxBinding.status === "conflict") {
-    return {
-      ...base,
-      status: "warning",
-      message: facts.tmuxBinding.message,
-    };
-  }
-  if (facts.tmux.status !== "ok") {
-    return {
-      ...base,
-      status: "skipped",
-      message: "Skipped until tmux is available.",
-    };
-  }
-  if (facts.launchers.tmuxPopup.status !== "ok") {
-    return {
-      ...base,
-      status: "warning",
-      message: "Resolve the stn-tmux-popup launcher, then rerun stn setup to install the binding.",
-    };
-  }
-  if (facts.tmuxBinding.status === "missing") {
-    return {
-      ...base,
-      status: "warning",
-      message: facts.tmuxBinding.message,
-    };
-  }
-  if (facts.tmuxBinding.insideTmux && facts.tmuxBinding.liveStatus !== "loaded") {
-    const liveMessage =
-      facts.tmuxBinding.liveStatus === "missing"
-        ? "is not loaded with that executable launcher"
-        : "could not be verified in the current tmux server";
-    return {
-      ...base,
-      status: "warning",
-      message: `tmux popup binding is persisted but ${liveMessage}; rerun stn setup to repair it.`,
-    };
-  }
-  return {
-    ...base,
-    status: "ok",
-    message: "tmux popup binding is installed.",
-  };
-}
-
-function stateDirCheck(facts: SetupFacts): SetupCheck {
-  return {
-    id: "state-dir",
-    tier: "required",
-    status: facts.stateDir.status === "ok" ? "ok" : "missing",
-    label: "STATION state directory",
-    message:
-      facts.stateDir.status === "ok"
-        ? "STATION state directory is writable."
-        : facts.stateDir.message,
-    details: { path: facts.stateDir.path },
-  };
-}
-
-function launcherCheck(facts: SetupFacts): SetupCheck {
-  const launchers = [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup];
-  const missing = launchers.filter((launcher) => launcher.status === "missing");
-  const launcherEntries = [
-    ["stn", facts.launchers.station],
-    ["stn-ingress", facts.launchers.ingress],
-    ["stn-tmux-popup", facts.launchers.tmuxPopup],
-  ] as const;
-  const checkoutOutsidePath = launcherEntries.flatMap((entry) =>
-    entry[1].source === "checkout" ? [entry[0]] : [],
+  const semanticPlan = planSetup(evidence, intent);
+  return projectCliSetupPlan(
+    options.configWrite === undefined
+      ? { plan: semanticPlan, facts }
+      : { plan: semanticPlan, facts, configWrite: options.configWrite },
   );
-  const installedOutsidePath = launcherEntries.flatMap((entry) =>
-    entry[1].source === "installed" ? [entry[0]] : [],
-  );
-  const stationExecutable = setupLauncherExecutable(facts.launchers.station);
-  const ingressExecutable = setupLauncherExecutable(facts.launchers.ingress);
-  const tmuxPopupExecutable = setupLauncherExecutable(facts.launchers.tmuxPopup);
-  const stationDirectory = dirname(stationExecutable);
-  const launchersShareDirectory = [ingressExecutable, tmuxPopupExecutable].every(
-    (executable) => dirname(executable) === stationDirectory,
-  );
-  const details: Record<string, string> = {
-    station: stationExecutable,
-    ingress: ingressExecutable,
-    tmuxPopup: tmuxPopupExecutable,
-  };
-  if (missing.length === 0 && installedOutsidePath.length > 0 && launchersShareDirectory) {
-    details.pathDirectory = stationDirectory;
-  }
-  let warningMessage: string | undefined;
-  if (missing.length > 0) {
-    warningMessage = `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`;
-  } else if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
-    warningMessage = `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}. Use the installer's PATH guidance for installed launchers; setup can link checkout launchers separately.`;
-  } else if (checkoutOutsidePath.length > 0) {
-    warningMessage = `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`;
-  } else if (installedOutsidePath.length > 0) {
-    warningMessage = `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}. Use the installer's PATH guidance to repair bare launcher resolution.`;
-  }
-  if (warningMessage !== undefined) {
-    return {
-      id: "station-launchers",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION launchers",
-      message: warningMessage,
-      details,
-    };
-  }
-  return {
-    id: "station-launchers",
-    tier: "recommended",
-    status: "ok",
-    label: "STATION launchers",
-    message: "stn, stn-ingress, and stn-tmux-popup are available on PATH.",
-    details,
-  };
 }
 
-function worktrunkShellIntegrationCheck(facts: SetupFacts): SetupCheck {
-  const integration = facts.worktrunkShellIntegration;
-  const details: Record<string, string> = {};
-  if (integration.shell !== undefined) details.shell = integration.shell;
-  if (integration.rcPath !== undefined) details.rcPath = integration.rcPath;
-  const check: SetupCheck = {
-    id: "worktrunk-shell-integration",
-    tier: "recommended",
-    status: integration.status,
-    label: "Worktrunk shell integration",
-    message: integration.message,
-  };
-  if (integration.shell !== undefined || integration.rcPath !== undefined) check.details = details;
-  return check;
-}
-
-function stationUiCheck(facts: SetupFacts): SetupCheck {
-  if (facts.stationUi.status === "installed") {
-    return {
-      id: "station-ui",
-      tier: "recommended",
-      status: "ok",
-      label: "STATION UI dependencies",
-      message: "The station/ Bun UI lane is installed.",
-    };
-  }
-  if (facts.stationUi.status === "missing") {
-    return {
-      id: "station-ui",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION UI dependencies",
-      message: `${stationUiInstallHint} Until then bare stn cannot render the terminal UI (stn doctor reports this as STATION_UI_NOT_INSTALLED).`,
-    };
-  }
-  return {
-    id: "station-ui",
-    tier: "recommended",
-    status: "skipped",
-    label: "STATION UI dependencies",
-    message: "Skipped until Bun is available (or a STATION_DASHBOARD_COMMAND override is set).",
-  };
-}
-
-function worktrunkHooksCheck(facts: SetupFacts): SetupCheck {
-  if (facts.worktrunk.status !== "ok") {
-    return {
-      id: "worktrunk-hooks",
-      tier: "recommended",
-      status: "skipped",
-      label: "Worktrunk hooks",
-      message: "Skipped until Worktrunk is available.",
-    };
-  }
-  if (facts.config.status !== "valid") {
-    return {
-      id: "worktrunk-hooks",
-      tier: "recommended",
-      status: "warning",
-      label: "Worktrunk hooks",
-      message: "Recommended: install Worktrunk lifecycle hooks during setup.",
-    };
-  }
-  if (facts.worktrunkAutomation.status !== "skipped") {
-    return {
-      id: "worktrunk-hooks",
-      tier: "recommended",
-      status: facts.worktrunkAutomation.status,
-      label: "Worktrunk hooks",
-      message: facts.worktrunkAutomation.message,
-      details: worktrunkAutomationDetails(facts.worktrunkAutomation),
-    };
-  }
-  return {
-    id: "worktrunk-hooks",
-    tier: "recommended",
-    status: "ok",
-    label: "Worktrunk hooks",
-    message: "Lifecycle hook automation uses Worktrunk defaults; no prompt flags are configured.",
-    details: { automationMode: "worktrunk-default" },
-  };
-}
-
-function worktrunkAutomationDetails(
-  automation: SetupFacts["worktrunkAutomation"],
-): Record<string, string> {
-  const details: Record<string, string> = {
-    automationMode: automation.automationMode,
-  };
-  if (automation.flag !== undefined) details.flag = automation.flag;
-  if (automation.missingSubcommands !== undefined && automation.missingSubcommands.length > 0) {
-    details.missingSubcommands = automation.missingSubcommands.join(", ");
-  }
-  return details;
-}
-
-function harnessTrackingChecks(
+function normalizeSetupPlanningFacts(
   facts: SetupFacts,
   harnessSelection: SetupHarnessSelection,
-): SetupCheck[] {
-  const harnessIds = relevantHarnessTrackingIds(facts, harnessSelection);
-  const required = new Set(harnessSelection.requiredHarnessIds);
-  return harnessIds.map((harnessId) =>
-    harnessTrackingCheck(facts, harnessId, required.has(harnessId), harnessSelection.source),
-  );
+  configWrite: ConfigWritePlan | undefined,
+): SetupPlanningFacts {
+  const configState = normalizeConfigState(facts);
+  return {
+    generatedAt: facts.generatedAt,
+    compiled: facts.compiled,
+    stateDirectoryWritable: facts.stateDir.status === "ok",
+    socketEvidenceAvailable: facts.socketEvidence.status === "ok",
+    xcodeTools: normalizeXcodeTools(facts),
+    tools: [
+      normalizeTool("worktrunk", facts.worktrunk.status === "ok", facts),
+      normalizeTool("tmux", facts.tmux.status === "ok", facts),
+      normalizeTool("bun", facts.bun.status === "ok", facts),
+      normalizeTool("diffnav", facts.diffnav.status === "ok", facts),
+      normalizeTool("git-delta", facts.gitDelta.status === "ok", facts),
+    ],
+    runtimeUi: normalizeRuntimeUi(facts),
+    git:
+      facts.git.status === "missing"
+        ? { state: "unusable", reason: facts.git.reason }
+        : { state: "usable", repository: facts.git.repository },
+    harnessSelection: normalizeHarnessSelectionFacts(facts),
+    config: {
+      state: configState,
+      write: normalizeConfigWrite(configWrite),
+      diagnostics:
+        facts.config.status === "valid"
+          ? (facts.config.diagnostics ?? []).map((diagnostic) => ({
+              code: diagnostic.code,
+              severity: diagnostic.severity,
+            }))
+          : [],
+    },
+    launchers: {
+      station: normalizeLauncher(facts.launchers.station),
+      ingress: normalizeLauncher(facts.launchers.ingress),
+      tmuxPopup: normalizeLauncher(facts.launchers.tmuxPopup),
+    },
+    worktrunkAutomation:
+      facts.worktrunkAutomation.status === "ok" ? "ready" : facts.worktrunkAutomation.status,
+    worktrunkShell:
+      facts.worktrunkShellIntegration.status === "ok"
+        ? "ready"
+        : facts.worktrunkShellIntegration.status === "warning"
+          ? "missing"
+          : "skipped",
+    tmuxPopup: {
+      persisted: facts.tmuxBinding.status === "ok" ? "ready" : facts.tmuxBinding.status,
+      live: normalizeTmuxLive(facts),
+    },
+    worktrunkHooks: normalizeWorktrunkHooks(facts),
+    harnessTracking: normalizeHarnessTracking(facts, harnessSelection),
+  };
 }
 
-function harnessTrackingCheck(
-  facts: SetupFacts,
-  harnessId: SupportedHarnessId,
-  required: boolean,
-  selectionSource: SetupHarnessSelection["source"],
-): SetupCheck {
-  const harnessLabel =
-    facts.harnesses.find((candidate) => candidate.id === harnessId)?.label ?? harnessId;
-  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
-  const trackingFacts = coreHarnessTrackingFacts(facts, harnessId, fact);
-  const assessment = assessHarnessTracking(trackingFacts);
-  const presentation = harnessTrackingPresentation(
-    assessment,
-    fact,
-    harnessId,
-    harnessLabel,
-    required,
-  );
-  const details: Record<string, string> = {
-    harness: harnessId,
-    selectionSource,
-    capability: trackingFacts.capability,
-    state: assessment.state,
-  };
-  if (assessment.state !== "not-applicable") {
-    if (assessment.requested !== undefined) details.requested = String(assessment.requested);
-    if (assessment.installed !== undefined) details.installed = String(assessment.installed);
+function normalizeHarnessSelectionFacts(facts: SetupFacts): HarnessSelectionFacts {
+  let config: HarnessSelectionFacts["config"];
+  switch (facts.config.status) {
+    case "missing":
+      config = { status: "missing" };
+      break;
+    case "invalid":
+      config = { status: "invalid" };
+      break;
+    case "valid":
+      config = { status: "valid", defaultHarness: facts.config.defaults.harness };
+      break;
   }
-  if (fact?.ownership !== undefined) addHookOwnershipDetails(details, fact.ownership);
   return {
-    id: `harness-tracking:${harnessId}`,
-    tier: required ? "required" : "recommended",
-    status: presentation.status,
-    label: `${harnessLabel} tracking`,
-    message: presentation.message,
-    details,
+    config,
+    harnesses: facts.harnesses.map((harness) => ({
+      id: harness.id,
+      availability: harness.status === "ok" ? "available" : "unavailable",
+    })),
   };
+}
+
+function normalizeHarnessSelectionIntent(
+  selection: SetupHarnessSelection | undefined,
+): HarnessSelectionIntent {
+  if (selection?.source === "explicit") {
+    return { kind: "explicit", harnessIds: selection.requiredHarnessIds };
+  }
+  return { kind: "automatic" };
+}
+
+function normalizeHarnessTracking(
+  facts: SetupFacts,
+  selection: SetupHarnessSelection,
+): SetupPlanningFacts["harnessTracking"] {
+  const requiredHarnessIds = new Set(selection.requiredHarnessIds);
+  return relevantHarnessTrackingIds(facts, selection).map((harnessId) => {
+    const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
+    return {
+      harnessId,
+      assessment: assessHarnessTracking(coreHarnessTrackingFacts(facts, harnessId, fact)),
+      required: requiredHarnessIds.has(harnessId),
+    };
+  });
 }
 
 function coreHarnessTrackingFacts(
@@ -462,651 +180,64 @@ function coreHarnessTrackingFacts(
   return { capability: "supported", configRequested, evidence };
 }
 
-function harnessTrackingPresentation(
-  assessment: HarnessTrackingAssessment,
-  fact: SetupFacts["harnessTracking"][number] | undefined,
-  harnessId: SupportedHarnessId,
-  harnessLabel: string,
-  required: boolean,
-): Pick<SetupCheck, "status" | "message"> {
-  const unavailableStatus = required ? "missing" : "warning";
-  switch (assessment.state) {
-    case "not-applicable":
-      return {
-        status: required ? "ok" : "skipped",
-        message: `${harnessLabel} has no Station-managed external tracking artifact.`,
-      };
-    case "probe-failed":
-      return {
-        status: unavailableStatus,
-        message: fact?.detail ?? `${harnessId} tracking status could not be inspected.`,
-      };
-    case "disabled":
-      return {
-        status: unavailableStatus,
-        message: `${harnessLabel} tracking is disabled in Station config.`,
-      };
-    case "artifact-missing-or-drifted":
-      return {
-        status: unavailableStatus,
-        message: fact?.detail ?? `${harnessId} tracking artifacts are absent or drifted.`,
-      };
-    case "prepared":
-      return {
-        status: "ok",
-        message: `${harnessLabel} Station tracking artifacts are prepared on disk.`,
-      };
-  }
+function normalizeConfigState(facts: SetupFacts): SetupPlanningFacts["config"]["state"] {
+  if (facts.config.status !== "valid") return facts.config.status;
+  const defaults = facts.config.defaults;
+  return defaults.worktreeProvider === "worktrunk" &&
+    defaults.terminal === "tmux" &&
+    isSupportedHarnessId(defaults.harness)
+    ? "valid"
+    : "invalid";
 }
 
-function addHookOwnershipDetails(
-  details: Record<string, string>,
-  ownership: ProviderHookArtifactOwnership,
-): void {
-  details.ownership = ownership.status;
-  details.requestedLauncher = ownership.requested.launcher;
-  details.requestedRuntimeKind = ownership.requested.runtimeKind;
-  details.requestedRuntimeVersion = ownership.requested.version;
-  details.requestedBuildIdentity = ownership.requested.buildIdentity;
-  if (ownership.status === "same-owner" || ownership.status === "different-owner") {
-    details.currentLauncher = ownership.currentLauncher;
-  }
-  if (ownership.status === "different-owner" && ownership.current !== undefined) {
-    details.currentRuntimeKind = ownership.current.runtimeKind;
-    details.currentRuntimeVersion = ownership.current.version;
-    details.currentBuildIdentity = ownership.current.buildIdentity;
-  }
-}
-
-function xcodeChecks(facts: SetupFacts): SetupCheck[] {
-  // Only surface a row when there is something to fix: a macOS host missing the
-  // Command Line Tools. Healthy or non-macOS hosts add no noise to the plan.
-  if (facts.xcode.status !== "missing") return [];
-  return [
-    {
-      id: "command-line-tools",
-      tier: "required",
-      status: "missing",
-      label: "Command Line Tools",
-      message: facts.xcode.message,
-    },
-  ];
-}
-
-function dependencyCheck(input: {
-  id: string;
-  label: string;
-  missingMessage: string;
-  dependency: SetupFacts["worktrunk"];
-}): SetupCheck {
-  const details: Record<string, string> = { command: input.dependency.command };
-  if (input.dependency.version !== undefined) details.version = input.dependency.version;
-  if (input.dependency.resolvedPath !== undefined) {
-    details.resolvedPath = input.dependency.resolvedPath;
-  }
-  return {
-    id: input.id,
-    tier: "required",
-    status: input.dependency.status === "ok" ? "ok" : "missing",
-    label: input.label,
-    message:
-      input.dependency.status === "ok" ? `${input.label} is available.` : input.missingMessage,
-    details,
-  };
-}
-
-function diffnavCheck(facts: SetupFacts): SetupCheck {
-  const details: Record<string, string> = { command: facts.diffnav.command };
-  if (facts.diffnav.resolvedPath !== undefined) details.resolvedPath = facts.diffnav.resolvedPath;
-  if (facts.diffnav.status === "ok") {
-    return {
-      id: "diffnav",
-      tier: "required",
-      status: "ok",
-      label: "diffnav",
-      message: "diffnav is available for the STATION 'See diff (split right)' automation.",
-      details,
-    };
-  }
-  return {
-    id: "diffnav",
-    tier: "required",
-    status: "missing",
-    label: "diffnav",
-    message:
-      facts.diffnav.message ??
-      "diffnav is required for the STATION 'See diff (split right)' automation.",
-    details,
-  };
-}
-
-function gitDeltaCheck(facts: SetupFacts): SetupCheck {
-  const details: Record<string, string> = { command: facts.gitDelta.command };
-  if (facts.gitDelta.resolvedPath !== undefined) details.resolvedPath = facts.gitDelta.resolvedPath;
-  if (facts.gitDelta.status === "ok") {
-    return {
-      id: "git-delta",
-      tier: "required",
-      status: "ok",
-      label: "git-delta",
-      message:
-        "git-delta is available; diffnav renders the STATION 'See diff' automation through it.",
-      details,
-    };
-  }
-  return {
-    id: "git-delta",
-    tier: "required",
-    status: "missing",
-    label: "git-delta",
-    message:
-      facts.gitDelta.message ??
-      "git-delta is required; diffnav renders the STATION 'See diff' automation through it.",
-    details,
-  };
-}
-
-type GitCheckAssessment = Pick<SetupCheck, "status" | "message" | "details">;
-
-function gitCheck(facts: SetupFacts): SetupCheck {
-  const assessment = assessGit(facts.git);
-  return {
-    id: "git-project",
-    tier: "required",
-    label: "Git",
-    ...assessment,
-  };
-}
-
-function assessGit(git: SetupFacts["git"]): GitCheckAssessment {
-  if (git.status === "missing") {
-    return {
-      status: "missing",
-      message: git.message,
-      details: { defaultBranch: git.defaultBranch, reason: git.reason },
-    };
-  }
-  if (git.repository === "absent") {
-    return {
-      status: "ok",
-      message: git.message,
-      details: { defaultBranch: git.defaultBranch },
-    };
-  }
-  return {
-    status: "ok",
-    message: "Git is available; choose projects explicitly in STATION.",
-    details: { root: git.root, defaultBranch: git.defaultBranch },
-  };
-}
-
-function harnessCheck(facts: SetupFacts, harnessSelection: SetupHarnessSelection): SetupCheck {
-  const available = facts.harnesses.filter((harness) => harness.status === "ok");
-  const details: Record<string, string> = {
-    available: available.map((harness) => harness.id).join(","),
-    selectionSource: harnessSelection.source,
-  };
-  if (harnessSelection.defaultHarness !== undefined) {
-    details.default = harnessSelection.defaultHarness;
-  }
-  if (harnessSelection.requiredHarnessIds.length > 0) {
-    details.enabled = harnessSelection.requiredHarnessIds.join(",");
-  }
-
-  if (harnessSelection.source === "unresolved") {
-    details.state = "selection-required";
-    return {
-      id: "harness",
-      tier: "required",
-      status: "missing",
-      label: "Agent CLI",
-      message: unresolvedHarnessMessage(available),
-      details,
-    };
-  }
-
-  const unavailable = harnessSelection.requiredHarnessIds.filter(
-    (id) => !available.some((harness) => harness.id === id),
-  );
-  if (unavailable.length > 0) {
-    details.unavailable = unavailable.join(",");
-    const defaultUnavailable =
-      harnessSelection.defaultHarness !== undefined &&
-      unavailable.includes(harnessSelection.defaultHarness);
-    details.defaultStatus = defaultUnavailable ? "unavailable" : "available";
-    return {
-      id: "harness",
-      tier: "required",
-      status: "missing",
-      label: "Agent CLI",
-      message:
-        harnessSelection.source === "configured"
-          ? `${unavailable[0]} remains configured as the default agent CLI, but it is unavailable; another agent CLI cannot satisfy that default.`
-          : `Selected agent CLIs are unavailable: ${unavailable.join(", ")}.`,
-      details,
-    };
-  }
-
-  const selectedDefault = available.find(
-    (harness) => harness.id === harnessSelection.defaultHarness,
-  );
-  if (selectedDefault !== undefined) {
-    details.command = selectedDefault.command;
-    details.defaultStatus = "available";
-  }
-  const selectedLabels = harnessSelection.requiredHarnessIds.map(
-    (id) => facts.harnesses.find((harness) => harness.id === id)?.label ?? id,
-  );
-  return {
-    id: "harness",
-    tier: "required",
-    status: "ok",
-    label: "Agent CLI",
-    message: selectedHarnessMessage(harnessSelection.source, selectedLabels),
-    details,
-  };
-}
-
-function unresolvedHarnessMessage(available: readonly SetupFacts["harnesses"][number][]): string {
-  if (available.length > 1) {
-    return `Multiple supported agent CLIs are available (${available.map((item) => item.id).join(", ")}); run guided setup and select one explicitly.`;
-  }
-  if (available.length === 0) {
-    return "Install one supported harness CLI: claude, codex, cursor agent, opencode, or pi.";
-  }
-  return "Harness selection could not be resolved from the current config.";
-}
-
-function selectedHarnessMessage(
-  source: SetupHarnessSelection["source"],
-  selectedLabels: readonly string[],
-): string {
-  if (source === "inferred") {
-    return `${selectedLabels[0]} was inferred because it is the only runnable supported agent CLI.`;
-  }
-  if (source === "explicit") {
-    return `Explicit agent selection: ${selectedLabels.join(", ")}.`;
-  }
-  return `${selectedLabels[0]} is preserved as the configured default agent CLI.`;
-}
-
-function configCheck(facts: SetupFacts): SetupCheck {
-  if (facts.config.status === "missing") {
-    return {
-      id: "config",
-      tier: "required",
-      status: "missing",
-      label: "STATION config",
-      message: facts.config.message,
-      details: { path: facts.config.path },
-    };
-  }
-  if (facts.config.status === "invalid") {
-    return {
-      id: "config",
-      tier: "required",
-      status: "missing",
-      label: "STATION config",
-      message: facts.config.message,
-      details: { path: facts.config.path },
-    };
-  }
-  const defaultCoreProblem = defaultConfigCoreProblem(facts.config);
-  if (defaultCoreProblem !== undefined) {
-    return {
-      id: "config",
-      tier: "required",
-      status: "missing",
-      label: "STATION config",
-      message: defaultCoreProblem,
-      details: {
-        path: facts.config.path,
-        worktreeProvider: facts.config.defaults.worktreeProvider,
-        terminal: facts.config.defaults.terminal,
-        harness: facts.config.defaults.harness,
-      },
-    };
-  }
-  return {
-    id: "config",
-    tier: "required",
-    status: "ok",
-    label: "STATION config",
-    message: "Core STATION config is ready; projects are added explicitly in STATION.",
-    details: {
-      path: facts.config.path,
-      harness: facts.config.defaults.harness,
-      configuredHarnesses: facts.config.configuredHarnesses.join(","),
-    },
-  };
-}
-
-function configDiagnosticsChecks(facts: SetupFacts): SetupCheck[] {
-  if (facts.config.status !== "valid") {
-    return [];
-  }
-  const diagnostics = facts.config.diagnostics ?? [];
-  if (diagnostics.length === 0) {
-    return [];
-  }
-  const details: Record<string, string> = { path: facts.config.path };
-  if (facts.config.matchedProject !== undefined) {
-    details.project = facts.config.matchedProject.id;
-  }
-  return [
-    {
-      id: "config-diagnostics",
-      tier: "recommended",
-      status: "warning",
-      label: "STATION config diagnostics",
-      message: `Config loaded with ${diagnostics.length} diagnostic(s): ${diagnostics
-        .map((diagnostic) => diagnostic.message)
-        .join("; ")}`,
-      details,
-    },
-  ];
-}
-
-function defaultConfigCoreProblem(
-  config: Extract<SetupFacts["config"], { status: "valid" }>,
-): string | undefined {
-  if (config.defaults.worktreeProvider !== "worktrunk") {
-    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; set defaults.worktree_provider to "worktrunk" for the setup core path.`;
-  }
-  if (config.defaults.terminal !== "tmux") {
-    return `Config defaults use terminal ${config.defaults.terminal}; set defaults.terminal to "tmux" for the setup core path.`;
-  }
-  if (!isSupportedHarnessId(config.defaults.harness)) {
-    return `Config defaults use unsupported harness ${config.defaults.harness}; choose claude, codex, cursor, opencode, or pi for the setup core path.`;
-  }
-  return undefined;
-}
-
-function setupActions(
-  facts: SetupFacts,
-  harnessSelection: SetupHarnessSelection,
+function normalizeConfigWrite(
   configWrite: ConfigWritePlan | undefined,
-  options: BuildSetupPlanOptions,
-): SetupAction[] {
-  const actions: SetupAction[] = [];
-  if (facts.worktrunk.status === "missing") {
-    actions.push(installAction("install-worktrunk", "Worktrunk", "worktrunk", facts.brew));
-  }
-  if (facts.tmux.status === "missing") {
-    actions.push(installAction("install-tmux", "tmux", "tmux", facts.brew));
-  }
-  if (!facts.compiled && facts.bun.status === "missing") {
-    actions.push(installAction("install-bun", "Bun", "bun", facts.brew));
-  }
-  if (facts.diffnav.status === "missing") {
-    actions.push(installAction("install-diffnav", "diffnav", "diffnav", facts.brew));
-  }
-  // delta is diffnav's renderer, not standalone-useful here; install it alongside
-  // so a required diffnav never yields a diffnav that errors for a missing delta.
-  if (facts.gitDelta.status === "missing") {
-    actions.push(installAction("install-git-delta", "git-delta", "git-delta", facts.brew));
-  }
-  if (stationLaunchersNeedLink(facts)) {
-    actions.push({
-      id: "link-station-launchers",
-      kind: "run-command",
-      tier: "recommended",
-      selected: false,
-      label: "Link STATION launchers",
-      message: "Link stn, stn-ingress, and stn-tmux-popup globally for bare terminal commands.",
-      command: ["pnpm", "--dir", facts.launchers.packageRoot, "station:link"],
-    });
-  }
-  if (
-    facts.worktrunk.status === "ok" &&
-    facts.worktrunkShellIntegration.status !== "ok" &&
-    facts.worktrunkShellIntegration.shell !== undefined
-  ) {
-    actions.push({
-      id: "worktrunk-shell-integration",
-      kind: "run-command",
-      tier: "recommended",
-      selected: false,
-      label: "Install Worktrunk shell integration",
-      message: "Run wt config shell install after core setup if you want Worktrunk shell helpers.",
-      command: [
-        facts.worktrunk.resolvedPath ?? facts.worktrunk.command,
-        "-y",
-        "config",
-        "shell",
-        "install",
-      ],
-    });
-  }
-  if (
-    facts.tmux.status === "ok" &&
-    facts.launchers.tmuxPopup.status === "ok" &&
-    facts.tmuxBinding.status === "missing"
-  ) {
-    actions.push({
-      id: "tmux-popup-binding",
-      kind: "append-file",
-      tier: "recommended",
-      selected: false,
-      label: "Install tmux popup binding",
-      message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} binding for the STATION popup dashboard in ~/.tmux.conf.`,
-      path: facts.tmuxBinding.path,
-      data: {
-        marker: facts.tmuxBinding.marker,
-        endMarker: tmuxPopupBindingEndMarker,
-        appendedText: tmuxPopupBindingBlock(facts.tmuxBinding.launcherCommand, {
-          bindingKey: facts.tmuxBinding.bindingKey,
-          runShellCommand: facts.tmuxBinding.runShellCommand,
-        }),
-      },
-    });
-  }
-  if (
-    facts.tmux.status === "ok" &&
-    facts.launchers.tmuxPopup.status === "ok" &&
-    facts.tmuxBinding.status !== "conflict" &&
-    facts.tmuxBinding.insideTmux &&
-    facts.tmuxBinding.liveStatus !== "loaded"
-  ) {
-    actions.push({
-      id: "tmux-live-popup-binding",
-      kind: "run-command",
-      tier: "recommended",
-      selected: false,
-      label: "Load tmux popup binding",
-      message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} STATION popup binding in the current tmux server.`,
-      command: [
-        facts.tmux.resolvedPath ?? facts.tmux.command,
-        "bind-key",
-        facts.tmuxBinding.bindingKey,
-        "run-shell",
-        "-b",
-        facts.tmuxBinding.runShellCommand,
-      ],
-    });
-  }
-
-  actions.push(...hookSetupActions(facts, harnessSelection, options));
-
-  const configActions = configWriteActions(configWrite, harnessSelection.selected.length > 0);
-  actions.push(...configActions);
-  return actions;
+): SetupPlanningFacts["config"]["write"] {
+  return configWrite?.operation ?? "none";
 }
 
-function stationLaunchersNeedLink(facts: SetupFacts): boolean {
-  return [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup].some(
-    (launcher) => launcher.source === "checkout",
-  );
-}
-
-function hookSetupActions(
+function normalizeTool(
+  id: SetupPlanningFacts["tools"][number]["id"],
+  available: boolean,
   facts: SetupFacts,
-  harnessSelection: SetupHarnessSelection,
-  options: BuildSetupPlanOptions,
-): SetupAction[] {
-  if (facts.launchers.station.status !== "ok" || facts.launchers.ingress.status !== "ok") {
-    return [];
-  }
-  const actions: SetupAction[] = [];
-  if (facts.worktrunk.status === "ok") {
-    actions.push({
-      id: "worktrunk-hooks",
-      kind: "run-command",
-      tier: "recommended",
-      selected: options.installWorktrunkHooks === true,
-      label: "Install Worktrunk hooks",
-      message: "Install Worktrunk lifecycle hooks that report worktree changes to STATION.",
-      command: [
-        setupLauncherExecutable(facts.launchers.station),
-        "--config",
-        facts.configPath,
-        "hooks",
-        "install",
-        "worktrunk",
-        "--yes",
-      ],
-      data: { setupRole: "hook" },
-    });
-  }
-  for (const repairTarget of harnessTrackingRepairTargets(facts, harnessSelection)) {
-    actions.push({
-      id: `${repairTarget.id}-hooks`,
-      kind: "run-command",
-      tier: harnessSelection.requiredHarnessIds.includes(repairTarget.id)
-        ? "required"
-        : "recommended",
-      selected: true,
-      label: `Install ${repairTarget.label} tracking`,
-      message: `Install Station-owned ${repairTarget.label} tracking artifacts.`,
-      command: harnessHookInstallCommand(facts, repairTarget.id),
-      data: { setupRole: "hook", harness: repairTarget.id },
-    });
-  }
-  return actions;
+): SetupPlanningFacts["tools"][number] {
+  return { id, available, installerAvailable: facts.brew.status === "ok" };
 }
 
-function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {
-  const command = [
-    setupLauncherExecutable(facts.launchers.station),
-    "--config",
-    facts.configPath,
-    "hooks",
-    "install",
-    harness,
-    "--yes",
-  ];
-  if (harness === "claude" || harness === "codex" || harness === "cursor") {
-    command.push("--hook-bin", setupLauncherExecutable(facts.launchers.ingress));
-  }
-  return command;
+function normalizeXcodeTools(facts: SetupFacts): SetupPlanningFacts["xcodeTools"] {
+  if (facts.xcode.status === "missing") return "missing";
+  return facts.xcode.applicable ? "available" : "not-applicable";
 }
 
-function installAction(
-  id: string,
-  label: string,
-  formula: string,
-  brew: SetupFacts["brew"],
-): SetupAction {
-  const action: SetupAction = {
-    id,
-    kind: brew.status === "ok" ? "brew-install" : "noop",
-    tier: "required",
-    selected: brew.status === "ok",
-    label: `Install ${label}`,
-    message:
-      brew.status === "ok"
-        ? `Install ${label} with Homebrew.`
-        : `Homebrew is unavailable; install ${label} manually with: brew install ${formula}`,
-    command: ["brew", "install", formula],
-    data: { formula },
-  };
-  return action;
+function normalizeRuntimeUi(facts: SetupFacts): SetupPlanningFacts["runtimeUi"] {
+  if (facts.compiled || facts.stationUi.status === "skipped") return "not-applicable";
+  return facts.stationUi.status === "installed" ? "available" : "missing";
 }
 
-function configWriteActions(
-  configWrite: ConfigWritePlan | undefined,
-  hasSelectedHarness: boolean,
-): SetupAction[] {
-  if (!hasSelectedHarness) return [];
-  if (configWrite === undefined || configWrite.operation === "none") {
-    return [];
-  }
-  if (configWrite.operation === "blocked") {
-    return [
-      {
-        id: "config-blocked",
-        kind: "noop",
-        tier: "required",
-        selected: false,
-        label: "Update STATION config",
-        message: configWrite.reason,
-        path: configWrite.path,
-      },
-    ];
-  }
-  const mkdirAction: SetupAction = {
-    id: "mkdir-config-dir",
-    kind: "mkdir",
-    tier: "required",
-    selected: true,
-    label: "Create config directory",
-    message: "Create the parent directory for the STATION config file.",
-    path: configWrite.path,
-  };
-  const writeAction: SetupAction = {
-    id: configWrite.operation === "create" ? "write-config" : "update-config",
-    kind: "write-config",
-    tier: "required",
-    selected: true,
-    label: configWrite.operation === "create" ? "Write STATION config" : "Update STATION config",
-    message:
-      configWrite.operation === "create"
-        ? "Create the core STATION config; add your first project in STATION."
-        : "Update selected harness settings and append safe missing setup blocks.",
-    path: configWrite.path,
-    data: {
-      operation: configWrite.operation,
-      content: configWrite.content,
-      ...(configWrite.backupPath === undefined ? {} : { backupPath: configWrite.backupPath }),
-    },
-  };
-  return [mkdirAction, writeAction];
+function normalizeLauncher(
+  launcher: SetupFacts["launchers"]["station"],
+): SetupPlanningFacts["launchers"]["station"] {
+  if (launcher.source === "checkout") return "checkout";
+  if (launcher.source === "installed") return "installed";
+  return launcher.status === "ok" ? "available" : "missing";
 }
 
-function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
-  if (requiredMissing === 0) {
-    const stationCommand = quoteCommandPart(facts.launchers.station.command);
-    return [`${stationCommand} doctor`, stationCommand];
+function normalizeTmuxLive(facts: SetupFacts): SetupPlanningFacts["tmuxPopup"]["live"] {
+  if (!facts.tmuxBinding.insideTmux) return "not-applicable";
+  switch (facts.tmuxBinding.liveStatus) {
+    case "loaded":
+      return "ready";
+    case "missing":
+      return "missing";
+    case "unknown":
+      return "unknown";
   }
-  if (facts.stateDir.status === "missing") {
-    return [facts.stateDir.message];
-  }
-  if (facts.xcode.status === "missing") {
-    return [facts.xcode.message];
-  }
-  if (facts.worktrunk.status === "missing") {
-    return ["Install Worktrunk, then run: stn setup check"];
-  }
-  if (facts.tmux.status === "missing") {
-    return ["Install tmux, then run: stn setup check"];
-  }
-  if (facts.bun.status === "missing") {
-    return ["Install Bun (brew install bun), then run: stn setup check"];
-  }
-  if (facts.git.status === "missing") {
-    return [facts.git.message];
-  }
-  if (facts.diffnav.status === "missing" || facts.gitDelta.status === "missing") {
-    return [
-      "Install diffnav and git-delta (brew install diffnav git-delta), then run: stn setup check",
-    ];
-  }
-  return ["Resolve the missing required setup items, then run: stn setup check"];
 }
 
-function quoteCommandPart(part: string): string {
-  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(part)) {
-    return part;
+function normalizeWorktrunkHooks(facts: SetupFacts): SetupPlanningFacts["worktrunkHooks"] {
+  if (facts.worktrunk.status !== "ok") return "not-applicable";
+  if (facts.config.status !== "valid" || facts.worktrunkAutomation.status === "warning") {
+    return "missing";
   }
-  return `'${part.replaceAll("'", "'\\''")}'`;
+  return "ready";
 }

--- a/apps/cli/src/commands/setup/presentation/projectCliSetupPlan.ts
+++ b/apps/cli/src/commands/setup/presentation/projectCliSetupPlan.ts
@@ -1,0 +1,1109 @@
+import { dirname } from "node:path";
+import type { ProviderHookArtifactOwnership } from "@station/contracts";
+import type {
+  SetupPlan as CoreSetupPlan,
+  HarnessTrackingAssessment,
+  SetupOperation,
+} from "@station/setup-core";
+import { stationUiInstallHint } from "../../../stationWorkspace.js";
+import { setupLauncherExecutable } from "../checks/launchers.js";
+import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "../checks/tmuxBinding.js";
+import {
+  harnessSupportsSetupHooks,
+  isSupportedHarnessId,
+  relevantHarnessTrackingIds,
+  type SetupHarnessSelection,
+} from "../harnessSelection.js";
+import type {
+  ConfigWritePlan,
+  SetupAction,
+  SetupCheck,
+  SetupFacts,
+  SetupPlan,
+  SupportedHarnessId,
+} from "../model.js";
+import { SetupHarnessTrackingFactSchema, SetupPlanSchema } from "../model.js";
+
+export type ProjectCliSetupPlanInput = {
+  readonly plan: CoreSetupPlan;
+  readonly facts: SetupFacts;
+  readonly configWrite?: ConfigWritePlan;
+};
+
+export function projectCliSetupPlan(input: ProjectCliSetupPlanInput): SetupPlan {
+  const { facts } = input;
+  SetupHarnessTrackingFactSchema.array().parse(facts.harnessTracking);
+  const harnessSelection = projectHarnessSelection(input.plan, facts);
+  const checks = setupChecks(input.plan, facts, harnessSelection);
+  const actions = setupActions(input.plan.operations, facts, harnessSelection, input.configWrite);
+  const { readiness } = input.plan.result;
+  assertCompatibilityCounts(input.plan, checks);
+  const summary = {
+    launchReady: readiness.launchReady,
+    workflowReady: readiness.workflowReady,
+    requiredOk: readiness.workflowReady,
+    requiredMissing: readiness.requiredMissing,
+    warnings: input.plan.result.warningCount,
+    selectedActions: actions.filter((action) => action.selected).length,
+    selectionSource: harnessSelection.source,
+    configPath: facts.configPath,
+    ...(harnessSelection.defaultHarness === undefined
+      ? {}
+      : { selectedHarness: harnessSelection.defaultHarness }),
+  };
+  const plan = {
+    generatedAt: input.plan.generatedAt,
+    mode: input.plan.mode,
+    checks,
+    actions,
+    summary,
+    nextSteps: nextSteps(readiness.requiredMissing, facts),
+  };
+  return SetupPlanSchema.parse(plan);
+}
+
+function assertCompatibilityCounts(plan: CoreSetupPlan, checks: readonly SetupCheck[]): void {
+  const requiredMissing = checks.filter(
+    (check) => check.tier === "required" && check.status !== "ok",
+  ).length;
+  const warnings = checks.filter((check) => check.status === "warning").length;
+  if (
+    plan.result.readiness.requiredMissing !== requiredMissing ||
+    plan.result.warningCount !== warnings
+  ) {
+    throw new Error(
+      `Semantic setup counts do not match the CLI compatibility projection: required ${plan.result.readiness.requiredMissing}/${requiredMissing}, warnings ${plan.result.warningCount}/${warnings}.`,
+    );
+  }
+}
+
+function projectHarnessSelection(plan: CoreSetupPlan, facts: SetupFacts): SetupHarnessSelection {
+  if (plan.selection.outcome !== "selected") {
+    return { selected: [], requiredHarnessIds: [], source: "unresolved" };
+  }
+  const selected = plan.selection.requiredHarnessIds.flatMap((harnessId) => {
+    const harness = facts.harnesses.find(
+      (candidate) => candidate.id === harnessId && candidate.status === "ok",
+    );
+    return harness === undefined ? [] : [harness];
+  });
+  return {
+    selected,
+    requiredHarnessIds: plan.selection.requiredHarnessIds,
+    source: plan.selection.source,
+    defaultHarness: plan.selection.defaultHarness,
+  };
+}
+
+function setupChecks(
+  plan: CoreSetupPlan,
+  facts: SetupFacts,
+  harnessSelection: SetupHarnessSelection,
+): SetupCheck[] {
+  return [
+    stateDirCheck(facts),
+    socketEvidenceCheck(facts),
+    ...(facts.compiled ? [] : xcodeChecks(facts)),
+    dependencyCheck({
+      id: "worktrunk",
+      label: "Worktrunk / wt",
+      missingMessage: facts.worktrunk.message ?? "Worktrunk is required for core worktree setup.",
+      dependency: facts.worktrunk,
+    }),
+    dependencyCheck({
+      id: "tmux",
+      label: "tmux",
+      missingMessage: facts.tmux.message ?? "tmux is required for the reference terminal workflow.",
+      dependency: facts.tmux,
+    }),
+    ...(facts.compiled
+      ? []
+      : [
+          dependencyCheck({
+            id: "bun",
+            label: "Bun",
+            missingMessage:
+              facts.bun.message ?? "Bun is required to run the STATION terminal UI (bare stn).",
+            dependency: facts.bun,
+          }),
+        ]),
+    gitCheck(facts),
+    harnessCheck(facts, harnessSelection),
+    configCheck(facts),
+    ...configDiagnosticsChecks(facts),
+    launcherCheck(facts),
+    ...(facts.compiled ? [] : [stationUiCheck(facts)]),
+    worktrunkShellIntegrationCheck(facts),
+    tmuxPopupBindingCheck(facts),
+    worktrunkHooksCheck(facts),
+    ...harnessTrackingChecks(plan, facts, harnessSelection),
+    diffnavCheck(facts),
+    gitDeltaCheck(facts),
+    {
+      id: "doctor",
+      tier: "recommended",
+      status: "warning",
+      label: "stn doctor",
+      message: "Run stn doctor after setup to validate the observer runtime.",
+    },
+  ];
+}
+
+function socketEvidenceCheck(facts: SetupFacts): SetupCheck {
+  const details = { command: facts.socketEvidence.command };
+  if (facts.socketEvidence.status === "ok") {
+    return {
+      id: "observer-socket-evidence",
+      tier: "recommended",
+      status: "ok",
+      label: "Observer socket evidence",
+      message: "lsof is available for safe Observer socket recovery and build handoff.",
+      details,
+    };
+  }
+  return {
+    id: "observer-socket-evidence",
+    tier: "recommended",
+    status: "warning",
+    label: "Observer socket evidence",
+    message: `Fresh Observer startup can continue, but stale-socket recovery and build handoff are blocked until lsof is executable at ${facts.socketEvidence.command}. Install lsof, then rerun stn setup check (Debian/Ubuntu: sudo apt-get install lsof; Fedora/RHEL: sudo dnf install lsof).`,
+    details,
+  };
+}
+
+function tmuxPopupBindingCheck(facts: SetupFacts): SetupCheck {
+  const base = {
+    id: "tmux-popup-binding",
+    tier: "recommended",
+    label: "tmux popup binding",
+    details: {
+      path: facts.tmuxBinding.path,
+      launcherCommand: facts.tmuxBinding.launcherCommand,
+      liveStatus: facts.tmuxBinding.liveStatus,
+      ...(facts.tmuxBinding.status === "conflict"
+        ? {}
+        : { bindingKey: facts.tmuxBinding.bindingKey }),
+    },
+  } as const;
+  if (facts.tmuxBinding.status === "conflict") {
+    return {
+      ...base,
+      status: "warning",
+      message: facts.tmuxBinding.message,
+    };
+  }
+  if (facts.tmux.status !== "ok") {
+    return {
+      ...base,
+      status: "skipped",
+      message: "Skipped until tmux is available.",
+    };
+  }
+  if (facts.launchers.tmuxPopup.status !== "ok") {
+    return {
+      ...base,
+      status: "warning",
+      message: "Resolve the stn-tmux-popup launcher, then rerun stn setup to install the binding.",
+    };
+  }
+  if (facts.tmuxBinding.status === "missing") {
+    return {
+      ...base,
+      status: "warning",
+      message: facts.tmuxBinding.message,
+    };
+  }
+  if (facts.tmuxBinding.insideTmux && facts.tmuxBinding.liveStatus !== "loaded") {
+    const liveMessage =
+      facts.tmuxBinding.liveStatus === "missing"
+        ? "is not loaded with that executable launcher"
+        : "could not be verified in the current tmux server";
+    return {
+      ...base,
+      status: "warning",
+      message: `tmux popup binding is persisted but ${liveMessage}; rerun stn setup to repair it.`,
+    };
+  }
+  return {
+    ...base,
+    status: "ok",
+    message: "tmux popup binding is installed.",
+  };
+}
+
+function stateDirCheck(facts: SetupFacts): SetupCheck {
+  return {
+    id: "state-dir",
+    tier: "required",
+    status: facts.stateDir.status === "ok" ? "ok" : "missing",
+    label: "STATION state directory",
+    message:
+      facts.stateDir.status === "ok"
+        ? "STATION state directory is writable."
+        : facts.stateDir.message,
+    details: { path: facts.stateDir.path },
+  };
+}
+
+function launcherCheck(facts: SetupFacts): SetupCheck {
+  const launchers = [facts.launchers.station, facts.launchers.ingress, facts.launchers.tmuxPopup];
+  const missing = launchers.filter((launcher) => launcher.status === "missing");
+  const launcherEntries = [
+    ["stn", facts.launchers.station],
+    ["stn-ingress", facts.launchers.ingress],
+    ["stn-tmux-popup", facts.launchers.tmuxPopup],
+  ] as const;
+  const checkoutOutsidePath = launcherEntries.flatMap((entry) =>
+    entry[1].source === "checkout" ? [entry[0]] : [],
+  );
+  const installedOutsidePath = launcherEntries.flatMap((entry) =>
+    entry[1].source === "installed" ? [entry[0]] : [],
+  );
+  const stationExecutable = setupLauncherExecutable(facts.launchers.station);
+  const ingressExecutable = setupLauncherExecutable(facts.launchers.ingress);
+  const tmuxPopupExecutable = setupLauncherExecutable(facts.launchers.tmuxPopup);
+  const stationDirectory = dirname(stationExecutable);
+  const launchersShareDirectory = [ingressExecutable, tmuxPopupExecutable].every(
+    (executable) => dirname(executable) === stationDirectory,
+  );
+  const details: Record<string, string> = {
+    station: stationExecutable,
+    ingress: ingressExecutable,
+    tmuxPopup: tmuxPopupExecutable,
+  };
+  if (missing.length === 0 && installedOutsidePath.length > 0 && launchersShareDirectory) {
+    details.pathDirectory = stationDirectory;
+  }
+  let warningMessage: string | undefined;
+  if (missing.length > 0) {
+    warningMessage = `Some STATION launchers are missing: ${missing.map((launcher) => launcher.command).join(", ")}.`;
+  } else if (checkoutOutsidePath.length > 0 && installedOutsidePath.length > 0) {
+    warningMessage = `These bare STATION launchers do not resolve to setup's selected executables on PATH: ${[...checkoutOutsidePath, ...installedOutsidePath].join(", ")}. Use the installer's PATH guidance for installed launchers; setup can link checkout launchers separately.`;
+  } else if (checkoutOutsidePath.length > 0) {
+    warningMessage = `These bare launchers do not resolve to this checkout on PATH: ${checkoutOutsidePath.join(", ")}; setup will use their current-checkout paths.`;
+  } else if (installedOutsidePath.length > 0) {
+    warningMessage = `STATION is installed, but these bare launchers do not resolve to this installation on PATH: ${installedOutsidePath.join(", ")}. Use the installer's PATH guidance to repair bare launcher resolution.`;
+  }
+  if (warningMessage !== undefined) {
+    return {
+      id: "station-launchers",
+      tier: "recommended",
+      status: "warning",
+      label: "STATION launchers",
+      message: warningMessage,
+      details,
+    };
+  }
+  return {
+    id: "station-launchers",
+    tier: "recommended",
+    status: "ok",
+    label: "STATION launchers",
+    message: "stn, stn-ingress, and stn-tmux-popup are available on PATH.",
+    details,
+  };
+}
+
+function worktrunkShellIntegrationCheck(facts: SetupFacts): SetupCheck {
+  const integration = facts.worktrunkShellIntegration;
+  const details: Record<string, string> = {};
+  if (integration.shell !== undefined) details.shell = integration.shell;
+  if (integration.rcPath !== undefined) details.rcPath = integration.rcPath;
+  const check: SetupCheck = {
+    id: "worktrunk-shell-integration",
+    tier: "recommended",
+    status: integration.status,
+    label: "Worktrunk shell integration",
+    message: integration.message,
+  };
+  if (integration.shell !== undefined || integration.rcPath !== undefined) check.details = details;
+  return check;
+}
+
+function stationUiCheck(facts: SetupFacts): SetupCheck {
+  if (facts.stationUi.status === "installed") {
+    return {
+      id: "station-ui",
+      tier: "recommended",
+      status: "ok",
+      label: "STATION UI dependencies",
+      message: "The station/ Bun UI lane is installed.",
+    };
+  }
+  if (facts.stationUi.status === "missing") {
+    return {
+      id: "station-ui",
+      tier: "recommended",
+      status: "warning",
+      label: "STATION UI dependencies",
+      message: `${stationUiInstallHint} Until then bare stn cannot render the terminal UI (stn doctor reports this as STATION_UI_NOT_INSTALLED).`,
+    };
+  }
+  return {
+    id: "station-ui",
+    tier: "recommended",
+    status: "skipped",
+    label: "STATION UI dependencies",
+    message: "Skipped until Bun is available (or a STATION_DASHBOARD_COMMAND override is set).",
+  };
+}
+
+function worktrunkHooksCheck(facts: SetupFacts): SetupCheck {
+  if (facts.worktrunk.status !== "ok") {
+    return {
+      id: "worktrunk-hooks",
+      tier: "recommended",
+      status: "skipped",
+      label: "Worktrunk hooks",
+      message: "Skipped until Worktrunk is available.",
+    };
+  }
+  if (facts.config.status !== "valid") {
+    return {
+      id: "worktrunk-hooks",
+      tier: "recommended",
+      status: "warning",
+      label: "Worktrunk hooks",
+      message: "Recommended: install Worktrunk lifecycle hooks during setup.",
+    };
+  }
+  if (facts.worktrunkAutomation.status !== "skipped") {
+    return {
+      id: "worktrunk-hooks",
+      tier: "recommended",
+      status: facts.worktrunkAutomation.status,
+      label: "Worktrunk hooks",
+      message: facts.worktrunkAutomation.message,
+      details: worktrunkAutomationDetails(facts.worktrunkAutomation),
+    };
+  }
+  return {
+    id: "worktrunk-hooks",
+    tier: "recommended",
+    status: "ok",
+    label: "Worktrunk hooks",
+    message: "Lifecycle hook automation uses Worktrunk defaults; no prompt flags are configured.",
+    details: { automationMode: "worktrunk-default" },
+  };
+}
+
+function worktrunkAutomationDetails(
+  automation: SetupFacts["worktrunkAutomation"],
+): Record<string, string> {
+  const details: Record<string, string> = {
+    automationMode: automation.automationMode,
+  };
+  if (automation.flag !== undefined) details.flag = automation.flag;
+  if (automation.missingSubcommands !== undefined && automation.missingSubcommands.length > 0) {
+    details.missingSubcommands = automation.missingSubcommands.join(", ");
+  }
+  return details;
+}
+
+function harnessTrackingChecks(
+  plan: CoreSetupPlan,
+  facts: SetupFacts,
+  harnessSelection: SetupHarnessSelection,
+): SetupCheck[] {
+  const harnessIds = relevantHarnessTrackingIds(facts, harnessSelection);
+  const required = new Set(harnessSelection.requiredHarnessIds);
+  return harnessIds.map((harnessId) =>
+    harnessTrackingCheck(plan, facts, harnessId, required.has(harnessId), harnessSelection.source),
+  );
+}
+
+function harnessTrackingCheck(
+  plan: CoreSetupPlan,
+  facts: SetupFacts,
+  harnessId: SupportedHarnessId,
+  required: boolean,
+  selectionSource: SetupHarnessSelection["source"],
+): SetupCheck {
+  const harnessLabel =
+    facts.harnesses.find((candidate) => candidate.id === harnessId)?.label ?? harnessId;
+  const fact = facts.harnessTracking.find((candidate) => candidate.harnessId === harnessId);
+  const assessment = plan.evidence.harnessTracking.find(
+    (tracking) => tracking.harnessId === harnessId,
+  )?.assessment;
+  if (assessment === undefined) {
+    throw new Error(`Semantic tracking evidence is missing for ${harnessId}.`);
+  }
+  const presentation = harnessTrackingPresentation(
+    assessment,
+    fact,
+    harnessId,
+    harnessLabel,
+    required,
+  );
+  const details: Record<string, string> = {
+    harness: harnessId,
+    selectionSource,
+    capability: harnessSupportsSetupHooks(harnessId) ? "supported" : "unsupported",
+    state: assessment.state,
+  };
+  if (assessment.state !== "not-applicable") {
+    if (assessment.requested !== undefined) details.requested = String(assessment.requested);
+    if (assessment.installed !== undefined) details.installed = String(assessment.installed);
+  }
+  if (fact?.ownership !== undefined) addHookOwnershipDetails(details, fact.ownership);
+  return {
+    id: `harness-tracking:${harnessId}`,
+    tier: required ? "required" : "recommended",
+    status: presentation.status,
+    label: `${harnessLabel} tracking`,
+    message: presentation.message,
+    details,
+  };
+}
+
+function harnessTrackingPresentation(
+  assessment: HarnessTrackingAssessment,
+  fact: SetupFacts["harnessTracking"][number] | undefined,
+  harnessId: SupportedHarnessId,
+  harnessLabel: string,
+  required: boolean,
+): Pick<SetupCheck, "status" | "message"> {
+  const unavailableStatus = required ? "missing" : "warning";
+  switch (assessment.state) {
+    case "not-applicable":
+      return {
+        status: required ? "ok" : "skipped",
+        message: `${harnessLabel} has no Station-managed external tracking artifact.`,
+      };
+    case "probe-failed":
+      return {
+        status: unavailableStatus,
+        message: fact?.detail ?? `${harnessId} tracking status could not be inspected.`,
+      };
+    case "disabled":
+      return {
+        status: unavailableStatus,
+        message: `${harnessLabel} tracking is disabled in Station config.`,
+      };
+    case "artifact-missing-or-drifted":
+      return {
+        status: unavailableStatus,
+        message: fact?.detail ?? `${harnessId} tracking artifacts are absent or drifted.`,
+      };
+    case "prepared":
+      return {
+        status: "ok",
+        message: `${harnessLabel} Station tracking artifacts are prepared on disk.`,
+      };
+  }
+}
+
+function addHookOwnershipDetails(
+  details: Record<string, string>,
+  ownership: ProviderHookArtifactOwnership,
+): void {
+  details.ownership = ownership.status;
+  details.requestedLauncher = ownership.requested.launcher;
+  details.requestedRuntimeKind = ownership.requested.runtimeKind;
+  details.requestedRuntimeVersion = ownership.requested.version;
+  details.requestedBuildIdentity = ownership.requested.buildIdentity;
+  if (ownership.status === "same-owner" || ownership.status === "different-owner") {
+    details.currentLauncher = ownership.currentLauncher;
+  }
+  if (ownership.status === "different-owner" && ownership.current !== undefined) {
+    details.currentRuntimeKind = ownership.current.runtimeKind;
+    details.currentRuntimeVersion = ownership.current.version;
+    details.currentBuildIdentity = ownership.current.buildIdentity;
+  }
+}
+
+function xcodeChecks(facts: SetupFacts): SetupCheck[] {
+  // Only surface a row when there is something to fix: a macOS host missing the
+  // Command Line Tools. Healthy or non-macOS hosts add no noise to the plan.
+  if (facts.xcode.status !== "missing") return [];
+  return [
+    {
+      id: "command-line-tools",
+      tier: "required",
+      status: "missing",
+      label: "Command Line Tools",
+      message: facts.xcode.message,
+    },
+  ];
+}
+
+function dependencyCheck(input: {
+  id: string;
+  label: string;
+  missingMessage: string;
+  dependency: SetupFacts["worktrunk"];
+}): SetupCheck {
+  const details: Record<string, string> = { command: input.dependency.command };
+  if (input.dependency.version !== undefined) details.version = input.dependency.version;
+  if (input.dependency.resolvedPath !== undefined) {
+    details.resolvedPath = input.dependency.resolvedPath;
+  }
+  return {
+    id: input.id,
+    tier: "required",
+    status: input.dependency.status === "ok" ? "ok" : "missing",
+    label: input.label,
+    message:
+      input.dependency.status === "ok" ? `${input.label} is available.` : input.missingMessage,
+    details,
+  };
+}
+
+function diffnavCheck(facts: SetupFacts): SetupCheck {
+  const details: Record<string, string> = { command: facts.diffnav.command };
+  if (facts.diffnav.resolvedPath !== undefined) details.resolvedPath = facts.diffnav.resolvedPath;
+  if (facts.diffnav.status === "ok") {
+    return {
+      id: "diffnav",
+      tier: "required",
+      status: "ok",
+      label: "diffnav",
+      message: "diffnav is available for the STATION 'See diff (split right)' automation.",
+      details,
+    };
+  }
+  return {
+    id: "diffnav",
+    tier: "required",
+    status: "missing",
+    label: "diffnav",
+    message:
+      facts.diffnav.message ??
+      "diffnav is required for the STATION 'See diff (split right)' automation.",
+    details,
+  };
+}
+
+function gitDeltaCheck(facts: SetupFacts): SetupCheck {
+  const details: Record<string, string> = { command: facts.gitDelta.command };
+  if (facts.gitDelta.resolvedPath !== undefined) details.resolvedPath = facts.gitDelta.resolvedPath;
+  if (facts.gitDelta.status === "ok") {
+    return {
+      id: "git-delta",
+      tier: "required",
+      status: "ok",
+      label: "git-delta",
+      message:
+        "git-delta is available; diffnav renders the STATION 'See diff' automation through it.",
+      details,
+    };
+  }
+  return {
+    id: "git-delta",
+    tier: "required",
+    status: "missing",
+    label: "git-delta",
+    message:
+      facts.gitDelta.message ??
+      "git-delta is required; diffnav renders the STATION 'See diff' automation through it.",
+    details,
+  };
+}
+
+type GitCheckAssessment = Pick<SetupCheck, "status" | "message" | "details">;
+
+function gitCheck(facts: SetupFacts): SetupCheck {
+  const assessment = assessGit(facts.git);
+  return {
+    id: "git-project",
+    tier: "required",
+    label: "Git",
+    ...assessment,
+  };
+}
+
+function assessGit(git: SetupFacts["git"]): GitCheckAssessment {
+  if (git.status === "missing") {
+    return {
+      status: "missing",
+      message: git.message,
+      details: { defaultBranch: git.defaultBranch, reason: git.reason },
+    };
+  }
+  if (git.repository === "absent") {
+    return {
+      status: "ok",
+      message: git.message,
+      details: { defaultBranch: git.defaultBranch },
+    };
+  }
+  return {
+    status: "ok",
+    message: "Git is available; choose projects explicitly in STATION.",
+    details: { root: git.root, defaultBranch: git.defaultBranch },
+  };
+}
+
+function harnessCheck(facts: SetupFacts, harnessSelection: SetupHarnessSelection): SetupCheck {
+  const available = facts.harnesses.filter((harness) => harness.status === "ok");
+  const details: Record<string, string> = {
+    available: available.map((harness) => harness.id).join(","),
+    selectionSource: harnessSelection.source,
+  };
+  if (harnessSelection.defaultHarness !== undefined) {
+    details.default = harnessSelection.defaultHarness;
+  }
+  if (harnessSelection.requiredHarnessIds.length > 0) {
+    details.enabled = harnessSelection.requiredHarnessIds.join(",");
+  }
+
+  if (harnessSelection.source === "unresolved") {
+    details.state = "selection-required";
+    return {
+      id: "harness",
+      tier: "required",
+      status: "missing",
+      label: "Agent CLI",
+      message: unresolvedHarnessMessage(available),
+      details,
+    };
+  }
+
+  const unavailable = harnessSelection.requiredHarnessIds.filter(
+    (id) => !available.some((harness) => harness.id === id),
+  );
+  if (unavailable.length > 0) {
+    details.unavailable = unavailable.join(",");
+    const defaultUnavailable =
+      harnessSelection.defaultHarness !== undefined &&
+      unavailable.includes(harnessSelection.defaultHarness);
+    details.defaultStatus = defaultUnavailable ? "unavailable" : "available";
+    return {
+      id: "harness",
+      tier: "required",
+      status: "missing",
+      label: "Agent CLI",
+      message:
+        harnessSelection.source === "configured"
+          ? `${unavailable[0]} remains configured as the default agent CLI, but it is unavailable; another agent CLI cannot satisfy that default.`
+          : `Selected agent CLIs are unavailable: ${unavailable.join(", ")}.`,
+      details,
+    };
+  }
+
+  const selectedDefault = available.find(
+    (harness) => harness.id === harnessSelection.defaultHarness,
+  );
+  if (selectedDefault !== undefined) {
+    details.command = selectedDefault.command;
+    details.defaultStatus = "available";
+  }
+  const selectedLabels = harnessSelection.requiredHarnessIds.map(
+    (id) => facts.harnesses.find((harness) => harness.id === id)?.label ?? id,
+  );
+  return {
+    id: "harness",
+    tier: "required",
+    status: "ok",
+    label: "Agent CLI",
+    message: selectedHarnessMessage(harnessSelection.source, selectedLabels),
+    details,
+  };
+}
+
+function unresolvedHarnessMessage(available: readonly SetupFacts["harnesses"][number][]): string {
+  if (available.length > 1) {
+    return `Multiple supported agent CLIs are available (${available.map((item) => item.id).join(", ")}); run guided setup and select one explicitly.`;
+  }
+  if (available.length === 0) {
+    return "Install one supported harness CLI: claude, codex, cursor agent, opencode, or pi.";
+  }
+  return "Harness selection could not be resolved from the current config.";
+}
+
+function selectedHarnessMessage(
+  source: SetupHarnessSelection["source"],
+  selectedLabels: readonly string[],
+): string {
+  if (source === "inferred") {
+    return `${selectedLabels[0]} was inferred because it is the only runnable supported agent CLI.`;
+  }
+  if (source === "explicit") {
+    return `Explicit agent selection: ${selectedLabels.join(", ")}.`;
+  }
+  return `${selectedLabels[0]} is preserved as the configured default agent CLI.`;
+}
+
+function configCheck(facts: SetupFacts): SetupCheck {
+  if (facts.config.status === "missing") {
+    return {
+      id: "config",
+      tier: "required",
+      status: "missing",
+      label: "STATION config",
+      message: facts.config.message,
+      details: { path: facts.config.path },
+    };
+  }
+  if (facts.config.status === "invalid") {
+    return {
+      id: "config",
+      tier: "required",
+      status: "missing",
+      label: "STATION config",
+      message: facts.config.message,
+      details: { path: facts.config.path },
+    };
+  }
+  const defaultCoreProblem = defaultConfigCoreProblem(facts.config);
+  if (defaultCoreProblem !== undefined) {
+    return {
+      id: "config",
+      tier: "required",
+      status: "missing",
+      label: "STATION config",
+      message: defaultCoreProblem,
+      details: {
+        path: facts.config.path,
+        worktreeProvider: facts.config.defaults.worktreeProvider,
+        terminal: facts.config.defaults.terminal,
+        harness: facts.config.defaults.harness,
+      },
+    };
+  }
+  return {
+    id: "config",
+    tier: "required",
+    status: "ok",
+    label: "STATION config",
+    message: "Core STATION config is ready; projects are added explicitly in STATION.",
+    details: {
+      path: facts.config.path,
+      harness: facts.config.defaults.harness,
+      configuredHarnesses: facts.config.configuredHarnesses.join(","),
+    },
+  };
+}
+
+function configDiagnosticsChecks(facts: SetupFacts): SetupCheck[] {
+  if (facts.config.status !== "valid") {
+    return [];
+  }
+  const diagnostics = facts.config.diagnostics ?? [];
+  if (diagnostics.length === 0) {
+    return [];
+  }
+  const details: Record<string, string> = { path: facts.config.path };
+  if (facts.config.matchedProject !== undefined) {
+    details.project = facts.config.matchedProject.id;
+  }
+  return [
+    {
+      id: "config-diagnostics",
+      tier: "recommended",
+      status: "warning",
+      label: "STATION config diagnostics",
+      message: `Config loaded with ${diagnostics.length} diagnostic(s): ${diagnostics
+        .map((diagnostic) => diagnostic.message)
+        .join("; ")}`,
+      details,
+    },
+  ];
+}
+
+function defaultConfigCoreProblem(
+  config: Extract<SetupFacts["config"], { status: "valid" }>,
+): string | undefined {
+  if (config.defaults.worktreeProvider !== "worktrunk") {
+    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; set defaults.worktree_provider to "worktrunk" for the setup core path.`;
+  }
+  if (config.defaults.terminal !== "tmux") {
+    return `Config defaults use terminal ${config.defaults.terminal}; set defaults.terminal to "tmux" for the setup core path.`;
+  }
+  if (!isSupportedHarnessId(config.defaults.harness)) {
+    return `Config defaults use unsupported harness ${config.defaults.harness}; choose claude, codex, cursor, opencode, or pi for the setup core path.`;
+  }
+  return undefined;
+}
+
+function setupActions(
+  operations: readonly SetupOperation[],
+  facts: SetupFacts,
+  harnessSelection: SetupHarnessSelection,
+  configWrite: ConfigWritePlan | undefined,
+): SetupAction[] {
+  const actions: SetupAction[] = [];
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case "install-tool": {
+        const presentation = installToolPresentation(operation.tool);
+        actions.push(
+          installAction(presentation.id, presentation.label, presentation.formula, facts.brew),
+        );
+        break;
+      }
+      case "link-launchers":
+        actions.push({
+          id: "link-station-launchers",
+          kind: "run-command",
+          tier: "recommended",
+          selected: false,
+          label: "Link STATION launchers",
+          message: "Link stn, stn-ingress, and stn-tmux-popup globally for bare terminal commands.",
+          command: ["pnpm", "--dir", facts.launchers.packageRoot, "station:link"],
+        });
+        break;
+      case "configure-worktrunk-shell":
+        if (facts.worktrunkShellIntegration.shell === undefined) break;
+        actions.push({
+          id: "worktrunk-shell-integration",
+          kind: "run-command",
+          tier: "recommended",
+          selected: false,
+          label: "Install Worktrunk shell integration",
+          message:
+            "Run wt config shell install after core setup if you want Worktrunk shell helpers.",
+          command: [
+            facts.worktrunk.resolvedPath ?? facts.worktrunk.command,
+            "-y",
+            "config",
+            "shell",
+            "install",
+          ],
+        });
+        break;
+      case "configure-tmux-popup":
+        actions.push(
+          operation.scope === "persisted"
+            ? persistedTmuxPopupAction(facts)
+            : liveTmuxPopupAction(facts),
+        );
+        break;
+      case "prepare-worktrunk-tracking":
+        actions.push({
+          id: "worktrunk-hooks",
+          kind: "run-command",
+          tier: "recommended",
+          selected: operation.selected,
+          label: "Install Worktrunk hooks",
+          message: "Install Worktrunk lifecycle hooks that report worktree changes to STATION.",
+          command: [
+            setupLauncherExecutable(facts.launchers.station),
+            "--config",
+            facts.configPath,
+            "hooks",
+            "install",
+            "worktrunk",
+            "--yes",
+          ],
+          data: { setupRole: "hook" },
+        });
+        break;
+      case "prepare-harness-tracking": {
+        const harnessLabel =
+          facts.harnesses.find((candidate) => candidate.id === operation.harnessId)?.label ??
+          operation.harnessId;
+        actions.push({
+          id: `${operation.harnessId}-hooks`,
+          kind: "run-command",
+          tier: operation.tier,
+          selected: true,
+          label: `Install ${harnessLabel} tracking`,
+          message: `Install Station-owned ${harnessLabel} tracking artifacts.`,
+          command: harnessHookInstallCommand(facts, operation.harnessId),
+          data: { setupRole: "hook", harness: operation.harnessId },
+        });
+        break;
+      }
+      case "write-config":
+        actions.push(...configWriteActions(configWrite, true));
+        break;
+    }
+  }
+  if (configWrite?.operation === "blocked") {
+    actions.push(...configWriteActions(configWrite, harnessSelection.selected.length > 0));
+  }
+  return actions;
+}
+
+function installToolPresentation(tool: Extract<SetupOperation, { kind: "install-tool" }>["tool"]): {
+  id: string;
+  label: string;
+  formula: string;
+} {
+  switch (tool) {
+    case "worktrunk":
+      return { id: "install-worktrunk", label: "Worktrunk", formula: "worktrunk" };
+    case "tmux":
+      return { id: "install-tmux", label: "tmux", formula: "tmux" };
+    case "bun":
+      return { id: "install-bun", label: "Bun", formula: "bun" };
+    case "diffnav":
+      return { id: "install-diffnav", label: "diffnav", formula: "diffnav" };
+    case "git-delta":
+      return { id: "install-git-delta", label: "git-delta", formula: "git-delta" };
+    default:
+      throw new Error(`Unsupported semantic setup tool: ${tool}`);
+  }
+}
+
+function persistedTmuxPopupAction(facts: SetupFacts): SetupAction {
+  if (facts.tmuxBinding.status === "conflict") {
+    throw new Error("A conflicting tmux popup binding cannot be persisted.");
+  }
+  return {
+    id: "tmux-popup-binding",
+    kind: "append-file",
+    tier: "recommended",
+    selected: false,
+    label: "Install tmux popup binding",
+    message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} binding for the STATION popup dashboard in ~/.tmux.conf.`,
+    path: facts.tmuxBinding.path,
+    data: {
+      marker: facts.tmuxBinding.marker,
+      endMarker: tmuxPopupBindingEndMarker,
+      appendedText: tmuxPopupBindingBlock(facts.tmuxBinding.launcherCommand, {
+        bindingKey: facts.tmuxBinding.bindingKey,
+        runShellCommand: facts.tmuxBinding.runShellCommand,
+      }),
+    },
+  };
+}
+
+function liveTmuxPopupAction(facts: SetupFacts): SetupAction {
+  if (facts.tmuxBinding.status === "conflict") {
+    throw new Error("A conflicting tmux popup binding cannot be loaded.");
+  }
+  return {
+    id: "tmux-live-popup-binding",
+    kind: "run-command",
+    tier: "recommended",
+    selected: false,
+    label: "Load tmux popup binding",
+    message: `Install the tmux prefix + ${facts.tmuxBinding.bindingKey} STATION popup binding in the current tmux server.`,
+    command: [
+      facts.tmux.resolvedPath ?? facts.tmux.command,
+      "bind-key",
+      facts.tmuxBinding.bindingKey,
+      "run-shell",
+      "-b",
+      facts.tmuxBinding.runShellCommand,
+    ],
+  };
+}
+
+function harnessHookInstallCommand(facts: SetupFacts, harness: SupportedHarnessId): string[] {
+  const command = [
+    setupLauncherExecutable(facts.launchers.station),
+    "--config",
+    facts.configPath,
+    "hooks",
+    "install",
+    harness,
+    "--yes",
+  ];
+  if (harness === "claude" || harness === "codex" || harness === "cursor") {
+    command.push("--hook-bin", setupLauncherExecutable(facts.launchers.ingress));
+  }
+  return command;
+}
+
+function installAction(
+  id: string,
+  label: string,
+  formula: string,
+  brew: SetupFacts["brew"],
+): SetupAction {
+  const action: SetupAction = {
+    id,
+    kind: brew.status === "ok" ? "brew-install" : "noop",
+    tier: "required",
+    selected: brew.status === "ok",
+    label: `Install ${label}`,
+    message:
+      brew.status === "ok"
+        ? `Install ${label} with Homebrew.`
+        : `Homebrew is unavailable; install ${label} manually with: brew install ${formula}`,
+    command: ["brew", "install", formula],
+    data: { formula },
+  };
+  return action;
+}
+
+function configWriteActions(
+  configWrite: ConfigWritePlan | undefined,
+  hasSelectedHarness: boolean,
+): SetupAction[] {
+  if (!hasSelectedHarness) return [];
+  if (configWrite === undefined || configWrite.operation === "none") {
+    return [];
+  }
+  if (configWrite.operation === "blocked") {
+    return [
+      {
+        id: "config-blocked",
+        kind: "noop",
+        tier: "required",
+        selected: false,
+        label: "Update STATION config",
+        message: configWrite.reason,
+        path: configWrite.path,
+      },
+    ];
+  }
+  const mkdirAction: SetupAction = {
+    id: "mkdir-config-dir",
+    kind: "mkdir",
+    tier: "required",
+    selected: true,
+    label: "Create config directory",
+    message: "Create the parent directory for the STATION config file.",
+    path: configWrite.path,
+  };
+  const writeAction: SetupAction = {
+    id: configWrite.operation === "create" ? "write-config" : "update-config",
+    kind: "write-config",
+    tier: "required",
+    selected: true,
+    label: configWrite.operation === "create" ? "Write STATION config" : "Update STATION config",
+    message:
+      configWrite.operation === "create"
+        ? "Create the core STATION config; add your first project in STATION."
+        : "Update selected harness settings and append safe missing setup blocks.",
+    path: configWrite.path,
+    data: {
+      operation: configWrite.operation,
+      content: configWrite.content,
+      ...(configWrite.backupPath === undefined ? {} : { backupPath: configWrite.backupPath }),
+    },
+  };
+  return [mkdirAction, writeAction];
+}
+
+function nextSteps(requiredMissing: number, facts: SetupFacts): string[] {
+  if (requiredMissing === 0) {
+    const stationCommand = quoteCommandPart(facts.launchers.station.command);
+    return [`${stationCommand} doctor`, stationCommand];
+  }
+  if (facts.stateDir.status === "missing") {
+    return [facts.stateDir.message];
+  }
+  if (facts.xcode.status === "missing") {
+    return [facts.xcode.message];
+  }
+  if (facts.worktrunk.status === "missing") {
+    return ["Install Worktrunk, then run: stn setup check"];
+  }
+  if (facts.tmux.status === "missing") {
+    return ["Install tmux, then run: stn setup check"];
+  }
+  if (facts.bun.status === "missing") {
+    return ["Install Bun (brew install bun), then run: stn setup check"];
+  }
+  if (facts.git.status === "missing") {
+    return [facts.git.message];
+  }
+  if (facts.diffnav.status === "missing" || facts.gitDelta.status === "missing") {
+    return [
+      "Install diffnav and git-delta (brew install diffnav git-delta), then run: stn setup check",
+    ];
+  }
+  return ["Resolve the missing required setup items, then run: stn setup check"];
+}
+
+function quoteCommandPart(part: string): string {
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(part)) {
+    return part;
+  }
+  return `'${part.replaceAll("'", "'\\''")}'`;
+}

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { runCli as runCliBase } from "@station/cli";
+import { CliSetupPlanSchema } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
@@ -67,7 +68,7 @@ describe("CLI setup command", () => {
     );
 
     expect(result.code).toBe(1);
-    expect(result.output).toMatchObject({
+    expect(CliSetupPlanSchema.parse(result.output)).toMatchObject({
       generatedAt: "2026-06-08T12:00:00.000Z",
       mode: "check",
       summary: {
@@ -117,9 +118,7 @@ describe("CLI setup command", () => {
       },
     });
 
-    const plan = result.output as {
-      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     expect(plan.checks.find((check) => check.id === "harness")?.details).toMatchObject({
       default: "codex",
       enabled: "codex",
@@ -190,9 +189,7 @@ describe("CLI setup command", () => {
       },
     });
 
-    const plan = result.output as {
-      checks: Array<{ id: string; details?: Record<string, string> }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     expect(plan.checks.find((check) => check.id === "harness-tracking:codex")?.details).toEqual(
       expect.objectContaining({
         ownership: "different-owner",
@@ -312,10 +309,7 @@ describe("CLI setup command", () => {
       },
     });
 
-    const plan = result.output as {
-      summary: { selectedHarness?: string };
-      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     expect(result.code).toBe(1);
     expect(plan.summary.selectedHarness).toBe("codex");
     expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
@@ -353,10 +347,7 @@ describe("CLI setup command", () => {
       },
     });
 
-    const plan = result.output as {
-      summary: { requiredOk: boolean };
-      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     expect(result.code).toBe(1);
     expect(plan.summary.requiredOk).toBe(false);
     expect(plan.checks.find((check) => check.id === "harness")).toMatchObject({
@@ -385,11 +376,7 @@ describe("CLI setup command", () => {
     });
 
     expect(result.code).toBe(1);
-    const plan = result.output as {
-      summary: { launchReady: boolean; workflowReady: boolean; requiredOk: boolean };
-      checks: Array<{ id: string }>;
-      actions: Array<{ id: string }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     expect(plan.summary).toMatchObject({
       launchReady: true,
       workflowReady: false,
@@ -423,10 +410,7 @@ describe("CLI setup command", () => {
         fs: readOnlyFs({}),
       },
     });
-    const plan = result.output as {
-      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-      actions: Array<{ id: string }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
 
     expect(plan.checks.find((check) => check.id === "station-launchers")).toMatchObject({
       status: "warning",
@@ -483,10 +467,7 @@ describe("CLI setup command", () => {
     const check = await runCli(["--config", configPath, "setup", "check", "--json"], {
       setupDeps,
     });
-    const finalPlan = check.output as {
-      checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-      summary: { requiredOk: boolean };
-    };
+    const finalPlan = CliSetupPlanSchema.parse(check.output);
     const output = chunks.join("");
 
     expect(apply.code).toBe(0);
@@ -573,10 +554,7 @@ describe("CLI setup command", () => {
     });
 
     expect(result.code).toBe(0);
-    const plan = result.output as {
-      actions: Array<{ id: string; data?: { appendedText?: string } }>;
-      checks: Array<{ id: string; details?: Record<string, string> }>;
-    };
+    const plan = CliSetupPlanSchema.parse(result.output);
     const runShellCommand = buildManagedFastPopupRunShellCommand({
       installedRoot,
       fallbackAlias: popupAlias,
@@ -754,7 +732,7 @@ describe("CLI setup command", () => {
     });
 
     expect(result.code).toBe(1);
-    expect(result.output).toMatchObject({
+    expect(CliSetupPlanSchema.parse(result.output)).toMatchObject({
       checks: expect.arrayContaining([
         expect.objectContaining({
           id: "harness-tracking:codex",
@@ -961,7 +939,7 @@ describe("CLI setup command", () => {
     });
 
     expect(result.code).toBe(1);
-    expect(result.output).toMatchObject({
+    expect(CliSetupPlanSchema.parse(result.output)).toMatchObject({
       summary: { workflowReady: false, requiredOk: false },
     });
   });

--- a/apps/cli/test/integration/setup-profiles.test.ts
+++ b/apps/cli/test/integration/setup-profiles.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { runCli } from "@station/cli";
+import { CliSetupPlanSchema } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { type MachineProfile, machineProfiles } from "@station/testing";
 import { afterEach, describe, expect, it } from "vitest";
@@ -33,10 +34,7 @@ describe("setup machine profiles", () => {
       });
 
       expect(result.code).toBe(profile.expect.exitCode);
-      const plan = result.output as {
-        summary: { requiredOk: boolean };
-        checks: { id: string; status: string }[];
-      };
+      const plan = CliSetupPlanSchema.parse(result.output);
       expect(plan.summary.requiredOk).toBe(profile.expect.requiredOk);
       const statusById = new Map(plan.checks.map((check) => [check.id, check.status]));
       for (const [id, status] of Object.entries(profile.expect.checks)) {

--- a/apps/cli/test/unit/setup-model.test.ts
+++ b/apps/cli/test/unit/setup-model.test.ts
@@ -4,7 +4,6 @@ import { harnessDefinitions } from "../../src/commands/setup/checks/harnesses.js
 import {
   SetupHarnessSelectionSourceSchema,
   SetupHarnessTrackingFactSchema,
-  SetupPlanSchema,
   supportedHarnessIds,
 } from "../../src/commands/setup/model.js";
 
@@ -43,97 +42,5 @@ describe("setup model", () => {
         extra: true,
       }),
     ).toThrow();
-  });
-
-  it("validates setup plan JSON shape", () => {
-    const parsed = SetupPlanSchema.parse({
-      generatedAt: "2026-06-08T12:00:00.000Z",
-      mode: "check",
-      checks: [
-        {
-          id: "worktrunk",
-          tier: "required",
-          status: "ok",
-          label: "Worktrunk",
-          message: "Worktrunk is available.",
-        },
-      ],
-      actions: [
-        {
-          id: "tmux-popup-binding",
-          kind: "append-file",
-          tier: "recommended",
-          selected: false,
-          label: "Install tmux popup binding",
-          message: "Append binding.",
-          path: "/tmp/home/.tmux.conf",
-          data: {
-            marker: "# >>> station popup binding >>>",
-            appendedText: "# >>> station popup binding >>>\n",
-          },
-        },
-      ],
-      summary: {
-        launchReady: true,
-        workflowReady: true,
-        requiredOk: true,
-        requiredMissing: 0,
-        warnings: 0,
-        selectedActions: 0,
-        selectionSource: "configured",
-        selectedHarness: "codex",
-        configPath: "/tmp/config.toml",
-      },
-      nextSteps: ["stn doctor"],
-    });
-
-    expect(parsed.summary.requiredOk).toBe(true);
-    expect(parsed.summary.launchReady).toBe(true);
-    expect(parsed.summary.workflowReady).toBe(true);
-  });
-
-  it("rejects unexpected output fields", () => {
-    expect(() =>
-      SetupPlanSchema.parse({
-        generatedAt: "2026-06-08T12:00:00.000Z",
-        mode: "check",
-        checks: [],
-        actions: [],
-        summary: {
-          launchReady: true,
-          workflowReady: true,
-          requiredOk: true,
-          requiredMissing: 0,
-          warnings: 0,
-          selectedActions: 0,
-          selectionSource: "unresolved",
-          configPath: "/tmp/config.toml",
-        },
-        nextSteps: [],
-        extra: true,
-      }),
-    ).toThrow();
-  });
-
-  it("keeps requiredOk as a compatibility alias of workflowReady", () => {
-    expect(() =>
-      SetupPlanSchema.parse({
-        generatedAt: "2026-06-08T12:00:00.000Z",
-        mode: "check",
-        checks: [],
-        actions: [],
-        summary: {
-          launchReady: true,
-          workflowReady: false,
-          requiredOk: true,
-          requiredMissing: 1,
-          warnings: 0,
-          selectedActions: 0,
-          selectionSource: "unresolved",
-          configPath: "/tmp/config.toml",
-        },
-        nextSteps: [],
-      }),
-    ).toThrow("requiredOk must match workflowReady");
   });
 });

--- a/apps/cli/test/unit/setup-plan-projection.test.ts
+++ b/apps/cli/test/unit/setup-plan-projection.test.ts
@@ -483,8 +483,7 @@ describe("setup plan projection", () => {
           {
             harnessId: "opencode",
             capability: "supported",
-            requested: true,
-            installed: false,
+            requested: false,
           },
         ],
         config: validConfigFact({
@@ -515,7 +514,7 @@ describe("setup plan projection", () => {
           {
             harnessId: "opencode",
             capability: "supported",
-            requested: false,
+            probeFailed: true,
           },
         ],
         config: validConfigFact({

--- a/apps/cli/test/unit/setup-plan-projection.test.ts
+++ b/apps/cli/test/unit/setup-plan-projection.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../src/commands/setup/model.js";
 import { buildSetupPlan } from "../../src/commands/setup/planner.js";
 
-describe("setup planner", () => {
+describe("setup plan projection", () => {
   it("reports all core checks ready and no selected actions", () => {
     const plan = buildSetupPlan(facts());
 
@@ -107,6 +107,9 @@ describe("setup planner", () => {
       status: "ok",
       details: { state: "not-applicable" },
     });
+    expect(
+      plan.checks.find((check) => check.id === "harness-tracking:pi")?.details,
+    ).not.toHaveProperty("requested");
     expect(plan.summary.requiredOk).toBe(true);
     expect(plan.actions.some((action) => action.id === "pi-hooks")).toBe(false);
   });
@@ -340,6 +343,7 @@ describe("setup planner", () => {
 
     expect(plan.summary).toMatchObject({ selectionSource: "unresolved", requiredOk: false });
     expect(plan.summary.selectedHarness).toBeUndefined();
+    expect("selectedHarness" in plan.summary).toBe(false);
   });
 
   it("respects an explicit selected harness when multiple are available", () => {
@@ -961,13 +965,15 @@ describe("setup planner", () => {
       },
     });
 
-    expect(plan.actions.find((action) => action.id === "update-config")).toMatchObject({
+    const updateAction = plan.actions.find((action) => action.id === "update-config");
+    expect(updateAction).toMatchObject({
       kind: "write-config",
       selected: true,
       data: {
         operation: "update",
       },
     });
+    expect(updateAction?.data).not.toHaveProperty("backupPath");
   });
 
   it("uses a noop action for invalid existing config", () => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ The repo is organized around these boundaries:
 - `packages/contracts` owns shared application schemas and types, including `ObserverApi`, external-launch values, commands, events, snapshots, observations, provider ports, hooks, diagnostics, and safe errors.
 - `packages/protocol` owns the observer NDJSON transport: envelopes, method mapping, validation execution, client/server mechanics, and fail-closed Unix-socket probing and stale-owner evidence.
 - `packages/runtime` owns shared runtime boundary helpers for timeouts, retry, cancellation, external commands, typed error conversion, and atomic text replacement.
-- `packages/setup-core` owns dependency-free deterministic setup decisions over normalized harness selection, tracking, repair, and readiness facts.
+- `packages/setup-core` owns dependency-free deterministic setup decisions over normalized evidence and intent, including semantic issues, operations, plans, and readiness results.
 - `packages/client` owns the framework-neutral rich-client observer runtime: snapshot loading, the event subscription/reconnect loop, event-to-snapshot reduction, and command dispatch/completion-wait wrappers consumed by the Station UI.
 - `apps/cli/src/ingress` owns the tiny `stn-ingress` sender: raw provider hook delivery to the observer socket and offline spool writes. Events sent through this raw path normalize and compact observer-side via provider hook adapters; integrations that submit typed harness reports normalize in their own adapter.
 - `packages/station-host` owns the standalone `station-station-host` daemon contract and client: a process that owns PTYs and their bounded raw/semantic replay state beyond the Station UI lifetime, exposing attach/list/close over its own local socket so panes can warm-reattach. Station consumes it directly; Observer application code can reach host-backed terminal behavior only through an adapter supplied by CLI composition.
@@ -74,7 +74,7 @@ When these disagree, reconcile from config, providers, and current observer stat
   context and on daemon-inherited color controls; only color controls carried
   by the explicit launch request are authoritative.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
-- Setup IO and orchestration remain in the CLI: it validates and normalizes external facts, projects setup-core outcomes into existing plan schemas and copy, and owns config, provider, process, and persistence effects. `@station/setup-core` imports none of those concerns.
+- Setup IO and orchestration remain in the CLI: it validates and normalizes external facts, projects setup-core semantic plans and results into the existing CLI compatibility schemas and copy, and owns config, provider, process, and persistence effects. `@station/setup-core` imports none of those concerns.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
 - The protocol validates transport messages and keeps consumer APIs simple. It should not become a provider boundary.
 - Client processes may spawn after an absent or proven-stale socket, but only the process binding the replacement may unlink it. Inaccessible ownership is preserved; pidfiles never establish liveness or authorize reclaim.

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -14028,6 +14028,37 @@
       "dependencies": []
     },
     {
+      "path": "packages/setup-core/src/policy/deriveSetupResult.ts",
+      "declaration": "deriveSetupResult",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Derives readiness and compatibility counts from current semantic evidence without trusting attempted mutations.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/policy/planSetup.ts",
+      "declaration": "planSetup",
+      "kind": "function",
+      "role": "POLICY",
+      "purpose": "Derives semantic setup issues and operations from normalized evidence and intent without rendering or performing effects.",
+      "dependencies": [
+        {
+          "path": "packages/setup-core/src/policy/deriveSetupResult.ts",
+          "declaration": "deriveSetupResult",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/setup-core/src/policy/resolveHarnessSelection.ts",
+          "declaration": "resolveHarnessSelection",
+          "kind": "function",
+          "role": "POLICY",
+          "edgeKind": "runtime"
+        }
+      ]
+    },
+    {
       "path": "packages/setup-core/src/policy/resolveHarnessSelection.ts",
       "declaration": "resolveHarnessSelection",
       "kind": "function",

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,6 +13,7 @@ export * from "./observer.js";
 export * from "./providers.js";
 export * from "./recovery.js";
 export * from "./recoveryBreadcrumbs.js";
+export * from "./setupTypes.js";
 export * from "./snapshot.js";
 export * from "./terminalIntents.js";
 export * from "./terminalTargets.js";

--- a/packages/contracts/src/setupTypes.ts
+++ b/packages/contracts/src/setupTypes.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+export const CliSetupHarnessIdSchema = z.enum(["codex", "cursor", "opencode", "pi", "claude"]);
+
+export const CliSetupCheckSchema = z
+  .object({
+    id: z.string().min(1),
+    tier: z.enum(["required", "recommended", "optional"]),
+    status: z.enum(["ok", "missing", "warning", "skipped"]),
+    label: z.string().min(1),
+    message: z.string().min(1),
+    details: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+export const CliSetupActionSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.enum(["brew-install", "run-command", "write-config", "append-file", "mkdir", "noop"]),
+    tier: z.enum(["required", "recommended", "optional"]),
+    selected: z.boolean(),
+    label: z.string().min(1),
+    message: z.string().min(1),
+    command: z.array(z.string()).optional(),
+    path: z.string().optional(),
+    status: z.enum(["pending", "completed", "failed", "skipped"]).optional(),
+    data: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+export const CliSetupSummarySchema = z
+  .object({
+    launchReady: z.boolean(),
+    workflowReady: z.boolean(),
+    requiredOk: z.boolean(),
+    requiredMissing: z.number().int().nonnegative(),
+    warnings: z.number().int().nonnegative(),
+    selectedActions: z.number().int().nonnegative(),
+    selectionSource: z.enum(["configured", "explicit", "inferred", "unresolved"]),
+    selectedHarness: CliSetupHarnessIdSchema.optional(),
+    configPath: z.string(),
+  })
+  .strict()
+  .refine((summary) => summary.requiredOk === summary.workflowReady, {
+    path: ["requiredOk"],
+    message: "requiredOk must match workflowReady",
+  });
+
+export const CliSetupPlanSchema = z
+  .object({
+    generatedAt: z.string().min(1),
+    mode: z.enum(["check", "plan", "apply"]),
+    checks: z.array(CliSetupCheckSchema),
+    actions: z.array(CliSetupActionSchema),
+    summary: CliSetupSummarySchema,
+    nextSteps: z.array(z.string()),
+  })
+  .strict();
+
+export type CliSetupHarnessId = z.infer<typeof CliSetupHarnessIdSchema>;
+export type CliSetupCheck = z.infer<typeof CliSetupCheckSchema>;
+export type CliSetupAction = z.infer<typeof CliSetupActionSchema>;
+export type CliSetupSummary = z.infer<typeof CliSetupSummarySchema>;
+export type CliSetupPlan = z.infer<typeof CliSetupPlanSchema>;

--- a/packages/contracts/test/schema/setup-types-schema.test.ts
+++ b/packages/contracts/test/schema/setup-types-schema.test.ts
@@ -1,0 +1,181 @@
+import {
+  CliSetupActionSchema,
+  CliSetupCheckSchema,
+  CliSetupHarnessIdSchema,
+  CliSetupPlanSchema,
+  CliSetupSummarySchema,
+} from "@station/contracts";
+import { supportedHarnessIds } from "@station/setup-core";
+import { describe, expect, it } from "vitest";
+
+const plan = {
+  generatedAt: "2026-07-29T12:00:00.000Z",
+  mode: "plan",
+  checks: [
+    {
+      id: "harness-tracking:codex",
+      tier: "required",
+      status: "missing",
+      label: "Codex tracking",
+      message: "Codex tracking artifacts need repair.",
+      details: {
+        harness: "codex",
+        selectionSource: "configured",
+        capability: "supported",
+        state: "artifact-missing-or-drifted",
+        requested: "true",
+        installed: "false",
+      },
+    },
+  ],
+  actions: [
+    {
+      id: "codex-hooks",
+      kind: "run-command",
+      tier: "required",
+      selected: true,
+      label: "Install Codex tracking",
+      message: "Install Station-owned Codex tracking artifacts.",
+      command: [
+        "/sandbox/bin/stn",
+        "--config",
+        "/sandbox/config.toml",
+        "hooks",
+        "install",
+        "codex",
+        "--yes",
+        "--hook-bin",
+        "/sandbox/bin/stn-ingress",
+      ],
+      data: { setupRole: "hook", harness: "codex" },
+    },
+  ],
+  summary: {
+    launchReady: true,
+    workflowReady: false,
+    requiredOk: false,
+    requiredMissing: 1,
+    warnings: 0,
+    selectedActions: 1,
+    selectionSource: "configured",
+    selectedHarness: "codex",
+    configPath: "/sandbox/config.toml",
+  },
+  nextSteps: ["Resolve the missing required setup items, then run: stn setup check"],
+} as const;
+
+describe("CLI setup schemas", () => {
+  it("accepts the existing strict setup payload", () => {
+    expect(CliSetupPlanSchema.parse(plan)).toEqual(plan);
+  });
+
+  it("rejects unknown top-level and nested keys", () => {
+    expect(CliSetupPlanSchema.safeParse({ ...plan, extra: true }).success).toBe(false);
+    expect(
+      CliSetupPlanSchema.safeParse({
+        ...plan,
+        checks: [{ ...plan.checks[0], extra: true }],
+      }).success,
+    ).toBe(false);
+    expect(
+      CliSetupPlanSchema.safeParse({
+        ...plan,
+        actions: [{ ...plan.actions[0], extra: true }],
+      }).success,
+    ).toBe(false);
+    expect(
+      CliSetupPlanSchema.safeParse({
+        ...plan,
+        summary: { ...plan.summary, extra: true },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts every wire enum and rejects values outside them", () => {
+    for (const mode of ["check", "plan", "apply"]) {
+      expect(CliSetupPlanSchema.safeParse({ ...plan, mode }).success).toBe(true);
+    }
+    for (const harnessId of ["codex", "cursor", "opencode", "pi", "claude"]) {
+      expect(CliSetupHarnessIdSchema.parse(harnessId)).toBe(harnessId);
+    }
+    for (const tier of ["required", "recommended", "optional"]) {
+      expect(CliSetupCheckSchema.safeParse({ ...plan.checks[0], tier }).success).toBe(true);
+      expect(CliSetupActionSchema.safeParse({ ...plan.actions[0], tier }).success).toBe(true);
+    }
+    for (const status of ["ok", "missing", "warning", "skipped"]) {
+      expect(CliSetupCheckSchema.safeParse({ ...plan.checks[0], status }).success).toBe(true);
+    }
+    for (const kind of [
+      "brew-install",
+      "run-command",
+      "write-config",
+      "append-file",
+      "mkdir",
+      "noop",
+    ]) {
+      expect(CliSetupActionSchema.safeParse({ ...plan.actions[0], kind }).success).toBe(true);
+    }
+    for (const status of ["pending", "completed", "failed", "skipped"]) {
+      expect(CliSetupActionSchema.safeParse({ ...plan.actions[0], status }).success).toBe(true);
+    }
+    for (const selectionSource of ["configured", "explicit", "inferred", "unresolved"]) {
+      expect(CliSetupSummarySchema.safeParse({ ...plan.summary, selectionSource }).success).toBe(
+        true,
+      );
+    }
+
+    expect(CliSetupPlanSchema.safeParse({ ...plan, mode: "repair" }).success).toBe(false);
+    expect(CliSetupHarnessIdSchema.safeParse("crush").success).toBe(false);
+    expect(CliSetupCheckSchema.safeParse({ ...plan.checks[0], tier: "blocking" }).success).toBe(
+      false,
+    );
+    expect(
+      CliSetupActionSchema.safeParse({ ...plan.actions[0], kind: "provider-command" }).success,
+    ).toBe(false);
+  });
+
+  it("keeps requiredOk equal to workflowReady", () => {
+    expect(CliSetupSummarySchema.safeParse({ ...plan.summary, requiredOk: true }).success).toBe(
+      false,
+    );
+  });
+
+  it("preserves absent optional fields", () => {
+    const check = CliSetupCheckSchema.parse({
+      id: "git-project",
+      tier: "required",
+      status: "ok",
+      label: "Git",
+      message: "Git is available.",
+    });
+    const action = CliSetupActionSchema.parse({
+      id: "link-station-launchers",
+      kind: "run-command",
+      tier: "recommended",
+      selected: false,
+      label: "Link STATION launchers",
+      message: "Link launchers.",
+    });
+    const summary = CliSetupSummarySchema.parse({
+      launchReady: true,
+      workflowReady: false,
+      requiredOk: false,
+      requiredMissing: 1,
+      warnings: 0,
+      selectedActions: 0,
+      selectionSource: "unresolved",
+      configPath: "/sandbox/config.toml",
+    });
+
+    expect("details" in check).toBe(false);
+    expect("command" in action).toBe(false);
+    expect("path" in action).toBe(false);
+    expect("status" in action).toBe(false);
+    expect("data" in action).toBe(false);
+    expect("selectedHarness" in summary).toBe(false);
+  });
+
+  it("keeps the intentionally duplicated wire harness enum aligned with setup-core", () => {
+    expect(CliSetupHarnessIdSchema.options).toEqual([...supportedHarnessIds]);
+  });
+});

--- a/packages/setup-core/src/index.ts
+++ b/packages/setup-core/src/index.ts
@@ -4,13 +4,21 @@ export {
   type HarnessTrackingAssessment,
   type HarnessTrackingFacts,
   type HarnessTrackingRepairFact,
+  type SetupPlanningFacts,
   type SetupReadiness,
   type SetupReadinessFacts,
+  type SetupToolId,
   type SupportedHarnessId,
   supportedHarnessIds,
 } from "./model/facts.js";
-export type { HarnessSelectionIntent } from "./model/intent.js";
+export type { HarnessSelectionIntent, SetupPlanningIntent } from "./model/intent.js";
+export type { SetupIssue } from "./model/issues.js";
+export type { SetupOperation } from "./model/operations.js";
+export type { SetupPlan } from "./model/plan.js";
+export type { SetupResult } from "./model/result.js";
 export { assessHarnessTracking } from "./policy/assessHarnessTracking.js";
 export { deriveSetupReadiness } from "./policy/deriveReadiness.js";
+export { type DeriveSetupResultInput, deriveSetupResult } from "./policy/deriveSetupResult.js";
+export { planSetup } from "./policy/planSetup.js";
 export { resolveHarnessSelection } from "./policy/resolveHarnessSelection.js";
 export { selectHarnessTrackingRepairTargets } from "./policy/selectRepairTargets.js";

--- a/packages/setup-core/src/model/facts.ts
+++ b/packages/setup-core/src/model/facts.ts
@@ -84,3 +84,55 @@ export type SetupReadiness = {
   readonly workflowReady: boolean;
   readonly requiredMissing: number;
 };
+
+export type SetupToolId = "worktrunk" | "tmux" | "bun" | "diffnav" | "git-delta";
+
+export type SetupPlanningFacts = {
+  readonly generatedAt: string;
+  readonly compiled: boolean;
+  readonly stateDirectoryWritable: boolean;
+  readonly socketEvidenceAvailable: boolean;
+  readonly xcodeTools: "available" | "missing" | "not-applicable";
+  readonly tools: readonly {
+    readonly id: SetupToolId;
+    readonly available: boolean;
+    readonly installerAvailable: boolean;
+  }[];
+  readonly runtimeUi: "available" | "missing" | "not-applicable";
+  readonly git:
+    | { readonly state: "usable"; readonly repository: "present" | "absent" }
+    | {
+        readonly state: "unusable";
+        readonly reason:
+          | "git-absent"
+          | "git-unusable"
+          | "repository-unusable"
+          | "dubious-ownership";
+      };
+  readonly harnessSelection: HarnessSelectionFacts;
+  readonly config: {
+    readonly state: "missing" | "valid" | "invalid";
+    readonly write: "none" | "create" | "update" | "blocked";
+    readonly diagnostics: readonly {
+      readonly code: string;
+      readonly severity: "warn" | "error";
+    }[];
+  };
+  readonly launchers: {
+    readonly station: "available" | "missing" | "checkout" | "installed";
+    readonly ingress: "available" | "missing" | "checkout" | "installed";
+    readonly tmuxPopup: "available" | "missing" | "checkout" | "installed";
+  };
+  readonly worktrunkAutomation: "ready" | "warning" | "skipped";
+  readonly worktrunkShell: "ready" | "missing" | "skipped";
+  readonly tmuxPopup: {
+    readonly persisted: "ready" | "missing" | "conflict";
+    readonly live: "ready" | "missing" | "not-applicable" | "unknown";
+  };
+  readonly worktrunkHooks: "ready" | "missing" | "not-applicable";
+  readonly harnessTracking: readonly {
+    readonly harnessId: SupportedHarnessId;
+    readonly assessment: HarnessTrackingAssessment;
+    readonly required: boolean;
+  }[];
+};

--- a/packages/setup-core/src/model/facts.ts
+++ b/packages/setup-core/src/model/facts.ts
@@ -134,5 +134,6 @@ export type SetupPlanningFacts = {
     readonly harnessId: SupportedHarnessId;
     readonly assessment: HarnessTrackingAssessment;
     readonly required: boolean;
+    readonly persistedIntent: boolean;
   }[];
 };

--- a/packages/setup-core/src/model/intent.ts
+++ b/packages/setup-core/src/model/intent.ts
@@ -7,3 +7,9 @@ export type HarnessSelectionIntent =
       readonly harnessIds: readonly SupportedHarnessId[];
     }
   | { readonly kind: "cancelled" };
+
+export type SetupPlanningIntent = {
+  readonly mode: "check" | "plan" | "apply";
+  readonly harnessSelection: HarnessSelectionIntent;
+  readonly installWorktrunkHooks: boolean;
+};

--- a/packages/setup-core/src/model/issues.ts
+++ b/packages/setup-core/src/model/issues.ts
@@ -1,0 +1,68 @@
+import type { SetupToolId, SupportedHarnessId } from "./facts.js";
+
+export type SetupIssue =
+  | { readonly code: "state-directory-unwritable"; readonly tier: "required" }
+  | { readonly code: "socket-evidence-unavailable"; readonly tier: "recommended" }
+  | { readonly code: "xcode-tools-missing"; readonly tier: "required" }
+  | {
+      readonly code: "tool-missing";
+      readonly tier: "required" | "recommended";
+      readonly tool: SetupToolId;
+    }
+  | {
+      readonly code: "git-unavailable";
+      readonly tier: "required";
+      readonly reason: "git-absent" | "git-unusable" | "repository-unusable" | "dubious-ownership";
+    }
+  | {
+      readonly code: "harness-selection-invalid";
+      readonly tier: "required";
+      readonly reason:
+        | "empty-explicit-selection"
+        | "no-available-harness"
+        | "invalid-config"
+        | "unsupported-configured-default"
+        | "cancelled";
+    }
+  | {
+      readonly code: "harness-selection-ambiguous";
+      readonly tier: "required";
+      readonly candidateHarnessIds: readonly SupportedHarnessId[];
+    }
+  | {
+      readonly code: "config-unready";
+      readonly tier: "required";
+      readonly state: "missing" | "invalid" | "write-blocked";
+    }
+  | {
+      readonly code: "config-diagnostic";
+      readonly tier: "recommended";
+      readonly diagnosticCode: string;
+      readonly severity: "warn" | "error";
+    }
+  | {
+      readonly code: "launcher-unready";
+      readonly tier: "recommended";
+      readonly launcher: "station" | "ingress" | "tmux-popup";
+      readonly state: "missing" | "checkout" | "installed";
+    }
+  | { readonly code: "station-ui-missing"; readonly tier: "required" }
+  | {
+      readonly code: "worktrunk-automation-unready";
+      readonly tier: "recommended";
+      readonly state: "warning" | "skipped";
+    }
+  | { readonly code: "worktrunk-shell-missing"; readonly tier: "recommended" }
+  | {
+      readonly code: "tmux-popup-unready";
+      readonly tier: "recommended";
+      readonly scope: "persisted" | "live";
+      readonly state: "missing" | "conflict" | "unknown";
+    }
+  | { readonly code: "worktrunk-hooks-missing"; readonly tier: "recommended" }
+  | {
+      readonly code: "harness-tracking-unprepared";
+      readonly tier: "required" | "recommended";
+      readonly harnessId: SupportedHarnessId;
+      readonly state: "probe-failed" | "disabled" | "artifact-missing-or-drifted";
+    };

--- a/packages/setup-core/src/model/operations.ts
+++ b/packages/setup-core/src/model/operations.ts
@@ -1,0 +1,49 @@
+import type { SetupToolId, SupportedHarnessId } from "./facts.js";
+
+export type SetupOperation =
+  | {
+      readonly id: `install:${SetupToolId}`;
+      readonly kind: "install-tool";
+      readonly tier: "required" | "recommended";
+      readonly selected: boolean;
+      readonly tool: SetupToolId;
+    }
+  | {
+      readonly id: "link-station-launchers";
+      readonly kind: "link-launchers";
+      readonly tier: "recommended";
+      readonly selected: false;
+    }
+  | {
+      readonly id: "configure-worktrunk-shell";
+      readonly kind: "configure-worktrunk-shell";
+      readonly tier: "recommended";
+      readonly selected: false;
+    }
+  | {
+      readonly id: "persist-tmux-popup" | "load-tmux-popup";
+      readonly kind: "configure-tmux-popup";
+      readonly tier: "recommended";
+      readonly selected: false;
+      readonly scope: "persisted" | "live";
+    }
+  | {
+      readonly id: "prepare-worktrunk-tracking";
+      readonly kind: "prepare-worktrunk-tracking";
+      readonly tier: "recommended";
+      readonly selected: boolean;
+    }
+  | {
+      readonly id: `prepare-harness-tracking:${SupportedHarnessId}`;
+      readonly kind: "prepare-harness-tracking";
+      readonly tier: "required" | "recommended";
+      readonly selected: true;
+      readonly harnessId: SupportedHarnessId;
+    }
+  | {
+      readonly id: "write-config";
+      readonly kind: "write-config";
+      readonly tier: "required";
+      readonly selected: true;
+      readonly change: "create" | "update";
+    };

--- a/packages/setup-core/src/model/plan.ts
+++ b/packages/setup-core/src/model/plan.ts
@@ -1,0 +1,15 @@
+import type { HarnessSelectionResolution, SetupPlanningFacts } from "./facts.js";
+import type { SetupPlanningIntent } from "./intent.js";
+import type { SetupIssue } from "./issues.js";
+import type { SetupOperation } from "./operations.js";
+import type { SetupResult } from "./result.js";
+
+export type SetupPlan = {
+  readonly generatedAt: string;
+  readonly mode: SetupPlanningIntent["mode"];
+  readonly selection: HarnessSelectionResolution;
+  readonly evidence: SetupPlanningFacts;
+  readonly issues: readonly SetupIssue[];
+  readonly operations: readonly SetupOperation[];
+  readonly result: SetupResult;
+};

--- a/packages/setup-core/src/model/result.ts
+++ b/packages/setup-core/src/model/result.ts
@@ -1,0 +1,8 @@
+import type { SetupReadiness } from "./facts.js";
+
+export type SetupResult = {
+  readonly readiness: SetupReadiness;
+  readonly requiredIssueCount: number;
+  readonly warningCount: number;
+  readonly selectedOperationCount: number;
+};

--- a/packages/setup-core/src/policy/deriveSetupResult.ts
+++ b/packages/setup-core/src/policy/deriveSetupResult.ts
@@ -1,0 +1,83 @@
+import type { SetupPlanningFacts } from "../model/facts.js";
+import type { SetupIssue } from "../model/issues.js";
+import type { SetupOperation } from "../model/operations.js";
+import type { SetupResult } from "../model/result.js";
+
+export type DeriveSetupResultInput = {
+  readonly evidence: SetupPlanningFacts;
+  readonly issues: readonly SetupIssue[];
+  readonly operations: readonly SetupOperation[];
+};
+
+/**
+ * POLICY
+ *
+ * Derives readiness and compatibility counts from current semantic evidence without trusting attempted mutations.
+ */
+export function deriveSetupResult(input: DeriveSetupResultInput): SetupResult {
+  const requiredIssues = input.issues.filter((issue) => issue.tier === "required");
+  const workflowIssues = requiredIssues.filter(
+    (issue) =>
+      issue.code !== "station-ui-missing" &&
+      !(
+        issue.code === "config-unready" &&
+        issue.state === "write-blocked" &&
+        input.evidence.config.state === "valid"
+      ),
+  );
+  const bunAvailable = toolAvailable(input.evidence, "bun");
+  const launchReady =
+    input.evidence.stateDirectoryWritable &&
+    (input.evidence.compiled || (bunAvailable && input.evidence.runtimeUi !== "missing"));
+
+  return {
+    readiness: {
+      launchReady,
+      workflowReady: workflowIssues.length === 0,
+      requiredMissing: workflowIssues.length,
+    },
+    requiredIssueCount: requiredIssues.length,
+    warningCount: deriveWarningCount(input.evidence, input.issues),
+    selectedOperationCount: input.operations.filter((operation) => operation.selected).length,
+  };
+}
+
+function deriveWarningCount(evidence: SetupPlanningFacts, issues: readonly SetupIssue[]): number {
+  let count = 1;
+  if (issues.some((issue) => issue.code === "socket-evidence-unavailable")) count += 1;
+  if (issues.some((issue) => issue.code === "config-diagnostic")) count += 1;
+  if (issues.some((issue) => issue.code === "launcher-unready")) count += 1;
+  if (issues.some((issue) => issue.code === "station-ui-missing")) count += 1;
+  if (issues.some((issue) => issue.code === "worktrunk-shell-missing")) count += 1;
+
+  const tmuxPopupConflict = issues.some(
+    (issue) =>
+      issue.code === "tmux-popup-unready" &&
+      issue.scope === "persisted" &&
+      issue.state === "conflict",
+  );
+  const tmuxPopupWarning =
+    tmuxPopupConflict ||
+    (toolAvailable(evidence, "tmux") &&
+      (evidence.launchers.tmuxPopup === "missing" ||
+        issues.some((issue) => issue.code === "tmux-popup-unready")));
+  if (tmuxPopupWarning) count += 1;
+
+  const worktrunkWarning =
+    toolAvailable(evidence, "worktrunk") &&
+    (evidence.worktrunkAutomation === "warning" ||
+      issues.some((issue) => issue.code === "worktrunk-hooks-missing"));
+  if (worktrunkWarning) count += 1;
+
+  count += issues.filter(
+    (issue) => issue.code === "harness-tracking-unprepared" && issue.tier === "recommended",
+  ).length;
+  return count;
+}
+
+function toolAvailable(
+  evidence: SetupPlanningFacts,
+  toolId: SetupPlanningFacts["tools"][number]["id"],
+): boolean {
+  return evidence.tools.find((tool) => tool.id === toolId)?.available === true;
+}

--- a/packages/setup-core/src/policy/planSetup.ts
+++ b/packages/setup-core/src/policy/planSetup.ts
@@ -1,0 +1,300 @@
+import type {
+  HarnessSelectionResolution,
+  SetupPlanningFacts,
+  SetupToolId,
+} from "../model/facts.js";
+import type { SetupPlanningIntent } from "../model/intent.js";
+import type { SetupIssue } from "../model/issues.js";
+import type { SetupOperation } from "../model/operations.js";
+import type { SetupPlan } from "../model/plan.js";
+import { deriveSetupResult } from "./deriveSetupResult.js";
+import { resolveHarnessSelection } from "./resolveHarnessSelection.js";
+
+/**
+ * POLICY
+ *
+ * Derives semantic setup issues and operations from normalized evidence and intent without rendering or performing effects.
+ */
+export function planSetup(facts: SetupPlanningFacts, intent: SetupPlanningIntent): SetupPlan {
+  const selection = resolveHarnessSelection(facts.harnessSelection, intent.harnessSelection);
+  const issues = deriveIssues(facts, selection);
+  const operations = deriveOperations(facts, intent, selection, issues);
+  return {
+    generatedAt: facts.generatedAt,
+    mode: intent.mode,
+    selection,
+    evidence: facts,
+    issues,
+    operations,
+    result: deriveSetupResult({ evidence: facts, issues, operations }),
+  };
+}
+
+function deriveIssues(
+  facts: SetupPlanningFacts,
+  selection: HarnessSelectionResolution,
+): SetupIssue[] {
+  const issues: SetupIssue[] = [];
+  if (!facts.stateDirectoryWritable) {
+    issues.push({ code: "state-directory-unwritable", tier: "required" });
+  }
+  if (!facts.socketEvidenceAvailable) {
+    issues.push({ code: "socket-evidence-unavailable", tier: "recommended" });
+  }
+  if (!facts.compiled && facts.xcodeTools === "missing") {
+    issues.push({ code: "xcode-tools-missing", tier: "required" });
+  }
+  for (const tool of facts.tools) {
+    if (!tool.available && toolApplies(tool.id, facts.compiled)) {
+      issues.push({ code: "tool-missing", tier: "required", tool: tool.id });
+    }
+  }
+  if (facts.git.state === "unusable") {
+    issues.push({ code: "git-unavailable", tier: "required", reason: facts.git.reason });
+  }
+  addHarnessSelectionIssues(issues, facts, selection);
+
+  if (facts.config.write === "blocked") {
+    issues.push({ code: "config-unready", tier: "required", state: "write-blocked" });
+  } else if (facts.config.state !== "valid") {
+    issues.push({
+      code: "config-unready",
+      tier: "required",
+      state: facts.config.state,
+    });
+  }
+  for (const diagnostic of facts.config.diagnostics) {
+    issues.push({
+      code: "config-diagnostic",
+      tier: "recommended",
+      diagnosticCode: diagnostic.code,
+      severity: diagnostic.severity,
+    });
+  }
+  addLauncherIssues(issues, facts);
+  if (!facts.compiled && facts.runtimeUi === "missing") {
+    issues.push({ code: "station-ui-missing", tier: "required" });
+  }
+  if (facts.worktrunkAutomation !== "ready") {
+    issues.push({
+      code: "worktrunk-automation-unready",
+      tier: "recommended",
+      state: facts.worktrunkAutomation,
+    });
+  }
+  if (facts.worktrunkShell === "missing") {
+    issues.push({ code: "worktrunk-shell-missing", tier: "recommended" });
+  }
+  if (facts.tmuxPopup.persisted !== "ready") {
+    issues.push({
+      code: "tmux-popup-unready",
+      tier: "recommended",
+      scope: "persisted",
+      state: facts.tmuxPopup.persisted,
+    });
+  }
+  if (facts.tmuxPopup.live === "missing" || facts.tmuxPopup.live === "unknown") {
+    issues.push({
+      code: "tmux-popup-unready",
+      tier: "recommended",
+      scope: "live",
+      state: facts.tmuxPopup.live,
+    });
+  }
+  if (facts.worktrunkHooks === "missing") {
+    issues.push({ code: "worktrunk-hooks-missing", tier: "recommended" });
+  }
+  for (const tracking of facts.harnessTracking) {
+    if (
+      tracking.assessment.state === "probe-failed" ||
+      tracking.assessment.state === "disabled" ||
+      tracking.assessment.state === "artifact-missing-or-drifted"
+    ) {
+      issues.push({
+        code: "harness-tracking-unprepared",
+        tier: tracking.required ? "required" : "recommended",
+        harnessId: tracking.harnessId,
+        state: tracking.assessment.state,
+      });
+    }
+  }
+  return issues;
+}
+
+function addHarnessSelectionIssues(
+  issues: SetupIssue[],
+  facts: SetupPlanningFacts,
+  selection: HarnessSelectionResolution,
+): void {
+  if (selection.outcome === "invalid") {
+    issues.push({
+      code: "harness-selection-invalid",
+      tier: "required",
+      reason: selection.reason,
+    });
+    return;
+  }
+  if (selection.outcome === "ambiguous") {
+    issues.push({
+      code: "harness-selection-ambiguous",
+      tier: "required",
+      candidateHarnessIds: selection.candidateHarnessIds,
+    });
+    return;
+  }
+  if (selection.outcome === "cancelled") {
+    issues.push({ code: "harness-selection-invalid", tier: "required", reason: "cancelled" });
+    return;
+  }
+  const unavailable = selection.requiredHarnessIds.some(
+    (harnessId) =>
+      facts.harnessSelection.harnesses.find((harness) => harness.id === harnessId)?.availability !==
+      "available",
+  );
+  if (unavailable) {
+    issues.push({
+      code: "harness-selection-invalid",
+      tier: "required",
+      reason: "no-available-harness",
+    });
+  }
+}
+
+function addLauncherIssues(issues: SetupIssue[], facts: SetupPlanningFacts): void {
+  const launchers = [
+    ["station", facts.launchers.station],
+    ["ingress", facts.launchers.ingress],
+    ["tmux-popup", facts.launchers.tmuxPopup],
+  ] as const;
+  for (const [launcher, state] of launchers) {
+    if (state !== "available") {
+      issues.push({ code: "launcher-unready", tier: "recommended", launcher, state });
+    }
+  }
+}
+
+function deriveOperations(
+  facts: SetupPlanningFacts,
+  intent: SetupPlanningIntent,
+  selection: HarnessSelectionResolution,
+  issues: readonly SetupIssue[],
+): SetupOperation[] {
+  const operations: SetupOperation[] = [];
+  for (const tool of facts.tools) {
+    if (!tool.available && toolApplies(tool.id, facts.compiled)) {
+      operations.push({
+        id: `install:${tool.id}`,
+        kind: "install-tool",
+        tier: "required",
+        selected: tool.installerAvailable,
+        tool: tool.id,
+      });
+    }
+  }
+  if (Object.values(facts.launchers).some((launcher) => launcher === "checkout")) {
+    operations.push({
+      id: "link-station-launchers",
+      kind: "link-launchers",
+      tier: "recommended",
+      selected: false,
+    });
+  }
+  if (facts.worktrunkShell === "missing") {
+    operations.push({
+      id: "configure-worktrunk-shell",
+      kind: "configure-worktrunk-shell",
+      tier: "recommended",
+      selected: false,
+    });
+  }
+  const tmuxReady = toolAvailable(facts, "tmux") && facts.launchers.tmuxPopup !== "missing";
+  if (tmuxReady && facts.tmuxPopup.persisted === "missing") {
+    operations.push({
+      id: "persist-tmux-popup",
+      kind: "configure-tmux-popup",
+      tier: "recommended",
+      selected: false,
+      scope: "persisted",
+    });
+  }
+  if (
+    tmuxReady &&
+    facts.tmuxPopup.persisted !== "conflict" &&
+    (facts.tmuxPopup.live === "missing" || facts.tmuxPopup.live === "unknown")
+  ) {
+    operations.push({
+      id: "load-tmux-popup",
+      kind: "configure-tmux-popup",
+      tier: "recommended",
+      selected: false,
+      scope: "live",
+    });
+  }
+
+  const hookLaunchersReady =
+    facts.launchers.station !== "missing" && facts.launchers.ingress !== "missing";
+  if (hookLaunchersReady && toolAvailable(facts, "worktrunk")) {
+    operations.push({
+      id: "prepare-worktrunk-tracking",
+      kind: "prepare-worktrunk-tracking",
+      tier: "recommended",
+      selected: intent.installWorktrunkHooks,
+    });
+  }
+  if (hookLaunchersReady) {
+    for (const issue of issues) {
+      if (issue.code !== "harness-tracking-unprepared") continue;
+      if (!harnessAvailable(facts, issue.harnessId)) continue;
+      const tracking = facts.harnessTracking.find(
+        (candidate) => candidate.harnessId === issue.harnessId,
+      );
+      if (tracking === undefined || !trackingNeedsRepair(tracking)) continue;
+      operations.push({
+        id: `prepare-harness-tracking:${issue.harnessId}`,
+        kind: "prepare-harness-tracking",
+        tier: issue.tier,
+        selected: true,
+        harnessId: issue.harnessId,
+      });
+    }
+  }
+  if (
+    selection.outcome === "selected" &&
+    selection.requiredHarnessIds.some((harnessId) => harnessAvailable(facts, harnessId)) &&
+    (facts.config.write === "create" || facts.config.write === "update")
+  ) {
+    operations.push({
+      id: "write-config",
+      kind: "write-config",
+      tier: "required",
+      selected: true,
+      change: facts.config.write,
+    });
+  }
+  return operations;
+}
+
+function trackingNeedsRepair(tracking: SetupPlanningFacts["harnessTracking"][number]): boolean {
+  const assessment = tracking.assessment;
+  if (assessment.state === "prepared" || assessment.state === "not-applicable") return false;
+  if (assessment.requested === true && assessment.installed === true) return false;
+  return tracking.required || assessment.state !== "disabled";
+}
+
+function toolApplies(toolId: SetupToolId, compiled: boolean): boolean {
+  return toolId !== "bun" || !compiled;
+}
+
+function toolAvailable(facts: SetupPlanningFacts, toolId: SetupToolId): boolean {
+  return facts.tools.find((tool) => tool.id === toolId)?.available === true;
+}
+
+function harnessAvailable(
+  facts: SetupPlanningFacts,
+  harnessId: SetupPlanningFacts["harnessTracking"][number]["harnessId"],
+): boolean {
+  return (
+    facts.harnessSelection.harnesses.find((harness) => harness.id === harnessId)?.availability ===
+    "available"
+  );
+}

--- a/packages/setup-core/src/policy/planSetup.ts
+++ b/packages/setup-core/src/policy/planSetup.ts
@@ -278,7 +278,7 @@ function trackingNeedsRepair(tracking: SetupPlanningFacts["harnessTracking"][num
   const assessment = tracking.assessment;
   if (assessment.state === "prepared" || assessment.state === "not-applicable") return false;
   if (assessment.requested === true && assessment.installed === true) return false;
-  return tracking.required || assessment.state !== "disabled";
+  return tracking.required || tracking.persistedIntent;
 }
 
 function toolApplies(toolId: SetupToolId, compiled: boolean): boolean {

--- a/packages/setup-core/test/unit/plan-setup.test.ts
+++ b/packages/setup-core/test/unit/plan-setup.test.ts
@@ -1,0 +1,397 @@
+import { planSetup, type SetupPlanningFacts, type SetupPlanningIntent } from "@station/setup-core";
+import { describe, expect, it } from "vitest";
+
+describe("planSetup", () => {
+  it("derives a ready semantic plan without selecting optional operations", () => {
+    const plan = planSetup(facts(), intent());
+
+    expect(plan.selection).toEqual({
+      outcome: "selected",
+      source: "configured",
+      requiredHarnessIds: ["codex"],
+      defaultHarness: "codex",
+    });
+    expect(plan.issues).toEqual([]);
+    expect(plan.operations).toEqual([
+      {
+        id: "prepare-worktrunk-tracking",
+        kind: "prepare-worktrunk-tracking",
+        tier: "recommended",
+        selected: false,
+      },
+    ]);
+    expect(plan.result).toEqual({
+      readiness: { launchReady: true, workflowReady: true, requiredMissing: 0 },
+      requiredIssueCount: 0,
+      warningCount: 1,
+      selectedOperationCount: 0,
+    });
+  });
+
+  it("derives required tool issues and installer-aware operations", () => {
+    const plan = planSetup(
+      facts({
+        tools: [
+          tool("worktrunk", false, true),
+          tool("tmux", false, false),
+          tool("bun", true, true),
+          tool("diffnav", true, true),
+          tool("git-delta", true, true),
+        ],
+      }),
+      intent(),
+    );
+
+    expect(plan.issues).toEqual([
+      { code: "tool-missing", tier: "required", tool: "worktrunk" },
+      { code: "tool-missing", tier: "required", tool: "tmux" },
+    ]);
+    expect(plan.operations.slice(0, 2)).toEqual([
+      {
+        id: "install:worktrunk",
+        kind: "install-tool",
+        tier: "required",
+        selected: true,
+        tool: "worktrunk",
+      },
+      {
+        id: "install:tmux",
+        kind: "install-tool",
+        tier: "required",
+        selected: false,
+        tool: "tmux",
+      },
+    ]);
+    expect(plan.result.readiness).toMatchObject({ workflowReady: false, requiredMissing: 2 });
+    expect(plan.result.selectedOperationCount).toBe(1);
+  });
+
+  it("ignores source-only requirements for compiled installations", () => {
+    const plan = planSetup(
+      facts({
+        compiled: true,
+        xcodeTools: "missing",
+        runtimeUi: "missing",
+        tools: [
+          tool("worktrunk", true, true),
+          tool("tmux", true, true),
+          tool("bun", false, true),
+          tool("diffnav", true, true),
+          tool("git-delta", true, true),
+        ],
+      }),
+      intent(),
+    );
+
+    expect(plan.issues).toEqual([]);
+    expect(plan.operations.some((operation) => operation.id === "install:bun")).toBe(false);
+    expect(plan.result.readiness).toEqual({
+      launchReady: true,
+      workflowReady: true,
+      requiredMissing: 0,
+    });
+  });
+
+  it("preserves a configured default during explicit selection", () => {
+    const plan = planSetup(
+      facts(),
+      intent({ harnessSelection: { kind: "explicit", harnessIds: ["opencode"] } }),
+    );
+
+    expect(plan.selection).toEqual({
+      outcome: "selected",
+      source: "explicit",
+      requiredHarnessIds: ["opencode", "codex"],
+      defaultHarness: "codex",
+    });
+  });
+
+  it("does not choose among ambiguous harness discovery", () => {
+    const plan = planSetup(
+      facts({
+        harnessSelection: {
+          config: { status: "missing" },
+          harnesses: [
+            { id: "codex", availability: "available" },
+            { id: "claude", availability: "available" },
+          ],
+        },
+        config: { state: "missing", write: "none", diagnostics: [] },
+        harnessTracking: [],
+      }),
+      intent(),
+    );
+
+    expect(plan.selection).toEqual({
+      outcome: "ambiguous",
+      candidateHarnessIds: ["codex", "claude"],
+    });
+    expect(plan.issues).toContainEqual({
+      code: "harness-selection-ambiguous",
+      tier: "required",
+      candidateHarnessIds: ["codex", "claude"],
+    });
+    expect(plan.operations.some((operation) => operation.kind === "write-config")).toBe(false);
+    expect(plan.operations.some((operation) => operation.kind === "prepare-harness-tracking")).toBe(
+      false,
+    );
+  });
+
+  it("keeps absent harness discovery as a typed selection failure", () => {
+    const plan = planSetup(
+      facts({
+        harnessSelection: {
+          config: { status: "missing" },
+          harnesses: [{ id: "codex", availability: "unavailable" }],
+        },
+        config: { state: "missing", write: "none", diagnostics: [] },
+        harnessTracking: [],
+      }),
+      intent(),
+    );
+
+    expect(plan.selection).toEqual({ outcome: "invalid", reason: "no-available-harness" });
+    expect(plan.issues).toContainEqual({
+      code: "harness-selection-invalid",
+      tier: "required",
+      reason: "no-available-harness",
+    });
+  });
+
+  it.each([
+    ["invalid-config", { config: { status: "invalid" } }],
+    ["unsupported-configured-default", { config: { status: "valid", defaultHarness: "crush" } }],
+  ] as const)("derives the %s selection failure", (reason, selectionConfig) => {
+    const plan = planSetup(
+      facts({
+        harnessSelection: {
+          config: selectionConfig.config,
+          harnesses: [{ id: "codex", availability: "available" }],
+        },
+      }),
+      intent(),
+    );
+
+    expect(plan.issues).toContainEqual({
+      code: "harness-selection-invalid",
+      tier: "required",
+      reason,
+    });
+  });
+
+  it.each([
+    "git-absent",
+    "git-unusable",
+    "repository-unusable",
+    "dubious-ownership",
+  ] as const)("keeps the hostile Git reason %s typed", (reason) => {
+    const plan = planSetup(facts({ git: { state: "unusable", reason } }), intent());
+    expect(plan.issues).toContainEqual({ code: "git-unavailable", tier: "required", reason });
+  });
+
+  it.each([
+    ["create", "create"],
+    ["update", "update"],
+  ] as const)("derives a selected config %s operation", (write, change) => {
+    const plan = planSetup(
+      facts({
+        config: { state: write === "create" ? "missing" : "valid", write, diagnostics: [] },
+      }),
+      intent(),
+    );
+    expect(plan.operations).toContainEqual({
+      id: "write-config",
+      kind: "write-config",
+      tier: "required",
+      selected: true,
+      change,
+    });
+  });
+
+  it("represents a blocked config as an issue, never a semantic no-op", () => {
+    const plan = planSetup(
+      facts({ config: { state: "invalid", write: "blocked", diagnostics: [] } }),
+      intent(),
+    );
+
+    expect(plan.issues).toContainEqual({
+      code: "config-unready",
+      tier: "required",
+      state: "write-blocked",
+    });
+    expect(plan.operations.some((operation) => operation.kind === "write-config")).toBe(false);
+  });
+
+  it("derives required and recommended tracking repairs independently", () => {
+    const plan = planSetup(
+      facts({
+        harnessSelection: {
+          config: { status: "valid", defaultHarness: "codex" },
+          harnesses: [
+            { id: "codex", availability: "available" },
+            { id: "opencode", availability: "available" },
+          ],
+        },
+        harnessTracking: [
+          {
+            harnessId: "codex",
+            assessment: {
+              state: "artifact-missing-or-drifted",
+              requested: true,
+              installed: false,
+            },
+            required: true,
+          },
+          {
+            harnessId: "opencode",
+            assessment: { state: "probe-failed" },
+            required: false,
+          },
+        ],
+      }),
+      intent(),
+    );
+
+    expect(plan.issues).toEqual([
+      {
+        code: "harness-tracking-unprepared",
+        tier: "required",
+        harnessId: "codex",
+        state: "artifact-missing-or-drifted",
+      },
+      {
+        code: "harness-tracking-unprepared",
+        tier: "recommended",
+        harnessId: "opencode",
+        state: "probe-failed",
+      },
+    ]);
+    expect(plan.operations).toContainEqual({
+      id: "prepare-harness-tracking:codex",
+      kind: "prepare-harness-tracking",
+      tier: "required",
+      selected: true,
+      harnessId: "codex",
+    });
+    expect(plan.operations).toContainEqual({
+      id: "prepare-harness-tracking:opencode",
+      kind: "prepare-harness-tracking",
+      tier: "recommended",
+      selected: true,
+      harnessId: "opencode",
+    });
+    expect(plan.result).toMatchObject({
+      requiredIssueCount: 1,
+      warningCount: 2,
+      selectedOperationCount: 2,
+    });
+  });
+
+  it("contains no presentation, command, config content, or serialized provider artifacts", () => {
+    const semanticPlan = planSetup(
+      facts({
+        config: {
+          state: "missing",
+          write: "create",
+          diagnostics: [{ code: "CONFIG_LOCAL_INVALID", severity: "warn" }],
+        },
+        harnessTracking: [
+          {
+            harnessId: "codex",
+            assessment: { state: "probe-failed" },
+            required: true,
+          },
+        ],
+      }),
+      intent({ installWorktrunkHooks: true }),
+    );
+    const forbiddenKeys = new Set([
+      "label",
+      "message",
+      "command",
+      "argv",
+      "path",
+      "content",
+      "toml",
+      "messageRef",
+      "messageId",
+      "data",
+      "stdout",
+      "stderr",
+      "rawResult",
+      "serializedResult",
+    ]);
+    const serialized = JSON.stringify(semanticPlan);
+
+    expect(findForbiddenKeys(semanticPlan, forbiddenKeys)).toEqual([]);
+    expect(serialized).not.toContain("Install Station-owned");
+    expect(serialized).not.toContain("schema_version = 1");
+    expect(serialized).not.toContain("hooks install codex");
+    expect(serialized).not.toContain('{"provider":"codex"}');
+  });
+});
+
+function facts(overrides: Partial<SetupPlanningFacts> = {}): SetupPlanningFacts {
+  return {
+    generatedAt: "2026-07-29T12:00:00.000Z",
+    compiled: false,
+    stateDirectoryWritable: true,
+    socketEvidenceAvailable: true,
+    xcodeTools: "available",
+    tools: [
+      tool("worktrunk", true, true),
+      tool("tmux", true, true),
+      tool("bun", true, true),
+      tool("diffnav", true, true),
+      tool("git-delta", true, true),
+    ],
+    runtimeUi: "available",
+    git: { state: "usable", repository: "present" },
+    harnessSelection: {
+      config: { status: "valid", defaultHarness: "codex" },
+      harnesses: [{ id: "codex", availability: "available" }],
+    },
+    config: { state: "valid", write: "none", diagnostics: [] },
+    launchers: { station: "available", ingress: "available", tmuxPopup: "available" },
+    worktrunkAutomation: "ready",
+    worktrunkShell: "ready",
+    tmuxPopup: { persisted: "ready", live: "not-applicable" },
+    worktrunkHooks: "ready",
+    harnessTracking: [
+      {
+        harnessId: "codex",
+        assessment: { state: "prepared", requested: true, installed: true },
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function intent(overrides: Partial<SetupPlanningIntent> = {}): SetupPlanningIntent {
+  return {
+    mode: "plan",
+    harnessSelection: { kind: "automatic" },
+    installWorktrunkHooks: false,
+    ...overrides,
+  };
+}
+
+function tool(
+  id: SetupPlanningFacts["tools"][number]["id"],
+  available: boolean,
+  installerAvailable: boolean,
+): SetupPlanningFacts["tools"][number] {
+  return { id, available, installerAvailable };
+}
+
+function findForbiddenKeys(value: unknown, forbidden: ReadonlySet<string>, at = "$"): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => findForbiddenKeys(item, forbidden, `${at}[${index}]`));
+  }
+  if (value === null || typeof value !== "object") return [];
+  return Object.entries(value).flatMap(([key, item]) => [
+    ...(forbidden.has(key) ? [`${at}.${key}`] : []),
+    ...findForbiddenKeys(item, forbidden, `${at}.${key}`),
+  ]);
+}

--- a/packages/setup-core/test/unit/plan-setup.test.ts
+++ b/packages/setup-core/test/unit/plan-setup.test.ts
@@ -241,11 +241,13 @@ describe("planSetup", () => {
               installed: false,
             },
             required: true,
+            persistedIntent: false,
           },
           {
             harnessId: "opencode",
             assessment: { state: "probe-failed" },
             required: false,
+            persistedIntent: true,
           },
         ],
       }),
@@ -287,6 +289,39 @@ describe("planSetup", () => {
     });
   });
 
+  it("does not repair optional tracking without persisted intent", () => {
+    const plan = planSetup(
+      facts({
+        harnessSelection: {
+          config: { status: "valid", defaultHarness: "codex" },
+          harnesses: [
+            { id: "codex", availability: "available" },
+            { id: "opencode", availability: "available" },
+          ],
+        },
+        harnessTracking: [
+          {
+            harnessId: "opencode",
+            assessment: { state: "probe-failed" },
+            required: false,
+            persistedIntent: false,
+          },
+        ],
+      }),
+      intent(),
+    );
+
+    expect(plan.issues).toContainEqual({
+      code: "harness-tracking-unprepared",
+      tier: "recommended",
+      harnessId: "opencode",
+      state: "probe-failed",
+    });
+    expect(plan.operations.some((operation) => operation.kind === "prepare-harness-tracking")).toBe(
+      false,
+    );
+  });
+
   it("contains no presentation, command, config content, or serialized provider artifacts", () => {
     const semanticPlan = planSetup(
       facts({
@@ -300,6 +335,7 @@ describe("planSetup", () => {
             harnessId: "codex",
             assessment: { state: "probe-failed" },
             required: true,
+            persistedIntent: false,
           },
         ],
       }),
@@ -362,6 +398,7 @@ function facts(overrides: Partial<SetupPlanningFacts> = {}): SetupPlanningFacts 
         harnessId: "codex",
         assessment: { state: "prepared", requested: true, installed: true },
         required: true,
+        persistedIntent: true,
       },
     ],
     ...overrides,

--- a/tests/diagnostics/setup-boundaries.test.ts
+++ b/tests/diagnostics/setup-boundaries.test.ts
@@ -20,6 +20,8 @@ const policyNames = [
   "assessHarnessTracking",
   "selectHarnessTrackingRepairTargets",
   "deriveSetupReadiness",
+  "planSetup",
+  "deriveSetupResult",
 ] as const;
 
 describe("setup core boundaries", () => {
@@ -46,7 +48,7 @@ describe("setup core boundaries", () => {
     }
   });
 
-  it("marks exactly the four public policies and no data declarations or barrels", async () => {
+  it("marks exactly the six public policies and no data declarations or barrels", async () => {
     const declarations: string[] = [];
     let markerCount = 0;
     for (const file of await sourceFiles(sourceRoot)) {
@@ -63,7 +65,7 @@ describe("setup core boundaries", () => {
       }
     }
 
-    expect(markerCount).toBe(4);
+    expect(markerCount).toBe(6);
     expect(declarations.sort()).toEqual([...policyNames].sort());
   });
 });

--- a/tests/e2e/setup-core-flow.test.ts
+++ b/tests/e2e/setup-core-flow.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadConfig } from "../../packages/config/src/index.js";
+import { CliSetupPlanSchema } from "../../packages/contracts/src/index.js";
 import { createObserverClient } from "../../packages/protocol/src/index.js";
 import { environmentWithoutGitLocals } from "../../packages/runtime/src/index.js";
 import { waitForSocketClosed } from "../support/sockets";
@@ -245,7 +246,7 @@ describe("setup core flow e2e", () => {
         allowFailure: true,
       });
       expect(firstCheck.status).toBe(1);
-      const firstPlan = JSON.parse(firstCheck.stdout);
+      const firstPlan = CliSetupPlanSchema.parse(JSON.parse(firstCheck.stdout));
       expect(firstPlan.checks).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ id: "worktrunk", status: "ok" }),
@@ -259,7 +260,7 @@ describe("setup core flow e2e", () => {
         cwd: setupCwd,
         env,
       });
-      const parsedPlan = JSON.parse(plan.stdout);
+      const parsedPlan = CliSetupPlanSchema.parse(JSON.parse(plan.stdout));
       expect(parsedPlan.actions).toEqual(
         expect.arrayContaining([expect.objectContaining({ id: "write-config" })]),
       );
@@ -316,7 +317,7 @@ describe("setup core flow e2e", () => {
         cwd: setupCwd,
         env,
       });
-      const finalPlan = JSON.parse(finalCheck.stdout);
+      const finalPlan = CliSetupPlanSchema.parse(JSON.parse(finalCheck.stdout));
       expect(finalPlan.summary.requiredOk).toBe(true);
       await expect(loadConfig({ configPath, homeDir: home })).resolves.toMatchObject({
         config: {
@@ -456,7 +457,7 @@ describe("setup core flow e2e", () => {
         },
         allowFailure: true,
       });
-      const output = JSON.parse(result.stdout);
+      const output = CliSetupPlanSchema.parse(JSON.parse(result.stdout));
 
       expect(result.status).toBe(1);
       expect(output.summary.requiredOk).toBe(false);

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -3,6 +3,7 @@ import { chmod, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { CliSetupPlanSchema } from "../../packages/contracts/src/index.js";
 import { createObserverClient } from "../../packages/protocol/src/index.js";
 import {
   expectedProviderHookScript,
@@ -113,9 +114,7 @@ describe("setup guided feedback e2e", () => {
         env: fixture.env,
         answers: [],
       });
-      const checkPlan = JSON.parse(check.stdout) as {
-        checks: Array<{ id: string; details?: Record<string, string> }>;
-      };
+      const checkPlan = CliSetupPlanSchema.parse(JSON.parse(check.stdout));
       expect(
         checkPlan.checks.find((candidate) => candidate.id === "harness-tracking:codex")?.details,
       ).toEqual(
@@ -162,9 +161,7 @@ describe("setup guided feedback e2e", () => {
         ["--config", fixture.configPath, "setup", "check", "--json"],
         { cwd: fixture.repo, env: fixture.env, answers: [] },
       );
-      const repairedPlan = JSON.parse(repairedCheck.stdout) as {
-        checks: Array<{ id: string; status: string; details?: Record<string, string> }>;
-      };
+      const repairedPlan = CliSetupPlanSchema.parse(JSON.parse(repairedCheck.stdout));
       expect(
         repairedPlan.checks.find((candidate) => candidate.id === "harness-tracking:codex"),
       ).toMatchObject({
@@ -388,7 +385,7 @@ describe("setup guided feedback e2e", () => {
           },
         );
         expect(check.exitCode).toBe(0);
-        expect(JSON.parse(check.stdout).checks).toEqual(
+        expect(CliSetupPlanSchema.parse(JSON.parse(check.stdout)).checks).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ id: "worktrunk-shell-integration", status: "ok" }),
           ]),


### PR DESCRIPTION
## What this fixes

Station setup currently derives its deterministic readiness and repair decisions inside presentation-rich CLI planning code. That couples setup policy to human copy, paths, provider commands, and serialized config content, making the policy difficult to reuse or verify independently. This moves semantic planning into `@station/setup-core` while preserving the existing CLI plan consumed by render and apply.

Closes #352.
Part of #276.

## What changed

- Added normalized setup evidence and intent plus finite semantic issue, operation, plan, and result types in `@station/setup-core`.
- Added `planSetup` and `deriveSetupResult` policies that derive current readiness without treating attempted mutations as evidence.
- Reduced the CLI planner to validation, normalization, semantic planning, and an explicit compatibility projection back to the existing checks, actions, summary, and next steps.
- Published the existing strict setup JSON schemas from `@station/contracts` while retaining CLI compatibility aliases and keeping copy, paths, provider argv, TOML, and compatibility detail bags outside setup-core.
- Added semantic negative tests, projection parity coverage, strict shared-schema coverage, six-policy boundary enforcement, JSON consumer validation, and updated architecture evidence.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- Focused setup-core, CLI projection/render/apply/guided, contracts, integration, and diagnostics suites
- `pnpm test:e2e:setup:core`
- `pnpm test:e2e:setup:guided:all-shells`
- `pnpm smoke:install`
- Isolated check/plan JSON parsing and apply dry-run non-mutation smoke
- `env -u CODEX_HOME -u STATION_CURSOR_HOME pnpm test:all` passes build, typecheck, lint, unit, contracts, integration, diagnostics, scripted-agent, and setup E2E stages; two unrelated Observer handoff E2Es fail identically on the clean pre-change `27e79ffb` baseline

## Safety and scope

The existing human output, strict check/plan JSON wire shape, action ordering, config activation ordering, independent provider repairs, and fresh post-effect probes are preserved. Rendering, mutation adapters, setup flows, provider integrations, package manifests, and TypeScript configuration remain unchanged.