### PR TITLE
fix(terminal): recover Cursor snapshot cell attributes

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -321,8 +321,10 @@ right-click, multi-click, wheel, and child mouse reporting remain unchanged.
 
 Station Host records and replays raw PTY data events, so a complete replay feeds
 the original OSC 8 open/close bytes back through xterm and restores link
-metadata without a Host protocol change. A replay whose required bytes were
-already truncated cannot reconstruct that state and remains owned by #216.
+metadata without a Host protocol change. After raw replay truncation, semantic
+recovery restores closed links as text without their URI. An xterm link marker
+may be normalized to ordinary underline only when that is the authored style;
+protected cells and true extended underline state still fail closed.
 
 Manual validation in a hyperlink-capable outer terminal:
 

--- a/station/src/host/ptyTable.test.ts
+++ b/station/src/host/ptyTable.test.ts
@@ -357,7 +357,7 @@ describe("createPtyTable", () => {
     await frames.return?.();
   });
 
-  it("logs safe unsupported-state detail while preserving live-reset recovery", async () => {
+  it("logs a safe cell-attribute subtype while preserving live-reset recovery", async () => {
     const scripted = createScriptedTerminal({ cols: 80, rows: 24 });
     const events: Array<{ event: string; attributes: Record<string, unknown> }> = [];
     const resetData = "\x1bc\x1b[?2004h";
@@ -366,7 +366,7 @@ describe("createPtyTable", () => {
       resize() {},
       capture: async () => {
         throw new TerminalSnapshotUnavailableError(
-          { reason: "unsupported-state", detail: "wrap-pending-cell" },
+          { reason: "unsupported-state", detail: "cell-underline-color" },
           resetData,
           "unsafe terminal context stays provider-private",
         );
@@ -396,7 +396,7 @@ describe("createPtyTable", () => {
       attributes: {
         ptyId,
         reason: "unsupported-state",
-        detail: "wrap-pending-cell",
+        detail: "cell-underline-color",
       },
     });
   });

--- a/station/src/host/semanticTerminalSnapshot.test.ts
+++ b/station/src/host/semanticTerminalSnapshot.test.ts
@@ -10,8 +10,14 @@ import {
   TerminalSnapshotPendingError,
   TerminalSnapshotUnavailableError,
 } from "./semanticTerminalSnapshot.js";
+import {
+  type PinnedXtermAttributes,
+  unsupportedXtermCellAttributeDetail,
+} from "./xtermSnapshotAttributes.js";
 
 const CSI = "\x1b[";
+const CURSOR_UNDERLINED_LINK =
+  "\x1b]8;;https://example.invalid\x07" + `${CSI}4mX${CSI}24m` + "\x1b]8;;\x07";
 
 async function write(terminal: Terminal, data: string): Promise<void> {
   await new Promise<void>((resolve) => terminal.write(data, resolve));
@@ -47,6 +53,30 @@ function margins(terminal: Terminal): [number, number] {
   ];
 }
 
+function unsupportedAttributes(options: {
+  protected?: boolean;
+  storedUnderlineStyle?: number;
+  underlineColor?: number;
+  underlineOffset?: number;
+  underlineStyle?: number;
+  urlId?: number;
+}): PinnedXtermAttributes {
+  const extended = {
+    underlineColor: options.underlineColor ?? 0,
+    underlineStyle: options.storedUnderlineStyle ?? options.underlineStyle ?? 1,
+    urlId: options.urlId ?? 0,
+    clone() {
+      return { ...this };
+    },
+  };
+  return {
+    extended,
+    getUnderlineStyle: () => options.underlineStyle ?? 1,
+    getUnderlineVariantOffset: () => options.underlineOffset ?? 0,
+    isProtected: () => (options.protected === true ? 1 : 0),
+  } as PinnedXtermAttributes;
+}
+
 async function captureError(source: SemanticTerminalSnapshot): Promise<Error> {
   try {
     await source.capture();
@@ -60,6 +90,31 @@ async function captureError(source: SemanticTerminalSnapshot): Promise<Error> {
 }
 
 describe("SemanticTerminalSnapshot", () => {
+  it("classifies rejected cell attributes without inspecting terminal content", () => {
+    expect(unsupportedXtermCellAttributeDetail(unsupportedAttributes({ protected: true }))).toBe(
+      "cell-protected",
+    );
+    expect(unsupportedXtermCellAttributeDetail(unsupportedAttributes({ underlineStyle: 3 }))).toBe(
+      "cell-underline-style",
+    );
+    expect(unsupportedXtermCellAttributeDetail(unsupportedAttributes({ underlineColor: 1 }))).toBe(
+      "cell-underline-color",
+    );
+    expect(unsupportedXtermCellAttributeDetail(unsupportedAttributes({ underlineOffset: 1 }))).toBe(
+      "cell-underline-offset",
+    );
+    expect(
+      unsupportedXtermCellAttributeDetail(
+        unsupportedAttributes({ underlineStyle: 5, storedUnderlineStyle: 1, urlId: 1 }),
+      ),
+    ).toBeUndefined();
+    expect(
+      unsupportedXtermCellAttributeDetail(
+        unsupportedAttributes({ underlineStyle: 5, storedUnderlineStyle: 3, urlId: 1 }),
+      ),
+    ).toBe("cell-underline-style");
+  });
+
   it("round-trips retained history, cursor, styling, and title", async () => {
     const source = new SemanticTerminalSnapshot(12, 4);
     const restored = target(12, 4);
@@ -488,19 +543,50 @@ describe("SemanticTerminalSnapshot", () => {
     }
   });
 
+  it("preserves history and ordinary underline from Cursor-style OSC 8 cells", async () => {
+    const source = new SemanticTerminalSnapshot(20, 4);
+    const restored = target(20, 4);
+    try {
+      source.write(`one\r\ntwo\r\nthree\r\nfour\r\n${CURSOR_UNDERLINED_LINK}`);
+      const [snapshot] = await source.capture();
+      await write(restored, snapshot);
+
+      expect(lines(restored)).toEqual(["one", "two", "three", "four", "X"]);
+      const linkedCell = restored.buffer.active.getLine(4)?.getCell(0);
+      expect(Boolean(linkedCell?.isUnderline())).toBe(true);
+      if (linkedCell === undefined) throw new Error("Restored underlined cell is unavailable.");
+      expect(resolveXtermCellHyperlink(restored, linkedCell)).toBeUndefined();
+    } finally {
+      source.dispose();
+      restored.dispose();
+    }
+  });
+
   it("rejects terminal state the serializer cannot represent exactly", async () => {
     const cases = [
       ["character-set", "Cannot restore non-default terminal character sets.", "\x1b(0"],
       ["custom-tabs", "Cannot restore custom normal tab stops.", `${CSI}3g${CSI}5G\x88`],
       [
-        "cell-attributes",
+        "cell-protected",
         "Cannot restore unsupported normal attributes at row 1, column 1.",
         `${CSI}1\"qX${CSI}0\"q`,
       ],
       [
-        "cell-attributes",
+        "cell-underline-style",
         "Cannot restore unsupported normal attributes at row 1, column 1.",
-        `${CSI}4:3;58:2::255:0:0mX${CSI}0m`,
+        `${CSI}4:3mX${CSI}0m`,
+      ],
+      [
+        "cell-underline-style",
+        "Cannot restore unsupported normal attributes at row 1, column 1.",
+        "\x1b]8;;https://example.invalid\x07" +
+          `${CSI}4:3mX${CSI}0m` +
+          "\x1b]8;;\x07",
+      ],
+      [
+        "cell-underline-color",
+        "Cannot restore unsupported normal attributes at row 1, column 1.",
+        `${CSI}4;58:2::255:0:0mX${CSI}0m`,
       ],
       [
         "current-attributes",

--- a/station/src/host/terminalSupplementalState.ts
+++ b/station/src/host/terminalSupplementalState.ts
@@ -23,10 +23,11 @@ import { MouseTrackingDecMode } from "../terminal/protocol/mouse.js";
 import { VtPrefix } from "../terminal/protocol/syntax.js";
 import {
   isUnsupportedBlankXtermAttribute,
-  isUnsupportedXtermCellAttribute,
   isUnsupportedXtermAttribute,
   type PinnedXtermAttributes,
   type PinnedXtermCellAttributes,
+  type UnsupportedXtermCellAttributeDetail,
+  unsupportedXtermCellAttributeDetail,
   xtermAttributeSgr,
   xtermBackgroundKey,
   xtermBackgroundSgr,
@@ -85,14 +86,12 @@ export type TerminalSnapshotUnsupportedStateDetail =
   | "cell-attributes"
   | "current-attributes"
   | "custom-tabs"
-  | "wrap-pending-cell";
+  | "wrap-pending-cell"
+  | UnsupportedXtermCellAttributeDetail;
 
 /** Exactness failure carrying only a stable, content-free diagnostic detail. */
 export class TerminalSnapshotUnsupportedStateError extends Error {
-  constructor(
-    readonly detail: TerminalSnapshotUnsupportedStateDetail,
-    message: string,
-  ) {
+  constructor(readonly detail: TerminalSnapshotUnsupportedStateDetail, message: string) {
     super(message);
   }
 }
@@ -558,40 +557,43 @@ export class TerminalSupplementalState {
     }
     for (const bufferType of buffers) {
       this.#assertDefaultTabs(bufferType);
-      const buffer = this.#buffer(bufferType);
-      const reusable = buffer.getNullCell();
-      for (let row = 0; row < buffer.length; row += 1) {
-        const line = buffer.getLine(row);
-        if (
-          line?.isWrapped &&
-          !hasNaturallySerializableWrap(buffer.getLine(row - 1), line)
-        ) {
-          throw new TerminalSnapshotUnsupportedStateError(
-            "nonserializable-wrap",
-            `Cannot restore a non-serializable wrapped ${bufferType} line at row ${row + 1}.`,
-          );
-        }
-        for (let column = 0; column < this.terminal.cols; column += 1) {
-          const cell = line?.getCell(column, reusable) as
-            | PinnedXtermCellAttributes
-            | undefined;
-          if (
-            cell !== undefined &&
-            (isUnsupportedXtermCellAttribute(cell) || isUnsupportedBlankXtermAttribute(cell))
-          ) {
-            throw new TerminalSnapshotUnsupportedStateError(
-              "cell-attributes",
-              `Cannot restore unsupported ${bufferType} attributes at row ${row + 1}, column ${column + 1}.`,
-            );
-          }
-        }
-      }
+      this.#assertSerializableBuffer(bufferType);
     }
     if (isUnsupportedXtermAttribute(pinned._core._inputHandler._curAttrData)) {
       throw new TerminalSnapshotUnsupportedStateError(
         "current-attributes",
         "Cannot restore unsupported current terminal attributes.",
       );
+    }
+  }
+
+  #assertSerializableBuffer(bufferType: BufferType): void {
+    const buffer = this.#buffer(bufferType);
+    const reusable = buffer.getNullCell();
+    for (let row = 0; row < buffer.length; row += 1) {
+      const line = buffer.getLine(row);
+      if (line?.isWrapped && !hasNaturallySerializableWrap(buffer.getLine(row - 1), line)) {
+        throw new TerminalSnapshotUnsupportedStateError(
+          "nonserializable-wrap",
+          `Cannot restore a non-serializable wrapped ${bufferType} line at row ${row + 1}.`,
+        );
+      }
+      if (line === undefined) continue;
+
+      for (let column = 0; column < this.terminal.cols; column += 1) {
+        const cell = line.getCell(column, reusable) as PinnedXtermCellAttributes | undefined;
+        if (cell === undefined) continue;
+
+        const detail =
+          unsupportedXtermCellAttributeDetail(cell) ??
+          (isUnsupportedBlankXtermAttribute(cell) ? "cell-attributes" : undefined);
+        if (detail === undefined) continue;
+
+        throw new TerminalSnapshotUnsupportedStateError(
+          detail,
+          `Cannot restore unsupported ${bufferType} attributes at row ${row + 1}, column ${column + 1}.`,
+        );
+      }
     }
   }
 

--- a/station/src/host/xtermSnapshotAttributes.ts
+++ b/station/src/host/xtermSnapshotAttributes.ts
@@ -21,8 +21,15 @@ type XtermStyleAttributes = Pick<
   | "isUnderline"
 >;
 
+type PinnedXtermExtendedAttributes = {
+  clone(): PinnedXtermExtendedAttributes;
+  underlineColor: number;
+  underlineStyle: number;
+  urlId: number;
+};
+
 export type PinnedXtermAttributes = XtermStyleAttributes & {
-  extended: { underlineColor: number; urlId: number };
+  extended: PinnedXtermExtendedAttributes;
   getUnderlineStyle(): number;
   getUnderlineVariantOffset(): number;
   isProtected(): number;
@@ -30,6 +37,12 @@ export type PinnedXtermAttributes = XtermStyleAttributes & {
 
 export type PinnedXtermCellAttributes = PinnedXtermAttributes &
   Pick<IBufferCell, "getChars" | "getWidth">;
+
+export type UnsupportedXtermCellAttributeDetail =
+  | "cell-protected"
+  | "cell-underline-style"
+  | "cell-underline-color"
+  | "cell-underline-offset";
 
 export function isUnsupportedXtermAttribute(attributes: PinnedXtermAttributes): boolean {
   return isUnsupportedXtermCellAttribute(attributes) || attributes.extended.urlId !== 0;
@@ -39,12 +52,27 @@ export function isUnsupportedXtermAttribute(attributes: PinnedXtermAttributes): 
 export function isUnsupportedXtermCellAttribute(
   attributes: PinnedXtermAttributes,
 ): boolean {
-  return (
-    Boolean(attributes.isProtected()) ||
-    attributes.getUnderlineStyle() > 1 ||
-    attributes.extended.underlineColor !== 0 ||
-    attributes.getUnderlineVariantOffset() !== 0
-  );
+  return unsupportedXtermCellAttributeDetail(attributes) !== undefined;
+}
+
+/** Classifies the first exactness-breaking cell attribute without inspecting cell content. */
+export function unsupportedXtermCellAttributeDetail(
+  attributes: PinnedXtermAttributes,
+): UnsupportedXtermCellAttributeDetail | undefined {
+  if (attributes.isProtected()) return "cell-protected";
+  if (authoredUnderlineStyle(attributes) > 1) return "cell-underline-style";
+  if (attributes.extended.underlineColor !== 0) return "cell-underline-color";
+  if (attributes.getUnderlineVariantOffset() !== 0) return "cell-underline-offset";
+  return undefined;
+}
+
+function authoredUnderlineStyle(attributes: PinnedXtermAttributes): number {
+  const style = attributes.getUnderlineStyle();
+  if (style <= 1 || attributes.extended.urlId === 0) return style;
+  // xterm reports underlined OSC 8 cells as dashed; clearing urlId reveals the authored style.
+  const extended = attributes.extended.clone();
+  extended.urlId = 0;
+  return extended.underlineStyle;
 }
 
 export function isUnsupportedBlankXtermAttribute(


### PR DESCRIPTION
## What this fixes

Station snapshots persistent terminal state so detached sessions can reattach with retained history. Cursor renders underlined links with OSC 8 plus basic underline, but pinned xterm exposes that combination as dashed underline. Station rejected an otherwise recoverable snapshot and fell back to live-only repaint, losing scrollback on reattach. This is the history-loss trigger in #527.

## What changed

- Normalize xterm's hyperlink-induced dashed marker back to the basic underline Cursor authored.
- Restore Cursor-style linked cells as underlined text while intentionally omitting hyperlink metadata that xterm's serializer cannot preserve.
- Preserve retained terminal history instead of degrading the entire snapshot for representable state.
- Continue rejecting genuinely unsupported protected cells, authored underline styles, underline colors, and underline offsets.
- Report the exact rejected attribute subtype without logging terminal content.

## Testing

- `pnpm build`
- `pnpm typecheck` — 46 tasks passed
- `pnpm --dir station test` — 1,521 tests passed
- `cd station && bun test src/host/semanticTerminalSnapshot.test.ts src/host/ptyTable.test.ts` — 58 tests passed
- Sanitized live Cursor `2026.08.04-aaa8809` reproduction through a real PTY at 213×59 identified OSC 8 plus SGR 4 as `cell-underline-style`; no transcript or provider content was retained.