### PR TITLE
refactor(deadcode): finish validated orphan pruning

### DIFF
--- a/apps/observer/src/diagnostics/errors.ts
+++ b/apps/observer/src/diagnostics/errors.ts
@@ -1,8 +1,6 @@
 import type { ErrorEnvelope, SafeError } from "@station/contracts";
 import * as observability from "@station/observability";
 
-export type { ErrorEnvelopeInput } from "@station/observability";
-
 export function toSafeError(
   error: unknown,
   fallback: observability.SafeErrorFallback = {

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -2943,12 +2943,6 @@
           "purpose": null
         },
         {
-          "name": "ErrorEnvelopeInput",
-          "kind": "type",
-          "role": null,
-          "purpose": null
-        },
-        {
           "name": "toSafeError",
           "kind": "function",
           "role": null,
@@ -2967,12 +2961,6 @@
           "resolvedPath": "packages/observability/src/index.ts",
           "edgeKind": "runtime",
           "bindings": ["* as observability"]
-        },
-        {
-          "specifier": "@station/observability",
-          "resolvedPath": "packages/observability/src/index.ts",
-          "edgeKind": "type-only",
-          "bindings": ["ErrorEnvelopeInput"]
         }
       ]
     },
@@ -4277,12 +4265,6 @@
         },
         {
           "name": "DrainProviderIngressSpoolOptions",
-          "kind": "type",
-          "role": null,
-          "purpose": null
-        },
-        {
-          "name": "ErrorEnvelopeInput",
           "kind": "type",
           "role": null,
           "purpose": null

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -2,6 +2,10 @@
   "$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
   "includeEntryExports": true,
   "ignoreExportsUsedInFile": true,
+  "ignoreIssues": {
+    // Default history and the safety ceiling are separate policies that intentionally match today.
+    "packages/config/src/workspace.ts": ["duplicates"]
+  },
   // Dynamic extension entrypoints carry this tag because consumers load them by file path.
   "tags": ["-knipignore"],
   "ignoreWorkspaces": [

--- a/packages/dashboard-core/src/state/commandBuilders.ts
+++ b/packages/dashboard-core/src/state/commandBuilders.ts
@@ -9,17 +9,11 @@ import type {
   WorktreeId,
   WorktreeRow,
 } from "@station/contracts";
-import { isRunningAgentState, normalizeObservedPath } from "@station/contracts";
+import { normalizeObservedPath } from "@station/contracts";
 
 type TerminalLayout = NonNullable<
   Extract<StationCommand, { type: "session.create" }>["payload"]["terminal"]["layout"]
 >;
-
-export type CleanupActionKind =
-  | "close-harness"
-  | "close-terminal"
-  | "close-all"
-  | "remove-worktree";
 
 export type CreateSessionCommandInput = {
   project: ProjectView;
@@ -129,14 +123,6 @@ export function buildResumeAgentCommand(
       },
     },
   };
-}
-
-export function cleanupForceRequired(row: WorktreeRow, action: CleanupActionKind): boolean {
-  const running = isRunningAgentState(row.agent?.state);
-  if (action === "remove-worktree") {
-    return row.worktree.dirty === true || running;
-  }
-  return running;
 }
 
 export function buildRemoveWorktreeCommand(row: WorktreeRow, force: boolean): StationCommand {

--- a/packages/dashboard-core/src/state/screens/removeWorktree.ts
+++ b/packages/dashboard-core/src/state/screens/removeWorktree.ts
@@ -5,7 +5,7 @@ import {
   sessionRowDisplayTitle,
 } from "../../selectors/dashboardSessionRows.js";
 import { safeErrorToToast } from "../../services/errors/errors.js";
-import { buildRemoveWorktreeCommand, cleanupForceRequired } from "../commandBuilders.js";
+import { buildRemoveWorktreeCommand } from "../commandBuilders.js";
 import type { TuiKey } from "../keys.js";
 import { isReturnKey } from "../keys.js";
 import { addPendingRemoveWorktreeRow } from "../localRows.js";
@@ -241,7 +241,8 @@ function removeWorktreeForceRequired(
   snapshot: DashboardSnapshotView,
 ): boolean {
   return (
-    cleanupForceRequired(row.worktree, "remove-worktree") ||
+    row.worktree.worktree.dirty === true ||
+    isRunningAgentState(row.worktree.agent?.state) ||
     snapshot.sessions.some(
       (session) =>
         session.worktreeId === row.worktree.id && isRunningAgentState(session.status.value),

--- a/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
+++ b/packages/dashboard-core/test/unit/state/commandBuilders.test.ts
@@ -2,10 +2,10 @@ import {
   buildCreateSessionCommand,
   buildFocusCommand,
   buildForkSessionCommand,
+  buildRemoveWorktreeCommand,
   buildRenameSessionCommand,
   buildResumeAgentCommand,
   buildStartAgentCommand,
-  cleanupForceRequired,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
 import { createCommandSnapshot, createDashboardSnapshot } from "../../fixtures/snapshots.js";
@@ -172,11 +172,15 @@ describe("TUI command builders", () => {
     });
   });
 
-  it("computes cleanup force requirements", () => {
+  it("builds remove-worktree commands with explicit force policy", () => {
     const snapshot = createCommandSnapshot("idle", { dirty: true });
     const row = snapshot.rows[0];
 
-    expect(cleanupForceRequired(row, "remove-worktree")).toBe(true);
-    expect(cleanupForceRequired(row, "close-terminal")).toBe(true);
+    expect(buildRemoveWorktreeCommand(row, false)).toMatchObject({
+      type: "worktree.remove",
+      payload: { worktreeId: "wt_web_idle" },
+    });
+    expect(buildRemoveWorktreeCommand(row, false).payload).not.toHaveProperty("force");
+    expect(buildRemoveWorktreeCommand(row, true)).toMatchObject({ payload: { force: true } });
   });
 });

--- a/packages/dashboard-core/test/unit/state/screens/removeWorktree.test.ts
+++ b/packages/dashboard-core/test/unit/state/screens/removeWorktree.test.ts
@@ -8,7 +8,7 @@ import {
   type TuiTransition,
 } from "@station/dashboard-core";
 import { describe, expect, it } from "vitest";
-import { createDashboardSnapshot } from "../../../fixtures/snapshots.js";
+import { createCommandSnapshot, createDashboardSnapshot } from "../../../fixtures/snapshots.js";
 
 const CTX = { cwd: "/Users/example/Developer/station", homeDir: "/Users/example" };
 const ENTER: TuiKey = { input: "\r", return: true };
@@ -16,10 +16,19 @@ const LEFT: TuiKey = { input: "", leftArrow: true };
 const RIGHT: TuiKey = { input: "", rightArrow: true };
 const ESC: TuiKey = { input: "", escape: true };
 
-function openConfirm(): TuiState {
+function openConfirm(rowId = "ses_wt_web_idle"): TuiState {
   return openRemoveWorktreeConfirmForRow(
     createInitialTuiState({ initialSnapshot: createDashboardSnapshot() }),
-    "ses_wt_web_idle",
+    rowId,
+  );
+}
+
+function openNoAgentConfirm(dirty = false): TuiState {
+  return openRemoveWorktreeConfirmForRow(
+    createInitialTuiState({
+      initialSnapshot: createCommandSnapshot("none", { dirty }),
+    }),
+    "ses_wt_web_no_agent",
   );
 }
 
@@ -41,6 +50,12 @@ describe("remove worktree confirmation", () => {
     expect(confirmScreen(opened).actionFocus).toBe("keep");
     expect(step(opened, ENTER).state.screen).toEqual({ name: "dashboard" });
     expect(step(opened, ENTER).operations).toBeUndefined();
+  });
+
+  it("requires force for dirty or running sessions", () => {
+    expect(confirmScreen(openNoAgentConfirm()).forceRequired).toBe(false);
+    expect(confirmScreen(openNoAgentConfirm(true)).forceRequired).toBe(true);
+    expect(confirmScreen(openConfirm("ses_wt_web_working")).forceRequired).toBe(true);
   });
 
   it("moves horizontally without wrapping", () => {

--- a/station/src/stationButton/layout.test.ts
+++ b/station/src/stationButton/layout.test.ts
@@ -3,7 +3,6 @@ import {
   attentionLines,
   celebrationText,
   COLLAPSED_BASE_COLS,
-  COLLAPSED_COUNTS_COLS,
   islandDisplay,
   type IslandDisplayInput,
   targetDims,
@@ -85,6 +84,7 @@ describe("targetDims", () => {
       dims(input({ workingCount, readyCount, idleCount }, { restCounts: true }), false);
     const workingOnly = at(1, 0, 0);
     const readyOnly = at(0, 1, 0);
+    const both = at(1, 1, 1);
 
     expect(at(0, 0, 0).width).toBe(COLLAPSED_BASE_COLS);
     expect(at(0, 0, 9).width).toBe(COLLAPSED_BASE_COLS);
@@ -93,8 +93,8 @@ describe("targetDims", () => {
     expect(readyOnly).toEqual(at(0, 99, 12));
     expect(workingOnly.width).toBe(readyOnly.width);
     expect(workingOnly.width).toBeGreaterThan(COLLAPSED_BASE_COLS);
-    expect(workingOnly.width).toBeLessThan(COLLAPSED_COUNTS_COLS);
-    expect(at(1, 1, 1).width).toBe(COLLAPSED_COUNTS_COLS);
+    expect(workingOnly.width).toBeLessThan(both.width);
+    expect(both).toEqual(at(99, 99, 12));
   });
 
   it("keeps the roll-up card width fixed while height tracks project count", () => {

--- a/station/src/stationButton/layout.ts
+++ b/station/src/stationButton/layout.ts
@@ -196,7 +196,6 @@ export function targetDims(display: IslandDisplay): Dims {
 // count ticks can't slide the box out from under an approaching cursor.
 const STABLE_COUNT_LANE_COLS = 1 + 2;
 const STABLE_COUNT_LANE_GAP_COLS = 1;
-export const COLLAPSED_COUNTS_COLS = collapsedCountCols(2);
 
 function countLaneCount(display: Extract<IslandDisplay, { kind: "counts" }>): number {
   return Number(display.working > 0) + Number(display.ready > 0);

--- a/station/src/terminal/vt/selection.test.ts
+++ b/station/src/terminal/vt/selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { orderSelection, rowColumns } from "./selection.js";
+import { orderSelection, rowColumnsOrdered } from "./selection.js";
 
 const sel = (ax: number, ay: number, fx: number, fy: number) => ({
   anchor: { x: ax, y: ay },
@@ -12,26 +12,33 @@ describe("orderSelection", () => {
   });
 });
 
-describe("rowColumns", () => {
+describe("rowColumnsOrdered", () => {
   it("includes both endpoint cells on a single-row selection", () => {
+    const ordered = orderSelection(sel(2, 0, 5, 0));
+
     // cells 2..5 inclusive → half-open [2, 6)
-    expect(rowColumns(sel(2, 0, 5, 0), 0, 80)).toEqual({ start: 2, end: 6 });
+    expect(rowColumnsOrdered(ordered, 0, 80)).toEqual({ start: 2, end: 6 });
   });
 
   it("runs to the line edges on intermediate rows of a multi-row selection", () => {
-    const selection = sel(3, 0, 4, 2);
-    expect(rowColumns(selection, 0, 80)).toEqual({ start: 3, end: 80 }); // first row: from anchor to edge
-    expect(rowColumns(selection, 1, 80)).toEqual({ start: 0, end: 80 }); // middle row: full width
-    expect(rowColumns(selection, 2, 80)).toEqual({ start: 0, end: 5 }); // last row: edge to focus (incl)
+    const ordered = orderSelection(sel(3, 0, 4, 2));
+
+    expect(rowColumnsOrdered(ordered, 0, 80)).toEqual({ start: 3, end: 80 });
+    expect(rowColumnsOrdered(ordered, 1, 80)).toEqual({ start: 0, end: 80 });
+    expect(rowColumnsOrdered(ordered, 2, 80)).toEqual({ start: 0, end: 5 });
   });
 
   it("returns null for rows outside the selection", () => {
-    expect(rowColumns(sel(0, 1, 0, 1), 1, 80)).toEqual({ start: 0, end: 1 });
-    expect(rowColumns(sel(0, 1, 0, 1), 0, 80)).toBeNull();
-    expect(rowColumns(sel(0, 1, 0, 1), 2, 80)).toBeNull();
+    const ordered = orderSelection(sel(0, 1, 0, 1));
+
+    expect(rowColumnsOrdered(ordered, 1, 80)).toEqual({ start: 0, end: 1 });
+    expect(rowColumnsOrdered(ordered, 0, 80)).toBeNull();
+    expect(rowColumnsOrdered(ordered, 2, 80)).toBeNull();
   });
 
   it("clamps the inclusive end to the row width", () => {
-    expect(rowColumns(sel(0, 0, 79, 0), 0, 80)).toEqual({ start: 0, end: 80 });
+    const ordered = orderSelection(sel(0, 0, 79, 0));
+
+    expect(rowColumnsOrdered(ordered, 0, 80)).toEqual({ start: 0, end: 80 });
   });
 });

--- a/station/src/terminal/vt/selection.ts
+++ b/station/src/terminal/vt/selection.ts
@@ -33,23 +33,10 @@ export function rowColumnsOrdered(
   }
   const start = row === ordered.startY ? ordered.startX : 0;
   const endExclusive = row === ordered.endY ? ordered.endX + 1 : width;
-  const lo = clamp(start, 0, width);
-  const hi = clamp(endExclusive, 0, width);
+  const lo = Math.max(0, Math.min(width, start));
+  const hi = Math.max(0, Math.min(width, endExclusive));
   if (hi <= lo) {
     return null;
   }
   return { start: lo, end: hi };
-}
-
-/** Convenience wrapper for a single-row lookup. */
-export function rowColumns(
-  selection: CellSelection,
-  row: number,
-  width: number,
-): RowColumns | null {
-  return rowColumnsOrdered(orderSelection(selection), row, width);
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.max(min, Math.min(max, value));
 }


### PR DESCRIPTION
## What this fixes

After the broader audit cleanups merged, Station still retained three production helpers whose only consumers were tests: a generic cleanup-force policy, a single-row selection wrapper, and a collapsed-width constant. Observer diagnostics also re-exported an unused error-envelope type, while Knip reported two intentionally equal scrollback policies as duplicate exports. These leftovers kept dead ownership and noise in the production surface.

## What changed

- Removed the generic cleanup action union and force helper, keeping dirty/running force detection in the remove-worktree screen that owns it.
- Preserved direct `buildRemoveWorktreeCommand` coverage and added screen-level force-policy coverage for clean, dirty, and running sessions.
- Removed the test-only VT selection wrapper and Station button width export; tests now exercise the live production APIs and behavior directly.
- Removed the unused Observer `ErrorEnvelopeInput` re-export and regenerated architecture evidence.
- Added a narrow Knip duplicate exemption for the intentionally distinct scrollback default and safety ceiling.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm deadcode`
- `pnpm exec knip --production --cycles --no-config-hints`
- `pnpm test:unit` — 2,274 passed
- `pnpm test:contracts` — 60 passed
- `cd station && bun run test` — 1,408 passed

## Safety and scope

Observer command contracts and handlers remain intact. The change removes only validated unused exports and relocates existing remove-worktree guard logic without changing its predicate.

## User-visible behavior

No intended UX change. Remove Session still starts on the safe Keep action, and Delete still requires force for dirty or running sessions before dispatching the same `worktree.remove` command.
