### PR TITLE
refactor(terminal): synchronize native VT with resolved appearance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,11 @@ When these disagree, reconcile from config, providers, and current observer stat
   complete provider-neutral theme, and terminal providers do not participate in
   appearance selection. Native `auto` remains Station-owned; Station does not
   request or consume outer-palette evidence for native appearance selection.
+  Native composition supplies one resolved `StationTerminalTheme` projection
+  to the PTY registry, which remembers it for future emulator screens and fans
+  updates out to existing Station-owned screens without becoming appearance
+  authority. This visual operation changes no PTY identity, environment,
+  lifecycle, provider behavior, or Observer/Station Host contract.
   Every Station-owned child PTY receives Station's terminal
   identity and supported capabilities at the final native spawn boundary; local
   bridge, Bun, and Station Host paths must not expose outer-emulator identity as

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -112,9 +112,31 @@ query can repopulate a cache already cleared by the event.
 The standalone renderer owns the controller beside its OpenTUI renderer. The
 controller starts from the complete built-in fallback, and palette I/O does not
 delay root rendering; normal exit, errors, and Bun HMR unmount the React root and
-dispose palette listeners before destroying OpenTUI. Live propagation of native
-pane VT palette state remains tracked by #417 and is not part of embedded
-appearance selection.
+dispose palette listeners before destroying OpenTUI.
+
+Native composition applies the resolved theme's `StationTerminalTheme`
+projection to the PTY registry before restored panes can create lazy screens.
+The registry is only the lifecycle fan-out point: it remembers the latest
+projection for future screens and updates existing screens without becoming an
+appearance authority or changing a PTY's process, environment, geometry,
+identity, or replay state. A compatible HMR composition retains its live PTYs
+and reapplies the current projection.
+
+`StationVtScreen` owns terminal-semantic color state. Updating its projection
+rebuilds the ANSI palette used when rows are projected, so default and ANSI
+indices 0-15 can repaint while the xterm buffer retains their original color
+intent. The fixed ANSI-256 tail at indices 16-255 and explicit RGB/truecolor
+cells remain stable. OSC 10/11 queries use the current default foreground and
+background; changing the projection itself never feeds or replays bytes and
+never sends an unsolicited reply to the child.
+
+`TerminalPane` and the active theme provider own UI paint presentation: the
+render-ready default foreground and `theme.pane.selection` flow directly to the
+custom terminal renderable. The native canvas continues to supply blank/default
+background cells through `theme.surfaces.canvas`, and the cursor remains inverse
+cell composition over the resolved cell/default colors. Native `auto` remains
+the exact opaque built-in Station appearance; user selection and native outer-
+palette observation remain deferred to #421.
 
 You can also run the renderer directly during development:
 

--- a/station/src/hmr/stationHotRuntime.test.ts
+++ b/station/src/hmr/stationHotRuntime.test.ts
@@ -41,10 +41,19 @@ function createSlots(): StationHotSlots {
 }
 
 describe("station hot runtime", () => {
-  it("reuses a compatible runtime so the store and registry survive a reload", () => {
+  it("reuses a compatible v5 runtime so its live PTYs survive a reload", () => {
     const slots = createSlots();
     const first = getOrCreateStationHotRuntime(slots, FREEZE_CONFIG);
     first.store.actions.createPane("pane-second");
+    const scripted = createScriptedTerminal();
+    first.registry.setRuntimeOptions({
+      createTerminal: () => scripted.terminal,
+      scrollOnOutput: FREEZE_CONFIG.scroll_on_output,
+      scrollbackLines: FREEZE_CONFIG.scrollback_lines,
+    });
+    first.registry.resize("pane-second", { cols: 80, rows: 24 });
+    const screen = first.registry.get("pane-second")?.screen;
+    const terminal = first.registry.get("pane-second")?.terminal;
 
     // A later boot (even with a changed config) returns the same instances, so
     // the active pane/session and live PTYs persist across the code edit.
@@ -53,10 +62,13 @@ describe("station hot runtime", () => {
     expect(second).toBe(first);
     expect(second.store).toBe(first.store);
     expect(second.registry).toBe(first.registry);
+    expect(second.registry.get("pane-second")?.screen).toBe(screen);
+    expect(second.registry.get("pane-second")?.terminal).toBe(terminal);
+    expect(scripted.helpers.isDisposed()).toBe(false);
     expect(second.store.getState().workspace.activePaneId).toEqual("pane-second");
   });
 
-  it("reboots a pre-scrollback v3 runtime and disposes its old PTYs", () => {
+  it("reboots an incompatible v4 runtime and disposes its old PTYs", () => {
     const slots = createSlots();
     const oldStore = createStationStore();
     const paneId = agentWorktreePaneId("wt_station_idle");
@@ -65,7 +77,7 @@ describe("station hot runtime", () => {
     const oldRegistry = createPtyRegistry({ createTerminal: () => scripted.terminal });
     oldRegistry.resize(paneId, { cols: 80, rows: 24 });
     const oldRuntime: StationHotRuntime = {
-      version: 3,
+      version: 4,
       store: oldStore,
       registry: oldRegistry,
     };

--- a/station/src/hmr/stationHotRuntime.ts
+++ b/station/src/hmr/stationHotRuntime.ts
@@ -10,7 +10,9 @@ import { createPtyRegistry, type PtyRegistry } from "../terminal/registry/ptyReg
 // preserved v2 registry would leave hot-reloaded panes without them.
 // v4: registries gained configurable scrollback; a preserved v3 registry would
 // ignore the refreshed depth when lazily creating screens after a hot reload.
-export const STATION_HOT_RUNTIME_VERSION = 4;
+// v5: registries/screens gained the terminal-projection update seam; a preserved
+// v4 registry cannot accept the native composition's projection refresh.
+export const STATION_HOT_RUNTIME_VERSION = 5;
 
 export type StationHotRenderer = { destroy(): void };
 

--- a/station/src/main.tsx
+++ b/station/src/main.tsx
@@ -207,6 +207,7 @@ async function startStationMain(
     stationConfig.config,
     restorePlan?.workspace,
   );
+  stationRuntime.registry.updateTerminalTheme(nativeStationTheme.terminal);
   const { store } = stationRuntime;
   // Seed each restored pane's spawn cwd / host placement into the registry BEFORE the
   // reconciler runs its no-option ensure (which would otherwise capture

--- a/station/src/terminal/TerminalPane.test.tsx
+++ b/station/src/terminal/TerminalPane.test.tsx
@@ -1,11 +1,17 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { getLinkId, rgbToHex, TextAttributes } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
 import { MAIN_PANE_ID } from "../state/types.js";
 import {
   nativeStationTheme,
+  rgbColor,
   stationColorSnapshotValue,
   StationThemeProvider,
+  toOpenTuiOpaqueColor,
+  useStationThemeSource,
+  type StationTheme,
+  type StationThemeSource,
 } from "../theme/index.js";
 import { PaneRegistryProvider } from "./registry/paneTerminalContext.js";
 import { createPtyRegistry, type PtyRegistry } from "./registry/ptyRegistry.js";
@@ -26,7 +32,73 @@ type PaneSetup = {
   scripted: ScriptedTerminal;
   spawnSizes: StationTerminalSize[];
   registry: PtyRegistry;
+  themeSource: MutableThemeSource;
 };
+
+class MutableThemeSource implements StationThemeSource {
+  private snapshot: StationTheme;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(snapshot: StationTheme) {
+    this.snapshot = snapshot;
+  }
+
+  readonly getSnapshot = (): StationTheme => this.snapshot;
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  set(theme: StationTheme): void {
+    this.snapshot = theme;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+function ThemedTerminalPane({
+  source,
+  registry,
+}: {
+  source: StationThemeSource;
+  registry: PtyRegistry;
+}) {
+  const theme = useStationThemeSource(source);
+  return (
+    <StationThemeProvider theme={theme}>
+      <box
+        width="100%"
+        height="100%"
+        backgroundColor={toOpenTuiOpaqueColor(theme.surfaces.canvas)}
+      >
+        <PaneRegistryProvider registry={registry}>
+          <TerminalPane paneId={MAIN_PANE_ID} />
+        </PaneRegistryProvider>
+      </box>
+    </StationThemeProvider>
+  );
+}
+
+function appearanceTheme(
+  defaultForeground: `#${string}`,
+  defaultBackground: `#${string}`,
+  ansiRed: `#${string}`,
+  selection: `#${string}`,
+  canvas: `#${string}`,
+): StationTheme {
+  const [ansiBlack, , ...ansiTail] = nativeStationTheme.terminal.ansi16;
+  return {
+    ...nativeStationTheme,
+    surfaces: { ...nativeStationTheme.surfaces, canvas: rgbColor(canvas) },
+    pane: { ...nativeStationTheme.pane, selection: rgbColor(selection) },
+    terminal: {
+      defaultForeground: rgbColor(defaultForeground),
+      defaultBackground: rgbColor(defaultBackground),
+      ansi16: [ansiBlack, rgbColor(ansiRed), ...ansiTail],
+    },
+  };
+}
 
 describe("TerminalPane frame rendering", () => {
   const teardowns: Array<() => void> = [];
@@ -36,7 +108,10 @@ describe("TerminalPane frame rendering", () => {
     }
   });
 
-  async function renderPane(spawnOptions?: StationTerminalSpawnOptions): Promise<PaneSetup> {
+  async function renderPane(
+    spawnOptions?: StationTerminalSpawnOptions,
+    theme: StationTheme = nativeStationTheme,
+  ): Promise<PaneSetup> {
     // The pane spawns its PTY on first layout and updates through the registry
     // (an external store), so updates land outside React's act() from the very
     // first render; tests poll rendered frames rather than relying on act.
@@ -52,17 +127,15 @@ describe("TerminalPane frame rendering", () => {
         return scripted.terminal;
       },
     });
+    registry.updateTerminalTheme(theme.terminal);
     // Pre-seed the entry so cwd is captured (the pane reports size but never
     // ensures); mirrors how an aux split is ensured with its inherited cwd.
     if (spawnOptions !== undefined) {
       registry.ensure(MAIN_PANE_ID, spawnOptions);
     }
+    const themeSource = new MutableThemeSource(theme);
     const setup = await testRender(
-      <StationThemeProvider theme={nativeStationTheme}>
-        <PaneRegistryProvider registry={registry}>
-          <TerminalPane paneId={MAIN_PANE_ID} />
-        </PaneRegistryProvider>
-      </StationThemeProvider>,
+      <ThemedTerminalPane source={themeSource} registry={registry} />,
       SURFACE,
     );
     teardowns.push(() => {
@@ -71,7 +144,7 @@ describe("TerminalPane frame rendering", () => {
     });
     await setup.flush();
     await waitFor(() => spawnSizes.length > 0);
-    return { setup, scripted, spawnSizes, registry };
+    return { setup, scripted, spawnSizes, registry, themeSource };
   }
 
   // The store flushes on a real timer, so frame-waiting must interleave
@@ -140,6 +213,75 @@ describe("TerminalPane frame rendering", () => {
     expect((errSpan?.attributes ?? 0) & TextAttributes.BOLD).toBe(TextAttributes.BOLD);
     const okSpan = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 4);
     expect(rgbToHex(okSpan?.fg as Parameters<typeof rgbToHex>[0])).toBe("#010203");
+  });
+
+  it("updates UI paint and indexed VT projection without replacing the pane runtime", async () => {
+    const initialTheme = appearanceTheme(
+      "#111213",
+      "#141516",
+      "#171819",
+      "#1a1b1c",
+      "#1d1e1f",
+    );
+    const nextTheme = appearanceTheme(
+      "#a1a2a3",
+      "#a4a5a6",
+      "#a7a8a9",
+      "#aaabac",
+      "#adaeaf",
+    );
+    const pane = await renderPane(undefined, initialTheme);
+    await feedAndFlush(
+      pane,
+      "D\x1b[31mI\x1b[38;5;196mF\x1b[38;2;1;2;3mT\x1b[0m",
+    );
+    await waitForPaneFrame(pane, (frame) => frame.includes("DIFT"));
+    const screen = pane.registry.get(MAIN_PANE_ID)?.screen;
+    const terminal = pane.registry.get(MAIN_PANE_ID)?.terminal;
+    const engine = screen?.unsafeEngine;
+    const version = screen?.getVersion();
+    const initialFrame = pane.setup.captureSpans();
+    const initialDefault = spanAtFrameCell(initialFrame, ORIGIN.y, ORIGIN.x);
+    const initialIndexed = spanAtFrameCell(initialFrame, ORIGIN.y, ORIGIN.x + 1);
+    expect(initialDefault?.fg === undefined ? undefined : rgbToHex(initialDefault.fg)).toBe(
+      "#111213",
+    );
+    expect(initialIndexed?.fg === undefined ? undefined : rgbToHex(initialIndexed.fg)).toBe(
+      "#171819",
+    );
+
+    await act(async () => {
+      pane.registry.updateTerminalTheme(nextTheme.terminal);
+      pane.themeSource.set(nextTheme);
+      await Promise.resolve();
+    });
+    await pane.setup.flush();
+
+    expect(pane.registry.get(MAIN_PANE_ID)?.screen).toBe(screen);
+    expect(pane.registry.get(MAIN_PANE_ID)?.terminal).toBe(terminal);
+    expect(screen?.unsafeEngine).toBe(engine);
+    expect(screen?.getVersion()).toBe((version ?? 0) + 1);
+    const frame = pane.setup.captureSpans();
+    const defaultCell = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x);
+    const indexedCell = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 1);
+    const fixedTailCell = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 2);
+    const truecolorCell = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 3);
+    const cursorCell = spanAtFrameCell(frame, ORIGIN.y, ORIGIN.x + 4);
+    expect(defaultCell?.fg === undefined ? undefined : rgbToHex(defaultCell.fg)).toBe("#a1a2a3");
+    expect(indexedCell?.fg === undefined ? undefined : rgbToHex(indexedCell.fg)).toBe("#a7a8a9");
+    expect(fixedTailCell?.fg === undefined ? undefined : rgbToHex(fixedTailCell.fg)).toBe(
+      "#ff0000",
+    );
+    expect(truecolorCell?.fg === undefined ? undefined : rgbToHex(truecolorCell.fg)).toBe(
+      "#010203",
+    );
+    expect((cursorCell?.attributes ?? 0) & TextAttributes.INVERSE).toBe(TextAttributes.INVERSE);
+    expect(defaultCell?.bg === undefined ? undefined : rgbToHex(defaultCell.bg)).toBe("#adaeaf");
+
+    await pane.setup.mockMouse.drag(ORIGIN.x, ORIGIN.y, ORIGIN.x + 1, ORIGIN.y);
+    await pane.setup.renderOnce();
+    const selected = spanAtFrameCell(pane.setup.captureSpans(), ORIGIN.y, ORIGIN.x);
+    expect(selected?.bg === undefined ? undefined : rgbToHex(selected.bg)).toBe("#aaabac");
   });
 
   it("projects an OSC 8 URI through the production registry, screen, and pane", async () => {

--- a/station/src/terminal/TerminalPane.tsx
+++ b/station/src/terminal/TerminalPane.tsx
@@ -2,7 +2,11 @@ import { basename } from "node:path";
 import type { ColorInput } from "@opentui/core";
 import "./TerminalScreenRenderable.js";
 import type { PaneId } from "../state/types.js";
-import { toOpenTuiColor, useStationTheme } from "../theme/index.js";
+import {
+  stationColorSnapshotValue,
+  toOpenTuiColor,
+  useStationTheme,
+} from "../theme/index.js";
 import { usePaneTerminal } from "./registry/paneTerminalContext.js";
 
 export type TerminalPaneProps = {
@@ -48,6 +52,8 @@ export function TerminalPane({
         width="100%"
         flexGrow={1}
         screen={term.screen}
+        defaultForeground={theme.terminal.defaultForeground.value}
+        selectionBackground={stationColorSnapshotValue(theme.pane.selection)}
         onViewportResize={term.reportSize}
         onCopySelection={onCopySelection}
         onForwardInput={onForwardInput}

--- a/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.clip.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { getLinkId } from "@opentui/core";
 import { createElement } from "react";
 import { testRender } from "@opentui/react/test-utils";
+import { nativeStationTheme, stationColorSnapshotValue } from "../theme/index.js";
 import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
 import "./TerminalScreenRenderable.js";
 
@@ -34,7 +35,13 @@ async function mountNarrowPane(feed: string): Promise<Mounted> {
   screen.feed(`\x1b[?25l${feed}`); // hide the cursor so only fed glyphs paint
   await screen.whenIdle();
   const setup = await testRender(
-    createElement("terminalScreen", { screen, width: PANE_COLS, height: "100%" }),
+    createElement("terminalScreen", {
+      screen,
+      width: PANE_COLS,
+      height: "100%",
+      defaultForeground: nativeStationTheme.terminal.defaultForeground.value,
+      selectionBackground: stationColorSnapshotValue(nativeStationTheme.pane.selection),
+    }),
     FRAME,
   );
   teardowns.push(() => {

--- a/station/src/terminal/TerminalScreenRenderable.osc8.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.osc8.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { Writable } from "node:stream";
 import { testRender } from "@opentui/react/test-utils";
+import { nativeStationTheme, stationColorSnapshotValue } from "../theme/index.js";
 import { waitFor } from "./testing/waitFor.js";
 import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
 import "./TerminalScreenRenderable.js";
@@ -60,7 +61,13 @@ async function mount(hyperlinks: boolean, width = 30): Promise<Mounted> {
   let setup: Awaited<ReturnType<typeof testRender>>;
   try {
     setup = await testRender(
-      <terminalScreen screen={screen} width="100%" height="100%" />,
+      <terminalScreen
+        screen={screen}
+        width="100%"
+        height="100%"
+        defaultForeground={nativeStationTheme.terminal.defaultForeground.value}
+        selectionBackground={stationColorSnapshotValue(nativeStationTheme.pane.selection)}
+      />,
       {
         width,
         height: rows,

--- a/station/src/terminal/TerminalScreenRenderable.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.test.tsx
@@ -167,6 +167,26 @@ describe("TerminalScreenRenderable selection", () => {
     }
   });
 
+  it("preserves selection across terminal projection updates", async () => {
+    const { setup, screen } = await renderPane("hello world");
+    try {
+      await setup.mockMouse.drag(0, 0, 4, 0);
+      await setup.renderOnce();
+      const versionBeforeUpdate = screen.getVersion();
+
+      screen.updateTerminalTheme(nativeStationTheme.terminal);
+      await setup.renderOnce();
+
+      const selected = spanAtFrameCell(setup.captureSpans(), 0, 0);
+      expect(selected?.bg === undefined ? undefined : rgbToHex(selected.bg)).toBe(
+        stationColorSnapshotValue(nativeStationTheme.pane.selection),
+      );
+      expect(screen.getVersion()).toBe(versionBeforeUpdate + 1);
+    } finally {
+      await teardown(setup, screen);
+    }
+  });
+
   it("copies the dragged range on release", async () => {
     const { setup, screen, copied } = await renderPane("hello world");
     try {

--- a/station/src/terminal/TerminalScreenRenderable.test.tsx
+++ b/station/src/terminal/TerminalScreenRenderable.test.tsx
@@ -1,10 +1,51 @@
 import { describe, expect, it } from "bun:test";
 import { getLinkId, rgbToHex } from "@opentui/core";
 import { testRender } from "@opentui/react/test-utils";
+import { act, useState, type Dispatch, type SetStateAction } from "react";
 import { nativeStationTheme, stationColorSnapshotValue } from "../theme/index.js";
 import { spanAtFrameCell } from "./testing/frameProbe.js";
 import { createStationVtScreen, type StationVtScreen } from "./vt/screen.js";
 import "./TerminalScreenRenderable.js";
+
+const NATIVE_PAINT = {
+  defaultForeground: nativeStationTheme.terminal.defaultForeground.value,
+  selectionBackground: stationColorSnapshotValue(nativeStationTheme.pane.selection),
+};
+const INITIAL_TEST_PAINT = {
+  defaultForeground: nativeStationTheme.text.primary.value,
+  selectionBackground: nativeStationTheme.interaction.compactFocus.value,
+};
+const NEXT_TEST_PAINT = {
+  defaultForeground: nativeStationTheme.action.success.value,
+  selectionBackground: nativeStationTheme.interaction.hover.value,
+};
+
+type Paint = {
+  defaultForeground: `#${string}`;
+  selectionBackground: `#${string}`;
+};
+
+function MutablePaintScreen({
+  screen,
+  initialPaint,
+  onSetter,
+}: {
+  screen: StationVtScreen;
+  initialPaint: Paint;
+  onSetter(setter: Dispatch<SetStateAction<Paint>>): void;
+}) {
+  const [paint, setPaint] = useState(initialPaint);
+  onSetter(setPaint);
+  return (
+    <terminalScreen
+      screen={screen}
+      width="100%"
+      height="100%"
+      defaultForeground={paint.defaultForeground}
+      selectionBackground={paint.selectionBackground}
+    />
+  );
+}
 
 async function renderPane(feed: string) {
   const screen = createStationVtScreen({ size: { cols: 20, rows: 6 } });
@@ -17,6 +58,8 @@ async function renderPane(feed: string) {
       screen={screen}
       width="100%"
       height="100%"
+      defaultForeground={NATIVE_PAINT.defaultForeground}
+      selectionBackground={NATIVE_PAINT.selectionBackground}
       now={() => 1000}
       onCopySelection={(text: string) => copied.push(text)}
       onForwardInput={(bytes: string) => forwarded.push(bytes)}
@@ -31,6 +74,66 @@ async function teardown(setup: { renderer: { destroy(): void } }, screen: Statio
   setup.renderer.destroy();
   screen.dispose();
 }
+
+describe("TerminalScreenRenderable paint props", () => {
+  it("redraws default foreground and selection without rebuilding or replacing the screen", async () => {
+    const screen = createStationVtScreen({ size: { cols: 20, rows: 6 } });
+    screen.feed("paint props");
+    await screen.whenIdle();
+    let rowBuilds = 0;
+    const buildRows = screen.buildRows.bind(screen);
+    screen.buildRows = (options) => {
+      rowBuilds += 1;
+      return buildRows(options);
+    };
+    const initialPaint: Paint = INITIAL_TEST_PAINT;
+    let setPaint: Dispatch<SetStateAction<Paint>> | undefined;
+    const setup = await testRender(
+      <MutablePaintScreen
+        screen={screen}
+        initialPaint={initialPaint}
+        onSetter={(setter) => {
+          setPaint = setter;
+        }}
+      />,
+      { width: 20, height: 6 },
+    );
+    try {
+      await setup.flush();
+      await setup.mockMouse.drag(0, 0, 1, 0);
+      await setup.renderOnce();
+      const before = spanAtFrameCell(setup.captureSpans(), 0, 0);
+      expect(before?.fg === undefined ? undefined : rgbToHex(before.fg)).toBe(
+        INITIAL_TEST_PAINT.defaultForeground,
+      );
+      expect(before?.bg === undefined ? undefined : rgbToHex(before.bg)).toBe(
+        INITIAL_TEST_PAINT.selectionBackground,
+      );
+      const engine = screen.unsafeEngine;
+      const version = screen.getVersion();
+      const buildsBeforeUpdate = rowBuilds;
+
+      await act(async () => {
+        setPaint?.(NEXT_TEST_PAINT);
+        await Promise.resolve();
+      });
+      await setup.flush();
+
+      const after = spanAtFrameCell(setup.captureSpans(), 0, 0);
+      expect(after?.fg === undefined ? undefined : rgbToHex(after.fg)).toBe(
+        NEXT_TEST_PAINT.defaultForeground,
+      );
+      expect(after?.bg === undefined ? undefined : rgbToHex(after.bg)).toBe(
+        NEXT_TEST_PAINT.selectionBackground,
+      );
+      expect(rowBuilds).toBe(buildsBeforeUpdate);
+      expect(screen.getVersion()).toBe(version);
+      expect(screen.unsafeEngine).toBe(engine);
+    } finally {
+      await teardown(setup, screen);
+    }
+  });
+});
 
 describe("TerminalScreenRenderable selection", () => {
   it("retains native hyperlink attributes while highlighting a selection", async () => {

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -110,12 +110,10 @@ export class TerminalScreenRenderable extends Renderable {
     this.#resetSelection();
     this.#middleDown = null;
     if (value !== null) {
-      this.#unsubscribe = value.subscribe(() => {
-        // Output or a scroll changes what the selection's viewport cells show,
-        // so a settled selection's highlight/deferred copy would go stale. Drop
-        // it — but leave an in-progress drag (anchor set) to finish and copy on
-        // release.
-        if (this.#anchor === null) {
+      this.#unsubscribe = value.subscribe((invalidation) => {
+        // Output or a scroll changes what selected viewport cells show; repaint-only
+        // updates preserve the selection while rebuilding its color projection.
+        if (invalidation === "content" && this.#anchor === null) {
           this.#resetSelection();
         }
         this.requestRender();

--- a/station/src/terminal/TerminalScreenRenderable.ts
+++ b/station/src/terminal/TerminalScreenRenderable.ts
@@ -13,7 +13,6 @@ import { buildMouseReportSequence } from "./input/mouseReport.js";
 import { type MouseButtonName, MouseTracking } from "./protocol/mouse.js";
 import type { VtRow } from "./vt/rows.js";
 import type { MouseProtocol, StationVtScreen } from "./vt/screen.js";
-import { nativeStationTheme, stationColorSnapshotValue } from "../theme/index.js";
 import {
   type CellPoint,
   type CellSelection,
@@ -31,6 +30,10 @@ const MULTI_CLICK_MS = 400;
 
 export type TerminalScreenOptions = RenderableOptions<TerminalScreenRenderable> & {
   screen?: StationVtScreen | null;
+  /** UI-theme-owned default foreground used when a VT span keeps default-color intent. */
+  defaultForeground: `#${string}`;
+  /** UI-theme-owned selection background, already resolved to an opaque RGB snapshot. */
+  selectionBackground: `#${string}`;
   /**
    * Fires with the laid-out interior size in cells. This is the source of
    * truth for PTY and screen dimensions: border, padding, and surrounding
@@ -56,6 +59,8 @@ export class TerminalScreenRenderable extends Renderable {
   #onCopySelection: ((text: string) => void) | undefined;
   #onForwardInput: ((bytes: string) => void) | undefined;
   #now: () => number;
+  #defaultForeground: `#${string}`;
+  #selectionBackground: `#${string}`;
   #rows: VtRow[] = [];
   #rowsVersion = -1;
   // Self-managed selection (we don't use OpenTUI's selectable path so the
@@ -83,6 +88,8 @@ export class TerminalScreenRenderable extends Renderable {
     this.#onCopySelection = options.onCopySelection;
     this.#onForwardInput = options.onForwardInput;
     this.#now = options.now ?? Date.now;
+    this.#defaultForeground = options.defaultForeground;
+    this.#selectionBackground = options.selectionBackground;
     this.screen = options.screen ?? null;
   }
 
@@ -127,6 +134,22 @@ export class TerminalScreenRenderable extends Renderable {
 
   set onForwardInput(handler: ((bytes: string) => void) | undefined) {
     this.#onForwardInput = handler;
+  }
+
+  set defaultForeground(value: `#${string}`) {
+    if (this.#defaultForeground === value) {
+      return;
+    }
+    this.#defaultForeground = value;
+    this.requestRender();
+  }
+
+  set selectionBackground(value: `#${string}`) {
+    if (this.#selectionBackground === value) {
+      return;
+    }
+    this.#selectionBackground = value;
+    this.requestRender();
   }
 
   protected override onLayoutResize(width: number, height: number): void {
@@ -456,8 +479,8 @@ export class TerminalScreenRenderable extends Renderable {
       this.#rowsVersion = version;
     }
 
-    const defaultFg = rgbaForHex(nativeStationTheme.terminal.defaultForeground.value);
-    const selectionBg = rgbaForHex(stationColorSnapshotValue(nativeStationTheme.pane.selection));
+    const defaultFg = rgbaForHex(this.#defaultForeground);
+    const selectionBg = rgbaForHex(this.#selectionBackground);
     // Order the selection once per frame, not once per row.
     const orderedSelection = this.#selection === null ? null : orderSelection(this.#selection);
     const rowLimit = Math.min(this.#rows.length, this.height);

--- a/station/src/terminal/registry/ptyRegistry.test.ts
+++ b/station/src/terminal/registry/ptyRegistry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { nativeStationTheme, type StationTerminalTheme } from "../../theme/index.js";
 import { createScriptedTerminal, type ScriptedTerminal } from "../testing/scriptedTerminal.js";
 import type {
   StationTerminalDisposable,
@@ -12,6 +13,27 @@ import { createPtyRegistry } from "./ptyRegistry.js";
 const PANE_A = "pane-a";
 const PANE_B = "pane-b";
 const SIZE: StationTerminalSize = { cols: 36, rows: 8 };
+
+function oscRgb(color: StationTerminalTheme["defaultForeground"]): string {
+  const value = color.value.slice(1);
+  const red = value.slice(0, 2);
+  const green = value.slice(2, 4);
+  const blue = value.slice(4, 6);
+  return `rgb:${red}${red}/${green}${green}/${blue}${blue}`;
+}
+
+function terminalTheme(
+  defaultForeground: StationTerminalTheme["defaultForeground"],
+  defaultBackground: StationTerminalTheme["defaultBackground"],
+  ansiRed: StationTerminalTheme["ansi16"][1],
+): StationTerminalTheme {
+  const [ansiBlack, , ...ansiTail] = nativeStationTheme.terminal.ansi16;
+  return {
+    defaultForeground,
+    defaultBackground,
+    ansi16: [ansiBlack, ansiRed, ...ansiTail],
+  };
+}
 
 /** A registry whose PTYs are scripted terminals handed out in spawn order. */
 function harness(options?: { count?: number; resizeDebounceMs?: number }) {
@@ -227,6 +249,112 @@ describe("createPtyRegistry", () => {
 
     expect(registry.get(PANE_A)?.screen?.bufferStats().baseY).toBe(1);
     expect(registry.get(PANE_B)?.screen?.bufferStats().baseY).toBe(3);
+  });
+
+  it("fans the latest terminal projection to existing and future screens only", async () => {
+    const firstTheme = terminalTheme(
+      nativeStationTheme.text.primary,
+      nativeStationTheme.surfaces.canvas,
+      nativeStationTheme.status.warning,
+    );
+    const nextTheme = terminalTheme(
+      nativeStationTheme.action.primary,
+      nativeStationTheme.contextMenu.surface,
+      nativeStationTheme.status.accent,
+    );
+    const first = createScriptedTerminal();
+    const second = createScriptedTerminal();
+    let replay:
+      | ((value: StationTerminalReplay) => void | Promise<void>)
+      | undefined;
+    first.terminal.onReplay = (listener) => {
+      replay = listener;
+      return { dispose: () => {} };
+    };
+    const spawned: StationTerminalProcess[] = [];
+    let spawnIndex = 0;
+    const registry = createPtyRegistry({
+      createTerminal: () => {
+        const terminal = [first.terminal, second.terminal][spawnIndex];
+        if (terminal === undefined) {
+          throw new Error("scripted terminal pool exhausted");
+        }
+        spawnIndex += 1;
+        spawned.push(terminal);
+        return terminal;
+      },
+    });
+    registry.updateTerminalTheme(firstTheme);
+    registry.ensure(PANE_A);
+    registry.ensure(PANE_B);
+    let structuralNotifications = 0;
+    registry.subscribe(() => {
+      structuralNotifications += 1;
+    });
+
+    registry.resize(PANE_A, SIZE);
+    const firstEntry = registry.get(PANE_A);
+    const firstScreen = firstEntry?.screen;
+    const firstTerminal = firstEntry?.terminal;
+    expect(firstScreen).not.toBeNull();
+    expect(firstTerminal).toBe(first.terminal);
+
+    await replay?.({
+      kind: "raw-complete",
+      initialSize: SIZE,
+      events: [{ type: "data", data: "\x1b]10;?\x07" }],
+    });
+    expect(first.helpers.writes).toEqual([]);
+    first.helpers.emitData("D\x1b[31mI\x1b[38;5;196mF\x1b[38;2;1;2;3mT");
+    await firstScreen?.whenIdle();
+    const initialForegrounds = firstScreen
+      ?.buildRows({ cursorVisible: false })[0]
+      ?.spans.map((span) => span.fg);
+    expect(initialForegrounds?.[0]).toBeUndefined();
+    expect(initialForegrounds?.[1]).toBe(firstTheme.ansi16[1].value);
+
+    const notificationCount = structuralNotifications;
+    const writesBefore = [...first.helpers.writes];
+    const resizesBefore = [...first.helpers.resizes];
+    const statsBefore = firstScreen?.bufferStats();
+    registry.updateTerminalTheme(nextTheme);
+
+    expect(registry.get(PANE_A)?.screen).toBe(firstScreen);
+    expect(registry.get(PANE_A)?.terminal).toBe(firstTerminal);
+    expect(firstScreen?.bufferStats()).toEqual(statsBefore);
+    const updatedForegrounds = firstScreen
+      ?.buildRows({ cursorVisible: false })[0]
+      ?.spans.map((span) => span.fg);
+    expect(updatedForegrounds?.[0]).toBeUndefined();
+    expect(updatedForegrounds?.[1]).toBe(nextTheme.ansi16[1].value);
+    expect(updatedForegrounds?.slice(2)).toEqual(initialForegrounds?.slice(2));
+    expect(structuralNotifications).toBe(notificationCount);
+    expect(first.helpers.writes).toEqual(writesBefore);
+    expect(first.helpers.resizes).toEqual(resizesBefore);
+    expect(first.helpers.isDisposed()).toBe(false);
+    expect(spawned).toEqual([first.terminal]);
+
+    registry.resize(PANE_B, SIZE);
+    const secondScreen = registry.get(PANE_B)?.screen;
+    second.helpers.emitData("D\x1b[31mI\x1b[38;5;196mF\x1b[38;2;1;2;3mT");
+    await secondScreen?.whenIdle();
+    expect(
+      secondScreen?.buildRows({ cursorVisible: false })[0]?.spans.map((span) => span.fg),
+    ).toEqual(updatedForegrounds);
+
+    first.helpers.emitData("\x1b]10;?\x07\x1b]11;?\x07");
+    second.helpers.emitData("\x1b]10;?\x07\x1b]11;?\x07");
+    await Promise.all([firstScreen?.whenIdle(), secondScreen?.whenIdle()]);
+    for (const scripted of [first, second]) {
+      expect(scripted.helpers.writes).toContain(
+        `\x1b]10;${oscRgb(nextTheme.defaultForeground)}\x07`,
+      );
+      expect(scripted.helpers.writes).toContain(
+        `\x1b]11;${oscRgb(nextTheme.defaultBackground)}\x07`,
+      );
+      expect(scripted.helpers.isDisposed()).toBe(false);
+    }
+    expect(spawned).toEqual([first.terminal, second.terminal]);
   });
 
   it("disables scrollback when the configured depth is zero", async () => {

--- a/station/src/terminal/registry/ptyRegistry.test.ts
+++ b/station/src/terminal/registry/ptyRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { nativeStationTheme, type StationTerminalTheme } from "../../theme/index.js";
 import { createScriptedTerminal, type ScriptedTerminal } from "../testing/scriptedTerminal.js";
+import { waitFor } from "../testing/waitFor.js";
 import type {
   StationTerminalDisposable,
   StationTerminalProcess,
@@ -8,10 +9,12 @@ import type {
   StationTerminalSize,
   StationTerminalSpawnOptions,
 } from "../types.js";
+import type { StationVtScreen } from "../vt/screen.js";
 import { createPtyRegistry } from "./ptyRegistry.js";
 
 const PANE_A = "pane-a";
 const PANE_B = "pane-b";
+const PANE_C = "pane-c";
 const SIZE: StationTerminalSize = { cols: 36, rows: 8 };
 
 function oscRgb(color: StationTerminalTheme["defaultForeground"]): string {
@@ -33,6 +36,10 @@ function terminalTheme(
     defaultBackground,
     ansi16: [ansiBlack, ansiRed, ...ansiTail],
   };
+}
+
+function firstForeground(screen: StationVtScreen): string | undefined {
+  return screen.buildRows({ cursorVisible: false })[0]?.spans[0]?.fg;
 }
 
 /** A registry whose PTYs are scripted terminals handed out in spawn order. */
@@ -355,6 +362,73 @@ describe("createPtyRegistry", () => {
       expect(scripted.helpers.isDisposed()).toBe(false);
     }
     expect(spawned).toEqual([first.terminal, second.terminal]);
+  });
+
+  it("publishes terminal projection atomically before repainting screens", async () => {
+    const initialTheme = terminalTheme(
+      nativeStationTheme.text.primary,
+      nativeStationTheme.surfaces.canvas,
+      nativeStationTheme.status.warning,
+    );
+    const nextTheme = terminalTheme(
+      nativeStationTheme.action.primary,
+      nativeStationTheme.contextMenu.surface,
+      nativeStationTheme.status.accent,
+    );
+    const { registry, scripted } = harness({ count: 3 });
+    registry.updateTerminalTheme(initialTheme);
+    registry.resize(PANE_A, SIZE);
+    registry.resize(PANE_B, SIZE);
+    const firstScreen = registry.get(PANE_A)?.screen;
+    const secondScreen = registry.get(PANE_B)?.screen;
+    if (
+      firstScreen === null ||
+      firstScreen === undefined ||
+      secondScreen === null ||
+      secondScreen === undefined
+    ) {
+      throw new Error("Expected both existing screens to be initialized.");
+    }
+    scripted[0].helpers.emitData("\x1b[31mA");
+    scripted[1].helpers.emitData("\x1b[31mB");
+    await Promise.all([firstScreen.whenIdle(), secondScreen.whenIdle()]);
+    await waitFor(() => firstScreen.getVersion() > 0 && secondScreen.getVersion() > 0);
+
+    let firstRepaints = 0;
+    let secondRepaints = 0;
+    let observedDuringFirstRepaint: readonly (string | undefined)[] = [];
+    firstScreen.subscribe((invalidation) => {
+      if (invalidation !== "repaint") {
+        return;
+      }
+      firstRepaints += 1;
+      registry.resize(PANE_C, SIZE);
+      observedDuringFirstRepaint = [
+        firstForeground(firstScreen),
+        firstForeground(secondScreen),
+      ];
+    });
+    secondScreen.subscribe((invalidation) => {
+      if (invalidation === "repaint") {
+        secondRepaints += 1;
+      }
+    });
+
+    registry.updateTerminalTheme(nextTheme);
+
+    expect(observedDuringFirstRepaint).toEqual([
+      nextTheme.ansi16[1].value,
+      nextTheme.ansi16[1].value,
+    ]);
+    expect(firstRepaints).toBe(1);
+    expect(secondRepaints).toBe(1);
+    const lazyScreen = registry.get(PANE_C)?.screen;
+    expect(lazyScreen).not.toBeNull();
+    scripted[2].helpers.emitData("\x1b[31mC");
+    await lazyScreen?.whenIdle();
+    expect(
+      lazyScreen === null || lazyScreen === undefined ? undefined : firstForeground(lazyScreen),
+    ).toBe(nextTheme.ansi16[1].value);
   });
 
   it("disables scrollback when the configured depth is zero", async () => {

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -540,9 +540,16 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
     },
 
     updateTerminalTheme: (theme) => {
+      const updates = [...entries.values()].flatMap((entry) =>
+        entry.screen === null ? [] : [entry.screen.prepareTerminalThemeUpdate(theme)],
+      );
       terminalTheme = theme;
-      for (const entry of entries.values()) {
-        entry.screen?.updateTerminalTheme(theme);
+      // Publish every complete projection before any repaint listener can observe another screen.
+      for (const update of updates) {
+        update.publish();
+      }
+      for (const update of updates) {
+        update.invalidate();
       }
     },
 

--- a/station/src/terminal/registry/ptyRegistry.ts
+++ b/station/src/terminal/registry/ptyRegistry.ts
@@ -1,5 +1,6 @@
 import type { ScrollOnOutputMode } from "../../config/stationConfig.js";
 import type { PaneId } from "../../state/types.js";
+import type { StationTerminalTheme } from "../../theme/index.js";
 import { reportTerminalCorruption, writePaneEvidenceDump } from "../diagnostics.js";
 import { BracketedPasteMarker } from "../protocol/csi.js";
 import { createLocalPtyTerminal } from "../pty/localPtyTerminal.js";
@@ -67,14 +68,21 @@ export type PtyRegistry = {
   /** Structural/status changes (spawn, exit, dispose) — NOT screen content. */
   subscribe(listener: () => void): () => void;
   /**
+   * Fan one terminal-semantic projection to existing screens and remember it
+   * for future lazy screens. This repaints emulator output only: it never
+   * mutates, resizes, writes to, signals, replaces, or respawns a PTY.
+   */
+  updateTerminalTheme(theme: StationTerminalTheme): void;
+  /**
    * Replace the pane-exit side effect. HMR can keep the registry and live PTYs
    * while recreating the app composition, so exits must report through the
    * current observer client instead of the callback captured at registry birth.
    */
   setPaneExitHandler(listener: ((paneId: PaneId) => void) | undefined): void;
   /**
-   * Refresh defaults used by future lazy spawns. Existing live panes keep their
-   * current terminal/screen semantics; HMR should not mutate a running shell.
+   * Refresh process and scroll defaults used by future lazy spawns. Existing
+   * live shells keep those semantics; live visual projection updates use
+   * `updateTerminalTheme` instead.
    */
   setRuntimeOptions(options: PtyRegistryRuntimeOptions): void;
   dispose(paneId: PaneId): void;
@@ -148,6 +156,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
   let createTerminal = options.createTerminal ?? createLocalPtyTerminal;
   let scrollOnOutput = options.scrollOnOutput;
   let scrollbackLines = options.scrollbackLines;
+  let terminalTheme: StationTerminalTheme | undefined;
   const resizeDebounceMs = options.resizeDebounceMs ?? DEFAULT_RESIZE_DEBOUNCE_MS;
   const geometrySettleMs = options.geometrySettleMs ?? GEOMETRY_SETTLE_MS;
   const entries = new Map<PaneId, InternalEntry>();
@@ -202,6 +211,7 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
       size,
       ...(scrollOnOutput === undefined ? {} : { scrollOnOutput }),
       ...(scrollbackLines === undefined ? {} : { scrollback: scrollbackLines }),
+      ...(terminalTheme === undefined ? {} : { theme: terminalTheme }),
       diagnosticsLabel: entry.paneId,
       onResponse: (data) => {
         // A replayed snapshot re-parses queries the child issued long ago
@@ -527,6 +537,13 @@ export function createPtyRegistry(options: PtyRegistryOptions = {}): PtyRegistry
 
     setPaneExitHandler: (listener) => {
       onPaneExit = listener;
+    },
+
+    updateTerminalTheme: (theme) => {
+      terminalTheme = theme;
+      for (const entry of entries.values()) {
+        entry.screen?.updateTerminalTheme(theme);
+      }
     },
 
     setRuntimeOptions: (nextOptions) => {

--- a/station/src/terminal/vt/screen.test.ts
+++ b/station/src/terminal/vt/screen.test.ts
@@ -1,11 +1,34 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { nativeStationTheme, rgbColor } from "../../theme/index.js";
+import {
+  nativeStationTheme,
+  rgbColor,
+  type StationTerminalTheme,
+} from "../../theme/index.js";
 import { DecMode } from "../protocol/decset.js";
 import { CsiCommand } from "../protocol/identifiers.js";
 import { KittyFlagUpdateMode, KittySequence } from "../protocol/kitty.js";
 import { VtPrefix } from "../protocol/syntax.js";
 import { waitFor } from "../testing/waitFor.js";
+import type { VtRow } from "./rows.js";
 import { createStationVtScreen, type StationVtScreen } from "./screen.js";
+
+function terminalTheme(
+  defaultForeground: `#${string}`,
+  defaultBackground: `#${string}`,
+  ansiBlack: `#${string}`,
+  ansiRed: `#${string}`,
+): StationTerminalTheme {
+  const [, , ...ansiTail] = nativeStationTheme.terminal.ansi16;
+  return {
+    defaultForeground: rgbColor(defaultForeground),
+    defaultBackground: rgbColor(defaultBackground),
+    ansi16: [rgbColor(ansiBlack), rgbColor(ansiRed), ...ansiTail],
+  };
+}
+
+function foregroundForText(rows: readonly VtRow[], text: string): string | undefined {
+  return rows.flatMap((row) => row.spans).find((span) => span.text.includes(text))?.fg;
+}
 
 describe("createStationVtScreen", () => {
   const cleanups: Array<() => void> = [];
@@ -170,6 +193,110 @@ describe("createStationVtScreen", () => {
     screen.feed("\x1b[30mX");
     await screen.whenIdle();
     expect(screen.buildRows({ cursorVisible: false })[0]?.spans[0]?.fg).toBe("#010203");
+  });
+
+  it("updates terminal color projection without mutating the parsed screen", async () => {
+    const initialTheme = terminalTheme("#101112", "#131415", "#161718", "#192021");
+    const nextTheme = terminalTheme("#a0a1a2", "#a3a4a5", "#a6a7a8", "#a9aaab");
+    const responses: string[] = [];
+    const screen = track(
+      createStationVtScreen({
+        size: { cols: 40, rows: 3 },
+        theme: initialTheme,
+        onResponse: (data) => responses.push(data),
+      }),
+    );
+    screen.feed(
+      "D\x1b[31mI\x1b[38;5;196mF\x1b[38;2;1;2;3mT\x1b[0m" +
+        "\x1b]8;;https://example.com/theme\x1b\\L\x1b]8;;\x1b\\" +
+        "\r\none\r\ntwo\r\nthree" +
+        "\x1b]2;theme-proof\x07\x1b[?2004h\x1b[?1000h\x1b[?1h\x1b[=1u" +
+        "\x1b]10;?\x07\x1b]11;?\x07",
+    );
+    await screen.whenIdle();
+    await waitFor(() => screen.getVersion() > 0);
+    screen.scrollBy(1);
+
+    expect(responses).toEqual([
+      "\x1b]10;rgb:1010/1111/1212\x07",
+      "\x1b]11;rgb:1313/1414/1515\x07",
+    ]);
+    const beforeRows = screen.buildRows({ cursorVisible: false });
+    expect(foregroundForText(beforeRows, "D")).toBeUndefined();
+    expect(foregroundForText(beforeRows, "I")).toBe("#192021");
+    expect(foregroundForText(beforeRows, "F")).toBe("#ff0000");
+    expect(foregroundForText(beforeRows, "T")).toBe("#010203");
+
+    const buffer = screen.unsafeEngine.buffer.active;
+    const parsedState = {
+      bufferContents: Array.from({ length: buffer.length }, (_, index) =>
+        buffer.getLine(index)?.translateToString(false),
+      ),
+      visibleText: Array.from({ length: screen.bufferStats().rows }, (_, index) =>
+        screen.viewRowText(index),
+      ),
+      cursor: screen.cursor(),
+      scrollOffset: screen.getScrollOffset(),
+      geometry: screen.bufferStats(),
+      modes: {
+        alt: screen.isAltScreen(),
+        applicationCursor: screen.isApplicationCursorKeys(),
+        bracketedPaste: screen.isBracketedPasteEnabled(),
+        cursorVisible: screen.isCursorVisible(),
+        kittyKeyboard: screen.isKittyKeyboardEnabled(),
+        mouse: screen.mouseProtocol(),
+      },
+      links: beforeRows.flatMap((row) => row.spans.map((span) => span.link)),
+      title: screen.getTitle(),
+    };
+    responses.length = 0;
+    let invalidations = 0;
+    screen.subscribe(() => {
+      invalidations += 1;
+    });
+    const versionBeforeUpdate = screen.getVersion();
+
+    screen.updateTerminalTheme(nextTheme);
+
+    expect(screen.getVersion()).toBe(versionBeforeUpdate + 1);
+    expect(invalidations).toBe(1);
+    expect(responses).toEqual([]);
+    const nextRows = screen.buildRows({ cursorVisible: false });
+    expect(foregroundForText(nextRows, "D")).toBeUndefined();
+    expect(foregroundForText(nextRows, "I")).toBe("#a9aaab");
+    expect(foregroundForText(nextRows, "F")).toBe("#ff0000");
+    expect(foregroundForText(nextRows, "T")).toBe("#010203");
+    expect({
+      bufferContents: Array.from({ length: buffer.length }, (_, index) =>
+        buffer.getLine(index)?.translateToString(false),
+      ),
+      visibleText: Array.from({ length: screen.bufferStats().rows }, (_, index) =>
+        screen.viewRowText(index),
+      ),
+      cursor: screen.cursor(),
+      scrollOffset: screen.getScrollOffset(),
+      geometry: screen.bufferStats(),
+      modes: {
+        alt: screen.isAltScreen(),
+        applicationCursor: screen.isApplicationCursorKeys(),
+        bracketedPaste: screen.isBracketedPasteEnabled(),
+        cursorVisible: screen.isCursorVisible(),
+        kittyKeyboard: screen.isKittyKeyboardEnabled(),
+        mouse: screen.mouseProtocol(),
+      },
+      links: nextRows.flatMap((row) => row.spans.map((span) => span.link)),
+      title: screen.getTitle(),
+    }).toEqual(parsedState);
+
+    screen.feed("\x1b]10;#ffffff\x07\x1b]11;#000000\x07");
+    await screen.whenIdle();
+    expect(responses).toEqual([]);
+    screen.feed("\x1b]10;?\x07\x1b]11;?\x07");
+    await waitFor(() => responses.length === 2);
+    expect(responses).toEqual([
+      "\x1b]10;rgb:a0a0/a1a1/a2a2\x07",
+      "\x1b]11;rgb:a3a3/a4a4/a5a5\x07",
+    ]);
   });
 
   // Executable proof of the headless gap: xterm's browser ThemeService is the

--- a/station/src/terminal/vt/screen.test.ts
+++ b/station/src/terminal/vt/screen.test.ts
@@ -250,16 +250,16 @@ describe("createStationVtScreen", () => {
       title: screen.getTitle(),
     };
     responses.length = 0;
-    let invalidations = 0;
-    screen.subscribe(() => {
-      invalidations += 1;
+    const invalidations: string[] = [];
+    screen.subscribe((invalidation) => {
+      invalidations.push(invalidation);
     });
     const versionBeforeUpdate = screen.getVersion();
 
     screen.updateTerminalTheme(nextTheme);
 
     expect(screen.getVersion()).toBe(versionBeforeUpdate + 1);
-    expect(invalidations).toBe(1);
+    expect(invalidations).toEqual(["repaint"]);
     expect(responses).toEqual([]);
     const nextRows = screen.buildRows({ cursorVisible: false });
     expect(foregroundForText(nextRows, "D")).toBeUndefined();

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -109,6 +109,15 @@ export type VtBufferStats = {
   length: number;
 };
 
+/** Why projected rows must be rebuilt and repainted. */
+export type VtScreenInvalidation = "content" | "repaint";
+
+/** Two-phase theme publication used to update every registry screen atomically. */
+export type StationVtThemeUpdate = Readonly<{
+  publish(): void;
+  invalidate(): void;
+}>;
+
 // The engine (xterm) must not escape this type: everything above vt/ consumes
 // this view, which is what keeps the conformance catalog and the renderer
 // engine-agnostic if the engine is ever swapped.
@@ -121,6 +130,11 @@ export type StationVtScreen = {
    * fixed ANSI indices 16-255, buffer state, and PTY I/O remain unchanged.
    */
   updateTerminalTheme(theme: StationTerminalTheme): void;
+  /**
+   * Build a complete replacement before registry-wide publication. Callers
+   * publish every prepared screen before invalidating any render listener.
+   */
+  prepareTerminalThemeUpdate(theme: StationTerminalTheme): StationVtThemeUpdate;
   /**
    * Style-merged spans for the rows currently in view (the live viewport, or
    * scrolled-back history when `getScrollOffset() > 0`). OSC 8 URIs follow the
@@ -192,7 +206,7 @@ export type StationVtScreen = {
   cursor(): VtCursor;
   isAltScreen(): boolean;
   bufferStats(): VtBufferStats;
-  subscribe(listener: () => void): () => void;
+  subscribe(listener: (invalidation: VtScreenInvalidation) => void): () => void;
   /**
    * The latest OSC 0/2 window title the child app set (trimmed, non-empty), or
    * undefined when no app has set one. This is the same signal terminal
@@ -336,13 +350,45 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
   // with scrollback eviction, so it tracks how far content has scrolled even at
   // the scrollback cap where baseY plateaus. `shift` never anchors (it slides).
   let scrollAnchor: IMarker | undefined;
-  const listeners = new Set<() => void>();
+  const listeners = new Set<(invalidation: VtScreenInvalidation) => void>();
 
-  const notifyListeners = (): void => {
+  const notifyListeners = (invalidation: VtScreenInvalidation): void => {
     version += 1;
     for (const listener of [...listeners]) {
-      listener();
+      listener(invalidation);
     }
+  };
+
+  const prepareTerminalThemeUpdate = (
+    nextTheme: StationTerminalTheme,
+  ): StationVtThemeUpdate => {
+    const nextProjection = {
+      theme: nextTheme,
+      palette: buildVtPalette256(nextTheme.ansi16.map((color) => color.value)),
+    };
+    let published = false;
+    let invalidated = false;
+    return {
+      publish: () => {
+        if (disposed || published) {
+          return;
+        }
+        terminalProjection = nextProjection;
+        published = true;
+      },
+      invalidate: () => {
+        if (disposed || invalidated) {
+          return;
+        }
+        if (!published) {
+          terminalProjection = nextProjection;
+          published = true;
+        }
+        invalidated = true;
+        // Projection changes never feed/replay bytes or emit a PTY response.
+        notifyListeners("repaint");
+      },
+    };
   };
 
   const clampScrollOffset = (): void => {
@@ -606,7 +652,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
     applyScrollOnOutput();
     clampScrollOffset();
     reanchorScroll();
-    notifyListeners();
+    notifyListeners("content");
     scanForEscapeFragments();
   };
 
@@ -651,17 +697,11 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       scheduleFlush();
     },
     updateTerminalTheme: (nextTheme) => {
-      if (disposed) {
-        return;
-      }
-      const nextProjection = {
-        theme: nextTheme,
-        palette: buildVtPalette256(nextTheme.ansi16.map((color) => color.value)),
-      };
-      terminalProjection = nextProjection;
-      // Projection changes invalidate rows only; never feed/replay bytes or emit a PTY response.
-      notifyListeners();
+      const update = prepareTerminalThemeUpdate(nextTheme);
+      update.publish();
+      update.invalidate();
     },
+    prepareTerminalThemeUpdate,
     buildRows: (rowOptions) =>
       buildVisibleRows(terminal, {
         cursorVisible: rowOptions?.cursorVisible ?? cursorVisible,
@@ -679,7 +719,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       }
       scrollOffset = next;
       reanchorScroll();
-      notifyListeners();
+      notifyListeners("content");
       return true;
     },
     scrollToBottom: () => {
@@ -688,7 +728,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       }
       scrollOffset = 0;
       disposeScrollAnchor();
-      notifyListeners();
+      notifyListeners("content");
       return true;
     },
     getScrollOffset: () => scrollOffset,

--- a/station/src/terminal/vt/screen.ts
+++ b/station/src/terminal/vt/screen.ts
@@ -65,6 +65,11 @@ export type StationVtScreenOptions = {
   flushIntervalMs?: number;
   /** Max hold for an open synchronized frame before the escape hatch flushes; injectable for tests. */
   syncHoldMaxMs?: number;
+  /**
+   * Initial terminal-semantic projection for defaults, ANSI indices 0-15, and
+   * OSC 10/11 replies. Explicit RGB and ANSI indices 16-255 remain independent.
+   * Direct low-level callers may omit it to use Station's built-in projection.
+   */
   theme?: StationTerminalTheme;
   /**
    * Terminal query replies (DA1/DA2/DSR/CPR/DECRQM from xterm, OSC 10/11 from
@@ -110,6 +115,12 @@ export type VtBufferStats = {
 export type StationVtScreen = {
   feed(data: string): void;
   resize(size: StationTerminalSize): void;
+  /**
+   * Replace terminal defaults and ANSI indices 0-15 for existing and future
+   * row projections and OSC 10/11 replies. Parsed text, explicit RGB cells,
+   * fixed ANSI indices 16-255, buffer state, and PTY I/O remain unchanged.
+   */
+  updateTerminalTheme(theme: StationTerminalTheme): void;
   /**
    * Style-merged spans for the rows currently in view (the live viewport, or
    * scrolled-back history when `getScrollOffset() > 0`). OSC 8 URIs follow the
@@ -209,10 +220,11 @@ export type StationVtScreen = {
 };
 
 export function createStationVtScreen(options: StationVtScreenOptions): StationVtScreen {
-  const theme = options.theme ?? nativeStationTheme.terminal;
-  const palette = buildVtPalette256(theme.ansi16.map((color) => color.value));
-  const defaultForeground = theme.defaultForeground.value;
-  const defaultBackground = theme.defaultBackground.value;
+  const initialTheme = options.theme ?? nativeStationTheme.terminal;
+  let terminalProjection = {
+    theme: initialTheme,
+    palette: buildVtPalette256(initialTheme.ansi16.map((color) => color.value)),
+  };
   const flushIntervalMs = options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
   const syncHoldMaxMs = options.syncHoldMaxMs ?? SYNC_OUTPUT_HOLD_MAX_MS;
   const requestedScrollback = options.scrollback ?? DEFAULT_SCROLLBACK_LINES;
@@ -417,7 +429,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       return false;
     }
     emitResponse(
-      `${VtPrefix.Osc}${OscCommand.DefaultForeground};${toOscRgb(defaultForeground)}${VtTerminator.Bell}`,
+      `${VtPrefix.Osc}${OscCommand.DefaultForeground};${toOscRgb(terminalProjection.theme.defaultForeground.value)}${VtTerminator.Bell}`,
     );
     return true;
   });
@@ -426,7 +438,7 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       return false;
     }
     emitResponse(
-      `${VtPrefix.Osc}${OscCommand.DefaultBackground};${toOscRgb(defaultBackground)}${VtTerminator.Bell}`,
+      `${VtPrefix.Osc}${OscCommand.DefaultBackground};${toOscRgb(terminalProjection.theme.defaultBackground.value)}${VtTerminator.Bell}`,
     );
     return true;
   });
@@ -638,11 +650,23 @@ export function createStationVtScreen(options: StationVtScreenOptions): StationV
       reanchorScroll();
       scheduleFlush();
     },
+    updateTerminalTheme: (nextTheme) => {
+      if (disposed) {
+        return;
+      }
+      const nextProjection = {
+        theme: nextTheme,
+        palette: buildVtPalette256(nextTheme.ansi16.map((color) => color.value)),
+      };
+      terminalProjection = nextProjection;
+      // Projection changes invalidate rows only; never feed/replay bytes or emit a PTY response.
+      notifyListeners();
+    },
     buildRows: (rowOptions) =>
       buildVisibleRows(terminal, {
         cursorVisible: rowOptions?.cursorVisible ?? cursorVisible,
         offset: scrollOffset,
-        palette,
+        palette: terminalProjection.palette,
       }),
     scrollBy: (deltaLines) => {
       if (disposed || deltaLines === 0) {


### PR DESCRIPTION
## What this fixes

Station's native terminal emulator captured its default colors and ANSI palette when each VT screen was created. Retained panes therefore had no safe way to follow a newly resolved native appearance, and later-created panes could disagree with existing ones. This adds the update seam required by #417 without giving the PTY registry appearance-policy ownership or replacing child processes.

## What changed

- Add an atomic `StationVtScreen` terminal-projection update that repaints default and ANSI 0-15 intent while preserving ANSI 16-255 and explicit RGB output.
- Use the current projection for OSC 10/11 replies without replaying bytes, mutating buffers, or emitting unsolicited child input.
- Fan the latest `StationTerminalTheme` through `PtyRegistry` to existing and future screens without PTY writes, resize, disposal, respawn, or structural notifications.
- Keep default foreground and selection presentation in the active UI theme/render path, including repainting cached VT rows when those paint props change.
- Initialize native composition with Station's built-in terminal projection and advance the HMR compatibility boundary so compatible runtimes retain live PTYs.
- Document the ownership boundary and add end-to-end coverage across VT, registry, renderable, pane, OSC, and HMR behavior.

Closes #417.

## Testing

- `cd station && bun run typecheck`
- Focused VT, registry, renderable, pane, OSC 8, and HMR suites: 110 passing
- `cd station && bun run test:vt`: 374 passing
- `cd station && bun run test`: 1,390 passing
- `cd station && bun run test:pty`
- `cd station && bun run build:ctty-helper && bun run test:pty:bun`
- `pnpm build`
- `pnpm lint`
- `pnpm smoke:install`

`pnpm test:all` was also attempted. It reached the untouched Observer lifecycle E2E lane, where two handoff tests reproduced `OBSERVER_HANDOFF_REFUSED` / `OBSERVER_INCUMBENT_HEALTH_TIMEOUT`; a focused `pnpm test:e2e:observer` rerun reproduced the same failures.

## User-visible behavior

Native `auto` remains Station's current built-in appearance. Theme projection updates retain the pane's process, content, scrollback, geometry, links, cursor state, and explicit truecolor while allowing default and theme-owned indexed colors to repaint consistently in existing and newly opened panes.
