### PR TITLE
feat(tui): complete remove and fork sheet interaction parity

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -943,6 +943,10 @@ popup with three independent passes:
 3. Focus: use arrows plus `Enter` for folder lists, review actions, and name
    editor actions at both wide and minimum supported widths.
 
+Also open Remove Session and Fork Session from a disposable row. Verify Delete/Keep with pointer,
+Y/N, and Left/Right plus Enter; then verify Fork Name/Copy/Fork with pointer and keyboard focus,
+including Copy-focused Enter toggling without submitting.
+
 Git-invalid Add Project submit must stay disabled, native Create Session must
 open a Station-managed pane, and the popup must continue through its configured
 terminal adapter.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -317,6 +317,17 @@ vertically stacked so Up/Down does not conflict with text-cursor movement. Missi
 keeps submit disabled and stale disabled targets inert; these interaction paths do not weaken
 project admission policy.
 
+Remove Session confirmation renders explicit Delete and Keep Session actions instead of generic
+Yes/No controls. Keep is the safe initial focus; Left/Right moves without wrapping, focused Enter
+activates the current choice, and Y/N retain their direct meanings. Both controls dispatch stable
+semantic actions, use the shared bounded button treatment, and keep trailing sheet cells inert.
+
+Fork Session renders Name and Copy through the same bounded field-control grammar as Create Session.
+Clicking Name focuses its editor, clicking Copy focuses and toggles it once, and the Fork button
+submits through a shared semantic action. Copy-focused Enter toggles rather than submitting; Enter
+on Name or Fork submits. Native Station intercepts only submit to host the fork in a managed pane,
+while standalone/tmux keeps the shared observer operation path.
+
 Create Session review renders Project, Name, and Agent as compact field controls, followed by a
 compact Create button. Labels, bold yellow accelerators (`P`, `N`, `A`, and `C`), values, and inline
 health status use separate spans so their roles and associations remain visible. Arrow focus uses

--- a/packages/dashboard-core/src/state/actions.ts
+++ b/packages/dashboard-core/src/state/actions.ts
@@ -7,7 +7,12 @@ import {
 } from "./projectHeaderActions.js";
 import { handleAddProjectAction } from "./screens/addProjectScreen.js";
 import { handleFirstProjectAddAction } from "./screens/dashboard.js";
+import { type ForkSessionActionId, handleForkSessionAction } from "./screens/fork.js";
 import { handleNewSessionAction } from "./screens/newSession.js";
+import {
+  handleRemoveWorktreeAction,
+  type RemoveWorktreeActionId,
+} from "./screens/removeWorktree.js";
 import { submitRenameSession } from "./screens/renameSession.js";
 import type { TuiRuntimeContext, TuiTransition } from "./transition.js";
 import type { ProjectHeaderControl, TuiState } from "./types.js";
@@ -23,6 +28,8 @@ export type TuiSemanticAction =
   | { type: "dashboard.emptyProject.activate"; projectId: ProjectId }
   | { type: "addProject.activate"; actionId: AddProjectActionId }
   | { type: "newSession.activate"; actionId: NewSessionActionId }
+  | { type: "removeWorktree.activate"; actionId: RemoveWorktreeActionId }
+  | { type: "forkSession.activate"; actionId: ForkSessionActionId }
   | { type: "renameSession.submit" };
 
 /** Resolves a semantic TUI action into the same pure transition used by keyboard input. */
@@ -42,6 +49,10 @@ export function handleTuiAction(
       return handleAddProjectAction(state, action.actionId);
     case "newSession.activate":
       return handleNewSessionAction(state, action.actionId);
+    case "removeWorktree.activate":
+      return handleRemoveWorktreeAction(state, action.actionId);
+    case "forkSession.activate":
+      return handleForkSessionAction(state, action.actionId);
     case "renameSession.submit":
       return submitRenameSession(state);
   }

--- a/packages/dashboard-core/src/state/screens/fork.ts
+++ b/packages/dashboard-core/src/state/screens/fork.ts
@@ -18,6 +18,8 @@ import { handleDashboardRowChoiceKey } from "./rowChoose.js";
 export type ForkDetailsScreen = Extract<TuiState["screen"], { name: "fork"; step: "details" }>;
 type ForkScreen = Extract<TuiState["screen"], { name: "fork" }>;
 
+export type ForkSessionActionId = "details.name" | "details.copyDirty" | "details.submit";
+
 const forkChooseSlotBehavior = {};
 const forkDetailsBehavior = { clickAway: backFromForkDetails };
 
@@ -84,6 +86,30 @@ export function handleForkKey(state: TuiState, key: TuiKey): TuiTransition {
     }));
   }
   return handleDetailsKey(state, key, state.screen);
+}
+
+/** Applies a visible Fork details action after validating the active screen. */
+export function handleForkSessionAction(
+  state: TuiState,
+  actionId: ForkSessionActionId,
+): TuiTransition {
+  if (state.screen.name !== "fork" || state.screen.step !== "details") {
+    return { state };
+  }
+  const screen = state.screen;
+  switch (actionId) {
+    case "details.name":
+      return { state: { ...state, screen: { ...screen, focus: "name" } } };
+    case "details.copyDirty":
+      return {
+        state: {
+          ...state,
+          screen: { ...screen, focus: "copyDirty", copyDirty: !screen.copyDirty },
+        },
+      };
+    case "details.submit":
+      return submitFork(state, screen);
+  }
 }
 
 export type OpenForkDetailsOptions = {
@@ -172,7 +198,10 @@ function handleDetailsKey(state: TuiState, key: TuiKey, screen: ForkDetailsScree
   }
 
   if (isReturnKey(key)) {
-    return submitFork(state, screen);
+    return handleForkSessionAction(
+      state,
+      screen.focus === "copyDirty" ? "details.copyDirty" : "details.submit",
+    );
   }
 
   if (key.upArrow === true || key.downArrow === true) {
@@ -186,7 +215,7 @@ function handleDetailsKey(state: TuiState, key: TuiKey, screen: ForkDetailsScree
 
   if (screen.focus === "copyDirty") {
     if (key.input === " " || key.leftArrow === true || key.rightArrow === true) {
-      return { state: { ...state, screen: { ...screen, copyDirty: !screen.copyDirty } } };
+      return handleForkSessionAction(state, "details.copyDirty");
     }
     return { state };
   }

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -16,6 +16,8 @@ import { handleDashboardRowChoiceKey } from "./rowChoose.js";
 
 type RemoveWorktreeScreen = Extract<TuiState["screen"], { name: "removeWorktree" }>;
 
+export type RemoveWorktreeActionId = "confirm.delete" | "confirm.keep";
+
 const removeWorktreeChooseSlotBehavior = {};
 const removeWorktreeDismissBehavior = { clickAway: cancelRemoveWorktree };
 
@@ -36,7 +38,9 @@ export function handleRemoveWorktreeKey(state: TuiState, key: TuiKey): TuiTransi
   }
 
   if (key.escape === true) {
-    return { state: cancelRemoveWorktree(state) };
+    return state.screen.step === "confirm"
+      ? handleRemoveWorktreeAction(state, "confirm.keep")
+      : { state: cancelRemoveWorktree(state) };
   }
 
   if (state.screen.step === "chooseSlot") {
@@ -100,6 +104,7 @@ export function openRemoveWorktreeConfirmForRow(state: TuiState, rowId: SessionI
       rowId: sessionRow.id,
       forceRequired: removeWorktreeForceRequired(sessionRow, snapshot),
       label,
+      actionFocus: "keep",
     },
   };
 }
@@ -109,17 +114,47 @@ function handleConfirmKey(state: TuiState, key: TuiKey): TuiTransition {
     return { state };
   }
 
-  const input = key.input.toLowerCase();
-
-  if (input === "n" || key.escape === true || isReturnKey(key)) {
-    return { state: cancelRemoveWorktree(state) };
+  if (key.leftArrow === true || key.rightArrow === true) {
+    const actionFocus = key.leftArrow === true ? "delete" : "keep";
+    return { state: { ...state, screen: { ...state.screen, actionFocus } } };
   }
 
-  if (input !== "y") {
+  const input = key.input.toLowerCase();
+  if (input === "n") {
+    return handleRemoveWorktreeAction(state, "confirm.keep");
+  }
+  if (input === "y") {
+    return handleRemoveWorktreeAction(state, "confirm.delete");
+  }
+  if (isReturnKey(key)) {
+    return handleRemoveWorktreeAction(
+      state,
+      state.screen.actionFocus === "delete" ? "confirm.delete" : "confirm.keep",
+    );
+  }
+  return { state };
+}
+
+/** Applies a visible Remove confirmation action after validating the active screen. */
+export function handleRemoveWorktreeAction(
+  state: TuiState,
+  actionId: RemoveWorktreeActionId,
+): TuiTransition {
+  if (state.screen.name !== "removeWorktree" || state.screen.step !== "confirm") {
     return { state };
   }
+  switch (actionId) {
+    case "confirm.keep":
+      return { state: cancelRemoveWorktree(state) };
+    case "confirm.delete":
+      return deleteRemoveWorktree(state, state.screen);
+  }
+}
 
-  const screen = state.screen;
+function deleteRemoveWorktree(
+  state: TuiState,
+  screen: Extract<RemoveWorktreeScreen, { step: "confirm" }>,
+): TuiTransition {
   const snapshot = state.snapshot;
   if (snapshot === undefined) {
     return { state: { ...state, screen: { name: "dashboard" } } };

--- a/packages/dashboard-core/src/state/types.ts
+++ b/packages/dashboard-core/src/state/types.ts
@@ -88,6 +88,7 @@ export type TuiScreen =
       rowId: SessionId;
       forceRequired: boolean;
       label: string;
+      actionFocus: "delete" | "keep";
     }
   | { name: "renameSession"; step: "chooseSlot" }
   | {

--- a/packages/dashboard-core/test/unit/state/interactionParity.test.ts
+++ b/packages/dashboard-core/test/unit/state/interactionParity.test.ts
@@ -9,6 +9,8 @@ import {
   handleTuiKey,
   newSessionIntentForAction,
   openAddProject,
+  openForkDetailsForRow,
+  openRemoveWorktreeConfirmForRow,
   transitionNewSessionFlow,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
@@ -181,6 +183,61 @@ describe("primary workflow interaction parity", () => {
     for (const id of ["editName.name", "editName.save", "editName.back"] as const) {
       expect(newSessionIntentForAction(edit, id).type, id).not.toBe("none");
     }
+  });
+
+  it("converges Remove pointer semantics with direct and focused activation", () => {
+    const base = openRemoveWorktreeConfirmForRow(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "ses_wt_web_idle",
+    );
+    const semantic = handleTuiAction(
+      base,
+      { type: "removeWorktree.activate", actionId: "confirm.delete" },
+      context,
+    );
+    const direct = handleTuiKey(base, { input: "y" }, context);
+    const focused = handleTuiKey(
+      handleTuiKey(base, { input: "", leftArrow: true }, context).state,
+      { input: "\r", return: true },
+      context,
+    );
+
+    const semanticOperation = semantic.operations?.[0];
+    const directOperation = direct.operations?.[0];
+    const focusedOperation = focused.operations?.[0];
+    if (
+      semanticOperation?.type !== "removeWorktree" ||
+      directOperation?.type !== "removeWorktree" ||
+      focusedOperation?.type !== "removeWorktree"
+    ) {
+      throw new Error("expected Remove Worktree operations");
+    }
+    expect(semanticOperation.command).toEqual(directOperation.command);
+    expect(focusedOperation.command).toEqual(directOperation.command);
+    expect(semantic.state.screen).toEqual({ name: "dashboard" });
+    expect(focused.state.screen).toEqual({ name: "dashboard" });
+  });
+
+  it("converges Fork Copy pointer semantics with focused Enter", () => {
+    const base = openForkDetailsForRow(
+      createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+      "ses_wt_web_idle",
+      { branchToken: "aaaaaa" },
+    );
+    const semantic = handleTuiAction(
+      base,
+      { type: "forkSession.activate", actionId: "details.copyDirty" },
+      context,
+    );
+    const keyboard = handleTuiKey(
+      handleTuiKey(base, { input: "", downArrow: true }, context).state,
+      { input: "\r", return: true },
+      context,
+    );
+
+    expect(semantic.state.screen).toEqual(keyboard.state.screen);
+    expect(semantic.operations).toBeUndefined();
+    expect(keyboard.operations).toBeUndefined();
   });
 
   it.each([

--- a/packages/dashboard-core/test/unit/state/screenBehavior.test.ts
+++ b/packages/dashboard-core/test/unit/state/screenBehavior.test.ts
@@ -36,7 +36,7 @@ const addFailed = failedStateForError(addReview, addReview.selectedPath, {
   message: "Project review failed.",
 });
 const newReview = requiredNewSessionFlow();
-const newEdit = requiredNewSessionTransition(newReview, { type: "editName" });
+const newEdit = requiredNewSessionEdit(newReview);
 const newPickProject = requiredNewSessionTransition(newReview, { type: "pickProject" });
 const newPickAgent = requiredNewSessionTransition(newReview, { type: "pickAgent" });
 
@@ -84,6 +84,7 @@ const screenBehaviorCases: readonly [
       rowId: "ses_wt_web_idle",
       forceRequired: false,
       label: "web",
+      actionFocus: "keep",
     },
     "present",
   ],
@@ -300,6 +301,16 @@ function requiredNewSessionFlow(): Extract<NewSessionFlowState, { mode: "review"
     throw new Error("Expected the dashboard fixture to support New Session.");
   }
   return flow;
+}
+
+function requiredNewSessionEdit(
+  flow: NewSessionFlowState,
+): Extract<NewSessionFlowState, { mode: "editName" }> {
+  const transitioned = transitionNewSessionFlow(flow, { type: "editName" });
+  if (transitioned?.mode !== "editName") {
+    throw new Error("Expected the New Session name editor.");
+  }
+  return transitioned;
 }
 
 function requiredNewSessionTransition(

--- a/packages/dashboard-core/test/unit/state/screens/fork.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/fork.test.ts
@@ -2,6 +2,7 @@ import type { StationSnapshot } from "@station/contracts";
 import type { TuiKey, TuiState, TuiTransition } from "@station/dashboard-core";
 import {
   createInitialTuiState,
+  handleTuiAction,
   handleTuiKey,
   openForkDetailsForRow,
 } from "@station/dashboard-core";
@@ -106,10 +107,66 @@ describe("fork screen", () => {
     expect(detailsScreen(toggled).copyDirty).toBe(false);
     expect(detailsScreen(toggled).focus).toBe("copyDirty");
 
-    const transition = step(toggled, ENTER);
+    const submitFocused = step(toggled, DOWN).state;
+    const transition = step(submitFocused, ENTER);
     const operation = transition.operations?.[0];
     if (operation?.type !== "forkSession") throw new Error("expected fork operation");
     expect(operation.command.payload.copyDirty).toBe(false);
+  });
+
+  it("uses semantic field actions for pointer focus and Copy toggling", () => {
+    const opened = openDetails();
+    const copy = handleTuiAction(
+      opened,
+      { type: "forkSession.activate", actionId: "details.copyDirty" },
+      CTX,
+    );
+
+    expect(detailsScreen(copy.state).focus).toBe("copyDirty");
+    expect(detailsScreen(copy.state).copyDirty).toBe(false);
+    expect(copy.operations).toBeUndefined();
+
+    const name = handleTuiAction(
+      copy.state,
+      { type: "forkSession.activate", actionId: "details.name" },
+      CTX,
+    );
+    expect(detailsScreen(name.state).focus).toBe("name");
+    expect(detailsScreen(name.state).draftTitle).toEqual(detailsScreen(opened).draftTitle);
+  });
+
+  it("toggles Copy on focused Enter without submitting", () => {
+    const copyFocused = step(openDetails(), DOWN).state;
+
+    const transition = step(copyFocused, ENTER);
+
+    expect(detailsScreen(transition.state).focus).toBe("copyDirty");
+    expect(detailsScreen(transition.state).copyDirty).toBe(false);
+    expect(transition.operations).toBeUndefined();
+  });
+
+  it("submits through the semantic Fork action", () => {
+    const opened = openDetails();
+
+    const transition = handleTuiAction(
+      opened,
+      { type: "forkSession.activate", actionId: "details.submit" },
+      CTX,
+    );
+
+    expect(transition.state.screen).toEqual({ name: "dashboard" });
+    expect(transition.operations?.[0]).toMatchObject({
+      type: "forkSession",
+      sourceWorktreeId: detailsScreen(opened).sourceWorktreeId,
+    });
+  });
+
+  it("keeps stale semantic Fork actions inert", () => {
+    const state = base();
+
+    expect(
+      handleTuiAction(state, { type: "forkSession.activate", actionId: "details.copyDirty" }, CTX),
+    ).toEqual({ state });
   });
 
   it("allows a custom title without changing the hidden branch", () => {

--- a/packages/dashboard-core/test/unit/state/screens/removeWorktree.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/removeWorktree.test.ts
@@ -1,0 +1,104 @@
+import {
+  createInitialTuiState,
+  handleTuiAction,
+  handleTuiKey,
+  openRemoveWorktreeConfirmForRow,
+  type TuiKey,
+  type TuiState,
+  type TuiTransition,
+} from "@station/dashboard-core";
+import { describe, expect, it } from "vitest";
+import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+
+const CTX = { cwd: "/Users/example/Developer/station", homeDir: "/Users/example" };
+const ENTER: TuiKey = { input: "\r", return: true };
+const LEFT: TuiKey = { input: "", leftArrow: true };
+const RIGHT: TuiKey = { input: "", rightArrow: true };
+const ESC: TuiKey = { input: "", escape: true };
+
+function openConfirm(): TuiState {
+  return openRemoveWorktreeConfirmForRow(
+    createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
+    "ses_wt_web_idle",
+  );
+}
+
+function step(state: TuiState, key: TuiKey): TuiTransition {
+  return handleTuiKey(state, key, CTX);
+}
+
+function confirmScreen(state: TuiState) {
+  if (state.screen.name !== "removeWorktree" || state.screen.step !== "confirm") {
+    throw new Error(`expected remove confirmation, got ${state.screen.name}`);
+  }
+  return state.screen;
+}
+
+describe("remove worktree confirmation", () => {
+  it("starts on the safe Keep session action and Enter cancels", () => {
+    const opened = openConfirm();
+
+    expect(confirmScreen(opened).actionFocus).toBe("keep");
+    expect(step(opened, ENTER).state.screen).toEqual({ name: "dashboard" });
+    expect(step(opened, ENTER).operations).toBeUndefined();
+  });
+
+  it("moves horizontally without wrapping", () => {
+    const opened = openConfirm();
+    const deleteFocused = step(opened, LEFT).state;
+
+    expect(confirmScreen(deleteFocused).actionFocus).toBe("delete");
+    expect(confirmScreen(step(deleteFocused, LEFT).state).actionFocus).toBe("delete");
+    expect(confirmScreen(step(deleteFocused, RIGHT).state).actionFocus).toBe("keep");
+    expect(confirmScreen(step(opened, RIGHT).state).actionFocus).toBe("keep");
+  });
+
+  it("converges focused Enter, direct Y, and semantic Delete", () => {
+    const opened = openConfirm();
+    const focused = step(step(opened, LEFT).state, ENTER);
+    const direct = step(opened, { input: "y" });
+    const semantic = handleTuiAction(
+      opened,
+      { type: "removeWorktree.activate", actionId: "confirm.delete" },
+      CTX,
+    );
+
+    for (const transition of [focused, direct, semantic]) {
+      expect(transition.state.screen).toEqual({ name: "dashboard" });
+      expect(transition.operations?.[0]).toMatchObject({
+        type: "removeWorktree",
+        projectId: "web",
+        worktreeId: "wt_web_idle",
+      });
+    }
+    expect(focused.operations?.[0]).toEqual(direct.operations?.[0]);
+    expect(semantic.operations?.[0]).toEqual(direct.operations?.[0]);
+  });
+
+  it("converges direct, focused, semantic, and Escape cancellation", () => {
+    const opened = openConfirm();
+    const transitions = [
+      step(opened, ENTER),
+      step(opened, { input: "n" }),
+      step(opened, ESC),
+      handleTuiAction(opened, { type: "removeWorktree.activate", actionId: "confirm.keep" }, CTX),
+    ];
+
+    for (const transition of transitions) {
+      expect(transition.state.screen).toEqual({ name: "dashboard" });
+      expect(transition.operations).toBeUndefined();
+    }
+  });
+
+  it("keeps stale semantic actions inert", () => {
+    const dashboard = createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+
+    expect(
+      handleTuiAction(
+        dashboard,
+        { type: "removeWorktree.activate", actionId: "confirm.delete" },
+        CTX,
+      ),
+    ).toEqual({ state: dashboard });
+  });
+});

--- a/packages/dashboard-core/test/unit/state/transition.test.ts
+++ b/packages/dashboard-core/test/unit/state/transition.test.ts
@@ -359,6 +359,7 @@ describe("TUI screen transitions", () => {
       rowId: "ses_wt_web_idle",
       forceRequired: true,
       label: "fix-nav-mobile",
+      actionFocus: "keep",
     });
   });
 

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -180,6 +180,54 @@ describe("FullscreenDashboard mouse composition", () => {
     });
   });
 
+  it("routes rendered Remove actions without leaking to the dashboard", async () => {
+    const fixture = makeStationTestStore({ terminalRows: SURFACE.height });
+    const setup = await render(fixture.store);
+    const row = cellFor(setup.captureCharFrame(), "docs-cleanup");
+    await actOn(async () => {
+      fixture.store.getState().handleKey({ input: "X" });
+      await setup.flush();
+      await setup.mockMouse.click(row.col, row.row, MouseButtons.LEFT);
+      await setup.flush();
+    });
+    const keep = cellFor(setup.captureCharFrame(), "Keep session");
+
+    await actOn(() => setup.mockMouse.click(keep.col, keep.row, MouseButtons.LEFT));
+
+    expect(fixture.store.getState().screen).toEqual({ name: "dashboard" });
+    expect(fixture.store.getState().localRows.pendingRemove).toEqual([]);
+  });
+
+  it("routes rendered Fork field clicks without submitting", async () => {
+    const fixture = makeStationTestStore({ terminalRows: SURFACE.height });
+    const setup = await render(fixture.store);
+    const row = cellFor(setup.captureCharFrame(), "docs-cleanup");
+    await actOn(async () => {
+      fixture.store.getState().handleKey({ input: "F" });
+      await setup.flush();
+      await setup.mockMouse.click(row.col, row.row, MouseButtons.LEFT);
+      await setup.flush();
+    });
+    const copy = cellFor(setup.captureCharFrame(), "Copy");
+
+    await actOn(() => setup.mockMouse.click(copy.col, copy.row, MouseButtons.LEFT));
+    expect(fixture.store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "copyDirty",
+      copyDirty: false,
+    });
+    const name = cellFor(setup.captureCharFrame(), "Name");
+
+    await actOn(() => setup.mockMouse.click(name.col, name.row, MouseButtons.LEFT));
+    expect(fixture.store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "name",
+      copyDirty: false,
+    });
+  });
+
   it("scrolls when the wheel is used over a child row", async () => {
     const fixture = makeStationTestStore({ terminalRows: 12 });
     const setup = await render(fixture.store, { width: 80, height: 12 });

--- a/station/src/dashboardRenderer/dashboardMouse.test.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.test.ts
@@ -47,6 +47,7 @@ const DASHBOARD_MOUSE_TARGET_KINDS = {
   openShellForRow: true,
   projectHeader: true,
   projectSettingsConfirmRemove: true,
+  removeWorktreeAction: true,
   projectSettingsItem: true,
   quickSessionForProject: true,
   renameSessionSubmit: true,
@@ -54,9 +55,8 @@ const DASHBOARD_MOUSE_TARGET_KINDS = {
   screenBackdrop: true,
   scrollIndicator: true,
   sheetBackdrop: true,
-  sheetButton: true,
   sheetChoice: true,
-  sheetSubmit: true,
+  forkSessionAction: true,
   showDefaultAgentPickerForProject: true,
   toast: true,
   widgetSettingsAdd: true,
@@ -226,7 +226,11 @@ describe("routeDashboardMouse", () => {
     store.getState().handleKey({ input: "X" });
     routeDashboardMouse({ kind: "row", rowId }, LEFT_DOWN, store);
     expect(store.getState().screen).toMatchObject({ name: "removeWorktree", step: "confirm" });
-    routeDashboardMouse({ kind: "sheetButton", key: "n" }, LEFT_DOWN, store);
+    routeDashboardMouse(
+      { kind: "removeWorktreeAction", actionId: "confirm.keep" },
+      LEFT_DOWN,
+      store,
+    );
     expect(store.getState().screen).toEqual({ name: "dashboard" });
 
     store.getState().handleKey({ input: "N" });
@@ -237,7 +241,32 @@ describe("routeDashboardMouse", () => {
 
     store.getState().handleKey({ input: "F" });
     routeDashboardMouse({ kind: "row", rowId }, LEFT_DOWN, store);
-    routeDashboardMouse({ kind: "sheetSubmit" }, LEFT_DOWN, store);
+    routeDashboardMouse(
+      { kind: "forkSessionAction", actionId: "details.copyDirty" },
+      LEFT_DOWN,
+      store,
+    );
+    expect(store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "copyDirty",
+      copyDirty: false,
+    });
+    routeDashboardMouse(
+      { kind: "forkSessionAction", actionId: "details.name" },
+      LEFT_DOWN,
+      store,
+    );
+    expect(store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "name",
+    });
+    routeDashboardMouse(
+      { kind: "forkSessionAction", actionId: "details.submit" },
+      LEFT_DOWN,
+      store,
+    );
     await waitFor(() => store.getState().screen.name === "dashboard");
   });
 

--- a/station/src/dashboardRenderer/dashboardMouse.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.ts
@@ -213,10 +213,11 @@ function routeModalClick(
         store.getState().handleKey({ input: target.choiceKey });
       }
       return true;
-    case "sheetButton":
-      if (mode === "removeConfirm") {
-        store.getState().handleKey({ input: target.key });
-      }
+    case "removeWorktreeAction":
+      store.getState().handleAction({
+        type: "removeWorktree.activate",
+        actionId: target.actionId,
+      });
       return true;
     case "projectSettingsItem":
       if (mode === "projectSettings") {
@@ -243,10 +244,11 @@ function routeModalClick(
         actionId: target.actionId,
       });
       return true;
-    case "sheetSubmit":
-      if (mode === "forkDetails") {
-        store.getState().handleKey({ input: "\r", return: true });
-      }
+    case "forkSessionAction":
+      store.getState().handleAction({
+        type: "forkSession.activate",
+        actionId: target.actionId,
+      });
       return true;
     default:
       return false;

--- a/station/src/input/stationInput.test.ts
+++ b/station/src/input/stationInput.test.ts
@@ -1015,6 +1015,7 @@ describe("createStationInputRuntime STATION context-menu actions", () => {
       rowId: "ses_wt_station_idle",
       forceRequired: true,
       label: "pty-buffer",
+      actionFocus: "keep",
     });
   });
 
@@ -2273,9 +2274,8 @@ describe("createStationInputRuntime New Session hosted launch", () => {
 });
 
 describe("createStationInputRuntime Fork hosted launch", () => {
-  // Driven end to end through the public runtime: open the overlay, "F" + a slot
-  // open the fork details, Enter submits as a Station-hosted launch (worktree.fork
-  // + a background managed launch) instead of the machine's tmux session.fork.
+  // Driven end to end through the public runtime: Name/Submit Enter hosts the
+  // fork in Station, while Copy-focused Enter remains a shared toggle.
   function forkPlan(worktreeId: string): AgentPrepareExternalLaunchResult {
     return {
       kind: "prepared",
@@ -2369,6 +2369,31 @@ describe("createStationInputRuntime Fork hosted launch", () => {
     delete fresh.terminal;
     return { ...base, rows: [...base.rows, fresh] };
   }
+
+  it("toggles Copy-focused Enter without dispatching a fork", () => {
+    const harness = forkHarness();
+    harness.store.actions.openOverlay(STATION_OVERLAY_ID);
+    harness.pressKey("F");
+    harness.pressKey("1");
+    harness.pressKey("\u001b[B");
+
+    expect(harness.stationViewStore.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "copyDirty",
+      copyDirty: true,
+    });
+    expect(harness.pressKey("\r")).toBe(true);
+    expect(harness.stationViewStore.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "copyDirty",
+      copyDirty: false,
+    });
+    expect(
+      harness.observerService.dispatched.some((command) => command.type === "worktree.fork"),
+    ).toBe(false);
+  });
 
   it("forks the worktree, shows an optimistic row, and launches the inherited agent in the background", async () => {
     const harness = forkHarness();

--- a/station/src/station/input/forkSubmit.test.ts
+++ b/station/src/station/input/forkSubmit.test.ts
@@ -7,8 +7,8 @@ import { resolveForkSessionSubmit, resolveKeyForkSessionSubmit } from "./station
 
 // Station hosts a fork in a pane (worktree.fork + managed launch) rather than
 // the shared machine's tmux session.fork. These resolvers are the interception
-// point: Enter on the details screen becomes a hosted-launch submit; everything
-// else (including an invalid title) falls through to the machine.
+// point: Enter on Name or Submit becomes a hosted launch, while Copy-focused
+// Enter and invalid input fall through to the shared screen transition.
 function newStore() {
   const snapshot = manyProjectsSnapshot();
   return createTuiStore({
@@ -75,10 +75,25 @@ describe("resolveForkSessionSubmit", () => {
 });
 
 describe("resolveKeyForkSessionSubmit", () => {
-  it("submits only on Enter", () => {
+  it("submits Enter from Name or Submit focus", () => {
     const store = storeOnForkDetails();
     expect(resolveKeyForkSessionSubmit(store, "\r").kind).toBe("submit");
-    // A navigation/edit key on the details screen stays with the shared machine.
+
+    store.getState().handleKey({ input: "", downArrow: true });
+    store.getState().handleKey({ input: "", downArrow: true });
+    expect(store.getState().screen).toMatchObject({ focus: "submit" });
+    expect(resolveKeyForkSessionSubmit(store, "\r").kind).toBe("submit");
     expect(resolveKeyForkSessionSubmit(store, "x").kind).toBe("none");
+  });
+
+  it("leaves Copy-focused Enter to the shared toggle transition", () => {
+    const store = storeOnForkDetails();
+    store.getState().handleKey({ input: "", downArrow: true });
+
+    expect(store.getState().screen).toMatchObject({ focus: "copyDirty", copyDirty: true });
+    expect(resolveKeyForkSessionSubmit(store, "\r")).toEqual({ kind: "none" });
+
+    store.getState().handleKey({ input: "\r", return: true });
+    expect(store.getState().screen).toMatchObject({ focus: "copyDirty", copyDirty: false });
   });
 });

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -352,6 +352,10 @@ export function resolveKeyForkSessionSubmit(
   if (sequenceToTuiKey(sequence)?.return !== true) {
     return { kind: "none" };
   }
+  const { screen } = store.getState();
+  if (screen.name !== "fork" || screen.step !== "details" || screen.focus === "copyDirty") {
+    return { kind: "none" };
+  }
   return resolveForkSessionSubmit(store);
 }
 

--- a/station/src/station/input/stationMouse.test.ts
+++ b/station/src/station/input/stationMouse.test.ts
@@ -193,14 +193,18 @@ describe("routeStationMouse", () => {
     expect(clicked.getState().screen).toMatchObject({ name: "removeWorktree", step: "confirm" });
   });
 
-  it("confirms remove with the sheet yes button", () => {
+  it("confirms remove with the semantic Delete action", () => {
     const store = makeStore();
     const worktreeId = "wt_station_working";
     const rowId = `ses_${worktreeId}`;
     store.getState().handleKey({ input: "X" });
     store.getState().handleKey({ input: slotForRow(store, rowId) });
 
-    const outcome = routeStationMouse({ kind: "sheetButton", key: "y" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "removeWorktreeAction", actionId: "confirm.delete" },
+      LEFT_DOWN,
+      store,
+    );
 
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toEqual({ name: "dashboard" });
@@ -209,31 +213,39 @@ describe("routeStationMouse", () => {
     ]);
   });
 
-  it("cancels remove with the sheet no button", () => {
+  it("cancels remove with the semantic Keep action", () => {
     const store = makeStore();
     const rowId = "ses_wt_station_working";
     store.getState().handleKey({ input: "X" });
     store.getState().handleKey({ input: slotForRow(store, rowId) });
 
-    const outcome = routeStationMouse({ kind: "sheetButton", key: "n" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "removeWorktreeAction", actionId: "confirm.keep" },
+      LEFT_DOWN,
+      store,
+    );
 
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toEqual({ name: "dashboard" });
     expect(store.getState().localRows.pendingRemove).toEqual([]);
   });
 
-  it("ignores sheet buttons outside remove confirm mode", () => {
+  it("keeps stale Remove actions inert", () => {
     const store = makeStore();
     const before = store.getState().screen;
+    const target = {
+      kind: "removeWorktreeAction",
+      actionId: "confirm.delete",
+    } as const;
 
-    const outcome = routeStationMouse({ kind: "sheetButton", key: "y" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(target, LEFT_DOWN, store);
 
     expect(outcome).toEqual({ kind: "handled" });
     expect(store.getState().screen).toEqual(before);
     expect(store.getState().localRows.pendingRemove).toEqual([]);
 
     store.getState().handleKey({ input: "X" });
-    routeStationMouse({ kind: "sheetButton", key: "y" }, LEFT_DOWN, store);
+    routeStationMouse(target, LEFT_DOWN, store);
     expect(store.getState().screen).toEqual({ name: "removeWorktree", step: "chooseSlot" });
     expect(store.getState().localRows.pendingRemove).toEqual([]);
   });
@@ -266,7 +278,42 @@ describe("routeStationMouse", () => {
     expect(keyedBranch).toContain("-fork-");
   });
 
-  it("launches a fork from the sheet submit button", () => {
+  it("focuses Fork Name and toggles Copy through semantic field actions", () => {
+    const store = makeStore();
+    const rowId = "ses_wt_station_working";
+    store.getState().handleKey({ input: "F" });
+    store.getState().handleKey({ input: slotForRow(store, rowId) });
+    store.getState().handleKey({ input: "", downArrow: true });
+    store.getState().handleKey({ input: "", downArrow: true });
+
+    expect(
+      routeStationMouse(
+        { kind: "forkSessionAction", actionId: "details.name" },
+        LEFT_DOWN,
+        store,
+      ),
+    ).toEqual({ kind: "handled" });
+    expect(store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "name",
+      copyDirty: true,
+    });
+
+    routeStationMouse(
+      { kind: "forkSessionAction", actionId: "details.copyDirty" },
+      LEFT_DOWN,
+      store,
+    );
+    expect(store.getState().screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      focus: "copyDirty",
+      copyDirty: false,
+    });
+  });
+
+  it("launches a fork from the semantic submit action", () => {
     const store = makeStore();
     const worktreeId = "wt_station_working";
     const rowId = `ses_${worktreeId}`;
@@ -274,7 +321,11 @@ describe("routeStationMouse", () => {
     store.getState().handleKey({ input: slotForRow(store, rowId) });
     expect(store.getState().screen).toMatchObject({ name: "fork", step: "details" });
 
-    const outcome = routeStationMouse({ kind: "sheetSubmit" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "forkSessionAction", actionId: "details.submit" },
+      LEFT_DOWN,
+      store,
+    );
 
     expect(outcome.kind).toBe("launch-fork");
     if (outcome.kind === "launch-fork") {
@@ -290,9 +341,13 @@ describe("routeStationMouse", () => {
     expect(store.getState().screen).toMatchObject({ name: "fork", step: "details" });
   });
 
-  it("ignores sheet submit outside fork details mode", () => {
+  it("keeps stale Fork actions inert", () => {
     const store = makeStore();
-    const outcome = routeStationMouse({ kind: "sheetSubmit" }, LEFT_DOWN, store);
+    const outcome = routeStationMouse(
+      { kind: "forkSessionAction", actionId: "details.submit" },
+      LEFT_DOWN,
+      store,
+    );
     expect(outcome).toEqual({ kind: "handled" });
   });
 

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -11,8 +11,12 @@ import {
   isRemoveProjectArmed,
   LIST_REGISTRY,
   tuiScreenBehavior,
+  type AddProjectActionId,
+  type ForkSessionActionId,
+  type NewSessionActionId,
   type ProjectHeaderControl,
   type ProjectSettingsItemId,
+  type RemoveWorktreeActionId,
   type TuiInputMode,
   type TuiStore,
 } from "@station/dashboard-core";
@@ -39,7 +43,6 @@ import {
   type RowAgentTarget,
   type StationKeyOutcome,
 } from "./stationActions.js";
-import type { AddProjectActionId, NewSessionActionId } from "@station/dashboard-core";
 
 export type StationMouseTarget =
   | { kind: "row"; rowId: string }
@@ -62,8 +65,8 @@ export type StationMouseTarget =
   | { kind: "toast" }
   /** A picker line inside a sheet; the key is the line's slot accelerator. */
   | { kind: "sheetChoice"; choiceKey: string }
-  /** A compact sheet button that dispatches its visible shortcut key. */
-  | { kind: "sheetButton"; key: "y" | "n" }
+  /** An explicit Remove confirmation control represented by its semantic action. */
+  | { kind: "removeWorktreeAction"; actionId: RemoveWorktreeActionId }
   /** A left-list row in the Project Settings panel; selecting opens its detail. */
   | { kind: "projectSettingsItem"; itemId: ProjectSettingsItemId }
   /** The armed "Remove project (R)" action in the panel's detail pane. */
@@ -86,8 +89,8 @@ export type StationMouseTarget =
   | { kind: "newSessionAction"; actionId: NewSessionActionId }
   /** The Rename Session button represented by its semantic submit action. */
   | { kind: "renameSessionSubmit" }
-  /** A sheet's primary submit button (the fork details "Fork" action). */
-  | { kind: "sheetSubmit" }
+  /** A Fork details field or submit control represented by its semantic action. */
+  | { kind: "forkSessionAction"; actionId: ForkSessionActionId }
   /** The viewport outside a bounded screen; primary-down safely cancels that screen. */
   | { kind: "screenBackdrop" }
   /** Sheets/prompts sit above the dashboard; their backdrop absorbs input. */
@@ -144,8 +147,7 @@ export type StationMouseOutcome =
     }
   /**
    * Consumed; the router should seed a worktree off a source and host its agent
-   * in a Station pane. The fork-button click counterpart of the keyboard Enter on
-   * the Fork details screen.
+   * in a Station pane. The semantic Fork submit counterpart of focused keyboard Enter.
    */
   | {
       kind: "launch-fork";
@@ -244,11 +246,13 @@ export function routeStationMouse(
         return { kind: "handled" };
       }
       return fromKeyOutcome(dispatchStationKey(store, { input: target.choiceKey }));
-    case "sheetButton":
-      if (mode !== "removeConfirm") {
-        return { kind: "handled" };
-      }
-      return fromKeyOutcome(dispatchStationKey(store, { input: target.key }));
+    case "removeWorktreeAction":
+      return fromKeyOutcome(
+        dispatchStationAction(store, {
+          type: "removeWorktree.activate",
+          actionId: target.actionId,
+        }),
+      );
     case "projectSettingsItem":
       if (mode !== "projectSettings") {
         return { kind: "handled" };
@@ -327,26 +331,8 @@ export function routeStationMouse(
       }
       return { kind: "handled" };
     }
-    case "sheetSubmit": {
-      // A click on the Fork details "Fork" button hosts the agent in Station,
-      // matching the keyboard Enter path (resolveKeyForkSessionSubmit) rather than
-      // dispatching the machine's tmux-bound session.fork.
-      if (mode !== "forkDetails") {
-        return { kind: "handled" };
-      }
-      const submit = resolveForkSessionSubmit(store);
-      if (submit.kind === "none") {
-        return { kind: "handled" };
-      }
-      return {
-        kind: "launch-fork",
-        projectId: submit.projectId,
-        sourceWorktreeId: submit.sourceWorktreeId,
-        title: submit.title,
-        branch: submit.branch,
-        copyDirty: submit.copyDirty,
-      };
-    }
+    case "forkSessionAction":
+      return routeForkSessionAction(store, target.actionId);
     case "screenBackdrop": {
       const state = store.getState();
       const clickAway = tuiScreenBehavior(state.screen).clickAway;
@@ -359,6 +345,27 @@ export function routeStationMouse(
     case "sheetBackdrop":
       return { kind: "handled" };
   }
+}
+
+function routeForkSessionAction(
+  store: StoreApi<TuiStore>,
+  actionId: ForkSessionActionId,
+): StationMouseOutcome {
+  const action = { type: "forkSession.activate", actionId } as const;
+  if (actionId === "details.submit") {
+    const submit = resolveForkSessionSubmit(store);
+    if (submit.kind === "submit") {
+      return {
+        kind: "launch-fork",
+        projectId: submit.projectId,
+        sourceWorktreeId: submit.sourceWorktreeId,
+        title: submit.title,
+        branch: submit.branch,
+        copyDirty: submit.copyDirty,
+      };
+    }
+  }
+  return fromKeyOutcome(dispatchStationAction(store, action));
 }
 
 function routeProjectHeaderActivation(

--- a/station/src/station/input/stationOverlayLayer.ts
+++ b/station/src/station/input/stationOverlayLayer.ts
@@ -54,9 +54,8 @@ export function createStationOverlayLayer(
       if (submit.kind === "submit") {
         return paneLaunchNewSessionOutcome(submit);
       }
-      // Enter on the Fork details screen seeds a worktree (worktree.fork) and
-      // hosts the inherited harness in Station, bypassing the machine's
-      // tmux-bound session.fork the same way New Session bypasses session.create.
+      // Enter on Fork Name or Submit hosts the inherited harness in Station;
+      // Copy-focused Enter falls through to the shared toggle transition.
       const fork = resolveKeyForkSessionSubmit(stationViewStore, key);
       if (fork.kind === "submit") {
         return paneLaunchForkSessionOutcome(fork);

--- a/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
+++ b/station/src/station/view/__snapshots__/modals.golden.test.tsx.snap
@@ -273,10 +273,58 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 │ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
 │ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
 │                                            │                                  
-│  Yes (y)     No (n)                        │                    [sh] [qs] [▾] 
-│ Esc/Enter:cancel                           │                                  
+│  Delete (Y)  ▸ Keep session (N)            │                    [sh] [qs] [▾] 
+│ ←→ choose · Enter activate · Esc cancel    │                                  
 │                                            │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
+"
+`;
+
+exports[`modal flow golden frames renders the remove confirm delete focus 1`] = `
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS            DIFF · PR 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       codex     no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
+                                                                                
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+ [8] ○ trace-bundle                       opencode  idle             +1 -1 #4 ✓ 
+┌────────────────────────────────────────────┐                                  
+│ Delete session?                            │                    [sh] [qs] [▾] 
+│ Session  cli-help-man                      │code  idle           +14 -6 #5 x1 
+│ Removes agent, worktree, and panes.        │code  unknown           +3 -1 #10 
+│                                            │                                  
+│▸ Delete (Y)    Keep session (N)            │                    [sh] [qs] [▾] 
+│ ←→ choose · Enter activate · Esc cancel    │                                  
+│                                            │───────────────────────────────── 
+└────────────────────────────────────────────┘ ? help  Q/esc:close              
+"
+`;
+
+exports[`modal flow golden frames renders the remove confirm narrow 1`] = `
+"                                        
+FLEET  ● 0 ready  ⠋ 2 working  ! 0      
+─────────────────────────────────────── 
+       SESSION             STATUS       
+▼ station  5 sessions · … [sh] [qs] [▾] 
+ [1] ○ cli-help-man        idle         
+ [2] - docs-cleanup        no agent     
+┌──────────────────────────────────────┐
+│ Delete session?                      │
+│ Session  cli-help-man                │
+│ Removes agent, worktree, and panes.  │
+│                                      │
+│  Delete (Y)  ▸ Keep session (N)      │
+│ ←→ · Enter activate · Esc cancel     │
+│                                      │
+└──────────────────────────────────────┘
 "
 `;
 
@@ -410,12 +458,40 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
 │ Fork Session                               │                                  
 │ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│ > Name   Hexagonal PT 12|                  │code  idle           +14 -6 #5 x1 
-│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
+│▸ Name   Hexagonal PT 12|                   │code  idle           +14 -6 #5 x1 
+│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
 │ Source keeps running — copy is read-only.  │                                  
 │                                            │                    [sh] [qs] [▾] 
 │  Fork (enter)                              │                                  
-│ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
+│ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
+└────────────────────────────────────────────┘ ? help  Q/esc:close              
+"
+`;
+
+exports[`modal flow golden frames renders the fork details copy focus 1`] = `
+"                                                                                
+FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4 idle 
+─────────────────────────────────────────────────────────────────────────────── 
+       SESSION                            AGENT     STATUS            DIFF · PR 
+▼ station  5 sessions · 4 agents                                  [sh] [qs] [▾] 
+ [1] ○ cli-help-man                       codex     idle           +14 -6 #70 ✓ 
+ [2] - docs-cleanup                       codex     no agent                    
+ [3] ○ pty-buffer                         codex     idle                  #73 ✓ 
+ [4] + session-resume                     codex     starting                    
+ [5] ⠋ station-XXXXXXy                    codex     working      +412 -96 #76 … 
+                                                                                
+▼ observer  3 sessions · 3 agents                                 [sh] [qs] [▾] 
+ [6] x batch-export                       opencode  exited                 #8 ✓ 
+ [7] ⠋ provider-hooks                     opencode  working        +32 -8 #16 … 
+┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
+│ Fork Session                               │                                  
+│ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
+│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1 
+│▸ Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
+│ Source keeps running — copy is read-only.  │                                  
+│                                            │                    [sh] [qs] [▾] 
+│  Fork (enter)                              │                                  
+│ Space/Enter toggle · ↑↓ focus · Esc back   │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
 "
 `;
@@ -438,13 +514,33 @@ FLEET  ● 0 ready  ⠋ 2 working  ! 0 needs you  ? 1 unknown  x 1 exited  ○ 4
 ┌────────────────────────────────────────────┐code  idle             +1 -1 #4 ✓ 
 │ Fork Session                               │                                  
 │ Source   station · cli-help-man            │                    [sh] [qs] [▾] 
-│   Name   cli-help-man-fork                 │code  idle           +14 -6 #5 x1 
-│   Copy   [x] uncommitted changes           │code  unknown           +3 -1 #10 
+│  Name   cli-help-man-fork                  │code  idle           +14 -6 #5 x1 
+│  Copy   [x] uncommitted changes            │code  unknown           +3 -1 #10 
 │ Source keeps running — copy is read-only.  │                                  
 │                                            │                    [sh] [qs] [▾] 
 │▸ Fork (enter)                              │                                  
-│ ↑↓:field space:toggle enter:fork esc:back  │───────────────────────────────── 
+│ ↑↓ focus · Enter fork · Esc back           │───────────────────────────────── 
 └────────────────────────────────────────────┘ ? help  Q/esc:close              
+"
+`;
+
+exports[`modal flow golden frames renders the fork details narrow copy focus 1`] = `
+"                                        
+FLEET  ● 0 ready  ⠋ 2 working  ! 0      
+─────────────────────────────────────── 
+       SESSION             STATUS       
+▼ station  5 sessions · … [sh] [qs] [▾] 
+ [1] ○ cli-help-man        idle         
+┌──────────────────────────────────────┐
+│ Fork Session                         │
+│ Source   station · cli-help-man      │
+│  Name   cli-help-man-fork            │
+│▸ Copy   [x] uncommitted changes      │
+│ Source running; copy is read-only.   │
+│                                      │
+│  Fork (enter)                        │
+│ Space/↵ toggle · ↑↓ · Esc back       │
+└──────────────────────────────────────┘
 "
 `;
 

--- a/station/src/station/view/modals.golden.test.tsx
+++ b/station/src/station/view/modals.golden.test.tsx
@@ -153,7 +153,29 @@ const CASES: ModalCase[] = [
   {
     name: "remove confirm sheet",
     keys: [{ input: "X" }, { input: "1" }],
-    expect: ["Delete session?", "Session", "cli-help-man", "Yes (y)", "No (n)"],
+    expect: [
+      "Delete session?",
+      "Session",
+      "cli-help-man",
+      "Delete (Y)",
+      "▸ Keep session (N)",
+      "←→ choose · Enter activate · Esc cancel",
+    ],
+  },
+  {
+    name: "remove confirm delete focus",
+    keys: [{ input: "X" }, { input: "1" }, { input: "", leftArrow: true }],
+    expect: ["Delete session?", "▸ Delete (Y)", "Keep session (N)"],
+  },
+  {
+    name: "remove confirm narrow",
+    keys: [{ input: "X" }, { input: "1" }],
+    size: { width: 40, height: 16 },
+    expect: [
+      "Delete (Y)",
+      "▸ Keep session (N)",
+      "←→ · Enter activate · Esc cancel",
+    ],
   },
   {
     name: "external agent removal information",
@@ -170,7 +192,7 @@ const CASES: ModalCase[] = [
       "Stop or remove it from its original terminal or external tooling.",
       "Esc/Enter:close",
     ],
-    reject: ["Yes (y)", "No (n)"],
+    reject: ["Delete (Y)", "Keep session (N)"],
   },
   {
     name: "rename slot prompt",
@@ -208,9 +230,14 @@ const CASES: ModalCase[] = [
       "Hexagonal PT 12",
       "uncommitted changes",
       "Fork (enter)",
-      "enter:fork",
+      "↑↓ focus · Enter fork · Esc back",
     ],
     reject: ["Branch"],
+  },
+  {
+    name: "fork details copy focus",
+    keys: [{ input: "F" }, { input: "1" }, { input: "", downArrow: true }],
+    expect: ["Fork Session", "▸ Copy", "Space/Enter toggle · ↑↓ focus · Esc back"],
   },
   {
     name: "fork details submit focus",
@@ -220,7 +247,19 @@ const CASES: ModalCase[] = [
       { input: "", downArrow: true },
       { input: "", downArrow: true },
     ],
-    expect: ["Fork Session", "▸ Fork (enter)"],
+    expect: ["Fork Session", "▸ Fork (enter)", "↑↓ focus · Enter fork · Esc back"],
+  },
+  {
+    name: "fork details narrow copy focus",
+    keys: [{ input: "F" }, { input: "1" }, { input: "", downArrow: true }],
+    size: { width: 40, height: 16 },
+    expect: [
+      "Name",
+      "▸ Copy",
+      "Fork (enter)",
+      "Source running; copy is read-only.",
+      "Space/↵ toggle · ↑↓ · Esc back",
+    ],
   },
   {
     name: "new session review",

--- a/station/src/station/view/sheets/ForkSessionSheetView.test.tsx
+++ b/station/src/station/view/sheets/ForkSessionSheetView.test.tsx
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { rgbToHex } from "@opentui/core";
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import { createEditableTextInputState, type TuiScreen } from "@station/dashboard-core";
+import { act } from "react";
+import { spanAtFrameCell } from "../../../terminal/testing/frameProbe.js";
+import type { StationMouseTarget } from "../../input/stationMouse.js";
+import { StationHoverProvider, StationMouseProvider } from "../stationMouseContext.js";
+import { STATION_COLORS } from "../theme.js";
+import { ForkSessionSheetView } from "./ForkSessionSheetView.js";
+
+type ForkDetailsScreen = Extract<TuiScreen, { name: "fork"; step: "details" }>;
+
+const teardowns: Array<() => void> = [];
+afterEach(() => {
+  for (const teardown of teardowns.splice(0)) teardown();
+});
+
+function detailsScreen(focus: ForkDetailsScreen["focus"]): ForkDetailsScreen {
+  return {
+    name: "fork",
+    step: "details",
+    sourceWorktreeId: "wt_example" as ForkDetailsScreen["sourceWorktreeId"],
+    projectId: "station" as ForkDetailsScreen["projectId"],
+    projectLabel: "station",
+    sourceBranch: "main",
+    sourceDirty: true,
+    sourceAgentRunning: true,
+    branch: "main-fork-aaaaaa",
+    draftTitle: createEditableTextInputState("fork-title"),
+    copyDirty: true,
+    focus,
+  };
+}
+
+async function render(focus: ForkDetailsScreen["focus"], width = 80) {
+  const targets: StationMouseTarget[] = [];
+  const setup = await testRender(
+    <StationHoverProvider value>
+      <StationMouseProvider value={(target) => targets.push(target)}>
+        <ForkSessionSheetView screen={detailsScreen(focus)} columns={width} rows={16} />
+      </StationMouseProvider>
+    </StationHoverProvider>,
+    { width, height: 16 },
+  );
+  teardowns.push(() => setup.renderer.destroy());
+  await setup.renderOnce();
+  return { setup, targets };
+}
+
+describe("ForkSessionSheetView", () => {
+  it("shows the cursor only while Name owns focus", async () => {
+    const name = await render("name");
+    expect(name.setup.captureCharFrame()).toContain("▸ Name");
+    expect(name.setup.captureCharFrame()).toContain("fork-title|");
+
+    const copy = await render("copyDirty");
+    expect(copy.setup.captureCharFrame()).toContain("▸ Copy");
+    expect(copy.setup.captureCharFrame()).not.toContain("fork-title|");
+    expect(copy.setup.captureCharFrame()).toContain("Space/Enter toggle");
+  });
+
+  it("emits exact bounded targets for Name, Copy, and Fork", async () => {
+    const { setup, targets } = await render("name");
+    const lines = setup.captureCharFrame().split("\n");
+    const nameRow = lines.findIndex((line) => line.includes("Name"));
+    const copyRow = lines.findIndex((line) => line.includes("Copy"));
+    const forkRow = lines.findIndex((line) => line.includes("Fork (enter)"));
+    const nameCol = lines[nameRow]?.indexOf("Name") ?? -1;
+    const copyCol = lines[copyRow]?.indexOf("Copy") ?? -1;
+    const forkCol = lines[forkRow]?.indexOf("Fork") ?? -1;
+
+    await setup.mockMouse.click(nameCol, nameRow, MouseButtons.LEFT);
+    await setup.mockMouse.click(copyCol, copyRow, MouseButtons.LEFT);
+    await setup.mockMouse.click(forkCol, forkRow, MouseButtons.LEFT);
+    await setup.mockMouse.click(58, copyRow, MouseButtons.LEFT);
+
+    expect(targets).toEqual([
+      { kind: "forkSessionAction", actionId: "details.name" },
+      { kind: "forkSessionAction", actionId: "details.copyDirty" },
+      { kind: "forkSessionAction", actionId: "details.submit" },
+    ]);
+  });
+
+  it("keeps Copy hover bounded to its control cells", async () => {
+    const { setup } = await render("name");
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("Copy"));
+    const copyCol = lines[row]?.indexOf("Copy") ?? -1;
+
+    await act(async () => {
+      await setup.mockMouse.moveTo(copyCol, row);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await setup.flush();
+
+    const inside = spanAtFrameCell(setup.captureSpans(), row, copyCol);
+    const trailing = spanAtFrameCell(setup.captureSpans(), row, 58);
+    expect(inside?.bg === undefined ? undefined : rgbToHex(inside.bg)).toBe(
+      STATION_COLORS.hoverBackground,
+    );
+    expect(trailing?.bg === undefined ? undefined : rgbToHex(trailing.bg)).not.toBe(
+      STATION_COLORS.hoverBackground,
+    );
+  });
+
+  it("keeps controls and contextual help readable when narrow", async () => {
+    const { setup } = await render("copyDirty", 40);
+    const frame = setup.captureCharFrame();
+
+    expect(frame).toContain("Name");
+    expect(frame).toContain("▸ Copy");
+    expect(frame).toContain("Fork (enter)");
+    expect(frame).toContain("Space/↵ toggle · ↑↓ · Esc back");
+    expect(frame).toContain("Source running; copy is read-only.");
+  });
+});

--- a/station/src/station/view/sheets/ForkSessionSheetView.tsx
+++ b/station/src/station/view/sheets/ForkSessionSheetView.tsx
@@ -1,13 +1,12 @@
-// OpenTUI bottom sheet for Fork Session: chooseSlot (pick a source row, mirrors
-// RemoveSessionSheetView) and details (name field + copy-dirty toggle + submit,
-// mirrors NewSessionSheetView's EditName). The submit button is a click target so
-// the fork launches in Station (sheetSubmit → launch-fork), never the tmux path.
+// Fork details share semantic controls across pointer and keyboard activation;
+// native Station intercepts only submit so Copy-focused Enter remains a core toggle.
 import { bottomSheetContentWidth, type TuiScreen } from "@station/dashboard-core";
 import { EditableTextInputView } from "../EditableTextInputView.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import {
   compactSheetWidth,
   SheetButtonRow,
+  SheetControlRow,
   SheetFooter,
   SheetLabelValue,
   SheetLine,
@@ -63,11 +62,21 @@ function ForkDetails({
   const focus = screen.focus;
   const titleValue =
     focus === "name" ? (
-      <EditableTextInputView {...screen.draftTitle} />
+      <EditableTextInputView {...screen.draftTitle} active />
     ) : (
       screen.draftTitle.value
     );
-  const extraRows = (screen.sourceAgentRunning ? 1 : 0) + (screen.validationError !== undefined ? 1 : 0);
+  const helper =
+    focus === "copyDirty"
+      ? contentWidth >= 40
+        ? "Space/Enter toggle · ↑↓ focus · Esc back"
+        : "Space/↵ toggle · ↑↓ · Esc back"
+      : contentWidth >= 32
+        ? "↑↓ focus · Enter fork · Esc back"
+        : "↑↓ · Enter fork · Esc";
+  const extraRows =
+    (screen.sourceAgentRunning ? 1 : 0) +
+    (screen.validationError !== undefined ? 1 : 0);
   return (
     <BottomSheetFrameView
       columns={columns}
@@ -83,21 +92,28 @@ function ForkDetails({
         labelWidth={LABEL_WIDTH}
         value={`${screen.projectLabel} · ${screen.sourceBranch}`}
       />
-      <SheetLabelValue
+      <SheetControlRow
         width={contentWidth}
-        label={focusLabel("Name", focus === "name")}
-        labelWidth={LABEL_WIDTH}
+        label="Name"
+        labelWidth={LABEL_WIDTH - 2}
         value={titleValue}
+        valueCells={screen.draftTitle.value.length + Number(focus === "name")}
+        focused={focus === "name"}
+        mouseTarget={{ kind: "forkSessionAction", actionId: "details.name" }}
       />
-      <SheetLabelValue
+      <SheetControlRow
         width={contentWidth}
-        label={focusLabel("Copy", focus === "copyDirty")}
-        labelWidth={LABEL_WIDTH}
+        label="Copy"
+        labelWidth={LABEL_WIDTH - 2}
         value={`[${screen.copyDirty ? "x" : " "}] uncommitted changes`}
+        focused={focus === "copyDirty"}
+        mouseTarget={{ kind: "forkSessionAction", actionId: "details.copyDirty" }}
       />
       {screen.sourceAgentRunning ? (
         <SheetMessageLine width={contentWidth} tone="muted">
-          Source keeps running — copy is read-only.
+          {contentWidth >= 41
+            ? "Source keeps running — copy is read-only."
+            : "Source running; copy is read-only."}
         </SheetMessageLine>
       ) : null}
       {screen.validationError !== undefined ? (
@@ -114,18 +130,16 @@ function ForkDetails({
             label: "Fork",
             shortcut: "enter",
             tone: "success",
-            mouseTarget: { kind: "sheetSubmit" },
+            mouseTarget: {
+              kind: "forkSessionAction",
+              actionId: "details.submit",
+            },
             focused: focus === "submit",
             disabled: false,
           },
         ]}
       />
-      <SheetFooter width={contentWidth}>↑↓:field space:toggle enter:fork esc:back</SheetFooter>
+      <SheetFooter width={contentWidth}>{helper}</SheetFooter>
     </BottomSheetFrameView>
   );
-}
-
-/** Prefix a field label with a focus caret so the active field reads clearly. */
-function focusLabel(label: string, focused: boolean): string {
-  return `${focused ? ">" : " "} ${label}`;
 }

--- a/station/src/station/view/sheets/ForkSessionSheetView.tsx
+++ b/station/src/station/view/sheets/ForkSessionSheetView.tsx
@@ -5,6 +5,9 @@ import { EditableTextInputView } from "../EditableTextInputView.js";
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import {
   compactSheetWidth,
+  responsiveSheetFooterText,
+  responsiveSheetText,
+  type ResponsiveSheetText,
   SheetButtonRow,
   SheetControlRow,
   SheetFooter,
@@ -22,7 +25,33 @@ export type ForkSessionSheetViewProps = {
   rows: number;
 };
 
-const LABEL_WIDTH = 8;
+const SOURCE_LABEL_WIDTH = 8;
+const CONTROL_LABEL_WIDTH = 6;
+const CHOOSE_SLOT_CONTENT_ROWS = 5;
+const CHOOSE_SLOT_MIN_HEIGHT = 7;
+const DETAILS_BASE_CONTENT_ROWS = 7;
+const DETAILS_MIN_HEIGHT = 9;
+
+const FORK_ACTION_HELP = {
+  expanded: "↑↓ focus · Enter fork · Esc back",
+  compact: "↑↓ · Enter fork · Esc",
+} as const satisfies ResponsiveSheetText;
+
+const COPY_DIRTY_HELP = {
+  expanded: "Space/Enter toggle · ↑↓ focus · Esc back",
+  compact: "Space/↵ toggle · ↑↓ · Esc back",
+} as const satisfies ResponsiveSheetText;
+
+const DETAILS_HELP_BY_FOCUS = {
+  name: FORK_ACTION_HELP,
+  copyDirty: COPY_DIRTY_HELP,
+  submit: FORK_ACTION_HELP,
+} as const satisfies Record<ForkDetailsScreen["focus"], ResponsiveSheetText>;
+
+const SOURCE_RUNNING_MESSAGE = {
+  expanded: "Source keeps running — copy is read-only.",
+  compact: "Source running; copy is read-only.",
+} as const satisfies ResponsiveSheetText;
 
 export function ForkSessionSheetView({ screen, columns, rows }: ForkSessionSheetViewProps) {
   const sheetWidth = compactSheetWidth(columns);
@@ -34,8 +63,8 @@ export function ForkSessionSheetView({ screen, columns, rows }: ForkSessionSheet
         rows={rows}
         width={sheetWidth}
         title="Select session to fork"
-        contentRows={5}
-        minHeight={7}
+        contentRows={CHOOSE_SLOT_CONTENT_ROWS}
+        minHeight={CHOOSE_SLOT_MIN_HEIGHT}
       >
         <SheetLine width={contentWidth}> </SheetLine>
         <SheetMessageLine width={contentWidth}>↑↓ move · ↵ choose · slot or click</SheetMessageLine>
@@ -43,7 +72,15 @@ export function ForkSessionSheetView({ screen, columns, rows }: ForkSessionSheet
       </BottomSheetFrameView>
     );
   }
-  return <ForkDetails screen={screen} columns={columns} rows={rows} contentWidth={contentWidth} sheetWidth={sheetWidth} />;
+  return (
+    <ForkDetails
+      screen={screen}
+      columns={columns}
+      rows={rows}
+      contentWidth={contentWidth}
+      sheetWidth={sheetWidth}
+    />
+  );
 }
 
 function ForkDetails({
@@ -66,36 +103,30 @@ function ForkDetails({
     ) : (
       screen.draftTitle.value
     );
-  const helper =
-    focus === "copyDirty"
-      ? contentWidth >= 40
-        ? "Space/Enter toggle · ↑↓ focus · Esc back"
-        : "Space/↵ toggle · ↑↓ · Esc back"
-      : contentWidth >= 32
-        ? "↑↓ focus · Enter fork · Esc back"
-        : "↑↓ · Enter fork · Esc";
-  const extraRows =
-    (screen.sourceAgentRunning ? 1 : 0) +
-    (screen.validationError !== undefined ? 1 : 0);
+  const footerText = responsiveSheetFooterText(contentWidth, DETAILS_HELP_BY_FOCUS[focus]);
+  const extraRows = [
+    screen.sourceAgentRunning,
+    screen.validationError !== undefined,
+  ].filter(Boolean).length;
   return (
     <BottomSheetFrameView
       columns={columns}
       rows={rows}
       width={sheetWidth}
       title="Fork Session"
-      contentRows={7 + extraRows}
-      minHeight={9}
+      contentRows={DETAILS_BASE_CONTENT_ROWS + extraRows}
+      minHeight={DETAILS_MIN_HEIGHT}
     >
       <SheetLabelValue
         width={contentWidth}
         label="Source"
-        labelWidth={LABEL_WIDTH}
+        labelWidth={SOURCE_LABEL_WIDTH}
         value={`${screen.projectLabel} · ${screen.sourceBranch}`}
       />
       <SheetControlRow
         width={contentWidth}
         label="Name"
-        labelWidth={LABEL_WIDTH - 2}
+        labelWidth={CONTROL_LABEL_WIDTH}
         value={titleValue}
         valueCells={screen.draftTitle.value.length + Number(focus === "name")}
         focused={focus === "name"}
@@ -104,16 +135,14 @@ function ForkDetails({
       <SheetControlRow
         width={contentWidth}
         label="Copy"
-        labelWidth={LABEL_WIDTH - 2}
+        labelWidth={CONTROL_LABEL_WIDTH}
         value={`[${screen.copyDirty ? "x" : " "}] uncommitted changes`}
         focused={focus === "copyDirty"}
         mouseTarget={{ kind: "forkSessionAction", actionId: "details.copyDirty" }}
       />
       {screen.sourceAgentRunning ? (
         <SheetMessageLine width={contentWidth} tone="muted">
-          {contentWidth >= 41
-            ? "Source keeps running — copy is read-only."
-            : "Source running; copy is read-only."}
+          {responsiveSheetText(contentWidth, SOURCE_RUNNING_MESSAGE)}
         </SheetMessageLine>
       ) : null}
       {screen.validationError !== undefined ? (
@@ -139,7 +168,7 @@ function ForkDetails({
           },
         ]}
       />
-      <SheetFooter width={contentWidth}>{helper}</SheetFooter>
+      <SheetFooter width={contentWidth}>{footerText}</SheetFooter>
     </BottomSheetFrameView>
   );
 }

--- a/station/src/station/view/sheets/RemoveSessionSheetView.test.tsx
+++ b/station/src/station/view/sheets/RemoveSessionSheetView.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { rgbToHex } from "@opentui/core";
+import { MouseButtons } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import type { TuiScreen } from "@station/dashboard-core";
+import { act } from "react";
+import { spanAtFrameCell } from "../../../terminal/testing/frameProbe.js";
+import type { StationMouseTarget } from "../../input/stationMouse.js";
+import { StationHoverProvider, StationMouseProvider } from "../stationMouseContext.js";
+import { STATION_COLORS } from "../theme.js";
+import { RemoveSessionSheetView } from "./RemoveSessionSheetView.js";
+
+type RemoveConfirmScreen = Extract<
+  TuiScreen,
+  { name: "removeWorktree"; step: "confirm" }
+>;
+
+const teardowns: Array<() => void> = [];
+afterEach(() => {
+  for (const teardown of teardowns.splice(0)) teardown();
+});
+
+function confirmScreen(actionFocus: RemoveConfirmScreen["actionFocus"]): RemoveConfirmScreen {
+  return {
+    name: "removeWorktree",
+    step: "confirm",
+    rowId: "ses_example" as RemoveConfirmScreen["rowId"],
+    forceRequired: false,
+    label: "cli-help-man",
+    actionFocus,
+  };
+}
+
+async function render(actionFocus: RemoveConfirmScreen["actionFocus"], width = 80) {
+  const targets: StationMouseTarget[] = [];
+  const setup = await testRender(
+    <StationHoverProvider value>
+      <StationMouseProvider value={(target) => targets.push(target)}>
+        <RemoveSessionSheetView
+          screen={confirmScreen(actionFocus)}
+          columns={width}
+          rows={16}
+        />
+      </StationMouseProvider>
+    </StationHoverProvider>,
+    { width, height: 16 },
+  );
+  teardowns.push(() => setup.renderer.destroy());
+  await setup.renderOnce();
+  return { setup, targets };
+}
+
+describe("RemoveSessionSheetView", () => {
+  it("renders explicit actions with safe Keep focus and danger-only Delete styling", async () => {
+    const { setup } = await render("keep");
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("Delete (Y)"));
+    const deleteCol = lines[row]?.indexOf("Delete") ?? -1;
+    const keepCol = lines[row]?.indexOf("Keep session") ?? -1;
+
+    expect(lines[row]).toContain("▸ Keep session (N)");
+    const deleteSpan = spanAtFrameCell(setup.captureSpans(), row, deleteCol);
+    const keepSpan = spanAtFrameCell(setup.captureSpans(), row, keepCol);
+    expect(deleteSpan?.fg === undefined ? undefined : rgbToHex(deleteSpan.fg)).toBe(
+      STATION_COLORS.red,
+    );
+    expect(keepSpan?.bg === undefined ? undefined : rgbToHex(keepSpan.bg)).toBe(
+      STATION_COLORS.focusBackground,
+    );
+  });
+
+  it("keeps button targets and hover fills bounded", async () => {
+    const { setup, targets } = await render("keep");
+    const lines = setup.captureCharFrame().split("\n");
+    const row = lines.findIndex((line) => line.includes("Delete (Y)"));
+    const deleteCol = lines[row]?.indexOf("Delete") ?? -1;
+    const keepCol = lines[row]?.indexOf("Keep session") ?? -1;
+
+    await act(async () => {
+      await setup.mockMouse.moveTo(deleteCol, row);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    await setup.flush();
+    const deleteSpan = spanAtFrameCell(setup.captureSpans(), row, deleteCol);
+    expect(deleteSpan?.bg === undefined ? undefined : rgbToHex(deleteSpan.bg)).toBe(
+      STATION_COLORS.red,
+    );
+
+    await setup.mockMouse.click(deleteCol, row, MouseButtons.LEFT);
+    await setup.mockMouse.click(keepCol, row, MouseButtons.LEFT);
+    await setup.mockMouse.click(58, row, MouseButtons.LEFT);
+    expect(targets).toEqual([
+      { kind: "removeWorktreeAction", actionId: "confirm.delete" },
+      { kind: "removeWorktreeAction", actionId: "confirm.keep" },
+    ]);
+  });
+
+  it("uses compact Delete and Keep labels when constrained", async () => {
+    const { setup } = await render("keep", 28);
+    const frame = setup.captureCharFrame();
+
+    expect(frame).toContain("Delete");
+    expect(frame).toContain("▸ Keep");
+    expect(frame).not.toContain("Keep session");
+  });
+});

--- a/station/src/station/view/sheets/RemoveSessionSheetView.tsx
+++ b/station/src/station/view/sheets/RemoveSessionSheetView.tsx
@@ -2,6 +2,8 @@ import { bottomSheetContentWidth, type TuiScreen } from "@station/dashboard-core
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import {
   compactSheetWidth,
+  responsiveSheetFooterText,
+  type ResponsiveSheetText,
   SheetButtonRow,
   SheetFooter,
   SheetLabelValue,
@@ -17,11 +19,21 @@ export type RemoveSessionSheetViewProps = {
   rows: number;
 };
 
+const MIN_SHEET_WIDTH = 1;
+const UNAVAILABLE_MAX_SHEET_WIDTH = 68;
+const CHOOSE_SLOT_CONTENT_ROWS = 5;
+const CHOOSE_SLOT_MIN_HEIGHT = 7;
+const DETAIL_CONTENT_ROWS = 7;
+const DETAIL_MIN_HEIGHT = 9;
+const SESSION_LABEL_WIDTH = 8;
+
+const CONFIRM_HELP = {
+  expanded: "←→ choose · Enter activate · Esc cancel",
+  compact: "←→ · Enter activate · Esc cancel",
+} as const satisfies ResponsiveSheetText;
+
 export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionSheetViewProps) {
-  const sheetWidth =
-    screen.step === "unavailable"
-      ? Math.min(Math.max(1, Math.floor(columns)), 68)
-      : compactSheetWidth(columns);
+  const sheetWidth = removeSheetWidth(screen.step, columns);
   const contentWidth = bottomSheetContentWidth(sheetWidth);
   if (screen.step === "chooseSlot") {
     return (
@@ -30,8 +42,8 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
         rows={rows}
         width={sheetWidth}
         title="Select session to delete"
-        contentRows={5}
-        minHeight={7}
+        contentRows={CHOOSE_SLOT_CONTENT_ROWS}
+        minHeight={CHOOSE_SLOT_MIN_HEIGHT}
       >
         <SheetLine width={contentWidth}> </SheetLine>
         <SheetMessageLine width={contentWidth}>↑↓ move · ↵ choose · slot or click</SheetMessageLine>
@@ -47,8 +59,8 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
         rows={rows}
         width={sheetWidth}
         title="Cannot delete worktree"
-        contentRows={7}
-        minHeight={9}
+        contentRows={DETAIL_CONTENT_ROWS}
+        minHeight={DETAIL_MIN_HEIGHT}
       >
         <SheetMessageLine width={contentWidth}>
           This agent was started outside Station.
@@ -72,10 +84,15 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
       rows={rows}
       width={sheetWidth}
       title="Delete session?"
-      contentRows={7}
-      minHeight={9}
+      contentRows={DETAIL_CONTENT_ROWS}
+      minHeight={DETAIL_MIN_HEIGHT}
     >
-      <SheetLabelValue width={contentWidth} label="Session" labelWidth={8} value={screen.label} />
+      <SheetLabelValue
+        width={contentWidth}
+        label="Session"
+        labelWidth={SESSION_LABEL_WIDTH}
+        value={screen.label}
+      />
       <SheetMessageLine width={contentWidth} tone="danger">
         Removes agent, worktree, and panes.
       </SheetMessageLine>
@@ -111,10 +128,18 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
         ]}
       />
       <SheetFooter width={contentWidth}>
-        {contentWidth >= 39
-          ? "←→ choose · Enter activate · Esc cancel"
-          : "←→ · Enter activate · Esc cancel"}
+        {responsiveSheetFooterText(contentWidth, CONFIRM_HELP)}
       </SheetFooter>
     </BottomSheetFrameView>
+  );
+}
+
+function removeSheetWidth(step: RemoveScreen["step"], columns: number): number {
+  if (step !== "unavailable") {
+    return compactSheetWidth(columns);
+  }
+  return Math.min(
+    Math.max(MIN_SHEET_WIDTH, Math.floor(columns)),
+    UNAVAILABLE_MAX_SHEET_WIDTH,
   );
 }

--- a/station/src/station/view/sheets/RemoveSessionSheetView.tsx
+++ b/station/src/station/view/sheets/RemoveSessionSheetView.tsx
@@ -2,7 +2,7 @@ import { bottomSheetContentWidth, type TuiScreen } from "@station/dashboard-core
 import { BottomSheetFrameView } from "./BottomSheetFrameView.js";
 import {
   compactSheetWidth,
-  SheetConfirmButtons,
+  SheetButtonRow,
   SheetFooter,
   SheetLabelValue,
   SheetLine,
@@ -80,8 +80,41 @@ export function RemoveSessionSheetView({ screen, columns, rows }: RemoveSessionS
         Removes agent, worktree, and panes.
       </SheetMessageLine>
       <SheetLine width={contentWidth}> </SheetLine>
-      <SheetConfirmButtons width={contentWidth} />
-      <SheetFooter width={contentWidth}>Esc/Enter:cancel</SheetFooter>
+      <SheetButtonRow
+        width={contentWidth}
+        buttons={[
+          {
+            id: "confirm.delete",
+            label: "Delete",
+            shortcut: "Y",
+            tone: "danger",
+            mouseTarget: {
+              kind: "removeWorktreeAction",
+              actionId: "confirm.delete",
+            },
+            focused: screen.actionFocus === "delete",
+            disabled: false,
+          },
+          {
+            id: "confirm.keep",
+            label: "Keep session",
+            compactLabel: "Keep",
+            shortcut: "N",
+            tone: "neutral",
+            mouseTarget: {
+              kind: "removeWorktreeAction",
+              actionId: "confirm.keep",
+            },
+            focused: screen.actionFocus === "keep",
+            disabled: false,
+          },
+        ]}
+      />
+      <SheetFooter width={contentWidth}>
+        {contentWidth >= 39
+          ? "←→ choose · Enter activate · Esc cancel"
+          : "←→ · Enter activate · Esc cancel"}
+      </SheetFooter>
     </BottomSheetFrameView>
   );
 }

--- a/station/src/station/view/sheets/parts.test.tsx
+++ b/station/src/station/view/sheets/parts.test.tsx
@@ -7,7 +7,12 @@ import { spanAtFrameCell } from "../../../terminal/testing/frameProbe.js";
 import type { StationMouseTarget } from "../../input/stationMouse.js";
 import { StationHoverProvider, StationMouseProvider } from "../stationMouseContext.js";
 import { STATION_COLORS } from "../theme.js";
-import { SheetButtonRow, type SheetButtonSpec } from "./parts.js";
+import {
+  responsiveSheetFooterText,
+  responsiveSheetText,
+  SheetButtonRow,
+  type SheetButtonSpec,
+} from "./parts.js";
 
 const teardowns: Array<() => void> = [];
 afterEach(() => {
@@ -115,5 +120,25 @@ describe("SheetButtonRow", () => {
     expect(trailing?.bg === undefined ? undefined : rgbToHex(trailing.bg)).not.toBe(
       STATION_COLORS.cyan,
     );
+  });
+});
+
+describe("responsive sheet text", () => {
+  const variants = {
+    expanded: "Expanded copy",
+    compact: "Compact",
+  } as const;
+
+  it("selects copy from measured available width", () => {
+    const expandedWidth = variants.expanded.length;
+    expect(responsiveSheetText(expandedWidth, variants)).toBe(variants.expanded);
+    const narrowerWidth = expandedWidth - " ".length;
+    expect(responsiveSheetText(narrowerWidth, variants)).toBe(variants.compact);
+  });
+
+  it("reserves the footer inset before selecting copy", () => {
+    const expandedFooter = ` ${variants.expanded}`;
+    expect(responsiveSheetFooterText(expandedFooter.length, variants)).toBe(variants.expanded);
+    expect(responsiveSheetFooterText(variants.expanded.length, variants)).toBe(variants.compact);
   });
 });

--- a/station/src/station/view/sheets/parts.test.tsx
+++ b/station/src/station/view/sheets/parts.test.tsx
@@ -24,7 +24,10 @@ function button(
     label: id,
     shortcut: key.toUpperCase(),
     tone: "primary",
-    mouseTarget: { kind: "sheetButton", key },
+    mouseTarget: {
+      kind: "removeWorktreeAction",
+      actionId: key === "y" ? "confirm.delete" : "confirm.keep",
+    },
     focused: options.focused ?? false,
     disabled: options.disabled ?? false,
     ...(options.compactLabel === undefined ? {} : { compactLabel: options.compactLabel }),
@@ -54,7 +57,9 @@ describe("SheetButtonRow", () => {
     expect(line.slice(10).trim()).toBe("");
 
     await setup.mockMouse.click(2, 0, MouseButtons.LEFT);
-    expect(targets).toEqual([{ kind: "sheetButton", key: "y" }]);
+    expect(targets).toEqual([
+      { kind: "removeWorktreeAction", actionId: "confirm.delete" },
+    ]);
     await setup.mockMouse.click(30, 0, MouseButtons.LEFT);
     expect(targets).toHaveLength(1);
   });
@@ -70,8 +75,8 @@ describe("SheetButtonRow", () => {
     await setup.mockMouse.click(backColumn, 0, MouseButtons.LEFT);
     await setup.mockMouse.click(35, 0, MouseButtons.LEFT);
     expect(targets).toEqual([
-      { kind: "sheetButton", key: "y" },
-      { kind: "sheetButton", key: "n" },
+      { kind: "removeWorktreeAction", actionId: "confirm.delete" },
+      { kind: "removeWorktreeAction", actionId: "confirm.keep" },
     ]);
   });
 
@@ -85,8 +90,8 @@ describe("SheetButtonRow", () => {
     await setup.mockMouse.click(2, 0, MouseButtons.LEFT);
     await setup.mockMouse.click(8, 0, MouseButtons.LEFT);
     expect(targets).toEqual([
-      { kind: "sheetButton", key: "y" },
-      { kind: "sheetButton", key: "n" },
+      { kind: "removeWorktreeAction", actionId: "confirm.delete" },
+      { kind: "removeWorktreeAction", actionId: "confirm.keep" },
     ]);
   });
 

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -459,31 +459,6 @@ export function SheetSectionLine({ width, children }: { width: number; children:
   );
 }
 
-/** The Yes/No confirm row shared by the bottom-sheet confirm dialogs. */
-export function SheetConfirmButtons({ width }: { width: number }) {
-  const gap = width >= 22 ? 2 : 0;
-  const buttonWidth = Math.max(1, Math.min(10, Math.floor((width - gap) / 2)));
-  return (
-    <box flexDirection="row" width={width}>
-      <SheetButton
-        label="Yes"
-        shortcut="y"
-        tone="success"
-        fixedWidth={buttonWidth}
-        mouseTarget={{ kind: "sheetButton", key: "y" }}
-      />
-      {gap > 0 ? <SheetText>{spaces(gap)}</SheetText> : null}
-      <SheetButton
-        label="No"
-        shortcut="n"
-        tone="danger"
-        fixedWidth={buttonWidth}
-        mouseTarget={{ kind: "sheetButton", key: "n" }}
-      />
-    </box>
-  );
-}
-
 /** Width for the compact bottom-sheet confirm dialogs (capped at 46 columns). */
 export function compactSheetWidth(columns: number): number {
   return Math.min(Math.max(1, Math.floor(columns)), 46);

--- a/station/src/station/view/sheets/parts.tsx
+++ b/station/src/station/view/sheets/parts.tsx
@@ -5,6 +5,7 @@
 import { TextAttributes } from "@opentui/core";
 import type { TextProps } from "@opentui/react";
 import { isValidElement, type ReactNode } from "react";
+import stringWidth from "string-width";
 import type { StationMouseTarget } from "../../input/stationMouse.js";
 import {
   useStationHoverState,
@@ -20,6 +21,30 @@ export function fit(value: string, width: number): string {
 
 export function spaces(width: number): string {
   return " ".repeat(Math.max(0, width));
+}
+
+export type ResponsiveSheetText = Readonly<{
+  expanded: string;
+  compact: string;
+}>;
+
+const SHEET_FOOTER_PREFIX = " ";
+
+/** Selects the expanded copy only when every cell fits the available width. */
+export function responsiveSheetText(
+  width: number,
+  variants: ResponsiveSheetText,
+): string {
+  return stringWidth(variants.expanded) <= width ? variants.expanded : variants.compact;
+}
+
+/** Accounts for the footer's leading inset when selecting responsive copy. */
+export function responsiveSheetFooterText(
+  width: number,
+  variants: ResponsiveSheetText,
+): string {
+  const textWidth = Math.max(0, width - stringWidth(SHEET_FOOTER_PREFIX));
+  return responsiveSheetText(textWidth, variants);
 }
 
 /** Text inside a sheet is never eligible for terminal drag selection. */
@@ -93,7 +118,7 @@ export function SheetFill({ count, width }: { count: number; width: number }) {
 export function SheetFooter({ width, children }: { width: number; children: string }) {
   return (
     <SheetText fg={STATION_COLORS.foreground} attributes={TextAttributes.DIM}>
-      {fit(` ${children}`, width)}
+      {fit(`${SHEET_FOOTER_PREFIX}${children}`, width)}
     </SheetText>
   );
 }


### PR DESCRIPTION
## What this fixes

Remove Session and Fork Session exposed visible sheet controls without consistent keyboard and pointer semantics. Remove confirmation lacked focusable outcomes, while Fork fields could not be clicked and native Station intercepted Copy-focused Enter as a submit. This made destructive confirmation less explicit and caused native/standalone behavior to diverge.

## What changed

- Render Remove confirmation as explicit **Delete** and **Keep Session** actions, defaulting safely to Keep.
- Clamp Left/Right focus, preserve Y/N/Esc shortcuts, and route focused Enter and pointer activation through shared semantic actions.
- Make Fork **Name**, **Copy**, and **Fork** controls pointer-accessible with bounded hover/focus treatment and responsive helper text.
- Toggle Copy exactly once when clicked or activated with Enter; submit only from Name or Fork focus.
- Keep native Station's managed-pane fork launch while preserving the shared observer operation path in standalone/tmux rendering.
- Add core parity, mouse routing, native input, fullscreen, component, and modal golden coverage; document the interaction contract and manual verification steps.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `cd station && bun run test` — 1,284 passed
- Focused core and Station suites — 124 and 236 passed
- `pnpm test:all` — unit, contracts, integration, diagnostics, scripted-agent, and setup E2E suites passed; the final Observer lifecycle shard remained 18/20 because two unrelated handoff tests returned `OBSERVER_HANDOFF_REFUSED`, reproduced on an isolated rerun
- LSP/pi-lens diagnostics and `git diff --check`

Closes #370
