### PR TITLE
refactor(tui): derive dashboard footer shortcuts from keymap registry

### DIFF
--- a/packages/dashboard-core/src/state/keymap.ts
+++ b/packages/dashboard-core/src/state/keymap.ts
@@ -80,12 +80,23 @@ type DashboardKeyPattern =
 
 type DashboardNamedKey = Extract<DashboardKeyPattern, { kind: "named" }>["named"];
 
+type DashboardFooterVariant = "full" | "compact" | "firstRunFull" | "firstRunCompact";
+
+type DashboardFooterMetadata = {
+  order: number;
+  labels: Partial<Record<DashboardFooterVariant, string>>;
+};
+
 type DashboardBindingSpec = {
   id: string;
   pattern: DashboardKeyPattern;
   action: string;
   outcome: "handled" | "exit" | "dismiss-popup";
-  help?: { keys: string; label: string };
+  help?: {
+    keys: string;
+    label: string;
+    footer?: DashboardFooterMetadata;
+  };
 };
 
 const slotHelp = { keys: "1-9 a-z", label: "open visible session" };
@@ -122,7 +133,19 @@ export const TUI_DASHBOARD_BINDINGS = [
     pattern: { kind: "named", named: "return" },
     action: "tui.focus.activate",
     outcome: "handled",
-    help: { keys: "↵", label: "activate focus" },
+    help: {
+      keys: "↵",
+      label: "activate focus",
+      footer: {
+        order: 10,
+        labels: {
+          full: "activate",
+          compact: "activate",
+          firstRunFull: "add first project",
+          firstRunCompact: "add first project",
+        },
+      },
+    },
   },
   {
     // Tab reaches the dashboard as legacy \t, which the byte path folds to
@@ -131,7 +154,14 @@ export const TUI_DASHBOARD_BINDINGS = [
     pattern: { kind: "char", char: "i", ctrl: true },
     action: "tui.focus.nextNeedsMe",
     outcome: "handled",
-    help: { keys: "⇥", label: "next session needing you" },
+    help: {
+      keys: "⇥",
+      label: "next session needing you",
+      footer: {
+        order: 40,
+        labels: { full: "next-needs-me", compact: "next" },
+      },
+    },
   },
   {
     id: "tui.dashboard.help",
@@ -145,6 +175,11 @@ export const TUI_DASHBOARD_BINDINGS = [
     pattern: { kind: "char", char: "?" },
     action: "tui.help.open",
     outcome: "handled",
+    help: {
+      keys: "?",
+      label: "help",
+      footer: { order: 70, labels: { full: "help", compact: "help" } },
+    },
   },
   {
     id: "tui.dashboard.quit",
@@ -164,7 +199,11 @@ export const TUI_DASHBOARD_BINDINGS = [
     pattern: { kind: "char", char: "/" },
     action: "tui.search.open",
     outcome: "handled",
-    help: { keys: "/", label: "search" },
+    help: {
+      keys: "/",
+      label: "search",
+      footer: { order: 50, labels: { full: "search", compact: "search" } },
+    },
   },
   {
     id: "tui.dashboard.rename",
@@ -192,21 +231,36 @@ export const TUI_DASHBOARD_BINDINGS = [
     pattern: { kind: "char", char: "X" },
     action: "tui.remove.open",
     outcome: "handled",
-    help: { keys: "X", label: "delete session" },
+    help: {
+      keys: "X",
+      label: "delete session",
+      footer: { order: 60, labels: { full: "delete", compact: "delete" } },
+    },
   },
   {
     id: "tui.dashboard.newSession",
     pattern: { kind: "char", char: "N" },
     action: "tui.newSession.open",
     outcome: "handled",
-    help: { keys: "N", label: "new" },
+    help: {
+      keys: "N",
+      label: "new",
+      footer: { order: 20, labels: { full: "new", compact: "new" } },
+    },
   },
   {
     id: "tui.dashboard.addProject",
     pattern: { kind: "char", char: "A" },
     action: "tui.addProject.open",
     outcome: "handled",
-    help: { keys: "A", label: "add" },
+    help: {
+      keys: "A",
+      label: "add",
+      footer: {
+        order: 30,
+        labels: { full: "add", firstRunFull: "add project" },
+      },
+    },
   },
   {
     id: "tui.dashboard.widgetSettings",
@@ -270,15 +324,10 @@ export function dashboardFooterLabel({
   quitHint: string;
   firstRun?: boolean;
 }): string {
-  const full = firstRun
-    ? `↵ add first project  A add project  ${quitHint}`
-    : `↵ activate  N new  A add  ⇥ next-needs-me  / search  X delete  ? help  ${quitHint}`;
-  const compactFirstRun = `↵ add first project  ${quitHint}`;
-  const compact = `↵ activate  N new  ⇥ next  / search  X delete  ? help  ${quitHint}`;
+  const full = dashboardFooterCandidate(firstRun ? "firstRunFull" : "full", quitHint);
+  const compact = dashboardFooterCandidate(firstRun ? "firstRunCompact" : "compact", quitHint);
   if (firstRun && full.length > columns) {
-    return quitHint === QUIT_HINT_DISMISS_ERROR && compactFirstRun.length > columns
-      ? quitHint
-      : compactFirstRun;
+    return quitHint === QUIT_HINT_DISMISS_ERROR && compact.length > columns ? quitHint : compact;
   }
   if (full.length <= columns) {
     return full;
@@ -287,6 +336,26 @@ export function dashboardFooterLabel({
     return compact;
   }
   return compact.length <= columns ? compact : quitHint;
+}
+
+function dashboardFooterCandidate(variant: DashboardFooterVariant, quitHint: string): string {
+  const bindings: readonly DashboardBindingSpec[] = TUI_DASHBOARD_BINDINGS;
+  // Presentation order stays in footer metadata so key-match precedence can remain independent.
+  const shortcuts = bindings
+    .flatMap((binding) => {
+      const help = binding.help;
+      if (help?.footer === undefined) {
+        return [];
+      }
+      const label = help.footer.labels[variant];
+      return label === undefined
+        ? []
+        : [{ order: help.footer.order, text: `${help.keys} ${label}` }];
+    })
+    .sort((left, right) => left.order - right.order)
+    .map(({ text }) => text)
+    .join("  ");
+  return shortcuts.length === 0 ? quitHint : `${shortcuts}  ${quitHint}`;
 }
 
 export function isSlotKey(key: TuiKey): boolean {

--- a/packages/dashboard-core/test/unit/state/keymap.test.ts
+++ b/packages/dashboard-core/test/unit/state/keymap.test.ts
@@ -6,7 +6,7 @@ import {
   QUIT_HINT_DISMISS_ERROR,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { matchDashboardBinding } from "../../../src/state/keymap.js";
+import { matchDashboardBinding, TUI_DASHBOARD_BINDINGS } from "../../../src/state/keymap.js";
 import { createDashboardSnapshot } from "../../fixtures/snapshots.js";
 
 const KEY_CONTEXT = { cwd: "/Users/example/Developer/station", homeDir: "/Users/example" };
@@ -79,36 +79,79 @@ describe("dashboard popup lifecycle keys", () => {
   });
 });
 
+type DashboardFooterVariant = "full" | "compact" | "firstRunFull" | "firstRunCompact";
+
+type DashboardFooterMetadata = {
+  order: number;
+  labels: Partial<Record<DashboardFooterVariant, string>>;
+};
+
+function footerBindingMetadata(
+  binding: (typeof TUI_DASHBOARD_BINDINGS)[number],
+): { keys: string; footer: DashboardFooterMetadata } | undefined {
+  if (!("help" in binding) || !("footer" in binding.help)) {
+    return undefined;
+  }
+  return { keys: binding.help.keys, footer: binding.help.footer };
+}
+
+function shortcutsFromBindingMetadata(variant: DashboardFooterVariant): string {
+  return TUI_DASHBOARD_BINDINGS.flatMap((binding) => {
+    const metadata = footerBindingMetadata(binding);
+    const label = metadata?.footer.labels[variant];
+    return metadata === undefined || label === undefined
+      ? []
+      : [{ order: metadata.footer.order, text: `${metadata.keys} ${label}` }];
+  })
+    .sort((left, right) => left.order - right.order)
+    .map(({ text }) => text)
+    .join("  ");
+}
+
 describe("dashboard footer", () => {
-  it("keeps the first-project action at wide and compact widths", () => {
-    for (const columns of [120, 40]) {
-      const label = dashboardFooterLabel({
-        columns,
-        quitHint: "Q/esc:close",
-        firstRun: true,
-      });
-      expect(label).toContain("add first project");
-      expect(label).not.toContain("open");
-      expect(label).not.toContain("N new");
-      expect(label).not.toContain("delete");
-    }
+  it("derives every responsive shortcut variant from binding metadata", () => {
+    expect(shortcutsFromBindingMetadata("full")).toBe(
+      "↵ activate  N new  A add  ⇥ next-needs-me  / search  X delete  ? help",
+    );
+    expect(shortcutsFromBindingMetadata("compact")).toBe(
+      "↵ activate  N new  ⇥ next  / search  X delete  ? help",
+    );
+    expect(shortcutsFromBindingMetadata("firstRunFull")).toBe("↵ add first project  A add project");
+    expect(shortcutsFromBindingMetadata("firstRunCompact")).toBe("↵ add first project");
   });
 
-  it("labels focused Enter as activate at wide and compact widths", () => {
-    for (const columns of [120, 80]) {
-      const label = dashboardFooterLabel({ columns, quitHint: "Q/esc:close" });
-      expect(label).toContain("↵ activate");
-      expect(label).not.toContain("↵ open");
-    }
+  it("selects full and compact registry projections without changing footer copy", () => {
+    expect(dashboardFooterLabel({ columns: 120, quitHint: "Q/esc:close" })).toBe(
+      `${shortcutsFromBindingMetadata("full")}  Q/esc:close`,
+    );
+    expect(dashboardFooterLabel({ columns: 80, quitHint: "Q/esc:close" })).toBe(
+      `${shortcutsFromBindingMetadata("compact")}  Q/esc:close`,
+    );
+    expect(dashboardFooterLabel({ columns: 120, quitHint: "Q/esc:close", firstRun: true })).toBe(
+      `${shortcutsFromBindingMetadata("firstRunFull")}  Q/esc:close`,
+    );
+    expect(dashboardFooterLabel({ columns: 40, quitHint: "Q/esc:close", firstRun: true })).toBe(
+      `${shortcutsFromBindingMetadata("firstRunCompact")}  Q/esc:close`,
+    );
   });
 
-  it("keeps error dismissal and close copy visible at compact widths", () => {
-    expect(dashboardFooterLabel({ columns: 120, quitHint: QUIT_HINT_DISMISS_ERROR })).toContain(
-      QUIT_HINT_DISMISS_ERROR,
+  it("keeps visible-error dismissal readable through compact and quit-only fallbacks", () => {
+    expect(dashboardFooterLabel({ columns: 120, quitHint: QUIT_HINT_DISMISS_ERROR })).toBe(
+      `${shortcutsFromBindingMetadata("full")}  ${QUIT_HINT_DISMISS_ERROR}`,
+    );
+    expect(dashboardFooterLabel({ columns: 80, quitHint: QUIT_HINT_DISMISS_ERROR })).toBe(
+      `${shortcutsFromBindingMetadata("compact")}  ${QUIT_HINT_DISMISS_ERROR}`,
     );
     expect(dashboardFooterLabel({ columns: 40, quitHint: QUIT_HINT_DISMISS_ERROR })).toBe(
       QUIT_HINT_DISMISS_ERROR,
     );
+    expect(
+      dashboardFooterLabel({
+        columns: 50,
+        quitHint: QUIT_HINT_DISMISS_ERROR,
+        firstRun: true,
+      }),
+    ).toBe(`${shortcutsFromBindingMetadata("firstRunCompact")}  ${QUIT_HINT_DISMISS_ERROR}`);
     expect(
       dashboardFooterLabel({
         columns: 40,


### PR DESCRIPTION
## What this fixes

The dashboard footer duplicated shortcut keys and labels already owned by the dashboard keymap registry. A binding change could therefore leave the visible footer stale and give users incorrect command guidance.

## What changed

- Add footer ordering and responsive-label metadata to the existing dashboard binding registry.
- Derive normal, compact, and first-run footer shortcuts from that metadata while preserving the current close and visible-error dismissal fallbacks.
- Add focused keymap tests that project expected footer text from the registry, preventing footer-visible bindings from drifting from their copy.

## Testing

- `pnpm exec vitest run --config config/vitest/vitest.unit.config.ts packages/dashboard-core/test/unit/state/keymap.test.ts packages/dashboard-core/test/unit/components/dashboardChrome.test.ts`
- `cd station && bun run typecheck && bun test src/station/view/dashboard.golden.test.tsx && bun run test`
- `pnpm lint`
- Attempted `pnpm test:all`; an unrelated timing assertion in `apps/cli/test/unit/ingress-delivery-policy.test.ts` failed once (`healthCalls` expected at least 2, received 1). Its immediate isolated rerun passed.