### PR TITLE
refactor(dashboard): replace direct store mutations with named actions

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -199,6 +199,7 @@ reattach; pane borders and neighboring panes must remain unlinked.
 - OpenTUI/React components should stay plain and readable. Runtime orchestration belongs in services or the Station state store, not presentation components.
 - Selectors, screen transitions, command builders, event reducers, and fixtures should stay pure TypeScript. The render-framework-free dashboard logic lives in `@station/dashboard-core` and is consumed by the OpenTUI render layer.
 - Each renderer composition resolves one `StationTuiComposition` through `station/src/config/tuiConfig.ts` and passes that opaque composition into the dashboard store. This is the only feature-decision boundary: reducers and render/input leaves must not select search behavior or inspect feature flags; legacy session and optimistic-row matching remains centralized in the pure dashboard search projection.
+- Native and standalone input adapters dispatch the closed dashboard action contract rather than importing reducers to replace store state. Hosted workspace creation temporarily crosses into dashboard state through the named `addPendingCreateSession`, `failPendingCreateSession`, and `removePendingCreateSession` actions; Station still owns failure-retention timers and expiry scheduling until that lifecycle moves behind the runtime facade.
 - New Session and Fork Session expose **Name** as the editable product concept. New Session initially names itself after its generated branch; Fork Session uses `<source>-fork` while its hidden branch carries a collision-resistant token that changes on each fresh open, so an unobserved Git-ref collision is recoverable by retrying. Later name edits may contain spaces and punctuation and never mutate that hidden branch identity. Quick Session uses its generated branch as the default name.
 - Station service code may use `@station/runtime` (and the shared `@station/client`) for observer IO, subscriptions, command dispatch, timeout, retry, cancellation, and cleanup boundaries. Prefer Effect in boundary code when a single path must coordinate async iterators, cancellation/interruption, cleanup, retry/reconnect, timeouts, and typed error conversion. Keep that Effect usage behind Promise/AsyncIterable facades for React callers.
 - The UI may filter, group, sort, label, and decorate snapshot rows. It must not infer agent truth from provider-specific details.
@@ -234,9 +235,9 @@ interception, and equivalence with keyboard transitions. They do not prove termi
 negotiation, SGR parsing, PTY delivery, or tmux forwarding.
 
 The fullscreen and tmux-popup dashboard routes primary-button clicks through a thin adapter.
-Workflow controls dispatch renderer-neutral semantic actions through `TuiStore.handleAction(...)`;
-direct hotkeys and focused Enter decode to the same pure intents before transitions or effects run.
-Dashboard-core owns action availability and resolution, while native Station and standalone/tmux
+Workflow controls dispatch renderer-neutral actions through `TuiStore.dispatch(...)`; direct hotkeys
+and focused Enter decode to the same pure intents before transitions or effects run. Dashboard-core
+owns action availability and resolution, while native Station and standalone/tmux
 retain their terminal-specific effects after shared resolution. Session rows are resolved by their
 exact current row ID before their visible slot key is dispatched, so
 observer-backed focus, start, resume, and picker behavior stays on the existing command path.
@@ -391,7 +392,7 @@ Station uses `bun test` (colocated `*.test.ts` / `*.test.tsx`), not vitest. `@st
 - Live command dispatch through the shared client (focus, jump-to-session, convergence, recovery) lives in `station/src/station/store/stationCommandDispatch.test.ts`.
 - Rendering correctness uses golden frames: `station/src/station/view/dashboard.golden.test.tsx` (scenario × size matrix) and `view/modals.golden.test.tsx`. Use golden frames when exact terminal text, spacing, layout, footer placement, or clipping matters.
 - Production popup acceptance lives in `integrations/terminal/tmux/test/integration/popup-real.test.ts`. Popup input and resize assertions must enter through an attached outer PTY, then prove the visible captured frame and converged nested-client/pane/renderer geometry; an internal store transition or command receipt is not sufficient evidence.
-- Isolation is enforced by `station/src/station/importBoundaries.test.ts`. It scans all production `station/src` modules for forbidden UI/provider imports and keeps exact, shrink-only inventories of temporary raw dashboard store imports, mutable store references, direct mutations, and runtime/operation internals. Dashboard-surface checks additionally enforce its linked `@station` package set, no local ported fork, and no `focusable`.
+- Isolation is enforced by `station/src/station/importBoundaries.test.ts`. It scans all production `station/src` modules for forbidden UI/provider imports and prohibits direct dashboard store mutation outright, while keeping exact, shrink-only inventories of temporary raw store imports, mutable store references, and runtime/operation internals. Dashboard-surface checks additionally enforce its linked `@station` package set, no local ported fork, and no `focusable`.
 - PTY/terminal behavior is tested under `station/src/terminal/` (VT conformance/stress) and via the smoke probes in the `test:pty` / `test:agents` scripts.
 
 Useful focused commands:

--- a/packages/dashboard-core/src/state/actions.ts
+++ b/packages/dashboard-core/src/state/actions.ts
@@ -1,23 +1,41 @@
-import type { ProjectId } from "@station/contracts";
+import type { ProjectId, SessionId } from "@station/contracts";
 import type { AddProjectActionId } from "../flows/addProject/actions.js";
 import type { NewSessionActionId } from "../flows/newSession.js";
+import { focusDashboardProjectHeader } from "./dashboardFocus.js";
+import { scrollDashboard } from "./dashboardScroll.js";
 import {
   activateEmptyProjectAction,
   activateProjectHeaderControl,
 } from "./projectHeaderActions.js";
-import { handleAddProjectAction } from "./screens/addProjectScreen.js";
+import { tuiScreenBehavior } from "./screenBehavior.js";
+import { handleAddProjectAction, selectAddProjectRow } from "./screens/addProjectScreen.js";
 import { handleFirstProjectAddAction } from "./screens/dashboard.js";
-import { type ForkSessionActionId, handleForkSessionAction } from "./screens/fork.js";
+import {
+  type ForkSessionActionId,
+  handleForkSessionAction,
+  openForkDetailsForRow,
+} from "./screens/fork.js";
 import { handleNewSessionAction } from "./screens/newSession.js";
+import { openProjectDefaultAgentPicker } from "./screens/projectDefaultAgent.js";
+import { focusProjectSettingsItem, openProjectSettings } from "./screens/projectSettings.js";
 import {
   handleRemoveWorktreeAction,
+  openRemoveWorktreeConfirmForRow,
   type RemoveWorktreeActionId,
 } from "./screens/removeWorktree.js";
 import { submitRenameSession } from "./screens/renameSession.js";
+import { openRenameEditForRow } from "./screens/sessionRows.js";
+import {
+  openWidgetSettings,
+  widgetSettingsAddFromPicker,
+  widgetSettingsOpenPicker,
+  widgetSettingsRemoveAt,
+  widgetSettingsToggleAt,
+} from "./screens/widgetSettings.js";
 import type { TuiRuntimeContext, TuiTransition } from "./transition.js";
-import type { ProjectHeaderControl, TuiState } from "./types.js";
+import type { ProjectHeaderControl, ProjectSettingsItemId, TuiState } from "./types.js";
 
-/** Renderer-neutral actions shared by mouse, accelerators, and focused activation. */
+/** User-interaction subset of {@link DashboardAction}, shared by pointer and keyboard activation. */
 export type TuiSemanticAction =
   | { type: "dashboard.addProject" }
   | {
@@ -32,10 +50,35 @@ export type TuiSemanticAction =
   | { type: "forkSession.activate"; actionId: ForkSessionActionId }
   | { type: "renameSession.submit" };
 
-/** Resolves a semantic TUI action into the same pure transition used by keyboard input. */
+/** State-only dashboard events for focus, screen, selection, scrolling, and widget transitions. */
+export type DashboardStateAction =
+  | { type: "dashboard.scroll"; delta: number }
+  | {
+      type: "dashboard.projectHeader.focus";
+      projectId: ProjectId;
+      control: ProjectHeaderControl;
+    }
+  | { type: "projectSettings.focusItem"; itemId: ProjectSettingsItemId }
+  | { type: "addProject.selectRow"; index: number }
+  | { type: "screen.clickAway" }
+  | { type: "renameSession.openEdit"; rowId: SessionId; returnTo: "dashboard" }
+  | { type: "removeWorktree.openConfirm"; rowId: SessionId }
+  | { type: "projectDefaultAgent.open"; projectId: ProjectId }
+  | { type: "projectSettings.open"; projectId: ProjectId }
+  | { type: "forkSession.openDetails"; rowId: SessionId; returnTo: "dashboard" }
+  | { type: "widgetSettings.open" }
+  | { type: "widgetSettings.toggle"; index: number }
+  | { type: "widgetSettings.remove"; index: number }
+  | { type: "widgetSettings.openPicker" }
+  | { type: "widgetSettings.addFromPicker"; index: number };
+
+/** Closed renderer-neutral action/event set accepted by dashboard state. */
+export type DashboardAction = TuiSemanticAction | DashboardStateAction;
+
+/** Resolves a dashboard action through the same pure transition model used by keyboard input. */
 export function handleTuiAction(
   state: TuiState,
-  action: TuiSemanticAction,
+  action: DashboardAction,
   context: TuiRuntimeContext,
 ): TuiTransition {
   switch (action.type) {
@@ -55,5 +98,93 @@ export function handleTuiAction(
       return handleForkSessionAction(state, action.actionId);
     case "renameSession.submit":
       return submitRenameSession(state);
+    default:
+      return handleDashboardStateAction(state, action);
   }
+}
+
+function handleDashboardStateAction(state: TuiState, action: DashboardStateAction): TuiTransition {
+  switch (action.type) {
+    case "dashboard.scroll":
+      return stateTransition(scrollDashboard(state, action.delta));
+    case "dashboard.projectHeader.focus":
+      return stateTransition(focusDashboardProjectHeader(state, action.projectId, action.control));
+    case "projectSettings.focusItem":
+      return stateTransition(focusProjectSettingsItem(state, action.itemId));
+    case "addProject.selectRow":
+      return stateTransition(selectAddProjectRow(state, action.index));
+    case "screen.clickAway":
+    case "renameSession.openEdit":
+    case "removeWorktree.openConfirm":
+    case "projectDefaultAgent.open":
+    case "projectSettings.open":
+    case "forkSession.openDetails":
+      return handleDashboardScreenAction(state, action);
+    default:
+      return handleDashboardWidgetAction(state, action);
+  }
+}
+
+function handleDashboardScreenAction(
+  state: TuiState,
+  action: Extract<
+    DashboardStateAction,
+    | { type: "screen.clickAway" }
+    | { type: "renameSession.openEdit" }
+    | { type: "removeWorktree.openConfirm" }
+    | { type: "projectDefaultAgent.open" }
+    | { type: "projectSettings.open" }
+    | { type: "forkSession.openDetails" }
+  >,
+): TuiTransition {
+  switch (action.type) {
+    case "screen.clickAway": {
+      const clickAway = tuiScreenBehavior(state.screen).clickAway;
+      return stateTransition(clickAway === undefined ? state : clickAway(state));
+    }
+    case "renameSession.openEdit":
+      return stateTransition(
+        openRenameEditForRow(state, action.rowId, { returnTo: action.returnTo }),
+      );
+    case "removeWorktree.openConfirm":
+      return stateTransition(openRemoveWorktreeConfirmForRow(state, action.rowId));
+    case "projectDefaultAgent.open":
+      return stateTransition(openProjectDefaultAgentPicker(state, action.projectId));
+    case "projectSettings.open":
+      return stateTransition(openProjectSettings(state, action.projectId));
+    case "forkSession.openDetails":
+      return stateTransition(
+        openForkDetailsForRow(state, action.rowId, { returnTo: action.returnTo }),
+      );
+    default:
+      return assertNeverAction(action);
+  }
+}
+
+function handleDashboardWidgetAction(
+  state: TuiState,
+  action: Extract<DashboardStateAction, { type: `widgetSettings.${string}` }>,
+): TuiTransition {
+  switch (action.type) {
+    case "widgetSettings.open":
+      return stateTransition(openWidgetSettings(state));
+    case "widgetSettings.toggle":
+      return stateTransition(widgetSettingsToggleAt(state, action.index));
+    case "widgetSettings.remove":
+      return stateTransition(widgetSettingsRemoveAt(state, action.index));
+    case "widgetSettings.openPicker":
+      return stateTransition(widgetSettingsOpenPicker(state));
+    case "widgetSettings.addFromPicker":
+      return stateTransition(widgetSettingsAddFromPicker(state, action.index));
+    default:
+      return assertNeverAction(action);
+  }
+}
+
+function assertNeverAction(action: never): never {
+  throw new Error(`Unhandled dashboard action: ${JSON.stringify(action)}`);
+}
+
+function stateTransition(state: TuiState): TuiTransition {
+  return { state };
 }

--- a/packages/dashboard-core/src/state/screens/fork.ts
+++ b/packages/dashboard-core/src/state/screens/fork.ts
@@ -118,8 +118,7 @@ export type OpenForkDetailsOptions = {
   branchToken?: string;
 };
 
-// Builds the fork details step from a dashboard row. Exported so the context menu can
-// open it directly for a clicked row (skipping chooseSlot), like renameSession.
+// The dashboard action resolver uses this pure transition to skip chooseSlot for context-menu entry.
 export function openForkDetailsForRow(
   state: TuiState,
   rowId: SessionId,

--- a/packages/dashboard-core/src/state/store.ts
+++ b/packages/dashboard-core/src/state/store.ts
@@ -1,6 +1,7 @@
 import { createStationClientRuntime, type StationClientRuntime } from "@station/client";
 import type {
   CommandReceipt,
+  SafeError,
   SessionId,
   StationCommand,
   StationSnapshot,
@@ -12,7 +13,7 @@ import { sessionForWorktreeRow } from "../selectors/selectors.js";
 import { safeErrorToToast, toSafeError } from "../services/errors/errors.js";
 import { createNodeFolderService, type TuiFolderService } from "../services/folderService.js";
 import type { TuiObserverService, TuiToast } from "../services/types.js";
-import { handleTuiAction, type TuiSemanticAction } from "./actions.js";
+import { type DashboardAction, handleTuiAction } from "./actions.js";
 import { buildFocusCommand } from "./commandBuilders.js";
 import {
   clearDashboardFocus as clearDashboardFocusState,
@@ -24,6 +25,12 @@ import {
   legacySearchExperience,
 } from "./experiences/dashboardSearch.js";
 import type { TuiKey } from "./keys.js";
+import {
+  addPendingCreateSessionRow,
+  failPendingCreateSessionRow,
+  type PendingCreateSessionRow,
+  removeCreateSessionLocalRow,
+} from "./localRows.js";
 import { bridgeOperationService, createObserverBridgeHooks } from "./observerBridge.js";
 import {
   createTuiLocalOperationRunner,
@@ -49,12 +56,12 @@ export type TuiHandleKeyResult = {
   controlIntent?: TuiControlIntent;
 };
 
-export type TuiStore = TuiState & {
-  start(): () => void;
+/** The sole public dashboard mutation authority. */
+export type DashboardActions = {
   /** Applies a key transition and returns any one-shot renderer-owned control intent. */
   handleKey(key: TuiKey): TuiHandleKeyResult;
-  /** Applies a semantic transition and returns any one-shot renderer-owned control intent. */
-  handleAction(action: TuiSemanticAction): TuiHandleKeyResult;
+  /** Resolves typed actions through the shared transition and effect path. */
+  dispatch(action: DashboardAction): TuiHandleKeyResult;
   /** Create a project session immediately with its configured default harness. */
   createQuickSession(projectId: string): void;
   setTerminalRows(rows: number): void;
@@ -67,7 +74,19 @@ export type TuiStore = TuiState & {
   dismissToasts(): void;
   expireToasts(nowMs?: number): void;
   refreshActiveToastExpiry(nowMs?: number): void;
+  /** Adds a pending hosted-create row until its workspace lifecycle resolves. */
+  addPendingCreateSession(row: PendingCreateSessionRow): void;
+  /** Moves a pending row to retained failure; the caller owns expiry and scheduled removal. */
+  failPendingCreateSession(localId: string, error: SafeError, expiresAt: number): void;
+  /** Removes a pending or retained-failure hosted-create row by local identity. */
+  removePendingCreateSession(localId: string): void;
 };
+
+/** Temporary composition of dashboard data, actions, and lifecycle pending the runtime facade. */
+export type TuiStore = TuiState &
+  DashboardActions & {
+    start(): () => void;
+  };
 
 export type TuiStoreOptions = {
   service: TuiObserverService;
@@ -176,7 +195,7 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
           dashboardSearchExperience,
         ),
       ),
-    handleAction: (action): TuiHandleKeyResult =>
+    dispatch: (action): TuiHandleKeyResult =>
       applyTransition(
         store,
         options.service,
@@ -223,6 +242,15 @@ export function createTuiStore(options: TuiStoreOptions): StoreApi<TuiStore> {
     },
     refreshActiveToastExpiry: (nowMs = Date.now()): void => {
       set(refreshActiveTuiToastExpiry(get(), nowMs));
+    },
+    addPendingCreateSession: (row): void => {
+      set((state) => addPendingCreateSessionRow(state, row));
+    },
+    failPendingCreateSession: (localId, error, expiresAt): void => {
+      set((state) => failPendingCreateSessionRow(state, localId, error, expiresAt));
+    },
+    removePendingCreateSession: (localId): void => {
+      set((state) => removeCreateSessionLocalRow(state, localId));
     },
   }));
 

--- a/packages/dashboard-core/test/unit/sourceBridge.test.ts
+++ b/packages/dashboard-core/test/unit/sourceBridge.test.ts
@@ -183,7 +183,7 @@ function makeStore(): StoreApi<TuiStore> {
     ...createInitialTuiState(),
     start: () => () => {},
     handleKey: () => ({ dismissPopup: false }),
-    handleAction: () => ({ dismissPopup: false }),
+    dispatch: () => ({ dismissPopup: false }),
     createQuickSession: () => {},
     setTerminalRows: () => {},
     focusDashboardSession: () => {},
@@ -192,5 +192,8 @@ function makeStore(): StoreApi<TuiStore> {
     dismissToasts: () => {},
     expireToasts: () => {},
     refreshActiveToastExpiry: () => {},
+    addPendingCreateSession: () => {},
+    failPendingCreateSession: () => {},
+    removePendingCreateSession: () => {},
   }));
 }

--- a/packages/dashboard-core/test/unit/state/actions.test.ts
+++ b/packages/dashboard-core/test/unit/state/actions.test.ts
@@ -1,9 +1,24 @@
 import {
   applyAddProjectFolderReviewed,
   createInitialTuiState,
+  type DashboardStateAction,
+  focusDashboardProjectHeader,
+  focusProjectSettingsItem,
   handleTuiKey,
   openAddProject,
+  openProjectDefaultAgentPicker,
+  openProjectSettings,
+  openRemoveWorktreeConfirmForRow,
+  openRenameEditForRow,
+  openWidgetSettings,
+  scrollDashboard,
+  selectAddProjectRow,
   type TuiState,
+  tuiScreenBehavior,
+  widgetSettingsAddFromPicker,
+  widgetSettingsOpenPicker,
+  widgetSettingsRemoveAt,
+  widgetSettingsToggleAt,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { handleTuiAction } from "../../../src/state/actions.js";
@@ -13,6 +28,136 @@ const context = {
   cwd: "/workspace",
   homeDir: "/home/example",
 };
+
+type StateActionCase = Readonly<{
+  name: string;
+  action: DashboardStateAction;
+  state: () => TuiState;
+  reduce: (state: TuiState) => TuiState;
+}>;
+
+const STATE_ACTION_CASES: readonly StateActionCase[] = [
+  {
+    name: "dashboard.scroll",
+    action: { type: "dashboard.scroll", delta: 5 },
+    state: scrollingDashboardState,
+    reduce: (state) => scrollDashboard(state, 5),
+  },
+  {
+    name: "dashboard.projectHeader.focus",
+    action: {
+      type: "dashboard.projectHeader.focus",
+      projectId: "web",
+      control: "quickSession",
+    },
+    state: dashboardState,
+    reduce: (state) => focusDashboardProjectHeader(state, "web", "quickSession"),
+  },
+  {
+    name: "projectSettings.focusItem",
+    action: { type: "projectSettings.focusItem", itemId: "remove" },
+    state: projectSettingsState,
+    reduce: (state) => focusProjectSettingsItem(state, "remove"),
+  },
+  {
+    name: "addProject.selectRow",
+    action: { type: "addProject.selectRow", index: 1 },
+    state: addProjectStartState,
+    reduce: (state) => selectAddProjectRow(state, 1),
+  },
+  {
+    name: "screen.clickAway",
+    action: { type: "screen.clickAway" },
+    state: widgetSettingsState,
+    reduce: clickAwayActiveScreen,
+  },
+  {
+    name: "renameSession.openEdit",
+    action: {
+      type: "renameSession.openEdit",
+      rowId: "ses_wt_web_idle",
+      returnTo: "dashboard",
+    },
+    state: dashboardState,
+    reduce: (state) => openRenameEditForRow(state, "ses_wt_web_idle", { returnTo: "dashboard" }),
+  },
+  {
+    name: "removeWorktree.openConfirm",
+    action: { type: "removeWorktree.openConfirm", rowId: "ses_wt_web_idle" },
+    state: dashboardState,
+    reduce: (state) => openRemoveWorktreeConfirmForRow(state, "ses_wt_web_idle"),
+  },
+  {
+    name: "projectDefaultAgent.open",
+    action: { type: "projectDefaultAgent.open", projectId: "web" },
+    state: dashboardState,
+    reduce: (state) => openProjectDefaultAgentPicker(state, "web"),
+  },
+  {
+    name: "projectSettings.open",
+    action: { type: "projectSettings.open", projectId: "web" },
+    state: dashboardState,
+    reduce: (state) => openProjectSettings(state, "web"),
+  },
+  {
+    name: "widgetSettings.open",
+    action: { type: "widgetSettings.open" },
+    state: dashboardState,
+    reduce: openWidgetSettings,
+  },
+  {
+    name: "widgetSettings.toggle",
+    action: { type: "widgetSettings.toggle", index: 1 },
+    state: widgetSettingsState,
+    reduce: (state) => widgetSettingsToggleAt(state, 1),
+  },
+  {
+    name: "widgetSettings.remove",
+    action: { type: "widgetSettings.remove", index: 0 },
+    state: widgetSettingsState,
+    reduce: (state) => widgetSettingsRemoveAt(state, 0),
+  },
+  {
+    name: "widgetSettings.openPicker",
+    action: { type: "widgetSettings.openPicker" },
+    state: widgetSettingsState,
+    reduce: widgetSettingsOpenPicker,
+  },
+  {
+    name: "widgetSettings.addFromPicker",
+    action: { type: "widgetSettings.addFromPicker", index: 2 },
+    state: widgetSettingsState,
+    reduce: (state) => widgetSettingsAddFromPicker(state, 2),
+  },
+];
+
+const STALE_STATE_ACTIONS: readonly DashboardStateAction[] = [
+  {
+    type: "dashboard.projectHeader.focus",
+    projectId: "missing",
+    control: "primary",
+  },
+  { type: "projectSettings.focusItem", itemId: "agent" },
+  { type: "addProject.selectRow", index: 0 },
+  { type: "screen.clickAway" },
+  {
+    type: "renameSession.openEdit",
+    rowId: "missing",
+    returnTo: "dashboard",
+  },
+  { type: "removeWorktree.openConfirm", rowId: "missing" },
+  { type: "projectDefaultAgent.open", projectId: "missing" },
+  { type: "projectSettings.open", projectId: "missing" },
+  {
+    type: "forkSession.openDetails",
+    rowId: "missing",
+    returnTo: "dashboard",
+  },
+  { type: "widgetSettings.toggle", index: 0 },
+  { type: "widgetSettings.remove", index: 0 },
+  { type: "widgetSettings.openPicker" },
+  { type: "widgetSettings.addFromPicker", index: 0 },
+];
 
 describe("semantic TUI actions", () => {
   it("opens first-project onboarding equivalently from A, focused Enter, and semantic activation", () => {
@@ -95,6 +240,89 @@ describe("semantic TUI actions", () => {
     expect(semantic).toEqual(direct);
   });
 });
+
+describe("dashboard state actions", () => {
+  it.each(STATE_ACTION_CASES)("maps $name to its pure reducer without effects", ({
+    action,
+    state,
+    reduce,
+  }) => {
+    const initial = state();
+    const transition = handleTuiAction(initial, action, context);
+
+    expect(transition).toEqual({ state: reduce(initial) });
+    expect(transition.state).not.toBe(initial);
+  });
+
+  it("opens Fork details with an explicit dashboard return target and no effects", () => {
+    const state = dashboardState();
+    const transition = handleTuiAction(
+      state,
+      {
+        type: "forkSession.openDetails",
+        rowId: "ses_wt_web_idle",
+        returnTo: "dashboard",
+      },
+      context,
+    );
+
+    expect(transition).toEqual({ state: transition.state });
+    expect(transition.state.screen).toMatchObject({
+      name: "fork",
+      step: "details",
+      sourceWorktreeId: "wt_web_idle",
+      returnTo: "dashboard",
+    });
+  });
+
+  it.each(STALE_STATE_ACTIONS)("keeps stale $type targets inert", (action) => {
+    const state = createInitialTuiState();
+
+    expect(handleTuiAction(state, action, context)).toEqual({ state });
+  });
+
+  it("keeps invalid widget rows inert", () => {
+    const state = widgetSettingsState();
+
+    expect(handleTuiAction(state, { type: "widgetSettings.toggle", index: 99 }, context)).toEqual({
+      state,
+    });
+    expect(
+      handleTuiAction(state, { type: "widgetSettings.addFromPicker", index: 99 }, context),
+    ).toEqual({ state });
+  });
+});
+
+function dashboardState(): TuiState {
+  return createInitialTuiState({ initialSnapshot: createDashboardSnapshot() });
+}
+
+function scrollingDashboardState(): TuiState {
+  return { ...dashboardState(), terminalRows: 8 };
+}
+
+function projectSettingsState(): TuiState {
+  return openProjectSettings(dashboardState(), "web");
+}
+
+function addProjectStartState(): TuiState {
+  return openAddProject(createInitialTuiState(), context);
+}
+
+function widgetSettingsState(): TuiState {
+  return openWidgetSettings({
+    ...dashboardState(),
+    widgets: [{ type: "time" }, { type: "moon" }],
+  });
+}
+
+function clickAwayActiveScreen(state: TuiState): TuiState {
+  const clickAway = tuiScreenBehavior(state.screen).clickAway;
+  if (clickAway === undefined) {
+    throw new Error("expected active screen click-away behavior");
+  }
+  return clickAway(state);
+}
 
 function addProjectReviewState(): TuiState {
   const state = openAddProject(createInitialTuiState(), context);

--- a/packages/dashboard-core/test/unit/state/store.test.ts
+++ b/packages/dashboard-core/test/unit/state/store.test.ts
@@ -46,7 +46,7 @@ describe("TUI store", () => {
     });
 
     const keyResult = keyStore.getState().handleKey({ input: "A" });
-    const actionResult = actionStore.getState().handleAction({ type: "dashboard.addProject" });
+    const actionResult = actionStore.getState().dispatch({ type: "dashboard.addProject" });
 
     expect(actionResult).toEqual(keyResult);
     expect(actionStore.getState().screen).toEqual(keyStore.getState().screen);
@@ -59,7 +59,7 @@ describe("TUI store", () => {
       initialSnapshot: snapshot,
     });
 
-    const result = store.getState().handleAction({
+    const result = store.getState().dispatch({
       type: "dashboard.projectHeader.activate",
       projectId: "web",
       actionId: "shell",
@@ -81,7 +81,7 @@ describe("TUI store", () => {
       initialSnapshot: snapshot,
     });
 
-    const result = store.getState().handleAction({
+    const result = store.getState().dispatch({
       type: "dashboard.emptyProject.activate",
       projectId: "web",
     });
@@ -100,6 +100,76 @@ describe("TUI store", () => {
       projectId: "web",
       control: "quickSession",
     });
+  });
+
+  it("routes state-only actions through the transition executor", () => {
+    const snapshot = createDashboardSnapshot();
+    const store = createTuiStore({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+    });
+
+    const result = store.getState().dispatch({
+      type: "dashboard.projectHeader.focus",
+      projectId: "web",
+      control: "defaultAgent",
+    });
+
+    expect(result).toEqual({ dismissPopup: false });
+    expect(store.getState().dashboardFocus).toEqual({
+      kind: "projectHeader",
+      projectId: "web",
+      control: "defaultAgent",
+    });
+  });
+
+  it("owns the optimistic hosted-create row lifecycle without replacing store actions", () => {
+    const snapshot = createDashboardSnapshot();
+    const store = createTuiStore({
+      service: new FakeTuiObserverService(snapshot),
+      initialSnapshot: snapshot,
+      initialState: { terminalRows: 42 },
+    });
+    const actions = {
+      dispatch: store.getState().dispatch,
+      handleKey: store.getState().handleKey,
+      start: store.getState().start,
+    };
+    const error: SafeError = {
+      tag: "StationLaunchError",
+      code: "HOSTED_CREATE_FAILED",
+      message: "The hosted create failed.",
+    };
+
+    store.getState().addPendingCreateSession({
+      localId: "local-create-1",
+      projectId: "web",
+      title: "new session",
+      branch: "new-session",
+      harnessProvider: "codex",
+      createdAt: fixtureNow,
+    });
+    expect(store.getState().localRows.pendingCreate).toEqual([
+      expect.objectContaining({ localId: "local-create-1", projectId: "web" }),
+    ]);
+
+    store.getState().failPendingCreateSession("local-create-1", error, 123_456);
+    expect(store.getState().localRows.pendingCreate).toEqual([]);
+    expect(store.getState().localRows.failedCreate).toEqual([
+      expect.objectContaining({
+        localId: "local-create-1",
+        error,
+        expiresAt: 123_456,
+      }),
+    ]);
+
+    store.getState().removePendingCreateSession("local-create-1");
+    expect(store.getState().localRows.failedCreate).toEqual([]);
+    expect(store.getState().terminalRows).toBe(42);
+    expect(store.getState().screen).toEqual({ name: "dashboard" });
+    expect(store.getState().dispatch).toBe(actions.dispatch);
+    expect(store.getState().handleKey).toBe(actions.handleKey);
+    expect(store.getState().start).toBe(actions.start);
   });
 
   it("loads initial snapshots and cleans up event subscriptions", async () => {

--- a/station/src/contextMenu/ContextMenuRoot.test.tsx
+++ b/station/src/contextMenu/ContextMenuRoot.test.tsx
@@ -82,7 +82,7 @@ function emptyStationStore(): StoreApi<TuiStore> {
     ...createInitialTuiState(),
     start: () => () => {},
     handleKey: () => ({ dismissPopup: false }),
-    handleAction: () => ({ dismissPopup: false }),
+    dispatch: () => ({ dismissPopup: false }),
     createQuickSession: () => {},
     setTerminalRows: () => {},
     focusDashboardSession: () => {},
@@ -91,6 +91,9 @@ function emptyStationStore(): StoreApi<TuiStore> {
     dismissToasts: () => {},
     expireToasts: () => {},
     refreshActiveToastExpiry: () => {},
+    addPendingCreateSession: () => {},
+    failPendingCreateSession: () => {},
+    removePendingCreateSession: () => {},
   } satisfies TuiStore;
   return {
     getState: () => state,

--- a/station/src/dashboardRenderer/dashboardMouse.ts
+++ b/station/src/dashboardRenderer/dashboardMouse.ts
@@ -1,18 +1,9 @@
 import type { TuiStore } from "@station/dashboard-core";
 import {
   deriveTuiInputMode,
-  focusProjectSettingsItem,
   isRemoveProjectArmed,
   LIST_REGISTRY,
-  openWidgetSettings,
-  scrollDashboard,
-  selectAddProjectRow,
   selectDashboardViewport,
-  tuiScreenBehavior,
-  widgetSettingsAddFromPicker,
-  widgetSettingsOpenPicker,
-  widgetSettingsRemoveAt,
-  widgetSettingsToggleAt,
   type ProjectHeaderControl,
   type TuiInputMode,
 } from "@station/dashboard-core";
@@ -55,7 +46,10 @@ export function routeDashboardMouse(
       target.kind !== "sheetBackdrop" &&
       ROW_INTERACTIVE_MODES.has(mode)
     ) {
-      store.getState().handleKey({ input: "", mouseScroll: scrollDirection });
+      store.getState().dispatch({
+        type: "dashboard.scroll",
+        delta: scrollDirection === "up" ? -1 : 1,
+      });
     }
     return;
   }
@@ -105,7 +99,7 @@ function routeSurfaceClick(
       return true;
     case "firstProjectAdd":
       if (mode === "dashboard") {
-        store.getState().handleAction({ type: "dashboard.addProject" });
+        store.getState().dispatch({ type: "dashboard.addProject" });
       }
       return true;
     case "scrollIndicator":
@@ -137,7 +131,7 @@ function activateProjectHeaderInMode(
   if (mode !== "dashboard") {
     return;
   }
-  const result = store.getState().handleAction({
+  const result = store.getState().dispatch({
     type: "dashboard.projectHeader.activate",
     projectId,
     actionId,
@@ -156,7 +150,7 @@ function activateEmptyProjectInMode(
   if (mode !== "dashboard") {
     return;
   }
-  const result = store.getState().handleAction({
+  const result = store.getState().dispatch({
     type: "dashboard.emptyProject.activate",
     projectId,
   });
@@ -186,9 +180,10 @@ function pageInMode(store: StoreApi<TuiStore>, direction: "up" | "down", mode: T
   if (!ROW_INTERACTIVE_MODES.has(mode)) {
     return;
   }
-  store.setState(
-    scrollDashboard(store.getState(), direction === "up" ? -SCROLL_PAGE_ROWS : SCROLL_PAGE_ROWS),
-  );
+  store.getState().dispatch({
+    type: "dashboard.scroll",
+    delta: direction === "up" ? -SCROLL_PAGE_ROWS : SCROLL_PAGE_ROWS,
+  });
 }
 
 function routeModalClick(
@@ -200,11 +195,7 @@ function routeModalClick(
     return true;
   }
   if (target.kind === "screenBackdrop") {
-    const state = store.getState();
-    const clickAway = tuiScreenBehavior(state.screen).clickAway;
-    if (clickAway !== undefined) {
-      store.setState(clickAway(state));
-    }
+    store.getState().dispatch({ type: "screen.clickAway" });
     return true;
   }
   switch (target.kind) {
@@ -214,14 +205,17 @@ function routeModalClick(
       }
       return true;
     case "removeWorktreeAction":
-      store.getState().handleAction({
+      store.getState().dispatch({
         type: "removeWorktree.activate",
         actionId: target.actionId,
       });
       return true;
     case "projectSettingsItem":
       if (mode === "projectSettings") {
-        store.setState(focusProjectSettingsItem(store.getState(), target.itemId));
+        store.getState().dispatch({
+          type: "projectSettings.focusItem",
+          itemId: target.itemId,
+        });
       }
       return true;
     case "projectSettingsConfirmRemove":
@@ -229,23 +223,23 @@ function routeModalClick(
       return true;
     case "addProjectRow":
       if (ADD_PROJECT_ROW_MODES.has(mode)) {
-        store.setState(selectAddProjectRow(store.getState(), target.index));
+        store.getState().dispatch({ type: "addProject.selectRow", index: target.index });
       }
       return true;
     case "addProjectAction":
-      store.getState().handleAction({
+      store.getState().dispatch({
         type: "addProject.activate",
         actionId: target.actionId,
       });
       return true;
     case "newSessionAction":
-      store.getState().handleAction({
+      store.getState().dispatch({
         type: "newSession.activate",
         actionId: target.actionId,
       });
       return true;
     case "forkSessionAction":
-      store.getState().handleAction({
+      store.getState().dispatch({
         type: "forkSession.activate",
         actionId: target.actionId,
       });
@@ -274,27 +268,29 @@ function routeWidgetClick(
   switch (target.kind) {
     case "widgetSettingsOpen":
       if (mode === "dashboard") {
-        store.setState(openWidgetSettings(store.getState()));
+        store.getState().dispatch({ type: "widgetSettings.open" });
       }
       return true;
     case "widgetSettingsRow":
       if (mode === "widgetSettings") {
-        store.setState(widgetSettingsToggleAt(store.getState(), target.index));
+        store.getState().dispatch({ type: "widgetSettings.toggle", index: target.index });
       }
       return true;
     case "widgetSettingsRemove":
       if (mode === "widgetSettings") {
-        store.setState(widgetSettingsRemoveAt(store.getState(), target.index));
+        store.getState().dispatch({ type: "widgetSettings.remove", index: target.index });
       }
       return true;
     case "widgetSettingsAdd":
       if (mode === "widgetSettings") {
-        store.setState(widgetSettingsOpenPicker(store.getState()));
+        store.getState().dispatch({ type: "widgetSettings.openPicker" });
       }
       return true;
     case "widgetSettingsPickerChoice":
       if (mode === "widgetSettings") {
-        store.setState(widgetSettingsAddFromPicker(store.getState(), target.index));
+        store
+          .getState()
+          .dispatch({ type: "widgetSettings.addFromPicker", index: target.index });
       }
       return true;
     default:

--- a/station/src/input/runtime/executeOutcome.ts
+++ b/station/src/input/runtime/executeOutcome.ts
@@ -1,12 +1,5 @@
 import { buildContextMenuItems, resolveContextMenuAction } from "../../contextMenu/items.js";
 import { STATION_OVERLAY_ID } from "../../state/types.js";
-import {
-  openForkDetailsForRow,
-  openProjectDefaultAgentPicker,
-  openProjectSettings,
-  openRemoveWorktreeConfirmForRow,
-  openRenameEditForRow,
-} from "@station/dashboard-core";
 import type { RouteOutcome } from "../router.js";
 import type { OpenPaneSpawn, StationInputEffects } from "../stationInput.js";
 
@@ -168,42 +161,42 @@ function selectContextMenuItem(effects: StationInputEffects, itemIndex: number |
       return;
     case "renameSession":
       if (stationViewStore !== undefined) {
-        stationViewStore.setState(
-          openRenameEditForRow(stationViewStore.getState(), action.rowId, {
-            returnTo: "dashboard",
-          }),
-        );
+        stationViewStore.getState().dispatch({
+          type: "renameSession.openEdit",
+          rowId: action.rowId,
+          returnTo: "dashboard",
+        });
         effects.store.actions.openOverlay(STATION_OVERLAY_ID);
       }
       return;
     case "removeWorktree":
       if (stationViewStore !== undefined) {
-        stationViewStore.setState(
-          openRemoveWorktreeConfirmForRow(stationViewStore.getState(), action.rowId),
-        );
+        stationViewStore
+          .getState()
+          .dispatch({ type: "removeWorktree.openConfirm", rowId: action.rowId });
       }
       return;
     case "setProjectDefaultAgent":
       if (stationViewStore !== undefined) {
-        stationViewStore.setState(
-          openProjectDefaultAgentPicker(stationViewStore.getState(), action.projectId),
-        );
+        stationViewStore
+          .getState()
+          .dispatch({ type: "projectDefaultAgent.open", projectId: action.projectId });
       }
       return;
     case "openProjectSettings":
       if (stationViewStore !== undefined) {
-        stationViewStore.setState(
-          openProjectSettings(stationViewStore.getState(), action.projectId),
-        );
+        stationViewStore
+          .getState()
+          .dispatch({ type: "projectSettings.open", projectId: action.projectId });
       }
       return;
     case "forkSession":
       if (stationViewStore !== undefined) {
-        stationViewStore.setState(
-          openForkDetailsForRow(stationViewStore.getState(), action.rowId, {
-            returnTo: "dashboard",
-          }),
-        );
+        stationViewStore.getState().dispatch({
+          type: "forkSession.openDetails",
+          rowId: action.rowId,
+          returnTo: "dashboard",
+        });
         effects.store.actions.openOverlay(STATION_OVERLAY_ID);
       }
       return;

--- a/station/src/input/runtime/managedLaunch.ts
+++ b/station/src/input/runtime/managedLaunch.ts
@@ -6,13 +6,7 @@ import { agentWorktreePaneId, type PaneId } from "../../state/types.js";
 import { dispatchStationKey } from "../../station/input/stationActions.js";
 import { safeErrorToNotice, toSafeError, type ObserverService } from "@station/client";
 import type { ProviderId, SafeError, StationCommand } from "@station/contracts";
-import {
-  addPendingCreateSessionRow,
-  failPendingCreateSessionRow,
-  FAILED_CREATE_ROW_TTL_MS,
-  removeCreateSessionLocalRow,
-  type TuiStore,
-} from "@station/dashboard-core";
+import { FAILED_CREATE_ROW_TTL_MS, type TuiStore } from "@station/dashboard-core";
 import { inheritedForkHarness, waitForWorktreeByBranch } from "./stationRows.js";
 import {
   createManagedLaunchAttempt,
@@ -71,23 +65,16 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
   }
 
   function clearPendingCreateRow(localId: string): void {
-    if (stationViewStore !== undefined) {
-      stationViewStore.setState(removeCreateSessionLocalRow(stationViewStore.getState(), localId));
-    }
+    stationViewStore?.getState().removePendingCreateSession(localId);
   }
 
   function failPendingCreateRow(localId: string, error: SafeError): void {
     if (stationViewStore === undefined) {
       return;
     }
-    stationViewStore.setState(
-      failPendingCreateSessionRow(
-        stationViewStore.getState(),
-        localId,
-        error,
-        Date.now() + FAILED_CREATE_ROW_TTL_MS,
-      ),
-    );
+    stationViewStore
+      .getState()
+      .failPendingCreateSession(localId, error, Date.now() + FAILED_CREATE_ROW_TTL_MS);
     setTimeout(() => clearPendingCreateRow(localId), FAILED_CREATE_ROW_TTL_MS);
   }
 
@@ -127,16 +114,14 @@ export function createManagedLaunch(deps: ManagedLaunchDeps): ManagedLaunch {
 
   function startHostedWorktreeLaunch(spec: HostedWorktreeLaunch): void {
     if (stationViewStore !== undefined) {
-      stationViewStore.setState(
-        addPendingCreateSessionRow(stationViewStore.getState(), {
-          localId: spec.localId,
-          projectId: spec.projectId,
-          title: spec.title,
-          branch: spec.branch,
-          createdAt: new Date().toISOString(),
-          harnessProvider: spec.harness,
-        }),
-      );
+      stationViewStore.getState().addPendingCreateSession({
+        localId: spec.localId,
+        projectId: spec.projectId,
+        title: spec.title,
+        branch: spec.branch,
+        createdAt: new Date().toISOString(),
+        harnessProvider: spec.harness,
+      });
     }
     void runHostedWorktreeLaunch(spec).catch((error) => {
       clearPendingCreateRow(spec.localId);

--- a/station/src/station/README.md
+++ b/station/src/station/README.md
@@ -30,8 +30,8 @@ the dashboard is open so the hidden native layout cannot change.
 ## Input
 
 Runtime keyboard dispatch goes through the shared dashboard-core transition
-machine. Workflow mouse targets call `TuiStore.handleAction(...)` with renderer-neutral
-semantic actions; direct commands and focused Enter decode to the same core intents,
+machine. Workflow mouse targets call `TuiStore.dispatch(...)` with renderer-neutral
+Dashboard actions; direct commands and focused Enter decode to the same core intents,
 and the store applies every resulting transition and effect through one executor.
 Station keeps only sequence translation and managed-pane overrides needed for row
 activation, new sessions, and forks. Native pointer Create, direct `C`, and focused

--- a/station/src/station/importBoundaries.test.ts
+++ b/station/src/station/importBoundaries.test.ts
@@ -480,7 +480,7 @@ const MUTABLE_STORE_REFERENCE_INVENTORY: Readonly<Record<string, number>> = {
   "input/stationInput.ts": 2,
   "state/reconcilers/overlayRowFocus.ts": 1,
   "station/StationOverlay.tsx": 1,
-  "station/input/stationActions.ts": 25,
+  "station/input/stationActions.ts": 17,
   "station/input/stationMouse.ts": 5,
   "station/input/stationOverlayLayer.ts": 1,
   "station/store/stationViewStore.ts": 1,
@@ -491,59 +491,7 @@ const MUTABLE_STORE_REFERENCE_INVENTORY: Readonly<Record<string, number>> = {
   "stationButton/useMergeCelebration.ts": 1,
   "terminal/PaneGrid.tsx": 2,
 };
-const DIRECT_DASHBOARD_MUTATION_INVENTORY: DirectDashboardMutationInventory = {
-  "dashboardRenderer/dashboardMouse.ts": {
-    receiver: "store",
-    transitions: [
-      "clickAway",
-      "focusProjectSettingsItem",
-      "openWidgetSettings",
-      "scrollDashboard",
-      "selectAddProjectRow",
-      "widgetSettingsAddFromPicker",
-      "widgetSettingsOpenPicker",
-      "widgetSettingsRemoveAt",
-      "widgetSettingsToggleAt",
-    ],
-  },
-  "input/runtime/executeOutcome.ts": {
-    receiver: "stationViewStore",
-    transitions: [
-      "openForkDetailsForRow",
-      "openProjectDefaultAgentPicker",
-      "openProjectSettings",
-      "openRemoveWorktreeConfirmForRow",
-      "openRenameEditForRow",
-    ],
-  },
-  "input/runtime/managedLaunch.ts": {
-    receiver: "stationViewStore",
-    transitions: [
-      "addPendingCreateSessionRow",
-      "failPendingCreateSessionRow",
-      "removeCreateSessionLocalRow",
-    ],
-  },
-  "station/input/stationActions.ts": {
-    receiver: "store",
-    transitions: [
-      "addTuiToast",
-      "focusDashboardProjectHeader",
-      "focusProjectSettingsItemState",
-      "openWidgetSettingsState",
-      "scrollDashboard",
-      "selectAddProjectRowState",
-      "widgetSettingsAddFromPicker",
-      "widgetSettingsOpenPicker",
-      "widgetSettingsRemoveAt",
-      "widgetSettingsToggleAt",
-    ],
-  },
-  "station/input/stationMouse.ts": {
-    receiver: "store",
-    transitions: ["clickAway"],
-  },
-};
+const DIRECT_DASHBOARD_MUTATION_INVENTORY: DirectDashboardMutationInventory = {};
 const DASHBOARD_INTERNAL_IMPORT_INVENTORY = [
   "config/tuiConfig.ts: import createTuiStore from @station/dashboard-core",
   "dashboardRenderer/main.tsx: import createTuiStore from @station/dashboard-core",
@@ -641,7 +589,7 @@ describe("station production boundaries", () => {
     expect(unexpectedReferences.sort()).toEqual([]);
   });
 
-  it("freezes direct dashboard store mutations", () => {
+  it("prohibits direct dashboard store mutations", () => {
     const expected = Object.entries(DIRECT_DASHBOARD_MUTATION_INVENTORY)
       .flatMap(([path, inventory]) =>
         inventory.transitions.map(

--- a/station/src/station/input/stationActions.ts
+++ b/station/src/station/input/stationActions.ts
@@ -1,34 +1,22 @@
-// Execution layer for the STATION view's input. Keyboard and semantic controls
-// share dashboard-core transitions; this module adds only Station-owned pane
-// effects and direct state helpers for controls outside the semantic action model.
-// Native New Session creation intentionally intercepts the resolved Create action
-// after shared validation so it can launch a managed pane instead of dispatching
-// the standalone observer operation.
+// Execution layer for the STATION view's input. Native Station adds pane and
+// control effects around shared dashboard actions without owning dashboard state
+// transitions. New Session creation intercepts the resolved Create action after
+// shared validation so it can launch a managed pane instead of dispatching the
+// standalone observer operation.
 import type { StoreApi } from "zustand/vanilla";
 import { worktreeHasLiveAgent, type ProviderId } from "@station/contracts";
 import {
-  addTuiToast,
   choiceValueByKey,
   deriveTuiInputMode,
-  focusDashboardProjectHeader,
   newSessionActionForInput,
   newSessionIntentForAction,
-  focusProjectSettingsItem as focusProjectSettingsItemState,
-  openWidgetSettings as openWidgetSettingsState,
   resolveQuickSessionIntent,
   safeErrorToToast,
-  selectAddProjectRow as selectAddProjectRowState,
   selectDashboardItems,
   selectDashboardSessionRow,
   selectDashboardViewport,
-  widgetSettingsAddFromPicker,
-  widgetSettingsOpenPicker,
-  widgetSettingsRemoveAt,
-  widgetSettingsToggleAt,
-  type ProjectSettingsItemId,
   type TuiSemanticAction,
 } from "@station/dashboard-core";
-import { scrollDashboard } from "@station/dashboard-core";
 import { validateForkSessionCreate, validateNewSessionCreate } from "@station/dashboard-core";
 import type { TuiKey } from "@station/dashboard-core";
 import type {
@@ -79,7 +67,7 @@ export function dispatchStationAction(
   store: StoreApi<TuiStore>,
   action: TuiSemanticAction,
 ): StationKeyOutcome {
-  return outcomeForResult(store, store.getState().handleAction(action));
+  return outcomeForResult(store, store.getState().dispatch(action));
 }
 
 function outcomeForResult(
@@ -376,10 +364,14 @@ export function resolveQuickSessionSubmit(
   const intent = resolveQuickSessionIntent(store.getState(), projectId);
   if (intent.kind === "missing") return { kind: "none" };
   if (intent.kind === "blocked") {
-    store.setState(addTuiToast(store.getState(), safeErrorToToast(intent.error)));
+    store.getState().pushToast(safeErrorToToast(intent.error));
     return { kind: "none" };
   }
-  store.setState(focusDashboardProjectHeader(store.getState(), intent.projectId, "quickSession"));
+  store.getState().dispatch({
+    type: "dashboard.projectHeader.focus",
+    projectId: intent.projectId,
+    control: "quickSession",
+  });
   return {
     kind: "submit",
     projectId: intent.projectId,
@@ -387,43 +379,6 @@ export function resolveQuickSessionSubmit(
     branch: intent.branch,
     harness: intent.harnessProvider,
   };
-}
-
-/**
- * Station mouse extension: clicking a left-list item selects it and drops into
- * its detail pane. No single keyboard key maps to this (the keyboard path is
- * arrow-move then enter), so the pointer adapter owns this direct-focus helper.
- */
-export function focusProjectSettingsItem(
-  store: StoreApi<TuiStore>,
-  itemId: ProjectSettingsItemId,
-): void {
-  store.setState(focusProjectSettingsItemState(store.getState(), itemId));
-}
-
-/** Header `[+]` affordance: open the widget-settings panel from the dashboard. */
-export function openWidgetSettingsPanel(store: StoreApi<TuiStore>): void {
-  store.setState(openWidgetSettingsState(store.getState()));
-}
-
-export function toggleWidgetSettingsRow(store: StoreApi<TuiStore>, index: number): void {
-  store.setState(widgetSettingsToggleAt(store.getState(), index));
-}
-
-export function selectAddProjectRow(store: StoreApi<TuiStore>, index: number): void {
-  store.setState(selectAddProjectRowState(store.getState(), index));
-}
-
-export function removeWidgetSettingsRow(store: StoreApi<TuiStore>, index: number): void {
-  store.setState(widgetSettingsRemoveAt(store.getState(), index));
-}
-
-export function openWidgetSettingsPicker(store: StoreApi<TuiStore>): void {
-  store.setState(widgetSettingsOpenPicker(store.getState()));
-}
-
-export function addWidgetSettingsPickerChoice(store: StoreApi<TuiStore>, index: number): void {
-  store.setState(widgetSettingsAddFromPicker(store.getState(), index));
 }
 
 /**
@@ -463,11 +418,6 @@ export function resolveProjectPaneTarget(
     return undefined;
   }
   return { paneId: projectPaneId(project.id), cwd: project.root, role: "shell" };
-}
-
-/** Wheel/indicator scrolling via the shared scroll math. */
-export function scrollStationView(store: StoreApi<TuiStore>, delta: number): void {
-  store.setState(scrollDashboard(store.getState(), delta));
 }
 
 export function dismissStationToasts(store: StoreApi<TuiStore>): void {

--- a/station/src/station/input/stationMouse.ts
+++ b/station/src/station/input/stationMouse.ts
@@ -10,7 +10,6 @@ import {
   deriveTuiInputMode,
   isRemoveProjectArmed,
   LIST_REGISTRY,
-  tuiScreenBehavior,
   type AddProjectActionId,
   type ForkSessionActionId,
   type NewSessionActionId,
@@ -23,22 +22,14 @@ import {
 import type { PaneRole } from "../../state/types.js";
 import type { StationMouseEvent } from "../../input/mouse.js";
 import {
-  addWidgetSettingsPickerChoice,
   dismissStationToasts,
   dispatchRowSlot,
   dispatchStationAction,
   dispatchStationKey,
-  focusProjectSettingsItem,
-  openWidgetSettingsPanel,
-  openWidgetSettingsPicker,
-  removeWidgetSettingsRow,
-  toggleWidgetSettingsRow,
   resolveForkSessionSubmit,
   resolveNewSessionSubmit,
   resolveRowAgentTarget,
   resolveRowPaneTarget,
-  scrollStationView,
-  selectAddProjectRow,
   type OpenPaneTarget,
   type RowAgentTarget,
   type StationKeyOutcome,
@@ -236,7 +227,10 @@ export function routeStationMouse(
       if (!ROW_INTERACTIVE_MODES.has(mode)) {
         return { kind: "handled" };
       }
-      scrollStationView(store, target.direction === "up" ? -SCROLL_PAGE_ROWS : SCROLL_PAGE_ROWS);
+      store.getState().dispatch({
+        type: "dashboard.scroll",
+        delta: target.direction === "up" ? -SCROLL_PAGE_ROWS : SCROLL_PAGE_ROWS,
+      });
       return { kind: "handled" };
     case "toast":
       dismissStationToasts(store);
@@ -257,43 +251,48 @@ export function routeStationMouse(
       if (mode !== "projectSettings") {
         return { kind: "handled" };
       }
-      focusProjectSettingsItem(store, target.itemId);
+      store.getState().dispatch({
+        type: "projectSettings.focusItem",
+        itemId: target.itemId,
+      });
       return { kind: "handled" };
     case "widgetSettingsOpen":
       if (mode !== "dashboard") {
         return { kind: "handled" };
       }
-      openWidgetSettingsPanel(store);
+      store.getState().dispatch({ type: "widgetSettings.open" });
       return { kind: "handled" };
     case "widgetSettingsRow":
       if (mode !== "widgetSettings") {
         return { kind: "handled" };
       }
-      toggleWidgetSettingsRow(store, target.index);
+      store.getState().dispatch({ type: "widgetSettings.toggle", index: target.index });
       return { kind: "handled" };
     case "widgetSettingsRemove":
       if (mode !== "widgetSettings") {
         return { kind: "handled" };
       }
-      removeWidgetSettingsRow(store, target.index);
+      store.getState().dispatch({ type: "widgetSettings.remove", index: target.index });
       return { kind: "handled" };
     case "widgetSettingsAdd":
       if (mode !== "widgetSettings") {
         return { kind: "handled" };
       }
-      openWidgetSettingsPicker(store);
+      store.getState().dispatch({ type: "widgetSettings.openPicker" });
       return { kind: "handled" };
     case "widgetSettingsPickerChoice":
       if (mode !== "widgetSettings") {
         return { kind: "handled" };
       }
-      addWidgetSettingsPickerChoice(store, target.index);
+      store
+        .getState()
+        .dispatch({ type: "widgetSettings.addFromPicker", index: target.index });
       return { kind: "handled" };
     case "addProjectRow":
       if (!ADD_PROJECT_ROW_MODES.has(mode)) {
         return { kind: "handled" };
       }
-      selectAddProjectRow(store, target.index);
+      store.getState().dispatch({ type: "addProject.selectRow", index: target.index });
       return { kind: "handled" };
     case "addProjectAction":
       return fromKeyOutcome(
@@ -333,14 +332,9 @@ export function routeStationMouse(
     }
     case "forkSessionAction":
       return routeForkSessionAction(store, target.actionId);
-    case "screenBackdrop": {
-      const state = store.getState();
-      const clickAway = tuiScreenBehavior(state.screen).clickAway;
-      if (clickAway !== undefined) {
-        store.setState(clickAway(state));
-      }
+    case "screenBackdrop":
+      store.getState().dispatch({ type: "screen.clickAway" });
       return { kind: "handled" };
-    }
     case "body":
     case "sheetBackdrop":
       return { kind: "handled" };
@@ -429,7 +423,10 @@ function routeStationWheel(
   ) {
     return { kind: "handled" };
   }
-  scrollStationView(store, eventKind === "scroll-up" ? -1 : 1);
+  store.getState().dispatch({
+    type: "dashboard.scroll",
+    delta: eventKind === "scroll-up" ? -1 : 1,
+  });
   return { kind: "handled" };
 }
 


### PR DESCRIPTION
## What this fixes

Station input adapters could mutate dashboard state directly by combining the raw Zustand store with dashboard-core reducers. That gave code outside dashboard-core arbitrary mutation authority and made the upcoming runtime facade unable to expose a closed state-changing contract.

Closes #427. Part of #168.

## What changed

- Added the closed `DashboardAction` union and `DashboardActions` authority, retaining `TuiSemanticAction` as the user-interaction subset.
- Renamed store-level `handleAction` to `dispatch` and routed state actions through the shared transition/effect executor.
- Added named optimistic create-row lifecycle actions while keeping hosted-launch timers and asynchronous ownership in Station.
- Migrated native and standalone mouse input, context-menu screen entry, Quick Session feedback/focus, and hosted New/Fork rows to named actions.
- Removed all 28 production direct dashboard mutations and made the boundary inventory empty, while leaving the raw store facade for #428.
- Documented the action boundary and temporary optimistic-row seam.

## Testing

- `pnpm exec vitest run packages/dashboard-core/test/unit/state/actions.test.ts packages/dashboard-core/test/unit/state/store.test.ts packages/dashboard-core/test/unit/state/localRows.test.ts packages/dashboard-core/test/unit/state/interactionParity.test.ts packages/dashboard-core/test/unit/state/screenBehavior.test.ts packages/dashboard-core/test/unit/state/widgetSettings.test.ts packages/dashboard-core/test/unit/state/screens/projectSettings.test.ts` — 141 passed
- Focused Station input/import suites — 211 passed
- Dashboard and modal golden suites — 77 passed, 59 snapshots unchanged
- `cd station && bun run typecheck`
- `cd station && bun run test` — 1,329 passed
- `pnpm lint`
- `pnpm test:all` reached Observer lifecycle E2E after passing the preceding deterministic lanes, then failed two handoff tests with `OBSERVER_HANDOFF_REFUSED` / `OBSERVER_INCUMBENT_HEALTH_TIMEOUT`; an isolated rerun reproduced the same two failures.
