### PR TITLE
refactor(terminal): make native pane padding per-axis, default zero

### DIFF
--- a/station/src/terminal/PaneGrid.test.tsx
+++ b/station/src/terminal/PaneGrid.test.tsx
@@ -23,8 +23,8 @@ import { makeStationTestRuntime } from "../station/test/support/makeStationTestR
 const SURFACE = { width: 40, height: 12 };
 const PRIMARY_BORDER_ACTIVE = stationColorSnapshotValue(nativeStationTheme.pane.primary.active);
 const PRIMARY_BORDER_INACTIVE = stationColorSnapshotValue(nativeStationTheme.pane.primary.inactive);
-// One pane filling the surface: TerminalPane border + padding eat 2 cells each side.
-const FULL_INTERIOR = { cols: SURFACE.width - 4, rows: SURFACE.height - 4 };
+// One pane filling the surface: TerminalPane's border eats 1 cell each side.
+const FULL_INTERIOR = { cols: SURFACE.width - 2, rows: SURFACE.height - 2 };
 
 describe("PaneGrid", () => {
   const teardowns: Array<() => void> = [];
@@ -244,10 +244,10 @@ describe("PaneGrid", () => {
     expect(screen!.mouseProtocol()).not.toBeNull();
 
     const before = terminals[0]!.helpers.writes.length;
-    // TerminalPane's border+padding put the screen interior origin at (2,2), so
-    // an absolute click at (5,5) lands on local cell (3,3) -> 1-based col 4, row 4.
+    // TerminalPane's border puts the screen interior origin at (1,1), so an
+    // absolute click at (5,5) lands on local cell (4,4) -> 1-based col 5, row 5.
     await setup.mockMouse.click(5, 5);
-    expect(terminals[0]!.helpers.writes.slice(before)).toEqual(["\x1b[<0;4;4M", "\x1b[<0;4;4m"]);
+    expect(terminals[0]!.helpers.writes.slice(before)).toEqual(["\x1b[<0;5;5M", "\x1b[<0;5;5m"]);
   });
 
   it("suppresses click forwarding while the STATION overlay owns input", async () => {

--- a/station/src/terminal/PaneGrid.tsx
+++ b/station/src/terminal/PaneGrid.tsx
@@ -93,7 +93,7 @@ function PaneLeaf({ paneId, ctx }: { paneId: PaneId; ctx: RenderCtx }): ReactNod
   const active = paneId === ctx.activePaneId;
   const presentation = panePresentation(theme, paneId, active, ctx);
   // A transparent (no border/padding) mouse-capturing wrapper keeps focus/menu
-  // routing per pane while TerminalPane keeps its own 4-cell chrome. Clicking
+  // routing per pane while TerminalPane keeps its own border chrome. Clicking
   // anywhere in the pane focuses it; right-click opens its context menu.
   return (
     <box

--- a/station/src/terminal/TerminalPane.test.tsx
+++ b/station/src/terminal/TerminalPane.test.tsx
@@ -21,11 +21,11 @@ import { createScriptedTerminal, type ScriptedTerminal } from "./testing/scripte
 import { waitFor } from "./testing/waitFor.js";
 import type { StationTerminalSize, StationTerminalSpawnOptions } from "./types.js";
 
-// Pane chrome: 1 border + 1 padding on each side. The origin-anchor test
-// below derives this empirically; everything else trusts the constant.
-const ORIGIN = { x: 2, y: 2 };
+// Pane chrome: 1 border on each side. The origin-anchor test below derives
+// this empirically; everything else trusts the constant.
+const ORIGIN = { x: 1, y: 1 };
 const SURFACE = { width: 40, height: 12 };
-const GRID = { cols: SURFACE.width - 4, rows: SURFACE.height - 4 };
+const GRID = { cols: SURFACE.width - 2, rows: SURFACE.height - 2 };
 
 type PaneSetup = {
   setup: Awaited<ReturnType<typeof testRender>>;
@@ -317,11 +317,11 @@ describe("TerminalPane frame rendering", () => {
     await feedAndFlush(pane, "before");
     pane.setup.resize(60, 20);
     await waitFor(() =>
-      pane.scripted.helpers.resizes.some((size) => size.cols === 56 && size.rows === 16),
+      pane.scripted.helpers.resizes.some((size) => size.cols === 58 && size.rows === 18),
     );
-    await feedAndFlush(pane, `\r\n${"=".repeat(56)}`);
-    const frame = await waitForPaneFrame(pane, (f) => f.includes("=".repeat(56)));
-    expect(frameChar(frame, ORIGIN.y + 1, ORIGIN.x + 55)).toBe("=");
+    await feedAndFlush(pane, `\r\n${"=".repeat(58)}`);
+    const frame = await waitForPaneFrame(pane, (f) => f.includes("=".repeat(58)));
+    expect(frameChar(frame, ORIGIN.y + 1, ORIGIN.x + 57)).toBe("=");
   });
 
   it("shrinking leaves no stale cells outside the new pane bounds", async () => {
@@ -331,7 +331,7 @@ describe("TerminalPane frame rendering", () => {
     await waitForPaneFrame(pane, (f) => f.includes("#"));
     pane.setup.resize(30, 10);
     await waitFor(() =>
-      pane.scripted.helpers.resizes.some((size) => size.cols === 26 && size.rows === 6),
+      pane.scripted.helpers.resizes.some((size) => size.cols === 28 && size.rows === 8),
     );
     await feedAndFlush(pane, "\x1b[2J\x1b[Hcompact");
     const frame = await waitForPaneFrame(pane, (f) => f.includes("compact"));
@@ -426,11 +426,11 @@ describe("TerminalPane frame rendering", () => {
     pane.setup.resize(60, 20);
     pane.setup.resize(50, 14);
     await waitFor(() =>
-      pane.scripted.helpers.resizes.some((size) => size.cols === 46 && size.rows === 10),
+      pane.scripted.helpers.resizes.some((size) => size.cols === 48 && size.rows === 12),
     );
     await new Promise((resolve) => setTimeout(resolve, 200));
     const last = pane.scripted.helpers.resizes[pane.scripted.helpers.resizes.length - 1];
-    expect(last).toEqual({ cols: 46, rows: 10 });
+    expect(last).toEqual({ cols: 48, rows: 12 });
   });
 
   it("renders a consistent final frame after a burst", async () => {

--- a/station/src/terminal/TerminalPane.tsx
+++ b/station/src/terminal/TerminalPane.tsx
@@ -22,6 +22,9 @@ export type TerminalPaneProps = {
   /** Visual only: the pane border color. PaneGrid passes the active accent. */
   borderColor?: ColorInput;
   title?: string;
+  /** Interior padding in cells between the border and the terminal screen. */
+  paddingX?: number;
+  paddingY?: number;
 };
 
 /**
@@ -34,6 +37,8 @@ export function TerminalPane({
   onForwardInput,
   borderColor,
   title,
+  paddingX = 0,
+  paddingY = 0,
 }: TerminalPaneProps) {
   const theme = useStationTheme();
   const term = usePaneTerminal(paneId);
@@ -46,7 +51,8 @@ export function TerminalPane({
       border
       borderColor={resolvedBorderColor}
       title={paneTitle(title, term.status, term.oscTitle, term.cwd)}
-      padding={1}
+      paddingX={paddingX}
+      paddingY={paddingY}
     >
       <terminalScreen
         width="100%"


### PR DESCRIPTION
## What this fixes

Native terminal panes in the Station workspace render with a hardcoded 1-cell padding between the border and the terminal screen, wasting two columns and two rows per pane. This removes the default padding so a full-screen pane reports `width - 2` columns (border only) instead of `width - 4`, and makes the padding configurable per axis.

## What changed

- `TerminalPane` now takes optional `paddingX` and `paddingY` props (both default to `0`), replacing the fixed `padding={1}` on the pane border box. OpenTUI 0.4.1 applies each axis independently through yoga, and `TerminalScreenRenderable.onLayoutResize` already reports the post-padding interior size, so no renderer changes were needed.
- `PaneGrid` passes nothing, so shipped behavior is zero padding; a caller can reintroduce spacing per axis (e.g. `paddingX={1}`).
- Updated pane-chrome geometry in `TerminalPane.test.tsx` and `PaneGrid.test.tsx` (interior origin `(1,1)`, grid = surface − 2, resized PTY dimensions, mouse-report column/row) and the `PaneGrid` chrome comment.

## Testing

- `bun test` (full Station suite): 1454 pass, 0 fail.
- `tsc -p tsconfig.json --noEmit` clean; `pnpm lint` clean (biome + source-order + no-raw-hex + VT-literals + observer architecture).

## User-visible behavior

Terminal panes gain 2 columns and 2 rows; text now sits flush against the pane border. Manual check: launch native Station, run `tput cols` in a full-screen pane — it reports surface width − 2 (previously width − 4).