### PR TITLE
fix(devbox): preserve usable private tmux terminals

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -74,6 +74,14 @@ strict minimal config. It never seeds real auth, Git, SSH, hooks, config, or
 default tmux state. `status` inspects only the recorded private manifest,
 server, sockets, and matching processes.
 
+Attach preserves the caller's `TERM` only when ncurses `tput` can resolve it
+inside the isolated environment with tmux's required `clear` and `cup`
+capabilities. Caller-specific `TERMINFO`, `TERMINFO_DIRS`, and external XDG data
+paths are intentionally not imported. An absent, unavailable, or unsuitable
+terminal falls back to `xterm-256color`; a rejected value is named in the
+fallback diagnostic, so the documented attach command never needs a manual
+`TERM` prefix.
+
 Use `Ctrl-b Space` in the attached base session. The binding enters the built
 CLI's production `popup` command; `_station-ui` owns the long-lived CLI parent,
 which retains the renderer-control IPC channel while the Bun renderer reloads

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -255,6 +255,12 @@ paths, base and `_station-ui` sessions, discovered CLI/renderer/Observer/Host
 owners, and the exact attach/log/stop commands. `tmux start` creates the same
 HMR-enabled lane but returns immediately.
 
+The ordinary attach command preserves a caller `TERM` whose terminfo provides
+`clear` and `cup` inside the private environment. It does not import external
+`TERMINFO`, `TERMINFO_DIRS`, or XDG data paths; if the caller value is absent or
+cannot satisfy tmux there, attach names any rejected value and uses
+`xterm-256color`. Do not add a manual `TERM` prefix to the command.
+
 The disposable root is `/tmp/stn-dbx-<checkout-hash>` and contains:
 
 - isolated `HOME`, XDG, runtime, temp, config, state, layout, log, spool, and

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -86,9 +86,13 @@ The Worktrunk provider shells out to `wt`. Install Worktrunk before using a conf
 worktree_provider = "worktrunk"
 ```
 
-The tmux provider shells out to `tmux` for the workbench and popup local-use path. Guided
-`stn setup` offers an optional recommended binding in a marked block in `~/.tmux.conf`; it is
-never selected without consent. A new block defaults to `tmux prefix + Space`:
+The tmux provider shells out to `tmux` for the workbench and popup local-use path. The
+source-only private tmux devbox also requires ncurses `tput` on `PATH` when attaching; it
+uses that tool against the isolated terminfo environment to preserve only caller terminals
+that provide tmux's required `clear` and `cup` capabilities. Compiled Station and ordinary
+tmux provider use do not add this development-only requirement. Guided `stn setup` offers
+an optional recommended binding in a marked block in `~/.tmux.conf`; it is never selected
+without consent. A new block defaults to `tmux prefix + Space`:
 
 ```tmux
 # >>> station popup binding >>>

--- a/scripts/station-tmux-devbox.mjs
+++ b/scripts/station-tmux-devbox.mjs
@@ -85,6 +85,7 @@ const lanePassthroughEnvironmentVariables = new Set([
   "TZ",
   "USER",
 ]);
+const fallbackAttachTerminal = "xterm-256color";
 const signalExitCodes = { SIGHUP: 129, SIGINT: 130, SIGTERM: 143 };
 const observerProcessTokenPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
@@ -171,15 +172,90 @@ function attach() {
   if (!privateServerAlive(manifest) || !privateSessionExists(manifest, manifest.baseSession)) {
     throw staleLaneError(manifest);
   }
+  const terminal = attachTerminal(manifest);
   const result = run(manifest.tmuxWrapper, ["attach-session", "-t", manifest.baseSession], {
     cwd: manifest.projectRoot,
-    // The isolated XDG home omits caller-specific terminfo such as Ghostty's app bundle.
-    env: laneEnvironment(manifest, { TERM: "xterm-256color" }),
+    env: laneEnvironment(manifest, { TERM: terminal }),
     stdio: "inherit",
     check: false,
     timeoutMs: undefined,
   });
   process.exitCode = result.status;
+}
+
+function attachTerminal(manifest) {
+  const tput = resolveExecutable("tput");
+  if (tput === undefined) {
+    throw new Error("Private tmux attach requires `tput` from ncurses on PATH.");
+  }
+
+  const requested = process.env.TERM?.trim();
+  if (requested !== undefined && requested.length > 0) {
+    const requestedProbe = probeAttachTerminal(manifest, tput, requested);
+    if (requestedProbe.usable) {
+      return requested;
+    }
+    const fallbackProbe =
+      requested === fallbackAttachTerminal
+        ? requestedProbe
+        : probeAttachTerminal(manifest, tput, fallbackAttachTerminal);
+    if (!fallbackProbe.usable) {
+      throw unusableFallbackTerminalError(fallbackProbe.reason);
+    }
+    process.stderr.write(
+      `Private tmux cannot use caller TERM=${JSON.stringify(requested)}: ${requestedProbe.reason}; ` +
+        `using TERM=${fallbackAttachTerminal}.\n`,
+    );
+    return fallbackAttachTerminal;
+  }
+
+  const fallbackProbe = probeAttachTerminal(manifest, tput, fallbackAttachTerminal);
+  if (!fallbackProbe.usable) {
+    throw unusableFallbackTerminalError(fallbackProbe.reason);
+  }
+  return fallbackAttachTerminal;
+}
+
+function probeAttachTerminal(manifest, tput, terminal) {
+  // Probe against the lane environment so caller-only terminfo paths cannot weaken isolation.
+  const probeEnvironment = laneEnvironment(manifest, { TERM: terminal });
+  const clear = run(tput, ["-T", terminal, "clear"], {
+    cwd: manifest.projectRoot,
+    env: probeEnvironment,
+    check: false,
+  });
+  if (clear.status !== 0) {
+    return {
+      usable: false,
+      reason:
+        clear.status === 1
+          ? "terminfo lacks the required clear capability"
+          : "terminfo is unavailable inside the isolated environment",
+    };
+  }
+
+  const cup = run(tput, ["-T", terminal, "cup", "0", "0"], {
+    cwd: manifest.projectRoot,
+    env: probeEnvironment,
+    check: false,
+  });
+  if (cup.status !== 0) {
+    return {
+      usable: false,
+      reason:
+        cup.status === 1
+          ? "terminfo lacks the required cup capability"
+          : "terminfo is unavailable inside the isolated environment",
+    };
+  }
+  return { usable: true };
+}
+
+function unusableFallbackTerminalError(reason) {
+  return new Error(
+    `Private tmux fallback TERM=${fallbackAttachTerminal} is unusable: ${reason}. ` +
+      "Install its ncurses terminfo entry before attaching.",
+  );
 }
 
 function status() {

--- a/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
+++ b/scripts/test-runners/run-station-tmux-devbox-smoke.mjs
@@ -40,7 +40,6 @@ winsize = struct.pack("HHHH", 40, 120, 0, 0)
 pid, fd = pty.fork()
 if pid == 0:
     fcntl.ioctl(sys.stdin.fileno(), termios.TIOCSWINSZ, winsize)
-    os.environ.setdefault("TERM", "xterm-256color")
     os.execvp(sys.argv[1], sys.argv[1:])
 
 fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
@@ -161,7 +160,15 @@ try {
   devbox(["tmux", "logs"]);
 
   proveManifestAndIsolation(manifest);
-  ptyClient = await startPtyClient(manifest);
+  await proveAttachTerminalFallbacks(manifest);
+  ptyClient = await startPtyClient(manifest, {
+    term: "xterm",
+    expectedTerminal: "xterm",
+  });
+  assert(
+    !ptyClient.output.includes("Private tmux cannot use caller TERM="),
+    "valid caller terminal unexpectedly used the fallback",
+  );
   assertPrivateServerEnvironment(manifest);
   await proveBaseShellIsolation(manifest);
   await triggerPopup(ptyClient);
@@ -376,7 +383,10 @@ function proveManifestAndIsolation(manifest) {
     assert(socketPath.length < 104, `Unix socket path is too long: ${socketPath}`);
   }
   assert(existsSync(manifest.observerSocketPath), "private Observer socket is absent");
-  const observerPidfile = JSON.parse(readFileSync(`${manifest.observerSocketPath}.pid`, "utf8"));
+  const observerPidfile = readJsonFile(
+    `${manifest.observerSocketPath}.pid`,
+    "private Observer pidfile",
+  );
   assert(
     JSON.stringify(observerPidfile) === JSON.stringify(manifest.observerIdentity),
     "manifest Observer identity does not match its strict pidfile",
@@ -614,13 +624,63 @@ function runtimeEvidence(manifest) {
   };
 }
 
-async function startPtyClient(manifest) {
+async function proveAttachTerminalFallbacks(manifest) {
+  const cases = [
+    {
+      label: "absent caller terminal",
+      term: undefined,
+      expectedTerminal: "xterm-256color",
+    },
+    {
+      label: "unavailable caller terminal",
+      term: "station-unsupported-terminal",
+      expectedTerminal: "xterm-256color",
+      expectedDiagnostic: "terminfo is unavailable inside the isolated environment",
+    },
+    {
+      label: "unsuitable caller terminal",
+      term: "dumb",
+      expectedTerminal: "xterm-256color",
+      expectedDiagnostic: "terminfo lacks the required clear capability",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const client = await startPtyClient(manifest, testCase);
+    try {
+      if (testCase.expectedDiagnostic === undefined) {
+        assert(
+          !client.output.includes("Private tmux cannot use caller TERM="),
+          `${testCase.label} unexpectedly reported a rejected caller terminal`,
+        );
+        continue;
+      }
+      await waitFor(
+        () =>
+          client.output.includes(`TERM=${JSON.stringify(testCase.term)}`) &&
+          client.output.includes(testCase.expectedDiagnostic) &&
+          client.output.includes("using TERM=xterm-256color"),
+        `${testCase.label} did not report the fallback reason`,
+      );
+    } finally {
+      await client.close();
+    }
+  }
+}
+
+async function startPtyClient(manifest, { term, expectedTerminal }) {
+  const clientEnvironment = { ...outerEnv };
+  if (term === undefined) {
+    delete clientEnvironment.TERM;
+  } else {
+    clientEnvironment.TERM = term;
+  }
   const child = spawn(
     "python3",
     ["-c", ptyBridgeScript, process.execPath, wrapperPath, "tmux", "attach"],
     {
       cwd: manifest.projectRoot,
-      env: { ...outerEnv, TERM: "station-unsupported-terminal" },
+      env: clientEnvironment,
       stdio: ["pipe", "pipe", "pipe"],
     },
   );
@@ -628,20 +688,41 @@ async function startPtyClient(manifest) {
     child.once("error", rejectExit);
     child.once("exit", (code, signal) => resolveExit({ code, signal }));
   });
+  let output = "";
+  const appendOutput = (chunk) => {
+    output = `${output}${chunk.toString("utf8")}`.slice(-32_000);
+  };
+  child.stdout.on("data", appendOutput);
+  child.stderr.on("data", appendOutput);
+
   let clientName;
+  let clientTerminal;
   await waitFor(() => {
-    const output = tmux(
+    const clients = tmux(
       manifest,
-      ["list-clients", "-t", manifest.baseSession, "-F", "#{client_name}"],
+      ["list-clients", "-t", manifest.baseSession, "-F", "#{client_name}\t#{client_termname}"],
       { check: false },
     ).stdout.trim();
-    clientName = output.split(/\r?\n/u).find(Boolean);
+    const client = clients
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((line) => line.split("\t"))
+      .find(([name]) => name !== undefined);
+    clientName = client?.[0];
+    clientTerminal = client?.[1];
     return clientName !== undefined;
   }, "ordinary PTY client did not attach");
+  assert(
+    clientTerminal === expectedTerminal,
+    `ordinary PTY client used TERM=${clientTerminal ?? "<unknown>"}; expected ${expectedTerminal}`,
+  );
   return {
     child,
     clientName,
     exit,
+    get output() {
+      return output;
+    },
     async write(bytes) {
       if (!child.stdin.write(bytes)) {
         await new Promise((resolveDrain, rejectDrain) => {
@@ -686,7 +767,15 @@ function tmux(manifest, args, options = {}) {
 }
 
 function readManifest() {
-  return JSON.parse(readFileSync(manifestPath, "utf8"));
+  return readJsonFile(manifestPath, "private tmux manifest");
+}
+
+function readJsonFile(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not parse ${label} at ${path}.`, { cause: error });
+  }
 }
 
 function assertOwnershipOutput(output, manifest) {


### PR DESCRIPTION
## What this fixes

The private tmux development lane could attach reliably after #404 only by forcing every client to `TERM=xterm-256color`. That fixed terminals whose terminfo was unavailable inside the isolated environment, including Ghostty's app-bundled entry, but it also discarded a valid caller terminal even when the lane could use it safely.

Fixes #203.

## What changed

- Probe the caller terminal with ncurses `tput` inside the private lane's environment, requiring the same `clear` and `cup` capabilities tmux needs.
- Preserve a usable caller `TERM`; use `xterm-256color` only when the value is absent, unavailable, or unsuitable.
- Keep caller-specific `TERMINFO`, `TERMINFO_DIRS`, and external XDG data outside the isolated boundary, and name rejected values plus the fallback reason.
- Cover absent, unavailable, resolvable-but-unsuitable, and valid terminals with real PTY clients while retaining popup, HMR, ownership, outer-state, default-tmux, and cleanup assertions.
- Document the selection behavior and the private attach lane's development-only `tput` dependency.

## Testing

- `node --check scripts/station-tmux-devbox.mjs`
- `node --check scripts/test-runners/run-station-tmux-devbox-smoke.mjs`
- `pnpm lint`
- `pnpm build`
- `pnpm station:devbox:tmux:smoke`
- `pnpm test:all` passed build/typecheck/lint, 2,191 unit tests, 60 contract tests, 590 integration tests, diagnostics, scripted-agent, and setup E2E lanes. The final local Observer lifecycle target remained non-green in two unrelated build-handoff cases with `OBSERVER_HANDOFF_REFUSED`; this change does not touch Observer startup or those tests.

## Safety and scope

Terminal probing and fallback apply only to `pnpm station:devbox tmux attach`. The private tmux server, Observer, config, provider homes, normal tmux server, and installed popup behavior are unchanged.

## User-visible behavior

`pnpm station:devbox tmux attach` now keeps a valid caller terminal without requiring a prefix. When isolated terminfo cannot support it, the command explains the rejected value and attaches with `xterm-256color`.
