### PR TITLE
test(benchmark): publish sealed incident-debugging process

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,14 @@
+# Benchmarks
+
+This directory contains opt-in research infrastructure that is intentionally excluded from Station's ordinary CI and `test:all`.
+
+`real-incident-debugging/` is the reusable, frozen-v13 A/B process for comparing a base CLI, a candidate CLI, and a raw-evidence arm on copied incident evidence. The committed fixture is synthetic. Private corpora, gold labels, review material, credentials, executable copies, model output, and study results must remain outside the repository.
+
+Run deterministic harness tests with:
+
+```bash
+pnpm benchmark:typecheck
+pnpm benchmark:real-incident-debugging
+```
+
+See [Real-incident debugging](real-incident-debugging/README.md) before preparing or running a study.

--- a/benchmark/real-incident-debugging/README.md
+++ b/benchmark/real-incident-debugging/README.md
@@ -1,0 +1,118 @@
+# Real-incident debugging benchmark
+
+This opt-in research lane compares frozen base and candidate Station CLIs with a raw-evidence arm using copied incident evidence. It implements the reusable process that reached the v13 exploratory decision contract. It does not contain the private v13 corpus or results and does not change production behavior.
+
+The lane is exploratory unless qualified humans independently validate the private gold and perform the blind semantic review. AI-authored gold or AI-only blind review cannot support a confirmatory production claim.
+
+## What is committed
+
+- strict schemas for incidents, manifests, freezes, schedules, trials, and model responses;
+- corpus integrity, review, temporal-validity, prior-use, and study-composition checks;
+- deterministic arm-balanced scheduling and resumable fail-closed run state;
+- isolated trial workspaces and per-trial provider homes;
+- base/candidate wrapper identity checks and raw-command allowlisting;
+- pinned Codex invocation, read-only sandboxing, disabled tool network, timeout, token, and command caps;
+- blind packet generation with arm/path sanitization and citation validation;
+- semantic scoring and incident-blocked bootstrap helpers;
+- a synthetic fixture and deterministic unit tests.
+
+Private corpus construction, gold-review records, review outputs, unblinding maps, executable builds, auth, and paid-study artifacts belong in a private ignored state directory.
+
+## Diagnosis contract
+
+The response schema separates:
+
+- `proximateFailure`: the most specific immediate retained failure at the operational boundary;
+- `underlyingCauseDisposition`: `established`, `unknown`, or `not_applicable`;
+- `underlyingCause`: the mechanism beneath the proximate failure;
+- `responsibleSubsystem`: the directly evidenced operation, provider boundary, watcher, parser, detector, or lifecycle;
+- `proximateEvidenceAdequacy`: evidence adequacy for the immediate failure rather than an unlimited causal chain.
+
+`ownershipCitation` must quote a specific operation, boundary, or failure description. A generic component, provider name, delivery outcome, or spool outcome is insufficient by itself. When Station output includes `evidenceRoles`, `operationalBoundaryEvidence` is failure-and-ownership evidence and the record component is logging provenance only.
+
+Citations use one-based `commandNumber` values. Each literal must occur in that command's output, be at most 160 characters, and contain no quote, backslash, or newline. A thirteenth command is a terminal study failure.
+
+A semantic success requires correct proximate failure, underlying-cause disposition and content, direct evidence grounding, ownership boundary, safe/relevant next action, and unsupported-claim discipline, with no unsafe recommendation.
+
+## Sealing order
+
+Before any paid trial:
+
+1. Freeze base and candidate commits and build exact wrappers from those commits.
+2. Select incidents that occurred before candidate selection; exclude every exact source used in an earlier acceptance study and enforce the preregistered deduplication rule.
+3. Keep symptoms, replay files, gold, provenance, resolution records, and redaction reports private.
+4. Obtain two independent corpus reviews and resolve every rejection before sealing.
+5. Seal the manifest, held-out IDs, source hashes, model/Codex versions, prompt/schema semantics, command cap, schedules, thresholds, review protocol, and executable hashes.
+6. Run the complete deterministic fake-Codex preflight.
+7. Verify the phase contract and executable identities immediately before paid execution.
+
+Trial workspaces may contain only `symptom.txt`, `replay.json`, `config.toml`, and declared copied evidence. Gold, provenance, reviews, schedules, prior outcomes, and arm identity must never enter a trial workspace.
+
+Never weaken or rewrite a failed gate after unblinding. Never reuse an executed incident as fresh acceptance evidence.
+
+## Sequential execution
+
+The first paid phase is an 18-turn pilot: six development incidents across three arms. Continue to the 144-turn held-out phase only when every sealed pilot gate passes:
+
+- candidate succeeds on at least five of six incidents;
+- candidate has no terminal failure;
+- no arm recommends an unsafe action;
+- candidate/base command ratio is at most 1.10;
+- candidate has no evidence-grounding failure.
+
+A failed gate stops the study for futility. The held-out set remains unopened.
+
+The default held-out schedule uses 24 incidents, three arms, and two replicates. Analyze confidence with incident-blocked resampling so all arms and replicates for an incident remain together.
+
+## Commands
+
+Deterministic harness tests (the real test remains skipped):
+
+```bash
+pnpm benchmark:real-incident-debugging
+```
+
+Private fake-Codex preflight:
+
+```bash
+STATION_REAL_INCIDENT_DEBUG_AB=1 \
+STATION_REAL_INCIDENT_DEBUG_AB_PHASE=preflight \
+STATION_REAL_INCIDENT_DEBUG_AB_CORPUS=/private/sealed-corpus \
+STATION_REAL_INCIDENT_DEBUG_AB_ARTIFACTS=/private/empty-artifact-root \
+STATION_REAL_INCIDENT_DEBUG_AB_FAKE_CODEX=/private/fake-codex \
+STATION_REAL_INCIDENT_DEBUG_AB_BASE_STN=/private/base-stn \
+STATION_REAL_INCIDENT_DEBUG_AB_CANDIDATE_STN=/private/candidate-stn \
+STATION_REAL_INCIDENT_DEBUG_AB_BASE_COMMIT=<base-commit> \
+STATION_REAL_INCIDENT_DEBUG_AB_CANDIDATE_COMMIT=<candidate-commit> \
+pnpm benchmark:real-incident-debugging -- --phase preflight
+```
+
+Paid `development` and `held-out` phases additionally require:
+
+- `STATION_REAL_INCIDENT_DEBUG_AB_RUN_PAID=1`;
+- `STATION_REAL_INCIDENT_DEBUG_AB_CODEX`;
+- `STATION_REAL_INCIDENT_DEBUG_AB_CODEX_VERSION`;
+- `STATION_REAL_INCIDENT_DEBUG_AB_CODEX_AUTH`.
+
+The v13 execution contract pins Codex CLI 0.146.0, `gpt-5.6-sol`, high reasoning, read-only sandbox, disabled tool network, ignored user rules/configuration, a 300-second timeout, a 32,000-token rollout budget, and at most 12 commands. Changing any item creates a new protocol and requires a new seal.
+
+## Review and unblinding
+
+1. Generate blind packets after all phase trials reach a terminal state.
+2. Scan packets for arm names, private paths, credentials, labels, and outcome leakage; fail closed on any match.
+3. Have two reviewers independently score every packet against the frozen protocol.
+4. Send only disagreements to an independent adjudicator.
+5. Seal packets, review files, final blind scores, and hashes.
+6. Create the arm/incident unblinding map only after the review seal exists.
+7. Run the frozen analysis and produce a final report and study seal.
+
+Machine-valid citations are necessary but cannot establish semantic correctness by themselves.
+
+## Safety boundaries
+
+- Real phases require both explicit enablement and the paid-run gate.
+- Every trial receives a private isolated home and ephemeral auth copy; cleanup is verified.
+- Raw trials may use only `rg`, `find`, `sed`, `tail`, and `sqlite3 -readonly` through declared replay patterns.
+- Neither arm may start/contact an Observer, reconcile, dispatch, mutate setup/hooks/config, create bundles, or write incident evidence.
+- Policy rejection, timeout, missing answer, citation mismatch, and command-cap overflow are terminal outcomes rather than retry invitations.
+- The benchmark remains excluded from ordinary CI and `test:all` because it may require private evidence, external executables, credentials, and paid model turns.

--- a/benchmark/real-incident-debugging/arms.ts
+++ b/benchmark/real-incident-debugging/arms.ts
@@ -1,0 +1,255 @@
+import { relative, resolve, sep } from "node:path";
+import type { Arm, CommandPattern, NeutralArmLabel, Replay } from "./protocol.js";
+
+const shellMetacharacters = new Set([";", "&", "|", "<", ">", "`", "$"]);
+const rawExecutables = new Set(["rg", "find", "sed", "tail", "sqlite3"]);
+
+export type ArmAccess = {
+  arm: Arm;
+  blindArm: NeutralArmLabel;
+  commandPatterns: CommandPattern[];
+};
+
+export type CommandPolicyResult = { ok: true; argv: string[] } | { ok: false; reason: string };
+
+export function createArmAccess(input: {
+  arm: Arm;
+  blindArm: NeutralArmLabel;
+  replay: Replay;
+}): ArmAccess {
+  return {
+    arm: input.arm,
+    blindArm: input.blindArm,
+    commandPatterns: input.arm === "raw" ? input.replay.rawCommands : input.replay.stationCommands,
+  };
+}
+
+export function parseRestrictedCommand(command: string): CommandPolicyResult {
+  const argv: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let escaping = false;
+
+  for (const character of command) {
+    if (escaping) {
+      current += character;
+      escaping = false;
+      continue;
+    }
+    if (character === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) {
+        quote = undefined;
+      } else if (quote === '"' && (character === "$" || character === "`")) {
+        return { ok: false, reason: "shell expansion is forbidden" };
+      } else {
+        current += character;
+      }
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      quote = character;
+      continue;
+    }
+    if (shellMetacharacters.has(character) || character === "\n" || character === "\r") {
+      return { ok: false, reason: "shell composition and expansion are forbidden" };
+    }
+    if (/\s/u.test(character)) {
+      if (current.length > 0) {
+        argv.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += character;
+  }
+
+  if (escaping || quote !== undefined) {
+    return { ok: false, reason: "unterminated shell token" };
+  }
+  if (current.length > 0) {
+    argv.push(current);
+  }
+  if (argv.length === 0) {
+    return { ok: false, reason: "empty command" };
+  }
+  return { ok: true, argv };
+}
+
+export function validateCommand(input: {
+  access: ArmAccess;
+  argv: string[];
+  workspaceRoot: string;
+}): CommandPolicyResult {
+  const [executable, ...arguments_] = input.argv;
+  if (executable === undefined || !matchesAnyPattern(input.argv, input.access.commandPatterns)) {
+    return { ok: false, reason: "command is not in this trial's allowlist" };
+  }
+  if (input.access.arm === "raw") {
+    if (!rawExecutables.has(executable)) {
+      return { ok: false, reason: "raw-evidence access permits only raw inspection tools" };
+    }
+    const rawCheck = validateRawInspection(executable, arguments_);
+    if (rawCheck.ok === false) {
+      return rawCheck;
+    }
+  } else if (executable !== "stn") {
+    return { ok: false, reason: "Station arms permit only public stn commands" };
+  }
+
+  const pathCheck = validateWorkspaceArguments(arguments_, input.workspaceRoot);
+  if (pathCheck.ok === false) {
+    return pathCheck;
+  }
+  return { ok: true, argv: input.argv };
+}
+
+export function validateExecutedCommand(input: {
+  access: ArmAccess;
+  command: string;
+  workspaceRoot: string;
+}): CommandPolicyResult {
+  const parsed = parseRestrictedCommand(input.command);
+  if (parsed.ok === false) {
+    return parsed;
+  }
+  const unwrapped = unwrapCodexShellCommand(parsed.argv);
+  if (unwrapped.ok === false) {
+    return unwrapped;
+  }
+  return validateCommand({
+    access: input.access,
+    argv: unwrapped.argv,
+    workspaceRoot: input.workspaceRoot,
+  });
+}
+
+function unwrapCodexShellCommand(argv: string[]): CommandPolicyResult {
+  if (argv[0] !== "/bin/zsh" && argv[0] !== "/bin/bash" && argv[0] !== "/bin/sh") {
+    return { ok: true, argv };
+  }
+  if (argv.length !== 3 || argv[1] !== "-lc" || argv[2] === undefined) {
+    return { ok: false, reason: "unsupported shell wrapper" };
+  }
+  return parseRestrictedCommand(argv[2]);
+}
+
+function matchesAnyPattern(argv: string[], patterns: CommandPattern[]): boolean {
+  return patterns.some((pattern) => {
+    if (argv.length !== pattern.arguments.length + 1 || argv[0] !== pattern.executable) {
+      return false;
+    }
+    return pattern.arguments.every((argument, index) => {
+      const value = argv[index + 1];
+      return value !== undefined && (argument === value || matchesPlaceholder(argument, value));
+    });
+  });
+}
+
+function matchesPlaceholder(pattern: string, value: string): boolean {
+  if (!/^\{(?:id|traceId|commandId|diagnosticId|query|path|sql|number)\}$/u.test(pattern)) {
+    return false;
+  }
+  return value.length > 0 && !/[\r\n]/u.test(value);
+}
+
+function validateRawInspection(executable: string, arguments_: string[]): CommandPolicyResult {
+  switch (executable) {
+    case "rg":
+      if (arguments_.some((argument) => argument === "--pre" || argument.startsWith("--pre="))) {
+        return { ok: false, reason: "rg --pre can execute arbitrary commands" };
+      }
+      return { ok: true, argv: [executable, ...arguments_] };
+    case "find":
+      if (
+        arguments_.some((argument) =>
+          [
+            "-delete",
+            "-exec",
+            "-execdir",
+            "-ok",
+            "-okdir",
+            "-fprint",
+            "-fprint0",
+            "-fprintf",
+            "-fls",
+          ].includes(argument),
+        )
+      ) {
+        return { ok: false, reason: "mutating or command-executing find predicates are forbidden" };
+      }
+      return { ok: true, argv: [executable, ...arguments_] };
+    case "sed":
+      if (
+        arguments_.length < 3 ||
+        arguments_[0] !== "-n" ||
+        !/^\d+(?:,\d+)?p$/u.test(arguments_[1] ?? "")
+      ) {
+        return { ok: false, reason: "sed is limited to numeric -n print ranges" };
+      }
+      return { ok: true, argv: [executable, ...arguments_] };
+    case "tail":
+      if (arguments_.some((argument) => argument === "-f" || argument === "--follow")) {
+        return { ok: false, reason: "tail follow mode is forbidden" };
+      }
+      return { ok: true, argv: [executable, ...arguments_] };
+    case "sqlite3":
+      if (!arguments_.includes("-readonly")) {
+        return { ok: false, reason: "sqlite3 must use -readonly" };
+      }
+      if (arguments_.some((argument) => argument === "-cmd" || argument.startsWith("-cmd="))) {
+        return { ok: false, reason: "sqlite3 -cmd is forbidden" };
+      }
+      if (!isReadOnlySql(arguments_.at(-1) ?? "")) {
+        return { ok: false, reason: "sqlite3 query is not read-only" };
+      }
+      return { ok: true, argv: [executable, ...arguments_] };
+    default:
+      return { ok: false, reason: "unsupported raw inspection executable" };
+  }
+}
+
+function validateWorkspaceArguments(
+  arguments_: string[],
+  workspaceRoot: string,
+): CommandPolicyResult {
+  const workspace = resolve(workspaceRoot);
+  for (const argument of arguments_) {
+    if (argument === ".." || argument.startsWith(`..${sep}`)) {
+      return { ok: false, reason: "parent-directory traversal is forbidden" };
+    }
+    if (argument.startsWith("/")) {
+      const target = resolve(argument);
+      const pathRelative = relative(workspace, target);
+      if (
+        pathRelative === ".." ||
+        pathRelative.startsWith(`..${sep}`) ||
+        pathRelative.startsWith("/")
+      ) {
+        return { ok: false, reason: "paths must stay inside the trial workspace" };
+      }
+    }
+  }
+  return { ok: true, argv: [] };
+}
+
+function isReadOnlySql(query: string): boolean {
+  const normalized = query.trim().toUpperCase();
+  if (normalized === ".TABLES" || normalized === ".SCHEMA") {
+    return true;
+  }
+  if (normalized.includes(";")) {
+    return false;
+  }
+  if (
+    /\b(?:INSERT|UPDATE|DELETE|REPLACE|CREATE|DROP|ALTER|VACUUM|ATTACH|DETACH|REINDEX|ANALYZE)\b/u.test(
+      normalized,
+    )
+  ) {
+    return false;
+  }
+  return /^(?:SELECT|PRAGMA|EXPLAIN|WITH)\b/u.test(normalized);
+}

--- a/benchmark/real-incident-debugging/artifacts.ts
+++ b/benchmark/real-incident-debugging/artifacts.ts
@@ -1,0 +1,205 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import type { Citation, TrialAttemptStatus, TrialOutput, TrialRecord } from "./protocol.js";
+
+export type RunPaths = {
+  root: string;
+  official: string;
+  raw: string;
+  blind: string;
+  state: string;
+};
+
+export type BlindReviewPacket = {
+  schemaVersion: 1;
+  reviewId: string;
+  caseId: string;
+  symptom: string;
+  terminalStatus: TrialAttemptStatus;
+  response?: TrialOutput;
+  citedEvidence: Array<{
+    field: "proximateFailure" | "ownership" | "underlyingCause";
+    commandNumber: number;
+    literal: string;
+    output: string;
+  }>;
+};
+
+export async function createRunPaths(root: string): Promise<RunPaths> {
+  const paths: RunPaths = {
+    root,
+    official: join(root, "official"),
+    raw: join(root, "raw"),
+    blind: join(root, "blind"),
+    state: join(root, "run-state.json"),
+  };
+  await Promise.all(
+    [paths.root, paths.official, paths.raw, paths.blind].map((path) =>
+      mkdir(path, { recursive: true, mode: 0o700 }),
+    ),
+  );
+  return paths;
+}
+
+export async function writeTrialArtifact(input: {
+  paths: RunPaths;
+  record: TrialRecord;
+  stdoutJsonl: string;
+}): Promise<void> {
+  const officialRoot = join(input.paths.official, "trials", input.record.trialId);
+  const rawRoot = join(input.paths.raw, "trials", input.record.trialId);
+  const attempt = input.record.attempts.at(-1);
+  if (attempt === undefined) {
+    throw new Error(
+      `Cannot write an artifact for a trial with no attempts: ${input.record.trialId}`,
+    );
+  }
+  await writeJson(join(officialRoot, "trial.json"), input.record);
+  await writeText(
+    join(rawRoot, `attempt-${attempt.attempt}-codex-events.jsonl`),
+    input.stdoutJsonl,
+  );
+}
+
+export async function writeRunState(paths: RunPaths, value: unknown): Promise<void> {
+  await writeJson(paths.state, value);
+}
+
+export async function readRunState<T>(paths: RunPaths): Promise<T | undefined> {
+  const text = await readFile(paths.state, "utf8").catch(() => undefined);
+  return text === undefined ? undefined : (JSON.parse(text) as T);
+}
+
+type CitationField = "proximateFailure" | "ownership" | "underlyingCause";
+
+function sanitizeCitation(citation: Citation, labels: readonly string[]): Citation {
+  return {
+    ...citation,
+    literal: sanitizeBlindText(citation.literal, labels),
+  };
+}
+
+function citationEntries(output: TrialOutput): Array<{ field: CitationField; citation: Citation }> {
+  const entries: Array<{ field: CitationField; citation: Citation }> = [
+    { field: "proximateFailure", citation: output.proximateCitation },
+    { field: "ownership", citation: output.ownershipCitation },
+  ];
+  if (output.underlyingCauseCitation !== null) {
+    entries.push({ field: "underlyingCause", citation: output.underlyingCauseCitation });
+  }
+  return entries;
+}
+
+export function createBlindReviewPacket(input: {
+  record: TrialRecord;
+  symptom: string;
+}): BlindReviewPacket {
+  const output = completedOutput(input.record);
+  const sensitiveLabels = [input.record.trialId, input.record.blindArm];
+  const sanitizedOutput =
+    output === undefined
+      ? undefined
+      : {
+          ...output,
+          proximateFailure: sanitizeBlindText(output.proximateFailure, sensitiveLabels),
+          underlyingCause: sanitizeBlindText(output.underlyingCause, sensitiveLabels),
+          responsibleSubsystem: sanitizeBlindText(output.responsibleSubsystem, sensitiveLabels),
+          nextActions: output.nextActions.map((action) =>
+            sanitizeBlindText(action, sensitiveLabels),
+          ),
+          proximateCitation: sanitizeCitation(output.proximateCitation, sensitiveLabels),
+          ownershipCitation: sanitizeCitation(output.ownershipCitation, sensitiveLabels),
+          underlyingCauseCitation:
+            output.underlyingCauseCitation === null
+              ? null
+              : sanitizeCitation(output.underlyingCauseCitation, sensitiveLabels),
+        };
+  const lastAttempt = input.record.attempts.at(-1);
+  if (lastAttempt === undefined) {
+    throw new Error(`Trial has no attempts: ${input.record.trialId}`);
+  }
+  const citedEvidence =
+    output === undefined
+      ? []
+      : citationEntries(output).map(({ field, citation }) => {
+          const command = lastAttempt.commands[citation.commandNumber - 1];
+          return {
+            field,
+            commandNumber: citation.commandNumber,
+            literal: sanitizeBlindText(citation.literal, sensitiveLabels),
+            output: sanitizeBlindText(command?.output ?? "", sensitiveLabels),
+          };
+        });
+  const packet: BlindReviewPacket = {
+    schemaVersion: 1,
+    reviewId: reviewIdFor(input.record.trialId),
+    caseId: input.record.incidentId,
+    symptom: sanitizeBlindText(input.symptom, sensitiveLabels),
+    terminalStatus: lastAttempt.status,
+    citedEvidence,
+  };
+  if (sanitizedOutput !== undefined) {
+    packet.response = sanitizedOutput;
+  }
+  return packet;
+}
+
+export async function writeBlindReviewPacket(
+  paths: RunPaths,
+  packet: BlindReviewPacket,
+): Promise<void> {
+  await writeJson(join(paths.blind, "packets", `${packet.reviewId}.json`), packet);
+}
+
+export function assertBlindPacketHasNoArmLabels(
+  packet: BlindReviewPacket,
+  labels: readonly string[],
+): void {
+  const serialized = JSON.stringify(packet);
+  for (const label of labels) {
+    if (serialized.includes(label)) {
+      throw new Error(`Blind review packet leaks arm label: ${label}`);
+    }
+  }
+}
+
+export function assertBlindPacketHasNoPrivatePaths(packet: BlindReviewPacket): void {
+  const serialized = JSON.stringify(packet);
+  if (/\/(?:Users|home)\//u.test(serialized)) {
+    throw new Error("Blind review packet leaks a private absolute path.");
+  }
+}
+
+export function reviewIdFor(trialId: string): string {
+  return `review-${createHash("sha256").update(trialId).digest("hex").slice(0, 20)}`;
+}
+
+export async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeText(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function writeText(path: string, value: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(temporary, value, { encoding: "utf8", mode: 0o600 });
+  await rename(temporary, path);
+}
+
+function sanitizeBlindText(value: string, labels: readonly string[]): string {
+  // CLI evidence may echo absolute copied-workspace paths that disclose the study checkout.
+  const pathSanitized = value.replace(
+    /\/(?:Users|home)\/[^"'\n\r\\]+/gu,
+    (path) => `[REDACTED_PATH]/${basename(path)}`,
+  );
+  return labels.reduce(
+    (sanitized, label) =>
+      label.length === 0 ? sanitized : sanitized.replaceAll(label, "[REDACTED]"),
+    pathSanitized,
+  );
+}
+
+function completedOutput(record: TrialRecord) {
+  const attempt = record.attempts.at(-1);
+  return attempt?.status === "completed" ? attempt.output : undefined;
+}

--- a/benchmark/real-incident-debugging/benchmark.real.test.ts
+++ b/benchmark/real-incident-debugging/benchmark.real.test.ts
@@ -1,0 +1,143 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { assertStudyComposition, loadSealedCorpus } from "./corpus.js";
+import {
+  createCodexExecutor,
+  generateBlindReviewPackets,
+  preflightCorpus,
+  runExperiment,
+} from "./harness.js";
+import { experimentTokenBudget } from "./protocol.js";
+
+const enabled = process.env.STATION_REAL_INCIDENT_DEBUG_AB === "1";
+const phase = process.env.STATION_REAL_INCIDENT_DEBUG_AB_PHASE ?? "run";
+const corpusRoot = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CORPUS;
+const artifactsRoot = process.env.STATION_REAL_INCIDENT_DEBUG_AB_ARTIFACTS;
+
+const describeReal = enabled ? describe : describe.skip;
+
+describeReal("real-incident Codex high debugging A/B", () => {
+  it("runs only an explicitly enabled sealed phase", async () => {
+    expect(
+      corpusRoot,
+      "Set STATION_REAL_INCIDENT_DEBUG_AB_CORPUS to the private sealed corpus.",
+    ).toBeDefined();
+    expect(
+      artifactsRoot,
+      "Set STATION_REAL_INCIDENT_DEBUG_AB_ARTIFACTS to an empty private artifact root.",
+    ).toBeDefined();
+    if (corpusRoot === undefined || artifactsRoot === undefined) {
+      return;
+    }
+
+    expect(["preflight", "development", "held-out"]).toContain(phase);
+    if (phase !== "preflight" && phase !== "development" && phase !== "held-out") {
+      return;
+    }
+    const corpus = await loadSealedCorpus(corpusRoot);
+    assertStudyComposition(corpus);
+    const stationExecutables = stationExecutablesFromEnvironment({
+      base: corpus.manifest.baseCommit,
+      candidate: corpus.manifest.candidateCommit,
+    });
+
+    if (phase === "preflight") {
+      const fakeCodex = process.env.STATION_REAL_INCIDENT_DEBUG_AB_FAKE_CODEX;
+      expect(
+        fakeCodex,
+        "Preflight requires STATION_REAL_INCIDENT_DEBUG_AB_FAKE_CODEX.",
+      ).toBeDefined();
+      if (fakeCodex === undefined) {
+        return;
+      }
+      await preflightCorpus({
+        corpus,
+        workspaceRoot: join(artifactsRoot, "preflight-workspaces"),
+        stationExecutables,
+      });
+      const run = await runExperiment({
+        corpus,
+        artifactRoot: join(artifactsRoot, "preflight"),
+        replicates: 1,
+        seed: corpus.manifest.selectionSeed,
+        stationExecutables,
+        executor: createCodexExecutor({
+          executable: fakeCodex,
+          timeoutMs: 30_000,
+          tokenBudget: experimentTokenBudget,
+        }),
+      });
+      await generateBlindReviewPackets({ paths: run.paths, corpus, state: run.state });
+      return;
+    }
+
+    expect(process.env.STATION_REAL_INCIDENT_DEBUG_AB_RUN_PAID).toBe("1");
+    const codex = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CODEX;
+    const codexVersion = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CODEX_VERSION;
+    const codexAuth = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CODEX_AUTH;
+    expect(
+      codex,
+      "Set STATION_REAL_INCIDENT_DEBUG_AB_CODEX to the pinned Codex CLI.",
+    ).toBeDefined();
+    expect(
+      codexVersion,
+      "Set STATION_REAL_INCIDENT_DEBUG_AB_CODEX_VERSION to the pinned Codex CLI version.",
+    ).toBeDefined();
+    expect(
+      codexAuth,
+      "Set STATION_REAL_INCIDENT_DEBUG_AB_CODEX_AUTH to an auth.json copied only into ephemeral homes.",
+    ).toBeDefined();
+    if (codex === undefined || codexVersion === undefined || codexAuth === undefined) {
+      return;
+    }
+    const selected =
+      phase === "development"
+        ? corpus.incidents.filter((incident) => incident.entry.cohort === "development")
+        : corpus.incidents.filter((incident) => incident.entry.cohort === "held-out");
+    const replicates = phase === "development" ? 1 : 2;
+    const selectedCorpus = { ...corpus, incidents: selected };
+    const run = await runExperiment({
+      corpus: selectedCorpus,
+      artifactRoot: join(artifactsRoot, phase),
+      replicates,
+      seed: corpus.manifest.selectionSeed,
+      stationExecutables,
+      executor: createCodexExecutor({
+        executable: codex,
+        expectedVersion: codexVersion,
+        authFilePath: codexAuth,
+        timeoutMs: 300_000,
+        tokenBudget: experimentTokenBudget,
+      }),
+    });
+    await generateBlindReviewPackets({
+      paths: run.paths,
+      corpus: selectedCorpus,
+      state: run.state,
+    });
+  });
+});
+
+function stationExecutablesFromEnvironment(input: {
+  base: string;
+  candidate: string;
+}): Record<"base" | "candidate", { path: string; commit: string }> {
+  const base = process.env.STATION_REAL_INCIDENT_DEBUG_AB_BASE_STN;
+  const candidate = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CANDIDATE_STN;
+  const baseCommit = process.env.STATION_REAL_INCIDENT_DEBUG_AB_BASE_COMMIT;
+  const candidateCommit = process.env.STATION_REAL_INCIDENT_DEBUG_AB_CANDIDATE_COMMIT;
+  if (
+    base === undefined ||
+    candidate === undefined ||
+    baseCommit !== input.base ||
+    candidateCommit !== input.candidate
+  ) {
+    throw new Error(
+      "Set frozen Station executable paths and matching STATION_REAL_INCIDENT_DEBUG_AB_BASE_COMMIT/CANDIDATE_COMMIT values.",
+    );
+  }
+  return {
+    base: { path: base, commit: baseCommit },
+    candidate: { path: candidate, commit: candidateCommit },
+  };
+}

--- a/benchmark/real-incident-debugging/codexRunner.ts
+++ b/benchmark/real-incident-debugging/codexRunner.ts
@@ -1,0 +1,427 @@
+import { spawn } from "node:child_process";
+import { chmod, copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { type ArmAccess, createArmAccess, validateExecutedCommand } from "./arms.js";
+import {
+  type Arm,
+  type CommandRecord,
+  type NeutralArmLabel,
+  type Replay,
+  responseJsonSchema,
+  type TrialAttempt,
+  TrialOutputSchema,
+  type TrialTelemetry,
+} from "./protocol.js";
+
+const commandEventSchema = {
+  type: "item.completed",
+  itemType: "command_execution",
+} as const;
+
+export type CodexRunnerInput = {
+  executable: string;
+  executableArgs?: string[];
+  workspaceRoot: string;
+  isolatedHome: string;
+  artifactRoot: string;
+  prompt: string;
+  arm: Arm;
+  blindArm: NeutralArmLabel;
+  replay: Replay;
+  timeoutMs: number;
+  tokenBudget: number;
+  authFilePath?: string;
+  environment?: Record<string, string>;
+};
+
+export type CodexRunResult = {
+  attempt: TrialAttempt;
+  stdoutJsonl: string;
+};
+
+export function buildTrialPrompt(input: { symptom: string; access: ArmAccess }): string {
+  return [
+    "You are diagnosing a frozen Station incident.",
+    "Read symptom.txt and replay.json, then inspect only the copied evidence.",
+    "Do not change files, start or contact an Observer, reconcile, dispatch commands, create bundles, modify setup/hooks/configuration, or use a command outside this allowlist.",
+    "The incident may have insufficient evidence. Do not claim a repair, current runtime truth, success, or failure beyond the copied evidence.",
+    "proximateFailure means the immediate retained failure condition at the responsible subsystem; do not substitute a reporting wrapper when copied evidence establishes a deeper failing boundary.",
+    "When evidenceRoles is present, operationalBoundaryEvidence is failure-and-ownership evidence and component is logging provenance only. Otherwise, responsibleSubsystem must still name the proximate failing operation, provider boundary, parser, watcher, detector, or lifecycle supported by the retained message, code, signal, and context.",
+    "A causeAssessment observed_failure with observedFailureSignals establishes that retained signal as the proximate failure; it does not establish the mechanism that produced the signal.",
+    "For an observedFailureSignal, keep responsibleSubsystem at the component-and-message boundary shown by copied evidence. Do not infer an internal handler, parser, decoder, or emitter unless copied evidence names it explicitly.",
+    "Set underlyingCauseDisposition to established only when copied evidence proves the mechanism beneath the proximate failure, to unknown when it does not, and to not_applicable only when no deeper mechanism is meaningful.",
+    "When the proximate failure itself cannot be established, say so explicitly, set proximateEvidenceAdequacy to insufficient, and keep underlyingCauseDisposition unknown.",
+    "Recommend at most two read-only diagnostic next actions; do not recommend installation, configuration changes, retries, starts, stops, replay, drain, or other mutation.",
+    "Aim to finish within four commands. After a matched record provides the proximate failure, proximate ownership boundary, and an explicit observed_failure or insufficient_evidence assessment, stop searching; do not investigate an underlying mechanism that copied evidence marks unknown.",
+    "When an allowed command query contains spaces, quote the query so it remains one command argument.",
+    "You may execute at most 12 allowed commands; exceeding the cap is a terminal study failure.",
+    "commandNumber is one-based in execution order. proximateCitation must support proximateFailure. ownershipCitation must quote a specific operation, boundary, or failure description that materially supports responsibleSubsystem; a generic component, provider name, delivery outcome, or spool outcome is insufficient by itself.",
+    "Set underlyingCauseCitation only when underlyingCauseDisposition is established; otherwise it must be null.",
+    "Each citation literal must occur exactly in its command output, be at most 160 characters, and contain no quote, backslash, or newline. Prefer a stable code or signal for proximateCitation, and a concise operation or failure-description literal for ownershipCitation.",
+    "Return only JSON that conforms to the supplied response schema.",
+    "Allowed commands:",
+    formatCommandPatterns(input.access),
+    "Symptom:",
+    input.symptom.trim(),
+  ].join("\n\n");
+}
+
+export async function runCodexTrial(input: CodexRunnerInput): Promise<CodexRunResult> {
+  if (!Number.isSafeInteger(input.tokenBudget) || input.tokenBudget <= 5_000) {
+    throw new Error("Codex rollout token budget must be an integer greater than 5,000.");
+  }
+  const access = createArmAccess({
+    arm: input.arm,
+    blindArm: input.blindArm,
+    replay: input.replay,
+  });
+  await mkdir(input.isolatedHome, { recursive: true, mode: 0o700 });
+  await mkdir(input.artifactRoot, { recursive: true, mode: 0o700 });
+  const isolatedAuthPath = join(input.isolatedHome, "auth.json");
+  if (input.authFilePath !== undefined) {
+    await copyFile(input.authFilePath, isolatedAuthPath);
+    await chmod(isolatedAuthPath, 0o600);
+  }
+  const schemaPath = join(input.artifactRoot, "response-schema.json");
+  const responsePath = join(input.artifactRoot, "response.json");
+  await writeFile(schemaPath, `${JSON.stringify(responseJsonSchema(), null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+
+  const args = [
+    ...(input.executableArgs ?? []),
+    "exec",
+    "--json",
+    "--color",
+    "never",
+    "--ephemeral",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--skip-git-repo-check",
+    "--sandbox",
+    "read-only",
+    "--model",
+    "gpt-5.6-sol",
+    "--config",
+    'model_reasoning_effort="high"',
+    "--config",
+    "sandbox_workspace_write.network_access=false",
+    "--config",
+    `features.rollout_budget={limit_tokens=${input.tokenBudget},reminder_at_remaining_tokens=[5000]}`,
+    "--cd",
+    input.workspaceRoot,
+    "--output-schema",
+    schemaPath,
+    "--output-last-message",
+    responsePath,
+    input.prompt,
+  ];
+  const environment = isolatedEnvironment(input);
+  const startedAt = performance.now();
+  const child = spawn(input.executable, args, {
+    cwd: input.workspaceRoot,
+    env: environment,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const commands: CommandRecord[] = [];
+  let modelStarted = false;
+  let modelCycles = 0;
+  let totalTokens = 0;
+  let timedOut = false;
+  let spawnFailure = "";
+  let policyFailure = "";
+  let stdoutRemainder = "";
+
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdoutChunks.push(chunk);
+    stdoutRemainder += chunk;
+    const lines = stdoutRemainder.split("\n");
+    stdoutRemainder = lines.pop() ?? "";
+    for (const line of lines) {
+      const event = parseCodexEvent(line);
+      if (event === undefined) {
+        continue;
+      }
+      if (event.kind === "model-started") {
+        modelStarted = true;
+      } else if (event.kind === "model-completed") {
+        modelStarted = true;
+        modelCycles += 1;
+        totalTokens += event.totalTokens;
+      } else if (event.kind === "command") {
+        if (commands.length >= 12 && policyFailure.length === 0) {
+          policyFailure = "Trial exceeded the 12-command cap.";
+          child.kill("SIGTERM");
+        }
+        const policy = validateExecutedCommand({
+          access,
+          command: event.command,
+          workspaceRoot: input.workspaceRoot,
+        });
+        if (policy.ok === false && policyFailure.length === 0) {
+          policyFailure = policy.reason;
+        }
+        commands.push({
+          argv: policy.ok ? policy.argv : [event.command],
+          output: event.output,
+          exitCode: event.exitCode,
+        });
+      }
+    }
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderrChunks.push(chunk);
+  });
+  child.on("error", (error) => {
+    spawnFailure = error.message;
+  });
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+  }, input.timeoutMs);
+  await waitForClose(child);
+  clearTimeout(timeout);
+
+  if (stdoutRemainder.trim().length > 0) {
+    const event = parseCodexEvent(stdoutRemainder);
+    if (event?.kind === "model-started") {
+      modelStarted = true;
+    }
+  }
+
+  const telemetry: TrialTelemetry = {
+    wallTimeMs: Math.round(performance.now() - startedAt),
+    commandCount: commands.length,
+    modelCycles,
+    totalTokens,
+    outputBytes: Buffer.byteLength(stdoutChunks.join(""), "utf8"),
+  };
+  const stderr = [spawnFailure, ...stderrChunks].filter((value) => value.length > 0).join("\n");
+  const output = await readTrialOutput(responsePath);
+  const attempt = classifyTrialAttempt({
+    modelStarted,
+    timedOut,
+    policyFailure,
+    output,
+    stderr,
+    telemetry,
+    commands,
+  });
+  if (input.authFilePath !== undefined) {
+    await rm(isolatedAuthPath, { force: true });
+  }
+  return { attempt, stdoutJsonl: stdoutChunks.join("") };
+}
+
+export async function assertCodexVersion(input: {
+  executable: string;
+  executableArgs?: string[];
+  expectedVersion: string;
+}): Promise<void> {
+  const child = spawn(input.executable, [...(input.executableArgs ?? []), "--version"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: string) => stderr.push(chunk));
+  const code = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (exitCode) => resolve(exitCode));
+  });
+  const version = stdout.join("").trim();
+  if (code !== 0 || !version.includes(input.expectedVersion)) {
+    throw new Error(
+      `Pinned Codex CLI version mismatch: expected ${input.expectedVersion}; received ${version || stderr.join("").trim() || `exit ${String(code)}`}.`,
+    );
+  }
+}
+
+export function classifyTrialAttempt(input: {
+  modelStarted: boolean;
+  timedOut: boolean;
+  policyFailure: string;
+  output: unknown | undefined;
+  stderr: string;
+  telemetry: TrialTelemetry;
+  commands: CommandRecord[];
+}): TrialAttempt {
+  if (input.policyFailure.length > 0) {
+    return {
+      attempt: 0,
+      status: "policy-rejected",
+      modelStarted: input.modelStarted,
+      stderr: `${input.stderr}\nCommand policy rejected: ${input.policyFailure}`.trim(),
+      telemetry: input.telemetry,
+      commands: input.commands,
+    };
+  }
+  if (input.timedOut && input.modelStarted) {
+    return {
+      attempt: 0,
+      status: "model-timeout",
+      modelStarted: true,
+      stderr: input.stderr,
+      telemetry: input.telemetry,
+      commands: input.commands,
+    };
+  }
+  if (input.timedOut || input.output === undefined) {
+    return {
+      attempt: 0,
+      status: input.modelStarted ? "model-no-answer" : "infrastructure-retryable",
+      modelStarted: input.modelStarted,
+      stderr: input.stderr,
+      telemetry: input.telemetry,
+      commands: input.commands,
+    };
+  }
+  const parsed = TrialOutputSchema.safeParse(input.output);
+  if (!parsed.success) {
+    return {
+      attempt: 0,
+      status: input.modelStarted ? "model-no-answer" : "infrastructure-retryable",
+      modelStarted: input.modelStarted,
+      stderr: `${input.stderr}\nInvalid final response: ${parsed.error.message}`.trim(),
+      telemetry: input.telemetry,
+      commands: input.commands,
+    };
+  }
+  return {
+    attempt: 0,
+    status: "completed",
+    modelStarted: input.modelStarted,
+    stderr: input.stderr,
+    telemetry: input.telemetry,
+    commands: input.commands,
+    output: parsed.data,
+  };
+}
+
+function formatCommandPatterns(access: ArmAccess): string {
+  return access.commandPatterns
+    .map((pattern) => [pattern.executable, ...pattern.arguments].join(" "))
+    .join("\n");
+}
+
+function isolatedEnvironment(input: CodexRunnerInput): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {
+    HOME: input.isolatedHome,
+    CODEX_HOME: input.isolatedHome,
+    XDG_CONFIG_HOME: join(input.isolatedHome, "config"),
+    XDG_STATE_HOME: join(input.isolatedHome, "state"),
+    LANG: process.env.LANG ?? "C.UTF-8",
+    LC_ALL: process.env.LC_ALL ?? "C.UTF-8",
+    PATH: process.env.PATH,
+    TZ: "UTC",
+  };
+  for (const [key, value] of Object.entries(input.environment ?? {})) {
+    environment[key] = value;
+  }
+  return environment;
+}
+
+async function readTrialOutput(path: string): Promise<unknown | undefined> {
+  const text = await readFile(path, "utf8").catch(() => undefined);
+  if (text === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+type ParsedEvent =
+  | { kind: "model-started" }
+  | { kind: "model-completed"; totalTokens: number }
+  | { kind: "command"; command: string; output: string; exitCode: number | null };
+
+function parseCodexEvent(line: string): ParsedEvent | undefined {
+  let value: unknown;
+  try {
+    value = JSON.parse(line) as unknown;
+  } catch {
+    return undefined;
+  }
+  const event = codexEventSchema.safeParse(value);
+  if (!event.success) {
+    return undefined;
+  }
+  if (event.data.type === "turn.started") {
+    return { kind: "model-started" };
+  }
+  if (event.data.type === "turn.completed") {
+    return { kind: "model-completed", totalTokens: tokenCount(event.data.usage) };
+  }
+  if (
+    event.data.type === commandEventSchema.type &&
+    event.data.item?.type === commandEventSchema.itemType &&
+    typeof event.data.item.command === "string"
+  ) {
+    return {
+      kind: "command",
+      command: event.data.item.command,
+      output:
+        typeof event.data.item.aggregated_output === "string"
+          ? event.data.item.aggregated_output
+          : "",
+      exitCode: typeof event.data.item.exit_code === "number" ? event.data.item.exit_code : null,
+    };
+  }
+  return undefined;
+}
+
+const codexEventSchema = z
+  .object({
+    type: z.string(),
+    item: z
+      .object({
+        type: z.string(),
+        command: z.string().optional(),
+        aggregated_output: z.string().optional(),
+        exit_code: z.number().int().optional(),
+      })
+      .loose()
+      .optional(),
+    usage: z
+      .object({
+        input_tokens: z.number().nonnegative().optional(),
+        cached_input_tokens: z.number().nonnegative().optional(),
+        output_tokens: z.number().nonnegative().optional(),
+      })
+      .loose()
+      .optional(),
+  })
+  .loose();
+
+function tokenCount(
+  usage:
+    | {
+        input_tokens?: number | undefined;
+        cached_input_tokens?: number | undefined;
+        output_tokens?: number | undefined;
+      }
+    | undefined,
+): number {
+  if (usage === undefined) {
+    return 0;
+  }
+  return (usage.input_tokens ?? 0) + (usage.output_tokens ?? 0);
+}
+
+async function waitForClose(child: ReturnType<typeof spawn>): Promise<void> {
+  await new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+  });
+}

--- a/benchmark/real-incident-debugging/corpus.ts
+++ b/benchmark/real-incident-debugging/corpus.ts
@@ -1,0 +1,365 @@
+import { createHash } from "node:crypto";
+import { cp, lstat, mkdir, readdir, readFile, realpath, rm } from "node:fs/promises";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import {
+  type CorpusFreeze,
+  CorpusFreezeSchema,
+  type CorpusManifest,
+  CorpusManifestSchema,
+  type Gold,
+  GoldSchema,
+  type IncidentManifestEntry,
+  type Provenance,
+  ProvenanceSchema,
+  type RedactionReport,
+  RedactionReportSchema,
+  type Replay,
+  ReplaySchema,
+} from "./protocol.js";
+
+export const frozenBaseCommit = "3399a48f3e084b51dc28852b200703169ada1fcd";
+export const frozenCandidateCommit = "890e8522f919fbdb3f47019f334614ad6434c0b4";
+
+export const privateCorpusFileNames = [
+  "gold.json",
+  "provenance.json",
+  "redaction-report.json",
+] as const;
+
+export type IncidentPackage = {
+  entry: IncidentManifestEntry;
+  root: string;
+  symptom: string;
+  replay: Replay;
+  gold: Gold;
+  provenance: Provenance;
+  redactionReport: RedactionReport;
+};
+
+export type LoadedCorpus = {
+  root: string;
+  manifest: CorpusManifest;
+  freeze: CorpusFreeze;
+  incidents: IncidentPackage[];
+};
+
+export type PreparedEvidence = {
+  root: string;
+  evidenceSha256: string;
+  copiedPaths: string[];
+};
+
+export async function loadSealedCorpus(corpusRoot: string): Promise<LoadedCorpus> {
+  const root = await canonicalDirectory(corpusRoot, "corpus root");
+  const manifestPath = join(root, "manifest.json");
+  const freezePath = join(root, "freeze.json");
+  const manifest = CorpusManifestSchema.parse(await readJson(manifestPath));
+  const freeze = CorpusFreezeSchema.parse(await readJson(freezePath));
+
+  if (
+    freeze.baseCommit !== manifest.baseCommit ||
+    freeze.candidateCommit !== manifest.candidateCommit
+  ) {
+    throw new Error("Corpus freeze commit identities do not match the manifest.");
+  }
+  if (freeze.manifestSha256 !== (await sha256File(manifestPath))) {
+    throw new Error("Corpus manifest hash does not match freeze.json.");
+  }
+
+  if (
+    manifest.baseCommit !== frozenBaseCommit ||
+    manifest.candidateCommit !== frozenCandidateCommit
+  ) {
+    throw new Error("Corpus does not use the preregistered frozen base and candidate commits.");
+  }
+  if (Date.parse(freeze.candidateFrozenAt) > Date.parse(freeze.corpusSelectedAt)) {
+    throw new Error("Candidate freeze must precede corpus selection.");
+  }
+
+  const incidents: IncidentPackage[] = [];
+  for (const entry of manifest.incidents) {
+    incidents.push(await loadIncidentPackage(root, entry));
+  }
+
+  const heldOutEntries = incidents.filter((incident) => incident.entry.cohort === "held-out");
+  const heldOutIds = heldOutEntries.map((incident) => incident.entry.id).sort();
+  if (JSON.stringify(heldOutIds) !== JSON.stringify([...freeze.heldOutIncidentIds].sort())) {
+    throw new Error("Held-out incident IDs do not match the sealed freeze record.");
+  }
+  if (freeze.heldOutCorpusSha256 !== (await sha256IncidentPackages(heldOutEntries))) {
+    throw new Error("Held-out corpus hash does not match freeze.json.");
+  }
+
+  return { root, manifest, freeze, incidents };
+}
+
+export function assertStudyComposition(corpus: LoadedCorpus): void {
+  const development = corpus.incidents.filter(
+    (incident) => incident.entry.cohort === "development",
+  );
+  const heldOut = corpus.incidents.filter((incident) => incident.entry.cohort === "held-out");
+  if (development.length !== 6 || heldOut.length !== 24) {
+    throw new Error(
+      `Expected 6 development and 24 held-out incidents; found ${development.length} and ${heldOut.length}.`,
+    );
+  }
+
+  const areaCounts = new Map<string, number>();
+  for (const incident of heldOut) {
+    areaCounts.set(incident.entry.area, (areaCounts.get(incident.entry.area) ?? 0) + 1);
+  }
+  const expectedAreaCounts = new Map([
+    ["configuration-startup", 3],
+    ["observer-lifecycle-socket", 3],
+    ["provider-operation-boundaries", 3],
+    ["provider-hooks-ingress", 3],
+    ["command-trace-correlation", 3],
+    ["persistence-retention", 3],
+    ["terminal-tui-runtime", 3],
+    ["reports-evidence-adequacy", 3],
+  ]);
+  for (const [area, expected] of expectedAreaCounts) {
+    if (areaCounts.get(area) !== expected) {
+      throw new Error(`Expected exactly ${expected} held-out incidents in ${area}.`);
+    }
+  }
+
+  const exactIds = corpus.incidents.filter((incident) => incident.entry.hasExactId).length;
+  const noRetainedIds = corpus.incidents.filter((incident) => !incident.entry.hasRetainedId).length;
+  const explicitUnknownUnderlyingCause = corpus.incidents.filter(
+    (incident) => incident.gold.underlyingCauseDisposition === "unknown",
+  ).length;
+  const conclusiveProximateDisposition = corpus.incidents.filter(
+    (incident) => incident.entry.correctDisposition === "success",
+  ).length;
+  if (
+    exactIds < 5 ||
+    noRetainedIds < 6 ||
+    explicitUnknownUnderlyingCause < 4 ||
+    conclusiveProximateDisposition < 4
+  ) {
+    throw new Error("Corpus does not meet the required incident cross-cutting distribution.");
+  }
+}
+
+export async function prepareTrialEvidence(input: {
+  incident: IncidentPackage;
+  workspaceRoot: string;
+}): Promise<PreparedEvidence> {
+  const targetRoot = resolve(input.workspaceRoot);
+  await rm(targetRoot, { recursive: true, force: true });
+  await mkdir(targetRoot, { recursive: true, mode: 0o700 });
+  const sourceRoot = input.incident.root;
+  const sourceRealRoot = await canonicalDirectory(sourceRoot, "incident package");
+  const copiedPaths = ["symptom.txt", "replay.json", ...input.incident.replay.evidencePaths];
+
+  for (const copiedPath of copiedPaths) {
+    const sourcePath = await safeExistingPath(sourceRealRoot, copiedPath);
+    const destinationPath = await safeDestinationPath(targetRoot, copiedPath);
+    await mkdir(dirname(destinationPath), { recursive: true, mode: 0o700 });
+    await cp(sourcePath, destinationPath, {
+      recursive: true,
+      dereference: false,
+      errorOnExist: true,
+      force: false,
+    });
+    await assertTreeHasNoSymlink(destinationPath);
+  }
+
+  await assertNoPrivateCorpusFiles(targetRoot);
+  const evidenceSha256 = await sha256Tree(targetRoot);
+  return { root: targetRoot, evidenceSha256, copiedPaths };
+}
+
+export async function assertNoPrivateCorpusFiles(workspaceRoot: string): Promise<void> {
+  for (const name of privateCorpusFileNames) {
+    const leaked = await findFileNamed(workspaceRoot, name);
+    if (leaked !== undefined) {
+      throw new Error(
+        `Private corpus file leaked into trial workspace: ${relative(workspaceRoot, leaked)}`,
+      );
+    }
+  }
+}
+
+export async function assertNoPrivateLabelLeakage(
+  workspaceRoot: string,
+  privateLabels: readonly string[],
+): Promise<void> {
+  const files = await regularFiles(workspaceRoot);
+  for (const file of files) {
+    const content = await readFile(file, "utf8");
+    for (const label of privateLabels) {
+      if (label.length > 0 && content.includes(label)) {
+        throw new Error(`Private corpus label leaked into trial workspace: ${basename(file)}`);
+      }
+    }
+  }
+}
+
+export async function sha256File(filePath: string): Promise<string> {
+  await assertRegularFile(filePath);
+  return sha256(await readFile(filePath));
+}
+
+export async function sha256Tree(root: string): Promise<string> {
+  const rootRealPath = await canonicalDirectory(root, "tree root");
+  const files = await regularFiles(rootRealPath);
+  const hash = createHash("sha256");
+  for (const file of files) {
+    const name = relative(rootRealPath, file).split(sep).join("/");
+    hash.update(name);
+    hash.update("\0");
+    hash.update(await readFile(file));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function loadIncidentPackage(
+  corpusRoot: string,
+  entry: IncidentManifestEntry,
+): Promise<IncidentPackage> {
+  const root = await safeExistingPath(corpusRoot, join("incidents", entry.id));
+  const symptomPath = await safeExistingPath(root, "symptom.txt");
+  const replayPath = await safeExistingPath(root, "replay.json");
+  const packageSha256 = await sha256Tree(root);
+  if (packageSha256 !== entry.packageSha256) {
+    throw new Error(`Incident package hash does not match manifest for ${entry.id}.`);
+  }
+  if ((await sha256File(symptomPath)) !== entry.symptomSha256) {
+    throw new Error(`Incident symptom hash does not match manifest for ${entry.id}.`);
+  }
+
+  const replay = ReplaySchema.parse(await readJson(replayPath));
+  if (replay.kind !== entry.replayKind) {
+    throw new Error(`Incident replay kind does not match manifest for ${entry.id}.`);
+  }
+  for (const evidencePath of replay.evidencePaths) {
+    await safeExistingPath(root, evidencePath);
+  }
+
+  return {
+    entry,
+    root,
+    symptom: await readFile(symptomPath, "utf8"),
+    replay,
+    gold: GoldSchema.parse(await readJson(await safeExistingPath(root, "gold.json"))),
+    provenance: ProvenanceSchema.parse(
+      await readJson(await safeExistingPath(root, "provenance.json")),
+    ),
+    redactionReport: RedactionReportSchema.parse(
+      await readJson(await safeExistingPath(root, "redaction-report.json")),
+    ),
+  };
+}
+
+async function sha256IncidentPackages(incidents: IncidentPackage[]): Promise<string> {
+  const hash = createHash("sha256");
+  for (const incident of [...incidents].sort((left, right) =>
+    left.entry.id.localeCompare(right.entry.id),
+  )) {
+    hash.update(incident.entry.id);
+    hash.update("\0");
+    hash.update(await sha256Tree(incident.root));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+async function safeExistingPath(root: string, child: string): Promise<string> {
+  const target = resolve(root, child);
+  assertWithin(root, target);
+  const targetRealPath = await realpath(target).catch(() => {
+    throw new Error(`Required corpus path does not exist: ${child}`);
+  });
+  assertWithin(root, targetRealPath);
+  await assertTreeHasNoSymlink(target);
+  return target;
+}
+
+async function safeDestinationPath(root: string, child: string): Promise<string> {
+  const target = resolve(root, child);
+  assertWithin(root, target);
+  return target;
+}
+
+function assertWithin(root: string, candidate: string): void {
+  const pathRelative = relative(root, candidate);
+  if (
+    pathRelative === "" ||
+    (!pathRelative.startsWith(`..${sep}`) && pathRelative !== ".." && !pathRelative.startsWith("/"))
+  ) {
+    return;
+  }
+  throw new Error(`Corpus path escapes its root: ${candidate}`);
+}
+
+async function canonicalDirectory(path: string, label: string): Promise<string> {
+  const stats = await lstat(path).catch(() => {
+    throw new Error(`Missing ${label}: ${path}`);
+  });
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new Error(`${label} must be a non-symlink directory: ${path}`);
+  }
+  return realpath(path);
+}
+
+async function assertRegularFile(path: string): Promise<void> {
+  const stats = await lstat(path).catch(() => {
+    throw new Error(`Missing required file: ${path}`);
+  });
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    throw new Error(`Expected a regular non-symlink file: ${path}`);
+  }
+}
+
+async function assertTreeHasNoSymlink(root: string): Promise<void> {
+  const stats = await lstat(root);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Symlinks are forbidden in corpus evidence: ${root}`);
+  }
+  if (!stats.isDirectory()) {
+    return;
+  }
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    await assertTreeHasNoSymlink(join(root, entry.name));
+  }
+}
+
+async function regularFiles(root: string): Promise<string[]> {
+  await assertTreeHasNoSymlink(root);
+  const output: string[] = [];
+  await collectRegularFiles(root, output);
+  return output.sort();
+}
+
+async function collectRegularFiles(root: string, output: string[]): Promise<void> {
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      await collectRegularFiles(path, output);
+    } else if (entry.isFile()) {
+      output.push(path);
+    } else {
+      throw new Error(`Unsupported corpus file type: ${path}`);
+    }
+  }
+}
+
+async function findFileNamed(root: string, name: string): Promise<string | undefined> {
+  for (const file of await regularFiles(root)) {
+    if (basename(file) === name) {
+      return file;
+    }
+  }
+  return undefined;
+}

--- a/benchmark/real-incident-debugging/fixtures/sample-corpus.json
+++ b/benchmark/real-incident-debugging/fixtures/sample-corpus.json
@@ -1,0 +1,63 @@
+{
+  "incident": {
+    "id": "sample-invalid-config",
+    "cohort": "held-out",
+    "area": "configuration-startup",
+    "replayKind": "invalid-config",
+    "hasExactId": false,
+    "hasRetainedId": false,
+    "hasOldOrTruncatedEvidence": false,
+    "correctDisposition": "abstain",
+    "symptom": "Station failed before startup after a configuration edit. Diagnose only from the copied invalid configuration and local diagnostic evidence.",
+    "replay": {
+      "schemaVersion": 1,
+      "kind": "invalid-config",
+      "evidencePaths": ["config.toml", "state"],
+      "stationCommands": [
+        { "executable": "stn", "arguments": ["debug", "logs", "{query}"] },
+        { "executable": "stn", "arguments": ["debug", "trace", "{id}"] }
+      ],
+      "rawCommands": [
+        { "executable": "rg", "arguments": ["{query}", "state"] },
+        { "executable": "find", "arguments": ["state", "-type", "f"] },
+        { "executable": "sed", "arguments": ["-n", "1,20p", "state/logs/observer.jsonl"] },
+        { "executable": "tail", "arguments": ["-n", "20", "state/logs/observer.jsonl"] },
+        { "executable": "sqlite3", "arguments": ["-readonly", "state/observer.sqlite", "{sql}"] }
+      ]
+    },
+    "files": {
+      "config.toml": "schema_version = 1\nprojects = []\n[defaults]\nworktree_provider = \"noop-worktree\"\nterminal = \"noop-terminal\"\nharness = \"noop-harness\"\nlayout = \"agent-shell\"\nunknown_key = true\n",
+      "state/logs/observer.jsonl": "{\"level\":\"error\",\"code\":\"CONFIG_VALIDATION_FAILED\",\"message\":\"Unknown key unknown_key\"}\n",
+      "state/observer.sqlite": "sample sqlite placeholder"
+    },
+    "gold": {
+      "schemaVersion": 2,
+      "acceptedProximateFailures": ["The strict runtime config contains an unknown key."],
+      "underlyingCauseDisposition": "unknown",
+      "acceptedUnderlyingCauses": [],
+      "responsibleSubsystems": ["configuration loader"],
+      "proximateEvidenceAdequacy": "sufficient",
+      "acceptableNextActions": ["Inspect the copied configuration and validation record."],
+      "prohibitedClaimsOrActions": ["Do not start an Observer or claim a repair occurred."],
+      "independentlyValidatedBy": ["reviewer-one", "reviewer-two"]
+    },
+    "provenance": {
+      "schemaVersion": 1,
+      "occurredOutsideExperiment": true,
+      "originalSymptomAvailable": true,
+      "independentResolutionAvailable": true,
+      "evidenceAvailable": true,
+      "candidateFrozenBeforeSelection": true,
+      "notPreviouslyUsed": true,
+      "recordedBy": "fixture-author",
+      "reviewedBy": "fixture-reviewer"
+    },
+    "redactionReport": {
+      "schemaVersion": 1,
+      "reviewedAt": "2026-07-30T00:00:00.000Z",
+      "reviewedBy": "fixture-reviewer",
+      "secretScan": "clean",
+      "redactions": []
+    }
+  }
+}

--- a/benchmark/real-incident-debugging/harness.ts
+++ b/benchmark/real-incident-debugging/harness.ts
@@ -1,0 +1,503 @@
+import { spawn } from "node:child_process";
+import { access, mkdir, rm, symlink } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+import { createArmAccess, validateCommand } from "./arms.js";
+import {
+  assertBlindPacketHasNoArmLabels,
+  assertBlindPacketHasNoPrivatePaths,
+  createBlindReviewPacket,
+  createRunPaths,
+  type RunPaths,
+  readRunState,
+  writeBlindReviewPacket,
+  writeJson,
+  writeRunState,
+  writeTrialArtifact,
+} from "./artifacts.js";
+import { assertCodexVersion, buildTrialPrompt, runCodexTrial } from "./codexRunner.js";
+import {
+  assertNoPrivateCorpusFiles,
+  type IncidentPackage,
+  type LoadedCorpus,
+  prepareTrialEvidence,
+} from "./corpus.js";
+import {
+  type Arm,
+  type ExperimentRunState,
+  ExperimentRunStateSchema,
+  type NeutralArmLabel,
+  type TrialAttempt,
+  type TrialPlan,
+  type TrialRecord,
+} from "./protocol.js";
+
+export type { ExperimentRunState, TrialPlan } from "./protocol.js";
+
+const arms: Arm[] = ["base", "candidate", "raw"];
+const neutralLabels: NeutralArmLabel[] = ["arm-a", "arm-b", "arm-c"];
+
+export type FrozenStationExecutable = {
+  path: string;
+  commit: string;
+};
+
+export type CodexExecution = {
+  executable: string;
+  executableArgs?: string[];
+  expectedVersion?: string;
+  authFilePath?: string;
+  timeoutMs: number;
+  tokenBudget: number;
+  environment?: Record<string, string>;
+};
+
+export type TrialExecutor = (input: {
+  plan: TrialPlan;
+  incident: IncidentPackage;
+  workspaceRoot: string;
+  artifactRoot: string;
+  isolatedHome: string;
+  stationPath?: string;
+}) => Promise<{ attempt: TrialAttempt; stdoutJsonl: string }>;
+
+export function createNeutralArmAssignments(seed: string): Record<Arm, NeutralArmLabel> {
+  const labels = shuffle([...neutralLabels], seededRandom(`${seed}:labels`));
+  const base = labels[0];
+  const candidate = labels[1];
+  const raw = labels[2];
+  if (base === undefined || candidate === undefined || raw === undefined) {
+    throw new Error("Unable to assign neutral arm labels.");
+  }
+  return { base, candidate, raw };
+}
+
+export function buildBalancedSchedule(input: {
+  incidents: readonly IncidentPackage[];
+  replicates: number;
+  seed: string;
+}): TrialPlan[] {
+  if (input.replicates < 1) {
+    throw new Error("At least one replicate is required.");
+  }
+  const assignments = createNeutralArmAssignments(input.seed);
+  const random = seededRandom(`${input.seed}:schedule`);
+  const schedule: TrialPlan[] = [];
+  for (let replicate = 1; replicate <= input.replicates; replicate += 1) {
+    const incidentOrder = shuffle([...input.incidents], random);
+    for (const incident of incidentOrder) {
+      const armOrder = shuffle([...arms], random);
+      for (const arm of armOrder) {
+        schedule.push({
+          trialId: `${incident.entry.id}-r${replicate}-${assignments[arm]}`,
+          incidentId: incident.entry.id,
+          replicate,
+          arm,
+          blindArm: assignments[arm],
+        });
+      }
+    }
+  }
+  return schedule;
+}
+
+export type PreflightCommandResult = {
+  incidentId: string;
+  arm: Arm;
+  argv: string[];
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export async function preflightCorpus(input: {
+  corpus: LoadedCorpus;
+  workspaceRoot: string;
+  stationExecutables?: Record<"base" | "candidate", FrozenStationExecutable>;
+}): Promise<void> {
+  if (input.stationExecutables !== undefined) {
+    assertFrozenStationExecutables(input.stationExecutables, input.corpus);
+  }
+  const evidenceByIncidentAndArm = new Map<string, string>();
+  const commandResults: PreflightCommandResult[] = [];
+  for (const incident of input.corpus.incidents) {
+    for (const arm of arms) {
+      const workspace = join(input.workspaceRoot, incident.entry.id, arm);
+      const prepared = await prepareTrialEvidence({ incident, workspaceRoot: workspace });
+      await assertNoPrivateCorpusFiles(prepared.root);
+      const access = createArmAccess({ arm, blindArm: "arm-a", replay: incident.replay });
+      for (const pattern of access.commandPatterns) {
+        const check = validateCommand({
+          access,
+          argv: [pattern.executable, ...pattern.arguments.map(exampleArgument)],
+          workspaceRoot: prepared.root,
+        });
+        if (check.ok === false) {
+          throw new Error(`Allowed command rejected for ${incident.entry.id}: ${check.reason}`);
+        }
+        if (input.stationExecutables !== undefined) {
+          const executable =
+            arm === "raw"
+              ? await resolveExecutable(check.argv[0] ?? "")
+              : input.stationExecutables[arm].path;
+          commandResults.push(
+            await executePreflightCommand({
+              incidentId: incident.entry.id,
+              arm,
+              executable,
+              argv: check.argv,
+              cwd: prepared.root,
+            }),
+          );
+        }
+      }
+      const forbidden = validateCommand({
+        access,
+        argv: arm === "raw" ? ["stn", "debug", "logs"] : ["stn", "observer", "start"],
+        workspaceRoot: prepared.root,
+      });
+      if (forbidden.ok) {
+        throw new Error(`Forbidden command accepted for ${incident.entry.id} ${arm}.`);
+      }
+      evidenceByIncidentAndArm.set(`${incident.entry.id}:${arm}`, prepared.evidenceSha256);
+    }
+    const base = evidenceByIncidentAndArm.get(`${incident.entry.id}:base`);
+    const candidate = evidenceByIncidentAndArm.get(`${incident.entry.id}:candidate`);
+    if (base === undefined || candidate === undefined || base !== candidate) {
+      throw new Error(`Base and candidate evidence differ for ${incident.entry.id}.`);
+    }
+  }
+  if (input.stationExecutables !== undefined) {
+    await writeJson(join(input.workspaceRoot, "preflight-command-report.json"), commandResults);
+  }
+}
+
+async function executePreflightCommand(input: {
+  incidentId: string;
+  arm: Arm;
+  executable: string;
+  argv: string[];
+  cwd: string;
+}): Promise<PreflightCommandResult> {
+  const child = spawn(input.executable, input.argv.slice(1), {
+    cwd: input.cwd,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => stdout.push(chunk));
+  child.stderr.on("data", (chunk: string) => stderr.push(chunk));
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    child.kill("SIGTERM");
+  }, 30_000);
+  const exitCode = await new Promise<number | null>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  }).finally(() => clearTimeout(timeout));
+  if (timedOut) {
+    throw new Error(`Allowed preflight command timed out: ${input.argv.join(" ")}`);
+  }
+  return {
+    incidentId: input.incidentId,
+    arm: input.arm,
+    argv: input.argv,
+    exitCode,
+    stdout: stdout.join("").slice(-65_536),
+    stderr: stderr.join("").slice(-65_536),
+  };
+}
+
+export async function runExperiment(input: {
+  corpus: LoadedCorpus;
+  artifactRoot: string;
+  replicates: number;
+  seed: string;
+  stationExecutables: Record<"base" | "candidate", FrozenStationExecutable>;
+  executor: TrialExecutor;
+  maxInfrastructureAttempts?: number;
+}): Promise<{ paths: RunPaths; state: ExperimentRunState }> {
+  assertFrozenStationExecutables(input.stationExecutables, input.corpus);
+  const paths = await createRunPaths(input.artifactRoot);
+  const manifestHash = input.corpus.freeze.manifestSha256;
+  const schedule = buildBalancedSchedule({
+    incidents: input.corpus.incidents,
+    replicates: input.replicates,
+    seed: input.seed,
+  });
+  const storedState = await readRunState<unknown>(paths);
+  const existing =
+    storedState === undefined ? undefined : ExperimentRunStateSchema.parse(storedState);
+  const state: ExperimentRunState = existing ?? {
+    schemaVersion: 1 as const,
+    corpusManifestSha256: manifestHash,
+    schedule,
+    records: {},
+  };
+  assertRunState(state, manifestHash, schedule);
+  const maxInfrastructureAttempts = input.maxInfrastructureAttempts ?? 3;
+
+  for (const plan of state.schedule) {
+    const record = state.records[plan.trialId];
+    if (record !== undefined && !shouldRetry(record)) {
+      continue;
+    }
+    const incident = input.corpus.incidents.find(
+      (candidate) => candidate.entry.id === plan.incidentId,
+    );
+    if (incident === undefined) {
+      throw new Error(`Schedule references missing incident: ${plan.incidentId}`);
+    }
+    const mutableRecord = record ?? {
+      schemaVersion: 1 as const,
+      trialId: plan.trialId,
+      incidentId: plan.incidentId,
+      replicate: plan.replicate,
+      arm: plan.arm,
+      blindArm: plan.blindArm,
+      evidenceSha256: "",
+      attempts: [],
+    };
+    while (shouldRetry(mutableRecord) || mutableRecord.attempts.length === 0) {
+      if (mutableRecord.attempts.length >= maxInfrastructureAttempts) {
+        break;
+      }
+      const attemptNumber = mutableRecord.attempts.length + 1;
+      const workspaceRoot = join(paths.raw, "workspaces", plan.trialId, `attempt-${attemptNumber}`);
+      const prepared = await prepareTrialEvidence({ incident, workspaceRoot });
+      if (mutableRecord.evidenceSha256.length === 0) {
+        mutableRecord.evidenceSha256 = prepared.evidenceSha256;
+      } else if (mutableRecord.evidenceSha256 !== prepared.evidenceSha256) {
+        throw new Error(`Evidence changed while resuming ${plan.trialId}.`);
+      }
+      const stationPath = plan.arm === "raw" ? undefined : input.stationExecutables[plan.arm].path;
+      const result = await input.executor({
+        plan,
+        incident,
+        workspaceRoot: prepared.root,
+        artifactRoot: join(paths.raw, "runner", plan.trialId, `attempt-${attemptNumber}`),
+        isolatedHome: join(paths.raw, "homes", plan.trialId, `attempt-${attemptNumber}`),
+        ...(stationPath === undefined ? {} : { stationPath }),
+      });
+      const attempt: TrialAttempt = { ...result.attempt, attempt: attemptNumber };
+      mutableRecord.attempts.push(attempt);
+      state.records[plan.trialId] = mutableRecord;
+      await writeTrialArtifact({ paths, record: mutableRecord, stdoutJsonl: result.stdoutJsonl });
+      await writeRunState(paths, state);
+      if (!shouldRetry(mutableRecord)) {
+        break;
+      }
+    }
+  }
+  assertStationEvidenceIdentity(state);
+  await writeRunState(paths, state);
+  return { paths, state };
+}
+
+export async function generateBlindReviewPackets(input: {
+  paths: RunPaths;
+  corpus: LoadedCorpus;
+  state: ExperimentRunState;
+}): Promise<number> {
+  let count = 0;
+  for (const plan of input.state.schedule) {
+    const record = input.state.records[plan.trialId];
+    const incident = input.corpus.incidents.find(
+      (candidate) => candidate.entry.id === plan.incidentId,
+    );
+    if (record === undefined || incident === undefined) {
+      continue;
+    }
+    const packet = createBlindReviewPacket({ record, symptom: incident.symptom });
+    assertBlindPacketHasNoArmLabels(packet, [record.trialId, record.blindArm]);
+    assertBlindPacketHasNoPrivatePaths(packet);
+    await writeBlindReviewPacket(input.paths, packet);
+    count += 1;
+  }
+  return count;
+}
+
+export function createCodexExecutor(input: CodexExecution): TrialExecutor {
+  let versionCheck: Promise<void> | undefined;
+  return async ({ plan, incident, workspaceRoot, artifactRoot, isolatedHome, stationPath }) => {
+    await Promise.all([
+      rm(artifactRoot, { recursive: true, force: true }),
+      rm(isolatedHome, { recursive: true, force: true }),
+    ]);
+    if (input.expectedVersion !== undefined) {
+      versionCheck ??= assertCodexVersion({
+        executable: input.executable,
+        ...(input.executableArgs === undefined ? {} : { executableArgs: input.executableArgs }),
+        expectedVersion: input.expectedVersion,
+      });
+      await versionCheck;
+    }
+    const access = createArmAccess({
+      arm: plan.arm,
+      blindArm: plan.blindArm,
+      replay: incident.replay,
+    });
+    const armPath = await createArmPath({
+      arm: plan.arm,
+      stationPath,
+      commandNames: access.commandPatterns.map((pattern) => pattern.executable),
+      root: join(artifactRoot, "command-bin"),
+    });
+    const environment: Record<string, string> = {};
+    for (const [key, value] of Object.entries(input.environment ?? {})) {
+      environment[key] = value;
+    }
+    environment.PATH = armPath;
+    return runCodexTrial({
+      executable: input.executable,
+      ...(input.executableArgs === undefined ? {} : { executableArgs: input.executableArgs }),
+      workspaceRoot,
+      isolatedHome,
+      artifactRoot,
+      prompt: buildTrialPrompt({ symptom: incident.symptom, access }),
+      arm: plan.arm,
+      blindArm: plan.blindArm,
+      replay: incident.replay,
+      timeoutMs: input.timeoutMs,
+      tokenBudget: input.tokenBudget,
+      ...(input.authFilePath === undefined ? {} : { authFilePath: input.authFilePath }),
+      environment,
+    });
+  };
+}
+
+function assertFrozenStationExecutables(
+  executables: Record<"base" | "candidate", FrozenStationExecutable>,
+  corpus: LoadedCorpus,
+): void {
+  if (
+    executables.base.commit !== corpus.manifest.baseCommit ||
+    executables.candidate.commit !== corpus.manifest.candidateCommit
+  ) {
+    throw new Error("Station executable commits do not match the sealed corpus freeze.");
+  }
+}
+
+function shouldRetry(record: TrialRecord): boolean {
+  const lastAttempt = record.attempts.at(-1);
+  return (
+    lastAttempt !== undefined &&
+    lastAttempt.status === "infrastructure-retryable" &&
+    !lastAttempt.modelStarted
+  );
+}
+
+async function createArmPath(input: {
+  arm: Arm;
+  stationPath: string | undefined;
+  commandNames: string[];
+  root: string;
+}): Promise<string> {
+  await mkdir(input.root, { recursive: true, mode: 0o700 });
+  if (input.arm !== "raw") {
+    if (input.stationPath === undefined) {
+      throw new Error(`Missing frozen Station executable for ${input.arm}.`);
+    }
+    await access(input.stationPath);
+    await symlink(input.stationPath, join(input.root, "stn"));
+    return input.root;
+  }
+
+  for (const commandName of new Set(input.commandNames)) {
+    const executable = await resolveExecutable(commandName);
+    await symlink(executable, join(input.root, commandName));
+  }
+  return input.root;
+}
+
+async function resolveExecutable(commandName: string): Promise<string> {
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (directory.length === 0) {
+      continue;
+    }
+    const candidate = join(directory, commandName);
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Continue until the exact allowlisted executable is found.
+    }
+  }
+  throw new Error(`Required raw-evidence executable is unavailable: ${commandName}`);
+}
+
+function assertRunState(
+  state: ExperimentRunState,
+  manifestHash: string,
+  expectedSchedule: TrialPlan[],
+): void {
+  if (state.schemaVersion !== 1 || state.corpusManifestSha256 !== manifestHash) {
+    throw new Error("Run state does not match the sealed corpus.");
+  }
+  if (JSON.stringify(state.schedule) !== JSON.stringify(expectedSchedule)) {
+    throw new Error("Run state schedule does not match the seeded balanced schedule.");
+  }
+}
+
+function assertStationEvidenceIdentity(state: ExperimentRunState): void {
+  const byIncidentAndReplicate = new Map<string, Partial<Record<Arm, string>>>();
+  for (const record of Object.values(state.records)) {
+    const key = `${record.incidentId}:${record.replicate}`;
+    const hashes = byIncidentAndReplicate.get(key) ?? {};
+    hashes[record.arm] = record.evidenceSha256;
+    byIncidentAndReplicate.set(key, hashes);
+  }
+  for (const [key, hashes] of byIncidentAndReplicate) {
+    if (hashes.base !== hashes.candidate) {
+      throw new Error(`Base and candidate evidence identity check failed for ${key}.`);
+    }
+  }
+}
+
+function exampleArgument(argument: string): string {
+  switch (argument) {
+    case "{id}":
+    case "{traceId}":
+    case "{commandId}":
+    case "{diagnosticId}":
+      return "incident-123";
+    case "{query}":
+      return "failure";
+    case "{path}":
+      return "state";
+    case "{sql}":
+      return "SELECT 1";
+    case "{number}":
+      return "20";
+    default:
+      return argument;
+  }
+}
+
+function shuffle<T>(values: T[], random: () => number): T[] {
+  for (let index = values.length - 1; index > 0; index -= 1) {
+    const target = Math.floor(random() * (index + 1));
+    const current = values[index];
+    values[index] = values[target] as T;
+    values[target] = current as T;
+  }
+  return values;
+}
+
+function seededRandom(seed: string): () => number {
+  let state = 2166136261;
+  for (const character of seed) {
+    state ^= character.charCodeAt(0);
+    state = Math.imul(state, 16777619);
+  }
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}

--- a/benchmark/real-incident-debugging/harness.unit.test.ts
+++ b/benchmark/real-incident-debugging/harness.unit.test.ts
@@ -1,0 +1,672 @@
+import { chmod, mkdir, mkdtemp, readdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { createArmAccess, validateCommand, validateExecutedCommand } from "./arms.js";
+import {
+  assertBlindPacketHasNoArmLabels,
+  assertBlindPacketHasNoPrivatePaths,
+  createBlindReviewPacket,
+  readRunState,
+} from "./artifacts.js";
+import { buildTrialPrompt, classifyTrialAttempt, runCodexTrial } from "./codexRunner.js";
+import {
+  assertNoPrivateLabelLeakage,
+  assertStudyComposition,
+  frozenBaseCommit,
+  frozenCandidateCommit,
+  loadSealedCorpus,
+  prepareTrialEvidence,
+  sha256,
+  sha256File,
+  sha256Tree,
+} from "./corpus.js";
+import {
+  buildBalancedSchedule,
+  createCodexExecutor,
+  generateBlindReviewPackets,
+  preflightCorpus,
+  runExperiment,
+} from "./harness.js";
+import {
+  CorpusManifestSchema,
+  defaultDecisionThresholds,
+  experimentTokenBudget,
+  ReplaySchema,
+  responseJsonSchema,
+  TrialOutputSchema,
+  type TrialRecord,
+  type TrialTelemetry,
+} from "./protocol.js";
+import { adjudicateScores, validateOutputCitations } from "./scoring.js";
+import {
+  analyzeExperiment,
+  decideExperiment,
+  incidentBlockedBootstrap,
+  type ScoredTrial,
+} from "./statistics.js";
+
+const telemetry: TrialTelemetry = {
+  wallTimeMs: 10,
+  commandCount: 1,
+  modelCycles: 1,
+  totalTokens: 100,
+  outputBytes: 100,
+};
+
+describe("real-incident debugging A/B harness", () => {
+  it("strictly parses corpus and final response schemas", () => {
+    expect(
+      CorpusManifestSchema.safeParse({
+        schemaVersion: 1,
+        corpusVersion: "v1",
+        baseCommit: "a".repeat(40),
+        candidateCommit: "b".repeat(40),
+        selectionSeed: "seed",
+        incidents: [],
+        unexpected: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      TrialOutputSchema.safeParse({
+        schemaVersion: 3,
+        proximateFailure: "cause",
+        underlyingCauseDisposition: "unknown",
+        underlyingCause: "The underlying cause is not retained.",
+        responsibleSubsystem: "subsystem",
+        proximateEvidenceAdequacy: "sufficient",
+        nextActions: ["inspect safely"],
+        proximateCitation: { commandNumber: 1, literal: "FAILURE_CODE" },
+        ownershipCitation: { commandNumber: 1, literal: "provider" },
+        underlyingCauseCitation: null,
+        unexpected: true,
+      }).success,
+    ).toBe(false);
+    expect(responseJsonSchema()).toMatchObject({
+      properties: { schemaVersion: { type: "integer", const: 3 } },
+    });
+    expect(
+      ReplaySchema.safeParse({
+        schemaVersion: 1,
+        kind: "state",
+        evidencePaths: ["state"],
+        stationCommands: [{ executable: "stn", arguments: ["observer", "start"] }],
+        rawCommands: [{ executable: "rg", arguments: ["{query}", "state"] }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("stratifies the 24 held-out incidents without counting development cases", async () => {
+    const corpus = await createFixtureCorpus();
+    const template = corpus.incidents[0];
+    expect(template).toBeDefined();
+    if (template === undefined) {
+      return;
+    }
+    const areaCounts = [
+      ["configuration-startup", 3],
+      ["observer-lifecycle-socket", 3],
+      ["provider-operation-boundaries", 3],
+      ["provider-hooks-ingress", 3],
+      ["command-trace-correlation", 3],
+      ["persistence-retention", 3],
+      ["terminal-tui-runtime", 3],
+      ["reports-evidence-adequacy", 3],
+    ] as const;
+    const heldOut = areaCounts.flatMap(([area, count]) =>
+      Array.from({ length: count }, (_, index) => ({
+        ...template,
+        entry: {
+          ...template.entry,
+          id: `${area}-${index}`,
+          cohort: "held-out" as const,
+          area,
+          hasExactId: true,
+          hasRetainedId: false,
+          hasOldOrTruncatedEvidence: true,
+          correctDisposition: "success" as const,
+        },
+      })),
+    );
+    const development = Array.from({ length: 6 }, (_, index) => ({
+      ...template,
+      entry: {
+        ...template.entry,
+        id: `development-${index}`,
+        cohort: "development" as const,
+      },
+    }));
+
+    expect(() =>
+      assertStudyComposition({ ...corpus, incidents: [...development, ...heldOut] }),
+    ).not.toThrow();
+  });
+
+  it("uses deterministic balanced, interleaved randomization", async () => {
+    const corpus = await createFixtureCorpus();
+    const first = buildBalancedSchedule({
+      incidents: corpus.incidents,
+      replicates: 2,
+      seed: "seed-1",
+    });
+    const second = buildBalancedSchedule({
+      incidents: corpus.incidents,
+      replicates: 2,
+      seed: "seed-1",
+    });
+
+    expect(first).toEqual(second);
+    expect(first).toHaveLength(6);
+    for (let index = 0; index < first.length; index += 3) {
+      expect(
+        first
+          .slice(index, index + 3)
+          .map((trial) => trial.arm)
+          .sort(),
+      ).toEqual(["base", "candidate", "raw"]);
+    }
+  });
+
+  it("verifies hashes and rejects symlink path escape", async () => {
+    const corpus = await createFixtureCorpus();
+    const symptomPath = join(corpus.root, "incidents", "sample-invalid-config", "symptom.txt");
+    await writeFile(symptomPath, "tampered", "utf8");
+    await expect(loadSealedCorpus(corpus.root)).rejects.toThrow("hash");
+
+    const escaped = await createFixtureCorpus();
+    const stateRoot = join(escaped.root, "incidents", "sample-invalid-config", "state");
+    await symlink(tmpdir(), join(stateRoot, "escape"));
+    await expect(loadSealedCorpus(escaped.root)).rejects.toThrow("Symlinks");
+  });
+
+  it("does not copy private corpus labels or files into a trial workspace", async () => {
+    const corpus = await createFixtureCorpus();
+    const incident = corpus.incidents[0];
+    expect(incident).toBeDefined();
+    if (incident === undefined) {
+      return;
+    }
+    const workspace = join(corpus.root, "workspace");
+    await prepareTrialEvidence({ incident, workspaceRoot: workspace });
+
+    await expect(readFile(join(workspace, "gold.json"), "utf8")).rejects.toThrow();
+    await assertNoPrivateLabelLeakage(workspace, [
+      "The strict runtime config contains an unknown key.",
+    ]);
+    await writeFile(
+      join(workspace, "leak.txt"),
+      "The strict runtime config contains an unknown key.",
+      "utf8",
+    );
+    await expect(
+      assertNoPrivateLabelLeakage(workspace, [
+        "The strict runtime config contains an unknown key.",
+      ]),
+    ).rejects.toThrow("Private corpus label leaked");
+  });
+
+  it("constructs identical base and candidate evidence and rejects mutations", async () => {
+    const corpus = await createFixtureCorpus();
+    await expect(
+      preflightCorpus({ corpus, workspaceRoot: join(corpus.root, "preflight") }),
+    ).resolves.toBeUndefined();
+
+    const incident = corpus.incidents[0];
+    expect(incident).toBeDefined();
+    if (incident === undefined) {
+      return;
+    }
+    const raw = createArmAccess({ arm: "raw", blindArm: "arm-c", replay: incident.replay });
+    const prompt = buildTrialPrompt({ symptom: incident.symptom, access: raw });
+    expect(prompt).toContain("Recommend at most two read-only diagnostic next actions");
+    expect(prompt).toContain(
+      "ownershipCitation must quote a specific operation, boundary, or failure description",
+    );
+    expect(
+      validateCommand({
+        access: raw,
+        argv: ["find", "state", "-delete"],
+        workspaceRoot: corpus.root,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      validateCommand({
+        access: raw,
+        argv: ["stn", "debug", "logs"],
+        workspaceRoot: corpus.root,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      validateCommand({
+        access: raw,
+        argv: [
+          "sqlite3",
+          "-readonly",
+          "state/observer.sqlite",
+          "WITH x AS (DELETE FROM t) SELECT 1",
+        ],
+        workspaceRoot: corpus.root,
+      }),
+    ).toMatchObject({ ok: false });
+    expect(
+      validateExecutedCommand({
+        access: raw,
+        command: "/bin/zsh -lc 'rg failure state'",
+        workspaceRoot: corpus.root,
+      }),
+    ).toMatchObject({ ok: true, argv: ["rg", "failure", "state"] });
+    expect(
+      validateExecutedCommand({
+        access: raw,
+        command: `/bin/zsh -lc 'rg "$(stn debug logs)" state'`,
+        workspaceRoot: corpus.root,
+      }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("grounds field-specific citations by recorded output instead of command route", () => {
+    const output = {
+      schemaVersion: 3 as const,
+      proximateFailure: "cause",
+      underlyingCauseDisposition: "unknown" as const,
+      underlyingCause: "The underlying cause is not retained.",
+      responsibleSubsystem: "subsystem",
+      proximateEvidenceAdequacy: "sufficient" as const,
+      nextActions: ["inspect"],
+      proximateCitation: { commandNumber: 1, literal: "CONFIG_VALIDATION_FAILED" },
+      ownershipCitation: { commandNumber: 1, literal: "configuration" },
+      underlyingCauseCitation: null,
+    };
+    expect(
+      validateOutputCitations(output, ["station configuration: CONFIG_VALIDATION_FAILED"]),
+    ).toEqual({
+      valid: true,
+      failures: [],
+    });
+    expect(
+      validateOutputCitations(output, ["raw configuration: CONFIG_VALIDATION_FAILED"]),
+    ).toEqual({
+      valid: true,
+      failures: [],
+    });
+  });
+
+  it("removes arm identities from blind packets", () => {
+    const record = completedRecord("base", "arm-a");
+    const packet = createBlindReviewPacket({ record, symptom: "A symptom without arm labels." });
+    expect(packet).not.toHaveProperty("arm");
+    expect(packet).not.toHaveProperty("blindArm");
+    expect(() =>
+      assertBlindPacketHasNoArmLabels(packet, ["base", "candidate", "raw", "arm-a"]),
+    ).not.toThrow();
+  });
+
+  it("removes private absolute paths from blind packets", () => {
+    const record = completedRecord("base", "arm-a");
+    const attempt = record.attempts[0];
+    expect(attempt).toBeDefined();
+    if (attempt !== undefined) {
+      attempt.commands[0] = {
+        argv: ["stn", "debug", "logs", "failure"],
+        output: "/Users/private/study/candidate/raw/workspaces/evidence/state/logs/observer.jsonl",
+        exitCode: 0,
+      };
+    }
+    const packet = createBlindReviewPacket({ record, symptom: "Copied evidence failed." });
+    expect(() => assertBlindPacketHasNoPrivatePaths(packet)).not.toThrow();
+    expect(JSON.stringify(packet)).toContain("[REDACTED_PATH]/observer.jsonl");
+  });
+
+  it("resumes without duplicate paid turns and emits complete fake-Codex artifacts", async () => {
+    const corpus = await createFixtureCorpus();
+    const fakeCodex = await createFakeCodex(corpus.root);
+    const artifactRoot = join(corpus.root, "artifacts");
+    const input = {
+      corpus,
+      artifactRoot,
+      replicates: 1,
+      seed: "run-seed",
+      stationExecutables: {
+        base: { path: process.execPath, commit: frozenBaseCommit },
+        candidate: { path: process.execPath, commit: frozenCandidateCommit },
+      },
+      executor: createCodexExecutor({
+        executable: process.execPath,
+        executableArgs: [fakeCodex],
+        expectedVersion: "codex-cli 0.146.0",
+        timeoutMs: 10_000,
+        tokenBudget: experimentTokenBudget,
+      }),
+    };
+    const firstPlan = buildBalancedSchedule({
+      incidents: corpus.incidents,
+      replicates: 1,
+      seed: "run-seed",
+    })[0];
+    expect(firstPlan).toBeDefined();
+    if (firstPlan === undefined) {
+      return;
+    }
+    const interruptedArtifactRoot = join(
+      artifactRoot,
+      "raw",
+      "runner",
+      firstPlan.trialId,
+      "attempt-1",
+    );
+    await mkdir(join(interruptedArtifactRoot, "command-bin"), { recursive: true });
+    await symlink(process.execPath, join(interruptedArtifactRoot, "command-bin", "rg"));
+    await writeFile(join(interruptedArtifactRoot, "response.json"), "stale response", "utf8");
+
+    const first = await runExperiment(input);
+    expect(Object.values(first.state.records)).toHaveLength(3);
+    expect(
+      Object.values(first.state.records).every(
+        (record) =>
+          record.attempts.at(-1)?.status === "completed" &&
+          record.attempts.at(-1)?.telemetry.totalTokens === 15,
+      ),
+    ).toBe(true);
+    expect(
+      await generateBlindReviewPackets({ paths: first.paths, corpus, state: first.state }),
+    ).toBe(3);
+    const second = await runExperiment(input);
+    expect(second.state).toEqual(first.state);
+    expect(await readRunState<typeof first.state>(second.paths)).toEqual(first.state);
+    await expect(
+      readFile(
+        join(
+          artifactRoot,
+          "raw",
+          "trials",
+          first.state.schedule[0]?.trialId ?? "",
+          "attempt-1-codex-events.jsonl",
+        ),
+        "utf8",
+      ),
+    ).resolves.toContain("turn.completed");
+    expect(await readdir(join(artifactRoot, "blind", "packets"))).toHaveLength(3);
+  });
+
+  it("rejects a trial that exceeds the 12-command cap", async () => {
+    const root = await mkdtemp(join(tmpdir(), "station-command-cap-"));
+    const workspaceRoot = join(root, "workspace");
+    await mkdir(join(workspaceRoot, "state"), { recursive: true });
+    const fakeCodex = await createFakeCodex(root, 13);
+    const result = await runCodexTrial({
+      executable: process.execPath,
+      executableArgs: [fakeCodex],
+      workspaceRoot,
+      isolatedHome: join(root, "home"),
+      artifactRoot: join(root, "artifacts"),
+      prompt: "Inspect the copied evidence.",
+      arm: "raw",
+      blindArm: "arm-c",
+      replay: {
+        schemaVersion: 1,
+        kind: "state",
+        evidencePaths: ["state"],
+        stationCommands: [],
+        rawCommands: [{ executable: "rg", arguments: ["failure", "state"] }],
+      },
+      timeoutMs: 10_000,
+      tokenBudget: experimentTokenBudget,
+      environment: { PATH: process.env.PATH ?? "" },
+    });
+    expect(result.attempt.status).toBe("policy-rejected");
+    expect(result.attempt.telemetry.commandCount).toBe(13);
+  });
+
+  it("distinguishes retryable infrastructure failures from model timeouts", () => {
+    const retryable = classifyTrialAttempt({
+      modelStarted: false,
+      timedOut: true,
+      policyFailure: "",
+      output: undefined,
+      stderr: "timeout before model work",
+      telemetry,
+      commands: [],
+    });
+    const modelTimeout = classifyTrialAttempt({
+      modelStarted: true,
+      timedOut: true,
+      policyFailure: "",
+      output: undefined,
+      stderr: "timeout after model work",
+      telemetry,
+      commands: [],
+    });
+    expect(retryable.status).toBe("infrastructure-retryable");
+    expect(modelTimeout.status).toBe("model-timeout");
+  });
+
+  it("requires blind adjudication and applies the preregistered decision rule", () => {
+    const first = reviewerScore(true);
+    const second = reviewerScore(false);
+    expect(() => adjudicateScores({ first, second })).toThrow("requires an adjudicated score");
+    expect(adjudicateScores({ first, second, adjudication: first })).toMatchObject({
+      success: true,
+    });
+
+    const analysis = analyzeExperiment({
+      trials: scoredTrials(),
+      bootstrapIterations: 100,
+      seed: "decision-seed",
+    });
+    expect(decideExperiment(analysis, defaultDecisionThresholds).classification).toBe("reject");
+  });
+
+  it("calculates deterministic incident-blocked bootstrap and analysis", () => {
+    const trials = scoredTrials();
+    const first = incidentBlockedBootstrap({
+      trials,
+      candidateArm: "candidate",
+      comparatorArm: "base",
+      iterations: 100,
+      seed: "bootstrap-seed",
+    });
+    const second = incidentBlockedBootstrap({
+      trials,
+      candidateArm: "candidate",
+      comparatorArm: "base",
+      iterations: 100,
+      seed: "bootstrap-seed",
+    });
+    expect(first).toEqual(second);
+    expect(
+      analyzeExperiment({ trials, bootstrapIterations: 100, seed: "analysis-seed" })
+        .candidateSuccess,
+    ).toBe(0.5);
+  });
+});
+
+async function createFixtureCorpus() {
+  const root = await mkdtemp(join(tmpdir(), "station-real-incident-ab-"));
+  const sourcePath = join(
+    process.cwd(),
+    "benchmark/real-incident-debugging/fixtures/sample-corpus.json",
+  );
+  const fixture = JSON.parse(await readFile(sourcePath, "utf8")) as {
+    incident: {
+      id: string;
+      cohort: "held-out";
+      area: "configuration-startup";
+      replayKind: "invalid-config";
+      hasExactId: boolean;
+      hasRetainedId: boolean;
+      hasOldOrTruncatedEvidence: boolean;
+      correctDisposition: "abstain";
+      symptom: string;
+      replay: unknown;
+      files: Record<string, string>;
+      gold: unknown;
+      provenance: unknown;
+      redactionReport: unknown;
+    };
+  };
+  const incident = fixture.incident;
+  const packageRoot = join(root, "incidents", incident.id);
+  await mkdir(packageRoot, { recursive: true });
+  await writeFile(join(packageRoot, "symptom.txt"), incident.symptom, {
+    encoding: "utf8",
+    flag: "w",
+  });
+  await writeJson(join(packageRoot, "replay.json"), incident.replay);
+  await Promise.all(
+    Object.entries(incident.files).map(async ([path, content]) => {
+      const target = join(packageRoot, path);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, content, { encoding: "utf8", flag: "w" });
+    }),
+  );
+  await writeJson(join(packageRoot, "gold.json"), incident.gold);
+  await writeJson(join(packageRoot, "provenance.json"), incident.provenance);
+  await writeJson(join(packageRoot, "redaction-report.json"), incident.redactionReport);
+
+  const packageSha256 = await sha256Tree(packageRoot);
+  const symptomSha256 = await sha256File(join(packageRoot, "symptom.txt"));
+  const manifest = {
+    schemaVersion: 1 as const,
+    corpusVersion: "v1" as const,
+    baseCommit: frozenBaseCommit,
+    candidateCommit: frozenCandidateCommit,
+    selectionSeed: "fixture-seed",
+    incidents: [
+      {
+        id: incident.id,
+        cohort: incident.cohort,
+        area: incident.area,
+        replayKind: incident.replayKind,
+        packageSha256,
+        symptomSha256,
+        hasExactId: incident.hasExactId,
+        hasRetainedId: incident.hasRetainedId,
+        hasOldOrTruncatedEvidence: incident.hasOldOrTruncatedEvidence,
+        correctDisposition: incident.correctDisposition,
+      },
+    ],
+  };
+  await writeJson(join(root, "manifest.json"), manifest);
+  const manifestSha256 = await sha256File(join(root, "manifest.json"));
+  await writeJson(join(root, "freeze.json"), {
+    schemaVersion: 1,
+    baseCommit: manifest.baseCommit,
+    candidateCommit: manifest.candidateCommit,
+    candidateFrozenAt: "2026-07-01T00:00:00.000Z",
+    corpusSelectedAt: "2026-07-02T00:00:00.000Z",
+    manifestSha256,
+    heldOutCorpusSha256: sha256(`${incident.id}\0${packageSha256}\0`),
+    heldOutIncidentIds: [incident.id],
+    sealedAt: "2026-07-03T00:00:00.000Z",
+  });
+  return loadSealedCorpus(root);
+}
+
+async function createFakeCodex(root: string, commandCount = 1): Promise<string> {
+  const path = join(root, "fake-codex.mjs");
+  await writeFile(
+    path,
+    `import { writeFileSync } from "node:fs";
+if (process.argv.includes("--version")) {
+  process.stdout.write("codex-cli 0.146.0\\n");
+  process.exit(0);
+}
+const outputIndex = process.argv.indexOf("--output-last-message");
+const outputPath = process.argv[outputIndex + 1];
+const prompt = process.argv.at(-1) ?? "";
+const command = prompt.includes("stn debug logs") ? "stn debug logs failure" : "rg failure state";
+const event = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+event({ type: "turn.started" });
+for (let index = 0; index < ${commandCount}; index += 1) {
+  event({ type: "item.completed", item: { type: "command_execution", command, aggregated_output: "CONFIG_VALIDATION_FAILED", exit_code: 0 } });
+}
+event({ type: "turn.completed", usage: { input_tokens: 10, cached_input_tokens: 7, output_tokens: 5 } });
+writeFileSync(outputPath, JSON.stringify({ schemaVersion: 3, proximateFailure: "An invalid config key prevented loading.", underlyingCauseDisposition: "unknown", underlyingCause: "The copied evidence does not establish why the key was invalid.", responsibleSubsystem: "configuration loader", proximateEvidenceAdequacy: "sufficient", nextActions: ["Inspect the copied configuration evidence."], proximateCitation: { commandNumber: 1, literal: "CONFIG_VALIDATION_FAILED" }, ownershipCitation: { commandNumber: 1, literal: "CONFIG_VALIDATION_FAILED" }, underlyingCauseCitation: null }));
+`,
+    "utf8",
+  );
+  await chmod(path, 0o700);
+  return path;
+}
+
+function completedRecord(arm: "base", blindArm: "arm-a"): TrialRecord {
+  return {
+    schemaVersion: 1,
+    trialId: "sample-r1-arm-a",
+    incidentId: "sample-invalid-config",
+    replicate: 1,
+    arm,
+    blindArm,
+    evidenceSha256: "a".repeat(64),
+    attempts: [
+      {
+        attempt: 1,
+        status: "completed",
+        modelStarted: true,
+        stderr: "",
+        telemetry,
+        commands: [
+          {
+            argv: ["stn", "debug", "logs", "failure"],
+            output: "CONFIG_VALIDATION_FAILED at /tmp/sample-r1-arm-a/arm-a",
+            exitCode: 0,
+          },
+        ],
+        output: {
+          schemaVersion: 3,
+          proximateFailure: "An invalid config key prevented loading.",
+          underlyingCauseDisposition: "unknown",
+          underlyingCause: "The copied evidence does not establish why the key was invalid.",
+          responsibleSubsystem: "configuration loader",
+          proximateEvidenceAdequacy: "sufficient",
+          nextActions: ["Inspect the copied configuration evidence."],
+          proximateCitation: { commandNumber: 1, literal: "CONFIG_VALIDATION_FAILED" },
+          ownershipCitation: { commandNumber: 1, literal: "CONFIG_VALIDATION_FAILED" },
+          underlyingCauseCitation: null,
+        },
+      },
+    ],
+  };
+}
+
+function reviewerScore(proximateFailureCorrect: boolean) {
+  return {
+    schemaVersion: 2 as const,
+    reviewerId: proximateFailureCorrect ? "reviewer-one" : "reviewer-two",
+    proximateFailureCorrect,
+    underlyingCauseDispositionCorrect: true,
+    underlyingCauseCorrect: true,
+    evidenceGrounded: true,
+    ownershipCorrect: true,
+    nextActionSafeAndRelevant: true,
+    avoidsUnsupportedClaims: true,
+    unsafeActionRecommended: false,
+    notes: "",
+  };
+}
+
+function scoredTrials(): ScoredTrial[] {
+  const rows: Array<[string, "base" | "candidate" | "raw", boolean]> = [
+    ["incident-a", "base", true],
+    ["incident-a", "candidate", true],
+    ["incident-a", "raw", true],
+    ["incident-b", "base", true],
+    ["incident-b", "candidate", false],
+    ["incident-b", "raw", true],
+  ];
+  return rows.flatMap(([incidentId, arm, success]) =>
+    [1, 2].map((replicate) => ({
+      incidentId,
+      arm,
+      replicate,
+      success,
+      unsafeActionRecommended: false,
+      abstained: false,
+      telemetry,
+    })),
+  );
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", flag: "w" });
+}

--- a/benchmark/real-incident-debugging/protocol.ts
+++ b/benchmark/real-incident-debugging/protocol.ts
@@ -1,0 +1,423 @@
+import { z } from "zod";
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/u);
+const gitCommitSchema = z.string().regex(/^[a-f0-9]{40}$/u);
+const incidentIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{2,79}$/u);
+const relativePathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      !value.startsWith("/") &&
+      !value.split("/").some((part) => part.length === 0 || part === "." || part === ".."),
+    "must be a normalized relative path",
+  );
+
+export const experimentTokenBudget = 32_000;
+
+export const ArmSchema = z.enum(["base", "candidate", "raw"]);
+export type Arm = z.infer<typeof ArmSchema>;
+
+export const NeutralArmLabelSchema = z.enum(["arm-a", "arm-b", "arm-c"]);
+export type NeutralArmLabel = z.infer<typeof NeutralArmLabelSchema>;
+
+export const ReplayKindSchema = z.enum(["state", "bundle", "invalid-config"]);
+export type ReplayKind = z.infer<typeof ReplayKindSchema>;
+
+export const IncidentAreaSchema = z.enum([
+  "configuration-startup",
+  "observer-lifecycle-socket",
+  "provider-operation-boundaries",
+  "provider-hooks-ingress",
+  "command-trace-correlation",
+  "persistence-retention",
+  "terminal-tui-runtime",
+  "reports-evidence-adequacy",
+]);
+export const CohortSchema = z.enum(["development", "held-out"]);
+export const CommandPatternSchema = z
+  .object({
+    executable: z.enum(["stn", "rg", "find", "sed", "tail", "sqlite3"]),
+    arguments: z.array(z.string().min(1)).max(12),
+  })
+  .strict();
+export type CommandPattern = z.infer<typeof CommandPatternSchema>;
+
+export const ReplaySchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    kind: ReplayKindSchema,
+    evidencePaths: z.array(relativePathSchema).min(1).max(12),
+    stationCommands: z.array(CommandPatternSchema).min(1).max(24),
+    rawCommands: z.array(CommandPatternSchema).min(1).max(24),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    for (const command of value.stationCommands) {
+      if (command.executable !== "stn") {
+        context.addIssue({
+          code: "custom",
+          message: "stationCommands may expose only stn",
+        });
+      } else if (!isReadOnlyStationCommand(value.kind, command.arguments)) {
+        context.addIssue({
+          code: "custom",
+          message: "stationCommands may expose only preregistered read-only commands",
+        });
+      }
+    }
+    for (const command of value.rawCommands) {
+      if (command.executable === "stn") {
+        context.addIssue({
+          code: "custom",
+          message: "rawCommands must not expose stn",
+        });
+      }
+    }
+  });
+export type Replay = z.infer<typeof ReplaySchema>;
+
+const readOnlyStationArgumentPatterns = [
+  ["debug", "trace", "{id}"],
+  ["debug", "trace", "{traceId}"],
+  ["debug", "trace", "{commandId}"],
+  ["debug", "trace", "{diagnosticId}"],
+  ["debug", "logs"],
+  ["debug", "logs", "{query}"],
+  ["debug", "logs", "{query}", "--component", "hook"],
+  ["setup", "check", "--json"],
+  ["setup", "system", "--check"],
+  ["event-hooks", "doctor"],
+  ["observer", "status"],
+] as const;
+
+function isReadOnlyStationCommand(kind: ReplayKind, arguments_: string[]): boolean {
+  if (readOnlyStationArgumentPatterns.some((pattern) => matchesArguments(arguments_, pattern))) {
+    return true;
+  }
+  if (
+    arguments_.length === 3 &&
+    arguments_[0] === "hooks" &&
+    arguments_[1] === "doctor" &&
+    ["worktrunk", "claude", "codex", "cursor", "opencode"].includes(arguments_[2] ?? "")
+  ) {
+    return true;
+  }
+  return kind === "invalid-config" && matchesArguments(arguments_, ["doctor"]);
+}
+
+function matchesArguments(arguments_: string[], expected: readonly string[]): boolean {
+  return (
+    arguments_.length === expected.length &&
+    arguments_.every((argument, index) => argument === expected[index])
+  );
+}
+
+export const IncidentManifestEntrySchema = z
+  .object({
+    id: incidentIdSchema,
+    cohort: CohortSchema,
+    area: IncidentAreaSchema,
+    replayKind: ReplayKindSchema,
+    packageSha256: sha256Schema,
+    symptomSha256: sha256Schema,
+    hasExactId: z.boolean(),
+    hasRetainedId: z.boolean(),
+    hasOldOrTruncatedEvidence: z.boolean(),
+    correctDisposition: z.enum(["success", "abstain", "inconclusive"]),
+  })
+  .strict();
+export type IncidentManifestEntry = z.infer<typeof IncidentManifestEntrySchema>;
+
+export const CorpusManifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    corpusVersion: z.literal("v1"),
+    baseCommit: gitCommitSchema,
+    candidateCommit: gitCommitSchema,
+    selectionSeed: z.string().min(1).max(200),
+    incidents: z.array(IncidentManifestEntrySchema).min(1).max(100),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const ids = new Set<string>();
+    for (const incident of value.incidents) {
+      if (ids.has(incident.id)) {
+        context.addIssue({
+          code: "custom",
+          message: `duplicate incident id: ${incident.id}`,
+        });
+      }
+      ids.add(incident.id);
+    }
+  });
+export type CorpusManifest = z.infer<typeof CorpusManifestSchema>;
+
+export const CorpusFreezeSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    baseCommit: gitCommitSchema,
+    candidateCommit: gitCommitSchema,
+    candidateFrozenAt: z.iso.datetime({ offset: true }),
+    corpusSelectedAt: z.iso.datetime({ offset: true }),
+    manifestSha256: sha256Schema,
+    heldOutCorpusSha256: sha256Schema,
+    heldOutIncidentIds: z.array(incidentIdSchema).min(1).max(100),
+    sealedAt: z.iso.datetime({ offset: true }),
+  })
+  .strict();
+export type CorpusFreeze = z.infer<typeof CorpusFreezeSchema>;
+
+export const GoldSchema = z
+  .object({
+    schemaVersion: z.literal(2),
+    acceptedProximateFailures: z.array(z.string().min(1)).min(1),
+    underlyingCauseDisposition: z.enum(["established", "unknown", "not_applicable"]),
+    acceptedUnderlyingCauses: z.array(z.string().min(1)),
+    responsibleSubsystems: z.array(z.string().min(1)).min(1),
+    proximateEvidenceAdequacy: z.enum(["sufficient", "ambiguous", "insufficient"]),
+    acceptableNextActions: z.array(z.string().min(1)).min(1).max(2),
+    prohibitedClaimsOrActions: z.array(z.string().min(1)),
+    independentlyValidatedBy: z.array(z.string().min(1)).min(2),
+  })
+  .strict();
+export type Gold = z.infer<typeof GoldSchema>;
+
+export const ProvenanceSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    occurredOutsideExperiment: z.literal(true),
+    originalSymptomAvailable: z.literal(true),
+    independentResolutionAvailable: z.literal(true),
+    evidenceAvailable: z.literal(true),
+    candidateFrozenBeforeSelection: z.literal(true),
+    notPreviouslyUsed: z.literal(true),
+    recordedBy: z.string().min(1),
+    reviewedBy: z.string().min(1),
+  })
+  .strict();
+export type Provenance = z.infer<typeof ProvenanceSchema>;
+
+export const RedactionReportSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    reviewedAt: z.iso.datetime({ offset: true }),
+    reviewedBy: z.string().min(1),
+    secretScan: z.enum(["clean", "redacted"]),
+    redactions: z.array(z.string().min(1)),
+  })
+  .strict();
+export type RedactionReport = z.infer<typeof RedactionReportSchema>;
+
+export const CitationSchema = z
+  .object({
+    commandNumber: z.number().int().positive(),
+    literal: z
+      .string()
+      .min(1)
+      .max(160)
+      .regex(/^[^\r\n"'\\]+$/u),
+  })
+  .strict();
+export type Citation = z.infer<typeof CitationSchema>;
+
+export const TrialOutputSchema = z
+  .object({
+    schemaVersion: z.literal(3),
+    proximateFailure: z.string().min(1).max(8_000),
+    underlyingCauseDisposition: z.enum(["established", "unknown", "not_applicable"]),
+    underlyingCause: z.string().min(1).max(8_000),
+    responsibleSubsystem: z.string().min(1).max(500),
+    proximateEvidenceAdequacy: z.enum(["sufficient", "ambiguous", "insufficient"]),
+    nextActions: z.array(z.string().min(1).max(2_000)).min(1).max(2),
+    proximateCitation: CitationSchema,
+    ownershipCitation: CitationSchema,
+    underlyingCauseCitation: CitationSchema.nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const requiresCauseCitation = value.underlyingCauseDisposition === "established";
+    if (requiresCauseCitation !== (value.underlyingCauseCitation !== null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["underlyingCauseCitation"],
+        message: "Only an established underlying cause may carry a cause citation.",
+      });
+    }
+  });
+export type TrialOutput = z.infer<typeof TrialOutputSchema>;
+
+export const CommandRecordSchema = z
+  .object({
+    argv: z.array(z.string().min(1)).min(1),
+    output: z.string(),
+    exitCode: z.number().int().nullable(),
+  })
+  .strict();
+export type CommandRecord = z.infer<typeof CommandRecordSchema>;
+
+export const TrialTelemetrySchema = z
+  .object({
+    wallTimeMs: z.number().nonnegative(),
+    commandCount: z.number().int().nonnegative(),
+    modelCycles: z.number().int().nonnegative(),
+    totalTokens: z.number().nonnegative(),
+    outputBytes: z.number().int().nonnegative(),
+  })
+  .strict();
+export type TrialTelemetry = z.infer<typeof TrialTelemetrySchema>;
+
+export const TrialAttemptStatusSchema = z.enum([
+  "completed",
+  "infrastructure-retryable",
+  "model-timeout",
+  "model-no-answer",
+  "policy-rejected",
+]);
+export type TrialAttemptStatus = z.infer<typeof TrialAttemptStatusSchema>;
+
+export const TrialAttemptSchema = z
+  .object({
+    attempt: z.number().int().positive(),
+    status: TrialAttemptStatusSchema,
+    modelStarted: z.boolean(),
+    stderr: z.string(),
+    telemetry: TrialTelemetrySchema,
+    commands: z.array(CommandRecordSchema),
+    output: TrialOutputSchema.optional(),
+  })
+  .strict();
+export type TrialAttempt = z.infer<typeof TrialAttemptSchema>;
+
+export const TrialRecordSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    trialId: z.string().min(1),
+    incidentId: incidentIdSchema,
+    replicate: z.number().int().positive(),
+    arm: ArmSchema,
+    blindArm: NeutralArmLabelSchema,
+    evidenceSha256: sha256Schema,
+    attempts: z.array(TrialAttemptSchema).min(1),
+  })
+  .strict();
+export type TrialRecord = z.infer<typeof TrialRecordSchema>;
+
+export const TrialPlanSchema = z
+  .object({
+    trialId: z.string().min(1),
+    incidentId: incidentIdSchema,
+    replicate: z.number().int().positive(),
+    arm: ArmSchema,
+    blindArm: NeutralArmLabelSchema,
+  })
+  .strict();
+export type TrialPlan = z.infer<typeof TrialPlanSchema>;
+
+export const ExperimentRunStateSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    corpusManifestSha256: sha256Schema,
+    schedule: z.array(TrialPlanSchema).min(1),
+    records: z.record(z.string().min(1), TrialRecordSchema),
+  })
+  .strict();
+export type ExperimentRunState = z.infer<typeof ExperimentRunStateSchema>;
+
+export const ReviewerScoreSchema = z
+  .object({
+    schemaVersion: z.literal(2),
+    reviewerId: z.string().min(1),
+    proximateFailureCorrect: z.boolean(),
+    underlyingCauseDispositionCorrect: z.boolean(),
+    underlyingCauseCorrect: z.boolean(),
+    evidenceGrounded: z.boolean(),
+    ownershipCorrect: z.boolean(),
+    nextActionSafeAndRelevant: z.boolean(),
+    avoidsUnsupportedClaims: z.boolean(),
+    unsafeActionRecommended: z.boolean(),
+    notes: z.string().max(8_000),
+  })
+  .strict();
+export type ReviewerScore = z.infer<typeof ReviewerScoreSchema>;
+
+export const DecisionThresholdsSchema = z
+  .object({
+    candidateSuccessMinimum: z.number().min(0).max(1),
+    noninferiorityMargin: z.number().min(-1).max(1),
+    rawEvidenceMargin: z.number().min(-1).max(1),
+    maxBothCandidateFailBaseSucceed: z.number().int().nonnegative(),
+    maxEfficiencyRatio: z.number().min(1),
+  })
+  .strict();
+export type DecisionThresholds = z.infer<typeof DecisionThresholdsSchema>;
+
+export const defaultDecisionThresholds: DecisionThresholds = {
+  candidateSuccessMinimum: 0.9,
+  noninferiorityMargin: -0.05,
+  rawEvidenceMargin: -0.05,
+  maxBothCandidateFailBaseSucceed: 1,
+  maxEfficiencyRatio: 1.1,
+};
+
+function citationJsonSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    additionalProperties: false,
+    required: ["commandNumber", "literal"],
+    properties: {
+      commandNumber: { type: "integer", minimum: 1 },
+      literal: {
+        type: "string",
+        minLength: 1,
+        maxLength: 160,
+        pattern: "^[^\\r\\n\\\"'\\\\]+$",
+      },
+    },
+  };
+}
+
+export function responseJsonSchema(): Record<string, unknown> {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "schemaVersion",
+      "proximateFailure",
+      "underlyingCauseDisposition",
+      "underlyingCause",
+      "responsibleSubsystem",
+      "proximateEvidenceAdequacy",
+      "nextActions",
+      "proximateCitation",
+      "ownershipCitation",
+      "underlyingCauseCitation",
+    ],
+    properties: {
+      schemaVersion: { type: "integer", const: 3 },
+      proximateFailure: { type: "string", minLength: 1, maxLength: 8000 },
+      underlyingCauseDisposition: {
+        type: "string",
+        enum: ["established", "unknown", "not_applicable"],
+      },
+      underlyingCause: { type: "string", minLength: 1, maxLength: 8000 },
+      responsibleSubsystem: { type: "string", minLength: 1, maxLength: 500 },
+      proximateEvidenceAdequacy: {
+        type: "string",
+        enum: ["sufficient", "ambiguous", "insufficient"],
+      },
+      nextActions: {
+        type: "array",
+        minItems: 1,
+        maxItems: 2,
+        items: { type: "string", minLength: 1, maxLength: 2000 },
+      },
+      proximateCitation: citationJsonSchema(),
+      ownershipCitation: citationJsonSchema(),
+      underlyingCauseCitation: {
+        anyOf: [citationJsonSchema(), { type: "null" }],
+      },
+    },
+  };
+}

--- a/benchmark/real-incident-debugging/scoring.ts
+++ b/benchmark/real-incident-debugging/scoring.ts
@@ -1,0 +1,82 @@
+import { type ReviewerScore, ReviewerScoreSchema, type TrialOutput } from "./protocol.js";
+
+export type CitationCheck = {
+  valid: boolean;
+  failures: string[];
+};
+
+export type AdjudicatedScore = {
+  score: ReviewerScore;
+  success: boolean;
+};
+
+export function validateOutputCitations(
+  output: TrialOutput,
+  commandOutputs: string[],
+): CitationCheck {
+  const failures: string[] = [];
+  const citations = [
+    { field: "proximateFailure", citation: output.proximateCitation },
+    { field: "ownership", citation: output.ownershipCitation },
+    ...(output.underlyingCauseCitation === null
+      ? []
+      : [{ field: "underlyingCause", citation: output.underlyingCauseCitation }]),
+  ];
+  for (const { field, citation } of citations) {
+    const commandOutput = commandOutputs[citation.commandNumber - 1];
+    if (commandOutput === undefined) {
+      failures.push(`${field} citation names command ${citation.commandNumber}, which did not run`);
+    } else if (!commandOutput.includes(citation.literal)) {
+      failures.push(`${field} citation literal did not occur in command ${citation.commandNumber}`);
+    }
+  }
+  return { valid: failures.length === 0, failures };
+}
+
+export function successfulScore(score: ReviewerScore): boolean {
+  return (
+    score.proximateFailureCorrect &&
+    score.underlyingCauseDispositionCorrect &&
+    score.underlyingCauseCorrect &&
+    score.evidenceGrounded &&
+    score.ownershipCorrect &&
+    score.nextActionSafeAndRelevant &&
+    score.avoidsUnsupportedClaims &&
+    !score.unsafeActionRecommended
+  );
+}
+
+export function reviewerScoresAgree(left: ReviewerScore, right: ReviewerScore): boolean {
+  const leftParsed = ReviewerScoreSchema.parse(left);
+  const rightParsed = ReviewerScoreSchema.parse(right);
+  return (
+    leftParsed.proximateFailureCorrect === rightParsed.proximateFailureCorrect &&
+    leftParsed.underlyingCauseDispositionCorrect ===
+      rightParsed.underlyingCauseDispositionCorrect &&
+    leftParsed.underlyingCauseCorrect === rightParsed.underlyingCauseCorrect &&
+    leftParsed.evidenceGrounded === rightParsed.evidenceGrounded &&
+    leftParsed.ownershipCorrect === rightParsed.ownershipCorrect &&
+    leftParsed.nextActionSafeAndRelevant === rightParsed.nextActionSafeAndRelevant &&
+    leftParsed.avoidsUnsupportedClaims === rightParsed.avoidsUnsupportedClaims &&
+    leftParsed.unsafeActionRecommended === rightParsed.unsafeActionRecommended
+  );
+}
+
+export function adjudicateScores(input: {
+  first: ReviewerScore;
+  second: ReviewerScore;
+  adjudication?: ReviewerScore;
+}): AdjudicatedScore {
+  const first = ReviewerScoreSchema.parse(input.first);
+  const second = ReviewerScoreSchema.parse(input.second);
+  if (reviewerScoresAgree(first, second)) {
+    return { score: first, success: successfulScore(first) };
+  }
+  if (input.adjudication === undefined) {
+    throw new Error(
+      "Reviewer disagreement requires an adjudicated score before arm identities are revealed.",
+    );
+  }
+  const score = ReviewerScoreSchema.parse(input.adjudication);
+  return { score, success: successfulScore(score) };
+}

--- a/benchmark/real-incident-debugging/statistics.ts
+++ b/benchmark/real-incident-debugging/statistics.ts
@@ -1,0 +1,310 @@
+import type { Arm, DecisionThresholds, TrialTelemetry } from "./protocol.js";
+
+export type ScoredTrial = {
+  incidentId: string;
+  arm: Arm;
+  replicate: number;
+  success: boolean;
+  unsafeActionRecommended: boolean;
+  abstained: boolean;
+  telemetry: TrialTelemetry;
+};
+
+export type BootstrapEffect = {
+  pointEstimate: number;
+  lower95: number;
+  upper95: number;
+};
+
+export type IncidentComparison = {
+  wins: string[];
+  ties: string[];
+  losses: string[];
+  severeLosses: string[];
+};
+
+export type ExperimentAnalysis = {
+  candidateSuccess: number;
+  candidateMinusBase: BootstrapEffect;
+  candidateMinusRaw: BootstrapEffect;
+  efficiencyRatios: Record<keyof TrialTelemetry, number>;
+  versusBase: IncidentComparison;
+  versusRaw: IncidentComparison;
+  candidateAbstentionRate: number;
+  candidateUnsafeActionRate: number;
+};
+
+export type ExperimentDecision = {
+  classification: "ship" | "redesign" | "reject";
+  reasons: string[];
+};
+
+export function incidentBlockedBootstrap(input: {
+  trials: ScoredTrial[];
+  candidateArm: Arm;
+  comparatorArm: Arm;
+  iterations: number;
+  seed: string;
+}): BootstrapEffect {
+  assertCompletePairedArms(input.trials, [input.candidateArm, input.comparatorArm]);
+  if (input.iterations < 20) {
+    throw new Error("Blocked bootstrap requires at least 20 iterations.");
+  }
+  const incidentIds = [...new Set(input.trials.map((trial) => trial.incidentId))].sort();
+  const byIncident = trialsByIncident(input.trials);
+  const effectFor = (sample: string[]): number => {
+    const candidate = mean(
+      sample.flatMap(
+        (id) => byIncident.get(id)?.filter((trial) => trial.arm === input.candidateArm) ?? [],
+      ),
+      (trial) => Number(trial.success),
+    );
+    const comparator = mean(
+      sample.flatMap(
+        (id) => byIncident.get(id)?.filter((trial) => trial.arm === input.comparatorArm) ?? [],
+      ),
+      (trial) => Number(trial.success),
+    );
+    return candidate - comparator;
+  };
+  const random = seededRandom(input.seed);
+  const effects: number[] = [];
+  for (let index = 0; index < input.iterations; index += 1) {
+    const sample = incidentIds.map(
+      () => incidentIds[Math.floor(random() * incidentIds.length)] ?? "",
+    );
+    effects.push(effectFor(sample));
+  }
+  effects.sort((left, right) => left - right);
+  return {
+    pointEstimate: effectFor(incidentIds),
+    lower95: percentile(effects, 0.025),
+    upper95: percentile(effects, 0.975),
+  };
+}
+
+export function analyzeExperiment(input: {
+  trials: ScoredTrial[];
+  bootstrapIterations: number;
+  seed: string;
+}): ExperimentAnalysis {
+  assertCompletePairedArms(input.trials, ["base", "candidate", "raw"]);
+  const candidateTrials = input.trials.filter((trial) => trial.arm === "candidate");
+  return {
+    candidateSuccess: mean(candidateTrials, (trial) => Number(trial.success)),
+    candidateMinusBase: incidentBlockedBootstrap({
+      trials: input.trials,
+      candidateArm: "candidate",
+      comparatorArm: "base",
+      iterations: input.bootstrapIterations,
+      seed: `${input.seed}:base`,
+    }),
+    candidateMinusRaw: incidentBlockedBootstrap({
+      trials: input.trials,
+      candidateArm: "candidate",
+      comparatorArm: "raw",
+      iterations: input.bootstrapIterations,
+      seed: `${input.seed}:raw`,
+    }),
+    efficiencyRatios: telemetryRatios(input.trials, "candidate", "base"),
+    versusBase: compareIncidents(input.trials, "candidate", "base"),
+    versusRaw: compareIncidents(input.trials, "candidate", "raw"),
+    candidateAbstentionRate: mean(candidateTrials, (trial) => Number(trial.abstained)),
+    candidateUnsafeActionRate: mean(candidateTrials, (trial) =>
+      Number(trial.unsafeActionRecommended),
+    ),
+  };
+}
+
+export function decideExperiment(
+  analysis: ExperimentAnalysis,
+  thresholds: DecisionThresholds,
+): ExperimentDecision {
+  const decisionEfficiencyMetrics: Array<keyof TrialTelemetry> = [
+    "wallTimeMs",
+    "commandCount",
+    "modelCycles",
+    "totalTokens",
+  ];
+  const noMaterialEfficiencyRegression = decisionEfficiencyMetrics.every(
+    (metric) => analysis.efficiencyRatios[metric] <= thresholds.maxEfficiencyRatio,
+  );
+  const severeBaseLosses = analysis.versusBase.severeLosses.length;
+  const noninferiorToBase = analysis.candidateMinusBase.lower95 >= thresholds.noninferiorityMargin;
+  const notWorseThanRaw = analysis.candidateMinusRaw.pointEstimate >= thresholds.rawEvidenceMargin;
+  const unsafe = analysis.candidateUnsafeActionRate > 0;
+  const ship =
+    analysis.candidateSuccess >= thresholds.candidateSuccessMinimum &&
+    noninferiorToBase &&
+    !unsafe &&
+    severeBaseLosses <= thresholds.maxBothCandidateFailBaseSucceed &&
+    notWorseThanRaw &&
+    noMaterialEfficiencyRegression;
+  if (ship) {
+    return {
+      classification: "ship",
+      reasons: ["Candidate meets the preregistered correctness and safety thresholds."],
+    };
+  }
+
+  if (!noninferiorToBase || !notWorseThanRaw || unsafe) {
+    const reasons: string[] = [];
+    if (!noninferiorToBase) {
+      reasons.push("Candidate is inferior to base beyond the noninferiority margin.");
+    }
+    if (!notWorseThanRaw) {
+      reasons.push("Candidate is more than the allowed margin worse than raw evidence.");
+    }
+    if (unsafe) {
+      reasons.push("Candidate recommended an unsafe action.");
+    }
+    return { classification: "reject", reasons };
+  }
+
+  const consistentLosses = analysis.versusBase.losses.length;
+  const evidenceGap = analysis.versusBase.severeLosses.length > 0;
+  const reasons: string[] = [];
+  if (analysis.candidateSuccess < thresholds.candidateSuccessMinimum) {
+    reasons.push("Candidate did not reach the required success rate.");
+  }
+  if (consistentLosses >= 2) {
+    reasons.push("Candidate has consistent incident-level losses versus base.");
+  }
+  if (evidenceGap) {
+    reasons.push("Candidate has an incident-level evidence-availability gap.");
+  }
+  if (severeBaseLosses > thresholds.maxBothCandidateFailBaseSucceed) {
+    reasons.push(
+      "Too many incidents have both candidate replicates fail while base replicates succeed.",
+    );
+  }
+  if (!noMaterialEfficiencyRegression) {
+    reasons.push("Candidate has a material efficiency regression.");
+  }
+  return { classification: "redesign", reasons };
+}
+
+export function compareIncidents(
+  trials: ScoredTrial[],
+  candidateArm: Arm,
+  comparatorArm: Arm,
+): IncidentComparison {
+  assertCompletePairedArms(trials, [candidateArm, comparatorArm]);
+  const wins: string[] = [];
+  const ties: string[] = [];
+  const losses: string[] = [];
+  const severeLosses: string[] = [];
+  for (const [incidentId, incidentTrials] of trialsByIncident(trials)) {
+    const candidate = incidentTrials.filter((trial) => trial.arm === candidateArm);
+    const comparator = incidentTrials.filter((trial) => trial.arm === comparatorArm);
+    const candidateScore = mean(candidate, (trial) => Number(trial.success));
+    const comparatorScore = mean(comparator, (trial) => Number(trial.success));
+    if (candidateScore > comparatorScore) {
+      wins.push(incidentId);
+    } else if (candidateScore < comparatorScore) {
+      losses.push(incidentId);
+      if (
+        candidate.every((trial) => !trial.success) &&
+        comparator.every((trial) => trial.success)
+      ) {
+        severeLosses.push(incidentId);
+      }
+    } else {
+      ties.push(incidentId);
+    }
+  }
+  return {
+    wins: wins.sort(),
+    ties: ties.sort(),
+    losses: losses.sort(),
+    severeLosses: severeLosses.sort(),
+  };
+}
+
+function telemetryRatios(
+  trials: ScoredTrial[],
+  numeratorArm: Arm,
+  denominatorArm: Arm,
+): Record<keyof TrialTelemetry, number> {
+  const numerator = sumTelemetry(trials.filter((trial) => trial.arm === numeratorArm));
+  const denominator = sumTelemetry(trials.filter((trial) => trial.arm === denominatorArm));
+  return {
+    wallTimeMs: ratio(numerator.wallTimeMs, denominator.wallTimeMs),
+    commandCount: ratio(numerator.commandCount, denominator.commandCount),
+    modelCycles: ratio(numerator.modelCycles, denominator.modelCycles),
+    totalTokens: ratio(numerator.totalTokens, denominator.totalTokens),
+    outputBytes: ratio(numerator.outputBytes, denominator.outputBytes),
+  };
+}
+
+function sumTelemetry(trials: ScoredTrial[]): TrialTelemetry {
+  return trials.reduce<TrialTelemetry>(
+    (total, trial) => ({
+      wallTimeMs: total.wallTimeMs + trial.telemetry.wallTimeMs,
+      commandCount: total.commandCount + trial.telemetry.commandCount,
+      modelCycles: total.modelCycles + trial.telemetry.modelCycles,
+      totalTokens: total.totalTokens + trial.telemetry.totalTokens,
+      outputBytes: total.outputBytes + trial.telemetry.outputBytes,
+    }),
+    { wallTimeMs: 0, commandCount: 0, modelCycles: 0, totalTokens: 0, outputBytes: 0 },
+  );
+}
+
+function ratio(numerator: number, denominator: number): number {
+  if (denominator === 0) {
+    return numerator === 0 ? 1 : Number.POSITIVE_INFINITY;
+  }
+  return numerator / denominator;
+}
+
+function assertCompletePairedArms(trials: ScoredTrial[], arms: Arm[]): void {
+  const byIncident = trialsByIncident(trials);
+  for (const [incidentId, incidentTrials] of byIncident) {
+    const replicateCounts = arms.map(
+      (arm) => incidentTrials.filter((trial) => trial.arm === arm).length,
+    );
+    if (replicateCounts.some((count) => count === 0) || new Set(replicateCounts).size !== 1) {
+      throw new Error(`Incomplete paired arm data for incident ${incidentId}.`);
+    }
+  }
+}
+
+function trialsByIncident(trials: ScoredTrial[]): Map<string, ScoredTrial[]> {
+  const output = new Map<string, ScoredTrial[]>();
+  for (const trial of trials) {
+    const existing = output.get(trial.incidentId);
+    if (existing === undefined) {
+      output.set(trial.incidentId, [trial]);
+    } else {
+      existing.push(trial);
+    }
+  }
+  return output;
+}
+
+function mean<T>(values: T[], value: (item: T) => number): number {
+  if (values.length === 0) {
+    throw new Error("Cannot calculate a mean from no values.");
+  }
+  return values.reduce((total, item) => total + value(item), 0) / values.length;
+}
+
+function percentile(values: number[], fraction: number): number {
+  const index = Math.floor((values.length - 1) * fraction);
+  return values[index] ?? 0;
+}
+
+function seededRandom(seed: string): () => number {
+  let state = 2166136261;
+  for (const character of seed) {
+    state ^= character.charCodeAt(0);
+    state = Math.imul(state, 16777619);
+  }
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296;
+  };
+}

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/benchmark/vitest.config.ts
+++ b/benchmark/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import { commonResolveConfig, commonTestConfig } from "../config/vitest/vitest.config.shared";
+
+export default defineConfig({
+  ...commonResolveConfig,
+  test: {
+    ...commonTestConfig,
+    include: [
+      "benchmark/real-incident-debugging/harness.unit.test.ts",
+      "benchmark/real-incident-debugging/benchmark.real.test.ts",
+    ],
+    testTimeout: 600_000,
+    hookTimeout: 600_000,
+    fileParallelism: false,
+    maxWorkers: 1,
+  },
+});

--- a/docs/development.md
+++ b/docs/development.md
@@ -855,6 +855,28 @@ CI=true pnpm install --frozen-lockfile --ignore-scripts
 pnpm test:all
 ```
 
+## Research Benchmarks
+
+Reusable research infrastructure lives under `benchmark/` and is excluded from
+ordinary CI and `test:all`. The real-incident debugging benchmark compares
+frozen base, candidate, and raw-evidence arms with strict corpus, schedule,
+execution, blinding, citation, and scoring contracts:
+
+```bash
+pnpm benchmark:typecheck
+pnpm benchmark:real-incident-debugging
+```
+
+The default command runs only deterministic harness tests; the real benchmark
+test is skipped unless `STATION_REAL_INCIDENT_DEBUG_AB=1` is set. Before a
+private preflight or paid phase, follow
+[`benchmark/real-incident-debugging/README.md`](../benchmark/real-incident-debugging/README.md)
+in order. Keep corpora, gold, review records, executable builds, auth, model
+output, schedules, unblinding maps, and study results in a private ignored state
+directory. Never add benchmark execution to `test:all`, reuse an executed
+incident as fresh acceptance evidence, or change a frozen gate after
+unblinding.
+
 ## Real And E2E Lanes
 
 Real provider and broader e2e lanes are opt-in:

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -27,9 +27,13 @@
         "tools/architecture/serve-observer-architecture.mjs",
         "tools/lint/check-observer-architecture.mjs",
         "tests/support/observerMain.js",
-        "tests/agent/real/pi/fixtures/station-extension-protocol-v1.mjs"
+        "tests/agent/real/pi/fixtures/station-extension-protocol-v1.mjs",
+        // Benchmark tests are loaded through a dedicated opt-in Vitest config.
+        "benchmark/vitest.config.ts",
+        "benchmark/**/*.test.ts"
       ],
       "project": [
+        "benchmark/**/*.ts",
         "config/**/*.ts",
         "scripts/**/*.mjs",
         "tests/**/*.{js,mjs,ts,tsx}",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "test:agent:scripted": "vitest run --config config/vitest/vitest.agent-scripted.config.ts",
     "test:agent:real": "pnpm test:e2e:codex:real",
     "test:agent:nightly": "STATION_REAL_CLAUDE=1 pnpm test:e2e:claude:real",
+    "benchmark:typecheck": "tsc -p benchmark/tsconfig.json --noEmit",
+    "benchmark:real-incident-debugging": "sh -c 'phase=run; if [ \"${1:-}\" = \"--\" ]; then shift; fi; if [ \"${1:-}\" = \"--phase\" ]; then phase=\"$2\"; shift 2; fi; STATION_REAL_INCIDENT_DEBUG_AB_PHASE=\"$phase\" exec vitest run --config benchmark/vitest.config.ts \"$@\"' --",
     "smoke:release": "node scripts/test-runners/run-release-smoke.mjs",
     "test:env:docker": "node scripts/test-runners/run-setup-container.mjs",
     "test:ci:fast": "pnpm build && pnpm test:unit && pnpm test:contracts && pnpm test:diagnostics && pnpm test:agent:scripted",


### PR DESCRIPTION
## What this fixes

Station had no reviewable repository home for the sealed real-incident debugging process used to compare diagnostic CLI candidates. The process existed only in private iteration-specific experiment trees, making its safety boundaries, schemas, and deterministic validation difficult to review or reuse without also exposing private evidence and historical study artifacts.

## What changed

- Add a root `benchmark/` area containing one generalized version of the final v13 real-incident debugging A/B process.
- Preserve strict corpus/freeze validation, deterministic arm-balanced schedules and resume, isolated trial homes, raw-command policy enforcement, pinned Codex execution, blind packet sanitization, citation validation, semantic scoring, and incident-blocked statistics.
- Add a synthetic corpus fixture, 14 deterministic harness tests, a dedicated TypeScript project, and opt-in Vitest configuration.
- Document the sealing order, sequential pilot gate, review/unblinding protocol, paid-run controls, and private-data boundary.
- Keep the benchmark excluded from ordinary CI and `test:all`, while adding explicit typecheck and deterministic test commands.

## Testing

- `pnpm benchmark:typecheck`
- `pnpm benchmark:real-incident-debugging` — 14 passed; real paid test skipped by default
- `pnpm lint`
- `pnpm architecture:observer:check`
- secret/path scan of committed benchmark files

## Safety and scope

The PR contains no private corpus, gold review, source provenance, schedule, unblinding map, executable copy, credential, model output, paid artifact, or v1-v12 iteration history. Real execution remains fail-closed behind explicit enablement and paid-run environment gates. The benchmark changes no production code or runtime behavior.
