### PR TITLE
fix(tui): preserve hierarchy and chroma in light terminal appearance

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -100,11 +100,13 @@ with unrelated Station foreground roles.
 
 A valid embedded palette resolves one complete provider-neutral semantic theme.
 Terminal-default and indexed intent retain their observed snapshots. Weak ANSI
-roles are deterministically corrected toward the observed foreground so they
-remain readable on both the canvas and adaptive interaction fills;
-muted/border/interaction roles derive from foreground/background blends. The
-observed luminance and contrast determine dark/light behavior; OpenTUI's theme
-mode label does not.
+roles are deterministically repaired in OKLab by shifting lightness toward the
+observed foreground while holding hue and chroma, so they remain readable on
+both the canvas and adaptive interaction fills without washing out; surface and
+muted/border/interaction roles mix in OKLCH from foreground/background blends
+and keep a minimum separation from the canvas so layered surfaces stay
+distinguishable. The observed luminance and contrast determine dark/light
+behavior; OpenTUI's theme mode label does not.
 
 OpenTUI emits palette responses before `getPalette()` resolves and treats theme
 mode changes as cache invalidation followed by a palette refresh. Station treats

--- a/station/bun.lock
+++ b/station/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@opentui/core": "0.4.1",
         "@opentui/react": "0.4.1",
+        "@texel/color": "^1.1.11",
         "@xterm/addon-serialize": "0.14.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/headless": "6.0.0",
@@ -53,6 +54,8 @@
     "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.4.1", "", { "os": "win32", "cpu": "x64" }, "sha512-s1kGBcloy4ksl3wFCMqqOUFtXWlTTpzxe6pkLFhFhzgqKsMXHE9pwebiS3pzJkkFUxah5MYG+kbcn2Dw2Gdncg=="],
 
     "@opentui/react": ["@opentui/react@0.4.1", "", { "dependencies": { "@opentui/core": "0.4.1", "react-reconciler": "^0.33.0" }, "peerDependencies": { "react": ">=19.2.0", "react-devtools-core": "^7.0.1", "ws": "^8.18.0" } }, "sha512-hYNS8yhwVA+aGru74rtaxI81TM+rEIhMVOdooQOZRHcyVlml3inmKcI5n0Kroy4Vj4M0rCiVAPhovvqf+xfxGA=="],
+
+    "@texel/color": ["@texel/color@1.1.11", "", {}, "sha512-/3kKgfBqzrRfLl4RsEccx+Yfj1kVL6Bh6DejVWZ+DPg/jJdcfdYZ5fpD1nXFwWd8OQNATjz+WqsfQfUynSsgRg=="],
 
     "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 

--- a/station/package.json
+++ b/station/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@opentui/core": "0.4.1",
     "@opentui/react": "0.4.1",
+    "@texel/color": "^1.1.11",
     "@xterm/addon-serialize": "0.14.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/headless": "6.0.0",

--- a/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
+++ b/station/src/dashboardRenderer/FullscreenDashboard.test.tsx
@@ -142,6 +142,34 @@ describe("FullscreenDashboard surface ownership", () => {
     ).toBeGreaterThanOrEqual(STATION_TEXT_CONTRAST_RATIO);
   });
 
+  it("keeps focused light controls visually distinct from the canvas", async () => {
+    const size = { width: 120, height: 40 };
+    const fixture = makeStationTestRuntime({
+      terminalRows: size.height,
+      initialState: {
+        dashboardFocus: { kind: "emptyProjectAction", projectId: "empty-project" },
+      },
+    });
+    const lightSource: StationThemeSource = {
+      getSnapshot: () => LIGHT_THEME,
+      subscribe: () => () => {},
+    };
+    const setup = await render(fixture.runtime, size, TEST_EFFECTS, lightSource);
+    const frame = setup.captureCharFrame();
+    const addSession = cellFor(frame, "[ + add session ]");
+    const title = cellFor(frame, "station · overview");
+    const controlSpan = spanAtFrameCell(setup.captureSpans(), addSession.row, addSession.col);
+    const canvasSpan = spanAtFrameCell(setup.captureSpans(), title.row, title.col);
+
+    expect(spanBgHex(controlSpan)).toBe(
+      stationColorSnapshotValue(LIGHT_THEME.interaction.compactFocus),
+    );
+    expect(spanBgHex(canvasSpan)).toBe(stationColorSnapshotValue(LIGHT_THEME.surfaces.canvas));
+    expect(
+      themeContrast(LIGHT_THEME.interaction.compactFocus, LIGHT_THEME.surfaces.canvas),
+    ).toBeGreaterThan(1.1);
+  });
+
   it("keeps focused light sheet-button roles readable", async () => {
     const fixture = makeStationTestRuntime({ terminalRows: SURFACE.height });
     const lightSource: StationThemeSource = {

--- a/station/src/theme/terminalPalette/contrast.test.ts
+++ b/station/src/theme/terminalPalette/contrast.test.ts
@@ -117,4 +117,33 @@ describe("terminal palette color math", () => {
       );
     }
   });
+
+  it("holds searched lightness and hue for out-of-gamut saturated accents", () => {
+    // The green hue is far outside sRGB gamut at the target foreground
+    // lightness; the correction must hold lightness (and with it hue) rather
+    // than drifting toward the hue's cusp and collapsing onto the foreground.
+    const background = rgbColor("#f9fafb");
+    const saturated = rgbColor("#7bff7b");
+    const foreground = rgbColor("#1f2937");
+    const corrected = adjustLightnessForContrast(
+      saturated,
+      foreground,
+      [background],
+      STATION_TEXT_CONTRAST_RATIO,
+    );
+    const source = oklch("#7bff7b");
+    const result = oklch(corrected.value);
+    const target = oklch("#1f2937");
+
+    expect(contrastRatio(corrected, background)).toBeGreaterThanOrEqual(
+      STATION_TEXT_CONTRAST_RATIO,
+    );
+    expect(corrected).not.toEqual(foreground);
+    expect(hueDistance(result[2], source[2])).toBeLessThan(6);
+    // The minimal lightness shift lands between source and foreground instead
+    // of collapsing onto the foreground's own lightness.
+    expect(result[0]).toBeLessThan(source[0]);
+    expect(result[0]).toBeGreaterThan(target[0]);
+    expect(Math.abs(result[0] - target[0])).toBeGreaterThan(0.05);
+  });
 });

--- a/station/src/theme/terminalPalette/contrast.test.ts
+++ b/station/src/theme/terminalPalette/contrast.test.ts
@@ -1,14 +1,28 @@
 import { describe, expect, it } from "bun:test";
+import { convert, hexToRGB, OKLCH, sRGB } from "@texel/color";
 import { rgbColor } from "../types.js";
 import {
-  blendUntilContrast,
-  blendUntilContrasts,
+  adjustLightnessForContrast,
   contrastRatio,
-  mixRgb,
+  mixOklch,
   STATION_TEXT_CONTRAST_RATIO,
 } from "./contrast.js";
 
-describe("terminal palette contrast math", () => {
+function oklch(value: string): [number, number, number] {
+  const lch = convert(hexToRGB(value), sRGB, OKLCH);
+  return [lch[0], lch[1], lch[2]];
+}
+
+function hue(value: string): number {
+  return oklch(value)[2];
+}
+
+function hueDistance(first: number, second: number): number {
+  const difference = Math.abs(first - second) % 360;
+  return Math.min(difference, 360 - difference);
+}
+
+describe("terminal palette color math", () => {
   it("calculates the WCAG endpoints", () => {
     const black = rgbColor("#000000");
     const white = rgbColor("#ffffff");
@@ -17,23 +31,45 @@ describe("terminal palette contrast math", () => {
     expect(contrastRatio(black, white)).toBe(21);
   });
 
-  it("mixes normalized sRGB channels and clamps the amount", () => {
+  it("mixes normalized OKLCH channels and clamps the amount", () => {
     const black = rgbColor("#000000");
     const white = rgbColor("#ffffff");
 
-    expect(mixRgb(black, white, 0.5).value).toBe("#808080");
-    expect(mixRgb(black, white, -1)).toEqual(black);
-    expect(mixRgb(black, white, 2)).toEqual(white);
+    expect(mixOklch(black, white, 0)).toEqual(black);
+    expect(mixOklch(black, white, 1)).toEqual(white);
+    expect(mixOklch(black, white, -1)).toEqual(black);
+    expect(mixOklch(black, white, 2)).toEqual(white);
+    expect(mixOklch(black, white, 0.5).value).not.toBe("#808080");
   });
 
-  it("finds the first 8-bit blend that meets the requested contrast", () => {
+  it("mixes perceptually near the midpoint of lightness", () => {
+    const mixed = oklch(mixOklch(rgbColor("#000000"), rgbColor("#ffffff"), 0.5).value);
+
+    expect(mixed[0]).toBeGreaterThan(0.45);
+    expect(mixed[0]).toBeLessThan(0.55);
+  });
+
+  it("keeps the hue when mixing two chromatic colors", () => {
+    const mixed = mixOklch(rgbColor("#ff8080"), rgbColor("#ff0000"), 0.5);
+
+    expect(hueDistance(hue(mixed.value), hue("#ff0000"))).toBeLessThan(5);
+  });
+
+  it("preserves chroma when mixing toward a near-white surface", () => {
+    const mixedLch = oklch(mixOklch(rgbColor("#f9fafb"), rgbColor("#ff0000"), 0.5).value);
+    const redChroma = oklch("#ff0000")[1];
+
+    expect(mixedLch[1]).toBeGreaterThan(0.45 * redChroma);
+  });
+
+  it("finds the smallest lightness shift that meets the requested contrast", () => {
     const background = rgbColor("#111827");
     const weak = rgbColor("#202834");
     const foreground = rgbColor("#e5e7eb");
-    const corrected = blendUntilContrast(
+    const corrected = adjustLightnessForContrast(
       weak,
       foreground,
-      background,
+      [background],
       STATION_TEXT_CONTRAST_RATIO,
     );
 
@@ -41,14 +77,34 @@ describe("terminal palette contrast math", () => {
       STATION_TEXT_CONTRAST_RATIO,
     );
     expect(corrected).toEqual(
-      blendUntilContrast(weak, foreground, background, STATION_TEXT_CONTRAST_RATIO),
+      adjustLightnessForContrast(weak, foreground, [background], STATION_TEXT_CONTRAST_RATIO),
     );
+  });
+
+  it("preserves hue and chroma while repairing a weak light accent", () => {
+    const background = rgbColor("#f9fafb");
+    const weak = rgbColor("#f0c0c0");
+    const foreground = rgbColor("#1f2937");
+    const corrected = adjustLightnessForContrast(
+      weak,
+      foreground,
+      [background],
+      STATION_TEXT_CONTRAST_RATIO,
+    );
+    const source = oklch("#f0c0c0");
+    const result = oklch(corrected.value);
+
+    expect(contrastRatio(corrected, background)).toBeGreaterThanOrEqual(
+      STATION_TEXT_CONTRAST_RATIO,
+    );
+    expect(Math.abs(result[2] - source[2])).toBeLessThan(6);
+    expect(result[1]).toBeGreaterThanOrEqual(0.6 * source[1]);
   });
 
   it("corrects one foreground against every supplied surface", () => {
     const surfaces = [rgbColor("#111827"), rgbColor("#373d4a")];
     const foreground = rgbColor("#e5e7eb");
-    const corrected = blendUntilContrasts(
+    const corrected = adjustLightnessForContrast(
       rgbColor("#f87171"),
       foreground,
       surfaces,

--- a/station/src/theme/terminalPalette/contrast.ts
+++ b/station/src/theme/terminalPalette/contrast.ts
@@ -1,59 +1,75 @@
 import { rgbColor, type StationRgbColor } from "../types.js";
+import {
+  clampedRGB,
+  constrainAngle,
+  convert,
+  gamutMapOKLCH,
+  hexToRGB,
+  lerpAngle,
+  OKLab,
+  OKLCH,
+  RGBToHex,
+  sRGB,
+  sRGBGamut,
+} from "@texel/color";
 
 /** WCAG contrast target for ordinary text and inverse action text. */
 export const STATION_TEXT_CONTRAST_RATIO = 4.5;
 /** WCAG contrast target for borders, disabled treatment, and interaction boundaries. */
 export const STATION_BOUNDARY_CONTRAST_RATIO = 3;
 
-export const SRGB_CHANNEL_MAX = 255;
+/** Fixed iteration count so identical observations resolve byte-for-byte identically. */
+const LIGHTNESS_SEARCH_STEPS = 32;
 
-type RgbTriplet = readonly [number, number, number];
-
-/** Blends toward a known readable color until the requested contrast is met. */
-export function blendUntilContrast(
-  start: StationRgbColor,
-  toward: StationRgbColor,
-  background: StationRgbColor,
-  target: number,
-): StationRgbColor {
-  return blendUntilContrasts(start, toward, [background], target);
-}
-
-/** Blends toward a known readable color until contrast is met on every supplied surface. */
-export function blendUntilContrasts(
-  start: StationRgbColor,
-  toward: StationRgbColor,
-  backgrounds: readonly StationRgbColor[],
-  target: number,
-): StationRgbColor {
-  const meetsTarget = (candidate: StationRgbColor): boolean =>
-    backgrounds.every((background) => contrastRatio(candidate, background) >= target);
-  if (meetsTarget(start)) {
-    return start;
-  }
-  for (let step = 1; step <= SRGB_CHANNEL_MAX; step += 1) {
-    const candidate = mixRgb(start, toward, step / SRGB_CHANNEL_MAX);
-    if (meetsTarget(candidate)) {
-      return candidate;
-    }
-  }
-  return toward;
-}
-
-/** Mixes two normalized sRGB colors using an amount clamped to the inclusive unit interval. */
-export function mixRgb(
+/** Mixes two colors in OKLCH with shortest-arc hue interpolation; perceptually uniform and chroma-preserving. */
+export function mixOklch(
   from: StationRgbColor,
   to: StationRgbColor,
   amount: number,
 ): StationRgbColor {
-  const fromRgb = rgbTriplet(from);
-  const toRgb = rgbTriplet(to);
   const clamped = Math.max(0, Math.min(1, amount));
-  return rgbFromTriplet([
-    Math.round(fromRgb[0] + (toRgb[0] - fromRgb[0]) * clamped),
-    Math.round(fromRgb[1] + (toRgb[1] - fromRgb[1]) * clamped),
-    Math.round(fromRgb[2] + (toRgb[2] - fromRgb[2]) * clamped),
-  ]);
+  const fromLch = convert(hexToRGB(from.value), sRGB, OKLCH);
+  const toLch = convert(hexToRGB(to.value), sRGB, OKLCH);
+  const mixed = [
+    fromLch[0] + (toLch[0] - fromLch[0]) * clamped,
+    fromLch[1] + (toLch[1] - fromLch[1]) * clamped,
+    lerpAngle(fromLch[2], toLch[2], clamped),
+  ];
+  return rgbFromSrgb(convert(mixed, OKLCH, sRGB));
+}
+
+/**
+ * Moves lightness toward `toward` in OKLab while holding hue and chroma until the
+ * contrast target is met on every supplied surface; falls back to the full blend.
+ */
+export function adjustLightnessForContrast(
+  color: StationRgbColor,
+  toward: StationRgbColor,
+  backgrounds: readonly StationRgbColor[],
+  target: number,
+): StationRgbColor {
+  if (meetsTarget(color, backgrounds, target)) {
+    return color;
+  }
+  const start = convert(hexToRGB(color.value), sRGB, OKLab);
+  const destination = convert(hexToRGB(toward.value), sRGB, OKLab);
+  const shift = destination[0] - start[0];
+  let low = 0;
+  let high = 1;
+  for (let step = 0; step < LIGHTNESS_SEARCH_STEPS; step += 1) {
+    const t = (low + high) / 2;
+    if (meetsTarget(rgbFromOklab([start[0] + t * shift, start[1], start[2]]), backgrounds, target)) {
+      high = t;
+    } else {
+      low = t;
+    }
+  }
+  const corrected = rgbFromOklab([start[0] + high * shift, start[1], start[2]]);
+  if (meetsTarget(corrected, backgrounds, target)) {
+    return corrected;
+  }
+  // A hue that cannot reach the target on this surface; the full blend is the last deterministic resort.
+  return rgbFromSrgb(hexToRGB(toward.value));
 }
 
 /** Returns the WCAG contrast ratio between two normalized sRGB colors. */
@@ -66,23 +82,42 @@ export function contrastRatio(first: StationRgbColor, second: StationRgbColor): 
 /** Returns WCAG relative luminance for a normalized sRGB color. */
 export function relativeLuminance(color: StationRgbColor): number {
   const [red, green, blue] = rgbTriplet(color).map((component) => {
-    const channel = component / SRGB_CHANNEL_MAX;
+    const channel = component / 255;
     return channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
   }) as [number, number, number];
   return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 }
 
-function rgbTriplet(color: StationRgbColor): RgbTriplet {
+function meetsTarget(
+  color: StationRgbColor,
+  backgrounds: readonly StationRgbColor[],
+  target: number,
+): boolean {
+  return backgrounds.every((background) => contrastRatio(color, background) >= target);
+}
+
+function rgbFromOklab(oklab: readonly [number, number, number]): StationRgbColor {
+  const [lightness, a, b] = oklab;
+  const chroma = Math.hypot(a, b);
+  const lch =
+    chroma === 0
+      ? [lightness, 0, 0]
+      : gamutMapOKLCH(
+          [lightness, chroma, constrainAngle((Math.atan2(b, a) * 180) / Math.PI)],
+          sRGBGamut,
+          OKLCH,
+        );
+  return rgbFromSrgb(convert(lch, OKLCH, sRGB));
+}
+
+function rgbFromSrgb(rgb: readonly number[]): StationRgbColor {
+  return rgbColor(RGBToHex(clampedRGB([...rgb])) as `#${string}`);
+}
+
+function rgbTriplet(color: StationRgbColor): [number, number, number] {
   return [
     Number.parseInt(color.value.slice(1, 3), 16),
     Number.parseInt(color.value.slice(3, 5), 16),
     Number.parseInt(color.value.slice(5, 7), 16),
   ];
-}
-
-function rgbFromTriplet([red, green, blue]: RgbTriplet): StationRgbColor {
-  const value = [red, green, blue]
-    .map((component) => component.toString(16).padStart(2, "0"))
-    .join("");
-  return rgbColor(`#${value}`);
 }

--- a/station/src/theme/terminalPalette/contrast.ts
+++ b/station/src/theme/terminalPalette/contrast.ts
@@ -6,6 +6,7 @@ import {
   gamutMapOKLCH,
   hexToRGB,
   lerpAngle,
+  MapToL,
   OKLab,
   OKLCH,
   RGBToHex,
@@ -106,6 +107,10 @@ function rgbFromOklab(oklab: readonly [number, number, number]): StationRgbColor
           [lightness, chroma, constrainAngle((Math.atan2(b, a) * 180) / Math.PI)],
           sRGBGamut,
           OKLCH,
+          undefined,
+          // Hold the searched lightness; cusp mapping would move L to the hue's
+          // cusp and defeat contrast searches on saturated accents.
+          MapToL,
         );
   return rgbFromSrgb(convert(lch, OKLCH, sRGB));
 }

--- a/station/src/theme/terminalPalette/test/fixtures.ts
+++ b/station/src/theme/terminalPalette/test/fixtures.ts
@@ -74,6 +74,34 @@ export const veryLightTerminalColors = {
   defaultBackground: "#ffffff",
 } as const;
 
+export const nearWhiteTerminalColors = {
+  ...lightTerminalColors,
+  defaultForeground: "#111827",
+  defaultBackground: "#fefefe",
+} as const;
+
+export const weakAnsiLightTerminalColors = {
+  ...lightTerminalColors,
+  palette: [
+    "#f1f2f3",
+    "#f2efee",
+    "#eef2ee",
+    "#f2f1e9",
+    "#eef1f4",
+    "#f1eef3",
+    "#edf2f2",
+    "#f3f3f3",
+    "#e9eaec",
+    "#f0c4c4",
+    "#c9e8c9",
+    "#ebe6b4",
+    "#c4d9f2",
+    "#e0c8ee",
+    "#bae4ea",
+    "#ebebeb",
+  ],
+} as const;
+
 export const weakAnsiTerminalColors = {
   ...darkTerminalColors,
   palette: [

--- a/station/src/theme/terminalPalette/test/fixtures.ts
+++ b/station/src/theme/terminalPalette/test/fixtures.ts
@@ -141,3 +141,56 @@ export const unsupportedTerminalColors = {
   defaultBackground: null,
   ...nullableSpecialColors,
 } as const;
+
+export const saturatedLightTerminalColors = {
+  ...lightTerminalColors,
+  palette: [
+    "#111827",
+    "#991b1b",
+    "#065f46",
+    "#854d0e",
+    "#1e40af",
+    "#6b21a8",
+    "#155e75",
+    "#374151",
+    "#4b5563",
+    "#ff5f5f",
+    "#7bff7b",
+    "#fff95b",
+    "#5f8bff",
+    "#ff7bff",
+    "#5fffff",
+    "#1f2937",
+  ],
+} as const;
+
+export const saturatedDarkTerminalColors = {
+  ...darkTerminalColors,
+  palette: [
+    "#111827",
+    "#7a0000",
+    "#004d00",
+    "#7a5f00",
+    "#001d7a",
+    "#5c007a",
+    "#004d5c",
+    "#d1d5db",
+    "#9ca3af",
+    "#ff0000",
+    "#00d500",
+    "#d5d500",
+    "#0055ff",
+    "#d500ff",
+    "#00e5e5",
+    "#f9fafb",
+  ],
+} as const;
+
+export const grayTerminalColors = {
+  ...darkTerminalColors,
+  palette: Array.from({ length: 16 }, (_, index) => {
+    const channel = 0x30 + index * 4;
+    const value = channel.toString(16).padStart(2, "0");
+    return `#${value}${value}${value}`;
+  }),
+} as const;

--- a/station/src/theme/terminalPalette/theme.test.ts
+++ b/station/src/theme/terminalPalette/theme.test.ts
@@ -2,13 +2,16 @@ import { describe, expect, it } from "bun:test";
 import { convert, hexToRGB, OKLCH, sRGB } from "@texel/color";
 import { nativeStationTheme } from "../builtInTheme.js";
 import { stationColorSnapshot, type StationColor, type StationTheme } from "../types.js";
-import { contrastRatio, STATION_TEXT_CONTRAST_RATIO } from "./contrast.js";
+import { contrastRatio, STATION_BOUNDARY_CONTRAST_RATIO, STATION_TEXT_CONTRAST_RATIO } from "./contrast.js";
 import { parseStationTerminalPaletteObservation } from "./observation.js";
 import {
   darkTerminalColors,
+  grayTerminalColors,
   lightTerminalColors,
   lowContrastTerminalColors,
   nearWhiteTerminalColors,
+  saturatedDarkTerminalColors,
+  saturatedLightTerminalColors,
   veryDarkTerminalColors,
   veryLightTerminalColors,
   weakAnsiLightTerminalColors,
@@ -78,6 +81,12 @@ describe("terminal palette theme construction", () => {
     ).toBe(nativeStationTheme);
   });
 
+  it("guards direct construction against unreadable default contrast", () => {
+    expect(createTerminalPaletteTheme(observation(lowContrastTerminalColors))).toBe(
+      nativeStationTheme,
+    );
+  });
+
   it("derives a terminal theme only from complete readable embedded evidence", () => {
     const observed = observation(darkTerminalColors);
     const theme = resolveEmbeddedStationTheme(observed);
@@ -107,6 +116,8 @@ describe("terminal palette theme construction", () => {
       lightTerminalColors,
       nearWhiteTerminalColors,
       weakAnsiLightTerminalColors,
+      saturatedLightTerminalColors,
+      saturatedDarkTerminalColors,
     ]) {
       const theme = terminalTheme(fixture);
       const foregrounds = [
@@ -168,8 +179,13 @@ describe("terminal palette theme construction", () => {
     }
   });
 
-  it("keeps layered light surfaces distinct from the canvas and each other", () => {
-    for (const fixture of [lightTerminalColors, nearWhiteTerminalColors]) {
+  it("keeps layered surfaces distinct from the canvas and each other", () => {
+    for (const fixture of [
+      lightTerminalColors,
+      nearWhiteTerminalColors,
+      veryLightTerminalColors,
+      veryDarkTerminalColors,
+    ]) {
       const theme = terminalTheme(fixture);
       const layered = [
         theme.surfaces.canvas,
@@ -213,12 +229,53 @@ describe("terminal palette theme construction", () => {
     }
   });
 
+  it("repairs saturated accents without collapsing onto the foreground", () => {
+    for (const fixture of [
+      saturatedLightTerminalColors,
+      saturatedDarkTerminalColors,
+    ]) {
+      const observed = observation(fixture);
+      const theme = terminalTheme(fixture);
+      const primary = stationColorSnapshot(theme.text.primary).value;
+      const roles = [
+        ["danger", 9],
+        ["success", 10],
+        ["warning", 11],
+        ["working", 12],
+        ["accent", 13],
+        ["info", 14],
+      ] as const;
+
+      for (const [role, index] of roles) {
+        const color = theme.status[role];
+        const source = oklchOf(observed.ansi16[index]);
+        const corrected = oklchOf(color);
+
+        expect(contrast(color, theme.surfaces.canvas)).toBeGreaterThanOrEqual(
+          STATION_TEXT_CONTRAST_RATIO,
+        );
+        if (color.kind === "rgb") {
+          // Out-of-gamut hues must hold their searched lightness and hue instead
+          // of drifting toward the hue's cusp and collapsing to the foreground.
+          expect(stationColorSnapshot(color).value).not.toBe(primary);
+          expect(hueDistance(corrected[2], source[2])).toBeLessThan(6);
+          expect(corrected[1]).toBeGreaterThanOrEqual(0.5 * source[1]);
+        } else {
+          expect(corrected[2]).toBe(source[2]);
+          expect(corrected[1]).toBe(source[1]);
+        }
+      }
+    }
+  });
+
   it("keeps chromatic status roles recognizably distinct", () => {
     for (const fixture of [
       darkTerminalColors,
       lightTerminalColors,
       nearWhiteTerminalColors,
       weakAnsiLightTerminalColors,
+      saturatedLightTerminalColors,
+      saturatedDarkTerminalColors,
     ]) {
       const theme = terminalTheme(fixture);
       const hues = ["danger", "warning", "success", "working", "info", "accent"] as const;
@@ -234,6 +291,41 @@ describe("terminal palette theme construction", () => {
       }
 
       expect(minimumDistance).toBeGreaterThanOrEqual(30);
+    }
+  });
+
+  it("resolves a readable, deterministic theme from a chroma-less gray palette", () => {
+    const theme = terminalTheme(grayTerminalColors);
+    const repeated = terminalTheme(grayTerminalColors);
+
+    // A fully neutral palette affords no hue separation; every corrected role
+    // converges on the same readable gray. Contrast floors still hold.
+    for (const color of Object.values(theme.status)) {
+      expect(color.kind).toBe("rgb");
+      expect(contrast(color, theme.surfaces.canvas)).toBeGreaterThanOrEqual(
+        STATION_TEXT_CONTRAST_RATIO,
+      );
+    }
+    const roleValues = Object.values(theme.status).map((color) =>
+      stationColorSnapshot(color).value,
+    );
+    expect(new Set(roleValues)).toHaveLength(1);
+    expect(theme).toEqual(repeated);
+  });
+
+  it("keeps pane accents and their inactive fills distinct on light palettes", () => {
+    const theme = terminalTheme(lightTerminalColors);
+    const pairs = [
+      [theme.pane.primary.active, theme.pane.primary.inactive],
+      [theme.pane.shells[0].active, theme.pane.shells[0].inactive],
+    ] as const;
+
+    for (const [active, inactive] of pairs) {
+      expect(stationColorSnapshot(inactive)).not.toEqual(stationColorSnapshot(active));
+      expect(contrast(inactive, theme.surfaces.canvas)).toBeGreaterThanOrEqual(
+        STATION_BOUNDARY_CONTRAST_RATIO,
+      );
+      expect(contrast(active, inactive)).toBeGreaterThan(1.1);
     }
   });
 

--- a/station/src/theme/terminalPalette/theme.test.ts
+++ b/station/src/theme/terminalPalette/theme.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { convert, hexToRGB, OKLCH, sRGB } from "@texel/color";
 import { nativeStationTheme } from "../builtInTheme.js";
 import { stationColorSnapshot, type StationColor, type StationTheme } from "../types.js";
 import { contrastRatio, STATION_TEXT_CONTRAST_RATIO } from "./contrast.js";
@@ -7,8 +8,10 @@ import {
   darkTerminalColors,
   lightTerminalColors,
   lowContrastTerminalColors,
+  nearWhiteTerminalColors,
   veryDarkTerminalColors,
   veryLightTerminalColors,
+  weakAnsiLightTerminalColors,
   weakAnsiTerminalColors,
 } from "./test/fixtures.js";
 import {
@@ -31,6 +34,16 @@ function terminalTheme(value: unknown): StationTheme {
 
 function contrast(first: StationColor, second: StationColor): number {
   return contrastRatio(stationColorSnapshot(first), stationColorSnapshot(second));
+}
+
+function oklchOf(color: StationColor): [number, number, number] {
+  const value = convert(hexToRGB(stationColorSnapshot(color).value), sRGB, OKLCH);
+  return [value[0], value[1], value[2]];
+}
+
+function hueDistance(first: number, second: number): number {
+  const difference = Math.abs(first - second) % 360;
+  return Math.min(difference, 360 - difference);
 }
 
 describe("terminal palette theme construction", () => {
@@ -89,7 +102,12 @@ describe("terminal palette theme construction", () => {
   });
 
   it("keeps ordinary foreground roles readable on every interaction surface", () => {
-    for (const fixture of [darkTerminalColors, lightTerminalColors]) {
+    for (const fixture of [
+      darkTerminalColors,
+      lightTerminalColors,
+      nearWhiteTerminalColors,
+      weakAnsiLightTerminalColors,
+    ]) {
       const theme = terminalTheme(fixture);
       const foregrounds = [
         theme.text.primary,
@@ -147,6 +165,75 @@ describe("terminal palette theme construction", () => {
       expect(contrast(color, theme.surfaces.canvas)).toBeGreaterThanOrEqual(
         STATION_TEXT_CONTRAST_RATIO,
       );
+    }
+  });
+
+  it("keeps layered light surfaces distinct from the canvas and each other", () => {
+    for (const fixture of [lightTerminalColors, nearWhiteTerminalColors]) {
+      const theme = terminalTheme(fixture);
+      const layered = [
+        theme.surfaces.canvas,
+        theme.interaction.hover,
+        theme.interaction.keyboardFocus,
+        theme.interaction.compactFocus,
+        theme.contextMenu.selected,
+      ];
+
+      for (let first = 0; first < layered.length; first += 1) {
+        for (let second = first + 1; second < layered.length; second += 1) {
+          expect(contrast(layered[first], layered[second])).toBeGreaterThan(1.1);
+        }
+      }
+    }
+  });
+
+  it("preserves hue and chroma when repairing weak light ANSI accents", () => {
+    const observed = observation(weakAnsiLightTerminalColors);
+    const theme = terminalTheme(weakAnsiLightTerminalColors);
+    const roles = [
+      ["danger", 9],
+      ["success", 10],
+      ["warning", 11],
+      ["working", 12],
+      ["accent", 13],
+      ["info", 14],
+    ] as const;
+
+    for (const [role, index] of roles) {
+      const color = theme.status[role];
+      const source = oklchOf(observed.ansi16[index]);
+      const corrected = oklchOf(color);
+
+      expect(color.kind).toBe("rgb");
+      expect(contrast(color, theme.surfaces.canvas)).toBeGreaterThanOrEqual(
+        STATION_TEXT_CONTRAST_RATIO,
+      );
+      expect(hueDistance(corrected[2], source[2])).toBeLessThan(6);
+      expect(corrected[1]).toBeGreaterThanOrEqual(0.6 * source[1]);
+    }
+  });
+
+  it("keeps chromatic status roles recognizably distinct", () => {
+    for (const fixture of [
+      darkTerminalColors,
+      lightTerminalColors,
+      nearWhiteTerminalColors,
+      weakAnsiLightTerminalColors,
+    ]) {
+      const theme = terminalTheme(fixture);
+      const hues = ["danger", "warning", "success", "working", "info", "accent"] as const;
+      const roleHues = hues.map((role) => oklchOf(theme.status[role])[2]);
+      let minimumDistance = 360;
+      for (let first = 0; first < roleHues.length; first += 1) {
+        for (let second = first + 1; second < roleHues.length; second += 1) {
+          minimumDistance = Math.min(
+            minimumDistance,
+            hueDistance(roleHues[first], roleHues[second]),
+          );
+        }
+      }
+
+      expect(minimumDistance).toBeGreaterThanOrEqual(30);
     }
   });
 

--- a/station/src/theme/terminalPalette/theme.ts
+++ b/station/src/theme/terminalPalette/theme.ts
@@ -9,12 +9,10 @@ import {
   type StationTheme,
 } from "../types.js";
 import {
-  blendUntilContrast,
-  blendUntilContrasts,
+  adjustLightnessForContrast,
   contrastRatio,
-  mixRgb,
+  mixOklch,
   relativeLuminance,
-  SRGB_CHANNEL_MAX,
   STATION_BOUNDARY_CONTRAST_RATIO,
   STATION_TEXT_CONTRAST_RATIO,
 } from "./contrast.js";
@@ -31,6 +29,10 @@ const ANSI_INDEX = {
 
 const INACTIVE_ACCENT_BLEND = 0.55;
 const WELCOME_SHIMMER_BLEND = 0.5;
+/** Fixed blend step so surface hierarchy resolution is byte-for-byte deterministic. */
+const BLEND_STEP = 1 / 255;
+/** Minimum WCAG contrast between adjacent layered surfaces so they stay distinguishable. */
+const SURFACE_SEPARATION_RATIO = 1.12;
 
 type TerminalPalettePolarity = "dark" | "light";
 type TerminalThemeRecipe = Readonly<{
@@ -60,10 +62,10 @@ const TERMINAL_THEME_RECIPES = {
     textDisabled: 0.46,
     border: 0.44,
     hairline: 0.38,
-    hover: 0.06,
-    keyboardFocus: 0.1,
-    compactFocus: 0.14,
-    selected: 0.16,
+    hover: 0.08,
+    keyboardFocus: 0.13,
+    compactFocus: 0.17,
+    selected: 0.19,
   },
 } as const satisfies Record<TerminalPalettePolarity, TerminalThemeRecipe>;
 
@@ -105,10 +107,11 @@ export function createTerminalPaletteTheme(
   const defaultBackground = terminalDefaultColor("background", background);
   const recipe = TERMINAL_THEME_RECIPES[terminalPalettePolarity(observation)];
 
-  const hover = readableSurfaceBlend(background, foreground, recipe.hover);
-  const keyboardFocus = readableSurfaceBlend(background, foreground, recipe.keyboardFocus);
-  const compactFocus = readableSurfaceBlend(background, foreground, recipe.compactFocus);
-  const selected = readableSurfaceBlend(background, foreground, recipe.selected);
+  const [hover, keyboardFocus, compactFocus, selected] = deriveInteractionSurfaces(
+    background,
+    foreground,
+    recipe,
+  );
   const interactionSurfaces = [background, hover, keyboardFocus, compactFocus] as const;
 
   const textMuted = foregroundBlend(
@@ -266,6 +269,65 @@ export function createTerminalPaletteTheme(
   };
 }
 
+function deriveInteractionSurfaces(
+  background: StationRgbColor,
+  foreground: StationRgbColor,
+  recipe: TerminalThemeRecipe,
+): readonly [StationRgbColor, StationRgbColor, StationRgbColor, StationRgbColor] {
+  const prior = [background];
+  const surfaces = [recipe.hover, recipe.keyboardFocus, recipe.compactFocus, recipe.selected].map(
+    (preferredAmount) => {
+      const surface = surfaceWithHierarchy(background, foreground, preferredAmount, prior);
+      prior.push(surface);
+      return surface;
+    },
+  );
+  return [surfaces[0], surfaces[1], surfaces[2], surfaces[3]];
+}
+
+/**
+ * Picks the strongest blend toward the foreground that keeps text readable, then widens it
+ * until the surface separates from every previously derived layered surface.
+ */
+function surfaceWithHierarchy(
+  background: StationRgbColor,
+  foreground: StationRgbColor,
+  preferredAmount: number,
+  priorSurfaces: readonly StationRgbColor[],
+): StationRgbColor {
+  const blendAt = (amount: number): StationRgbColor => mixOklch(background, foreground, amount);
+  const textSafe = (amount: number): boolean =>
+    contrastRatio(blendAt(amount), foreground) >= STATION_TEXT_CONTRAST_RATIO;
+  const separated = (surface: StationRgbColor): boolean =>
+    priorSurfaces.every((prior) => contrastRatio(surface, prior) >= SURFACE_SEPARATION_RATIO);
+
+  const preferred = blendAt(preferredAmount);
+  if (textSafe(preferredAmount) && separated(preferred)) {
+    return preferred;
+  }
+  if (!textSafe(preferredAmount)) {
+    // Preferred amount oversteps the text floor; walk down to the largest readable amount.
+    let amount = preferredAmount;
+    while (amount > 0 && !textSafe(amount)) {
+      amount -= BLEND_STEP;
+    }
+    return blendAt(Math.max(0, amount));
+  }
+  // Text-safe but not separated yet; walk up toward the foreground, which always separates.
+  let amount = preferredAmount;
+  while (amount < 1) {
+    amount += BLEND_STEP;
+    const candidate = blendAt(amount);
+    if (separated(candidate)) {
+      return candidate;
+    }
+    if (!textSafe(amount)) {
+      break;
+    }
+  }
+  return preferred;
+}
+
 function ansiColorWithContrast(
   observation: StationTerminalTheme,
   index: number,
@@ -280,7 +342,7 @@ function ansiColorWithContrast(
   if (backgrounds.every((background) => contrastRatio(snapshot, background) >= target)) {
     return indexedColor(index, snapshot);
   }
-  return blendUntilContrasts(snapshot, foreground, backgrounds, target);
+  return adjustLightnessForContrast(snapshot, foreground, backgrounds, target);
 }
 
 function inactiveAccent(
@@ -288,10 +350,10 @@ function inactiveAccent(
   active: StationSemanticColor,
 ): StationRgbColor {
   const activeSnapshot = stationColorSnapshot(active);
-  return blendUntilContrast(
-    mixRgb(background, activeSnapshot, INACTIVE_ACCENT_BLEND),
+  return adjustLightnessForContrast(
+    mixOklch(background, activeSnapshot, INACTIVE_ACCENT_BLEND),
     activeSnapshot,
-    background,
+    [background],
     STATION_BOUNDARY_CONTRAST_RATIO,
   );
 }
@@ -306,28 +368,10 @@ function foregroundBlend(
   if (background === undefined) {
     throw new RangeError("Foreground blends require at least one background.");
   }
-  return blendUntilContrasts(
-    mixRgb(background, foreground, amount),
+  return adjustLightnessForContrast(
+    mixOklch(background, foreground, amount),
     foreground,
     backgrounds,
     target,
   );
-}
-
-function readableSurfaceBlend(
-  background: StationRgbColor,
-  foreground: StationRgbColor,
-  preferredAmount: number,
-): StationRgbColor {
-  for (
-    let step = Math.round(preferredAmount * SRGB_CHANNEL_MAX);
-    step >= 0;
-    step -= 1
-  ) {
-    const candidate = mixRgb(background, foreground, step / SRGB_CHANNEL_MAX);
-    if (contrastRatio(candidate, foreground) >= STATION_TEXT_CONTRAST_RATIO) {
-      return candidate;
-    }
-  }
-  return background;
 }

--- a/station/src/theme/terminalPalette/theme.ts
+++ b/station/src/theme/terminalPalette/theme.ts
@@ -85,22 +85,23 @@ export function terminalPalettePolarity(
 export function resolveEmbeddedStationTheme(
   observation: StationTerminalTheme | null | undefined,
 ): StationTheme {
-  if (
-    observation === undefined ||
-    observation === null ||
-    contrastRatio(observation.defaultForeground, observation.defaultBackground) <
-      STATION_TEXT_CONTRAST_RATIO
-  ) {
-    // Whole-theme fallback prevents terminal surfaces from mixing with unrelated Station roles.
+  if (observation === undefined || observation === null) {
     return nativeStationTheme;
   }
   return createTerminalPaletteTheme(observation);
 }
 
-/** Creates one complete embedded theme from a validated, readable terminal palette. */
+/** Creates one complete embedded theme from a readable terminal palette observation. */
 export function createTerminalPaletteTheme(
   observation: StationTerminalTheme,
 ): StationTheme {
+  if (
+    contrastRatio(observation.defaultForeground, observation.defaultBackground) <
+    STATION_TEXT_CONTRAST_RATIO
+  ) {
+    // Whole-theme fallback prevents terminal surfaces from mixing with unrelated Station roles.
+    return nativeStationTheme;
+  }
   const foreground = observation.defaultForeground;
   const background = observation.defaultBackground;
   const defaultForeground = terminalDefaultColor("foreground", foreground);


### PR DESCRIPTION
## What this fixes

The embedded standalone/tmux dashboard resolves its complete semantic theme from the outer terminal palette. On light and near-white palettes, the previous derivation mixed and contrast-corrected colors in sRGB space, which collapsed layered surfaces (hover, focus, selection, sheets) into nearly indistinguishable grays and washed ANSI accent chroma toward the foreground while repairing readability.

## What changed

- Added `@texel/color` (zero-dependency OKLab/OKLCH math) and replaced hand-rolled sRGB mixing with `mixOklch` (perceptual mix, shortest-arc hue) and `adjustLightnessForContrast` (OKLab lightness shift holding chroma/hue, hue-preserving gamut mapping, fixed search steps so identical palettes resolve byte-for-byte identically). WCAG contrast/luminance math stays local, since the library does not provide it.
- Layered surfaces now guarantee a minimum 1.12:1 separation from the canvas and from each other, walking the blend up only until the 4.5 text-contrast floor; the light-polarity surface recipes were retuned to match.
- Weak ANSI accents repair toward readable lightness while retaining recognizable hue and chroma. The indexed-intent fast path, existing contrast floors, terminal-default intent, and the whole-theme fallback for invalid observations are unchanged.
- New fixtures (`nearWhiteTerminalColors`, `weakAnsiLightTerminalColors`) and tests for surface hierarchy, hue/chroma retention after repair, and chromatic-role hue separation; added a styled-cell distinctness assertion in the FullscreenDashboard light coverage.
- Golden snapshots are unaffected (they serialize character frames only, not colors).

## Testing

- Full `station` suite: 1440 pass, 0 fail (67 snapshots).
- `pnpm --dir station typecheck` clean; root `pnpm lint` clean (biome, source-order, no-raw-hex, no-raw-VT, observer architecture).

## User-visible behavior

Under a near-white terminal palette, sheets, panels, hover/focus fills, and selection are visibly stepped away from the canvas, and corrected status/action accents keep their hue instead of reading gray. Verify by launching the dashboard under a light palette and comparing with an isolated tmux popup under the same palette.