### PR TITLE
feat(tmux): hide Station popup status bar by default

### DIFF
--- a/apps/cli/src/commands/setup/checks/system.ts
+++ b/apps/cli/src/commands/setup/checks/system.ts
@@ -311,7 +311,8 @@ function usesManagedFastPopupDefaults(config: SetupConfigFact): boolean {
     tmux.popupScope === "server" &&
     tmux.popupWidth === defaultTmuxWorkbenchConfig.popupWidth &&
     tmux.popupHeight === defaultTmuxWorkbenchConfig.popupHeight &&
-    tmux.popupPosition === defaultTmuxWorkbenchConfig.popupPosition
+    tmux.popupPosition === defaultTmuxWorkbenchConfig.popupPosition &&
+    tmux.popupStatusBar === defaultTmuxWorkbenchConfig.popupStatusBar
   );
 }
 

--- a/apps/cli/src/commands/setup/checks/tmuxBinding.ts
+++ b/apps/cli/src/commands/setup/checks/tmuxBinding.ts
@@ -140,7 +140,10 @@ export function tmuxPopupRunShellCommand(
   }
   const command = ["env"];
   if (configPath !== undefined) {
-    command.push(`STATION_CONFIG_PATH=${quoteShellValue(escapeTmuxFormat(configPath))}`);
+    command.push(
+      `STATION_CONFIG_PATH=${quoteShellValue(escapeTmuxFormat(configPath))}`,
+      "STATION_DISABLE_FAST_POPUP=1",
+    );
   }
   command.push(
     "STATION_FOCUS_PROVIDER=tmux",

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -290,6 +290,7 @@ describe("CLI popup command", () => {
         popupHeight: "80%",
         popupPosition: "C",
         popupScope: "client",
+        popupStatusBar: true,
       },
     };
     const calls: TmuxPopupOptions[] = [];
@@ -324,6 +325,7 @@ describe("CLI popup command", () => {
           popupHeight: "80%",
           popupPosition: "C",
           popupScope: "client",
+          popupStatusBar: true,
         },
         env: {
           TMUX: "/tmp/tmux-501/default,123,0",

--- a/apps/cli/test/unit/setup-checks.test.ts
+++ b/apps/cli/test/unit/setup-checks.test.ts
@@ -330,6 +330,10 @@ describe("setup dependency checks", () => {
       label: "client popup scope",
       popup: { popupScope: "client" as const },
     },
+    {
+      label: "visible popup status bar",
+      popup: { popupStatusBar: true },
+    },
   ])("uses the config-aware popup alias for compiled bindings with $label", async ({ popup }) => {
     const root = await tempRoot(tempRoots);
     const repo = join(root, "repo");
@@ -1206,6 +1210,7 @@ scroll_on_output = "teleport"
     );
 
     expect(command).toContain("STATION_CONFIG_PATH='/tmp/station-##{session_name}/config.toml'");
+    expect(command).toContain("STATION_DISABLE_FAST_POPUP=1");
     expect(command).toContain("--config '/tmp/station-##{session_name}/config.toml'");
   });
 
@@ -1607,6 +1612,7 @@ scroll_on_output = "teleport"
       checkSetupTmuxBinding({
         homeDir,
         launcherCommand,
+        env: {},
         fs: readOnlyFs({
           [join(homeDir, ".tmux.conf")]: tmuxPopupBindingBlock(launcherCommand),
         }),
@@ -2295,6 +2301,7 @@ function configToml(
     popupHeight?: string;
     popupPosition?: string;
     popupScope?: "server" | "client";
+    popupStatusBar?: boolean;
   } = {},
 ): string {
   const lines = [
@@ -2330,7 +2337,8 @@ function configToml(
     options.popupWidth !== undefined ||
     options.popupHeight !== undefined ||
     options.popupPosition !== undefined ||
-    options.popupScope !== undefined
+    options.popupScope !== undefined ||
+    options.popupStatusBar !== undefined
   ) {
     lines.push("[terminal.tmux]");
     if (options.popupWidth !== undefined) {
@@ -2344,6 +2352,9 @@ function configToml(
     }
     if (options.popupScope !== undefined) {
       lines.push(`popup_scope = ${JSON.stringify(options.popupScope)}`);
+    }
+    if (options.popupStatusBar !== undefined) {
+      lines.push(`popup_status_bar = ${options.popupStatusBar ? "true" : "false"}`);
     }
     lines.push("");
   }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,7 @@ Worktrunk, and recreate it under the managed root.
 | `window_naming` | `project-branch` | Single-value enum. |
 | `primary_agent_pane` | bool | |
 | `popup_width` / `popup_height` / `popup_position` | string | Free-form, e.g. `"50%"`, `"C"`. |
+| `popup_status_bar` | bool | Show the persistent popup's nested tmux status bar. Defaults to `false`; this never changes the invoking tmux session's status bar. Rerun `stn setup` after changing it so an installed popup binding uses the config-aware launch path when needed. |
 | `popup_scope` | `server` \| `client` | Popup ownership scope. Defaults to `server`, preserving one popup and warm renderer per tmux server and transferring it between clients. `client` creates an independent popup and warm renderer for each tmux client. Close existing popups before changing this value, then rerun `stn setup` to refresh an installed popup binding; an open renderer retains the scope it started with until dismissed. |
 
 ### `[harness.<id>]` — agent harnesses (optional)

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,10 +34,10 @@ provider homes are checkout-local. See the copy-paste recipe in
 - Source popup registrations are scoped to the canonical checkout root that
   created them. Compiled registrations are scoped to the canonical installed
   binary directory instead; neither path may register filesystem root `/`.
-- With default popup geometry, the optional binding installed by a compiled
-  `stn setup` uses the generated direct tmux fast path. Custom geometry uses the
-  config-aware exact sibling `stn-tmux-popup` alias instead, as does setup run
-  with an explicit `--config` path. The fast path's
+- With default popup settings, the optional binding installed by a compiled
+  `stn setup` uses the generated direct tmux fast path. Custom geometry, client
+  scope, or an enabled popup status bar uses the config-aware exact sibling
+  `stn-tmux-popup` alias instead, as does setup run with an explicit `--config` path. The fast path's
   first use can enter that alias, while a valid warm use attaches, toggles, or
   transfers the existing `_station-ui` session without Bun, config loading, or
   Observer startup. Build the binary with

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -115,15 +115,15 @@ server. Reloading after a key change can leave the old key active until
 `tmux unbind-key <old-key>` or a server restart; Station does not unbind a key
 whose ownership it cannot prove.
 
-For a compiled install with default popup geometry, the generated fast command
+For a compiled install with the default popup settings, the generated fast command
 uses the canonical installed directory, the exact sibling `stn-tmux-popup`
 alias, and the resolved tmux executable. First use can invoke that full CLI
 fallback to initialize the hidden UI; a valid warm use directly attaches or
 toggles it without loading config or starting Bun or the Observer. Configured
-custom geometry and `popup_scope = "client"` use the config-aware sibling alias
-instead so every open reads its geometry and ownership scope; setup with an
-explicit `--config` path also uses that alias so an existing hidden UI cannot
-mask a config change. Rerun `stn setup` after changing either setting so the
+custom geometry, `popup_scope = "client"`, and `popup_status_bar = true` use the
+config-aware sibling alias instead so every open reads those settings; setup with
+an explicit `--config` path also uses that alias so an existing hidden UI cannot
+mask a config change. Rerun `stn setup` after changing any of these settings so the
 managed binding is regenerated. Controlled
 binding failures are silent, return success to tmux, and show at most a
 temporary status-line message. Run `stn popup` directly for ordinary diagnostic

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -36,6 +36,7 @@ primary_agent_pane = true
 popup_width = "50%"
 popup_height = "50%"
 popup_position = "C"
+popup_status_bar = false         # true restores the nested tmux status bar inside the popup
 popup_scope = "server"           # "server" moves one popup between clients; "client" isolates one per client
 
 [harness.claude]

--- a/examples/local-real-config.toml
+++ b/examples/local-real-config.toml
@@ -35,6 +35,7 @@ primary_agent_pane = true
 popup_width = "50%"
 popup_height = "50%"
 popup_position = "C"
+popup_status_bar = false         # true restores the nested tmux status bar inside the popup
 popup_scope = "server"           # "server" moves one popup between clients; "client" isolates one per client
 
 [harness.claude]

--- a/integrations/terminal/tmux/bin/stn-popup
+++ b/integrations/terminal/tmux/bin/stn-popup
@@ -167,6 +167,8 @@ fi
 "$tmux_bin" set-option -gq @station_popup_client "$client_id" || exit 1
 "$tmux_bin" set-option -gq @station_popup_focus_client "$client_id" || exit 1
 "$tmux_bin" set-option -t "$session_name" mouse on >/dev/null 2>&1 || true
+# Keep this session-scoped so the invoking tmux session retains the user's status setting.
+"$tmux_bin" set-option -t "$session_name" status off >/dev/null 2>&1 || true
 
 width=${STATION_POPUP_WIDTH:-50%}
 height=${STATION_POPUP_HEIGHT:-50%}

--- a/integrations/terminal/tmux/src/popup/fastBinding.ts
+++ b/integrations/terminal/tmux/src/popup/fastBinding.ts
@@ -275,10 +275,10 @@ run_action() {
   prefix="set-option -gq ${activePopupClaimOption} $new_claim ; set-option -gq ${activePopupClientOption} $claim_target_client ; set-option -gq ${focusPopupClientOption} $claim_target_client"
   case "$action_kind" in
     open)
-      action="$prefix ; set-option -t $session_name mouse on ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      action="$prefix ; set-option -t $session_name mouse on ; set-option -t $session_name status off ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
       ;;
     replace)
-      action="$prefix ; display-popup -c $previous_client -C ; set-option -t $session_name mouse on ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
+      action="$prefix ; display-popup -c $previous_client -C ; set-option -t $session_name mouse on ; set-option -t $session_name status off ; display-popup -c $client_name -w 50% -h 50% -E $attach_arg ; $finish"
       ;;
     close)
       action="$prefix ; display-popup -c $previous_client -C ; $finish"

--- a/integrations/terminal/tmux/src/popup/index.ts
+++ b/integrations/terminal/tmux/src/popup/index.ts
@@ -1,6 +1,7 @@
 import type { TmuxConfig } from "@station/config";
 import type { TmuxCommandInput } from "../command.js";
 import { tmuxProviderErrorFromUnknown } from "../errors.js";
+import { resolveTmuxWorkbenchConfig } from "../topology.js";
 import { buildTmuxPopupArgs } from "./args.js";
 import {
   popupCommandInput,
@@ -117,6 +118,7 @@ function persistentSessionOptions(
 ): TmuxPersistentPopupSessionOptions {
   const input: TmuxPersistentPopupSessionOptions = {
     command,
+    popupStatusBar: resolveTmuxWorkbenchConfig(options.config).popupStatusBar,
     tuiCommand: persistentUi.command,
     uiSessionName: persistentUi.sessionName,
   };

--- a/integrations/terminal/tmux/src/popup/persistentUi.ts
+++ b/integrations/terminal/tmux/src/popup/persistentUi.ts
@@ -2,6 +2,7 @@ import type { SafeError } from "@station/contracts";
 import { stationObserverBuildVersion } from "@station/runtime";
 import type { TmuxCommandInput } from "../command.js";
 import { shellQuote } from "../shell.js";
+import { defaultTmuxWorkbenchConfig } from "../topology.js";
 import { buildPersistentPopupTuiCommand } from "./args.js";
 import {
   hasTmuxSession,
@@ -249,12 +250,28 @@ async function enablePersistentPopupSessionMouse(
   });
 }
 
+async function configurePersistentPopupSessionStatusBar(
+  input: TmuxCommandInput,
+  sessionName: string,
+  visible: boolean,
+): Promise<void> {
+  // This option is session-scoped so Station never changes the invoking tmux session's status bar.
+  await runTmuxPopupCommand(input, {
+    args: ["set-option", "-t", sessionName, "status", visible ? "on" : "off"],
+    operation: "provider.tmux.popup.configureStatusBar",
+    message: "tmux failed to configure the persistent station popup UI status bar.",
+    timeoutMessage: "tmux persistent popup UI status bar setup timed out.",
+  });
+}
+
 async function configurePersistentPopupSession(
   input: TmuxCommandInput,
   sessionName: string,
   focusClientId: string | undefined,
+  popupStatusBar: boolean,
 ): Promise<void> {
   await enablePersistentPopupSessionMouse(input, sessionName);
+  await configurePersistentPopupSessionStatusBar(input, sessionName, popupStatusBar);
   if (focusClientId !== undefined) {
     await setPersistentPopupSessionOwnerClient(input, {
       clientId: focusClientId,
@@ -280,6 +297,7 @@ export async function ensurePersistentPopupSession(
   const input = persistentSessionOptions(options, command);
   const sessionName = options.uiSessionName ?? defaultPersistentPopupSessionName;
   const tuiCommand = options.tuiCommand ?? defaultPersistentPopupTuiCommand;
+  const popupStatusBar = options.popupStatusBar ?? defaultTmuxWorkbenchConfig.popupStatusBar;
   const signature = persistentPopupSignature(
     tuiCommand,
     stationObserverBuildVersion(),
@@ -288,7 +306,12 @@ export async function ensurePersistentPopupSession(
   if (await hasTmuxSession(input, sessionName)) {
     const currentSignature = await resolvePersistentPopupSessionSignature(input, sessionName);
     if (currentSignature === signature) {
-      await configurePersistentPopupSession(input, sessionName, options.focusClientId);
+      await configurePersistentPopupSession(
+        input,
+        sessionName,
+        options.focusClientId,
+        popupStatusBar,
+      );
       return { sessionName, created: false };
     }
     if (currentSignature !== undefined) {
@@ -298,7 +321,12 @@ export async function ensurePersistentPopupSession(
         // only its exact signature is reusable.
         const contenderSignature = await resolvePersistentPopupSessionSignature(input, sessionName);
         if (contenderSignature === signature) {
-          await configurePersistentPopupSession(input, sessionName, options.focusClientId);
+          await configurePersistentPopupSession(
+            input,
+            sessionName,
+            options.focusClientId,
+            popupStatusBar,
+          );
           return { sessionName, created: false };
         }
         throw persistentPopupOwnershipError(
@@ -334,7 +362,7 @@ export async function ensurePersistentPopupSession(
     sessionName,
     signature,
   });
-  await configurePersistentPopupSession(input, sessionName, options.focusClientId);
+  await configurePersistentPopupSession(input, sessionName, options.focusClientId, popupStatusBar);
   return { sessionName, created: true };
 }
 

--- a/integrations/terminal/tmux/src/popup/types.ts
+++ b/integrations/terminal/tmux/src/popup/types.ts
@@ -53,6 +53,7 @@ export type TmuxClientIdentity = {
 export type TmuxPersistentPopupSessionOptions = {
   command?: string;
   focusClientId?: string;
+  popupStatusBar?: boolean;
   runner?: ExternalCommandRunner;
   timeoutMs?: number;
   tuiCommand?: string;

--- a/integrations/terminal/tmux/src/topology.ts
+++ b/integrations/terminal/tmux/src/topology.ts
@@ -11,6 +11,7 @@ export type TmuxWorkbenchConfig = {
   popupHeight: string;
   popupPosition: string;
   popupScope: TmuxPopupScope;
+  popupStatusBar: boolean;
 };
 
 export type TmuxSessionOption = {
@@ -27,6 +28,7 @@ export const defaultTmuxWorkbenchConfig: TmuxWorkbenchConfig = {
   popupHeight: "50%",
   popupPosition: "C",
   popupScope: "server",
+  popupStatusBar: false,
 };
 
 export const defaultTmuxWorkbenchSessionOptions: readonly TmuxSessionOption[] = [
@@ -45,6 +47,7 @@ export function resolveTmuxWorkbenchConfig(config: TmuxConfig = {}): TmuxWorkben
     popupHeight: config.popupHeight ?? defaultTmuxWorkbenchConfig.popupHeight,
     popupPosition: config.popupPosition ?? defaultTmuxWorkbenchConfig.popupPosition,
     popupScope: config.popupScope ?? defaultTmuxWorkbenchConfig.popupScope,
+    popupStatusBar: config.popupStatusBar ?? defaultTmuxWorkbenchConfig.popupStatusBar,
   };
 }
 

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -46,7 +46,7 @@ const realDashboardFrameUrl = new URL(
 const outputTailBytes = 64 * 1024;
 const popupBorderColumns = 2;
 const popupBorderRows = 2;
-const nestedTmuxStatusRows = 1;
+const nestedTmuxStatusRows = 0;
 const outerTmuxStatusRows = 1;
 const ptyBridgeScript = `
 import fcntl
@@ -384,7 +384,7 @@ describeRealTmux("real tmux dev popup routing", () => {
     );
     const firstRuntime = await waitForDashboardRuntimeEvidence(fixture, firstPopup, process.pid);
     const popupAttach = await waitForPopupAttachRecord(fixture);
-    expect(popupAttach).toMatchObject({ rows: 41, columns: 120 });
+    expect(popupAttach).toMatchObject({ rows: 40, columns: 120 });
     await expectConvergedDashboardDimensions(fixture, { rows: 40, columns: 120 });
     await resizeDashboardSurface(fixture, { rows: 25, columns: 99 });
 
@@ -678,49 +678,49 @@ describeRealTmux("real tmux dev popup routing", () => {
         label: "cold issue geometry",
         outer: { columns: 169, rows: 47 },
         nested: { columns: 99, rows: 26 },
-        pane: { columns: 99, rows: 25 },
+        pane: { columns: 99, rows: 26 },
       },
       {
         label: "tiny fallback",
         outer: { columns: 70, rows: 25 },
         nested: { columns: 40, rows: 13 },
-        pane: { columns: 40, rows: 12 },
+        pane: { columns: 40, rows: 13 },
       },
       {
         label: "supported minimum",
         outer: { columns: 104, rows: 32 },
         nested: { columns: 60, rows: 17 },
-        pane: { columns: 60, rows: 16 },
+        pane: { columns: 60, rows: 17 },
       },
       {
         label: "standard terminal",
         outer: { columns: 137, rows: 45 },
         nested: { columns: 80, rows: 25 },
-        pane: { columns: 80, rows: 24 },
+        pane: { columns: 80, rows: 25 },
       },
       {
         label: "percentage round down",
         outer: { columns: 168, rows: 47 },
         nested: { columns: 98, rows: 26 },
-        pane: { columns: 98, rows: 25 },
+        pane: { columns: 98, rows: 26 },
       },
       {
         label: "above issue geometry",
         outer: { columns: 170, rows: 47 },
         nested: { columns: 100, rows: 26 },
-        pane: { columns: 100, rows: 25 },
+        pane: { columns: 100, rows: 26 },
       },
       {
         label: "large terminal",
         outer: { columns: 204, rows: 72 },
         nested: { columns: 120, rows: 41 },
-        pane: { columns: 120, rows: 40 },
+        pane: { columns: 120, rows: 41 },
       },
       {
         label: "return to issue geometry",
         outer: { columns: 169, rows: 47 },
         nested: { columns: 99, rows: 26 },
-        pane: { columns: 99, rows: 25 },
+        pane: { columns: 99, rows: 26 },
       },
     ];
 
@@ -753,7 +753,7 @@ describeRealTmux("real tmux dev popup routing", () => {
       ).toEqual(geometry.nested);
 
       const pane = await waitForPaneDimensions(fixture, geometry.pane);
-      expect(nestedClient.rows, `${geometry.label} hidden status row`).toBe(pane.rows + 1);
+      expect(nestedClient.rows, `${geometry.label} status-free popup geometry`).toBe(pane.rows);
       const content = await waitForPaneContent(
         fixture,
         popup,
@@ -3068,6 +3068,7 @@ function snapshotObserver(
       return { commandId, accepted: true, status: "accepted" };
     },
     getCommand: async (commandId) => records.get(commandId),
+    getSessionRecoveryReadiness: async () => unsupportedObserverCall("getSessionRecoveryReadiness"),
     reconcile: async (reason = "manual") => ({
       schemaVersion: STATION_SCHEMA_VERSION,
       reason,
@@ -3129,6 +3130,7 @@ function popupFocusObserver(focusCommands: StationCommand[]): ObserverApi {
       return { commandId, accepted: true, status: "accepted" };
     },
     getCommand: async (commandId) => records.get(commandId),
+    getSessionRecoveryReadiness: async () => unsupportedObserverCall("getSessionRecoveryReadiness"),
     reconcile: async (reason = "manual") => ({
       schemaVersion: STATION_SCHEMA_VERSION,
       reason,

--- a/integrations/terminal/tmux/test/integration/popup-real.test.ts
+++ b/integrations/terminal/tmux/test/integration/popup-real.test.ts
@@ -25,7 +25,11 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 import { tmuxPopupRunShellCommand } from "../../../../../apps/cli/src/commands/setup/checks/tmuxBinding.js";
 import { mockObserverSnapshot } from "../../../../../station/src/sources/fixtures/mockObserverSnapshot.js";
-import { buildManagedFastPopupRunShellCommand, openTmuxPopup } from "../../src/popup";
+import {
+  buildManagedFastPopupRunShellCommand,
+  ensurePersistentPopupSession,
+  openTmuxPopup,
+} from "../../src/popup";
 import { parsePopupActiveClaim } from "../../src/popup/fastProtocol";
 import { TmuxProvider } from "../../src/provider";
 import { shellQuote } from "../../src/shell";
@@ -350,6 +354,67 @@ describeRealTmux("real tmux dev popup routing", () => {
 
     await expect(readFile(normalMarker, "utf8")).resolves.toBe("start\n");
   }, 60_000);
+
+  it("keeps popup status session-scoped and reapplies config on warm reuse", async () => {
+    const root = await makeCheckoutTempRoot();
+    const wrapperLogPath = join(root, "tmux-wrapper.log");
+    const wrapper = await writeTmuxWrapper({
+      root,
+      tmux,
+      label: `stn-popup-status-${process.pid}-${Date.now()}`,
+      attachLogPath: join(root, "attach.log"),
+      wrapperLogPath,
+    });
+    const fixture: MarkerFixture = { root, wrapper, wrapperLogPath };
+    cleanup = () => cleanupMarkerFixture(fixture);
+
+    const baseSession = "base";
+    const popupSession = "_station-ui-status-real";
+    const marker = join(root, "popup-started.txt");
+    const tuiCommand = persistentMarkerCommand(marker);
+    const sessionStatus = async (sessionName: string): Promise<string> =>
+      tmuxExec(wrapper, ["show-options", "-t", sessionName, "-qv", "status"]).then((value) =>
+        value.trim(),
+      );
+
+    await tmuxExec(wrapper, ["new-session", "-d", "-s", baseSession, "sleep 300"]);
+    await tmuxExec(wrapper, ["set-option", "-t", baseSession, "status", "on"]);
+
+    await expect(
+      ensurePersistentPopupSession({ command: wrapper, tuiCommand, uiSessionName: popupSession }),
+    ).resolves.toEqual({ created: true, sessionName: popupSession });
+    await waitForFileText(marker, "start\n");
+    const initialPid = await panePid(wrapper, popupSession);
+    await expect(
+      Promise.all([sessionStatus(baseSession), sessionStatus(popupSession)]),
+    ).resolves.toEqual(["on", "off"]);
+
+    await expect(
+      ensurePersistentPopupSession({
+        command: wrapper,
+        popupStatusBar: true,
+        tuiCommand,
+        uiSessionName: popupSession,
+      }),
+    ).resolves.toEqual({ created: false, sessionName: popupSession });
+    expect(await panePid(wrapper, popupSession)).toBe(initialPid);
+    await expect(
+      Promise.all([sessionStatus(baseSession), sessionStatus(popupSession)]),
+    ).resolves.toEqual(["on", "on"]);
+
+    await expect(
+      ensurePersistentPopupSession({
+        command: wrapper,
+        popupStatusBar: false,
+        tuiCommand,
+        uiSessionName: popupSession,
+      }),
+    ).resolves.toEqual({ created: false, sessionName: popupSession });
+    expect(await panePid(wrapper, popupSession)).toBe(initialPid);
+    await expect(
+      Promise.all([sessionStatus(baseSession), sessionStatus(popupSession)]),
+    ).resolves.toEqual(["on", "off"]);
+  }, 30_000);
 
   it("renders an exact real dashboard and routes outer keyboard and resize without replacing the renderer", async () => {
     const fixture = await createDashboardFixture(tmux, {

--- a/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
@@ -146,6 +146,7 @@ describe("managed tmux popup fast binding", () => {
     expect(action.indexOf("set-option -gq @station_popup_active_claim v1.open.")).toBeLessThan(
       action.indexOf("display-popup -c /dev/ttys001 -C"),
     );
+    expect(action).toContain("set-option -t _station-ui status off");
     expect(action).toContain("display-popup -c /dev/ttys002 -w 50% -h 50%");
   });
 

--- a/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-fast-binding.test.ts
@@ -93,6 +93,7 @@ describe("managed tmux popup fast binding", () => {
     const action = calls[1]?.args.at(-2) ?? "";
     const claim = /active_claim (v1\.open\.[^ ;]+)/.exec(action)?.[1];
     expect(claim).toBeDefined();
+    expect(action).toContain("set-option -t _station-ui status off");
     expect(action).toContain("display-popup -c /dev/ttys001");
     expect(action).toContain(
       `if-shell -F '#{==:#{@station_popup_active_claim},${claim}}' 'set-option -gq -u @station_popup_active_claim ; if-shell -F "#{==:#{@station_popup_client},/dev/ttys001}" "set-option -gq -u @station_popup_client" ; if-shell -F "#{==:#{@station_popup_focus_client},/dev/ttys001}" "set-option -gq -u @station_popup_focus_client"'`,

--- a/integrations/terminal/tmux/test/unit/popup-launcher.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup-launcher.test.ts
@@ -34,6 +34,7 @@ describe("tmux popup launcher", () => {
       "set-option -gq @station_popup_client client_1",
       "set-option -gq @station_popup_focus_client client_1",
       "set-option -t _station-ui-dev mouse on",
+      "set-option -t _station-ui-dev status off",
       expect.stringContaining(
         `display-popup -c client_1 -w 50% -h 50% -E env -u TMUX '${fixture.tmuxPath}' -T hyperlinks attach-session -t '_station-ui-dev'`,
       ),
@@ -89,6 +90,7 @@ describe("tmux popup launcher", () => {
       "set-option -gq @station_popup_client client_1",
       "set-option -gq @station_popup_focus_client client_1",
       "set-option -t _station-ui mouse on",
+      "set-option -t _station-ui status off",
       expect.stringContaining(
         `display-popup -c client_1 -w 50% -h 50% -E env -u TMUX '${fixture.tmuxPath}' -T hyperlinks attach-session -t '_station-ui'`,
       ),

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -154,6 +154,13 @@ describe("tmux popup", () => {
       "set-option",
       "-t",
       "_station-ui-client",
+      "status",
+      "off",
+    ]);
+    expect(calls.map((call) => call.args)).toContainEqual([
+      "set-option",
+      "-t",
+      "_station-ui-client",
       "-q",
       persistentUiOwnerClientOption,
       "/dev/ttys001",
@@ -763,6 +770,31 @@ describe("tmux popup", () => {
     legacy.globalOptions.set("@station_popup_focus_client", "/dev/ttys001");
     await openTmuxPopup({ env: {}, runner: legacy.runner });
     expect(legacy.globalOptions.has("@station_popup_focus_client")).toBe(false);
+  });
+
+  it("fails before display when the persistent status bar cannot be configured", async () => {
+    const calls: ExternalCommandInput[] = [];
+
+    await expect(
+      openTmuxPopup({
+        env: {},
+        runner: async (input) => {
+          calls.push(input);
+          if (input.args?.at(-2) === "status") {
+            throw Object.assign(new Error("failed"), { code: 1, stderr: "status failed" });
+          }
+          if (input.args?.includes("@station_popup_ui_signature")) {
+            return tmuxCommandResult(input, `${defaultSignature}\n`);
+          }
+          return tmuxCommandResult(input);
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "TERMINAL_OPEN_FAILED",
+      message: "tmux failed to configure the persistent station popup UI status bar.",
+      provider: "tmux",
+    });
+    expect(calls.some((call) => call.args?.[0] === "display-popup")).toBe(false);
   });
 
   it("handles interactive duration, exit 129, and provider errors", async () => {

--- a/integrations/terminal/tmux/test/unit/popup.test.ts
+++ b/integrations/terminal/tmux/test/unit/popup.test.ts
@@ -72,6 +72,7 @@ describe("tmux popup", () => {
       ],
       ["set-option", "-t", "_station-ui", "-q", "@station_popup_ui_signature", defaultSignature],
       popupMouseCall,
+      popupStatusOffCall,
     ]);
 
     const reusedCalls: ExternalCommandInput[] = [];
@@ -90,6 +91,7 @@ describe("tmux popup", () => {
       ["has-session", "-t", "_station-ui"],
       ["show-options", "-t", "_station-ui", "-qv", "@station_popup_ui_signature"],
       popupMouseCall,
+      popupStatusOffCall,
     ]);
 
     let replacedAlive = true;
@@ -211,7 +213,12 @@ describe("tmux popup", () => {
     await expect(
       openTmuxPopup({
         checkoutRoot: fake.root,
-        config: { popupHeight: "80%", popupPosition: "C", popupWidth: "90%" },
+        config: {
+          popupHeight: "80%",
+          popupPosition: "C",
+          popupStatusBar: true,
+          popupWidth: "90%",
+        },
         env: { TMUX: "/tmp/tmux/default,1,0" },
         runner: fake.runner,
       }),
@@ -239,6 +246,13 @@ describe("tmux popup", () => {
     const display = fake.calls.findLast(claimedPopupAction);
     expect(display?.args?.[3]).toContain("display-popup -c /dev/ttys001 -w 90% -h 80% -E");
     expect(display?.args?.[3]).toContain("@station_popup_active_claim");
+    expect(fake.calls.map((call) => call.args)).toContainEqual([
+      "set-option",
+      "-t",
+      "_station-ui",
+      "status",
+      "on",
+    ]);
     expect(fake.globalOptions.get("@station_popup_active_claim")).toMatch(/^v1\.open\./);
   });
 
@@ -797,6 +811,7 @@ describe("tmux popup", () => {
 });
 
 const popupMouseCall = ["set-option", "-t", "_station-ui", "mouse", "on"];
+const popupStatusOffCall = ["set-option", "-t", "_station-ui", "status", "off"];
 
 type PopupFakeOptions = {
   activeClaim?: boolean;

--- a/integrations/terminal/tmux/test/unit/topology.test.ts
+++ b/integrations/terminal/tmux/test/unit/topology.test.ts
@@ -20,6 +20,7 @@ describe("tmux workbench topology", () => {
       popupHeight: "50%",
       popupPosition: "C",
       popupScope: "server",
+      popupStatusBar: false,
     });
   });
 

--- a/packages/config/src/load/normalize.ts
+++ b/packages/config/src/load/normalize.ts
@@ -85,6 +85,7 @@ function normalizeTmuxConfig(value: unknown): unknown {
     popup_height: "popupHeight",
     popup_position: "popupPosition",
     popup_scope: "popupScope",
+    popup_status_bar: "popupStatusBar",
   });
 }
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -144,6 +144,7 @@ export const TmuxConfigSchema = z
     popupHeight: nonEmptyStringSchema.optional(),
     popupPosition: nonEmptyStringSchema.optional(),
     popupScope: TmuxPopupScopeSchema.optional(),
+    popupStatusBar: z.boolean().optional(),
   })
   .strict();
 

--- a/packages/config/test/fixtures/valid-config.json
+++ b/packages/config/test/fixtures/valid-config.json
@@ -33,7 +33,8 @@
       "popupWidth": "50%",
       "popupHeight": "50%",
       "popupPosition": "C",
-      "popupScope": "server"
+      "popupScope": "server",
+      "popupStatusBar": false
     }
   },
   "harness": {

--- a/packages/config/test/unit/config-schema.test.ts
+++ b/packages/config/test/unit/config-schema.test.ts
@@ -191,17 +191,26 @@ describe("config schemas", () => {
     ).toBe(false);
   });
 
-  it("accepts tmux popup scopes and rejects unsupported ownership modes", async () => {
+  it("accepts tmux popup display settings and rejects unsupported values", async () => {
     const config = StationConfigSchema.parse({
       ...(await loadJson("valid-config.json")),
-      terminal: { tmux: { popupScope: "client" } },
+      terminal: { tmux: { popupScope: "client", popupStatusBar: true } },
     });
 
-    expect(config.terminal?.tmux?.popupScope).toBe("client");
+    expect(config.terminal?.tmux).toMatchObject({
+      popupScope: "client",
+      popupStatusBar: true,
+    });
     expect(
       StationConfigSchema.safeParse({
         ...config,
         terminal: { tmux: { popupScope: "window" } },
+      }).success,
+    ).toBe(false);
+    expect(
+      StationConfigSchema.safeParse({
+        ...config,
+        terminal: { tmux: { popupStatusBar: "yes" } },
       }).success,
     ).toBe(false);
   });

--- a/packages/config/test/unit/load-config.test.ts
+++ b/packages/config/test/unit/load-config.test.ts
@@ -113,15 +113,18 @@ describe("config loading", () => {
     expect(loaded.diagnostics).toEqual([]);
   });
 
-  it("normalizes the configured tmux popup scope", async () => {
+  it("normalizes the configured tmux popup settings", async () => {
     const tempDir = await makeTempDir();
     const root = await makeProjectRoot(tempDir, "web");
     const loaded = await loadConfigFromToml(
-      `${baseToml(projectToml("web", root))}\n[terminal.tmux]\npopup_scope = "client"\n`,
+      `${baseToml(projectToml("web", root))}\n[terminal.tmux]\npopup_scope = "client"\npopup_status_bar = true\n`,
       { configPath: join(tempDir, "config.toml"), homeDir: tempDir },
     );
 
-    expect(loaded.config.terminal?.tmux?.popupScope).toBe("client");
+    expect(loaded.config.terminal?.tmux).toMatchObject({
+      popupScope: "client",
+      popupStatusBar: true,
+    });
   });
 
   it("loads TOML, applies defaults, expands paths, and keeps every configured project", async () => {

--- a/scripts/station-tmux-devbox.mjs
+++ b/scripts/station-tmux-devbox.mjs
@@ -86,6 +86,8 @@ const lanePassthroughEnvironmentVariables = new Set([
   "USER",
 ]);
 const signalExitCodes = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143 };
+const observerProcessTokenPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 const psPath = process.platform === "darwin" ? "/bin/ps" : "/usr/bin/ps";
 
 const [rawCommand = "dev", ...commandArgs] = process.argv.slice(2);
@@ -777,11 +779,14 @@ function writeManifest(manifest) {
 function validateObserverIdentity(identity, socketPath) {
   const keys = Object.keys(identity).sort();
   if (
-    JSON.stringify(keys) !== JSON.stringify(["osStartTime", "pid", "socketPath", "version"]) ||
+    JSON.stringify(keys) !==
+      JSON.stringify(["osStartTime", "pid", "processToken", "socketPath", "version"]) ||
     !Number.isInteger(identity.pid) ||
     identity.pid <= 0 ||
     typeof identity.osStartTime !== "string" ||
     identity.osStartTime.length === 0 ||
+    typeof identity.processToken !== "string" ||
+    !observerProcessTokenPattern.test(identity.processToken) ||
     typeof identity.version !== "string" ||
     identity.version.length === 0 ||
     identity.socketPath !== socketPath
@@ -1060,7 +1065,8 @@ function assertObserverOwnership(manifest, identity) {
     record.startTime !== identity.osStartTime ||
     !record.command.includes("observerMain.js") ||
     !record.command.includes(`--socket ${manifest.observerSocketPath}`) ||
-    !record.command.includes(`--state-dir ${manifest.stateDir}`)
+    !record.command.includes(`--state-dir ${manifest.stateDir}`) ||
+    !record.command.includes(`--process-token ${identity.processToken}`)
   ) {
     throw new Error(`Private Observer process evidence no longer matches pid ${identity.pid}.`);
   }

--- a/scripts/station-tmux-devbox.mjs
+++ b/scripts/station-tmux-devbox.mjs
@@ -173,7 +173,8 @@ function attach() {
   }
   const result = run(manifest.tmuxWrapper, ["attach-session", "-t", manifest.baseSession], {
     cwd: manifest.projectRoot,
-    env: laneEnvironment(manifest),
+    // The isolated XDG home omits caller-specific terminfo such as Ghostty's app bundle.
+    env: laneEnvironment(manifest, { TERM: "xterm-256color" }),
     stdio: "inherit",
     check: false,
     timeoutMs: undefined,

--- a/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
@@ -620,7 +620,7 @@ async function startPtyClient(manifest) {
     ["-c", ptyBridgeScript, process.execPath, wrapperPath, "tmux", "attach"],
     {
       cwd: manifest.projectRoot,
-      env: { ...outerEnv, TERM: "xterm-256color" },
+      env: { ...outerEnv, TERM: "station-unsupported-terminal" },
       stdio: ["pipe", "pipe", "pipe"],
     },
   );

--- a/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
@@ -149,7 +149,8 @@ try {
   const manifestAfterRefusal = readManifest();
   assert(
     manifestAfterRefusal.tmuxServerPid === manifest.tmuxServerPid &&
-      manifestAfterRefusal.observerIdentity.pid === manifest.observerIdentity.pid &&
+      JSON.stringify(manifestAfterRefusal.observerIdentity) ===
+        JSON.stringify(manifest.observerIdentity) &&
       privateSessionExists(manifest, manifest.baseSession),
     "preexisting lane refusal stopped or replaced the private lane",
   );
@@ -212,12 +213,12 @@ try {
   }
 
   const source = targetBytes.toString("utf8");
-  const insertion = "        <DashboardRoot store={store} columns={width} rows={height} />";
+  const insertion = "          <DashboardRoot\n";
   assert(source.includes(insertion), `HMR insertion point missing from ${hmrTarget}`);
   const nextProbeTargetBytes = Buffer.from(
     source.replace(
       insertion,
-      `        <text position="absolute" left={0} top={2} zIndex={100}>${probe}</text>\n${insertion}`,
+      `          <text position="absolute" left={0} top={2} zIndex={100}>${probe}</text>\n${insertion}`,
     ),
     "utf8",
   );
@@ -375,6 +376,11 @@ function proveManifestAndIsolation(manifest) {
     assert(socketPath.length < 104, `Unix socket path is too long: ${socketPath}`);
   }
   assert(existsSync(manifest.observerSocketPath), "private Observer socket is absent");
+  const observerPidfile = JSON.parse(readFileSync(`${manifest.observerSocketPath}.pid`, "utf8"));
+  assert(
+    JSON.stringify(observerPidfile) === JSON.stringify(manifest.observerIdentity),
+    "manifest Observer identity does not match its strict pidfile",
+  );
   assert(existsSync(manifest.tmuxSocketPath), "private tmux socket is absent");
   assert(!existsSync(manifest.hostSocketPath), "read-only lane unexpectedly started Station Host");
   assert(!existsSync(manifest.bareTmuxLogPath), "a child invoked the failing bare tmux shim");


### PR DESCRIPTION
## What this fixes

Station's tmux popup is backed by a persistent hidden tmux session. That session inherited a tmux status bar, which consumed the popup's bottom row and exposed unrelated tmux chrome inside the Station frame. The popup should be clean by default without changing the user's invoking tmux session, while still allowing users to opt back into the status bar.

The isolated tmux devbox used to verify this behavior also rejected the Observer's current strict process identity after launch tokens were added, and its intentionally private XDG environment could not resolve caller-specific terminal definitions such as Ghostty's app-bundled terminfo.

## What changed

- Added optional `[terminal.tmux].popup_status_bar`; omission defaults to `false`, while `true` restores the nested popup status bar.
- Applied the setting only to Station's signed persistent popup session on creation and warm reuse, leaving the invoking tmux session untouched.
- Updated source and compiled fast popup paths to enforce the hidden default; an enabled status bar uses the config-aware binding path so warm opens keep honoring config.
- Updated config documentation, examples, unit/integration coverage, and real-popup geometry expectations for the reclaimed row.
- Added regression coverage for cross-client fast replacement, client-scoped renderers, status-configuration failure, and real tmux warm-session reuse.
- Updated the private tmux devbox to validate and preserve the Observer process token as part of signal authority.
- Made private devbox attachment use the system-supported `xterm-256color` baseline rather than depending on terminfo paths deliberately excluded from the isolated environment, and refreshed its HMR smoke probe for the current dashboard composition.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- 216 focused unit tests across config, setup, and tmux popup behavior
- 16 focused CLI popup integration tests
- `pnpm station:devbox:tmux:smoke`, including attachment from an intentionally unsupported caller `TERM`
- Private devbox `start` → `status` → `stop` lifecycle
- Focused private-tmux regression passed: default `off` → opt-in `on` → explicit `off` on the same warm renderer PID, while the invoking session remained `on`
- The broader real-tmux dashboard lane remains non-green locally in unrelated dashboard content/focus and compiled Observer fixture paths. The status-specific real-tmux case and private devbox smoke pass independently, and retained fixture processes, private servers, and directories were cleaned.

## Safety and scope

The tmux mutation is session-scoped (`set-option -t <Station popup session>`). This change does not alter the parent session, Observer contracts, provider state, or native/fullscreen Station behavior. Devbox identity and terminal normalization remain confined to its disposable `/tmp/stn-dbx-*` runtime.


## Related issues

- Fixes #411.
- Partially addresses #203 by providing a safe baseline fallback; follow-up PR #414 preserves usable caller terminals conditionally.
- Organized under local tmux development-lane parent #410. The separate real-state lane in #218 is unchanged by this PR.


