### PR TITLE
chore(release): prepare pre-alpha.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Station gives every agent an isolated Git worktree, keeps its terminal session a
 ## Install
 
 Station is experimental pre-alpha software. Install the current public version,
-`v0.0.0-pre-alpha.5`, with one command:
+`v0.0.0-pre-alpha.5.1`, with one command:
 
 ```sh
-curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh | sh
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh | sh
 ```
 
 Then complete and verify first-run setup:
@@ -125,11 +125,11 @@ Paste this prompt into a coding agent running on the machine where you want
 Station installed:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.1 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -207,7 +207,7 @@ or real-agent lanes.
 
 ## Release status
 
-Station `v0.0.0-pre-alpha.5` is an experimental pre-alpha. User-facing commands,
+Station `v0.0.0-pre-alpha.5.1` is an experimental pre-alpha. User-facing commands,
 configuration, state, and release packaging may change without compatibility.
 The old `v0.7.1-rc.*` releases were internal previews, not predecessors in the
 public version line. Report feedback and bugs through

--- a/apps/cli/test/integration/codex-hooks-command.test.ts
+++ b/apps/cli/test/integration/codex-hooks-command.test.ts
@@ -680,7 +680,7 @@ function artifactOwner(launcher: string, runtimeKind: "compiled" | "source", dig
     schemaVersion: 1 as const,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/manual-smoke-commands.test.ts
+++ b/apps/cli/test/integration/manual-smoke-commands.test.ts
@@ -117,7 +117,7 @@ describe("CLI manual-smoke commands", () => {
       "--version",
     ]);
 
-    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5", outputFormat: "text" });
+    expect(direct).toEqual({ code: 0, output: "0.0.0-pre-alpha.5.1", outputFormat: "text" });
     expect(withMissingConfig).toEqual(direct);
   });
 

--- a/apps/cli/test/integration/popup-command.test.ts
+++ b/apps/cli/test/integration/popup-command.test.ts
@@ -15,7 +15,7 @@ import { createTempState, writeConfigToml } from "../../../../tests/support/temp
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.1+station.${buildIdentity}`;
 const tuiObserverBuildMismatchError = {
   tag: "TuiCommandError",
   code: "TUI_OBSERVER_BUILD_MISMATCH",

--- a/apps/cli/test/integration/provider-hook-ownership.test.ts
+++ b/apps/cli/test/integration/provider-hook-ownership.test.ts
@@ -165,7 +165,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/integration/setup-command.test.ts
+++ b/apps/cli/test/integration/setup-command.test.ts
@@ -165,7 +165,7 @@ describe("CLI setup command", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "source", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/cli/test/integration/tui-command.test.ts
+++ b/apps/cli/test/integration/tui-command.test.ts
@@ -19,7 +19,7 @@ import { resolveStationWorkspaceDir } from "../../src/stationWorkspace.js";
 const now = "2026-05-20T12:00:00.000Z";
 const buildIdentity = "a".repeat(64);
 const observerBuildVersion = `0.0.0-local+station.${buildIdentity}`;
-const higherObserverBuildVersion = `0.0.0-pre-alpha.5+station.${buildIdentity}`;
+const higherObserverBuildVersion = `0.0.0-pre-alpha.5.1+station.${buildIdentity}`;
 const nestedTuiDisabledError = {
   tag: "TuiCommandError",
   code: "NESTED_TUI_DISABLED",

--- a/apps/cli/test/integration/worktrunk-hooks-command.test.ts
+++ b/apps/cli/test/integration/worktrunk-hooks-command.test.ts
@@ -352,7 +352,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
+++ b/apps/cli/test/unit/observer-process/activation-surfacing.test.ts
@@ -17,7 +17,7 @@ import { createTempState } from "../../../../../tests/support/temp-projects";
 
 const now = "2026-05-20T12:00:00.000Z";
 const sourceBuildVersion = `0.0.0-pre-alpha.4+station.${"e".repeat(64)}`;
-const compiledBuildVersion = `0.0.0-pre-alpha.5+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.1+station.${"d".repeat(64)}`;
 
 const bootReason = "FATAL: socket owned by foreign build dbf7f368";
 

--- a/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
+++ b/apps/cli/test/unit/observer-process/setup-observer-activation.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/observerProcess.js", async (importActual) => {
 });
 
 const now = "2026-05-20T12:00:00.000Z";
-const compiledBuildVersion = `0.0.0-pre-alpha.5+station.${"d".repeat(64)}`;
+const compiledBuildVersion = `0.0.0-pre-alpha.5.1+station.${"d".repeat(64)}`;
 
 restartObserverSpy.mockImplementation(async () => ({
   status: "running",

--- a/apps/cli/test/unit/setup-json-presenter.test.ts
+++ b/apps/cli/test/unit/setup-json-presenter.test.ts
@@ -262,7 +262,7 @@ describe("setup plan projection", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       buildIdentity: "a".repeat(64),
     };
     const current = {

--- a/apps/observer/src/runtime/observerHandoff.ts
+++ b/apps/observer/src/runtime/observerHandoff.ts
@@ -17,7 +17,8 @@ const GRACEFUL_HANDOFF_BUDGET_RATIO = 0.5;
 const DEFAULT_HANDOFF_POLL_INTERVAL_MS = 50;
 const MIN_HANDOFF_TIMEOUT_MS = 1;
 const INTERNAL_PREVIEW_VERSION_PATTERN = /^0\.7\.1-rc\.(?:0|[1-9]\d*)$/u;
-const PUBLIC_PRE_ALPHA_VERSION_PATTERN = /^0\.0\.0-pre-alpha\.(?:0|[1-9]\d*)$/u;
+const PUBLIC_PRE_ALPHA_VERSION_PATTERN =
+  /^0\.0\.0-pre-alpha\.(?:0|[1-9]\d*)(?:\.(?:0|[1-9]\d*))*$/u;
 
 const SemVerSchema = z
   .string()

--- a/apps/observer/test/unit/observerHandoff.test.ts
+++ b/apps/observer/test/unit/observerHandoff.test.ts
@@ -90,7 +90,7 @@ describe("classifyObserverIncumbent", () => {
   });
 
   it("orders the public pre-alpha after the internal preview version line", () => {
-    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.1", higherBuildIdentity);
+    const publicPreAlpha = observerBuildVersion("0.0.0-pre-alpha.5.1", higherBuildIdentity);
     const internalPreview = observerBuildVersion("0.7.1-rc.8", lowerBuildIdentity);
 
     expect(decisionFor(publicPreAlpha, internalPreview)).toEqual({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ can use it or help improve it.
 
 > [!IMPORTANT]
 > Station is experimental pre-alpha software. The current public version is
-> `v0.0.0-pre-alpha.5`. Native binaries support macOS 13+ and glibc 2.39+ Linux
+> `v0.0.0-pre-alpha.5.1`. Native binaries support macOS 13+ and glibc 2.39+ Linux
 > on arm64 and x64.
 
 ## Start Here
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 Install the current release:
 
 ```sh
-curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh | sh
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh | sh
 ```
 
 Then complete and verify setup:

--- a/docs/development.md
+++ b/docs/development.md
@@ -733,23 +733,23 @@ containing spaces and apostrophes. Source-checkout acceptance separately
 requires the preserved `pnpm --dir <checkout> station:link` command when
 linking is declined.
 
-The public candidate is experimental pre-alpha `v0.0.0-pre-alpha.5`. The old
+The public candidate is experimental pre-alpha `v0.0.0-pre-alpha.5.1`. The old
 `v0.7.1-rc.*` releases were internal previews, not predecessors in the public
 version line. `v0.7.1-rc.8` is retained as the installed-version fixture that
 proves the intentional version-number reset:
 
 1. Enable GitHub immutable releases, confirm the release commit is on `main`
-   with `package.json` and runtime reporting at `0.0.0-pre-alpha.5`, then create
-   and push `v0.0.0-pre-alpha.5`.
+   with `package.json` and runtime reporting at `0.0.0-pre-alpha.5.1`, then create
+   and push `v0.0.0-pre-alpha.5.1`.
 2. Confirm every release job passed and the successful run contains exactly one
-   `accepted-release-candidate-0.0.0-pre-alpha.5-attempt-*` artifact.
+   `accepted-release-candidate-0.0.0-pre-alpha.5.1-attempt-*` artifact.
 3. Install the draft on clean native machines for `darwin-arm64`, `darwin-x64`,
    `linux-arm64`, and `linux-x64`, then complete the manual UX gate below.
 4. Install `v0.7.1-rc.8`, upgrade to the accepted candidate, and confirm the
    lower public version number does not block replacement. Confirm the complete
    version and all three launchers after every transition.
 5. Dispatch `promote-release.yml` with the successful release run ID, tag
-   `v0.0.0-pre-alpha.5`, and the manual-acceptance confirmation. It rechecks the
+   `v0.0.0-pre-alpha.5.1`, and the manual-acceptance confirmation. It rechecks the
    successful run SHA, immutable candidate manifest, tag commit, release ID,
    asset IDs, the stamped installer, and all hashes immediately before
    publishing that exact draft. Its four public-install jobs must then pass.
@@ -874,7 +874,7 @@ promotion will verify:
   set -eu
   umask 077
   export GH_HOST=github.com
-  tag=v0.0.0-pre-alpha.5
+  tag=v0.0.0-pre-alpha.5.1
   version=${tag#v}
   release_run_id=123456789
   case "$release_run_id" in
@@ -1058,7 +1058,7 @@ manually verify the actual user experience, not a dashboard override:
    scrollback before the idle host is replaced.
 9. In terminal A, continuously run the installed `stn --version`. In terminal
    B, repeatedly reinstall the draft. Terminal A may print only
-   `0.0.0-pre-alpha.5`:
+   `0.0.0-pre-alpha.5.1`:
    never command-not-found or malformed output. After each transition, confirm
    `stn-ingress` and `stn-tmux-popup` still link to `stn`, so the runtime never
    has mixed entrypoints. Repeat the same checks while alternating the draft

--- a/docs/homebrew.md
+++ b/docs/homebrew.md
@@ -3,7 +3,7 @@
 Homebrew installation is not currently supported for Station.
 
 The public installation path for experimental pre-alpha
-`v0.0.0-pre-alpha.5` is the exact-tag native installer documented in
+`v0.0.0-pre-alpha.5.1` is the exact-tag native installer documented in
 [Install Station](install.md). Do not use the historical tap for public
 onboarding, and do not update it as part of pre-alpha publication.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,7 +1,7 @@
 # Install Station
 
 Station is experimental pre-alpha software. The current public version is
-`v0.0.0-pre-alpha.5`.
+`v0.0.0-pre-alpha.5.1`.
 
 ## Binary Requirements
 
@@ -33,11 +33,11 @@ If you prefer an agent-led install, paste this prompt into a coding agent on the
 target machine:
 
 ```text
-Install experimental Station v0.0.0-pre-alpha.5 and validate setup on this machine.
+Install experimental Station v0.0.0-pre-alpha.5.1 and validate setup on this machine.
 
 Safety and scope:
 - Do not clone the repository or build from source. Use only
-  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh`.
+  `https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh`.
 - Install to `~/.local/bin` unless I approve another location. Do not edit any
   shell startup file. If the installer reports a PATH mismatch, do not assume
   an export persists across agent tool calls or reaches my Terminal. Use the
@@ -71,10 +71,10 @@ choices.
 From any directory, run:
 
 ```bash
-curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh | sh
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh | sh
 ```
 
-The released `install.sh` is stamped with `v0.0.0-pre-alpha.5`. With no
+The released `install.sh` is stamped with `v0.0.0-pre-alpha.5.1`. With no
 arguments it downloads only that tag's matching native archive and
 `SHA256SUMS` over unauthenticated HTTPS. The old `v0.7.1-rc.*` releases were
 internal previews, not predecessors in the public version line.
@@ -138,7 +138,7 @@ it separately.
 Pass an absolute or home-relative path through the exact installer:
 
 ```bash
-curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh | \
+curl -fsSL https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh | \
   sh -s -- --install-dir "$HOME/bin"
 ```
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
 # Limitations and Workarounds
 
-Station `v0.0.0-pre-alpha.5` is experimental pre-alpha software. This page
+Station `v0.0.0-pre-alpha.5.1` is experimental pre-alpha software. This page
 lists user-visible constraints and the available operational workaround for
 each one.
 

--- a/docs/single-binary.md
+++ b/docs/single-binary.md
@@ -1,6 +1,6 @@
 # Single-binary Station
 
-> **Status: implemented; distribution updated for `v0.0.0-pre-alpha.5`.** v1
+> **Status: implemented; distribution updated for `v0.0.0-pre-alpha.5.1`.** v1
 > was feasibility evidence, not an implementation-ready roadmap; an adversarial audit of commit `e0d4307`
 > found 11 blocking issues, all reproduced and confirmed (see
 > [Audit findings](#audit-findings-all-confirmed)). v1.1 is subtractive:
@@ -147,7 +147,7 @@ stn (bun build --compile, per platform, no ambient env)
   atomically published `station-build-id` sidecar and reverifies its repository
   inputs plus production package outputs; compiled and source output from the
   same whole-repository build therefore produce the same Observer selector while
-  retaining `{ version: "0.0.0-pre-alpha.5", compiled: false }` display semantics.
+  retaining `{ version: "0.0.0-pre-alpha.5.1", compiled: false }` display semantics.
   Self-spawns route through `selfExecArgv(target, developmentArgv)`: compiled →
   `[process.execPath]` for CLI or `[process.execPath, internalToken]` for an
   internal target; dev → today's command. All
@@ -396,7 +396,7 @@ Each native job runs the full binary smoke and uploads one archive:
 - `stn-v{version}-darwin-arm64.tar.gz`
 
 Here `{version}` is the package version without the tag's leading `v`, for
-example `stn-v0.0.0-pre-alpha.5-darwin-arm64.tar.gz`.
+example `stn-v0.0.0-pre-alpha.5.1-darwin-arm64.tar.gz`.
 
 Every archive contains exactly `stn`, the `stn-ingress` and
 `stn-tmux-popup` symlinks, and `LICENSE`. The aggregate job rejects missing or
@@ -505,7 +505,7 @@ The future-shell export appears only when physical current-process resolution
 is incomplete. The installer never reads, selects, creates, or edits shell
 startup files.
 
-Candidate `v0.0.0-pre-alpha.5` promotes only after all four native targets pass
+Candidate `v0.0.0-pre-alpha.5.1` promotes only after all four native targets pass
 automated and manual acceptance, including installation over an existing
 `v0.7.1-rc.8` internal preview despite the intentional public version reset.
 After promotion, all four targets test the unauthenticated public exact-tag URL
@@ -740,7 +740,7 @@ flow:
    GitHub credentials or a `gh` executable.
 9. With terminal A continuously running installed `stn --version`, terminal B
    repeatedly installs the draft → only complete `0.7.1-rc.8` or
-   `0.0.0-pre-alpha.5` output appears, never command-not-found or malformed
+   `0.0.0-pre-alpha.5.1` output appears, never command-not-found or malformed
    output; both aliases remain links to `stn`, so entrypoints never mix. Install
    the reset public version over the internal preview to prove the intentional
    lower SemVer is accepted.

--- a/integrations/harness/claude/test/unit/hooks.test.ts
+++ b/integrations/harness/claude/test/unit/hooks.test.ts
@@ -354,7 +354,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/cursor/test/unit/hooks.test.ts
+++ b/integrations/harness/cursor/test/unit/hooks.test.ts
@@ -419,7 +419,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/pluginInstall.test.ts
+++ b/integrations/harness/opencode/test/unit/pluginInstall.test.ts
@@ -643,7 +643,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/integrations/harness/opencode/test/unit/provider.test.ts
+++ b/integrations/harness/opencode/test/unit/provider.test.ts
@@ -307,7 +307,7 @@ describe("OpenCodeHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: join(root, "requester", "bin", "stn-ingress"),
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       buildIdentity: "a".repeat(64),
     };
 

--- a/integrations/worktree/worktrunk/test/unit/hooks.test.ts
+++ b/integrations/worktree/worktrunk/test/unit/hooks.test.ts
@@ -266,7 +266,7 @@ function artifactOwner(
     schemaVersion: 1,
     launcher,
     runtimeKind,
-    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5",
+    version: runtimeKind === "compiled" ? "0.7.1" : "0.0.0-pre-alpha.5.1",
     buildIdentity: digit.repeat(64),
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "station",
-  "version": "0.0.0-pre-alpha.5",
+  "version": "0.0.0-pre-alpha.5.1",
   "private": true,
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -98,7 +98,7 @@ describe("contract schemas", () => {
       schemaVersion: 1,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source",
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       buildIdentity: "a".repeat(64),
     } as const;
     const current = {

--- a/packages/contracts/test/schema/diagnostics-schema.test.ts
+++ b/packages/contracts/test/schema/diagnostics-schema.test.ts
@@ -210,7 +210,7 @@ describe("diagnostics schemas", () => {
         schemaVersion: 1,
         launcher: "/checkout/station/bin/stn-ingress",
         runtimeKind: "source",
-        version: "0.0.0-pre-alpha.5",
+        version: "0.0.0-pre-alpha.5.1",
         buildIdentity: "a".repeat(64),
       },
     };

--- a/packages/harness-shared/test/unit/provider.test.ts
+++ b/packages/harness-shared/test/unit/provider.test.ts
@@ -175,7 +175,7 @@ describe("createTerminalBoundHarnessProvider", () => {
       schemaVersion: 1 as const,
       launcher: "/source/bin/stn-ingress",
       runtimeKind: "source" as const,
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       buildIdentity: "a".repeat(64),
     };
 
@@ -205,6 +205,8 @@ describe("versionInfo", () => {
       {
         now: () => now,
         runner: async (input) => ({
+          command: input.command,
+          args: input.args ?? [],
           stdout: input.command === "npm" ? "1.4.0\n" : "test-cli 1.2.3 (build abc)\n",
           stderr: "",
           exitCode: 0,
@@ -226,7 +228,13 @@ describe("versionInfo", () => {
           if (input.command === "npm") {
             throw new Error("offline");
           }
-          return { stdout: "test-cli 1.2.3\n", stderr: "", exitCode: 0 };
+          return {
+            command: input.command,
+            args: input.args ?? [],
+            stdout: "test-cli 1.2.3\n",
+            stderr: "",
+            exitCode: 0,
+          };
         },
       },
     );

--- a/packages/runtime/src/buildInfo.ts
+++ b/packages/runtime/src/buildInfo.ts
@@ -28,7 +28,7 @@ export type StationBuildInfo = {
 export function stationBuildInfo(): StationBuildInfo {
   return {
     version:
-      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5" : STATION_BUILD_VERSION,
+      typeof STATION_BUILD_VERSION === "undefined" ? "0.0.0-pre-alpha.5.1" : STATION_BUILD_VERSION,
     compiled: isCompiledBinary(),
     buildIdentity:
       typeof STATION_BUILD_IDENTITY === "undefined"

--- a/packages/runtime/test/unit/buildInfo.test.ts
+++ b/packages/runtime/test/unit/buildInfo.test.ts
@@ -34,14 +34,14 @@ describe("station build info", () => {
     expect(isCompiledBinary()).toBe(false);
     expect(verifyBuildIdentity).not.toHaveBeenCalled();
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       compiled: false,
       buildIdentity,
     });
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5+station.${buildIdentity}`);
-    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.1+station.${buildIdentity}`);
+    expect(currentObserverBuildVersion()).toBe(`0.0.0-pre-alpha.5.1+station.${buildIdentity}`);
     expect(stationBuildInfo()).toEqual({
-      version: "0.0.0-pre-alpha.5",
+      version: "0.0.0-pre-alpha.5.1",
       compiled: false,
       buildIdentity,
     });

--- a/tests/diagnostics/release-readiness-docs.test.ts
+++ b/tests/diagnostics/release-readiness-docs.test.ts
@@ -63,9 +63,9 @@ describe("release readiness docs", () => {
         "let your agent install and validate station",
       );
       expect(prompt).toContain(
-        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh",
+        "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh",
       );
-      expect(prompt).toContain("v0.0.0-pre-alpha.5");
+      expect(prompt).toContain("v0.0.0-pre-alpha.5.1");
       expect(prompt).toContain("stn setup check --json");
       expect(prompt).toContain("stn doctor");
       expect(prompt).toContain("summary.requiredOk: true");
@@ -144,9 +144,9 @@ describe("release readiness docs", () => {
       ].map(read),
     );
     const packageJson = await readPackageManifest();
-    const exactVersion = "v0.0.0-pre-alpha.5";
+    const exactVersion = "v0.0.0-pre-alpha.5.1";
     const exactInstallerUrl =
-      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5/install.sh";
+      "https://github.com/jeremy0dell/station/releases/download/v0.0.0-pre-alpha.5.1/install.sh";
 
     for (const [path, document] of [
       ["README.md", readme],
@@ -187,7 +187,7 @@ describe("release readiness docs", () => {
     expect(singleBinary).toContain("six assets");
     expect(singleBinary).toContain("workflow cannot enforce the precondition itself");
     expect(development).toMatch(/workflow never\s+publishes\s+the draft automatically/);
-    expect(development).toContain("accepted-release-candidate-0.0.0-pre-alpha.5");
+    expect(development).toContain("accepted-release-candidate-0.0.0-pre-alpha.5.1");
     expect(development).toContain("v0.7.1-rc.8");
     expect(homebrew).toContain("Homebrew installation is not currently supported");
     expect(homebrew).toContain("This distribution policy is separate from first-run dependencies");
@@ -255,7 +255,7 @@ describe("release readiness docs", () => {
       expect(singleBinary).toContain(target);
     }
 
-    expect(packageJson.version).toBe("0.0.0-pre-alpha.5");
+    expect(packageJson.version).toBe("0.0.0-pre-alpha.5.1");
     expect(packageJson.scripts["smoke:install"]).toBe(
       "node scripts/test-runners/run-install-smoke.mjs",
     );


### PR DESCRIPTION
## What this fixes

Station needs a narrow patch release for the pre-alpha.5 line. The patch aligns the repository's published version metadata and documentation and fixes Observer handoff version selection so the public `pre-alpha.5.1` release outranks internal preview versions.

## What changed

- Bump package, runtime, documentation, and fixture version references to `0.0.0-pre-alpha.5.1`.
- Correct public pre-alpha version matching and ordering in Observer handoff compatibility logic.
- Add regression coverage for the `pre-alpha.5.1` handoff selection.
- Keep the release based on the current `main` baseline, including the merged runtime inventory work.

## Testing

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:all`
- `pnpm smoke:release`
- `git diff --check`

This PR is release preparation only; it does not include the deferred stabilization work in #502 or #503.
