### PR TITLE
fix(typescript): expose native compiler to repository-aware tools

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -11,24 +11,26 @@ Status: current living doc for development, test, and documentation workflow.
 
 ## TypeScript Compiler And Editor
 
-Root and renderer build/typecheck commands use the native TypeScript 7 compiler. Repository tools
-that import the compiler API intentionally remain on the TypeScript 6 compatibility package until
-TypeScript 7 provides a stable replacement API. Verify the split with:
+Root and renderer build/typecheck commands use the native TypeScript 7 compiler. The conventional
+`typescript` dependency also resolves to TypeScript 7 so repository-aware tools and LSP clients can
+discover the native compiler. Tools that import the compiler API use the explicit TypeScript 6
+compatibility package until TypeScript 7 provides a stable replacement API. Verify the split with:
 
 ```bash
 pnpm exec tsc --version
-node -p 'require("typescript").version'
+node -p 'require("typescript/package.json").version'
+node -p 'require("@typescript/typescript6").version'
 cd station && bun run tsc --version
 ```
 
 VS Code does not select the native language server from this dependency split automatically. To opt
 in, install the official [TypeScript 7 extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview),
 then run **TypeScript: Enable TypeScript 7** or set `"js/ts.experimental.useTsgo": true` in a user or
-profile setting. Do not point `js/ts.tsdk.path` at `node_modules/typescript`; that package intentionally
-provides the TypeScript 6 API compatibility layer. Disable the setting or extension to return to VS
-Code's standard TypeScript service. Editors that accept a custom LSP command can start
-`pnpm exec tsc --lsp --stdio` with the repository root as the working directory; integrations that
-require `tsserver` should use the editor's bundled TypeScript service.
+profile setting. Do not point `js/ts.tsdk.path` at `node_modules/typescript`; that package provides the
+native compiler and LSP rather than the legacy `tsserver` plugin layout. Disable the setting or
+extension to return to VS Code's standard TypeScript service. Editors that accept a custom LSP
+command can start `pnpm exec tsc --lsp --stdio` with the repository root as the working directory;
+integrations that require `tsserver` should use the editor's bundled TypeScript service.
 
 ## Local TUI Workflow
 

--- a/package.json
+++ b/package.json
@@ -92,11 +92,12 @@
     "@biomejs/biome": "^2.2.4",
     "@typescript/native": "npm:typescript@7.0.2",
     "@types/node": "^24.12.4",
+    "@typescript/typescript6": "6.0.2",
     "d3": "^7.9.0",
     "knip": "^6.29.0",
     "lefthook": "^1.13.6",
     "turbo": "^2.9.15",
-    "typescript": "npm:@typescript/typescript6@6.0.2",
+    "typescript": "7.0.2",
     "vitest": "^3.2.4",
     "zod": "^4.1.12"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@typescript/native':
         specifier: npm:typescript@7.0.2
         version: typescript@7.0.2
+      '@typescript/typescript6':
+        specifier: 6.0.2
+        version: 6.0.2
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -30,8 +33,8 @@ importers:
         specifier: ^2.9.15
         version: 2.9.15
       typescript:
-        specifier: npm:@typescript/typescript6@6.0.2
-        version: '@typescript/typescript6@6.0.2'
+        specifier: 7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.12.4)(jiti@2.7.0)(yaml@2.9.0)

--- a/station/bun.lock
+++ b/station/bun.lock
@@ -23,7 +23,8 @@
         "@types/node": "^25.9.3",
         "@types/react": "19.2.17",
         "@typescript/native": "npm:typescript@7.0.2",
-        "typescript": "npm:@typescript/typescript6@6.0.2",
+        "@typescript/typescript6": "6.0.2",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -101,6 +102,8 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
+    "@typescript/typescript6": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
+
     "@xterm/addon-serialize": ["@xterm/addon-serialize@0.14.0", "", {}, "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA=="],
 
     "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
@@ -139,7 +142,7 @@
 
     "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 

--- a/station/package.json
+++ b/station/package.json
@@ -48,6 +48,7 @@
     "@typescript/native": "npm:typescript@7.0.2",
     "@types/node": "^25.9.3",
     "@types/react": "19.2.17",
-    "typescript": "npm:@typescript/typescript6@6.0.2"
+    "@typescript/typescript6": "6.0.2",
+    "typescript": "7.0.2"
   }
 }

--- a/station/src/station/importBoundaries.test.ts
+++ b/station/src/station/importBoundaries.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
-import ts from "typescript";
+// TypeScript 7 has no stable compiler API, so AST checks use its official TS6 compatibility package.
+import ts from "@typescript/typescript6";
 
 const STATION_VIEW_ROOT = fileURLToPath(new URL(".", import.meta.url));
 const STATION_SOURCE_ROOT = fileURLToPath(new URL("../", import.meta.url));

--- a/station/src/typescriptToolchain.test.ts
+++ b/station/src/typescriptToolchain.test.ts
@@ -1,20 +1,25 @@
 import { describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import ts from "typescript";
+import ts from "@typescript/typescript6";
 
 const require = createRequire(import.meta.url);
 
 describe("TypeScript toolchain", () => {
-  it("keeps native TypeScript 7 on the CLI and TypeScript 6 behind the compiler API", () => {
-    const nativePackage = require("@typescript/native/package.json") as { version: string };
-    const compatibilityPackage = require("typescript/package.json") as { version: string };
-    const nativeTsc = fileURLToPath(new URL("../node_modules/.bin/tsc", import.meta.url));
-    const compiler = spawnSync(nativeTsc, ["--version"], { encoding: "utf8" });
+  it("exposes native TypeScript 7 to tools and isolates the TypeScript 6 compiler API", () => {
+    const nativeAliasPackage = require("@typescript/native/package.json") as { version: string };
+    const nativePackage = require("typescript/package.json") as { version: string };
+    const compatibilityPackage = require("@typescript/typescript6/package.json") as {
+      version: string;
+    };
+    const binDirectory = fileURLToPath(new URL("../node_modules/.bin/", import.meta.url));
+    const compiler = spawnSync(join(binDirectory, "tsc"), ["--version"], { encoding: "utf8" });
 
     expect(compiler.status).toBe(0);
     expect(compiler.stdout.trim()).toBe("Version 7.0.2");
+    expect(nativeAliasPackage.version).toBe("7.0.2");
     expect(nativePackage.version).toBe("7.0.2");
     expect(compatibilityPackage.version).toBe("6.0.2");
     expect(ts.version).toBe("6.0.3");

--- a/tests/diagnostics/boundary-inventory.test.ts
+++ b/tests/diagnostics/boundary-inventory.test.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
-import ts from "typescript";
+// TypeScript 7 has no stable compiler API, so AST diagnostics use its official TS6 compatibility package.
+import ts from "@typescript/typescript6";
 import { describe, expect, it } from "vitest";
 
 const roots = ["apps", "packages", "integrations"];

--- a/tests/diagnostics/typescript-toolchain.test.ts
+++ b/tests/diagnostics/typescript-toolchain.test.ts
@@ -1,20 +1,25 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
 
 describe("TypeScript toolchain", () => {
-  it("keeps native TypeScript 7 on the CLI and TypeScript 6 behind the compiler API", () => {
-    const nativePackage = require("@typescript/native/package.json") as { version: string };
-    const compatibilityPackage = require("typescript/package.json") as { version: string };
-    const compatibilityApi = require("typescript") as { version: string };
-    const nativeTsc = fileURLToPath(new URL("../../node_modules/.bin/tsc", import.meta.url));
-    const compiler = spawnSync(nativeTsc, ["--version"], { encoding: "utf8" });
+  it("exposes native TypeScript 7 to tools and isolates the TypeScript 6 compiler API", () => {
+    const nativeAliasPackage = require("@typescript/native/package.json") as { version: string };
+    const nativePackage = require("typescript/package.json") as { version: string };
+    const compatibilityPackage = require("@typescript/typescript6/package.json") as {
+      version: string;
+    };
+    const compatibilityApi = require("@typescript/typescript6") as { version: string };
+    const binDirectory = fileURLToPath(new URL("../../node_modules/.bin/", import.meta.url));
+    const compiler = spawnSync(join(binDirectory, "tsc"), ["--version"], { encoding: "utf8" });
 
     expect(compiler.status, compiler.stderr).toBe(0);
     expect(compiler.stdout.trim()).toBe("Version 7.0.2");
+    expect(nativeAliasPackage.version).toBe("7.0.2");
     expect(nativePackage.version).toBe("7.0.2");
     expect(compatibilityPackage.version).toBe("6.0.2");
     expect(compatibilityApi.version).toBe("6.0.3");

--- a/tools/lint/check-no-raw-vt-literals.mjs
+++ b/tools/lint/check-no-raw-vt-literals.mjs
@@ -7,7 +7,8 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
-import ts from "typescript";
+// TypeScript 7 has no stable compiler API, so AST linting uses its official TS6 compatibility package.
+import ts from "@typescript/typescript6";
 
 const root = process.cwd();
 const ignoredDirs = new Set(["node_modules", "dist", ".turbo", "coverage"]);

--- a/tools/lint/check-observer-architecture.mjs
+++ b/tools/lint/check-observer-architecture.mjs
@@ -9,11 +9,10 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { createRequire } from "node:module";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
-
-const ts = createRequire(import.meta.url)("typescript");
+// TypeScript 7 has no stable compiler API, so architecture analysis uses its official TS6 compatibility package.
+import ts from "@typescript/typescript6";
 
 const roles = ["DRIVING PORT", "DRIVEN PORT", "ADAPTER", "USE CASE", "POLICY", "COMPOSITION ROOT"];
 const roleSet = new Set(roles);

--- a/tools/lint/check-source-order.mjs
+++ b/tools/lint/check-source-order.mjs
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { createRequire } from "node:module";
 import { basename, join, relative, sep } from "node:path";
-
-const require = createRequire(`${process.cwd()}/package.json`);
-const ts = require("typescript");
+// TypeScript 7 has no stable compiler API, so AST linting uses its official TS6 compatibility package.
+import ts from "@typescript/typescript6";
 
 const root = process.cwd();
 const defaultTargets = [


### PR DESCRIPTION
## What this fixes

Station builds and typechecks with native TypeScript 7, but the conventional `typescript` package name still resolved to the TypeScript 6 compatibility API. Repository-aware language-server launchers such as pi-lens inspect that conventional package to select a local compiler, so diagnostics could fall back to an older server and disagree with CI-facing checks.

## What changed

- Makes `typescript` resolve to native TypeScript 7 in both the root and Bun renderer workspaces while retaining the native alias that protects `tsc` bin selection.
- Moves every AST-based lint and diagnostic consumer to the explicit `@typescript/typescript6` compatibility package.
- Strengthens root and renderer toolchain guards to verify the TS7 package, TS7 executable, and TS6 API independently.
- Updates developer guidance for native LSP discovery and the explicit compiler-API boundary.

## Testing

- Frozen pnpm and Bun installs.
- Root and renderer `tsc`, conventional package, and compatibility API version checks.
- Root and renderer typechecks, lint, architecture checks, and build.
- 128 diagnostics tests and 16 focused renderer toolchain/import-boundary tests.
