### PR TITLE
feat(cli): separate operational failure evidence from log provenance

### DIFF
--- a/apps/cli/src/commands/debugLogs.ts
+++ b/apps/cli/src/commands/debugLogs.ts
@@ -4,6 +4,19 @@ import type { LogRecord, SafeError } from "@station/contracts";
 import { LogRecordSchema, SafeErrorSchema } from "@station/contracts";
 import { componentLogPath } from "@station/observability";
 import { resolveObserverPaths } from "../paths.js";
+import {
+  assessCauseEvidence,
+  type CauseAssessment,
+  type DiagnosticContextEntry,
+  type DiagnosticEvidenceRoles,
+  type DiagnosticMatchEvidence,
+  diagnosticEvidenceRoles,
+  extractDiagnosticMatchEvidence,
+  type OperationalBoundaryEvidence,
+  projectDiagnosticContext,
+  projectOperationalBoundaryEvidence,
+  retainedFailureSignal,
+} from "./diagnosticEvidence.js";
 
 export type DebugLogsCommandOptions = {
   config?: StationConfig;
@@ -20,6 +33,11 @@ export type DebugLogsResult = {
     filesSearched: string[];
     matchedFiles: string[];
   };
+  causeAssessment: Pick<
+    CauseAssessment,
+    "status" | "observedFailureCodes" | "observedFailureSignals"
+  >;
+  evidenceRoles: DiagnosticEvidenceRoles;
   records: DebugLogRecordSummary[];
 };
 
@@ -27,6 +45,7 @@ type DebugLogRecordSummary = {
   timestamp: string;
   level: DebugLogLevel;
   component: DebugLogComponent;
+  componentRole: "logging_location";
   message: string;
   traceId?: string;
   spanId?: string;
@@ -35,6 +54,9 @@ type DebugLogRecordSummary = {
   worktreeId?: string;
   sessionId?: string;
   provider?: string;
+  operationalBoundaryEvidence?: OperationalBoundaryEvidence;
+  context?: DiagnosticContextEntry[];
+  matchEvidence?: DiagnosticMatchEvidence[];
   error?: DebugLogErrorSummary;
 };
 
@@ -98,6 +120,33 @@ export async function runDebugLogsCommand(
     .flatMap((match) => match.records)
     .sort((left, right) => timestamp(left) - timestamp(right))
     .slice(-parsed.limit);
+  const includeOperationalBoundaryEvidence = parsed.query !== undefined || selected.length === 1;
+  const records = selected.map((record) =>
+    logSummary(record, parsed.query, includeOperationalBoundaryEvidence),
+  );
+  const observedFailureCodes = records.flatMap((record) =>
+    record.error?.code === undefined ? [] : [record.error.code],
+  );
+  const observedFailureSignals = records.flatMap((record) => {
+    const signal = retainedFailureSignal(contextString(record.context ?? [], "/attributes/kind"));
+    return signal === undefined ? [] : [signal];
+  });
+  const assessedCause = assessCauseEvidence({
+    explicitRootCauseCodes: [],
+    observedFailureCodes,
+    observedFailureSignals,
+    matched: selected.length > 0,
+    searchComplete: true,
+    invalidLines: 0,
+    reportingBoundaryOnly: selected.length > 0,
+  });
+  const causeAssessment: DebugLogsResult["causeAssessment"] = {
+    status: assessedCause.status,
+    observedFailureCodes: assessedCause.observedFailureCodes,
+  };
+  if (assessedCause.observedFailureSignals !== undefined) {
+    causeAssessment.observedFailureSignals = assessedCause.observedFailureSignals;
+  }
   const result: DebugLogsResult = {
     components: parsed.components,
     minLevel: parsed.minLevel,
@@ -107,7 +156,9 @@ export async function runDebugLogsCommand(
       filesSearched,
       matchedFiles: matches.map((match) => match.path),
     },
-    records: selected.map(logSummary),
+    causeAssessment,
+    evidenceRoles: diagnosticEvidenceRoles(),
+    records,
   };
   if (parsed.query !== undefined) result.query = parsed.query;
   if (parsed.since !== undefined) result.since = parsed.since;
@@ -207,13 +258,35 @@ function logMatches(record: LogRecord, args: DebugLogsArgs): boolean {
   );
 }
 
-function logSummary(record: LogRecord): DebugLogRecordSummary {
+function logSummary(
+  record: LogRecord,
+  query: string | undefined,
+  includeOperationalBoundaryEvidence: boolean,
+): DebugLogRecordSummary {
+  const context = projectDiagnosticContext(record);
+  const error = errorSummary(record.attributes?.error);
   const summary: DebugLogRecordSummary = {
     timestamp: record.timestamp,
     level: record.level,
     component: record.component,
+    componentRole: "logging_location",
     message: record.message,
   };
+  if (includeOperationalBoundaryEvidence) {
+    const operationalInput: OperationalBoundaryEvidence = { recordSummary: record.message };
+    const operation = contextString(context, "/attributes/operation");
+    if (operation !== undefined) operationalInput.operation = operation;
+    const commandType = contextString(context, "/attributes/commandType");
+    if (commandType !== undefined) operationalInput.commandType = commandType;
+    const signalKind = retainedFailureSignal(contextString(context, "/attributes/kind"));
+    if (signalKind !== undefined) operationalInput.signalKind = signalKind;
+    if (error?.code !== undefined) operationalInput.errorCode = error.code;
+    if (error?.message !== undefined) operationalInput.errorMessage = error.message;
+    const operationalBoundaryEvidence = projectOperationalBoundaryEvidence(operationalInput);
+    if (operationalBoundaryEvidence !== undefined) {
+      summary.operationalBoundaryEvidence = operationalBoundaryEvidence;
+    }
+  }
   if (record.traceId !== undefined) summary.traceId = record.traceId;
   if (record.spanId !== undefined) summary.spanId = record.spanId;
   if (record.commandId !== undefined) summary.commandId = record.commandId;
@@ -221,12 +294,21 @@ function logSummary(record: LogRecord): DebugLogRecordSummary {
   if (record.worktreeId !== undefined) summary.worktreeId = record.worktreeId;
   if (record.sessionId !== undefined) summary.sessionId = record.sessionId;
   if (record.provider !== undefined) summary.provider = record.provider;
-
-  const error = errorSummary(record.attributes?.error);
-  if (error !== undefined) {
-    summary.error = error;
+  if (context.length > 0) summary.context = context;
+  if (query !== undefined) {
+    const matchEvidence = extractDiagnosticMatchEvidence(record, query);
+    if (matchEvidence.length > 0) summary.matchEvidence = matchEvidence;
   }
+  if (error !== undefined) summary.error = error;
   return summary;
+}
+
+function contextString(
+  context: readonly DiagnosticContextEntry[],
+  path: string,
+): string | undefined {
+  const value = context.find((entry) => entry.path === path)?.value;
+  return typeof value === "string" ? value : undefined;
 }
 
 function errorSummary(value: unknown): DebugLogErrorSummary | undefined {

--- a/apps/cli/src/commands/debugTrace.ts
+++ b/apps/cli/src/commands/debugTrace.ts
@@ -21,6 +21,15 @@ import {
 } from "@station/contracts";
 import { z } from "zod";
 import { resolveObserverPaths } from "../paths.js";
+import {
+  assessCauseEvidence,
+  type CauseAssessment,
+  type DiagnosticEvidenceRoles,
+  diagnosticEvidenceRoles,
+  type OperationalBoundaryEvidence,
+  projectOperationalBoundaryEvidence,
+  retainedFailureSignal,
+} from "./diagnosticEvidence.js";
 
 export type DebugTraceCommandOptions = {
   config?: StationConfig;
@@ -51,6 +60,9 @@ export type DebugTraceResult = {
     diagnostics?: DiagnosticDetail[];
   };
   rootCauseCodes: string[];
+  causeAssessment: CauseAssessment;
+  evidenceRoles: DiagnosticEvidenceRoles;
+  operationalBoundaryEvidence?: OperationalBoundaryEvidence;
   evidence: {
     filesSearched: string[];
     matchedFiles: string[];
@@ -60,6 +72,10 @@ export type DebugTraceResult = {
 
 type DebugTraceCommandSummary = NonNullable<DebugTraceResult["command"]>;
 type DebugTraceErrorSummary = NonNullable<DebugTraceResult["error"]>;
+type DebugTraceReportingProvenance = {
+  component: LogRecord["component"];
+  operation?: string;
+};
 
 type DebugTraceArgs = {
   query?: string;
@@ -75,6 +91,12 @@ type DebugTraceMatch = {
   traceId?: string;
   spanId?: string;
   rootCauseCodes: string[];
+  explicitRootCauseCodes: string[];
+  observedFailureCodes: string[];
+  observedFailureRecord?: boolean;
+  reportedBy?: DebugTraceReportingProvenance;
+  recordSummary?: string;
+  signalKind?: string;
   matchedFiles: string[];
   createdAt?: string;
 };
@@ -84,6 +106,8 @@ type ParsedDebugTraceLogAttributes = {
   traceId?: string;
   spanId?: string;
   commandType?: string;
+  operation?: string;
+  kind?: string;
   error?: DebugTraceErrorSummary;
 };
 
@@ -93,6 +117,8 @@ const DebugTraceLogAttributesSchema = z
     traceId: TraceIdSchema.optional(),
     spanId: SpanIdSchema.optional(),
     commandType: z.string().min(1).optional(),
+    operation: z.string().min(1).optional(),
+    kind: z.string().min(1).optional(),
     error: z.unknown().optional(),
   })
   .passthrough();
@@ -111,6 +137,18 @@ export async function runDebugTraceCommand(
     latestFailure: parsed.latestFailure,
     matched: match !== undefined,
     rootCauseCodes: match?.rootCauseCodes ?? [],
+    causeAssessment: assessCauseEvidence({
+      explicitRootCauseCodes: match?.explicitRootCauseCodes ?? [],
+      observedFailureCodes: match?.observedFailureCodes ?? [],
+      observedFailureSignals: match?.signalKind === undefined ? [] : [match.signalKind],
+      observedFailureRecord: match?.observedFailureRecord ?? false,
+      matched: match !== undefined,
+      ...(match?.command?.status === undefined ? {} : { commandStatus: match.command.status }),
+      searchComplete: true,
+      invalidLines: 0,
+      reportingBoundaryOnly: match?.reportedBy?.component === "cli",
+    }),
+    evidenceRoles: diagnosticEvidenceRoles(),
     evidence: {
       filesSearched,
       matchedFiles: match?.matchedFiles ?? [],
@@ -125,6 +163,19 @@ export async function runDebugTraceCommand(
   if (match?.spanId !== undefined) result.spanId = match.spanId;
   if (match?.command !== undefined) result.command = match.command;
   if (match?.error !== undefined) result.error = match.error;
+  const operationalInput: OperationalBoundaryEvidence = {};
+  if (result.command?.type !== undefined) operationalInput.commandType = result.command.type;
+  if (match?.reportedBy?.operation !== undefined) {
+    operationalInput.operation = match.reportedBy.operation;
+  }
+  if (match?.signalKind !== undefined) operationalInput.signalKind = match.signalKind;
+  if (match?.recordSummary !== undefined) operationalInput.recordSummary = match.recordSummary;
+  if (result.error?.code !== undefined) operationalInput.errorCode = result.error.code;
+  if (result.error?.message !== undefined) operationalInput.errorMessage = result.error.message;
+  const operationalBoundaryEvidence = projectOperationalBoundaryEvidence(operationalInput);
+  if (operationalBoundaryEvidence !== undefined) {
+    result.operationalBoundaryEvidence = operationalBoundaryEvidence;
+  }
   return result;
 }
 
@@ -257,6 +308,8 @@ function matchBundle(input: {
     matchedIdType: matchedIdType(input.args.query, command, error),
     bundlePath: input.bundlePath,
     rootCauseCodes: rootCauseCodes(input.index, command, error),
+    explicitRootCauseCodes: explicitRootCauseCodes(input.index, command, error),
+    observedFailureCodes: observedFailureCodes(command, error),
     matchedFiles,
   };
   const commandResult = commandSummary(command);
@@ -362,6 +415,8 @@ function matchFromLog(log: LogRecord, path: string, query: string | undefined): 
   const traceId = attributes.traceId ?? log.traceId;
   const spanId = attributes.spanId ?? log.spanId;
   const commandType = attributes.commandType;
+  const reportedBy: DebugTraceReportingProvenance = { component: log.component };
+  if (attributes.operation !== undefined) reportedBy.operation = attributes.operation;
   const command =
     commandId === undefined
       ? undefined
@@ -380,9 +435,16 @@ function matchFromLog(log: LogRecord, path: string, query: string | undefined): 
     ...(traceId === undefined ? {} : { traceId }),
     ...(spanId === undefined ? {} : { spanId }),
     rootCauseCodes: errorResult?.code === undefined ? [] : [errorResult.code],
+    explicitRootCauseCodes: [],
+    observedFailureCodes: errorResult?.code === undefined ? [] : [errorResult.code],
+    observedFailureRecord: log.level === "warn" || log.level === "error",
+    reportedBy,
+    recordSummary: log.message,
     matchedFiles: [path],
     createdAt: log.timestamp,
   };
+  const signalKind = retainedFailureSignal(attributes.kind);
+  if (signalKind !== undefined) match.signalKind = signalKind;
   if (errorResult !== undefined) match.error = errorResult;
   return match;
 }
@@ -472,6 +534,47 @@ function commandErrorSummary(command: CommandRecord | undefined): DebugTraceResu
   return Object.keys(summary).length === 0 ? undefined : summary;
 }
 
+function explicitRootCauseCodes(
+  index: DiagnosticEvidenceIndex | undefined,
+  command: CommandRecord | undefined,
+  error: ErrorEnvelope | undefined,
+): string[] {
+  const codes = new Set<string>();
+  const correlatedItemIds = new Set(
+    index?.items
+      .filter(
+        (item) =>
+          (command?.id !== undefined && item.commandId === command.id) ||
+          (command?.traceId !== undefined && item.traceId === command.traceId) ||
+          (error?.id !== undefined && item.diagnosticId === error.id),
+      )
+      .map((item) => item.id) ?? [],
+  );
+  for (const rootCause of index?.rootCauses ?? []) {
+    if (
+      (command?.id !== undefined && rootCause.commandId === command.id) ||
+      (error?.id !== undefined && rootCause.diagnosticId === error.id) ||
+      rootCause.itemIds.some((itemId) => correlatedItemIds.has(itemId))
+    ) {
+      codes.add(rootCause.code);
+    }
+  }
+  if (command === undefined && error === undefined) {
+    for (const code of index?.summary.rootCauseCodes ?? []) codes.add(code);
+  }
+  return [...codes].sort();
+}
+
+function observedFailureCodes(
+  command: CommandRecord | undefined,
+  error: ErrorEnvelope | undefined,
+): string[] {
+  const codes = new Set<string>();
+  if (command?.error?.code !== undefined) codes.add(command.error.code);
+  if (error?.code !== undefined) codes.add(error.code);
+  return [...codes].sort();
+}
+
 function rootCauseCodes(
   index: DiagnosticEvidenceIndex | undefined,
   command: CommandRecord | undefined,
@@ -505,6 +608,8 @@ function parseDebugTraceLogAttributes(
   if (parsed.data.traceId !== undefined) result.traceId = parsed.data.traceId;
   if (parsed.data.spanId !== undefined) result.spanId = parsed.data.spanId;
   if (parsed.data.commandType !== undefined) result.commandType = parsed.data.commandType;
+  if (parsed.data.operation !== undefined) result.operation = parsed.data.operation;
+  if (parsed.data.kind !== undefined) result.kind = parsed.data.kind;
   const error = parseLogAttributeError(parsed.data.error);
   if (error !== undefined) result.error = error;
   return result;

--- a/apps/cli/src/commands/diagnosticEvidence.ts
+++ b/apps/cli/src/commands/diagnosticEvidence.ts
@@ -1,0 +1,269 @@
+import type { LogRecord } from "@station/contracts";
+
+export type CauseAssessmentStatus =
+  | "explicit_root_cause"
+  | "observed_failure"
+  | "matched_success"
+  | "insufficient_evidence";
+
+export type CauseAssessmentLimitation =
+  | "no_explicit_root_cause"
+  | "reporting_boundary_only"
+  | "incomplete_search"
+  | "invalid_evidence";
+
+export type CauseAssessment = {
+  status: CauseAssessmentStatus;
+  explicitRootCauseCodes: string[];
+  observedFailureCodes: string[];
+  observedFailureSignals?: string[];
+  limitations: CauseAssessmentLimitation[];
+};
+
+export type DiagnosticMatchEvidence = {
+  path: string;
+  excerpt: string;
+};
+
+export type DiagnosticContextEntry = {
+  path: string;
+  value: string | number | boolean | null;
+};
+
+export type OperationalBoundaryEvidence = {
+  operation?: string;
+  commandType?: string;
+  signalKind?: string;
+  recordSummary?: string;
+  errorCode?: string;
+  errorMessage?: string;
+};
+
+export type DiagnosticEvidenceRoles = {
+  operationalBoundaryEvidence: "failure_and_ownership_evidence";
+  component: "logging_location_only";
+};
+
+const maxMatchEvidence = 3;
+const maxExcerptCodePoints = 160;
+const maxContextEntries = 6;
+const maxContextStringCodePoints = 120;
+const maxOperationalTextCodePoints = 240;
+// attributes.kind also classifies normal hook events, so only retained corruption kinds establish failure signals.
+const observedFailureSignalKinds = new Set([
+  "escape_fragment",
+  "replacement_char",
+  "unhandled_sequence",
+]);
+const duplicatedAttributeKeys = new Set([
+  "commandId",
+  "error",
+  "projectId",
+  "provider",
+  "sessionId",
+  "spanId",
+  "startupTail",
+  "traceId",
+  "worktreeId",
+]);
+
+export function assessCauseEvidence(input: {
+  explicitRootCauseCodes: readonly string[];
+  observedFailureCodes: readonly string[];
+  observedFailureSignals?: readonly string[];
+  observedFailureRecord?: boolean;
+  matched: boolean;
+  commandStatus?: string;
+  searchComplete: boolean;
+  invalidLines: number;
+  reportingBoundaryOnly: boolean;
+}): CauseAssessment {
+  const explicitRootCauseCodes = uniqueSorted(input.explicitRootCauseCodes);
+  const observedFailureCodes = uniqueSorted(input.observedFailureCodes);
+  const observedFailureSignals = uniqueSorted(input.observedFailureSignals ?? []);
+  // Only diagnostic-index root-cause declarations authorize this status; an error code is evidence of a failure, not proof of its underlying cause.
+  // An exactly matched warning or error record establishes its retained event as a proximate failure without establishing a deeper mechanism.
+  let status: CauseAssessmentStatus = "insufficient_evidence";
+  if (explicitRootCauseCodes.length > 0) {
+    status = "explicit_root_cause";
+  } else if (input.commandStatus === "succeeded") {
+    status = "matched_success";
+  } else if (
+    observedFailureCodes.length > 0 ||
+    observedFailureSignals.length > 0 ||
+    input.observedFailureRecord === true
+  ) {
+    status = "observed_failure";
+  }
+  const limitations: CauseAssessmentLimitation[] = [];
+  if (status === "observed_failure" || status === "insufficient_evidence") {
+    limitations.push("no_explicit_root_cause");
+  }
+  if (input.reportingBoundaryOnly) limitations.push("reporting_boundary_only");
+  if (!input.searchComplete) limitations.push("incomplete_search");
+  if (input.invalidLines > 0) limitations.push("invalid_evidence");
+  const assessment: CauseAssessment = {
+    status,
+    explicitRootCauseCodes,
+    observedFailureCodes,
+    limitations,
+  };
+  if (observedFailureSignals.length > 0) {
+    assessment.observedFailureSignals = observedFailureSignals;
+  }
+  return assessment;
+}
+
+export function extractDiagnosticMatchEvidence(
+  record: LogRecord,
+  query: string,
+): DiagnosticMatchEvidence[] {
+  const normalizedQuery = query.toLocaleLowerCase();
+  if (normalizedQuery.length === 0) return [];
+  const matches: DiagnosticMatchEvidence[] = [];
+  const matchedPaths = new Set<string>();
+
+  // LogRecord has already crossed strict parsing and redaction; this generic traversal only projects bounded excerpts from that safe representation.
+  visit(record, "", (path, key, value) => {
+    if (matches.length >= maxMatchEvidence) return;
+    const scalar = scalarText(value);
+    const keyMatches = key.toLocaleLowerCase().includes(normalizedQuery);
+    const valueMatches = scalar?.toLocaleLowerCase().includes(normalizedQuery) === true;
+    if (!keyMatches && !valueMatches) return;
+    const evidencePath = path.length === 0 ? "/" : path;
+    if (matchedPaths.has(evidencePath)) return;
+    matchedPaths.add(evidencePath);
+    const source = keyMatches && scalar !== undefined ? `${key}: ${scalar}` : (scalar ?? key);
+    matches.push({
+      path: evidencePath,
+      excerpt: boundedExcerpt(source, normalizedQuery),
+    });
+  });
+  return matches;
+}
+
+export function projectDiagnosticContext(record: LogRecord): DiagnosticContextEntry[] {
+  const attributes = record.attributes;
+  if (attributes === undefined) return [];
+  const context: DiagnosticContextEntry[] = [];
+  for (const key of Object.keys(attributes).sort((left, right) => left.localeCompare(right))) {
+    if (context.length >= maxContextEntries) break;
+    if (duplicatedAttributeKeys.has(key)) continue;
+    const value = scalarValue(attributes[key]);
+    if (value === undefined) continue;
+    if (typeof value === "string" && [...value].length > maxContextStringCodePoints) continue;
+    context.push({ path: `/attributes/${escapePointerToken(key)}`, value });
+  }
+  return context;
+}
+
+export function diagnosticEvidenceRoles(): DiagnosticEvidenceRoles {
+  return {
+    operationalBoundaryEvidence: "failure_and_ownership_evidence",
+    component: "logging_location_only",
+  };
+}
+
+export function retainedFailureSignal(kind: string | undefined): string | undefined {
+  return kind !== undefined && observedFailureSignalKinds.has(kind) ? kind : undefined;
+}
+
+// Keep this projection to retained facts so CLI presentation never invents subsystem ownership.
+export function projectOperationalBoundaryEvidence(input: {
+  operation?: string;
+  commandType?: string;
+  signalKind?: string;
+  recordSummary?: string;
+  errorCode?: string;
+  errorMessage?: string;
+}): OperationalBoundaryEvidence | undefined {
+  const evidence: OperationalBoundaryEvidence = {};
+  if (input.operation !== undefined) evidence.operation = boundedOperationalText(input.operation);
+  if (input.commandType !== undefined) {
+    evidence.commandType = boundedOperationalText(input.commandType);
+  }
+  if (input.signalKind !== undefined) {
+    evidence.signalKind = boundedOperationalText(input.signalKind);
+  }
+  if (input.recordSummary !== undefined) {
+    evidence.recordSummary = boundedOperationalText(input.recordSummary);
+  }
+  if (input.errorCode !== undefined) evidence.errorCode = boundedOperationalText(input.errorCode);
+  if (input.errorMessage !== undefined) {
+    evidence.errorMessage = boundedOperationalText(input.errorMessage);
+  }
+  return Object.keys(evidence).length === 0 ? undefined : evidence;
+}
+
+function visit(
+  value: unknown,
+  path: string,
+  onScalar: (path: string, key: string, value: unknown) => void,
+): void {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      const itemPath = `${path}/${index}`;
+      if (isContainer(item)) visit(item, itemPath, onScalar);
+      else onScalar(itemPath, String(index), item);
+    }
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  for (const key of Object.keys(value).sort((left, right) => left.localeCompare(right))) {
+    const item = (value as Record<string, unknown>)[key];
+    const itemPath = `${path}/${escapePointerToken(key)}`;
+    if (isContainer(item)) visit(item, itemPath, onScalar);
+    else onScalar(itemPath, key, item);
+  }
+}
+
+function isContainer(value: unknown): value is object {
+  return value !== null && typeof value === "object";
+}
+
+function scalarText(value: unknown): string | undefined {
+  const scalar = scalarValue(value);
+  return scalar === undefined ? undefined : String(scalar);
+}
+
+function scalarValue(value: unknown): string | number | boolean | null | undefined {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return undefined;
+}
+
+function boundedOperationalText(value: string): string {
+  const codePoints = [...value];
+  return codePoints.length <= maxOperationalTextCodePoints
+    ? value
+    : `${codePoints.slice(0, maxOperationalTextCodePoints - 1).join("")}…`;
+}
+
+function boundedExcerpt(value: string, normalizedQuery: string): string {
+  const codePoints = [...value];
+  if (codePoints.length <= maxExcerptCodePoints) return value;
+  const lower = value.toLocaleLowerCase();
+  const matchIndex = lower.indexOf(normalizedQuery);
+  const prefix = matchIndex < 0 ? 0 : [...value.slice(0, matchIndex)].length;
+  const halfWindow = Math.floor(maxExcerptCodePoints / 2);
+  const proposedStart = Math.max(
+    0,
+    Math.min(prefix - halfWindow, codePoints.length - maxExcerptCodePoints),
+  );
+  const prefixMarker = proposedStart > 0 ? "…" : "";
+  const available = maxExcerptCodePoints - [...prefixMarker].length - 1;
+  const end = Math.min(codePoints.length, proposedStart + available);
+  const suffixMarker = end < codePoints.length ? "…" : "";
+  const excerpt = codePoints
+    .slice(proposedStart, end + (suffixMarker.length === 0 ? 1 : 0))
+    .join("");
+  return `${prefixMarker}${excerpt}${suffixMarker}`;
+}
+
+function escapePointerToken(value: string): string {
+  return value.replaceAll("~", "~0").replaceAll("/", "~1");
+}
+
+function uniqueSorted(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}

--- a/apps/cli/src/commands/registry/debug.ts
+++ b/apps/cli/src/commands/registry/debug.ts
@@ -80,9 +80,17 @@ export const debugCliCommand: CliCommandNode = {
           name: "--latest-failure",
           description: "Find the most recent failure when no query is provided.",
         },
-        { name: "--json", description: "Keep JSON output for agent-readable inspection." },
+        {
+          name: "--json",
+          description: "Include cause assessment and evidence-role metadata.",
+        },
       ],
       examples: ["pnpm stn debug trace --latest-failure"],
+      notes: [
+        "A matched record does not by itself establish an underlying root cause.",
+        "causeAssessment separates explicit diagnostic-index roots from observed failure codes.",
+        "Evidence roles distinguish operational failure evidence from logging provenance.",
+      ],
     },
     {
       name: "logs",
@@ -105,11 +113,21 @@ export const debugCliCommand: CliCommandNode = {
           description: "Only include records at or after a timestamp.",
         },
         { name: "--limit <count>", description: "Limit returned records." },
-        { name: "--json", description: "Keep JSON output for agent-readable inspection." },
+        {
+          name: "--json",
+          description: "Include match, cause, and operational-boundary evidence.",
+        },
       ],
       examples: [
         "pnpm stn debug logs protocol",
         "pnpm stn debug logs --all-components --min-level warn",
+      ],
+      notes: [
+        "Queried records include bounded match evidence showing why they matched.",
+        "The result separates observed failures from insufficient causal evidence.",
+        "Operational boundary evidence groups retained facts without inferring ownership.",
+        "Evidence roles direct ownership citations away from logging provenance.",
+        "componentRole marks each record component as a logging location, not failure ownership.",
       ],
     },
   ],

--- a/apps/cli/test/integration/diagnostic-commands.test.ts
+++ b/apps/cli/test/integration/diagnostic-commands.test.ts
@@ -392,6 +392,21 @@ describe("CLI diagnostic commands", () => {
           ],
         },
         rootCauseCodes: expect.arrayContaining(["WORKTRUNK_UNSUPPORTED_FLAG"]),
+        causeAssessment: {
+          status: "explicit_root_cause",
+          explicitRootCauseCodes: ["COMMAND_FAILED"],
+          observedFailureCodes: ["WORKTRUNK_UNSUPPORTED_FLAG"],
+          limitations: [],
+        },
+        evidenceRoles: {
+          operationalBoundaryEvidence: "failure_and_ownership_evidence",
+          component: "logging_location_only",
+        },
+        operationalBoundaryEvidence: {
+          commandType: "session.create",
+          errorCode: "WORKTRUNK_UNSUPPORTED_FLAG",
+          errorMessage: "Worktrunk rejected an automation flag used by STATION.",
+        },
       },
     });
   });
@@ -455,6 +470,21 @@ describe("CLI diagnostic commands", () => {
         error: {
           code: "WORKTRUNK_BRANCH_EXISTS",
         },
+        causeAssessment: {
+          status: "observed_failure",
+          explicitRootCauseCodes: [],
+          observedFailureCodes: ["WORKTRUNK_BRANCH_EXISTS"],
+        },
+        evidenceRoles: {
+          operationalBoundaryEvidence: "failure_and_ownership_evidence",
+          component: "logging_location_only",
+        },
+        operationalBoundaryEvidence: {
+          commandType: "session.sendPrompt",
+          recordSummary: "Command failed.",
+          errorCode: "WORKTRUNK_BRANCH_EXISTS",
+          errorMessage: "Branch exists.",
+        },
       },
     });
   });
@@ -501,6 +531,22 @@ describe("CLI diagnostic commands", () => {
         spanId: "spn_lifecycle",
         error: {
           code: "OBSERVER_START_FAILED",
+        },
+        causeAssessment: {
+          status: "observed_failure",
+          explicitRootCauseCodes: [],
+          observedFailureCodes: ["OBSERVER_START_FAILED"],
+          limitations: ["no_explicit_root_cause", "reporting_boundary_only"],
+        },
+        evidenceRoles: {
+          operationalBoundaryEvidence: "failure_and_ownership_evidence",
+          component: "logging_location_only",
+        },
+        operationalBoundaryEvidence: {
+          operation: "cli.observer.start",
+          recordSummary: "Observer lifecycle failed.",
+          errorCode: "OBSERVER_START_FAILED",
+          errorMessage: "Observer did not become healthy before the startup timeout.",
         },
         suggestedCommands: expect.arrayContaining(["stn debug bundle --trace trc_lifecycle"]),
       },
@@ -559,11 +605,28 @@ describe("CLI diagnostic commands", () => {
         query: "protocol",
         components: ["observer", "cli", "tui"],
         matched: 1,
+        causeAssessment: {
+          status: "observed_failure",
+          observedFailureCodes: ["PROTOCOL_VALIDATION_FAILED"],
+        },
+        evidenceRoles: {
+          operationalBoundaryEvidence: "failure_and_ownership_evidence",
+          component: "logging_location_only",
+        },
         records: [
           {
             component: "observer",
+            componentRole: "logging_location",
             level: "error",
             message: "Observer protocol payload failed validation.",
+            operationalBoundaryEvidence: {
+              recordSummary: "Observer protocol payload failed validation.",
+              errorCode: "PROTOCOL_VALIDATION_FAILED",
+              errorMessage: "Observer protocol payload failed validation.",
+            },
+            matchEvidence: expect.arrayContaining([
+              expect.objectContaining({ excerpt: expect.stringContaining("protocol") }),
+            ]),
             error: {
               code: "PROTOCOL_VALIDATION_FAILED",
             },

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -178,10 +178,26 @@ describe("CLI manual-smoke commands", () => {
 
   it("resolves nested debug and project manual topics", async () => {
     const bundle = await runCli(["debug", "bundle", "--help"]);
+    const logsHelp = await runCli(["debug", "logs", "--help"]);
+    const logsManual = await runCli(["debug", "logs", "--man"]);
+    const traceHelp = await runCli(["debug", "trace", "--help"]);
+    const traceManual = await runCli(["debug", "trace", "--man"]);
     const projectAdd = await runCli(["project", "add", "--man"]);
 
     expect(bundle).toMatchObject({ code: 0, outputFormat: "text" });
     expect(textOutput(bundle)).toContain("stn debug bundle --latest-failure");
+    expect(logsHelp).toMatchObject({ code: 0, outputFormat: "text" });
+    expect(textOutput(logsHelp)).toContain("operational-boundary evidence");
+    expect(logsManual).toMatchObject({ code: 0, outputFormat: "text" });
+    expect(textOutput(logsManual)).toContain(
+      "componentRole marks each record component as a logging location",
+    );
+    expect(traceHelp).toMatchObject({ code: 0, outputFormat: "text" });
+    expect(textOutput(traceHelp)).toContain("cause assessment and evidence-role metadata");
+    expect(traceManual).toMatchObject({ code: 0, outputFormat: "text" });
+    expect(textOutput(traceManual)).toContain(
+      "causeAssessment separates explicit diagnostic-index roots from observed failure codes",
+    );
     expect(projectAdd).toMatchObject({ code: 0, outputFormat: "text" });
     expect(textOutput(projectAdd)).toContain("Usage:\n  stn project add <path>");
     expect(textOutput(projectAdd)).toContain("Behavior Notes:");

--- a/apps/cli/test/unit/diagnostic-evidence.test.ts
+++ b/apps/cli/test/unit/diagnostic-evidence.test.ts
@@ -1,0 +1,209 @@
+import type { LogRecord } from "@station/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  assessCauseEvidence,
+  diagnosticEvidenceRoles,
+  extractDiagnosticMatchEvidence,
+  projectDiagnosticContext,
+  projectOperationalBoundaryEvidence,
+  retainedFailureSignal,
+} from "../../src/commands/diagnosticEvidence.js";
+
+const record: LogRecord = {
+  timestamp: "2026-07-18T13:55:39.044Z",
+  level: "error",
+  component: "cli",
+  message: "Observer lifecycle failed.",
+  attributes: {
+    operation: "cli.observer.start",
+    kind: "replacement_char",
+    startupTail: "Persistence initialization failed: SQLITE_BUSY database is locked.",
+    error: {
+      code: "OBSERVER_EXITED_ON_START",
+      message: "Observer exited before becoming healthy.",
+    },
+    nested: { reason: "database is locked" },
+    oversized: "x".repeat(200),
+  },
+};
+
+describe("diagnostic evidence projection", () => {
+  it("reserves explicit root-cause status for correlated diagnostic-index declarations", () => {
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: ["SQLITE_BUSY"],
+        observedFailureCodes: ["OBSERVER_EXITED_ON_START"],
+        matched: true,
+        searchComplete: true,
+        invalidLines: 0,
+        reportingBoundaryOnly: true,
+      }),
+    ).toEqual({
+      status: "explicit_root_cause",
+      explicitRootCauseCodes: ["SQLITE_BUSY"],
+      observedFailureCodes: ["OBSERVER_EXITED_ON_START"],
+      limitations: ["reporting_boundary_only"],
+    });
+  });
+
+  it("classifies a generic wrapper error as an observed failure with limitations", () => {
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: [],
+        observedFailureCodes: ["OBSERVER_START_FAILED"],
+        matched: true,
+        searchComplete: false,
+        invalidLines: 2,
+        reportingBoundaryOnly: true,
+      }),
+    ).toEqual({
+      status: "observed_failure",
+      explicitRootCauseCodes: [],
+      observedFailureCodes: ["OBSERVER_START_FAILED"],
+      limitations: [
+        "no_explicit_root_cause",
+        "reporting_boundary_only",
+        "incomplete_search",
+        "invalid_evidence",
+      ],
+    });
+  });
+
+  it("classifies only retained corruption kinds as observed failure signals", () => {
+    expect(retainedFailureSignal("replacement_char")).toBe("replacement_char");
+    expect(retainedFailureSignal("harness")).toBeUndefined();
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: [],
+        observedFailureCodes: [],
+        observedFailureSignals: ["replacement_char"],
+        matched: true,
+        searchComplete: true,
+        invalidLines: 0,
+        reportingBoundaryOnly: true,
+      }),
+    ).toEqual({
+      status: "observed_failure",
+      explicitRootCauseCodes: [],
+      observedFailureCodes: [],
+      observedFailureSignals: ["replacement_char"],
+      limitations: ["no_explicit_root_cause", "reporting_boundary_only"],
+    });
+  });
+
+  it("treats an exactly matched warning record as an observed proximate failure", () => {
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: [],
+        observedFailureCodes: [],
+        observedFailureRecord: true,
+        matched: true,
+        searchComplete: true,
+        invalidLines: 0,
+        reportingBoundaryOnly: true,
+      }),
+    ).toMatchObject({
+      status: "observed_failure",
+      limitations: ["no_explicit_root_cause", "reporting_boundary_only"],
+    });
+  });
+
+  it("distinguishes matched success and absent evidence", () => {
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: [],
+        observedFailureCodes: [],
+        matched: true,
+        commandStatus: "succeeded",
+        searchComplete: true,
+        invalidLines: 0,
+        reportingBoundaryOnly: false,
+      }).status,
+    ).toBe("matched_success");
+    expect(
+      assessCauseEvidence({
+        explicitRootCauseCodes: [],
+        observedFailureCodes: [],
+        matched: false,
+        searchComplete: true,
+        invalidLines: 0,
+        reportingBoundaryOnly: false,
+      }),
+    ).toMatchObject({
+      status: "insufficient_evidence",
+      limitations: ["no_explicit_root_cause"],
+    });
+  });
+
+  it("returns deterministic bounded evidence for nested values and matching keys", () => {
+    expect(extractDiagnosticMatchEvidence(record, "SQLITE_BUSY")).toEqual([
+      {
+        path: "/attributes/startupTail",
+        excerpt: "Persistence initialization failed: SQLITE_BUSY database is locked.",
+      },
+    ]);
+    expect(extractDiagnosticMatchEvidence(record, "reason")).toEqual([
+      { path: "/attributes/nested/reason", excerpt: "reason: database is locked" },
+    ]);
+  });
+
+  it("caps match count and clips Unicode by code point", () => {
+    const many: LogRecord = {
+      ...record,
+      attributes: {
+        a: `before ${"🧭".repeat(200)} needle after`,
+        b: "needle two",
+        c: "needle three",
+        d: "needle four",
+      },
+    };
+    const evidence = extractDiagnosticMatchEvidence(many, "needle");
+    expect(evidence).toHaveLength(3);
+    expect(evidence.map((item) => item.path)).toEqual([
+      "/attributes/a",
+      "/attributes/b",
+      "/attributes/c",
+    ]);
+    expect([...(evidence[0]?.excerpt ?? "")].length).toBeLessThanOrEqual(160);
+    expect(evidence[0]?.excerpt).toContain("needle");
+  });
+
+  it("projects bounded scalar context while excluding duplicated and oversized fields", () => {
+    expect(projectDiagnosticContext(record)).toEqual([
+      { path: "/attributes/kind", value: "replacement_char" },
+      { path: "/attributes/operation", value: "cli.observer.start" },
+    ]);
+  });
+
+  it("labels operational facts and logging provenance with distinct evidence roles", () => {
+    expect(diagnosticEvidenceRoles()).toEqual({
+      operationalBoundaryEvidence: "failure_and_ownership_evidence",
+      component: "logging_location_only",
+    });
+  });
+
+  it("groups retained operational facts without inferring an owner", () => {
+    const evidence = projectOperationalBoundaryEvidence({
+      operation: "cli.observer.start",
+      commandType: "worktree.remove",
+      signalKind: "replacement_char",
+      recordSummary: "Local git metadata refresh failed.",
+      errorCode: "LOCAL_GIT_REF_UNRESOLVED",
+      errorMessage: "The worktree ref could not be resolved.",
+    });
+    expect(evidence).toEqual({
+      operation: "cli.observer.start",
+      commandType: "worktree.remove",
+      signalKind: "replacement_char",
+      recordSummary: "Local git metadata refresh failed.",
+      errorCode: "LOCAL_GIT_REF_UNRESOLVED",
+      errorMessage: "The worktree ref could not be resolved.",
+    });
+    expect(projectOperationalBoundaryEvidence({})).toBeUndefined();
+    const bounded = projectOperationalBoundaryEvidence({
+      recordSummary: "🧭".repeat(300),
+    })?.recordSummary;
+    expect([...(bounded ?? "")]).toHaveLength(240);
+    expect(bounded).toMatch(/…$/u);
+  });
+});

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -63,6 +63,16 @@ were ignored before Observer delivery because Station ownership was missing or
 cwd did not match configured roots. Unsupported provider events intentionally
 produce no per-occurrence log.
 
+Each returned log record marks its `componentRole` as `logging_location`. The
+component says where Station retained the record, not which subsystem owns the
+failure. For a query or a single selected record, `operationalBoundaryEvidence`
+groups only retained operation, command type, signal, record summary, error
+code, and error message facts. `evidenceRoles` identifies that projection as
+failure-and-ownership evidence while keeping the component as logging
+provenance. Queried records also include bounded `matchEvidence` and scalar
+`context` so a caller can cite why the record matched without treating those
+facts as proof of an unrecorded mechanism.
+
 Current-truth tools interact with the live observer. `doctor`, `snapshot`,
 `observe`, `command get`, `reconcile`, and `debug bundle` all contact the
 observer or start it when needed. `debug bundle` also writes a
@@ -83,8 +93,13 @@ stn command get <commandId>
 `stn debug trace` searches existing bundles and structured logs. When a command
 error envelope includes diagnostics, the trace summary can include redacted
 external-command details: command, cwd, exit code, duration, and bounded
-stdout/stderr snippets. It also derives `rootCauseCodes` from command records,
-error envelopes, diagnostic indexes, and matching log errors.
+stdout/stderr snippets. The compatibility `rootCauseCodes` field retains command, envelope, index, and
+matching-log codes. Use `causeAssessment` for causal interpretation: only a
+correlated diagnostic-index root-cause declaration produces
+`explicit_root_cause`; an error code, retained signal, or exactly matched
+warning/error record produces `observed_failure` and does not establish the
+deeper mechanism. Trace output uses the same `evidenceRoles` and
+`operationalBoundaryEvidence` semantics as `debug logs`.
 
 `stn command get <commandId>` asks the live observer for the command lifecycle
 record. Failed provider commands may include the same redacted diagnostics when

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -57,14 +57,26 @@ correlate trace ids, command ids, diagnostic ids, root-cause codes, redacted
 command diagnostics, and suggested next commands without contacting the observer.
 When a command error envelope includes external-command diagnostics, trace output
 can show the command, cwd, exit code, duration, and bounded stdout/stderr
-snippets after redaction.
+snippets after redaction. `causeAssessment` distinguishes a correlated,
+diagnostic-index-declared root cause from an observed command/error failure or
+insufficient evidence. A generic error code is failure evidence, not proof of
+the mechanism beneath it.
+
+Trace and log results expose `evidenceRoles` so consumers do not confuse the
+record's logging component with failure ownership. `operationalBoundaryEvidence`
+groups only retained operation, command type, signal kind, record summary,
+error code, and error message facts. It does not infer a subsystem or handler.
 
 `stn debug logs` reads structured JSONL logs from the configured state
 directory without contacting the observer. By default it searches `observer`,
 `cli`, and `tui` logs, excludes noisy hook logs, returns recent `warn`/`error`
 records when no query is supplied, and searches all levels when a query is
 supplied. Use `--component hook` or `--all-components` only when hook delivery
-or provider-ingress noise is relevant.
+or provider-ingress noise is relevant. Each record marks `componentRole` as
+`logging_location`; queried records include bounded `matchEvidence` and scalar
+`context` for direct citation. An exactly matched warning or error record can
+establish the retained event as an observed proximate failure without
+establishing a deeper cause.
 
 `stn observer status` checks the configured observer process/socket state. It is
 non-mutating, but it is still a live status check rather than an existing-state

--- a/tests/agent/scenarios/diagnosis/cli-causal-evidence.test.ts
+++ b/tests/agent/scenarios/diagnosis/cli-causal-evidence.test.ts
@@ -1,0 +1,123 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { runCli } from "../../../../apps/cli/src/index.js";
+import { createTempState, writeConfigToml } from "../../../support/temp-projects";
+
+describe("CLI causal evidence projection", () => {
+  it("separates operational failure evidence from log provenance", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    await writeFile(
+      join(fixture.stateDir, "logs", "cli.jsonl"),
+      `${JSON.stringify({
+        timestamp: "2026-05-20T12:02:00.000Z",
+        level: "error",
+        component: "cli",
+        message: "Observer lifecycle failed.",
+        traceId: "trc_lifecycle",
+        attributes: {
+          operation: "cli.observer.start",
+          error: {
+            tag: "ObserverStartupError",
+            code: "OBSERVER_START_FAILED",
+            message: "Observer did not become healthy before the startup timeout.",
+          },
+        },
+      })}\n`,
+    );
+
+    const result = await runCli(["--config", configPath, "debug", "trace", "--latest-failure"], {
+      observerDeps: {
+        clientFactory: () => {
+          throw new Error("debug trace must remain local");
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      code: 0,
+      output: {
+        causeAssessment: {
+          status: "observed_failure",
+          explicitRootCauseCodes: [],
+          observedFailureCodes: ["OBSERVER_START_FAILED"],
+        },
+        evidenceRoles: {
+          operationalBoundaryEvidence: "failure_and_ownership_evidence",
+          component: "logging_location_only",
+        },
+        operationalBoundaryEvidence: {
+          operation: "cli.observer.start",
+          recordSummary: "Observer lifecycle failed.",
+          errorCode: "OBSERVER_START_FAILED",
+          errorMessage: "Observer did not become healthy before the startup timeout.",
+        },
+      },
+    });
+    expect(result.output).not.toHaveProperty("reportedBy");
+  });
+
+  it("retains bounded citation context for a queried log record", async () => {
+    const fixture = await createTempState();
+    const configPath = await writeConfigToml(fixture.root, fixture.config);
+    await mkdir(join(fixture.stateDir, "logs"), { recursive: true });
+    await writeFile(
+      join(fixture.stateDir, "logs", "observer.jsonl"),
+      `${JSON.stringify({
+        timestamp: "2026-05-20T12:03:00.000Z",
+        level: "warn",
+        component: "observer",
+        message: "Local Git ref resolution failed.",
+        attributes: {
+          operation: "metadata.localGit.resolveRef",
+          error: {
+            tag: "LocalGitError",
+            code: "LOCAL_GIT_REF_UNRESOLVED",
+            message: "Git ref could not be resolved.",
+          },
+        },
+      })}\n`,
+    );
+
+    const result = await runCli(
+      ["--config", configPath, "debug", "logs", "LOCAL_GIT_REF_UNRESOLVED"],
+      {
+        observerDeps: {
+          clientFactory: () => {
+            throw new Error("debug logs must remain local");
+          },
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      code: 0,
+      output: {
+        causeAssessment: {
+          status: "observed_failure",
+          observedFailureCodes: ["LOCAL_GIT_REF_UNRESOLVED"],
+        },
+        records: [
+          {
+            component: "observer",
+            componentRole: "logging_location",
+            operationalBoundaryEvidence: {
+              operation: "metadata.localGit.resolveRef",
+              recordSummary: "Local Git ref resolution failed.",
+              errorCode: "LOCAL_GIT_REF_UNRESOLVED",
+              errorMessage: "Git ref could not be resolved.",
+            },
+            matchEvidence: [
+              {
+                path: "/attributes/error/code",
+                excerpt: "LOCAL_GIT_REF_UNRESOLVED",
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What this fixes

Station's local debug commands expose the component that wrote a record, but consumers can mistake that logging location for the subsystem that owns the observed failure. Generic error codes can likewise be presented as if they prove the mechanism beneath a failure. This makes otherwise useful local evidence easy to overinterpret during incident diagnosis.

## What changed

- Add a bounded CLI-local evidence projection for cause assessment, direct match context, and retained operational-boundary facts.
- Mark record components explicitly as logging locations and publish evidence roles that distinguish provenance from failure-and-ownership evidence.
- Treat error codes, retained signals, and exactly matched warning/error records as observed proximate failures without claiming an unrecorded deeper mechanism.
- Preserve current-main log scanning, Observer behavior, and the existing compatibility `rootCauseCodes` field while documenting `causeAssessment` as the causal interpretation surface.
- Add focused unit, integration, and scripted-agent coverage for local Git, Observer lifecycle, protocol, command, and explicit diagnostic-index evidence.

## Testing

- `pnpm build`
- `pnpm --filter @station/cli typecheck`
- `pnpm lint`
- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts apps/cli/test/unit/diagnostic-evidence.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/cli/test/integration/diagnostic-commands.test.ts`
- `pnpm exec vitest run --config config/vitest/vitest.integration.config.ts apps/cli/test/integration/manual-smoke-commands.test.ts`
- Manual inspection of `stn debug logs --help`, `stn debug trace --help`, and `stn debug logs --man`
- `pnpm exec vitest run --config config/vitest/vitest.agent-scripted.config.ts tests/agent/scenarios/diagnosis/cli-causal-evidence.test.ts`

## Safety and scope

This is CLI-local evidence projection only. It changes no Observer API, provider contract, persistence, protocol, configuration, or TUI behavior. It ports the selected v13 evidence contract onto current `main`; resource measurements from the frozen exploratory study belong to that sealed candidate build, not this rebased diff.

## User-visible behavior

`stn debug logs` and `stn debug trace` now identify operational failure evidence separately from the component that logged it. To verify, query a retained failure and confirm `evidenceRoles`, `componentRole`, `causeAssessment`, and `operationalBoundaryEvidence` are present without a `reportedBy` ownership claim.
