### PR TITLE
fix(recovery): preserve titles across session migration

### DIFF
--- a/apps/observer/src/commands/session/importRecoveryHandle.ts
+++ b/apps/observer/src/commands/session/importRecoveryHandle.ts
@@ -12,6 +12,7 @@ import type { EventJournal, SessionStore } from "../../persistence/index.js";
 import type { ProviderRegistry } from "../../providers/registry.js";
 import type { ObserverCore } from "../../reconcile/core.js";
 import type { ObserverEventBus } from "../../runtime/eventBus.js";
+import { nowIso } from "../../utils/time.js";
 import { assertCommandType } from "../assertCommand.js";
 import type { CommandHandler } from "../queue.js";
 import { reconcileAndPublish } from "../reconcile.js";
@@ -35,8 +36,8 @@ export type CreateSessionImportRecoveryHandleHandlerOptions = {
 /**
  * USE CASE
  *
- * Imports one verified provider-native recovery identity into an idle target
- * worktree after revalidating launch capability and existing durable ownership.
+ * Atomically imports one verified provider-native recovery identity and optional
+ * canonical title into an idle target before reconcile can expose it for resume.
  */
 export function createSessionImportRecoveryHandleHandler(
   options: CreateSessionImportRecoveryHandleHandlerOptions,
@@ -74,7 +75,12 @@ export function createSessionImportRecoveryHandleHandler(
       provider: payload.handle.provider,
     });
     assertNoRecoveryIdentityConflict(existing, payload.handle);
-    await options.persistence.upsertSessionRecoveryHandle(payload.handle);
+    const importInput: Parameters<SessionStore["importSessionRecoveryHandle"]>[0] = {
+      handle: payload.handle,
+      importedAt: nowIso(options.clock),
+    };
+    if (payload.title !== undefined) importInput.title = payload.title;
+    await options.persistence.importSessionRecoveryHandle(importInput);
     throwIfAborted(context.signal);
 
     await reconcileAndPublish({

--- a/apps/observer/src/persistence/ports.ts
+++ b/apps/observer/src/persistence/ports.ts
@@ -140,6 +140,7 @@ export interface ReconcileStore {
  *
  * Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical
  * worktree-scoped title authority, synchronized session projections, recovery, and readiness.
+ * Canonical-title handoff and recovery import commit atomically before recovery can reconcile.
  */
 export interface SessionStore {
   listSessions(): Promise<PersistedSession[]>;
@@ -187,6 +188,11 @@ export interface SessionStore {
     worktreeId: string;
     endedAt: string;
   }): Promise<{ endedSessions: number; deletedWorktreeTitles: number }>;
+  importSessionRecoveryHandle(input: {
+    handle: SessionRecoveryHandle;
+    title?: string;
+    importedAt: string;
+  }): Promise<SessionRecoveryHandle>;
   upsertSessionRecoveryHandle(input: SessionRecoveryHandle): Promise<SessionRecoveryHandle>;
   getSessionRecoveryHandle(handleId: string): Promise<SessionRecoveryHandle | undefined>;
   listSessionRecoveryHandles(

--- a/apps/observer/src/persistence/sqliteAdapter.ts
+++ b/apps/observer/src/persistence/sqliteAdapter.ts
@@ -345,6 +345,21 @@ export function createSqliteObserverPersistence(
         correlationStore.retireRemovedWorktreeSessionState(database, input),
       ),
 
+    importSessionRecoveryHandle: (input) =>
+      transaction((database) => {
+        if (input.title !== undefined) {
+          const canonical = worktreeDisplayTitleStore.upsertWorktreeDisplayTitle(database, {
+            projectId: input.handle.projectId,
+            worktreeId: input.handle.worktreeId,
+            title: input.title,
+            createdAt: input.importedAt,
+            updatedAt: input.importedAt,
+          });
+          worktreeDisplayTitleStore.synchronizeSessionTitleProjections(database, canonical);
+        }
+        return sessionRecoveryHandleStore.upsertSessionRecoveryHandle(database, input.handle);
+      }),
+
     upsertSessionRecoveryHandle: (input) =>
       transaction((database) =>
         sessionRecoveryHandleStore.upsertSessionRecoveryHandle(database, input),

--- a/apps/observer/src/runtime/api.ts
+++ b/apps/observer/src/runtime/api.ts
@@ -305,6 +305,7 @@ function sessionRecoveryReadiness(options: CreateObserverApiOptions): SessionRec
   const managedTerminal = options.providers?.managedTerminal;
   const readiness: SessionRecoveryReadiness = {
     resumeEnabled: options.config?.featureFlags?.sessionResumeAgent === true,
+    canonicalTitleImport: true,
     harnesses: Array.from(options.providers?.harnesses.values() ?? [])
       .map((provider) => ({
         provider: provider.id,

--- a/apps/observer/test/integration/in-memory-observer-api.test.ts
+++ b/apps/observer/test/integration/in-memory-observer-api.test.ts
@@ -81,6 +81,7 @@ describe("Observer API composition with in-memory persistence", () => {
 
     await expect(api.getSessionRecoveryReadiness()).resolves.toEqual({
       resumeEnabled: false,
+      canonicalTitleImport: true,
       harnesses: [{ provider: "fake-harness", canResume: true }],
     });
 

--- a/apps/observer/test/integration/session-commands.test.ts
+++ b/apps/observer/test/integration/session-commands.test.ts
@@ -1329,6 +1329,7 @@ describe("session command vertical slice", () => {
         projectId: "web",
         worktreeId: worktree.id,
         expectedPath: worktree.path,
+        title: "Imported recovery title",
         handle: {
           id: "rec_import_recovery",
           provider: "fake-harness",
@@ -1347,6 +1348,16 @@ describe("session command vertical slice", () => {
     await expect(fixture.persistence.getCommand(receipt.commandId)).resolves.toMatchObject({
       status: "succeeded",
     });
+    expect(fixture.core.getSnapshot().rows).toEqual([
+      expect.objectContaining({
+        id: worktree.id,
+        title: "Imported recovery title",
+        branch: worktree.branch,
+        path: worktree.path,
+      }),
+    ]);
+    expect(fixture.core.getSnapshot().rows[0]).not.toHaveProperty("agent");
+    expect(fixture.core.getSnapshot().sessions).toEqual([]);
     const conflict = await fixture.queue.dispatch({
       type: "session.importRecoveryHandle",
       payload: {
@@ -1430,6 +1441,7 @@ describe("session command vertical slice", () => {
     const fixture = createFixture({
       terminalIntentRunner,
       featureFlags: { sessionResumeAgent: true },
+      managedTerminal: persistentManagedTerminal(),
       worktree: new FakeWorktreeProvider({
         now,
         worktrees: [
@@ -1469,18 +1481,35 @@ describe("session command vertical slice", () => {
       subject: { kind: "session", sessionId: "ses_previous" },
       endedAt: now,
     });
-    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
-      id: "report_resume",
-      provider: "fake-harness",
-      projectId: "web",
-      worktreeId: "wt_web_resume",
-      sessionId: "ses_previous",
-      target: { kind: "native-session", id: "native_session_123" },
-      cwd: "/tmp/station/web/resume",
-      observedAt: now,
-      lastSeenAt: now,
+    await fixture.core.reconcile("pre-import-resume");
+    const importReceipt = await fixture.queue.dispatch({
+      type: "session.importRecoveryHandle",
+      payload: {
+        projectId: "web",
+        worktreeId: "wt_web_resume",
+        expectedPath: "/tmp/station/web/resume",
+        title: "Recovered custom title",
+        handle: {
+          id: "report_resume",
+          provider: "fake-harness",
+          projectId: "web",
+          worktreeId: "wt_web_resume",
+          sessionId: "ses_previous",
+          target: { kind: "native-session", id: "native_session_123" },
+          cwd: "/tmp/station/web/resume",
+          observedAt: now,
+          lastSeenAt: now,
+        },
+      },
     });
-    await fixture.core.reconcile("pre-resume");
+    await fixture.queue.drain();
+    await expect(fixture.persistence.getCommand(importReceipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    const [handle] = await fixture.persistence.listSessionRecoveryHandles({
+      worktreeId: "wt_web_resume",
+    });
+    if (handle === undefined) throw new Error("Expected imported recovery handle.");
 
     expect(fixture.core.getSnapshot().rows[0]?.recovery).toMatchObject({
       kind: "agent-resume",
@@ -1488,6 +1517,12 @@ describe("session command vertical slice", () => {
       provider: "fake-harness",
       targetKind: "native-session",
       sessionId: "ses_previous",
+    });
+    expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
+      id: "wt_web_resume",
+      title: "Recovered custom title",
+      branch: "resume",
+      path: "/tmp/station/web/resume",
     });
 
     const receipt = await fixture.queue.dispatch({
@@ -1530,8 +1565,17 @@ describe("session command vertical slice", () => {
       (await fixture.persistence.listSessions()).find((session) => session.id === "ses_previous"),
     ).not.toHaveProperty("endedAt");
     expect(fixture.core.getSnapshot().sessions).toEqual([
-      expect.objectContaining({ id: "ses_previous", origin: "station" }),
+      expect.objectContaining({
+        id: "ses_previous",
+        title: "Recovered custom title",
+        origin: "station",
+      }),
     ]);
+    expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
+      title: "Recovered custom title",
+      branch: "resume",
+      path: "/tmp/station/web/resume",
+    });
     fixture.sqlite.close();
   });
 
@@ -1549,19 +1593,38 @@ describe("session command vertical slice", () => {
       terminal,
       harness: unavailableHarness(),
       featureFlags: { sessionResumeAgent: true },
+      managedTerminal: persistentManagedTerminal(),
       sessionIds: ["ses_should_not_exist"],
     });
-    const handle = await fixture.persistence.upsertSessionRecoveryHandle({
-      id: "report_resume_gate",
-      provider: "fake-harness",
-      projectId: "web",
-      worktreeId: existing.id,
-      target: { kind: "native-session", id: "native_resume_gate" },
-      cwd: existing.path,
-      observedAt: now,
-      lastSeenAt: now,
+    await fixture.core.reconcile("pre-import-resume-gate");
+    const importReceipt = await fixture.queue.dispatch({
+      type: "session.importRecoveryHandle",
+      payload: {
+        projectId: "web",
+        worktreeId: existing.id,
+        expectedPath: existing.path,
+        title: "Retryable recovered title",
+        handle: {
+          id: "report_resume_gate",
+          provider: "fake-harness",
+          projectId: "web",
+          worktreeId: existing.id,
+          sessionId: "ses_resume_gate",
+          target: { kind: "native-session", id: "native_resume_gate" },
+          cwd: existing.path,
+          observedAt: now,
+          lastSeenAt: now,
+        },
+      },
     });
-    await fixture.core.reconcile("pre-resume-preflight");
+    await fixture.queue.drain();
+    await expect(fixture.persistence.getCommand(importReceipt.commandId)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+    const [handle] = await fixture.persistence.listSessionRecoveryHandles({
+      worktreeId: existing.id,
+    });
+    if (handle === undefined) throw new Error("Expected imported recovery handle.");
     const titlesBefore = await fixture.persistence.listWorktreeDisplayTitles();
 
     const receipt = await fixture.queue.dispatch({
@@ -1583,6 +1646,19 @@ describe("session command vertical slice", () => {
     expect(terminal.snapshot()).toMatchObject({ targets: [], launches: [] });
     await expect(fixture.persistence.listSessions()).resolves.toEqual([]);
     await expect(fixture.persistence.listWorktreeDisplayTitles()).resolves.toEqual(titlesBefore);
+    expect(fixture.core.getSnapshot().rows[0]).toMatchObject({
+      title: "Retryable recovered title",
+      branch: existing.branch,
+      path: existing.path,
+      recovery: {
+        handleId: handle.id,
+        provider: "fake-harness",
+        targetKind: "native-session",
+      },
+    });
+    await expect(
+      fixture.persistence.listSessionRecoveryHandles({ worktreeId: existing.id }),
+    ).resolves.toEqual([handle]);
     fixture.sqlite.close();
   });
 

--- a/apps/observer/test/support/inMemoryObserverPersistence.ts
+++ b/apps/observer/test/support/inMemoryObserverPersistence.ts
@@ -540,6 +540,24 @@ export function createInMemoryObserverPersistence(
         return { endedSessions, deletedWorktreeTitles };
       }),
 
+    importSessionRecoveryHandle: (input) =>
+      transaction((draft) => {
+        if (input.title !== undefined) {
+          const key = worktreeDisplayTitleKey(input.handle.projectId, input.handle.worktreeId);
+          const current = draft.worktreeDisplayTitles.get(key);
+          const canonical: PersistedWorktreeDisplayTitle = {
+            projectId: input.handle.projectId,
+            worktreeId: input.handle.worktreeId,
+            title: input.title,
+            createdAt: current?.createdAt ?? input.importedAt,
+            updatedAt: input.importedAt,
+          };
+          draft.worktreeDisplayTitles.set(key, canonical);
+          synchronizeInMemorySessionTitleProjections(draft, canonical);
+        }
+        return upsertSessionRecoveryHandle(draft, input.handle);
+      }),
+
     upsertSessionRecoveryHandle: (input) =>
       transaction((draft) => upsertSessionRecoveryHandle(draft, input)),
 

--- a/apps/observer/test/support/observerPersistenceContract.ts
+++ b/apps/observer/test/support/observerPersistenceContract.ts
@@ -1778,6 +1778,90 @@ export function observerPersistenceContract(
         });
       });
 
+      it("atomically imports a canonical title with its recovery handle", async () => {
+        await withPersistence(createFixture, async ({ persistence }) => {
+          await persistence.seedSession({
+            sessionId: "ses_import_title",
+            projectId: "web",
+            worktreeId: "wt_import_title",
+            initialTitle: "branch-title",
+            createdAt: earlier,
+            lastSeenAt: earlier,
+          });
+          const handle: SessionRecoveryHandle = {
+            id: "report_import_title",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: "wt_import_title",
+            sessionId: "ses_import_title",
+            target: { kind: "native-session", id: "native_import_title" },
+            cwd: "/tmp/station/web/import-title",
+            observedAt: now,
+            lastSeenAt: now,
+          };
+
+          const imported = await persistence.importSessionRecoveryHandle({
+            handle,
+            title: "Recovered workspace",
+            importedAt: later,
+          });
+
+          await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+            {
+              projectId: "web",
+              worktreeId: "wt_import_title",
+              title: "Recovered workspace",
+              createdAt: earlier,
+              updatedAt: later,
+            },
+          ]);
+          await expect(persistence.listSessions()).resolves.toEqual([
+            expect.objectContaining({
+              id: "ses_import_title",
+              title: "Recovered workspace",
+            }),
+          ]);
+          await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([imported]);
+
+          await expect(
+            persistence.importSessionRecoveryHandle({
+              handle,
+              title: "Recovered workspace",
+              importedAt: later,
+            }),
+          ).resolves.toEqual(imported);
+          await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([imported]);
+
+          const invalidHandle = {
+            ...handle,
+            target: { kind: "native-session", id: "" },
+          } as SessionRecoveryHandle;
+          await expectPersistenceFailure(
+            persistence.importSessionRecoveryHandle({
+              handle: invalidHandle,
+              title: "Must roll back",
+              importedAt: latest,
+            }),
+          );
+          await expect(persistence.listWorktreeDisplayTitles()).resolves.toEqual([
+            {
+              projectId: "web",
+              worktreeId: "wt_import_title",
+              title: "Recovered workspace",
+              createdAt: earlier,
+              updatedAt: later,
+            },
+          ]);
+          await expect(persistence.listSessions()).resolves.toEqual([
+            expect.objectContaining({
+              id: "ses_import_title",
+              title: "Recovered workspace",
+            }),
+          ]);
+          await expect(persistence.listSessionRecoveryHandles()).resolves.toEqual([imported]);
+        });
+      });
+
       it("ends open sessions without generic evidence reviving them and reopens explicitly", async () => {
         await withPersistence(createFixture, async ({ persistence }) => {
           for (const sessionId of ["ses_lifecycle_a", "ses_lifecycle_b"]) {

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -275,10 +275,12 @@ pnpm station:sessions:migrate -- \
 ```
 
 The plan is read-only: it uses `snapshot --require-running`, checks the exact
-source Observer and Host census, verifies target worktree and Host identities,
-refuses live target sessions on providers being migrated, checks provider-file
-conflicts, and prints a SHA-256 digest. It never starts an Observer or
-edits configuration. Apply must bind confirmation to that evidence:
+source Observer and Host census, requires each source row title to match its
+session projection, verifies target worktree and Host identities, records the
+target's current canonical title, refuses live target sessions on providers
+being migrated, requires canonical-title import readiness, checks provider-file
+conflicts, and prints a SHA-256 digest over that evidence. It never starts an
+Observer or edits configuration. Apply must bind confirmation to that evidence:
 
 ```bash
 pnpm station:sessions:migrate -- \
@@ -289,13 +291,15 @@ pnpm station:sessions:migrate -- \
 ```
 
 Apply intentionally has downtime. It closes only the planned source sessions
-without force, proves the source Host owns no live PTY, captures stable final
-provider state into a hash-inventoried private directory, and stops the pinned source
-Observer before importing handles through the recorded
-`session.importRecoveryHandle` command. It then resumes each target and verifies
-its exact Host PTY and provider-native identity. Source and target agents never
-run concurrently, target TOML is never edited, target SQLite is never opened by
-the maintenance script, and an entire devbox is never stopped as a side effect.
+without force only after revalidating the source and target titles, proves the
+source Host owns no live PTY, captures stable final provider state into a
+hash-inventoried private directory, and stops the pinned source Observer before
+atomically importing each canonical title and handle through the recorded
+`session.importRecoveryHandle` command. It then resumes each target without a
+post-launch rename and verifies both title projections, its exact Host PTY, and
+provider-native identity. Source and target agents never run concurrently,
+target TOML is never edited, target SQLite is never opened by the maintenance
+script, and an entire devbox is never stopped as a side effect.
 
 Only one apply process may own a digest at a time; a stale owner-private lock is
 reclaimed only after its recorded process is gone. `SIGINT`, `SIGTERM`, and
@@ -306,7 +310,9 @@ of source sessions running; rerun with the same digest so the journal closes the
 remaining sessions. After `source-sealed`, source agents remain stopped and the
 sealed directory is authoritative; the same retry accepts already-resumed exact
 target sessions and continues from sealed evidence instead of rerunning live
-source planning checks.
+source planning checks. A journal created by the former resume-then-rename flow
+may issue one idempotent rename repair for an already-resumed target; new
+journals import the canonical title before resume and do not use that repair.
 
 Codex and OpenCode migration accept each provider's shared source database, an
 absent target database, or a byte-identical target database. They refuse instead

--- a/docs/generated/observer-architecture-manifest.json
+++ b/docs/generated/observer-architecture-manifest.json
@@ -1486,7 +1486,7 @@
           "name": "createSessionImportRecoveryHandleHandler",
           "kind": "function",
           "role": "USE CASE",
-          "purpose": "Imports one verified provider-native recovery identity into an idle target worktree after revalidating launch capability and existing durable ownership."
+          "purpose": "Atomically imports one verified provider-native recovery identity and optional canonical title into an idle target before reconcile can expose it for resume."
         },
         {
           "name": "CreateSessionImportRecoveryHandleHandlerOptions",
@@ -1554,6 +1554,12 @@
           "resolvedPath": "apps/observer/src/runtime/eventBus.ts",
           "edgeKind": "type-only",
           "bindings": ["ObserverEventBus"]
+        },
+        {
+          "specifier": "../../utils/time.js",
+          "resolvedPath": "apps/observer/src/utils/time.ts",
+          "edgeKind": "runtime",
+          "bindings": ["nowIso"]
         },
         {
           "specifier": "@station/contracts",
@@ -5185,7 +5191,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness. Canonical-title handoff and recovery import commit atomically before recovery can reconcile."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -7189,7 +7195,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness. Canonical-title handoff and recovery import commit atomically before recovery can reconcile."
         },
         {
           "name": "SessionTurnReadinessMutation",
@@ -7493,7 +7499,7 @@
           "name": "SessionStore",
           "kind": "interface",
           "role": "DRIVEN PORT",
-          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness."
+          "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness. Canonical-title handoff and recovery import commit atomically before recovery can reconcile."
         },
         {
           "name": "WorktreeMetadataStore",
@@ -12405,8 +12411,16 @@
       "declaration": "createSessionImportRecoveryHandleHandler",
       "kind": "function",
       "role": "USE CASE",
-      "purpose": "Imports one verified provider-native recovery identity into an idle target worktree after revalidating launch capability and existing durable ownership.",
-      "dependencies": []
+      "purpose": "Atomically imports one verified provider-native recovery identity and optional canonical title into an idle target before reconcile can expose it for resume.",
+      "dependencies": [
+        {
+          "path": "apps/observer/src/persistence/ports.ts",
+          "declaration": "SessionStore",
+          "kind": "interface",
+          "role": "DRIVEN PORT",
+          "edgeKind": "type-only"
+        }
+      ]
     },
     {
       "path": "apps/observer/src/commands/session/rename.ts",
@@ -12777,7 +12791,7 @@
       "declaration": "SessionStore",
       "kind": "interface",
       "role": "DRIVEN PORT",
-      "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness.",
+      "purpose": "Maintains Observer-owned session lifecycle, provider-native execution bindings, canonical worktree-scoped title authority, synchronized session projections, recovery, and readiness. Canonical-title handoff and recovery import commit atomically before recovery can reconcile.",
       "dependencies": []
     },
     {

--- a/docs/observer-architecture.md
+++ b/docs/observer-architecture.md
@@ -182,7 +182,7 @@ ownership even where current ownership is still a deviation.
 
 | Conversation | Direction | Application seam | Actor or adapter | Rule and current status |
 | --- | --- | --- | --- | --- |
-| Observer operations | Driving | `ObserverApi` | NDJSON/Unix-socket server, direct tests | Conforming application-owned driving port; protocol adapts transport messages while direct tests can invoke it without transport. Recovery readiness is a read-only query over loaded feature policy and injected provider capabilities. |
+| Observer operations | Driving | `ObserverApi` | NDJSON/Unix-socket server, direct tests | Conforming application-owned driving port; protocol adapts transport messages while direct tests can invoke it without transport. Recovery readiness is a read-only query over loaded feature policy, canonical-title import support, and injected provider capabilities. |
 | Observer reap | Driving | `ObserverReap` | CLI observer-reap adapter, direct tests | Observer-owned local-process operation; dry-run and explicit force share one selection and revalidation use case while CLI composition supplies boundary evidence. |
 | Recorded mutations | Driving | `StationCommand`, `dispatch`, command handlers | CLI, Station client, protocol client | Commands persist acceptance and completion; the production handler map is compile-time exhaustive over the command union. |
 | Provider hook delivery | Driving | provider hook ingress | `stn-ingress`, protocol method, offline spool, provider hook adapters | Raw input is validated once and provider vocabulary is normalized at the adapter boundary. |
@@ -388,20 +388,27 @@ trace-correlated diagnostic evidence.
 
 Session migration is an exclusive cutover, not a blue/green launch. Its
 read-only plan pins source and target Observer identities, compares the complete
-source Host PTY census, verifies target worktree identity, queries live recovery
-readiness, and binds confirmation to a digest. Apply closes only those exact
-source sessions without force and requires the source Host to reach zero live
-PTYs before final provider artifacts are sealed.
+source Host PTY census, requires each canonical source row title to match its
+session projection, verifies target worktree identity, records the target's
+current canonical title, queries live recovery readiness, and binds all of that
+evidence to a digest. Apply revalidates both sides' titles and requires explicit
+canonical-title import support before it closes any source session. It closes
+only those exact source sessions without force and requires the source Host to
+reach zero live PTYs before final provider artifacts are sealed.
 
 The sealed private directory becomes temporary authority after source
 quiescence. Provider integrations locate exact native artifacts; target file
 collisions require byte-identical content. Recovery handles enter target
 Observer memory only through the recorded `session.importRecoveryHandle`
-command, while the maintenance process treats the target database as opaque.
-Each target launch rechecks that the source Observer remains stopped and verifies
-the resulting Host PTY, worktree, provider, session, and native identity before
-completion. An append-only owner-private journal makes interruption retryable;
-it never authorizes concurrent source and target agents.
+command, which atomically installs the sealed source title and recovery handle
+before reconcile can expose the idle row for resume; the maintenance process
+treats the target database as opaque. Each target launch rechecks that the source
+Observer remains stopped and verifies the resulting Host PTY, worktree, provider,
+Station session, canonical row and session titles, and provider-native identity
+before completion. An append-only owner-private journal makes interruption
+retryable; journals created under the former resume-then-rename ordering retain
+an idempotent rename repair. The journal never authorizes concurrent source and
+target agents.
 
 ### Reconciliation
 
@@ -682,7 +689,8 @@ when it changes several tables:
 - `SessionStore` owns explicit session lifecycle, canonical worktree-scoped title authority,
   synchronized per-session title projections, durable provider-native execution bindings,
   recovery handles, turn readiness, and purpose-specific remembered-harness lookup. Rename,
-  fresh-session seeding, and confirmed worktree retirement keep their multi-table changes atomic.
+  fresh-session seeding, confirmed worktree retirement, and canonical-title/recovery import keep
+  their multi-table changes atomic.
 - `WorktreeMetadataStore` owns current change, pull-request, and check metadata
   plus its expiry.
 

--- a/packages/contracts/src/commands.ts
+++ b/packages/contracts/src/commands.ts
@@ -129,6 +129,7 @@ export const ImportRecoveryHandlePayloadSchema = z
     worktreeId: WorktreeIdSchema,
     expectedPath: nonEmptyStringSchema,
     expectedRegistrationIdentity: nonEmptyStringSchema.optional(),
+    title: userFacingTitleSchema.optional(),
     handle: SessionRecoveryHandleSchema,
   })
   .strict();

--- a/packages/contracts/src/sessionRecovery.ts
+++ b/packages/contracts/src/sessionRecovery.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { type ProviderId, ProviderIdSchema, TimestampSchema } from "./ids.js";
 import type { SessionRecoveryHandle } from "./recovery.js";
-import { nonEmptyStringSchema } from "./shared.js";
+import { nonEmptyStringSchema, userFacingTitleSchema } from "./shared.js";
 
 export const SessionRecoveryHarnessReadinessSchema = z
   .object({
@@ -13,6 +13,7 @@ export const SessionRecoveryHarnessReadinessSchema = z
 export const SessionRecoveryReadinessSchema = z
   .object({
     resumeEnabled: z.boolean(),
+    canonicalTitleImport: z.literal(true).optional(),
     managedTerminal: z
       .object({
         provider: ProviderIdSchema,
@@ -125,6 +126,17 @@ export const SessionMigrationJournalEntrySchema = z
       .optional(),
     sealedRoot: nonEmptyStringSchema.optional(),
     sessionId: nonEmptyStringSchema.optional(),
+    titleEvidence: z
+      .array(
+        z
+          .object({
+            sessionId: nonEmptyStringSchema,
+            sourceTitle: userFacingTitleSchema,
+            targetTitle: userFacingTitleSchema,
+          })
+          .strict(),
+      )
+      .optional(),
     error: nonEmptyStringSchema.optional(),
   })
   .strict();

--- a/packages/contracts/test/schema/contracts-schema.test.ts
+++ b/packages/contracts/test/schema/contracts-schema.test.ts
@@ -1016,6 +1016,55 @@ describe("contract schemas", () => {
     expectParses(
       StationCommandSchema,
       {
+        type: "session.importRecoveryHandle",
+        payload: {
+          projectId: "web",
+          worktreeId: "wt_web_feature",
+          expectedPath: "/tmp/station/web/feature",
+          title: "  Recovered workspace  ",
+          handle: {
+            id: "rec_web_feature",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: "wt_web_feature",
+            sessionId: "ses_web_feature",
+            target: { kind: "native-session", id: "thread-web-feature" },
+            cwd: "/tmp/station/web/feature",
+            observedAt: "2026-07-29T12:00:00.000Z",
+            lastSeenAt: "2026-07-29T12:00:00.000Z",
+          },
+        },
+      },
+      "recovery import with canonical title",
+    );
+    expectFails(
+      StationCommandSchema,
+      {
+        type: "session.importRecoveryHandle",
+        payload: {
+          projectId: "web",
+          worktreeId: "wt_web_feature",
+          expectedPath: "/tmp/station/web/feature",
+          title: "   ",
+          handle: {
+            id: "rec_web_feature",
+            provider: "codex",
+            projectId: "web",
+            worktreeId: "wt_web_feature",
+            sessionId: "ses_web_feature",
+            target: { kind: "native-session", id: "thread-web-feature" },
+            cwd: "/tmp/station/web/feature",
+            observedAt: "2026-07-29T12:00:00.000Z",
+            lastSeenAt: "2026-07-29T12:00:00.000Z",
+          },
+        },
+      },
+      "recovery import with blank canonical title",
+    );
+
+    expectParses(
+      StationCommandSchema,
+      {
         type: "worktree.create",
         payload: { projectId: "web", branch: "feature/agent", launchHarness: "codex" },
       },
@@ -1720,6 +1769,13 @@ describe("contract schemas", () => {
         status: "complete",
         digest: "a".repeat(64),
         sealedRoot: "/tmp/session-migration/sealed",
+        titleEvidence: [
+          {
+            sessionId: "ses_1",
+            sourceTitle: "Recovered workspace",
+            targetTitle: "feature/recovery",
+          },
+        ],
       },
       "session migration journal entry",
     );
@@ -1764,6 +1820,7 @@ describe("contract schemas", () => {
       SessionRecoveryReadinessSchema,
       {
         resumeEnabled: true,
+        canonicalTitleImport: true,
         managedTerminal: {
           provider: "native",
           canLaunchProcessPersistently: true,
@@ -1776,6 +1833,16 @@ describe("contract schemas", () => {
       SessionRecoveryReadinessSchema,
       { resumeEnabled: true, harnesses: [], providerData: {} },
       "session recovery readiness with unknown fields",
+    );
+    expectParses(
+      SessionRecoveryReadinessSchema,
+      { resumeEnabled: true, harnesses: [] },
+      "older session recovery readiness without canonical title import",
+    );
+    expectFails(
+      SessionRecoveryReadinessSchema,
+      { resumeEnabled: true, canonicalTitleImport: false, harnesses: [] },
+      "session recovery readiness with false canonical title import",
     );
   });
 

--- a/packages/protocol/test/integration/client-server.test.ts
+++ b/packages/protocol/test/integration/client-server.test.ts
@@ -47,6 +47,7 @@ describe("protocol client/server", () => {
     });
     await expect(client.getSessionRecoveryReadiness()).resolves.toEqual({
       resumeEnabled: true,
+      canonicalTitleImport: true,
       managedTerminal: { provider: "native", canLaunchProcessPersistently: true },
       harnesses: [],
     });

--- a/packages/protocol/test/support/fixtures.ts
+++ b/packages/protocol/test/support/fixtures.ts
@@ -28,6 +28,7 @@ export function createFakeObserverApi(
     getSnapshot: async () => snapshot,
     getSessionRecoveryReadiness: async () => ({
       resumeEnabled: true,
+      canonicalTitleImport: true,
       managedTerminal: { provider: "native", canLaunchProcessPersistently: true },
       harnesses: [],
     }),

--- a/scripts/maintenance/session-migrate.mjs
+++ b/scripts/maintenance/session-migrate.mjs
@@ -195,6 +195,9 @@ export function buildSessionMigrationPlan(
     ) {
       throw new Error(`Session ${item.sessionId} is absent from the archived snapshot`);
     }
+    if (sourceSession.title !== sourceRow.title) {
+      throw new Error(`Session ${item.sessionId} archived row and session titles differ`);
+    }
     if (
       targetRow === undefined ||
       targetRow.projectId !== item.projectId ||
@@ -228,7 +231,8 @@ export function buildSessionMigrationPlan(
     }
     return {
       sessionId: item.sessionId,
-      title: sourceSession.title,
+      title: sourceRow.title,
+      targetTitle: targetRow.title,
       provider: item.provider,
       projectId: item.projectId,
       worktreeId: item.worktreeId,
@@ -397,6 +401,10 @@ async function loadResumableMigration(options, journalPath) {
       entry.status === "complete" &&
       ["source-sealed", "target-staged", "verified", "complete"].includes(entry.phase),
   );
+  const titleEvidence = records.find((entry) => entry.titleEvidence !== undefined)?.titleEvidence;
+  if (!sourceSealed && titleEvidence !== undefined) {
+    assertPlanMatchesTitleEvidence(plan, titleEvidence);
+  }
   if (plan.some((item) => item.alreadyResumed) && !sourceSealed) {
     throw new Error("Target sessions appeared before the source-sealed journal phase");
   }
@@ -412,6 +420,7 @@ async function loadResumableMigration(options, journalPath) {
     targetReadiness,
     plan,
     digest: recordedDigest,
+    legacyJournal: titleEvidence === undefined,
     sourceQuiesced: records.some(
       (entry) =>
         entry.status === "complete" &&
@@ -456,7 +465,12 @@ async function applyMigration(options) {
   try {
     sourceAlreadySealed = await pathExists(join(sealedRoot, "sealed.json"));
     if (sourceAlreadySealed) sourceQuiesced = true;
-    await appendJournal(journalPath, { phase, status: "complete", digest });
+    await appendJournal(journalPath, {
+      phase,
+      status: "complete",
+      digest,
+      ...(resumed === undefined ? { titleEvidence: migrationTitleEvidence(plan) } : {}),
+    });
     if (sourceAlreadySealed) {
       await verifySealedProviderState(sealedRoot, digest, plan);
     }
@@ -500,10 +514,12 @@ async function applyMigration(options) {
       throwIfInterrupted(signals);
       await assertSourceStopped(options, sourceConfig, inputs);
       if (item.alreadyResumed) {
-        await dispatchCommand(options.targetStn, options.targetConfig, {
-          type: "session.rename",
-          payload: { sessionId: item.sessionId, title: item.title },
-        });
+        if (resumed?.legacyJournal === true) {
+          await dispatchCommand(options.targetStn, options.targetConfig, {
+            type: "session.rename",
+            payload: { sessionId: item.sessionId, title: item.title },
+          });
+        }
         launched.push(item.sessionId);
         await appendJournal(journalPath, {
           phase: "target-session-resumed",
@@ -522,6 +538,7 @@ async function applyMigration(options) {
           ...(item.registrationIdentity === undefined
             ? {}
             : { expectedRegistrationIdentity: item.registrationIdentity }),
+          title: item.title,
           handle: targetHandle,
         },
       });
@@ -534,10 +551,6 @@ async function applyMigration(options) {
           recoveryHandleId,
           terminal: { provider: "native", layout: "agent-only", focus: false },
         },
-      });
-      await dispatchCommand(options.targetStn, options.targetConfig, {
-        type: "session.rename",
-        payload: { sessionId: item.sessionId, title: item.title },
       });
       launched.push(item.sessionId);
       await appendJournal(journalPath, {
@@ -612,12 +625,14 @@ async function assertTargetUnchangedForCutover(options, planned) {
   ) {
     throw new Error("Target Observer identity changed before source cutover");
   }
-  buildSessionMigrationPlan(
+  const revalidatedPlan = buildSessionMigrationPlan(
     planned.inputs.coverage,
     planned.inputs.handles,
     planned.inputs.snapshot,
     snapshot,
   );
+  assertTargetTitlesMatchPlan(snapshot, planned.plan);
+  assertPlanSourceTitlesMatch(revalidatedPlan, planned.plan);
   assertNoTargetHostConflicts(await readTargetHostPtys(options.targetConfig), planned.plan);
   await preflightProviderState(options, planned.inputs, planned.plan);
 }
@@ -711,7 +726,7 @@ async function recoveryReadiness(configPath) {
   return client.getSessionRecoveryReadiness();
 }
 
-function assertTargetReadiness(readiness, plan) {
+export function assertTargetReadiness(readiness, plan) {
   if (!readiness.resumeEnabled) {
     throw new Error(
       "Target Observer has session resume disabled; enable feature_flags.session_resume_agent and restart it",
@@ -720,6 +735,11 @@ function assertTargetReadiness(readiness, plan) {
   if (readiness.managedTerminal?.canLaunchProcessPersistently !== true) {
     throw new Error(
       "Target Observer cannot persist native launches; enable feature_flags.station_persistent_agents and restart it",
+    );
+  }
+  if (readiness.canonicalTitleImport !== true) {
+    throw new Error(
+      "Target Observer does not support canonical recovery-title import; update and restart it",
     );
   }
   const harnesses = new Map(readiness.harnesses.map((item) => [item.provider, item.canResume]));
@@ -756,6 +776,7 @@ function assertSourceMatchesPlan(snapshot, plan) {
       `Source session census changed after rescue: ${active.map((session) => session.id).join(", ")}`,
     );
   }
+  assertSourceTitlesMatchPlan(snapshot, plan);
   for (const item of plan) {
     const session = active.find((candidate) => candidate.id === item.sessionId);
     if (
@@ -765,6 +786,64 @@ function assertSourceMatchesPlan(snapshot, plan) {
       session.harness.provider !== item.provider
     ) {
       throw new Error(`Source session identity changed after rescue: ${item.sessionId}`);
+    }
+  }
+}
+
+export function assertSourceTitlesMatchPlan(snapshot, plan, options = {}) {
+  for (const item of plan) {
+    const row = snapshot.rows.find(
+      (candidate) => candidate.id === item.worktreeId && candidate.projectId === item.projectId,
+    );
+    const session = snapshot.sessions.find((candidate) => candidate.id === item.sessionId);
+    if (
+      row?.title !== item.title ||
+      (session === undefined ? options.allowMissingSessions !== true : session.title !== item.title)
+    ) {
+      throw new Error(`Source title changed after migration planning: ${item.sessionId}`);
+    }
+  }
+}
+
+export function assertTargetTitlesMatchPlan(snapshot, plan) {
+  for (const item of plan) {
+    const row = snapshot.rows.find(
+      (candidate) => candidate.id === item.worktreeId && candidate.projectId === item.projectId,
+    );
+    if (row?.title !== item.targetTitle) {
+      throw new Error(`Target title changed after migration planning: ${item.sessionId}`);
+    }
+  }
+}
+
+function assertPlanSourceTitlesMatch(actual, expected) {
+  for (const item of expected) {
+    const current = actual.find((candidate) => candidate.sessionId === item.sessionId);
+    if (current?.title !== item.title) {
+      throw new Error(`Source title changed after migration planning: ${item.sessionId}`);
+    }
+  }
+}
+
+function migrationTitleEvidence(plan) {
+  return plan.map((item) => ({
+    sessionId: item.sessionId,
+    sourceTitle: item.title,
+    targetTitle: item.targetTitle,
+  }));
+}
+
+function assertPlanMatchesTitleEvidence(plan, evidence) {
+  if (plan.length !== evidence.length) {
+    throw new Error("Migration title evidence changed after planning");
+  }
+  for (const expected of evidence) {
+    const item = plan.find((candidate) => candidate.sessionId === expected.sessionId);
+    if (item?.title !== expected.sourceTitle) {
+      throw new Error(`Source title changed after migration planning: ${expected.sessionId}`);
+    }
+    if (item.targetTitle !== expected.targetTitle) {
+      throw new Error(`Target title changed after migration planning: ${expected.sessionId}`);
     }
   }
 }
@@ -794,6 +873,7 @@ async function quiesceSource(options, sourceConfig, inputs, plan, signals) {
       `New source sessions appeared before cutover: ${unexpected.map((session) => session.id).join(", ")}`,
     );
   }
+  assertSourceTitlesMatchPlan(snapshot, plan, { allowMissingSessions: true });
   for (const item of plan) {
     const session = active.find((candidate) => candidate.id === item.sessionId);
     if (
@@ -1212,6 +1292,7 @@ async function stageProviderState(options, inputs, plan, sealedRoot) {
 async function assertTargetConverged(options, plan) {
   const snapshot = await waitForSnapshot(options.targetStn, options.targetConfig);
   const hostPtys = await readTargetHostPtys(options.targetConfig);
+  assertTargetTitlesConverged(snapshot, plan);
   for (const item of plan) {
     const session = snapshot.sessions.find((candidate) => candidate.id === item.sessionId);
     const hostPty = hostPtys.find(
@@ -1234,6 +1315,18 @@ async function assertTargetConverged(options, plan) {
       !nativeIdentityMatches
     ) {
       throw new Error(`Target session did not converge with its exact Host PTY: ${item.sessionId}`);
+    }
+  }
+}
+
+export function assertTargetTitlesConverged(snapshot, plan) {
+  for (const item of plan) {
+    const row = snapshot.rows.find(
+      (candidate) => candidate.id === item.worktreeId && candidate.projectId === item.projectId,
+    );
+    const session = snapshot.sessions.find((candidate) => candidate.id === item.sessionId);
+    if (row?.title !== item.title || session?.title !== item.title) {
+      throw new Error(`Target titles did not converge: ${item.sessionId}`);
     }
   }
 }
@@ -1511,6 +1604,7 @@ async function main() {
           sessions: plan.map((item) => ({
             sessionId: item.sessionId,
             title: item.title,
+            targetTitle: item.targetTitle,
             provider: item.provider,
             projectId: item.projectId,
             worktreeId: item.worktreeId,

--- a/tests/contract-fixtures/commands/commands.json
+++ b/tests/contract-fixtures/commands/commands.json
@@ -98,6 +98,7 @@
       "worktreeId": "wt_api_cache",
       "expectedPath": "/tmp/station/api/worktrees/cache",
       "expectedRegistrationIdentity": "git-registration:fixture-cache",
+      "title": "Cache Investigation",
       "handle": {
         "id": "rec_codex_123",
         "provider": "codex",

--- a/tests/diagnostics/agent-scripts.test.ts
+++ b/tests/diagnostics/agent-scripts.test.ts
@@ -28,6 +28,10 @@ import {
   parseRuntimeInventoryArgs,
 } from "../../scripts/maintenance/runtime-inventory.mjs";
 import {
+  assertSourceTitlesMatchPlan,
+  assertTargetReadiness,
+  assertTargetTitlesConverged,
+  assertTargetTitlesMatchPlan,
   buildSessionMigrationPlan,
   parseSessionMigrationArgs,
 } from "../../scripts/maintenance/session-migrate.mjs";
@@ -497,6 +501,8 @@ describe("session migration script", () => {
     expect(source.indexOf("await quiesceSource")).toBeLessThan(
       source.indexOf('type: "session.importRecoveryHandle"'),
     );
+    expect(source).toContain("title: item.title");
+    expect(source.match(/type: "session\.rename"/gu)).toHaveLength(1);
     expect(source.lastIndexOf("await verifySealedProviderState")).toBeLessThan(
       source.indexOf('phase = "staging-target"'),
     );
@@ -514,11 +520,15 @@ describe("session migration script", () => {
       observedAt: "2026-07-29T12:00:00.000Z",
       lastSeenAt: "2026-07-29T12:00:00.000Z",
     };
-    const row = {
+    const sourceRow = {
       id: "wt_station_feature",
       projectId: "station",
       path: "/worktrees/feature",
-      title: "Feature",
+      title: "PR #365 · session rescue",
+    };
+    const targetRow = {
+      ...sourceRow,
+      title: "feature-branch",
     };
     const plan = buildSessionMigrationPlan(
       [
@@ -526,34 +536,120 @@ describe("session migration script", () => {
           sessionId: "ses_feature",
           provider: "codex",
           projectId: "station",
-          worktreeId: row.id,
+          worktreeId: sourceRow.id,
           exactHandleIds: [handle.id],
           candidateHandleIds: [],
         },
       ],
       [handle],
       {
-        rows: [row],
+        rows: [sourceRow],
         sessions: [
           {
             id: "ses_feature",
             title: "PR #365 · session rescue",
             projectId: "station",
-            worktreeId: row.id,
+            worktreeId: sourceRow.id,
           },
         ],
       },
-      { rows: [row], sessions: [] },
+      { rows: [targetRow], sessions: [] },
     );
 
     expect(plan).toEqual([
       expect.objectContaining({
         sessionId: "ses_feature",
         title: "PR #365 · session rescue",
+        targetTitle: "feature-branch",
         worktreePath: "/worktrees/feature",
         handle,
       }),
     ]);
+  });
+
+  it("rejects inconsistent or changed migration title authority", () => {
+    const handle = {
+      id: "rec_title",
+      provider: "codex",
+      projectId: "station",
+      worktreeId: "wt_title",
+      sessionId: "ses_title",
+      target: { kind: "native-session" as const, id: "thread-title" },
+      cwd: "/worktrees/title",
+    };
+    const coverage = [
+      {
+        sessionId: "ses_title",
+        provider: "codex",
+        projectId: "station",
+        worktreeId: "wt_title",
+        exactHandleIds: [handle.id],
+        candidateHandleIds: [],
+      },
+    ];
+    const sourceRow = {
+      id: "wt_title",
+      projectId: "station",
+      path: "/worktrees/title",
+      title: "Canonical title",
+    };
+    const sourceSession = {
+      id: "ses_title",
+      title: "Canonical title",
+      projectId: "station",
+      worktreeId: "wt_title",
+    };
+    const targetRow = { ...sourceRow, title: "Target title" };
+
+    expect(() =>
+      buildSessionMigrationPlan(
+        coverage,
+        [handle],
+        { rows: [sourceRow], sessions: [{ ...sourceSession, title: "Stale projection" }] },
+        { rows: [targetRow], sessions: [] },
+      ),
+    ).toThrow("archived row and session titles differ");
+
+    const plan = buildSessionMigrationPlan(
+      coverage,
+      [handle],
+      { rows: [sourceRow], sessions: [sourceSession] },
+      { rows: [targetRow], sessions: [] },
+    );
+    expect(() =>
+      assertSourceTitlesMatchPlan(
+        { rows: [{ ...sourceRow, title: "Changed source" }], sessions: [sourceSession] },
+        plan,
+      ),
+    ).toThrow("Source title changed after migration planning");
+    expect(() =>
+      assertTargetTitlesMatchPlan(
+        { rows: [{ ...targetRow, title: "Changed target" }], sessions: [] },
+        plan,
+      ),
+    ).toThrow("Target title changed after migration planning");
+    expect(() =>
+      assertTargetTitlesConverged(
+        {
+          rows: [{ ...targetRow, title: "Canonical title" }],
+          sessions: [{ ...sourceSession, title: "Wrong projection" }],
+        },
+        plan,
+      ),
+    ).toThrow("Target titles did not converge");
+  });
+
+  it("requires canonical title import readiness before migration", () => {
+    const plan = [{ provider: "codex" }];
+    const readiness = {
+      resumeEnabled: true,
+      managedTerminal: { provider: "native", canLaunchProcessPersistently: true },
+      harnesses: [{ provider: "codex", canResume: true }],
+    };
+    expect(() => assertTargetReadiness(readiness, plan)).toThrow("canonical recovery-title import");
+    expect(() =>
+      assertTargetReadiness({ ...readiness, canonicalTitleImport: true }, plan),
+    ).not.toThrow();
   });
 
   it("refuses migration when the target worktree already owns a session", () => {
@@ -582,6 +678,7 @@ describe("session migration script", () => {
       id: "wt_station_feature",
       projectId: "station",
       path: "/worktrees/feature",
+      title: "Source",
     };
     const source = {
       rows: [row],


### PR DESCRIPTION
## What this fixes

Cross-runtime session migration imported the provider recovery handle, resumed under the target worktree's branch-derived title, and renamed only after launch. That ordering could expose the wrong title during recovery and left title handoff outside the durable import boundary.

## What changed

- Extend recovery import with an optional canonical title and advertise the capability through recovery readiness.
- Persist the canonical worktree title, synchronized session projections, and recovery handle in one transaction before reconcile.
- Bind source and target titles into the confirmed migration plan and revalidate both immediately before cutover.
- Resume directly with the imported title; retain rename only as an idempotent repair for already-resumed legacy journals.
- Require final row and session title convergence alongside the existing Station, Host PTY, and provider-native identity checks.

## Testing

- `pnpm architecture:observer:generate`
- `pnpm architecture:observer:check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- 321 focused contract, persistence, Observer command, protocol, diagnostics, external-launch, dashboard selector, and migration E2E tests
- `pnpm test:sqlite:bun` passed before rebasing; the focused SQLite persistence contract passed again after rebasing
- Full `pnpm test:e2e:observer` was not clean before rebasing because lifecycle handoff cases intermittently returned the outer `OBSERVER_START_FAILED` wrapper instead of `OBSERVER_HANDOFF_REFUSED`; the migration E2E passed before and after rebasing

## Safety and scope

No SQLite migration changes. Targets without canonical-title import support fail before source quiescence. Same-runtime recovery selection from #264 remains unchanged and out of scope.