### PR TITLE
refactor(setup): execute semantic operations through typed adapters

### DIFF
--- a/apps/cli/src/commands/providerHookAdapters.ts
+++ b/apps/cli/src/commands/providerHookAdapters.ts
@@ -109,6 +109,14 @@ function isWorktrunkEnabled(config: StationConfig | undefined): boolean {
 }
 
 export function runClaudeHooksCommand(
+  args: ["install", ...string[]],
+  options?: ProviderHooksCommandOptions,
+): Promise<ClaudeHookInstallResult>;
+export function runClaudeHooksCommand(
+  args: string[],
+  options?: ProviderHooksCommandOptions,
+): Promise<ClaudeHooksCommandResult>;
+export function runClaudeHooksCommand(
   args: string[],
   options: ProviderHooksCommandOptions = {},
 ): Promise<ClaudeHooksCommandResult> {
@@ -139,6 +147,14 @@ export function runClaudeHooksCommand(
   return runner(args, options) as Promise<ClaudeHooksCommandResult>;
 }
 
+export function runCodexHooksCommand(
+  args: ["install", ...string[]],
+  options?: ProviderHooksCommandOptions,
+): Promise<CodexHookInstallResult>;
+export function runCodexHooksCommand(
+  args: string[],
+  options?: ProviderHooksCommandOptions,
+): Promise<CodexHooksCommandResult>;
 export function runCodexHooksCommand(
   args: string[],
   options: ProviderHooksCommandOptions = {},
@@ -171,6 +187,14 @@ export function runCodexHooksCommand(
 }
 
 export function runCursorHooksCommand(
+  args: ["install", ...string[]],
+  options?: ProviderHooksCommandOptions,
+): Promise<CursorHookInstallResult>;
+export function runCursorHooksCommand(
+  args: string[],
+  options?: ProviderHooksCommandOptions,
+): Promise<CursorHooksCommandResult>;
+export function runCursorHooksCommand(
   args: string[],
   options: ProviderHooksCommandOptions = {},
 ): Promise<CursorHooksCommandResult> {
@@ -201,6 +225,14 @@ export function runCursorHooksCommand(
   return runner(args, options) as Promise<CursorHooksCommandResult>;
 }
 
+export function runOpenCodeHooksCommand(
+  args: ["install", ...string[]],
+  options?: ProviderHooksCommandOptions,
+): Promise<OpenCodePluginInstallResult>;
+export function runOpenCodeHooksCommand(
+  args: string[],
+  options?: ProviderHooksCommandOptions,
+): Promise<OpenCodeHooksCommandResult>;
 export function runOpenCodeHooksCommand(
   args: string[],
   options: ProviderHooksCommandOptions = {},
@@ -234,6 +266,14 @@ export function runOpenCodeHooksCommand(
   return runner(args, options) as Promise<OpenCodeHooksCommandResult>;
 }
 
+export function runWorktrunkHooksCommand(
+  args: ["install", ...string[]],
+  options: WorktrunkHooksCommandOptions,
+): Promise<WorktrunkHookInstallResult>;
+export function runWorktrunkHooksCommand(
+  args: string[],
+  options: WorktrunkHooksCommandOptions,
+): Promise<WorktrunkHooksCommandResult>;
 export function runWorktrunkHooksCommand(
   args: string[],
   options: WorktrunkHooksCommandOptions,

--- a/apps/cli/src/commands/setup/adapters/config.ts
+++ b/apps/cli/src/commands/setup/adapters/config.ts
@@ -1,0 +1,168 @@
+import {
+  type PersistSetupConfigMutationOptions,
+  persistSetupConfigMutation,
+  planSetupConfigMutation,
+  type SetupConfigDesiredState,
+  type SetupConfigMutationInput,
+} from "@station/config";
+import { publicSafeErrorFromUnknown } from "@station/runtime";
+import type {
+  SetupConfigMutationPort,
+  SetupOperation,
+  SetupOperationOutcome,
+} from "@station/setup-core";
+import type { SetupFacts } from "../model.js";
+
+export type SetupConfigAdapterOptions = {
+  readonly facts: SetupFacts;
+  readonly now?: () => Date;
+  readonly fs?: PersistSetupConfigMutationOptions["fs"];
+  readonly onCommitted?: (configPath: string) => void;
+};
+
+/**
+ * ADAPTER
+ *
+ * Translates semantic setup configuration policy into validated config-owned planning and persistence.
+ */
+export function createSetupConfigAdapter(
+  options: SetupConfigAdapterOptions,
+): SetupConfigMutationPort {
+  return async (operation) => {
+    try {
+      const input = setupConfigMutationInput(operation, options.facts);
+      const plan = await planSetupConfigMutation(input);
+      if (plan.operation === "blocked") {
+        throw {
+          tag: "SetupConfigError",
+          code: "SETUP_CONFIG_PRECONDITION_FAILED",
+          message: plan.reason,
+          hint: plan.path,
+        };
+      }
+      if (plan.operation === "none") {
+        options.onCommitted?.(options.facts.config.path);
+        return completedConfigOutcome(operation, {
+          status: "unchanged",
+          configPath: options.facts.config.path,
+        });
+      }
+      const persistenceOptions: {
+        homeDir: string;
+        now?: NonNullable<PersistSetupConfigMutationOptions["now"]>;
+        fs?: NonNullable<PersistSetupConfigMutationOptions["fs"]>;
+      } = { homeDir: options.facts.homeDir };
+      if (options.now !== undefined) persistenceOptions.now = options.now;
+      if (options.fs !== undefined) persistenceOptions.fs = options.fs;
+      const result = await persistSetupConfigMutation(plan, persistenceOptions);
+      options.onCommitted?.(result.configPath);
+      return completedConfigOutcome(operation, result);
+    } catch (error) {
+      return {
+        status: "failed",
+        operationId: operation.id,
+        error: publicSafeErrorFromUnknown(error, {
+          tag: "SetupConfigError",
+          code: "CONFIG_WRITE_FAILED",
+          message: "Could not update config.toml.",
+          hint: options.facts.config.path,
+        }),
+      };
+    }
+  };
+}
+
+export function setupConfigMutationInput(
+  operation: Extract<SetupOperation, { kind: "write-config" }>,
+  facts: SetupFacts,
+): SetupConfigMutationInput {
+  const desired: {
+    defaultHarness: SetupConfigDesiredState["defaultHarness"];
+    harnesses: SetupConfigDesiredState["harnesses"];
+    worktrunkCommand: string;
+    tmuxCommand?: string;
+    installWorktrunkHooks: boolean;
+  } = {
+    defaultHarness: operation.defaultHarnessId,
+    harnesses: operation.harnessIds.map((harnessId) => {
+      const harness = facts.harnesses.find((candidate) => candidate.id === harnessId);
+      if (harness === undefined) {
+        throw new Error(`Setup facts do not include selected harness ${harnessId}.`);
+      }
+      return {
+        id: harnessId,
+        command: harness.command,
+        installHooks: operation.trackingHarnessIds.includes(harnessId),
+      };
+    }),
+    worktrunkCommand: detectedCommand(facts.worktrunk, "wt"),
+    installWorktrunkHooks: operation.installWorktrunkTracking,
+  };
+  const tmuxCommand = detectedOptionalCommand(facts.tmux, "tmux");
+  if (tmuxCommand !== undefined) desired.tmuxCommand = tmuxCommand;
+
+  let current: SetupConfigMutationInput["current"];
+  switch (facts.config.status) {
+    case "missing":
+      current = { state: "missing" };
+      break;
+    case "valid":
+      current = { state: "valid", source: facts.config.source };
+      break;
+    case "invalid":
+      throw {
+        tag: "SetupConfigError",
+        code: "SETUP_CONFIG_PRECONDITION_FAILED",
+        message: facts.config.message,
+        hint: facts.config.path,
+      };
+  }
+  return {
+    configPath: facts.config.path,
+    homeDir: facts.homeDir,
+    current,
+    desired,
+  };
+}
+
+function completedConfigOutcome(
+  operation: Extract<SetupOperation, { kind: "write-config" }>,
+  result: {
+    readonly status: "created" | "updated" | "unchanged";
+    readonly configPath: string;
+    readonly backupPath?: string;
+  },
+): SetupOperationOutcome {
+  return result.backupPath === undefined
+    ? {
+        status: "completed",
+        operationId: operation.id,
+        commit: { kind: "config", configPath: result.configPath, change: result.status },
+      }
+    : {
+        status: "completed",
+        operationId: operation.id,
+        commit: {
+          kind: "config",
+          configPath: result.configPath,
+          change: result.status,
+          backupPath: result.backupPath,
+        },
+      };
+}
+
+function detectedCommand(
+  fact: { command: string; resolvedPath?: string },
+  defaultCommand: string,
+): string {
+  if (fact.command !== defaultCommand || fact.command.includes("/")) return fact.command;
+  return fact.resolvedPath ?? defaultCommand;
+}
+
+function detectedOptionalCommand(
+  fact: { command: string; resolvedPath?: string },
+  defaultCommand: string,
+): string | undefined {
+  if (fact.command !== defaultCommand || fact.command.includes("/")) return fact.command;
+  return fact.resolvedPath;
+}

--- a/apps/cli/src/commands/setup/adapters/harnessTracking.ts
+++ b/apps/cli/src/commands/setup/adapters/harnessTracking.ts
@@ -1,0 +1,195 @@
+import type { ClaudeHookInstallResult } from "@station/claude";
+import type { CodexHookInstallResult } from "@station/codex";
+import { type LoadedStationConfig, loadConfig } from "@station/config";
+import type { ProviderHookArtifactOwner } from "@station/contracts";
+import type { CursorHookInstallResult } from "@station/cursor";
+import type { OpenCodePluginInstallResult } from "@station/opencode";
+import { publicSafeErrorFromUnknown } from "@station/runtime";
+import type { SetupHarnessTrackingPort, SupportedHarnessId } from "@station/setup-core";
+import type { CliEnv } from "../../../env.js";
+import {
+  type ProviderHooksCommandOptions,
+  runClaudeHooksCommand,
+  runCodexHooksCommand,
+  runCursorHooksCommand,
+  runOpenCodeHooksCommand,
+} from "../../providerHookAdapters.js";
+
+export type SetupHarnessTrackingRunners = {
+  readonly claude: (
+    args: ["install", ...string[]],
+    options?: ProviderHooksCommandOptions,
+  ) => Promise<ClaudeHookInstallResult>;
+  readonly codex: (
+    args: ["install", ...string[]],
+    options?: ProviderHooksCommandOptions,
+  ) => Promise<CodexHookInstallResult>;
+  readonly cursor: (
+    args: ["install", ...string[]],
+    options?: ProviderHooksCommandOptions,
+  ) => Promise<CursorHookInstallResult>;
+  readonly opencode: (
+    args: ["install", ...string[]],
+    options?: ProviderHooksCommandOptions,
+  ) => Promise<OpenCodePluginInstallResult>;
+};
+
+export type SetupHarnessTrackingAdapterOptions = {
+  readonly configPath: () => string | undefined;
+  readonly homeDir: string;
+  readonly env?: CliEnv;
+  readonly providerHookIngressLauncher?: string;
+  readonly providerHookArtifactOwner?: ProviderHookArtifactOwner;
+  readonly loadConfig?: (options: {
+    configPath: string;
+    homeDir: string;
+  }) => Promise<LoadedStationConfig>;
+  readonly runners?: SetupHarnessTrackingRunners;
+};
+
+/**
+ * ADAPTER
+ *
+ * Translates harness tracking preparation into an in-process provider installer and sanitized commit evidence.
+ */
+export function createHarnessTrackingAdapter(
+  options: SetupHarnessTrackingAdapterOptions,
+): SetupHarnessTrackingPort {
+  const runners = options.runners ?? defaultRunners;
+  return async (operation) => {
+    try {
+      if (operation.harnessId === "pi") {
+        return {
+          status: "completed",
+          operationId: operation.id,
+          commit: { kind: "provider-tracking", provider: "pi", changed: false },
+        };
+      }
+      const configPath = options.configPath();
+      if (configPath === undefined) throw providerTrackingError(operation.harnessId);
+      const loaded = await (options.loadConfig ?? loadConfig)({
+        configPath,
+        homeDir: options.homeDir,
+      });
+      const commandOptions = providerCommandOptions(options, loaded);
+      switch (operation.harnessId) {
+        case "claude":
+          return installResultOutcome(
+            operation,
+            await runners.claude(["install", "--yes"], commandOptions),
+            claudeBackupPaths,
+          );
+        case "codex":
+          return installResultOutcome(
+            operation,
+            await runners.codex(["install", "--yes"], commandOptions),
+            codexBackupPaths,
+          );
+        case "cursor":
+          return installResultOutcome(
+            operation,
+            await runners.cursor(["install", "--yes"], commandOptions),
+            cursorBackupPaths,
+          );
+        case "opencode":
+          return installResultOutcome(
+            operation,
+            await runners.opencode(["install", "--yes"], commandOptions),
+            openCodeBackupPaths,
+          );
+      }
+    } catch (error) {
+      return {
+        status: "failed",
+        operationId: operation.id,
+        error: publicSafeErrorFromUnknown(error, providerTrackingError(operation.harnessId)),
+      };
+    }
+  };
+}
+
+const defaultRunners: SetupHarnessTrackingRunners = {
+  claude: runClaudeHooksCommand,
+  codex: runCodexHooksCommand,
+  cursor: runCursorHooksCommand,
+  opencode: runOpenCodeHooksCommand,
+};
+
+type HarnessInstallResult =
+  | ClaudeHookInstallResult
+  | CodexHookInstallResult
+  | CursorHookInstallResult
+  | OpenCodePluginInstallResult;
+
+function installResultOutcome<Result extends HarnessInstallResult>(
+  operation: Parameters<SetupHarnessTrackingPort>[0],
+  result: Result,
+  backupPaths: (result: Result) => readonly string[],
+) {
+  if (!result.installed) throw providerTrackingError(operation.harnessId);
+  const paths = backupPaths(result);
+  return {
+    status: "completed" as const,
+    operationId: operation.id,
+    commit:
+      paths.length === 0
+        ? {
+            kind: "provider-tracking" as const,
+            provider: operation.harnessId,
+            changed: result.changed,
+          }
+        : {
+            kind: "provider-tracking" as const,
+            provider: operation.harnessId,
+            changed: result.changed,
+            backupPaths: paths,
+          },
+  };
+}
+
+function providerCommandOptions(
+  options: SetupHarnessTrackingAdapterOptions,
+  loaded: LoadedStationConfig,
+): ProviderHooksCommandOptions {
+  const result: ProviderHooksCommandOptions = {
+    config: loaded.config,
+    configPath: loaded.configPath,
+  };
+  if (options.env !== undefined) result.env = options.env;
+  if (options.providerHookIngressLauncher !== undefined) {
+    result.providerHookIngressLauncher = options.providerHookIngressLauncher;
+  }
+  if (options.providerHookArtifactOwner !== undefined) {
+    result.providerHookArtifactOwner = options.providerHookArtifactOwner;
+  }
+  return result;
+}
+
+function claudeBackupPaths(result: ClaudeHookInstallResult): readonly string[] {
+  return result.backupPaths ?? singleBackupPath(result.backupPath);
+}
+
+function codexBackupPaths(result: CodexHookInstallResult): readonly string[] {
+  return result.backupPaths ?? singleBackupPath(result.backupPath);
+}
+
+function cursorBackupPaths(result: CursorHookInstallResult): readonly string[] {
+  return result.backupPaths ?? singleBackupPath(result.backupPath);
+}
+
+function openCodeBackupPaths(result: OpenCodePluginInstallResult): readonly string[] {
+  return singleBackupPath(result.backupPath);
+}
+
+function singleBackupPath(path: string | undefined): readonly string[] {
+  return path === undefined ? [] : [path];
+}
+
+function providerTrackingError(provider: SupportedHarnessId) {
+  return {
+    tag: "SetupProviderTrackingError",
+    code: "SETUP_PROVIDER_TRACKING_FAILED",
+    message: `Station tracking could not be prepared for ${provider}.`,
+    provider,
+  };
+}

--- a/apps/cli/src/commands/setup/adapters/observerActivation.ts
+++ b/apps/cli/src/commands/setup/adapters/observerActivation.ts
@@ -1,0 +1,78 @@
+import { loadConfig, resolveObserverPaths } from "@station/config";
+import { publicSafeErrorFromUnknown, safeErrorFromUnknown } from "@station/runtime";
+import type { SetupObserverActivationPort } from "@station/setup-core";
+import { restartObserver } from "../../../observerProcess.js";
+
+export type SetupObserverActivationAdapterOptions = {
+  readonly configPath: () => string | undefined;
+  readonly homeDir: string;
+  readonly activateObserverConfig?: (input: {
+    configPath: string;
+    homeDir: string;
+  }) => Promise<void>;
+};
+
+/**
+ * ADAPTER
+ *
+ * Translates setup activation into config loading, Observer path resolution, restart, and health confirmation.
+ */
+export function createObserverActivationAdapter(
+  options: SetupObserverActivationAdapterOptions,
+): SetupObserverActivationPort {
+  return async (operation) => {
+    const configPath = options.configPath();
+    if (configPath === undefined) {
+      return failedActivation(operation.id, observerActivationError);
+    }
+    try {
+      await (options.activateObserverConfig ?? activateObserverConfig)({
+        configPath,
+        homeDir: options.homeDir,
+      });
+      return {
+        status: "completed",
+        operationId: operation.id,
+        commit: { kind: "observer-activation", configPath },
+      };
+    } catch (error) {
+      return failedActivation(
+        operation.id,
+        publicSafeErrorFromUnknown(error, observerActivationError),
+      );
+    }
+  };
+}
+
+async function activateObserverConfig(input: {
+  configPath: string;
+  homeDir: string;
+}): Promise<void> {
+  try {
+    const loaded = await loadConfig({ configPath: input.configPath, homeDir: input.homeDir });
+    const paths = resolveObserverPaths(loaded.config, input.homeDir);
+    const status = await restartObserver({
+      config: loaded.config,
+      configPath: loaded.configPath,
+      paths,
+    });
+    if (status.status !== "running") {
+      throw safeErrorFromUnknown(status.error, observerActivationError);
+    }
+  } catch (error) {
+    throw safeErrorFromUnknown(error, observerActivationError);
+  }
+}
+
+const observerActivationError = {
+  tag: "ObserverActivationError",
+  code: "OBSERVER_ACTIVATION_FAILED",
+  message: "Observer configuration could not be activated.",
+} as const;
+
+function failedActivation(
+  operationId: "activate-observer-config",
+  error: ReturnType<typeof publicSafeErrorFromUnknown>,
+) {
+  return { status: "failed" as const, operationId, error };
+}

--- a/apps/cli/src/commands/setup/adapters/operations.ts
+++ b/apps/cli/src/commands/setup/adapters/operations.ts
@@ -1,0 +1,409 @@
+import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { loadConfig, type PersistSetupConfigMutationOptions } from "@station/config";
+import {
+  type ExternalCommandInput,
+  publicSafeErrorFromUnknown,
+  runExternalCommand,
+} from "@station/runtime";
+import {
+  performSetupOperation,
+  type SetupOperation,
+  type SetupOperationCommit,
+  type SetupOperationExecutor,
+  type SetupOperationOutcome,
+  type SetupOperationPorts,
+  type SetupPackageInstallationPort,
+} from "@station/setup-core";
+import { runWorktrunkHooksCommand } from "../../providerHookAdapters.js";
+import type { SetupApplyFileSystem } from "../apply.js";
+import { commandEnv } from "../checks/env.js";
+import { tmuxPopupBindingBlock, tmuxPopupBindingEndMarker } from "../checks/tmuxBinding.js";
+import { resolveHarnessInstallDefinition } from "../harnessInstall.js";
+import type { SetupFacts } from "../model.js";
+import type { SetupCommandDeps } from "../types.js";
+import { createSetupConfigAdapter } from "./config.js";
+import { createHarnessTrackingAdapter } from "./harnessTracking.js";
+import { createObserverActivationAdapter } from "./observerActivation.js";
+
+export type SetupOperationAdapterOptions = {
+  readonly facts?: SetupFacts;
+  readonly deps: SetupCommandDeps;
+};
+
+/**
+ * ADAPTER
+ *
+ * Assigns semantic setup operations to config, provider, process, filesystem, and Observer boundary implementations.
+ */
+export function createSetupOperationAdapter(
+  options: SetupOperationAdapterOptions,
+): SetupOperationExecutor {
+  const { deps, facts } = options;
+  let committedConfigPath: string | undefined;
+  const config: SetupOperationPorts["config"] = (operation) =>
+    createSetupConfigAdapter({
+      facts: requireFacts(facts),
+      ...(deps.now === undefined ? {} : { now: deps.now }),
+      ...(deps.fs === undefined ? {} : { fs: configPersistenceFileSystem(deps.fs) }),
+      onCommitted: (configPath) => {
+        committedConfigPath = configPath;
+      },
+    })(operation);
+  const observer = createObserverActivationAdapter({
+    configPath: () => committedConfigPath,
+    homeDir: facts?.homeDir ?? deps.homeDir ?? process.env.HOME ?? "",
+    ...(deps.activateObserverConfig === undefined
+      ? {}
+      : { activateObserverConfig: deps.activateObserverConfig }),
+  });
+  const defaultHarnessTracking = createHarnessTrackingAdapter({
+    configPath: () => committedConfigPath ?? facts?.configPath,
+    homeDir: facts?.homeDir ?? deps.homeDir ?? process.env.HOME ?? "",
+    ...(deps.env === undefined ? {} : { env: deps.env }),
+    ...(deps.providerHookIngressLauncher === undefined
+      ? {}
+      : { providerHookIngressLauncher: deps.providerHookIngressLauncher }),
+    ...(deps.providerHookArtifactOwner === undefined
+      ? {}
+      : { providerHookArtifactOwner: deps.providerHookArtifactOwner }),
+  });
+
+  const ports: SetupOperationPorts = {
+    config,
+    observer,
+    harnessTracking: (operation) =>
+      deps.providerTrackingPort?.(operation) ?? defaultHarnessTracking(operation),
+    worktrunk: (operation) => {
+      if (operation.kind === "configure-worktrunk-shell") {
+        const currentFacts = requireFacts(facts);
+        const base = [
+          currentFacts.worktrunk.resolvedPath ?? currentFacts.worktrunk.command,
+          "-y",
+          "config",
+          "shell",
+          "install",
+        ];
+        const shell = currentFacts.worktrunkShellIntegration.shell;
+        const command = shell === undefined ? base : [...base, shell];
+        return runExternalOperation(operation, command, { kind: "worktrunk-shell" }, deps);
+      }
+      const currentFacts = requireFacts(facts);
+      return (
+        deps.providerTrackingPort?.(operation) ??
+        prepareWorktrunkTracking(
+          operation,
+          currentFacts,
+          committedConfigPath ?? currentFacts.config.path,
+          deps,
+        )
+      );
+    },
+    tmux: (operation) => configureTmux(operation, requireFacts(facts), deps),
+    packages: createPackageInstallationAdapter(facts, deps),
+    launchers: (operation) => {
+      const currentFacts = requireFacts(facts);
+      return runExternalOperation(
+        operation,
+        ["pnpm", "--dir", currentFacts.launchers.packageRoot, "station:link"],
+        { kind: "launcher-link" },
+        deps,
+      );
+    },
+  };
+  return (operation) => performSetupOperation(operation, ports);
+}
+
+function createPackageInstallationAdapter(
+  facts: SetupFacts | undefined,
+  deps: SetupCommandDeps,
+): SetupPackageInstallationPort {
+  return (operation) => {
+    const command = packageInstallCommand(operation, facts);
+    const target = packageTarget(operation);
+    return runExternalOperation(operation, command, { kind: "package-installer", target }, deps);
+  };
+}
+
+function packageInstallCommand(
+  operation: Parameters<SetupPackageInstallationPort>[0],
+  facts: SetupFacts | undefined,
+): readonly string[] {
+  switch (operation.kind) {
+    case "install-tool":
+      return ["brew", "install", toolFormula(operation.tool)];
+    case "install-harness": {
+      const currentFacts = requireFacts(facts);
+      return resolveHarnessInstallDefinition(operation.harnessId, {
+        brewAvailable: currentFacts.brew.status === "ok",
+        homeDir: currentFacts.homeDir,
+        macos: currentFacts.xcode.applicable,
+      }).command;
+    }
+    case "install-homebrew":
+      return [
+        "/bin/bash",
+        "-c",
+        [
+          "set -eu",
+          'installer="$(mktemp)"',
+          "trap 'rm -f \"$installer\"' EXIT",
+          'curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "$installer"',
+          '/bin/bash "$installer"',
+        ].join("; "),
+      ];
+    case "install-xcode-command-line-tools":
+      return ["xcode-select", "--install"];
+  }
+}
+
+function packageTarget(
+  operation: Parameters<SetupPackageInstallationPort>[0],
+): Extract<SetupOperationCommit, { kind: "package-installer" }>["target"] {
+  switch (operation.kind) {
+    case "install-tool":
+      return { kind: "tool", id: operation.tool };
+    case "install-harness":
+      return { kind: "harness", id: operation.harnessId };
+    case "install-homebrew":
+      return { kind: "bootstrap", id: "homebrew" };
+    case "install-xcode-command-line-tools":
+      return { kind: "bootstrap", id: "xcode-command-line-tools" };
+  }
+}
+
+async function prepareWorktrunkTracking(
+  operation: Extract<SetupOperation, { kind: "prepare-worktrunk-tracking" }>,
+  facts: SetupFacts,
+  configPath: string,
+  deps: SetupCommandDeps,
+): Promise<SetupOperationOutcome> {
+  try {
+    const loaded = await loadConfig({ configPath, homeDir: facts.homeDir });
+    const result = await runWorktrunkHooksCommand(["install", "--yes"], {
+      config: loaded.config,
+      configPath: loaded.configPath,
+      ...(deps.env === undefined ? {} : { env: deps.env }),
+      ...(deps.providerHookIngressLauncher === undefined
+        ? {}
+        : { providerHookIngressLauncher: deps.providerHookIngressLauncher }),
+      ...(deps.providerHookArtifactOwner === undefined
+        ? {}
+        : { providerHookArtifactOwner: deps.providerHookArtifactOwner }),
+    });
+    if (!result.installed) throw worktrunkTrackingFallback;
+    const commit =
+      result.backupPath === undefined
+        ? {
+            kind: "provider-tracking" as const,
+            provider: "worktrunk" as const,
+            changed: result.changed,
+          }
+        : {
+            kind: "provider-tracking" as const,
+            provider: "worktrunk" as const,
+            changed: result.changed,
+            backupPaths: [result.backupPath],
+          };
+    return { status: "completed", operationId: operation.id, commit };
+  } catch (error) {
+    return failedOutcome(operation, error, worktrunkTrackingFallback);
+  }
+}
+
+async function configureTmux(
+  operation: Extract<SetupOperation, { kind: "configure-tmux-popup" }>,
+  facts: SetupFacts,
+  deps: SetupCommandDeps,
+): Promise<SetupOperationOutcome> {
+  if (facts.tmuxBinding.status === "conflict") {
+    return failedOutcome(operation, tmuxConflictFallback, tmuxConflictFallback);
+  }
+  if (operation.scope === "live") {
+    return runExternalOperation(
+      operation,
+      [
+        facts.tmux.resolvedPath ?? facts.tmux.command,
+        "bind-key",
+        facts.tmuxBinding.bindingKey,
+        "run-shell",
+        "-b",
+        facts.tmuxBinding.runShellCommand,
+      ],
+      { kind: "tmux-popup", scope: "live", changed: true },
+      deps,
+    );
+  }
+
+  try {
+    const fs = deps.fs ?? nodeSetupFileSystem();
+    const existing = await readFileIfPresent(fs, facts.tmuxBinding.path);
+    const block = tmuxPopupBindingBlock(facts.tmuxBinding.launcherCommand, {
+      bindingKey: facts.tmuxBinding.bindingKey,
+      runShellCommand: facts.tmuxBinding.runShellCommand,
+    });
+    const content = replaceMarkedBlock(
+      existing ?? "",
+      facts.tmuxBinding.marker,
+      tmuxPopupBindingEndMarker,
+      block,
+    );
+    const changed = content !== existing;
+    if (changed) await replaceWithSetupFileSystem(fs, facts.tmuxBinding.path, content);
+    return {
+      status: "completed",
+      operationId: operation.id,
+      commit: { kind: "tmux-popup", scope: "persisted", changed },
+    };
+  } catch (error) {
+    return failedOutcome(operation, error, tmuxWriteFallback);
+  }
+}
+
+async function runExternalOperation(
+  operation: SetupOperation,
+  command: readonly string[],
+  commit: SetupOperationCommit,
+  deps: Pick<SetupCommandDeps, "runner" | "env">,
+): Promise<SetupOperationOutcome> {
+  try {
+    const [binary, ...args] = command;
+    if (binary === undefined) throw externalOperationFallback;
+    const input: ExternalCommandInput = {
+      command: binary,
+      args,
+      stdio: "inherit",
+      maxOutputChars: 4096,
+    };
+    const env = commandEnv(deps.env);
+    if (env !== undefined) input.env = env;
+    await runExternalCommand(input, deps.runner);
+    return { status: "completed", operationId: operation.id, commit };
+  } catch (error) {
+    return failedOutcome(operation, error, externalOperationFallback);
+  }
+}
+
+function failedOutcome(
+  operation: SetupOperation,
+  error: unknown,
+  fallback: { tag: string; code: string; message: string; provider?: string },
+): SetupOperationOutcome {
+  return {
+    status: "failed",
+    operationId: operation.id,
+    error: publicSafeErrorFromUnknown(error, fallback),
+  };
+}
+
+function configPersistenceFileSystem(
+  fs: SetupApplyFileSystem,
+): NonNullable<PersistSetupConfigMutationOptions["fs"]> {
+  return {
+    readTextFile: (path) => readFileIfPresent(fs, path),
+    writeBackup: (path, content) => fs.writeFile(path, content),
+    replaceText: (path, content) => replaceWithSetupFileSystem(fs, path, content),
+  };
+}
+
+async function readFileIfPresent(
+  fs: SetupApplyFileSystem,
+  path: string,
+): Promise<string | undefined> {
+  try {
+    await fs.access(path);
+    return await fs.readFile(path);
+  } catch {
+    return undefined;
+  }
+}
+
+async function replaceWithSetupFileSystem(
+  fs: SetupApplyFileSystem,
+  path: string,
+  content: string,
+): Promise<void> {
+  await fs.mkdir(dirname(path), { recursive: true });
+  const tempPath = `${path}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    await fs.writeFile(tempPath, content);
+    await fs.rename(tempPath, path);
+  } catch (error) {
+    await fs.rm?.(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function nodeSetupFileSystem(): SetupApplyFileSystem {
+  return {
+    mkdir: async (path, options) => {
+      await mkdir(path, options);
+    },
+    readFile: (path) => readFile(path, "utf8"),
+    writeFile: (path, content) => writeFile(path, content, "utf8"),
+    rename,
+    access,
+    rm,
+  };
+}
+
+function replaceMarkedBlock(
+  existing: string,
+  marker: string,
+  endMarker: string,
+  block: string,
+): string {
+  const start = existing.indexOf(marker);
+  if (start === -1) return `${ensureTrailingNewline(existing)}${block}`;
+  const end = existing.indexOf(endMarker, start + marker.length);
+  if (end === -1) throw new Error(`Existing marker ${marker} has no closing marker.`);
+  const after = existing.indexOf("\n", end + endMarker.length);
+  const suffix = after === -1 ? "" : existing.slice(after + 1);
+  return `${existing.slice(0, start)}${block}${suffix}`;
+}
+
+function ensureTrailingNewline(value: string): string {
+  return value.length === 0 || value.endsWith("\n") ? value : `${value}\n`;
+}
+
+function requireFacts(facts: SetupFacts | undefined): SetupFacts {
+  if (facts === undefined) throw new Error("This setup operation requires collected setup facts.");
+  return facts;
+}
+
+function toolFormula(tool: Extract<SetupOperation, { kind: "install-tool" }>["tool"]): string {
+  switch (tool) {
+    case "worktrunk":
+      return "worktrunk";
+    case "tmux":
+      return "tmux";
+    case "bun":
+      return "bun";
+    case "diffnav":
+      return "diffnav";
+    case "git-delta":
+      return "git-delta";
+  }
+}
+
+const externalOperationFallback = {
+  tag: "SetupOperationError",
+  code: "SETUP_OPERATION_FAILED",
+  message: "The setup operation failed.",
+};
+const worktrunkTrackingFallback = {
+  tag: "SetupProviderTrackingError",
+  code: "SETUP_PROVIDER_TRACKING_FAILED",
+  message: "Station Worktrunk tracking could not be prepared.",
+  provider: "worktrunk",
+};
+const tmuxConflictFallback = {
+  tag: "SetupTmuxError",
+  code: "SETUP_TMUX_CONFLICT",
+  message: "The tmux popup binding conflicts with an existing configuration.",
+};
+const tmuxWriteFallback = {
+  tag: "SetupTmuxError",
+  code: "SETUP_TMUX_WRITE_FAILED",
+  message: "The tmux popup binding could not be persisted.",
+};

--- a/apps/cli/src/commands/setup/adapters/operations.ts
+++ b/apps/cli/src/commands/setup/adapters/operations.ts
@@ -111,7 +111,13 @@ export function createSetupOperationAdapter(
       );
     },
   };
-  return (operation) => performSetupOperation(operation, ports);
+  return async (operation) => {
+    try {
+      return await performSetupOperation(operation, ports);
+    } catch (error) {
+      return failedOutcome(operation, error, unexpectedOperationFallback(operation));
+    }
+  };
 }
 
 function createPackageInstallationAdapter(
@@ -249,11 +255,27 @@ async function configureTmux(
       block,
     );
     const changed = content !== existing;
-    if (changed) await replaceWithSetupFileSystem(fs, facts.tmuxBinding.path, content);
+    if (!changed) {
+      return {
+        status: "completed",
+        operationId: operation.id,
+        commit: { kind: "tmux-popup", scope: "persisted", changed: false },
+      };
+    }
+
+    // A failed backup must leave the user-authored tmux file untouched.
+    const backupPath =
+      existing === undefined
+        ? undefined
+        : await writeTmuxBackup(fs, facts.tmuxBinding.path, existing, deps.now);
+    await replaceWithSetupFileSystem(fs, facts.tmuxBinding.path, content);
     return {
       status: "completed",
       operationId: operation.id,
-      commit: { kind: "tmux-popup", scope: "persisted", changed },
+      commit:
+        backupPath === undefined
+          ? { kind: "tmux-popup", scope: "persisted", changed: true }
+          : { kind: "tmux-popup", scope: "persisted", changed: true, backupPath },
     };
   } catch (error) {
     return failedOutcome(operation, error, tmuxWriteFallback);
@@ -302,7 +324,13 @@ function configPersistenceFileSystem(
   return {
     readTextFile: (path) => readFileIfPresent(fs, path),
     writeBackup: (path, content) => fs.writeFile(path, content),
-    replaceText: (path, content) => replaceWithSetupFileSystem(fs, path, content),
+    replaceTextIfCurrent: async (path, expectedContent, content) => {
+      const current = await readFileIfPresent(fs, path);
+      if (current === content) return "unchanged";
+      if (current !== expectedContent) return "stale";
+      await replaceWithSetupFileSystem(fs, path, content);
+      return "replaced";
+    },
   };
 }
 
@@ -311,11 +339,33 @@ async function readFileIfPresent(
   path: string,
 ): Promise<string | undefined> {
   try {
-    await fs.access(path);
     return await fs.readFile(path);
-  } catch {
-    return undefined;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException | null | undefined)?.code === "ENOENT") return undefined;
+    throw cause;
   }
+}
+
+async function writeTmuxBackup(
+  fs: SetupApplyFileSystem,
+  path: string,
+  content: string,
+  now: (() => Date) | undefined,
+): Promise<string> {
+  const stamp = (now ?? (() => new Date()))().toISOString().replaceAll(/[:.]/g, "-");
+  const backupPath = `${path}.${stamp}.bak`;
+  if (fs.writeFileExclusive !== undefined) {
+    await fs.writeFileExclusive(backupPath, content);
+    return backupPath;
+  }
+  try {
+    await fs.access(backupPath);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException | null | undefined)?.code !== "ENOENT") throw cause;
+    await fs.writeFile(backupPath, content);
+    return backupPath;
+  }
+  throw Object.assign(new Error(`Backup already exists: ${backupPath}`), { code: "EEXIST" });
 }
 
 async function replaceWithSetupFileSystem(
@@ -341,6 +391,9 @@ function nodeSetupFileSystem(): SetupApplyFileSystem {
     },
     readFile: (path) => readFile(path, "utf8"),
     writeFile: (path, content) => writeFile(path, content, "utf8"),
+    writeFileExclusive: async (path, content) => {
+      await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    },
     rename,
     access,
     rm,
@@ -384,6 +437,25 @@ function toolFormula(tool: Extract<SetupOperation, { kind: "install-tool" }>["to
     case "git-delta":
       return "git-delta";
   }
+}
+
+function unexpectedOperationFallback(operation: SetupOperation): {
+  tag: string;
+  code: string;
+  message: string;
+  provider?: string;
+} {
+  if (operation.kind === "prepare-harness-tracking") {
+    return {
+      tag: "SetupProviderTrackingError",
+      code: "SETUP_PROVIDER_TRACKING_FAILED",
+      message: `Station tracking could not be prepared for ${operation.harnessId}.`,
+      provider: operation.harnessId,
+    };
+  }
+  if (operation.kind === "prepare-worktrunk-tracking") return worktrunkTrackingFallback;
+  if (operation.kind === "configure-tmux-popup") return tmuxWriteFallback;
+  return externalOperationFallback;
 }
 
 const externalOperationFallback = {

--- a/apps/cli/src/commands/setup/apply.ts
+++ b/apps/cli/src/commands/setup/apply.ts
@@ -16,6 +16,7 @@ export type SetupApplyFileSystem = {
   mkdir(path: string, options: { recursive: true }): Promise<void>;
   readFile(path: string): Promise<string>;
   writeFile(path: string, content: string): Promise<void>;
+  writeFileExclusive?(path: string, content: string): Promise<void>;
   rename(from: string, to: string): Promise<void>;
   access(path: string): Promise<void>;
   rm?(path: string, options: { force: true }): Promise<void>;
@@ -354,6 +355,9 @@ function nodeApplyFs(): SetupApplyFileSystem {
     },
     async writeFile(path, content) {
       await writeFile(path, content, "utf8");
+    },
+    async writeFileExclusive(path, content) {
+      await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
     },
     rename,
     access,

--- a/apps/cli/src/commands/setup/apply.ts
+++ b/apps/cli/src/commands/setup/apply.ts
@@ -1,10 +1,15 @@
-import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import {
   type ExternalCommandInput,
   type ExternalCommandRunner,
   runExternalCommand,
 } from "@station/runtime";
+import type {
+  SetupOperation,
+  SetupOperationExecutor,
+  SetupOperationOutcome,
+} from "@station/setup-core";
 import type { SetupAction, SetupPlan } from "./model.js";
 
 export type SetupApplyFileSystem = {
@@ -13,6 +18,12 @@ export type SetupApplyFileSystem = {
   writeFile(path: string, content: string): Promise<void>;
   rename(from: string, to: string): Promise<void>;
   access(path: string): Promise<void>;
+  rm?(path: string, options: { force: true }): Promise<void>;
+};
+
+export type SetupOperationBinding = {
+  readonly actionId: string;
+  readonly operation: SetupOperation;
 };
 
 export type ApplySetupPlanOptions = {
@@ -29,11 +40,15 @@ export type ApplySetupPlanOptions = {
   onActionStart?: (action: SetupAction) => void | Promise<void>;
   onActionComplete?: (action: SetupAction) => void | Promise<void>;
   onActionFailed?: (action: SetupAction) => void | Promise<void>;
+  operationBindings?: readonly SetupOperationBinding[];
+  executeOperation?: SetupOperationExecutor;
 };
 
 export type ApplySetupPlanResult = {
   plan: SetupPlan;
   failedAction?: SetupAction;
+  failedOperation?: Extract<SetupOperationOutcome, { status: "failed" }>;
+  operationOutcomes: readonly SetupOperationOutcome[];
 };
 
 export async function applySetupPlan(
@@ -41,7 +56,13 @@ export async function applySetupPlan(
   options: ApplySetupPlanOptions = {},
 ): Promise<ApplySetupPlanResult> {
   const actions: SetupAction[] = [];
+  const operationOutcomes: SetupOperationOutcome[] = [];
+  const bindings = new Map(
+    options.operationBindings?.map((binding) => [binding.actionId, binding] as const) ?? [],
+  );
   const fs = options.fs ?? nodeApplyFs();
+  let failedAction: SetupAction | undefined;
+  let failedOperation: Extract<SetupOperationOutcome, { status: "failed" }> | undefined;
   for (const action of plan.actions) {
     if (!action.selected || options.actionFilter?.(action) === false) {
       actions.push({ ...action, status: "skipped" });
@@ -51,37 +72,105 @@ export async function applySetupPlan(
       actions.push({ ...action, status: "skipped" });
       continue;
     }
-    try {
-      const context: {
-        fs: SetupApplyFileSystem;
-        runner?: ExternalCommandRunner;
-        env?: Record<string, string>;
-        now?: () => Date;
-        showCommandOutput?: boolean;
-      } = {
-        fs,
-      };
-      if (options.runner !== undefined) context.runner = options.runner;
-      if (options.env !== undefined) context.env = options.env;
-      if (options.now !== undefined) context.now = options.now;
-      if (options.showCommandOutput !== undefined) {
-        context.showCommandOutput = options.showCommandOutput;
+    const binding = bindings.get(action.id);
+    await options.onActionStart?.(action);
+    if (
+      binding !== undefined &&
+      options.executeOperation !== undefined &&
+      action.id !== "mkdir-config-dir"
+    ) {
+      const outcome = await options.executeOperation(binding.operation);
+      operationOutcomes.push(outcome);
+      if (outcome.status === "completed") {
+        const completed = completedAction(action, outcome);
+        await options.onActionComplete?.(completed);
+        actions.push(completed);
+        continue;
       }
-      await options.onActionStart?.(action);
-      await applyAction(action, context);
-      await options.onActionComplete?.(action);
-      actions.push({ ...action, status: "completed" });
-    } catch {
+
       const failed = { ...action, status: "failed" as const };
+      failedAction ??= failed;
+      failedOperation ??= outcome;
       await options.onActionFailed?.(failed);
       actions.push(failed);
-      return {
-        plan: { ...plan, actions: [...actions, ...remainingSkipped(plan.actions, actions.length)] },
-        failedAction: failed,
-      };
+      if (
+        binding.operation.kind === "prepare-harness-tracking" ||
+        binding.operation.kind === "prepare-worktrunk-tracking"
+      ) {
+        continue;
+      }
+      return applyResult(plan, actions, operationOutcomes, failedAction, failedOperation, true);
+    }
+
+    try {
+      if (binding === undefined || action.id !== "mkdir-config-dir") {
+        const context: {
+          fs: SetupApplyFileSystem;
+          runner?: ExternalCommandRunner;
+          env?: Record<string, string>;
+          now?: () => Date;
+          showCommandOutput?: boolean;
+        } = { fs };
+        if (options.runner !== undefined) context.runner = options.runner;
+        if (options.env !== undefined) context.env = options.env;
+        if (options.now !== undefined) context.now = options.now;
+        if (options.showCommandOutput !== undefined) {
+          context.showCommandOutput = options.showCommandOutput;
+        }
+        await applyAction(action, context);
+      }
+      const completed = { ...action, status: "completed" as const };
+      await options.onActionComplete?.(completed);
+      actions.push(completed);
+    } catch {
+      const failed = { ...action, status: "failed" as const };
+      failedAction ??= failed;
+      await options.onActionFailed?.(failed);
+      actions.push(failed);
+      return applyResult(plan, actions, operationOutcomes, failedAction, failedOperation, true);
     }
   }
-  return { plan: { ...plan, actions } };
+  return applyResult(plan, actions, operationOutcomes, failedAction, failedOperation, false);
+}
+
+function completedAction(action: SetupAction, outcome: SetupOperationOutcome): SetupAction {
+  if (
+    outcome.status === "completed" &&
+    outcome.commit.kind === "config" &&
+    outcome.commit.backupPath !== undefined
+  ) {
+    return {
+      ...action,
+      status: "completed",
+      data: { ...(action.data ?? {}), backupPath: outcome.commit.backupPath },
+    };
+  }
+  return { ...action, status: "completed" };
+}
+
+function applyResult(
+  plan: SetupPlan,
+  actions: readonly SetupAction[],
+  operationOutcomes: readonly SetupOperationOutcome[],
+  failedAction: SetupAction | undefined,
+  failedOperation: Extract<SetupOperationOutcome, { status: "failed" }> | undefined,
+  skipRemaining: boolean,
+): ApplySetupPlanResult {
+  const projectedActions = skipRemaining
+    ? [...actions, ...remainingSkipped(plan.actions, actions.length)]
+    : [...actions];
+  const result: {
+    plan: SetupPlan;
+    operationOutcomes: readonly SetupOperationOutcome[];
+    failedAction?: SetupAction;
+    failedOperation?: Extract<SetupOperationOutcome, { status: "failed" }>;
+  } = {
+    plan: { ...plan, actions: projectedActions },
+    operationOutcomes,
+  };
+  if (failedAction !== undefined) result.failedAction = failedAction;
+  if (failedOperation !== undefined) result.failedOperation = failedOperation;
+  return result;
 }
 
 async function applyAction(
@@ -268,5 +357,6 @@ function nodeApplyFs(): SetupApplyFileSystem {
     },
     rename,
     access,
+    rm,
   };
 }

--- a/apps/cli/src/commands/setup/configWriter.ts
+++ b/apps/cli/src/commands/setup/configWriter.ts
@@ -1,17 +1,16 @@
-import { setHarnessInstallHooksInToml } from "@station/config";
+import {
+  planSetupConfigMutation,
+  renderSetupConfig,
+  type SetupConfigDesiredState,
+} from "@station/config";
+import type { SetupOperation } from "@station/setup-core";
+import { setupConfigMutationInput } from "./adapters/config.js";
 import {
   harnessSupportsSetupHooks,
-  isSupportedHarnessId,
   resolveSetupHarnessSelection,
   type SetupHarnessSelection,
 } from "./harnessSelection.js";
-import type {
-  ConfigWritePlan,
-  SetupConfigFact,
-  SetupFacts,
-  SetupHarnessFact,
-  SupportedHarnessId,
-} from "./model.js";
+import type { ConfigWritePlan, SetupFacts, SetupHarnessFact, SupportedHarnessId } from "./model.js";
 
 export type PlanSetupConfigWriteOptions = {
   harnessSelection?: SetupHarnessSelection;
@@ -25,11 +24,7 @@ export async function planSetupConfigWrite(
 ): Promise<ConfigWritePlan> {
   const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
   if (facts.config.status === "invalid") {
-    return {
-      operation: "blocked",
-      path: facts.config.path,
-      reason: facts.config.message,
-    };
+    return { operation: "blocked", path: facts.config.path, reason: facts.config.message };
   }
   if (harnessSelection.selected.length === 0) {
     return {
@@ -42,15 +37,19 @@ export async function planSetupConfigWrite(
           : "No unambiguous supported harness CLI is available; config was not planned.",
     };
   }
-  if (facts.config.status === "missing") {
-    return {
-      operation: "create",
-      path: facts.configPath,
-      content: renderNewSetupConfig(harnessSelection.selected, facts, options),
-    };
-  }
 
-  return planExistingConfigUpdate(facts.config, harnessSelection.selected, options, facts.homeDir);
+  const operation = configOperation(harnessSelection, options);
+  const plan = await planSetupConfigMutation(setupConfigMutationInput(operation, facts));
+  switch (plan.operation) {
+    case "none":
+      return plan;
+    case "blocked":
+      return plan;
+    case "create":
+      return { operation: "create", path: plan.path, content: plan.content };
+    case "update":
+      return { operation: "update", path: plan.path, content: plan.content };
+  }
 }
 
 export function renderNewSetupConfig(
@@ -60,159 +59,60 @@ export function renderNewSetupConfig(
 ): string {
   const defaultHarness = harnesses[0];
   if (defaultHarness === undefined) throw new Error("New setup config requires an agent CLI.");
-  const worktrunkCommand =
-    facts?.worktrunk === undefined ? "wt" : detectedCommand(facts.worktrunk, "wt");
+  const desired: {
+    defaultHarness: SetupConfigDesiredState["defaultHarness"];
+    harnesses: SetupConfigDesiredState["harnesses"];
+    worktrunkCommand: string;
+    tmuxCommand?: string;
+    installWorktrunkHooks: boolean;
+  } = {
+    defaultHarness: defaultHarness.id,
+    harnesses: harnesses.map((harness) => ({
+      id: harness.id,
+      command: harness.command,
+      installHooks:
+        harnessSupportsSetupHooks(harness.id) &&
+        options.installHarnessHooks?.includes(harness.id) === true,
+    })),
+    worktrunkCommand:
+      facts?.worktrunk === undefined ? "wt" : detectedCommand(facts.worktrunk, "wt"),
+    installWorktrunkHooks: options.installWorktrunkHooks === true,
+  };
   const tmuxCommand =
     facts?.tmux === undefined ? undefined : detectedOptionalCommand(facts.tmux, "tmux");
-  const installWorktrunkHooks = options.installWorktrunkHooks === true;
-  return [
-    "schema_version = 1",
-    "projects = []",
-    "",
-    "[observer]",
-    'state_dir = "~/.local/state/station"',
-    "",
-    "[defaults]",
-    'worktree_provider = "worktrunk"',
-    'terminal = "tmux"',
-    `harness = ${tomlString(defaultHarness.id)}`,
-    'layout = "agent-shell"',
-    "",
-    "[worktree.worktrunk]",
-    `command = ${tomlString(worktrunkCommand)}`,
-    'managed_root = "~/.worktrees"',
-    "include_main = false",
-    "include_external = false",
-    `use_lifecycle_hooks = ${installWorktrunkHooks ? "true" : "false"}`,
-    `hook_mode = ${tomlString(installWorktrunkHooks ? "required-for-mvp" : "disabled")}`,
-    "",
-    "[terminal.tmux]",
-    ...(tmuxCommand === undefined ? [] : [`command = ${tomlString(tmuxCommand)}`]),
-    'session_prefix = "station"',
-    'topology = "workbench"',
-    'workbench_session = "station"',
-    'window_naming = "project-branch"',
-    "primary_agent_pane = true",
-    "",
-    ...harnesses.flatMap((selectedHarness) => [
-      ...renderHarnessBlock(
-        selectedHarness,
-        options.installHarnessHooks?.includes(selectedHarness.id) === true,
-      ).split("\n"),
-      "",
-    ]),
-  ].join("\n");
+  if (tmuxCommand !== undefined) desired.tmuxCommand = tmuxCommand;
+  return renderSetupConfig(desired);
 }
 
-async function planExistingConfigUpdate(
-  config: Extract<SetupConfigFact, { status: "valid" }>,
-  harnesses: readonly SetupHarnessFact[],
-  options: Pick<PlanSetupConfigWriteOptions, "installHarnessHooks">,
-  homeDir: string,
-): Promise<ConfigWritePlan> {
-  const coreProblem = existingConfigUpdateCoreProblem(config);
-  if (coreProblem !== undefined) {
-    return {
-      operation: "blocked",
-      path: config.path,
-      reason: coreProblem,
-    };
-  }
-
-  let content = config.source;
-  for (const harness of harnesses) {
-    if (
-      config.configuredHarnesses.includes(harness.id) &&
-      !config.configuredHookHarnesses.includes(harness.id) &&
-      options.installHarnessHooks?.includes(harness.id) === true
-    ) {
-      content = await setHarnessInstallHooksInToml(content, {
-        harness: harness.id,
-        installHooks: true,
-        configPath: config.path,
-        homeDir,
-      });
-    }
-  }
-
-  const appendedText = renderAppendText(
-    harnesses.filter((harness) => !config.configuredHarnesses.includes(harness.id)),
-    options.installHarnessHooks,
-    preferredNewline(config.source),
+function configOperation(
+  selection: SetupHarnessSelection,
+  options: PlanSetupConfigWriteOptions,
+): Extract<SetupOperation, { kind: "write-config" }> {
+  const defaultHarnessId = selection.defaultHarness ?? selection.requiredHarnessIds[0];
+  if (defaultHarnessId === undefined) throw new Error("Setup config requires a default harness.");
+  const trackingHarnessIds = selection.requiredHarnessIds.filter(
+    (harnessId) =>
+      harnessSupportsSetupHooks(harnessId) &&
+      options.installHarnessHooks?.includes(harnessId) === true,
   );
-  if (appendedText.length > 0) {
-    content = `${content}${content.endsWith("\n") ? "" : preferredNewline(content)}${appendedText}`;
-  }
-  if (content === config.source) {
-    return {
-      operation: "none",
-      reason:
-        harnesses.length === 1
-          ? "Config already includes the selected harness and core defaults."
-          : "Config already includes the selected harnesses and core defaults.",
-    };
-  }
   return {
-    operation: "update",
-    path: config.path,
-    content,
+    id: "write-config",
+    kind: "write-config",
+    tier: "required",
+    selected: true,
+    change: "create",
+    defaultHarnessId,
+    harnessIds: selection.requiredHarnessIds,
+    trackingHarnessIds,
+    installWorktrunkTracking: options.installWorktrunkHooks === true,
   };
-}
-
-function existingConfigUpdateCoreProblem(
-  config: Extract<SetupConfigFact, { status: "valid" }>,
-): string | undefined {
-  if (config.defaults.worktreeProvider !== "worktrunk") {
-    return `Config defaults use worktree provider ${config.defaults.worktreeProvider}; setup will not rewrite existing defaults.`;
-  }
-  if (config.defaults.terminal !== "tmux") {
-    return `Config defaults use terminal ${config.defaults.terminal}; setup will not rewrite existing defaults.`;
-  }
-  if (!isSupportedHarnessId(config.defaults.harness)) {
-    return `Config defaults use unsupported harness ${config.defaults.harness}; setup will not rewrite existing defaults.`;
-  }
-  return undefined;
-}
-
-function renderAppendText(
-  harnesses: readonly SetupHarnessFact[],
-  installHarnessHooks: readonly SupportedHarnessId[] | undefined,
-  newline = "\n",
-): string {
-  if (harnesses.length === 0) return "";
-  const blocks = harnesses.map((harness) =>
-    renderHarnessBlock(harness, installHarnessHooks?.includes(harness.id) === true).replaceAll(
-      "\n",
-      newline,
-    ),
-  );
-  return `${newline}${blocks.join(`${newline}${newline}`)}${newline}`;
-}
-
-function renderHarnessBlock(harness: SetupHarnessFact, installHooks: boolean): string {
-  return [
-    `[harness.${harness.id}]`,
-    "enabled = true",
-    `command = ${tomlString(harness.command)}`,
-    ...(installHooks && harnessSupportsSetupHooks(harness.id) ? ["install_hooks = true"] : []),
-  ].join("\n");
-}
-
-function tomlString(value: string): string {
-  return JSON.stringify(value);
-}
-
-function preferredNewline(source: string): "\n" | "\r\n" {
-  return source.includes("\r\n") ? "\r\n" : "\n";
 }
 
 function detectedCommand(
   fact: { command: string; resolvedPath?: string },
   defaultCommand: string,
 ): string {
-  if (fact.command !== defaultCommand || fact.command.includes("/")) {
-    return fact.command;
-  }
+  if (fact.command !== defaultCommand || fact.command.includes("/")) return fact.command;
   return fact.resolvedPath ?? defaultCommand;
 }
 
@@ -220,8 +120,6 @@ function detectedOptionalCommand(
   fact: { command: string; resolvedPath?: string },
   defaultCommand: string,
 ): string | undefined {
-  if (fact.command !== defaultCommand || fact.command.includes("/")) {
-    return fact.command;
-  }
+  if (fact.command !== defaultCommand || fact.command.includes("/")) return fact.command;
   return fact.resolvedPath;
 }

--- a/apps/cli/src/commands/setup/flowUtils.ts
+++ b/apps/cli/src/commands/setup/flowUtils.ts
@@ -1,8 +1,9 @@
-import { loadConfig, resolveObserverPaths } from "@station/config";
+import type { SafeError } from "@station/contracts";
 import { type RuntimeSafeError, safeErrorFromUnknown } from "@station/runtime";
+import type { SetupPlan as CoreSetupPlan, SetupOperationExecutor } from "@station/setup-core";
 import type { CliEnv } from "../../env.js";
-import { restartObserver } from "../../observerProcess.js";
-import type { applySetupPlan } from "./apply.js";
+import { createSetupOperationAdapter } from "./adapters/operations.js";
+import type { applySetupPlan, SetupOperationBinding } from "./apply.js";
 import { commandEnv } from "./checks/env.js";
 import {
   type CollectSetupFactsOptions,
@@ -27,12 +28,13 @@ import type {
   SupportedHarnessId,
 } from "./model.js";
 import { SetupHarnessTrackingFactSchema } from "./model.js";
-import { buildSetupPlan } from "./planner.js";
+import { type buildSetupPlan, buildSetupPlans } from "./planner.js";
 import {
   formatCommand,
   renderActionComplete,
   renderActionFailed,
   renderActionStart,
+  renderBoundActionStart,
 } from "./render.js";
 import type { SetupCommandDeps, SetupCommandOptions } from "./types.js";
 
@@ -70,6 +72,9 @@ export type CollectedSetupPlan = {
   facts: SetupFacts;
   harnessSelection: SetupHarnessSelection;
   plan: SetupPlan;
+  semanticPlan: CoreSetupPlan;
+  operationBindings: readonly SetupOperationBinding[];
+  executeOperation: SetupOperationExecutor;
 };
 
 type SetupPlanCollectionOptions = {
@@ -115,10 +120,14 @@ export async function collectSetupPlanFromFacts(
         : { installWorktrunkHooks: input.installWorktrunkHooks }),
     });
   }
+  const built = buildSetupPlans(facts, plannerOptions);
   return {
     facts,
     harnessSelection,
-    plan: buildSetupPlan(facts, plannerOptions),
+    plan: built.compatibilityPlan,
+    semanticPlan: built.semanticPlan,
+    operationBindings: built.operationBindings,
+    executeOperation: createSetupOperationAdapter({ facts, deps }),
   };
 }
 
@@ -201,6 +210,7 @@ export function applyOptions(
     actionFilter?: (action: SetupAction) => boolean;
     showCommandOutput?: boolean;
     announceActions?: boolean;
+    execution?: Pick<CollectedSetupPlan, "operationBindings" | "executeOperation">;
   },
 ): Parameters<typeof applySetupPlan>[1] {
   const options: Parameters<typeof applySetupPlan>[1] = {};
@@ -213,9 +223,19 @@ export function applyOptions(
   if (input.dryRun !== undefined) options.dryRun = input.dryRun;
   if (input.actionFilter !== undefined) options.actionFilter = input.actionFilter;
   if (input.showCommandOutput !== undefined) options.showCommandOutput = input.showCommandOutput;
+  if (input.execution !== undefined) {
+    options.operationBindings = input.execution.operationBindings;
+    options.executeOperation = input.execution.executeOperation;
+  }
   if (input.announceActions === true) {
+    const boundActionIds = new Set(
+      input.execution?.operationBindings.map((binding) => binding.actionId) ?? [],
+    );
     options.onActionStart = async (action) => {
-      await write(deps, `${renderActionStart(action, renderOptions(deps))}\n`);
+      const rendered = boundActionIds.has(action.id)
+        ? renderBoundActionStart(action, renderOptions(deps))
+        : renderActionStart(action, renderOptions(deps));
+      await write(deps, `${rendered}\n`);
     };
     options.onActionComplete = async (action) => {
       await write(deps, `${renderActionComplete(action, renderOptions(deps))}\n`);
@@ -228,65 +248,25 @@ export function applyOptions(
 }
 
 export async function activateCompletedConfigWrite(
-  plan: SetupPlan,
-  homeDir: string,
+  collected: Pick<CollectedSetupPlan, "semanticPlan" | "executeOperation" | "facts">,
   deps: SetupCommandDeps,
-): Promise<RuntimeSafeError | undefined> {
-  const completedWrite = plan.actions.find(
-    (action) => action.kind === "write-config" && action.status === "completed",
+): Promise<SafeError | undefined> {
+  const operation = collected.semanticPlan.operations.find(
+    (candidate) => candidate.kind === "activate-observer-config",
   );
-  if (completedWrite === undefined) {
-    return undefined;
-  }
+  if (operation === undefined) return undefined;
 
   await write(deps, "Activating observer configuration...\n");
-  try {
-    if (completedWrite.path === undefined) {
-      throw observerActivationError;
-    }
-    await (deps.activateObserverConfig ?? activateObserverConfig)({
-      configPath: completedWrite.path,
-      homeDir,
-    });
+  const outcome = await collected.executeOperation(operation);
+  if (outcome.status === "completed") {
     await write(deps, "Observer configuration active.\n");
     return undefined;
-  } catch (error) {
-    const safeError = safeErrorFromUnknown(error, observerActivationError);
-    await write(deps, renderObserverActivationFailure(safeError, completedWrite.path));
-    return safeError;
   }
+  await write(deps, renderObserverActivationFailure(outcome.error, collected.facts.configPath));
+  return outcome.error;
 }
 
-async function activateObserverConfig(input: {
-  configPath: string;
-  homeDir: string;
-}): Promise<void> {
-  try {
-    const loaded = await loadConfig({ configPath: input.configPath, homeDir: input.homeDir });
-    const paths = resolveObserverPaths(loaded.config, input.homeDir);
-    const status = await restartObserver({
-      config: loaded.config,
-      configPath: loaded.configPath,
-      paths,
-    });
-    if (status.status !== "running") {
-      throw safeErrorFromUnknown(status.error, observerActivationError);
-    }
-  } catch (error) {
-    throw safeErrorFromUnknown(error, observerActivationError);
-  }
-}
-
-const observerActivationError: RuntimeSafeError = {
-  tag: "ObserverActivationError",
-  code: "OBSERVER_ACTIVATION_FAILED",
-  message: "Observer configuration could not be activated.",
-};
-
-function renderObserverActivationFailure(
-  error: RuntimeSafeError,
-  configPath: string | undefined,
-): string {
+function renderObserverActivationFailure(error: SafeError, configPath: string | undefined): string {
   const lines = [
     "Config was written, but observer activation failed.",
     error.message,
@@ -353,18 +333,6 @@ export function isHookSetupAction(action: SetupAction): boolean {
 
 export function isTmuxPopupBindingAction(action: SetupAction): boolean {
   return action.id === "tmux-popup-binding" || action.id === "tmux-live-popup-binding";
-}
-
-export function markRequiredIncomplete(plan: SetupPlan): SetupPlan {
-  return {
-    ...plan,
-    summary: {
-      ...plan.summary,
-      workflowReady: false,
-      requiredOk: false,
-      requiredMissing: Math.max(1, plan.summary.requiredMissing),
-    },
-  };
 }
 
 export function coreReadyForConfigWrite(plan: SetupPlan): boolean {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -1,10 +1,12 @@
 import { access } from "node:fs/promises";
+import type { SetupOperation } from "@station/setup-core";
+import { createSetupOperationAdapter } from "../adapters/operations.js";
 import { applySetupPlan } from "../apply.js";
 import { checkSetupTmuxBinding } from "../checks/tmuxBinding.js";
-import { planSetupConfigWrite } from "../configWriter.js";
 import {
   activateCompletedConfigWrite,
   applyOptions,
+  type CollectedSetupPlan,
   collectForCommand,
   collectSetupPlanForCommand,
   collectSetupPlanFromFacts,
@@ -14,7 +16,6 @@ import {
   isHookSetupAction,
   isInstallAction,
   isTmuxPopupBindingAction,
-  markRequiredIncomplete,
 } from "../flowUtils.js";
 import {
   harnessInstallPlan,
@@ -105,16 +106,11 @@ async function runGuidedSetupWithPrompt(
     return { code: 1 };
   }
 
-  const configActivation = await writeAndActivateConfig(
-    preflight.plan,
-    preflight.facts,
-    prompt,
-    deps,
-  );
+  const configActivation = await writeAndActivateConfig(preflight, prompt, deps);
   if (configActivation.status === "halt") return { code: 1 };
 
   // Provider artifacts must target the config already activated by the Observer.
-  if (!(await installSelectedHooks(preflight.plan, deps))) return { code: 1 };
+  const trackingSucceeded = await installSelectedHooks(preflight, deps);
 
   const tmuxPopupState = await collectGuidedPopupState({
     configWritten: configActivation.writtenPlan !== undefined,
@@ -123,16 +119,10 @@ async function runGuidedSetupWithPrompt(
     reprobeDeps,
     selectedHarnessIds,
   });
-  await offerWorktrunkShellIntegration(preflight.plan, preflight.facts, prompt, deps);
-  await offerTmuxPopupBinding({
-    facts: tmuxPopupState.facts,
-    plan: tmuxPopupState.plan,
-    options,
-    deps,
-    prompt,
-  });
+  await offerWorktrunkShellIntegration(preflight, prompt, deps);
+  await offerTmuxPopupBinding({ ...tmuxPopupState, options, deps, prompt });
 
-  // Successful actions do not prove readiness; rebuild the plan from current config and artifacts.
+  // Operation outcomes do not prove readiness; rebuild the plan from current config and artifacts.
   const finalState = await collectSetupPlanForCommand(
     "apply",
     options,
@@ -140,7 +130,7 @@ async function runGuidedSetupWithPrompt(
     selectedHarnessPlanInput(selectedHarnessIds),
   );
   await write(deps, renderSetupApplyResult(finalState.plan, renderOptions(deps)));
-  return { code: finalState.plan.summary.requiredOk ? 0 : 1 };
+  return { code: trackingSucceeded && finalState.plan.summary.requiredOk ? 0 : 1 };
 }
 
 type GuidedFactsResult = { status: "continue"; facts: SetupFacts } | { status: "halt" };
@@ -159,7 +149,10 @@ async function ensureRequiredTools(
   deps: SetupCommandDeps,
   prompt: SetupPromptAdapter,
 ): Promise<GuidedFactsResult> {
-  const initialState = await collectSetupPlanFromFacts(facts, deps, { planConfigWrite: true });
+  const installDeps = depsWithBrewBinPath(deps);
+  const initialState = await collectSetupPlanFromFacts(facts, installDeps, {
+    planConfigWrite: true,
+  });
   const plan = initialState.plan;
   await write(deps, renderSetupPlan(plan, renderOptions(deps)));
   const installActions = plan.actions.filter(
@@ -175,18 +168,18 @@ async function ensureRequiredTools(
     applySetupPlan(
       plan,
       // A fresh Homebrew install usually has not updated the current process PATH yet.
-      applyOptions(depsWithBrewBinPath(deps), {
+      applyOptions(installDeps, {
         actionFilter: isInstallAction,
         announceActions: true,
         showCommandOutput: true,
+        execution: initialState,
       }),
     ),
   );
   if (installResult.failedAction !== undefined) {
-    await write(
-      deps,
-      renderSetupApplyResult(markRequiredIncomplete(installResult.plan), renderOptions(deps)),
-    );
+    const finalFacts = await collectForCommand("apply", options, depsWithBrewBinPath(deps), {});
+    const finalState = await collectSetupPlanFromFacts(finalFacts, deps, {});
+    await write(deps, renderSetupApplyResult(finalState.plan, renderOptions(deps)));
     return { status: "halt" };
   }
   const refreshedFacts = await collectForCommand("apply", options, depsWithBrewBinPath(deps), {});
@@ -250,11 +243,11 @@ function selectedHarnessPlanInput(selectedHarnessIds: readonly SupportedHarnessI
 }
 
 async function writeAndActivateConfig(
-  plan: SetupPlan,
-  facts: SetupFacts,
+  collected: CollectedSetupPlan,
   prompt: SetupPromptAdapter,
   deps: SetupCommandDeps,
 ): Promise<GuidedConfigActivation> {
+  const { plan } = collected;
   const configWriteSelected = plan.actions.some(
     (action) => isConfigAction(action) && action.selected,
   );
@@ -266,25 +259,38 @@ async function writeAndActivateConfig(
   }
   const writeResult = await applySetupPlan(
     plan,
-    applyOptions(deps, { actionFilter: isConfigAction, announceActions: true }),
+    applyOptions(deps, {
+      actionFilter: isConfigAction,
+      announceActions: true,
+      execution: collected,
+    }),
   );
   if (writeResult.failedAction !== undefined) {
     await write(deps, "Config write failed. Run: stn setup plan\n");
     return { status: "halt" };
   }
-  const activationError = await activateCompletedConfigWrite(writeResult.plan, facts.homeDir, deps);
+  const activationError = await activateCompletedConfigWrite(collected, deps);
   if (activationError !== undefined) return { status: "halt" };
   return { status: "continue", writtenPlan: writeResult.plan };
 }
 
-async function installSelectedHooks(plan: SetupPlan, deps: SetupCommandDeps): Promise<boolean> {
-  const hookActions = plan.actions.filter((action) => isHookSetupAction(action) && action.selected);
+async function installSelectedHooks(
+  collected: CollectedSetupPlan,
+  deps: SetupCommandDeps,
+): Promise<boolean> {
+  const hookActions = collected.plan.actions.filter(
+    (action) => isHookSetupAction(action) && action.selected,
+  );
   let failed = false;
   // Hook providers are independent; one failed installer must not suppress the rest.
   for (const action of hookActions) {
     const hookResult = await applySetupPlan(
-      { ...plan, actions: [action] },
-      applyOptions(deps, { announceActions: true, showCommandOutput: true }),
+      { ...collected.plan, actions: [action] },
+      applyOptions(deps, {
+        announceActions: true,
+        showCommandOutput: true,
+        execution: collected,
+      }),
     );
     if (hookResult.failedAction !== undefined) failed = true;
   }
@@ -294,7 +300,7 @@ async function installSelectedHooks(plan: SetupPlan, deps: SetupCommandDeps): Pr
   return !failed;
 }
 
-type GuidedPopupState = { facts: SetupFacts; plan: SetupPlan };
+type GuidedPopupState = CollectedSetupPlan;
 
 type TmuxPopupInput = GuidedPopupState & {
   options: SetupCommandOptions;
@@ -319,15 +325,16 @@ function collectGuidedPopupState(input: {
 }
 
 async function offerWorktrunkShellIntegration(
-  plan: SetupPlan,
-  facts: SetupFacts,
+  collected: CollectedSetupPlan,
   prompt: SetupPromptAdapter,
   deps: SetupCommandDeps,
 ): Promise<void> {
-  const action = plan.actions.find((candidate) => candidate.id === "worktrunk-shell-integration");
+  const action = collected.plan.actions.find(
+    (candidate) => candidate.id === "worktrunk-shell-integration",
+  );
   if (action === undefined) return;
   if (await prompt.confirm("Install Worktrunk shell integration?")) {
-    await installWorktrunkShellIntegration(action, plan, facts, deps);
+    await installWorktrunkShellIntegration(action, collected, deps);
   }
 }
 
@@ -375,7 +382,11 @@ async function applyTmuxPopupBinding(
       ...plan,
       actions: bindingActions.map((action) => ({ ...action, selected: true })),
     },
-    applyOptions(deps, { announceActions: true, showCommandOutput: true }),
+    applyOptions(deps, {
+      announceActions: true,
+      showCommandOutput: true,
+      execution: input,
+    }),
   );
   const completedIds = new Set(
     result.plan.actions.flatMap((action) => (action.status === "completed" ? [action.id] : [])),
@@ -414,10 +425,10 @@ async function recheckTmuxPopupBinding(
 
 async function installWorktrunkShellIntegration(
   action: SetupAction,
-  plan: SetupPlan,
-  facts: SetupFacts,
+  collected: CollectedSetupPlan,
   deps: SetupCommandDeps,
 ): Promise<void> {
+  const { facts, plan } = collected;
   const baseCommand = action.command;
   if (baseCommand === undefined) return;
 
@@ -438,7 +449,11 @@ async function installWorktrunkShellIntegration(
   }
 
   const shellApplyOptions =
-    applyOptions(deps, { announceActions: true, showCommandOutput: true }) ?? {};
+    applyOptions(deps, {
+      announceActions: true,
+      showCommandOutput: true,
+      execution: collected,
+    }) ?? {};
   shellApplyOptions.onActionFailed = () => undefined;
   const result = await applySetupPlan(
     { ...plan, actions: [{ ...action, command, selected: true }] },
@@ -507,7 +522,16 @@ async function ensureBootstrapTools(
       await withPromptPaused(prompt, () =>
         applySetupPlan(
           harnessInstallPlan(facts, [commandLineToolsInstallAction()]),
-          applyOptions(deps, { announceActions: true, showCommandOutput: true }),
+          applyOptions(deps, {
+            announceActions: true,
+            showCommandOutput: true,
+            execution: standaloneOperationExecution(
+              facts,
+              deps,
+              "install-command-line-tools",
+              commandLineToolsOperation(),
+            ),
+          }),
         ),
       );
       // The CLT installer runs asynchronously in its own window; we cannot continue
@@ -541,7 +565,15 @@ async function ensureBootstrapTools(
     const result = await withPromptPaused(prompt, () =>
       applySetupPlan(
         harnessInstallPlan(facts, [homebrewInstallAction()]),
-        applyOptions(deps, { showCommandOutput: true }),
+        applyOptions(deps, {
+          showCommandOutput: true,
+          execution: standaloneOperationExecution(
+            facts,
+            deps,
+            "install-homebrew",
+            homebrewOperation(),
+          ),
+        }),
       ),
     );
     if (result.failedAction !== undefined) {
@@ -634,16 +666,22 @@ async function maybeLinkStationLaunchers(
   deps: SetupCommandDeps,
   prompt: SetupPromptAdapter,
 ): Promise<SetupFacts> {
-  const plan = buildSetupPlan(facts, { configWrite: await planSetupConfigWrite(facts) });
-  const action = plan.actions.find((candidate) => candidate.id === "link-station-launchers");
+  const planned = await collectSetupPlanFromFacts(facts, deps, { planConfigWrite: true });
+  const action = planned.plan.actions.find(
+    (candidate) => candidate.id === "link-station-launchers",
+  );
   if (action === undefined || !shouldPromptLauncherLink(facts)) return facts;
 
   const accepted = await prompt.confirm("Link STATION launchers globally?");
   if (!accepted) return facts;
 
   const result = await applySetupPlan(
-    { ...plan, actions: [{ ...action, selected: true }] },
-    applyOptions(deps, { announceActions: true, showCommandOutput: true }),
+    { ...planned.plan, actions: [{ ...action, selected: true }] },
+    applyOptions(deps, {
+      announceActions: true,
+      showCommandOutput: true,
+      execution: planned,
+    }),
   );
   if (result.failedAction !== undefined) {
     await write(deps, "STATION launcher link failed. Continuing with checkout launcher paths.\n");
@@ -760,6 +798,12 @@ async function ensureHarnessAvailable(
         applyOptions(installDeps, {
           actionFilter: isHarnessInstallAction,
           showCommandOutput: true,
+          execution: standaloneOperationExecution(
+            facts,
+            installDeps,
+            action.id,
+            harnessInstallOperation(harnessId),
+          ),
         }),
       ),
     );
@@ -826,6 +870,54 @@ function prependPath(path: string, existing: string | undefined): string {
     return path;
   }
   return existing.split(":").includes(path) ? existing : `${path}:${existing}`;
+}
+
+function standaloneOperationExecution(
+  facts: SetupFacts,
+  deps: SetupCommandDeps,
+  actionId: string,
+  operation: SetupOperation,
+): Pick<CollectedSetupPlan, "operationBindings" | "executeOperation"> {
+  return {
+    operationBindings: [{ actionId, operation }],
+    executeOperation: createSetupOperationAdapter({ facts, deps }),
+  };
+}
+
+function commandLineToolsOperation(): Extract<
+  SetupOperation,
+  { kind: "install-xcode-command-line-tools" }
+> {
+  return {
+    id: "install:xcode-command-line-tools",
+    kind: "install-xcode-command-line-tools",
+    tier: "required",
+    selected: true,
+  };
+}
+
+function homebrewOperation(): Extract<SetupOperation, { kind: "install-homebrew" }> {
+  return {
+    id: "install:homebrew",
+    kind: "install-homebrew",
+    tier: "required",
+    selected: true,
+  };
+}
+
+function harnessInstallOperation(
+  harnessId: string | undefined,
+): Extract<SetupOperation, { kind: "install-harness" }> {
+  if (harnessId === undefined || !isSupportedHarnessId(harnessId)) {
+    throw new Error("Harness install action requires a supported harness.");
+  }
+  return {
+    id: `install-harness:${harnessId}`,
+    kind: "install-harness",
+    tier: "required",
+    selected: true,
+    harnessId,
+  };
 }
 
 async function withPromptPaused<T>(prompt: SetupPromptAdapter, task: () => Promise<T>): Promise<T> {

--- a/apps/cli/src/commands/setup/flows/guided.ts
+++ b/apps/cli/src/commands/setup/flows/guided.ts
@@ -519,7 +519,7 @@ async function ensureBootstrapTools(
       "Install Xcode Command Line Tools now? (runs xcode-select --install)",
     );
     if (accepted) {
-      await withPromptPaused(prompt, () =>
+      const installResult = await withPromptPaused(prompt, () =>
         applySetupPlan(
           harnessInstallPlan(facts, [commandLineToolsInstallAction()]),
           applyOptions(deps, {
@@ -534,12 +534,18 @@ async function ensureBootstrapTools(
           }),
         ),
       );
-      // The CLT installer runs asynchronously in its own window; we cannot continue
-      // until it finishes, so stop here and have the user re-run.
-      await write(
-        deps,
-        "Command Line Tools installation started in a separate window. Finish it, then run: stn setup\n",
-      );
+      if (installResult.failedAction === undefined) {
+        // The CLT installer runs asynchronously in its own window; setup cannot continue until it finishes.
+        await write(
+          deps,
+          "Command Line Tools installation started in a separate window. Finish it, then run: stn setup\n",
+        );
+      } else {
+        await write(
+          deps,
+          "Command Line Tools installation did not start. Run: xcode-select --install, then rerun: stn setup\n",
+        );
+      }
     } else {
       await write(
         deps,

--- a/apps/cli/src/commands/setup/flows/nonInteractive.ts
+++ b/apps/cli/src/commands/setup/flows/nonInteractive.ts
@@ -8,7 +8,6 @@ import {
   isConfigAction,
   isHookSetupAction,
   isInstallAction,
-  markRequiredIncomplete,
 } from "../flowUtils.js";
 import { renderOptions, write } from "../io.js";
 import { renderSetupApplyResult, renderSetupPlan } from "../render.js";
@@ -25,7 +24,10 @@ export async function runNonInteractiveApply(
   });
 
   if (flags.dryRun) {
-    const dryRun = await applySetupPlan(initial.plan, applyOptions(deps, { dryRun: true }));
+    const dryRun = await applySetupPlan(
+      initial.plan,
+      applyOptions(deps, { dryRun: true, execution: initial }),
+    );
     await write(deps, renderSetupPlan(dryRun.plan, renderOptions(deps)));
     return { code: initial.harnessSelection.source === "unresolved" ? 1 : 0 };
   }
@@ -47,17 +49,18 @@ export async function runNonInteractiveApply(
       actionFilter: isInstallAction,
       announceActions: true,
       showCommandOutput: true,
+      execution: initial,
     }),
   );
+  const reprobeDeps = depsWithBrewBinPath(deps);
   if (installResult.failedAction !== undefined) {
-    await write(
-      deps,
-      renderSetupApplyResult(markRequiredIncomplete(installResult.plan), renderOptions(deps)),
-    );
+    const final = await collectSetupPlanForCommand("apply", options, reprobeDeps, {
+      noBrew: flags.noBrew,
+    });
+    await write(deps, renderSetupApplyResult(final.plan, renderOptions(deps)));
     return { code: 1 };
   }
 
-  const reprobeDeps = depsWithBrewBinPath(deps);
   const refreshed = await collectSetupPlanForCommand("apply", options, reprobeDeps, {
     noBrew: flags.noBrew,
     planConfigWrite: true,
@@ -69,18 +72,18 @@ export async function runNonInteractiveApply(
 
   const writeResult = await applySetupPlan(
     refreshed.plan,
-    applyOptions(reprobeDeps, { actionFilter: isConfigAction, announceActions: true }),
+    applyOptions(reprobeDeps, {
+      actionFilter: isConfigAction,
+      announceActions: true,
+      execution: refreshed,
+    }),
   );
   if (writeResult.failedAction !== undefined) {
     await write(deps, renderSetupApplyResult(writeResult.plan, renderOptions(deps)));
     return { code: 1 };
   }
 
-  const activationError = await activateCompletedConfigWrite(
-    writeResult.plan,
-    refreshed.facts.homeDir,
-    reprobeDeps,
-  );
+  const activationError = await activateCompletedConfigWrite(refreshed, reprobeDeps);
   if (activationError !== undefined) {
     return { code: 1 };
   }
@@ -94,20 +97,16 @@ export async function runNonInteractiveApply(
       actionFilter: isHookSetupAction,
       announceActions: true,
       showCommandOutput: true,
+      execution: trackingPlan,
     }),
   );
-  if (trackingResult.failedAction !== undefined) {
-    await write(
-      deps,
-      renderSetupApplyResult(markRequiredIncomplete(trackingResult.plan), renderOptions(deps)),
-    );
-    return { code: 1 };
-  }
 
-  // Successful actions do not prove readiness; rebuild the plan from current config and artifacts.
+  // Operation outcomes do not prove readiness; rebuild the plan from current config and artifacts.
   const final = await collectSetupPlanForCommand("apply", options, reprobeDeps, {
     noBrew: flags.noBrew,
   });
   await write(deps, renderSetupApplyResult(final.plan, renderOptions(deps)));
-  return { code: final.plan.summary.requiredOk ? 0 : 1 };
+  return {
+    code: trackingResult.failedAction === undefined && final.plan.summary.requiredOk ? 0 : 1,
+  };
 }

--- a/apps/cli/src/commands/setup/harnessInstall.ts
+++ b/apps/cli/src/commands/setup/harnessInstall.ts
@@ -7,7 +7,7 @@ export type HarnessInstallOptions = {
   macos: boolean;
 };
 
-type HarnessInstallDefinition = {
+export type HarnessInstallDefinition = {
   id: SetupHarnessFact["id"];
   command: readonly string[];
   message: string;
@@ -33,7 +33,7 @@ export function missingHarnessInstallActions(
     if (!missing.has(id)) continue;
     const harness = harnessDefinitions.find((candidate) => candidate.id === id);
     if (harness === undefined) continue;
-    const definition = harnessInstallDefinition(id, options);
+    const definition = resolveHarnessInstallDefinition(id, options);
     actions.push({
       id: `install-harness-${id}`,
       kind: "run-command",
@@ -48,7 +48,7 @@ export function missingHarnessInstallActions(
   return actions;
 }
 
-function harnessInstallDefinition(
+export function resolveHarnessInstallDefinition(
   id: SetupHarnessFact["id"],
   options: HarnessInstallOptions,
 ): HarnessInstallDefinition {

--- a/apps/cli/src/commands/setup/planner.ts
+++ b/apps/cli/src/commands/setup/planner.ts
@@ -1,12 +1,15 @@
 import {
   assessHarnessTracking,
+  type SetupPlan as CoreSetupPlan,
   type HarnessSelectionFacts,
   type HarnessSelectionIntent,
   type HarnessTrackingFacts,
   planSetup,
+  type SetupOperation,
   type SetupPlanningFacts,
   type SetupPlanningIntent,
 } from "@station/setup-core";
+import type { SetupOperationBinding } from "./apply.js";
 import {
   harnessSupportsSetupHooks,
   isSupportedHarnessId,
@@ -24,7 +27,20 @@ export type BuildSetupPlanOptions = {
   installWorktrunkHooks?: boolean;
 };
 
+export type BuiltSetupPlans = {
+  readonly semanticPlan: CoreSetupPlan;
+  readonly compatibilityPlan: SetupPlan;
+  readonly operationBindings: readonly SetupOperationBinding[];
+};
+
 export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions = {}): SetupPlan {
+  return buildSetupPlans(facts, options).compatibilityPlan;
+}
+
+export function buildSetupPlans(
+  facts: SetupFacts,
+  options: BuildSetupPlanOptions = {},
+): BuiltSetupPlans {
   SetupHarnessTrackingFactSchema.array().parse(facts.harnessTracking);
   const harnessSelection = options.harnessSelection ?? resolveSetupHarnessSelection(facts);
   const evidence = normalizeSetupPlanningFacts(facts, harnessSelection, options.configWrite);
@@ -34,11 +50,63 @@ export function buildSetupPlan(facts: SetupFacts, options: BuildSetupPlanOptions
     installWorktrunkHooks: options.installWorktrunkHooks === true,
   };
   const semanticPlan = planSetup(evidence, intent);
-  return projectCliSetupPlan(
+  const compatibilityPlan = projectCliSetupPlan(
     options.configWrite === undefined
       ? { plan: semanticPlan, facts }
       : { plan: semanticPlan, facts, configWrite: options.configWrite },
   );
+  return {
+    semanticPlan,
+    compatibilityPlan,
+    operationBindings: bindSetupOperations(semanticPlan.operations),
+  };
+}
+
+function bindSetupOperations(
+  operations: readonly SetupOperation[],
+): readonly SetupOperationBinding[] {
+  const bindings: SetupOperationBinding[] = [];
+  for (const operation of operations) {
+    switch (operation.kind) {
+      case "install-tool":
+        bindings.push({ actionId: `install-${operation.tool}`, operation });
+        break;
+      case "link-launchers":
+        bindings.push({ actionId: "link-station-launchers", operation });
+        break;
+      case "configure-worktrunk-shell":
+        bindings.push({ actionId: "worktrunk-shell-integration", operation });
+        break;
+      case "configure-tmux-popup":
+        bindings.push({
+          actionId:
+            operation.scope === "persisted" ? "tmux-popup-binding" : "tmux-live-popup-binding",
+          operation,
+        });
+        break;
+      case "prepare-worktrunk-tracking":
+        bindings.push({ actionId: "worktrunk-hooks", operation });
+        break;
+      case "prepare-harness-tracking":
+        bindings.push({ actionId: `${operation.harnessId}-hooks`, operation });
+        break;
+      case "write-config":
+        bindings.push(
+          { actionId: "mkdir-config-dir", operation },
+          {
+            actionId: operation.change === "create" ? "write-config" : "update-config",
+            operation,
+          },
+        );
+        break;
+      case "activate-observer-config":
+      case "install-harness":
+      case "install-homebrew":
+      case "install-xcode-command-line-tools":
+        break;
+    }
+  }
+  return bindings;
 }
 
 function normalizeSetupPlanningFacts(

--- a/apps/cli/src/commands/setup/presentation/projectCliSetupPlan.ts
+++ b/apps/cli/src/commands/setup/presentation/projectCliSetupPlan.ts
@@ -908,6 +908,14 @@ function setupActions(
       case "write-config":
         actions.push(...configWriteActions(configWrite, true));
         break;
+      case "activate-observer-config":
+        // Activation is orchestration-only until the compatibility action contract is retired.
+        break;
+      case "install-harness":
+      case "install-homebrew":
+      case "install-xcode-command-line-tools":
+        // Guided and system-only installers are projected by their existing compatibility helpers.
+        break;
     }
   }
   if (configWrite?.operation === "blocked") {

--- a/apps/cli/src/commands/setup/render.ts
+++ b/apps/cli/src/commands/setup/render.ts
@@ -220,6 +220,14 @@ function bareLauncherConvenienceLines(
   return lines;
 }
 
+export function renderBoundActionStart(
+  action: SetupAction,
+  options: SetupRenderOptions = {},
+): string {
+  const theme = setupTheme(options);
+  return `${theme.bold("Applying:")} ${action.label}`;
+}
+
 export function renderActionStart(action: SetupAction, options: SetupRenderOptions = {}): string {
   const theme = setupTheme(options);
   if (action.command !== undefined) {

--- a/apps/cli/src/commands/setup/systemCommand.ts
+++ b/apps/cli/src/commands/setup/systemCommand.ts
@@ -1,4 +1,6 @@
 import { isCompiledBinary } from "@station/runtime";
+import type { SetupOperation, SetupToolId } from "@station/setup-core";
+import { createSetupOperationAdapter } from "./adapters/operations.js";
 import { applySetupPlan } from "./apply.js";
 import { checkBrewDependency } from "./checks/brew.js";
 import { checkSetupBun } from "./checks/bun.js";
@@ -20,25 +22,35 @@ export async function runSetupSystemCommand(
   const initial = await collectSystemFacts(args, options, deps);
   await write(deps, renderSystemStatus("stn setup system", initial));
 
+  let operationFailed = false;
   if (args.yes && initial.brew.status === "ok") {
-    const actions: SetupAction[] = [];
+    const operations: Array<Extract<SetupOperation, { kind: "install-tool" }>> = [];
     if (initial.worktrunk.status === "missing")
-      actions.push(systemInstallAction("worktrunk", "worktrunk"));
-    if (initial.tmux.status === "missing") actions.push(systemInstallAction("tmux", "tmux"));
+      operations.push(systemInstallOperation("worktrunk"));
+    if (initial.tmux.status === "missing") operations.push(systemInstallOperation("tmux"));
     if (!initial.compiled && initial.bun.status === "missing") {
-      actions.push(systemInstallAction("bun", "bun"));
+      operations.push(systemInstallOperation("bun"));
     }
-    if (initial.diffnav.status === "missing")
-      actions.push(systemInstallAction("diffnav", "diffnav"));
-    if (initial.gitDelta.status === "missing")
-      actions.push(systemInstallAction("git-delta", "git-delta"));
+    if (initial.diffnav.status === "missing") operations.push(systemInstallOperation("diffnav"));
+    if (initial.gitDelta.status === "missing") operations.push(systemInstallOperation("git-delta"));
+    const actions = operations.map((operation) => systemInstallAction(operation.tool));
     const result = await applySetupPlan(
       systemPlan(actions),
-      applyOptions(deps, { announceActions: true, showCommandOutput: true }),
+      applyOptions(deps, {
+        announceActions: true,
+        showCommandOutput: true,
+        execution: {
+          operationBindings: operations.map((operation) => ({
+            actionId: `install-${operation.tool}`,
+            operation,
+          })),
+          executeOperation: createSetupOperationAdapter({ deps }),
+        },
+      }),
     );
-    if (result.failedAction !== undefined) {
+    operationFailed = result.failedAction !== undefined;
+    if (operationFailed) {
       await write(deps, "Install failed. Run: stn setup system --check\n");
-      return { code: 1 };
     }
   }
 
@@ -48,7 +60,7 @@ export async function runSetupSystemCommand(
 
   const refreshed = await collectSystemFacts(args, options, deps);
   await write(deps, renderSystemStatus("stn setup system final", refreshed));
-  return { code: systemReady(refreshed) ? 0 : 1 };
+  return { code: !operationFailed && systemReady(refreshed) ? 0 : 1 };
 }
 
 type SystemFacts = {
@@ -126,17 +138,34 @@ function systemReady(facts: SystemFacts): boolean {
   );
 }
 
-function systemInstallAction(label: string, formula: string): SetupAction {
+function systemInstallAction(tool: SetupToolId): SetupAction {
+  const formula = toolFormula(tool);
   return {
-    id: `install-${label}`,
+    id: `install-${tool}`,
     kind: "brew-install",
     tier: "required",
     selected: true,
-    label: `Install ${label}`,
-    message: `Install ${label} with Homebrew.`,
+    label: `Install ${tool}`,
+    message: `Install ${tool} with Homebrew.`,
     command: ["brew", "install", formula],
     data: { formula },
   };
+}
+
+function systemInstallOperation(
+  tool: SetupToolId,
+): Extract<SetupOperation, { kind: "install-tool" }> {
+  return {
+    id: `install:${tool}`,
+    kind: "install-tool",
+    tier: "required",
+    selected: true,
+    tool,
+  };
+}
+
+function toolFormula(tool: SetupToolId): string {
+  return tool === "worktrunk" ? "worktrunk" : tool;
 }
 
 function systemPlan(actions: SetupAction[]): SetupPlan {

--- a/apps/cli/src/commands/setup/types.ts
+++ b/apps/cli/src/commands/setup/types.ts
@@ -1,5 +1,6 @@
-import type { HarnessHooksStatus } from "@station/contracts";
+import type { HarnessHooksStatus, ProviderHookArtifactOwner } from "@station/contracts";
 import type { ExternalCommandRunner } from "@station/runtime";
+import type { SetupOperation, SetupOperationOutcome } from "@station/setup-core";
 import type { CliEnv } from "../../env.js";
 import type { SetupApplyFileSystem } from "./apply.js";
 import type { SetupFileSystemReader } from "./checks/config.js";
@@ -35,6 +36,13 @@ export type SetupCommandDeps = {
   platform?: NodeJS.Platform;
   compiled?: boolean;
   providerHookIngressLauncher?: string;
+  providerHookArtifactOwner?: ProviderHookArtifactOwner;
+  providerTrackingPort?: (
+    operation: Extract<
+      SetupOperation,
+      { kind: "prepare-harness-tracking" | "prepare-worktrunk-tracking" }
+    >,
+  ) => Promise<SetupOperationOutcome>;
   /**
    * Inspects Station-owned tracking artifacts without contacting the Observer.
    * An absent result is valid only for a harness with no external tracking artifact.

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -142,6 +142,9 @@ function withProviderHookSetupComposition(options: CliRunOptions): CliRunOptions
   if (options.providerHookIngressLauncher !== undefined) {
     setupDeps.providerHookIngressLauncher = options.providerHookIngressLauncher;
   }
+  if (options.providerHookArtifactOwner !== undefined) {
+    setupDeps.providerHookArtifactOwner = options.providerHookArtifactOwner;
+  }
   setupDeps.probeHarnessHooksStatus ??= (harnessId, configPath) =>
     probeHarnessHooksStatus(harnessId, configPath, {
       ...(options.providerHookIngressLauncher === undefined

--- a/apps/cli/test/fixtures/setupTrackingSupport.ts
+++ b/apps/cli/test/fixtures/setupTrackingSupport.ts
@@ -25,6 +25,18 @@ export function configBackedHarnessHooksProbe(
   };
 }
 
+export const successfulProviderTrackingPort: NonNullable<
+  SetupCommandDeps["providerTrackingPort"]
+> = async (operation) => ({
+  status: "completed",
+  operationId: operation.id,
+  commit: {
+    kind: "provider-tracking",
+    provider: operation.kind === "prepare-worktrunk-tracking" ? "worktrunk" : operation.harnessId,
+    changed: true,
+  },
+});
+
 export function withRequiredTrackingConsent(prompt: SetupPromptAdapter): SetupPromptAdapter {
   return {
     ...prompt,

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -6,6 +6,7 @@ import { CliSetupPlanSchema } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
 import { buildManagedFastPopupRunShellCommand } from "@station/tmux";
 import { afterEach, describe, expect, it } from "vitest";
+import type { SetupCommandDeps } from "../../src/commands/setup/types.js";
 import { configBackedHarnessHooksProbe } from "../fixtures/setupTrackingSupport.js";
 
 async function runCli(...args: Parameters<typeof runCliBase>) {
@@ -230,7 +231,7 @@ describe("CLI setup command", () => {
       "opencode --version": "opencode 1.0.0\n",
     });
 
-    const setupDeps = {
+    const setupDeps: SetupCommandDeps = {
       cwd: repo,
       homeDir: join(root, "home"),
       env: { PATH: "/fake/bin" },
@@ -243,6 +244,18 @@ describe("CLI setup command", () => {
       },
       access: readySetupAccess(),
       fs: fakeFs({ [configPath]: source }),
+      async providerTrackingPort(operation) {
+        const provider =
+          operation.kind === "prepare-worktrunk-tracking"
+            ? "worktrunk"
+            : (operation.harnessId ?? "opencode");
+        installed.add(provider);
+        return {
+          status: "completed" as const,
+          operationId: operation.id,
+          commit: { kind: "provider-tracking" as const, provider, changed: true },
+        };
+      },
       async probeHarnessHooksStatus(harnessId: string) {
         const prepared = installed.has(harnessId);
         return {
@@ -266,12 +279,7 @@ describe("CLI setup command", () => {
       actions: expect.arrayContaining([expect.objectContaining({ id: "opencode-hooks" })]),
     });
     expect(result.code).toBe(0);
-    expect(calls).toContainEqual(
-      expect.objectContaining({
-        command: "/fake/bin/stn",
-        args: ["--config", configPath, "hooks", "install", "opencode", "--yes"],
-      }),
-    );
+    expect(calls.some((call) => (call.args ?? []).includes("hooks"))).toBe(false);
     expect(calls.flatMap((call) => call.args ?? [])).not.toContain("--takeover");
     expect(installed).toContain("opencode");
   });

--- a/apps/cli/test/unit/setup-apply.test.ts
+++ b/apps/cli/test/unit/setup-apply.test.ts
@@ -27,9 +27,15 @@ describe("setup apply engine", () => {
     const result = await applySetupPlan(plan([brewAction("install-worktrunk", "worktrunk")]), {
       runner: fakeRunner(calls),
       showCommandOutput: true,
-      onActionStart: (action) => events.push(`start:${action.id}`),
-      onActionComplete: (action) => events.push(`complete:${action.id}`),
-      onActionFailed: (action) => events.push(`failed:${action.id}`),
+      onActionStart: (action) => {
+        events.push(`start:${action.id}`);
+      },
+      onActionComplete: (action) => {
+        events.push(`complete:${action.id}`);
+      },
+      onActionFailed: (action) => {
+        events.push(`failed:${action.id}`);
+      },
     });
 
     expect(result.failedAction).toBeUndefined();
@@ -93,6 +99,130 @@ describe("setup apply engine", () => {
     expect(result.failedAction).toMatchObject({ id: "install-worktrunk", status: "failed" });
     expect(fs.writes).toEqual({});
     expect(result.plan.actions.map((action) => action.status)).toEqual(["failed", "skipped"]);
+  });
+
+  it("executes bound semantic operations without trusting compatibility command data", async () => {
+    const runnerCalls: ExternalCommandInput[] = [];
+    const executed: string[] = [];
+    const operation = {
+      id: "install:tmux",
+      kind: "install-tool",
+      tier: "required",
+      selected: true,
+      tool: "tmux",
+    } as const;
+    const compatibilityAction = {
+      ...brewAction("install-tmux", "hostile-formula"),
+      command: ["hostile-command", "--leak", "serializedResult"],
+      data: { rawResult: "provider sentinel" },
+    };
+
+    const result = await applySetupPlan(plan([compatibilityAction]), {
+      runner: fakeRunner(runnerCalls),
+      operationBindings: [{ actionId: compatibilityAction.id, operation }],
+      executeOperation: async (selected) => {
+        executed.push(selected.id);
+        return {
+          status: "completed",
+          operationId: selected.id,
+          commit: {
+            kind: "package-installer",
+            target: { kind: "tool", id: "tmux" },
+          },
+        };
+      },
+    });
+
+    expect(executed).toEqual(["install:tmux"]);
+    expect(runnerCalls).toEqual([]);
+    expect(result.operationOutcomes).toHaveLength(1);
+    expect(JSON.stringify(result.operationOutcomes)).not.toContain("provider sentinel");
+  });
+
+  it("continues independent provider tracking after one bound failure", async () => {
+    const operations = ["codex", "opencode"].map((harnessId) => ({
+      id: `prepare-harness-tracking:${harnessId}` as
+        | "prepare-harness-tracking:codex"
+        | "prepare-harness-tracking:opencode",
+      kind: "prepare-harness-tracking" as const,
+      tier: "required" as const,
+      selected: true as const,
+      harnessId: harnessId as "codex" | "opencode",
+    }));
+    const actions = operations.map((operation) => ({
+      id: `${operation.harnessId}-hooks`,
+      kind: "run-command" as const,
+      tier: "required" as const,
+      selected: true,
+      label: `Install ${operation.harnessId} tracking`,
+      message: "tracking",
+      command: ["hostile-child-command"],
+    }));
+    const executed: string[] = [];
+
+    const result = await applySetupPlan(plan(actions), {
+      operationBindings: operations.map((operation) => ({
+        actionId: `${operation.harnessId}-hooks`,
+        operation,
+      })),
+      executeOperation: async (operation) => {
+        executed.push(operation.id);
+        return operation.id === "prepare-harness-tracking:codex"
+          ? {
+              status: "failed",
+              operationId: operation.id,
+              error: {
+                tag: "SyntheticTrackingError",
+                code: "SYNTHETIC_TRACKING_FAILED",
+                message: "synthetic failure",
+              },
+            }
+          : {
+              status: "completed",
+              operationId: operation.id,
+              commit: { kind: "provider-tracking", provider: "opencode", changed: true },
+            };
+      },
+    });
+
+    expect(executed).toEqual([
+      "prepare-harness-tracking:codex",
+      "prepare-harness-tracking:opencode",
+    ]);
+    expect(result.failedAction).toMatchObject({ id: "codex-hooks", status: "failed" });
+    expect(result.plan.actions.map((action) => action.status)).toEqual(["failed", "completed"]);
+  });
+
+  it("does not invoke bound ports during dry-run", async () => {
+    let executions = 0;
+    const operation = {
+      id: "install:tmux",
+      kind: "install-tool",
+      tier: "required",
+      selected: true,
+      tool: "tmux",
+    } as const;
+    const action = brewAction("install-tmux", "tmux");
+
+    const result = await applySetupPlan(plan([action]), {
+      dryRun: true,
+      operationBindings: [{ actionId: action.id, operation }],
+      executeOperation: async (selected) => {
+        executions += 1;
+        return {
+          status: "completed",
+          operationId: selected.id,
+          commit: {
+            kind: "package-installer",
+            target: { kind: "tool", id: "tmux" },
+          },
+        };
+      },
+    });
+
+    expect(executions).toBe(0);
+    expect(result.operationOutcomes).toEqual([]);
+    expect(result.plan.actions[0]?.status).toBe("skipped");
   });
 
   it("writes config atomically with a backup for existing targets", async () => {
@@ -224,6 +354,7 @@ function plan(actions: SetupPlan["actions"]): SetupPlan {
       requiredMissing: 0,
       warnings: 0,
       selectedActions: actions.filter((action) => action.selected).length,
+      selectionSource: "unresolved",
       configPath: "/tmp/config.toml",
     },
     nextSteps: [],

--- a/apps/cli/test/unit/setup-config-writer.test.ts
+++ b/apps/cli/test/unit/setup-config-writer.test.ts
@@ -617,7 +617,10 @@ describe("setup config writer", () => {
     const otherRepo = join(root, "other");
     await mkdir(repo, { recursive: true });
     await mkdir(otherRepo, { recursive: true });
-    const source = existingConfigToml(root, { projectRoot: otherRepo });
+    const source = existingConfigToml(root, { projectRoot: otherRepo }).replace(
+      'worktree_provider = "worktrunk"',
+      'worktree_provider = "noop-worktree"',
+    );
     const facts = setupFacts(repo, {
       config: {
         status: "valid",

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -992,12 +992,12 @@ describe("guided setup command", () => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
     const homeDir = join(root, "home");
-    await mkdir(repo, { recursive: true });
-    const fs = fakeFs({
-      [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock("/old/stn-tmux-popup", {
-        bindingKey: "C-s",
-      }),
+    const tmuxConfigPath = join(homeDir, ".tmux.conf");
+    const originalTmuxConfig = tmuxPopupBindingBlock("/old/stn-tmux-popup", {
+      bindingKey: "C-s",
     });
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [tmuxConfigPath]: originalTmuxConfig });
     const chunks: string[] = [];
 
     const result = await runSetupCommand(
@@ -1027,18 +1027,107 @@ describe("guided setup command", () => {
         fs,
         activateObserverConfig: noopActivateObserverConfig,
         prompt: popupInstallPrompt,
+        now: () => new Date("2026-06-08T12:00:00.000Z"),
         writeStdout: (chunk) => {
           chunks.push(chunk);
         },
       },
     );
 
-    const tmuxConfig = fs.files[join(homeDir, ".tmux.conf")];
+    const tmuxConfig = fs.files[tmuxConfigPath];
     expect(result.code).toBe(0);
+    expect(fs.files[`${tmuxConfigPath}.2026-06-08T12-00-00-000Z.bak`]).toBe(originalTmuxConfig);
     expect(tmuxConfig).toContain("bind-key C-s run-shell -b");
     expect(tmuxConfig).toContain("'/fake/bin/stn-tmux-popup'");
     expect(tmuxConfig).not.toContain("/old/stn-tmux-popup");
     expect(chunks.join("")).toContain("Tmux popup binding: tmux prefix + C-s is persisted");
+  });
+
+  it.each([
+    ["the existing file is unreadable", "read"],
+    ["the backup cannot be created", "backup"],
+  ] as const)("does not replace tmux config when %s", async (_description, failure) => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    const homeDir = join(root, "home");
+    const tmuxConfigPath = join(homeDir, ".tmux.conf");
+    const originalTmuxConfig = "set -g mouse on\n";
+    await mkdir(repo, { recursive: true });
+    const fs = fakeFs({ [tmuxConfigPath]: originalTmuxConfig });
+    const readFile = fs.readFile.bind(fs);
+    const writeFile = fs.writeFile.bind(fs);
+    let rejectTmuxPersistence = false;
+    fs.readFile = async (path) => {
+      if (rejectTmuxPersistence && failure === "read" && path === tmuxConfigPath) {
+        throw Object.assign(new Error("tmux config denied"), { code: "EACCES" });
+      }
+      return readFile(path);
+    };
+    fs.writeFile = async (path, content) => {
+      if (
+        rejectTmuxPersistence &&
+        failure === "backup" &&
+        path.startsWith(`${tmuxConfigPath}.`) &&
+        path.endsWith(".bak")
+      ) {
+        throw Object.assign(new Error("tmux backup denied"), { code: "EACCES" });
+      }
+      return writeFile(path, content);
+    };
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir,
+        env: { PATH: "/fake/bin" },
+        runner: fakeRunner([], {
+          "git rev-parse --show-toplevel": repo,
+          "git symbolic-ref --quiet --short refs/remotes/origin/HEAD": "origin/main\n",
+          "wt --version": "worktrunk 1.2.3\n",
+          "tmux -V": "tmux 3.5a\n",
+          "codex --version": "codex 0.1.0\n",
+        }),
+        access: fakeAccess([
+          "/fake/bin/wt",
+          "/fake/bin/tmux",
+          "/fake/bin/bun",
+          "/fake/bin/diffnav",
+          "/fake/bin/delta",
+          "/fake/bin/stn",
+          "/fake/bin/stn-ingress",
+          "/fake/bin/stn-tmux-popup",
+        ]),
+        fs,
+        activateObserverConfig: noopActivateObserverConfig,
+        prompt: {
+          async confirm(message) {
+            if (message === "Install or load tmux popup binding?") {
+              rejectTmuxPersistence = true;
+              return true;
+            }
+            return message === "Write core STATION config?";
+          },
+          async selectMany() {
+            return ["codex"];
+          },
+        },
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
+      },
+    );
+
+    expect(result.code).toBe(0);
+    expect(fs.files[tmuxConfigPath]).toBe(originalTmuxConfig);
+    expect(
+      Object.keys(fs.files).some(
+        (path) => path.startsWith(`${tmuxConfigPath}.`) && path.endsWith(".bak"),
+      ),
+    ).toBe(false);
+    expect(chunks.join("")).toContain("Failed: Install tmux popup binding");
   });
 
   it("does not report a rebound tmux launcher as loaded when startup still fails", async () => {
@@ -1313,15 +1402,7 @@ describe("guided setup command", () => {
         if (operation.harnessId === "codex") {
           codexHookAttempts += 1;
           if (codexHookAttempts === 1) {
-            return {
-              status: "failed",
-              operationId: operation.id,
-              error: {
-                tag: "SyntheticTrackingError",
-                code: "SYNTHETIC_CODEX_TRACKING_FAILED",
-                message: "synthetic Codex hook failure",
-              },
-            };
+            throw new Error("synthetic Codex hook failure");
           }
         }
         if (operation.harnessId === "opencode") openCodeHookAttempts += 1;
@@ -1639,6 +1720,46 @@ describe("guided setup command", () => {
       "Command Line Tools installation started in a separate window.",
     );
     expect(Object.keys(fs.files)).toEqual([]);
+  });
+
+  it("does not claim the Command Line Tools installer started when launch fails", async () => {
+    const root = await tempRoot(tempRoots);
+    const repo = join(root, "repo");
+    await mkdir(repo, { recursive: true });
+    const chunks: string[] = [];
+
+    const result = await runSetupCommand(
+      [],
+      {},
+      {
+        cwd: repo,
+        homeDir: join(root, "home"),
+        env: { PATH: "/fake/bin" },
+        platform: "darwin",
+        runner: async (input) => {
+          const key = `${input.command} ${(input.args ?? []).join(" ")}`;
+          if (key === "xcode-select -p") {
+            throw Object.assign(new Error("no developer tools"), { code: "ENOENT" });
+          }
+          if (key === "xcode-select --install") {
+            throw new Error("installer launch denied");
+          }
+          return commandResult(input, "");
+        },
+        access: fakeAccess([]),
+        fs: fakeFs({}),
+        prompt: prompt({ confirms: [true] }),
+        writeStdout: (chunk) => {
+          chunks.push(chunk);
+        },
+      },
+    );
+
+    const output = chunks.join("");
+    expect(result.code).toBe(1);
+    expect(output).toContain("Failed: Install Command Line Tools");
+    expect(output).toContain("Command Line Tools installation did not start.");
+    expect(output).not.toContain("installation started in a separate window");
   });
 
   it("prints Command Line Tools guidance on macOS when declined", async () => {

--- a/apps/cli/test/unit/setup-guided.test.ts
+++ b/apps/cli/test/unit/setup-guided.test.ts
@@ -11,10 +11,12 @@ import {
 } from "../../src/commands/setup/checks/tmuxBinding.js";
 import {
   runSetupCommand as runSetupCommandBase,
+  type SetupCommandDeps,
   type SetupPromptAdapter,
 } from "../../src/commands/setup/index.js";
 import {
   configBackedHarnessHooksProbe,
+  successfulProviderTrackingPort,
   withRequiredTrackingConsent,
 } from "../fixtures/setupTrackingSupport.js";
 
@@ -29,6 +31,7 @@ async function runSetupCommand(...args: Parameters<typeof runSetupCommandBase>) 
       configBackedHarnessHooksProbe(
         async (configPath) => (await deps.fs?.readFile(configPath)) ?? "",
       ),
+    providerTrackingPort: deps.providerTrackingPort ?? successfulProviderTrackingPort,
   });
 }
 
@@ -90,7 +93,8 @@ describe("guided setup command", () => {
     const configPath = join(root, "home/.config/station/config.toml");
     expect(fs.files[configPath]).toContain("projects = []");
     expect(activations).toEqual([{ configPath, homeDir: join(root, "home") }]);
-    expect(chunks.join("")).toContain(`Applying: Write STATION config (${configPath})`);
+    expect(chunks.join("")).toContain("Applying: Write STATION config");
+    expect(chunks.join("")).not.toContain(`Applying: Write STATION config (${configPath})`);
     expect(chunks.join("")).toContain("Completed: Write STATION config");
     expect(chunks.join("")).toContain("Observer configuration active.");
     expect(chunks.join("")).toContain("Core setup complete.");
@@ -455,7 +459,7 @@ describe("guided setup command", () => {
       stdio: "inherit",
     });
     expect(fs.files[zshrc]).toBe("# existing zsh config\n");
-    expect(chunks.join("")).toContain("Running: /fake/bin/wt -y config shell install zsh");
+    expect(chunks.join("")).toContain("Applying: Install Worktrunk shell integration");
     expect(chunks.join("")).toContain("Completed: Install Worktrunk shell integration");
   });
 
@@ -717,21 +721,7 @@ describe("guided setup command", () => {
     expect(fs.files[configPath]).toContain(
       '[harness.codex]\ninstall_hooks = true\nenabled = true\ncommand = "codex"',
     );
-    expect(calls).toContainEqual(
-      expect.objectContaining({
-        command: "/fake/bin/stn",
-        args: [
-          "--config",
-          configPath,
-          "hooks",
-          "install",
-          "codex",
-          "--yes",
-          "--hook-bin",
-          "/fake/bin/stn-ingress",
-        ],
-      }),
-    );
+    expect(calls.some((call) => (call.args ?? []).includes("hooks"))).toBe(false);
   });
 
   it("prepares explicit selections and the preserved configured default", async () => {
@@ -743,6 +733,7 @@ describe("guided setup command", () => {
     const fs = fakeFs({ [configPath]: configuredProjectToml(repo) });
     const calls: ExternalCommandInput[] = [];
     const prompts: string[] = [];
+    const preparedProviders: string[] = [];
 
     const result = await runSetupCommand(
       [],
@@ -760,6 +751,12 @@ describe("guided setup command", () => {
           "opencode --version": "opencode 1.0.0\n",
           [`stn --config ${configPath} hooks install opencode --yes`]: "",
         }),
+        providerTrackingPort: async (operation) => {
+          preparedProviders.push(
+            operation.kind === "prepare-worktrunk-tracking" ? "worktrunk" : operation.harnessId,
+          );
+          return successfulProviderTrackingPort(operation);
+        },
         access: fakeAccess([
           "/fake/bin/wt",
           "/fake/bin/tmux",
@@ -791,11 +788,8 @@ describe("guided setup command", () => {
     expect(result.code).toBe(0);
     expect(prompts).not.toContain("Install OpenCode agent hooks?");
     expect(prompts).not.toContain("Install Codex agent hooks?");
-    expect(
-      calls
-        .filter((call) => call.command === "/fake/bin/stn" && call.args?.[2] === "hooks")
-        .map((call) => call.args?.[4]),
-    ).toEqual(["opencode", "codex"]);
+    expect(preparedProviders).toEqual(["opencode", "codex"]);
+    expect(calls.some((call) => (call.args ?? []).includes("hooks"))).toBe(false);
     expect(fs.files[configPath].match(/^harness = "codex"$/gm)).toHaveLength(1);
     expect(fs.files[configPath].match(/^\[harness\.codex\]$/gm)).toHaveLength(1);
     expect(fs.files[configPath].match(/^\[harness\.opencode\]$/gm)).toHaveLength(1);
@@ -1173,6 +1167,14 @@ describe("guided setup command", () => {
         activateObserverConfig: async () => {
           order.push("activate");
         },
+        providerTrackingPort: async (operation) => {
+          order.push(
+            `hook:${
+              operation.kind === "prepare-worktrunk-tracking" ? "worktrunk" : operation.harnessId
+            }`,
+          );
+          return successfulProviderTrackingPort(operation);
+        },
         prompt: prompt({
           confirms: [true, true, true, true, false, false],
           multiSelects: [["codex", "opencode"]],
@@ -1185,34 +1187,7 @@ describe("guided setup command", () => {
     expect(order).toEqual(["activate", "hook:worktrunk", "hook:codex", "hook:opencode"]);
     expect(fs.files[configPath]).toContain("use_lifecycle_hooks = true");
     expect(fs.files[configPath].match(/install_hooks = true/g)).toHaveLength(2);
-    expect(calls).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          command: "/fake/bin/stn",
-          args: ["--config", configPath, "hooks", "install", "worktrunk", "--yes"],
-          stdio: "inherit",
-        }),
-        expect.objectContaining({
-          command: "/fake/bin/stn",
-          args: [
-            "--config",
-            configPath,
-            "hooks",
-            "install",
-            "codex",
-            "--yes",
-            "--hook-bin",
-            "/fake/bin/stn-ingress",
-          ],
-          stdio: "inherit",
-        }),
-        expect.objectContaining({
-          command: "/fake/bin/stn",
-          args: ["--config", configPath, "hooks", "install", "opencode", "--yes"],
-          stdio: "inherit",
-        }),
-      ]),
-    );
+    expect(calls.some((call) => (call.args ?? []).includes("hooks"))).toBe(false);
   });
 
   it("keeps the activated config when a later hook install fails", async () => {
@@ -1257,6 +1232,15 @@ describe("guided setup command", () => {
         activateObserverConfig: async () => {
           activations += 1;
         },
+        providerTrackingPort: async (operation) => ({
+          status: "failed",
+          operationId: operation.id,
+          error: {
+            tag: "SyntheticTrackingError",
+            code: "SYNTHETIC_TRACKING_FAILED",
+            message: "synthetic hook install failure",
+          },
+        }),
         prompt: prompt({ confirms: [true, true] }),
         writeStdout: (chunk) => {
           chunks.push(chunk);
@@ -1270,7 +1254,7 @@ describe("guided setup command", () => {
     expect(fs.files[configPath]).toContain("use_lifecycle_hooks = true");
     expect(output).toContain("Hook install failed.");
     expect(output).toContain("Observer configuration active.");
-    expect(output).not.toContain("Core setup complete.");
+    expect(output).toContain("Core setup complete.");
   });
 
   it("continues after one agent hook fails and retries enabled hooks on the next run", async () => {
@@ -1292,17 +1276,7 @@ describe("guided setup command", () => {
       [`stn --config ${configPath} hooks install codex --yes --hook-bin /fake/bin/stn-ingress`]: "",
       [`stn --config ${configPath} hooks install opencode --yes`]: "",
     });
-    const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
-      if (input.command === "/fake/bin/stn" && input.args?.[4] === "codex") {
-        calls.push(input);
-        codexHookAttempts += 1;
-        if (codexHookAttempts === 1) {
-          throw new Error("synthetic Codex hook failure");
-        }
-        return commandResult(input, "");
-      }
-      return baseRunner(input);
-    };
+    let openCodeHookAttempts = 0;
     const promptAdapter: SetupPromptAdapter = {
       async confirm(message) {
         return (
@@ -1315,11 +1289,11 @@ describe("guided setup command", () => {
         return ["codex", "opencode"];
       },
     };
-    const deps = {
+    const deps: SetupCommandDeps = {
       cwd: repo,
       homeDir,
       env: { PATH: "/fake/bin" },
-      runner,
+      runner: baseRunner,
       access: fakeAccess([
         "/fake/bin/wt",
         "/fake/bin/tmux",
@@ -1332,14 +1306,32 @@ describe("guided setup command", () => {
       ]),
       fs,
       activateObserverConfig: noopActivateObserverConfig,
+      providerTrackingPort: async (operation) => {
+        if (operation.kind === "prepare-worktrunk-tracking") {
+          return successfulProviderTrackingPort(operation);
+        }
+        if (operation.harnessId === "codex") {
+          codexHookAttempts += 1;
+          if (codexHookAttempts === 1) {
+            return {
+              status: "failed",
+              operationId: operation.id,
+              error: {
+                tag: "SyntheticTrackingError",
+                code: "SYNTHETIC_CODEX_TRACKING_FAILED",
+                message: "synthetic Codex hook failure",
+              },
+            };
+          }
+        }
+        if (operation.harnessId === "opencode") openCodeHookAttempts += 1;
+        return successfulProviderTrackingPort(operation);
+      },
       probeHarnessHooksStatus: async (
         harnessId: "codex" | "opencode" | "pi" | "cursor" | "claude",
       ) => {
         if (harnessId === "pi") return undefined;
-        const attempts = calls.filter(
-          (call) => call.command === "/fake/bin/stn" && call.args?.[4] === harnessId,
-        ).length;
-        const installed = harnessId === "codex" ? codexHookAttempts > 1 : attempts > 0;
+        const installed = harnessId === "codex" ? codexHookAttempts > 1 : openCodeHookAttempts > 0;
         return {
           provider: harnessId,
           requested: fs.files[configPath]?.includes("install_hooks = true") === true,
@@ -1360,12 +1352,9 @@ describe("guided setup command", () => {
     expect(first.code).toBe(1);
     expect(second.code).toBe(0);
     expect(fs.files[configPath].match(/install_hooks = true/g)).toHaveLength(2);
-    expect(
-      calls.filter((call) => call.command === "/fake/bin/stn" && call.args?.[4] === "codex"),
-    ).toHaveLength(2);
-    expect(
-      calls.filter((call) => call.command === "/fake/bin/stn" && call.args?.[4] === "opencode"),
-    ).toHaveLength(1);
+    expect(codexHookAttempts).toBe(2);
+    expect(openCodeHookAttempts).toBe(1);
+    expect(calls.some((call) => (call.args ?? []).includes("hooks"))).toBe(false);
   });
 
   it("installs a selected agent CLI when no harness is available, then continues", async () => {

--- a/apps/cli/test/unit/setup-operation-adapter.test.ts
+++ b/apps/cli/test/unit/setup-operation-adapter.test.ts
@@ -1,16 +1,18 @@
+import type { ClaudeHookInstallResult } from "@station/claude";
+import type { CodexHookInstallResult } from "@station/codex";
 import { emptyConfig } from "@station/config";
+import type { CursorHookInstallResult } from "@station/cursor";
+import type { OpenCodePluginInstallResult } from "@station/opencode";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
-import { describe, expect, it, vi } from "vitest";
-import { createHarnessTrackingAdapter } from "../../src/commands/setup/adapters/harnessTracking.js";
+import type { SupportedHarnessId } from "@station/setup-core";
+import { describe, expect, it } from "vitest";
+import {
+  createHarnessTrackingAdapter,
+  type SetupHarnessTrackingRunners,
+} from "../../src/commands/setup/adapters/harnessTracking.js";
 import { createSetupOperationAdapter } from "../../src/commands/setup/adapters/operations.js";
 
-const opencodeOperation = {
-  id: "prepare-harness-tracking:opencode",
-  kind: "prepare-harness-tracking",
-  tier: "required",
-  selected: true,
-  harnessId: "opencode",
-} as const;
+const trackedProviders = ["claude", "codex", "cursor", "opencode"] as const;
 
 describe("setup operation adapters", () => {
   it("streams genuine external installers through inherited stdio", async () => {
@@ -52,94 +54,198 @@ describe("setup operation adapters", () => {
     ]);
   });
 
-  it("sanitizes provider-native installation fields into commit evidence", async () => {
-    const opencode = vi.fn(async () => ({
-      provider: "opencode" as const,
-      configDir: "/provider/config",
-      pluginPath: "/provider/config/plugin.ts",
-      changed: true,
-      installed: true,
-      before: "native before sentinel",
-      after: "native after sentinel",
-      backupPath: "/provider/config/plugin.ts.bak",
-    }));
-    const adapter = createHarnessTrackingAdapter({
-      configPath: () => "/station/config.toml",
-      homeDir: "/home/test",
-      loadConfig: async () => ({
-        configPath: "/station/config.toml",
-        config: emptyConfig(),
-        projects: [],
-        diagnostics: [],
-      }),
-      runners: {
-        claude: async () => {
-          throw new Error("unused");
-        },
-        codex: async () => {
-          throw new Error("unused");
-        },
-        cursor: async () => {
-          throw new Error("unused");
-        },
-        opencode,
-      },
-    });
+  it.each(
+    trackedProviders,
+  )("sanitizes %s installation fields into commit evidence", async (provider) => {
+    const adapter = harnessTrackingAdapter(provider, false);
+    const operation = trackingOperation(provider);
 
-    const outcome = await adapter(opencodeOperation);
+    const outcome = await adapter(operation);
 
     expect(outcome).toEqual({
       status: "completed",
-      operationId: opencodeOperation.id,
+      operationId: operation.id,
       commit: {
         kind: "provider-tracking",
-        provider: "opencode",
+        provider,
         changed: true,
-        backupPaths: ["/provider/config/plugin.ts.bak"],
+        backupPaths: [`/provider/${provider}.bak`],
       },
     });
-    expect(JSON.stringify(outcome)).not.toMatch(/native before|native after|pluginPath|configDir/);
-    expect(opencode).toHaveBeenCalledWith(
-      ["install", "--yes"],
-      expect.objectContaining({ configPath: "/station/config.toml" }),
+    expect(JSON.stringify(outcome)).not.toMatch(
+      /native before sentinel|native after sentinel|hookScriptPath|pluginPath|configDir/,
     );
   });
 
-  it("normalizes unknown provider failures without raw data", async () => {
-    const adapter = createHarnessTrackingAdapter({
-      configPath: () => "/station/config.toml",
-      homeDir: "/home/test",
-      loadConfig: async () => ({
-        configPath: "/station/config.toml",
-        config: emptyConfig(),
-        projects: [],
-        diagnostics: [],
-      }),
-      runners: {
-        claude: async () => {
-          throw new Error("unused");
-        },
-        codex: async () => {
-          throw new Error("unused");
-        },
-        cursor: async () => {
-          throw new Error("unused");
-        },
-        opencode: async () => {
-          throw new Error("raw provider sentinel");
-        },
-      },
-    });
-
-    const outcome = await adapter(opencodeOperation);
+  it.each(trackedProviders)("normalizes unknown %s failures without raw data", async (provider) => {
+    const adapter = harnessTrackingAdapter(provider, true);
+    const outcome = await adapter(trackingOperation(provider));
 
     expect(outcome).toMatchObject({
       status: "failed",
       error: {
         code: "SETUP_PROVIDER_TRACKING_FAILED",
-        provider: "opencode",
+        provider,
       },
     });
     expect(JSON.stringify(outcome)).not.toContain("raw provider sentinel");
   });
+
+  it("normalizes a rejected injected tracking port", async () => {
+    const execute = createSetupOperationAdapter({
+      deps: {
+        providerTrackingPort: async () => {
+          throw new Error("raw injected port sentinel");
+        },
+      },
+    });
+
+    const outcome = await execute(trackingOperation("opencode"));
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      operationId: "prepare-harness-tracking:opencode",
+      error: {
+        code: "SETUP_PROVIDER_TRACKING_FAILED",
+        provider: "opencode",
+      },
+    });
+    expect(JSON.stringify(outcome)).not.toContain("raw injected port sentinel");
+  });
 });
+
+function harnessTrackingAdapter(provider: (typeof trackedProviders)[number], fail: boolean) {
+  return createHarnessTrackingAdapter({
+    configPath: () => "/station/config.toml",
+    homeDir: "/home/test",
+    loadConfig: async () => ({
+      configPath: "/station/config.toml",
+      config: emptyConfig(),
+      projects: [],
+      diagnostics: [],
+    }),
+    runners: providerRunners(provider, fail),
+  });
+}
+
+function providerRunners(
+  provider: (typeof trackedProviders)[number],
+  fail: boolean,
+): SetupHarnessTrackingRunners {
+  const rejected = () => {
+    throw new Error(fail ? "raw provider sentinel" : "unused provider runner");
+  };
+  return {
+    claude: async () => {
+      if (provider !== "claude" || fail) return rejected();
+      return providerInstallResult("claude");
+    },
+    codex: async () => {
+      if (provider !== "codex" || fail) return rejected();
+      return providerInstallResult("codex");
+    },
+    cursor: async () => {
+      if (provider !== "cursor" || fail) return rejected();
+      return providerInstallResult("cursor");
+    },
+    opencode: async () => {
+      if (provider !== "opencode" || fail) return rejected();
+      return providerInstallResult("opencode");
+    },
+  };
+}
+
+function providerInstallResult(provider: "claude"): ClaudeHookInstallResult;
+function providerInstallResult(provider: "codex"): CodexHookInstallResult;
+function providerInstallResult(provider: "cursor"): CursorHookInstallResult;
+function providerInstallResult(provider: "opencode"): OpenCodePluginInstallResult;
+function providerInstallResult(
+  provider: (typeof trackedProviders)[number],
+):
+  | ClaudeHookInstallResult
+  | CodexHookInstallResult
+  | CursorHookInstallResult
+  | OpenCodePluginInstallResult {
+  const shared = {
+    changed: true,
+    installed: true,
+    before: "native before sentinel",
+    after: "native after sentinel",
+  };
+  switch (provider) {
+    case "claude":
+      return {
+        ...shared,
+        provider,
+        settingsPath: "/provider/claude.json",
+        userSettingsPath: "/provider/claude-user.json",
+        hookScriptPath: "/provider/claude.sh",
+        events: [],
+        missing: [],
+        settingsChanged: true,
+        scriptChanged: true,
+        artifactInvalid: false,
+        userSettingsCleanup: {
+          settingsPath: "/provider/claude-user.json",
+          changed: false,
+          stale: [],
+          before: "",
+          after: "",
+        },
+        backupPaths: ["/provider/claude.bak"],
+      };
+    case "codex":
+      return {
+        ...shared,
+        provider,
+        configPath: "/provider/codex.toml",
+        profileName: "station",
+        profileConfigPath: "/provider/codex-profile.toml",
+        baseConfigPath: "/provider/codex-base.toml",
+        hookScriptPath: "/provider/codex.sh",
+        commands: {} as CodexHookInstallResult["commands"],
+        missing: [],
+        configChanged: true,
+        generatedGlobalChanged: false,
+        scriptChanged: true,
+        generatedGlobalCleanup: {
+          configPath: "/provider/codex-base.toml",
+          changed: false,
+          stale: [],
+          before: "",
+          after: "",
+        },
+        backupPaths: ["/provider/codex.bak"],
+      };
+    case "cursor":
+      return {
+        ...shared,
+        provider,
+        hooksPath: "/provider/cursor.json",
+        hookScriptPath: "/provider/cursor.sh",
+        commands: {} as CursorHookInstallResult["commands"],
+        missing: [],
+        configChanged: true,
+        scriptChanged: true,
+        backupPaths: ["/provider/cursor.bak"],
+      };
+    case "opencode":
+      return {
+        ...shared,
+        provider,
+        configDir: "/provider/opencode",
+        pluginPath: "/provider/opencode/plugin.ts",
+        backupPath: "/provider/opencode.bak",
+      };
+  }
+}
+
+function trackingOperation(harnessId: SupportedHarnessId) {
+  return {
+    id: `prepare-harness-tracking:${harnessId}` as const,
+    kind: "prepare-harness-tracking" as const,
+    tier: "required" as const,
+    selected: true as const,
+    harnessId,
+  };
+}

--- a/apps/cli/test/unit/setup-operation-adapter.test.ts
+++ b/apps/cli/test/unit/setup-operation-adapter.test.ts
@@ -1,0 +1,145 @@
+import { emptyConfig } from "@station/config";
+import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
+import { describe, expect, it, vi } from "vitest";
+import { createHarnessTrackingAdapter } from "../../src/commands/setup/adapters/harnessTracking.js";
+import { createSetupOperationAdapter } from "../../src/commands/setup/adapters/operations.js";
+
+const opencodeOperation = {
+  id: "prepare-harness-tracking:opencode",
+  kind: "prepare-harness-tracking",
+  tier: "required",
+  selected: true,
+  harnessId: "opencode",
+} as const;
+
+describe("setup operation adapters", () => {
+  it("streams genuine external installers through inherited stdio", async () => {
+    const calls: ExternalCommandInput[] = [];
+    const runner = async (input: ExternalCommandInput): Promise<ExternalCommandResult> => {
+      calls.push(input);
+      return {
+        command: input.command,
+        args: input.args ?? [],
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      };
+    };
+    const execute = createSetupOperationAdapter({ deps: { runner, env: { PATH: "/bin" } } });
+
+    await expect(
+      execute({
+        id: "install:tmux",
+        kind: "install-tool",
+        tier: "required",
+        selected: true,
+        tool: "tmux",
+      }),
+    ).resolves.toEqual({
+      status: "completed",
+      operationId: "install:tmux",
+      commit: {
+        kind: "package-installer",
+        target: { kind: "tool", id: "tmux" },
+      },
+    });
+    expect(calls).toEqual([
+      expect.objectContaining({
+        command: "brew",
+        args: ["install", "tmux"],
+        stdio: "inherit",
+      }),
+    ]);
+  });
+
+  it("sanitizes provider-native installation fields into commit evidence", async () => {
+    const opencode = vi.fn(async () => ({
+      provider: "opencode" as const,
+      configDir: "/provider/config",
+      pluginPath: "/provider/config/plugin.ts",
+      changed: true,
+      installed: true,
+      before: "native before sentinel",
+      after: "native after sentinel",
+      backupPath: "/provider/config/plugin.ts.bak",
+    }));
+    const adapter = createHarnessTrackingAdapter({
+      configPath: () => "/station/config.toml",
+      homeDir: "/home/test",
+      loadConfig: async () => ({
+        configPath: "/station/config.toml",
+        config: emptyConfig(),
+        projects: [],
+        diagnostics: [],
+      }),
+      runners: {
+        claude: async () => {
+          throw new Error("unused");
+        },
+        codex: async () => {
+          throw new Error("unused");
+        },
+        cursor: async () => {
+          throw new Error("unused");
+        },
+        opencode,
+      },
+    });
+
+    const outcome = await adapter(opencodeOperation);
+
+    expect(outcome).toEqual({
+      status: "completed",
+      operationId: opencodeOperation.id,
+      commit: {
+        kind: "provider-tracking",
+        provider: "opencode",
+        changed: true,
+        backupPaths: ["/provider/config/plugin.ts.bak"],
+      },
+    });
+    expect(JSON.stringify(outcome)).not.toMatch(/native before|native after|pluginPath|configDir/);
+    expect(opencode).toHaveBeenCalledWith(
+      ["install", "--yes"],
+      expect.objectContaining({ configPath: "/station/config.toml" }),
+    );
+  });
+
+  it("normalizes unknown provider failures without raw data", async () => {
+    const adapter = createHarnessTrackingAdapter({
+      configPath: () => "/station/config.toml",
+      homeDir: "/home/test",
+      loadConfig: async () => ({
+        configPath: "/station/config.toml",
+        config: emptyConfig(),
+        projects: [],
+        diagnostics: [],
+      }),
+      runners: {
+        claude: async () => {
+          throw new Error("unused");
+        },
+        codex: async () => {
+          throw new Error("unused");
+        },
+        cursor: async () => {
+          throw new Error("unused");
+        },
+        opencode: async () => {
+          throw new Error("raw provider sentinel");
+        },
+      },
+    });
+
+    const outcome = await adapter(opencodeOperation);
+
+    expect(outcome).toMatchObject({
+      status: "failed",
+      error: {
+        code: "SETUP_PROVIDER_TRACKING_FAILED",
+        provider: "opencode",
+      },
+    });
+    expect(JSON.stringify(outcome)).not.toContain("raw provider sentinel");
+  });
+});

--- a/apps/cli/test/unit/setup-plan-projection.test.ts
+++ b/apps/cli/test/unit/setup-plan-projection.test.ts
@@ -6,9 +6,40 @@ import type {
   SetupHarnessFact,
   SupportedHarnessId,
 } from "../../src/commands/setup/model.js";
-import { buildSetupPlan } from "../../src/commands/setup/planner.js";
+import { buildSetupPlan, buildSetupPlans } from "../../src/commands/setup/planner.js";
 
 describe("setup plan projection", () => {
+  it("binds every projected production mutation to semantic execution authority", () => {
+    const currentFacts = facts({
+      config: {
+        status: "missing",
+        path: "/tmp/config.toml",
+        message: "missing",
+      },
+    });
+    const built = buildSetupPlans(currentFacts, {
+      configWrite: {
+        operation: "create",
+        path: "/tmp/config.toml",
+        content: "schema_version = 1\n",
+      },
+    });
+    const boundActionIds = new Set(built.operationBindings.map((binding) => binding.actionId));
+    const mutatingActions = built.compatibilityPlan.actions.filter(
+      (action) => action.kind !== "noop",
+    );
+
+    expect(mutatingActions.length).toBeGreaterThan(0);
+    for (const action of mutatingActions) expect(boundActionIds.has(action.id)).toBe(true);
+    expect(
+      built.compatibilityPlan.actions.some((action) => action.id === "activate-observer-config"),
+    ).toBe(false);
+    expect(
+      built.semanticPlan.operations.some(
+        (operation) => operation.kind === "activate-observer-config",
+      ),
+    ).toBe(true);
+  });
   it("reports all core checks ready and no selected actions", () => {
     const plan = buildSetupPlan(facts());
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,11 +37,11 @@ The repo is organized around these boundaries:
 - `packages/contracts` owns shared application schemas and types, including `ObserverApi`, external-launch values, commands, events, snapshots, observations, provider ports, hooks, diagnostics, and safe errors.
 - `packages/protocol` owns the observer NDJSON transport: envelopes, method mapping, validation execution, client/server mechanics, and fail-closed Unix-socket probing and stale-owner evidence.
 - `packages/runtime` owns shared runtime boundary helpers for timeouts, retry, cancellation, external commands, typed error conversion, and atomic text replacement.
-- `packages/setup-core` owns dependency-free deterministic setup decisions over normalized evidence and intent, including semantic issues, operations, plans, and readiness results.
+- `packages/setup-core` owns runtime-independent setup decisions and operation ports over normalized evidence and intent, including semantic issues, operations, plans, typed outcomes, and readiness results. Its only package dependency is the shared `SafeError` type from contracts.
 - `packages/client` owns the framework-neutral rich-client observer runtime: snapshot loading, the event subscription/reconnect loop, event-to-snapshot reduction, and command dispatch/completion-wait wrappers consumed by the Station UI.
 - `apps/cli/src/ingress` owns the tiny `stn-ingress` sender: raw provider hook delivery to the observer socket and offline spool writes. Events sent through this raw path normalize and compact observer-side via provider hook adapters; integrations that submit typed harness reports normalize in their own adapter.
 - `packages/station-host` owns the standalone `station-station-host` daemon contract and client: a process that owns PTYs and their bounded raw/semantic replay state beyond the Station UI lifetime, exposing attach/list/close over its own local socket so panes can warm-reattach. Station consumes it directly; Observer application code can reach host-backed terminal behavior only through an adapter supplied by CLI composition.
-- `packages/config`, `packages/observability`, and `packages/testing` are shared support packages.
+- `packages/config` owns runtime-config parsing plus setup config generation, source-preserving mutation planning, validation, preconditions, backups, and atomic persistence. `packages/observability` and `packages/testing` are shared support packages.
 - `integrations/...` adapt external tools: Worktrunk, tmux, Claude Code, Codex, Cursor, Pi, OpenCode, scripted harnesses, and GitHub repository metadata.
 
 ## Source Of Truth
@@ -78,7 +78,7 @@ When these disagree, reconcile from config, providers, and current observer stat
   context and on daemon-inherited color controls; only color controls carried
   by the explicit launch request are authoritative.
 - The CLI is the command/debug entrypoint, but long-lived runtime correlation belongs in the observer.
-- Setup IO and orchestration remain in the CLI: it validates and normalizes external facts, projects setup-core semantic plans and results into the existing CLI compatibility schemas and copy, and owns config, provider, process, and persistence effects. `@station/setup-core` imports none of those concerns.
+- Setup orchestration remains in the CLI: it validates and normalizes external facts, projects semantic plans into the existing CLI compatibility schema, and implements setup-core driven ports with config, provider, process, filesystem, and Observer adapters. Compatibility action commands and data are presentation only when a semantic binding exists; provider tracking runs in-process and only sanitized commit evidence returns to setup-core. `@station/setup-core` imports none of those runtime concerns.
 - `packages/contracts` defines shared language with strict schemas for untrusted input and shared payloads.
 - The protocol validates transport messages and keeps consumer APIs simple. It should not become a provider boundary.
 - Client processes may spawn after an absent or proven-stale socket, but only the process binding the replacement may unlink it. Inaccessible ownership is preserved; pidfiles never establish liveness or authorize reclaim.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,9 +13,9 @@ existing empty-state UI. They do not create a config file; `stn setup` remains
 the writer. Setup writes `projects = []` and never infers a project from its
 working directory; use the empty dashboard's **Add your first project** flow to
 choose an existing Git repository explicitly. Setup validates generated or
-source-preserving edited TOML before writing, requires the planned source bytes
-to remain current, writes a timestamped backup
-for updates, and atomically replaces the target through a private mode-`0600`
+source-preserving edited TOML before writing, revalidates the planned source bytes
+at the serialized commit boundary, refuses concurrent creates, writes a timestamped
+backup for updates, and atomically replaces the target through a private mode-`0600`
 temporary file. After every successful guided or non-interactive setup config
 write, setup starts or restarts the observer and waits for it to become healthy
 with the updated configuration. Only after activation succeeds does setup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,11 +12,15 @@ routes use in-memory first-run defaults, ensure the observer, and show the
 existing empty-state UI. They do not create a config file; `stn setup` remains
 the writer. Setup writes `projects = []` and never infers a project from its
 working directory; use the empty dashboard's **Add your first project** flow to
-choose an existing Git repository explicitly. After every successful guided or
-non-interactive setup config write, setup starts or restarts the observer and
-waits for it to become healthy with the updated configuration. Only after
-activation succeeds does setup install remaining tracking artifacts and perform
-a final read-only re-probe. If activation fails, setup retains the config, exits
+choose an existing Git repository explicitly. Setup validates generated or
+source-preserving edited TOML before writing, requires the planned source bytes
+to remain current, writes a timestamped backup
+for updates, and atomically replaces the target through a private mode-`0600`
+temporary file. After every successful guided or non-interactive setup config
+write, setup starts or restarts the observer and waits for it to become healthy
+with the updated configuration. Only after activation succeeds does setup
+install remaining tracking artifacts in-process and perform a final read-only
+re-probe. If activation fails, setup retains the config, exits
 nonzero, and prints both `stn observer restart` and the setup command that must
 follow it. This exception applies only to the implicit default
 path: a missing explicit `--config`, an unreadable file, malformed TOML, or

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -11917,6 +11917,105 @@
       ]
     },
     {
+      "path": "apps/cli/src/commands/setup/adapters/config.ts",
+      "declaration": "createSetupConfigAdapter",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Translates semantic setup configuration policy into validated config-owned planning and persistence.",
+      "dependencies": [
+        {
+          "path": "packages/setup-core/src/ports.ts",
+          "declaration": "SetupConfigMutationPort",
+          "kind": "type",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/commands/setup/adapters/harnessTracking.ts",
+      "declaration": "createHarnessTrackingAdapter",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Translates harness tracking preparation into an in-process provider installer and sanitized commit evidence.",
+      "dependencies": [
+        {
+          "path": "packages/setup-core/src/ports.ts",
+          "declaration": "SetupHarnessTrackingPort",
+          "kind": "type",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/commands/setup/adapters/observerActivation.ts",
+      "declaration": "createObserverActivationAdapter",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Translates setup activation into config loading, Observer path resolution, restart, and health confirmation.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/observerProcess.ts",
+          "declaration": "restartObserver",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/setup-core/src/ports.ts",
+          "declaration": "SetupObserverActivationPort",
+          "kind": "type",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
+      "path": "apps/cli/src/commands/setup/adapters/operations.ts",
+      "declaration": "createSetupOperationAdapter",
+      "kind": "function",
+      "role": "ADAPTER",
+      "purpose": "Assigns semantic setup operations to config, provider, process, filesystem, and Observer boundary implementations.",
+      "dependencies": [
+        {
+          "path": "apps/cli/src/commands/setup/adapters/config.ts",
+          "declaration": "createSetupConfigAdapter",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/commands/setup/adapters/harnessTracking.ts",
+          "declaration": "createHarnessTrackingAdapter",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "apps/cli/src/commands/setup/adapters/observerActivation.ts",
+          "declaration": "createObserverActivationAdapter",
+          "kind": "function",
+          "role": "ADAPTER",
+          "edgeKind": "runtime"
+        },
+        {
+          "path": "packages/setup-core/src/ports.ts",
+          "declaration": "SetupOperationExecutor",
+          "kind": "type",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        },
+        {
+          "path": "packages/setup-core/src/ports.ts",
+          "declaration": "SetupPackageInstallationPort",
+          "kind": "type",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
+    },
+    {
       "path": "apps/cli/src/commands/snapshot.ts",
       "declaration": "runSnapshotCommand",
       "kind": "function",
@@ -14363,6 +14462,70 @@
       "kind": "function",
       "role": "POLICY",
       "purpose": "Selects available, supported, unprepared harnesses whose selected or persisted intent requires repair.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupConfigMutationPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Commits the desired Station setup configuration without exposing its representation to setup policy.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupHarnessTrackingPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Prepares one selected harness's Station-owned tracking artifacts.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupLauncherLinkPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Links the Station launchers required for bare terminal commands.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupObserverActivationPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Activates a committed setup configuration and confirms Observer health.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupOperationExecutor",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Executes one semantic setup operation through its assigned outward capability.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupPackageInstallationPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Runs the installer selected for a setup package target.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupTmuxConfigurationPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Persists or live-loads the selected tmux popup configuration.",
+      "dependencies": []
+    },
+    {
+      "path": "packages/setup-core/src/ports.ts",
+      "declaration": "SetupWorktrunkIntegrationPort",
+      "kind": "type",
+      "role": "DRIVEN PORT",
+      "purpose": "Applies Worktrunk tracking or shell integration requested by setup.",
       "dependencies": []
     }
   ]

--- a/docs/harness-authoring.md
+++ b/docs/harness-authoring.md
@@ -63,6 +63,7 @@ integration's documentation of record; prose goes stale, fixtures fail loudly.
   verifiable, and remember doctor verifies *installation*, not build identity —
   check that `stn` and `stn-ingress` on PATH resolve to the same checkout.
 - Add the harness to setup checks if it needs system dependencies.
+- Setup tracking preparation must call the same typed provider installer in-process through the setup adapter. Return only installed/changed and backup-path commit evidence; provider plans, commands, before/after source, and other native result fields must not cross the setup port or print in guided output.
 
 ## 6. Support launch preflight
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -6,4 +6,5 @@ export * from "./observerPaths.js";
 export * from "./observerProcessArgs.js";
 export * from "./projects/index.js";
 export * from "./schema.js";
+export * from "./setup/index.js";
 export * from "./tui/index.js";

--- a/packages/config/src/projects/source.ts
+++ b/packages/config/src/projects/source.ts
@@ -1,7 +1,6 @@
-import { constants } from "node:fs";
-import { access, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { replaceTextFile } from "@station/runtime";
 import { ConfigError } from "../load/errors.js";
 import { loadConfigFromToml } from "../load/index.js";
 import { DEFAULT_CONFIG_PATH, normalizeConfigPath } from "../load/paths.js";
@@ -30,13 +29,13 @@ export async function loadConfigSource(options: {
 }
 
 export async function atomicWriteConfig(configPath: string, source: string): Promise<void> {
-  const configDir = dirname(configPath);
-  const tempPath = join(configDir, `.${basename(configPath)}.${process.pid}.${Date.now()}.tmp`);
   try {
-    await mkdir(configDir, { recursive: true, mode: 0o700 });
-    await access(configDir, constants.W_OK);
-    await writeFile(tempPath, source, { encoding: "utf8", mode: 0o600 });
-    await rename(tempPath, configPath);
+    await replaceTextFile({
+      path: configPath,
+      contents: source,
+      mode: 0o600,
+      directoryMode: 0o700,
+    });
   } catch (cause) {
     throw projectConfigSafeError({
       code: "CONFIG_WRITE_FAILED",

--- a/packages/config/src/setup/index.ts
+++ b/packages/config/src/setup/index.ts
@@ -1,0 +1,10 @@
+export {
+  planSetupConfigMutation,
+  renderSetupConfig,
+  type SetupConfigDesiredState,
+  type SetupConfigMutationInput,
+} from "./mutations.js";
+export {
+  type PersistSetupConfigMutationOptions,
+  persistSetupConfigMutation,
+} from "./persistence.js";

--- a/packages/config/src/setup/mutations.ts
+++ b/packages/config/src/setup/mutations.ts
@@ -1,0 +1,202 @@
+import { setHarnessInstallHooksInToml } from "../harnesses/installHooks.js";
+import { loadConfigFromToml } from "../load/index.js";
+import { quoteTomlString } from "../tomlEdit.js";
+
+type SetupConfigHarnessId = "claude" | "codex" | "cursor" | "opencode" | "pi";
+
+export type SetupConfigDesiredState = {
+  readonly defaultHarness: SetupConfigHarnessId;
+  readonly harnesses: readonly {
+    readonly id: SetupConfigHarnessId;
+    readonly command: string;
+    readonly installHooks: boolean;
+  }[];
+  readonly worktrunkCommand: string;
+  readonly tmuxCommand?: string;
+  readonly installWorktrunkHooks: boolean;
+};
+
+export type SetupConfigMutationInput = {
+  readonly configPath: string;
+  readonly homeDir: string;
+  readonly current:
+    | { readonly state: "missing" }
+    | { readonly state: "valid"; readonly source: string };
+  readonly desired: SetupConfigDesiredState;
+};
+
+export type SetupConfigMutationPlan =
+  | { readonly operation: "none"; readonly reason: string }
+  | {
+      readonly operation: "blocked";
+      readonly path: string;
+      readonly reason: string;
+    }
+  | {
+      readonly operation: "create";
+      readonly path: string;
+      readonly content: string;
+    }
+  | {
+      readonly operation: "update";
+      readonly path: string;
+      readonly before: string;
+      readonly content: string;
+    };
+
+export async function planSetupConfigMutation(
+  input: SetupConfigMutationInput,
+): Promise<SetupConfigMutationPlan> {
+  if (input.current.state === "missing") {
+    const content = renderSetupConfig(input.desired);
+    await validateCandidate(content, input);
+    return { operation: "create", path: input.configPath, content };
+  }
+
+  const loaded = await loadConfigFromToml(input.current.source, {
+    configPath: input.configPath,
+    homeDir: input.homeDir,
+  });
+  const coreProblem = existingConfigUpdateCoreProblem(loaded.config.defaults);
+  if (coreProblem !== undefined) {
+    return { operation: "blocked", path: input.configPath, reason: coreProblem };
+  }
+
+  let content = input.current.source;
+  for (const harness of input.desired.harnesses) {
+    const configured = loaded.config.harness?.[harness.id];
+    if (configured !== undefined && harness.installHooks && configured.installHooks !== true) {
+      content = await setHarnessInstallHooksInToml(content, {
+        harness: harness.id,
+        installHooks: true,
+        configPath: input.configPath,
+        homeDir: input.homeDir,
+      });
+    }
+  }
+
+  const missingHarnesses = input.desired.harnesses.filter(
+    (harness) => loaded.config.harness?.[harness.id] === undefined,
+  );
+  const appendedText = renderHarnessAppendText(
+    missingHarnesses,
+    preferredNewline(input.current.source),
+  );
+  if (appendedText.length > 0) {
+    content = `${content}${content.endsWith("\n") ? "" : preferredNewline(content)}${appendedText}`;
+  }
+  if (content === input.current.source) {
+    return {
+      operation: "none",
+      reason:
+        input.desired.harnesses.length === 1
+          ? "Config already includes the selected harness and core defaults."
+          : "Config already includes the selected harnesses and core defaults.",
+    };
+  }
+
+  await validateCandidate(content, input);
+  return {
+    operation: "update",
+    path: input.configPath,
+    before: input.current.source,
+    content,
+  };
+}
+
+export function renderSetupConfig(desired: SetupConfigDesiredState): string {
+  const defaultHarness = desired.harnesses.find((harness) => harness.id === desired.defaultHarness);
+  if (defaultHarness === undefined) {
+    throw new Error("New setup config requires its default harness in the selected harnesses.");
+  }
+  return [
+    "schema_version = 1",
+    "projects = []",
+    "",
+    "[observer]",
+    'state_dir = "~/.local/state/station"',
+    "",
+    "[defaults]",
+    'worktree_provider = "worktrunk"',
+    'terminal = "tmux"',
+    `harness = ${quoteTomlString(defaultHarness.id)}`,
+    'layout = "agent-shell"',
+    "",
+    "[worktree.worktrunk]",
+    `command = ${quoteTomlString(desired.worktrunkCommand)}`,
+    'managed_root = "~/.worktrees"',
+    "include_main = false",
+    "include_external = false",
+    `use_lifecycle_hooks = ${desired.installWorktrunkHooks ? "true" : "false"}`,
+    `hook_mode = ${quoteTomlString(desired.installWorktrunkHooks ? "required-for-mvp" : "disabled")}`,
+    "",
+    "[terminal.tmux]",
+    ...(desired.tmuxCommand === undefined
+      ? []
+      : [`command = ${quoteTomlString(desired.tmuxCommand)}`]),
+    'session_prefix = "station"',
+    'topology = "workbench"',
+    'workbench_session = "station"',
+    'window_naming = "project-branch"',
+    "primary_agent_pane = true",
+    "",
+    ...desired.harnesses.flatMap((harness) => [...renderHarnessBlock(harness).split("\n"), ""]),
+  ].join("\n");
+}
+
+function renderHarnessAppendText(
+  harnesses: SetupConfigDesiredState["harnesses"],
+  newline: "\n" | "\r\n",
+): string {
+  if (harnesses.length === 0) return "";
+  const blocks = harnesses.map((harness) => renderHarnessBlock(harness).replaceAll("\n", newline));
+  return `${newline}${blocks.join(`${newline}${newline}`)}${newline}`;
+}
+
+function renderHarnessBlock(harness: SetupConfigDesiredState["harnesses"][number]): string {
+  return [
+    `[harness.${harness.id}]`,
+    "enabled = true",
+    `command = ${quoteTomlString(harness.command)}`,
+    ...(harness.installHooks ? ["install_hooks = true"] : []),
+  ].join("\n");
+}
+
+function existingConfigUpdateCoreProblem(defaults: {
+  worktreeProvider: string;
+  terminal: string;
+  harness: string;
+}): string | undefined {
+  if (defaults.worktreeProvider !== "worktrunk") {
+    return `Config defaults use worktree provider ${defaults.worktreeProvider}; setup will not rewrite existing defaults.`;
+  }
+  if (defaults.terminal !== "tmux") {
+    return `Config defaults use terminal ${defaults.terminal}; setup will not rewrite existing defaults.`;
+  }
+  if (!supportedSetupHarnessIds.has(defaults.harness)) {
+    return `Config defaults use unsupported harness ${defaults.harness}; setup will not rewrite existing defaults.`;
+  }
+  return undefined;
+}
+
+const supportedSetupHarnessIds: ReadonlySet<string> = new Set<SetupConfigHarnessId>([
+  "claude",
+  "codex",
+  "cursor",
+  "opencode",
+  "pi",
+]);
+
+async function validateCandidate(
+  content: string,
+  input: Pick<SetupConfigMutationInput, "configPath" | "homeDir">,
+): Promise<void> {
+  await loadConfigFromToml(content, {
+    configPath: input.configPath,
+    homeDir: input.homeDir,
+  });
+}
+
+function preferredNewline(source: string): "\n" | "\r\n" {
+  return source.includes("\r\n") ? "\r\n" : "\n";
+}

--- a/packages/config/src/setup/persistence.ts
+++ b/packages/config/src/setup/persistence.ts
@@ -1,0 +1,115 @@
+import { writeFile } from "node:fs/promises";
+import { readTextFileIfPresent, replaceTextFile } from "@station/runtime";
+import { loadConfigFromToml } from "../load/index.js";
+import type { SetupConfigMutationPlan } from "./mutations.js";
+
+type SetupConfigPersistenceResult = {
+  readonly status: "created" | "updated" | "unchanged";
+  readonly configPath: string;
+  readonly backupPath?: string;
+};
+
+type SetupConfigPersistenceFileSystem = {
+  readTextFile(path: string): Promise<string | undefined>;
+  writeBackup(path: string, content: string): Promise<void>;
+  replaceText(path: string, content: string): Promise<void>;
+};
+
+export type PersistSetupConfigMutationOptions = {
+  readonly homeDir: string;
+  readonly now?: () => Date;
+  readonly fs?: SetupConfigPersistenceFileSystem;
+};
+
+export async function persistSetupConfigMutation(
+  plan: Exclude<SetupConfigMutationPlan, { operation: "none" | "blocked" }>,
+  options: PersistSetupConfigMutationOptions,
+): Promise<SetupConfigPersistenceResult> {
+  await loadConfigFromToml(plan.content, {
+    configPath: plan.path,
+    homeDir: options.homeDir,
+  });
+
+  const fs = options.fs ?? nodePersistenceFileSystem();
+  const current = await fs.readTextFile(plan.path);
+  if (current === plan.content) {
+    return { status: "unchanged", configPath: plan.path };
+  }
+  if (plan.operation === "create") {
+    if (current !== undefined) {
+      throw setupConfigPersistenceError(
+        "SETUP_CONFIG_PRECONDITION_FAILED",
+        "Station config changed after setup planning; no setup config was written.",
+        plan.path,
+      );
+    }
+  } else if (current !== plan.before) {
+    throw setupConfigPersistenceError(
+      "SETUP_CONFIG_PRECONDITION_FAILED",
+      "Station config changed after setup planning; no setup config was written.",
+      plan.path,
+    );
+  }
+
+  let backupPath: string | undefined;
+  if (plan.operation === "update") {
+    const stamp = (options.now ?? (() => new Date()))().toISOString().replaceAll(/[:.]/g, "-");
+    backupPath = `${plan.path}.${stamp}.bak`;
+    try {
+      await fs.writeBackup(backupPath, plan.before);
+    } catch (cause) {
+      throw setupConfigPersistenceError(
+        "SETUP_CONFIG_BACKUP_FAILED",
+        "Could not back up config.toml; the existing config was not changed.",
+        backupPath,
+        cause,
+      );
+    }
+  }
+
+  try {
+    await fs.replaceText(plan.path, plan.content);
+  } catch (cause) {
+    throw setupConfigPersistenceError(
+      "CONFIG_WRITE_FAILED",
+      "Could not update config.toml.",
+      plan.path,
+      cause,
+    );
+  }
+
+  const status = plan.operation === "create" ? "created" : "updated";
+  return backupPath === undefined
+    ? { status, configPath: plan.path }
+    : { status, configPath: plan.path, backupPath };
+}
+
+function nodePersistenceFileSystem(): SetupConfigPersistenceFileSystem {
+  return {
+    readTextFile: readTextFileIfPresent,
+    writeBackup: async (path, content) => {
+      await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+    },
+    replaceText: async (path, content) => {
+      await replaceTextFile({ path, contents: content, mode: 0o600, directoryMode: 0o700 });
+    },
+  };
+}
+
+function setupConfigPersistenceError(
+  code: "SETUP_CONFIG_PRECONDITION_FAILED" | "SETUP_CONFIG_BACKUP_FAILED" | "CONFIG_WRITE_FAILED",
+  message: string,
+  hint: string,
+  cause?: unknown,
+): Error & { tag: "SetupConfigError"; code: string; hint: string } {
+  const error = new Error(message, { cause }) as Error & {
+    tag: "SetupConfigError";
+    code: string;
+    hint: string;
+  };
+  error.name = "SetupConfigError";
+  error.tag = "SetupConfigError";
+  error.code = code;
+  error.hint = hint;
+  return error;
+}

--- a/packages/config/src/setup/persistence.ts
+++ b/packages/config/src/setup/persistence.ts
@@ -1,5 +1,7 @@
-import { writeFile } from "node:fs/promises";
-import { readTextFileIfPresent, replaceTextFile } from "@station/runtime";
+import { randomUUID } from "node:crypto";
+import { chmod, link, mkdir, open, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { readTextFileIfPresent } from "@station/runtime";
 import { loadConfigFromToml } from "../load/index.js";
 import type { SetupConfigMutationPlan } from "./mutations.js";
 
@@ -9,10 +11,16 @@ type SetupConfigPersistenceResult = {
   readonly backupPath?: string;
 };
 
+type SetupConfigCommitStatus = "replaced" | "unchanged" | "stale";
+
 type SetupConfigPersistenceFileSystem = {
   readTextFile(path: string): Promise<string | undefined>;
   writeBackup(path: string, content: string): Promise<void>;
-  replaceText(path: string, content: string): Promise<void>;
+  replaceTextIfCurrent(
+    path: string,
+    expectedContent: string | undefined,
+    content: string,
+  ): Promise<SetupConfigCommitStatus>;
 };
 
 export type PersistSetupConfigMutationOptions = {
@@ -67,8 +75,13 @@ export async function persistSetupConfigMutation(
     }
   }
 
+  let commitStatus: SetupConfigCommitStatus;
   try {
-    await fs.replaceText(plan.path, plan.content);
+    commitStatus = await fs.replaceTextIfCurrent(
+      plan.path,
+      plan.operation === "create" ? undefined : plan.before,
+      plan.content,
+    );
   } catch (cause) {
     throw setupConfigPersistenceError(
       "CONFIG_WRITE_FAILED",
@@ -77,11 +90,26 @@ export async function persistSetupConfigMutation(
       cause,
     );
   }
+  if (commitStatus === "stale") {
+    throw setupConfigPersistenceError(
+      "SETUP_CONFIG_PRECONDITION_FAILED",
+      "Station config changed during setup persistence; no newer config was replaced.",
+      plan.path,
+    );
+  }
 
-  const status = plan.operation === "create" ? "created" : "updated";
+  const status = setupConfigPersistenceStatus(commitStatus, plan.operation);
   return backupPath === undefined
     ? { status, configPath: plan.path }
     : { status, configPath: plan.path, backupPath };
+}
+
+function setupConfigPersistenceStatus(
+  commitStatus: SetupConfigCommitStatus,
+  operation: "create" | "update",
+): SetupConfigPersistenceResult["status"] {
+  if (commitStatus === "unchanged") return "unchanged";
+  return operation === "create" ? "created" : "updated";
 }
 
 function nodePersistenceFileSystem(): SetupConfigPersistenceFileSystem {
@@ -90,11 +118,111 @@ function nodePersistenceFileSystem(): SetupConfigPersistenceFileSystem {
     writeBackup: async (path, content) => {
       await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
     },
-    replaceText: async (path, content) => {
-      await replaceTextFile({ path, contents: content, mode: 0o600, directoryMode: 0o700 });
-    },
+    replaceTextIfCurrent: commitSetupConfigText,
   };
 }
+
+async function commitSetupConfigText(
+  path: string,
+  expectedContent: string | undefined,
+  content: string,
+): Promise<SetupConfigCommitStatus> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  // Serialize Station writers, then revalidate staged commits to reject edits from non-cooperating tools.
+  const lock = await acquireSetupConfigLock(`${path}.station-setup.lock`);
+  if (lock === undefined) return "stale";
+
+  try {
+    const targetPath = await setupConfigCommitTarget(path, expectedContent);
+    if (targetPath === undefined) return "stale";
+    const targetDirectory = dirname(targetPath);
+    await mkdir(targetDirectory, { recursive: true, mode: 0o700 });
+    const temporaryPath = join(targetDirectory, `.${basename(targetPath)}.${randomUUID()}.tmp`);
+    try {
+      await writeFile(temporaryPath, content, {
+        encoding: "utf8",
+        flag: "wx",
+        mode: 0o600,
+      });
+      await chmod(temporaryPath, 0o600);
+
+      const current = await readTextFileIfPresent(path);
+      if (current === content) return "unchanged";
+      if (current !== expectedContent) return "stale";
+
+      if (expectedContent === undefined) {
+        try {
+          // A hard link commits the staged create without replacing a path that appeared after planning.
+          await link(temporaryPath, path);
+          return "replaced";
+        } catch (cause) {
+          if (errorCode(cause) !== "EEXIST") throw cause;
+          return (await readTextFileIfPresent(path)) === content ? "unchanged" : "stale";
+        }
+      }
+
+      const revalidatedTarget = await resolvedPathIfPresent(path);
+      if (revalidatedTarget !== targetPath) return "stale";
+      const revalidatedContent = await readTextFileIfPresent(targetPath);
+      if (revalidatedContent === content) return "unchanged";
+      if (revalidatedContent !== expectedContent) return "stale";
+      await rename(temporaryPath, targetPath);
+      return "replaced";
+    } finally {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  } finally {
+    await lock.close().catch(() => undefined);
+    await rm(lock.path, { force: true }).catch(() => undefined);
+  }
+}
+
+async function setupConfigCommitTarget(
+  path: string,
+  expectedContent: string | undefined,
+): Promise<string | undefined> {
+  if (expectedContent === undefined) return path;
+  return resolvedPathIfPresent(path);
+}
+
+async function resolvedPathIfPresent(path: string): Promise<string | undefined> {
+  try {
+    return await realpath(path);
+  } catch (cause) {
+    if (errorCode(cause) === "ENOENT") return undefined;
+    throw cause;
+  }
+}
+
+async function acquireSetupConfigLock(
+  path: string,
+): Promise<{ close(): Promise<void>; path: string } | undefined> {
+  try {
+    const handle = await open(path, "wx", 0o600);
+    return { close: () => handle.close(), path };
+  } catch (cause) {
+    if (errorCode(cause) !== "EEXIST") throw cause;
+    const metadata = await stat(path).catch(() => undefined);
+    if (metadata === undefined || Date.now() - metadata.mtimeMs <= setupConfigLockStaleMs) {
+      return undefined;
+    }
+    await rm(path, { force: true });
+    try {
+      const handle = await open(path, "wx", 0o600);
+      return { close: () => handle.close(), path };
+    } catch (retryCause) {
+      if (errorCode(retryCause) === "EEXIST") return undefined;
+      throw retryCause;
+    }
+  }
+}
+
+function errorCode(cause: unknown): string | undefined {
+  return (cause as NodeJS.ErrnoException | null | undefined)?.code;
+}
+
+const setupConfigLockStaleMs = 5 * 60 * 1_000;
 
 function setupConfigPersistenceError(
   code: "SETUP_CONFIG_PRECONDITION_FAILED" | "SETUP_CONFIG_BACKUP_FAILED" | "CONFIG_WRITE_FAILED",

--- a/packages/config/test/fixtures/setup/create.expected.toml
+++ b/packages/config/test/fixtures/setup/create.expected.toml
@@ -1,0 +1,31 @@
+schema_version = 1
+projects = []
+
+[observer]
+state_dir = "~/.local/state/station"
+
+[defaults]
+worktree_provider = "worktrunk"
+terminal = "tmux"
+harness = "codex"
+layout = "agent-shell"
+
+[worktree.worktrunk]
+command = "wt"
+managed_root = "~/.worktrees"
+include_main = false
+include_external = false
+use_lifecycle_hooks = true
+hook_mode = "required-for-mvp"
+
+[terminal.tmux]
+session_prefix = "station"
+topology = "workbench"
+workbench_session = "station"
+window_naming = "project-branch"
+primary_agent_pane = true
+
+[harness.codex]
+enabled = true
+command = "codex"
+install_hooks = true

--- a/packages/config/test/fixtures/setup/update.before.toml
+++ b/packages/config/test/fixtures/setup/update.before.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+projects = []
+
+# Keep this comment and the authored quoting.
+[defaults]
+worktree_provider = 'worktrunk'
+terminal = "tmux"
+harness = "codex"
+layout = "agent-shell"
+
+[harness.codex] # selected default
+enabled = true
+command = "codex"
+install_hooks = false # setup flips only this value

--- a/packages/config/test/fixtures/setup/update.expected.toml
+++ b/packages/config/test/fixtures/setup/update.expected.toml
@@ -1,0 +1,19 @@
+schema_version = 1
+projects = []
+
+# Keep this comment and the authored quoting.
+[defaults]
+worktree_provider = 'worktrunk'
+terminal = "tmux"
+harness = "codex"
+layout = "agent-shell"
+
+[harness.codex] # selected default
+enabled = true
+command = "codex"
+install_hooks = true # setup flips only this value
+
+[harness.opencode]
+enabled = true
+command = "opencode"
+install_hooks = true

--- a/packages/config/test/unit/setup-mutations.test.ts
+++ b/packages/config/test/unit/setup-mutations.test.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  planSetupConfigMutation,
+  renderSetupConfig,
+  type SetupConfigDesiredState,
+} from "@station/config";
+import { describe, expect, it } from "vitest";
+
+const fixtureRoot = "packages/config/test/fixtures/setup";
+
+const createDesired: SetupConfigDesiredState = {
+  defaultHarness: "codex",
+  harnesses: [{ id: "codex", command: "codex", installHooks: true }],
+  worktrunkCommand: "wt",
+  installWorktrunkHooks: true,
+};
+
+const updateDesired: SetupConfigDesiredState = {
+  defaultHarness: "codex",
+  harnesses: [
+    { id: "codex", command: "codex", installHooks: true },
+    { id: "opencode", command: "opencode", installHooks: true },
+  ],
+  worktrunkCommand: "wt",
+  installWorktrunkHooks: false,
+};
+
+describe("setup config mutations", () => {
+  it("renders a byte-exact new setup config", async () => {
+    const expected = await fixture("create.expected.toml");
+
+    expect(renderSetupConfig(createDesired)).toBe(expected);
+    await expect(
+      planSetupConfigMutation({
+        configPath: "/tmp/station-config.toml",
+        homeDir: "/tmp",
+        current: { state: "missing" },
+        desired: createDesired,
+      }),
+    ).resolves.toEqual({
+      operation: "create",
+      path: "/tmp/station-config.toml",
+      content: expected,
+    });
+  });
+
+  it("preserves existing source while updating and appending harness state", async () => {
+    const before = await fixture("update.before.toml");
+    const expected = await fixture("update.expected.toml");
+
+    await expect(
+      planSetupConfigMutation({
+        configPath: "/tmp/station-config.toml",
+        homeDir: "/tmp",
+        current: { state: "valid", source: before },
+        desired: updateDesired,
+      }),
+    ).resolves.toEqual({
+      operation: "update",
+      path: "/tmp/station-config.toml",
+      before,
+      content: expected,
+    });
+  });
+
+  it("retains CRLF and an absent final newline", async () => {
+    const source = (await fixture("update.before.toml")).trimEnd().replaceAll("\n", "\r\n");
+    const plan = await planSetupConfigMutation({
+      configPath: "/tmp/station-config.toml",
+      homeDir: "/tmp",
+      current: { state: "valid", source },
+      desired: {
+        ...updateDesired,
+        harnesses: [{ id: "codex", command: "codex", installHooks: true }],
+      },
+    });
+
+    expect(plan.operation).toBe("update");
+    if (plan.operation !== "update") throw new Error("expected update plan");
+    expect(plan.content.replaceAll("\r\n", "")).not.toContain("\n");
+    expect(plan.content).toContain("install_hooks = true # setup flips only this value");
+    expect(plan.content.endsWith("\n")).toBe(false);
+  });
+});
+
+function fixture(name: string): Promise<string> {
+  return readFile(join(fixtureRoot, name), "utf8");
+}

--- a/packages/config/test/unit/setup-persistence.test.ts
+++ b/packages/config/test/unit/setup-persistence.test.ts
@@ -1,4 +1,5 @@
-import { readFile } from "node:fs/promises";
+import { lstat, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type PersistSetupConfigMutationOptions,
@@ -30,6 +31,63 @@ describe("setup config persistence", () => {
       configPath,
     });
     expect(fs.backups).toEqual([]);
+  });
+
+  it("allows only one concurrent real-filesystem create to commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-setup-config-race-"));
+    const path = join(root, "config.toml");
+    const alternate = `${content}\n# alternate concurrent plan\n`;
+    try {
+      const results = await Promise.allSettled([
+        persistSetupConfigMutation({ operation: "create", path, content }, { homeDir: root }),
+        persistSetupConfigMutation(
+          { operation: "create", path, content: alternate },
+          { homeDir: root },
+        ),
+      ]);
+
+      expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      const rejected = results.find((result) => result.status === "rejected");
+      expect(rejected).toMatchObject({
+        status: "rejected",
+        reason: { code: "SETUP_CONFIG_PRECONDITION_FAILED" },
+      });
+      expect([content, alternate]).toContain(await readFile(path, "utf8"));
+      expect((await stat(path)).mode & 0o777).toBe(0o600);
+      expect(await readdir(root)).toEqual(["config.toml"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("updates a real symlink target without replacing the link", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-setup-config-symlink-"));
+    const targetPath = join(root, "target.toml");
+    const linkPath = join(root, "config.toml");
+    const backupPath = `${linkPath}.2026-06-08T12-00-00-000Z.bak`;
+    try {
+      await writeFile(targetPath, before, { encoding: "utf8", mode: 0o600 });
+      await symlink(targetPath, linkPath);
+
+      await expect(
+        persistSetupConfigMutation(
+          { operation: "update", path: linkPath, before, content },
+          {
+            homeDir: root,
+            now: () => new Date("2026-06-08T12:00:00.000Z"),
+          },
+        ),
+      ).resolves.toEqual({
+        status: "updated",
+        configPath: linkPath,
+        backupPath,
+      });
+      expect((await lstat(linkPath)).isSymbolicLink()).toBe(true);
+      expect(await readFile(targetPath, "utf8")).toBe(content);
+      expect(await readFile(backupPath, "utf8")).toBe(before);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("writes one timestamped backup and makes no second backup on retry", async () => {
@@ -71,7 +129,42 @@ describe("setup config persistence", () => {
       ),
     ).rejects.toMatchObject({ code: "SETUP_CONFIG_PRECONDITION_FAILED" });
     expect(fs.files.get(configPath)).toBe(stale);
-    expect(fs.replaceText).not.toHaveBeenCalled();
+    expect(fs.replaceTextIfCurrent).not.toHaveBeenCalled();
+  });
+
+  it("rejects a create that appears at the commit boundary", async () => {
+    const concurrent = `${before}\n# created concurrently\n`;
+    const fs = memoryFileSystem();
+    fs.replaceTextIfCurrent.mockImplementationOnce(async (path) => {
+      fs.files.set(path, concurrent);
+      return "stale";
+    });
+
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "create", path: configPath, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "SETUP_CONFIG_PRECONDITION_FAILED" });
+    expect(fs.files.get(configPath)).toBe(concurrent);
+  });
+
+  it("revalidates an update after backup creation", async () => {
+    const concurrent = `${before}\n# changed during backup\n`;
+    const fs = memoryFileSystem({ [configPath]: before });
+    fs.writeBackup.mockImplementationOnce(async (path, value) => {
+      fs.backups.push(path);
+      fs.files.set(path, value);
+      fs.files.set(configPath, concurrent);
+    });
+
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "update", path: configPath, before, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "SETUP_CONFIG_PRECONDITION_FAILED" });
+    expect(fs.files.get(configPath)).toBe(concurrent);
   });
 
   it("leaves the target unchanged when backup creation fails", async () => {
@@ -85,12 +178,12 @@ describe("setup config persistence", () => {
       ),
     ).rejects.toMatchObject({ code: "SETUP_CONFIG_BACKUP_FAILED" });
     expect(fs.files.get(configPath)).toBe(before);
-    expect(fs.replaceText).not.toHaveBeenCalled();
+    expect(fs.replaceTextIfCurrent).not.toHaveBeenCalled();
   });
 
   it("leaves the target unchanged when atomic replacement fails", async () => {
     const fs = memoryFileSystem({ [configPath]: before });
-    fs.replaceText.mockRejectedValueOnce(new Error("rename denied"));
+    fs.replaceTextIfCurrent.mockRejectedValueOnce(new Error("rename denied"));
 
     await expect(
       persistSetupConfigMutation(
@@ -111,10 +204,16 @@ function memoryFileSystem(initial: Record<string, string> = {}) {
     backups.push(path);
     files.set(path, value);
   });
-  const replaceText = vi.fn(async (path: string, value: string) => {
-    files.set(path, value);
-  });
-  const fs = { readTextFile, writeBackup, replaceText } satisfies NonNullable<
+  const replaceTextIfCurrent = vi.fn(
+    async (path: string, expectedValue: string | undefined, value: string) => {
+      const current = files.get(path);
+      if (current === value) return "unchanged" as const;
+      if (current !== expectedValue) return "stale" as const;
+      files.set(path, value);
+      return "replaced" as const;
+    },
+  );
+  const fs = { readTextFile, writeBackup, replaceTextIfCurrent } satisfies NonNullable<
     PersistSetupConfigMutationOptions["fs"]
   >;
   return { ...fs, files, backups };

--- a/packages/config/test/unit/setup-persistence.test.ts
+++ b/packages/config/test/unit/setup-persistence.test.ts
@@ -1,0 +1,125 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  type PersistSetupConfigMutationOptions,
+  persistSetupConfigMutation,
+} from "@station/config";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const configPath = "/tmp/station-config.toml";
+const homeDir = "/tmp";
+let before: string;
+let content: string;
+
+beforeEach(async () => {
+  before = await fixture("update.before.toml");
+  content = await fixture("update.expected.toml");
+});
+
+describe("setup config persistence", () => {
+  it("creates a missing config and treats the same bytes as an idempotent retry", async () => {
+    const fs = memoryFileSystem();
+    const plan = { operation: "create" as const, path: configPath, content };
+
+    await expect(persistSetupConfigMutation(plan, { homeDir, fs })).resolves.toEqual({
+      status: "created",
+      configPath,
+    });
+    await expect(persistSetupConfigMutation(plan, { homeDir, fs })).resolves.toEqual({
+      status: "unchanged",
+      configPath,
+    });
+    expect(fs.backups).toEqual([]);
+  });
+
+  it("writes one timestamped backup and makes no second backup on retry", async () => {
+    const fs = memoryFileSystem({ [configPath]: before });
+    const plan = { operation: "update" as const, path: configPath, before, content };
+    const options = {
+      homeDir,
+      fs,
+      now: () => new Date("2026-06-08T12:00:00.000Z"),
+    };
+
+    const first = await persistSetupConfigMutation(plan, options);
+    const second = await persistSetupConfigMutation(plan, options);
+
+    expect(first).toEqual({
+      status: "updated",
+      configPath,
+      backupPath: `${configPath}.2026-06-08T12-00-00-000Z.bak`,
+    });
+    expect(second).toEqual({ status: "unchanged", configPath });
+    expect(fs.backups).toEqual([`${configPath}.2026-06-08T12-00-00-000Z.bak`]);
+    expect(fs.files.get(configPath)).toBe(content);
+  });
+
+  it("rejects stale create and update preconditions without mutation", async () => {
+    const stale = `${before}\n# concurrent change\n`;
+    const fs = memoryFileSystem({ [configPath]: stale });
+
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "create", path: configPath, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "SETUP_CONFIG_PRECONDITION_FAILED" });
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "update", path: configPath, before, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "SETUP_CONFIG_PRECONDITION_FAILED" });
+    expect(fs.files.get(configPath)).toBe(stale);
+    expect(fs.replaceText).not.toHaveBeenCalled();
+  });
+
+  it("leaves the target unchanged when backup creation fails", async () => {
+    const fs = memoryFileSystem({ [configPath]: before });
+    fs.writeBackup.mockRejectedValueOnce(new Error("backup denied"));
+
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "update", path: configPath, before, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "SETUP_CONFIG_BACKUP_FAILED" });
+    expect(fs.files.get(configPath)).toBe(before);
+    expect(fs.replaceText).not.toHaveBeenCalled();
+  });
+
+  it("leaves the target unchanged when atomic replacement fails", async () => {
+    const fs = memoryFileSystem({ [configPath]: before });
+    fs.replaceText.mockRejectedValueOnce(new Error("rename denied"));
+
+    await expect(
+      persistSetupConfigMutation(
+        { operation: "update", path: configPath, before, content },
+        { homeDir, fs },
+      ),
+    ).rejects.toMatchObject({ code: "CONFIG_WRITE_FAILED" });
+    expect(fs.files.get(configPath)).toBe(before);
+    expect(fs.backups).toHaveLength(1);
+  });
+});
+
+function memoryFileSystem(initial: Record<string, string> = {}) {
+  const files = new Map(Object.entries(initial));
+  const backups: string[] = [];
+  const readTextFile = vi.fn(async (path: string) => files.get(path));
+  const writeBackup = vi.fn(async (path: string, value: string) => {
+    backups.push(path);
+    files.set(path, value);
+  });
+  const replaceText = vi.fn(async (path: string, value: string) => {
+    files.set(path, value);
+  });
+  const fs = { readTextFile, writeBackup, replaceText } satisfies NonNullable<
+    PersistSetupConfigMutationOptions["fs"]
+  >;
+  return { ...fs, files, backups };
+}
+
+function fixture(name: string): Promise<string> {
+  return readFile(join("packages/config/test/fixtures/setup", name), "utf8");
+}

--- a/packages/setup-core/package.json
+++ b/packages/setup-core/package.json
@@ -12,5 +12,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@station/contracts": "workspace:*"
   }
 }

--- a/packages/setup-core/src/execution/performOperation.ts
+++ b/packages/setup-core/src/execution/performOperation.ts
@@ -1,0 +1,28 @@
+import type { SetupOperation } from "../model/operations.js";
+import type { SetupOperationOutcome, SetupOperationPorts } from "../ports.js";
+
+export async function performSetupOperation(
+  operation: SetupOperation,
+  ports: SetupOperationPorts,
+): Promise<SetupOperationOutcome> {
+  switch (operation.kind) {
+    case "write-config":
+      return ports.config(operation);
+    case "activate-observer-config":
+      return ports.observer(operation);
+    case "prepare-harness-tracking":
+      return ports.harnessTracking(operation);
+    case "prepare-worktrunk-tracking":
+    case "configure-worktrunk-shell":
+      return ports.worktrunk(operation);
+    case "configure-tmux-popup":
+      return ports.tmux(operation);
+    case "install-tool":
+    case "install-harness":
+    case "install-homebrew":
+    case "install-xcode-command-line-tools":
+      return ports.packages(operation);
+    case "link-launchers":
+      return ports.launchers(operation);
+  }
+}

--- a/packages/setup-core/src/index.ts
+++ b/packages/setup-core/src/index.ts
@@ -1,3 +1,4 @@
+export { performSetupOperation } from "./execution/performOperation.js";
 export {
   type HarnessSelectionFacts,
   type HarnessSelectionResolution,
@@ -22,3 +23,17 @@ export { type DeriveSetupResultInput, deriveSetupResult } from "./policy/deriveS
 export { planSetup } from "./policy/planSetup.js";
 export { resolveHarnessSelection } from "./policy/resolveHarnessSelection.js";
 export { selectHarnessTrackingRepairTargets } from "./policy/selectRepairTargets.js";
+export type {
+  SetupConfigMutationPort,
+  SetupHarnessTrackingPort,
+  SetupLauncherLinkPort,
+  SetupObserverActivationPort,
+  SetupOperationCommit,
+  SetupOperationExecutor,
+  SetupOperationOutcome,
+  SetupOperationPorts,
+  SetupPackageInstallationPort,
+  SetupPackageTarget,
+  SetupTmuxConfigurationPort,
+  SetupWorktrunkIntegrationPort,
+} from "./ports.js";

--- a/packages/setup-core/src/model/operations.ts
+++ b/packages/setup-core/src/model/operations.ts
@@ -9,6 +9,25 @@ export type SetupOperation =
       readonly tool: SetupToolId;
     }
   | {
+      readonly id: `install-harness:${SupportedHarnessId}`;
+      readonly kind: "install-harness";
+      readonly tier: "required";
+      readonly selected: boolean;
+      readonly harnessId: SupportedHarnessId;
+    }
+  | {
+      readonly id: "install:homebrew";
+      readonly kind: "install-homebrew";
+      readonly tier: "required";
+      readonly selected: boolean;
+    }
+  | {
+      readonly id: "install:xcode-command-line-tools";
+      readonly kind: "install-xcode-command-line-tools";
+      readonly tier: "required";
+      readonly selected: boolean;
+    }
+  | {
       readonly id: "link-station-launchers";
       readonly kind: "link-launchers";
       readonly tier: "recommended";
@@ -46,4 +65,14 @@ export type SetupOperation =
       readonly tier: "required";
       readonly selected: true;
       readonly change: "create" | "update";
+      readonly defaultHarnessId: SupportedHarnessId;
+      readonly harnessIds: readonly SupportedHarnessId[];
+      readonly trackingHarnessIds: readonly SupportedHarnessId[];
+      readonly installWorktrunkTracking: boolean;
+    }
+  | {
+      readonly id: "activate-observer-config";
+      readonly kind: "activate-observer-config";
+      readonly tier: "required";
+      readonly selected: true;
     };

--- a/packages/setup-core/src/policy/planSetup.ts
+++ b/packages/setup-core/src/policy/planSetup.ts
@@ -263,12 +263,28 @@ function deriveOperations(
     selection.requiredHarnessIds.some((harnessId) => harnessAvailable(facts, harnessId)) &&
     (facts.config.write === "create" || facts.config.write === "update")
   ) {
+    const trackingHarnessIds = selection.requiredHarnessIds.filter((harnessId) =>
+      facts.harnessTracking.some(
+        (tracking) =>
+          tracking.harnessId === harnessId && tracking.assessment.state !== "not-applicable",
+      ),
+    );
     operations.push({
       id: "write-config",
       kind: "write-config",
       tier: "required",
       selected: true,
       change: facts.config.write,
+      defaultHarnessId: selection.defaultHarness,
+      harnessIds: selection.requiredHarnessIds,
+      trackingHarnessIds,
+      installWorktrunkTracking: intent.installWorktrunkHooks,
+    });
+    operations.push({
+      id: "activate-observer-config",
+      kind: "activate-observer-config",
+      tier: "required",
+      selected: true,
     });
   }
   return operations;

--- a/packages/setup-core/src/ports.ts
+++ b/packages/setup-core/src/ports.ts
@@ -1,0 +1,144 @@
+import type { SafeError } from "@station/contracts";
+import type { SetupToolId, SupportedHarnessId } from "./model/facts.js";
+import type { SetupOperation } from "./model/operations.js";
+
+export type SetupPackageTarget =
+  | { readonly kind: "tool"; readonly id: SetupToolId }
+  | { readonly kind: "harness"; readonly id: SupportedHarnessId }
+  | {
+      readonly kind: "bootstrap";
+      readonly id: "homebrew" | "xcode-command-line-tools";
+    };
+
+export type SetupOperationCommit =
+  | {
+      readonly kind: "config";
+      readonly configPath: string;
+      readonly change: "created" | "updated" | "unchanged";
+      readonly backupPath?: string;
+    }
+  | {
+      readonly kind: "observer-activation";
+      readonly configPath: string;
+    }
+  | {
+      readonly kind: "package-installer";
+      readonly target: SetupPackageTarget;
+    }
+  | {
+      readonly kind: "provider-tracking";
+      readonly provider: "worktrunk" | SupportedHarnessId;
+      readonly changed: boolean;
+      readonly backupPaths?: readonly string[];
+    }
+  | { readonly kind: "launcher-link" }
+  | { readonly kind: "worktrunk-shell" }
+  | {
+      readonly kind: "tmux-popup";
+      readonly scope: "persisted" | "live";
+      readonly changed: boolean;
+    };
+
+export type SetupOperationOutcome =
+  | {
+      readonly status: "completed";
+      readonly operationId: SetupOperation["id"];
+      readonly commit: SetupOperationCommit;
+    }
+  | {
+      readonly status: "failed";
+      readonly operationId: SetupOperation["id"];
+      readonly error: SafeError;
+    };
+
+/**
+ * DRIVEN PORT
+ *
+ * Commits the desired Station setup configuration without exposing its representation to setup policy.
+ */
+export type SetupConfigMutationPort = (
+  operation: Extract<SetupOperation, { kind: "write-config" }>,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Activates a committed setup configuration and confirms Observer health.
+ */
+export type SetupObserverActivationPort = (
+  operation: Extract<SetupOperation, { kind: "activate-observer-config" }>,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Prepares one selected harness's Station-owned tracking artifacts.
+ */
+export type SetupHarnessTrackingPort = (
+  operation: Extract<SetupOperation, { kind: "prepare-harness-tracking" }>,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Applies Worktrunk tracking or shell integration requested by setup.
+ */
+export type SetupWorktrunkIntegrationPort = (
+  operation: Extract<
+    SetupOperation,
+    { kind: "prepare-worktrunk-tracking" | "configure-worktrunk-shell" }
+  >,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Persists or live-loads the selected tmux popup configuration.
+ */
+export type SetupTmuxConfigurationPort = (
+  operation: Extract<SetupOperation, { kind: "configure-tmux-popup" }>,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Runs the installer selected for a setup package target.
+ */
+export type SetupPackageInstallationPort = (
+  operation: Extract<
+    SetupOperation,
+    {
+      kind:
+        | "install-tool"
+        | "install-harness"
+        | "install-homebrew"
+        | "install-xcode-command-line-tools";
+    }
+  >,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Links the Station launchers required for bare terminal commands.
+ */
+export type SetupLauncherLinkPort = (
+  operation: Extract<SetupOperation, { kind: "link-launchers" }>,
+) => Promise<SetupOperationOutcome>;
+
+/**
+ * DRIVEN PORT
+ *
+ * Executes one semantic setup operation through its assigned outward capability.
+ */
+export type SetupOperationExecutor = (operation: SetupOperation) => Promise<SetupOperationOutcome>;
+
+export type SetupOperationPorts = {
+  readonly config: SetupConfigMutationPort;
+  readonly observer: SetupObserverActivationPort;
+  readonly harnessTracking: SetupHarnessTrackingPort;
+  readonly worktrunk: SetupWorktrunkIntegrationPort;
+  readonly tmux: SetupTmuxConfigurationPort;
+  readonly packages: SetupPackageInstallationPort;
+  readonly launchers: SetupLauncherLinkPort;
+};

--- a/packages/setup-core/src/ports.ts
+++ b/packages/setup-core/src/ports.ts
@@ -37,6 +37,7 @@ export type SetupOperationCommit =
       readonly kind: "tmux-popup";
       readonly scope: "persisted" | "live";
       readonly changed: boolean;
+      readonly backupPath?: string;
     };
 
 export type SetupOperationOutcome =

--- a/packages/setup-core/test/unit/perform-operation.test.ts
+++ b/packages/setup-core/test/unit/perform-operation.test.ts
@@ -1,0 +1,136 @@
+import type {
+  SetupOperation,
+  SetupOperationOutcome,
+  SetupOperationPorts,
+} from "@station/setup-core";
+import { performSetupOperation } from "@station/setup-core";
+import { describe, expect, it, vi } from "vitest";
+
+const completed = (operation: SetupOperation): SetupOperationOutcome => ({
+  status: "completed",
+  operationId: operation.id,
+  commit: { kind: "launcher-link" },
+});
+
+function ports() {
+  const config = vi.fn(async (operation) => completed(operation));
+  const observer = vi.fn(async (operation) => completed(operation));
+  const harnessTracking = vi.fn(async (operation) => completed(operation));
+  const worktrunk = vi.fn(async (operation) => completed(operation));
+  const tmux = vi.fn(async (operation) => completed(operation));
+  const packages = vi.fn(async (operation) => completed(operation));
+  const launchers = vi.fn(async (operation) => completed(operation));
+  return {
+    value: {
+      config,
+      observer,
+      harnessTracking,
+      worktrunk,
+      tmux,
+      packages,
+      launchers,
+    } satisfies SetupOperationPorts,
+    spies: { config, observer, harnessTracking, worktrunk, tmux, packages, launchers },
+  };
+}
+
+describe("performSetupOperation", () => {
+  it.each([
+    [writeConfigOperation(), "config"],
+    [operation("activate-observer-config"), "observer"],
+    [operation("prepare-harness-tracking"), "harnessTracking"],
+    [operation("prepare-worktrunk-tracking"), "worktrunk"],
+    [operation("configure-worktrunk-shell"), "worktrunk"],
+    [operation("configure-tmux-popup"), "tmux"],
+    [operation("install-tool"), "packages"],
+    [operation("install-harness"), "packages"],
+    [operation("install-homebrew"), "packages"],
+    [operation("install-xcode-command-line-tools"), "packages"],
+    [operation("link-launchers"), "launchers"],
+  ] as const)("dispatches %s through its driven port", async (setupOperation, port) => {
+    const setupPorts = ports();
+
+    await expect(performSetupOperation(setupOperation, setupPorts.value)).resolves.toMatchObject({
+      status: "completed",
+      operationId: setupOperation.id,
+    });
+
+    expect(setupPorts.spies[port]).toHaveBeenCalledExactlyOnceWith(setupOperation);
+    expect(Object.values(setupPorts.spies).filter((spy) => spy.mock.calls.length > 0)).toHaveLength(
+      1,
+    );
+  });
+});
+
+function writeConfigOperation(): Extract<SetupOperation, { kind: "write-config" }> {
+  return {
+    id: "write-config",
+    kind: "write-config",
+    tier: "required",
+    selected: true,
+    change: "create",
+    defaultHarnessId: "codex",
+    harnessIds: ["codex"],
+    trackingHarnessIds: ["codex"],
+    installWorktrunkTracking: false,
+  };
+}
+
+function operation(kind: Exclude<SetupOperation["kind"], "write-config">): SetupOperation {
+  switch (kind) {
+    case "activate-observer-config":
+      return { id: kind, kind, tier: "required", selected: true };
+    case "prepare-harness-tracking":
+      return {
+        id: "prepare-harness-tracking:codex",
+        kind,
+        tier: "required",
+        selected: true,
+        harnessId: "codex",
+      };
+    case "prepare-worktrunk-tracking":
+      return { id: kind, kind, tier: "recommended", selected: true };
+    case "configure-worktrunk-shell":
+      return { id: kind, kind, tier: "recommended", selected: false };
+    case "configure-tmux-popup":
+      return {
+        id: "persist-tmux-popup",
+        kind,
+        tier: "recommended",
+        selected: false,
+        scope: "persisted",
+      };
+    case "install-tool":
+      return {
+        id: "install:tmux",
+        kind,
+        tier: "required",
+        selected: true,
+        tool: "tmux",
+      };
+    case "install-harness":
+      return {
+        id: "install-harness:codex",
+        kind,
+        tier: "required",
+        selected: true,
+        harnessId: "codex",
+      };
+    case "install-homebrew":
+      return { id: "install:homebrew", kind, tier: "required", selected: true };
+    case "install-xcode-command-line-tools":
+      return {
+        id: "install:xcode-command-line-tools",
+        kind,
+        tier: "required",
+        selected: true,
+      };
+    case "link-launchers":
+      return {
+        id: "link-station-launchers",
+        kind,
+        tier: "recommended",
+        selected: false,
+      };
+  }
+}

--- a/packages/setup-core/test/unit/plan-setup.test.ts
+++ b/packages/setup-core/test/unit/plan-setup.test.ts
@@ -205,6 +205,16 @@ describe("planSetup", () => {
       tier: "required",
       selected: true,
       change,
+      defaultHarnessId: "codex",
+      harnessIds: ["codex"],
+      trackingHarnessIds: ["codex"],
+      installWorktrunkTracking: false,
+    });
+    expect(plan.operations).toContainEqual({
+      id: "activate-observer-config",
+      kind: "activate-observer-config",
+      tier: "required",
+      selected: true,
     });
   });
 

--- a/packages/setup-core/tsconfig.json
+++ b/packages/setup-core/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "paths": {
+      "@station/contracts": ["../../packages/contracts/dist/index.d.ts"]
+    }
   },
   "include": ["src/**/*.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,7 +385,11 @@ importers:
         specifier: ^3.21.2
         version: 3.21.2
 
-  packages/setup-core: {}
+  packages/setup-core:
+    dependencies:
+      '@station/contracts':
+        specifier: workspace:*
+        version: link:../contracts
 
   packages/station-host:
     dependencies:

--- a/tests/diagnostics/setup-boundaries.test.ts
+++ b/tests/diagnostics/setup-boundaries.test.ts
@@ -23,13 +23,25 @@ const policyNames = [
   "planSetup",
   "deriveSetupResult",
 ] as const;
+const drivenPortNames = [
+  "SetupConfigMutationPort",
+  "SetupObserverActivationPort",
+  "SetupHarnessTrackingPort",
+  "SetupWorktrunkIntegrationPort",
+  "SetupTmuxConfigurationPort",
+  "SetupPackageInstallationPort",
+  "SetupLauncherLinkPort",
+  "SetupOperationExecutor",
+] as const;
 
 describe("setup core boundaries", () => {
-  it("has no runtime, CLI, provider, presentation, or package dependency", async () => {
+  it("has no runtime, CLI, provider, or presentation dependency", async () => {
     const packageJson = JSON.parse(await readFile("packages/setup-core/package.json", "utf8")) as {
       dependencies?: Record<string, string>;
     };
-    expect(packageJson.dependencies ?? {}).toEqual({});
+    expect(packageJson.dependencies ?? {}).toEqual({
+      "@station/contracts": "workspace:*",
+    });
 
     for (const file of await sourceFiles(sourceRoot)) {
       const source = await readFile(file, "utf8");
@@ -39,6 +51,12 @@ describe("setup core boundaries", () => {
       for (const specifier of importSpecifiers(source)) {
         expect(nodeBuiltins.has(specifier), `${displayPath}: ${specifier}`).toBe(false);
         expect(forbiddenPackage.test(specifier), `${displayPath}: ${specifier}`).toBe(false);
+        if (specifier === "@station/contracts") {
+          expect(source, `${displayPath}: contracts imports must be type-only`).toMatch(
+            /import\s+type\s+\{[^}]*\}\s+from\s+["']@station\/contracts["']/s,
+          );
+          continue;
+        }
         if (!specifier.startsWith(".")) continue;
         const target = resolve(dirname(file), specifier);
         expect(target === sourceRoot || target.startsWith(`${sourceRoot}/`), displayPath).toBe(
@@ -48,8 +66,9 @@ describe("setup core boundaries", () => {
     }
   });
 
-  it("marks exactly the six public policies and no data declarations or barrels", async () => {
-    const declarations: string[] = [];
+  it("marks exactly the six policies and eight driven ports", async () => {
+    const policies: string[] = [];
+    const drivenPorts: string[] = [];
     let markerCount = 0;
     for (const file of await sourceFiles(sourceRoot)) {
       const source = await readFile(file, "utf8");
@@ -61,12 +80,19 @@ describe("setup core boundaries", () => {
         /\/\*\*\s*\n\s*\* POLICY\s*\n\s*\*\s*\n(?:\s*\* .+\n)+?\s*\*\/\s*\nexport function (\w+)/g;
       for (const match of source.matchAll(policyPattern)) {
         const name = match[1];
-        if (name !== undefined) declarations.push(name);
+        if (name !== undefined) policies.push(name);
+      }
+      const portPattern =
+        /\/\*\*\s*\n\s*\* DRIVEN PORT\s*\n\s*\*\s*\n(?:\s*\* .+\n)+?\s*\*\/\s*\nexport type (\w+)/g;
+      for (const match of source.matchAll(portPattern)) {
+        const name = match[1];
+        if (name !== undefined) drivenPorts.push(name);
       }
     }
 
-    expect(markerCount).toBe(6);
-    expect(declarations.sort()).toEqual([...policyNames].sort());
+    expect(markerCount).toBe(14);
+    expect(policies.sort()).toEqual([...policyNames].sort());
+    expect(drivenPorts.sort()).toEqual([...drivenPortNames].sort());
   });
 });
 

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -49,11 +49,10 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Link STATION launchers globally?");
       expect(result.stdout).toContain("Install Worktrunk lifecycle hooks?");
       expect(result.stdout).toContain("Install Codex tracking?");
-      expect(result.stdout).toContain(`Applying: Write STATION config (${fixture.configPath})`);
+      expect(result.stdout).toContain("Applying: Write STATION config");
+      expect(result.stdout).not.toContain(`Applying: Write STATION config (${fixture.configPath})`);
       expect(result.stdout).toContain("Completed: Write STATION config");
-      expect(result.stdout).toContain(
-        `Running: ${join(fixture.bin, "wt")} -y config shell install zsh`,
-      );
+      expect(result.stdout).toContain("Applying: Install Worktrunk shell integration");
       expect(result.stdout).toContain("fake shell integration installed");
       expect(result.stdout).toContain("Completed: Install Worktrunk shell integration");
       expect(result.stdout).toContain("Core setup complete.");
@@ -194,6 +193,14 @@ describe("setup guided feedback e2e", () => {
       expect(result.stdout).toContain("Install OpenCode tracking?");
       expect(result.stdout).toContain("Completed: Install Codex tracking");
       expect(result.stdout).toContain("Completed: Install OpenCode tracking");
+      expect(result.stdout).not.toMatch(
+        /"(?:provider|commands|before|after|rawResult|serializedResult)"\s*:/,
+      );
+      expect(
+        result.stdout
+          .split("\n")
+          .some((line) => line.trimStart().startsWith("{") || line.trimStart().startsWith("[")),
+      ).toBe(false);
       const config = await readFile(fixture.configPath, "utf8");
       expect(config).toContain('harness = "codex"');
       expect(config).toContain("[harness.codex]");
@@ -369,13 +376,10 @@ describe("setup guided feedback e2e", () => {
 
         expect(first.exitCode).toBe(0);
         expect(second.exitCode).toBe(0);
-        expect(first.stdout).toContain(
-          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-        );
+        expect(first.stdout).toContain("Applying: Install Worktrunk shell integration");
+        expect(first.stdout).toContain("fake shell integration installed");
         expect(second.stdout).not.toContain("Install Worktrunk shell integration?");
-        expect(second.stdout).not.toContain(
-          `Running: ${join(fixture.bin, "wt")} -y config shell install ${shell}`,
-        );
+        expect(second.stdout).not.toContain("Applying: Install Worktrunk shell integration");
         const check = await runStation(
           ["--config", fixture.configPath, "setup", "check", "--json"],
           {

--- a/tests/e2e/setup-guided-feedback.test.ts
+++ b/tests/e2e/setup-guided-feedback.test.ts
@@ -469,6 +469,9 @@ describe("setup guided feedback e2e", () => {
 
   it("runs the persisted absolute popup launcher in a fresh minimal-PATH tmux context", async () => {
     const fixture = await createFixture({ harness: "codex", launchers: "complex" });
+    const tmuxConfigPath = join(fixture.home, ".tmux.conf");
+    const originalTmuxConfig = "# user tmux config\n";
+    await writeFile(tmuxConfigPath, originalTmuxConfig, "utf8");
     try {
       const result = await runStation(["--config", fixture.configPath, "setup"], {
         cwd: fixture.repo,
@@ -487,9 +490,16 @@ describe("setup guided feedback e2e", () => {
         `Direct fallback: ${join(process.cwd(), "bin", "stn")} popup`,
       );
 
-      const tmuxConfigPath = join(fixture.home, ".tmux.conf");
       const tmuxConfig = await readFile(tmuxConfigPath, "utf8");
+      expect(tmuxConfig).toContain(originalTmuxConfig.trim());
       expect(tmuxConfig).toContain("bind-key Space run-shell -b");
+      const tmuxBackups = (await readdir(fixture.home)).filter(
+        (name) => name.startsWith(".tmux.conf.") && name.endsWith(".bak"),
+      );
+      expect(tmuxBackups).toHaveLength(1);
+      await expect(readFile(join(fixture.home, tmuxBackups[0] ?? ""), "utf8")).resolves.toBe(
+        originalTmuxConfig,
+      );
       expect(tmuxConfig).not.toContain("STATION_FOCUS_CLIENT_ID=#{q:client_name} stn-tmux-popup");
 
       const freshTmux = spawnSync(


### PR DESCRIPTION
## What this fixes

Station setup projected semantic plans into compatibility actions, then still trusted those actions' serialized commands and data as execution authority. That kept setup config mutation in the CLI, launched nested `stn hooks` processes, and leaked provider-native JSON into guided setup output. This change gives setup effects explicit typed boundaries while preserving existing plan and direct-hook contracts.

Closes #353.

## What changed

- Route semantic setup operations through eight typed `@station/setup-core` driven ports with explicit success, failure, and sanitized commit evidence.
- Implement CLI adapters for config mutation, Observer activation, package installation, launcher linking, tmux, Worktrunk, and in-process harness tracking; independent provider failures still allow later providers to run.
- Move setup config rendering, source-preserving edits, candidate validation, stale-plan preconditions, timestamped backups, and atomic persistence into `@station/config`.
- Keep compatibility actions as presentation output only when a semantic binding exists, including their existing commands, data, ordering, and dry-run behavior.
- Preserve post-effect readiness re-probes and direct `stn hooks` JSON output while removing provider-native fields from guided setup output.
- Document the resulting setup/config ownership boundaries and regenerate the Observer architecture manifest.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:contracts`
- `pnpm test:integration`
- `pnpm test:diagnostics`
- `pnpm test:agent:scripted`
- `pnpm test:e2e:setup`
- `pnpm test:e2e:setup:guided:all-shells`
- `pnpm smoke:install`
- Provider hook command integration suites for Claude, Codex, Cursor, OpenCode, Worktrunk, and ownership transfer
- Baseline note: `pnpm test:e2e:observer` has the same two `OBSERVER_HANDOFF_REFUSED` build-handoff failures on `origin/main` and this branch; the other 17 scenarios pass.

## User-visible behavior

Guided setup now reports concise `Applying` / `Completed` progress for semantic operations instead of printing nested provider JSON. `stn setup plan` compatibility fields and direct `stn hooks` JSON behavior remain unchanged.
