### PR TITLE
feat(tui): focus empty-project Add Session actions

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -243,28 +243,31 @@ segments dispatch one `dashboard.projectHeader.activate` action, so a click firs
 segment and then follows the same activation path as focused Enter. Wheel events over child rows use
 dashboard scrolling, and active modal surfaces intercept background clicks and scrolling.
 
-Dashboard focus follows rendered order through each project header and its visible session rows.
-Entering a header vertically always selects `primary`; Left/Right then moves, without wrapping,
-through `primary` → `shell` → `quickSession` → `defaultAgent`. Up/Down leaves any header segment
-immediately, and Left/Right on a session row is inert. Remove, rename, and fork row choosers retain
-a separate session-only traversal, as do slot keys and next-needs-me. Gaps, empty placeholders, and
-optimistic create rows remain non-focusable.
+Dashboard focus follows rendered order through each project header, its visible session rows, or the
+stable Add Session action rendered when that project is empty. Entering a header vertically always
+selects `primary`; Left/Right then moves, without wrapping, through `primary` → `shell` →
+`quickSession` → `defaultAgent`. Up/Down leaves any header segment immediately, and Left/Right on a
+session row or empty-project action is inert. Remove, rename, and fork row choosers retain a separate
+session-only traversal, as do slot keys and next-needs-me. `N` continues to open the session flow
+without changing dashboard focus. Gaps and optimistic create rows remain non-focusable.
 
-Only the focused header segment receives the stronger bounded fill from
-`STATION_COLORS.projectHeaderFocusBackground`: primary covers the rendered
+Focused compact controls use the stronger bounded fill from
+`STATION_COLORS.compactFocusBackground`. A project header's primary segment covers the rendered
 disclosure/name/summary text without painting flexible trailing whitespace, while each trailing
-control owns exactly its label cells and separator spaces remain inert. Wide and compact
-labels preserve the same control identity. Hover stays component-local, temporarily supersedes the
-focus background, and reveals persistent keyboard focus again when the pointer leaves; no focus
-glyph is added.
+control owns exactly its label cells and separator spaces remain inert. An empty project's fill and
+pointer target cover only `[ + add session ]`; its explanatory text and surrounding whitespace
+remain inert and unpainted. Wide and compact labels preserve the same control identity. Hover stays
+component-local, temporarily supersedes the focus background, and reveals persistent keyboard focus
+again when the pointer leaves; no focus glyph is added.
 
-Collapse keeps primary focus and clamps scrolling. Snapshot replacement and accepted search changes
-preserve stable focus identity, otherwise choose the next focusable item at the old position before
-the preceding item; resize preserves identity and scrolls it into view. The Default Agent picker
-retains its header focus beneath the screen, so Escape, click-away, unchanged selection, and a
-successful change return to `defaultAgent`; project removal while open uses the same deterministic
-focus fallback. The dashboard footer describes Enter as `activate` because it may activate either a
-session row or a project-header control.
+Collapse moves focus from a hidden session or empty-project action to that project's header
+`primary` and clamps scrolling; expanding and moving Down reaches the first visible child again.
+Snapshot replacement and accepted search changes preserve stable focus identity, otherwise choose
+the next focusable item at the old position before the preceding item; resize preserves identity
+and scrolls it into view. The Default Agent picker retains its header focus beneath the screen, so
+Escape, click-away, unchanged selection, and a successful change return to `defaultAgent`; project
+removal while open uses the same deterministic focus fallback. The dashboard footer describes Enter
+as `activate` because it may activate a session row, project-header control, or empty-project action.
 
 Bounded screens use one active-screen overlay layer. Dashboard-core exposes the narrow
 `TuiScreenBehavior` contract, and the owning screen module supplies its safe `clickAway`
@@ -278,12 +281,15 @@ and hover keep selecting; search and the dashboard likewise remain unchanged. In
 the inner screen receives the click before the outer popup backdrop, so one click closes only the
 topmost safe surface.
 
-Native and standalone rendering expose the same project actions. Quick-session
-intent resolves the same project and default harness before terminal-specific
-execution: native Station hosts the session in a Station pane, while the
-standalone dashboard dispatches the configured terminal default. The
-empty-project button uses that same quick-session intent, and the agent-picker
-uses the shared project-default screen transition. Link cells use the same
+Native and standalone rendering expose the same project actions. Header Quick Session and the
+empty-project button emit the same core quick-session intent, then resolve availability at their
+terminal-specific acceptance boundary: native Station hosts the session in a Station pane, while the
+standalone dashboard dispatches the configured terminal default. Pointer clicks use
+`dashboard.emptyProject.activate`; focused Enter routes through the same core activation helper.
+Blocked activation keeps Add Session focused while showing the existing error; stale targets are
+inert. Successful activation transfers focus to that project's header `quickSession` segment before
+an optimistic create row replaces the empty row. The agent-picker uses the shared
+project-default screen transition. Link cells use the same
 validated platform opener. The project-header shell control delegates only its
 terminal effect: native Station opens or focuses a Station pane, while a tmux
 popup sends a strict renderer-control request to its CLI parent. The tmux adapter

--- a/packages/dashboard-core/src/state/actions.ts
+++ b/packages/dashboard-core/src/state/actions.ts
@@ -1,7 +1,10 @@
 import type { ProjectId } from "@station/contracts";
 import type { AddProjectActionId } from "../flows/addProject/actions.js";
 import type { NewSessionActionId } from "../flows/newSession.js";
-import { activateProjectHeaderControl } from "./projectHeaderActions.js";
+import {
+  activateEmptyProjectAction,
+  activateProjectHeaderControl,
+} from "./projectHeaderActions.js";
 import { handleAddProjectAction } from "./screens/addProjectScreen.js";
 import { handleFirstProjectAddAction } from "./screens/dashboard.js";
 import { handleNewSessionAction } from "./screens/newSession.js";
@@ -17,6 +20,7 @@ export type TuiSemanticAction =
       projectId: ProjectId;
       actionId: ProjectHeaderControl;
     }
+  | { type: "dashboard.emptyProject.activate"; projectId: ProjectId }
   | { type: "addProject.activate"; actionId: AddProjectActionId }
   | { type: "newSession.activate"; actionId: NewSessionActionId }
   | { type: "renameSession.submit" };
@@ -32,6 +36,8 @@ export function handleTuiAction(
       return handleFirstProjectAddAction(state, context);
     case "dashboard.projectHeader.activate":
       return activateProjectHeaderControl(state, action.projectId, action.actionId);
+    case "dashboard.emptyProject.activate":
+      return activateEmptyProjectAction(state, action.projectId);
     case "addProject.activate":
       return handleAddProjectAction(state, action.actionId);
     case "newSession.activate":

--- a/packages/dashboard-core/src/state/dashboardFocus.ts
+++ b/packages/dashboard-core/src/state/dashboardFocus.ts
@@ -12,7 +12,8 @@ import type { DashboardFocus, ProjectHeaderControl, TuiState } from "./types.js"
 
 type SessionItem = Extract<DashboardViewportItem, { type: "session" }>;
 type ProjectHeaderItem = Extract<DashboardViewportItem, { type: "projectHeader" }>;
-type FocusableItem = SessionItem | ProjectHeaderItem;
+type EmptyProjectItem = Extract<DashboardViewportItem, { type: "emptyProject" }>;
+type FocusableItem = SessionItem | ProjectHeaderItem | EmptyProjectItem;
 
 const PROJECT_HEADER_CONTROLS: readonly ProjectHeaderControl[] = [
   "primary",
@@ -51,6 +52,20 @@ export function focusDashboardProjectHeader(
     : focusItem(state, items, index, { kind: "projectHeader", projectId, control });
 }
 
+/** Focuses the stable action rendered for a currently empty project. */
+export function focusDashboardEmptyProjectAction(state: TuiState, projectId: ProjectId): TuiState {
+  if (state.snapshot === undefined) {
+    return state;
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  const index = items.findIndex(
+    (item) => item.type === "emptyProject" && item.project.id === projectId,
+  );
+  return index === -1
+    ? state
+    : focusItem(state, items, index, { kind: "emptyProjectAction", projectId });
+}
+
 /** Removes transient dashboard focus without disturbing other view state. */
 export function clearDashboardFocus(state: TuiState): TuiState {
   const cleared = { ...state };
@@ -58,8 +73,8 @@ export function clearDashboardFocus(state: TuiState): TuiState {
   return cleared;
 }
 
-// Vertical dashboard traversal includes project headers, while row chooser
-// traversal deliberately uses moveDashboardSessionFocus to remain session-only.
+// Vertical dashboard traversal includes project headers and empty-project actions, while row
+// chooser traversal deliberately uses moveDashboardSessionFocus to remain session-only.
 export function moveDashboardFocus(state: TuiState, delta: -1 | 1): TuiState {
   return moveFocus(state, delta, "dashboard");
 }
@@ -117,6 +132,18 @@ export function focusedProjectHeaderControl(
 ): Extract<DashboardFocus, { kind: "projectHeader" }> | undefined {
   const focus = state.dashboardFocus;
   if (focus?.kind !== "projectHeader" || state.snapshot === undefined) {
+    return undefined;
+  }
+  const items = selectDashboardItems(state.snapshot, state);
+  return focusedItemIndex(items, focus) === undefined ? undefined : focus;
+}
+
+/** Returns the focused empty-project action only while its row remains rendered. */
+export function focusedEmptyProjectAction(
+  state: TuiState,
+): Extract<DashboardFocus, { kind: "emptyProjectAction" }> | undefined {
+  const focus = state.dashboardFocus;
+  if (focus?.kind !== "emptyProjectAction" || state.snapshot === undefined) {
     return undefined;
   }
   const items = selectDashboardItems(state.snapshot, state);
@@ -209,7 +236,8 @@ function focusableIndexes(
   mode: "dashboard" | "session",
 ): number[] {
   return items.flatMap((item, index) =>
-    item.type === "session" || (mode === "dashboard" && item.type === "projectHeader")
+    item.type === "session" ||
+    (mode === "dashboard" && (item.type === "projectHeader" || item.type === "emptyProject"))
       ? [index]
       : [],
   );
@@ -232,6 +260,8 @@ function focusMatchesItem(focus: DashboardFocus, item: DashboardViewportItem): b
       return item.type === "session" && item.row.id === focus.sessionId;
     case "projectHeader":
       return item.type === "projectHeader" && item.project.id === focus.projectId;
+    case "emptyProjectAction":
+      return item.type === "emptyProject" && item.project.id === focus.projectId;
   }
 }
 
@@ -271,7 +301,10 @@ function focusItem(
   focus?: DashboardFocus,
 ): TuiState {
   const item = items[index];
-  if (item === undefined || (item.type !== "session" && item.type !== "projectHeader")) {
+  if (
+    item === undefined ||
+    (item.type !== "session" && item.type !== "projectHeader" && item.type !== "emptyProject")
+  ) {
     return state;
   }
   const { bodyRows, offset } = viewportWindow(state, items.length);
@@ -289,9 +322,14 @@ function focusItem(
 }
 
 function focusForItem(item: FocusableItem): DashboardFocus {
-  return item.type === "session"
-    ? { kind: "session", sessionId: item.row.id }
-    : { kind: "projectHeader", projectId: item.project.id, control: "primary" };
+  switch (item.type) {
+    case "session":
+      return { kind: "session", sessionId: item.row.id };
+    case "projectHeader":
+      return { kind: "projectHeader", projectId: item.project.id, control: "primary" };
+    case "emptyProject":
+      return { kind: "emptyProjectAction", projectId: item.project.id };
+  }
 }
 
 function withClampedScroll(state: TuiState, itemCount: number): TuiState {

--- a/packages/dashboard-core/src/state/projectHeaderActions.ts
+++ b/packages/dashboard-core/src/state/projectHeaderActions.ts
@@ -1,6 +1,10 @@
 import type { ProjectId } from "@station/contracts";
 import { selectDashboardItems } from "../selectors/dashboardViewport.js";
-import { focusDashboardProjectHeader, reconcileDashboardFocus } from "./dashboardFocus.js";
+import {
+  focusDashboardEmptyProjectAction,
+  focusDashboardProjectHeader,
+  reconcileDashboardFocus,
+} from "./dashboardFocus.js";
 import { openProjectDefaultAgentPicker } from "./screens/projectDefaultAgent.js";
 import type { TuiTransition } from "./transition.js";
 import type { ProjectHeaderControl, TuiState } from "./types.js";
@@ -34,6 +38,20 @@ export function activateProjectHeaderControl(
 }
 
 /**
+ * Focuses the rendered empty-project action and emits its Quick Session intent.
+ * Renderer consumers alone resolve project availability and move accepted focus.
+ */
+export function activateEmptyProjectAction(state: TuiState, projectId: ProjectId): TuiTransition {
+  if (state.screen.name !== "dashboard" || !hasVisibleEmptyProject(state, projectId)) {
+    return { state };
+  }
+  return {
+    state: focusDashboardEmptyProjectAction(state, projectId),
+    controlIntent: { type: "quickSession.create", projectId },
+  };
+}
+
+/**
  * Toggles one current project and normalizes focus/scroll for both header
  * activation and the existing C project picker.
  */
@@ -49,21 +67,35 @@ export function toggleDashboardProjectCollapsed(state: TuiState, projectId: Proj
   }
   const next: TuiState = { ...state, collapsedProjectIds };
   const focus = state.dashboardFocus;
-  const focusedSessionProjectId =
+  const focusedChildProjectId =
     focus?.kind === "session"
       ? state.snapshot?.sessions.find((session) => session.id === focus.sessionId)?.projectId
-      : undefined;
-  if (collapsing && focusedSessionProjectId === project.id) {
+      : focus?.kind === "emptyProjectAction"
+        ? focus.projectId
+        : undefined;
+  if (collapsing && focusedChildProjectId === project.id) {
     return focusDashboardProjectHeader(next, project.id, "primary");
   }
   return reconcileDashboardFocus(state, next);
 }
 
 function hasVisibleProjectHeader(state: TuiState, projectId: ProjectId): boolean {
+  return hasVisibleItem(state, projectId, "projectHeader");
+}
+
+function hasVisibleEmptyProject(state: TuiState, projectId: ProjectId): boolean {
+  return hasVisibleItem(state, projectId, "emptyProject");
+}
+
+function hasVisibleItem(
+  state: TuiState,
+  projectId: ProjectId,
+  type: "projectHeader" | "emptyProject",
+): boolean {
   return (
     state.snapshot !== undefined &&
     selectDashboardItems(state.snapshot, state).some(
-      (item) => item.type === "projectHeader" && item.project.id === projectId,
+      (item) => item.type === type && item.project.id === projectId,
     )
   );
 }

--- a/packages/dashboard-core/src/state/screens/dashboard.ts
+++ b/packages/dashboard-core/src/state/screens/dashboard.ts
@@ -4,6 +4,7 @@ import { choiceValueByKey } from "../../selectors/selectors.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
 import {
   activateFocusedDashboardRow,
+  focusedEmptyProjectAction,
   focusedProjectHeaderControl,
   focusNextNeedsMe,
   moveDashboardFocus,
@@ -12,7 +13,10 @@ import {
 import { scrollDashboard } from "../dashboardScroll.js";
 import { matchDashboardBinding, type TuiDashboardAction } from "../keymap.js";
 import type { TuiKey } from "../keys.js";
-import { activateProjectHeaderControl } from "../projectHeaderActions.js";
+import {
+  activateEmptyProjectAction,
+  activateProjectHeaderControl,
+} from "../projectHeaderActions.js";
 import { activateDashboardRow } from "../rowActivation.js";
 import { addTuiToast } from "../toasts.js";
 import type { TuiRuntimeContext, TuiTransition } from "../transition.js";
@@ -69,6 +73,10 @@ function handleDashboardAction(
     case "tui.focus.activate": {
       if (hasNoProjects(state)) {
         return handleDashboardAddProjectAction(state, context);
+      }
+      const emptyProject = focusedEmptyProjectAction(state);
+      if (emptyProject !== undefined) {
+        return activateEmptyProjectAction(state, emptyProject.projectId);
       }
       const header = focusedProjectHeaderControl(state);
       return header === undefined

--- a/packages/dashboard-core/src/state/screens/quickSession.ts
+++ b/packages/dashboard-core/src/state/screens/quickSession.ts
@@ -6,6 +6,7 @@ import {
 } from "../../flows/newSession.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
 import { buildCreateSessionCommand } from "../commandBuilders.js";
+import { focusDashboardProjectHeader } from "../dashboardFocus.js";
 import { addPendingCreateSessionRow } from "../localRows.js";
 import { addTuiToast } from "../toasts.js";
 import type { TuiTransition } from "../transition.js";
@@ -47,7 +48,10 @@ export function resolveQuickSessionIntent(
   };
 }
 
-/** Builds the immediate configured-terminal transition for a resolved quick-session intent. */
+/**
+ * Resolves standalone Quick Session availability and builds its immediate operation.
+ * Only an accepted operation moves focus to the header's Quick Session control.
+ */
 export function submitQuickSession(state: TuiState, projectId: string): TuiTransition {
   const resolution = resolveQuickSessionIntent(state, projectId);
   if (resolution.kind === "missing") return { state };
@@ -67,14 +71,17 @@ export function submitQuickSession(state: TuiState, projectId: string): TuiTrans
   }
 
   return {
-    state: addPendingCreateSessionRow(state, {
-      localId,
-      projectId: project.id,
-      title,
-      branch,
-      harnessProvider,
-      createdAt: new Date().toISOString(),
-    }),
+    state: addPendingCreateSessionRow(
+      focusDashboardProjectHeader(state, project.id, "quickSession"),
+      {
+        localId,
+        projectId: project.id,
+        title,
+        branch,
+        harnessProvider,
+        createdAt: new Date().toISOString(),
+      },
+    ),
     operations: [
       {
         type: "createSession",

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -17,10 +17,11 @@ import type { TuiSelectionState } from "./selection/types.js";
 /** Stable control identities for the four project-header action segments. */
 export type ProjectHeaderControl = "primary" | "shell" | "quickSession" | "defaultAgent";
 
-/** Renderer-neutral dashboard focus over session rows and project-header controls. */
+/** Renderer-neutral focus over session rows, project headers, and empty-project actions. */
 export type DashboardFocus =
   | { kind: "session"; sessionId: SessionId }
-  | { kind: "projectHeader"; projectId: ProjectId; control: ProjectHeaderControl };
+  | { kind: "projectHeader"; projectId: ProjectId; control: ProjectHeaderControl }
+  | { kind: "emptyProjectAction"; projectId: ProjectId };
 
 export type TuiRuntimeState = {
   persistentPopup: boolean;

--- a/packages/dashboard-core/test/unit/sourceBridge.test.ts
+++ b/packages/dashboard-core/test/unit/sourceBridge.test.ts
@@ -11,7 +11,7 @@ import {
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { createStore, type StoreApi } from "zustand/vanilla";
-import { createDashboardSnapshot } from "../fixtures/snapshots.js";
+import { createDashboardSnapshot, createZeroWorktreeSnapshot } from "../fixtures/snapshots.js";
 
 const NOW = 1_750_000_000_000;
 
@@ -85,6 +85,32 @@ describe("applySnapshotSourceState", () => {
       kind: "projectHeader",
       projectId: "api",
       control: "primary",
+    });
+  });
+
+  it("preserves or positionally reconciles empty-project focus across source snapshots", () => {
+    const snapshot = createZeroWorktreeSnapshot();
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      dashboardFocus: { kind: "emptyProjectAction", projectId: "web" },
+    });
+    const connected = { state: "connected" as const, since: NOW };
+
+    const preserved = applySnapshotSourceState(
+      initial,
+      { snapshot: { ...snapshot, generatedAt: "2026-05-20T12:01:00.000Z" }, connection: connected },
+      NOW,
+    );
+    expect(preserved.dashboardFocus).toEqual({ kind: "emptyProjectAction", projectId: "web" });
+
+    const reconciled = applySnapshotSourceState(
+      initial,
+      { snapshot: createDashboardSnapshot(), connection: connected },
+      NOW,
+    );
+    expect(reconciled.dashboardFocus).toEqual({
+      kind: "session",
+      sessionId: "ses_wt_web_working",
     });
   });
 

--- a/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
+++ b/packages/dashboard-core/test/unit/state/dashboardFocus.test.ts
@@ -4,6 +4,7 @@ import {
   clearDashboardFocus,
   createInitialTuiState,
   createTuiStore,
+  focusDashboardEmptyProjectAction,
   focusDashboardSession,
   handleTuiKey,
   replaceSnapshot,
@@ -34,6 +35,10 @@ function session(sessionId: string): DashboardFocus {
 
 function header(projectId: string, control: ProjectHeaderControl): DashboardFocus {
   return { kind: "projectHeader", projectId, control };
+}
+
+function emptyAction(projectId: string): DashboardFocus {
+  return { kind: "emptyProjectAction", projectId };
 }
 
 describe("dashboard focus", () => {
@@ -187,15 +192,135 @@ describe("dashboard focus", () => {
     expect(collapsed.dashboardFocus).toEqual(header("web", "primary"));
   });
 
-  it("keeps empty projects focusable only through their headers", () => {
-    const empty = createInitialTuiState({
+  it("walks empty-project actions between their headers in rendered order", () => {
+    let current = createInitialTuiState({
       initialSnapshot: createZeroWorktreeSnapshot(),
       terminalRows: 40,
     });
-    const web = handleTuiKey(empty, DOWN).state;
-    const api = handleTuiKey(web, DOWN).state;
-    expect(web.dashboardFocus).toEqual(header("web", "primary"));
-    expect(api.dashboardFocus).toEqual(header("api", "primary"));
+    for (const focus of [
+      header("web", "primary"),
+      emptyAction("web"),
+      header("api", "primary"),
+      emptyAction("api"),
+    ]) {
+      current = handleTuiKey(current, DOWN).state;
+      expect(current.dashboardFocus).toEqual(focus);
+    }
+  });
+
+  it("focuses a stable empty-project action and leaves horizontal movement inert", () => {
+    const initial = createInitialTuiState({
+      initialSnapshot: createZeroWorktreeSnapshot(),
+      terminalRows: 40,
+    });
+    const focused = focusDashboardEmptyProjectAction(initial, "api");
+
+    expect(focused.dashboardFocus).toEqual(emptyAction("api"));
+    expect(handleTuiKey(focused, LEFT).state).toBe(focused);
+    expect(handleTuiKey(focused, RIGHT).state).toBe(focused);
+  });
+
+  it("enters and scrolls empty-project focus from the current viewport", () => {
+    const base = createInitialTuiState({
+      initialSnapshot: createZeroWorktreeSnapshot(),
+      terminalRows: 10,
+      scrollOffset: 2,
+    });
+    expect(handleTuiKey(base, DOWN).state.dashboardFocus).toEqual(header("api", "primary"));
+    expect(handleTuiKey(base, UP).state.dashboardFocus).toEqual(emptyAction("api"));
+
+    let current = createInitialTuiState({
+      initialSnapshot: createZeroWorktreeSnapshot(),
+      terminalRows: 10,
+    });
+    for (let presses = 0; presses < 4; presses += 1) {
+      current = handleTuiKey(current, DOWN).state;
+    }
+    expect(current.dashboardFocus).toEqual(emptyAction("api"));
+    expect(current.scrollOffset).toBe(2);
+  });
+
+  it("moves a collapsed empty action to primary and returns to it after expansion", () => {
+    const focused = focusDashboardEmptyProjectAction(
+      createInitialTuiState({
+        initialSnapshot: createZeroWorktreeSnapshot(),
+        terminalRows: 40,
+      }),
+      "web",
+    );
+    const collapsed = handleTuiKey(handleTuiKey(focused, { input: "C" }).state, {
+      input: "1",
+    }).state;
+    expect(collapsed.dashboardFocus).toEqual(header("web", "primary"));
+
+    const expanded = handleTuiKey(handleTuiKey(collapsed, { input: "C" }).state, {
+      input: "1",
+    }).state;
+    expect(handleTuiKey(expanded, DOWN).state.dashboardFocus).toEqual(emptyAction("web"));
+  });
+
+  it("preserves empty-action identity through accepted search and resize", () => {
+    let current = focusDashboardEmptyProjectAction(
+      createInitialTuiState({
+        initialSnapshot: createZeroWorktreeSnapshot(),
+        terminalRows: 40,
+      }),
+      "api",
+    );
+    current = handleTuiKey(current, { input: "/" }).state;
+    current = handleTuiKey(current, { input: "no-match" }).state;
+    current = handleTuiKey(current, RETURN).state;
+    expect(current.dashboardFocus).toEqual(emptyAction("api"));
+
+    const snapshot = createZeroWorktreeSnapshot();
+    const store = createTuiStore({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      initialState: {
+        terminalRows: 40,
+        dashboardFocus: emptyAction("api"),
+      },
+    });
+    store.getState().setTerminalRows(10);
+    expect(store.getState().dashboardFocus).toEqual(emptyAction("api"));
+    expect(store.getState().scrollOffset).toBe(2);
+  });
+
+  it("reconciles removed empty actions by their old rendered position", () => {
+    const snapshot = createZeroWorktreeSnapshot();
+    const initial = createInitialTuiState({
+      initialSnapshot: snapshot,
+      terminalRows: 40,
+      dashboardFocus: emptyAction("web"),
+    });
+    const withoutWeb: StationSnapshot = {
+      ...snapshot,
+      projects: snapshot.projects.filter((project) => project.id !== "web"),
+      counts: { ...snapshot.counts, projects: 1 },
+    };
+
+    expect(replaceSnapshot(initial, withoutWeb).dashboardFocus).toEqual(emptyAction("api"));
+  });
+
+  it("keeps session-only traversal away from empty actions", () => {
+    const snapshot = createDashboardSnapshot();
+    const withoutApiSessions: StationSnapshot = {
+      ...snapshot,
+      rows: snapshot.rows.filter((row) => row.projectId !== "api"),
+      sessions: snapshot.sessions.filter((candidate) => candidate.projectId !== "api"),
+    };
+    const focused = createInitialTuiState({
+      initialSnapshot: withoutApiSessions,
+      terminalRows: 40,
+      dashboardFocus: emptyAction("api"),
+    });
+
+    expect(handleTuiKey(focused, NEXT_NEEDS_ME).state.dashboardFocus).toEqual(
+      session("ses_wt_web_attention"),
+    );
+    const choosing = handleTuiKey(focused, { input: "X" }).state;
+    expect(handleTuiKey(choosing, DOWN).state.dashboardFocus?.kind).toBe("session");
+    expect(handleTuiKey(focused, { input: "N" }).state.dashboardFocus).toEqual(emptyAction("api"));
   });
 
   it("scrolls to keep project-header and session focus visible", () => {

--- a/packages/dashboard-core/test/unit/state/interactionParity.test.ts
+++ b/packages/dashboard-core/test/unit/state/interactionParity.test.ts
@@ -12,7 +12,7 @@ import {
   transitionNewSessionFlow,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
+import { createDashboardSnapshot, createZeroWorktreeSnapshot } from "../../fixtures/snapshots.js";
 
 const context = { cwd: "/workspace", homeDir: "/home/example" };
 
@@ -212,7 +212,30 @@ describe("primary workflow interaction parity", () => {
     expect(semantic.controlIntent).toEqual(keyboard.controlIntent);
   });
 
-  it("defers Quick Session availability to the renderer consumer and keeps stale targets inert", () => {
+  it("converges empty-project pointer semantics with focused Enter", () => {
+    const base = createInitialTuiState({ initialSnapshot: createZeroWorktreeSnapshot() });
+    const semantic = handleTuiAction(
+      base,
+      { type: "dashboard.emptyProject.activate", projectId: "web" },
+      context,
+    );
+    const focused = handleTuiKey(
+      handleTuiKey(base, { input: "", downArrow: true }, context).state,
+      { input: "", downArrow: true },
+      context,
+    ).state;
+    const keyboard = handleTuiKey(focused, { input: "\r", return: true }, context);
+
+    expect(semantic.state.dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "web",
+    });
+    expect(semantic.state.dashboardFocus).toEqual(keyboard.state.dashboardFocus);
+    expect(semantic.controlIntent).toEqual(keyboard.controlIntent);
+    expect(semantic.controlIntent).toEqual({ type: "quickSession.create", projectId: "web" });
+  });
+
+  it("defers header and empty-project Quick Session availability to renderer consumers", () => {
     const snapshot = createDashboardSnapshot();
     const unavailable = {
       ...snapshot,
@@ -239,6 +262,24 @@ describe("primary workflow interaction parity", () => {
       control: "quickSession",
     });
     expect(blocked.state.toasts).toEqual([]);
+
+    const emptySnapshot = createZeroWorktreeSnapshot();
+    const unavailableEmpty = {
+      ...emptySnapshot,
+      projects: emptySnapshot.projects.map((project) =>
+        project.id === "web"
+          ? { ...project, health: { ...project.health, status: "unavailable" as const } }
+          : project,
+      ),
+    };
+    const empty = handleTuiAction(
+      createInitialTuiState({ initialSnapshot: unavailableEmpty }),
+      { type: "dashboard.emptyProject.activate", projectId: "web" },
+      context,
+    );
+    expect(empty.controlIntent).toEqual({ type: "quickSession.create", projectId: "web" });
+    expect(empty.state.dashboardFocus).toEqual({ kind: "emptyProjectAction", projectId: "web" });
+    expect(empty.state.toasts).toEqual([]);
 
     const stale = handleTuiAction(
       state,

--- a/packages/dashboard-core/test/unit/state/quickSession.test.ts
+++ b/packages/dashboard-core/test/unit/state/quickSession.test.ts
@@ -1,6 +1,6 @@
 import { createTuiStore } from "@station/dashboard-core";
 import { describe, expect, it, vi } from "vitest";
-import { createCommandSnapshot } from "../../fixtures/snapshots.js";
+import { createCommandSnapshot, createZeroWorktreeSnapshot } from "../../fixtures/snapshots.js";
 import { FakeTuiObserverService } from "../../support/fakeObserverService.js";
 
 describe("quick session", () => {
@@ -31,8 +31,24 @@ describe("quick session", () => {
     expect(service.waitedForCommandIds).toEqual(["cmd_tui_1"]);
   });
 
+  it("moves accepted empty-project Quick Session focus at the standalone consumer", async () => {
+    const snapshot = createZeroWorktreeSnapshot();
+    const service = new FakeTuiObserverService(snapshot);
+    const store = createTuiStore({ service, initialSnapshot: snapshot });
+
+    store.setState({ dashboardFocus: { kind: "emptyProjectAction", projectId: "web" } });
+    store.getState().createQuickSession("web");
+
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "web",
+      control: "quickSession",
+    });
+    await vi.waitFor(() => expect(service.dispatched).toHaveLength(1));
+  });
+
   it("shows the unavailable project's exact error without dispatching", () => {
-    const snapshot = createCommandSnapshot("idle");
+    const snapshot = createZeroWorktreeSnapshot();
     const project = snapshot.projects[0];
     if (project === undefined) throw new Error("project fixture missing");
     const error = {
@@ -56,10 +72,15 @@ describe("quick session", () => {
     };
     const service = new FakeTuiObserverService(unavailable);
     const store = createTuiStore({ service, initialSnapshot: unavailable });
+    store.setState({ dashboardFocus: { kind: "emptyProjectAction", projectId: project.id } });
 
     store.getState().createQuickSession(project.id);
 
     expect(service.dispatched).toEqual([]);
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: project.id,
+    });
     expect(store.getState().localRows.pendingCreate).toEqual([]);
     expect(store.getState().toasts.at(-1)?.toast).toMatchObject({
       kind: "error",

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -74,6 +74,34 @@ describe("TUI store", () => {
     expect(store.getState().handleKey({ input: "" }).controlIntent).toBeUndefined();
   });
 
+  it("returns an empty-project Quick Session intent before standalone resolution transfers focus", () => {
+    const snapshot = createZeroWorktreeSnapshot();
+    const store = createTuiStore({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+    });
+
+    const result = store.getState().handleAction({
+      type: "dashboard.emptyProject.activate",
+      projectId: "web",
+    });
+
+    expect(result.controlIntent).toEqual({ type: "quickSession.create", projectId: "web" });
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "web",
+    });
+    expect(store.getState().handleKey({ input: "" }).controlIntent).toBeUndefined();
+
+    store.getState().createQuickSession("web");
+    expect(store.getState().localRows.pendingCreate).toHaveLength(1);
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "web",
+      control: "quickSession",
+    });
+  });
+
   it("loads initial snapshots and cleans up event subscriptions", async () => {
     const snapshot = createCommandSnapshot("idle");
     const service = new FakeTuiObserverService(snapshot);

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -1052,6 +1052,63 @@ describe("TUI screen transitions", () => {
     expect(up.selection.get("projectDefaultAgent")).toBe("codex");
   });
 
+  it("emits focused empty-project Quick Session intents without resolving availability", () => {
+    const transition = handleTuiKey(
+      createInitialTuiState({
+        initialSnapshot: createZeroWorktreeSnapshot(),
+        dashboardFocus: { kind: "emptyProjectAction", projectId: "web" },
+      }),
+      { input: "\r", return: true },
+    );
+
+    expect(transition.controlIntent).toEqual({ type: "quickSession.create", projectId: "web" });
+    expect(transition.state.dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "web",
+    });
+  });
+
+  it("leaves focused empty-project availability to the Quick Session consumer", () => {
+    const snapshot = createZeroWorktreeSnapshot();
+    const unavailable = {
+      ...snapshot,
+      projects: snapshot.projects.map((project) =>
+        project.id === "web"
+          ? { ...project, health: { ...project.health, status: "unavailable" as const } }
+          : project,
+      ),
+    };
+    const transition = handleTuiKey(
+      createInitialTuiState({
+        initialSnapshot: unavailable,
+        dashboardFocus: { kind: "emptyProjectAction", projectId: "web" },
+      }),
+      { input: "\r", return: true },
+    );
+
+    expect(transition.controlIntent).toEqual({ type: "quickSession.create", projectId: "web" });
+    expect(transition.state.dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "web",
+    });
+    expect(transition.state.toasts).toEqual([]);
+  });
+
+  it("keeps stale projects and no-longer-empty actions inert", () => {
+    for (const state of [
+      createInitialTuiState({
+        initialSnapshot: createZeroWorktreeSnapshot(),
+        dashboardFocus: { kind: "emptyProjectAction", projectId: "ghost" },
+      }),
+      createInitialTuiState({
+        initialSnapshot: createDashboardSnapshot(),
+        dashboardFocus: { kind: "emptyProjectAction", projectId: "web" },
+      }),
+    ]) {
+      expect(handleTuiKey(state, { input: "\r", return: true })).toEqual({ state });
+    }
+  });
+
   it("adds a safe error toast when no project exists for a new session", () => {
     const snapshot = {
       ...createZeroWorktreeSnapshot(),

--- a/station/src/dashboardRenderer/dashboardMouse.test.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.test.ts
@@ -39,6 +39,7 @@ const DASHBOARD_MOUSE_TARGET_KINDS = {
   addProjectAction: true,
   addProjectRow: true,
   body: true,
+  emptyProjectAction: true,
   firstProjectAdd: true,
   link: true,
   newSessionAction: true,
@@ -340,6 +341,70 @@ describe("routeDashboardMouse", () => {
     expect(creates[0]).toMatchObject({
       payload: { title: "Standalone mouse", harness: { provider: "codex" } },
     });
+  });
+
+  it("routes an empty-project click through Quick Session and transfers successful focus", async () => {
+    const fixture = makeStationTestStore({ terminalRows: 40 });
+    const store = fixture.store;
+
+    routeDashboardMouse(
+      { kind: "emptyProjectAction", projectId: "empty-project" },
+      LEFT_DOWN,
+      store,
+    );
+
+    await waitFor(() =>
+      fixture.service.dispatched.some((command) => command.type === "session.create"),
+    );
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "empty-project",
+      control: "quickSession",
+    });
+    const creates = fixture.service.dispatched.filter(
+      (command) => command.type === "session.create",
+    );
+    expect(creates).toHaveLength(1);
+    expect(creates[0]).toMatchObject({ payload: { projectId: "empty-project" } });
+  });
+
+  it("guards blocked, stale, and modal empty-project clicks", () => {
+    const snapshot = manyProjectsSnapshot();
+    const blockedSnapshot: StationSnapshot = {
+      ...snapshot,
+      projects: snapshot.projects.map((project) =>
+        project.id === "empty-project"
+          ? { ...project, health: { ...project.health, status: "unavailable" as const } }
+          : project,
+      ),
+    };
+    const blockedFixture = makeStationTestStore({ snapshot: blockedSnapshot, terminalRows: 40 });
+    routeDashboardMouse(
+      { kind: "emptyProjectAction", projectId: "empty-project" },
+      LEFT_DOWN,
+      blockedFixture.store,
+    );
+    expect(blockedFixture.store.getState().dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "empty-project",
+    });
+    expect(blockedFixture.store.getState().toasts.at(-1)?.toast.kind).toBe("error");
+    expect(blockedFixture.service.dispatched).toEqual([]);
+
+    const stale = makeStore();
+    routeDashboardMouse({ kind: "emptyProjectAction", projectId: "ghost" }, LEFT_DOWN, stale);
+    routeDashboardMouse({ kind: "emptyProjectAction", projectId: "station" }, LEFT_DOWN, stale);
+    expect(stale.getState().dashboardFocus).toBeUndefined();
+
+    const modal = makeStore();
+    modal.getState().handleKey({ input: "H" });
+    routeDashboardMouse(
+      { kind: "emptyProjectAction", projectId: "empty-project" },
+      LEFT_DOWN,
+      modal,
+    );
+    expect(modal.getState().screen).toEqual({ name: "help" });
+    expect(modal.getState().dashboardFocus).toBeUndefined();
   });
 
   it("routes project shell, quick-session, and agent-picker actions", async () => {

--- a/station/src/dashboardRenderer/dashboardMouse.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.ts
@@ -97,6 +97,9 @@ function routeSurfaceClick(
     case "quickSessionForProject":
       activateProjectHeaderInMode(store, target.projectId, "quickSession", mode, effects);
       return true;
+    case "emptyProjectAction":
+      activateEmptyProjectInMode(store, target.projectId, mode, effects);
+      return true;
     case "showDefaultAgentPickerForProject":
       activateProjectHeaderInMode(store, target.projectId, "defaultAgent", mode, effects);
       return true;
@@ -138,6 +141,24 @@ function activateProjectHeaderInMode(
     type: "dashboard.projectHeader.activate",
     projectId,
     actionId,
+  });
+  if (result.controlIntent !== undefined) {
+    executeDashboardControlIntent(result.controlIntent, store, effects);
+  }
+}
+
+function activateEmptyProjectInMode(
+  store: StoreApi<TuiStore>,
+  projectId: string,
+  mode: TuiInputMode,
+  effects: DashboardRendererEffects,
+): void {
+  if (mode !== "dashboard") {
+    return;
+  }
+  const result = store.getState().handleAction({
+    type: "dashboard.emptyProject.activate",
+    projectId,
   });
   if (result.controlIntent !== undefined) {
     executeDashboardControlIntent(result.controlIntent, store, effects);

--- a/station/src/dashboardRenderer/inputBridge.test.ts
+++ b/station/src/dashboardRenderer/inputBridge.test.ts
@@ -92,6 +92,31 @@ describe("createDashboardSequenceHandler", () => {
     ).toHaveLength(1);
   });
 
+  it("consumes focused empty-project Enter as one Quick Session intent", async () => {
+    const fixture = makeStationTestStore({ snapshot: manyProjectsSnapshot() });
+    fixture.store.setState({
+      dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+    });
+    const effects = { openShell: () => {}, openUrl: () => {} };
+    const handle = createDashboardSequenceHandler(fixture.store, (intent) => {
+      executeDashboardControlIntent(intent, fixture.store, effects);
+    });
+
+    handle("\r");
+
+    await waitFor(() =>
+      fixture.service.dispatched.some((command) => command.type === "session.create"),
+    );
+    expect(
+      fixture.service.dispatched.filter((command) => command.type === "session.create"),
+    ).toHaveLength(1);
+    expect(fixture.store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "empty-project",
+      control: "quickSession",
+    });
+  });
+
   it("swallows terminal query replies without dispatching", () => {
     const { handle, keys } = harness();
     expect(handle("\x1b[1;1R")).toBe(true); // cursor position report

--- a/station/src/station/input/focusedRowActivate.test.ts
+++ b/station/src/station/input/focusedRowActivate.test.ts
@@ -4,15 +4,14 @@ import { resolveInitialState } from "../../state/initialState.js";
 import { manyProjectsSnapshot } from "../fixtures/scenarios.js";
 import { FakeTuiObserverService } from "../test/support/fakeObserverService.js";
 import { FakeStationSource } from "../test/support/fakeStationSource.js";
-import { resolveKeyFocusedRowAgentTarget } from "./stationActions.js";
+import { resolveKeyFocusedRowAgentTarget, resolveQuickSessionSubmit } from "./stationActions.js";
 import { createStationOverlayLayer } from "./stationOverlayLayer.js";
 
 // Station opens rows as managed pane launches (not the machine's
 // terminal.focus, which Station-hosted panes can't honor). Enter on the
 // focused cursor row must resolve to the same RowAgentTarget a slot key or
 // click does; anything unresolved falls through to the shared machine.
-function newStore() {
-  const snapshot = manyProjectsSnapshot();
+function newStore(snapshot = manyProjectsSnapshot()) {
   return createTuiStore({
     source: new FakeStationSource(snapshot),
     service: new FakeTuiObserverService(snapshot),
@@ -76,6 +75,61 @@ describe("resolveKeyFocusedRowAgentTarget", () => {
       projectId: "station",
       harness: "codex",
     });
+  });
+
+  it("maps focused empty-project Enter to the native Quick Session executor", () => {
+    const store = newStore();
+    store.setState({
+      dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+    });
+
+    expect(createStationOverlayLayer(store).catchAll?.("\r", resolveInitialState())).toMatchObject({
+      kind: "pane-launch-new-session",
+      projectId: "empty-project",
+      harness: "codex",
+    });
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "empty-project",
+      control: "quickSession",
+    });
+  });
+
+  it("resolves empty-project Quick Session availability at the native consumer", () => {
+    const available = newStore();
+    available.setState({
+      dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+    });
+
+    expect(resolveQuickSessionSubmit(available, "empty-project")).toMatchObject({
+      kind: "submit",
+      projectId: "empty-project",
+    });
+    expect(available.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "empty-project",
+      control: "quickSession",
+    });
+
+    const snapshot = manyProjectsSnapshot();
+    const blocked = newStore({
+      ...snapshot,
+      projects: snapshot.projects.map((project) =>
+        project.id === "empty-project"
+          ? { ...project, health: { ...project.health, status: "unavailable" as const } }
+          : project,
+      ),
+    });
+    blocked.setState({
+      dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+    });
+
+    expect(resolveQuickSessionSubmit(blocked, "empty-project")).toEqual({ kind: "none" });
+    expect(blocked.getState().dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "empty-project",
+    });
+    expect(blocked.getState().toasts.at(-1)?.toast.kind).toBe("error");
   });
 
   it("is inert while an operation is pending on the focused row", () => {

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -10,6 +10,7 @@ import {
   addTuiToast,
   choiceValueByKey,
   deriveTuiInputMode,
+  focusDashboardProjectHeader,
   newSessionActionForInput,
   newSessionIntentForAction,
   focusProjectSettingsItem as focusProjectSettingsItemState,
@@ -355,10 +356,10 @@ export function resolveKeyForkSessionSubmit(
 }
 
 /**
- * Resolve a project header's quick-session activation to its create target. Uses
- * the project's default harness and a generated branch name — no wizard, no
- * review screen. Blocked projects preserve their provider error as a toast;
- * only a missing or stale project is an inert miss.
+ * Resolves native Quick Session availability to its managed create target. Uses
+ * the project's default harness and a generated branch name — no wizard or
+ * review screen. Blocked projects preserve their provider error and retain any
+ * inline action focus; accepted targets move focus to the header Quick Session.
  */
 export type QuickSessionSubmitTarget =
   | { kind: "submit"; projectId: string; title: string; branch: string; harness: ProviderId }
@@ -374,6 +375,7 @@ export function resolveQuickSessionSubmit(
     store.setState(addTuiToast(store.getState(), safeErrorToToast(intent.error)));
     return { kind: "none" };
   }
+  store.setState(focusDashboardProjectHeader(store.getState(), intent.projectId, "quickSession"));
   return {
     kind: "submit",
     projectId: intent.projectId,

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -597,6 +597,66 @@ describe("routeStationMouse", () => {
     });
   });
 
+  it("routes the empty-project action to the native managed launch outcome", () => {
+    const store = makeStore();
+    const outcome = routeStationMouse(
+      { kind: "emptyProjectAction", projectId: "empty-project" },
+      LEFT_DOWN,
+      store,
+    );
+
+    expect(outcome).toMatchObject({
+      kind: "launch-new-session",
+      projectId: "empty-project",
+      harness: "codex",
+    });
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "empty-project",
+      control: "quickSession",
+    });
+  });
+
+  it("keeps blocked empty-project activation focused for retry", () => {
+    const store = makeStore(snapshotWithBareProject("empty-project"));
+
+    expect(
+      routeStationMouse(
+        { kind: "emptyProjectAction", projectId: "empty-project" },
+        LEFT_DOWN,
+        store,
+      ),
+    ).toEqual({ kind: "handled" });
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "emptyProjectAction",
+      projectId: "empty-project",
+    });
+    expect(store.getState().toasts.at(-1)?.toast.kind).toBe("error");
+  });
+
+  it("keeps stale and modal empty-project targets inert", () => {
+    const stale = makeStore();
+    expect(
+      routeStationMouse({ kind: "emptyProjectAction", projectId: "ghost" }, LEFT_DOWN, stale),
+    ).toEqual({ kind: "handled" });
+    expect(
+      routeStationMouse({ kind: "emptyProjectAction", projectId: "station" }, LEFT_DOWN, stale),
+    ).toEqual({ kind: "handled" });
+    expect(stale.getState().dashboardFocus).toBeUndefined();
+
+    const modal = makeStore();
+    modal.getState().handleKey({ input: "H" });
+    expect(
+      routeStationMouse(
+        { kind: "emptyProjectAction", projectId: "empty-project" },
+        LEFT_DOWN,
+        modal,
+      ),
+    ).toEqual({ kind: "handled" });
+    expect(modal.getState().screen).toEqual({ name: "help" });
+    expect(modal.getState().dashboardFocus).toBeUndefined();
+  });
+
   it("shows the blocked Quick Session error without emitting a launch outcome", () => {
     const store = makeStore(snapshotWithBareProject("station"));
 

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -51,6 +51,8 @@ export type StationMouseTarget =
   | { kind: "openShellForProject"; projectId: string }
   /** The `[+]` quick-session affordance on a project header. */
   | { kind: "quickSessionForProject"; projectId: string }
+  /** The Add Session control rendered for a project with no visible sessions. */
+  | { kind: "emptyProjectAction"; projectId: string }
   /** The `[▾]` default-agent affordance on a project header. */
   | { kind: "showDefaultAgentPickerForProject"; projectId: string }
   /** The zero-project dashboard CTA; guarded against stale non-empty snapshots. */
@@ -213,6 +215,15 @@ export function routeStationMouse(
       return routeProjectHeaderActivation(store, mode, target.projectId, "shell");
     case "quickSessionForProject":
       return routeProjectHeaderActivation(store, mode, target.projectId, "quickSession");
+    case "emptyProjectAction":
+      return mode === "dashboard"
+        ? fromKeyOutcome(
+            dispatchStationAction(store, {
+              type: "dashboard.emptyProject.activate",
+              projectId: target.projectId,
+            }),
+          )
+        : { kind: "handled" };
     case "showDefaultAgentPickerForProject":
       return routeProjectHeaderActivation(store, mode, target.projectId, "defaultAgent");
     case "firstProjectAdd":

--- a/station/src/station/view/DashboardView.tsx
+++ b/station/src/station/view/DashboardView.tsx
@@ -306,7 +306,13 @@ function DashboardViewportRow({
       return (
         <box flexDirection="row" height={1}>
           <text fg={STATION_COLORS.gray}>{emptyProjectLabel()}</text>
-          <EmptySessionButton projectId={item.project.id} />
+          <EmptySessionButton
+            projectId={item.project.id}
+            focused={
+              dashboardFocus?.kind === "emptyProjectAction" &&
+              dashboardFocus.projectId === item.project.id
+            }
+          />
         </box>
       );
     case "session":
@@ -383,17 +389,21 @@ function FirstProjectButton({ columns }: { columns: number }) {
 
 const EMPTY_SESSION_BUTTON_LABEL = "[ + add session ]";
 
-// Mouse-native empty-state action: one click creates a session (default agent)
-// for the project — the same semantic action as the project header segment.
-function EmptySessionButton({ projectId }: { projectId: string }) {
+/** Paints and activates only the empty project's bounded Add Session cells. */
+function EmptySessionButton({ projectId, focused }: { projectId: string; focused: boolean }) {
   const dispatch = useStationMouse();
   const [hover, setHover] = useStationHoverState();
+  const background = hover
+    ? { bg: STATION_COLORS.cyan }
+    : focused
+      ? { bg: STATION_COLORS.compactFocusBackground }
+      : {};
   return (
     <text
       flexShrink={0}
       fg={hover ? STATION_COLORS.background : STATION_COLORS.cyan}
-      {...(hover ? { bg: STATION_COLORS.cyan } : {})}
-      {...stationMouseProps(dispatch, { kind: "quickSessionForProject", projectId })}
+      {...background}
+      {...stationMouseProps(dispatch, { kind: "emptyProjectAction", projectId })}
       onMouseOver={() => setHover(true)}
       onMouseOut={() => setHover(false)}
     >
@@ -470,7 +480,7 @@ function ProjectHeaderPrimary({
   const background = hover
     ? { bg: HOVER_BG }
     : focused
-      ? { bg: STATION_COLORS.projectHeaderFocusBackground }
+      ? { bg: STATION_COLORS.compactFocusBackground }
       : {};
   return (
     <text
@@ -500,7 +510,7 @@ function ProjectHeaderActionSegment({
   const background = hover
     ? { bg: HOVER_BG }
     : focused
-      ? { bg: STATION_COLORS.projectHeaderFocusBackground }
+      ? { bg: STATION_COLORS.compactFocusBackground }
       : {};
   return (
     <text

--- a/station/src/station/view/dashboard.golden.test.tsx
+++ b/station/src/station/view/dashboard.golden.test.tsx
@@ -392,42 +392,68 @@ describe("dashboard golden frames", () => {
     expect(frame).toContain("[ + add session ]");
   });
 
-  it("keeps the empty-project add-session action readable on hover", async () => {
-    const setup = await renderDashboard({ width: 120, height: 40, snapshot: manyProjectsSnapshot() });
-    const lines = setup.captureCharFrame().split("\n");
-    const row = lines.findIndex((line) => line.includes("[ + add session ]"));
-    const col = lines[row]?.indexOf("[ + add session ]") ?? -1;
-    expect(row).toBeGreaterThan(0);
-    expect(col).toBeGreaterThan(0);
+  it("bounds empty-project focus, hover, and hit testing to Add Session cells", async () => {
+    for (const width of [120, 80]) {
+      const targets: StationMouseTarget[] = [];
+      const setup = await renderDashboard({
+        width,
+        height: 40,
+        snapshot: manyProjectsSnapshot(),
+        dispatchMouse: (target) => targets.push(target),
+      });
+      await act(async () => {
+        setup.store.setState({
+          dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+        });
+      });
+      await setup.flush();
 
-    const ordinarySpan = spanAtFrameCell(setup.captureSpans(), row, col);
-    const ordinaryForeground = spanHex(ordinarySpan);
-    const ordinaryBackground = spanBgHex(ordinarySpan);
-    expect(ordinaryForeground).toBe(STATION_COLORS.cyan);
-    expect(ordinaryForeground).not.toBe(ordinaryBackground);
+      const lines = setup.captureCharFrame().split("\n");
+      const row = lines.findIndex((line) => line.includes("[ + add session ]"));
+      const col = lines[row]?.indexOf("[ + add session ]") ?? -1;
+      const after = col + "[ + add session ]".length;
+      expect(row).toBeGreaterThan(0);
+      expect(col).toBeGreaterThan(0);
 
-    await act(async () => {
-      await setup.mockMouse.moveTo(col, row);
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    });
-    await setup.flush();
+      let spans = setup.captureSpans();
+      expect(spanBgHex(spanAtFrameCell(spans, row, col))).toBe(
+        STATION_COLORS.compactFocusBackground,
+      );
+      expect(spanBgHex(spanAtFrameCell(spans, row, after - 1))).toBe(
+        STATION_COLORS.compactFocusBackground,
+      );
+      expect(spanBgHex(spanAtFrameCell(spans, row, col - 1))).not.toBe(
+        STATION_COLORS.compactFocusBackground,
+      );
+      expect(spanBgHex(spanAtFrameCell(spans, row, after))).not.toBe(
+        STATION_COLORS.compactFocusBackground,
+      );
 
-    const hoveredSpan = spanAtFrameCell(setup.captureSpans(), row, col);
-    const hoveredForeground = spanHex(hoveredSpan);
-    const hoveredBackground = spanBgHex(hoveredSpan);
-    expect(hoveredForeground).toBe(STATION_COLORS.background);
-    expect(hoveredBackground).toBe(STATION_COLORS.cyan);
-    expect(hoveredForeground).not.toBe(hoveredBackground);
+      await act(async () => {
+        await setup.mockMouse.moveTo(col, row);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      await setup.flush();
+      spans = setup.captureSpans();
+      expect(spanHex(spanAtFrameCell(spans, row, col))).toBe(STATION_COLORS.background);
+      expect(spanBgHex(spanAtFrameCell(spans, row, col))).toBe(STATION_COLORS.cyan);
 
-    await act(async () => {
-      await setup.mockMouse.moveTo(0, 0);
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    });
-    await setup.flush();
+      await act(async () => {
+        await setup.mockMouse.moveTo(0, 0);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      await setup.flush();
+      expect(spanBgHex(spanAtFrameCell(setup.captureSpans(), row, col))).toBe(
+        STATION_COLORS.compactFocusBackground,
+      );
 
-    const restoredSpan = spanAtFrameCell(setup.captureSpans(), row, col);
-    expect(spanHex(restoredSpan)).toBe(ordinaryForeground);
-    expect(spanBgHex(restoredSpan)).toBe(ordinaryBackground);
+      await setup.mockMouse.click(col - 1, row, MouseButtons.LEFT);
+      await setup.mockMouse.click(col, row, MouseButtons.LEFT);
+      await setup.mockMouse.click(after, row, MouseButtons.LEFT);
+      expect(targets).toEqual([
+        { kind: "emptyProjectAction", projectId: "empty-project" },
+      ]);
+    }
   });
 
   it("renders the focus cursor and jumps it to the next session needing you", async () => {
@@ -504,22 +530,22 @@ describe("dashboard golden frames", () => {
         for (const [control, column] of Object.entries(samples)) {
           const background = spanBgHex(spanAtFrameCell(spans, row, column));
           if (control === controls[index]) {
-            expect(background).toBe(STATION_COLORS.projectHeaderFocusBackground);
+            expect(background).toBe(STATION_COLORS.compactFocusBackground);
           } else {
-            expect(background).not.toBe(STATION_COLORS.projectHeaderFocusBackground);
+            expect(background).not.toBe(STATION_COLORS.compactFocusBackground);
           }
         }
         expect(spanBgHex(spanAtFrameCell(spans, row, primaryEnd))).not.toBe(
-          STATION_COLORS.projectHeaderFocusBackground,
+          STATION_COLORS.compactFocusBackground,
         );
         expect(spanBgHex(spanAtFrameCell(spans, row, shellStart - 1))).not.toBe(
-          STATION_COLORS.projectHeaderFocusBackground,
+          STATION_COLORS.compactFocusBackground,
         );
         expect(spanBgHex(spanAtFrameCell(spans, row, quickStart - 1))).not.toBe(
-          STATION_COLORS.projectHeaderFocusBackground,
+          STATION_COLORS.compactFocusBackground,
         );
         expect(spanBgHex(spanAtFrameCell(spans, row, defaultStart - 1))).not.toBe(
-          STATION_COLORS.projectHeaderFocusBackground,
+          STATION_COLORS.compactFocusBackground,
         );
       }
     }
@@ -578,7 +604,7 @@ describe("dashboard golden frames", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
     await setup.flush();
     expect(spanBgHex(spanAtFrameCell(setup.captureSpans(), row, shell))).toBe(
-      STATION_COLORS.projectHeaderFocusBackground,
+      STATION_COLORS.compactFocusBackground,
     );
   });
 

--- a/station/src/station/view/theme.ts
+++ b/station/src/station/view/theme.ts
@@ -19,7 +19,7 @@ export const STATION_COLORS = {
   hairline: "#20252c",
   frozenSurface: "#12161b",
   focusBackground: "#15222e",
-  projectHeaderFocusBackground: "#1b3448",
+  compactFocusBackground: "#1b3448",
 } as const;
 
 export function rowColorToHex(color: RowColor | undefined): string | undefined {


### PR DESCRIPTION
## What this fixes

Expanded projects with no sessions exposed an Add Session control to pointer users but not dashboard traversal. Its availability was also resolved too early in dashboard-core, breaking the renderer-consumer boundary used by Quick Session.

## What changed

- Makes the rendered empty-project Add Session control a stable dashboard focus target.
- Routes focused Enter and pointer clicks through `dashboard.emptyProject.activate`.
- Defers Quick Session availability to the standalone and native renderer acceptance boundaries; blocked activation retains inline focus, while accepted activation transfers focus to the header Quick Session control.
- Bounds the focus/hover fill and mouse target to `[ + add session ]` and documents the interaction model.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec vitest run packages/dashboard-core/test`
- `cd station && bun run typecheck && bun run test`
- `git diff --check`
- `pnpm test:all` *(fails in two unrelated Observer handoff lifecycle tests with `OBSERVER_HANDOFF_REFUSED`)*
