### PR TITLE
refactor(test): separate real tmux acceptance configuration

### DIFF
--- a/config/vitest/vitest.integration.config.ts
+++ b/config/vitest/vitest.integration.config.ts
@@ -14,5 +14,6 @@ export default defineConfig({
       "packages/*/test/integration/**/*.test.ts",
       "integrations/*/*/test/integration/**/*.test.ts",
     ],
+    exclude: ["integrations/terminal/tmux/test/integration/popup-real.test.ts"],
   },
 });

--- a/config/vitest/vitest.tmux-popup-real.config.ts
+++ b/config/vitest/vitest.tmux-popup-real.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+
+export default defineConfig({
+  ...commonResolveConfig,
+  test: {
+    ...commonTestConfig,
+    testTimeout: 30_000,
+    include: ["integrations/terminal/tmux/test/integration/popup-real.test.ts"],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "test:e2e:real:codex-hooks": "node scripts/test-runners/run-real-e2e.mjs tests/e2e/real/real-codex-hooks.test.ts",
     "test:e2e:real:codex-hooks:keep-temp": "node scripts/test-runners/run-real-e2e.mjs --keep-temp tests/e2e/real/real-codex-hooks.test.ts",
     "test:e2e:worktrunk:real": "vitest run --config config/vitest/vitest.worktrunk-real.config.ts",
-    "test:tmux-popup:real": "vitest run --config config/vitest/vitest.integration.config.ts integrations/terminal/tmux/test/integration/popup-real.test.ts",
+    "test:tmux-popup:real": "vitest run --config config/vitest/vitest.tmux-popup-real.config.ts",
     "test:e2e:claude:real": "vitest run --config config/vitest/vitest.claude-real.config.ts",
     "test:e2e:codex:real": "vitest run --config config/vitest/vitest.codex-real.config.ts",
     "test:e2e:cursor:real": "vitest run --config config/vitest/vitest.cursor-real.config.ts",


### PR DESCRIPTION
## What this fixes

Station's ordinary integration suite and opt-in real tmux popup acceptance lane shared one Vitest configuration. That coupling would make upcoming machine-environment isolation for deterministic integration tests alter a real acceptance lane with intentionally explicit machine interactions.

## What changed

- Gave the real tmux popup acceptance test a dedicated Vitest configuration while preserving its Node environment, aliases, and timeout.
- Excluded the real popup test from ordinary integration discovery, including when `STATION_REAL_TMUX` is inherited.
- Kept the public `test:tmux-popup:real` command and explicit opt-in behavior unchanged while routing it through the real-only configuration.
- Left shared Vitest defaults and all production tmux behavior untouched.

## Testing

- `pnpm test:all`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm lint`
- Vitest discovery checks proving the integration config excludes, and the dedicated config selects, the nine real popup tests
- `pnpm test:tmux-popup:real` without the opt-in flag, confirming the dedicated lane collects and skips its nine tests

## Safety and scope

The fully opted-in real tmux lane was not executed because it requires the documented tmux, Bun, Python, dependency, and binary-build prerequisites. This change only separates test-runner composition and introduces no product-visible behavior.

Closes #391
