### PR TITLE
docs(dev): define the supported real-state development boundary

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -18,7 +18,13 @@ Status: current living doc for development, test, and documentation workflow.
 | CLI/package-output watcher | `pnpm dev` / `pnpm station:tui-dev` | Isolated by default, not Bun HMR |
 | Isolated Station sandbox | `pnpm station:devbox` | Isolated observer, host, state, and supported hooks |
 | Isolated Station sandbox with UI HMR | `pnpm station:devbox dev` | Same devbox isolation, Bun renderer hot reload |
-| Isolated real tmux popup with UI HMR | `pnpm station:devbox tmux dev` | Private tmux server, Observer, config/state, and production popup CLI |
+| Isolated tmux popup with UI HMR | `pnpm station:devbox tmux dev` | Private tmux server, Observer, config/state, and production popup CLI |
+
+Real-state source development is intentionally native-only: use
+`pnpm station:ui-dev` for checkout UI code against the selected live Observer.
+Station does not support routing checkout popup code through the normal tmux
+server against that live runtime; use the private tmux lane for popup transport,
+geometry, HMR, and lifecycle validation instead.
 
 Do not use `station:dev` as a catch-all name until it truthfully owns the UI,
 CLI/package, observer, provider, protocol, and host restart boundaries.
@@ -45,7 +51,7 @@ provider homes are checkout-local. See the copy-paste recipe in
   `pnpm build` does not create the installed artifact ownership used by the
   binding.
 - `pnpm station:ui-dev` starts the Bun renderer with hot reload for `station/src/**` UI changes from the current checkout.
-- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. Its watcher restarts the TUI only after the identity-aware whole-graph build publishes a stable `station-build-id` sentinel. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` when you intentionally want a specific observer/config. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
+- `pnpm station:tui-dev` starts the CLI-side dev TUI for the checkout where it is run. It watches the built Node CLI/package outputs, not the Bun renderer source. Its watcher restarts the TUI only after the identity-aware whole-graph build publishes a stable `station-build-id` sentinel. By default it uses a generated worktree-local config at `.dev-state/tui-dev/config.toml`, with observer `state_dir` and supported harness hook homes under `.dev-state` and a short checkout-keyed socket path under the OS temp dir so Unix socket names do not overflow on long worktree roots. It preconfigures isolated Codex, Claude, Cursor, and OpenCode hooks for that observer. Pass `--config <path>` or set `STATION_CONFIG_PATH` only to select a controlled development config. This selector retains ordinary CLI Observer startup and handoff behavior; it is not a safe real-state popup lane and should not target a live runtime that must remain undisturbed. While that process is alive, popup routing can reuse that dev UI only from the same checkout root. If another checkout already owns the dev popup, the command shows that root/session and asks whether to stop it before starting here.
 - `pnpm station:devbox dev` starts the isolated Station sandbox with Bun hot reload for `station/src/**`; use it when UI iteration should not connect to the real observer.
 - Before Observer startup, `station:devbox` creates or repairs only its checkout-keyed socket directory to mode `0700`. It refuses symlinks, non-directories, and directories owned by another user; it never repairs or replaces socket and claim files.
 - If a devbox socket is inaccessible, startup exits nonzero without replacing the Observer or `.dev-state` and prints recovery commands. Restore access (normally mode `0600`) or install the named `lsof` executable, inspect with `pnpm station:devbox status`, then rerun the same start command; it reconnects to the original Observer. `pnpm station:devbox reset -- --yes` is only for intentionally disposable state because it deletes `.dev-state` and its agents.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -439,13 +439,19 @@ input file and it reloads in place. The split:
   the worktree UI must also be on a compatible commit.) The host runs the
   observer's checkout too, so host changes need that rebuild — not just the UI reload.
 
+Real-state source development stops at this native lane. There is intentionally
+no supported workflow that registers checkout popup code in the normal tmux
+server against the live runtime. Use `pnpm station:devbox tmux dev` when the
+behavior under test is popup transport, geometry, HMR, or lifecycle; its private
+state avoids Observer handoff and popup-registration risk.
+
 ---
 
 ## 3. Launching via the CLI (`stn tui`)
 
 ```bash
 pnpm dev                                  # rebuild @station/cli on change, isolated by default
-pnpm dev --config /abs/other-config.toml  # ...against a specific observer/config
+pnpm dev --config /abs/other-config.toml  # ...against a controlled development config
 node apps/cli/dist/main.js --config /abs/iso-config.toml tui   # one-shot, no watcher
 ```
 
@@ -459,9 +465,10 @@ opens the **read-only dashboard** in a tmux popup (tmux owns the panes there). I
 passes explicit `--config` choices straight through, and `stn tui` auto-starts
 the observer for the configured socket. The generated default config uses
 `terminal = "noop-terminal"`, so it avoids machine-global tmux pane discovery.
-If you pass an explicit config with `terminal = "tmux"` for tmux-integration
-testing, the popup dashboard can still show your real tmux agents (see the tmux
-gotcha in §1).
+Treat explicit `--config` as a selector for a controlled development fixture,
+not as a safe way to point checkout popup code at the normal live runtime. The
+CLI retains ordinary Observer startup and handoff behavior, so it does not
+provide the no-replacement contract required around a live Observer and Host.
 
 > `pnpm dev` rebuilds the **Node CLI**, not the Bun renderer. To hot-reload the
 > Station UI itself as you edit `station/src/**`, use `pnpm station:ui-dev` from §2b.


### PR DESCRIPTION
## What this fixes

Station's development documentation left the real-state tmux-popup quadrant looking like required unfinished work, even though real-state UI iteration already has a native hot-reload lane and the popup-specific lane is safely covered by private tmux. The remaining proposed live-popup workflow would add Observer handoff and popup-registration risk without a demonstrated development need.

## What changed

- Define real-state source development as the native `pnpm station:ui-dev` lane.
- Keep tmux popup transport, geometry, HMR, and lifecycle testing in `pnpm station:devbox tmux dev`.
- Clarify that `station:tui-dev --config` selects controlled development fixtures and does not provide a no-replacement contract for a live Observer and Host.
- Document the real-state tmux popup lane as intentionally unsupported rather than an incomplete required quadrant.

## Testing

- `pnpm lint`
