### PR TITLE
test(tooling): classify deterministic lane isolation

### DIFF
--- a/apps/cli/test/unit/observer-process/spawn.test.ts
+++ b/apps/cli/test/unit/observer-process/spawn.test.ts
@@ -8,6 +8,9 @@ import { selfExecArgv } from "../../../src/selfExec.js";
 const paths = {
   socketPath: "/tmp/station/run/observer.sock",
   stateDir: "/tmp/station",
+  dbPath: "/tmp/station/observer.sqlite",
+  logDir: "/tmp/station/logs",
+  diagnosticsDir: "/tmp/station/diagnostics",
   hookSpoolDir: "/tmp/station/spool/hooks",
 };
 const buildVersion = `1.2.3+station.${"a".repeat(64)}`;

--- a/config/vitest/vitest.agent-scripted.config.ts
+++ b/config/vitest/vitest.agent-scripted.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vitest/config";
-import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+import { commonResolveConfig, machineIsolatedTestConfig } from "./vitest.config.shared";
 
 export default defineConfig({
   ...commonResolveConfig,
   test: {
-    ...commonTestConfig,
+    ...machineIsolatedTestConfig,
     include: ["tests/agent/scripted/**/*.test.ts", "tests/agent/scenarios/**/*.test.ts"],
   },
 });

--- a/config/vitest/vitest.contracts.config.ts
+++ b/config/vitest/vitest.contracts.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vitest/config";
-import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+import { commonResolveConfig, machineIsolatedTestConfig } from "./vitest.config.shared";
 
 export default defineConfig({
   ...commonResolveConfig,
   test: {
-    ...commonTestConfig,
+    ...machineIsolatedTestConfig,
     include: ["packages/contracts/test/schema/**/*.test.ts"],
   },
 });

--- a/config/vitest/vitest.diagnostics.config.ts
+++ b/config/vitest/vitest.diagnostics.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "vitest/config";
-import { commonResolveConfig, commonTestConfig } from "./vitest.config.shared";
+import { commonResolveConfig, machineIsolatedTestConfig } from "./vitest.config.shared";
 
 export default defineConfig({
   ...commonResolveConfig,
   test: {
-    ...commonTestConfig,
+    ...machineIsolatedTestConfig,
     include: ["tests/diagnostics/**/*.test.ts"],
   },
 });

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,23 +121,53 @@ intermediate repaint.
 
 ## Deterministic Gates
 
-### Unit and integration test machines
+### Deterministic test isolation
 
-The ordinary `vitest.unit.config.ts` and `vitest.integration.config.ts` lanes create a private
-machine root for each test file. They redirect the home, temporary, XDG, harness, Git, GitHub CLI,
-and shell-history paths; clear Station runtime/correlation overrides plus inherited Git, SSH, and
-GitHub credentials; and pass the sandbox paths to child processes. The root is removed after the
-file, including ordinary test failures.
+Each test lane declares one of four boundaries: automatic per-file machine isolation, lane-owned
+fixtures, an explicitly controlled process runner, or intentional machine interaction. The boundary
+is an environment and default-path guarantee, not an OS security boundary.
+
+| Lane | Config or runner | Classification | State and environment ownership |
+| --- | --- | --- | --- |
+| Unit | `vitest.unit.config.ts` | Automatic machine isolation | One private machine root and restored environment per test file. |
+| Integration | `vitest.integration.config.ts` | Automatic machine isolation | One private machine root and restored environment per test file. |
+| Contracts | `vitest.contracts.config.ts` | Automatic machine isolation | Schema tests stay pure while new files fail closed onto private defaults. |
+| Diagnostics | `vitest.diagnostics.config.ts` | Automatic machine isolation | Diagnostics and their child processes start from private machine defaults unless a test supplies an explicit environment. |
+| Scripted agent | `vitest.agent-scripted.config.ts` | Automatic machine isolation | Scripted harness state, provider homes, Git defaults, and child processes inherit the private file root. |
+| Setup E2E | `vitest.setup-e2e.config.ts` | Lane-owned fixtures | Each fixture constructs its complete home, PATH, provider shims, runtime directory, and hostile inputs; a parent sandbox would mask missing fixture inputs. |
+| Observer and general E2E | `vitest.e2e.config.ts` | Lane-owned fixtures | Tests own config, state, sockets, repositories, and Observer process cleanup, including deliberate default-path scenarios. |
+| Installer smoke | `scripts/test-runners/run-install-smoke.mjs` | Controlled process runner | The runner supplies a private root and sanitized install, config, state, and tool environment. |
+| SQLite and Observer-claim cross-runtime | `scripts/test-runners/run-sqlite-cross-runtime.mjs` and `scripts/test-runners/run-observer-claim-cross-runtime.mjs` | Lane-owned process paths | Runners own temporary databases, sockets, claims, and cleanup while inheriting only the ambient toolchain needed to launch Node and Bun. |
+| Station renderer and PTY | `pnpm test:ci:station` | Intentional non-Vitest exception | Bun tests own focused temporary fixtures; there is no suite-wide machine sandbox, so tests must not use default Station paths for mutation. |
+| Binary smoke and handoff stress | `scripts/test-runners/run-binary-smoke.mjs` | Controlled process runner | The runner owns private build, worktree, config, state, evidence, and child-process paths while preserving required build-tool discovery. |
+| Build, typecheck, and lint | Root package scripts | Checkout tooling | These commands intentionally read the checkout and write declared build outputs; they are not test-machine sandboxes. |
+| Real provider, Worktrunk, E2E, and tmux popup | Real Vitest configs below | Intentional machine interaction | These opt-in lanes exercise installed providers, real worktrees, or a real tmux server and retain their deliberate machine contract. |
+
+The automatic group is exactly `vitest.unit.config.ts`, `vitest.integration.config.ts`,
+`vitest.contracts.config.ts`, `vitest.diagnostics.config.ts`, and
+`vitest.agent-scripted.config.ts`. Each creates a private machine root for every test file. The
+shared setup redirects home, temporary, XDG, harness, Git, GitHub CLI, and shell-history paths;
+clears Station runtime/correlation overrides plus inherited Git, SSH, and GitHub credentials; and
+passes the sandbox paths to child processes. The root is removed after the file, including ordinary
+test failures.
 
 Use `vi.stubEnv` for test-local environment changes and let the shared setup restore the complete
 per-file baseline. Environment-mutating tests must not use `it.concurrent` or otherwise overlap in
 the same file because `process.env` is process-global. Set `STATION_TEST_MACHINE_KEEP_ROOT=1` for a
-focused run to retain the root and print its location, inspect it, and remove it manually afterward.
+focused automatic-lane run to retain the root and print its location, inspect it, and remove it
+manually afterward.
 
-Contracts, diagnostics, scripted-agent, setup E2E, Observer E2E, real-provider, and real tmux popup
-configs do not use this boundary. The isolation prevents accidental inheritance and environment
-leakage; it does not contain explicit absolute paths, signals, file descriptors, network access, or
-subprocesses that deliberately escape the redirected environment.
+The intentional real-machine configs are `vitest.real-e2e.config.ts`,
+`vitest.claude-real.config.ts`, `vitest.codex-real.config.ts`,
+`vitest.cursor-real.config.ts`, `vitest.opencode-real.config.ts`,
+`vitest.pi-real.config.ts`, `vitest.tmux-popup-real.config.ts`, and
+`vitest.worktrunk-real.config.ts`. They do not compose the automatic setup. Setup E2E and Observer
+E2E also omit it because their owned environment construction is part of what those lanes test.
+
+Automatic isolation prevents accidental inheritance and environment leakage. It does not contain
+explicit absolute paths, signals, file descriptors, network access, custom child environments,
+installed tools, or subprocesses that deliberately escape the redirected environment. The
+OS-level containment decision belongs to #401.
 
 Git-backed fixtures and child processes must clear Git's repository-local environment variables;
 `cwd` and `git -C` do not isolate a command when variables such as `GIT_DIR` or `GIT_WORK_TREE`

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "test:sqlite:bun": "node scripts/test-runners/run-sqlite-cross-runtime.mjs && pnpm test:observer-claim:cross-runtime",
     "test:sqlite:bun:pr": "node scripts/test-runners/run-sqlite-cross-runtime.mjs && pnpm test:observer-claim:cross-runtime:pr",
     "test:diagnostics": "vitest run --config config/vitest/vitest.diagnostics.config.ts",
-    "test:diagnostics:policy": "vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-classification.test.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts",
+    "test:diagnostics:policy": "vitest run --config config/vitest/vitest.diagnostics.config.ts tests/diagnostics/ci-classification.test.ts tests/diagnostics/ci-workflow-policy.test.ts tests/diagnostics/release-readiness-docs.test.ts tests/diagnostics/vitest-machine-isolation-policy.test.ts",
     "test:e2e:setup": "vitest run --config config/vitest/vitest.setup-e2e.config.ts",
     "test:e2e:setup:guided": "vitest run --config config/vitest/vitest.setup-e2e.config.ts tests/e2e/setup-guided-feedback.test.ts",
     "test:e2e:setup:guided:all-shells": "STATION_SETUP_E2E_ALL_SHELLS=true pnpm test:e2e:setup:guided",

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -1,10 +1,11 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { parseCleanupArgs } from "../../scripts/maintenance/agent-cleanup.mjs";
 import {
   isUnder,
@@ -56,22 +57,45 @@ const rescueMetadata = {
   observerBuildVersion: "0.0.0-test+station.test",
 };
 
-type TurboConfig = {
-  futureFlags?: {
-    watchUsingTaskInputs?: boolean;
-  };
-  tasks?: {
-    build?: {
-      inputs?: string[];
-      outputs?: string[];
-    };
-    "build:identity"?: {
-      cache?: boolean;
-      dependsOn?: string[];
-      inputs?: string[];
-    };
-  };
-};
+const turboConfigSchema = z.object({
+  futureFlags: z
+    .object({
+      watchUsingTaskInputs: z.boolean().optional(),
+    })
+    .optional(),
+  tasks: z
+    .object({
+      build: z
+        .object({
+          inputs: z.array(z.string()).optional(),
+          outputs: z.array(z.string()).optional(),
+        })
+        .optional(),
+      "build:identity": z
+        .object({
+          cache: z.boolean().optional(),
+          dependsOn: z.array(z.string()).optional(),
+          inputs: z.array(z.string()).optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+const packageScriptsSchema = z.object({
+  scripts: z.record(z.string(), z.string()).optional(),
+});
+
+const turboDryRunSchema = z.object({
+  tasks: z
+    .array(
+      z.object({
+        taskId: z.string().optional(),
+        inputs: z.record(z.string(), z.string()).optional(),
+      }),
+    )
+    .optional(),
+});
 
 describe("agent cleanup/reset scripts", () => {
   it("defaults cleanup and reset to dry-run mode", () => {
@@ -145,6 +169,10 @@ managed_root = "~/.worktrees"`);
 
 describe("session migration script", () => {
   it("defaults to a read-only plan and requires --yes for full migration", () => {
+    vi.stubEnv("CODEX_HOME", undefined);
+    vi.stubEnv("XDG_DATA_HOME", undefined);
+    vi.stubEnv("CLAUDE_CONFIG_DIR", undefined);
+
     expect(
       parseSessionMigrationArgs(["--archive", "rescue", "--target-config", "target.toml"], {
         cwd: "/tmp",
@@ -517,10 +545,11 @@ describe("binary smoke script", () => {
     const scriptPath = fileURLToPath(
       new URL("../../scripts/test-runners/run-binary-smoke.mjs", import.meta.url),
     );
-    execFileSync(process.execPath, [scriptPath], {
+    const reaped = spawnSync(process.execPath, [scriptPath], {
       env: { ...process.env, STATION_BINARY_SMOKE_CANCELLATION_SELF_CHECK: "1" },
-      stdio: "pipe",
+      encoding: "utf8",
     });
+    expect(reaped.status, reaped.stderr).toBe(0);
 
     const interrupted = spawnSync(process.execPath, [scriptPath], {
       env: { ...process.env, STATION_BINARY_SMOKE_CANCELLATION_EXIT_SELF_CHECK: "1" },
@@ -768,12 +797,17 @@ describe("tui dev script", () => {
   });
 
   it("keeps turbo build watch inputs from reacting to tests", () => {
-    const turboConfig = JSON.parse(
-      readFileSync(new URL("../../turbo.json", import.meta.url), "utf8"),
-    ) as TurboConfig;
-    const cliPackage = JSON.parse(
-      readFileSync(new URL("../../apps/cli/package.json", import.meta.url), "utf8"),
-    ) as { scripts?: Record<string, string> };
+    const turboConfigResult = turboConfigSchema.safeParse(
+      JSON.parse(readFileSync(new URL("../../turbo.json", import.meta.url), "utf8")),
+    );
+    const cliPackageResult = packageScriptsSchema.safeParse(
+      JSON.parse(readFileSync(new URL("../../apps/cli/package.json", import.meta.url), "utf8")),
+    );
+    expect(turboConfigResult.success).toBe(true);
+    expect(cliPackageResult.success).toBe(true);
+    if (!turboConfigResult.success || !cliPackageResult.success) return;
+    const turboConfig = turboConfigResult.data;
+    const cliPackage = cliPackageResult.data;
 
     expect(turboConfig.tasks?.build?.inputs).toEqual(
       expect.arrayContaining([
@@ -794,16 +828,19 @@ describe("tui dev script", () => {
     });
     expect(cliPackage.scripts?.["build:identity"]).toBe("node ../../scripts/build-identity.mjs");
 
-    const dryRun = JSON.parse(
-      execFileSync(
-        "pnpm",
-        ["exec", "turbo", "run", "build:identity", "--filter=@station/cli", "--dry=json"],
-        {
-          cwd: fileURLToPath(new URL("../../", import.meta.url)),
-          encoding: "utf8",
-        },
-      ),
-    ) as { tasks?: Array<{ taskId?: string; inputs?: Record<string, string> }> };
+    const dryRunProcess = spawnSync(
+      "pnpm",
+      ["exec", "turbo", "run", "build:identity", "--filter=@station/cli", "--dry=json"],
+      {
+        cwd: fileURLToPath(new URL("../../", import.meta.url)),
+        encoding: "utf8",
+      },
+    );
+    expect(dryRunProcess.status, dryRunProcess.stderr).toBe(0);
+    const dryRunResult = turboDryRunSchema.safeParse(JSON.parse(dryRunProcess.stdout));
+    expect(dryRunResult.success).toBe(true);
+    if (!dryRunResult.success) return;
+    const dryRun = dryRunResult.data;
     const identityTask = dryRun.tasks?.find(
       (task) => task.taskId === "@station/cli#build:identity",
     );

--- a/tests/diagnostics/vitest-machine-isolation-policy.test.ts
+++ b/tests/diagnostics/vitest-machine-isolation-policy.test.ts
@@ -1,0 +1,136 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import type { UserConfig } from "vitest/config";
+
+const repositoryRoot = new URL("../../", import.meta.url);
+const configDirectory = new URL("config/vitest/", repositoryRoot);
+const fixtureConfig = new URL(
+  "tests/diagnostics/fixtures/vitest-machine-isolation/vitest.config.ts",
+  repositoryRoot,
+);
+const machineSetupSuffix = "/config/vitest/test-machine-sandbox.setup.ts";
+
+// This inventory stays independent from config composition so a new config cannot satisfy its own policy.
+const machineIsolatedConfigs = [
+  "vitest.agent-scripted.config.ts",
+  "vitest.contracts.config.ts",
+  "vitest.diagnostics.config.ts",
+  "vitest.integration.config.ts",
+  "vitest.unit.config.ts",
+] as const;
+
+const laneOwnedConfigs = [
+  {
+    file: "vitest.e2e.config.ts",
+    rationale:
+      "Observer E2E owns explicit config, state, socket, repository, and process fixtures.",
+  },
+  {
+    file: "vitest.setup-e2e.config.ts",
+    rationale:
+      "Setup E2E constructs complete homes, PATHs, provider shims, and hostile environments.",
+  },
+] as const;
+
+const realMachineConfigs = [
+  {
+    file: "vitest.claude-real.config.ts",
+    rationale: "The lane exercises the installed Claude provider and its real machine state.",
+  },
+  {
+    file: "vitest.codex-real.config.ts",
+    rationale: "The lane exercises the installed Codex provider and its real machine state.",
+  },
+  {
+    file: "vitest.cursor-real.config.ts",
+    rationale: "The lane exercises the installed Cursor provider and its real machine state.",
+  },
+  {
+    file: "vitest.opencode-real.config.ts",
+    rationale: "The lane exercises the installed OpenCode provider and its real machine state.",
+  },
+  {
+    file: "vitest.pi-real.config.ts",
+    rationale: "The lane exercises the installed Pi provider and its real machine state.",
+  },
+  {
+    file: "vitest.real-e2e.config.ts",
+    rationale: "The lane deliberately exercises real providers and external machine integrations.",
+  },
+  {
+    file: "vitest.tmux-popup-real.config.ts",
+    rationale: "The lane drives a real tmux server and production popup process boundaries.",
+  },
+  {
+    file: "vitest.worktrunk-real.config.ts",
+    rationale: "The lane exercises the installed Worktrunk provider and real Git worktrees.",
+  },
+] as const;
+
+const exceptionConfigs = [...laneOwnedConfigs, ...realMachineConfigs];
+const centralConfigs = [...machineIsolatedConfigs, ...exceptionConfigs.map(({ file }) => file)];
+
+describe("Vitest machine-isolation policy", () => {
+  it("classifies every executable central config exactly once", () => {
+    const executableConfigs = readdirSync(configDirectory, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && /^vitest\..+\.config\.ts$/u.test(entry.name))
+      .map((entry) => entry.name)
+      .sort();
+
+    expect(new Set(centralConfigs).size).toBe(centralConfigs.length);
+    expect([...centralConfigs].sort()).toEqual(executableConfigs);
+  });
+
+  it.each(machineIsolatedConfigs)("keeps %s on automatic machine isolation", async (file) => {
+    assertMachineIsolated(await loadConfig(new URL(file, configDirectory)));
+  });
+
+  it.each(exceptionConfigs)("keeps $file outside automatic machine isolation", async (entry) => {
+    expect(entry.rationale.trim().length).toBeGreaterThan(0);
+    expect(setupFilesFor(await loadConfig(new URL(entry.file, configDirectory)))).not.toEqual(
+      expect.arrayContaining([expect.stringMatching(/test-machine-sandbox\.setup\.ts$/u)]),
+    );
+  });
+
+  it("keeps the process-level regression fixture machine isolated", async () => {
+    assertMachineIsolated(await loadConfig(fixtureConfig));
+  });
+
+  it("keeps central configs reachable from package scripts and documented", () => {
+    const packageDocument = readFileSync(new URL("package.json", repositoryRoot), "utf8");
+    const developmentDocument = readFileSync(
+      new URL("docs/development.md", repositoryRoot),
+      "utf8",
+    );
+
+    for (const file of centralConfigs) {
+      expect(packageDocument, `${file} is not referenced by a package script`).toContain(
+        `config/vitest/${file}`,
+      );
+      expect(developmentDocument, `${file} is missing from the test isolation matrix`).toContain(
+        `\`${file}\``,
+      );
+    }
+  });
+});
+
+async function loadConfig(url: URL): Promise<UserConfig> {
+  const configModule = (await import(url.href)) as { default: UserConfig };
+  return configModule.default;
+}
+
+function setupFilesFor(config: UserConfig): readonly string[] {
+  const setupFiles = config.test?.setupFiles;
+  if (setupFiles === undefined) return [];
+  return typeof setupFiles === "string" ? [setupFiles] : setupFiles;
+}
+
+function assertMachineIsolated(config: UserConfig): void {
+  expect(config.test?.isolate).toBe(true);
+  expect(config.test?.unstubEnvs).toBe(true);
+  expect(config.test?.sequence?.hooks).toBe("stack");
+  expect(config.test?.sequence?.setupFiles).toBe("list");
+  expect(setupFilesFor(config)).toEqual(
+    expect.arrayContaining([expect.stringMatching(new RegExp(`${machineSetupSuffix}$`, "u"))]),
+  );
+}


### PR DESCRIPTION
## What this fixes

Station's automatic test-machine boundary covered unit and integration suites, but other deterministic Vitest lanes could still inherit developer HOME, XDG, Git, Station, and provider state. New Vitest configs also had no enforced requirement to declare whether they were sandboxed, lane-owned, or intentionally real-machine, making containment policy vulnerable to silent drift.

## What changed

- Extended per-file machine isolation to contracts, diagnostics, and scripted-agent suites.
- Added an independent diagnostics policy that classifies every executable Vitest config, verifies the effective setup semantics, protects E2E and real-machine exclusions, and requires script and documentation coverage.
- Added that policy to the documentation-only diagnostics gate.
- Removed an ambient provider-home dependency from the session-migration diagnostic and tightened test-only JSON/process boundaries surfaced by the stricter scan.
- Documented automatic, lane-owned, process-runner, checkout-tooling, and real-machine boundaries, including the limits of environment isolation.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` — 2,191 tests
- `pnpm test:contracts` — 60 tests
- `pnpm test:integration` — 590 tests
- `pnpm test:diagnostics` — 118 tests
- `pnpm test:diagnostics:policy` — 47 tests
- `pnpm test:agent:scripted` — 5 tests
- `pnpm test:e2e:setup` — 18 tests
- `pnpm smoke:install`
- `pnpm test:sqlite:bun:pr`
- `pnpm test:ci:station`
- hostile inherited-environment runs for diagnostics and scripted-agent suites
- real tmux config collection

`pnpm test:e2e:observer` and therefore `pnpm test:all` still reproduce the existing local `OBSERVER_HANDOFF_REFUSED` health-convergence timeout in “hands off between different builds with the same display version”; this change does not modify that config or test. Local binary smoke also reached its inaccessible-process inventory check but reproduced a process-enumeration race on macOS; hosted binary validation is pending.

## Safety and scope

Setup E2E, Observer E2E, real-provider, Worktrunk, and real tmux configs remain outside the generic setup, and the new policy fails if that contract changes. This is environment and default-path isolation, not an OS security boundary; #401 retains the containment decision.

Closes #400
