### PR TITLE
test(vitest): isolate unit and integration machine state

### DIFF
--- a/apps/cli/test/unit/observerProviders.test.ts
+++ b/apps/cli/test/unit/observerProviders.test.ts
@@ -16,7 +16,8 @@ import { createOpenCodeHarnessProvider, openCodeHookAdapter } from "@station/ope
 import { createPiHarnessProvider } from "@station/pi";
 import { ScriptedAgentHarnessProvider } from "@station/scripted-harness";
 import { createStationHostController } from "@station/terminal";
-import { describe, expect, it, vi } from "vitest";
+import { assertPathInsideTestMachineRoot } from "@station/testing";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createProviderRegistry, probeHarnessHooksStatus } from "../../src/observerProviders";
 
 vi.mock("@station/claude", async (importOriginal) => {
@@ -68,24 +69,21 @@ vi.mock("@station/pi", async (importOriginal) => {
 });
 
 const now = "2026-05-21T12:00:00.000Z";
+const usesSharedTestMachine = process.env.STATION_TEST_MACHINE_ROOT !== undefined;
+
+if (!usesSharedTestMachine) {
+  // Focused test runners can execute this file without loading the suite-level setup.
+  afterEach(() => vi.unstubAllEnvs());
+}
 
 describe("observer providers", () => {
   it("supplies a finalized source host command from CLI composition", () => {
-    const previousBun = process.env.STATION_BUN;
-    const previousEntry = process.env.STATION_HOST_ENTRY;
-    process.env.STATION_BUN = "/opt/station/bun";
-    process.env.STATION_HOST_ENTRY = "/opt/station/hostMain.ts";
-    try {
-      createProviderRegistry({
-        ...config,
-        featureFlags: { stationPersistentAgents: true },
-      });
-    } finally {
-      if (previousBun === undefined) delete process.env.STATION_BUN;
-      else process.env.STATION_BUN = previousBun;
-      if (previousEntry === undefined) delete process.env.STATION_HOST_ENTRY;
-      else process.env.STATION_HOST_ENTRY = previousEntry;
-    }
+    vi.stubEnv("STATION_BUN", "/opt/station/bun");
+    vi.stubEnv("STATION_HOST_ENTRY", "/opt/station/hostMain.ts");
+    createProviderRegistry({
+      ...config,
+      featureFlags: { stationPersistentAgents: true },
+    });
 
     expect(vi.mocked(createStationHostController)).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -665,42 +663,36 @@ describe("observer providers", () => {
       "utf8",
     );
 
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = root;
-    try {
-      await installCursorHooks({
-        hookBin: ingressLauncher,
-        stationConfigPath: configPath,
-        observerSocketPath,
-        stateDir,
-        hookSpoolDir,
-        autoStartFromHooks: false,
-      });
+    stubCursorTestHome(root);
+    await installCursorHooks({
+      hookBin: ingressLauncher,
+      stationConfigPath: configPath,
+      observerSocketPath,
+      stateDir,
+      hookSpoolDir,
+      autoStartFromHooks: false,
+    });
 
-      await expect(
-        probeHarnessHooksStatus("cursor", configPath, { ingressLauncher }),
-      ).resolves.toMatchObject({
-        provider: "cursor",
-        requested: true,
-        installed: true,
-      });
-      const loaded = await loadConfig(configPath);
-      const provider = createProviderRegistry(loaded.config, {
-        configPath: loaded.configPath,
-        providerHookIngressLauncher: ingressLauncher,
-      }).harnesses.get("cursor");
-      await expect(
-        provider?.hooksStatus?.({ stationConfigPath: loaded.configPath }),
-      ).resolves.toMatchObject({
-        provider: "cursor",
-        requested: true,
-        installed: true,
-      });
-      await expect(probeHarnessHooksStatus("pi", configPath)).resolves.toBeUndefined();
-    } finally {
-      if (previousCursorHome === undefined) delete process.env.STATION_CURSOR_HOME;
-      else process.env.STATION_CURSOR_HOME = previousCursorHome;
-    }
+    await expect(
+      probeHarnessHooksStatus("cursor", configPath, { ingressLauncher }),
+    ).resolves.toMatchObject({
+      provider: "cursor",
+      requested: true,
+      installed: true,
+    });
+    const loaded = await loadConfig(configPath);
+    const provider = createProviderRegistry(loaded.config, {
+      configPath: loaded.configPath,
+      providerHookIngressLauncher: ingressLauncher,
+    }).harnesses.get("cursor");
+    await expect(
+      provider?.hooksStatus?.({ stationConfigPath: loaded.configPath }),
+    ).resolves.toMatchObject({
+      provider: "cursor",
+      requested: true,
+      installed: true,
+    });
+    await expect(probeHarnessHooksStatus("pi", configPath)).resolves.toBeUndefined();
   });
 
   it("normalizes setup hook probe failures", async () => {
@@ -773,6 +765,7 @@ describe("observer providers", () => {
     const hookScriptPath = join(stateDir, "hooks", "station-cursor-hook.sh");
     const configPath = join(root, "station.config.toml");
 
+    stubCursorTestHome(root);
     await installCursorHooks({
       hookScriptPath,
       stationConfigPath: configPath,
@@ -783,44 +776,34 @@ describe("observer providers", () => {
       homeDir: root,
     });
 
-    const previousHome = process.env.HOME;
-    process.env.HOME = root;
-    try {
-      const registry = createProviderRegistry(
-        {
-          ...config,
-          observer: {
-            stateDir,
-            socketPath: observerSocketPath,
-            autoStartFromHooks: false,
-          },
-          defaults: {
-            ...config.defaults,
-            harness: "cursor",
-          },
-          harness: {
-            cursor: {
-              installHooks: true,
-            },
+    const registry = createProviderRegistry(
+      {
+        ...config,
+        observer: {
+          stateDir,
+          socketPath: observerSocketPath,
+          autoStartFromHooks: false,
+        },
+        defaults: {
+          ...config.defaults,
+          harness: "cursor",
+        },
+        harness: {
+          cursor: {
+            installHooks: true,
           },
         },
-        { configPath },
-      );
-      const provider = registry.harnesses.get("cursor");
+      },
+      { configPath },
+    );
+    const provider = registry.harnesses.get("cursor");
 
-      await expect(provider?.doctorChecks?.()).resolves.toContainEqual(
-        expect.objectContaining({
-          name: "cursor-hooks",
-          status: "ok",
-        }),
-      );
-    } finally {
-      if (previousHome === undefined) {
-        delete process.env.HOME;
-      } else {
-        process.env.HOME = previousHome;
-      }
-    }
+    await expect(provider?.doctorChecks?.()).resolves.toContainEqual(
+      expect.objectContaining({
+        name: "cursor-hooks",
+        status: "ok",
+      }),
+    );
   });
 
   it("passes Codex config defaults into the Codex harness provider", async () => {
@@ -1210,6 +1193,13 @@ const config: StationConfig = {
     },
   ],
 };
+
+function stubCursorTestHome(root: string): void {
+  if (!usesSharedTestMachine) vi.stubEnv("STATION_TEST_MACHINE_ROOT", root);
+  assertPathInsideTestMachineRoot(root, "Cursor test home");
+  vi.stubEnv("STATION_CURSOR_HOME", root);
+  vi.stubEnv("STATION_CURSOR_HOOKS_PATH", "");
+}
 
 function launchRequest(harness: string): Parameters<contracts.HarnessProvider["buildLaunch"]>[0] {
   const project = firstProject();

--- a/apps/cli/test/unit/setup-harness-install.test.ts
+++ b/apps/cli/test/unit/setup-harness-install.test.ts
@@ -61,6 +61,7 @@ describe("guided agent installers", () => {
     const result = await applySetupPlan(testPlan(actions), {
       env: {
         HOME: homeDir,
+        CODEX_HOME: join(homeDir, ".codex"),
         PATH: `${binDir}:/usr/bin:/bin`,
         FAKE_INSTALLER_DIR: fixtureDir,
         FAKE_RESULTS: resultDir,

--- a/config/vitest/test-machine-sandbox.setup.ts
+++ b/config/vitest/test-machine-sandbox.setup.ts
@@ -1,0 +1,199 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { afterAll, afterEach } from "vitest";
+import { gitLocalEnvironmentVariables } from "../../packages/runtime/src/gitEnvironment.js";
+
+const stationEnvironmentVariables = [
+  "STATION_CONFIG_PATH",
+  "STATION_OBSERVER_SOCKET_PATH",
+  "STATION_HOST_SOCKET_PATH",
+  "STATION_LAYOUT_PATH",
+  "STATION_CURSOR_HOOKS_PATH",
+  "STATION_WORKTRUNK_BIN",
+  "STATION_TMUX_BIN",
+  "STATION_GH_BIN",
+  "STATION_CLAUDE_BIN",
+  "STATION_CODEX_BIN",
+  "STATION_CURSOR_AGENT_BIN",
+  "STATION_OPENCODE_BIN",
+  "STATION_PI_BIN",
+  "STATION_SOURCE",
+  "STATION_SCENARIO",
+  "STATION_PTY_IMPL",
+  "STATION_NODE",
+  "STATION_BUN",
+  "STATION_HOST_ENTRY",
+  "STATION_INGRESS_BIN",
+  "STATION_DASHBOARD_COMMAND",
+  "STATION_TUI_COMMAND",
+  "STATION_TUI_SESSION_NAME",
+  "STATION_SHELL_AUTOCLOSE",
+  "STATION_PROFILE",
+  "STATION_PROJECT_ID",
+  "STATION_WORKTREE_ID",
+  "STATION_WORKTREE_PATH",
+  "STATION_WORKTREE_MANAGED_ROOT",
+  "STATION_SESSION_ID",
+  "STATION_HARNESS_PROVIDER",
+  "STATION_TERMINAL_PROVIDER",
+  "STATION_TERMINAL_TARGET_ID",
+  "STATION_OBSERVER_STATE_DIR",
+  "STATION_STATE_DIR",
+  "STATION_HOOK_SPOOL_DIR",
+  "STATION_CLIENT_BUILD_VERSION",
+  "STATION_OBSERVER_BUILD_VERSION",
+  "STATION_PANE",
+  "STATION_OUTER_TMUX",
+  "STATION_OUTER_TMUX_PANE",
+  "STATION_TUI_POPUP",
+  "STATION_TUI_PERSISTENT",
+  "STATION_FOCUS_PROVIDER",
+  "STATION_FOCUS_CLIENT_ID",
+] as const;
+
+const credentialEnvironmentVariables = [
+  "GIT_ASKPASS",
+  "GIT_SSH",
+  "GIT_SSH_COMMAND",
+  "SSH_ASKPASS",
+  "SSH_ASKPASS_REQUIRE",
+  "SSH_AUTH_SOCK",
+  "SSH_AGENT_PID",
+  "GIT_AUTHOR_NAME",
+  "GIT_AUTHOR_EMAIL",
+  "GIT_AUTHOR_DATE",
+  "GIT_COMMITTER_NAME",
+  "GIT_COMMITTER_EMAIL",
+  "GIT_COMMITTER_DATE",
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "GH_ENTERPRISE_TOKEN",
+  "GITHUB_ENTERPRISE_TOKEN",
+] as const;
+
+const workerEnvironment = process.env;
+const originalEnvironment = { ...workerEnvironment };
+const originalTemporaryDirectory = tmpdir();
+const keepRoot = originalEnvironment.STATION_TEST_MACHINE_KEEP_ROOT === "1";
+let machineRoot = "";
+let temporaryDirectoryAlias: string | undefined;
+let exitCleanupPending = false;
+
+function removeMachineRootOnExit(): void {
+  if (!exitCleanupPending) return;
+  if (temporaryDirectoryAlias !== undefined) {
+    rmSync(temporaryDirectoryAlias, { force: true });
+  }
+  if (!keepRoot && machineRoot.length > 0) {
+    rmSync(machineRoot, { recursive: true, force: true });
+  }
+}
+
+machineRoot = mkdtempSync(join(originalTemporaryDirectory, "s-"));
+exitCleanupPending = true;
+// This fallback covers failures before Vitest teardown; SIGKILL still cannot run process cleanup.
+process.once("exit", removeMachineRootOnExit);
+
+const home = join(machineRoot, "home");
+const temporaryDirectory = join(machineRoot, "tmp");
+const xdgConfig = join(machineRoot, "xdg", "config");
+const xdgData = join(machineRoot, "xdg", "data");
+const xdgCache = join(machineRoot, "xdg", "cache");
+const xdgState = join(machineRoot, "xdg", "state");
+const xdgRuntime = join(machineRoot, "xdg", "runtime");
+const claudeHome = join(machineRoot, "harness", "claude");
+const codexHome = join(machineRoot, "harness", "codex");
+const cursorHome = join(machineRoot, "harness", "cursor");
+const openCodeHome = join(machineRoot, "harness", "opencode");
+const gitConfig = join(machineRoot, "git", "global.gitconfig");
+
+for (const directory of [
+  home,
+  temporaryDirectory,
+  xdgConfig,
+  xdgData,
+  xdgCache,
+  xdgState,
+  xdgRuntime,
+  claudeHome,
+  codexHome,
+  cursorHome,
+  openCodeHome,
+  join(machineRoot, "git"),
+]) {
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+}
+writeFileSync(gitConfig, "", { mode: 0o600 });
+
+let redirectedTemporaryDirectory = temporaryDirectory;
+// A short symlink keeps nested Unix socket fixtures below macOS's 104-byte path limit.
+if (process.platform !== "win32" && temporaryDirectory.length >= 40) {
+  temporaryDirectoryAlias = join("/tmp", `st-${process.pid}-${basename(machineRoot)}`);
+  symlinkSync(temporaryDirectory, temporaryDirectoryAlias, "dir");
+  redirectedTemporaryDirectory = temporaryDirectoryAlias;
+}
+
+const sandboxEnvironment: NodeJS.ProcessEnv = {
+  ...originalEnvironment,
+  HOME: home,
+  TMPDIR: redirectedTemporaryDirectory,
+  TMP: redirectedTemporaryDirectory,
+  TEMP: redirectedTemporaryDirectory,
+  XDG_CONFIG_HOME: xdgConfig,
+  XDG_DATA_HOME: xdgData,
+  XDG_CACHE_HOME: xdgCache,
+  XDG_STATE_HOME: xdgState,
+  XDG_RUNTIME_DIR: xdgRuntime,
+  CODEX_HOME: codexHome,
+  CLAUDE_CONFIG_DIR: claudeHome,
+  STATION_CURSOR_HOME: cursorHome,
+  OPENCODE_CONFIG_DIR: openCodeHome,
+  GH_CONFIG_DIR: join(xdgConfig, "gh"),
+  GIT_CONFIG_GLOBAL: gitConfig,
+  ZDOTDIR: home,
+  HISTFILE: join(home, ".shell_history"),
+  GIT_CONFIG_NOSYSTEM: "1",
+  GIT_TERMINAL_PROMPT: "0",
+  GH_PROMPT_DISABLED: "1",
+  STATION_TEST_MACHINE_ROOT: machineRoot,
+};
+
+for (const key of [
+  ...stationEnvironmentVariables,
+  ...gitLocalEnvironmentVariables,
+  ...credentialEnvironmentVariables,
+  "TMUX",
+  "TMUX_PANE",
+]) {
+  delete sandboxEnvironment[key];
+}
+restoreEnvironment(sandboxEnvironment);
+
+function restoreEnvironment(environment: NodeJS.ProcessEnv): void {
+  if (process.env !== workerEnvironment) process.env = workerEnvironment;
+  for (const key of Object.keys(workerEnvironment)) {
+    if (!(key in environment)) delete workerEnvironment[key];
+  }
+  for (const [key, value] of Object.entries(environment)) {
+    if (value !== undefined) workerEnvironment[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnvironment(sandboxEnvironment);
+});
+
+afterAll(() => {
+  restoreEnvironment(originalEnvironment);
+  if (temporaryDirectoryAlias !== undefined) {
+    rmSync(temporaryDirectoryAlias, { force: true });
+  }
+  if (keepRoot) {
+    process.stderr.write(`[station test machine] retained root: ${machineRoot}\n`);
+  } else {
+    rmSync(machineRoot, { recursive: true, force: true });
+  }
+  exitCleanupPending = false;
+  process.off("exit", removeMachineRootOnExit);
+});

--- a/config/vitest/vitest.config.shared.ts
+++ b/config/vitest/vitest.config.shared.ts
@@ -1,6 +1,9 @@
 import { fileURLToPath } from "node:url";
 
 const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const testMachineSetupPath = fileURLToPath(
+  new URL("./test-machine-sandbox.setup.ts", import.meta.url),
+);
 const dashboardCoreSourceDir = fileURLToPath(
   new URL("../../packages/dashboard-core/src", import.meta.url),
 );
@@ -95,4 +98,15 @@ export const commonTestConfig = {
   environment: "node",
   globals: false,
   passWithNoTests: false,
+} as const;
+
+export const machineIsolatedTestConfig = {
+  ...commonTestConfig,
+  isolate: true,
+  setupFiles: [testMachineSetupPath] as string[],
+  unstubEnvs: true,
+  sequence: {
+    hooks: "stack",
+    setupFiles: "list",
+  },
 } as const;

--- a/config/vitest/vitest.integration.config.ts
+++ b/config/vitest/vitest.integration.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vitest/config";
-import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+import { commonResolveConfig, machineIsolatedTestConfig } from "./vitest.config.shared";
 
 export default defineConfig({
   ...commonResolveConfig,
   test: {
-    ...commonTestConfig,
+    ...machineIsolatedTestConfig,
     testTimeout: 30_000,
     include: [
       "apps/*/src/**/*.integration.test.ts",

--- a/config/vitest/vitest.unit.config.ts
+++ b/config/vitest/vitest.unit.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vitest/config";
-import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+import { commonResolveConfig, machineIsolatedTestConfig } from "./vitest.config.shared";
 
 export default defineConfig({
   ...commonResolveConfig,
   test: {
-    ...commonTestConfig,
+    ...machineIsolatedTestConfig,
     include: [
       "apps/*/src/**/*.test.ts",
       "apps/*/src/**/*.test.tsx",

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,6 +121,24 @@ intermediate repaint.
 
 ## Deterministic Gates
 
+### Unit and integration test machines
+
+The ordinary `vitest.unit.config.ts` and `vitest.integration.config.ts` lanes create a private
+machine root for each test file. They redirect the home, temporary, XDG, harness, Git, GitHub CLI,
+and shell-history paths; clear Station runtime/correlation overrides plus inherited Git, SSH, and
+GitHub credentials; and pass the sandbox paths to child processes. The root is removed after the
+file, including ordinary test failures.
+
+Use `vi.stubEnv` for test-local environment changes and let the shared setup restore the complete
+per-file baseline. Environment-mutating tests must not use `it.concurrent` or otherwise overlap in
+the same file because `process.env` is process-global. Set `STATION_TEST_MACHINE_KEEP_ROOT=1` for a
+focused run to retain the root and print its location, inspect it, and remove it manually afterward.
+
+Contracts, diagnostics, scripted-agent, setup E2E, Observer E2E, real-provider, and real tmux popup
+configs do not use this boundary. The isolation prevents accidental inheritance and environment
+leakage; it does not contain explicit absolute paths, signals, file descriptors, network access, or
+subprocesses that deliberately escape the redirected environment.
+
 Git-backed fixtures and child processes must clear Git's repository-local environment variables;
 `cwd` and `git -C` do not isolate a command when variables such as `GIT_DIR` or `GIT_WORK_TREE`
 are inherited. Lefthook commands run through `scripts/run-without-git-locals.mjs`, which removes

--- a/integrations/harness/cursor/test/unit/provider.test.ts
+++ b/integrations/harness/cursor/test/unit/provider.test.ts
@@ -8,11 +8,18 @@ import type {
   RawHarnessEvent,
 } from "@station/contracts";
 import type { ExternalCommandInput, ExternalCommandResult } from "@station/runtime";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { assertPathInsideTestMachineRoot } from "../../../../../packages/testing/src/index.js";
 import { installCursorHooks } from "../../src/hooks";
 import { createCursorHarnessProvider } from "../../src/provider";
 
 const now = "2026-06-03T12:00:00.000Z";
+const usesSharedTestMachine = process.env.STATION_TEST_MACHINE_ROOT !== undefined;
+
+if (!usesSharedTestMachine) {
+  // Focused test runners can execute this file without loading the suite-level setup.
+  afterEach(() => vi.unstubAllEnvs());
+}
 
 describe("CursorHarnessProvider", () => {
   it("declares hook-only Cursor capabilities", () => {
@@ -63,26 +70,21 @@ describe("CursorHarnessProvider", () => {
 
   it("reports unrequested and missing hook preparation", async () => {
     const root = await mkdtemp(join(tmpdir(), "station-cursor-provider-missing-"));
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = root;
-    try {
-      await expect(createCursorHarnessProvider().hooksStatus?.()).resolves.toMatchObject({
-        provider: "cursor",
-        requested: false,
-        installed: false,
-      });
-      await expect(
-        createCursorHarnessProvider({ installHooks: true }).hooksStatus?.(),
-      ).resolves.toMatchObject({
-        provider: "cursor",
-        requested: true,
-        installed: false,
-        message: expect.stringContaining("missing or stale"),
-      });
-    } finally {
-      if (previousCursorHome === undefined) delete process.env.STATION_CURSOR_HOME;
-      else process.env.STATION_CURSOR_HOME = previousCursorHome;
-    }
+    stubCursorTestHome(root);
+
+    await expect(createCursorHarnessProvider().hooksStatus?.()).resolves.toMatchObject({
+      provider: "cursor",
+      requested: false,
+      installed: false,
+    });
+    await expect(
+      createCursorHarnessProvider({ installHooks: true }).hooksStatus?.(),
+    ).resolves.toMatchObject({
+      provider: "cursor",
+      requested: true,
+      installed: false,
+      message: expect.stringContaining("missing or stale"),
+    });
   });
 
   it("uses observer hook paths when checking installed hook diagnostics", async () => {
@@ -93,6 +95,7 @@ describe("CursorHarnessProvider", () => {
     const stateDir = join(root, "state");
     const hookSpoolDir = join(stateDir, "spool", "hooks");
 
+    stubCursorTestHome(root);
     await installCursorHooks({
       hookScriptPath,
       stationConfigPath,
@@ -103,46 +106,36 @@ describe("CursorHarnessProvider", () => {
       homeDir: root,
     });
 
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = root;
-    try {
-      const provider = createCursorHarnessProvider({
-        installHooks: true,
-        configPath: stationConfigPath,
-        observerSocketPath,
-        stateDir,
-        hookSpoolDir,
-        autoStartFromHooks: false,
-      });
+    const provider = createCursorHarnessProvider({
+      installHooks: true,
+      configPath: stationConfigPath,
+      observerSocketPath,
+      stateDir,
+      hookSpoolDir,
+      autoStartFromHooks: false,
+    });
 
-      const doctorChecks = provider.doctorChecks;
-      if (doctorChecks === undefined) throw new Error("Cursor doctor checks are unavailable.");
-      await expect(doctorChecks()).resolves.toContainEqual(
-        expect.objectContaining({
-          name: "cursor-hooks",
-          status: "ok",
-        }),
-      );
-      await expect(provider.hooksStatus?.()).resolves.toMatchObject({
-        provider: "cursor",
-        requested: true,
-        installed: true,
-      });
+    const doctorChecks = provider.doctorChecks;
+    if (doctorChecks === undefined) throw new Error("Cursor doctor checks are unavailable.");
+    await expect(doctorChecks()).resolves.toContainEqual(
+      expect.objectContaining({
+        name: "cursor-hooks",
+        status: "ok",
+      }),
+    );
+    await expect(provider.hooksStatus?.()).resolves.toMatchObject({
+      provider: "cursor",
+      requested: true,
+      installed: true,
+    });
 
-      await writeFile(hookScriptPath, "# drifted\n", "utf8");
-      await expect(provider.hooksStatus?.()).resolves.toMatchObject({
-        provider: "cursor",
-        requested: true,
-        installed: false,
-        message: expect.stringContaining("missing or stale"),
-      });
-    } finally {
-      if (previousCursorHome === undefined) {
-        delete process.env.STATION_CURSOR_HOME;
-      } else {
-        process.env.STATION_CURSOR_HOME = previousCursorHome;
-      }
-    }
+    await writeFile(hookScriptPath, "# drifted\n", "utf8");
+    await expect(provider.hooksStatus?.()).resolves.toMatchObject({
+      provider: "cursor",
+      requested: true,
+      installed: false,
+      message: expect.stringContaining("missing or stale"),
+    });
   });
 
   it("does not re-add the incumbent config when the requester omits it", async () => {
@@ -156,35 +149,26 @@ describe("CursorHarnessProvider", () => {
       hookSpoolDir: join(requesterStateDir, "spool", "hooks"),
       autoStartFromHooks: false,
     };
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = root;
-    try {
-      await installCursorHooks({
-        hookBin: providerHookRuntime.ingressLauncher,
-        observerSocketPath: providerHookRuntime.observerSocketPath,
-        stateDir: providerHookRuntime.stateDir,
-        hookSpoolDir: providerHookRuntime.hookSpoolDir,
-        autoStartFromHooks: providerHookRuntime.autoStartFromHooks,
-      });
-      const provider = createCursorHarnessProvider({
-        installHooks: true,
-        configPath: join(root, "checkout-A", "config.toml"),
-        observerSocketPath: providerHookRuntime.observerSocketPath,
-        stateDir: incumbentStateDir,
-        hookSpoolDir: join(incumbentStateDir, "spool", "hooks"),
-        autoStartFromHooks: true,
-      });
+    stubCursorTestHome(root);
+    await installCursorHooks({
+      hookBin: providerHookRuntime.ingressLauncher,
+      observerSocketPath: providerHookRuntime.observerSocketPath,
+      stateDir: providerHookRuntime.stateDir,
+      hookSpoolDir: providerHookRuntime.hookSpoolDir,
+      autoStartFromHooks: providerHookRuntime.autoStartFromHooks,
+    });
+    const provider = createCursorHarnessProvider({
+      installHooks: true,
+      configPath: join(root, "checkout-A", "config.toml"),
+      observerSocketPath: providerHookRuntime.observerSocketPath,
+      stateDir: incumbentStateDir,
+      hookSpoolDir: join(incumbentStateDir, "spool", "hooks"),
+      autoStartFromHooks: true,
+    });
 
-      await expect(provider.doctorChecks?.({ providerHookRuntime })).resolves.toContainEqual(
-        expect.objectContaining({ name: "cursor-hooks", status: "ok" }),
-      );
-    } finally {
-      if (previousCursorHome === undefined) {
-        delete process.env.STATION_CURSOR_HOME;
-      } else {
-        process.env.STATION_CURSOR_HOME = previousCursorHome;
-      }
-    }
+    await expect(provider.doctorChecks?.({ providerHookRuntime })).resolves.toContainEqual(
+      expect.objectContaining({ name: "cursor-hooks", status: "ok" }),
+    );
   });
 
   it("routes shared-home hooks through the launching runtime", async () => {
@@ -201,36 +185,30 @@ describe("CursorHarnessProvider", () => {
       stateDir: join(root, "runtime-b", "state"),
       hookSpoolDir: join(root, "runtime-b", "state", "spool", "hooks"),
     };
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = root;
-    try {
-      await installCursorHooks({
-        homeDir: root,
-        stationConfigPath: runtimeA.configPath,
-        observerSocketPath: runtimeA.observerSocketPath,
-        stateDir: runtimeA.stateDir,
-        hookSpoolDir: runtimeA.hookSpoolDir,
-        autoStartFromHooks: false,
-      });
-      const providerB = createCursorHarnessProvider({
-        installHooks: true,
-        ...runtimeB,
-        autoStartFromHooks: false,
-      });
+    stubCursorTestHome(root);
+    await installCursorHooks({
+      homeDir: root,
+      stationConfigPath: runtimeA.configPath,
+      observerSocketPath: runtimeA.observerSocketPath,
+      stateDir: runtimeA.stateDir,
+      hookSpoolDir: runtimeA.hookSpoolDir,
+      autoStartFromHooks: false,
+    });
+    const providerB = createCursorHarnessProvider({
+      installHooks: true,
+      ...runtimeB,
+      autoStartFromHooks: false,
+    });
 
-      await expect(providerB.hooksStatus?.()).resolves.toMatchObject({ installed: true });
-      await expect(providerB.buildLaunch(request())).resolves.toMatchObject({
-        env: {
-          STATION_CONFIG_PATH: runtimeB.configPath,
-          STATION_OBSERVER_SOCKET_PATH: runtimeB.observerSocketPath,
-          STATION_OBSERVER_STATE_DIR: runtimeB.stateDir,
-          STATION_HOOK_SPOOL_DIR: runtimeB.hookSpoolDir,
-        },
-      });
-    } finally {
-      if (previousCursorHome === undefined) delete process.env.STATION_CURSOR_HOME;
-      else process.env.STATION_CURSOR_HOME = previousCursorHome;
-    }
+    await expect(providerB.hooksStatus?.()).resolves.toMatchObject({ installed: true });
+    await expect(providerB.buildLaunch(request())).resolves.toMatchObject({
+      env: {
+        STATION_CONFIG_PATH: runtimeB.configPath,
+        STATION_OBSERVER_SOCKET_PATH: runtimeB.observerSocketPath,
+        STATION_OBSERVER_STATE_DIR: runtimeB.stateDir,
+        STATION_HOOK_SPOOL_DIR: runtimeB.hookSpoolDir,
+      },
+    });
   });
 
   it("launches interactive Cursor agent with STATION correlation env", async () => {
@@ -261,24 +239,16 @@ describe("CursorHarnessProvider", () => {
   });
 
   it("launches Cursor with the isolated dev home when configured", async () => {
-    const previousCursorHome = process.env.STATION_CURSOR_HOME;
-    process.env.STATION_CURSOR_HOME = "/tmp/station/cursor-home";
-    try {
-      const provider = createCursorHarnessProvider({ command: "agent-test" });
+    const root = await mkdtemp(join(tmpdir(), "station-cursor-launch-home-"));
+    stubCursorTestHome(root);
+    const provider = createCursorHarnessProvider({ command: "agent-test" });
 
-      await expect(provider.buildLaunch(request())).resolves.toMatchObject({
-        env: {
-          HOME: "/tmp/station/cursor-home",
-          STATION_HARNESS_PROVIDER: "cursor",
-        },
-      });
-    } finally {
-      if (previousCursorHome === undefined) {
-        delete process.env.STATION_CURSOR_HOME;
-      } else {
-        process.env.STATION_CURSOR_HOME = previousCursorHome;
-      }
-    }
+    await expect(provider.buildLaunch(request())).resolves.toMatchObject({
+      env: {
+        HOME: root,
+        STATION_HARNESS_PROVIDER: "cursor",
+      },
+    });
   });
 
   it("launches interactive Cursor resume with the native session id", async () => {
@@ -389,6 +359,13 @@ describe("CursorHarnessProvider", () => {
     });
   });
 });
+
+function stubCursorTestHome(root: string): void {
+  if (!usesSharedTestMachine) vi.stubEnv("STATION_TEST_MACHINE_ROOT", root);
+  assertPathInsideTestMachineRoot(root, "Cursor test home");
+  vi.stubEnv("STATION_CURSOR_HOME", root);
+  vi.stubEnv("STATION_CURSOR_HOOKS_PATH", "");
+}
 
 function result(input: ExternalCommandInput, stdout: string): ExternalCommandResult {
   return {

--- a/integrations/worktree/worktrunk/test/unit/provider.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/provider.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ProviderProjectConfig } from "@station/contracts";
@@ -617,7 +617,8 @@ describe("WorktrunkProvider", () => {
     const commonDir = (
       await git(srcPath, "rev-parse", "--path-format=absolute", "--git-common-dir")
     ).stdout.trim();
-    expect(commonDir.replace(/^\/private(?=\/var\/)/, "").startsWith(root)).toBe(true);
+    const physicalRoot = await realpath(root);
+    expect(commonDir.startsWith(physicalRoot)).toBe(true);
     await writeFile(join(srcPath, "tracked.txt"), "base\n");
     await writeFile(join(srcPath, "staged.txt"), "base\n");
     await writeFile(join(srcPath, "deleteme.txt"), "bye\n");

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -27,7 +27,9 @@
         "tools/architecture/serve-observer-architecture.mjs",
         "tools/lint/check-observer-architecture.mjs",
         "tests/support/observerMain.js",
-        "tests/agent/real/pi/fixtures/station-extension-protocol-v1.mjs"
+        "tests/agent/real/pi/fixtures/station-extension-protocol-v1.mjs",
+        "tests/diagnostics/fixtures/vitest-machine-isolation/*.fixture.ts",
+        "tests/diagnostics/fixtures/vitest-machine-isolation/vitest.config.ts"
       ],
       "project": [
         "config/**/*.ts",

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -730,3 +730,4 @@ export class FakeHarnessProvider implements HarnessProvider {
 }
 
 export * from "./setupProfiles.js";
+export * from "./testMachine.js";

--- a/packages/testing/src/testMachine.ts
+++ b/packages/testing/src/testMachine.ts
@@ -1,0 +1,30 @@
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+/** Fails fast when a test mutation path escapes its machine root; this is not a security boundary. */
+export function assertPathInsideTestMachineRoot(path: string, label: string): void {
+  const configuredRoot = process.env.STATION_TEST_MACHINE_ROOT;
+  if (configuredRoot === undefined || configuredRoot.length === 0) {
+    throw new Error(`${label} requires STATION_TEST_MACHINE_ROOT.`);
+  }
+
+  const physicalRoot = realpathSync(resolve(configuredRoot));
+  const destination = resolve(path);
+  let existingParent = destination;
+  while (!existsSync(existingParent)) {
+    const parent = dirname(existingParent);
+    if (parent === existingParent) break;
+    existingParent = parent;
+  }
+
+  const physicalParent = realpathSync(existingParent);
+  const physicalDestination = resolve(physicalParent, relative(existingParent, destination));
+  const relativeDestination = relative(physicalRoot, physicalDestination);
+  if (
+    relativeDestination === ".." ||
+    relativeDestination.startsWith(`..${sep}`) ||
+    isAbsolute(relativeDestination)
+  ) {
+    throw new Error(`${label} must stay inside STATION_TEST_MACHINE_ROOT: ${path}`);
+  }
+}

--- a/packages/testing/test/unit/testMachine.test.ts
+++ b/packages/testing/test/unit/testMachine.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdir, mkdtemp, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { assertPathInsideTestMachineRoot } from "@station/testing";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const fallbackMachineRoots: string[] = [];
+
+afterAll(() => {
+  for (const root of fallbackMachineRoots) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("assertPathInsideTestMachineRoot", () => {
+  it("accepts a path inside the physical machine root", async () => {
+    const root = machineRoot();
+    const fixture = await mkdtemp(join(root, "tmp", "path-assertion-"));
+
+    expect(() =>
+      assertPathInsideTestMachineRoot(join(fixture, "missing", "file"), "fixture"),
+    ).not.toThrow();
+  });
+
+  it("rejects a lexical parent escape", () => {
+    const root = machineRoot();
+
+    expect(() => assertPathInsideTestMachineRoot(join(root, "..", "escaped"), "fixture")).toThrow(
+      /fixture must stay inside STATION_TEST_MACHINE_ROOT/,
+    );
+  });
+
+  it("rejects a symlink escape", async () => {
+    const root = machineRoot();
+    const fixture = join(root, "tmp", "symlink-assertion");
+    await mkdir(fixture, { recursive: true });
+    const link = join(fixture, "outside");
+    await symlink(dirname(root), link);
+
+    expect(() => assertPathInsideTestMachineRoot(join(link, "escaped"), "fixture")).toThrow(
+      /fixture must stay inside STATION_TEST_MACHINE_ROOT/,
+    );
+  });
+
+  it("requires the machine root variable", () => {
+    vi.stubEnv("STATION_TEST_MACHINE_ROOT", "");
+
+    expect(() => assertPathInsideTestMachineRoot("/tmp/example", "fixture")).toThrow(
+      /fixture requires STATION_TEST_MACHINE_ROOT/,
+    );
+  });
+});
+
+function machineRoot(): string {
+  const configuredRoot = process.env.STATION_TEST_MACHINE_ROOT;
+  if (configuredRoot !== undefined) return configuredRoot;
+
+  const root = mkdtempSync(join(tmpdir(), "station-test-machine-helper-"));
+  mkdirSync(join(root, "tmp"));
+  fallbackMachineRoots.push(root);
+  vi.stubEnv("STATION_TEST_MACHINE_ROOT", root);
+  return root;
+}

--- a/tests/diagnostics/fixtures/vitest-machine-isolation/distinct-root.fixture.ts
+++ b/tests/diagnostics/fixtures/vitest-machine-isolation/distinct-root.fixture.ts
@@ -1,0 +1,27 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { expect, it } from "vitest";
+
+it("uses a private per-file machine root", async () => {
+  const machineRoot = process.env.STATION_TEST_MACHINE_ROOT;
+  const resultDirectory = process.env.STATION_TEST_MACHINE_RESULT_DIR;
+  const hostileRoot = process.env.STATION_TEST_MACHINE_HOSTILE_ROOT;
+  if (machineRoot === undefined || resultDirectory === undefined || hostileRoot === undefined) {
+    throw new Error("Machine isolation fixture controls are missing.");
+  }
+
+  await mkdir(resultDirectory, { recursive: true });
+  await writeFile(
+    join(resultDirectory, "distinct-root.json"),
+    JSON.stringify({ machineRoot }),
+    "utf8",
+  );
+
+  expect(machineRoot).not.toBe(hostileRoot);
+  expect(basename(machineRoot)).toMatch(/^s-/);
+  expect(process.env.HOME).toBe(join(machineRoot, "home"));
+
+  if (process.env.STATION_TEST_MACHINE_FAIL === "1") {
+    throw new Error("intentional machine-isolation fixture failure");
+  }
+});

--- a/tests/diagnostics/fixtures/vitest-machine-isolation/environment-reset.fixture.ts
+++ b/tests/diagnostics/fixtures/vitest-machine-isolation/environment-reset.fixture.ts
@@ -1,0 +1,181 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, realpath, writeFile } from "node:fs/promises";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { installCursorHooks } from "../../../../integrations/harness/cursor/src/index.js";
+import { resolveObserverPaths } from "../../../../packages/config/src/index.js";
+import { assertPathInsideTestMachineRoot } from "../../../../packages/testing/src/index.js";
+
+const childEnvironmentSchema = z
+  .object({
+    HOME: z.string(),
+    TMPDIR: z.string(),
+    XDG_RUNTIME_DIR: z.string(),
+    STATION_TEST_MACHINE_ROOT: z.string(),
+  })
+  .strict();
+
+const machineRoot = requiredEnvironmentVariable("STATION_TEST_MACHINE_ROOT");
+const resultDirectory = requiredEnvironmentVariable("STATION_TEST_MACHINE_RESULT_DIR");
+const hostileRoot = requiredEnvironmentVariable("STATION_TEST_MACHINE_HOSTILE_ROOT");
+let mutationPending = false;
+
+afterEach(() => {
+  if (!mutationPending) return;
+  expect(process.env.HOME).toBe(hostileRoot);
+  expect(process.env.CLAUDE_CONFIG_DIR).toBe(hostileRoot);
+  expect(process.env.STATION_TEST_MACHINE_ADDED).toBe("added");
+  mutationPending = false;
+});
+
+describe("per-file test machine environment", () => {
+  it("redirects machine paths and clears inherited integration state", async () => {
+    await mkdir(resultDirectory, { recursive: true });
+    await writeFile(
+      join(resultDirectory, "environment-reset.json"),
+      JSON.stringify({ machineRoot }),
+      "utf8",
+    );
+
+    expect(machineRoot).not.toBe(hostileRoot);
+    expect(process.env.HOME).toBe(join(machineRoot, "home"));
+    const redirectedTemporaryDirectory = requiredEnvironmentVariable("TMPDIR");
+    expect(tmpdir()).toBe(redirectedTemporaryDirectory);
+    await expect(realpath(redirectedTemporaryDirectory)).resolves.toBe(
+      await realpath(join(machineRoot, "tmp")),
+    );
+    expect(process.env.XDG_CONFIG_HOME).toBe(join(machineRoot, "xdg", "config"));
+    expect(process.env.XDG_DATA_HOME).toBe(join(machineRoot, "xdg", "data"));
+    expect(process.env.XDG_CACHE_HOME).toBe(join(machineRoot, "xdg", "cache"));
+    expect(process.env.XDG_STATE_HOME).toBe(join(machineRoot, "xdg", "state"));
+    expect(process.env.XDG_RUNTIME_DIR).toBe(join(machineRoot, "xdg", "runtime"));
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(join(machineRoot, "harness", "claude"));
+    expect(process.env.CODEX_HOME).toBe(join(machineRoot, "harness", "codex"));
+    expect(process.env.STATION_CURSOR_HOME).toBe(join(machineRoot, "harness", "cursor"));
+    expect(process.env.OPENCODE_CONFIG_DIR).toBe(join(machineRoot, "harness", "opencode"));
+    expect(process.env.GIT_CONFIG_GLOBAL).toBe(join(machineRoot, "git", "global.gitconfig"));
+    expect(process.env.GIT_CONFIG_NOSYSTEM).toBe("1");
+    expect(process.env.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(process.env.GH_PROMPT_DISABLED).toBe("1");
+
+    for (const key of [
+      "STATION_CONFIG_PATH",
+      "STATION_OBSERVER_SOCKET_PATH",
+      "STATION_HOST_SOCKET_PATH",
+      "STATION_LAYOUT_PATH",
+      "STATION_CURSOR_HOOKS_PATH",
+      "STATION_SESSION_ID",
+      "STATION_WORKTREE_PATH",
+      "STATION_TMUX_BIN",
+      "GIT_DIR",
+      "GIT_WORK_TREE",
+      "GIT_ASKPASS",
+      "SSH_AUTH_SOCK",
+      "GIT_AUTHOR_NAME",
+      "GIT_COMMITTER_EMAIL",
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+      "TMUX",
+      "TMUX_PANE",
+    ]) {
+      expect(process.env[key], key).toBeUndefined();
+    }
+
+    expect(process.env.PATH).toBe(process.env.STATION_TEST_MACHINE_EXPECTED_PATH);
+    expect(process.env.LANG).toBe("C");
+    expect(process.env.CI).toBe("machine-isolation-regression");
+  });
+
+  it("allows direct, deletion, replacement-object, and stub mutations", () => {
+    process.env.HOME = hostileRoot;
+    delete process.env.XDG_CONFIG_HOME;
+    vi.stubEnv("CLAUDE_CONFIG_DIR", hostileRoot);
+    process.env.STATION_TEST_MACHINE_ADDED = "added";
+    process.env = { ...process.env, STATION_TEST_MACHINE_REPLACED: "replaced" };
+    mutationPending = true;
+  });
+
+  it("restores the complete sandbox baseline before the next test", () => {
+    expect(process.env.HOME).toBe(join(machineRoot, "home"));
+    expect(process.env.XDG_CONFIG_HOME).toBe(join(machineRoot, "xdg", "config"));
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(join(machineRoot, "harness", "claude"));
+    expect(process.env.STATION_TEST_MACHINE_ADDED).toBeUndefined();
+    expect(process.env.STATION_TEST_MACHINE_REPLACED).toBeUndefined();
+  });
+
+  it("passes sandbox paths to child processes", () => {
+    const child = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "process.stdout.write(JSON.stringify({HOME:process.env.HOME,TMPDIR:process.env.TMPDIR,XDG_RUNTIME_DIR:process.env.XDG_RUNTIME_DIR,STATION_TEST_MACHINE_ROOT:process.env.STATION_TEST_MACHINE_ROOT}))",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(child.status).toBe(0);
+    expect(parseChildEnvironment(child.stdout)).toEqual({
+      HOME: join(machineRoot, "home"),
+      TMPDIR: process.env.TMPDIR,
+      XDG_RUNTIME_DIR: join(machineRoot, "xdg", "runtime"),
+      STATION_TEST_MACHINE_ROOT: machineRoot,
+    });
+  });
+
+  it("cannot resolve the default Observer socket to the hostile listener", async () => {
+    const socketPath = resolveObserverPaths().socketPath;
+    expect(socketPath).toBe(join(machineRoot, "xdg", "runtime", "station", "observer.sock"));
+    expect(socketPath).not.toBe(process.env.STATION_TEST_MACHINE_HOSTILE_SOCKET_PATH);
+    await expect(socketOutcome(socketPath)).resolves.toBe("error");
+  });
+
+  it("installs default Cursor hooks only inside the sandbox", async () => {
+    const hooksPath = join(machineRoot, "harness", "cursor", ".cursor", "hooks.json");
+    const hookScriptPath = join(
+      machineRoot,
+      "xdg",
+      "state",
+      "station",
+      "hooks",
+      "station-cursor-hook.sh",
+    );
+    assertPathInsideTestMachineRoot(hooksPath, "Cursor hooks path");
+    assertPathInsideTestMachineRoot(hookScriptPath, "Cursor hook script path");
+
+    const installed = await installCursorHooks();
+
+    expect(installed.hooksPath).toBe(hooksPath);
+    expect(installed.hookScriptPath).toBe(hookScriptPath);
+    expect(installed.installed).toBe(true);
+  });
+});
+
+function requiredEnvironmentVariable(key: string): string {
+  const value = process.env[key];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Missing ${key}.`);
+  }
+  return value;
+}
+
+function parseChildEnvironment(source: string): z.infer<typeof childEnvironmentSchema> {
+  try {
+    return childEnvironmentSchema.parse(JSON.parse(source));
+  } catch (cause) {
+    throw new Error("Child process returned an invalid environment payload.", { cause });
+  }
+}
+
+function socketOutcome(path: string): Promise<"connected" | "error"> {
+  return new Promise((resolve) => {
+    const socket = connect(path);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve("connected");
+    });
+    socket.once("error", () => resolve("error"));
+  });
+}

--- a/tests/diagnostics/fixtures/vitest-machine-isolation/vitest.config.ts
+++ b/tests/diagnostics/fixtures/vitest-machine-isolation/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import {
+  commonResolveConfig,
+  machineIsolatedTestConfig,
+} from "../../../../config/vitest/vitest.config.shared";
+
+/**
+ * The diagnostics regression loads this child Vitest config by file path.
+ *
+ * @knipignore
+ */
+export default defineConfig({
+  ...commonResolveConfig,
+  test: {
+    ...machineIsolatedTestConfig,
+    include: ["tests/diagnostics/fixtures/vitest-machine-isolation/*.fixture.ts"],
+  },
+});

--- a/tests/diagnostics/vitest-machine-isolation.test.ts
+++ b/tests/diagnostics/vitest-machine-isolation.test.ts
@@ -1,0 +1,238 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+const vitestPath = fileURLToPath(new URL("../../node_modules/vitest/vitest.mjs", import.meta.url));
+const fixtureConfig = join(
+  repoRoot,
+  "tests/diagnostics/fixtures/vitest-machine-isolation/vitest.config.ts",
+);
+const distinctRootFixture =
+  "tests/diagnostics/fixtures/vitest-machine-isolation/distinct-root.fixture.ts";
+const environmentResetFixture =
+  "tests/diagnostics/fixtures/vitest-machine-isolation/environment-reset.fixture.ts";
+
+const fixtureResultSchema = z
+  .object({
+    machineRoot: z.string().min(1),
+  })
+  .strict();
+
+type ChildResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+};
+
+describe("Vitest machine isolation", () => {
+  it("isolates hostile inherited machine state and cleans roots on every exit path", async () => {
+    const controllerRoot = await mkdtemp(join(tmpdir(), "station-machine-isolation-regression-"));
+    const socketRoot = await mkdtemp("/tmp/stn-mi-");
+    const hostileRoot = join(controllerRoot, "hostile-machine");
+    const hostileRuntimeDirectory = socketRoot;
+    const hostileSocketPath = join(hostileRuntimeDirectory, "station", "observer.sock");
+    const hostileConfigPath = join(hostileRoot, "xdg", "config", "station", "config.toml");
+    const hostileCursorHooksPath = join(hostileRoot, "cursor", ".cursor", "hooks.json");
+    const hostileLayoutPath = join(hostileRoot, "state", "layout.json");
+    const hostileGitConfigPath = join(hostileRoot, "git", "global.gitconfig");
+    const sentinels = new Map<string, string>([
+      [hostileConfigPath, "hostile station config sentinel\n"],
+      [hostileCursorHooksPath, "hostile cursor hooks sentinel\n"],
+      [hostileLayoutPath, "hostile layout sentinel\n"],
+      [hostileGitConfigPath, "hostile git config sentinel\n"],
+    ]);
+    let hostileConnections = 0;
+    let retainedRoot: string | undefined;
+    const server = createServer((socket) => {
+      hostileConnections += 1;
+      socket.destroy();
+    });
+
+    try {
+      for (const [path, contents] of sentinels) {
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, contents, "utf8");
+      }
+      await mkdir(dirname(hostileSocketPath), { recursive: true });
+      server.listen(hostileSocketPath);
+      await once(server, "listening");
+
+      const hostileEnvironment = machineHostileEnvironment({
+        hostileRoot,
+        hostileRuntimeDirectory,
+        hostileSocketPath,
+        hostileConfigPath,
+        hostileCursorHooksPath,
+        hostileLayoutPath,
+        hostileGitConfigPath,
+      });
+
+      const passingResults = join(controllerRoot, "passing-results");
+      const passing = await runFixtureVitest(
+        [distinctRootFixture, environmentResetFixture],
+        hostileEnvironment,
+        passingResults,
+      );
+      expect(passing.code, passing.stderr || passing.stdout).toBe(0);
+      const distinct = await readFixtureResult(join(passingResults, "distinct-root.json"));
+      const reset = await readFixtureResult(join(passingResults, "environment-reset.json"));
+      expect(distinct.machineRoot).not.toBe(reset.machineRoot);
+      await expect(access(distinct.machineRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(access(reset.machineRoot)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const failureResults = join(controllerRoot, "failure-results");
+      const failing = await runFixtureVitest(
+        [distinctRootFixture],
+        { ...hostileEnvironment, STATION_TEST_MACHINE_FAIL: "1" },
+        failureResults,
+      );
+      expect(failing.code).not.toBe(0);
+      expect(`${failing.stdout}\n${failing.stderr}`).toContain(
+        "intentional machine-isolation fixture failure",
+      );
+      const failed = await readFixtureResult(join(failureResults, "distinct-root.json"));
+      await expect(access(failed.machineRoot)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const retainedResults = join(controllerRoot, "retained-results");
+      const retained = await runFixtureVitest(
+        [distinctRootFixture],
+        { ...hostileEnvironment, STATION_TEST_MACHINE_KEEP_ROOT: "1" },
+        retainedResults,
+      );
+      expect(retained.code, retained.stderr || retained.stdout).toBe(0);
+      const retainedFixture = await readFixtureResult(join(retainedResults, "distinct-root.json"));
+      retainedRoot = retainedFixture.machineRoot;
+      await expect(access(retainedRoot)).resolves.toBeUndefined();
+      expect(`${retained.stdout}\n${retained.stderr}`).toContain(
+        `[station test machine] retained root: ${retainedRoot}`,
+      );
+
+      for (const [path, contents] of sentinels) {
+        await expect(readFile(path, "utf8")).resolves.toBe(contents);
+      }
+      expect(hostileConnections).toBe(0);
+    } finally {
+      if (server.listening) {
+        server.close();
+        await once(server, "close");
+      }
+      if (retainedRoot !== undefined) {
+        await rm(retainedRoot, { recursive: true, force: true });
+      }
+      await rm(controllerRoot, { recursive: true, force: true });
+      await rm(socketRoot, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+function machineHostileEnvironment(input: {
+  hostileRoot: string;
+  hostileRuntimeDirectory: string;
+  hostileSocketPath: string;
+  hostileConfigPath: string;
+  hostileCursorHooksPath: string;
+  hostileLayoutPath: string;
+  hostileGitConfigPath: string;
+}): NodeJS.ProcessEnv {
+  const expectedPath = process.env.PATH ?? "";
+  return {
+    ...process.env,
+    HOME: join(input.hostileRoot, "home"),
+    XDG_CONFIG_HOME: join(input.hostileRoot, "xdg", "config"),
+    XDG_DATA_HOME: join(input.hostileRoot, "xdg", "data"),
+    XDG_CACHE_HOME: join(input.hostileRoot, "xdg", "cache"),
+    XDG_STATE_HOME: join(input.hostileRoot, "xdg", "state"),
+    XDG_RUNTIME_DIR: input.hostileRuntimeDirectory,
+    CODEX_HOME: join(input.hostileRoot, "codex"),
+    CLAUDE_CONFIG_DIR: join(input.hostileRoot, "claude"),
+    STATION_CURSOR_HOME: join(input.hostileRoot, "cursor"),
+    STATION_CURSOR_HOOKS_PATH: input.hostileCursorHooksPath,
+    OPENCODE_CONFIG_DIR: join(input.hostileRoot, "opencode"),
+    GH_CONFIG_DIR: join(input.hostileRoot, "gh"),
+    GIT_CONFIG_GLOBAL: input.hostileGitConfigPath,
+    STATION_CONFIG_PATH: input.hostileConfigPath,
+    STATION_OBSERVER_SOCKET_PATH: input.hostileSocketPath,
+    STATION_HOST_SOCKET_PATH: join(input.hostileRoot, "state", "hostile-host.sock"),
+    STATION_LAYOUT_PATH: input.hostileLayoutPath,
+    STATION_OBSERVER_STATE_DIR: join(input.hostileRoot, "state"),
+    STATION_STATE_DIR: join(input.hostileRoot, "state"),
+    STATION_HOOK_SPOOL_DIR: join(input.hostileRoot, "state", "spool", "hooks"),
+    STATION_SESSION_ID: "hostile-session",
+    STATION_PROJECT_ID: "hostile-project",
+    STATION_WORKTREE_ID: "hostile-worktree",
+    STATION_WORKTREE_PATH: input.hostileRoot,
+    STATION_TERMINAL_TARGET_ID: "hostile-terminal",
+    STATION_TMUX_BIN: join(input.hostileRoot, "bin", "tmux"),
+    STATION_CURSOR_AGENT_BIN: join(input.hostileRoot, "bin", "agent"),
+    STATION_INGRESS_BIN: join(input.hostileRoot, "bin", "stn-ingress"),
+    TMUX: `${join(input.hostileRoot, "tmux.sock")},1,0`,
+    TMUX_PANE: "%9",
+    GIT_DIR: join(input.hostileRoot, "repo", ".git"),
+    GIT_WORK_TREE: join(input.hostileRoot, "repo"),
+    GIT_CONFIG_PARAMETERS: "'user.name=Hostile'",
+    GIT_CONFIG_COUNT: "1",
+    GIT_ASKPASS: join(input.hostileRoot, "bin", "askpass"),
+    SSH_ASKPASS: join(input.hostileRoot, "bin", "ssh-askpass"),
+    SSH_AUTH_SOCK: join(input.hostileRoot, "ssh-agent.sock"),
+    SSH_AGENT_PID: "1234",
+    GIT_AUTHOR_NAME: "Hostile Author",
+    GIT_AUTHOR_EMAIL: "hostile@example.invalid",
+    GIT_COMMITTER_NAME: "Hostile Committer",
+    GIT_COMMITTER_EMAIL: "hostile@example.invalid",
+    GH_TOKEN: "hostile-gh-token",
+    GITHUB_TOKEN: "hostile-github-token",
+    STATION_TEST_MACHINE_ROOT: input.hostileRoot,
+    STATION_TEST_MACHINE_HOSTILE_ROOT: input.hostileRoot,
+    STATION_TEST_MACHINE_HOSTILE_SOCKET_PATH: input.hostileSocketPath,
+    STATION_TEST_MACHINE_EXPECTED_PATH: expectedPath,
+    PATH: expectedPath,
+    LANG: "C",
+    CI: "machine-isolation-regression",
+  };
+}
+
+function runFixtureVitest(
+  fixtures: string[],
+  environment: NodeJS.ProcessEnv,
+  resultDirectory: string,
+): Promise<ChildResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [vitestPath, "run", "--no-color", "--config", fixtureConfig, ...fixtures],
+      {
+        cwd: repoRoot,
+        env: { ...environment, STATION_TEST_MACHINE_RESULT_DIR: resultDirectory },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code, signal, stdout, stderr }));
+  });
+}
+
+async function readFixtureResult(path: string): Promise<z.infer<typeof fixtureResultSchema>> {
+  try {
+    return fixtureResultSchema.parse(JSON.parse(await readFile(path, "utf8")));
+  } catch (cause) {
+    throw new Error(`Machine-isolation fixture returned invalid JSON: ${path}`, { cause });
+  }
+}


### PR DESCRIPTION
## What this fixes

Ordinary Vitest unit and integration files could inherit a developer's Station runtime paths, harness homes, Git/SSH credentials, tmux state, and live sockets. That made local and CI results depend on ambient machine state and allowed environment mutations in one test to leak into later tests in the same file.

Closes #392.

## What changed

- Opted only the unit and integration Vitest configs into a shared private machine environment created per test file; real-provider, E2E, diagnostics, contracts, and real tmux configs retain their existing behavior.
- Redirected home, temporary, XDG, harness, Git, GitHub CLI, and shell-history paths while clearing inherited Station, Git-local, SSH, credential, and tmux state.
- Restored the complete sandbox environment after every test, including tests that replace `process.env`, and restored the worker environment plus removed the sandbox after each file.
- Added failure-safe cleanup, retained-root debugging through `STATION_TEST_MACHINE_KEEP_ROOT=1`, and short temporary aliases for Unix socket path limits.
- Added a test-only physical-path assertion and used it to harden Cursor hook incident coverage against lexical and symlink escapes.
- Added process-level diagnostics covering hostile inheritance, distinct roots, mutation reset, child inheritance, socket and hook containment, cleanup on pass/failure, and retained roots.
- Documented the isolation boundary, environment mutation rules, limitations, and manual inspection workflow.

## Testing

- `pnpm test:unit`
- `pnpm test:integration`
- `pnpm test:diagnostics`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm smoke:install`
- Focused machine-isolation diagnostics and affected unit suites
- `pnpm test:tmux-popup:real` (all nine tests collected and skipped without isolation setup)

`pnpm test:all` passed build, static checks, unit, contracts, integration, diagnostics, scripted-agent, and setup E2E lanes, then stopped locally at the unchanged Observer lifecycle case `hands off between different builds with the same display version` with `OBSERVER_HANDOFF_REFUSED` and incumbent health-convergence timeout. The corresponding PR Observer E2E and binary-smoke lanes pass; neither config was changed by this PR.

## User-visible behavior

Developers running ordinary unit or integration tests no longer expose live machine state to those tests. A focused sandbox can be retained and inspected by setting `STATION_TEST_MACHINE_KEEP_ROOT=1`; Vitest prints the retained root for manual cleanup.

